### PR TITLE
AP_Terrain: added a TERRAIN_MARGIN parameter

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -59,6 +59,14 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Bitmask: 0:Disable Download
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",   2, AP_Terrain, options, 0),
+
+    // @Param: MARGIN
+    // @DisplayName: Acceptance margin
+    // @Description: Margin in centi-meters to accept terrain data from the GCS. This can be used to allow older terrain data generated with less accurate latitude/longitude scaling to be used
+    // @Units: cm
+    // @Range: 2 30000
+    // @User: Advanced
+    AP_GROUPINFO("MARGIN",   3, AP_Terrain, margin, 2),
     
     AP_GROUPEND
 };

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -62,7 +62,7 @@
 // we allow for a 2cm discrepancy in the grid corners. This is to
 // account for different rounding in terrain DAT file generators using
 // different programming languages
-#define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= 2)
+#define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= unsigned(margin.get()))
 
 #if TERRAIN_DEBUG
 #include <assert.h>
@@ -352,6 +352,7 @@ private:
 
     // parameters
     AP_Int8  enable;
+    AP_Int16 margin;
     AP_Int16 grid_spacing; // meters between grid points
     AP_Int16 options; // option bits
 


### PR DESCRIPTION
this sets the acceptance margin for GCS generated terrain data. You can raise this to allow old data generated with the less accurate longitude scaling to be used
test with mavproxy by using this in $HOME/.mavinit_scr:
```
 terrain set enable 0
```
for testing on a real vehicle do this:
```
 module load fakegps
 fakegps set lat -35.23
 fakegps set lon 149.1234
```
then set GPS_TYPE=14