### PR TITLE
Correct RPM_PIN dt

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -282,7 +282,7 @@ bool AP_RPM::arming_checks(size_t buflen, char *buffer) const
 }
 
 #if HAL_LOGGING_ENABLED
-void AP_RPM::Log_RPM()
+void AP_RPM::Log_RPM() const
 {
     float rpm1 = -1, rpm2 = -1;
 

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -118,7 +118,7 @@ private:
 
     void detect_instance(uint8_t instance);
 
-    void Log_RPM();
+    void Log_RPM() const;
 };
 
 namespace AP {

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -116,8 +116,6 @@ private:
     AP_RPM_Backend *drivers[RPM_MAX_INSTANCES];
     uint8_t num_instances;
 
-    void detect_instance(uint8_t instance);
-
     void Log_RPM() const;
 };
 

--- a/libraries/AP_RPM/RPM_Backend.cpp
+++ b/libraries/AP_RPM/RPM_Backend.cpp
@@ -17,8 +17,6 @@
 
 #if AP_RPM_ENABLED
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_RPM.h"
 
 /*

--- a/libraries/AP_RPM/RPM_EFI.cpp
+++ b/libraries/AP_RPM/RPM_EFI.cpp
@@ -24,7 +24,6 @@
 AP_RPM_EFI::AP_RPM_EFI(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
     AP_RPM_Backend(_ap_rpm, _instance, _state)
 {
-    instance = _instance;
 }
 
 void AP_RPM_EFI::update(void)

--- a/libraries/AP_RPM/RPM_EFI.h
+++ b/libraries/AP_RPM/RPM_EFI.h
@@ -30,7 +30,6 @@ public:
     void update(void) override;
 
 private:
-    uint8_t instance;
 };
 
 #endif

--- a/libraries/AP_RPM/RPM_ESC_Telem.cpp
+++ b/libraries/AP_RPM/RPM_ESC_Telem.cpp
@@ -28,7 +28,6 @@ extern const AP_HAL::HAL& hal;
 AP_RPM_ESC_Telem::AP_RPM_ESC_Telem(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
     AP_RPM_Backend(_ap_rpm, _instance, _state)
 {
-    instance = _instance;
 }
 
 

--- a/libraries/AP_RPM/RPM_ESC_Telem.h
+++ b/libraries/AP_RPM/RPM_ESC_Telem.h
@@ -28,7 +28,6 @@ public:
     // update state
     void update(void) override;
 private:
-    uint8_t instance;
 };
 
 #endif  // AP_RPM_ESC_TELEM_ENABLED

--- a/libraries/AP_RPM/RPM_HarmonicNotch.cpp
+++ b/libraries/AP_RPM/RPM_HarmonicNotch.cpp
@@ -23,7 +23,6 @@
 AP_RPM_HarmonicNotch::AP_RPM_HarmonicNotch(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
     AP_RPM_Backend(_ap_rpm, _instance, _state)
 {
-    instance = _instance;
 }
 
 void AP_RPM_HarmonicNotch::update(void)

--- a/libraries/AP_RPM/RPM_HarmonicNotch.h
+++ b/libraries/AP_RPM/RPM_HarmonicNotch.h
@@ -29,7 +29,7 @@ public:
     void update(void) override;
 
 private:
-    uint8_t instance;
+
 };
 
 #endif  // AP_RPM_HARMONICNOTCH_ENABLED

--- a/libraries/AP_RPM/RPM_Pin.cpp
+++ b/libraries/AP_RPM/RPM_Pin.cpp
@@ -76,11 +76,10 @@ void AP_RPM_Pin::update(void)
     }
 
     if (irq_state[state.instance].dt_count > 0) {
-        float dt_avg;
 
         // disable interrupts to prevent race with irq_handler
         void *irqstate = hal.scheduler->disable_interrupts_save();
-        dt_avg = irq_state[state.instance].dt_sum / irq_state[state.instance].dt_count;
+        const float dt_avg = static_cast<float>(irq_state[state.instance].dt_sum) / irq_state[state.instance].dt_count;
         irq_state[state.instance].dt_count = 0;
         irq_state[state.instance].dt_sum = 0;
         hal.scheduler->restore_interrupts(irqstate);

--- a/libraries/AP_RPM/RPM_Pin.cpp
+++ b/libraries/AP_RPM/RPM_Pin.cpp
@@ -85,11 +85,11 @@ void AP_RPM_Pin::update(void)
         hal.scheduler->restore_interrupts(irqstate);
 
         const float scaling = ap_rpm._params[state.instance].scaling;
-        float maximum = ap_rpm._params[state.instance].maximum;
-        float minimum = ap_rpm._params[state.instance].minimum;
-        float quality = 0;
-        float rpm = scaling * (1.0e6 / dt_avg) * 60;
-        float filter_value = signal_quality_filter.get();
+        const float maximum = ap_rpm._params[state.instance].maximum;
+        const float minimum = ap_rpm._params[state.instance].minimum;
+        float quality;
+        const float rpm = scaling * (1.0e6 / dt_avg) * 60;
+        const float filter_value = signal_quality_filter.get();
 
         state.rate_rpm = signal_quality_filter.apply(rpm);
 


### PR DESCRIPTION
dt_avg was using integer division and thus lost some part of the division. Changing the division to float correct this.

The other commit remove a zero assignement that is useless and bring more const.