### PR TITLE
Plane: allow fallback to DCM in VTOL modes

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -208,8 +208,8 @@ void AC_Loiter::sanity_check_params()
 ///		updated velocity sent directly to position controller
 void AC_Loiter::calc_desired_velocity(float nav_dt, bool avoidance_on)
 {
-    float ekfGndSpdLimit, ekfNavVelGainScaler;
-    AP::ahrs().getEkfControlLimits(ekfGndSpdLimit, ekfNavVelGainScaler);
+    float ekfGndSpdLimit, ahrsControlScaleXY;
+    AP::ahrs().getControlLimits(ekfGndSpdLimit, ahrsControlScaleXY);
 
     // calculate a loiter speed limit which is the minimum of the value set by the LOITER_SPEED
     // parameter and the value set by the EKF to observe optical flow limits

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -188,7 +188,8 @@ public:
     void writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeStamp_ms, uint16_t delay_ms) override;
 
     // get speed limit
-    void getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const;
+    void getControlLimits(float &ekfGndSpdLimit, float &controlScaleXY) const;
+    float getControlScaleZ(void) const;
 
     // is the AHRS subsystem healthy?
     bool healthy() const override;
@@ -310,7 +311,7 @@ public:
     void set_alt_measurement_noise(float noise) override;
 
     // active EKF type for logging
-    uint8_t get_active_AHRS_type(void) const override {
+    uint8_t get_active_AHRS_type(void) const {
         return uint8_t(active_EKF_type());
     }
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -438,9 +438,6 @@ public:
         return _rsem;
     }
 
-    // active AHRS type for logging
-    virtual uint8_t get_active_AHRS_type(void) const { return 0; }
-
     // Logging to disk functions
     void Write_AHRS2(void) const;
     void Write_Attitude(const Vector3f &targets) const;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -35,7 +35,6 @@ public:
     AP_AHRS_DCM(const AP_AHRS_DCM &other) = delete;
     AP_AHRS_DCM &operator=(const AP_AHRS_DCM&) = delete;
 
-
     // return the smoothed gyro vector corrected for drift
     const Vector3f &get_gyro() const override {
         return _omega;
@@ -113,6 +112,12 @@ public:
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 
+    // relative-origin functions for fallback in AP_InertialNav
+    bool get_origin_fallback(Location &ret) const;
+    bool get_relative_position_NED_origin(Vector3f &vec) const override;
+    bool get_relative_position_NE_origin(Vector2f &posNE) const override;
+    bool get_relative_position_D_origin(float &posD) const override;
+    
 private:
 
     // these are experimentally derived from the simulator
@@ -191,6 +196,7 @@ private:
     // the lat/lng where we last had GPS lock
     int32_t _last_lat;
     int32_t _last_lng;
+    uint32_t _last_pos_ms;
 
     // position offset from last GPS lock
     float _position_offset_north;
@@ -216,4 +222,7 @@ private:
 
     // time when DCM was last reset
     uint32_t _last_startup_ms;
+
+    // last origin we returned, for DCM fallback from EKF
+    Location last_origin;
 };

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -58,7 +58,7 @@ void AP_AHRS_Backend::Write_Attitude(const Vector3f &targets) const
         yaw             : (uint16_t)wrap_360_cd(yaw_sensor),
         error_rp        : (uint16_t)(get_error_rp() * 100),
         error_yaw       : (uint16_t)(get_error_yaw() * 100),
-        active          : get_active_AHRS_type(),
+        active          : AP::ahrs().get_active_AHRS_type(),
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
@@ -110,7 +110,8 @@ void AP_AHRS_View::Write_AttitudeView(const Vector3f &targets) const
         control_yaw     : (uint16_t)wrap_360_cd(targets.z),
         yaw             : (uint16_t)wrap_360_cd(yaw_sensor),
         error_rp        : (uint16_t)(get_error_rp() * 100),
-        error_yaw       : (uint16_t)(get_error_yaw() * 100)
+        error_yaw       : (uint16_t)(get_error_yaw() * 100),
+        active          : AP::ahrs().get_active_AHRS_type()
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Scripting/examples/AHRS_switch.lua
+++ b/libraries/AP_Scripting/examples/AHRS_switch.lua
@@ -1,0 +1,19 @@
+-- switch between DCM and EKF3 on a switch
+
+local scripting_rc1 = rc:find_channel_for_option(300)
+local EKF_TYPE = Parameter()
+if not EKF_TYPE:init('AHRS_EKF_TYPE') then
+  gcs:send_text(6, 'init AHRS_EKF_TYPE failed')
+end
+
+function update()
+   local sw_pos = scripting_rc1:get_aux_switch_pos()
+   if sw_pos == 0 then
+      EKF_TYPE:set(3)
+   else
+      EKF_TYPE:set(0)
+   end
+   return update, 100
+end
+
+return update()


### PR DESCRIPTION
this adds the necessary functions to allow for flying a quadplane on DCM as an emergency fallback. It sets the NavGainScalar to 0.5 to reduce the VTOL controller gains to allow planes to cope with the higher lag of DCM
Tested in RealFlight only so far
Thanks to @lthall for assistance with this PR

Test log on a Foxtech HWing here:
http://uav.tridgell.net/HWing/2021-08-15/log48.bin

Video of the test here:
https://www.youtube.com/watch?v=ZI65d29dIXs
