### PR TITLE
Copter: always check GPS in super simple modes

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -425,10 +425,10 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     #endif
 
     // check if flight mode requires GPS
-    bool mode_requires_gps = copter.flightmode->requires_GPS();
+    bool mode_requires_gps = copter.flightmode->requires_GPS() || fence_requires_gps || (copter.simple_mode == Copter::SimpleMode::SUPERSIMPLE);
 
     // call parent gps checks
-    if (mode_requires_gps || fence_requires_gps) {
+    if (mode_requires_gps) {
         if (!AP_Arming::gps_checks(display_failure)) {
             AP_Notify::flags.pre_arm_gps_check = false;
             return false;
@@ -442,7 +442,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     }
 
     // return true if GPS is not required
-    if (!mode_requires_gps && !fence_requires_gps) {
+    if (!mode_requires_gps) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }


### PR DESCRIPTION
Fixes #1338

Currently it is possible to get into stab supper simple with no GPS, in which case the yaw rotation based on GPS position doesn't work. This fixes that. 

Of course we will still not trip a EKF fail-safe, but I think that is a different discussion and that problem also exists for fences.