### PR TITLE
AC_Poscontrol: Fixed Z controller init bug

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -749,10 +749,10 @@ void AC_PosControl::init_z_controller_no_descent()
     init_z_controller();
 
     // remove all descent if present
-    _vel_desired.z = MAX(0.0f, _vel_desired.z);
-    _vel_target.z = MAX(0.0f, _vel_target.z);
-    _accel_desired.z = MAX(GRAVITY_MSS * 100.0f, _accel_desired.z);
-    _accel_target.z = MAX(GRAVITY_MSS * 100.0f, _accel_target.z);
+    _vel_desired.z = MAX(0.0, _vel_desired.z);
+    _vel_target.z = MAX(0.0, _vel_target.z);
+    _accel_desired.z = MAX(0.0, _accel_desired.z);
+    _accel_target.z = MAX(0.0, _accel_target.z);
 }
 
 /// init_z_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
@@ -800,7 +800,7 @@ void AC_PosControl::init_z()
     _pid_vel_z.reset_filter();
     _pid_vel_z.set_integrator(0.0f);
 
-    _accel_desired.z = -(curr_accel.z + GRAVITY_MSS) * 100.0f;
+    _accel_desired.z = constrain_float(-(curr_accel.z + GRAVITY_MSS) * 100.0f, -_accel_max_z_cmss, _accel_max_z_cmss);
     _accel_target.z = -(curr_accel.z + GRAVITY_MSS) * 100.0f;
     _pid_accel_z.reset_filter();
 

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -296,12 +296,13 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
         scaled_servos[1] = constrain_float(pitch_rate + 0.5, 0, 1);
     }
 
+    const uint16_t channels = hal.scheduler->is_system_initialized()?4095:0;
     if (!sock) {
         soap_request_start("ExchangeData", R"(<?xml version='1.0' encoding='UTF-8'?><soap:Envelope xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
 <soap:Body>
 <ExchangeData>
 <pControlInputs>
-<m-selectedChannels>4095</m-selectedChannels>
+<m-selectedChannels>%u</m-selectedChannels>
 <m-channelValues-0to1>
 <item>%.4f</item>
 <item>%.4f</item>
@@ -320,18 +321,19 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
 </ExchangeData>
 </soap:Body>
 </soap:Envelope>)",
-                               scaled_servos[0],
-                               scaled_servos[1],
-                               scaled_servos[2],
-                               scaled_servos[3],
-                               scaled_servos[4],
-                               scaled_servos[5],
-                               scaled_servos[6],
-                               scaled_servos[7],
-                               scaled_servos[8],
-                               scaled_servos[9],
-                               scaled_servos[10],
-                               scaled_servos[11]);
+                           channels,
+                           scaled_servos[0],
+                           scaled_servos[1],
+                           scaled_servos[2],
+                           scaled_servos[3],
+                           scaled_servos[4],
+                           scaled_servos[5],
+                           scaled_servos[6],
+                           scaled_servos[7],
+                           scaled_servos[8],
+                           scaled_servos[9],
+                           scaled_servos[10],
+                           scaled_servos[11]);
     }
 
     char *reply = nullptr;


### PR DESCRIPTION
This fixes a bug in the Z controller init which could lead to a very high PSCZ.DAZ which takes a long time to decay. Fixes the bug found here:
https://www.rcgroups.com/forums/showpost.php?p=47631021&postcount=30
@lthall found the cause and the fix.
@rmackay9 this will also impact copter throw mode
