### PR TITLE
AP_ESC_TELEM: Remove unused get_raw_rpm()

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -121,25 +121,6 @@ bool AP_ESC_Telem::get_rpm(uint8_t esc_index, float& rpm) const
     return false;
 }
 
-// get an individual ESC's raw rpm if available, returns true on success
-bool AP_ESC_Telem::get_raw_rpm(uint8_t esc_index, float& rpm) const
-{
-    if (esc_index >= ESC_TELEM_MAX_ESCS) {
-        return false;
-    }
-
-    const volatile AP_ESC_Telem_Backend::RpmData& rpmdata = _rpm_data[esc_index];
-
-    const uint32_t now = AP_HAL::micros();
-
-    if (now < rpmdata.last_update_us || now - rpmdata.last_update_us > ESC_RPM_DATA_TIMEOUT_US) {
-        return false;
-    }
-
-    rpm = rpmdata.rpm;
-    return true;
-}
-
 // get an individual ESC's temperature in centi-degrees if available, returns true on success
 bool AP_ESC_Telem::get_temperature(uint8_t esc_index, int16_t& temp) const
 {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -24,9 +24,6 @@ public:
     // get an individual ESC's slewed rpm if available, returns true on success
     bool get_rpm(uint8_t esc_index, float& rpm) const;
 
-    // get an individual ESC's raw rpm if available
-    bool get_raw_rpm(uint8_t esc_index, float& rpm) const;
-
     // return the average motor RPM
     float get_average_motor_rpm(uint32_t servo_channel_mask) const;
 


### PR DESCRIPTION
Stumbled across this function: get_raw_rpm().  Grep'd the code and it is not called anywhere.  Should we remove it if it is not being used?