### PR TITLE
Copter/Blimp: only arming check compass calibrated once

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -90,23 +90,6 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
     return ret;
 }
 
-bool AP_Arming_Copter::compass_checks(bool display_failure)
-{
-    bool ret = AP_Arming::compass_checks(display_failure);
-
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
-        // check compass offsets have been set.  AP_Arming only checks
-        // this if learning is off; Copter *always* checks.
-        char failure_msg[50] = {};
-        if (!AP::compass().configured(failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_COMPASS, display_failure, "%s", failure_msg);
-            ret = false;
-        }
-    }
-
-    return ret;
-}
-
 bool AP_Arming_Copter::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -38,7 +38,6 @@ protected:
 
     // NOTE! the following check functions *DO* call into AP_Arming:
     bool ins_checks(bool display_failure) override;
-    bool compass_checks(bool display_failure) override;
     bool gps_checks(bool display_failure) override;
     bool barometer_checks(bool display_failure) override;
     bool board_voltage_checks(bool display_failure) override;

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -78,23 +78,6 @@ bool AP_Arming_Blimp::barometer_checks(bool display_failure)
     return ret;
 }
 
-bool AP_Arming_Blimp::compass_checks(bool display_failure)
-{
-    bool ret = AP_Arming::compass_checks(display_failure);
-
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
-        // check compass offsets have been set.  AP_Arming only checks
-        // this if learning is off; Blimp *always* checks.
-        char failure_msg[50] = {};
-        if (!AP::compass().configured(failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_COMPASS, display_failure, "%s", failure_msg);
-            ret = false;
-        }
-    }
-
-    return ret;
-}
-
 bool AP_Arming_Blimp::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);

--- a/Blimp/AP_Arming.h
+++ b/Blimp/AP_Arming.h
@@ -37,7 +37,6 @@ protected:
 
     // NOTE! the following check functions *DO* call into AP_Arming:
     bool ins_checks(bool display_failure) override;
-    bool compass_checks(bool display_failure) override;
     bool gps_checks(bool display_failure) override;
     bool barometer_checks(bool display_failure) override;
     bool board_voltage_checks(bool display_failure) override;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -437,7 +437,12 @@ bool AP_Arming::compass_checks(bool report)
             return false;
         }
         // check compass learning is on or offsets have been set
-        if (!_compass.learn_offsets_enabled()) {
+#if !APM_BUILD_TYPE(APM_BUILD_ArduCopter) && !APM_BUILD_TYPE(APM_BUILD_Blimp)
+        // check compass offsets have been set if learning is off
+        // copter and blimp always require configured compasses
+        if (!_compass.learn_offsets_enabled())
+#endif
+        {
             char failure_msg[50] = {};
             if (!_compass.configured(failure_msg, ARRAY_SIZE(failure_msg))) {
                 check_failed(ARMING_CHECK_COMPASS, report, "%s", failure_msg);

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -146,7 +146,7 @@ protected:
 
     virtual bool ins_checks(bool report);
 
-    virtual bool compass_checks(bool report);
+    bool compass_checks(bool report);
 
     virtual bool gps_checks(bool report);
 


### PR DESCRIPTION
We were overriding the check in AP_Arming to run a duplicate check, this removes the duplication and replaces the functionality with a #if Copter and Blimp are the only users of the function in anycase, so we could have just hard coded it. This removes the need for it to be virtual, so we should save flash all round.

Fixes https://github.com/ArduPilot/ardupilot/issues/12914