### PR TITLE
GCS_MAVLink: add support for MAV_CMD_EKF_SOURCE_SET

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -505,6 +505,7 @@ protected:
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_fence_enable(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_debug_trap(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_set_ekf_source_set(const mavlink_command_long_t &packet);
 
     void handle_optical_flow(const mavlink_message_t &msg);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3945,6 +3945,18 @@ MAV_RESULT GCS_MAVLINK::handle_command_debug_trap(const mavlink_command_long_t &
     return MAV_RESULT_UNSUPPORTED;
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_set_ekf_source_set(const mavlink_command_long_t &packet)
+{
+    // source set must be between 1 and 3
+    uint32_t source_set = uint32_t(packet.param1);
+    if ((source_set >= 1) && (source_set <= 3)) {
+        // mavlink command uses range 1 to 3 while ahrs interface accepts 0 to 2
+        AP::ahrs().set_posvelyaw_source_set(source_set-1);
+        return MAV_RESULT_ACCEPTED;
+    }
+    return MAV_RESULT_DENIED;
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(const mavlink_command_long_t &packet)
 {
     AP_Gripper *gripper = AP::gripper();
@@ -4179,6 +4191,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
 
     case MAV_CMD_DEBUG_TRAP:
         result = handle_command_debug_trap(packet);
+        break;
+
+    case MAV_CMD_SET_EKF_SOURCE_SET:
+        result = handle_command_set_ekf_source_set(packet);
         break;
 
     case MAV_CMD_PREFLIGHT_STORAGE:


### PR DESCRIPTION
This adds support for the new MAV_CMD_EKF_SOURCE_SET command that allows external systems to set the active EKF sensor source set.

This has been tested in SITL and works.  I think the only question is whether we want the mavlink command to accept the source set in the range 1 to 3 (to match the parameters) or 0 to 2 (to match the ahrs interface).  Currently it is implemented in the 1 to 3 range.

MAVLink PR https://github.com/ArduPilot/mavlink/pull/220 should be merged first.

This resolves the "add support for switching source via MAVLink" item in issue https://github.com/ArduPilot/ardupilot/issues/15859

Below is a screen shot of the SITL test with some extra debug added.
![ekf-source-set-sitl-test](https://user-images.githubusercontent.com/1498098/129516099-b4bb8b23-2233-47fc-9993-1acc721d8c10.png)

