### PR TITLE
Plane: fixed EKF fly-forward flag for tailsitters

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -430,7 +430,10 @@ void Plane::update_control_mode(void)
     // ensure we are fly-forward when we are flying as a pure fixed
     // wing aircraft. This helps the EKF produce better state
     // estimates as it can make stronger assumptions
-    if (quadplane.in_vtol_mode() ||
+    if (quadplane.available() &&
+        quadplane.tailsitter.is_in_fw_flight()) {
+        ahrs.set_fly_forward(true);
+    } else if (quadplane.in_vtol_mode() ||
         quadplane.in_assisted_flight()) {
         ahrs.set_fly_forward(false);
     } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {


### PR DESCRIPTION
for tailsitters that are always using the VTOL controllers (forced QAssist) we need a different way to determine the fly-forward flag.
This bug resulted in no wind estimation on the HWing, and no sideslip fusion

