### PR TITLE
Sub: Parameters: Add default value for MNT_TYPE

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -725,6 +725,7 @@ void Sub::load_parameters()
     AP_Param::set_default_by_name("RC3_TRIM", 1100);
     AP_Param::set_default_by_name("COMPASS_OFFS_MAX", 1000);
     AP_Param::set_default_by_name("INS_GYR_CAL", 0);
+    AP_Param::set_default_by_name("MNT_TYPE", 1);
     AP_Param::set_default_by_name("MNT_DEFLT_MODE", MAV_MOUNT_MODE_RC_TARGETING);
     AP_Param::set_default_by_name("MNT_JSTICK_SPD", 100);
     AP_Param::set_by_name("MNT_RC_IN_PAN", 7);


### PR DESCRIPTION
It's very unlikely that a ROV may exist without a gimbal or any kind of camera control,
the common use case is to use a single servo to control the camera and this is why
we set the default value of MNT_TYPE as 1 (Servo).

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>