### PR TITLE
Add option to allow arming on centered throttle controllers when using a switch or mav command

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -476,6 +476,10 @@ public:
         return _options & uint32_t(Option::ARMING_CHECK_THROTTLE);
     }
 
+    bool arming_check_centered_throttle() const {
+        return _options & uint32_t(Option::ARMING_CHECK_CENTERED_THROTTLE);
+    }
+
     bool arming_skip_checks_rpy() const {
         return _options & uint32_t(Option::ARMING_SKIP_CHECK_RPY);
     }
@@ -534,16 +538,17 @@ public:
 protected:
 
     enum class Option {
-        IGNORE_RECEIVER         = (1U << 0), // RC receiver modules
-        IGNORE_OVERRIDES        = (1U << 1), // MAVLink overrides
-        IGNORE_FAILSAFE         = (1U << 2), // ignore RC failsafe bits
-        FPORT_PAD               = (1U << 3), // pad fport telem output
-        LOG_DATA                = (1U << 4), // log rc input bytes
-        ARMING_CHECK_THROTTLE   = (1U << 5), // run an arming check for neutral throttle
-        ARMING_SKIP_CHECK_RPY   = (1U << 6), // skip the an arming checks for the roll/pitch/yaw channels
-        ALLOW_SWITCH_REV        = (1U << 7), // honor the reversed flag on switches
-        CRSF_CUSTOM_TELEMETRY   = (1U << 8), // use passthrough data for crsf telemetry
-        SUPPRESS_CRSF_MESSAGE   = (1U << 9), // suppress CRSF mode/rate message for ELRS systems
+        IGNORE_RECEIVER                  = (1U << 0), // RC receiver modules
+        IGNORE_OVERRIDES                 = (1U << 1), // MAVLink overrides
+        IGNORE_FAILSAFE                  = (1U << 2), // ignore RC failsafe bits
+        FPORT_PAD                        = (1U << 3), // pad fport telem output
+        LOG_DATA                         = (1U << 4), // log rc input bytes
+        ARMING_CHECK_THROTTLE            = (1U << 5), // run an arming check for throttle position, either idle or center
+        ARMING_SKIP_CHECK_RPY            = (1U << 6), // skip the an arming checks for the roll/pitch/yaw channels
+        ALLOW_SWITCH_REV                 = (1U << 7), // honor the reversed flag on switches
+        CRSF_CUSTOM_TELEMETRY            = (1U << 8), // use passthrough data for crsf telemetry
+        SUPPRESS_CRSF_MESSAGE            = (1U << 9), // suppress CRSF mode/rate message for ELRS systems
+        ARMING_CHECK_CENTERED_THROTTLE   = (1U << 10), // make throttle arm check position be the center
     };
 
     void new_override_received() {

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttles for idle input, 6:Skip the arming check for neutral Roll/Pitch/Yay sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems, 10:Check for centered instead of idle throttle for switch arming
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
makes arming HWing a lot easier....rudder arming is still allowed at low throttle