### PR TITLE
AP_Arming: remove redundant checks_to_perform check

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -475,15 +475,12 @@ bool AP_Arming::gps_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS)) {
 
         // Any failure messages from GPS backends
-        if ((checks_to_perform & ARMING_CHECK_ALL) ||
-            (checks_to_perform & ARMING_CHECK_GPS)) {
             char failure_msg[50] = {};
             if (!AP::gps().backends_healthy(failure_msg, ARRAY_SIZE(failure_msg))) {
                 if (failure_msg[0] != '\0') {
                     check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
                 }
                 return false;
-            }
         }
 
         //GPS OK?


### PR DESCRIPTION
This is identical to the check just above it

Reported https://discuss.ardupilot.org/t/report-some-memory-bugs/74863/1

( @KimHyungSub )
