### PR TITLE
Plane: Quadplane: relaxing fixes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -987,11 +987,9 @@ void QuadPlane::relax_attitude_control()
  */
 void QuadPlane::check_attitude_relax(void)
 {
-    uint32_t now = AP_HAL::millis();
-    if (now - last_att_control_ms > 100) {
+    if (AP_HAL::millis() - last_att_control_ms > 100) {
         relax_attitude_control();
     }
-    last_att_control_ms = now;
 }
 
 /*
@@ -1943,8 +1941,10 @@ void QuadPlane::update_throttle_hover()
  */
 void QuadPlane::motors_output(bool run_rate_controller)
 {
+    const uint32_t now = AP_HAL::millis();
     if (run_rate_controller) {
         attitude_control->rate_controller_run();
+        last_att_control_ms = now;
     }
 
     /* Delay for ARMING_DELAY_MS after arming before allowing props to spin:
@@ -1992,7 +1992,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
 
     // remember when motors were last active for throttle suppression
     if (motors->get_throttle() > 0.01f || tilt.motors_active) {
-        last_motors_active_ms = AP_HAL::millis();
+        last_motors_active_ms = now;
     }
 
 }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -444,8 +444,6 @@ bool Tailsitter::transition_vtol_complete(void) const
         gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, timeout");
         return true;
     }
-    // still waiting
-    quadplane.attitude_control->reset_rate_controller_I_terms();
     return false;
 }
 


### PR DESCRIPTION
Firstly this changes `last_att_control_ms` to actually be the last time attitude controllers were run, currently it is the last time we checked for relaxing. 

This removes the attitude controller relax from tailsitters in transition from forward to VTOL flight, this should be a big improvement  for none control surface tailsitters where the motors are active the whole time. We rely on the fixed `check_attitude_relax` function to correctly relax for us in the cases there the VTOL controllers are not active in forward flight. (need to check this is working as expected, and were calling `check_attitude_relax` everywhere we should be). I'm actualy quite tempted to say that we should just check every time we call `rate_controller_run` but it is possible there might be some valid cases where we might be valid to not relax, maybe just zero I terms there and keep the existing logic for a full relax?

~As a semi drive-by I have also changed E-stop to do a full relax as we would when disarmed, this might be a step too far, but we should certainly be relaxing the Z controller while in E-stop.~