### PR TITLE
Tools: Move RebootRequired from table to note

### DIFF
--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -241,12 +241,16 @@ This list is automatically generated from the latest ardupilot source code, and 
 
             if d.get('User', None) == 'Advanced':
                 ret += '\n| *Note: This parameter is for advanced users*'
+            if d.get('RebootRequired', None) == 'True':
+                ret += '\n| *Note: Reboot required after change*'
+            elif 'RebootRequired' in d and d.get('RebootRequired') != 'True':
+                raise Exception("Bad RebootRequired metadata tag value for {} in {}".format(d.get('name'),d.get('real_path')))
             ret += "\n\n%s\n" % self.escape(param.Description)
 
             headings = []
             row = []
             for field in sorted(param.__dict__.keys()):
-                if field not in ['name', 'DisplayName', 'Description', 'User'] and field in known_param_fields:
+                if field not in ['name', 'DisplayName', 'Description', 'User', 'RebootRequired'] and field in known_param_fields:
                     headings.append(field)
                     if field in field_table_info and Emit.prog_values_field.match(param.__dict__[field]):
                         row.append(self.render_prog_values_field(field_table_info[field], param, field))


### PR DESCRIPTION
DELAY MERGE for #18377

This is part of splitting #18160 into smaller pieces.

I'll need to rebase off master once this goes in. I tried to rebase off origin/master, but git just said was up to date. probably user error.

@peterbarker This should be good. Compiled and grepped the output to check. A double check wouldn't be bad.

Changes this (ADSB_TYPE):
![image](https://user-images.githubusercontent.com/5710309/129839833-30378b2d-10ae-42d8-9526-25a257561995.png)

to this:
![image](https://user-images.githubusercontent.com/5710309/129840051-45beeb5f-3c0d-4f5f-b357-a796967137b2.png)

and adds a note that looks like: `| *Note: Reboot required after change*`
