### PR TITLE
AHRS/VisualOdom/Copter: allow visual odometry to align yaw to GPS-for-yaw

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -630,8 +630,8 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     }
 
 #ifndef ALLOW_ARM_NO_COMPASS
-    // if external source of heading is available, we can skip compass health check
-    if (!ahrs.is_ext_nav_used_for_yaw()) {
+    // if non-compass is source of heading we can skip compass health check
+    if (!ahrs.using_noncompass_for_yaw()) {
         const Compass &_compass = AP::compass();
         // check compass health
         if (!_compass.healthy()) {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2298,11 +2298,11 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
 
         // Check vs DCM yaw if this vehicle could use DCM in flight
         // and if not using an external yaw source (DCM does not support external yaw sources)
-        bool using_external_yaw = false;
+        bool using_noncompass_for_yaw = false;
 #if HAL_NAVEKF3_AVAILABLE
-        using_external_yaw = ekf_type() == EKFType::THREE && EKF3.using_external_yaw();
+        using_noncompass_for_yaw = (ekf_type() == EKFType::THREE) && EKF3.using_noncompass_for_yaw();
 #endif
-        if (!always_use_EKF() && !using_external_yaw) {
+        if (!always_use_EKF() && !using_noncompass_for_yaw) {
             Vector3f angle_diff;
             primary_quat.angular_difference(dcm_quat).to_axis_angle(angle_diff);
             const float yaw_diff = fabsf(angle_diff.z);
@@ -3015,8 +3015,8 @@ void AP_AHRS::Log_Write()
 #endif
 }
 
-// check whether compass can be bypassed for arming check in case when external navigation data is available 
-bool AP_AHRS::is_ext_nav_used_for_yaw(void) const
+// check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
+bool AP_AHRS::using_noncompass_for_yaw(void) const
 {
     switch (active_EKF_type()) {
 #if HAL_NAVEKF2_AVAILABLE
@@ -3026,7 +3026,7 @@ bool AP_AHRS::is_ext_nav_used_for_yaw(void) const
     case EKFType::NONE:
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        return EKF3.using_external_yaw();
+        return EKF3.using_noncompass_for_yaw();
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     case EKFType::SIM:

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3040,6 +3040,31 @@ bool AP_AHRS::using_noncompass_for_yaw(void) const
     return false;
 }
 
+// check if external nav is providing yaw
+bool AP_AHRS::using_extnav_for_yaw(void) const
+{
+    switch (active_EKF_type()) {
+#if HAL_NAVEKF2_AVAILABLE
+    case EKFType::TWO:
+        return EKF2.isExtNavUsedForYaw();
+#endif
+    case EKFType::NONE:
+#if HAL_NAVEKF3_AVAILABLE
+    case EKFType::THREE:
+        return EKF3.using_extnav_for_yaw();
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    case EKFType::SIM:
+#endif
+#if HAL_EXTERNAL_AHRS_ENABLED
+    case EKFType::EXTERNAL:
+#endif
+        return false;
+    }
+    // since there is no default case above, this is unreachable
+    return false;
+}
+
 // set and save the alt noise parameter value
 void AP_AHRS::set_alt_measurement_noise(float noise)
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -328,8 +328,8 @@ public:
 
     void Log_Write();
 
-    // check whether external navigation is providing yaw.  Allows compass pre-arm checks to be bypassed
-    bool is_ext_nav_used_for_yaw(void) const override;
+    // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
+    bool using_noncompass_for_yaw(void) const override;
 
     // set and save the ALT_M_NSE parameter value
     void set_alt_measurement_noise(float noise) override;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -331,6 +331,9 @@ public:
     // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
     bool using_noncompass_for_yaw(void) const override;
 
+    // check if external nav is providing yaw
+    bool using_extnav_for_yaw(void) const override;
+
     // set and save the ALT_M_NSE parameter value
     void set_alt_measurement_noise(float noise) override;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -92,7 +92,10 @@ public:
 
     // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
     virtual bool using_noncompass_for_yaw(void) const { return false; }
-    
+
+    // check if external nav is providing yaw
+    virtual bool using_extnav_for_yaw(void) const { return false; }
+
     // request EKF yaw reset to try and avoid the need for an EKF lane switch or failsafe
     virtual void request_yaw_reset(void) {}
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -90,8 +90,8 @@ public:
     // see if EKF lane switching is possible to avoid EKF failsafe
     virtual void check_lane_switch(void) {}
 
-    // check whether external navigation is providing yaw.  Allows compass pre-arm checks to be bypassed
-    virtual bool is_ext_nav_used_for_yaw(void) const { return false; }
+    // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
+    virtual bool using_noncompass_for_yaw(void) const { return false; }
     
     // request EKF yaw reset to try and avoid the need for an EKF lane switch or failsafe
     virtual void request_yaw_reset(void) {}

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1475,6 +1475,15 @@ bool NavEKF3::using_noncompass_for_yaw(void) const
     return core[primary].using_noncompass_for_yaw();
 }
 
+// are we using (aka fusing) external nav for yaw?
+bool NavEKF3::using_extnav_for_yaw() const
+{
+    if (!core) {
+        return false;
+    }
+    return core[primary].using_extnav_for_yaw();
+}
+
 // check if configured to use GPS for horizontal position estimation
 bool NavEKF3::configuredToUseGPSForPosXY(void) const
 {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1466,13 +1466,13 @@ bool NavEKF3::use_compass(void) const
     return core[primary].use_compass();
 }
 
-// are we using an external yaw source? Needed for ahrs attitudes_consistent
-bool NavEKF3::using_external_yaw(void) const
+// are we using (aka fusing) a non-compass yaw?
+bool NavEKF3::using_noncompass_for_yaw(void) const
 {
     if (!core) {
         return false;
     }
-    return core[primary].using_external_yaw();
+    return core[primary].using_noncompass_for_yaw();
 }
 
 // check if configured to use GPS for horizontal position estimation

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -336,8 +336,8 @@ public:
     // write EKF information to on-board logs
     void Log_Write();
 
-    // are we using an external yaw source? This is needed by AHRS attitudes_consistent check
-    bool using_external_yaw(void) const;
+    // are we using (aka fusing) a non-compass yaw?
+    bool using_noncompass_for_yaw() const;
 
     // check if configured to use GPS for horizontal position estimation
     bool configuredToUseGPSForPosXY(void) const;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -339,6 +339,9 @@ public:
     // are we using (aka fusing) a non-compass yaw?
     bool using_noncompass_for_yaw() const;
 
+    // are we using (aka fusing) external nav for yaw?
+    bool using_extnav_for_yaw() const;
+
     // check if configured to use GPS for horizontal position estimation
     bool configuredToUseGPSForPosXY(void) const;
     

--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -236,7 +236,7 @@ void NavEKF3_core::SelectBetaDragFusion()
 
     // use of air data to constrain drift is necessary if we have limited sensor data or are doing inertial dead reckoning
     bool is_dead_reckoning = ((imuSampleTime_ms - lastPosPassTime_ms) > frontend->deadReckonDeclare_ms) && ((imuSampleTime_ms - lastVelPassTime_ms) > frontend->deadReckonDeclare_ms);
-    const bool noYawSensor = !use_compass() && !using_external_yaw();
+    const bool noYawSensor = !use_compass() && !using_noncompass_for_yaw();
     const bool f_required = (noYawSensor && (frontend->_betaMask & (1<<1))) || is_dead_reckoning;
 
     // set true when sideslip fusion is feasible (requires zero sideslip assumption to be valid and use of wind states)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -588,6 +588,17 @@ bool NavEKF3_core::using_noncompass_for_yaw(void) const
     return false;
 }
 
+// are we using (aka fusing) external nav for yaw?
+bool NavEKF3_core::using_extnav_for_yaw() const
+{
+#if EK3_FEATURE_EXTERNAL_NAV
+    if (frontend->sources.getYawSource() == AP_NavEKF_Source::SourceYaw::EXTNAV) {
+        return ((imuSampleTime_ms - last_extnav_yaw_fusion_ms < 5000) || (imuSampleTime_ms - lastSynthYawTime_ms < 5000));
+    }
+#endif
+    return false;
+}
+
 /*
   should we assume zero sideslip?
  */

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -572,8 +572,8 @@ bool NavEKF3_core::use_compass(void) const
            !allMagSensorsFailed;
 }
 
-// are we using a yaw source other than the magnetomer?
-bool NavEKF3_core::using_external_yaw(void) const
+// are we using (aka fusing) a non-compass yaw?
+bool NavEKF3_core::using_noncompass_for_yaw(void) const
 {
     const AP_NavEKF_Source::SourceYaw yaw_source = frontend->sources.getYawSource();
 #if EK3_FEATURE_EXTERNAL_NAV

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -397,6 +397,9 @@ public:
     // are we using (aka fusing) a non-compass yaw?
     bool using_noncompass_for_yaw(void) const;
 
+    // are we using (aka fusing) external nav for yaw?
+    bool using_extnav_for_yaw() const;
+
     // Writes the default equivalent airspeed and 1-sigma uncertainty in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed, float uncertainty);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -394,8 +394,8 @@ public:
         // 6 was EXTERNAL_YAW_FALLBACK (do not use)
     };
 
-    // are we using an external yaw source? This is needed by AHRS attitudes_consistent check
-    bool using_external_yaw(void) const;
+    // are we using (aka fusing) a non-compass yaw?
+    bool using_noncompass_for_yaw(void) const;
 
     // Writes the default equivalent airspeed and 1-sigma uncertainty in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed, float uncertainty);

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -129,8 +129,8 @@ void AP_VisualOdom_IntelT265::rotate_attitude(Quaternion &attitude) const
 // use sensor provided attitude to calculate rotation to align sensor with AHRS/EKF attitude
 bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude)
 {
-    // do not align to ahrs if it is using us as its yaw source
-    if (AP::ahrs().using_noncompass_for_yaw()) {
+    // do not align to ahrs if we are its yaw source
+    if (AP::ahrs().using_extnav_for_yaw()) {
         return false;
     }
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -130,7 +130,7 @@ void AP_VisualOdom_IntelT265::rotate_attitude(Quaternion &attitude) const
 bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude)
 {
     // do not align to ahrs if it is using us as its yaw source
-    if (AP::ahrs().is_ext_nav_used_for_yaw()) {
+    if (AP::ahrs().using_noncompass_for_yaw()) {
         return false;
     }
 


### PR DESCRIPTION
This PR (in a roundabout way) allows AP_VisualOdom (aka ExternalNav) to align its yaw to the AHRS's yaw even if the yaw source is GSF or GPS-for-yaw.  This resolves the 2nd item in issue https://github.com/ArduPilot/ardupilot/issues/15859

To provide some background, in AP_VisualOdom_IntelT265::align_sensor_to_vehicle() we have the check shown below to protect against re-aligning the external nav system's yaw (e.g. T265) to the AHRS's yaw if the AHRS is using the camera as its source (aka "drinking our own bathwater").  This is important to avoid a slight random shift on each alignment.

    // do not align to ahrs if it is using us as its yaw source
    if (AP::ahrs().is_ext_nav_used_for_yaw()) {
        return false;
    }

The problem is that the AP_AHRS::is_ext_nav_used_for_yaw() returns true (if EKF3 is active) if the yaw source is ExtNav, GSF or GPS-for-yaw meaning AP_VisualOdom can't align to any of these sources.. but it should be able to align to GSF or GPS-for-yaw.  This badly named method is renamed to "using_noncompass_for_yaw" and a new "using_extnav_for_yaw" method is added.

This has been tested in SITL using gps-for-yaw and vicon together and below are screenshots showing BEFORE (where the visual odom could not be re-aligned to match gps-for-yaw) and AFTER where it was re-aligned.
![sitl-before](https://user-images.githubusercontent.com/1498098/130190099-72ee60cc-dbc6-4e1a-aac7-36b1a94d5b94.png)
![sitl-test-aligned-yaw-to-gps-for-yaw](https://user-images.githubusercontent.com/1498098/130190110-627b9556-9b3b-4ab4-89c0-dfa62489c933.png)
