### PR TITLE
plane: quadplane: tailsitter: run FW transition check and assist immediately

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1786,7 +1786,7 @@ void QuadPlane::update(void)
         // output to motors
         motors_output();
 
-        if (now - last_vtol_mode_ms > 1000 && tailsitter.enabled()) {
+        if (tailsitter.enabled() && (now - last_vtol_mode_ms) > 1000) {
             /*
               we are just entering a VTOL mode as a tailsitter, set
               our transition state so the fixed wing controller brings
@@ -1796,7 +1796,8 @@ void QuadPlane::update(void)
             transition_state = TRANSITION_ANGLE_WAIT_VTOL;
             transition_start_ms = now;
             transition_initial_pitch = constrain_float(ahrs.pitch_sensor,-8500,8500);
-        } else if (tailsitter.enabled() &&
+        }
+        if (tailsitter.enabled() &&
                    transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
             float aspeed;
             bool have_airspeed = ahrs.airspeed_estimate(aspeed);


### PR DESCRIPTION
This fixes a issue with the transition logic highlighted by https://github.com/ArduPilot/ardupilot/pull/18311

We do not run Qassist in the first loop where we enter a VTOL mode. This change means that we both run Qassist and check for transition complete in the same loop that the transition was entered on. 

This also fixes the issue seen in https://github.com/ArduPilot/ardupilot/pull/18311 because the time spent in `TRANSITION_ANGLE_WAIT_VTOL` is now only a few lines rather than 1 loop + the few lines. Of course the race is still there, but your now much much less likely to hit it. 

Just a draft because I can't test in RF this week. 