### PR TITLE
Tools: Fix emit.py regex

### DIFF
--- a/Tools/autotest/param_metadata/emit.py
+++ b/Tools/autotest/param_metadata/emit.py
@@ -10,7 +10,7 @@ class Emit:
     def __init__(self, sitl=False):
         self.sitl = sitl
 
-    prog_values_field = re.compile(r"\s*(-?\w+:\w+)+,*")
+    prog_values_field = re.compile(r"-?\d*\.?\d+: ?[\w ]+,?")
 
     def close(self):
         pass


### PR DESCRIPTION
Split from #18160

This fixes a bug with several parameters not having their metadata parse correctly. Creating a simpler and more robust regex expression fixes this.

Current issue (TERRAIN_FOLLOW):
![image](https://user-images.githubusercontent.com/5710309/129990758-49acb13f-4ecb-4ee7-853e-7fcb41b2f465.png)

With this fix:
![image](https://user-images.githubusercontent.com/5710309/129990780-07d58e7f-55a6-4ef7-b3de-aafe2458eb76.png)

