### PR TITLE
AP_HAL_ChibiOS: fix compilation when no GPIO pins defined

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1794,6 +1794,7 @@ def write_GPIO_config(f):
                 (gpio, pwm, port, pin, p))
     # and write #defines for use by config code
     f.write('}\n\n')
+    f.write('#define HAL_GPIO_NUM_PINS %u\\\n' % len(gpios))
     f.write('// full pin define list\n')
     last_label = None
     for l in sorted(list(set(bylabel.keys()))):


### PR DESCRIPTION
```
../../libraries/AP_HAL_ChibiOS/GPIO.cpp: In function 'void __static_initialization_and_destruction_0(int, int)':
../../libraries/AP_HAL_ChibiOS/GPIO.cpp:43:3: error: statement has no effect [-Werror=unused-value]
   43 | } _gpio_tab[] = HAL_GPIO_PINS;
      |   ^~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors
```
