### PR TITLE
AP_Compass: fail calibration unless at least 1 compass to cal

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -173,8 +173,10 @@ public:
         _per_motor.calibration_end();
     }
 #endif
-    
-    void start_calibration_all(bool retry=false, bool autosave=false, float delay_sec=0.0f, bool autoreboot = false);
+
+    // start_calibration_all will only return false if there are no
+    // compasses to calibrate.
+    bool start_calibration_all(bool retry=false, bool autosave=false, float delay_sec=0.0f, bool autoreboot = false);
 
     void cancel_calibration_all();
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -126,27 +126,33 @@ bool Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, f
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
 
+    bool at_least_one_started = false;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         if ((1<<i) & mask) {
             if (!_start_calibration(i,retry,delay)) {
                 _cancel_calibration_mask(mask);
                 return false;
             }
+            at_least_one_started = true;
         }
     }
-    return true;
+    return at_least_one_started;
 }
 
-void Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
+bool Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
 {
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
 
+    bool at_least_one_started = false;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         // ignore any compasses that fail to start calibrating
         // start all should only calibrate compasses that are being used
-        _start_calibration(i,retry,delay);
+        if (_start_calibration(i,retry,delay)) {
+            at_least_one_started = true;
+        }
     }
+    return at_least_one_started;
 }
 
 void Compass::_cancel_calibration(uint8_t i)
@@ -376,7 +382,9 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
 
         if (mag_mask == 0) { // 0 means all
             _reset_compass_id();
-            start_calibration_all(retry, autosave, delay, autoreboot);
+            if (!start_calibration_all(retry, autosave, delay, autoreboot)) {
+                result = MAV_RESULT_FAILED;
+            }
         } else {
             if (!_start_calibration_mask(mag_mask, retry, autosave, delay, autoreboot)) {
                 result = MAV_RESULT_FAILED;


### PR DESCRIPTION
Noticed this on a bare H743 - you can start the calibration process but it won't ever go anywhere as there aren't any onboard compasses.
