### PR TITLE
ArduPlane: relax i term upon TRANSITION completions in tailsitter

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1569,6 +1569,7 @@ void QuadPlane::update_transition(void)
         if (transition_state == TRANSITION_ANGLE_WAIT_FW &&
             tailsitter.transition_fw_complete()) {
             transition_state = TRANSITION_DONE;
+            attitude_control->reset_rate_controller_I_terms();
             transition_start_ms = 0;
             transition_low_airspeed_ms = 0;
         }
@@ -1810,6 +1811,7 @@ void QuadPlane::update(void)
                 */
                 transition_state = TRANSITION_ANGLE_WAIT_FW;
                 transition_start_ms = now;
+                attitude_control->reset_rate_controller_I_terms();
             }
         } else {
             /*

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -413,7 +413,6 @@ bool Tailsitter::transition_vtol_complete(void) const
         return true;
     }
     // still waiting
-    quadplane.attitude_control->reset_rate_controller_I_terms();
     return false;
 }
 


### PR DESCRIPTION
start each new VTOL/FW completed transition with zero'd I term instead of only relaxing during the entire FW->VTOL transition....this allows any I tem built up while vertical or horizontal to be removed and re-acculmulated when switching orientation

alternate to tailsitter commit in #18375 

no way to test against an I build up in SITL, I guess....HWing sim flies fine with the changes but it has no I term buildup in either VTOL or FW....