### PR TITLE
Copter: Change to a definition name

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -40,7 +40,7 @@ void ModeRTL::restart_without_terrain()
 ModeRTL::RTLAltType ModeRTL::get_alt_type() const
 {
     // sanity check parameter
-    if (g.rtl_alt_type < 0 || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
+    if (g.rtl_alt_type < (int)RTLAltType::RTL_ALTTYPE_RELATIVE || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
         return RTLAltType::RTL_ALTTYPE_RELATIVE;
     }
     return (RTLAltType)g.rtl_alt_type.get();


### PR DESCRIPTION
This conditional expression determines that the value is not a defined value.
Therefore, it should be judged by the defined value.
Also, since ENUM can be set to a negative value, I don't think it makes sense to judge it by its direct value.