### PR TITLE
AP_Logger: Use actual MAVLink constant

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -274,9 +274,9 @@ void AP_Logger_MAVLink::remote_log_block_status_msg(const GCS_MAVLINK &link,
     if (!semaphore.take_nonblocking()) {
         return;
     }
-    if(packet.status == 0){
+    if(packet.status == MAV_REMOTE_LOG_DATA_BLOCK_NACK) {
         handle_retry(packet.seqno);
-    } else{
+    } else {
         handle_ack(link, msg, packet.seqno);
     }
     semaphore.give();


### PR DESCRIPTION
This isn't a functional change, it just improves the readability of the file.