### PR TITLE
AP_Logger: Be stricter on MAVLink ack handling

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -274,10 +274,16 @@ void AP_Logger_MAVLink::remote_log_block_status_msg(const GCS_MAVLINK &link,
     if (!semaphore.take_nonblocking()) {
         return;
     }
-    if(packet.status == MAV_REMOTE_LOG_DATA_BLOCK_NACK) {
-        handle_retry(packet.seqno);
-    } else {
-        handle_ack(link, msg, packet.seqno);
+    switch ((MAV_REMOTE_LOG_DATA_BLOCK_STATUSES)packet.status) {
+        case MAV_REMOTE_LOG_DATA_BLOCK_NACK:
+            handle_retry(packet.seqno);
+            break;
+        case MAV_REMOTE_LOG_DATA_BLOCK_ACK:
+            handle_ack(link, msg, packet.seqno);
+            break;
+        // we apparently have to handle an END enum entry, just drop it so we catch future additions
+        case MAV_REMOTE_LOG_DATA_BLOCK_STATUSES_ENUM_END:
+            break;
     }
     semaphore.give();
 }


### PR DESCRIPTION
This is an expanded version of #18397, see the comment from the commit below for more reasoning.

This is a change in bevaiour. The previous behaviour was to check for a NACK, and if it wasn't a NACK it was assumed to be an ACK. This is a bad assumption to let people get away with, because in the future if we ever add other options to the enum we are more likely to have to cope with bad implementation in the wild

This was tested with SITL and mavlink-router and seems to work fine. We need to also test that all the other known backends work:
- [ ] Solo
- [x] mavproxy
- [x] mavlink-router
- [ ] dronekit-la
- [ ] MissionPlanner

As a final aside handling the `_END` entry in the enum doesn't increase code size at all, it just gets optimized out.