### PR TITLE
APM_Control: remove unused variables

### DIFF
--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -50,7 +50,6 @@ private:
     bool failed_autotune_alloc;
 	AP_Int16 _max_rate_neg;
 	AP_Float _roll_ff;
-	uint32_t _last_t;
     float _last_out;
     AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -55,7 +55,6 @@ private:
     AP_AutoTune::ATGains gains;
     AP_AutoTune *autotune;
     bool failed_autotune_alloc;
-	uint32_t _last_t;
 	float _last_out;
     AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;


### PR DESCRIPTION
recent refactoring made these unused IIUC.
