### PR TITLE
Split AHRS parameters between DCM and frontend / groundspeed_vector up

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -116,6 +116,10 @@ public:
     // return a wind estimation vector, in m/s
     Vector3f wind_estimate() const override;
 
+    // return the parameter AHRS_WIND_MAX in metres per second
+    uint8_t get_max_wind() const {
+        return _wind_max;
+    }
 
     /*
      * airspeed support
@@ -335,6 +339,11 @@ public:
         return uint8_t(active_EKF_type());
     }
 
+    // get the selected ekf type, for allocation decisions
+    int8_t get_ekf_type(void) const {
+        return _ekf_type;
+    }
+
     // these are only out here so vehicles can reference them for parameters
 #if HAL_NAVEKF2_AVAILABLE
     NavEKF2 EKF2;
@@ -465,6 +474,16 @@ private:
      * from AP_AHRS by other libraries
      */
     VehicleClass _vehicle_class{VehicleClass::UNKNOWN};
+
+    /*
+     * Parameters
+     */
+    AP_Int8 _wind_max;
+    AP_Int8 _board_orientation;
+    AP_Int8 _ekf_type;
+    AP_Float _custom_roll;
+    AP_Float _custom_pitch;
+    AP_Float _custom_yaw;
 
     enum class EKFType {
         NONE = 0

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -485,6 +485,11 @@ private:
     AP_Float _custom_pitch;
     AP_Float _custom_yaw;
 
+    /*
+     * support for custom AHRS orientation, replacing _board_orientation
+     */
+    Matrix3f _custom_rotation;
+
     enum class EKFType {
         NONE = 0
 #if HAL_NAVEKF3_AVAILABLE

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -77,7 +77,7 @@ void AP_AHRS::update_orientation()
 }
 
 // return a ground speed estimate in m/s
-Vector2f AP_AHRS_Backend::groundspeed_vector(void)
+Vector2f AP_AHRS_DCM::groundspeed_vector(void)
 {
     // Generate estimate of ground speed vector using air data system
     Vector2f gndVelADS;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -207,7 +207,7 @@ public:
     }
 
     // return a ground vector estimate in meters/second, in North/East order
-    virtual Vector2f groundspeed_vector(void);
+    virtual Vector2f groundspeed_vector(void) = 0;
 
     // return a ground velocity in meters/second, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is
@@ -464,12 +464,6 @@ protected:
     // accelerometer values in the earth frame in m/s/s
     Vector3f        _accel_ef[INS_MAX_INSTANCES];
     Vector3f        _accel_ef_blended;
-
-    // Declare filter states for HPF and LPF used by complementary
-    // filter in AP_AHRS::groundspeed_vector
-    Vector2f _lp; // ground vector low-pass filter
-    Vector2f _hp; // ground vector high-pass filter
-    Vector2f _lastGndVelADS; // previous HPF input
 
     // helper trig variables
     float _cos_roll{1.0f};

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -430,8 +430,6 @@ protected:
     // multi-thread access support
     HAL_Semaphore _rsem;
 
-    Matrix3f _custom_rotation;
-
     // calculate sin/cos of roll/pitch/yaw from rotation
     void calc_trig(const Matrix3f &rot,
                    float &cr, float &cp, float &cy,

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -206,11 +206,6 @@ public:
         return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
     }
 
-    // return the parameter AHRS_WIND_MAX in metres per second
-    uint8_t get_max_wind() const {
-        return _wind_max;
-    }
-
     // return a ground vector estimate in meters/second, in North/East order
     virtual Vector2f groundspeed_vector(void);
 
@@ -374,11 +369,6 @@ public:
         return false;
     }
 
-    // get the selected ekf type, for allocation decisions
-    int8_t get_ekf_type(void) const {
-        return _ekf_type;
-    }
-
     // Retrieves the corrected NED delta velocity in use by the inertial navigation
     virtual void getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const {
         ret.zero();
@@ -455,13 +445,7 @@ protected:
     };
 
     AP_Enum<GPSUse> _gps_use;
-    AP_Int8 _wind_max;
-    AP_Int8 _board_orientation;
     AP_Int8 _gps_minsats;
-    AP_Int8 _ekf_type;
-    AP_Float _custom_roll;
-    AP_Float _custom_pitch;
-    AP_Float _custom_yaw;
 
     Matrix3f _custom_rotation;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -430,23 +430,6 @@ protected:
     // multi-thread access support
     HAL_Semaphore _rsem;
 
-    // settable parameters
-    // these are public for ArduCopter
-    AP_Float _kp_yaw;
-    AP_Float _kp;
-    AP_Float gps_gain;
-
-    AP_Float beta;
-
-    enum class GPSUse : uint8_t {
-        Disable = 0,
-        Enable  = 1,
-        EnableWithHeight = 2,
-    };
-
-    AP_Enum<GPSUse> _gps_use;
-    AP_Int8 _gps_minsats;
-
     Matrix3f _custom_rotation;
 
     // calculate sin/cos of roll/pitch/yaw from rotation

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -453,7 +453,4 @@ protected:
     float _sin_roll;
     float _sin_pitch;
     float _sin_yaw;
-
-    // which accelerometer instance is active
-    uint8_t _active_accel_instance;
 };

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1091,6 +1091,7 @@ bool AP_AHRS_DCM::airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret)
         return false;
     }
 
+    const float _wind_max = AP::ahrs().get_max_wind();
     if (_wind_max > 0 && AP::gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
         // constrain the airspeed by the ground speed
         // and AHRS_WIND_MAX

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -125,7 +125,25 @@ public:
     bool get_relative_position_NED_origin(Vector3f &vec) const override;
     bool get_relative_position_NE_origin(Vector2f &posNE) const override;
     bool get_relative_position_D_origin(float &posD) const override;
-    
+
+protected:
+
+    // settable parameters
+    AP_Float _kp_yaw;
+    AP_Float _kp;
+    AP_Float gps_gain;
+
+    AP_Float beta;
+
+    enum class GPSUse : uint8_t {
+        Disable = 0,
+        Enable  = 1,
+        EnableWithHeight = 2,
+    };
+
+    AP_Enum<GPSUse> _gps_use;
+    AP_Int8 _gps_minsats;
+
 private:
 
     // these are experimentally derived from the simulator

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -214,6 +214,9 @@ private:
     float _ra_deltat;
     uint32_t _ra_sum_start;
 
+    // which accelerometer instance is active
+    uint8_t _active_accel_instance;
+
     // the earths magnetic field
     float _last_declination;
     Vector2f _mag_earth{1, 0};

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -101,6 +101,9 @@ public:
         return true;
     }
 
+    // return a ground vector estimate in meters/second, in North/East order
+    Vector2f groundspeed_vector() override;
+
     bool            use_compass() override;
 
     // return the quaternion defining the rotation from NED to XYZ (body) axes
@@ -232,4 +235,10 @@ private:
 
     // last origin we returned, for DCM fallback from EKF
     Location last_origin;
+
+    // Declare filter states for HPF and LPF used by complementary
+    // filter in AP_AHRS::groundspeed_vector
+    Vector2f _lp; // ground vector low-pass filter
+    Vector2f _hp; // ground vector high-pass filter
+    Vector2f _lastGndVelADS; // previous HPF input
 };


### PR DESCRIPTION
... and move `groundspeed_vector` from Backend to DCM (other estimators implement their own versions of this)
