### PR TITLE
Tools: Enable Unit Testing for SITL 

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -143,7 +143,7 @@ def build_examples(**kwargs):
 
 def build_unit_tests(**kwargs):
     """Build tests."""
-    for target in ['linux']:
+    for target in ['linux', 'sitl']:
         print("Running build.unit_tests for %s" % target)
         try:
             util.build_tests(target, **kwargs)
@@ -163,20 +163,22 @@ def run_unit_test(test):
 
 def run_unit_tests():
     """Run all unit tests files."""
-    binary_dir = util.reltopdir(os.path.join('build',
-                                             'linux',
-                                             'tests',
-                                             ))
-    tests = glob.glob("%s/*" % binary_dir)
     success = True
     fail_list = []
-    for test in tests:
-        try:
-            run_unit_test(test)
-        except subprocess.CalledProcessError:
-            print("Exception running (%s)" % test)
-            fail_list.append(os.path.basename(test))
-            success = False
+    for target in ['linux', 'sitl']:
+        binary_dir = util.reltopdir(os.path.join('build',
+                                                 target,
+                                                 'tests',
+                                                 ))
+        tests = glob.glob("%s/*" % binary_dir)
+        for test in tests:
+            try:
+                run_unit_test(test)
+            except subprocess.CalledProcessError:
+                print("Exception running (%s)" % test)
+                fail_list.append(target + '/' + os.path.basename(test))
+                success = False
+
     print("Failing tests:")
     for failure in fail_list:
         print("  %s" % failure)

--- a/libraries/AP_Common/tests/test_bitmask.cpp
+++ b/libraries/AP_Common/tests/test_bitmask.cpp
@@ -45,10 +45,22 @@ TEST(Bitmask, Tests)
 
     Bitmask<49> x2;
     x2 = x;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     x.set(50);
-    for (uint8_t i=0; i<50; i++) {
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    EXPECT_EXIT(x.set(50), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bitmask_range");
+#endif
+
+    for (uint8_t i=0; i<49; i++) {
         EXPECT_EQ(x2.get(i), x.get(i));
     }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+    EXPECT_EQ(x2.get(50), x.get(50));
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    EXPECT_EXIT(x2.get(50), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bitmask_range");
+#endif
 }
 
 TEST(Bitmask, SetAll)
@@ -87,4 +99,5 @@ TEST(Bitmask, Assignment)
     EXPECT_EQ(true, y.get(48));
 }
 
+AP_GTEST_PANIC()
 AP_GTEST_MAIN()

--- a/libraries/AP_HAL_Linux/system.cpp
+++ b/libraries/AP_HAL_Linux/system.cpp
@@ -21,7 +21,7 @@ void init()
     clock_gettime(CLOCK_MONOTONIC, &state.start_time);
 }
 
-void panic(const char *errormsg, ...)
+void WEAK panic(const char *errormsg, ...)
 {
     va_list ap;
 

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -25,7 +25,7 @@ void init()
     gettimeofday(&state.start_time, nullptr);
 }
 
-void panic(const char *errormsg, ...)
+void WEAK panic(const char *errormsg, ...)
 {
     va_list ap;
 

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -83,6 +83,9 @@ public:
     // internal errors.  buffer will always be null-terminated.
     void errors_as_string(uint8_t *buffer, uint16_t len) const;
 
+    // convert an error code to a string
+    void error_to_string(char *buffer, uint16_t len, error_t error_code) const;
+
     uint32_t count() const { return total_error_count; }
 
     // internal_errors - return mask of internal errors seen

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -81,8 +81,15 @@ TEST(VectorTest, Rotations)
     TEST_ROTATION(ROTATION_ROLL_45, 1, 0, SQRT_2);
     TEST_ROTATION(ROTATION_ROLL_315, 1, SQRT_2, 0);
     EXPECT_EQ(ROTATION_MAX, rotation_count) << "All rotations are expect to be tested";
-    TEST_ROTATION(ROTATION_CUSTOM, 1, 1, 1);  // TODO look at internal error ?
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+    TEST_ROTATION(ROTATION_CUSTOM, 1, 1, 1);
     TEST_ROTATION(ROTATION_MAX, 1, 1, 1);
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    Vector3F v {1, 1, 1};
+    EXPECT_EXIT(v.rotate(ROTATION_CUSTOM), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::flow_of_ctrl");
+    EXPECT_EXIT(v.rotate(ROTATION_MAX), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
+#endif
 }
 
 TEST(MathTest, IsZero)
@@ -370,8 +377,13 @@ TEST(MathTest, Constrain)
     EXPECT_EQ(19.9, constrain_value(19.8, 19.9, 20.1));
     EXPECT_EQ(19.9f, constrain_value(19.8f, 19.9f, 20.1f));
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     EXPECT_EQ(1.0f, constrain_float(nanf("0x4152"), 1.0f, 1.0f));
     EXPECT_EQ(1.0f, constrain_value(nanf("0x4152"), 1.0f, 1.0f));
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    EXPECT_EXIT(constrain_float(nanf("0x4152"), 1.0f, 1.0f), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::cnstring_nan");
+    EXPECT_EXIT(constrain_value(nanf("0x4152"), 1.0f, 1.0f), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::cnstring_nan");
+#endif
 }
 
 TEST(MathWrapTest, Angle180)
@@ -660,6 +672,7 @@ TEST(MathTest, FIXEDWINGTURNRATE)
     EXPECT_NEAR(56.187965393066406f, fixedwing_turn_rate(45, 10.0f), accuracy);
 }
 
+AP_GTEST_PANIC()
 AP_GTEST_MAIN()
 
 #pragma GCC diagnostic pop

--- a/libraries/AP_Math/tests/test_math_double.cpp
+++ b/libraries/AP_Math/tests/test_math_double.cpp
@@ -86,7 +86,11 @@ TEST(MathTest, ConstrainDouble)
 
     EXPECT_EQ(19.9, constrain_value(19.8, 19.9, 20.1));
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     EXPECT_EQ(1.0, constrain_value(nan("0x4152"), 1.0, 1.0));
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    EXPECT_EXIT(constrain_value(nan("0x4152"), 1.0, 1.0), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::cnstring_nan");
+#endif
 }
 
 TEST(MathWrapTest, Angle180Double)
@@ -232,6 +236,7 @@ TEST(MathTest, NormDouble)
     EXPECT_DOUBLE_EQ(norm_6, 13.0);
 }
 
+AP_GTEST_PANIC()
 AP_GTEST_MAIN()
 
 #pragma GCC diagnostic pop

--- a/libraries/SITL/tests/test_sim_ms5611.cpp
+++ b/libraries/SITL/tests/test_sim_ms5611.cpp
@@ -30,8 +30,8 @@ const struct forward_check {
         float P_Pa;
         float Temp_C;
     } conversion_table [] = {
-        {3897939, 7529942, 1200, -20},          // < -15 deg C Temperature, Low Pressure
-        {10398464, 7529942, 115200, -20},       // < -15 deg C Temperatures, High Pressure
+        {3894332, 7304992, 1200, -30},          // < -15 deg C Temperature, Low Pressure
+        {10566581, 7304992, 115200, -30},       // < -15 deg C Temperatures, High Pressure
 
         {3919542, 8425824, 1200, 15.15},        // < 20 deg C Temperatures, Low Pressure
         {9937566, 8425824, 115200, 15.15},      // < 20 deg C Temperatures, High Pressure

--- a/tests/AP_gtest.h
+++ b/tests/AP_gtest.h
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #include <gtest/gtest.h>
+#include <gtest/gtest-spi.h>
 
 
 #define AP_GTEST_PRINTATBLE_PARAM_MEMBER(class_name_, printable_member_) \
@@ -12,6 +13,27 @@
 ::std::ostream& operator<<(::std::ostream& os, const class_name_& param) \
 { \
     return os << param.printable_member_; \
+}
+
+/*
+* Override the WEAK version of AP_HAL_SITL/system.cpp panic() instead of staying in an infinite loop
+* This is used by the gtest suite to test for an exit signal caused by a test statement and continue testing
+* Printing to stderr  is required for gtest matching
+*/
+#define AP_GTEST_PANIC() \
+void AP_HAL::panic(const char *errormsg, ...) \
+{ \
+    va_list ap; \
+    auto outputs = {stdout, stderr}; \
+    for( auto output : outputs) { \
+        fflush(stdout); \
+        fprintf(output, "PANIC: "); \
+        va_start(ap, errormsg); \
+        vfprintf(output, errormsg, ap); \
+        va_end(ap); \
+        fprintf(output, "\n"); \
+    } \
+    abort(); \
 }
 
 #define AP_GTEST_MAIN() \


### PR DESCRIPTION
This enables units tests to be run by CI when built under SITL. The reasoning for this came from PR #18365 & #18363 where I was trying to fix simulated drivers and spent far to long in the debugger when a unit test would have worked perfectly. 

It enables GTest to catch exit events such as an abort. 
Thus we can test that SITL creates Internal_Errors where required and prevent regressions as a bonus.

There are some details, such as the method to detect if the unit tests or running inside the `Panic()`, that I'm not sure will work across all platforms?

Log from the "test unit tests ...." tab in this PR showing the `Panic: AP_Internal_Error` being printed and caught by GTest for evaluation. 
![image](https://user-images.githubusercontent.com/69225461/130198335-5069c3cf-3443-4b4e-9e9b-604423f3c9d1.png)
