### PR TITLE
Plane: tailsitter: reset plane yaw I in assist

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -334,9 +334,10 @@ void Tailsitter::output(void)
         quadplane.motors_output(false);
     }
 
-    // In full Q assist it is better to use cotper I and zero plane
+    // In full Q assist it is better to use copter I and zero plane
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
+    plane.yawController.reset_I();
 
     // pull in copter control outputs
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, (motors->get_yaw()+motors->get_yaw_ff())*-SERVO_MAX);


### PR DESCRIPTION
This adds a yaw I reset along with the existing roll and pitch ones, this is just a bug. Should not make any difference to the control surface less tailsitters we have been looking at recently.