### PR TITLE
More GCC warning

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -260,6 +260,10 @@ class Board:
             '-Wno-trigraphs',
             '-Werror=parentheses',
             '-DARDUPILOT_BUILD',
+            '-Wuninitialized',
+            '-Wmaybe-uninitialized',
+            '-Warray-bounds',
+            '-Wduplicated-cond',
         ]
 
         if 'clang++' in cfg.env.COMPILER_CXX:


### PR DESCRIPTION
Add some more gcc warning
correct syntax for some pragma. There using #pragma pop instead of the GCC one's. It shouldn't matter but it trigger some static analyzer
The AP_Scheduler change is a nullprt check that this reported by analyzer and -Wnull-dereference. I didn''t add this flag as it bring more noise 