### PR TITLE
plane: tailsitter: enable = 2 for control surface less

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -252,7 +252,7 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
     plane.throttle_suppressed = plane.control_mode->does_auto_throttle();
 
     // if no airmode switch assigned, ensure airmode is off:
-    if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRMODE) == nullptr) {
+    if ((plane.quadplane.air_mode == AirMode::ON) && (rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRMODE) == nullptr)) {
         plane.quadplane.air_mode = AirMode::OFF;
     }
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -180,6 +180,7 @@ enum guided_heading_type_t {
 enum class AirMode {
     OFF,
     ON,
+    ASSISTED_FLIGHT_ONLY,
 };
 
 enum class FenceAutoEnable : uint8_t {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -503,23 +503,6 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
 };
 
 /*
-  extra defaults for tailsitters
- */
-static const struct AP_Param::defaults_table_struct defaults_table_tailsitter[] = {
-    { "KFF_RDDRMIX",       0.02 },
-    { "Q_A_RAT_PIT_FF",    0.2 },
-    { "Q_A_RAT_YAW_FF",    0.2 },
-    { "Q_A_RAT_YAW_I",     0.18 },
-    { "Q_A_ANGLE_BOOST",   0 },
-    { "LIM_PITCH_MAX",    3000 },
-    { "LIM_PITCH_MIN",    -3000 },
-    { "MIXING_GAIN",      1.0 },
-    { "RUDD_DT_GAIN",      10 },
-    { "Q_TRANSITION_MS",   2000 },
-    { "Q_TRANS_DECEL",    6 },
-};
-
-/*
   conversion table for quadplane parameters
  */
 const AP_Param::ConversionInfo q_conversion_table[] = {
@@ -664,11 +647,6 @@ bool QuadPlane::setup(void)
         AP_BoardConfig::config_error("Unsupported Q_FRAME_CLASS %u", frame_class);
     }
 
-    // Set tailsitter enable flag based on old heuristics
-    if (!tailsitter.enable.configured() && (((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || (tailsitter.motor_mask != 0)) && (tilt.tilt_type != TILT_TYPE_BICOPTER))) {
-        tailsitter.enable.set_and_save(1);
-    }
-
     // Make sure not both a tailsiter and tiltrotor
     if (tailsitter.enabled() && (tilt.tilt_mask != 0)) {
         AP_BoardConfig::config_error("set TAILSIT_ENABLE 0 or TILT_MASK 0");
@@ -746,13 +724,6 @@ bool QuadPlane::setup(void)
     attitude_control->parameter_sanity_check();
     wp_nav->wp_and_spline_init();
 
-    // TODO: update this if servo function assignments change
-    // used by relax_attitude_control() to control special behavior for vectored tailsitters
-    tailsitter._is_vectored = (frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) &&
-                   (!is_zero(tailsitter.vectored_hover_gain) &&
-                    (SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft) ||
-                     SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorRight)));
-
     // setup the trim of any motors used by AP_Motors so I/O board
     // failsafe will disable motors
     for (uint8_t i=0; i<8; i++) {
@@ -784,10 +755,7 @@ bool QuadPlane::setup(void)
 
     AP_Param::convert_old_parameters(&q_conversion_table[0], ARRAY_SIZE(q_conversion_table));
 
-    // Set tailsitter transition rate to match old caculation
-    if (!tailsitter.transition_rate_fw.configured()) {
-        tailsitter.transition_rate_fw.set_and_save(tailsitter.transition_angle_fw / (transition_time_ms/2000.0f));
-    }
+    tailsitter.setup();
 
     // param count will have changed
     AP_Param::invalidate_count();
@@ -804,10 +772,6 @@ void QuadPlane::setup_defaults(void)
 {
     AP_Param::set_defaults_from_table(defaults_table, ARRAY_SIZE(defaults_table));
 
-    if (frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) {
-        AP_Param::set_defaults_from_table(defaults_table_tailsitter, ARRAY_SIZE(defaults_table_tailsitter));
-    }
-    
     // reset ESC calibration
     if (esc_calibration != 0) {
         esc_calibration.set_and_save(0);

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -180,8 +180,11 @@ private:
     // vertical acceleration the pilot may request
     AP_Int16 pilot_accel_z;
 
-     // air mode state: OFF, ON
+    // air mode state: OFF, ON, ASSISTED_FLIGHT_ONLY
     AirMode air_mode;
+
+    // return true if airmode should be active
+    bool air_mode_active() const;
 
     // check for quadplane assistance needed
     bool should_assist(float aspeed, bool have_airspeed);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -24,8 +24,7 @@ const AP_Param::GroupInfo Tailsitter::var_info[] = {
 
     // @Param: ENABLE
     // @DisplayName: Enable Tailsitter
-    // @Description: This enables Tailsitter functionality
-    // @Values: 0:Disable,1:Enable
+    // @Description: This enables Tailsitter functionality, 2: forces Qassist active and always stabilize in forward flight with airmode for stabalisation at 0 throttle, for use on vehicles with no control surfaces, vehicle will not arm in forward flight modes, see also Q_OPTIONS "Mtrs_Only_Qassist"
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("ENABLE", 1, Tailsitter, enable, 0, AP_PARAM_FLAG_ENABLE),
@@ -183,6 +182,16 @@ void Tailsitter::setup()
     // set defaults for dual/single motor tailsitter
     if (quadplane.frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) {
         AP_Param::set_defaults_from_table(defaults_table_tailsitter, ARRAY_SIZE(defaults_table_tailsitter));
+    }
+
+    // Setup for control surface less operation
+    if (enable == 2) {
+        quadplane.q_assist_state = QuadPlane::Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE;
+        quadplane.air_mode = AirMode::ASSISTED_FLIGHT_ONLY;
+
+        // Do not allow arming in forward flight modes
+        // motors will become active due to assisted flight airmode, the vehicle will try very hard to get level
+        quadplane.options.set(quadplane.options.get() | QuadPlane::OPTION_ONLY_ARM_IN_QMODE_OR_AUTO);
     }
 
 }

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -27,6 +27,8 @@ public:
 
     bool enabled() const { return enable > 0;}
 
+    void setup();
+
     // return true when flying a control surface only tailsitter
     bool is_control_surface_tailsitter(void) const;
 


### PR DESCRIPTION
this moves tailsitter init stuff to its own function and adds the ability to set enable = 2 to force Q_Assist and enable airmode in forward flight only. 

It is already possible to force Q_assist by using the Q option, and one can get air mode by setting it on a switch. The adds the ability to be in airmode for only forward flight.

This would replace https://github.com/ArduPilot/ardupilot/pull/18170