### PR TITLE
Plane: add param for throttle control in transition to VTOL

### DIFF
--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -92,6 +92,7 @@ public:
     AP_Float transition_rate_fw;
     AP_Int8 transition_angle_vtol;
     AP_Float transition_rate_vtol;
+    AP_Float transition_throttle_vtol;
     AP_Int8 input_type;
     AP_Int8 input_mask;
     AP_Int8 input_mask_chan;


### PR DESCRIPTION
Allows either hover throttle or user param for throttle level in tailsitter back transistion...can be used to make a flat transition (when the z controller gets fixed.... with master it can reduce  zoom a lot)