### PR TITLE
AC_Loiter: update ANG_MAX param description

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -16,8 +16,9 @@ extern const AP_HAL::HAL& hal;
 const AP_Param::GroupInfo AC_Loiter::var_info[] = {
 
     // @Param: ANG_MAX
-    // @DisplayName: Loiter Angle Max
-    // @Description: Loiter maximum lean angle. Set to zero for 2/3 of PSC_ANGLE_MAX or ANGLE_MAX
+    // @DisplayName: Loiter pilot angle max
+    // @Description{Copter, Sub}: Loiter maximum pilot requested lean angle. Set to zero for 2/3 of PSC_ANGLE_MAX/ANGLE_MAX. The maximum vehicle lean angle is still limited by PSC_ANGLE_MAX/ANGLE_MAX
+    // @Description{Plane}: Loiter maximum pilot requested lean angle. Set to zero for 2/3 of Q_P_ANGLE_MAX/Q_ANGLE_MAX. The maximum vehicle lean angle is still limited by Q_P_ANGLE_MAX/Q_ANGLE_MAX
     // @Units: deg
     // @Range: 0 45
     // @Increment: 1


### PR DESCRIPTION
This updates the loiter angle max description to make it clear that it is pilot requested lean angle not absolute lean angle. 

I have also split out the plane description to so it can mention the `Q_` param names.