### PR TITLE
AC_PosControl: limit init xy accel desired to max accel

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -516,6 +516,7 @@ void AC_PosControl::init_xy()
     const Vector3f &curr_accel = _ahrs.get_accel_ef_blended() * 100.0f;
     _accel_desired.x = curr_accel.x;
     _accel_desired.y = curr_accel.y;
+    _accel_desired.xy().limit_length(_accel_max_xy_cmss);
 
     lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
 


### PR DESCRIPTION
This is the same fix for xy as https://github.com/ArduPilot/ardupilot/pull/18335 did for Z.

I do wonder if we should also be constraining the _vel_desired in a similar way but that was not done for Z so I have not done it here.