### PR TITLE
AP_AHRS: constrain airspeed sensor airspeed using WIND_MAX

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -623,6 +623,18 @@ bool AP_AHRS_NavEKF::airspeed_estimate(float &airspeed_ret) const
     bool ret = false;
     if (airspeed_sensor_enabled()) {
         airspeed_ret = AP::airspeed()->get_airspeed();
+
+        if (_wind_max > 0 && AP::gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
+            // constrain the airspeed by the ground speed
+            // and AHRS_WIND_MAX
+            const float gnd_speed = AP::gps().ground_speed();
+            float true_airspeed = airspeed_ret * get_EAS2TAS();
+            true_airspeed = constrain_float(true_airspeed,
+                                            gnd_speed - _wind_max,
+                                            gnd_speed + _wind_max);
+            airspeed_ret = true_airspeed / get_EAS2TAS();
+        }
+
         return true;
     }
 


### PR DESCRIPTION
fixes regression from d1d790019c1c99e286a4b948cd7aff97dcfbb3ad

Tested in SITL using gdb and `SIM_ARSPD_OFS` - value was constrained by this newly added code to `AHRS_WIND_MAX`

This code was swiped from AP_AHRS_DCM - which was run before the above commit.
