### PR TITLE
Copter/Scripting: add get_circle_radius and set_circle_rate

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -337,6 +337,20 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     mode_guided.set_angle(q, climb_rate_ms*100, use_yaw_rate, radians(yaw_rate_degs), false);
     return true;
 }
+
+// circle mode controls
+bool Copter::get_circle_radius(float &radius_m)
+{
+    radius_m = circle_nav->get_radius() * 0.01f;
+    return true;
+}
+
+bool Copter::set_circle_rate(float rate_dps)
+{
+    circle_nav->set_rate(rate_dps);
+    return true;
+}
+
 #endif // ENABLE_SCRIPTING
 
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -651,6 +651,8 @@ private:
     bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
+    bool get_circle_radius(float &radius_m) override;
+    bool set_circle_rate(float rate_dps) override;
 #endif // ENABLE_SCRIPTING
     void rc_loop();
     void throttle_loop();

--- a/libraries/AP_Scripting/examples/copter-circle-speed.lua
+++ b/libraries/AP_Scripting/examples/copter-circle-speed.lua
@@ -1,0 +1,36 @@
+-- Maintain a constant ground speed while flying in Circle mode even if the pilot adjusts the radius
+--
+-- CAUTION: This script only works for Copter
+-- this script waits for the vehicle to be armed and in circle mode and then
+-- updates the target rate around the circle (in degrees / sec) to maintain the desired ground speed
+
+local circle_ground_speed = 6 -- the ground speed in circle mode (m/s)
+
+function update() -- this is the loop which periodically runs
+
+  -- must be armed, flying and in circle mode
+  if (not arming:is_armed()) or (not vehicle:get_likely_flying()) or (vehicle:get_mode() ~= 7) then
+    return update, 1000 -- reschedules the loop, 1hz
+  end
+
+  -- get circle radius
+  local radius = vehicle:get_circle_radius()
+  if not radius then
+    gcs:send_text(0, "speed-circle.lua: failed to get circle radius")
+    return update, 1000
+  end
+
+  -- set the rate to give the desired ground speed at the current radius
+  local new_rate = 360 * (circle_ground_speed / (radius*math.pi*2))
+  new_rate = math.max(new_rate, -90)
+  new_rate = math.min(new_rate, 90)
+  if not vehicle:set_circle_rate(new_rate) then
+    gcs:send_text(0, "speed-circle.lua: failed to set rate")
+  else
+    gcs:send_text(0, string.format("speed-circle.lua: radius:%f new_rate=%f", radius, new_rate))
+  end
+
+  return update, 100 -- reschedules the loop, 10hz
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -206,6 +206,8 @@ singleton AP_Vehicle method get_control_output boolean AP_Vehicle::ControlOutput
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method set_target_velocity_NED boolean Vector3f
 singleton AP_Vehicle method set_target_angle_and_climbrate boolean float -180 180 float -90 90 float -360 360 float -FLT_MAX FLT_MAX boolean float -FLT_MAX FLT_MAX
+singleton AP_Vehicle method get_circle_radius boolean float'Null
+singleton AP_Vehicle method set_circle_rate boolean float -FLT_MAX FLT_MAX
 singleton AP_Vehicle method set_steering_and_throttle boolean float -1 1 float -1 1
 singleton AP_Vehicle method get_wp_distance_m boolean float'Null
 singleton AP_Vehicle method get_wp_bearing_deg boolean float'Null

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -191,6 +191,10 @@ public:
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }
 
+    // circle mode controls (only used by scripting with Copter)
+    virtual bool get_circle_radius(float &radius_m) { return false; }
+    virtual bool set_circle_rate(float rate_dps) { return false; }
+
     // set steering and throttle (-1 to +1) (for use by scripting with Rover)
     virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
 #endif // ENABLE_SCRIPTING


### PR DESCRIPTION
This allows scripts to read the radius and write the rotation rate of a copter in Circle mode (or executing LOITER_TURNS).  This has been tested in SITL and resolves a 4.1 issue reported by Arace.