### PR TITLE
GCS_Mavlink: Make rssi adhere to MAVLink standard #3

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -117,10 +117,10 @@ void GCS_MAVLINK_Rover::send_nav_controller_output() const
         control_mode->crosstrack_error());
 }
 
-void Rover::send_servo_out(mavlink_channel_t chan)
+void GCS_MAVLINK_Rover::send_servo_out()
 {
     float motor1, motor3;
-    if (g2.motors.have_skid_steering()) {
+    if (rover.g2.motors.have_skid_steering()) {
         motor1 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft) / 1000.0f);
         motor3 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight) / 1000.0f);
     } else {
@@ -139,7 +139,7 @@ void Rover::send_servo_out(mavlink_channel_t chan)
         0,
         0,
         0,
-        rssi.read_receiver_rssi_uint8());
+        receiver_rssi());
 }
 
 int16_t GCS_MAVLINK_Rover::vfr_hud_throttle() const
@@ -329,7 +329,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
 
     case MSG_SERVO_OUT:
         CHECK_PAYLOAD_SIZE(RC_CHANNELS_SCALED);
-        rover.send_servo_out(chan);
+        send_servo_out();
         break;
 
     case MSG_WHEEL_DISTANCE:

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -44,6 +44,8 @@ private:
     void handle_set_position_target_global_int(const mavlink_message_t &msg);
     void handle_radio(const mavlink_message_t &msg);
 
+    void send_servo_out();
+
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;
 
     MAV_MODE base_mode() const override;

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -325,7 +325,6 @@ private:
     void fence_check();
 
     // GCS_Mavlink.cpp
-    void send_servo_out(mavlink_channel_t chan);
     void send_wheel_encoder_distance(mavlink_channel_t chan);
 
     // Log.cpp

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -546,6 +546,8 @@ protected:
 
     void manual_override(RC_Channel *c, int16_t value_in, uint16_t offset, float scaler, const uint32_t tnow, bool reversed = false);
 
+    uint8_t receiver_rssi() const;
+
     /*
       correct an offboard timestamp in microseconds to a local time
       since boot in milliseconds

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1618,12 +1618,6 @@ void GCS_MAVLINK::send_system_time()
  */
 void GCS_MAVLINK::send_rc_channels() const
 {
-    AP_RSSI *rssi = AP::rssi();
-    uint8_t receiver_rssi = 0;
-    if (rssi != nullptr) {
-        receiver_rssi = rssi->read_receiver_rssi_uint8();
-    }
-
     uint16_t values[18] = {};
     rc().get_radio_in(values, ARRAY_SIZE(values));
 
@@ -1649,7 +1643,7 @@ void GCS_MAVLINK::send_rc_channels() const
         values[15],
         values[16],
         values[17],
-        receiver_rssi);        
+        receiver_rssi());
 }
 
 bool GCS_MAVLINK::sending_mavlink1() const
@@ -1669,11 +1663,7 @@ void GCS_MAVLINK::send_rc_channels_raw() const
     if (!sending_mavlink1()) {
         return;
     }
-    AP_RSSI *rssi = AP::rssi();
-    uint8_t receiver_rssi = 0;
-    if (rssi != nullptr) {
-        receiver_rssi = rssi->read_receiver_rssi_uint8();
-    }
+
     uint16_t values[8] = {};
     rc().get_radio_in(values, ARRAY_SIZE(values));
 
@@ -1689,7 +1679,7 @@ void GCS_MAVLINK::send_rc_channels_raw() const
         values[5],
         values[6],
         values[7],
-        receiver_rssi);
+        receiver_rssi());
 }
 
 void GCS_MAVLINK::send_raw_imu()
@@ -5459,6 +5449,21 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
         override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
     }
     c->set_override(override_value, tnow);
+}
+
+uint8_t GCS_MAVLINK::receiver_rssi() const
+{
+    AP_RSSI *aprssi = AP::rssi();
+    if (aprssi == nullptr) {
+        return 255;
+    }
+
+    if (!aprssi->enabled()) {
+        return 255;
+    }
+
+    uint8_t rssi = aprssi->read_receiver_rssi() * 255;
+    return (rssi < 255) ? rssi : 254;
 }
 
 GCS &gcs()


### PR DESCRIPTION
continuation of https://github.com/ArduPilot/ardupilot/pull/18244

all done as suggested, rebased, cleaned up, etc

the question which scaling to choose has unfortunately still not been finally decided

for your convenience, I recall https://github.com/ArduPilot/ardupilot/pull/18244#issuecomment-896804440, which was

> concerning scaling, we talk about two scenarios, in my understanding:
> 
> scenario A:
> 
> ```
> rssi = read_receiver_rssi() * 255;
> return (rssi < 255) ? rssi : 254;
> ```
> 
> scenario B:
> 
> ```
> return read_receiver_rssi() * 254;
> ```
> 
> In scenario A, the rssi values would be equal across the different telemetries (and logs?)(and support tools), except of 255 which is excluded, i.e. the range of 0 ... 254 would not exactly be 0 ... 1, but only 0 ... 0.9961
> 
> In scenario B the rssi would be 0.39% smaller than different telemetries (and logs?)(and support tools), but the range of 0 ... 254 would exactly correspond to 0 ... 1.

in this PR it is scenario A so far. Please tell/decide if that is OK or should be changed to scenario B.


