### PR TITLE
GCS_MAVLink: Return the result of the process

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -234,8 +234,8 @@ MAV_MISSION_RESULT MissionItemProtocol_Fence::allocate_update_resources()
     if (ret != MAV_MISSION_ACCEPTED) {
         delete[] _updated_mask;
         _updated_mask = nullptr;
-        return ret;
+    } else {
+        _new_items_count = _item_count;
     }
-    _new_items_count = _item_count;
-    return MAV_MISSION_ACCEPTED;
+    return ret;
 }


### PR DESCRIPTION
The return value is a fixed value.
I would make it return the result of the processing of the allocate_receive_resources method.