### PR TITLE
Tools: autotest: enable tailsitter for tailsitter test

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -674,6 +674,7 @@ class AutoTestQuadPlane(AutoTest):
         '''tailsitter test'''
         self.set_parameter('Q_FRAME_CLASS', 10)
         self.set_parameter('Q_ENABLE', 1)
+        self.set_parameter('Q_TAILSIT_ENABLE', 1)
 
         self.reboot_sitl()
         self.wait_ready_to_arm()


### PR DESCRIPTION
This was overlooked in the recent addition of `Q_TAILSIT_ENABLE`, not that it makes any difference ATM. 