### PR TITLE
AP_GPS: Add new NMEA GPS type: UM482

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -653,7 +653,9 @@ void AP_GPS::detect_instance(uint8_t instance)
             } else if (_type[instance] == GPS_TYPE_UBLOX && (_driver_options & AP_GPS_Backend::DriverOptions::UBX_Use115200)) {
                 static const char blob[] = UBLOX_SET_BINARY_115200;
                 send_blob_start(instance, blob, sizeof(blob));
-            } else {
+            } else if(_type[instance] == GPS_TYPE_UM482_NMEA){
+                send_blob_start(instance, AP_GPS_NMEA_UM482_INIT_STRING, strlen(AP_GPS_NMEA_UM482_INIT_STRING));
+            }else {
                 send_blob_start(instance, _initialisation_blob, sizeof(_initialisation_blob));
             }
         }
@@ -727,7 +729,8 @@ void AP_GPS::detect_instance(uint8_t instance)
             new_gps = new AP_GPS_ERB(*this, state[instance], _port[instance]);
         } else if ((_type[instance] == GPS_TYPE_NMEA ||
                     _type[instance] == GPS_TYPE_HEMI ||
-                    _type[instance] == GPS_TYPE_ALLYSTAR) &&
+                    _type[instance] == GPS_TYPE_ALLYSTAR ||
+                     _type[instance] == GPS_TYPE_UM482_NMEA ) &&
                    AP_GPS_NMEA::_detect(dstate->nmea_detect_state, data)) {
             new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);
         }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -119,6 +119,7 @@ public:
         GPS_TYPE_MSP = 19,
         GPS_TYPE_ALLYSTAR = 20, // AllyStar NMEA
         GPS_TYPE_EXTERNAL_AHRS = 21,
+        GPS_TYPE_UM482_NMEA = 22,    //UM482 NMEA
     };
 
     /// GPS status codes

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -409,8 +409,9 @@ bool AP_GPS_NMEA::_term_complete()
             _sentence_type = _GPS_SENTENCE_GGA;
         } else if (strcmp(term_type, "HDT") == 0) {
             _sentence_type = _GPS_SENTENCE_HDT;
-            // HDT doesn't have a data qualifier
-            _gps_data_good = true;
+            // HDT message has no data valid field 
+            // _gps_data_good should be set to true when the angle is successfully parsed
+            // example " $GPHDT,,T*1B " is invalid 
         } else if (strcmp(term_type, "THS") == 0) {
             _sentence_type = _GPS_SENTENCE_THS;
         } else if (strcmp(term_type, "VTG") == 0) {
@@ -491,6 +492,8 @@ bool AP_GPS_NMEA::_term_complete()
             break;
         case _GPS_SENTENCE_HDT + 1: // Course (HDT)
             _new_gps_yaw = _parse_decimal_100(_term);
+            // with heading angle output 
+            _gps_data_good = true;
             break;
         case _GPS_SENTENCE_THS + 1: // Course (THS)
             _new_gps_yaw = _parse_decimal_100(_term);

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -188,3 +188,13 @@ private:
         "$JASC,GPVTG,5\r\n" /* VTG at 5Hz */                            \
         "$JASC,GPHDT,5\r\n" /* HDT at 5Hz */                            \
         "$JMODE,SBASR,YES\r\n" /* Enable SBAS */
+
+/// Unicorecomm GNSS UM482(Optional Dual Antenna) Auto configuration command 
+/// Ardupilot connection UM482 serial port 1 
+#define AP_GPS_NMEA_UM482_INIT_STRING \
+        "gpgga com1 0.2\r\n"   /* GGA at 5Hz */             \
+        "gpvtg com1 0.2\r\n"   /* VTG at 5Hz */             \
+        "gprmc com1 0.2\r\n"   /* RMC at 5Hz */             \
+        "gphdt com1 0.2\r\n"   /* HDT at 5Hz */             \
+        "saveconfig\r\n"       /* save configuration */     
+


### PR DESCRIPTION
Add new NMEA GPS type UM482. The module supports RTK, you can choose dual antennas to determine the heading .