### PR TITLE
vehicles: set-mode-notification cleanups

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -221,10 +221,9 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
     }
 #endif
 
-    Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
+    Mode *new_flightmode = mode_from_mode_num(mode);
     if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode");
-        AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
+        notify_no_such_mode((uint8_t)mode);
         return false;
     }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -281,12 +281,8 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 bool Plane::set_mode(const uint8_t new_mode, const ModeReason reason)
 {
     static_assert(sizeof(Mode::Number) == sizeof(new_mode), "The new mode can't be mapped to the vehicles mode number");
-    Mode *mode = plane.mode_from_mode_num(static_cast<Mode::Number>(new_mode));
-    if (mode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Error: invalid mode number: %u", (unsigned)new_mode);
-        return false;
-    }
-    return set_mode(*mode, reason);
+
+    return set_mode_by_number(static_cast<Mode::Number>(new_mode), reason);
 }
 
 bool Plane::set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason)

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -289,7 +289,7 @@ bool Plane::set_mode_by_number(const Mode::Number new_mode_number, const ModeRea
 {
     Mode *new_mode = plane.mode_from_mode_num(new_mode_number);
     if (new_mode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Error: invalid mode number: %d", new_mode_number);
+        notify_no_such_mode(new_mode_number);
         return false;
     }
     return set_mode(*new_mode, reason);

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -62,8 +62,7 @@ bool Blimp::set_mode(Mode::Number mode, ModeReason reason)
 
     Mode *new_flightmode = mode_from_mode_num((Mode::Number)mode);
     if (new_flightmode == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No such mode");
-        AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
+        notify_no_such_mode((uint8_t)mode);
         return false;
     }
 

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -21,10 +21,8 @@ void RC_Channel_Rover::mode_switch_changed(modeswitch_pos_t new_pos)
         // should not have been called
         return;
     }
-    Mode *new_mode = rover.mode_from_mode_num((Mode::Number)rover.modes[new_pos].get());
-    if (new_mode != nullptr) {
-        rover.set_mode(*new_mode, ModeReason::RC_COMMAND);
-    }
+
+    rover.set_mode((Mode::Number)rover.modes[new_pos].get(), ModeReason::RC_COMMAND);
 }
 
 // init_aux_switch_function - initialize aux functions

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -380,7 +380,6 @@ private:
     bool set_mode(Mode &new_mode, ModeReason reason);
     bool set_mode(const uint8_t new_mode, ModeReason reason) override;
     uint8_t get_mode() const override { return (uint8_t)control_mode->mode_number(); }
-    bool mavlink_set_mode(uint8_t mode);
     void startup_INS_ground(void);
     void notify_mode(const Mode *new_mode);
     uint8_t check_digital_pin(uint8_t pin);

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -248,6 +248,7 @@ bool Rover::set_mode(const uint8_t new_mode, ModeReason reason)
     static_assert(sizeof(Mode::Number) == sizeof(new_mode), "The new mode can't be mapped to the vehicles mode number");
     Mode *mode = rover.mode_from_mode_num((enum Mode::Number)new_mode);
     if (mode == nullptr) {
+        notify_no_such_mode(new_mode);
         return false;
     }
     return rover.set_mode(*mode, reason);

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -349,6 +349,12 @@ void AP_Vehicle::update_dynamic_notch_at_specified_rate()
     }
 }
 
+void AP_Vehicle::notify_no_such_mode(uint8_t mode_number)
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"No such mode %u", mode_number);
+    AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode_number));
+}
+
 // reboot the vehicle in an orderly manner, doing various cleanups and
 // flashing LEDs as appropriate
 void AP_Vehicle::reboot(bool hold_in_bootloader)

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -85,6 +85,12 @@ public:
         return control_mode_reason;
     }
 
+    // perform any notifications required to indicate a mode change
+    // failed due to a bad mode number being supplied.  This can
+    // happen for many reasons - bad mavlink packet and bad mode
+    // parameters for example.
+    void notify_no_such_mode(uint8_t mode_number);
+
     /*
       common parameters for fixed wing aircraft
      */


### PR DESCRIPTION
Text should be consistent across vehicles now, and all vehicles will create the log event message.

I tested the Plane implementation of `set_mode(uint8_t, Reason)` using the doublets script; it was still able to change mode.

I checked the Rover changes in SITL by changing all the MODE* parameters to 78 and flipping the mode switch

No vehicle was playing the sad tones in the case of a bad mode number being supplied - we could potentially add that.
