### PR TITLE
Minor position controller fixes

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -514,8 +514,8 @@ void AC_PosControl::init_xy()
 
 
     const Vector3f &curr_accel = _ahrs.get_accel_ef_blended() * 100.0f;
-    _accel_desired.x = curr_accel.x;
-    _accel_desired.y = curr_accel.y;
+    _accel_desired.xy() = curr_accel.xy();
+    _accel_desired.xy().limit_length(_accel_max_xy_cmss);
 
     lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
 
@@ -801,7 +801,7 @@ void AC_PosControl::init_z()
     _pid_vel_z.set_integrator(0.0f);
 
     _accel_desired.z = constrain_float(-(curr_accel.z + GRAVITY_MSS) * 100.0f, -_accel_max_z_cmss, _accel_max_z_cmss);
-    _accel_target.z = -(curr_accel.z + GRAVITY_MSS) * 100.0f;
+    _accel_target.z = _accel_desired.z;
     _pid_accel_z.reset_filter();
 
     // initialise vertical offsets

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1023,21 +1023,6 @@ void AC_PosControl::update_z_controller()
 /// Accessors
 ///
 
-/// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-void AC_PosControl::get_stopping_point_z_cm(postype_t &stopping_point) const
-{
-    const float curr_pos_z = _inav.get_position().z;
-    float curr_vel_z = _inav.get_velocity().z;
-
-    // avoid divide by zero by using current position if kP is very low or acceleration is zero
-    if (!is_positive(_p_pos_z.kP()) || !is_positive(_accel_max_z_cmss)) {
-        stopping_point = curr_pos_z;
-        return;
-    }
-
-    stopping_point = curr_pos_z + constrain_float(stopping_distance(curr_vel_z, _p_pos_z.kP(), _accel_max_z_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
-}
-
 /// get_lean_angle_max_cd - returns the maximum lean angle the autopilot may request
 float AC_PosControl::get_lean_angle_max_cd() const
 {
@@ -1118,6 +1103,21 @@ void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
     const float t = stopping_dist / vel_total;
     stopping_point.x += t * curr_vel.x;
     stopping_point.y += t * curr_vel.y;
+}
+
+/// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
+void AC_PosControl::get_stopping_point_z_cm(postype_t &stopping_point) const
+{
+    const float curr_pos_z = _inav.get_position().z;
+    float curr_vel_z = _inav.get_velocity().z;
+
+    // avoid divide by zero by using current position if kP is very low or acceleration is zero
+    if (!is_positive(_p_pos_z.kP()) || !is_positive(_accel_max_z_cmss)) {
+        stopping_point = curr_pos_z;
+        return;
+    }
+
+    stopping_point = curr_pos_z + constrain_float(stopping_distance(curr_vel_z, _p_pos_z.kP(), _accel_max_z_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
 }
 
 /// get_bearing_to_target_cd - get bearing to target position in centi-degrees

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -70,7 +70,7 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @Param: JERK
     // @DisplayName: Waypoint Jerk
     // @Description: Defines the horizontal jerk in m/s/s used during missions
-    // @Units: m/s/s
+    // @Units: m/s/s/s
     // @Range: 1 20
     // @User: Standard
     AP_GROUPINFO("JERK",   11, AC_WPNav, _wp_jerk, 1.0f),


### PR DESCRIPTION
The most important fix here are:
1. addition of acceleration limits during initialisation to prevent an impulse creating an excessive desired acceleration in the horizontal.
2. setting the desired velocity and acceleration to zero when initialising with a stopping point.
3. removing the desired velocity offset from the stopping point calculation as it is no longer required and is unnecessarily confusing.
4. Fix jerk units

I have also added some non-functional changes to clean up the position controller and make it more readable.