### PR TITLE
AP_Scheduler: fix loop rate & period initialization

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -123,26 +123,11 @@ public:
     float load_average();
 
     // get the active main loop rate
-    uint16_t get_loop_rate_hz(void) {
-        if (_active_loop_rate_hz == 0) {
-            _active_loop_rate_hz = _loop_rate_hz;
-        }
-        return _active_loop_rate_hz;
-    }
+    uint16_t get_loop_rate_hz(void) const { return _active_loop_rate_hz; }
     // get the time-allowed-per-loop in microseconds
-    uint32_t get_loop_period_us() {
-        if (_loop_period_us == 0) {
-            _loop_period_us = 1000000UL / _loop_rate_hz;
-        }
-        return _loop_period_us;
-    }
+    uint32_t get_loop_period_us() const { return _loop_period_us; }
     // get the time-allowed-per-loop in seconds
-    float get_loop_period_s() {
-        if (is_zero(_loop_period_s)) {
-            _loop_period_s = 1.0f / _loop_rate_hz;
-        }
-        return _loop_period_s;
-    }
+    float get_loop_period_s() const { return _loop_period_s; }
 
     float get_filtered_loop_time(void) const {
         return perf_info.get_filtered_time();
@@ -177,12 +162,12 @@ private:
     // overall scheduling rate in Hz
     AP_Int16 _loop_rate_hz;
 
-    // loop rate in Hz as set at startup
-    AP_Int16 _active_loop_rate_hz;
-
     // scheduler options
     AP_Int8 _options;
     
+    // loop rate in Hz as set at startup
+    uint16_t _active_loop_rate_hz;
+
     // calculated loop period in usec
     uint16_t _loop_period_us;
 


### PR DESCRIPTION
this is a follow up of https://github.com/ArduPilot/ardupilot/pull/18436

The scheduler implementation has two (now three) issues

* _active_loop_rate_hz is an AP_Int16 but not used for a parameter
* the initializations in get_loop_rate_hz(), get_loop_period_us(), and get_loop_period_s() are not consistent, i.e., it technically could happen that _period_us and _loop_period_s would be initialized incorrectly depending o the history of events
* in doing this PR here another issue was found in line https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scheduler/AP_Scheduler.cpp#L165, there _loop_rate_hz is used and not _active_loop_rate_hz, which to me looks like would almost certainly cause issues when _loop_rate_hz is changed during operation

The initialization for these variables has been done upon function call. I'm not sure why, maybe the intention was that it's possible to call these data before the scheduler is initialized (but even then the code would be buggy). I am not sure this is really realistic or was the intention or is actually happening. So, for this PR I made the assumption

* assumption: the scheduler is init-ed before it is used in any way

If this assumption of me is incorrect, then this PR needs to be changed. So pl check/tell if that assumption is correct.

Therefore, in this PR the rate and loop data are initialized in the init() method. Furthermore, it is ensured that _loop_rate_hz is not called anytime later, but all reference is made to only _active_loop_rate_hz, and the derived values _period_us and _loop_period_s. Since now properly initialized in init(), method calls could be replaced by the variables themselves, which should be some improvement. Lastly, _active_loop_rate_hz is now just a variable and not an AP_Int16 anymore.

The changes were flight tested as follows: 

I merged them 1-to-1 into my fork, which is based off ArduCopter4.1-beta7. I have set logging to disarmed = 1. I then flew the copter, which has a MatekF743, for a couple of minutes with some "stunts" as possible in my smaller yard, I disarmed, ran into my basement with the copter still powered up and changed the loop rate from the default 400 Hz to 50 Hz, and flew again for few minutes. 

I would have expected that this would give me one log file, but this procedure produced two, which however seem to contain the right flights (I'm not using logging disarm = 1 normally, so I'm somewhat unexperienced what exactly goes on in that case) : [2021-08-25-owpr-scheduler-test.zip](https://github.com/ArduPilot/ardupilot/files/7045615/2021-08-25-owpr-scheduler-test.zip)

I'm not sure this a proper test, I'm assuming that this is a proper way to change the loop rate parameter during operation, but I'm not totally sure about this - you will know.

I could not observe any abnormalies during both flights.

