### PR TITLE
AP_Math: fix vectorN ctor warning by using C++11 brace initilization …

### DIFF
--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -36,7 +36,9 @@ class VectorN
 public:
     // trivial ctor
     inline VectorN<T,N>() {
-        memset(_v, 0, sizeof(T)*N);
+        for (auto i = 0; i < N; i++) {
+            _v[i] = T{};
+        }
     }
 
     // vector ctor


### PR DESCRIPTION
…in all cases

```
In file included from ../../libraries/AP_AccelCal/AccelCalibrator.h:16,
                 from ../../libraries/AP_AccelCal/AP_AccelCal.h:4,
                 from ../../libraries/AP_InertialSensor/AP_InertialSensor.h:41,
                 from ../../libraries/AP_HAL_SITL/SITL_State.h:23,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.h:9,
                 from ../../libraries/AP_HAL_SITL/AP_HAL_SITL.h:7,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:10:
../../libraries/AP_Math/vectorN.h: In instantiation of ‘VectorN<T, N>::VectorN() [with T = HALSITL::SITL_State::readings_mag; unsigned char N = 250]’:
../../libraries/AP_HAL_SITL/SITL_State.h:63:16:   required from here
../../libraries/AP_Math/vectorN.h:39:15: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct HALSITL::SITL_State::readings_mag’; use assignment or value-initialization instead [-Wclass-memaccess]
   39 |         memset(_v, 0, sizeof(T)*N);
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.h:9,
                 from ../../libraries/AP_HAL_SITL/AP_HAL_SITL.h:7,
                 from ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:10:
../../libraries/AP_HAL_SITL/SITL_State.h:227:12: note: ‘struct HALSITL::SITL_State::readings_mag’ declared here
  227 |     struct readings_mag {
      |            ^~~~~~~~~~~~


```