### PR TITLE
AP_NavEKF2: init rngOnGnd to 5cm to avoid div-by-zero

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -194,6 +194,7 @@ void NavEKF2_core::InitialiseVariables()
     gpsPosAccuracy = 0.0f;
     gpsHgtAccuracy = 0.0f;
     baroHgtOffset = 0.0f;
+    rngOnGnd = 0.05f;
     yawResetAngle = 0.0f;
     lastYawReset_ms = 0;
     tiltErrFilt = 1.0f;


### PR DESCRIPTION
This PR is the equivalent of PR https://github.com/ArduPilot/ardupilot/pull/17577 but for EKF2.  This issue was reported as part of 4.1 beta testing.

This resolves a crash in SITL by ensuring that the rngOnGnd is never zero and thus avoids a divide-by-zero when fusing optical flow measurements [here in AP_NavEKF2_OptFlowFusion.cpp](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp#L322).

The problem is in the lines shown below.  "range" can be zero because "rngOnGnd" can be zero which leads to the div-by-zero.  We fix this by simply initialising rngOnGnd to 5cm and from then on it can never be set back to zero.

```
        // calculate range from ground plain to centre of sensor fov assuming flat earth
        ftype range = constrain_ftype((heightAboveGndEst/prevTnb.c.z),rngOnGnd,1000.0f);

        <snip>

        // divide velocity by range  to get predicted angular LOS rates relative to X and Y axes
        losPred[0] =  relVelSensor.y/range;
        losPred[1] = -relVelSensor.x/range;
```

Testing has been only in SITL but I have checked before and after that this resolves the divide-by-zero. I think from inspection it is also clear that this is a safe change.