### PR TITLE
Tools: scripts: Add PIE support in firmware_version_decoder

### DIFF
--- a/Tools/scripts/firmware_version_decoder.py
+++ b/Tools/scripts/firmware_version_decoder.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
         "-f",
         dest="file",
         required=True,
-        help="File that contains a valid ardupilot firmware.",
+        help="File that contains a valid ardupilot firmware in ELF format.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Calculate pointer offset for PIE (Position Independent Executables) binaries.

A PIE binary can have a pointer pointing to: 0x0014a700
```
0014a700  6c 65 73 73 20 74 68 61  6e 20 46 45 4e 43 45 5f  |less than FENCE_|
0014a710  52 41 44 49 55 53 00 00  46 65 6e 63 65 73 20 69  |RADIUS..Fences i|
0014a720  6e 76 61 6c 69 64 00 00  4d 61 72 67 69 6e 20 69  |nvalid..Margin i|
0014a730  73 20 6c 65 73 73 20 74  68 61 6e 20 69 6e 63 6c  |s less than incl|
```

But the correct pointer address is: 0x0013a700
```
0013a700  6f 6e 00 00 41 72 64 75  53 75 62 20 56 34 2e 32  |on..ArduSub V4.2|
0013a730  41 72 64 75 53 75 62 20  56 34 2e 32 2e 30 64 65  |ArduSub V4.2.0de|
00146680  73 69 6e 67 20 41 72 64  75 50 69 6c 6f 74 00 00  |sing ArduPilot..|
001466a0  52 41 4d 3a 20 25 75 0a  00 00 00 00 41 72 64 75  |RAM: %u.....Ardu|
```

The PR uses `elftools` to calculate the pointer offset based on `PT_LOAD` (Loadable segment), `p_vaddr` (Virtual address of the segment in memory) and `p_offset` (Offset of the segment in the file image).
References: 
https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
