### PR TITLE
Copter: auto RTL: don't switch modes if already in auto

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -166,7 +166,8 @@ bool ModeAuto::jump_to_landing_sequence_auto_RTL(ModeReason reason)
 {
     if (mission.jump_to_landing_sequence()) {
         mission.set_force_resume(true);
-        if (set_mode(Mode::Number::AUTO, reason)) {
+        // if not already in auto switch to auto
+        if ((copter.flightmode == &copter.mode_auto) || set_mode(Mode::Number::AUTO, reason)) {
             auto_RTL = true;
             return true;
         }


### PR DESCRIPTION
This fixes a bug that can happen if one trys to enter auto RTL twice via the DO_LAND_START command. It will re-enter auto, but as the old mode exit function is called after the new mode is entered we end up calling auto enter and then auto exit so the mission gets left in the stopped state.

The fix is to check that were not already in auto mode before switching, by doing the pointer comparison and not the mode number we compare the true mode so both auto and auto RTL are handled the same. 