### PR TITLE
AP_Scripting: re-emit error messages every 10 seconds 10 times

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -21,6 +21,7 @@
 #include <AP_Filesystem/posix_compat.h>
 #include "lua_bindings.h"
 #include <AP_Scripting/AP_Scripting.h>
+#include <GCS_MAVLink/GCS.h>
 
 #ifndef REPL_DIRECTORY
   #if HAL_OS_FATFS_IO
@@ -120,4 +121,11 @@ private:
     static void *alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
     static void *_heap;
+
+    // must be static for use in atpanic
+    static void print_error(MAV_SEVERITY severity);
+    static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
+    static char *error_msg_buf;
+    static uint8_t print_error_count;
+    static uint32_t last_print_ms;
 };


### PR DESCRIPTION
Very easy to miss scripting error messages because they happen so soon after boot. This re-prints them every 10 seconds so you can catch them if you missed them first time.