### PR TITLE
AP_AHRS: call INS update in AP_AHRS::update w/o holding data sem

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -293,7 +293,7 @@ void Sub::read_AHRS()
     //-----------------------------------------------
     // <true> tells AHRS to skip INS update as we have already done it in fast_loop()
     ahrs.update(true);
-    ahrs_view.update(true);
+    ahrs_view.update();
 }
 
 // read baro and rangefinder altitude at 10hz

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -410,7 +410,7 @@ void AP_AHRS::update_DCM()
     yaw = _dcm_attitude.z;
     update_cd_values();
 
-    AP_AHRS_DCM::update();
+    AP_AHRS_DCM::_update();
 
     // keep DCM attitude available for get_secondary_attitude()
     _dcm_attitude = {roll, pitch, yaw};

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -90,7 +90,7 @@ public:
     //  should be called if gyro offsets are recalculated
     void reset_gyro_drift() override;
 
-    void            update(bool skip_ins_update=false) override;
+    void            update(bool skip_ins_update=false);
     void            reset(bool recover_eulers = false) override;
 
     // dead-reckoning support
@@ -537,7 +537,7 @@ private:
     uint8_t _ekf_flags; // bitmask from Flags enumeration
 
     EKFType ekf_type(void) const;
-    void update_DCM(bool skip_ins_update);
+    void update_DCM();
 
     // get the index of the current primary IMU
     uint8_t get_primary_IMU_index(void) const;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -78,7 +78,7 @@ public:
     }
 
     // Methods
-    virtual void update() = 0;
+    virtual void _update() = 0;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -78,7 +78,7 @@ public:
     }
 
     // Methods
-    virtual void update(bool skip_ins_update=false) = 0;
+    virtual void update() = 0;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -65,17 +65,9 @@ void AP_AHRS::load_watchdog_home()
 
 // run a full DCM update round
 void
-AP_AHRS_DCM::update(bool skip_ins_update)
+AP_AHRS_DCM::update()
 {
-    // support locked access functions to AHRS data
-    WITH_SEMAPHORE(_rsem);
-
     AP_InertialSensor &_ins = AP::ins();
-
-    if (!skip_ins_update) {
-        // tell the IMU to grab some data
-        _ins.update();
-    }
 
     // ask the IMU how much time this sensor reading represents
     const float delta_t = _ins.get_delta_time();

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -65,7 +65,7 @@ void AP_AHRS::load_watchdog_home()
 
 // run a full DCM update round
 void
-AP_AHRS_DCM::update()
+AP_AHRS_DCM::_update()
 {
     AP_InertialSensor &_ins = AP::ins();
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -58,7 +58,7 @@ public:
     void reset_gyro_drift() override;
 
     // Methods
-    void            update(bool skip_ins_update=false) override;
+    void            update() override;
     void            reset(bool recover_eulers = false) override;
 
     // return true if yaw has been initialised

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -58,7 +58,7 @@ public:
     void reset_gyro_drift() override;
 
     // Methods
-    void            update() override;
+    void            _update() override;
     void            reset(bool recover_eulers = false) override;
 
     // return true if yaw has been initialised

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -58,7 +58,7 @@ void AP_AHRS_View::set_pitch_trim(float trim_deg) {
 };
 
 // update state
-void AP_AHRS_View::update(bool skip_ins_update)
+void AP_AHRS_View::update()
 {
     rot_body_to_ned = ahrs.get_rotation_body_to_ned();
     gyro = ahrs.get_gyro();

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -34,7 +34,7 @@ public:
     AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim_deg=0);
 
     // update state
-    void update(bool skip_ins_update=false);
+    void update();
 
     // empty virtual destructor
     virtual ~AP_AHRS_View() {}

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -32,7 +32,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 float temperature;
 
 // create an AHRS object for get_airspeed_max
-AP_AHRS_DCM ahrs;
+AP_AHRS ahrs;
 
 // create airspeed object
 AP_Airspeed airspeed;

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -31,7 +31,7 @@ static AP_BoardConfig board_config;
 
 class DummyVehicle {
 public:
-    AP_AHRS_DCM ahrs;  // Need since https://github.com/ArduPilot/ardupilot/pull/10890
+    AP_AHRS ahrs;  // Need since https://github.com/ArduPilot/ardupilot/pull/10890
     AP_Baro baro; // Compass tries to set magnetic model based on location.
 #if HAL_EXTERNAL_AHRS_ENABLED
     AP_ExternalAHRS eAHRS;

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -29,7 +29,7 @@ private:
     AP_Baro baro;
     AP_GPS  gps;
     Compass compass;
-    AP_AHRS_DCM ahrs{};
+    AP_AHRS ahrs{};
     GCS_Dummy _gcs;
 
     // global constants that control how many verify calls must be made for a command before it completes

--- a/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
+++ b/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
@@ -24,7 +24,7 @@ static AP_Baro baro;
 static AP_SerialManager serial_manager;
 
 // choose which AHRS system to use
-static AP_AHRS_DCM ahrs{};
+static AP_AHRS ahrs{};
 
 void setup(void)
 {


### PR DESCRIPTION
We shouldn't be holding the data semaphore while waiting for the samples
- lots of things might be unnecessarily blocked

DCM's update function doesn't need to take the semaphore as it is
already taken by AP_AHRS