### PR TITLE
Eliminate AP::ahrs().get_location(...)

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -81,7 +81,7 @@ void Tracker::one_second_loop()
     if (!ahrs.home_is_set()) {
         // set home to current location
         Location temp_loc;
-        if (ahrs.get_location(temp_loc)) {
+        if (ahrs.get_position(temp_loc)) {
             if (!set_home(temp_loc)){
                 // fail silently
             }

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -24,7 +24,7 @@ void Copter::set_home_to_current_location_inflight() {
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             return;
@@ -40,7 +40,7 @@ void Copter::set_home_to_current_location_inflight() {
 bool Copter::set_home_to_current_location(bool lock) {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_location(temp_loc)) {
+    if (ahrs.get_position(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -25,7 +25,7 @@ void Sub::set_home_to_current_location_inflight()
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             // ignore this failure
@@ -38,7 +38,7 @@ bool Sub::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_location(temp_loc)) {
+    if (ahrs.get_position(temp_loc)) {
 
         // Make home always at the water's surface.
         // This allows disarming and arming again at depth.

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -25,7 +25,7 @@ void Blimp::set_home_to_current_location_inflight()
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             return;
@@ -38,7 +38,7 @@ bool Blimp::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_location(temp_loc)) {
+    if (ahrs.get_position(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2658,37 +2658,6 @@ void AP_AHRS::set_terrain_hgt_stable(bool stable)
 #endif
 }
 
-// get_location - updates the provided location with the latest calculated location
-//  returns true on success (i.e. the backend knows it's latest position), false on failure
-bool AP_AHRS::get_location(struct Location &loc) const
-{
-    switch (active_EKF_type()) {
-    case EKFType::NONE:
-        return get_position(loc);
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return EKF2.getLLH(loc);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return EKF3.getLLH(loc);
-#endif
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    case EKFType::SIM:
-        return get_position(loc);
-#endif
-#if HAL_EXTERNAL_AHRS_ENABLED
-    case EKFType::EXTERNAL:
-        return get_position(loc);
-#endif
-    }
-
-    return false;
-}
-
 // return the innovations for the primariy EKF
 // boolean false is returned if innovations are not available
 bool AP_AHRS::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -270,12 +270,6 @@ public:
     // this is not related to terrain following
     void set_terrain_hgt_stable(bool stable) override;
 
-    // get_location - updates the provided location with the latest
-    // calculated location including absolute altitude
-    // returns true on success (i.e. the EKF knows it's latest
-    // position), false on failure
-    bool get_location(struct Location &loc) const;
-
     // return the innovations for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -97,7 +97,7 @@ void AP_NMEA_Output::update()
 
     // get location (note: get_position from AHRS always returns true after having GPS position once)
     Location loc;
-    bool pos_valid = ahrs.get_location(loc);
+    bool pos_valid = ahrs.get_position(loc);
 
     // format latitude
     char lat_string[13];


### PR DESCRIPTION
get_position and get_location are very, very similar - the difference being one allows for the possibility of falling back to DCM position estimates, the other doesn't.

This eliminates the method which doesn't allow fallback.

Copter and Sub won't be affected by this as they set the "don't fallback" flag in the EKF.

Tracker will now use DCM when drifting home.  I'm good with that.

NMEA_Output will now fall back to DCM if the primary is bad - on vehicles which don't set the "no fallback" flag, at least.
