### PR TITLE
Plane: remove use of recompute_pwm_no_deadzone in training mode

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -166,15 +166,6 @@ void Plane::read_radio()
         failsafe.last_valid_rc_ms = millis();
     }
 
-    if (control_mode == &mode_training) {
-        // in training mode we don't want to use a deadzone, as we
-        // want manual pass through when not exceeding attitude limits
-        channel_roll->recompute_pwm_no_deadzone();
-        channel_pitch->recompute_pwm_no_deadzone();
-        channel_throttle->recompute_pwm_no_deadzone();
-        channel_rudder->recompute_pwm_no_deadzone();
-    }
-
     control_failsafe();
 
 #if AC_FENCE == ENABLED

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -154,19 +154,6 @@ bool RC_Channel::update(void)
     return true;
 }
 
-// recompute control values with no deadzone
-// When done this way the control_in value can be used as servo_out
-// to give the same output as input
-void RC_Channel::recompute_pwm_no_deadzone()
-{
-    if (type_in == RC_CHANNEL_TYPE_RANGE) {
-        control_in = pwm_to_range_dz(0);
-    } else {
-        //RC_CHANNEL_ANGLE
-        control_in = pwm_to_angle_dz(0);
-    }
-}
-
 /*
   return the center stick position expressed as a control_in value
   used for thr_mid in copter

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -35,7 +35,6 @@ public:
 
     // read input from hal.rcin - create a control_in value
     bool        update(void);
-    void        recompute_pwm_no_deadzone();
 
     // calculate an angle given dead_zone and trim. This is used by the quadplane code
     // for hover throttle


### PR DESCRIPTION
Fixes #17925

This removes the recomputing of RC in with no dead zone in training mode. This should not cause any change, except the arming check,  because since https://github.com/ArduPilot/ardupilot/pull/18043 were using the zero deadzone calls here: https://github.com/ArduPilot/ardupilot/blob/fd95c32d886503709ce1a7bece72df2d7c66b17a/ArduPlane/Attitude.cpp#L315

https://github.com/ArduPilot/ardupilot/blob/fd95c32d886503709ce1a7bece72df2d7c66b17a/ArduPlane/radio.cpp#L393