### PR TITLE
Tools: catch IOError in include processing

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -438,11 +438,14 @@ def get_ap_periph_boards():
                 if m is None:
                     continue
                 include_path = os.path.join(os.path.dirname(hwdef), m.group(1))
-                with open(include_path, "r") as g:
-                    content = g.read()
-                    if 'AP_PERIPH' in content:
-                        list_ap.append(d)
-                        continue
+                try:
+                    with open(include_path, "r") as g:
+                        content = g.read()
+                        if 'AP_PERIPH' in content:
+                            list_ap.append(d)
+                            continue
+                except IOError:
+                    continue
 
     list_ap = list(set(list_ap))
     return list_ap


### PR DESCRIPTION
this happens if you have uncommitted hwdef.dat files with bad
includes. We shouldn't die with an IOError