### PR TITLE
SRV_Channels: call update_aux_servo_function in function_assigned if not initialised

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -452,6 +452,9 @@ SRV_Channels::set_output_limit(SRV_Channel::Aux_servo_function_t function, SRV_C
 bool
 SRV_Channels::function_assigned(SRV_Channel::Aux_servo_function_t function)
 {
+    if (!initialised) {
+        update_aux_servo_function();
+    }
     return function_mask.get(uint16_t(function));
 }
 
@@ -486,9 +489,6 @@ SRV_Channels::move_servo(SRV_Channel::Aux_servo_function_t function,
  */
 bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t function, uint8_t channel)
 {
-    if (!initialised) {
-        update_aux_servo_function();
-    }
     if (function_assigned(function)) {
         // already assigned
         return true;
@@ -513,9 +513,6 @@ bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t fun
 // find first channel that a function is assigned to
 bool SRV_Channels::find_channel(SRV_Channel::Aux_servo_function_t function, uint8_t &chan)
 {
-    if (!initialised) {
-        update_aux_servo_function();
-    }
     if (!function_assigned(function)) {
         return false;
     }


### PR DESCRIPTION
Fixes #16264

~I have no idea why, but this fixes the initial servo outputs. Unlike most servo outs the landing gear and mount are one time sets at init until something happens. Something in the quadplane setup code wipes this initial value to 0. Moving the init after avoids the wipe. This is not noticed in most outputs as they are continually set.~

With the help of the conditional breakpoint tip from @hendjoshsr71 I have tracked this down. Servos was not initialised. This fix will init when the function assigned check is done. Still not really sure why this showed up for only quadplanes. 

Test with `./Tools/autotest/sim_vehicle.py -v ArduPlane -f quadplane  --mavproxy-args "--cmd \"graph SERVO_OUTPUT_RAW.servo9_raw\""`

having set `SERVO9_FUNCTION` 29 and `LGR_DEPLOY` 2