### PR TITLE
HAL_ChibiOS: reduce the impact of UART DMA contention

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -438,11 +438,15 @@ def write_dma_header(f, peripheral_list, mcu_type, dma_exclude=[],
     for key in ordered_up_channels:
         ordered_timers.append(key[0:-3])
 
+    shared_set = set()
+
     for key in sorted(curr_dict.keys()):
         stream = curr_dict[key]
         shared = ''
         if len(stream_assign[stream]) > 1:
             shared = ' // shared %s' % ','.join(stream_assign[stream])
+            if stream[0] in [1,2]:
+                shared_set.add("(1U<<STM32_DMA_STREAM_ID(%u,%u))" % (stream[0],stream[1]))
         if curr_dict[key] == "STM32_DMA_STREAM_ID_ANY":
             f.write("#define %-30s STM32_DMA_STREAM_ID_ANY\n" % (chibios_dma_define_name(key)+'STREAM'))
             f.write("#define %-30s %s\n" % (chibios_dma_define_name(key)+'CHAN', dmamux_channel(key)))
@@ -485,6 +489,12 @@ def write_dma_header(f, peripheral_list, mcu_type, dma_exclude=[],
                                 (chibios_dma_define_name(chkey)+'CHAN', 
                                 chan.replace('_UP', '_CH{}'.format(ch))))
                 break
+
+    f.write("\n// Mask of DMA streams which are shared\n")
+    if len(shared_set) == 0:
+        f.write("#define SHARED_DMA_MASK 0\n")
+    else:
+        f.write("#define SHARED_DMA_MASK (%s)\n" % '|'.join(list(shared_set)))
 
     # now generate UARTDriver.cpp DMA config lines
     f.write("\n\n// generated UART DMA configuration lines\n")

--- a/libraries/AP_HAL_ChibiOS/shared_dma.cpp
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.cpp
@@ -53,6 +53,14 @@ Shared_DMA::Shared_DMA(uint8_t _stream_id1,
     deallocate = _deallocate;
 }
 
+/*
+  return true if a stream ID is shared between two peripherals
+*/
+bool Shared_DMA::is_shared(uint8_t stream_id)
+{
+    return (stream_id < SHARED_DMA_MAX_STREAM_ID) && ((1U<<stream_id) & SHARED_DMA_MASK) != 0;
+}
+
 //remove any assigned deallocator or allocator
 void Shared_DMA::unregister()
 {

--- a/libraries/AP_HAL_ChibiOS/shared_dma.h
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.h
@@ -67,6 +67,9 @@ public:
     // display dma contention statistics as text buffer for @SYS/dma.txt
     static void dma_info(ExpandingString &str);
 
+    // return true if a stream ID is shared between two peripherals
+    static bool is_shared(uint8_t stream_id);
+
 private:
     dma_allocate_fn_t allocate;
     dma_allocate_fn_t deallocate;

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -90,7 +90,7 @@ uint16_t comm_get_txspace(mavlink_channel_t chan)
  */
 void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len)
 {
-    if (!valid_channel(chan)) {
+    if (!valid_channel(chan) || mavlink_comm_port[chan] == nullptr) {
         return;
     }
     if (gcs_alternative_active[chan]) {


### PR DESCRIPTION
This changes the heuristics for UART TX DMA allocation to greatly reduce the chances of DMA contention causing long delays on other  devices
    
This fixes issues with FETTec driver output and gimbal status messages as reported by @amilcarlucas and @olliw42 . The problem is particularly bad when no GPS is connected to GPS1 on fmuv3 and derived boards (such as CubeBlack)
    
key changes:
 - remember the contention_counter across begin() calls, as the GPS calls begin with new baudrates regularly
 - added a is_shared() API to Shared_DMA, allowing the UART driver to avoid TX DMA on shared streams when at low baudrates.

