### PR TITLE
Plane: quadplane: set `last_pidz_init_ms`

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1002,6 +1002,7 @@ void QuadPlane::run_z_controller(void)
             // initialise the vertical position controller with no descent
             pos_control->init_z_controller_no_descent();
         }
+        last_pidz_init_ms = now;
     }
     last_pidz_active_ms = now;
     pos_control->update_z_controller();


### PR DESCRIPTION
This re-instates the setting of `last_pidz_init_ms`. Looks like it was lost in https://github.com/ArduPilot/ardupilot/pull/17345 / https://github.com/ArduPilot/ardupilot/commit/57952861d64463ce062cfe1cc1ac2c9479363453

This fixes initial pitch in transition into Q_LOITER

https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/mode_qloiter.cpp#L83-L92

and the motor ramp down after a climb rate assist

https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/quadplane.cpp#L1372-L1377