### PR TITLE
Copter: Change flight mode determination from pointer to mode number

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -901,7 +901,7 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
 
 #if AUTOTUNE_ENABLED == ENABLED
     // save auto tuned parameters
-    if (copter.flightmode == &copter.mode_autotune) {
+    if (copter.flightmode->mode_number() == Mode::Number::AUTOTUNE) {
         copter.mode_autotune.save_tuning_gains();
     } else {
         copter.mode_autotune.reset();

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -454,7 +454,7 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
 
         case AUX_FUNC::ZIGZAG_SaveWP:
 #if MODE_ZIGZAG_ENABLED == ENABLED
-            if (copter.flightmode == &copter.mode_zigzag) {
+            if (copter.flightmode->mode_number() == Mode::Number::ZIGZAG) {
                 // initialize zigzag auto
                 copter.mode_zigzag.init_auto();
                 switch (ch_flag) {
@@ -543,7 +543,7 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
 
         case AUX_FUNC::ZIGZAG_Auto:
 #if MODE_ZIGZAG_ENABLED == ENABLED
-            if (copter.flightmode == &copter.mode_zigzag) {
+            if (copter.flightmode->mode_number() == Mode::Number::ZIGZAG) {
                 switch (ch_flag) {
                 case AuxSwitchPos::HIGH:
                     copter.mode_zigzag.run_auto();
@@ -619,7 +619,7 @@ void Copter::auto_trim_cancel()
 void Copter::auto_trim()
 {
     if (auto_trim_counter > 0) {
-        if (copter.flightmode != &copter.mode_stabilize ||
+        if (copter.flightmode->mode_number() != Mode::Number::STABILIZE ||
             !copter.motors->armed()) {
             auto_trim_cancel();
             return;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -717,7 +717,7 @@ Return true if we do not recognize the command so that we move on to the next co
 //      we double check that the flight mode is AUTO to avoid the possibility of ap-mission triggering actions while we're not in AUTO mode
 bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 {
-    if (copter.flightmode != &copter.mode_auto) {
+    if (copter.flightmode->mode_number() != Mode::Number::AUTO) {
         return false;
     }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -717,7 +717,7 @@ Return true if we do not recognize the command so that we move on to the next co
 //      we double check that the flight mode is AUTO to avoid the possibility of ap-mission triggering actions while we're not in AUTO mode
 bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 {
-    if (copter.flightmode->mode_number() != Mode::Number::AUTO) {
+    if ((copter.flightmode->mode_number() != Mode::Number::AUTO) && (copter.flightmode->mode_number() != Mode::Number::AUTO_RTL)) {
         return false;
     }
 


### PR DESCRIPTION
The current flight mode is determined by the pointer.
I think it is better to use the mode number rather than the pointer.