### PR TITLE
AP_GPS: add support for novatel and unicore dual antenna GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -621,6 +621,8 @@ void AP_GPS::detect_instance(uint8_t instance)
         break;
 
     case GPS_TYPE_NOVA:
+    case GPS_TYPE_NOVA_DUAL:
+    case GPS_TYPE_UNICORE_DUAL:
         new_gps = new AP_GPS_NOVA(*this, state[instance], _port[instance]);
         break;
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -121,6 +121,8 @@ public:
         GPS_TYPE_EXTERNAL_AHRS = 21,
         GPS_TYPE_UAVCAN_RTK_BASE = 22,
         GPS_TYPE_UAVCAN_RTK_ROVER = 23,
+        GPS_TYPE_NOVA_DUAL = 24,
+        GPS_TYPE_UNICORE_DUAL = 25,
     };
 
     /// GPS status codes

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -93,7 +93,7 @@ AP_GPS_NOVA::read(void)
         }
     }
 
-    if (now - state.gps_yaw_time_ms >= 1000) {
+    if (now - state.gps_yaw_time_ms > 1000) {
         state.have_gps_yaw = false;
     }
 


### PR DESCRIPTION
This PR add support for novatel dual antenna for gps yaw, and also support the unicore binary protocol,  which is partially compatible with novatel protocol, the only difference between them is gps yaw message id and some signal mask bytes(which is not used by ardupilot), it's has been tested on really hardware, works fine. and one more problem about the vdop calculate. accroding the novatel's manual the vdop should calculate like this: vdop = √ pdop2 - hdop2, but the code is calculated by `state.vdop = (uint16_t) (psrdopu.htdop*100);`, @WickedShell any ideas why?