### PR TITLE
Generate board list

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -243,6 +243,10 @@ class generate_apj(Task.Task):
             "board_revision": 0,
             "USBID": self.env.USBID
         }
+        if self.env.MANUFACTURER:
+            d["manufacturer"] = self.env.MANUFACTURER
+        if self.env.BRAND_NAME:
+            d["brand_name"] = self.env.BRAND_NAME
         if self.env.build_dates:
             # we omit build_time when we don't have build_dates so that apj
             # file is idential for same git hash and compiler

--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -1,140 +1,138 @@
 #!/usr/bin/env python
+
+import os
+import re
+
 '''
 list of boards for build_binaries.py and custom build server
+
+AP_FLAKE8_CLEAN
 '''
 
-AUTOBUILD_BOARDS = ["fmuv2",
-                    "fmuv3",
-                    "fmuv5",
-                    "mindpx-v2",
-                    "erlebrain2",
-                    "navigator",
-                    "navio",
-                    "navio2",
-                    "edge",
-                    "pxf",
-                    "pxfmini",
-                    "KakuteF4",
-                    "KakuteF7",
-                    "KakuteH7",
-                    "KakuteF7Mini",
-                    "KakuteF4Mini",
-                    "MambaF405v2",
-                    "MatekF405",
-                    "MatekF405-bdshot",
-                    "MatekF405-STD",
-                    "MatekF405-Wing",
-                    "MatekF405-TE",
-                    "MatekF765-Wing",
-                    "MatekF765-SE",
-                    "MatekF405-CAN",
-                    "MatekH743",
-                    "MatekH743-bdshot",
-                    "OMNIBUSF7V2",
-                    "sparky2",
-                    "omnibusf4",
-                    "omnibusf4pro",
-                    "omnibusf4pro-bdshot",
-                    "omnibusf4v6",
-                    "OmnibusNanoV6",
-                    "OmnibusNanoV6-bdshot",
-                    "mini-pix",
-                    "airbotf4",
-                    "revo-mini",
-                    "revo-mini-bdshot",
-                    "revo-mini-i2c",
-                    "revo-mini-i2c-bdshot",
-                    "CubeBlack",
-                    "CubeBlack+",
-                    "CubePurple",
-                    "Pixhawk1",
-                    "Pixhawk1-1M",
-                    "Pixhawk4",
-                    "Pixhawk4-bdshot",
-                    "Pix32v5",
-                    "PH4-mini",
-                    "CUAVv5",
-                    "CUAVv5-bdshot",
-                    "CUAVv5Nano",
-                    "CUAVv5Nano-bdshot",
-                    "CUAV-Nora",
-                    "CUAV-X7",
-                    "CUAV-X7-bdshot",
-                    "mRoX21",
-                    "Pixracer",
-                    "Pixracer-bdshot",
-                    "F4BY",
-                    "mRoX21-777",
-                    "mRoControlZeroF7",
-                    "mRoNexus",
-                    "mRoPixracerPro",
-                    "mRoPixracerPro-bdshot",
-                    "mRoControlZeroOEMH7",
-                    "mRoControlZeroClassic",
-                    "mRoControlZeroH7",
-                    "mRoControlZeroH7-bdshot",
-                    "F35Lightning",
-                    "speedybeef4",
-                    "SuccexF4",
-                    "DrotekP3Pro",
-                    "VRBrain-v51",
-                    "VRBrain-v52",
-                    "VRUBrain-v51",
-                    "VRCore-v10",
-                    "VRBrain-v54",
-                    "TBS-Colibri-F7",
-                    "Durandal",
-                    "Durandal-bdshot",
-                    "CubeOrange",
-                    "CubeOrange-bdshot",
-                    "CubeYellow",
-                    "R9Pilot",
-                    "QioTekZealotF427",
-                    "QioTekZealotH743",
-                    "BeastH7",
-                    "BeastF7",
-                    "BeastF7v2",
-                    "FlywooF745",
-                    "FlywooF745Nano",
-                    "luminousbee5",
-                    "MambaF405US-I2C",
-                    "Swan-K1",
-                    "obal",
-                    "modalai_fc-v1",
-                    "Pixhawk5X",
-                    "AIRLink",
-                    "PixC4-Jetson",
-                    # SITL targets
-                    "SITL_x86_64_linux_gnu",
-                    "SITL_arm_linux_gnueabihf",
-                    ]
 
-AP_PERIPH_BOARDS = ["f103-GPS",
-                    "f103-QiotekPeriph",
-                    "f103-ADSB",
-                    "f103-RangeFinder",
-                    "f303-GPS",
-                    "f303-Universal",
-                    "f303-M10025",
-                    "f303-HWESC",
-                    "f303-PWM",
-                    "f303-M10070",
-                    "f303-MatekGPS",
-                    "f405-MatekGPS",
-                    "f103-Airspeed",
-                    "CUAV_GPS",
-                    "ZubaxGNSS",
-                    "CubeOrange-periph",
-                    "CubeBlack-periph",
-                    "MatekH743-periph",
-                    "HitecMosaic",
-                    "FreeflyRTK",
-                    "HolybroGPS",
-                    "BirdCANdy",
-                    "Hitec-Airspeed",
-                    "Sierra-L431",
-                    "Sierra-F405",
-                    "Sierra-F412",
-                    "CarbonixL496",
-                    "mRo-M10095",
-                    ]
+class Board(object):
+    def __init__(self, name):
+        self.name = name
+        self.is_ap_periph = False
+
+
+class BoardList(object):
+
+    def __init__(self):
+        self.hwdef_dir = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "..", "..", "libraries", "AP_HAL_ChibiOS", "hwdef")
+
+        if not os.path.exists(self.hwdef_dir):
+            raise ValueError("%s does not exist" % self.hwdef_dir)
+
+        # no hwdefs for Linux boards - yet?
+        self.boards = [
+            Board("erlebrain2"),
+            Board("navigator"),
+            Board("navio"),
+            Board("navio2"),
+            Board("edge"),
+            Board("obal"),
+            Board("pxf"),
+            Board("pxfmini"),
+            Board("SITL_x86_64_linux_gnu"),
+            Board("SITL_arm_linux_gnueabihf"),
+        ]
+
+        for adir in os.listdir(self.hwdef_dir):
+            if adir is None:
+                continue
+            if not os.path.isdir(os.path.join(self.hwdef_dir, adir)):
+                continue
+            if adir in ["scripts", "common", "STM32CubeConf"]:
+                continue
+            filepath = os.path.join(self.hwdef_dir, adir, "hwdef.dat")
+            if not os.path.exists(filepath):
+                continue
+            filepath = os.path.join(self.hwdef_dir, adir, "hwdef.dat")
+            text = self.read_hwdef(filepath)
+
+            board = Board(adir)
+            self.boards.append(board)
+            for line in text:
+                if re.match(r"^\s*env AP_PERIPH 1", line):
+                    board.is_ap_periph = 1
+
+    def read_hwdef(self, filepath):
+        fh = open(filepath)
+        ret = []
+        text = fh.readlines()
+        for line in text:
+            m = re.match(r"^\s*include\s+(.+)\s*$", line)
+            if m is not None:
+                ret += self.read_hwdef(os.path.join(os.path.dirname(filepath), m.group(1)))
+            else:
+                ret += [line]
+        return ret
+
+    def find_autobuild_boards(self):
+        ret = []
+        for board in self.boards:
+            if board.is_ap_periph:
+                continue
+            ret.append(board.name)
+
+        # these were missing in the original list for unknown reasons.
+        # Omitting them for backwards-compatability here - but we
+        # should probably have a line in the hwdef indicating they
+        # shouldn't be auto-built...
+        blacklist = [
+            "skyviper-journey",
+            "skyviper-v2450",
+            "CubeGreen-solo",
+            "omnibusf4pro-one",
+            "CubeSolo",
+            "MazzyStarDrone",
+            "fmuv3-bdshot",
+            "CubeYellow-bdshot",
+            "crazyflie2",
+            "NucleoH743",
+            "Pixhawk1-1M-bdshot",
+            "Nucleo-G491",
+            "fmuv5-bdshot",
+            "KakuteF7-bdshot",
+            "iomcu",
+            "luminousbee4",
+            "skyviper-f412-rev1",
+            "CubeOrange-joey",
+            "OMNIBUSF7V2-bdshot",
+            'H757I_EVAL',
+            'H757I_EVAL_intf',
+            'iomcu_f103_8MHz',
+        ]
+
+        ret = filter(lambda x : x not in blacklist, ret)
+
+        return list(ret)
+
+    def find_ap_periph_boards(self):
+        blacklist = [
+            "Pixracer-periph",
+            "f103-Trigger",
+            "H757I_EVAL",
+            "HerePro",
+            "HereID",
+            "G4-ESC",
+            "CubeOrange-periph-heavy",
+            "f103-HWESC",
+            "Nucleo-L476",
+            "Nucleo-L496",
+        ]
+        ret = []
+        for x in self.boards:
+            if not x.is_ap_periph:
+                continue
+            if x.name in blacklist:
+                continue
+            ret.append(x.name)
+        return list(ret)
+
+
+AUTOBUILD_BOARDS = BoardList().find_autobuild_boards()
+AP_PERIPH_BOARDS = BoardList().find_ap_periph_boards()

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -275,8 +275,9 @@ class ManifestGenerator():
             (brand_name, manufacturer) = brand_map[platform]
             firmware['brand_name'] = brand_name
             firmware['manufacturer'] = manufacturer
+
         # copy over some extra information if available
-        extra_tags = [ 'image_size' ]
+        extra_tags = [ 'image_size', 'brand_name', 'manufacturer' ]
         for tag in extra_tags:
             if tag in apj_json:
                 firmware[tag] = apj_json[tag]

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoPixracerPro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoPixracerPro/hwdef.dat
@@ -24,6 +24,9 @@ MCU STM32H7xx STM32H743xx
 # board ID for firmware load
 APJ_BOARD_ID 1017
 
+env MANUFACTURER mRo
+env BRAND_NAME mRo Pixracer Pro
+
 # crystal frequency
 OSCILLATOR_HZ 24000000
 


### PR DESCRIPTION
When adding a board we currently have to add it to several places.  This *might* reduce it to just adding the hwdef.

This walks the hwdef directory in the same way that the uploader.py script does to find hwdef files.

The output for this script is the same before/after this patch - but to do that I've had to hard-code some blacklists.  I'm quite sure there are things on that list that shouldn't be there.  If there really are boards that shouldn't be built by the autotest server that should be marked in the hwdef file.

Sometime in the future `chibios_hwdef.py` should be rewritten to factor out its parsing.
