### PR TITLE
Linux:missing PTHREAD_STACK_MIN

### DIFF
--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -240,6 +240,10 @@ bool PeriodicThread::set_rate(uint32_t rate_hz)
     return true;
 }
 
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 16384U
+#endif
+
 bool Thread::set_stack_size(size_t stack_size)
 {
     if (_started) {


### PR DESCRIPTION
This solve an issue appears when doing the following:

`./waf configure --toolchain=/opt/cross-pi-gcc/bin/arm-linux-gnueabihf --board pxfmini
`
`./waf rover   or ./waf copter`  ...etc.

I use this compiler  to generate code for RPI-Zero.

The issue does not appear when you call make pxfmini or any linux based board as it does not call this specific compiler.

