### PR TITLE
GCS_MAVLink: add option to create internal error via preflight-reboot

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2776,6 +2776,11 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
             }
             return MAV_RESULT_ACCEPTED;
         }
+        if (is_equal(packet.param4, 98.0f)) {
+            send_text(MAV_SEVERITY_WARNING,"Creating internal error");
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            return MAV_RESULT_ACCEPTED;
+        }
     }
 
     if (hal.util->get_soft_armed()) {


### PR DESCRIPTION
useful for testing our handling of internal errors