### PR TITLE
AP_InertialSensor: fixed locking issue in delta accumulation

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1495,14 +1495,6 @@ void AP_InertialSensor::update(void)
             _backends[i]->update();
         }
 
-        // clear accumulators
-        for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
-            _delta_velocity_acc[i].zero();
-            _delta_velocity_acc_dt[i] = 0;
-            _delta_angle_acc[i].zero();
-            _delta_angle_acc_dt[i] = 0;
-        }
-
         if (!_startup_error_counts_set) {
             for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
                 _accel_startup_error_count[i] = _accel_error_count[i];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -175,6 +175,9 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._delta_angle[instance] = _imu._delta_angle_acc[instance];
     _imu._delta_angle_dt[instance] = _imu._delta_angle_acc_dt[instance];
     _imu._delta_angle_valid[instance] = true;
+
+    _imu._delta_angle_acc[instance].zero();
+    _imu._delta_angle_acc_dt[instance] = 0;
 }
 
 void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
@@ -334,6 +337,8 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     _imu._delta_velocity_dt[instance] = _imu._delta_velocity_acc_dt[instance];
     _imu._delta_velocity_valid[instance] = true;
 
+    _imu._delta_velocity_acc[instance].zero();
+    _imu._delta_velocity_acc_dt[instance] = 0;
 
     if (_imu._accel_calibrator != nullptr && _imu._accel_calibrator[instance].get_status() == ACCEL_CAL_COLLECTING_SAMPLE) {
         Vector3f cal_sample = _imu._delta_velocity[instance];


### PR DESCRIPTION
this fixes a bug in calculating delta velocity and delta acceleration between threads. The problem was the accumulators were being cleared while the _sem lock was not held.
In practice this only makes a very small difference, showing up as some noise in delta_velocity and delta_angle
I've marked this for 4.1 backport, but I don't think it should be rushed into 4.1.0, it needs flight testing
