### PR TITLE
HAL_ChibiOS: use more USB buffers on higher end F7 chips

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
@@ -458,7 +458,8 @@
  * @note    The default is 2 buffers.
  */
 #if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
-#if defined(STM32H7)
+// more USB buffers works well on H7 and higher end F7
+#if defined(STM32H7) || (defined(STM32F7) && HAL_MEMORY_TOTAL_KB>=512)
 #define SERIAL_USB_BUFFERS_NUMBER   4
 #else
 #define SERIAL_USB_BUFFERS_NUMBER   2


### PR DESCRIPTION
This increases USB log download speed on F765 and F777 from around 190 kByte/s to about 580 kByte/s
I think this should be included in 4.1.1 and later (not rushed into 4.1.0)
