### PR TITLE
AP_MSP: fix ESC temperature reporting

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -165,13 +165,13 @@ bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 }
 
 // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-bool AP_ESC_Telem::get_highest_motor_temperature(int16_t& temp) const
+bool AP_ESC_Telem::get_highest_temperature(int16_t& temp) const
 {
     uint8_t valid_escs = 0;
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         int16_t temp_temp;
-        if (get_motor_temperature(i, temp_temp)) {
+        if (get_temperature(i, temp_temp)) {
             temp = MAX(temp, temp_temp);
             valid_escs++;
         }

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -40,7 +40,7 @@ public:
     bool get_motor_temperature(uint8_t esc_index, int16_t& temp) const;
 
     // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-    bool get_highest_motor_temperature(int16_t& temp) const;
+    bool get_highest_temperature(int16_t& temp) const;
 
     // get an individual ESC's current in Ampere if available, returns true on success
     bool get_current(uint8_t esc_index, float& amps) const;

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -127,9 +127,9 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
     if (msp && msp->check_option(AP_MSP::MspOption::OPTION_TELEMETRY_DJI_WORKAROUNDS)) {
         AP_ESC_Telem& telem = AP::esc_telem();
         int16_t highest_temperature = 0;
-        telem.get_highest_motor_temperature(highest_temperature);
-        sbuf_write_u8(dst, uint8_t(highest_temperature / 100));         // deg, report max temperature
-        sbuf_write_u16(dst, uint16_t(telem.get_average_motor_rpm() * 0.1f));  // rpm, report average RPM across all motors
+        telem.get_highest_temperature(highest_temperature);
+        sbuf_write_u8(dst, uint8_t(highest_temperature * 0.01f));               // deg, report max temperature
+        sbuf_write_u16(dst, uint16_t(telem.get_average_motor_rpm() * 0.1f));    // rpm, report average RPM across all motors
     } else {
         return AP_MSP_Telem_Backend::msp_process_out_esc_sensor_data(dst);
     }


### PR DESCRIPTION
The MSP library was using a method to get MAX motor temperature while the expected behaviour was to get MAX esc temperature.