### PR TITLE
AP_Logger: log transfer: add error message if armed

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -260,6 +260,10 @@ bool AP_Arming::logging_checks(bool report)
             check_failed(ARMING_CHECK_LOGGING, report, "No SD card");
             return false;
         }
+        if (AP::logger().in_log_download()) {
+            check_failed(ARMING_CHECK_LOGGING, report, "Downloading logs");
+            return false;
+        }
     }
     return true;
 }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -553,6 +553,7 @@ private:
 
     // last time we handled a log-transfer-over-mavlink message:
     uint32_t _last_mavlink_log_transfer_message_handled_ms;
+    bool _warned_log_disarm; // true if we have sent a message warning to disarm for logging
 
     // next log list entry to send
     uint16_t _log_next_list_entry;
@@ -588,7 +589,6 @@ private:
     // can be used by other subsystems to detect if they should log data
     uint8_t _log_start_count;
 
-    bool should_handle_log_message() const;
     void handle_log_message(class GCS_MAVLINK &, const mavlink_message_t &msg);
 
     void handle_log_request_list(class GCS_MAVLINK &, const mavlink_message_t &msg);

--- a/libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp
@@ -26,27 +26,23 @@
 
 extern const AP_HAL::HAL& hal;
 
-// We avoid doing log messages when timing is critical:
-bool AP_Logger::should_handle_log_message() const
-{
-    if (!WritesEnabled()) {
-        // this is currently used as a proxy for "in_mavlink_delay"
-        return false;
-    }
-    if (vehicle_is_armed()) {
-        return false;
-    }
-    return true;
-}
-
 /**
    handle all types of log download requests from the GCS
  */
 void AP_Logger::handle_log_message(GCS_MAVLINK &link, const mavlink_message_t &msg)
 {
-    if (!should_handle_log_message()) {
+    if (!WritesEnabled()) {
+        // this is currently used as a proxy for "in_mavlink_delay"
         return;
     }
+    if (vehicle_is_armed()) {
+        if (!_warned_log_disarm) {
+            link.send_text(MAV_SEVERITY_ERROR, "Disarm for log download");
+            _warned_log_disarm = true;
+        }
+        return;
+    }
+    _warned_log_disarm = false;
     _last_mavlink_log_transfer_message_handled_ms = AP_HAL::millis();
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_LOG_REQUEST_LIST:


### PR DESCRIPTION
Fixes #8914

This is used on all vehicles, although the issue is just for rover.

Currently log related mavlink stuff will silently fail if armed. Will also fail if `!WritesEnabled()` but in that case AP will be printing "Initialising ArduPilot" every 5 seconds, so I don't think we need another message.