### PR TITLE
AP_Rangefinder: MAVLink: accept data only from configured orientation

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -24,8 +24,8 @@ void AP_RangeFinder_MAVLink::handle_msg(const mavlink_message_t &msg)
     mavlink_distance_sensor_t packet;
     mavlink_msg_distance_sensor_decode(&msg, &packet);
 
-    // only accept distances for downward facing sensors
-    if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_270) {
+    // only accept distances for the configured orentation
+    if (packet.orientation == orientation()) {
         state.last_reading_ms = AP_HAL::millis();
         distance_cm = packet.current_distance;
         _max_distance_cm = packet.max_distance;


### PR DESCRIPTION
Spotted while investigating https://github.com/ArduPilot/ardupilot/issues/8828 

Will be NFC in most cases because the default orientation is down.

This could have caused funny things where the rangefinder orientation is not down but the backed is using the down distance. 