### PR TITLE
Fail to arm if in RC_Calibration

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -746,7 +746,7 @@ bool AP_Arming_Copter::mandatory_checks(bool display_failure)
         result = false;
     }
 
-    return result;
+    return result & AP_Arming::mandatory_checks(display_failure);
 }
 
 void AP_Arming_Copter::set_pre_arm_check(bool b)

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -303,7 +303,7 @@ bool AP_Arming_Blimp::mandatory_checks(bool display_failure)
         result = false;
     }
 
-    return result;
+    return result & AP_Arming::mandatory_checks(display_failure);
 }
 
 void AP_Arming_Blimp::set_pre_arm_check(bool b)

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -686,6 +686,15 @@ bool AP_Arming::rc_calibration_checks(bool report)
     return check_passed;
 }
 
+bool AP_Arming::rc_in_calibration_check(bool report)
+{
+    if (rc().calibrating()) {
+        check_failed(ARMING_CHECK_RC, report, "RC calibrating");
+        return false;
+    }
+    return true;
+}
+
 bool AP_Arming::manual_transmitter_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
@@ -701,7 +710,7 @@ bool AP_Arming::manual_transmitter_checks(bool report)
         }
     }
 
-    return true;
+    return rc_in_calibration_check(report);
 }
 
 bool AP_Arming::mission_checks(bool report)
@@ -1329,6 +1338,11 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
         }
     }
     return true;
+}
+
+bool AP_Arming::mandatory_checks(bool report)
+{
+    return rc_in_calibration_check(report);
 }
 
 //returns true if arming occurred successfully

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -158,6 +158,8 @@ protected:
 
     virtual bool rc_calibration_checks(bool report);
 
+    bool rc_in_calibration_check(bool report);
+
     bool rc_arm_checks(AP_Arming::Method method);
 
     bool manual_transmitter_checks(bool report);
@@ -195,7 +197,7 @@ protected:
     bool disarm_switch_checks(bool report) const;
 
     // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
-    virtual bool mandatory_checks(bool report) { return true; }
+    virtual bool mandatory_checks(bool report);
 
     // returns true if a particular check is enabled
     bool check_enabled(const enum AP_Arming::ArmingChecks check) const;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3822,6 +3822,8 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
         return _handle_command_preflight_calibration_baro();
     }
 
+    rc().calibrating(is_positive(packet.param4));
+
 #if HAL_INS_ENABLED
     if (is_equal(packet.param5,1.0f)) {
         // start with gyro calibration

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -546,6 +546,10 @@ public:
     // flight_mode_channel_number must be overridden in vehicle specific code
     virtual int8_t flight_mode_channel_number() const = 0;
 
+    // set and get calibrating flag, stops arming if true
+    void calibrating(bool b) { gcs_is_calibrating = b; }
+    bool calibrating() { return gcs_is_calibrating; }
+
 protected:
 
     enum class Option {
@@ -583,6 +587,9 @@ private:
 
     // Allow override by default at start
     bool _gcs_overrides_enabled = true;
+
+    // true if GCS is performing a RC calibration
+    bool gcs_is_calibrating;
 };
 
 RC_Channels &rc();


### PR DESCRIPTION
Fixes #8735

Although as far as I can tell QGC no longer sets that bit. I think it would be a nice enhancement to all the GCSs tho.

I'm not sure on the exact way to use the pram. 

https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_CALIBRATION

Says: 
     1: radio RC calibration, 2: RC trim calibration

Currently I have 1 = running 0 = stop. But that means we cant ack the stop. Maybe it should be a continues set and timeout. Or a toggle. 

Since QGC seems not to send it anymore we have no base line to compare to.... 
