### PR TITLE
AP_Arming: update primary GPS type 0 string

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -496,7 +496,7 @@ bool AP_Arming::gps_checks(bool report)
 #endif
                     (gps.get_type(i) == AP_GPS::GPS_Type::GPS_TYPE_NONE)) {
                 if (gps.primary_sensor() == i) {
-                    check_failed(ARMING_CHECK_GPS, report, "GPS %i: primary but not configured", i+1);
+                    check_failed(ARMING_CHECK_GPS, report, "GPS %i: primary but TYPE 0", i+1);
                     return false;
                 }
                 continue;


### PR DESCRIPTION
Updates the error message. We cant do the exact param string easily because the first gps is `GPS_TPYE` and the second is `GPS_TYPE2` so we would have to so some messing with strings. 