### PR TITLE
OSD/Hott_Telem: fix btemp and cope with BARO_MAX_INSTANCES < 3

### DIFF
--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -128,9 +128,11 @@ void AP_Hott_Telem::send_EAM(void)
 
     const AP_Baro &baro = AP::baro();
     msg.temp1 = uint8_t(baro.get_temperature(0) + 20.5);
+#if BARO_MAX_INSTANCES > 1
     if (baro.healthy(1)) {
         msg.temp2 = uint8_t(baro.get_temperature(1) + 20.5);
     }
+#endif
 
     AP_AHRS &ahrs = AP::ahrs();
     float alt = 0;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -25,6 +25,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_OLC/AP_OLC.h>
 #include <AP_MSP/msp.h>
+#include <AP_Baro/AP_Baro.h>
 
 #ifndef OSD_ENABLED
 #define OSD_ENABLED !HAL_MINIMIZE_FEATURES
@@ -176,7 +177,9 @@ private:
     AP_OSD_Setting roll_angle{false, 0, 0};
     AP_OSD_Setting pitch_angle{false, 0, 0};
     AP_OSD_Setting temp{false, 0, 0};
+#if BARO_MAX_INSTANCES > 1
     AP_OSD_Setting btemp{false, 0, 0};
+#endif
     AP_OSD_Setting hdop{false, 0, 0};
     AP_OSD_Setting waypoint{false, 0, 0};
     AP_OSD_Setting xtrack_error{false, 0, 0};
@@ -252,7 +255,9 @@ private:
     void draw_roll_angle(uint8_t x, uint8_t y);
     void draw_pitch_angle(uint8_t x, uint8_t y);
     void draw_temp(uint8_t x, uint8_t y);
+#if BARO_MAX_INSTANCES > 1
     void draw_btemp(uint8_t x, uint8_t y);
+#endif
     void draw_hdop(uint8_t x, uint8_t y);
     void draw_waypoint(uint8_t x, uint8_t y);
     void draw_xtrack_error(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -33,7 +33,6 @@
 #include <AP_Common/Location.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_GPS/AP_GPS.h>
-#include <AP_Baro/AP_Baro.h>
 #include <AP_RTC/AP_RTC.h>
 #include <AP_MSP/msp.h>
 #include <AP_OLC/AP_OLC.h>
@@ -603,6 +602,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(eff, "EFF", 36, AP_OSD_Screen, AP_OSD_Setting),
 
+#if BARO_MAX_INSTANCES > 1
     // @Param: BTEMP_EN
     // @DisplayName: BTEMP_EN
     // @Description: Displays temperature reported by secondary barometer
@@ -618,6 +618,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(btemp, "BTEMP", 37, AP_OSD_Screen, AP_OSD_Setting),
+#endif
 
     // @Param: ATEMP_EN
     // @DisplayName: ATEMP_EN
@@ -1961,12 +1962,14 @@ void AP_OSD_Screen::draw_climbeff(uint8_t x, uint8_t y)
     }
 }
 
+#if BARO_MAX_INSTANCES > 1
 void AP_OSD_Screen::draw_btemp(uint8_t x, uint8_t y)
 {
     AP_Baro &barometer = AP::baro();
     float btmp = barometer.get_temperature(1);
     backend->write(x, y, false, "%3d%c", (int)u_scale(TEMPERATURE, btmp), u_icon(TEMPERATURE));
 }
+#endif
 
 void AP_OSD_Screen::draw_atemp(uint8_t x, uint8_t y)
 {
@@ -2193,7 +2196,9 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(roll_angle);
     DRAW_SETTING(pitch_angle);
     DRAW_SETTING(temp);
+#if BARO_MAX_INSTANCES > 1
     DRAW_SETTING(btemp);
+#endif
     DRAW_SETTING(atemp);
     DRAW_SETTING(hdop);
     DRAW_SETTING(flightime);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -226,8 +226,12 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     AP_GROUPINFO("BARO_COUNT",    33, SIM,  baro_count, 2),
 
     AP_SUBGROUPINFO(baro[0], "BARO_", 34, SIM, SIM::BaroParm),
+#if BARO_MAX_INSTANCES > 1
     AP_SUBGROUPINFO(baro[1], "BAR2_", 35, SIM, SIM::BaroParm),
+#endif
+#if BARO_MAX_INSTANCES > 2
     AP_SUBGROUPINFO(baro[2], "BAR3_", 36, SIM, SIM::BaroParm),
+#endif
 
     // user settable parameters for the 1st barometer
     // @Param: BARO_RND


### PR DESCRIPTION
This is a fix to allow BARO_MAX_INSTANCES  to be set to 1 or 2.

I removed OSDn_BTEMP_* parameters when BARO_MAX_INSTANCES=1.
~~And I also changed OSDx_BTEMP to display a non-primary value.
OSD_TEMP displays the temperature of the primary barometer.
If the primary is BARO2, then BTEMP displays BARO1's temperature.~~

[BARO_MAX_INSTANCES  = 1]
![image](https://user-images.githubusercontent.com/16643069/131429363-fc7e9b94-4158-40f7-8eb0-e7db90158c8f.png)
The secondary does not exist, so no value will be displayed.

[BARO_MAX_INSTANCES  = 2]
![image](https://user-images.githubusercontent.com/16643069/131429374-c7ce229f-a8e4-4e85-a1e1-fb4f3125d480.png)
The secondary barometer temperature will be displayed.