### PR TITLE
SITL: add locations of RealFlight airports

### DIFF
--- a/Tools/autotest/locations.txt
+++ b/Tools/autotest/locations.txt
@@ -88,3 +88,7 @@ OSPN=30.53202,-97.62892,199,7 #Old Settlers Park , Austin, TX, North takeof
 OSP=30.53202,-97.62892,199,187 #Old Settlers Park , Austin, TX, South takeof
 KalaupapaCliffs=21.16564233,-156.88680160,165.25,0
 LakeGeorgeLookout=-35.10122092,149.37517574,708.12,90
+RF_AirStadium=36.893328,-2.720371,1434,0
+RF_BuenaVista=37.093686,-2.890969,2390,0
+RF_Castle=37.090662,-3.074557,2736,0
+RF_Garage=37.621798,-2.646596,788,0


### PR DESCRIPTION
RealFlight's terrain model is taken from the Sierra Nevada region of Spain. Several points of interest were identified between RealFlight and Google Earth to create a way to convert between RealFlight's absolute coordinates and lat/lon. This allows one to utilize terrain map layers and SRTM terrain height (though the error is on the order of 30m or so) for SITL flights.

Four airports were chosen. Three of them for their interesting terrain, and one (Joe's Garage) for its distinct lack of interesting terrain.

The following Octave code was used for the conversion:
```
DEGLAT_TO_METER = 111195;
METER_TO_FOOT = 3.280839895;
SCALE_TWEAK_X = 1.0021;
SCALE_TWEAK_Y = 0.9977;
LAT0 = 37.200130;
LON0 = -3.034696;

lat = y./(SCALE_TWEAK_Y*DEGLAT_TO_METER*METER_TO_FOOT) + LAT0;
lon = x./(SCALE_TWEAK_X*DEGLAT_TO_METER*METER_TO_FOOT.*cosd(lat)) + LON0;
```
Where x and y are the absolute RF coordinates of the spawn point in feet.

For historical purposes, I have included the kml containing the landmarks that were used to generate the above fit.
[RF Sim Landmarks.zip](https://github.com/ArduPilot/ardupilot/files/7081079/RF.Sim.Landmarks.zip)
