### PR TITLE
OSD: hide parameters correctly on var_info2

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1000,6 +1000,9 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 };
 
 const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
+    // duplicate of OSDn_ENABLE to ensure params are hidden when not enabled
+    AP_GROUPINFO_FLAGS("ENABLE", 2, AP_OSD_Screen, enabled, 0, AP_PARAM_FLAG_ENABLE | AP_PARAM_FLAG_HIDDEN),
+
     // @Param: LINK_Q_EN
     // @DisplayName: LINK_Q_EN
     // @Description: Displays Receiver link quality

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1682,6 +1682,9 @@ AP_Param *AP_Param::next_group(const uint16_t vindex, const struct GroupInfo *gr
                     ((AP_Int8 *)ret)->get() == 0) {
                     token->last_disabled = 1;
                 }
+                if (group_info[i].flags & AP_PARAM_FLAG_HIDDEN) {
+                    continue;
+                }
                 return ret;
             }
             if (group_id(group_info, group_base, i, group_shift) == token->group_element) {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -72,13 +72,16 @@
 // use.
 #define AP_PARAM_FLAG_INTERNAL_USE_ONLY (1<<5)
 
+// hide parameter from param download
+#define AP_PARAM_FLAG_HIDDEN (1<<6)
+
 // keep all flags before the FRAME tags
 
 // vehicle and frame type flags, used to hide parameters when not
 // relevent to a vehicle type. Use AP_Param::set_frame_type_flags() to
 // enable parameters flagged in this way. frame type flags are stored
 // in flags field, shifted by AP_PARAM_FRAME_TYPE_SHIFT.
-#define AP_PARAM_FRAME_TYPE_SHIFT   6
+#define AP_PARAM_FRAME_TYPE_SHIFT   7
 
 // supported frame types for parameters
 #define AP_PARAM_FRAME_COPTER       (1<<0)


### PR DESCRIPTION
This adds a duplicate enable parameter for var_info2 in AP_OSD, allowing for parameters to be hidden correctly. I know this is quite a strange approach, but I haven't found a better way
Thanks to @giacomo892 for reporting this
Fixes #18418 