### PR TITLE
Do not overwrite FETTecESC telemetry data w/SITL ESC data

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7282,7 +7282,7 @@ class AutoTestCopter(AutoTest):
         # before the motors will spin:
         self.wait_esc_telem_rpm(
             esc=mot,
-            rpm_min=0,   # FIXME: was 17640
+            rpm_min=17640,
             rpm_max=17640,
             minimum_duration=2,
             timeout=5,
@@ -7292,7 +7292,7 @@ class AutoTestCopter(AutoTest):
         self.set_safetyswitch_off()
         self.wait_esc_telem_rpm(
             esc=mot,
-            rpm_min=0,   # FIXME: was 17640
+            rpm_min=17640,
             rpm_max=17640,
             minimum_duration=2,
             timeout=5,

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -85,6 +85,14 @@ void RCOutput::push(void)
         memcpy(_sitlState->pwm_output, _pending, SITL_NUM_CHANNELS * sizeof(uint16_t));
         _corked = false;
     }
+
+    // do not overwrite FETTec simulation's ESC telemetry data:
+    SITL::SIM *sitl = AP::sitl();
+    if (sitl != nullptr &&
+        sitl->fetteconewireesc_sim.enabled()) {
+        return;
+    }
+
     if (esc_telem == nullptr) {
         esc_telem = new AP_ESC_Telem_SITL;
     }


### PR DESCRIPTION
@andyp1per 

@amilcarlucas had to disable one of the tests for the FETTec ESCs.  When I wrote the test it worked, but sometime when Amilcar was finishing up the driver it crossed with a merge-to-master which started filling in the ESC telemetry data generically in SITL.

This PR reverts the patch which disabled the test, and stops SITL overwriting the FETTec data.
