### PR TITLE
GCS_MAVLINK: private channels definition

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -145,10 +145,8 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     memset(sent_to_chan, 0, sizeof(sent_to_chan));
     for (uint8_t i=0; i<num_routes; i++) {
 
-        // Skip if channel is private and the target system or component IDs do not match
-        if ((GCS_MAVLINK::is_private(routes[i].channel)) &&
-            (target_system != routes[i].sysid ||
-             target_component != routes[i].compid)) {
+        // Skip if channel is private
+        if (GCS_MAVLINK::is_private(routes[i].channel)) {
             continue;
         }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -96,12 +96,7 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
         msg.compid == mavlink_system.compid) {
         return true;
     }
-
-    // don't ever forward data from a private channel
-    if ((GCS_MAVLINK::is_private(in_channel))) {
-        return true;
-    }
-
+    
     // learn new routes
     learn_route(in_channel, msg);
 
@@ -126,6 +121,17 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     int16_t target_system = -1;
     int16_t target_component = -1;
     get_targets(msg, target_system, target_component);
+
+    // don't ever forward data from a private channel
+    // If it is a broadcast message, it should not be processed locally.
+    if (GCS_MAVLINK::is_private(in_channel)) {
+        if (target_system == mavlink_system.sysid &&
+            target_component == mavlink_system.compid) {
+            return true;
+        }
+        else
+            return false;
+    }
 
     bool broadcast_system = (target_system == 0 || target_system == -1);
     bool broadcast_component = (target_component == 0 || target_component == -1);


### PR DESCRIPTION
The private channel definition is written on the 88th line of libraries/GCS_MAVLink/GCS_common.cpp
: private channels are ones used for point-to-point protocols, and don't get broadcasts or fwded packets

1. don't ever forward data from a private channel.
     If it is a broadcast message, it should not be processed locally.
2. If the channel in the route table is private, it should not be forwarded even if the system and component id match.