### PR TITLE
.github: migrate semaphore to github actions

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -38,6 +38,12 @@ jobs:
         exclude:
           - gcc: 10
             toolchain: chibios-clang
+          - gcc: 6
+            config: fmuv2-plane
+          - gcc: 6
+            config: revo-mini
+          - gcc: 6
+            config: MatekF405-Wing
 
     steps:
       # git checkout the PR

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -24,7 +24,11 @@ jobs:
             iofirmware,
             CubeOrange-bootloader,
             revo-bootloader,
-            stm32h7-debug
+            stm32h7-debug,
+            fmuv3,
+            revo-mini,
+            MatekF405-Wing,
+            configure-all
         ]
         toolchain: [
             chibios,  # GCC-6

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -71,8 +71,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "chibios-clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/usr/lib/ccache:/opt/gcc-arm-none-eabi-${{matrix.gcc}}/bin:$PATH"
           PATH="/github/home/.local/bin:$PATH"

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -16,7 +16,16 @@ jobs:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
         config: [
-            navigator
+            linux,
+            navigator,
+            navio,
+            navio2,
+            bbbmini,
+            bhat,
+            bebop,
+            erlebrain2,
+            pxfmini,
+            pxf
         ]
         toolchain: [
             armhf,
@@ -24,8 +33,12 @@ jobs:
         include:
           - config: navigator
             toolchain: armhf-musl
+          - config: linux
+            toolchain: base # GCC
         exclude:
           - config: navigator
+            toolchain: armhf
+          - config: linux
             toolchain: armhf
 
     steps:
@@ -59,7 +72,7 @@ jobs:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
         run: |
-          if [[ ${{ matrix.toolchain }} == ",clang" ]]; then
+          if [[ ${{ matrix.toolchain }} == "clang" ]]; then
             export CC=clang-7
             export CXX=clang++-7
           fi

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -73,8 +73,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -54,8 +54,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -49,8 +49,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           ./waf configure --board sitl

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -49,8 +49,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           ./waf configure --board sitl

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -49,8 +49,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           ./waf configure --board sitl

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -49,8 +49,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           ./waf configure --board sitl

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -49,8 +49,8 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           ./waf configure --board sitl

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -24,6 +24,7 @@ jobs:
         config: [
             unit-tests,
             python-cleanliness,
+            sitl
             # examples,
         ]
     steps:

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -59,8 +59,8 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
-            export CC=clang-7
-            export CXX=clang++-7
+            export CC=clang
+            export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh


### PR DESCRIPTION
We could probably remove 
bebop, erlebrain2, pxfmini, pxf, and navio build . There are discontinued since long ago, I don't think there is much user left
