### PR TITLE
autotest: re-enable Heli spline waypoint test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8202,7 +8202,6 @@ class AutoTestHeli(AutoTestCopter):
 
     def disabled_tests(self):
         return {
-            "SplineWaypoint": "See https://github.com/ArduPilot/ardupilot/issues/14593",
         }
 
 


### PR DESCRIPTION
position controller has been completely rewritten, so the bug should be
gone now.... certainly the referenced issue has been closed with "fixed".
