### PR TITLE
CI: disable clang build for chibios as broken

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -28,7 +28,7 @@ jobs:
         ]
         toolchain: [
             chibios,  # GCC-6
-            chibios-clang,
+            #chibios-clang,
         ]
         gcc: [6, 10]
         exclude:


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/18542
