### PR TITLE
Copter: ignore pilot yaw during takeoff with option

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1287,6 +1287,7 @@ public:
     void exit() override;
 
     bool is_landing() const override;
+    bool use_pilot_yaw() const override;
 
     // Safe RTL states
     enum class SubMode : uint8_t {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -106,6 +106,9 @@ public:
     // send output to the motors, can be overridden by subclasses
     virtual void output_to_motors();
 
+    // returns true if pilot's yaw input should be used to adjust vehicle's heading
+    virtual bool use_pilot_yaw() const {return true; }
+
 protected:
 
     // helper functions
@@ -415,6 +418,7 @@ public:
     bool is_landing() const override;
 
     bool is_taking_off() const override;
+    bool use_pilot_yaw() const override;
 
     bool requires_terrain_failsafe() const override { return true; }
 
@@ -452,8 +456,6 @@ private:
         AllowTakeOffWithoutRaisingThrottle = (1 << 1U),
         IgnorePilotYaw                     = (1 << 2U),
     };
-
-    bool use_pilot_yaw(void) const;
 
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
@@ -920,6 +922,8 @@ public:
     // return guided mode timeout in milliseconds.  Only used for velocity, acceleration and angle control
     uint32_t get_timeout_ms() const;
 
+    bool use_pilot_yaw() const override;
+
 protected:
 
     const char *name() const override { return "GUIDED"; }
@@ -953,7 +957,6 @@ private:
     void posvelaccel_control_run();
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
-    bool use_pilot_yaw(void) const;
 
     // controls which controller is run (pos or vel):
     SubMode guided_mode = SubMode::TakeOff;
@@ -1178,6 +1181,8 @@ public:
     // for reporting to GCS
     bool get_wp(Location &loc) const override;
 
+    bool use_pilot_yaw() const override;
+
     // RTL states
     enum class SubMode : uint8_t {
         STARTING,
@@ -1259,8 +1264,6 @@ private:
         // First pair of bits are still available, pilot yaw was mapped to bit 2 for symmetry with auto
         IgnorePilotYaw    = (1U << 2),
     };
-
-    bool use_pilot_yaw(void) const;
 
 };
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -82,7 +82,7 @@ void ModeSmartRTL::wait_cleanup_run()
 void ModeSmartRTL::path_follow_run()
 {
     float target_yaw_rate = 0.0f;
-    if (!copter.failsafe.radio && g2.smart_rtl.use_pilot_yaw()) {
+    if (!copter.failsafe.radio && use_pilot_yaw()) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
@@ -205,6 +205,11 @@ uint32_t ModeSmartRTL::wp_distance() const
 int32_t ModeSmartRTL::wp_bearing() const
 {
     return wp_nav->get_wp_bearing_to_destination();
+}
+
+bool ModeSmartRTL::use_pilot_yaw() const
+{
+    return g2.smart_rtl.use_pilot_yaw();
 }
 
 #endif

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -108,7 +108,7 @@ void Mode::auto_takeoff_run()
 
     // process pilot's yaw input
     float target_yaw_rate = 0;
-    if (!copter.failsafe.radio) {
+    if (!copter.failsafe.radio && copter.flightmode->use_pilot_yaw()) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }


### PR DESCRIPTION
Fix #17951

This PR allow "Ignore pilot yaw" bit of GUID_OPTIONS and AUTO_OPTIONS with takeoff.

I tested that "Ignore pilot yaw" works in the following conditions in SITL.
 - takeoff in Guided and Auto mode
 - flying in RTL and SmartRTL mode