### PR TITLE
AC_WPNav: protect from divide by zero especially when using CH6 tuning of WP speed

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -154,7 +154,7 @@ void ModeGuided::pva_control_start()
     // initialise yaw
     auto_yaw.set_mode_to_default(false);
 
-    // initialise terain alt
+    // initialise terrain alt
     guided_pos_terrain_alt = false;
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -151,12 +151,16 @@ void AC_WPNav::wp_and_spline_init(float speed_cms)
     // check _wp_radius_cm is reasonable
     _wp_radius_cm.set_and_save_ifchanged(MAX(_wp_radius_cm, WPNAV_WP_RADIUS_MIN));
 
+    // check _wp_speed
+    _wp_speed_cms.set_and_save_ifchanged(MAX(_wp_speed_cms, WPNAV_WP_SPEED_MIN));
+
     // initialise position controller
     _pos_control.init_z_controller_stopping_point();
     _pos_control.init_xy_controller_stopping_point();
 
     // initialize the desired wp speed if not already done
     _wp_desired_speed_xy_cms = is_positive(speed_cms) ? speed_cms : _wp_speed_cms;
+    _wp_desired_speed_xy_cms = MAX(_wp_desired_speed_xy_cms, WPNAV_WP_SPEED_MIN);
 
     // initialise position controller speed and acceleration
     _pos_control.set_max_speed_accel_xy(_wp_desired_speed_xy_cms, _wp_accel_cmss);
@@ -194,8 +198,8 @@ void AC_WPNav::wp_and_spline_init(float speed_cms)
 /// set_speed_xy - allows main code to pass target horizontal velocity for wp navigation
 void AC_WPNav::set_speed_xy(float speed_cms)
 {
-    // range check target speed
-    if (speed_cms >= WPNAV_WP_SPEED_MIN) {
+    // range check target speed and protect against divide by zero
+    if (speed_cms >= WPNAV_WP_SPEED_MIN && is_positive(_wp_desired_speed_xy_cms)) {
         // update terrain following speed scalar
         _terrain_vel = speed_cms * _terrain_vel / _wp_desired_speed_xy_cms;
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -3,6 +3,16 @@
 
 extern const AP_HAL::HAL& hal;
 
+// maximum velocities and accelerations
+#define WPNAV_ACCELERATION              250.0f      // maximum horizontal acceleration in cm/s/s that wp navigation will request
+#define WPNAV_WP_SPEED                 1000.0f      // default horizontal speed between waypoints in cm/s
+#define WPNAV_WP_SPEED_MIN               20.0f      // minimum horizontal speed between waypoints in cm/s
+#define WPNAV_WP_RADIUS                 200.0f      // default waypoint radius in cm
+#define WPNAV_WP_RADIUS_MIN               5.0f      // minimum waypoint radius in cm
+#define WPNAV_WP_SPEED_UP               250.0f      // default maximum climb velocity
+#define WPNAV_WP_SPEED_DOWN             150.0f      // default maximum descent velocity
+#define WPNAV_WP_ACCEL_Z_DEFAULT        100.0f      // default vertical acceleration between waypoints in cm/s/s
+
 const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // index 0 was used for the old orientation matrix
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -177,8 +177,8 @@ void AC_WPNav::wp_and_spline_init(float speed_cms)
     _this_leg_is_spline = false;
 
     // initialise the terrain velocity to the current maximum velocity
-    _terain_vel = _wp_desired_speed_xy_cms;
-    _terain_accel = 0.0;
+    _terrain_vel = _wp_desired_speed_xy_cms;
+    _terrain_accel = 0.0;
 }
 
 /// set_speed_xy - allows main code to pass target horizontal velocity for wp navigation
@@ -187,7 +187,7 @@ void AC_WPNav::set_speed_xy(float speed_cms)
     // range check target speed
     if (speed_cms >= WPNAV_WP_SPEED_MIN) {
         // update terrain following speed scalar
-        _terain_vel = speed_cms * _terain_vel / _wp_desired_speed_xy_cms;
+        _terrain_vel = speed_cms * _terrain_vel / _wp_desired_speed_xy_cms;
 
         // initialize the desired wp speed
         _wp_desired_speed_xy_cms = speed_cms;
@@ -463,11 +463,11 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     float vel_time_scalar = 1.0;
     if (is_positive(_wp_desired_speed_xy_cms)) {
-        update_vel_accel(_terain_vel, _terain_accel, dt, false);
+        update_vel_accel(_terrain_vel, _terrain_accel, dt, false);
         shape_vel_accel( _wp_desired_speed_xy_cms * offset_z_scaler, 0.0,
-            _terain_vel, _terain_accel,
+            _terrain_vel, _terrain_accel,
             -_wp_accel_cmss, _wp_accel_cmss, _pos_control.get_shaping_jerk_xy_cmsss(), dt, true);
-        vel_time_scalar = _terain_vel / _wp_desired_speed_xy_cms;
+        vel_time_scalar = _terrain_vel / _wp_desired_speed_xy_cms;
     }
 
     // change s-curve time speed with a time constant of maximum acceleration / maximum jerk

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -12,18 +12,6 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
-// maximum velocities and accelerations
-#define WPNAV_ACCELERATION              250.0f      // maximum horizontal acceleration in cm/s/s that wp navigation will request
-#define WPNAV_WP_SPEED                 1000.0f      // default horizontal speed between waypoints in cm/s
-#define WPNAV_WP_SPEED_MIN               20.0f      // minimum horizontal speed between waypoints in cm/s
-#define WPNAV_WP_RADIUS                 200.0f      // default waypoint radius in cm
-#define WPNAV_WP_RADIUS_MIN               5.0f      // minimum waypoint radius in cm
-
-#define WPNAV_WP_SPEED_UP               250.0f      // default maximum climb velocity
-#define WPNAV_WP_SPEED_DOWN             150.0f      // default maximum descent velocity
-
-#define WPNAV_WP_ACCEL_Z_DEFAULT        100.0f      // default vertical acceleration between waypoints in cm/s/s
-
 class AC_WPNav
 {
 public:

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -262,8 +262,8 @@ protected:
     Vector3f    _origin;                // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination;           // target destination in cm from ekf origin
     float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
-    float       _terain_vel;            // maximum horizontal velocity used to ensure the aircraft can maintain height above terain
-    float       _terain_accel;          // acceleration value used to change _terain_vel
+    float       _terrain_vel;            // maximum horizontal velocity used to ensure the aircraft can maintain height above terrain
+    float       _terrain_accel;          // acceleration value used to change _terain_vel
 
     // terrain following variables
     bool        _terrain_alt;   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -263,7 +263,7 @@ protected:
     Vector3f    _destination;           // target destination in cm from ekf origin
     float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
     float       _terrain_vel;            // maximum horizontal velocity used to ensure the aircraft can maintain height above terrain
-    float       _terrain_accel;          // acceleration value used to change _terain_vel
+    float       _terrain_accel;          // acceleration value used to change _terrain_vel
 
     // terrain following variables
     bool        _terrain_alt;   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin


### PR DESCRIPTION
This PR includes a few cosmetic fixes to AC_WPNav:

- correct spelling of "terrain"
- move definitions from .h to .cpp

.. and one real fix to avoid a divide-by-zero if ch6 tuning is being used to change the WP speed inflight.  The reason the divide-by-zero could happen was that channel 6 tuning would call AC_WPNav::set_speed_xy() before AC_WPNav::wp_and_spline_init() was called.  This means that _wp_desired_speed_xy_cms was still zero and led to the divide-by-zero.

This has been tested in SITL both before and after this change.  Below is a screenshot of the ch6 tuning knob being used to set the WPNAV_SPEED value.  Before this fix the simulator would crash and report the divide-by-zero.
![image](https://user-images.githubusercontent.com/1498098/131963736-ae0dc0d4-f6c6-4927-a3f3-72cf1aeac0e9.png)


This issue was discovered as part of the Copter-4.1.0-beta report, "Ch6 tuning of WP speed broken" on the [4.1 issues list](https://github.com/ArduPilot/ardupilot/issues/16478) and was reported [here on the forums](https://discuss.ardupilot.org/t/wp-speed-on-in-flight-tuning-not-functioning/75226).
