### PR TITLE
Honour WPNAV_SPEED changes during flight

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -101,6 +101,9 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS_View& ahrs, AC_PosC
     // init flags
     _flags.reached_destination = false;
     _flags.fast_waypoint = false;
+
+    // initialise old WPNAV_SPEED value
+    _last_wp_speed_cms = _wp_speed_down_cms;
 }
 
 // get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)
@@ -561,6 +564,11 @@ int32_t AC_WPNav::get_wp_bearing_to_destination() const
 bool AC_WPNav::update_wpnav()
 {
     bool ret = true;
+
+    if (!is_equal(_wp_speed_cms.get(), _last_wp_speed_cms)) {
+        set_speed_xy(_wp_speed_cms);
+        _last_wp_speed_cms = _wp_speed_cms;
+    }
 
     // advance the target if necessary
     if (!advance_wp_target_along_track(_pos_control.get_dt())) {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -241,6 +241,8 @@ protected:
     AP_Float    _wp_jerk;               // maximum jerk used to generate scurve trajectories in m/s/s/s
     AP_Float    _terrain_margin;        // terrain following altitude margin. vehicle will stop if distance from target altitude is larger than this margin
 
+    float _last_wp_speed_cms;  // last recorded WPNAV_SPEED, used for changing speed in-flight
+
     // scurve
     SCurve _scurve_prev_leg;            // previous scurve trajectory used to blend with current scurve trajectory
     SCurve _scurve_this_leg;            // current scurve trajectory


### PR DESCRIPTION
I thought we already did this years ago.

Closes https://github.com/ArduPilot/ardupilot/issues/6193

I'm not sure we should actually do this, but perhaps add information to the parameter description indicating we only "sample" `WPNAV_SPEED` at the beginning of the mission or similar.
