### PR TITLE
Log source sysid/compid in MAVC packets

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -317,7 +317,11 @@ public:
     void Write_Mode(uint8_t mode, const ModeReason reason);
 
     void Write_EntireMission();
-    void Write_Command(const mavlink_command_int_t &packet, MAV_RESULT result, bool was_command_long=false);
+    void Write_Command(const mavlink_command_int_t &packet,
+                       uint8_t source_system,
+                       uint8_t source_component,
+                       MAV_RESULT result,
+                       bool was_command_long=false);
     void Write_Mission_Cmd(const AP_Mission &mission,
                                const AP_Mission::Mission_Command &cmd);
     void Write_RPM(const AP_RPM &rpm_sensor);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -217,6 +217,8 @@ void AP_Logger::Write_RSSI()
 }
 
 void AP_Logger::Write_Command(const mavlink_command_int_t &packet,
+                              uint8_t source_system,
+                              uint8_t source_component,
                               const MAV_RESULT result,
                               bool was_command_long)
 {
@@ -225,10 +227,10 @@ void AP_Logger::Write_Command(const mavlink_command_int_t &packet,
         time_us         : AP_HAL::micros64(),
         target_system   : packet.target_system,
         target_component: packet.target_component,
+        source_system   : source_system,
+        source_component: source_component,
         frame           : packet.frame,
         command         : packet.command,
-        current         : packet.current,
-        autocontinue    : packet.autocontinue,
         param1          : packet.param1,
         param2          : packet.param2,
         param3          : packet.param3,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -336,10 +336,10 @@ struct PACKED log_MAVLink_Command {
     uint64_t time_us;
     uint8_t target_system;
     uint8_t target_component;
+    uint8_t source_system;
+    uint8_t source_component;
     uint8_t frame;
     uint16_t command;
-    uint8_t current;
-    uint8_t autocontinue;
     float param1;
     float param2;
     float param3;
@@ -908,10 +908,10 @@ struct PACKED log_PSCZ {
 // @Field: TimeUS: Time since system startup
 // @Field: TS: target system for command
 // @Field: TC: target component for command
+// @Field: SS: target system for command
+// @Field: SC: target component for command
 // @Field: Fr: command frame
 // @Field: Cmd: mavlink command enum value
-// @Field: Cur: current flag from mavlink packet
-// @Field: AC: autocontinue flag from mavlink packet
 // @Field: P1: first parameter from mavlink packet
 // @Field: P2: second parameter from mavlink packet
 // @Field: P3: third parameter from mavlink packet
@@ -1249,7 +1249,7 @@ LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_CMD_MSG, sizeof(log_Cmd), \
       "CMD", "QHHHffffLLfB","TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt,Frame", "s-------DUm-", "F-------GG0-" }, \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \
-      "MAVC", "QBBBHBBffffiifBB","TimeUS,TS,TC,Fr,Cmd,Cur,AC,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
+      "MAVC", "QBBBBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4358,7 +4358,7 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
     // log the packet:
     mavlink_command_int_t packet_int;
     convert_COMMAND_LONG_to_COMMAND_INT(packet, packet_int);
-    AP::logger().Write_Command(packet_int, result, true);
+    AP::logger().Write_Command(packet_int, msg.sysid, msg.compid, result, true);
 
     hal.util->persistent_data.last_mavlink_cmd = 0;
 }
@@ -4545,7 +4545,7 @@ void GCS_MAVLINK::handle_command_int(const mavlink_message_t &msg)
                                  msg.sysid,
                                  msg.compid);
 
-    AP::logger().Write_Command(packet, result);
+    AP::logger().Write_Command(packet, msg.sysid, msg.compid, result);
 
     hal.util->persistent_data.last_mavlink_cmd = 0;
 }


### PR DESCRIPTION
We log mavlink commands as we execute them.  We did not include the source system and component - but these are potentially much more useful than the "Current" and "AutoContinue" flags.

I had to remove Current and AutoContinue because we can only have 16 fields.

This log was generated by autotest - it uses a sysid/compid of 250/250:

```
2021-09-04 16:39:17.01: MAVC {TimeUS : 6033419, TS : 1, TC : 1, SS : 250, SC : 250, Fr : 3, Cmd : 176, P1 : 1.0, P2 : 0.0, P3 : 0.0, P4 : 0.0, X : 0, Y : 0, Z : 0.0, Res : 0, WL : 1}
2021-09-04 16:39:18.04: MAVC {TimeUS : 7071337, TS : 1, TC : 1, SS : 250, SC : 250, Fr : 3, Cmd : 209, P1 : 2.0, P2 : 1.0, P3 : 1300.0, P4 : 2.0, X : 2, Y : 0, Z : 0.0, Res : 0, WL : 1}
2021-09-04 16:39:23.64: MAVC {TimeUS : 12670763, TS : 1, TC : 1, SS : 250, SC : 250, Fr : 3, Cmd : 209, P1 : 2.0, P2 : 0.0, P3 : 90.0999984741211, P4 : 2.0, X : 2, Y : 0, Z : 0.0, Res : 0, WL : 1}
```
