### PR TITLE
Tools: windows install scripts include arm-gcc install

### DIFF
--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -4,25 +4,31 @@ Import-Module BitsTransfer
 
 Write-Output "Starting Downloads"
 
-Write-Output "Downloading MAVProxy (1/6)"
+Write-Output "Downloading MAVProxy (1/8)"
 Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
 
-Write-Output "Downloading Cygwin x64 (2/6)"
+Write-Output "Downloading Cygwin x64 (2/8)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
-Write-Output "Installing Cygwin x64 (3/6)"
+Write-Output "Downloading ARM GCC Compiler 10-2020-Q4-Major (3/8)"
+Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-win32.exe" -Destination "$PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe"
+
+Write-Output "Installing Cygwin x64 (4/8)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd --quiet-mode"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
-Write-Output "Downloading extra Python packages (4/6)"
+Write-Output "Downloading extra Python packages (5/8)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"
 
-Write-Output "Downloading APM source (5/6)"
+Write-Output "Downloading APM source (6/8)"
 Copy-Item "APM_install.sh" -Destination "C:\cygwin64\home"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c ../APM_install.sh"
 
-Write-Output "Installing MAVProxy (6/6)"
+Write-Output "Installing ARM GCC Compiler 10-2020-Q4-Major (7/8)"
+& $PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe /S /P /R
+
+Write-Output "Installing MAVProxy (8/8)"
 & $PSScriptRoot\MAVProxySetup-latest.exe /SILENT | Out-Null
 
 Write-Host "Finished. Press any key to continue ..."

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -4,21 +4,27 @@ Import-Module BitsTransfer
 
 Write-Output "Starting Downloads"
 
-Write-Output "Downloading MAVProxy (1/5)"
+Write-Output "Downloading MAVProxy (1/7)"
 Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
 
-Write-Output "Downloading Cygwin x64 (2/5)"
+Write-Output "Downloading Cygwin x64 (2/7)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
-Write-Output "Installing Cygwin x64 (3/5)"
+Write-Output "Downloading ARM GCC Compiler 10-2020-Q4-Major (3/7)"
+Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-win32.exe" -Destination "$PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe"
+
+Write-Output "Installing Cygwin x64 (4/7)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
-Write-Output "Downloading extra Python packages (4/5)"
+Write-Output "Downloading extra Python packages (5/7)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"
 
-Write-Output "Installing MAVProxy (5/5)"
+Write-Output "Installing ARM GCC Compiler 10-2020-Q4-Major (6/7)"
+& $PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe /S /P /R
+
+Write-Output "Installing MAVProxy (7/7)"
 & $PSScriptRoot\MAVProxySetup-latest.exe /SILENT | Out-Null
 
 Write-Host "Finished. Press any key to continue ..."


### PR DESCRIPTION
This adds the latest arm compilers to the windows install scripts.  I'm not 100% how useful it is considering WSL is better for that purpose but if it saves some user support who insist on using cygwin...

https://discuss.ardupilot.org/t/using-eclipse-compile-errors-occur/75429/2?u=hendjosh

Tested by deleting my cygwin and uninstalling arm-gcc. And then compiling using Eclipse.
