### PR TITLE
Copter: move simple transform into mode class stop using set_control_in

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -599,34 +599,6 @@ void Copter::init_simple_bearing()
     }
 }
 
-// update_simple_mode - rotates pilot input if we are in simple mode
-void Copter::update_simple_mode(void)
-{
-    float rollx, pitchx;
-
-    // exit immediately if no new radio frame or not in simple mode
-    if (simple_mode == SimpleMode::NONE || !ap.new_radio_frame) {
-        return;
-    }
-
-    // mark radio frame as consumed
-    ap.new_radio_frame = false;
-
-    if (simple_mode == SimpleMode::SIMPLE) {
-        // rotate roll, pitch input by -initial simple heading (i.e. north facing)
-        rollx = channel_roll->get_control_in()*simple_cos_yaw - channel_pitch->get_control_in()*simple_sin_yaw;
-        pitchx = channel_roll->get_control_in()*simple_sin_yaw + channel_pitch->get_control_in()*simple_cos_yaw;
-    }else{
-        // rotate roll, pitch input by -super simple heading (reverse of heading to home)
-        rollx = channel_roll->get_control_in()*super_simple_cos_yaw - channel_pitch->get_control_in()*super_simple_sin_yaw;
-        pitchx = channel_roll->get_control_in()*super_simple_sin_yaw + channel_pitch->get_control_in()*super_simple_cos_yaw;
-    }
-
-    // rotate roll, pitch input from north facing to vehicle's perspective
-    channel_roll->set_control_in(rollx*ahrs.cos_yaw() + pitchx*ahrs.sin_yaw());
-    channel_pitch->set_control_in(-rollx*ahrs.sin_yaw() + pitchx*ahrs.cos_yaw());
-}
-
 // update_super_simple_bearing - adjusts simple bearing based on location
 // should be called after home_bearing has been updated
 void Copter::update_super_simple_bearing(bool force_update)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -347,7 +347,7 @@ private:
             uint8_t auto_armed              : 1; // 5       // stops auto missions from beginning until throttle is raised
             uint8_t logging_started         : 1; // 6       // true if logging has started
             uint8_t land_complete           : 1; // 7       // true if we have detected a landing
-            uint8_t new_radio_frame         : 1; // 8       // Set true if we have new PWM data to act on from the Radio
+            uint8_t new_radio_frame         : 1; // 8       // UNUSED
             uint8_t usb_connected_unused    : 1; // 9       // UNUSED
             uint8_t rc_receiver_present     : 1; // 10      // true if we have an rc receiver present (i.e. if we've ever received an update
             uint8_t compass_mot             : 1; // 11      // true if we are currently performing compassmot calibration
@@ -666,7 +666,6 @@ private:
     void three_hz_loop();
     void one_hz_loop();
     void init_simple_bearing();
-    void update_simple_mode(void);
     void update_super_simple_bearing(bool force_update);
     void read_AHRS(void);
     void update_altitude();

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -409,6 +409,8 @@ void Mode::get_pilot_desired_lean_angles(float &roll_out, float &pitch_out, floa
     roll_out = channel_roll->get_control_in();
     pitch_out = channel_pitch->get_control_in();
 
+    apply_simple_mode(roll_out, pitch_out);
+
     // limit max lean angle
     angle_limit = constrain_float(angle_limit, 1000.0f, angle_max);
 
@@ -619,9 +621,6 @@ void Mode::land_run_horizontal_control()
         }
 
         if (g.land_repositioning) {
-            // apply SIMPLE mode transform to pilot inputs
-            update_simple_mode();
-
             // convert pilot input to lean angles
             get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
 
@@ -959,8 +958,29 @@ float Mode::get_non_takeoff_throttle()
     return copter.get_non_takeoff_throttle();
 }
 
-void Mode::update_simple_mode(void) {
-    copter.update_simple_mode();
+// apply_simple_mode - rotates pilot input if we are in simple mode
+void Mode::apply_simple_mode(float& roll, float& pitch) const
+{
+    // exit immediately if not in simple mode
+    if (!allows_simple() || copter.simple_mode == Copter::SimpleMode::NONE) {
+        return;
+    }
+
+    float rollx, pitchx;
+
+    if (copter.simple_mode == Copter::SimpleMode::SIMPLE) {
+        // rotate roll, pitch input by -initial simple heading (i.e. north facing)
+        rollx =  roll*copter.simple_cos_yaw - pitch*copter.simple_sin_yaw;
+        pitchx = roll*copter.simple_sin_yaw + pitch*copter.simple_cos_yaw;
+    } else {
+        // rotate roll, pitch input by -super simple heading (reverse of heading to home)
+        rollx  = roll*copter.super_simple_cos_yaw - pitch*copter.super_simple_sin_yaw;
+        pitchx = roll*copter.super_simple_sin_yaw + pitch*copter.super_simple_cos_yaw;
+    }
+
+    // rotate roll, pitch input from north facing to vehicle's perspective
+    roll  =  rollx*ahrs.cos_yaw() + pitchx*ahrs.sin_yaw();
+    pitch = -rollx*ahrs.sin_yaw() + pitchx*ahrs.cos_yaw();
 }
 
 bool Mode::set_mode(Mode::Number mode, ModeReason reason)

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -66,6 +66,7 @@ public:
     virtual bool allows_save_trim() const { return false; }
     virtual bool allows_autotune() const { return false; }
     virtual bool allows_flip() const { return false; }
+    virtual bool allows_simple() const { return false; }
 
     // return a string for this flightmode
     virtual const char *name() const = 0;
@@ -260,12 +261,14 @@ public:
     };
     static AutoYaw auto_yaw;
 
+    // apply simple/supper-simple transform to roll and pitch
+    void apply_simple_mode(float& roll, float& pitch) const;
+
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle(void);
-    void update_simple_mode(void);
     bool set_mode(Mode::Number mode, ModeReason reason);
     void set_land_complete(bool b);
     GCS_Copter &gcs();
@@ -357,6 +360,7 @@ public:
     }
     bool allows_autotune() const override { return true; }
     bool allows_flip() const override { return true; }
+    bool allows_simple() const override { return true; }
 
 protected:
 
@@ -620,6 +624,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; }
     bool is_autopilot() const override { return false; }
+    bool allows_simple() const override { return true; }
 
     void save_tuning_gains();
     void reset();
@@ -789,6 +794,7 @@ public:
         return !must_navigate;
     }
     bool allows_flip() const override { return true; }
+    bool allows_simple() const override { return true; }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -1000,6 +1006,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return true; }
+    bool allows_simple() const override { return true; }
 
     bool is_landing() const override { return true; };
 
@@ -1043,6 +1050,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool allows_autotune() const override { return true; }
+    bool allows_simple() const override { return true; }
 
 #if PRECISION_LANDING == ENABLED
     void set_precision_loiter_enabled(bool value) { _precision_loiter_enabled = value; }
@@ -1087,6 +1095,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool allows_autotune() const override { return true; }
+    bool allows_simple() const override { return true; }
 
 protected:
 
@@ -1172,6 +1181,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return true; }
+    bool allows_simple() const override { return true; }
 
     bool requires_terrain_failsafe() const override { return true; }
 
@@ -1337,6 +1347,7 @@ public:
     bool has_user_takeoff(bool must_navigate) const override {
         return !must_navigate;
     }
+    bool allows_simple() const override { return true; }
 
 protected:
 
@@ -1364,6 +1375,7 @@ public:
     bool allows_save_trim() const override { return true; }
     bool allows_autotune() const override { return true; }
     bool allows_flip() const override { return true; }
+    bool allows_simple() const override { return true; }
 
 protected:
 
@@ -1405,6 +1417,7 @@ public:
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return false; }
     bool logs_attitude() const override { return true; }
+    bool allows_simple() const override { return true; }
 
     void set_magnitude(float input) { waveform_magnitude = input; }
 
@@ -1636,6 +1649,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return true; }
     bool is_autopilot() const override { return true; }
+    bool allows_simple() const override { return true; }
 
     // save current position as A or B.  If both A and B have been saved move to the one specified
     void save_or_move_to_destination(Destination ab_dest);

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -28,9 +28,6 @@ void ModeAltHold::run()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
-    // apply SIMPLE mode transform to pilot inputs
-    update_simple_mode();
-
     // get pilot desired lean angles
     float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max());

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -35,9 +35,6 @@ bool AutoTune::init()
 
 void AutoTune::run()
 {
-    // apply SIMPLE mode transform to pilot inputs
-    copter.update_simple_mode();
-
     // reset target lean angles and heading while landed
     if (copter.ap.land_complete) {
         // we are landed, shut down

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -233,9 +233,6 @@ void ModeFlowHold::run()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
-    // apply SIMPLE mode transform to pilot inputs
-    update_simple_mode();
-
     // check for filter change
     if (!is_equal(flow_filter.get_cutoff_freq(), flow_filter_hz.get())) {
         flow_filter.set_cutoff_frequency(flow_filter_hz.get());
@@ -311,8 +308,11 @@ void ModeFlowHold::run()
     Vector2f bf_angles;
 
     // calculate alt-hold angles
-    int16_t roll_in = copter.channel_roll->get_control_in();
-    int16_t pitch_in = copter.channel_pitch->get_control_in();
+    float roll_in = copter.channel_roll->get_control_in();
+    float pitch_in = copter.channel_pitch->get_control_in();
+
+    apply_simple_mode(roll_in, pitch_in);
+
     float angle_max = copter.aparm.angle_max;
     get_pilot_desired_lean_angles(bf_angles.x, bf_angles.y, angle_max, attitude_control->get_althold_lean_angle_max());
 
@@ -321,7 +321,7 @@ void ModeFlowHold::run()
         // don't use for first 3s when we are just taking off
         Vector2f flow_angles;
 
-        flowhold_flow_to_angle(flow_angles, (roll_in != 0) || (pitch_in != 0));
+        flowhold_flow_to_angle(flow_angles, !is_zero(roll_in) || !is_zero(pitch_in));
         flow_angles.x = constrain_float(flow_angles.x, -angle_max/2, angle_max/2);
         flow_angles.y = constrain_float(flow_angles.y, -angle_max/2, angle_max/2);
         bf_angles += flow_angles;

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -106,9 +106,6 @@ void ModeLand::nogps_run()
         }
 
         if (g.land_repositioning) {
-            // apply SIMPLE mode transform to pilot inputs
-            update_simple_mode();
-
             // get pilot desired lean angles
             get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max());
         }

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -11,8 +11,6 @@ bool ModeLoiter::init(bool ignore_checks)
 {
     if (!copter.failsafe.radio) {
         float target_roll, target_pitch;
-        // apply SIMPLE mode transform to pilot inputs
-        update_simple_mode();
 
         // convert pilot input to lean angles
         get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
@@ -86,9 +84,6 @@ void ModeLoiter::run()
 
     // process pilot inputs unless we are in radio failsafe
     if (!copter.failsafe.radio) {
-        // apply SIMPLE mode transform to pilot inputs
-        update_simple_mode();
-
         // convert pilot input to lean angles
         get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
 

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -75,9 +75,6 @@ void ModePosHold::run()
     pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
     loiter_nav->clear_pilot_desired_acceleration();
 
-    // apply SIMPLE mode transform to pilot inputs
-    update_simple_mode();
-
     // convert pilot input to lean angles
     float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max());

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -315,9 +315,6 @@ void ModeRTL::descent_run()
         }
 
         if (g.land_repositioning) {
-            // apply SIMPLE mode transform to pilot inputs
-            update_simple_mode();
-
             // convert pilot input to lean angles
             get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
 

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -28,14 +28,13 @@ void ModeSport::run()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
-    // apply SIMPLE mode transform
-    update_simple_mode();
-
     // get pilot's desired roll and pitch rates
 
     // calculate rate requests
     float target_roll_rate = channel_roll->get_control_in() * g.acro_rp_p;
     float target_pitch_rate = channel_pitch->get_control_in() * g.acro_rp_p;
+
+    apply_simple_mode(target_roll_rate, target_pitch_rate);
 
     // get attitude targets
     const Vector3f att_target = attitude_control->get_att_target_euler_cd();

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -8,9 +8,6 @@
 // should be called at 100hz or more
 void ModeStabilize::run()
 {
-    // apply simple mode transform to pilot inputs
-    update_simple_mode();
-
     // convert pilot input to lean angles
     float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -22,9 +22,6 @@ void ModeStabilize_Heli::run()
     float target_yaw_rate;
     float pilot_throttle_scaled;
 
-    // apply SIMPLE mode transform to pilot inputs
-    update_simple_mode();
-
     // convert pilot input to lean angles
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -106,9 +106,6 @@ bool ModeSystemId::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeSystemId::run()
 {
-    // apply simple mode transform to pilot inputs
-    update_simple_mode();
-
     // convert pilot input to lean angles
     float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -68,9 +68,6 @@ ModeZigZag::ModeZigZag(void) : Mode()
 bool ModeZigZag::init(bool ignore_checks)
 {
     if (!copter.failsafe.radio) {
-        // apply simple mode transform to pilot inputs
-        update_simple_mode();
-
         // convert pilot input to lean angles
         float target_roll, target_pitch;
         get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
@@ -296,9 +293,6 @@ void ModeZigZag::manual_control()
     // process pilot inputs unless we are in radio failsafe
     if (!copter.failsafe.radio) {
         float target_roll, target_pitch;
-        // apply SIMPLE mode transform to pilot inputs
-        update_simple_mode();
-
         // convert pilot input to lean angles
         get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -83,8 +83,6 @@ void Copter::read_radio()
     const uint32_t tnow_ms = millis();
 
     if (rc().read_input()) {
-        ap.new_radio_frame = true;
-
         set_throttle_and_failsafe(channel_throttle->get_radio_in());
         set_throttle_zero_flag(channel_throttle->get_control_in());
 


### PR DESCRIPTION
Fixes #1658 and a step towards https://github.com/ArduPilot/ardupilot/issues/17915 by removing uses of set_control_in

