### PR TITLE
Copter: Move "land_run_horizontal_control()" to use position controller for Prec Land 

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -357,6 +357,7 @@ private:
             uint8_t unused3                 : 1; // 25      // was compass_init_location; true when the compass's initial location has been set
             uint8_t unused2                 : 1; // 26      // aux switch rc_override is allowed
             uint8_t armed_with_airmode_switch : 1; // 27      // we armed using a arming switch
+            uint8_t prec_land_active        : 1; // 28      // true if precland is active
         };
         uint32_t value;
     } ap_t;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1079,6 +1079,7 @@ private:
 
 #if PRECISION_LANDING == ENABLED
     bool _precision_loiter_enabled;
+    bool _precision_loiter_active; // true if user has switched on prec loiter
 #endif
 
 };

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -335,6 +335,12 @@ void ModeAuto::land_start(const Vector2f& destination)
     // disable the fence on landing
     copter.fence.auto_disable_fence_for_landing();
 #endif
+
+    // reset flag indicating if pilot has applied roll or pitch inputs during landing
+    copter.ap.land_repo_active = false;
+
+    // this will be set true if prec land is later active
+    copter.ap.prec_land_active = false;
 }
 
 // auto_circle_movetoedge_start - initialise waypoint controller to move to edge of a circle with it's center at the specified location

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -28,6 +28,9 @@ bool ModeLand::init(bool ignore_checks)
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
 
+    // this will be set true if prec land is later active
+    copter.ap.prec_land_active = false;
+
     // initialise yaw
     auto_yaw.set_mode(AUTO_YAW_HOLD);
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -25,6 +25,9 @@ bool ModeRTL::init(bool ignore_checks)
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
 
+    // this will be set true if prec land is later active
+    copter.ap.prec_land_active = false;
+
 #if PRECISION_LANDING == ENABLED
     // initialise precland state machine
     copter.precland_statemachine.init();

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -162,6 +162,13 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Units: m
     AP_GROUPINFO("ALT_MAX", 16, AC_PrecLand, _sensor_max_alt, 8),
 
+    // @Param: MOVING
+    // @DisplayName: Precision Landing Target stationary/moving
+    // @Description: Precision Landing Target stationary/moving
+    // @Values: 0:Stationary, 1:Moving
+    // @User: Advanced
+    AP_GROUPINFO("MOVING", 17, AC_PrecLand, _moving, 0),
+
     AP_GROUPEND
 };
 
@@ -410,6 +417,31 @@ bool AC_PrecLand::get_target_velocity_relative_cms(Vector2f& ret)
     }
     ret = _target_vel_rel_out_NE*100.0f;
     return true;
+}
+
+// get the absolute velocity of the vehicle
+void AC_PrecLand::get_target_velocity_cms(const Vector2f& vehicle_velocity_cms, Vector2f& target_vel_cms)
+{
+    if (!_moving) {
+        // the target should not be moving
+        target_vel_cms.zero();
+        return;
+    }
+    if ((EstimatorType)_estimator_type.get() == EstimatorType::RAW_SENSOR) {
+        // We do not predict the velocity of the target in this case
+        // assume velocity to be zero
+        target_vel_cms.zero();
+        return;
+    }
+    Vector2f target_vel_rel_cms;
+    if (!get_target_velocity_relative_cms(target_vel_rel_cms)) {
+        // Don't know where the target is
+        // assume velocity to be zero
+        target_vel_cms.zero();
+        return;
+    }
+    // return the absolute velocity
+    target_vel_cms  = target_vel_rel_cms + vehicle_velocity_cms;
 }
 
 // handle_msg - Process a LANDING_TARGET mavlink message

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -72,6 +72,9 @@ public:
     // returns target velocity relative to vehicle
     bool get_target_velocity_relative_cms(Vector2f& ret);
 
+    // get the absolute velocity of the vehicle
+    void get_target_velocity_cms(const Vector2f& vehicle_velocity_cms, Vector2f& target_vel_cms);
+
     // returns true when the landing target has been detected
     bool target_acquired();
 
@@ -165,6 +168,7 @@ private:
     AP_Int8                     _retry_behave;      // Action to do when trying a landing retry
     AP_Float                    _sensor_min_alt;     // PrecLand minimum height required for detecting target
     AP_Float                    _sensor_max_alt;     // PrecLand maximum height the sensor can detect target
+    AP_Int8                     _moving;             // True if the landing target is moving (non-stationary)
 
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently after estimator is initialized


### PR DESCRIPTION
This is a rework of #18111
It keeps the Loiter control for repositioning however uses the updated position controller for Prec Landing