### PR TITLE
AP_MSP: removed unstructured writes to msp dst buffer

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -618,13 +618,13 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_comp_gps(sbuf_t *dst)
         uint16_t dist_home_m;
         uint16_t home_angle_deg;
         uint8_t toggle_gps;
-    } p;
+    } gps;
 
-    p.dist_home_m = home_state.home_distance_m;
-    p.home_angle_deg = home_angle_deg;
-    p.toggle_gps = 1;
+    gps.dist_home_m = home_state.home_distance_m;
+    gps.home_angle_deg = home_angle_deg;
+    gps.toggle_gps = 1;
 
-    sbuf_write_data(dst, &p, sizeof(p));
+    sbuf_write_data(dst, &gps, sizeof(gps));
 
     return MSP_RESULT_ACK;
 }
@@ -710,25 +710,26 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_name(sbuf_t *dst)
 
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_status(sbuf_t *dst)
 {
-    const uint32_t mode_bitmask = get_osd_flight_mode_bitmask();
-    sbuf_write_u16(dst, 0);                     // task delta time
-    sbuf_write_u16(dst, 0);                     // I2C error count
-    sbuf_write_u16(dst, 0);                     // sensor status
-    sbuf_write_data(dst, &mode_bitmask, 4);     // unconditional part of flags, first 32 bits
-    sbuf_write_u8(dst, 0);
 
-    sbuf_write_u16(dst, constrain_int16(0, 0, 100));  //system load
-    sbuf_write_u16(dst, 0);                     // gyro cycle time
+    struct PACKED {
+        uint16_t task_delta_time;
+        uint16_t i2c_error_count;
+        uint16_t sensor_status;
+        uint32_t flight_mode_flags;
+        uint8_t pid_profile;
+        uint16_t system_load;
+        uint16_t gyro_cycle_time;
+        uint8_t box_mode_flags;
+        uint8_t arming_disable_flags_count;
+        uint32_t arming_disable_flags;
+        uint8_t extra_flags;
+    } status {};
 
-    // Cap BoxModeFlags to 32 bits
-    sbuf_write_u8(dst, 0);
+    status.flight_mode_flags = get_osd_flight_mode_bitmask();
+    status.arming_disable_flags_count = 1;
+    status.arming_disable_flags = !AP::notify().flags.armed;
 
-    // Write arming disable flags
-    sbuf_write_u8(dst, 1);
-    sbuf_write_u32(dst, !AP::notify().flags.armed);
-
-    // Extra flags
-    sbuf_write_u8(dst, 0);
+    sbuf_write_data(dst, &status, sizeof(status));
     return MSP_RESULT_ACK;
 }
 
@@ -744,25 +745,40 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_osd_config(sbuf_t *dst)
     if (msp == nullptr) {
         return MSP_RESULT_ERROR;
     }
-    sbuf_write_u8(dst, OSD_FLAGS_OSD_FEATURE);                      // flags
-    sbuf_write_u8(dst, 0);                                          // video system
+    struct PACKED {
+        uint8_t flags;
+        uint8_t video_system;
+        uint8_t units;
+        uint8_t rssi_alarm;
+        uint16_t capacity_alarm;
+        uint8_t unused_0;
+        uint8_t item_count;
+        uint16_t alt_alarm;
+        uint16_t items_position[OSD_ITEM_COUNT];
+        uint8_t stats_items_count;
+        uint16_t stats_items[OSD_STAT_COUNT] ;
+        uint8_t timers_count;
+        uint16_t timers[OSD_TIMER_COUNT];
+        uint16_t enabled_warnings_old;
+        uint8_t warnings_count_new;
+        uint32_t enabled_warnings_new;
+        uint8_t available_profiles;
+        uint8_t selected_profile;
+        uint8_t osd_stick_overlay;
+    } osd_config {};
+
     // Configuration
-    uint8_t units = OSD_UNIT_METRIC;
+    osd_config.units = OSD_UNIT_METRIC;
 #if OSD_ENABLED
-    units = osd->units == AP_OSD::UNITS_METRIC ? OSD_UNIT_METRIC : OSD_UNIT_IMPERIAL;
+    osd_config.units = osd->units == AP_OSD::UNITS_METRIC ? OSD_UNIT_METRIC : OSD_UNIT_IMPERIAL;
 #endif
-
-    sbuf_write_u8(dst, units);                                 // units
     // Alarms
-    sbuf_write_u8(dst, msp->_osd_config.rssi_alarm);                 // rssi alarm
-    sbuf_write_u16(dst, msp->_osd_config.cap_alarm);                 // capacity alarm
+    osd_config.rssi_alarm = msp->_osd_config.rssi_alarm;
+    osd_config.capacity_alarm = msp->_osd_config.cap_alarm;
+    osd_config.alt_alarm = msp->_osd_config.alt_alarm;
     // Reuse old timer alarm (U16) as OSD_ITEM_COUNT
-    sbuf_write_u8(dst, 0);
-    sbuf_write_u8(dst, OSD_ITEM_COUNT);                             // osd items count
-
-    sbuf_write_u16(dst, msp->_osd_config.alt_alarm);                 // altitude alarm
-
-    // element position and visibility
+    osd_config.item_count = OSD_ITEM_COUNT;
+    // Element position and visibility
     uint16_t pos = 0;   // default is hide this element
     for (uint8_t i = 0; i < OSD_ITEM_COUNT; i++) {
         pos = 0;    // 0 is hide this item
@@ -774,43 +790,27 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_osd_config(sbuf_t *dst)
                 }
             }
         }
-        sbuf_write_u16(dst, pos);
+        osd_config.items_position[i] = pos;
     }
-
-    // post flight statistics
-    sbuf_write_u8(dst, OSD_STAT_COUNT);                         // stats items count
-    for (uint8_t i = 0; i < OSD_STAT_COUNT; i++ ) {
-        sbuf_write_u16(dst, 0);                                 // stats not supported
-    }
-
-    // timers
-    sbuf_write_u8(dst, OSD_TIMER_COUNT);                      // timers
-    for (uint8_t i = 0; i < OSD_TIMER_COUNT; i++) {
-        // no timer support
-        sbuf_write_u16(dst, 0);
-    }
-
+    // Post flight statistics
+    osd_config.stats_items_count = OSD_STAT_COUNT;             // stats items count
+    // Timers
+    osd_config.timers_count = OSD_TIMER_COUNT;                      // timers
     // Enabled warnings
     // API < 1.41
     // Send low word first for backwards compatibility
-    sbuf_write_u16(dst, (uint16_t)(msp->_osd_config.enabled_warnings & 0xFFFF)); // Enabled warnings
+    osd_config.enabled_warnings_old = (uint16_t)(msp->_osd_config.enabled_warnings & 0xFFFF);
     // API >= 1.41
     // Send the warnings count and 32bit enabled warnings flags.
     // Add currently active OSD profile (0 indicates OSD profiles not available).
     // Add OSD stick overlay mode (0 indicates OSD stick overlay not available).
-    sbuf_write_u8(dst, OSD_WARNING_COUNT);            // warning count
-    sbuf_write_u32(dst, msp->_osd_config.enabled_warnings);  // enabled warning
-
+    osd_config.warnings_count_new = OSD_WARNING_COUNT;
+    osd_config.enabled_warnings_new = msp->_osd_config.enabled_warnings;
     // If the feature is not available there is only 1 profile and it's always selected
-    sbuf_write_u8(dst, 1);    // available profiles
-    sbuf_write_u8(dst, 1);    // selected profile
+    osd_config.available_profiles = 1;
+    osd_config.selected_profile = 1;
 
-    sbuf_write_u8(dst, 0);    // OSD stick overlay
-
-    // API >= 1.43
-    // Add the camera frame element width/height
-    //sbuf_write_u8(dst, osdConfig()->camera_frame_width);
-    //sbuf_write_u8(dst, osdConfig()->camera_frame_height);
+    sbuf_write_data(dst, &osd_config, sizeof(osd_config));
     return MSP_RESULT_ACK;
 }
 
@@ -838,8 +838,15 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_altitude(sbuf_t *dst)
     home_state_t home_state;
     update_home_pos(home_state);
 
-    sbuf_write_u32(dst, home_state.rel_altitude_cm);                // relative altitude cm
-    sbuf_write_u16(dst, int16_t(get_vspeed_ms() * 100));            // climb rate cm/s
+    struct PACKED {
+        int32_t rel_altitude_cm;    // relative altitude cm
+        int16_t vspeed_cms;         // climb rate cm/s
+    } altitude {};
+
+    altitude.rel_altitude_cm = home_state.rel_altitude_cm;
+    altitude.vspeed_cms = int16_t(get_vspeed_ms() * 100);
+
+    sbuf_write_data(dst, &altitude, sizeof(altitude));
     return MSP_RESULT_ACK;
 }
 
@@ -906,16 +913,24 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_esc_sensor_data(sbuf_t *d
 #if HAL_WITH_ESC_TELEM
     AP_ESC_Telem& telem = AP::esc_telem();
     if (telem.get_last_telem_data_ms(0)) {
-        const uint8_t num_motors = telem.get_num_active_escs();
-        sbuf_write_u8(dst, num_motors);
-        for (uint8_t i = 0; i < num_motors; i++) {
+        struct PACKED {
+            uint8_t num_motors;
+            struct PACKED {
+                uint8_t temp;
+                uint16_t rpm;
+            } data[ESC_TELEM_MAX_ESCS];
+        } esc_sensor {};
+
+        esc_sensor.num_motors = telem.get_num_active_escs();
+        for (uint8_t i = 0; i < esc_sensor.num_motors; i++) {
             int16_t temp = 0;
             float rpm = 0.0f;
             telem.get_rpm(i, rpm);
             telem.get_temperature(i, temp);
-            sbuf_write_u8(dst, uint8_t(temp / 100));        // deg
-            sbuf_write_u16(dst, uint16_t(rpm * 0.1));
+            esc_sensor.data[i].temp = uint8_t(temp * 0.01f);
+            esc_sensor.data[i].rpm = uint16_t(rpm * 0.1f);
         }
+        sbuf_write_data(dst, &esc_sensor, 1 + 3*esc_sensor.num_motors);
     }
 #endif
     return MSP_RESULT_ACK;
@@ -981,11 +996,22 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_board_info(sbuf_t *dst)
 {
     const AP_FWVersion &fwver = AP::fwversion();
 
+    struct PACKED {
+        uint16_t hw_revision;
+        uint8_t aio_flags;
+        uint8_t capabilities;
+        uint8_t fw_string_len;
+    } fw_info {};
+
+#if HAL_WITH_OSD_BITMAP
+    fw_info.aio_flags = 2; // 2 == FC with MAX7456
+#else
+    fw_info.aio_flags = 0; // 0 == FC without MAX7456
+#endif
+    fw_info.fw_string_len = strlen(fwver.fw_string);
+
     sbuf_write_data(dst, "ARDU", BOARD_IDENTIFIER_LENGTH);
-    sbuf_write_u16(dst, 0);
-    sbuf_write_u8(dst, 0);
-    sbuf_write_u8(dst, 0);
-    sbuf_write_u8(dst, strlen(fwver.fw_string));
+    sbuf_write_data(dst, &fw_info, sizeof(fw_info));
     sbuf_write_data(dst, fwver.fw_string, strlen(fwver.fw_string));
     return MSP_RESULT_ACK;
 }

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -608,24 +608,23 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_comp_gps(sbuf_t *dst)
     update_home_pos(home_state);
 
     // no need to apply yaw compensation, the DJI air unit will do it for us :-)
-    int32_t home_angle_deg = home_state.home_bearing_cd * 0.01;
+    uint16_t angle_deg = home_state.home_bearing_cd * 0.01;
     if (home_state.home_distance_m < 2) {
         //avoid fast rotating arrow at small distances
-        home_angle_deg = 0;
+        angle_deg = 0;
     }
 
-    struct PACKED {
+    const struct PACKED {
         uint16_t dist_home_m;
         uint16_t home_angle_deg;
         uint8_t toggle_gps;
-    } gps;
-
-    gps.dist_home_m = home_state.home_distance_m;
-    gps.home_angle_deg = home_angle_deg;
-    gps.toggle_gps = 1;
+    } gps {
+        dist_home_m : uint16_t(constrain_int32(home_state.home_distance_m, 0, 0xFFFF)),
+        home_angle_deg : angle_deg,
+        toggle_gps : 1
+    };
 
     sbuf_write_data(dst, &gps, sizeof(gps));
-
     return MSP_RESULT_ACK;
 }
 
@@ -819,15 +818,15 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_attitude(sbuf_t *dst)
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
 
-    struct PACKED {
+    const struct PACKED {
         int16_t roll;
         int16_t pitch;
         int16_t yaw;
-    } attitude;
-
-    attitude.roll = ahrs.roll_sensor * 0.1;     // centidegress to decidegrees
-    attitude.pitch = ahrs.pitch_sensor * 0.1;   // centidegress to decidegrees
-    attitude.yaw = ahrs.yaw_sensor * 0.01;      // centidegress to degrees
+    } attitude {
+        roll : int16_t(ahrs.roll_sensor * 0.1),     // centidegress to decidegrees
+        pitch : int16_t(ahrs.pitch_sensor * 0.1),   // centidegress to decidegrees
+        yaw : int16_t(ahrs.yaw_sensor * 0.01)       // centidegress to degrees
+    };
 
     sbuf_write_data(dst, &attitude, sizeof(attitude));
     return MSP_RESULT_ACK;
@@ -838,13 +837,13 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_altitude(sbuf_t *dst)
     home_state_t home_state;
     update_home_pos(home_state);
 
-    struct PACKED {
+    const struct PACKED {
         int32_t rel_altitude_cm;    // relative altitude cm
         int16_t vspeed_cms;         // climb rate cm/s
-    } altitude {};
-
-    altitude.rel_altitude_cm = home_state.rel_altitude_cm;
-    altitude.vspeed_cms = int16_t(get_vspeed_ms() * 100);
+    } altitude {
+        rel_altitude_cm : home_state.rel_altitude_cm,
+        vspeed_cms : int16_t(get_vspeed_ms() * 100)
+    };
 
     sbuf_write_data(dst, &altitude, sizeof(altitude));
     return MSP_RESULT_ACK;
@@ -859,19 +858,19 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_analog(sbuf_t *dst)
     battery_state_t battery_state;
     update_battery_state(battery_state);
 
-    struct PACKED {
+    const struct PACKED {
         uint8_t voltage_dv;
         uint16_t mah;
         uint16_t rssi;
         int16_t current_ca;
         uint16_t voltage_cv;
-    } battery;
-
-    battery.voltage_dv = constrain_int16(battery_state.batt_voltage_v * 10, 0, 255);            // battery voltage V to dV
-    battery.mah = constrain_int32(battery_state.batt_consumed_mah, 0, 0xFFFF);                  // milliamp hours drawn from battery
-    battery.rssi = rssi->enabled() ? rssi->read_receiver_rssi() * 1023 : 0;                     // rssi 0-1 to 0-1023
-    battery.current_ca = constrain_int32(battery_state.batt_current_a * 100, -0x8000, 0x7FFF);  // current A to cA (0.01 steps, range is -320A to 320A)
-    battery.voltage_cv = constrain_int32(battery_state.batt_voltage_v * 100,0,0xFFFF);          // battery voltage in 0.01V steps
+    } battery {
+        voltage_dv : (uint8_t)constrain_int16(battery_state.batt_voltage_v * 10, 0, 255),                   // battery voltage V to dV
+        mah : (uint16_t)constrain_int32(battery_state.batt_consumed_mah, 0, 0xFFFF),                        // milliamp hours drawn from battery
+        rssi : uint16_t(rssi->enabled() ? rssi->read_receiver_rssi() * 1023 : 0),                           // rssi 0-1 to 0-1023
+        current_ca : (int16_t)constrain_int32(battery_state.batt_current_a * 100, -0x8000, 0x7FFF),         // current A to cA (0.01 steps, range is -320A to 320A)
+        voltage_cv : (uint16_t)constrain_int32(battery_state.batt_voltage_v * 100,0,0xFFFF)                 // battery voltage in 0.01V steps
+    };
 
     sbuf_write_data(dst, &battery, sizeof(battery));
     return MSP_RESULT_ACK;
@@ -886,7 +885,7 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_battery_state(sbuf_t *dst
     battery_state_t battery_state;
     update_battery_state(battery_state);
 
-    struct PACKED {
+    const struct PACKED {
         uint8_t cellcount;
         uint16_t capacity_mah;
         uint8_t voltage_dv;
@@ -894,15 +893,15 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_battery_state(sbuf_t *dst
         int16_t current_ca;
         uint8_t state;
         uint16_t voltage_cv;
-    } battery;
-
-    battery.cellcount = constrain_int16((msp->_cellcount > 0 ? msp->_cellcount : battery_state.batt_cellcount), 0, 255);    // cell count 0 indicates battery not detected.
-    battery.capacity_mah = battery_state.batt_capacity_mah;                                                                          // in mAh
-    battery.voltage_dv = constrain_int16(battery_state.batt_voltage_v * 10, 0, 255);                                        // battery voltage V to dV
-    battery.mah = MIN(battery_state.batt_consumed_mah, 0xFFFF);                                                             // milliamp hours drawn from battery
-    battery.current_ca = constrain_int32(battery_state.batt_current_a * 100, -0x8000, 0x7FFF);                              // current A to cA (0.01 steps, range is -320A to 320A)
-    battery.state = battery_state.batt_state;                                                                               // BATTERY: OK=0, CRITICAL=2
-    battery.voltage_cv = constrain_int32(battery_state.batt_voltage_v * 100, 0, 0x7FFF);                                    // battery voltage in 0.01V steps
+    } battery {
+        cellcount : (uint8_t)constrain_int16((msp->_cellcount > 0 ? msp->_cellcount : battery_state.batt_cellcount), 0, 255),   // cell count 0 indicates battery not detected.
+        capacity_mah : (uint16_t)battery_state.batt_capacity_mah,                                                               // in mAh
+        voltage_dv : (uint8_t)constrain_int16(battery_state.batt_voltage_v * 10, 0, 255),                                       // battery voltage V to dV
+        mah : (uint16_t)MIN(battery_state.batt_consumed_mah, 0xFFFF),                                                           // milliamp hours drawn from battery
+        current_ca : (int16_t)constrain_int32(battery_state.batt_current_a * 100, -0x8000, 0x7FFF),                             // current A to cA (0.01 steps, range is -320A to 320A)
+        state : (uint8_t)battery_state.batt_state,                                                                              // BATTERY: OK=0, CRITICAL=2
+        voltage_cv : (uint16_t)constrain_int32(battery_state.batt_voltage_v * 100, 0, 0x7FFF)                                   // battery voltage in 0.01V steps
+    };
 
     sbuf_write_data(dst, &battery, sizeof(battery));
     return MSP_RESULT_ACK;
@@ -944,7 +943,7 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rtc(sbuf_t *dst)
         const time_t time_sec = time_usec / 1000000;
         localtime_tm = *gmtime(&time_sec);
     }
-    struct PACKED {
+    const struct PACKED {
         uint16_t year;
         uint8_t mon;
         uint8_t mday;
@@ -952,15 +951,15 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rtc(sbuf_t *dst)
         uint8_t min;
         uint8_t sec;
         uint16_t millis;
-    } rtc;
-
-    rtc.year = localtime_tm.tm_year + 1900;   // tm_year is relative to year 1900
-    rtc.mon = localtime_tm.tm_mon + 1;        // MSP requires [1-12] months
-    rtc.mday = localtime_tm.tm_mday;
-    rtc.hour = localtime_tm.tm_hour;
-    rtc.min = localtime_tm.tm_min;
-    rtc.sec = localtime_tm.tm_sec;
-    rtc.millis = (time_usec / 1000U) % 1000U;
+    } rtc {
+        year : uint16_t(localtime_tm.tm_year + 1900),   // tm_year is relative to year 1900
+        mon : uint8_t(localtime_tm.tm_mon + 1),        // MSP requires [1-12] months
+        mday : uint8_t(localtime_tm.tm_mday),
+        hour : uint8_t(localtime_tm.tm_hour),
+        min : uint8_t(localtime_tm.tm_min),
+        sec : uint8_t(localtime_tm.tm_sec),
+        millis : uint16_t((time_usec / 1000U) % 1000U)
+    };
 
     sbuf_write_data(dst, &rtc, sizeof(rtc));
     return MSP_RESULT_ACK;
@@ -975,18 +974,19 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rc(sbuf_t *dst)
     uint16_t values[16] = {};
     rc().get_radio_in(values, ARRAY_SIZE(values));
 
-    struct PACKED {
+    const struct PACKED {
         uint16_t a;
         uint16_t e;
         uint16_t r;
         uint16_t t;
-    } rc;
-    // send only 4 channels, MSP order is AERT
-    // note: rcmap channels start at 1
-    rc.a = values[rcmap->roll()-1];       // A
-    rc.e = values[rcmap->pitch()-1];      // E
-    rc.r = values[rcmap->yaw()-1];        // R
-    rc.t = values[rcmap->throttle()-1];   // T
+    } rc {
+        // send only 4 channels, MSP order is AERT
+        // note: rcmap channels start at 1
+        a : values[rcmap->roll()-1],       // A
+        e : values[rcmap->pitch()-1],      // E
+        r : values[rcmap->yaw()-1],        // R
+        t : values[rcmap->throttle()-1]    // T
+    };
 
     sbuf_write_data(dst, &rc, sizeof(rc));
     return MSP_RESULT_ACK;
@@ -1143,10 +1143,7 @@ void AP_MSP_Telem_Backend::msp_displayport_draw_screen()
 
 void AP_MSP_Telem_Backend::msp_displayport_write_string(uint8_t col, uint8_t row, bool blink, const char *string)
 {
-    int len = strlen(string);
-    if (len >= OSD_MSP_DISPLAYPORT_MAX_STRING_LENGTH) {
-        len = OSD_MSP_DISPLAYPORT_MAX_STRING_LENGTH;
-    }
+    const uint8_t len = strnlen(string, OSD_MSP_DISPLAYPORT_MAX_STRING_LENGTH);
 
     struct PACKED {
         uint8_t sub_cmd;

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -576,6 +576,44 @@ void AP_MSP_Telem_Backend::msp_handle_airspeed(const MSP::msp_airspeed_data_mess
 #endif
 }
 
+MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_api_version(sbuf_t *dst)
+{
+    const struct {
+        uint8_t proto;
+        uint8_t major;
+        uint8_t minor;
+    } api_version  {
+        proto : MSP_PROTOCOL_VERSION,
+        major : API_VERSION_MAJOR,
+        minor : API_VERSION_MINOR
+    };
+
+    sbuf_write_data(dst, &api_version, sizeof(api_version));
+    return MSP_RESULT_ACK;
+}
+
+MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_fc_version(sbuf_t *dst)
+{
+    const struct {
+        uint8_t major;
+        uint8_t minor;
+        uint8_t patch;
+    } fc_version {
+        major : FC_VERSION_MAJOR,
+        minor : FC_VERSION_MINOR,
+        patch : FC_VERSION_PATCH_LEVEL
+    };
+
+    sbuf_write_data(dst, &fc_version, sizeof(fc_version));
+    return MSP_RESULT_ACK;
+}
+
+MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_fc_variant(sbuf_t *dst)
+{
+    sbuf_write_data(dst, "ARDU", FLIGHT_CONTROLLER_IDENTIFIER_LENGTH);
+    return MSP_RESULT_ACK;
+}
+
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_raw_gps(sbuf_t *dst)
 {
 #if OSD_ENABLED

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.h
@@ -191,9 +191,9 @@ protected:
     virtual AP_SerialManager::SerialProtocol get_serial_protocol() const = 0;
 
     // implementation specific MSP out command processing
-    virtual MSP::MSPCommandResult msp_process_out_api_version(MSP::sbuf_t *dst) = 0;
-    virtual MSP::MSPCommandResult msp_process_out_fc_version(MSP::sbuf_t *dst) = 0;
-    virtual MSP::MSPCommandResult msp_process_out_fc_variant(MSP::sbuf_t *dst) = 0;
+    virtual MSP::MSPCommandResult msp_process_out_api_version(MSP::sbuf_t *dst);
+    virtual MSP::MSPCommandResult msp_process_out_fc_version(MSP::sbuf_t *dst);
+    virtual MSP::MSPCommandResult msp_process_out_fc_variant(MSP::sbuf_t *dst);
     virtual MSP::MSPCommandResult msp_process_out_uid(MSP::sbuf_t *dst);
     virtual MSP::MSPCommandResult msp_process_out_board_info(MSP::sbuf_t *dst);
     virtual MSP::MSPCommandResult msp_process_out_build_info(MSP::sbuf_t *dst);

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -84,15 +84,15 @@ uint32_t AP_MSP_Telem_DJI::get_osd_flight_mode_bitmask(void)
 
 MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_api_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t proto;
         uint8_t major;
         uint8_t minor;
-    } api_version;
-
-    api_version.proto = MSP_PROTOCOL_VERSION;
-    api_version.major = API_VERSION_MAJOR;
-    api_version.minor = API_VERSION_MINOR;
+    } api_version  {
+        proto : MSP_PROTOCOL_VERSION,
+        major : API_VERSION_MAJOR,
+        minor : API_VERSION_MINOR
+    };
 
     sbuf_write_data(dst, &api_version, sizeof(api_version));
     return MSP_RESULT_ACK;
@@ -100,15 +100,15 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_api_version(sbuf_t *dst)
 
 MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_fc_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t major;
         uint8_t minor;
         uint8_t patch;
-    } fc_version;
-
-    fc_version.major = FC_VERSION_MAJOR;
-    fc_version.minor = FC_VERSION_MINOR;
-    fc_version.patch = FC_VERSION_PATCH_LEVEL;
+    } fc_version {
+        major : FC_VERSION_MAJOR,
+        minor : FC_VERSION_MINOR,
+        patch : FC_VERSION_PATCH_LEVEL
+    };
 
     sbuf_write_data(dst, &fc_version, sizeof(fc_version));
     return MSP_RESULT_ACK;
@@ -129,13 +129,14 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
         int16_t highest_temperature = 0;
         telem.get_highest_motor_temperature(highest_temperature);
 
-        struct PACKED {
+        const struct PACKED {
             uint8_t temp;
             uint16_t rpm;
-        } esc_sensor_data {};
+        } esc_sensor_data {
+            temp : uint8_t(highest_temperature * 0.01f),            // deg, report max temperature
+            rpm : uint16_t(telem.get_average_motor_rpm() * 0.1f)    // rpm, report average RPM across all motors
+        };
 
-        esc_sensor_data.temp = uint8_t(highest_temperature * 0.01f);            // deg, report max temperature
-        esc_sensor_data.rpm = uint16_t(telem.get_average_motor_rpm() * 0.1f);   // rpm, report average RPM across all motors
         sbuf_write_data(dst, &esc_sensor_data, sizeof(esc_sensor_data));
     } else {
         return AP_MSP_Telem_Backend::msp_process_out_esc_sensor_data(dst);

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -128,8 +128,15 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
         AP_ESC_Telem& telem = AP::esc_telem();
         int16_t highest_temperature = 0;
         telem.get_highest_motor_temperature(highest_temperature);
-        sbuf_write_u8(dst, uint8_t(highest_temperature / 100));         // deg, report max temperature
-        sbuf_write_u16(dst, uint16_t(telem.get_average_motor_rpm() * 0.1f));  // rpm, report average RPM across all motors
+
+        struct PACKED {
+            uint8_t temp;
+            uint16_t rpm;
+        } esc_sensor_data {};
+
+        esc_sensor_data.temp = uint8_t(highest_temperature * 0.01f);            // deg, report max temperature
+        esc_sensor_data.rpm = uint16_t(telem.get_average_motor_rpm() * 0.1f);   // rpm, report average RPM across all motors
+        sbuf_write_data(dst, &esc_sensor_data, sizeof(esc_sensor_data));
     } else {
         return AP_MSP_Telem_Backend::msp_process_out_esc_sensor_data(dst);
     }

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -82,38 +82,6 @@ uint32_t AP_MSP_Telem_DJI::get_osd_flight_mode_bitmask(void)
     return mode_mask;
 }
 
-MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_api_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t proto;
-        uint8_t major;
-        uint8_t minor;
-    } api_version  {
-        proto : MSP_PROTOCOL_VERSION,
-        major : API_VERSION_MAJOR,
-        minor : API_VERSION_MINOR
-    };
-
-    sbuf_write_data(dst, &api_version, sizeof(api_version));
-    return MSP_RESULT_ACK;
-}
-
-MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_fc_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t major;
-        uint8_t minor;
-        uint8_t patch;
-    } fc_version {
-        major : FC_VERSION_MAJOR,
-        minor : FC_VERSION_MINOR,
-        patch : FC_VERSION_PATCH_LEVEL
-    };
-
-    sbuf_write_data(dst, &fc_version, sizeof(fc_version));
-    return MSP_RESULT_ACK;
-}
-
 MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_fc_variant(sbuf_t *dst)
 {
     sbuf_write_data(dst, "BTFL", FLIGHT_CONTROLLER_IDENTIFIER_LENGTH);

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.h
@@ -55,8 +55,6 @@ public:
     AP_SerialManager::SerialProtocol get_serial_protocol() const override { return AP_SerialManager::SerialProtocol::SerialProtocol_DJI_FPV; };
     uint32_t get_osd_flight_mode_bitmask(void) override;
     void hide_osd_items(void) override;
-    MSP::MSPCommandResult msp_process_out_api_version(MSP::sbuf_t *dst) override;
-    MSP::MSPCommandResult msp_process_out_fc_version(MSP::sbuf_t *dst) override;
     MSP::MSPCommandResult msp_process_out_fc_variant(MSP::sbuf_t *dst) override;
     MSP::MSPCommandResult msp_process_out_esc_sensor_data(MSP::sbuf_t *dst) override;
 

--- a/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.cpp
@@ -25,38 +25,6 @@ extern const AP_HAL::HAL& hal;
 
 using namespace MSP;
 
-MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_api_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t proto;
-        uint8_t major;
-        uint8_t minor;
-    } api_version  {
-        proto : MSP_PROTOCOL_VERSION,
-        major : API_VERSION_MAJOR,
-        minor : API_VERSION_MINOR
-    };
-
-    sbuf_write_data(dst, &api_version, sizeof(api_version));
-    return MSP_RESULT_ACK;
-}
-
-MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_fc_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t major;
-        uint8_t minor;
-        uint8_t patch;
-    } fc_version {
-        major : FC_VERSION_MAJOR,
-        minor : FC_VERSION_MINOR,
-        patch : FC_VERSION_PATCH_LEVEL
-    };
-
-    sbuf_write_data(dst, &fc_version, sizeof(fc_version));
-    return MSP_RESULT_ACK;
-}
-
 MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_fc_variant(sbuf_t *dst)
 {
     const AP_MSP *msp = AP::msp();

--- a/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.cpp
@@ -27,15 +27,15 @@ using namespace MSP;
 
 MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_api_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t proto;
         uint8_t major;
         uint8_t minor;
-    } api_version;
-
-    api_version.proto = MSP_PROTOCOL_VERSION;
-    api_version.major = API_VERSION_MAJOR;
-    api_version.minor = API_VERSION_MINOR;
+    } api_version  {
+        proto : MSP_PROTOCOL_VERSION,
+        major : API_VERSION_MAJOR,
+        minor : API_VERSION_MINOR
+    };
 
     sbuf_write_data(dst, &api_version, sizeof(api_version));
     return MSP_RESULT_ACK;
@@ -43,15 +43,15 @@ MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_api_version(sbuf_t *d
 
 MSPCommandResult AP_MSP_Telem_DisplayPort::msp_process_out_fc_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t major;
         uint8_t minor;
         uint8_t patch;
-    } fc_version;
-
-    fc_version.major = FC_VERSION_MAJOR;
-    fc_version.minor = FC_VERSION_MINOR;
-    fc_version.patch = FC_VERSION_PATCH_LEVEL;
+    } fc_version {
+        major : FC_VERSION_MAJOR,
+        minor : FC_VERSION_MINOR,
+        patch : FC_VERSION_PATCH_LEVEL
+    };
 
     sbuf_write_data(dst, &fc_version, sizeof(fc_version));
     return MSP_RESULT_ACK;

--- a/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_DisplayPort.h
@@ -28,8 +28,6 @@ public:
     bool use_msp_thread() const override { return false; }
     AP_SerialManager::SerialProtocol get_serial_protocol() const override { return AP_SerialManager::SerialProtocol::SerialProtocol_MSP_DisplayPort; };
 
-    MSP::MSPCommandResult msp_process_out_api_version(MSP::sbuf_t *dst) override;
-    MSP::MSPCommandResult msp_process_out_fc_version(MSP::sbuf_t *dst) override;
     MSP::MSPCommandResult msp_process_out_fc_variant(MSP::sbuf_t *dst) override;
 };
 

--- a/libraries/AP_MSP/AP_MSP_Telem_Generic.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Generic.cpp
@@ -27,15 +27,15 @@ using namespace MSP;
 
 MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_api_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t proto;
         uint8_t major;
         uint8_t minor;
-    } api_version;
-
-    api_version.proto = MSP_PROTOCOL_VERSION;
-    api_version.major = API_VERSION_MAJOR;
-    api_version.minor = API_VERSION_MINOR;
+    } api_version  {
+        proto : MSP_PROTOCOL_VERSION,
+        major : API_VERSION_MAJOR,
+        minor : API_VERSION_MINOR
+    };
 
     sbuf_write_data(dst, &api_version, sizeof(api_version));
     return MSP_RESULT_ACK;
@@ -43,15 +43,15 @@ MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_api_version(sbuf_t *dst)
 
 MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_fc_version(sbuf_t *dst)
 {
-    struct {
+    const struct {
         uint8_t major;
         uint8_t minor;
         uint8_t patch;
-    } fc_version;
-
-    fc_version.major = FC_VERSION_MAJOR;
-    fc_version.minor = FC_VERSION_MINOR;
-    fc_version.patch = FC_VERSION_PATCH_LEVEL;
+    } fc_version {
+        major : FC_VERSION_MAJOR,
+        minor : FC_VERSION_MINOR,
+        patch : FC_VERSION_PATCH_LEVEL
+    };
 
     sbuf_write_data(dst, &fc_version, sizeof(fc_version));
     return MSP_RESULT_ACK;

--- a/libraries/AP_MSP/AP_MSP_Telem_Generic.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Generic.cpp
@@ -25,42 +25,4 @@ extern const AP_HAL::HAL& hal;
 
 using namespace MSP;
 
-MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_api_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t proto;
-        uint8_t major;
-        uint8_t minor;
-    } api_version  {
-        proto : MSP_PROTOCOL_VERSION,
-        major : API_VERSION_MAJOR,
-        minor : API_VERSION_MINOR
-    };
-
-    sbuf_write_data(dst, &api_version, sizeof(api_version));
-    return MSP_RESULT_ACK;
-}
-
-MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_fc_version(sbuf_t *dst)
-{
-    const struct {
-        uint8_t major;
-        uint8_t minor;
-        uint8_t patch;
-    } fc_version {
-        major : FC_VERSION_MAJOR,
-        minor : FC_VERSION_MINOR,
-        patch : FC_VERSION_PATCH_LEVEL
-    };
-
-    sbuf_write_data(dst, &fc_version, sizeof(fc_version));
-    return MSP_RESULT_ACK;
-}
-
-MSPCommandResult AP_MSP_Telem_Generic::msp_process_out_fc_variant(sbuf_t *dst)
-{
-    sbuf_write_data(dst, "ARDU", FLIGHT_CONTROLLER_IDENTIFIER_LENGTH);
-    return MSP_RESULT_ACK;
-}
-
 #endif //HAL_MSP_ENABLED

--- a/libraries/AP_MSP/AP_MSP_Telem_Generic.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Generic.h
@@ -26,9 +26,6 @@ class AP_MSP_Telem_Generic : public AP_MSP_Telem_Backend
 public:
     bool is_scheduler_enabled() const override { return false; }
     AP_SerialManager::SerialProtocol get_serial_protocol() const override { return AP_SerialManager::SerialProtocol::SerialProtocol_MSP; };
-    MSP::MSPCommandResult msp_process_out_api_version(MSP::sbuf_t *dst) override;
-    MSP::MSPCommandResult msp_process_out_fc_version(MSP::sbuf_t *dst) override;
-    MSP::MSPCommandResult msp_process_out_fc_variant(MSP::sbuf_t *dst) override;
 };
 
 #endif //HAL_MSP_ENABLED

--- a/libraries/AP_MSP/msp_sbuf.cpp
+++ b/libraries/AP_MSP/msp_sbuf.cpp
@@ -33,32 +33,6 @@ void MSP::sbuf_switch_to_reader(sbuf_t *buf, uint8_t *base)
     buf->ptr = base;
 }
 
-void MSP::sbuf_write_u8(sbuf_t *dst, uint8_t val)
-{
-    if (!sbuf_check_bounds(dst, 1)) {
-        return;
-    }
-    *dst->ptr++ = val;
-}
-
-void MSP::sbuf_write_u16(sbuf_t *dst, uint16_t val)
-{
-    if (!sbuf_check_bounds(dst, 2)) {
-        return;
-    }
-    put_le16_ptr(dst->ptr, val);
-    dst->ptr += 2;
-}
-
-void MSP::sbuf_write_u32(sbuf_t *dst, uint32_t val)
-{
-    if (!sbuf_check_bounds(dst, 4)) {
-        return;
-    }
-    put_le32_ptr(dst->ptr, val);
-    dst->ptr += 4;
-}
-
 void MSP::sbuf_write_data(sbuf_t *dst, const void *data, int len)
 {
     if (!sbuf_check_bounds(dst, len)) {

--- a/libraries/AP_MSP/msp_sbuf.h
+++ b/libraries/AP_MSP/msp_sbuf.h
@@ -19,9 +19,6 @@ uint8_t* sbuf_ptr(sbuf_t *buf);
 uint16_t sbuf_bytes_remaining(const sbuf_t *buf);
 bool sbuf_check_bounds(const sbuf_t *buf, const uint8_t len);
 void sbuf_switch_to_reader(sbuf_t *buf, uint8_t *base);
-void sbuf_write_u8(sbuf_t *dst, uint8_t val);
-void sbuf_write_u16(sbuf_t *dst, uint16_t val);
-void sbuf_write_u32(sbuf_t *dst, uint32_t val);
 void sbuf_write_data(sbuf_t *dst, const void *data, int len);
 }
 


### PR DESCRIPTION
This removes 3 methods that allowed unstructured writes to the msp destination buffer:

sbuf_write_u8()
sbuf_write_u16()
sbuf_write_u32()

Where possible it also uses const structures and brace initializations.

It has a nice side effect of saving about 400 bytes on a matek H743 plane build