### PR TITLE
SITL: Add build sitl32 option for SITL, autotests, & unit tests

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -609,8 +609,21 @@ class sitl(Board):
                 '-fno-slp-vectorize' # compiler bug when trying to use SLP
             ]
 
+        if cfg.options.sitl_32bit:
+            # 32bit platform flags
+            env.CXXFLAGS += [
+                '-m32',
+            ]
+            env.CFLAGS += [
+                '-m32',
+            ]
+            env.LDFLAGS += [
+                '-m32',
+            ]
+
     def get_name(self):
         return self.__class__.__name__
+
 
 class sitl_periph_gps(sitl):
     def configure_env(self, cfg, env):

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -435,6 +435,7 @@ def run_step(step):
         "postype_single": opts.postype_single,
         "extra_configure_args": opts.waf_configure_args,
         "coverage": opts.coverage,
+        "sitl_32bit" : opts.sitl_32bit,
     }
 
     if opts.Werror:
@@ -938,6 +939,11 @@ if __name__ == "__main__":
                            action="store_true",
                            dest="ekf_single",
                            help="force single precision EKF")
+    group_build.add_option("--sitl-32bit",
+                           default=False,
+                           action='store_true',
+                           dest="sitl_32bit",
+                           help="compile sitl using 32-bit")
     parser.add_option_group(group_build)
 
     group_sim = optparse.OptionGroup(parser, "Simulation options")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1220,7 +1220,8 @@ class AutoTest(ABC):
                  force_ahrs_type=None,
                  replay=False,
                  sup_binaries=[],
-                 reset_after_every_test=False):
+                 reset_after_every_test=False,
+                 sitl_32bit=False):
 
         self.start_time = time.time()
         global __autotest__ # FIXME; make progress a non-staticmethod
@@ -1244,6 +1245,7 @@ class AutoTest(ABC):
             self.speedup = self.default_speedup()
         self.sup_binaries = sup_binaries
         self.reset_after_every_test = reset_after_every_test
+        self.sitl_32bit = sitl_32bit
 
         self.mavproxy = None
         self._mavproxy = None  # for auto-cleanup on failed tests

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -96,7 +96,7 @@ def relwaf():
     return "./modules/waf/waf-light"
 
 
-def waf_configure(board, j=None, debug=False, math_check_indexes=False, coverage=False, ekf_single=False, postype_single=False, extra_args=[]):
+def waf_configure(board, j=None, debug=False, math_check_indexes=False, coverage=False, ekf_single=False, postype_single=False, sitl_32bit=False, extra_args=[]):
     cmd_configure = [relwaf(), "configure", "--board", board]
     if debug:
         cmd_configure.append('--debug')
@@ -108,6 +108,8 @@ def waf_configure(board, j=None, debug=False, math_check_indexes=False, coverage
         cmd_configure.append('--ekf-single')
     if postype_single:
         cmd_configure.append('--postype-single')
+    if sitl_32bit:
+        cmd_configure.append('--sitl-32bit')
     if j is not None:
         cmd_configure.extend(['-j', str(j)])
     pieces = [shlex.split(x) for x in extra_args]
@@ -121,8 +123,7 @@ def waf_clean():
 
 
 def build_SITL(build_target, j=None, debug=False, board='sitl', clean=True, configure=True, math_check_indexes=False, coverage=False,
-               ekf_single=False, postype_single=False, extra_configure_args=[]):
-    """Build desktop SITL."""
+               ekf_single=False, postype_single=False, sitl_32bit=False, extra_configure_args=[]):
 
     # first configure
     if configure:
@@ -133,6 +134,7 @@ def build_SITL(build_target, j=None, debug=False, board='sitl', clean=True, conf
                       ekf_single=ekf_single,
                       postype_single=postype_single,
                       coverage=coverage,
+                      sitl_32bit=sitl_32bit,
                       extra_args=extra_configure_args)
 
     # then clean
@@ -148,7 +150,7 @@ def build_SITL(build_target, j=None, debug=False, board='sitl', clean=True, conf
 
 
 def build_examples(board, j=None, debug=False, clean=False, configure=True, math_check_indexes=False, coverage=False,
-                   ekf_single=False, postype_single=False,
+                   ekf_single=False, postype_single=False, sitl_32bit=False,
                    extra_configure_args=[]):
     # first configure
     if configure:
@@ -159,6 +161,7 @@ def build_examples(board, j=None, debug=False, clean=False, configure=True, math
                       ekf_single=ekf_single,
                       postype_single=postype_single,
                       coverage=coverage,
+                      sitl_32bit=sitl_32bit,
                       extra_args=extra_configure_args)
 
     # then clean
@@ -184,7 +187,8 @@ def build_replay(board, j=None, debug=False, clean=False):
     return True
 
 def build_tests(board, j=None, debug=False, clean=False, configure=True, math_check_indexes=False, coverage=False,
-                ekf_single=False, postype_single=False, extra_configure_args=[]):
+                ekf_single=False, postype_single=False, sitl_32bit=False, extra_configure_args=[]):
+
     # first configure
     if configure:
         waf_configure(board,
@@ -194,6 +198,7 @@ def build_tests(board, j=None, debug=False, clean=False, configure=True, math_ch
                       ekf_single=ekf_single,
                       postype_single=postype_single,
                       coverage=coverage,
+                      sitl_32bit=sitl_32bit,
                       extra_args=extra_configure_args)
 
     # then clean

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -341,6 +341,9 @@ def do_build(opts, frame_options):
     if opts.ekf_single:
         cmd_configure.append("--ekf-single")
 
+    if opts.sitl_32bit:
+        cmd_configure.append("--sitl-32bit")
+
     pieces = [shlex.split(x) for x in opts.waf_configure_args]
     for piece in pieces:
         cmd_configure.extend(piece)
@@ -919,6 +922,11 @@ group_build.add_option("--enable-math-check-indexes",
                        action="store_true",
                        dest="math_check_indexes",
                        help="enable checking of math indexes")
+group_build.add_option("", "--sitl-32bit",
+                       default=False,
+                       action='store_true',
+                       dest="sitl_32bit",
+                       help="compile sitl using 32-bit")
 group_build.add_option("", "--rebuild-on-failure",
                        dest="rebuild_on_failure",
                        action='store_true',

--- a/libraries/SITL/SIM_MS5611.cpp
+++ b/libraries/SITL/SIM_MS5611.cpp
@@ -59,13 +59,13 @@ void MS5611::convert(float P_Pa, float Temp_C, uint32_t &D1, uint32_t &D2)
     // second order temperature compensation when under 20 degrees C
     if (TEMP < 2000) {
         // Solve the quadratic equation for D2 when TEMP < 2000
-        D2 = 128 * (2 * prom[5] - sqrt(sq(prom[6]) - 131072 * (TEMP - 2000)) + prom[6]);
+        D2 = 128 * (2 * int64_t(prom[5]) - sqrt(sq(int64_t(prom[6])) - 131072 * (TEMP - 2000)) + int64_t(prom[6]));
 
         // Must compute the pressure compensation values using D2
-        const float dT = float(D2) - (prom[5] << Q5);
-        float TEMP_forward = 2000 + (dT * prom[6]) / (1L << Q6);
-        float OFF  = prom[2] * (1L << Q2) + (prom[4] * dT) / (1L << Q4);
-        float SENS = prom[1] * (1L << Q1) + (prom[3] * dT) / (1L << Q3);
+        const float dT = float(D2) - (int64_t(prom[5]) << Q5);
+        float TEMP_forward = 2000 + (dT * int64_t(prom[6])) / (1L << Q6);
+        float OFF  = int64_t(prom[2]) * (1L << Q2) + (int64_t(prom[4]) * dT) / (1L << Q4);
+        float SENS = int64_t(prom[1]) * (1L << Q1) + (int64_t(prom[3]) * dT) / (1L << Q3);
 
         const float Aux = sq(TEMP_forward - 2000);
         float OFF2  = 2.5 * Aux;
@@ -81,12 +81,12 @@ void MS5611::convert(float P_Pa, float Temp_C, uint32_t &D1, uint32_t &D2)
 
         D1 = ((P_Pa * float(1L << 15) + OFF) * float(1L << 21)) / SENS;
     } else {
-        const float dT = (TEMP - 2000) * (1L << Q6) / prom[6];
-        const float OFF  = prom[2] * (1L << Q2) + (prom[4] * dT) / (1L << Q4);
-        const float SENS = prom[1] * (1L << Q1) + (prom[3] * dT) / (1L << Q3);
+        const float dT = (TEMP - 2000) * (1L << Q6) / int64_t(prom[6]);
+        const float OFF  = int64_t(prom[2]) * (1L << Q2) + (int64_t(prom[4]) * dT) / (1L << Q4);
+        const float SENS = int64_t(prom[1]) * (1L << Q1) + (int64_t(prom[3]) * dT) / (1L << Q3);
 
         D1 = ((P_Pa * float(1L << 15) + OFF) * float(1L << 21)) / SENS;
-        D2 = dT + (prom[5] << Q5);
+        D2 = dT + (int64_t(prom[5]) << Q5);
     }
 }
 

--- a/libraries/SITL/tests/test_sim_ms5611.cpp
+++ b/libraries/SITL/tests/test_sim_ms5611.cpp
@@ -63,8 +63,10 @@ TEST(MS5611, convert)
         uint32_t D1;
         uint32_t D2;
         ms5611.convert_pub(elem.P_Pa, elem.Temp_C, D1, D2);
-        EXPECT_EQ(D1, elem.D1);
-        EXPECT_EQ(D2, elem.D2);
+
+        // Expect NEAR here instead of EQ because in 32bit they are off by 1
+        EXPECT_NEAR(D1, elem.D1, 1);
+        EXPECT_NEAR(D2, elem.D2, 1);
     }
 }
 

--- a/wscript
+++ b/wscript
@@ -242,6 +242,10 @@ configuration in order to save typing.
                  default=False,
                  help="Enable SITL RGBLed")
 
+    g.add_option('--sitl-32bit', action='store_true',
+                 default=False,
+                 help="Enable SITL 32bit")
+
     g.add_option('--build-dates', action='store_true',
                  default=False,
                  help="Include build date in binaries.  Appears in AUTOPILOT_VERSION.os_sw_version")
@@ -331,6 +335,7 @@ def configure(cfg):
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
     cfg.env.COVERAGE = cfg.options.coverage
+    cfg.env.SITL32BIT = cfg.options.sitl_32bit
     cfg.env.ENABLE_ASSERTS = cfg.options.enable_asserts
     cfg.env.BOOTLOADER = cfg.options.bootloader
     cfg.env.ENABLE_MALLOC_GUARD = cfg.options.enable_malloc_guard
@@ -414,6 +419,12 @@ def configure(cfg):
 
     cfg.start_msg('Coverage build')
     if cfg.env.COVERAGE:
+        cfg.end_msg('enabled')
+    else:
+        cfg.end_msg('disabled', color='YELLOW')
+
+    cfg.start_msg('SITL 32-bit build')
+    if cfg.env.SITL32BIT:
         cfg.end_msg('enabled')
     else:
         cfg.end_msg('disabled', color='YELLOW')


### PR DESCRIPTION
This adds a `sitl_32bit` board to allow easier compiling of sitl, autotest, unit tests, etc using the flag `--sitl-32bit`

Unit_tests: Tested and found my addition to the MS5611's simulated driver was missing int64_t() in 4 spots so I fixed that as well here.

Autotest: I built with this option using plane & copter and then ran `test.Plane.AirspeedDrivers` & `test.Copter.BaroDrivers`

simvehicle.py: tested it built and launched with copter and plane 

I think I got all the spots that hard coded `\sitl` but possibly I missed some cases or some caveats?

Also there are probably betters ways to do this? But no better way to learn the build system then to try :)