### PR TITLE
SITL: update simpleRover C++ JSON interface example

### DIFF
--- a/libraries/SITL/examples/JSON/C++/CMakeLists.txt
+++ b/libraries/SITL/examples/JSON/C++/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(minimal)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(minimal
+  minimal.cpp
+)
+
+add_executable(simpleRover
+  simpleRover.cpp
+)

--- a/libraries/SITL/examples/JSON/C++/readme.md
+++ b/libraries/SITL/examples/JSON/C++/readme.md
@@ -5,3 +5,41 @@ This library links a simulator written in C++ with ArduPilot through a UDP JSON 
 Connection to SITL is made via a UDP link. The physics backend should listen for incoming messages on port 9002. The sim should then reply to the IP and port the messages were received from. This is handled by libAP_JSON. This removes the need to configure the target IP and port for SITL in the physics backend. ArduPilot SITL will send an output message every 10 seconds allowing the physics backend to auto-detect.
 
 After a connection has been made, the optional values should be set. Then the vehicle state can be sent with `SendState`. This call includes all of the required values. The `servo_out` array supports 16 servo outputs from ArduPilot.
+
+### Running the `simpleRover` example
+
+The examples can be built using `cmake`:
+
+```bash
+$ mkdir build && cd build
+$ cmake ..
+$ make
+```
+
+Run the `simpleRover` physics engine:
+
+```bash
+$ ./simpleRover
+```
+
+Run SITL with the JSON backend:
+
+```bash
+sim_vehicle.py -v Rover -f JSON --console --map
+```
+
+The rover responds to throttle commands on RC channel 3:
+
+```bash
+# arm throttle
+MANUAL> arm throttle
+
+# move forwards at max throttle (expected velocity 1 m/s)
+MANUAL> rc 3 1900
+
+# move backwards at max throttle (expected velocity -1 m/s)
+MANUAL> rc 3 1100
+
+# stop
+MANUAL> rc 3 1500
+```

--- a/libraries/SITL/examples/JSON/C++/simpleRover.cpp
+++ b/libraries/SITL/examples/JSON/C++/simpleRover.cpp
@@ -59,7 +59,7 @@ bool simpleRover::update(simpleRover &rover, uint16_t servo_out[]) {
 
     // how fast is the rover moving
     double max_velocity = 1; // m/s
-    double body_v = _interp1D(servo_out[0], 1100, 1900, 0, max_velocity);
+    double body_v = _interp1D(servo_out[2], 1100, 1900, -max_velocity, max_velocity);
 
     // how fast is the rover turning
     // Just doing 1-D right now. This Needs a bit of system dynamics math and geometry to get to 2-D.


### PR DESCRIPTION
This PR adds some minor enhancements to the simpleRover C++ JSON interface example 

- Add a CMakeLists.txt file to help with cross-platform builds.
- Modify the simpleRover example to respond to throttle commands on RC channel 3 (default for Rover) and move backwards as well as forwards.
- Add more detail to the readme doc.
