### PR TITLE
AP_Scripting: Only use messages that are useful for debugging

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -54,7 +54,6 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
     if (int error = luaL_loadfile(L, filename)) {
         switch (error) {
             case LUA_ERRSYNTAX:
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Syntax error in %s", filename);
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Lua: Error: %s", lua_tostring(L, -1));
                 lua_pop(L, lua_gettop(L));
                 return nullptr;


### PR DESCRIPTION
I see two error messages at the same time.
I think one is enough.
I leave only the detailed error message.

AFTER
![Screenshot from 2021-09-08 23-25-28](https://user-images.githubusercontent.com/646194/132529213-d2b86a83-4daf-41ad-8c2c-45d3873eec59.png)

BEFORE
![Screenshot from 2021-09-08 23-23-12](https://user-images.githubusercontent.com/646194/132529185-0e77e248-9d98-48cb-a00c-61e0a3dd5f5d.png)
