### PR TITLE
Rover: rework limit flags, reset slew rates in E-stop, rework omni motor saturation

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -381,7 +381,12 @@ void Rover::update_current_mode(void)
     // check for emergency stop
     if (SRV_Channels::get_emergency_stop()) {
         // relax controllers, motor stopping done at output level
-        g2.attitude_control.relax_I();
+        g2.attitude_control.get_throttle_speed_pid().reset_I();
+        g2.attitude_control.get_pitch_to_throttle_pid().reset_I();
+        if (!rover.g2.sailboat.sail_enabled()) {
+            // sailboats can still move along in E-stop, so dont reset I
+            g2.attitude_control.get_steering_rate_pid().reset_I();
+        }
     }
 
     control_mode->update();

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -843,11 +843,3 @@ float AR_AttitudeControl::get_stopping_distance(float speed) const
     // assume linear deceleration
     return 0.5f * sq(speed) / accel_max;
 }
-
-// relax I terms of throttle and steering controllers
-void AR_AttitudeControl::relax_I()
-{
-    _steer_rate_pid.reset_I();
-    _throttle_speed_pid.reset_I();
-    _pitch_to_throttle_pid.reset_I();
-}

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -148,9 +148,6 @@ public:
     // get speed below which vehicle is considered stopped (in m/s)
     float get_stop_speed() const { return MAX(_stop_speed, 0.0f); }
 
-    // relax I terms of throttle and steering controllers
-    void relax_I();
-
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -295,8 +295,21 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
     // soft-armed overrides passed in armed status
     if (!hal.util->get_soft_armed()) {
         armed = false;
-        _throttle = 0.0f;
+        _throttle = 0.0;
+        _throttle_prev = 0.0;
     }
+
+    const bool E_stop = SRV_Channels::get_emergency_stop();
+    if (E_stop) {
+        _throttle = 0.0;
+        _throttle_prev = 0.0;
+    }
+
+    // reset limit flags
+    limit.steer_left = false;
+    limit.steer_right = false;
+    limit.throttle_lower = !(armed || E_stop);
+    limit.throttle_upper = !(armed || E_stop);
 
     // sanity check parameters
     sanity_check_parameters();
@@ -306,6 +319,17 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
 
     // output for regular steering/throttle style frames
     output_regular(armed, ground_speed, _steering, _throttle);
+
+    if (armed || E_stop) {
+        // Skid and Omni both use motors to actuate sterring
+        // no point in trying in e-stop
+        _steering = 0.0;
+        if (have_skid_steering() || is_omni()) {
+            // if output type setup then set limit flags
+            limit.steer_left = true;
+            limit.steer_right = true;
+        }
+    }
 
     // output for skid steering style frames
     output_skid_steering(armed, _steering, _throttle, dt);
@@ -714,9 +738,9 @@ void AP_MotorsUGV::output_regular(bool armed, float ground_speed, float steering
         }
     }
 
-    // clear and set limits based on input
+    // Set limits based on input
     // we do this here because vectored thrust or speed scaling may have reduced steering request
-    set_limits_from_input(armed, steering, throttle);
+    set_limits_from_input(steering, throttle);
 
     // constrain steering
     steering = constrain_float(steering, -4500.0f, 4500.0f);
@@ -733,7 +757,7 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
     }
 
     // clear and set limits based on input
-    set_limits_from_input(armed, steering, throttle);
+    set_limits_from_input(steering, throttle);
 
     // constrain steering
     steering = constrain_float(steering, -4500.0f, 4500.0f);
@@ -772,6 +796,10 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
             throttle_scaled *= linear_interpolate(fair_scaler, 1.0f, 0.5f - str_thr_mix, 0.0f, 0.5f);
             steering_scaled = (1.0f - fabsf(throttle_scaled)) * (is_negative(steering_scaled) ? -1.0f : 1.0f);
         }
+        limit.steer_left = true;
+        limit.steer_right = true;
+        limit.throttle_lower = true;
+        limit.throttle_upper = true;
     }
 
     // add in throttle and steering
@@ -787,13 +815,13 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
 void AP_MotorsUGV::output_omni(bool armed, float steering, float throttle, float lateral)
 {
     // exit immediately if the frame type is set to UNDEFINED
-    if (_frame_type == FRAME_TYPE_UNDEFINED) {
+    if (!is_omni()) {
         return;
     }
 
     if (armed) {
         // clear and set limits based on input
-        set_limits_from_input(armed, steering, throttle);
+        set_limits_from_input(steering, throttle);
 
         // constrain steering
         steering = constrain_float(steering, -4500.0f, 4500.0f);
@@ -809,11 +837,19 @@ void AP_MotorsUGV::output_omni(bool armed, float steering, float throttle, float
             thr_str_ltr_out = (scaled_throttle * _throttle_factor[i]) +
                               (scaled_steering * _steering_factor[i]) +
                               (scaled_lateral * _lateral_factor[i]);
-            if (fabsf(thr_str_ltr_out) > thr_str_ltr_max) {
-                thr_str_ltr_max = fabsf(thr_str_ltr_out);
-            }
-
-            float output_vectored = (thr_str_ltr_out / thr_str_ltr_max);
+            thr_str_ltr_max = MAX(thr_str_ltr_max, fabsf(thr_str_ltr_out));
+        }
+        const float output_vectored = 1 / thr_str_ltr_max;
+        if (output_vectored < 1.0) {
+            limit.steer_left = true;
+            limit.steer_right = true;
+            limit.throttle_lower = true;
+            limit.throttle_upper = true;
+        }
+        for (uint8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
+            thr_str_ltr_out = (scaled_throttle * _throttle_factor[i]) +
+                              (scaled_steering * _steering_factor[i]) +
+                              (scaled_lateral * _lateral_factor[i]);
 
             // send output for each motor
             output_throttle(SRV_Channels::get_motor_function(i), 100.0f * output_vectored);
@@ -925,13 +961,13 @@ void AP_MotorsUGV::slew_limit_throttle(float dt)
 }
 
 // set limits based on steering and throttle input
-void AP_MotorsUGV::set_limits_from_input(bool armed, float steering, float throttle)
+void AP_MotorsUGV::set_limits_from_input(float steering, float throttle)
 {
     // set limits based on inputs
-    limit.steer_left = !armed || (steering <= -4500.0f);
-    limit.steer_right = !armed || (steering >= 4500.0f);
-    limit.throttle_lower = !armed || (throttle <= -_throttle_max);
-    limit.throttle_upper = !armed || (throttle >= _throttle_max);
+    limit.steer_left |= steering <= -4500.0;
+    limit.steer_right |= steering >= 4500.0;
+    limit.throttle_lower |= throttle <= -_throttle_max;
+    limit.throttle_upper |= throttle >= _throttle_max;
 }
 
 // scale a throttle using the _throttle_min and _thrust_curve_expo parameters.  throttle should be in the range -100 to +100

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -102,6 +102,8 @@ public:
     // true if vehicle has vectored thrust (i.e. boat with motor on steering servo)
     bool have_vectored_thrust() const { return is_positive(_vector_angle_max); }
 
+    bool is_omni() const { return _motors_num > 0; }
+
     // output to motors and steering servos
     // ground_speed should be the vehicle's speed over the surface in m/s
     // dt should be expected time between calls to this function
@@ -176,7 +178,7 @@ protected:
     void slew_limit_throttle(float dt);
 
     // set limits based on steering and throttle input
-    void set_limits_from_input(bool armed, float steering, float throttle);
+    void set_limits_from_input(float steering, float throttle);
 
     // scale a throttle using the _thrust_curve_expo parameter.  throttle should be in the range -100 to +100
     float get_scaled_throttle(float throttle) const;


### PR DESCRIPTION
While messing about with https://github.com/ArduPilot/ardupilot/pull/18611 I spotted that were not setting the limit flags correctly. The current `set_limits_from_input` clears previously set inputs and is used several times in the output function. For example the `output_regular` function had lots of code to set the limits correctly, but then the `set_limits_from_input` function is called at the end throwing away those calculated values. 

This now also sets limits when in E-Stop and resets the throttle slew rate code when disarmed or in E-stop. 

I have re-worked the omni output code so that all motors are scaled evenly. Currently it scales the one that would exceed the limits and any that come after, because of this I would expect current Omni vehicles to do quite odd things at output saturation. 

This also stops resting the steering I term on sailboats in E-stop, they are perfectly capable of moving along with no throttle. 

This has not been extensively tested, hence it is a draft. 