### PR TITLE
Rover: partial fix for e-stop handling

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -594,7 +594,7 @@ float AR_AttitudeControl::get_throttle_out_speed(float desired_speed, bool motor
     }
 
     // calculate final output
-    float throttle_out = _throttle_speed_pid.update_all(desired_speed, speed, (_throttle_limit_low || _throttle_limit_high));
+    float throttle_out = _throttle_speed_pid.update_all(desired_speed, speed, (motor_limit_low || motor_limit_high || _throttle_limit_low || _throttle_limit_high));
     throttle_out += _throttle_speed_pid.get_ff();
     throttle_out += throttle_base;
 

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -208,8 +208,8 @@ void AP_MotorsUGV::set_steering(float steering, bool apply_scaling)
 // set throttle as a value from -100 to 100
 void AP_MotorsUGV::set_throttle(float throttle)
 {
-    // only allow setting throttle if armed
-    if (!hal.util->get_soft_armed()) {
+    // only allow setting throttle if armed and not emergency stopped
+    if (!hal.util->get_soft_armed() || SRV_Channels::get_emergency_stop()) {
         return;
     }
 
@@ -292,8 +292,8 @@ bool AP_MotorsUGV::has_sail() const
 
 void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
 {
-    // soft-armed overrides passed in armed status
-    if (!hal.util->get_soft_armed()) {
+    // soft-armed and emergency stop overrides local armed status
+    if (!hal.util->get_soft_armed() || SRV_Channels::get_emergency_stop()) {
         armed = false;
         _throttle = 0.0f;
     }
@@ -988,7 +988,7 @@ float AP_MotorsUGV::get_rate_controlled_throttle(SRV_Channel::Aux_servo_function
 bool AP_MotorsUGV::active() const
 {
     // if soft disarmed, motors not active
-    if (!hal.util->get_soft_armed()) {
+    if (!hal.util->get_soft_armed() || SRV_Channels::get_emergency_stop()) {
         return false;
     }
 


### PR DESCRIPTION
This mostly resolves issue https://github.com/ArduPilot/ardupilot/issues/16804:

- GCS displays 0% throttle when E-Stop is engaged
- Throttle not longer immediately jumps to 100% as soon as E-Stop is released (MOT_THR_SLEWRATE was not being applied)
- Speed controller's I-term stays at zero while E-Stop is active

**Before**
![master-before](https://user-images.githubusercontent.com/1498098/132617018-5398a66f-c90e-48ab-bc5a-e0905c39599b.png)

**After**
![after](https://user-images.githubusercontent.com/1498098/132617030-d282b21b-2e22-4bc0-be4c-39f5c0c47b25.png)

Note: there is an additional problem not directly mentioned in the linked issue which is that the desired speed is not being dropped back to zero when e-stop is engaged.  This means that the acceleration limiting of the desired speed is being skipped and the throttle ends up climbing much higher than it should.

![image](https://user-images.githubusercontent.com/1498098/132614355-02c3ab8c-b5c4-472f-8700-3ede463bc018.png)



