### PR TITLE
AP_Airspeed: Allow setting of use-zero-offset in parameters

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -123,7 +123,8 @@ public:
     bool healthy(uint8_t i) const {
         bool ok = state[i].healthy && enabled(i);
 #ifndef HAL_BUILD_AP_PERIPH
-        ok &= (fabsf(param[i].offset) > 0 || state[i].use_zero_offset);
+        // sanity check the offset parameter.  Zero is permitted if we are skipping calibration.
+        ok &= (fabsf(param[i].offset) > 0 || state[i].use_zero_offset || param[i].skip_cal);
 #endif
         return ok;
     }


### PR DESCRIPTION
If a NMEA or SPD3X airspeed sensor is used as part of an AP_Periph node then the airspeed data returned to the autopilot is already calibrated.  When used directly both of these sensors flag that a zero-offset should be used, but when the data is returned via uavcan's `RawAirData` packet we do not have this information.

Problems arise when these sensors return perfect-zeroes as readings for the entire calibration routine, as we then set `offset` to zero - and at that point the sensor is considered unhealthy and is not used.

This PR allows a user to set a bit indicating the data is already compensated - forcing `SET_USE_ZERO`

There are three other approaches I've considered:
 - have the user set `ARSPD_SKIP_CAL` to 1 and `ARSPD_OFFSET` to 0.00001 and move on with life
 - stop sending `RawAirData` in AP_Periph for sensors which use zero offset.  Instead, send `IndicatedAirSpeed` or `TrueAirspeed` if we have a baro.  This would also involve wrangling the airspeed values in ArduPilot somehow, and that is a difficult story to tell; AP_Airspeed would probably have to fake things up.
 - have NMEA and SPD3X return a very, very small pressure all the time to avoid the calibration issue

