### PR TITLE
Blimp: remove defines for functions that dont exist

### DIFF
--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -361,8 +361,6 @@ private:
     // landing_detector.cpp
     void update_land_and_crash_detectors();
     void update_land_detector();
-    void set_land_complete(bool b);
-    void set_land_complete_maybe(bool b);
 
     // landing_gear.cpp
     void landinggear_update();

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -177,11 +177,6 @@ bool Mode::set_mode(Mode::Number mode, ModeReason reason)
     return blimp.set_mode(mode, reason);
 }
 
-void Mode::set_land_complete(bool b)
-{
-    return blimp.set_land_complete(b);
-}
-
 GCS_Blimp &Mode::gcs()
 {
     return blimp.gcs();

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -178,9 +178,7 @@ public:
     // these are candidates for moving into the Mode base
     // class.
     bool set_mode(Mode::Number mode, ModeReason reason);
-    void set_land_complete(bool b);
     GCS_Blimp &gcs();
-    void set_throttle_takeoff(void);
 
     // end pass-through functions
 };


### PR DESCRIPTION
This fixes a compile error I hit when compiling a SITL exe with Cygwin.

```
Blimp/mode.cpp.38.o:mode.cpp:(.text$_ZN4Mode17set_land_completeEb+0x12): undefined reference to `Blimp::set_land_complete(bool)'
```

Neither of the functions are used anywhere which is why this is not a error with the standard compiler, I guess. 