### PR TITLE
Plane: loiter altitude control like FBWB

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -229,6 +229,11 @@ void Plane::stabilize_stick_mixing_direct()
     aileron = channel_roll->stick_mixing(aileron);
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, aileron);
 
+    if ((control_mode == &mode_loiter) && ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0)) {
+        // loiter is using altitude control based on the pitch stick, don't use it again here
+        return;
+    }
+
     int16_t elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
     elevator = channel_pitch->stick_mixing(elevator);
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, elevator);
@@ -274,7 +279,12 @@ void Plane::stabilize_stick_mixing_fbw()
     }
     nav_roll_cd += roll_input * roll_limit_cd;
     nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
-    
+
+    if ((control_mode == &mode_loiter) && ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0)) {
+        // loiter is using altitude control based on the pitch stick, don't use it again here
+        return;
+    }
+
     float pitch_input = channel_pitch->norm_input();
     if (pitch_input > 0.5f) {
         pitch_input = (3*pitch_input - 1);

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1075,7 +1075,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor., 7:EnableDefaultAirspeed for takeoff, 8: Remove the TRIM_PITCH_CD on the GCS horizon, 9: Remove the TRIM_PITCH_CD on the OSD horizon, 10: Adjust mid-throttle to be TRIM_THROTTLE in non-auto throttle modes except MANUAL
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor., 7:EnableDefaultAirspeed for takeoff, 8: Remove the TRIM_PITCH_CD on the GCS horizon, 9: Remove the TRIM_PITCH_CD on the OSD horizon, 10: Adjust mid-throttle to be TRIM_THROTTLE in non-auto throttle modes except MANUAL, 11: remove FBWB style loiter altitude control
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -164,6 +164,7 @@ enum FlightOptions {
     GCS_REMOVE_TRIM_PITCH_CD = (1 << 8),
     OSD_REMOVE_TRIM_PITCH_CD = (1 << 9),
     CENTER_THROTTLE_TRIM = (1<<10),
+    DISABLE_LOITER_ALT_CONTROL = (1<<11),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -5,6 +5,11 @@ bool ModeLoiter::_enter()
 {
     plane.do_loiter_at_location();
     plane.setup_terrain_target_alt(plane.next_WP_loc);
+
+    // make sure the local target altitude is the same as the nav target used for loiter nav
+    // this allows us to do FBWB style stick control
+    IGNORE_RETURN(plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, plane.target_altitude.amsl_cm));
+
     plane.loiter_angle_reset();
 
     return true;
@@ -13,8 +18,12 @@ bool ModeLoiter::_enter()
 void ModeLoiter::update()
 {
     plane.calc_nav_roll();
-    plane.calc_nav_pitch();
-    plane.calc_throttle();
+    if (plane.stick_mixing_enabled() && ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0)) {
+        plane.update_fbwb_speed_height();
+    } else {
+        plane.calc_nav_pitch();
+        plane.calc_throttle();
+    }
 }
 
 bool ModeLoiter::isHeadingLinedUp(const Location loiterCenterLoc, const Location targetLoc)
@@ -74,6 +83,11 @@ bool ModeLoiter::isHeadingLinedUp_cd(const int32_t bearing_cd)
 
 void ModeLoiter::navigate()
 {
+    if ((plane.g2.flight_options & FlightOptions::DISABLE_LOITER_ALT_CONTROL) == 0) {
+        // update the WP alt from the global target adjusted by update_fbwb_speed_height
+        plane.next_WP_loc.set_alt_cm(plane.target_altitude.amsl_cm, Location::AltFrame::ABSOLUTE);
+    }
+
     // Zero indicates to use WP_LOITER_RAD
     plane.update_loiter(0);
 }

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2046,6 +2046,8 @@ class AutoTestPlane(AutoTest):
         self.fly_home_land_and_disarm()
 
     def LOITER(self):
+        # first test old loiter behavour
+        self.set_parameter("FLIGHT_OPTIONS", 1 << 11)
         self.takeoff(alt=200)
         self.set_rc(3, 1500)
         self.change_mode("LOITER")
@@ -2099,6 +2101,20 @@ class AutoTestPlane(AutoTest):
         self.progress("Centering elevator and ensuring we get back to loiter altitude")
         self.set_rc(2, 1500)
         self.wait_altitude(initial_alt-1, initial_alt+1)
+        # Test new loiter behavour
+        self.set_parameter("FLIGHT_OPTIONS", 0)
+        # should decend at max stick
+        self.set_rc(2, int(rc2_max))
+        self.wait_altitude(initial_alt - 110, initial_alt - 90, timeout=90)
+        # should not climb back at mid stick
+        self.set_rc(2, 1500)
+        self.delay_sim_time(60)
+        self.wait_altitude(initial_alt - 110, initial_alt - 90)
+        # should climb at min stick
+        self.set_rc(2, 1100)
+        self.wait_altitude(initial_alt - 10, initial_alt + 10, timeout=90)
+        # return stick to center and fly home
+        self.set_rc(2, 1500)
         self.fly_home_land_and_disarm()
 
     def CPUFailsafe(self):


### PR DESCRIPTION
This makes loiter work like everyone thinks it should. 

https://discuss.ardupilot.org/t/loiter-altitude-behaviour/75856
Fixes #17388
Fixes #9792

https://inavfixedwinggroup.com/rc-news/i-betrayed-inav-with-ardupilot-and-i-almost-dont-regret-it/
"I cannot change the altitude in LOITER mode by default. When I pitch down it sinks like in FBWA mode but climbs back when I release the stick. What! That makes no sense to me."

This is a change in behavior but I have added a `FLIGHT_OPTION` so you can go back to the old way.
