### PR TITLE
HAL_Linux: Implement force_safety_on/off in RCOutput_PCA9685, do force_safety_on before shutting down

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -413,6 +413,8 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         callbacks->loop();
     }
 
+    // At least try to stop all PWM before shutting down
+    rcout->force_safety_on();
     rcin->teardown();
     I2CDeviceManager::from(i2c_mgr)->teardown();
     SPIDeviceManager::from(spi)->teardown();

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
@@ -26,6 +26,8 @@ public:
     uint16_t get_freq(uint8_t ch) override;
     void     enable_ch(uint8_t ch) override;
     void     disable_ch(uint8_t ch) override;
+    bool     force_safety_on() override;
+    void     force_safety_off() override;
     void     write(uint8_t ch, uint16_t period_us) override;
     void     cork() override;
     void     push() override;


### PR DESCRIPTION
This fixes an issue where Linux builds actually quit when receiving a sigterm, but do so in a rush. This leaves the PCA9685 PWMs running, which is far from ideal.

This patch implements `force_safety_on()` and `force_safety_off()` for the PCA9685 and makes HAL_Linux use it to stop the PWMs before quitting. 

It can also be tested using pymavlink:
```
# set safety on
master.mav.set_mode_send(1, 128, 1)

# set safety off
master.mav.set_mode_send(1, 128, 0)

```