### PR TITLE
AP_HAL_ChibiOS: add batt mon defaults to Kakutef4 Mini

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/defaults.parm
@@ -5,3 +5,6 @@ SERIAL3_BAUD 115
 # default Serial1 to FrSky telemetry
 SERIAL1_PROTOCOL 10
 SERIAL1_OPTIONS 7
+# batt monitor defaults
+BATT_VOLT_SCALE 10.9
+BATT_CURR_SCALE 28.5


### PR DESCRIPTION
I guess its normally done in the hwdef, but it would require undefining and redefining sinc eits build off the non mini version...think this is simpler