### PR TITLE
Copter: Notification of landing detection status

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -118,6 +118,7 @@ void Copter::set_land_complete(bool b)
     land_detector_count = 0;
 
     if(b){
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Land Complete");
         AP::logger().Write_Event(LogEvent::LAND_COMPLETE);
     } else {
         AP::logger().Write_Event(LogEvent::NOT_LANDED);
@@ -148,6 +149,7 @@ void Copter::set_land_complete_maybe(bool b)
         return;
 
     if (b) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Land Complete Maybe");
         AP::logger().Write_Event(LogEvent::LAND_COMPLETE_MAYBE);
     }
     ap.land_complete_maybe = b;


### PR DESCRIPTION
I want to inform the operator of the landing detection status.
I know that there is a discrepancy between the operator's landing judgment and the FC's landing detection.
I want to resolve this discrepancy.
I know that there is a discrepancy between the operator's landing decision and the FC's landing detection.
The operator does not always carry a radio and a PC with him.