### PR TITLE
Copter: `FS_OPTION` continue if landing actually continues and use mission DO_LAND_START flag

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -55,7 +55,7 @@ void Copter::failsafe_radio_on_event()
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING)) {
         // Allow landing to continue when FS_OPTIONS is set to continue landing
         gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Landing");
-        desired_action = Failsafe_Action_Land;
+        desired_action = Failsafe_Action_None;
 
     } else if (flightmode->mode_number() == Mode::Number::AUTO && failsafe_option(FailsafeOption::RC_CONTINUE_IF_AUTO)) {
         // Allow mission to continue when FS_OPTIONS is set to continue mission
@@ -100,7 +100,7 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING) && desired_action != Failsafe_Action_None) {
         // Allow landing to continue when FS_OPTIONS is set to continue when landing
-        desired_action = Failsafe_Action_Land;
+        desired_action = Failsafe_Action_None;
         gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe - Continuing Landing");
     } else {
         gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe");
@@ -199,7 +199,7 @@ void Copter::failsafe_gcs_on_event(void)
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING)) {
         // Allow landing to continue when FS_OPTIONS is set to continue landing
         gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe - Continuing Landing");
-        desired_action = Failsafe_Action_Land;
+        desired_action = Failsafe_Action_None;
 
     } else if (flightmode->mode_number() == Mode::Number::AUTO && failsafe_option(FailsafeOption::GCS_CONTINUE_IF_AUTO)) {
         // Allow mission to continue when FS_OPTIONS is set to continue mission

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -426,7 +426,7 @@ bool ModeAuto::is_landing() const
     case SubMode::RTL:
         return copter.mode_rtl.is_landing();
     default:
-        return false;
+        return (mission.state() == AP_Mission::MISSION_RUNNING) && mission.get_in_landing_sequence_flag();
     }
     return false;
 }


### PR DESCRIPTION
Currently the option to continue if landing actually switches to land mode. This results in a unnecessary re-int of the XY controller and a potential movement way from the original lading location. The new behavior is to do nothing, after all we already checked that were landing anyway. 

The second change is to treat the `in_landing_sequence` mission flag as a valid landing to continue doing. This is only set if you have a passed DO_LAND_START command, either in the natural course of the mission or by jumping to it with Auto RTL mode. This means that hitting a failsafe while in AUTO_RTL will have no change rather than jumping back tho the DO_LAND_START and starting the landing sequence again. (if you have set the `FS_OPTION` of course)