### PR TITLE
AP_Generator and AP_HAL_ChibiOS: Convert atof to strtof 

### DIFF
--- a/libraries/AP_Generator/AP_Generator_IE_2400.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.cpp
@@ -77,12 +77,12 @@ void AP_Generator_IE_2400::decode_latest_term()
     switch (_term_number) {
         case 1:
             // Float
-            _parsed.tank_bar = atof(_term);
+            _parsed.tank_bar = strtof(_term, NULL);
             break;
 
         case 2:
             // Float
-            _parsed.battery_volt = atof(_term);
+            _parsed.battery_volt = strtof(_term, NULL);
             break;
 
         case 3:

--- a/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
@@ -61,7 +61,7 @@ void AP_Generator_IE_650_800::decode_latest_term()
 
     switch (_term_number) {
         case 1:
-            _parsed.tank_pct = atof(_term);
+            _parsed.tank_pct = strtof(_term, NULL);
             // Out of range values
             if (_parsed.tank_pct > 100.0f || _parsed.tank_pct < 0.0f) {
                 _data_valid = false;
@@ -69,7 +69,7 @@ void AP_Generator_IE_650_800::decode_latest_term()
             break;
 
         case 2:
-            _parsed.battery_pct = atof(_term);
+            _parsed.battery_pct = strtof(_term, NULL);
             // Out of range values
             if (_parsed.battery_pct > 100.0f || _parsed.battery_pct < 0.0f) {
                 _data_valid = false;

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -531,7 +531,7 @@ void Util::apply_persistent_params(void) const
         if (eq) {
             *eq = 0;
             const char *pname = p;
-            const float value = atof(eq+1);
+            const float value = strtof(eq+1, NULL);
             if (AP_Param::set_default_by_name(pname, value)) {
                 count++;
                 /*


### PR DESCRIPTION
This converts the five remaining  `atof` in the flight code to `strtof`. Hopefully that is sufficient to close https://github.com/ArduPilot/ardupilot/issues/3285

We still have a few in Replay, SITL and sub-modules, but I wasn't going to bother with those.

Fixes #3285