### PR TITLE
AC_PosControl, AC_Loiter: protect against negative angle max.

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1032,7 +1032,7 @@ void AC_PosControl::update_z_controller()
 /// get_lean_angle_max_cd - returns the maximum lean angle the autopilot may request
 float AC_PosControl::get_lean_angle_max_cd() const
 {
-    if (is_zero(_lean_angle_max)) {
+    if (!is_positive(_lean_angle_max)) {
         return _attitude_control.lean_angle_max_cd();
     }
     return _lean_angle_max * 100.0f;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -185,7 +185,7 @@ void AC_Loiter::get_stopping_point_xy(Vector2f& stopping_point) const
 /// get maximum lean angle when using loiter
 float AC_Loiter::get_angle_max_cd() const
 {
-    if (is_zero(_angle_max)) {
+    if (!is_positive(_angle_max)) {
         return MIN(_attitude_control.lean_angle_max_cd(), _pos_control.get_lean_angle_max_cd()) * (2.0f/3.0f);
     }
     return MIN(_angle_max*100.0f, _pos_control.get_lean_angle_max_cd());


### PR DESCRIPTION
Fixes #14136

Trivial change makes loiter and PSC angle max params slightly more idiot proof. 

You can still make exciting things happen if you set them >= 90 deg. 