### PR TITLE
HAL_ChibiOS: fixed RTSCTS flow control issue

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1118,6 +1118,7 @@ void UARTDriver::write_pending_bytes(void)
     if (_flow_control == FLOW_CONTROL_AUTO) {
         if (_first_write_started_us == 0) {
             _first_write_started_us = AP_HAL::micros();
+            _total_written = 0;
         }
 #ifndef HAL_UART_NODMA
         if (tx_dma_enabled) {


### PR DESCRIPTION
this fixes an issue reported on MatekH743, but also applies to other
boards. When not using DMA if there have been bytes written before the
auto flow control detection was enabled then these must be cleared
from _total_written so the flow control detection can work correctly