### PR TITLE
Sub 4.0: update install-prereqs-ubuntu

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -583,7 +583,7 @@ class AutoTest(ABC):
             flist = glob.glob("logs/*.BIN")
             for e in ['BIN', 'bin', 'tlog']:
                 flist += glob.glob(os.path.join(logdir, '*.%s' % e))
-            print("Uploading %u logs to http://firmware.ardupilot.org/CI-Logs/%s" % (len(flist), datedir))
+            print("Uploading %u logs to https://firmware.ardupilot.org/CI-Logs/%s" % (len(flist), datedir))
             cmd = ['rsync', '-avz'] + flist + ['cilogs@autotest.ardupilot.org::CI-Logs/%s/' % datedir]
             subprocess.call(cmd)
 

--- a/Tools/autotest/web-firmware/index.html
+++ b/Tools/autotest/web-firmware/index.html
@@ -9,7 +9,7 @@
 
 <body>
 <div id="main">
-<a href="http://firmware.ardupilot.org/">
+<a href="https://firmware.ardupilot.org/">
 <div id="logo">
 </div>
 </a>

--- a/Tools/completion/bash/_sim_vehicle
+++ b/Tools/completion/bash/_sim_vehicle
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+_sim_vehicle() {
+  local cur prev opts
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD - 1]}"
+
+  # TODO: generate for waf help
+  opts="--help -h"
+  opts+=" -j --jobs"
+  opts+=" -N --no-rebuild"
+  opts+=" -D --debug"
+  opts+=" -c --clean"
+  opts+=" -I --instance"
+  opts+=" -V --valgrind"
+  opts+=" --callgrind"
+  opts+=" -T --tracker"
+  opts+=" -A --sitl-instance-args"
+  opts+=" -G --gdb"
+  opts+=" -g --gdb-stopped"
+  opts+=" --lldb"
+  opts+=" --lldb-stopped"
+  opts+=" -d --delay-start"
+  opts+=" -B --breakpoint"
+  opts+=" -M --mavlink-gimbal"
+  opts+=" -L --location"
+  opts+=" -l --custom-location"
+  opts+=" -S --speedup"
+  opts+=" -t --tracker-location"
+  opts+=" -w --wipe-eeprom"
+  opts+=" -m --mavproxy-args"
+  opts+=" --strace"
+  opts+=" --model"
+  opts+=" --use-dir"
+  opts+=" --no-mavproxy"
+  opts+=" --fresh-params"
+  opts+=" --mcast"
+  opts+=" --osd"
+  opts+=" --tonealarm"
+  opts+=" --rgbled"
+  opts+=" --add-param-file"
+  opts+=" --no-extra-ports"
+  opts+=" -Z --swarm"
+  opts+=" --flash-storage"
+  opts+=" --out"
+  opts+=" --map"
+  opts+=" --console"
+  opts+=" --aircraft"
+  opts+=" --moddebug"
+  opts+=" -v --vehicle"
+  opts+=" -f --frame"
+
+  # Prevent word reuse TODO: add -vvv case
+  lim=$((COMP_CWORD - 1))
+  for i in $(seq 0 $lim); do
+    if [[ $opts == *"${COMP_WORDS[i]}"* ]]; then
+      opts=${opts/" ${COMP_WORDS[i]}"/}
+      opts=${opts/" --${COMP_WORDS[i]}"/}
+    fi
+  done
+
+  # TODO: generate for waf help
+  case $prev in
+  -v | --vehicle)
+    opts="ArduCopter AntennaTracker APMrover2 ArduSub ArduPlane"
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+    ;;
+  -f | --frame)
+    opts=""
+    if [[ ${COMP_WORDS[@]} == *"ArduCopter"* ]]; then
+      opts+=" +"
+      opts+=" X"
+      opts+=" airsim-copter"
+      opts+=" coaxcopter"
+      opts+=" djix"
+      opts+=" dodeca-hexa"
+      opts+=" gazebo-iris"
+      opts+=" heli"
+      opts+=" heli-compound"
+      opts+=" heli-dual"
+      opts+=" hexa"
+      opts+=" octa"
+      opts+=" octa-quad"
+      opts+=" quad"
+      opts+=" scrimmage-copter"
+      opts+=" singlecopter"
+      opts+=" tri"
+      opts+=" y6"
+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+      return 0
+    fi
+    if [[ ${COMP_WORDS[@]} == *"AntennaTracker"* ]]; then
+      opts+=" tracker"
+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+      return 0
+    fi
+    if [[ ${COMP_WORDS[@]} == *"APMrover2"* ]]; then
+      opts+=" balancebot"
+      opts+=" gazebo-rover"
+      opts+=" rover"
+      opts+=" rover-skid"
+      opts+=" sailboat"
+      opts+=" sailboat-motor"
+      opts+=" balancebot"
+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+      return 0
+    fi
+    if [[ ${COMP_WORDS[@]} == *"ArduSub"* ]]; then
+      opts+=" gazebo-bluerov2"
+      opts+=" vectored"
+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+      return 0
+    fi
+    if [[ ${COMP_WORDS[@]} == *"ArduPlane"* ]]; then
+      opts+=" CRRCSim"
+      opts+=" gazebo-zephyr"
+      opts+=" jsbsim"
+      opts+=" plane"
+      opts+=" plane-dspoilers"
+      opts+=" plane-elevon"
+      opts+=" plane-jet"
+      opts+=" plane-tailsitter"
+      opts+=" plane-vtailjet"
+      opts+=" quadplane"
+      opts+=" quadplane-cl84"
+      opts+=" quadplane-tilttrivec"
+      opts+=" quadplane-tri"
+      opts+=" scrimmage-plane"
+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+      return 0
+    fi
+    ;;
+  esac
+
+  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+}
+
+complete -F _sim_vehicle sim_vehicle.py
+

--- a/Tools/completion/bash/_waf
+++ b/Tools/completion/bash/_waf
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+_waf()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # TODO: generate for waf help
+    opts="--help -h"
+    opts+=" -j --jobs"
+    opts+=" -v --verbose"
+    opts+=" --debug"
+    opts+=" --bootloader"
+    opts+=" --default-parameters"
+    opts+=" --enable-sfml"
+    opts+=" --enable-sfml-audio"
+    opts+=" --sitl-osd"
+    opts+=" --sitl-rgbled"
+    opts+=" --build-dates"
+    opts+=" --sitl-flash-storage"
+    opts+=" --upload"
+    opts+=" --board"
+
+    opts+=" AP_Periph"
+    opts+=" copter"
+    opts+=" heli"
+    opts+=" plane"
+    opts+=" rover"
+    opts+=" sub"
+    opts+=" antennatracker"
+    opts+=" tools"
+    opts+=" examples"
+    opts+=" bootloader"
+    opts+=" iofirmware"
+    opts+=" list"
+    opts+=" all"
+    opts+=" build"
+    opts+=" configure"
+    opts+=" clean"
+    opts+=" distclean"
+
+    # Prevent word reuse TODO: add -vvv case
+    lim=$((COMP_CWORD - 1))
+    for i in $( seq 0 $lim )
+    do
+        if [[ $opts == *"${COMP_WORDS[i]}"* ]]; then
+          opts=${opts/" ${COMP_WORDS[i]}"}
+          opts=${opts/" --${COMP_WORDS[i]}"}
+        fi
+    done
+
+    # TODO: generate for waf help
+    case $prev in 
+	--board)
+		opts="CubeBlack bbbmini fmuv2 fmuv3 fmuv4 iomcu sitl"
+	    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+	    return 0
+	    ;;
+	esac
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+}
+
+
+complete -F _waf waf

--- a/Tools/completion/completion.bash
+++ b/Tools/completion/completion.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+_AP_COMPLETION_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)
+source "$_AP_COMPLETION_DIR/bash/_waf"
+source "$_AP_COMPLETION_DIR/bash/_sim_vehicle"
+

--- a/Tools/debug/README.md
+++ b/Tools/debug/README.md
@@ -23,7 +23,7 @@ that the probe will be loaded as /dev/ttyBmpGdb
 
 Now make sure you have the right version of arm-none-eabi-gdb
 installed. We recommend version 6-2017-q2-update, which is available
-here: http://firmware.ardupilot.org/Tools/STM32-tools/
+here: https://firmware.ardupilot.org/Tools/STM32-tools/
 
 Now build ArduPilot with the --debug configure option. You may also
 like to include the --enable-asserts. Enabling asserts will slow down

--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -16,7 +16,7 @@ PYTHON3_PKGS="pyserial empy"
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
 ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="ardupilot/Tools/autotest"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -9,69 +9,15 @@ if [ $EUID == 0 ]; then
 fi
 
 OPT="/opt"
-RELEASE_CODENAME=$(lsb_release -c -s)
-if [ ${RELEASE_CODENAME} == 'xenial' ]; then
-    SITLFML_VERSION="2.3v5"
-    SITLCFML_VERSION="2.3"
-elif [ ${RELEASE_CODENAME} == 'disco' ]; then
-    SITLFML_VERSION="2.5"
-    SITLCFML_VERSION="2.5"
-elif [ ${RELEASE_CODENAME} == 'eoan' ]; then
-    SITLFML_VERSION="2.5"
-    SITLCFML_VERSION="2.5"
-else
-    SITLFML_VERSION="2.4"
-    SITLCFML_VERSION="2.4"
-fi
-
-BASE_PKGS="build-essential ccache g++ gawk git make wget"
-PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
-# add some Python packages required for commonly-used MAVProxy modules and hex file generation:
-PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
-PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
-          autoconf texinfo libftdi-dev zlib1g-dev \
-          zip genromfs python-empy cmake cmake-data"
-ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
-# python-wxgtk packages are added to SITL_PKGS below
-SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing xterm lcov gcovr"
-# add some packages required for commonly-used MAVProxy modules:
-SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION} python-yaml python3-yaml"
-
-ASSUME_YES=false
-QUIET=false
-
-MACHINE_TYPE=$(uname -m)
-if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-    PX4_PKGS+=" libc6-i386"
-else
-  echo "no extra pkgs for i386"
-fi
-
-# GNU Tools for ARM Embedded Processors
-# (see https://launchpad.net/gcc-arm-embedded/)
-ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
-ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
-ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
-
 # Ardupilot Tools
 ARDUPILOT_TOOLS="Tools/autotest"
 
-function maybe_prompt_user() {
-    if $ASSUME_YES; then
-        return 0
-    else
-        read -p "$1"
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            return 0
-        else
-            return 1
-        fi
-    fi
-}
-
+ASSUME_YES=false
+QUIET=false
+sep="##############################################"
 
 OPTIND=1  # Reset in case getopts has been used previously in the shell.
-while getopts "y" opt; do
+while getopts "yq" opt; do
     case "$opt" in
         \?)
             exit 1
@@ -91,56 +37,204 @@ if $QUIET; then
     APT_GET="$APT_GET -qq"
 fi
 
+# update apt package list
+$APT_GET update
+
+# Install lsb-release as it is needed to check Ubuntu version
 if ! dpkg-query -l "lsb-release"; then
+    echo "$sep"
+    echo "Installing lsb-release"
+    echo "$sep"
     $APT_GET install lsb-release
+    echo "Done!"
 fi
+
+# Checking Ubuntu release to adapt software version to install
+RELEASE_CODENAME=$(lsb_release -c -s)
+PYTHON_V="python"  # starting from ubuntu 20.04, python isn't symlink to default python interpreter
+if [ ${RELEASE_CODENAME} == 'xenial' ]; then
+    SITLFML_VERSION="2.3v5"
+    SITLCFML_VERSION="2.3"
+elif [ ${RELEASE_CODENAME} == 'disco' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+elif [ ${RELEASE_CODENAME} == 'eoan' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+elif [ ${RELEASE_CODENAME} == 'focal' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+    PYTHON_V="python3"
+elif [ ${RELEASE_CODENAME} == 'trusty' ]; then
+    SITLFML_VERSION="2"
+    SITLCFML_VERSION="2"
+else
+    SITLFML_VERSION="2.4"
+    SITLCFML_VERSION="2.4"
+fi
+
+# Lists of packages to install
+BASE_PKGS="build-essential ccache g++ gawk git make wget cmake"
+PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
+# add some Python packages required for commonly-used MAVProxy modules and hex file generation:
+if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
+  PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
+fi
+ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
+# python-wxgtk packages are added to SITL_PKGS below
+SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing"
+# add some packages required for commonly-used MAVProxy modules:
+if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
+  SITL_PKGS="$SITL_PKGS xterm ${PYTHON_V}-matplotlib ${PYTHON_V}-serial ${PYTHON_V}-scipy ${PYTHON_V}-opencv libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION} ${PYTHON_V}-yaml"
+fi
+if [[ $SKIP_AP_COV_ENV -ne 1 ]]; then
+  # Coverage utilities
+  COVERAGE_PKGS="lcov gcovr"
+fi
+
+# ArduPilot official Toolchain for STM32 boards
+function install_arm_none_eabi_toolchain() {
+  # GNU Tools for ARM Embedded Processors
+  # (see https://launchpad.net/gcc-arm-embedded/)
+  ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
+  ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
+  ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
+  if [ ! -d $OPT/$ARM_ROOT ]; then
+    (
+        cd $OPT;
+        echo "$sep"
+        echo "Installing toolchain for STM32 Boards"
+        echo "$sep"
+        echo "Downloading from ArduPilot server"
+        sudo wget $ARM_TARBALL_URL
+        echo "Installing..."
+        sudo tar xjf ${ARM_TARBALL}
+        echo "... Cleaning"
+        sudo rm ${ARM_TARBALL};
+    )
+  fi
+  echo "Registering STM32 Toolchain for ccache"
+  sudo ln -s $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
+  sudo ln -s $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
+  echo "Done!"
+}
+
+function maybe_prompt_user() {
+    if $ASSUME_YES; then
+        return 0
+    else
+        read -p "$1"
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+}
+
 # possibly grab a newer cmake for older ubuntu releases
-read -r UBUNTU_CODENAME <<<$(lsb_release -c -s)
-if [ "$UBUNTU_CODENAME" = "precise" ]; then
+if [ ${RELEASE_CODENAME} == "precise" ]; then
     sudo add-apt-repository ppa:george-edison55/precise-backports -y
-elif [ "$UBUNTU_CODENAME" = "trusty" ]; then
+    $APT_GET update
+elif [ ${RELEASE_CODENAME} == "trusty" ]; then
     sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
+    $APT_GET update
 fi
 
+echo "$sep"
+echo "Add user to dialout group to allow managing serial ports"
+echo "$sep"
 sudo usermod -a -G dialout $USER
+echo "Done!"
 
+echo "$sep"
+echo "Removing modemmanager package that could conflict with firmware uploading"
+echo "$sep"
 if dpkg-query -l "modemmanager"; then
     $APT_GET remove modemmanager
 fi
-$APT_GET update
+echo "Done!"
 
-if apt-cache search python-wxgtk3.0 | grep wx; then
-    SITL_PKGS+=" python-wxgtk3.0 libtool-bin"
+# Add back python symlink to python interpreter on Ubuntu >= 20.04
+if [ ${RELEASE_CODENAME} == 'focal' ]; then
+    BASE_PKGS+=" python-is-python3"
+    SITL_PKGS+=" libpython3-stdlib" # for argparse
 else
-    # we only support back to trusty:
-    SITL_PKGS+=" python-wxgtk2.8"
+  SITL_PKGS+=" python-argparse"
 fi
 
+# Check for graphical package for MAVProxy
+if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
+  if [ ${RELEASE_CODENAME} == 'focal' ]; then
+    SITL_PKGS+=" python3-wxgtk4.0"
+    SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  elif apt-cache search python-wxgtk3.0 | grep wx; then
+      SITL_PKGS+=" python-wxgtk3.0"
+  else
+      # we only support back to trusty:
+      SITL_PKGS+=" python-wxgtk2.8"
+      SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng12-0 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  fi
+fi
+
+# Check if we need to manually install realpath
 RP=$(apt-cache search -n '^realpath$')
 if [ -n "$RP" ]; then
     BASE_PKGS+=" realpath"
 fi
 
-$APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS
-pip2 -q install --user -U $PYTHON_PKGS
-
-
-if [ ! -d $OPT/$ARM_ROOT ]; then
-    (
-        cd $OPT;
-        sudo wget $ARM_TARBALL_URL;
-        sudo tar xjf ${ARM_TARBALL};
-        sudo rm ${ARM_TARBALL};
-    )
+# Check if we need to manually install libtool-bin
+LBTBIN=$(apt-cache search -n '^libtool-bin')
+if [ -n "$LBTBIN" ]; then
+    SITL_PKGS+=" libtool-bin"
 fi
+
+# Install all packages
+$APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS $COVERAGE_PKGS
+# Check python version for distro that don't have python2 support by default
+PYTHON_VERSION_MAJOR=$(python -c"import sys; print(sys.version_info.major)")
+if [ "$PYTHON_VERSION_MAJOR" -eq 2 ]; then
+    pip2 install --user -U $PYTHON_PKGS
+elif [ "$PYTHON_VERSION_MAJOR" -eq 3 ]; then
+    pip3 install --user -U $PYTHON_PKGS
+else
+    echo "Unknown python version: $PYTHON_VERSION_MAJOR"
+fi
+
+if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 toolchain [N/y]?" ; then
+    DO_AP_STM_ENV=1
+fi
+
+CCACHE_PATH=$(which ccache)
+if [[ $DO_AP_STM_ENV -eq 1 ]]; then
+  install_arm_none_eabi_toolchain
+fi
+
+echo "$sep"
+echo "Check if we are inside docker environment..."
+echo "$sep"
+IS_DOCKER=false
+if [[ -f /.dockerenv ]] || grep -Eq '(lxc|docker)' /proc/1/cgroup ; then
+    IS_DOCKER=true
+fi
+echo "Done!"
+
+SHELL_LOGIN=".profile"
+if $IS_DOCKER; then
+    echo "Inside docker, we add the tools path into .bashrc directly"
+    SHELL_LOGIN=".bashrc"
+fi
+
+echo "$sep"
+echo "Adding ArduPilot Tools to environment"
+echo "$sep"
 
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
-
 exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
-grep -Fxq "$exportline" ~/.profile 2>/dev/null || {
+grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
-        echo $exportline >> ~/.profile
+        echo $exportline >> ~/$SHELL_LOGIN
         eval $exportline
     else
         echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
@@ -148,19 +242,45 @@ grep -Fxq "$exportline" ~/.profile 2>/dev/null || {
 }
 
 exportline2="export PATH=$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\$PATH";
-grep -Fxq "$exportline2" ~/.profile 2>/dev/null || {
+grep -Fxq "$exportline2" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add $ARDUPILOT_ROOT/$ARDUPILOT_TOOLS to your PATH [N/y]?" ; then
-        echo $exportline2 >> ~/.profile
+        echo $exportline2 >> ~/$SHELL_LOGIN
         eval $exportline2
     else
         echo "Skipping adding $ARDUPILOT_ROOT/$ARDUPILOT_TOOLS to PATH."
     fi
 }
 
-apt-cache search arm-none-eabi
+exportline3="source $ARDUPILOT_ROOT/Tools/completion/completion.bash";
+grep -Fxq "$exportline3" ~/$SHELL_LOGIN 2>/dev/null || {
+    if maybe_prompt_user "Add ArduPilot Bash Completion to your bash shell [N/y]?" ; then
+        echo $exportline3 >> ~/.bashrc
+        eval $exportline3
+    else
+        echo "Skipping adding ArduPilot Bash Completion."
+    fi
+}
 
-(
- cd $ARDUPILOT_ROOT
- git submodule update --init --recursive
-)
+
+exportline4="export PATH=/usr/lib/ccache:\$PATH";
+grep -Fxq "$exportline4" ~/$SHELL_LOGIN 2>/dev/null || {
+    if maybe_prompt_user "Append CCache to your PATH [N/y]?" ; then
+        echo $exportline4 >> ~/$SHELL_LOGIN
+        eval $exportline4
+    else
+        echo "Skipping appending CCache to PATH."
+    fi
+}
+echo "Done!"
+
+if [[ $SKIP_AP_GIT_CHECK -ne 1 ]]; then
+  if [ -d ".git" ]; then
+    echo "$sep"
+    echo "Update git submodules"
+    echo "$sep"
+    cd $ARDUPILOT_ROOT
+    git submodule update --init --recursive
+    echo "Done!"
+  fi
+fi
 echo "---------- $0 end ----------"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -40,8 +40,12 @@ fi
 # update apt package list
 $APT_GET update
 
+function package_is_installed() {
+    return $(dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -c "ok installed")
+}
+
 # Install lsb-release as it is needed to check Ubuntu version
-if ! dpkg-query -l "lsb-release"; then
+if package_is_installed "lsb-release" -ne 1; then
     echo "$sep"
     echo "Installing lsb-release"
     echo "$sep"
@@ -150,7 +154,7 @@ echo "Done!"
 echo "$sep"
 echo "Removing modemmanager package that could conflict with firmware uploading"
 echo "$sep"
-if dpkg-query -l "modemmanager"; then
+if package_is_installed "modemmanager" -ne 1; then
     $APT_GET remove modemmanager
 fi
 echo "Done!"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -41,11 +41,11 @@ fi
 $APT_GET update
 
 function package_is_installed() {
-    return $(dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -c "ok installed")
+    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -c "ok installed"
 }
 
 # Install lsb-release as it is needed to check Ubuntu version
-if package_is_installed "lsb-release" -ne 1; then
+if package_is_installed "lsb-release" -eq 1; then
     echo "$sep"
     echo "Installing lsb-release"
     echo "$sep"
@@ -154,7 +154,7 @@ echo "Done!"
 echo "$sep"
 echo "Removing modemmanager package that could conflict with firmware uploading"
 echo "$sep"
-if package_is_installed "modemmanager" -ne 1; then
+if package_is_installed "modemmanager" -eq 1; then
     $APT_GET remove modemmanager
 fi
 echo "Done!"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -154,14 +154,6 @@ echo "$sep"
 sudo usermod -a -G dialout $USER
 echo "Done!"
 
-echo "$sep"
-echo "Removing modemmanager package that could conflict with firmware uploading"
-echo "$sep"
-if package_is_installed "modemmanager" -eq 1; then
-    $APT_GET remove modemmanager
-fi
-echo "Done!"
-
 # Add back python symlink to python interpreter on Ubuntu >= 20.04
 if [ ${RELEASE_CODENAME} == 'focal' ]; then
     BASE_PKGS+=" python-is-python3"
@@ -203,6 +195,14 @@ $PIP install --user -U $PYTHON_PKGS
 if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 toolchain [N/y]?" ; then
     DO_AP_STM_ENV=1
 fi
+
+echo "$sep"
+echo "Removing modemmanager package that could conflict with firmware uploading"
+echo "$sep"
+if package_is_installed "modemmanager" -eq 1; then
+    $APT_GET remove modemmanager
+fi
+echo "Done!"
 
 CCACHE_PATH=$(which ccache)
 if [[ $DO_AP_STM_ENV -eq 1 ]]; then

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -56,6 +56,8 @@ fi
 # Checking Ubuntu release to adapt software version to install
 RELEASE_CODENAME=$(lsb_release -c -s)
 PYTHON_V="python"  # starting from ubuntu 20.04, python isn't symlink to default python interpreter
+PIP=pip2
+
 if [ ${RELEASE_CODENAME} == 'xenial' ]; then
     SITLFML_VERSION="2.3v5"
     SITLCFML_VERSION="2.3"
@@ -69,6 +71,7 @@ elif [ ${RELEASE_CODENAME} == 'focal' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
     PYTHON_V="python3"
+    PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'trusty' ]; then
     SITLFML_VERSION="2"
     SITLCFML_VERSION="2"
@@ -195,15 +198,7 @@ fi
 
 # Install all packages
 $APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS $COVERAGE_PKGS
-# Check python version for distro that don't have python2 support by default
-PYTHON_VERSION_MAJOR=$(python -c"import sys; print(sys.version_info.major)")
-if [ "$PYTHON_VERSION_MAJOR" -eq 2 ]; then
-    pip2 install --user -U $PYTHON_PKGS
-elif [ "$PYTHON_VERSION_MAJOR" -eq 3 ]; then
-    pip3 install --user -U $PYTHON_PKGS
-else
-    echo "Unknown python version: $PYTHON_VERSION_MAJOR"
-fi
+$PIP install --user -U $PYTHON_PKGS
 
 if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 toolchain [N/y]?" ; then
     DO_AP_STM_ENV=1

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -11,12 +11,17 @@ fi
 OPT="/opt"
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
+# add some Python packages required for commonly-used MAVProxy modules:
+PYTHON_PKGS="$PYTHON_PKGS pygame"
 PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo libftdi-dev zlib1g-dev \
           zip genromfs python-empy cmake cmake-data"
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # python-wxgtk packages are added to SITL_PKGS below
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing xterm lcov gcovr"
+# add some packages required for commonly-used MAVProxy modules:
+SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio2.4 libcsfml-dev libcsfml-graphics2.4 libcsfml-network2.4 libcsfml-system2.4 libcsfml-window2.4 libsfml-audio2.4 libsfml-dev libsfml-graphics2.4 libsfml-network2.4 libsfml-system2.4 libsfml-window2.4 python-yaml python3-yaml"
+
 ASSUME_YES=false
 QUIET=false
 

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -118,8 +118,8 @@ function install_arm_none_eabi_toolchain() {
     )
   fi
   echo "Registering STM32 Toolchain for ccache"
-  sudo ln -s $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
-  sudo ln -s $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
+  sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
+  sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
   echo "Done!"
 }
 

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -9,6 +9,18 @@ if [ $EUID == 0 ]; then
 fi
 
 OPT="/opt"
+RELEASE_CODENAME=$(lsb_release -c -s)
+if [ ${RELEASE_CODENAME} == 'xenial' ]; then
+    SITLFML_VERSION="2.3v5"
+    SITLCFML_VERSION="2.3"
+elif [ ${RELEASE_CODENAME} == 'disco' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+else
+    SITLFML_VERSION="2.4"
+    SITLCFML_VERSION="2.4"
+fi
+
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
 # add some Python packages required for commonly-used MAVProxy modules:
@@ -20,7 +32,7 @@ ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # python-wxgtk packages are added to SITL_PKGS below
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing xterm lcov gcovr"
 # add some packages required for commonly-used MAVProxy modules:
-SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio2.4 libcsfml-dev libcsfml-graphics2.4 libcsfml-network2.4 libcsfml-system2.4 libcsfml-window2.4 libsfml-audio2.4 libsfml-dev libsfml-graphics2.4 libsfml-network2.4 libsfml-system2.4 libsfml-window2.4 python-yaml python3-yaml"
+SITL_PKGS="$SITL_PKGS libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION} python-yaml python3-yaml"
 
 ASSUME_YES=false
 QUIET=false

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -31,7 +31,7 @@ fi
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
 ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="Tools/autotest"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -16,6 +16,9 @@ if [ ${RELEASE_CODENAME} == 'xenial' ]; then
 elif [ ${RELEASE_CODENAME} == 'disco' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
+elif [ ${RELEASE_CODENAME} == 'eoan' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
 else
     SITLFML_VERSION="2.4"
     SITLCFML_VERSION="2.4"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -3,6 +3,11 @@ echo "---------- $0 start ----------"
 set -e
 set -x
 
+if [ $EUID == 0 ]; then
+    echo "Please do not run this script as root; don't sudo it!"
+    exit 1
+fi
+
 OPT="/opt"
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -26,8 +26,8 @@ fi
 
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect"
-# add some Python packages required for commonly-used MAVProxy modules:
-PYTHON_PKGS="$PYTHON_PKGS pygame"
+# add some Python packages required for commonly-used MAVProxy modules and hex file generation:
+PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
 PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo libftdi-dev zlib1g-dev \
           zip genromfs python-empy cmake cmake-data"
@@ -123,6 +123,7 @@ fi
 
 $APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS
 pip2 -q install --user -U $PYTHON_PKGS
+
 
 if [ ! -d $OPT/$ARM_ROOT ]; then
     (

--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -5,7 +5,7 @@ Import-Module BitsTransfer
 Write-Output "Starting Downloads"
 
 Write-Output "Downloading MAVProxy (1/6)"
-Start-BitsTransfer -Source "http://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
+Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
 
 Write-Output "Downloading Cygwin x64 (2/6)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -5,7 +5,7 @@ Import-Module BitsTransfer
 Write-Output "Starting Downloads"
 
 Write-Output "Downloading MAVProxy (1/5)"
-Start-BitsTransfer -Source "http://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
+Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
 
 Write-Output "Downloading Cygwin x64 (2/5)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -627,7 +627,7 @@ is bob we will attempt to checkout bob-AVR'''
     def generate_manifest(self):
         '''generate manigest files for GCS to download'''
         self.progress("Generating manifest")
-        base_url = 'http://firmware.ardupilot.org'
+        base_url = 'https://firmware.ardupilot.org'
         generator = generate_manifest.ManifestGenerator(self.binaries,
                                                         base_url)
         content = generator.json()

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -21,14 +21,14 @@ pushd $HOME
 # PX4 toolchain
 dir=$ARM_ROOT
 if [ ! -d "$HOME/opt/$dir" -o ! -x "$HOME/opt/$dir/bin/arm-none-eabi-g++" ]; then
-  wget http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL
+  wget https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL
   tar -xf $ARM_TARBALL -C opt
 fi
 
 # RPi/BBB toolchain
 dir="tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64"
 if [ ! -d "$HOME/opt/$dir" -o ! -x "$HOME/opt/$dir/bin/arm-linux-gnueabihf-g++" ]; then
-  wget http://firmware.ardupilot.org/Tools/Travis/NavIO/$RPI_TARBALL
+  wget https://firmware.ardupilot.org/Tools/Travis/NavIO/$RPI_TARBALL
   tar -xf $RPI_TARBALL -C opt $dir
 fi
 

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -480,7 +480,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='generate manifest.json')
 
     parser.add_argument('--outfile', type=str, default=None, help='output file, default stdout')
-    parser.add_argument('--baseurl', type=str, default="http://firmware.ardupilot.org", help='base binaries directory')
+    parser.add_argument('--baseurl', type=str, default="https://firmware.ardupilot.org", help='base binaries directory')
     parser.add_argument('basedir', type=str, default="-", help='base binaries directory')
 
     args = parser.parse_args()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,18 +45,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # LTS, EOL April, 2019:
   config.vm.define "trusty32", autostart: false do |trusty32|
-    config.vm.box = "ubuntu/trusty32"
-    config.vm.provision "trusty32", type: "shell", path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    trusty32.vm.box = "ubuntu/trusty32"
+    trusty32.vm.provision "trusty32", type: "shell", path: "Tools/vagrant/initvagrant.sh"
+    trusty32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (trusty32)"
     end
   end
 
   # 14.04.5 LTS, EOL April, 2019:
   config.vm.define "trusty64", autostart: false do |trusty64|
-    config.vm.box = "ubuntu/trusty64"
-    config.vm.provision "trusty64", type: "shell", path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    trusty64.vm.box = "ubuntu/trusty64"
+    trusty64.vm.provision "trusty64", type: "shell", path: "Tools/vagrant/initvagrant.sh"
+    trusty64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (trusty64)"
     end
   end
@@ -64,16 +64,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # LTS, EOL April 2021
   # this VM is useful for running valgrind on!
   config.vm.define "xenial32", autostart: false do |xenial32|
-    config.vm.box = "ubuntu/xenial32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    xenial32.vm.box = "ubuntu/xenial32"
+    xenial32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    xenial32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (xenial32)"
     end
   end
+
   config.vm.define "xenial64", autostart: false do |xenial64|
-    config.vm.box = "ubuntu/xenial64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    xenial64.vm.box = "ubuntu/xenial64"
+    xenial64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    xenial64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (xenial64)"
     end
   end
@@ -82,9 +83,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # EOL January 2018
   # Only kept around for those few dev's who have already got this image and continue to use it.
   config.vm.define "zesty32", autostart: false do |zesty32|
-    config.vm.box = "ubuntu/zesty32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    zesty32.vm.box = "ubuntu/zesty32"
+    zesty32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    zesty32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (zesty32)"
     end
   end
@@ -92,55 +93,55 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # 17.10, EOL July 2018
   # Only kept around for those few dev's who have already got this image and continue to use it; not available for download
   config.vm.define "artful32", autostart: false do |artful32|
-    config.vm.box = "ubuntu/artful32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    artful32.vm.box = "ubuntu/artful32"
+    artful32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    artful32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (artful32)"
     end
   end
 
   # 18.04 LTS
+  # Only kept around for those few dev's who have already got this image and continue to use it; not available for download
   config.vm.define "bionic32", autostart: false do |bionic32|
-    config.vm.box = "ubuntu/bionic32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    bionic32.vm.box = "ubuntu/bionic32"
+    bionic32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    bionic32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (bionic32)"
     end
   end
 
   # 18.04 LTS
   config.vm.define "bionic64", primary: true do |bionic64|
-    config.vm.box = "ubuntu/bionic64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    bionic64.vm.box = "ubuntu/bionic64"
+    bionic64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    bionic64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (bionic64)"
     end
   end
 
-
   # 18.10
   config.vm.define "cosmic32", autostart: false do |cosmic32|
-    config.vm.box = "ubuntu/cosmic32"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    cosmic32.vm.box = "ubuntu/cosmic32"
+    cosmic32.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    cosmic32.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (cosmic32)"
     end
   end
 
   # 18.10
   config.vm.define "cosmic64", autostart: false do |cosmic64|
-    config.vm.box = "ubuntu/cosmic64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    cosmic64.vm.box = "ubuntu/cosmic64"
+    cosmic64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    cosmic64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (cosmic64)"
     end
   end
 
   # 19.04 bleeding edge
   config.vm.define "disco64", autostart: false do |disco64|
-    config.vm.box = "ubuntu/disco64"
-    config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    config.vm.provider "virtualbox" do |vb|
+    disco64.vm.box = "ubuntu/disco64"
+    disco64.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+    disco64.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot (disco64)"
       vb.gui = true
     end


### PR DESCRIPTION
This just cherry-picks a bunch of commits from master to Sub-4.0 to fix installing the Ubuntu prereqs. We don't recommend our developers to the the script in master as it can have breaking changes (it updated to gcc 10, for example).

This was tested on Ubunut 20.04 by me and @ES-Alexander 