### PR TITLE
Allow coverage data with sim_vehicle.py

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -220,6 +220,9 @@ class Board:
                 '-lgcov',
                 '-coverage',
             ]
+            env.DEFINES.update(
+                HAL_COVERAGE_BUILD = 1,
+            )
 
         if cfg.options.bootloader:
             # don't let bootloaders try and pull scripting in

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -170,6 +170,12 @@ void HAL_SITL::setup_signal_handlers() const
     sa.sa_flags = SA_NOCLDSTOP;
     sa.sa_handler = HAL_SITL::exit_signal_handler;
     sigaction(SIGTERM, &sa, NULL);
+#if defined(HAL_COVERAGE_BUILD) && HAL_COVERAGE_BUILD == 1
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGHUP, &sa, NULL);
+    sigaction(SIGQUIT, &sa, NULL);
+#endif
+
 }
 
 /*


### PR DESCRIPTION
This allow SITL to correctly exit with most exit signals

HUP and QUIT are used when the terminal that is running SITL is closed. This is important when using sim_vehicle.py as we are running SITL in xterm. Then on Ctrl-C the xterm will be close and SITL get a HUP signal and not INT. 

This allow SITL to be run normally and still write the coverage .gcda file at the end !