### PR TITLE
github: build MatekF405 with/without HAL_QUADPLANE_ENABLED

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -86,6 +86,20 @@ jobs:
           mkdir $GITHUB_WORKSPACE/pr_bin
           cp -r build/${{matrix.config}}/bin/* $GITHUB_WORKSPACE/pr_bin/
 
+          # build MatekF405 Plane without quadplane
+          if [ "${{matrix.config}}" = "MatekF405" ]; then
+            PLANE_BINARY="build/MatekF405/bin/arduplane.bin"
+            echo "normal size"
+            ls -l "$PLANE_BINARY"
+            EXTRA_HWDEF="/tmp/extra-options.def"
+            echo "define HAL_QUADPLANE_ENABLED 0" >"$EXTRA_HWDEF"
+            ./waf configure --board ${{matrix.config}} --extra-hwdef="$EXTRA_HWDEF"
+            ./waf plane
+            rm "$EXTRA_HWDEF"
+            echo "non-quadplane size:"
+            ls -l "$PLANE_BINARY"
+          fi
+
       - name: Full size compare with Master
         shell: bash
         run: |


### PR DESCRIPTION
Builds Plane with quadplane disabled as well as enabled.

Sample output:

```
2021-09-14T04:26:17.0643654Z 'build' finished successfully (52.291s)
2021-09-14T04:26:17.1913248Z normal size
2021-09-14T04:26:17.1929298Z -rwxr-xr-x 1 root root 969640 Sep 14 04:26 build/MatekF405/bin/arduplane.bin
.
.
2021-09-14T04:26:35.1745073Z 'plane' finished successfully (17.078s)
2021-09-14T04:26:35.2198304Z non-quadplane size:
2021-09-14T04:26:35.2211869Z -rwxr-xr-x 1 root root 852080 Sep 14 04:26 build/MatekF405/bin/arduplane.bin
```
