### PR TITLE
Add alternate (betaflight) rates to copter in Acro mode

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -471,7 +471,68 @@ const AP_Param::Info Copter::var_info[] = {
     // @Range: -0.5 1.0
     // @User: Advanced
     GSCALAR(acro_rp_expo,  "ACRO_RP_EXPO",    ACRO_RP_EXPO_DEFAULT),
+
+ 
 #endif
+    // @Param: ALTRATE_TYPE
+    // @DisplayName: Alternate Rate Type
+    // @Description: Enables use of alternative rates (ie. betaflight rates)
+    // @Values: 0:default, 1:Betaflight
+    // @Range: 0 1
+    // @User: Advanced
+    GSCALAR(altrate_type,  "ARATE_TYPE",    ALTRATE_TYPE_DEFAULT),
+
+
+    // @Param: ALTRATE_BF_RP_RC
+    // @DisplayName: Acro Betaflight Pitch/Yaw RC rate 
+    // @Description: Acro Betaflight Pitch/Yaw RC rate 
+    // @Values: 0:min, 2.55:max
+    // @Range: 0 2.55
+    // @User: Advanced
+    GSCALAR(altrate_bf_rp_rc,  "ARATE_BF_RP_RC",    ALTRATE_BF_RP_RC_DEFAULT),
+
+    // @Param: ALTRATE_BF_RP_SUPER
+    // @DisplayName: Acro Betaflight Pitch/Yaw Super rate 
+    // @Description: Acro Betaflight Pitch/Yaw Super rate 
+    // @Values: 0:min, 0.99:max
+    // @Range: 0 0.99
+    // @User: Advanced
+    GSCALAR(altrate_bf_rp_super,  "ARATE_BF_RP_SPR",    ALTRATE_BF_RP_SUPER_DEFAULT),
+
+    // @Param: ALTRATE_BF_RP_EXPO
+    // @DisplayName: Acro Betaflight Pitch/Yaw Expo  
+    // @Description: Acro Betaflight Pitch/Yaw Expo  
+    // @Values: 0:min, 1:max
+    // @Range: 0 1
+    // @User: Advanced
+    GSCALAR(altrate_bf_rp_expo,  "ARATE_BF_RP_EXP",    ALTRATE_BF_RP_EXPO_DEFAULT),
+
+    // @Param: ALTRATE_BF_Y_RC
+    // @DisplayName: Acro Betaflight Pitch/Yaw RC rate 
+    // @Description: Acro Betaflight Pitch/Yaw RC rate 
+    // @Values: 0:min 2.55:max
+    // @Range: 0 2.55
+    // @User: Advanced
+    GSCALAR(altrate_bf_y_rc,  "ARATE_BF_Y_RC",    ALTRATE_BF_Y_RC_DEFAULT),
+
+    // @Param: ALTRATE_BF_Y_SUPER
+    // @DisplayName: Acro Betaflight Pitch/Yaw Super rate 
+    // @Description: Acro Betaflight Pitch/Yaw Super rate 
+    // @Values: 0:min 0.99:max
+    // @Range: 0 0.99
+    // @User: Advanced
+    GSCALAR(altrate_bf_y_super,  "ARATE_BF_Y_SPR",    ALTRATE_BF_Y_SUPER_DEFAULT),
+
+    // @Param: ALTRATE_BF_RP_EXPO
+    // @DisplayName: Acro Betaflight Pitch/Yaw Expo  
+    // @Description: Acro Betaflight Pitch/Yaw Expo  
+    // @Values: 0:min 1:max
+    // @Range: 0 1
+    // @User: Advanced
+    GSCALAR(altrate_bf_y_expo,  "ARATE_BF_Y_EXP",    ALTRATE_BF_Y_EXPO_DEFAULT),
+
+    
+
 
     // variables not in the g class which contain EEPROM saved variables
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -377,6 +377,20 @@ public:
 
         k_param_vehicle = 257, // vehicle common block of parameters
 
+        //
+        //270: acro betaflight rate
+        k_param_altrate_type = 270,
+        k_param_altrate_bf_rp_rc,
+        k_param_altrate_bf_rp_super,
+        k_param_altrate_bf_rp_expo,
+        k_param_altrate_bf_y_rc,
+        k_param_altrate_bf_y_super,
+        k_param_altrate_bf_y_expo,   //275
+
+    
+
+
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -467,6 +481,15 @@ public:
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
     AP_Float                acro_rp_expo;
+
+    //Alternative rates
+    AP_Int8                 altrate_type;       //enables and selects alternative rate. 0: acro default, 1: betaflight
+    AP_Float                altrate_bf_rp_rc;   
+    AP_Float                altrate_bf_rp_super;
+    AP_Float                altrate_bf_rp_expo;
+    AP_Float                altrate_bf_y_rc;
+    AP_Float                altrate_bf_y_super;
+    AP_Float                altrate_bf_y_expo;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -474,6 +474,39 @@
  #define ACRO_RP_EXPO_DEFAULT       0.3f
 #endif
 
+#ifndef ALTRATE_TYPE_DEFAULT
+ #define ALTRATE_TYPE_DEFAULT           0
+#endif
+
+#ifndef ALTRATE_TYPE_BETAFLIGHT
+  #define ALTRATE_TYPE_BETAFLIGHT       1
+#endif 
+
+#ifndef ALTRATE_BF_RP_RC_DEFAULT
+ #define ALTRATE_BF_RP_RC_DEFAULT       1.0f
+#endif
+
+#ifndef ALTRATE_BF_RP_SUPER_DEFAULT
+ #define ALTRATE_BF_RP_SUPER_DEFAULT    0.2f
+#endif
+
+#ifndef ALTRATE_BF_RP_EXPO_DEFAULT
+# define ALTRATE_BF_RP_EXPO_DEFAULT      0.4f
+#endif
+
+#ifndef ALTRATE_BF_Y_RC_DEFAULT
+# define ALTRATE_BF_Y_RC_DEFAULT        1.0f
+#endif
+
+#ifndef ALTRATE_BF_Y_SUPER_DEFAULT
+ #define ALTRATE_BF_Y_SUPER_DEFAULT      0.2f
+#endif
+
+#ifndef ALTRATE_BF_Y_EXPO_DEFAULT
+ #define ALTRATE_BF_Y_EXPO_DEFAULT      0.4f
+#endif
+
+
 #ifndef ACRO_Y_EXPO_DEFAULT
  #define ACRO_Y_EXPO_DEFAULT        0.0f
 #endif


### PR DESCRIPTION
Added support for alternative rates. Betaflight rates are added in this commit.

Roll/pitch rates will apply in ACRO mode.
Yaw rates will apply in all modes

Rate parameters are under ARATE_*
ARATE_TYPE = 0 to use default ardupilot rates (any value that's not defined will also default to ardupilot rates)
ARATE_TYPE = 1 to use betaflight rates
ARATE_BF_RP* and ARATE_BF_Y_* = set the betaflight roll/pitch and yaw RC,Super,Expo values.


Tested RPY on the bench with props off with two sets of BF values by comparing RATE_DES against RC_IN in the logs.
Also passed build_all.sh