### PR TITLE
Copter: convert RTL_ALT to int32

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -109,7 +109,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: RTL Altitude
     // @Description: The minimum alt above home the vehicle will climb to before returning.  If the vehicle is flying higher than this value it will return at its current altitude.
     // @Units: cm
-    // @Range: 200 8000
+    // @Range: 200 300000
     // @Increment: 1
     // @User: Standard
     GSCALAR(rtl_altitude,   "RTL_ALT",     RTL_ALT),
@@ -1185,6 +1185,10 @@ void Copter::load_parameters(void)
 
     // convert fs_options parameters
     convert_fs_options_params();
+
+#if MODE_RTL_ENABLED == ENABLED
+    g.rtl_altitude.convert_parameter_width(AP_PARAM_INT16);
+#endif
 
     hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -394,7 +394,7 @@ public:
     AP_Float        pilot_takeoff_alt;
 
 #if MODE_RTL_ENABLED == ENABLED
-    AP_Int16        rtl_altitude;
+    AP_Int32        rtl_altitude;
     AP_Int16        rtl_speed_cms;
     AP_Float        rtl_cone_slope;
     AP_Int16        rtl_alt_final;

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -144,7 +144,7 @@ void AP_Avoidance_Copter::set_mode_else_try_RTL_else_LAND(Mode::Number mode)
     }
 }
 
-int16_t AP_Avoidance_Copter::get_altitude_minimum() const
+int32_t AP_Avoidance_Copter::get_altitude_minimum() const
 {
 #if MODE_RTL_ENABLED == ENABLED
     // do not descend if below RTL alt

--- a/ArduCopter/avoidance_adsb.h
+++ b/ArduCopter/avoidance_adsb.h
@@ -20,7 +20,7 @@ private:
     void set_mode_else_try_RTL_else_LAND(Mode::Number mode);
 
     // get minimum limit altitude allowed on descend
-    int16_t get_altitude_minimum() const;
+    int32_t get_altitude_minimum() const;
 
 protected:
     // override avoidance handler


### PR DESCRIPTION
Closes #7787

This allows a user to set a RTL_ALT higher than the previous max. of 326.67m which could be limiting depending upon terrain. 

Tested that it retains the user param value from master to this PR.
Tested that if the param is changed after the PR the param value is kept.
Tested in SITL that a RTL_Alt of  85600 cm is achieved before heading home.

Note I had to also change the RTL_CONE to 10 to get it to go above 32767 since my WPs were so close. 

Picture Below shows climb at current location to RTL_ALT, moves to RTL location at RTL_ALT, and then descends.
![rtl_alt_to_int32_PR](https://user-images.githubusercontent.com/69225461/133306238-9f528fed-077a-449f-b043-d05ade6a5a3b.png)



