### PR TITLE
SRV_Channel: fix override timeout without repeated calls

### DIFF
--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -328,7 +328,16 @@ void SRV_Channels::set_output_pwm_chan_timeout(uint8_t chan, uint16_t value, uin
         const uint32_t loop_count = ((timeout_ms * 1000U) + (loop_period_us - 1U)) / loop_period_us;
         override_counter[chan] = constrain_int32(loop_count, 0, UINT16_MAX);
         channels[chan].set_override(true);
+        const bool had_pwm = SRV_Channel::have_pwm_mask & (1U<<chan);
         channels[chan].set_output_pwm(value,true);
+        if (!had_pwm) {
+            // clear the have PWM mask so the channel will default back to the scaled value when timeout expires
+            // this is also cleared by set_output_scaled but that requires it to be re-called as some point
+            // after the timeout is applied
+            // note that we can't default back to a pre-override PWM value as it is not stored
+            // checking had_pwm means the PWM will not change after the timeout, this was the existing behaviour
+            SRV_Channel::have_pwm_mask &= ~(1U<<chan);
+        }
     }
 }
 


### PR DESCRIPTION
This is a pair of fixes that mainly help with scripting. This makes little difference to the common output channels that are re-sent every loop. 

Firstly `calc_pwm` no longer sets `have_pwm_mask` this means that you can change SERVO min/max/trim and that will be directly reflected in the output. Currently the output will only change when `set_servo_scaled` is next called.

The second change is to no longer change `have_pwm_mask` when setting a override.

In combination these changes mean that overrides timeout correctly for output that are not being called repeatedly, like the scripting servo functions. 

For example:
```
local chan = SRV_Channels:find_channel(94)
SRV_Channels:set_range(94,100)
SRV_Channels:set_output_scaled(94,0)
SRV_Channels:set_output_pwm_chan_timeout(chan, 2000, 1000)
```
On master this will result in a PWM of 2000 for ever, the is no `set_output_scaled` call to clear `have_pwm_mask`. With this PR it will revert back to `SERVOx_MIN` after 1 second.

This only works for scaled outputs, timeouts will not revert to a past PWM value. For example this will not work:
```
local chan = SRV_Channels:find_channel(94)
SRV_Channels:set_output_pwm_chan(chan, 1000)
SRV_Channels:set_output_pwm_chan_timeout(chan, 2000, 1000)
```

This is useful if you want to use the scripting outputs for something that must failsafe if the script goes away. 


