### PR TITLE
Blimp: Initial SITL dynamics

### DIFF
--- a/Tools/autotest/default_params/blimp.parm
+++ b/Tools/autotest/default_params/blimp.parm
@@ -74,3 +74,57 @@ INS_ACC3SCAL_Z   1.000
 
 ARMING_RUDDER 0
 GCS_PID_MASK 255
+
+# default PID params for position and velocity-controlled modes
+MAX_POS_XY       0.3
+MAX_POS_YAW      0.3
+MAX_POS_Z        0.15
+MAX_VEL_XY       0.4
+MAX_VEL_YAW      0.5
+MAX_VEL_Z        0.2
+
+VELXY_D          0.0
+VELXY_FF         0.0
+VELXY_FLTD       3.0
+VELXY_FLTE       3.0
+VELXY_I          1.5
+VELXY_IMAX       5.0
+VELXY_P          5.0
+VELYAW_D         0.0
+VELYAW_FF        0.0
+VELYAW_FLTD      3.0
+VELYAW_FLTE      3.0
+VELYAW_I         0.8
+VELYAW_IMAX      5.0
+VELYAW_P         15.0
+VELZ_D           0.0
+VELZ_FF          0.0
+VELZ_FLTD        3.0
+VELZ_FLTE        3.0
+VELZ_I           1.0
+VELZ_IMAX        2.0
+VELZ_P           15.0
+
+POSXY_D          0.0
+POSXY_FF         0.0
+POSXY_FLTD       3.0
+POSXY_FLTE       3.0
+POSXY_I          0.05
+POSXY_IMAX       0.1
+POSXY_P          1.0
+POSYAW_D         0.0
+POSYAW_FF        0.0
+POSYAW_FLTD      3.0
+POSYAW_FLTE      3.0
+POSYAW_FLTT      3.0
+POSYAW_I         0.1
+POSYAW_IMAX      1.0
+POSYAW_P         1.0
+POSYAW_SMAX      0.0
+POSZ_D           0.0
+POSZ_FF          0.0
+POSZ_FLTD        3.0
+POSZ_FLTE        3.0
+POSZ_I           0.0
+POSZ_IMAX        0.0
+POSZ_P           0.7

--- a/Tools/autotest/default_params/blimp.parm
+++ b/Tools/autotest/default_params/blimp.parm
@@ -12,43 +12,46 @@ COMPASS_OFS3_X   5
 COMPASS_OFS3_Y   13
 COMPASS_OFS3_Z   -18
 FRAME_CLASS     1
-RC1_MAX         2000.000000
-RC1_MIN         1000.000000
-RC1_TRIM        1500.000000
-RC2_MAX         2000.000000
-RC2_MIN         1000.000000
-RC2_TRIM        1500.000000
-RC3_MAX         2000.000000
-RC3_MIN         1000.000000
-RC3_TRIM        1500.000000
-RC4_MAX         2000.000000
-RC4_MIN         1000.000000
-RC4_TRIM        1500.000000
-RC5_MAX         2000.000000
-RC5_MIN         1000.000000
-RC5_TRIM        1500.000000
-RC6_MAX         2000.000000
-RC6_MIN         1000.000000
-RC6_TRIM        1500.000000
-RC7_MAX         2000.000000
-RC7_MIN         1000.000000
-RC7_TRIM        1500.000000
-RC8_MAX         2000.000000
-RC8_MIN         1000.000000
-RC8_TRIM        1500.000000
+RC1_MAX         2000
+RC1_MIN         1000
+RC1_TRIM        1500
+RC2_MAX         2000
+RC2_MIN         1000
+RC2_TRIM        1500
+RC3_MAX         2000
+RC3_MIN         1000
+RC3_TRIM        1500
+RC4_MAX         2000
+RC4_MIN         1000
+RC4_TRIM        1500
+RC5_MAX         2000
+RC5_MIN         1000
+RC5_TRIM        1500
+RC6_MAX         2000
+RC6_MIN         1000
+RC6_TRIM        1500
+RC7_MAX         2000
+RC7_MIN         1000
+RC7_TRIM        1500
+RC8_MAX         2000
+RC8_MIN         1000
+RC8_TRIM        1500
+
 # setting servo functions for the four fins
 SERVO1_FUNCTION 33
-SERVO1_FUNCTION 34
-SERVO1_FUNCTION 35
-SERVO1_FUNCTION 36
+SERVO2_FUNCTION 34
+SERVO3_FUNCTION 35
+SERVO4_FUNCTION 36
 
-FLTMODE1        7
-FLTMODE2        9
-FLTMODE3        6
-FLTMODE4        3
-FLTMODE5        5
-FLTMODE6		0
+FLTMODE1         0
+FLTMODE2         1
+FLTMODE3         2
+FLTMODE4         3
+FLTMODE5         1
+FLTMODE6         1
+
 SIM_BARO_RND    0
+
 # we need small INS_ACC offsets so INS is recognised as being calibrated
 INS_ACCOFFS_X   0.001
 INS_ACCOFFS_Y   0.001
@@ -68,20 +71,6 @@ INS_ACC3OFFS_Z   0.000
 INS_ACC3SCAL_X   1.000
 INS_ACC3SCAL_Y   1.000
 INS_ACC3SCAL_Z   1.000
-# flightmodes
-# switch 1 Circle
-# switch 2 LAND
-# switch 3 RTL
-# switch 4 Auto
-# switch 5 Loiter
-# switch 6 Stab
-# STABILIZE 	0 !
-# ACRO 			1
-# ALT_HOLD 		2
-# AUTO 			3 !
-# GUIDED 		4
-# LOITER 		5 !
-# RTL 			6 !
-# CIRCLE 		7 !
-# POSITION 		8
-# LAND 			9 !
+
+ARMING_RUDDER 0
+GCS_PID_MASK 255

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -206,11 +206,9 @@ class VehicleInfo(object):
         },
     },
     "Blimp": {
-        "default_frame": "quad",
+        "default_frame": "Blimp",
         "frames": {
-            # BLIMP
-            "quad": {
-                "model": "+",
+            "Blimp": {
                 "waf_target": "bin/blimp",
                 "default_params_filename": "default_params/blimp.parm",
             },

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -546,6 +546,11 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         for(uint8_t i = 0; i < 8; i++) {
             pwm_input[i] = 1500;
         }
+    } else if (strcmp(SKETCH, "Blimp") == 0) {
+        _vehicle = Blimp;
+        for(uint8_t i = 0; i < 8; i++) {
+            pwm_input[i] = 1500;
+        }
     } else {
         _vehicle = ArduPlane;
         if (_framerate == 0) {

--- a/libraries/SITL/SIM_Blimp.cpp
+++ b/libraries/SITL/SIM_Blimp.cpp
@@ -17,30 +17,87 @@
 */
 
 #include "SIM_Blimp.h"
-#include <AP_Motors/AP_Motors.h>
 
 #include <stdio.h>
 
 using namespace SITL;
 
+extern const AP_HAL::HAL& hal;
+
 Blimp::Blimp(const char *frame_str) :
     Aircraft(frame_str)
 {
-    frame_height = 0.0;
-    ground_behavior = GROUND_BEHAVIOR_NONE;
+    mass = 0.07;
+    radius = 0.25;
+    moment_of_inertia = {0.004375, 0.004375, 0.004375}; //m*r^2 for hoop...
+    k_tan = 5.52e-4; //Tangential (thrust) multiplier
+    drag_constant = 0.05;
+    drag_gyr_constant = 0.08;
+
     lock_step_scheduled = true;
+    ::printf("Starting Blimp AirFish model...\n");
 }
 
 // calculate rotational and linear accelerations
 void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
-    // float fin_back  = filtered_servo_angle(input, 0);
-    // float fin_front = filtered_servo_angle(input, 1);
-    // float fin_right = filtered_servo_angle(input, 2);
-    // float fin_left  = filtered_servo_angle(input, 3);
+  if (!hal.scheduler->is_system_initialized()) {
+      return;
+  }
 
-    // ::printf("FINS (%.1f %.1f %.1f %.1f)\n",
-    //          fin_back, fin_front, fin_right, fin_left);
+  //all fin setup
+  for (uint8_t i=0; i<4; i++) {
+    fin[i].last_angle = fin[i].angle;
+    fin[i].angle = filtered_servo_angle(input, i)*radians(75.0f); //for servo range of -75 deg to +75 deg
+    
+    if (fin[i].angle < fin[i].last_angle) fin[i].dir = 0; //thus 0 = "angle is reducing"
+    else fin[i].dir = 1;
+    
+    fin[i].vel = (fin[i].angle - fin[i].last_angle)/delta_time; //rad/s
+    fin[i].vel = constrain_float(fin[i].vel, radians(-450), radians(450));
+    fin[i].T = pow(fin[i].vel,2) * k_tan;
+    
+    fin[i].Fx = 0;
+    fin[i].Fy = 0;
+    fin[i].Fz = 0;
+  }
+
+  //TODO: Add normal force calculations and include roll & pitch oscillation.
+  //Back fin
+  fin[0].Fx =  fin[0].T*cos(fin[0].angle); //causes forward movement
+  fin[0].Fz =  fin[0].T*sin(fin[0].angle); //causes height change
+
+  //Front fin
+  fin[1].Fx = -fin[1].T*cos(fin[1].angle); //causes backward movement
+  fin[1].Fz =  fin[1].T*sin(fin[1].angle); //causes height change
+
+  //Right fin
+  fin[2].Fy = -fin[2].T*cos(fin[2].angle); //causes left movement
+  fin[2].Fx =  fin[2].T*sin(fin[2].angle); //causes yaw
+
+  //Left fin
+  fin[3].Fy =  fin[3].T*cos(fin[3].angle); //causes right movement
+  fin[3].Fx = -fin[3].T*sin(fin[3].angle); //causes yaw
+
+  Vector3f force_bf{0,0,0}; 
+  for (uint8_t i=0; i<4; i++) {
+    force_bf.x = force_bf.x + fin[i].Fx;
+    force_bf.y = force_bf.y + fin[i].Fy;
+    force_bf.z = force_bf.z + fin[i].Fz;
+  }
+
+  //mass in kg, thus accel in m/s/s
+  body_accel.x = force_bf.x/mass;
+  body_accel.y = force_bf.y/mass;
+  body_accel.z = force_bf.z/mass;
+
+  Vector3f rot_T{0,0,0};
+  rot_T.z = fin[2].Fx * radius + fin[3].Fx * radius;//in N*m (Torque = force * lever arm)
+
+  //rot accel = torque / moment of inertia
+  rot_accel.x = 0;
+  rot_accel.y = 0;
+  rot_accel.z = rot_T.z / moment_of_inertia.z;
 }
 
 /*
@@ -48,20 +105,50 @@ void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
  */
 void Blimp::update(const struct sitl_input &input)
 {
-    // get wind vector setup
-    update_wind(input);
+  delta_time = frame_time_us * 1.0e-6f;
 
-    Vector3f rot_accel;
+  Vector3f rot_accel = Vector3f(0,0,0);
+  calculate_forces(input, rot_accel, accel_body);
 
-    calculate_forces(input, rot_accel, accel_body);
+  if (hal.scheduler->is_system_initialized()) {
+    float gyr_sq = gyro.length_squared();
+    if (is_positive(gyr_sq)) {
+        Vector3f force_gyr = (gyro.normalized() * drag_gyr_constant * gyr_sq);
+        Vector3f ef_drag_accel_gyr = -force_gyr / mass;
+        Vector3f bf_drag_accel_gyr = dcm.transposed() * ef_drag_accel_gyr;
+        rot_accel += bf_drag_accel_gyr;
+    }
+  }
 
-    update_dynamics(rot_accel);
-    update_external_payload(input);
+  // update rotational rates in body frame
+  gyro += rot_accel * delta_time;
+  gyro.x = constrain_float(gyro.x, -radians(2000.0f), radians(2000.0f));
+  gyro.y = constrain_float(gyro.y, -radians(2000.0f), radians(2000.0f));
+  gyro.z = constrain_float(gyro.z, -radians(2000.0f), radians(2000.0f));
 
-    // update lat/lon/altitude
-    update_position();
-    time_advance();
+  // update attitude
+  dcm.rotate(gyro * delta_time);
+  dcm.normalize();
 
-    // update magnetic field
-    update_mag_field_bf();
+  if (hal.scheduler->is_system_initialized()) {
+    float speed_sq = velocity_ef.length_squared();
+    if (is_positive(speed_sq)) {
+        Vector3f force = (velocity_ef.normalized() * drag_constant * speed_sq);
+        Vector3f ef_drag_accel = -force / mass;
+        Vector3f bf_drag_accel = dcm.transposed() * ef_drag_accel;
+        accel_body += bf_drag_accel;
+    }
+
+    // add lifting force exactly equal to gravity, for neutral buoyancy
+    accel_body += dcm.transposed() * Vector3f(0,0,-GRAVITY_MSS);
+  }
+  
+  Vector3f accel_earth = dcm * accel_body;
+  accel_earth += Vector3f(0.0f, 0.0f, GRAVITY_MSS); //add gravity
+  velocity_ef += accel_earth * delta_time;
+  position += (velocity_ef * delta_time).todouble(); //update position vector
+
+  update_position(); //updates the position from the Vector3f position
+  time_advance();
+  update_mag_field_bf();
 }

--- a/libraries/SITL/SIM_Blimp.h
+++ b/libraries/SITL/SIM_Blimp.h
@@ -19,10 +19,20 @@
 #pragma once
 
 #include "SIM_Aircraft.h"
-#include "SIM_Motor.h"
-#include "SIM_Frame.h"
 
 namespace SITL {
+
+struct Fins
+{
+  float angle;
+  float last_angle;
+  bool dir;
+  float vel; // velocity, in rad/s
+  float T; //Tangential (thrust) force, in Neutons
+  float Fx; //Fx,y,z = Force in bodyframe orientation at servo position, in Newtons
+  float Fy;
+  float Fz;
+};
 
 /*
   a blimp simulator
@@ -41,10 +51,18 @@ public:
     }
 
 protected:
-    const struct {
-        float mass = 0.02;
-    } model;
+    float mass; //kilograms
+    float radius; //metres
+    Vector3f moment_of_inertia;
+
+    //Airfish-specific variables
+    Fins fin[4];
+    float k_tan; //Tangential force multiplier
+    float drag_constant;
+    float drag_gyr_constant;
+    float delta_time;
 
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
 };
+
 }


### PR DESCRIPTION
This PR adds some basic SITL dynamics for Blimp, allowing it to be flown in manual, loiter etc in SITL.

Some default PID tuning parameters are also added as the real Blimp's defaults are unfortunately not suited to the SITL version.