### PR TITLE
SITL: cope with a socket error in FlightAxis

### DIFF
--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -188,6 +188,8 @@ private:
     SocketAPM *sock;
     char replybuf[10000];
     pid_t socket_pid;
+    uint32_t sock_error_count;
+    double last_recv_sec;
 };
 
 


### PR DESCRIPTION
this fixes an issue that has arisen with the new threading approach
where RF would occasionally freeze