### PR TITLE
Plane: fixed overshoot in guided takeoff of quadplanes

### DIFF
--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -99,6 +99,11 @@ void Plane::set_guided_WP(void)
     auto_state.vtol_loiter = false;
     
     loiter_angle_reset();
+
+#if HAL_QUADPLANE_ENABLED
+    // cancel pending takeoff
+    quadplane.guided_takeoff = false;
+#endif
 }
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2011,6 +2011,10 @@ bool QuadPlane::in_vtol_mode(void) const
         poscontrol.get_state() > QPOS_APPROACH) {
         return true;
     }
+    if (plane.control_mode == &plane.mode_guided &&
+        guided_takeoff) {
+        return true;
+    }
     if (in_vtol_auto()) {
         if (!plane.auto_state.vtol_loiter || poscontrol.get_state() > QPOS_APPROACH) {
             return true;


### PR DESCRIPTION
this prevents height overshoot in quadplane guided mode takeoff. Target velocity needs to be set to zero and takeoff height used to allow new Z controller to do its job properly
This also fixes guided takeoff in tailsitters