### PR TITLE
AP_GPS: add femtomes gps driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -23,6 +23,7 @@
 #include <AP_RTC/AP_RTC.h>
 #include <climits>
 
+#include "AP_GPS_FEMTO.h"
 #include "AP_GPS_NOVA.h"
 #include "AP_GPS_ERB.h"
 #include "AP_GPS_GSOF.h"
@@ -81,7 +82,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: 1st GPS type
     // @Description: GPS type of 1st GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:UAVCAN-MovingBaseline-Base,23:UAVCAN-MovingBaseline-Rover
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:UAVCAN-MovingBaseline-Base,23:UAVCAN-MovingBaseline-Rover,24:Femto
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("_TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
@@ -90,7 +91,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _TYPE2
     // @DisplayName: 2nd GPS type
     // @Description: GPS type of 2nd GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:UAVCAN-MovingBaseline-Base,23:UAVCAN-MovingBaseline-Rover
+    // @Values: 0:None,1:AUTO,2:uBlox,3:MTK,4:MTK19,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:UAVCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:UAVCAN-MovingBaseline-Base,23:UAVCAN-MovingBaseline-Rover,24:Femto
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("_TYPE2",   1, AP_GPS, _type[1], 0),
@@ -622,6 +623,10 @@ void AP_GPS::detect_instance(uint8_t instance)
 
     case GPS_TYPE_NOVA:
         new_gps = new AP_GPS_NOVA(*this, state[instance], _port[instance]);
+        break;
+        
+    case GPS_TYPE_FEMTO:
+        new_gps = new AP_GPS_FEMTO(*this, state[instance], _port[instance]);
         break;
 
     default:

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -79,6 +79,7 @@ class AP_GPS
     friend class AP_GPS_UBLOX;
     friend class AP_GPS_Backend;
     friend class AP_GPS_UAVCAN;
+    friend class AP_GPS_FEMTO;
 
 public:
     AP_GPS();
@@ -121,6 +122,7 @@ public:
         GPS_TYPE_EXTERNAL_AHRS = 21,
         GPS_TYPE_UAVCAN_RTK_BASE = 22,
         GPS_TYPE_UAVCAN_RTK_ROVER = 23,
+        GPS_TYPE_FEMTO = 24,
     };
 
     /// GPS status codes

--- a/libraries/AP_GPS/AP_GPS_BinaryCRCMessageParser.cpp
+++ b/libraries/AP_GPS/AP_GPS_BinaryCRCMessageParser.cpp
@@ -1,0 +1,135 @@
+#include "AP_GPS_BinaryCRCMessageParser.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define AP_GPS_COMMON_BINARY_CRC_MSG_PARSER_DEBUG 0
+
+#if AP_GPS_COMMON_BINARY_CRC_MSG_PARSER_DEBUG
+# define Debug(fmt, args ...)                  \
+do {                                            \
+    hal.console->printf("%s:%d: " fmt "\n",     \
+                        __FUNCTION__, __LINE__, \
+                        ## args);               \
+    hal.scheduler->delay(1);                    \
+} while(0)
+#else
+ # define Debug(fmt, args ...)
+#endif
+
+AP_GPS_BinaryCRCMessageParser::AP_GPS_BinaryCRCMessageParser(const std::vector<uint8_t> &preambles,  uint8_t min_header_length, uint8_t max_header_length, uint16_t max_body_length)
+    :_preambles(preambles),
+    _min_header_length(min_header_length),
+    _max_header_length(max_header_length),
+    _max_body_length(max_body_length)   
+{
+}
+
+AP_GPS_BinaryCRCMessageParser::~AP_GPS_BinaryCRCMessageParser()
+{
+}
+
+bool AP_GPS_BinaryCRCMessageParser::parse(uint8_t data)
+{
+    uint8_t *msg_header_buff = get_message_header_buff();
+    uint8_t *msg_body_buff = get_message_body_buff();
+    reset:
+        switch (_decode_step) {
+            default:
+            case 0: //preambles
+                if (data == _preambles[_preamble_step]) {
+                    msg_header_buff[_preamble_step] = data;
+                    _preamble_step++;
+                    _read_size = _preamble_step;
+                    Debug("Got preamble %x",data);
+                } else if(0 == _preamble_step) {  // failed check the first preamble
+                    break;
+                } else {
+                    reset_parse();
+                    goto reset;
+                }       
+                if(_preamble_step >= _preambles.size()) {   // finish preambles 
+                    _decode_step++;
+                    Debug("Preambles exit");
+                }
+                break;
+            case 1: //get real header length
+                msg_header_buff[_read_size] = data;
+                _read_size++;
+                if(_read_size >= _min_header_length) {
+                    uint8_t header_len = get_message_header_length_from_header_buff();
+                    if(header_len < _min_header_length || header_len > _max_header_length) {
+                        Debug("Wrong header length : %u in header buff",header_len);
+                        Debug("buffinfo:%x,%x,%x,%u,size:%lu",msg_header_buff[0],msg_header_buff[1],msg_header_buff[2],msg_header_buff[3],_read_size);
+                        reset_parse();
+                        goto reset;
+                    }
+                    _real_header_length = header_len;
+                    _decode_step++;
+                    Debug("Got real message header length: %u",header_len);
+                }
+                break;
+            case 2: // header data
+                if (_read_size < _real_header_length) {
+                    msg_header_buff[_read_size] = data;
+                    _read_size++;
+                    
+                } else {
+                    uint16_t body_len = get_message_body_length_from_header_buff();
+                    if(body_len > _max_body_length) {
+                        Debug("Wrong body length : %u in header buff",body_len);
+                        reset_parse();
+                        goto reset;
+                    }
+                    _real_body_length = body_len;
+                    _decode_step++;
+                    Debug("Header data exit,Got real body length:%u",body_len);
+                    goto reset; // current data have not been readed, goto next case to read the data
+                }   
+                break;
+            case 3: //body data
+                if(_read_size < (_real_header_length + _real_body_length)) {
+                    msg_body_buff[_read_size - _real_header_length] = data;
+                    _read_size++;
+                    
+                } else {
+                    _decode_step++;
+                    Debug("Body data exit");
+                    goto reset; // current data have not been readed, goto next case to read the data 
+                }   
+                break;
+            case 4: //CRC1
+                _msg_crc = (uint32_t) (data << 0);
+                _decode_step++;
+                break;
+            case 5: //CRC2
+                _msg_crc += (uint32_t) (data << 8);
+                _decode_step++;
+                break;
+            case 6: //CRC3
+                _msg_crc += (uint32_t) (data << 16);
+                _decode_step++;
+                break;
+            case 7: //CRC4
+                _msg_crc += (uint32_t) (data << 24);
+                reset_parse();
+
+                uint32_t real_crc = crc_crc32((uint32_t)0, msg_header_buff, (uint32_t)_real_header_length);
+                real_crc = crc_crc32(real_crc, msg_body_buff, (uint32_t)_real_body_length);
+
+                if(real_crc != _msg_crc){
+                    Debug("CRC check failed,msg_crc:%lx,real_crc:%lx",_msg_crc,real_crc);
+                    goto reset;
+                }
+                Debug("Got new message");
+                return process_message();   /**< One whole message received */
+        }
+
+    return false;
+}
+
+void AP_GPS_BinaryCRCMessageParser::reset_parse()
+{
+    _decode_step = 0;
+    _read_size = 0;
+    _preamble_step = 0;
+}

--- a/libraries/AP_GPS/AP_GPS_BinaryCRCMessageParser.h
+++ b/libraries/AP_GPS/AP_GPS_BinaryCRCMessageParser.h
@@ -1,0 +1,53 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "AP_GPS.h"
+#include <vector>
+
+/*
+    parser abstract class for parse binary crc32 gps message
+*/
+class AP_GPS_BinaryCRCMessageParser
+{
+public:
+    explicit AP_GPS_BinaryCRCMessageParser(const std::vector<uint8_t> &preambles, uint8_t min_header_length, uint8_t max_header_length, uint16_t max_body_length);
+    ~AP_GPS_BinaryCRCMessageParser();
+
+protected:
+    virtual uint16_t get_message_body_length_from_header_buff() = 0;
+    virtual uint8_t get_message_header_length_from_header_buff() = 0;
+    virtual uint8_t *get_message_header_buff() = 0;
+    virtual uint8_t *get_message_body_buff() = 0;
+    bool parse(uint8_t data);
+    virtual bool process_message() = 0;
+
+private:
+    void reset_parse();
+
+    const std::vector<uint8_t> _preambles;
+    uint8_t _min_header_length;
+    uint8_t _max_header_length;
+    uint16_t _max_body_length;
+
+    uint8_t _decode_step;   // step number of message decode
+    uint32_t _msg_crc;      // message crc data
+    uint32_t _read_size;    // readed size of current message
+    uint8_t _preamble_step; // step of preamble decode
+    uint8_t _real_header_length;    //header length from real message header
+    uint16_t _real_body_length;     //body length from read message header
+};
+

--- a/libraries/AP_GPS/AP_GPS_FEMTO.cpp
+++ b/libraries/AP_GPS/AP_GPS_FEMTO.cpp
@@ -1,0 +1,183 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//  Femtomes GPS driver for ArduPilot.
+//  Code by Rui Zheng <ruizheng@femtomes.com>
+
+
+#include "AP_GPS.h"
+#include "AP_GPS_FEMTO.h"
+
+
+#define FEMTO_DEBUG 0
+
+#if FEMTO_DEBUG
+#include <cstdio>
+ # define Debug(fmt, args ...)                  \
+do {                                            \
+    printf("%s:%d: " fmt "\n",     \
+                        __FUNCTION__, __LINE__, \
+                        ## args);               \
+} while(0)
+#else
+ # define Debug(fmt, args ...)
+#endif
+
+const char* const AP_GPS_FEMTO::_initialisation_blob[] {
+    "\r\n\r\nUNLOGALL THISPORT\r\n",         /**< cleanup enviroment */
+    "LOG UAVGPSB ontime 0.2\r\n",   /**< get uavgps */
+    "LOG UAVSTATUSB ontime 0.2\r\n", /**< get uavstatus */
+};
+
+AP_GPS_FEMTO::AP_GPS_FEMTO(AP_GPS &_gps, AP_GPS::GPS_State &_state,
+                       AP_HAL::UARTDriver *_port) :
+    AP_GPS_Backend(_gps, _state, _port),
+    AP_GPS_BinaryCRCMessageParser({FEMTO_PREAMBLE1, FEMTO_PREAMBLE2, FEMTO_PREAMBLE3},4,sizeof(_femto_msg.header),sizeof(_femto_msg.body)),
+    _init_blob_index(0),
+    _init_blob_time(0),
+    _new_uavstatus(false),
+    _last_uav_status_time(0),
+    _new_uavgps(false),
+    _last_uav_gps_time(0)
+{
+    const char *init_str = _initialisation_blob[0];
+    port->write((const uint8_t*)init_str, strlen(init_str));
+}
+
+/** Process all bytes available from the stream */
+bool AP_GPS_FEMTO::read(void)
+{
+    uint8_t data;
+    int16_t numc;
+    bool parsed = false;
+    uint32_t now = AP_HAL::millis();
+
+    /** send initialisation commands to device */
+    if (_init_blob_index < (sizeof(_initialisation_blob) / sizeof(_initialisation_blob[0]))) {
+        const char *init_str = _initialisation_blob[_init_blob_index];
+
+        if (now > _init_blob_time) {
+            port->write((const uint8_t*)init_str, strlen(init_str));
+            _init_blob_time = now + 200;
+            _init_blob_index++;
+        }
+    }
+
+    /** receive and parse msg */
+    numc = port->available();
+    for (int16_t i = 0; i < numc; i++) {
+        data = port->read();
+        parsed |= parse(data);
+    }
+    
+    return parsed;
+}
+
+bool AP_GPS_FEMTO::process_message(void)
+{
+    uint16_t messageid = _femto_msg.header.msg_header.messageid;
+
+    Debug("FEMTO message messid=%u\n",messageid);
+
+    check_new_itow(_femto_msg.header.msg_header.tow, _femto_msg.header.msg_header.messagelength + _femto_msg.header.msg_header.headerlength);
+    
+    if (messageid == FEMTO_MSG_ID_UAVGPS) {  /**< uavgps */
+        const femto_uav_gps_t &uav_gps = _femto_msg.body.uav_gps;
+
+        state.time_week = _femto_msg.header.msg_header.week;
+        state.time_week_ms = (uint32_t) _femto_msg.header.msg_header.tow;
+
+        _last_uav_gps_time = state.time_week_ms;
+
+        state.last_gps_time_ms = AP_HAL::millis();
+
+        state.location.lat = uav_gps.lat;
+        state.location.lng = uav_gps.lon;
+        state.location.alt = uav_gps.alt/10;
+
+        state.num_sats = uav_gps.satellites_used;
+
+        state.horizontal_accuracy = uav_gps.eph;
+        state.vertical_accuracy = uav_gps.epv;
+        state.have_horizontal_accuracy = true;
+        state.have_vertical_accuracy = true;
+        state.rtk_num_sats = state.num_sats;
+
+        switch (uav_gps.fix_type) {
+            case 0:
+            case 1:
+                state.status = AP_GPS::NO_FIX;
+                break;
+            case 2:
+                state.status = AP_GPS::GPS_OK_FIX_2D;
+                break;                
+            case 3:
+                state.status = AP_GPS::GPS_OK_FIX_3D;
+                break;  
+            case 4:
+                state.status = AP_GPS::GPS_OK_FIX_3D_DGPS;
+                break;              
+            case 5:
+                state.status = AP_GPS::GPS_OK_FIX_3D_RTK_FLOAT;
+                break;                
+            case 6:
+                state.status = AP_GPS::GPS_OK_FIX_3D_RTK_FIXED;
+                break;             
+            default:
+                state.status = AP_GPS::NO_FIX;
+                break;
+        }
+
+        state.ground_speed = uav_gps.vel_m_s;
+        state.ground_course = uav_gps.cog_rad * RAD_TO_DEG;
+        fill_3d_velocity();
+        state.velocity.z = uav_gps.vel_d_m_s;
+        state.have_vertical_velocity = true;
+
+        state.hdop = (uint16_t) (uav_gps.hdop*100);
+        state.vdop = (uint16_t) (uav_gps.vdop*100);
+
+        /** about heading */
+        state.gps_yaw = uav_gps.heading;
+        state.gps_yaw_time_ms = state.last_gps_time_ms;
+        state.gps_yaw_accuracy = uav_gps.c_variance_rad * RAD_TO_DEG;
+        bool headingFixed = uav_gps.heading_type == 6;
+        state.gps_yaw_configured = headingFixed;
+        state.have_gps_yaw = headingFixed;
+        state.have_gps_yaw_accuracy = headingFixed;
+
+
+        _new_uavgps = true;
+    }
+
+    if (messageid == FEMTO_MSG_ID_UAVSTATUS) { /**< uavstatus */
+        const femto_uav_status_t &uavstatus = _femto_msg.body.uav_status;
+
+        state.rtk_age_ms = uavstatus.diff_age * 1000;
+
+        _last_uav_status_time = (uint32_t) _femto_msg.header.msg_header.tow;
+
+        _new_uavstatus = true;
+    }
+
+    /** ensure uavstatus and uavgps stay insync */
+    if (_new_uavstatus && _new_uavgps && _last_uav_status_time == _last_uav_gps_time) {
+        _new_uavstatus = _new_uavgps = false;
+
+        return true;
+    }
+
+    return false;
+}

--- a/libraries/AP_GPS/AP_GPS_FEMTO.h
+++ b/libraries/AP_GPS/AP_GPS_FEMTO.h
@@ -1,0 +1,158 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//  Femtomes GPS driver for ArduPilot.
+//  Code by Rui Zheng <ruizheng@femtomes.com>
+
+#pragma once
+
+#include "AP_GPS.h"
+#include "GPS_Backend.h"
+#include "AP_GPS_BinaryCRCMessageParser.h"
+
+
+class AP_GPS_FEMTO : public AP_GPS_Backend, public AP_GPS_BinaryCRCMessageParser
+{
+public:
+    AP_GPS_FEMTO(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
+
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+
+    // Methods
+    bool read() override;
+
+    const char *name() const override { return "FEMTO"; }
+
+private:
+    virtual uint16_t get_message_body_length_from_header_buff() override{return _femto_msg.header.msg_header.messagelength;};
+    virtual uint8_t get_message_header_length_from_header_buff() override{return _femto_msg.header.msg_header.headerlength;};
+    virtual uint8_t *get_message_header_buff() override{return (uint8_t *)&_femto_msg.header;};
+    virtual uint8_t *get_message_body_buff() override{return (uint8_t *)&_femto_msg.body;};
+    virtual bool process_message() override;
+
+    /**
+    * femto_msg_header_t is femto data header
+    */
+    struct PACKED femto_msg_header_t 
+    {
+        uint8_t 	preamble[3];	    /**< Frame header preamble 0xaa 0x44 0x12 */
+        uint8_t 	headerlength;	    /**< Frame header length ,from the beginning 0xaa */
+        uint16_t 	messageid;          /**< Frame message id ,example the FEMTO_MSG_ID_UAVGPS 8001*/
+        uint8_t 	messagetype;	    /**< Frame message id type */
+        uint8_t 	portaddr;	        /**< Frame message port address */
+        uint16_t 	messagelength;      /**< Frame message data length,from the beginning headerlength+1,end headerlength + messagelength*/
+        uint16_t 	sequence;
+        uint8_t 	idletime;	        /**< Frame message idle module time */
+        uint8_t 	timestatus;
+        uint16_t 	week;
+        uint32_t 	tow;
+        uint32_t 	recvstatus;
+        uint16_t 	resv;
+        uint16_t 	recvswver;
+    };
+
+    /**
+    * femto_uav_gps_t struct need to be packed
+    */
+    struct PACKED femto_uav_gps_t
+    {
+        uint64_t 	time_utc_usec;		/** Timestamp (microseconds, UTC), this is the timestamp which comes from the gps module. It might be unavailable right after cold start, indicated by a value of 0*/
+        int32_t 	lat;			    /** Latitude in 1E-7 degrees*/
+        int32_t 	lon;			    /** Longitude in 1E-7 degrees*/
+        int32_t 	alt;			    /** Altitude in 1E-3 meters above MSL, (millimetres)*/
+        int32_t 	alt_ellipsoid;		/** Altitude in 1E-3 meters bove Ellipsoid, (millimetres)*/
+        float 		s_variance_m_s;		/** GPS speed accuracy estimate, (metres/sec)*/
+        float 		c_variance_rad;		/** GPS course accuracy estimate, (radians)*/
+        float 		eph;			    /** GPS horizontal position accuracy (metres)*/
+        float 		epv;			    /** GPS vertical position accuracy (metres)*/
+        float 		hdop;			    /** Horizontal dilution of precision*/
+        float 		vdop;			    /** Vertical dilution of precision*/
+        int32_t 	noise_per_ms;		/** GPS noise per millisecond*/
+        int32_t 	jamming_indicator;	/** indicates jamming is occurring*/
+        float 		vel_m_s;		    /** GPS ground speed, (metres/sec)*/
+        float 		vel_n_m_s;		    /** GPS North velocity, (metres/sec)*/
+        float 		vel_e_m_s;		    /** GPS East velocity, (metres/sec)*/
+        float 		vel_d_m_s;		    /** GPS Down velocity, (metres/sec)*/
+        float 		cog_rad;		    /** Course over ground (NOT heading, but direction of movement), -PI..PI, (radians)*/
+        int32_t 	timestamp_time_relative;/** timestamp + timestamp_time_relative = Time of the UTC timestamp since system start, (microseconds)*/
+        float 		heading;		    /** heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])*/
+        uint8_t 	fix_type;		    /** 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic, float, 6: Real-Time Kinematic, fixed, 8: Extrapolated. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.*/
+        bool 		vel_ned_valid;		/** True if NED velocity is valid*/
+        uint8_t 	satellites_used;	/** Number of satellites used*/
+        uint8_t		heading_type;		/**< 0 invalid,5 for float,6 for fix*/
+    };
+
+    /** uav status data */
+    struct PACKED femto_uav_status_t
+    {
+        int32_t     master_ant_status;
+        int32_t     slave_ant_status;
+        uint16_t    master_ant_power;
+        uint16_t    slave_ant_power;
+        uint32_t    jam_status;
+        uint32_t    spoofing_status;
+        uint16_t    reserved16_1;
+        uint16_t    diff_age;		    /**< in unit of second*/
+        uint32_t    base_id;
+        uint32_t    reserved32_1;
+        uint32_t    reserved32_2;
+        uint32_t    sat_number;
+        struct PACKED femto_uav_sat_status_data_t{  
+            uint8_t   svid;
+            uint8_t   system_id;
+            uint8_t   cn0;		        /**< in unit of dB-Hz*/
+            uint8_t   ele;		        /**< in unit of degree*/
+            uint16_t  azi;		        /**< in unit of degree*/
+            uint16_t  status;
+        } sat_status[64];               /**< uav status of all satellites */
+    };
+
+
+
+    struct PACKED femto_msg_parser_t
+    {
+        union PACKED {
+            DEFINE_BYTE_ARRAY_METHODS
+            femto_uav_status_t uav_status;
+            femto_uav_gps_t uav_gps;
+        } body;
+        uint32_t crc;
+        union PACKED {
+            DEFINE_BYTE_ARRAY_METHODS
+            femto_msg_header_t msg_header;
+        } header;
+        uint16_t read;
+    };
+
+    static const uint8_t FEMTO_PREAMBLE1 = 0xaa;
+    static const uint8_t FEMTO_PREAMBLE2 = 0x44;
+    static const uint8_t FEMTO_PREAMBLE3 = 0x12;
+
+    static const uint16_t FEMTO_MSG_ID_UAVGPS = 8001;
+    static const uint16_t FEMTO_MSG_ID_UAVSTATUS = 8017;
+
+    static const char* const _initialisation_blob[];
+
+    femto_msg_parser_t _femto_msg;
+
+    uint8_t _init_blob_index;
+    uint32_t _init_blob_time;
+
+    bool _new_uavstatus;    /**< have new uav status */
+    uint32_t _last_uav_status_time;
+
+    bool _new_uavgps;       /**< have new uav gps */
+    uint32_t _last_uav_gps_time;
+};

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -40,9 +40,10 @@ do {                                            \
 
 AP_GPS_NOVA::AP_GPS_NOVA(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                        AP_HAL::UARTDriver *_port) :
-    AP_GPS_Backend(_gps, _state, _port)
+    AP_GPS_Backend(_gps, _state, _port),
+    AP_GPS_BinaryCRCMessageParser({NOVA_PREAMBLE1, NOVA_PREAMBLE2, NOVA_PREAMBLE3},4,sizeof(nova_msg.header),sizeof(nova_msg.data))
 {
-    nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+    // nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
 
     const char *init_str = _initialisation_blob[0];
     const char *init_str1 = _initialisation_blob[1];
@@ -86,107 +87,107 @@ AP_GPS_NOVA::read(void)
     return ret;
 }
 
-bool
-AP_GPS_NOVA::parse(uint8_t temp)
-{
-    switch (nova_msg.nova_state)
-    {
-        default:
-        case nova_msg_parser::PREAMBLE1:
-            if (temp == NOVA_PREAMBLE1)
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE2;
-            nova_msg.read = 0;
-            break;
-        case nova_msg_parser::PREAMBLE2:
-            if (temp == NOVA_PREAMBLE2)
-            {
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE3;
-            }
-            else
-            {
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
-            }
-            break;
-        case nova_msg_parser::PREAMBLE3:
-            if (temp == NOVA_PREAMBLE3)
-            {
-                nova_msg.nova_state = nova_msg_parser::HEADERLENGTH;
-            }
-            else
-            {
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
-            }
-            break;
-        case nova_msg_parser::HEADERLENGTH:
-            Debug("NOVA HEADERLENGTH\n");
-            nova_msg.header.data[0] = NOVA_PREAMBLE1;
-            nova_msg.header.data[1] = NOVA_PREAMBLE2;
-            nova_msg.header.data[2] = NOVA_PREAMBLE3;
-            nova_msg.header.data[3] = temp;
-            nova_msg.header.nova_headeru.headerlength = temp;
-            nova_msg.nova_state = nova_msg_parser::HEADERDATA;
-            nova_msg.read = 4;
-            break;
-        case nova_msg_parser::HEADERDATA:
-            if (nova_msg.read >= sizeof(nova_msg.header.data)) {
-                Debug("parse header overflow length=%u\n", (unsigned)nova_msg.read);
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
-                break;
-            }
-            nova_msg.header.data[nova_msg.read] = temp;
-            nova_msg.read++;
-            if (nova_msg.read >= nova_msg.header.nova_headeru.headerlength)
-            {
-                nova_msg.nova_state = nova_msg_parser::DATA;
-            }
-            break;
-        case nova_msg_parser::DATA:
-            if (nova_msg.read >= sizeof(nova_msg.data)) {
-                Debug("parse data overflow length=%u msglength=%u\n", (unsigned)nova_msg.read,nova_msg.header.nova_headeru.messagelength);
-                nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
-                break;
-            }
-            nova_msg.data.bytes[nova_msg.read - nova_msg.header.nova_headeru.headerlength] = temp;
-            nova_msg.read++;
-            if (nova_msg.read >= (nova_msg.header.nova_headeru.messagelength + nova_msg.header.nova_headeru.headerlength))
-            {
-                Debug("NOVA DATA exit\n");
-                nova_msg.nova_state = nova_msg_parser::CRC1;
-            }
-            break;
-        case nova_msg_parser::CRC1:
-            nova_msg.crc = (uint32_t) (temp << 0);
-            nova_msg.nova_state = nova_msg_parser::CRC2;
-            break;
-        case nova_msg_parser::CRC2:
-            nova_msg.crc += (uint32_t) (temp << 8);
-            nova_msg.nova_state = nova_msg_parser::CRC3;
-            break;
-        case nova_msg_parser::CRC3:
-            nova_msg.crc += (uint32_t) (temp << 16);
-            nova_msg.nova_state = nova_msg_parser::CRC4;
-            break;
-        case nova_msg_parser::CRC4:
-            nova_msg.crc += (uint32_t) (temp << 24);
-            nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+// bool
+// AP_GPS_NOVA::parse(uint8_t temp)
+// {
+//     switch (nova_msg.nova_state)
+//     {
+//         default:
+//         case nova_msg_parser::PREAMBLE1:
+//             if (temp == NOVA_PREAMBLE1)
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE2;
+//             nova_msg.read = 0;
+//             break;
+//         case nova_msg_parser::PREAMBLE2:
+//             if (temp == NOVA_PREAMBLE2)
+//             {
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE3;
+//             }
+//             else
+//             {
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+//             }
+//             break;
+//         case nova_msg_parser::PREAMBLE3:
+//             if (temp == NOVA_PREAMBLE3)
+//             {
+//                 nova_msg.nova_state = nova_msg_parser::HEADERLENGTH;
+//             }
+//             else
+//             {
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+//             }
+//             break;
+//         case nova_msg_parser::HEADERLENGTH:
+//             Debug("NOVA HEADERLENGTH\n");
+//             nova_msg.header.data[0] = NOVA_PREAMBLE1;
+//             nova_msg.header.data[1] = NOVA_PREAMBLE2;
+//             nova_msg.header.data[2] = NOVA_PREAMBLE3;
+//             nova_msg.header.data[3] = temp;
+//             nova_msg.header.nova_headeru.headerlength = temp;
+//             nova_msg.nova_state = nova_msg_parser::HEADERDATA;
+//             nova_msg.read = 4;
+//             break;
+//         case nova_msg_parser::HEADERDATA:
+//             if (nova_msg.read >= sizeof(nova_msg.header.data)) {
+//                 Debug("parse header overflow length=%u\n", (unsigned)nova_msg.read);
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+//                 break;
+//             }
+//             nova_msg.header.data[nova_msg.read] = temp;
+//             nova_msg.read++;
+//             if (nova_msg.read >= nova_msg.header.nova_headeru.headerlength)
+//             {
+//                 nova_msg.nova_state = nova_msg_parser::DATA;
+//             }
+//             break;
+//         case nova_msg_parser::DATA:
+//             if (nova_msg.read >= sizeof(nova_msg.data)) {
+//                 Debug("parse data overflow length=%u msglength=%u\n", (unsigned)nova_msg.read,nova_msg.header.nova_headeru.messagelength);
+//                 nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
+//                 break;
+//             }
+//             nova_msg.data.bytes[nova_msg.read - nova_msg.header.nova_headeru.headerlength] = temp;
+//             nova_msg.read++;
+//             if (nova_msg.read >= (nova_msg.header.nova_headeru.messagelength + nova_msg.header.nova_headeru.headerlength))
+//             {
+//                 Debug("NOVA DATA exit\n");
+//                 nova_msg.nova_state = nova_msg_parser::CRC1;
+//             }
+//             break;
+//         case nova_msg_parser::CRC1:
+//             nova_msg.crc = (uint32_t) (temp << 0);
+//             nova_msg.nova_state = nova_msg_parser::CRC2;
+//             break;
+//         case nova_msg_parser::CRC2:
+//             nova_msg.crc += (uint32_t) (temp << 8);
+//             nova_msg.nova_state = nova_msg_parser::CRC3;
+//             break;
+//         case nova_msg_parser::CRC3:
+//             nova_msg.crc += (uint32_t) (temp << 16);
+//             nova_msg.nova_state = nova_msg_parser::CRC4;
+//             break;
+//         case nova_msg_parser::CRC4:
+//             nova_msg.crc += (uint32_t) (temp << 24);
+//             nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
 
-            uint32_t crc = CalculateBlockCRC32((uint32_t)nova_msg.header.nova_headeru.headerlength, (uint8_t *)&nova_msg.header.data, (uint32_t)0);
-            crc = CalculateBlockCRC32((uint32_t)nova_msg.header.nova_headeru.messagelength, (uint8_t *)&nova_msg.data, crc);
+//             uint32_t crc = CalculateBlockCRC32((uint32_t)nova_msg.header.nova_headeru.headerlength, (uint8_t *)&nova_msg.header.data, (uint32_t)0);
+//             crc = CalculateBlockCRC32((uint32_t)nova_msg.header.nova_headeru.messagelength, (uint8_t *)&nova_msg.data, crc);
 
-            if (nova_msg.crc == crc)
-            {
-                return process_message();
-            }
-            else
-            {
-                Debug("crc failed");
-                crc_error_counter++;
-            }
-            break;
-    }
+//             if (nova_msg.crc == crc)
+//             {
+//                 return process_message();
+//             }
+//             else
+//             {
+//                 Debug("crc failed");
+//                 crc_error_counter++;
+//             }
+//             break;
+//     }
 
-    return false;
-}
+//     return false;
+// }
 
 bool
 AP_GPS_NOVA::process_message(void)
@@ -290,26 +291,26 @@ AP_GPS_NOVA::process_message(void)
     return false;
 }
 
-#define CRC32_POLYNOMIAL 0xEDB88320L
-uint32_t AP_GPS_NOVA::CRC32Value(uint32_t icrc)
-{
-    int i;
-    uint32_t crc = icrc;
-    for ( i = 8 ; i > 0; i-- )
-    {
-        if ( crc & 1 )
-            crc = ( crc >> 1 ) ^ CRC32_POLYNOMIAL;
-        else
-            crc >>= 1;
-    }
-    return crc;
-}
+// #define CRC32_POLYNOMIAL 0xEDB88320L
+// uint32_t AP_GPS_NOVA::CRC32Value(uint32_t icrc)
+// {
+//     int i;
+//     uint32_t crc = icrc;
+//     for ( i = 8 ; i > 0; i-- )
+//     {
+//         if ( crc & 1 )
+//             crc = ( crc >> 1 ) ^ CRC32_POLYNOMIAL;
+//         else
+//             crc >>= 1;
+//     }
+//     return crc;
+// }
 
-uint32_t AP_GPS_NOVA::CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc)
-{
-    while ( length-- != 0 )
-    {
-        crc = ((crc >> 8) & 0x00FFFFFFL) ^ (CRC32Value(((uint32_t) crc ^ *buffer++) & 0xff));
-    }
-    return( crc );
-}
+// uint32_t AP_GPS_NOVA::CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc)
+// {
+//     while ( length-- != 0 )
+//     {
+//         crc = ((crc >> 8) & 0x00FFFFFFL) ^ (CRC32Value(((uint32_t) crc ^ *buffer++) & 0xff));
+//     }
+//     return( crc );
+// }

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -21,8 +21,9 @@
 
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
+#include "AP_GPS_BinaryCRCMessageParser.h"
 
-class AP_GPS_NOVA : public AP_GPS_Backend
+class AP_GPS_NOVA : public AP_GPS_Backend, public AP_GPS_BinaryCRCMessageParser
 {
 public:
     AP_GPS_NOVA(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
@@ -36,14 +37,20 @@ public:
 
 private:
 
-    bool parse(uint8_t temp);
-    bool process_message();
-    uint32_t CRC32Value(uint32_t icrc);
-    uint32_t CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc);
+    // bool parse(uint8_t temp);
+    // bool process_message();
+    // uint32_t CRC32Value(uint32_t icrc);
+    // uint32_t CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc);
 
     static const uint8_t NOVA_PREAMBLE1 = 0xaa;
     static const uint8_t NOVA_PREAMBLE2 = 0x44;
     static const uint8_t NOVA_PREAMBLE3 = 0x12;
+
+    virtual uint8_t get_message_header_length_from_header_buff() override {return nova_msg.header.nova_headeru.headerlength;}
+    virtual uint16_t get_message_body_length_from_header_buff() override {return nova_msg.header.nova_headeru.messagelength;}
+    virtual uint8_t *get_message_header_buff() override {return (uint8_t *)&nova_msg.header;}
+    virtual uint8_t *get_message_body_buff() override {return (uint8_t *)&nova_msg.data;}
+    virtual bool process_message() override;
 
     // do we have new position information?
     bool            _new_position:1;
@@ -56,7 +63,7 @@ private:
     uint32_t _init_blob_time = 0;
     static const char* const _initialisation_blob[6];
    
-    uint32_t crc_error_counter = 0;
+    // uint32_t crc_error_counter = 0;
 
     struct PACKED nova_header
     {
@@ -155,23 +162,23 @@ private:
 
     struct PACKED nova_msg_parser
     {
-        enum
-        {
-            PREAMBLE1 = 0,
-            PREAMBLE2,
-            PREAMBLE3,
-            HEADERLENGTH,
-            HEADERDATA,
-            DATA,
-            CRC1,
-            CRC2,
-            CRC3,
-            CRC4,
-        } nova_state;
+        // enum
+        // {
+        //     PREAMBLE1 = 0,
+        //     PREAMBLE2,
+        //     PREAMBLE3,
+        //     HEADERLENGTH,
+        //     HEADERDATA,
+        //     DATA,
+        //     CRC1,
+        //     CRC2,
+        //     CRC3,
+        //     CRC4,
+        // } nova_state;
         
         msgbuffer data;
-        uint32_t crc;
+        // uint32_t crc;
         msgheader header;
-        uint16_t read;
+        // uint16_t read;
     } nova_msg;
 };


### PR DESCRIPTION
1. The AP_GPS_BinaryCRCMessageParser class was added to extract the message parsing process
2. Modify Nova gps driver code to use the AP_GPS_BinaryCRCMessageParser class
3. Add Femtomes gps driver class
4. Modify AP_GPS class to use Femtomes gps driver