### PR TITLE
use config error instead of panic on allocation failure

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -493,13 +493,13 @@ case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
 #endif
     }
     if (motors == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
+        AP_BoardConfig::allocation_error("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
     }
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
 
     ahrs_view = ahrs.create_view(ROTATION_NONE);
     if (ahrs_view == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate AP_AHRS_View");
+        AP_BoardConfig::allocation_error("Unable to allocate AP_AHRS_View");
     }
 
     const struct AP_Param::GroupInfo *ac_var_info;
@@ -519,13 +519,13 @@ case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
     ac_var_info = AC_AttitudeControl_Heli::var_info;
 #endif
     if (attitude_control == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate AttitudeControl");
+        AP_BoardConfig::allocation_error("Unable to allocate AttitudeControl");
     }
     AP_Param::load_object_from_eeprom(attitude_control, ac_var_info);
         
     pos_control = new AC_PosControl(*ahrs_view, inertial_nav, *motors, *attitude_control, scheduler.get_loop_period_s());
     if (pos_control == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate PosControl");
+        AP_BoardConfig::allocation_error("Unable to allocate PosControl");
     }
     AP_Param::load_object_from_eeprom(pos_control, pos_control->var_info);
 
@@ -535,20 +535,20 @@ case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
     wp_nav = new AC_WPNav(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
 #endif
     if (wp_nav == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate WPNav");
+        AP_BoardConfig::allocation_error("Unable to allocate WPNav");
     }
     AP_Param::load_object_from_eeprom(wp_nav, wp_nav->var_info);
 
     loiter_nav = new AC_Loiter(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
     if (loiter_nav == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate LoiterNav");
+        AP_BoardConfig::allocation_error("Unable to allocate LoiterNav");
     }
     AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
 
 #if MODE_CIRCLE_ENABLED == ENABLED
     circle_nav = new AC_Circle(inertial_nav, *ahrs_view, *pos_control);
     if (circle_nav == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate CircleNav");
+        AP_BoardConfig::allocation_error("Unable to allocate CircleNav");
     }
     AP_Param::load_object_from_eeprom(circle_nav, circle_nav->var_info);
 #endif

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -637,7 +637,7 @@ bool QuadPlane::setup(void)
     }
 
     if (!motors) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "motors");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "motors");
     }
 
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
@@ -645,29 +645,29 @@ bool QuadPlane::setup(void)
     // create the attitude view used by the VTOL code
     ahrs_view = ahrs.create_view(tailsitter.enabled() ? ROTATION_PITCH_90 : ROTATION_NONE, ahrs_trim_pitch);
     if (ahrs_view == nullptr) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "ahrs_view");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "ahrs_view");
     }
 
     attitude_control = new AC_AttitudeControl_TS(*ahrs_view, aparm, *motors, loop_delta_t);
     if (!attitude_control) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "attitude_control");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "attitude_control");
     }
 
     AP_Param::load_object_from_eeprom(attitude_control, attitude_control->var_info);
     pos_control = new AC_PosControl(*ahrs_view, inertial_nav, *motors, *attitude_control, loop_delta_t);
     if (!pos_control) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "pos_control");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "pos_control");
     }
     AP_Param::load_object_from_eeprom(pos_control, pos_control->var_info);
     wp_nav = new AC_WPNav(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
     if (!wp_nav) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "wp_nav");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "wp_nav");
     }
     AP_Param::load_object_from_eeprom(wp_nav, wp_nav->var_info);
 
     loiter_nav = new AC_Loiter(inertial_nav, *ahrs_view, *pos_control, *attitude_control);
     if (!loiter_nav) {
-        AP_BoardConfig::config_error("Unable to allocate %s", "loiter_nav");
+        AP_BoardConfig::allocation_error("Unable to allocate %s", "loiter_nav");
     }
     AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
 

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -263,7 +263,7 @@ void Blimp::allocate_motors(void)
         break;
     }
     if (motors == nullptr) {
-        AP_HAL::panic("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
+        AP_BoardConfig::allocation_error("Unable to allocate FRAME_CLASS=%u", (unsigned)g2.frame_class.get());
     }
     AP_Param::load_object_from_eeprom(motors, Fins::var_info);
 

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -199,7 +199,7 @@ void AP_CANManager::init()
             _drivers[drv_num] = _drv_param[drv_num]._uavcan = new AP_UAVCAN;
 
             if (_drivers[drv_num] == nullptr) {
-                AP_BoardConfig::config_error("Failed to allocate uavcan %d\n\r", i + 1);
+                AP_BoardConfig::allocation_error("Failed to allocate uavcan %d\n\r", i + 1);
                 continue;
             }
 
@@ -210,7 +210,7 @@ void AP_CANManager::init()
             _drivers[drv_num] = _drv_param[drv_num]._kdecan = new AP_KDECAN;
 
             if (_drivers[drv_num] == nullptr) {
-                AP_BoardConfig::config_error("Failed to allocate KDECAN %d\n\r", drv_num + 1);
+                AP_BoardConfig::allocation_error("Failed to allocate KDECAN %d\n\r", drv_num + 1);
                 continue;
             }
 
@@ -220,7 +220,7 @@ void AP_CANManager::init()
             _drivers[drv_num] = new AP_ToshibaCAN;
 
             if (_drivers[drv_num] == nullptr) {
-                AP_BoardConfig::config_error("Failed to allocate ToshibaCAN %d\n\r", drv_num + 1);
+                AP_BoardConfig::allocation_error("Failed to allocate ToshibaCAN %d\n\r", drv_num + 1);
                 continue;
             }
         } else if (drv_type[drv_num] == Driver_Type_PiccoloCAN) {
@@ -228,7 +228,7 @@ void AP_CANManager::init()
             _drivers[drv_num] = _drv_param[drv_num]._piccolocan = new AP_PiccoloCAN;
 
             if (_drivers[drv_num] == nullptr) {
-                AP_BoardConfig::config_error("Failed to allocate PiccoloCAN %d\n\r", drv_num + 1);
+                AP_BoardConfig::allocation_error("Failed to allocate PiccoloCAN %d\n\r", drv_num + 1);
                 continue;
             }
 
@@ -239,7 +239,7 @@ void AP_CANManager::init()
             _drivers[drv_num] = _drv_param[drv_num]._testcan = new CANTester;
 
             if (_drivers[drv_num] == nullptr) {
-                AP_BoardConfig::config_error("Failed to allocate CANTester %d\n\r", drv_num + 1);
+                AP_BoardConfig::allocation_error("Failed to allocate CANTester %d\n\r", drv_num + 1);
                 continue;
             }
             AP_Param::load_object_from_eeprom((CANTester*)_drivers[drv_num], CANTester::var_info);

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -145,7 +145,7 @@ void AP_DAL::init_sensors(void)
 #endif
 
     if (alloc_failed) {
-        AP_BoardConfig::config_error("Unable to allocate DAL backends");
+        AP_BoardConfig::allocation_error("Unable to allocate DAL backends");
     }
 }
 

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -27,7 +27,7 @@ AP_DAL_RangeFinder::AP_DAL_RangeFinder()
     }
     return;
 failed:
-    AP_BoardConfig::config_error("Unable to allocate DAL backends");
+    AP_BoardConfig::allocation_error("Unable to allocate DAL backends");
 #endif
 }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -29,6 +29,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Common/NMEA.h>
 #include <stdio.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 #if HAL_EXTERNAL_AHRS_ENABLED
 
@@ -120,7 +121,7 @@ AP_ExternalAHRS_VectorNav::AP_ExternalAHRS_VectorNav(AP_ExternalAHRS *_frontend,
     last_pkt2 = new VN_packet2;
 
     if (!pktbuf || !last_pkt1 || !last_pkt2) {
-        AP_HAL::panic("Failed to allocate ExternalAHRS");
+        AP_BoardConfig::allocation_error("Failed to allocate ExternalAHRS");
     }
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_ExternalAHRS_VectorNav::update_thread, void), "AHRS", 2048, AP_HAL::Scheduler::PRIORITY_SPI, 0)) {

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -279,7 +279,7 @@ bool AP_UAVCAN_DNA_Server::init(AP_UAVCAN *ap_uavcan)
     //Setup publisher for this driver index
     allocation_pub[driver_index] = new uavcan::Publisher<uavcan::protocol::dynamic_node_id::Allocation>(*_node);
     if (allocation_pub[driver_index] == nullptr) {
-        return false;
+        AP_BoardConfig::allocation_error("AP_UAVCAN_DNA: allocation_pub[%d]", driver_index);
     }
 
     int res = allocation_pub[driver_index]->init(uavcan::TransferPriority::Default);
@@ -291,7 +291,7 @@ bool AP_UAVCAN_DNA_Server::init(AP_UAVCAN *ap_uavcan)
     //Setup GetNodeInfo Client
     getNodeInfo_client[driver_index] = new uavcan::ServiceClient<uavcan::protocol::GetNodeInfo>(*_node);
     if (getNodeInfo_client[driver_index] == nullptr) {
-        return false;
+        AP_BoardConfig::allocation_error("AP_UAVCAN_DNA: getNodeInfo_client[%d]", driver_index);
     }
 
     res = getNodeInfo_client[driver_index]->init();

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.cpp
@@ -29,6 +29,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include "AP_UAVCAN_Clock.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 extern const AP_HAL::HAL& hal;
 
 #define NODEDATA_MAGIC 0xAC01
@@ -62,8 +63,7 @@ void AP_UAVCAN_DNA_Server::subscribe_msgs(AP_UAVCAN* ap_uavcan)
     uavcan::Subscriber<uavcan::protocol::dynamic_node_id::Allocation, AllocationCb> *AllocationListener;
     AllocationListener = new uavcan::Subscriber<uavcan::protocol::dynamic_node_id::Allocation, AllocationCb>(*node);
     if (AllocationListener == nullptr) {
-        AP_HAL::panic("Allocation Subscriber allocation failed\n\r");
-        return;
+        AP_BoardConfig::allocation_error("AP_UAVCAN_DNA: AllocationListener");
     }
     const int alloc_listener_res = AllocationListener->start(AllocationCb(ap_uavcan, &trampoline_handleAllocation));
     if (alloc_listener_res < 0) {
@@ -77,8 +77,7 @@ void AP_UAVCAN_DNA_Server::subscribe_msgs(AP_UAVCAN* ap_uavcan)
     uavcan::Subscriber<uavcan::protocol::NodeStatus, NodeStatusCb> *NodeStatusListener;
     NodeStatusListener = new uavcan::Subscriber<uavcan::protocol::NodeStatus, NodeStatusCb>(*node);
     if (NodeStatusListener == nullptr) {
-        AP_HAL::panic("NodeStatus Subscriber allocation failed\n\r");
-        return;
+        AP_BoardConfig::allocation_error("AP_UAVCAN_DNA: NodeStatusListener");
     }
     const int nodestatus_listener_res = NodeStatusListener->start(NodeStatusCb(ap_uavcan, &trampoline_handleNodeStatus));
     if (nodestatus_listener_res < 0) {


### PR DESCRIPTION
based on https://github.com/ArduPilot/ardupilot/pull/18405

There is a change in behaviour where the allocation failure inside UAVCAN DNA Server enters allocation_error rather than just continuing with failure.