### PR TITLE
Plane: split transition in to separate class for SLT, tailsitter and tiltrotor

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -462,16 +462,10 @@ void Plane::stabilize()
     float speed_scaler = get_speed_scaler();
 
     uint32_t now = AP_HAL::millis();
+    bool allow_stick_mixing = true;
 #if HAL_QUADPLANE_ENABLED
-    if (quadplane.tailsitter.in_vtol_transition(now)) {
-        /*
-          during transition to vtol in a tailsitter try to raise the
-          nose while keeping the wings level
-         */
-        uint32_t dt = now - quadplane.transition_start_ms;
-        // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
-        nav_pitch_cd = constrain_float(quadplane.transition_initial_pitch + (quadplane.tailsitter.transition_rate_vtol * dt) * 0.1f, -8500, 8500);
-        nav_roll_cd = 0;
+    if (quadplane.available()) {
+        quadplane.transition->set_FW_roll_pitch(nav_pitch_cd, nav_roll_cd, allow_stick_mixing);
     }
 #endif
 
@@ -506,12 +500,12 @@ void Plane::stabilize()
         }
 #endif
     } else {
-        if (g.stick_mixing == STICK_MIXING_FBW && control_mode != &mode_stabilize) {
+        if (allow_stick_mixing && g.stick_mixing == STICK_MIXING_FBW && control_mode != &mode_stabilize) {
             stabilize_stick_mixing_fbw();
         }
         stabilize_roll(speed_scaler);
         stabilize_pitch(speed_scaler);
-        if (g.stick_mixing == STICK_MIXING_DIRECT || control_mode == &mode_stabilize) {
+        if (allow_stick_mixing && (g.stick_mixing == STICK_MIXING_DIRECT || control_mode == &mode_stabilize)) {
             stabilize_stick_mixing_direct();
         }
         stabilize_yaw(speed_scaler);
@@ -753,10 +747,7 @@ void Plane::update_load_factor(void)
     aerodynamic_load_factor = 1.0f / safe_sqrt(cosf(radians(demanded_roll)));
 
 #if HAL_QUADPLANE_ENABLED
-    if (quadplane.in_transition() &&
-        (quadplane.options & QuadPlane::OPTION_LEVEL_TRANSITION)) {
-        // the user wants transitions to be kept level to within LEVEL_ROLL_LIMIT
-        roll_limit_cd = MIN(roll_limit_cd, g.level_roll_limit*100);
+    if (quadplane.available() && quadplane.transition->set_FW_roll_limit(roll_limit_cd)) {
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
         return;
     }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -136,6 +136,8 @@ public:
     friend class RC_Channels_Plane;
     friend class Tailsitter;
     friend class Tiltrotor;
+    friend class SLT_Transition;
+    friend class Tailsitter_Transition;
 
     friend class Mode;
     friend class ModeCircle;

--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -6,7 +6,7 @@
 bool ModeQAcro::_enter()
 {
     quadplane.throttle_wait = false;
-    quadplane.transition_state = QuadPlane::TRANSITION_DONE;
+    quadplane.transition->force_transistion_complete();
     attitude_control->relax_attitude_controllers();
     return true;
 }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -22,6 +22,7 @@
 #include "defines.h"
 #include "tailsitter.h"
 #include "tiltrotor.h"
+#include "transition.h"
 
 /*
   QuadPlane specific functionality
@@ -39,6 +40,8 @@ public:
     friend class RC_Channel;
     friend class Tailsitter;
     friend class Tiltrotor;
+    friend class SLT_Transition;
+    friend class Tailsitter_Transition;
 
     friend class Mode;
     friend class ModeAuto;
@@ -110,11 +113,6 @@ public:
 
     // vtol help for is_flying()
     bool is_flying(void);
-
-    // return current throttle as a percentate
-    uint8_t throttle_percentage(void) const {
-        return last_throttle * 100;
-    }
 
     // return desired forward throttle percentage
     float forward_throttle_pct();
@@ -372,16 +370,8 @@ private:
     } weathervane;
     
     bool initialised;
-    
-    // timer start for transition
-    uint32_t transition_start_ms;
-    float transition_initial_pitch;
-    uint32_t transition_low_airspeed_ms;
 
     Location last_auto_target;
-
-    // last throttle value when active
-    float last_throttle;
 
     // pitch when we enter loiter mode
     int32_t loiter_initial_pitch_cd;
@@ -389,14 +379,8 @@ private:
     // when did we last run the attitude controller?
     uint32_t last_att_control_ms;
 
-    // true if we have reached the airspeed threshold for transition
-    enum {
-        TRANSITION_AIRSPEED_WAIT,
-        TRANSITION_TIMER,
-        TRANSITION_ANGLE_WAIT_FW,
-        TRANSITION_ANGLE_WAIT_VTOL,
-        TRANSITION_DONE
-    } transition_state;
+    // transition logic
+    Transition *transition = nullptr;
 
     // true when waiting for pilot throttle
     bool throttle_wait:1;
@@ -487,9 +471,6 @@ private:
     // time when we last ran the vertical accel controller
     uint32_t last_pidz_active_ms;
     uint32_t last_pidz_init_ms;
-
-    // time when we were last in a vtol control mode
-    uint32_t last_vtol_mode_ms;
 
     // throttle scailing for vectored motors in FW flighy
     float FW_vector_throttle_scaling(void);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -448,7 +448,7 @@ int8_t Plane::throttle_percentage(void)
 {
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.in_vtol_mode() && !quadplane.tailsitter.in_vtol_transition()) {
-        return quadplane.throttle_percentage();
+        return quadplane.motors->get_throttle_out() * 100.0;
     }
 #endif
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -211,6 +211,13 @@ void Tailsitter::setup()
         quadplane.options.set(quadplane.options.get() | QuadPlane::OPTION_ONLY_ARM_IN_QMODE_OR_AUTO);
     }
 
+    transition = new Tailsitter_Transition(quadplane, motors, *this);
+    if (!transition) {
+        AP_BoardConfig::config_error("Unable to allocate tailsitter transition");
+    }
+    quadplane.transition = transition;
+
+    setup_complete = true;
 }
 
 /*
@@ -234,7 +241,7 @@ bool Tailsitter::active(void)
         return true;
     }
     // check if we are in ANGLE_WAIT fixed wing transition
-    if (quadplane.transition_state == QuadPlane::TRANSITION_ANGLE_WAIT_FW) {
+    if (transition->transition_state == Tailsitter_Transition::TRANSITION_ANGLE_WAIT_FW) {
         return true;
     }
     return false;
@@ -317,7 +324,7 @@ void Tailsitter::output(void)
     // the MultiCopter rate controller has already been run in an earlier call
     // to motors_output() from quadplane.update(), unless we are in assisted flight
     // tailsitter in TRANSITION_ANGLE_WAIT_FW is not really in assisted flight, its still in a VTOL mode
-    if (quadplane.assisted_flight && (quadplane.transition_state != QuadPlane::TRANSITION_ANGLE_WAIT_FW)) {
+    if (quadplane.assisted_flight && (transition->transition_state != Tailsitter_Transition::TRANSITION_ANGLE_WAIT_FW)) {
         quadplane.hold_stabilize(throttle);
         quadplane.motors_output(true);
 
@@ -426,7 +433,7 @@ bool Tailsitter::transition_fw_complete(void)
         gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, roll error");
         return true;
     }
-    if (AP_HAL::millis() - quadplane.transition_start_ms > ((transition_angle_fw+(quadplane.transition_initial_pitch*0.01f))/transition_rate_fw)*1500) {
+    if (AP_HAL::millis() - transition->transition_start_ms > ((transition_angle_fw+(transition->transition_initial_pitch*0.01f))/transition_rate_fw)*1500) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, timeout");
         return true;
     }
@@ -466,7 +473,7 @@ bool Tailsitter::transition_vtol_complete(void) const
         gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, roll error");
         return true;
     }
-    if (AP_HAL::millis() - quadplane.transition_start_ms >  ((trans_angle-(quadplane.transition_initial_pitch*0.01f))/transition_rate_vtol)*1500) {
+    if (AP_HAL::millis() - transition->transition_start_ms >  ((trans_angle-(transition->transition_initial_pitch*0.01f))/transition_rate_vtol)*1500) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, timeout");
         return true;
     }
@@ -496,10 +503,10 @@ bool Tailsitter::in_vtol_transition(uint32_t now) const
     if (!enabled() || !quadplane.in_vtol_mode()) {
         return false;
     }
-    if (quadplane.transition_state == QuadPlane::TRANSITION_ANGLE_WAIT_VTOL) {
+    if (transition->transition_state == Tailsitter_Transition::TRANSITION_ANGLE_WAIT_VTOL) {
         return true;
     }
-    if ((now != 0) && ((now - quadplane.last_vtol_mode_ms) > 1000)) {
+    if ((now != 0) && ((now - transition->last_vtol_mode_ms) > 1000)) {
         // only just come out of forward flight
         return true;
     }
@@ -511,7 +518,7 @@ bool Tailsitter::in_vtol_transition(uint32_t now) const
  */
 bool Tailsitter::is_in_fw_flight(void) const
 {
-    return enabled() && !quadplane.in_vtol_mode() && quadplane.transition_state == QuadPlane::TRANSITION_DONE;
+    return enabled() && !quadplane.in_vtol_mode() && transition->transition_state == Tailsitter_Transition::TRANSITION_DONE;
 }
 
 /*
@@ -657,6 +664,145 @@ void Tailsitter::speed_scaling(void)
         }
         v = constrain_int32(v, -SERVO_MAX, SERVO_MAX);
         SRV_Channels::set_output_scaled(functions[i], v);
+    }
+}
+
+/*
+  update for transition from quadplane to fixed wing mode
+ */
+void Tailsitter_Transition::update()
+{
+    const uint32_t now = millis();
+
+    float aspeed;
+    bool have_airspeed = quadplane.ahrs.airspeed_estimate(aspeed);
+
+    /*
+      see if we should provide some assistance
+     */
+    quadplane.assisted_flight = quadplane.should_assist(aspeed, have_airspeed);
+
+    if (transition_state == TRANSITION_ANGLE_WAIT_FW &&
+        quadplane.tailsitter.transition_fw_complete()) {
+        transition_state = TRANSITION_DONE;
+        transition_start_ms = 0;
+    }
+
+    if (transition_state < TRANSITION_DONE) {
+        // during transition we ask TECS to use a synthetic
+        // airspeed. Otherwise the pitch limits will throw off the
+        // throttle calculation which is driven by pitch
+        plane.TECS_controller.use_synthetic_airspeed();
+    }
+
+    switch (transition_state) {
+
+    case TRANSITION_ANGLE_WAIT_FW: {
+        quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+        quadplane.assisted_flight = true;
+        uint32_t dt = now - transition_start_ms;
+        // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
+        plane.nav_pitch_cd = constrain_float(transition_initial_pitch - (quadplane.tailsitter.transition_rate_fw * dt) * 0.1f * (plane.fly_inverted()?-1.0f:1.0f), -8500, 8500);
+        plane.nav_roll_cd = 0;
+        quadplane.check_attitude_relax();
+        quadplane.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                      plane.nav_pitch_cd,
+                                                                      0);
+        // set throttle at either hover throttle or current throttle, whichever is higher, through the transition
+        quadplane.attitude_control->set_throttle_out(MAX(motors->get_throttle_hover(),quadplane.attitude_control->get_throttle_in()), true, 0);
+        break;
+    }
+
+    case TRANSITION_ANGLE_WAIT_VTOL:
+        // nothing to do, this is handled in the fixed wing attitude controller
+        return;
+
+    case TRANSITION_DONE:
+        return;
+    }
+
+    quadplane.motors_output();
+}
+
+void Tailsitter_Transition::VTOL_update()
+{
+    const uint32_t now = millis();
+
+    if (quadplane.tailsitter.enabled() && (now - last_vtol_mode_ms) > 1000) {
+        /*
+          we are just entering a VTOL mode as a tailsitter, set
+          our transition state so the fixed wing controller brings
+          the nose up before we start trying to fly as a
+          multicopter
+         */
+        transition_state = TRANSITION_ANGLE_WAIT_VTOL;
+        transition_start_ms = now;
+        transition_initial_pitch = constrain_float(quadplane.ahrs.pitch_sensor,-8500,8500);
+    }
+    if (quadplane.tailsitter.enabled() &&
+               transition_state == TRANSITION_ANGLE_WAIT_VTOL) {
+        float aspeed;
+        bool have_airspeed = quadplane.ahrs.airspeed_estimate(aspeed);
+        // provide asistance in forward flight portion of tailsitter transision
+        if (quadplane.should_assist(aspeed, have_airspeed)) {
+            quadplane.assisted_flight = true;
+        }
+        if (quadplane.tailsitter.transition_vtol_complete()) {
+            /*
+              we have completed transition to VTOL as a tailsitter,
+              setup for the back transition when needed
+            */
+            transition_state = TRANSITION_ANGLE_WAIT_FW;
+            transition_start_ms = now;
+        }
+    } else {
+        /*
+          setup the transition state appropriately for next time we go into a non-VTOL mode
+        */
+        transition_start_ms = 0;
+        if (quadplane.throttle_wait && !plane.is_flying()) {
+            transition_state = TRANSITION_DONE;
+        } else {
+            /*
+              setup for the transition back to fixed wing for later
+             */
+            transition_state = TRANSITION_ANGLE_WAIT_FW;
+            transition_start_ms = now;
+            transition_initial_pitch = constrain_float(quadplane.ahrs_view->pitch_sensor,-8500,8500);
+        }
+    }
+    last_vtol_mode_ms = now;
+}
+
+// return true if we should show VTOL view
+bool Tailsitter_Transition::show_vtol_view() const
+{
+    bool show_vtol = quadplane.in_vtol_mode();
+
+    if (show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_VTOL)) {
+        // in a vtol mode but still transitioning from forward flight
+        return false;
+    }
+    if (!show_vtol && (transition_state == TRANSITION_ANGLE_WAIT_FW)) {
+        // not in VTOL mode but still transitioning from VTOL
+        return true;
+    }
+    return show_vtol;
+}
+
+void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing)
+{
+    uint32_t now = AP_HAL::millis();
+    if (tailsitter.in_vtol_transition(now)) {
+        /*
+          during transition to vtol in a tailsitter try to raise the
+          nose while keeping the wings level
+         */
+        uint32_t dt = now - transition_start_ms;
+        // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
+        nav_pitch_cd = constrain_float(transition_initial_pitch + (tailsitter.transition_rate_vtol * dt) * 0.1f, -8500, 8500);
+        nav_roll_cd = 0;
+        allow_stick_mixing = false;
     }
 }
 

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -137,7 +137,8 @@ public:
 
     bool complete() const override { return transition_state == TRANSITION_DONE; }
 
-    void restart() override { transition_state = TRANSITION_ANGLE_WAIT_FW; };
+    // setup for the transition back to fixed wing
+    void restart() override;
 
     uint8_t get_log_transision_state() const override { return static_cast<uint8_t>(transition_state); }
 

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -15,17 +15,21 @@
 #pragma once
 
 #include <AP_Param/AP_Param.h>
+#include "transition.h"
+
 class QuadPlane;
 class AP_MotorsMulticopter;
+class Tiltrotor_Transition;
 class Tiltrotor
 {
 friend class QuadPlane;
 friend class Plane;
+friend class Tiltrotor_Transition;
 public:
 
     Tiltrotor(QuadPlane& _quadplane, AP_MotorsMulticopter*& _motors);
 
-    bool enabled() const { return enable > 0;}
+    bool enabled() const { return (enable > 0) && setup_complete;}
 
     void setup();
 
@@ -81,8 +85,30 @@ public:
 
 private:
 
+    bool setup_complete;
+
     // refences for convenience
     QuadPlane& quadplane;
     AP_MotorsMulticopter*& motors;
+
+    Tiltrotor_Transition* transition;
+
+};
+
+// Transition for separate left thrust quadplanes
+class Tiltrotor_Transition : public SLT_Transition
+{
+friend class Tiltrotor;
+public:
+
+    Tiltrotor_Transition(QuadPlane& _quadplane, AP_MotorsMulticopter*& _motors, Tiltrotor& _tiltrotor):SLT_Transition(_quadplane, _motors), tiltrotor(_tiltrotor) {};
+
+    bool update_yaw_target(float& yaw_target_cd) override;
+
+    bool show_vtol_view() const override;
+
+private:
+
+    Tiltrotor& tiltrotor;
 
 };

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -1,0 +1,105 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+class QuadPlane;
+class AP_MotorsMulticopter;
+// Transition empty base class
+class Transition
+{
+public:
+
+    Transition(QuadPlane& _quadplane, AP_MotorsMulticopter*& _motors):quadplane(_quadplane),motors(_motors) {};
+
+    virtual void update() = 0;
+
+    virtual void VTOL_update() = 0;
+
+    virtual void force_transistion_complete() = 0;
+
+    virtual bool complete() const = 0;
+
+    virtual void restart() = 0;
+
+    virtual uint8_t get_log_transision_state() const = 0;
+
+    virtual bool active() const = 0;
+
+    virtual bool show_vtol_view() const = 0;
+
+    virtual void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) {};
+
+    virtual bool set_FW_roll_limit(int32_t& roll_limit_cd) { return false; }
+
+    virtual bool allow_update_throttle_mix() const { return true; }
+
+    virtual bool update_yaw_target(float& yaw_target_cd) { return false; }
+
+protected:
+
+    // refences for convenience
+    QuadPlane& quadplane;
+    AP_MotorsMulticopter*& motors;
+
+};
+
+// Transition for separate left thrust quadplanes
+class SLT_Transition : public Transition
+{
+public:
+
+    using Transition::Transition;
+
+    void update() override;
+
+    void VTOL_update() override;
+
+    void force_transistion_complete() override {
+        transition_state = TRANSITION_DONE; 
+        transition_start_ms = 0;
+        transition_low_airspeed_ms = 0;
+    };
+
+    bool complete() const override { return transition_state == TRANSITION_DONE; }
+
+    void restart() override { transition_state = TRANSITION_AIRSPEED_WAIT; }
+
+    uint8_t get_log_transision_state() const override { return static_cast<uint8_t>(transition_state); }
+
+    bool active() const override;
+
+    bool show_vtol_view() const override;
+
+    bool set_FW_roll_limit(int32_t& roll_limit_cd) override;
+
+    bool allow_update_throttle_mix() const override;
+
+protected:
+
+    enum {
+        TRANSITION_AIRSPEED_WAIT,
+        TRANSITION_TIMER,
+        TRANSITION_DONE
+    } transition_state;
+
+    // timer start for transition
+    uint32_t transition_start_ms;
+    uint32_t transition_low_airspeed_ms;
+
+    // last throttle value when active
+    float last_throttle;
+
+};
+


### PR DESCRIPTION
Still needs testing, just want to get some feedback on the approach.

Tailsitter is completely removed from separate lift thrust, tilt rotor and STL still share lots of logic. 

This more or less the bare minimum to allow the split, there is more that can be done to make the split cleaner. 