### PR TITLE
Copter: allow mid stick arming

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -48,6 +48,16 @@ bool RC_Channels_Copter::has_valid_input() const
     return true;
 }
 
+// returns true if throttle arming checks should be run
+bool RC_Channels_Copter::arming_check_throttle() const {
+    if ((copter.g.throttle_behavior & THR_BEHAVE_FEEDBACK_FROM_MID_STICK) != 0) {
+        // center sprung throttle configured, dont run AP_Arming check
+        // Copter already checks this case in its own arming checks
+        return false;
+    }
+    return RC_Channels::arming_check_throttle();
+}
+
 RC_Channel * RC_Channels_Copter::get_arming_channel(void) const
 {
     return copter.channel_yaw;

--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -42,6 +42,9 @@ public:
         return &obj_channels[chan];
     }
 
+    // returns true if throttle arming checks should be run
+    bool arming_check_throttle() const override;
+
 protected:
 
     int8_t flight_mode_channel_number() const override;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -477,7 +477,7 @@ public:
         return _options & uint32_t(Option::LOG_DATA);
     }
     
-    bool arming_check_throttle() const {
+    virtual bool arming_check_throttle() const {
         return _options & uint32_t(Option::ARMING_CHECK_THROTTLE);
     }
 


### PR DESCRIPTION
Fixes #18692

This skips  the AP_Arming throttle check if PILOT_THR_BHV bit "Feedback from mid stick" is set. This is used as a center throttle flag on for landing detection.

Copters own throttle arming checks are quite comprehensive, we might want to skip the AP_Arming one in all cases. 