### PR TITLE
Copter: Auto and Guided takeoff support external yaw control

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -969,7 +969,7 @@ private:
     // controls which controller is run (pos or vel):
     SubMode guided_mode = SubMode::TakeOff;
     bool send_notification;     // used to send one time notification to ground station
-
+    bool takeoff_complete;      // true once takeoff has completed (used to trigger retracting of landing gear)
 };
 
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -138,6 +138,9 @@ bool ModeGuided::do_user_takeoff_start(float takeoff_alt_cm)
     // get initial alt for WP_NAVALT_MIN
     auto_takeoff_set_start_alt();
 
+    // record takeoff has not completed
+    takeoff_complete = false;
+
     return true;
 }
 
@@ -629,14 +632,12 @@ void ModeGuided::set_angle(const Quaternion &q, float climb_rate_cms_or_thrust, 
 void ModeGuided::takeoff_run()
 {
     auto_takeoff_run();
-    if (wp_nav->reached_wp_destination()) {
+    if (!takeoff_complete && wp_nav->reached_wp_destination()) {
+        takeoff_complete = true;
 #if LANDING_GEAR_ENABLED == ENABLED
         // optionally retract landing gear
         copter.landinggear.retract_after_takeoff();
 #endif
-
-        // change to velocity control after take off.
-        init(true);
     }
 }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7190,7 +7190,7 @@ class AutoTestCopter(AutoTest):
             0,  # p6
             0,  # p7
         )
-        self.wait_heading(target, minimum_duration=2)
+        self.wait_heading(target, minimum_duration=2, timeout=50)
 
         degsecond = 2
 


### PR DESCRIPTION
This PR resolves https://github.com/ArduPilot/ardupilot/issues/18699 by keeping Guided mode in the takeoff submode even after the takeoff has completed.  While in the takeoff submode, wp_nav is used (not "pva") so the vehicle will not yaw because of position corrections.

This PR goes on to add support for "auto yaw" (aka external yaw control) while takingoff in either Auto or Guided.  This is required because the whole reason that Guided mode was switching from the takeoff submode to "pva" mode was because years ago @khancyr needed to be able to control the yaw of the vehicle once takeoff had completed using do-conditional-yaw commands (not set-attitude-target commands).  Potentially controversially this means that the yaw can be controlled not only after takeoff completes but at any time during takeoff (or even before takeoff).  This may be dangerous but it is also consistent with other Auto and Guided submodes.

This has been tested in SITL by performing before-and-after checks to confirm that do-conditional-yaw commands can control the vehicle's yaw during Auto and Guided takeoffs.