### PR TITLE
Copter: GCSMavlink Guided inputs check force_set and reject

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1009,6 +1009,8 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         POSITION_TARGET_TYPEMASK_YAW_IGNORE;
     constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE =
         POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE;
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_FORCE_SET =
+        POSITION_TARGET_TYPEMASK_FORCE_SET;
 
     switch (msg.msgid) {
 
@@ -1119,6 +1121,12 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
         bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
+
+        // force_set true, do not accept command
+        if (force_set) {
+            break;
+        }
 
         // prepare position
         Vector3f pos_vector;
@@ -1207,6 +1215,12 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
         bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
+
+        // force_set true, do not accept command
+        if (force_set) {
+            break;
+        }
 
         // extract location from message
         Location loc;


### PR DESCRIPTION
Closes this issue https://github.com/ArduPilot/ardupilot/issues/18660

Copter: `set_position_target_local_ned()` & `set_position_target_global_int()`

Both messages allow acceleration targets in Newtons via force_set, but we aren't checking this type mask.
Thus someone could get accelerations much less/higher than they expect.... because the parsing function currently acts as if all accelerations targets are in m/s^2

This PR rejects messages with the  force_set mask. However, if we added a parameter or mavlink extension for the body mass we could accept force_set and convert to m/s^2 for internal use.

To replicate issue:

`mode guided`
`arm throttle`
`takeoff 50`
`module load message`
`message SET_POSITION_TARGET_GLOBAL_INT 0 1 0 6 3647 0 0 0 0 0 0 0 0 -5 0  0`   ignore all but Accel and Force_Set==True, -5 m/s^2 in z-axis