### PR TITLE
EKF3: fix wind speed state variance initialisation

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -88,11 +88,9 @@ void NavEKF3_core::setWindMagStateLearningMode()
             }
 
             // set the wind state variances to the measurement uncertainty
-            for (uint8_t index=22; index<=23; index++) {
-                zeroCols(P, 22, 23);
-                zeroRows(P, 22, 23);
-                P[index][index] = trueAirspeedVariance;
-            }
+            zeroCols(P, 22, 23);
+            zeroRows(P, 22, 23);
+            P[22][22] = P[23][23] = trueAirspeedVariance;
 
             windStatesAligned = true;
 


### PR DESCRIPTION
The north wind speed state variance was being set to zero. This fix also treats issue https://github.com/ArduPilot/ardupilot/issues/18718 when patch is applied to Plane4.1.0 and used to replay the linked log:

<img width="1013" alt="Screen Shot 2021-09-20 at 10 06 56 pm" src="https://user-images.githubusercontent.com/3596952/133999533-118222af-8874-4e6b-83ab-d8cb5f5eb41d.png">

<img width="1044" alt="Screen Shot 2021-09-20 at 10 08 43 pm" src="https://user-images.githubusercontent.com/3596952/133999612-c932111f-4c8d-470a-b5ec-c2f71821be5e.png">

