### PR TITLE
Plane: Tailsitter: add param for VTOL transition throttle and fix throttle scaling

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -246,40 +246,44 @@ void Tailsitter::output(void)
     float tilt_left = 0.0f;
     float tilt_right = 0.0f;
 
-
+    // throttle 0 to 1
+    float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01;
 
     // handle forward flight modes and transition to VTOL modes
     if (!active() || in_vtol_transition()) {
         // get FW controller throttle demand and mask of motors enabled during forward flight
-        float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
         if (hal.util->get_soft_armed() && in_vtol_transition() && !quadplane.throttle_wait && quadplane.is_flying()) {
             /*
-              during transitions to vtol mode set the throttle to
-              hover thrust, center the rudder and set the altitude controller
-              integrator to the same throttle level
-              convert the hover throttle to the same output that would result if used via AP_Motors
-              apply expo, battery scaling and SPIN min/max. 
+              during transitions to vtol mode set the throttle to hover thrust, center the rudder
             */
-            throttle = motors->thrust_to_actuator(motors->get_throttle_hover()) * 100;
-            throttle = MAX(throttle,plane.aparm.throttle_cruise.get());
+            throttle = motors->get_throttle_hover();
+            // work out equivelent motors throttle level for cruise
+            throttle = MAX(throttle,motors->actuator_to_thrust(plane.aparm.throttle_cruise.get() * 0.01));
 
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
-            quadplane.pos_control->get_accel_z_pid().set_integrator(throttle*10);
+            plane.rudder_dt = 0;
 
-            // override AP_MotorsTailsitter throttles during back transition
+            // in assisted flight this is done in the normal motor output path
+            if (!quadplane.assisted_flight) {
+                // convert the hover throttle to the same output that would result if used via AP_Motors
+                // apply expo, battery scaling and SPIN min/max.
+                throttle = motors->thrust_to_actuator(throttle);
 
-            // apply PWM min and MAX to throttle left and right, just as via AP_Motors
-            uint16_t throttle_pwm = motors->get_pwm_output_min() + (motors->get_pwm_output_max() - motors->get_pwm_output_min()) * throttle * 0.01f;
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, throttle_pwm);
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, throttle_pwm);
+                // override AP_MotorsTailsitter throttles during back transition
 
-            // throttle output is not used by AP_Motors so might have diffrent PWM range, set scaled
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                // apply PWM min and MAX to throttle left and right, just as via AP_Motors
+                uint16_t throttle_pwm = motors->get_pwm_output_min() + (motors->get_pwm_output_max() - motors->get_pwm_output_min()) * throttle;
+                SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, throttle_pwm);
+                SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, throttle_pwm);
+
+                // throttle output is not used by AP_Motors so might have diffrent PWM range, set scaled
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle * 100.0);
+            }
         }
 
         if (!quadplane.assisted_flight) {
             // set AP_MotorsMatrix throttles for forward flight
-            motors->output_motor_mask(throttle * 0.01f, motor_mask, plane.rudder_dt);
+            motors->output_motor_mask(throttle, motor_mask, plane.rudder_dt);
 
             // in forward flight: set motor tilt servos and throttles using FW controller
             if (vectored_forward_gain > 0) {
@@ -302,7 +306,7 @@ void Tailsitter::output(void)
     // to motors_output() from quadplane.update(), unless we are in assisted flight
     // tailsitter in TRANSITION_ANGLE_WAIT_FW is not really in assisted flight, its still in a VTOL mode
     if (quadplane.assisted_flight && (quadplane.transition_state != QuadPlane::TRANSITION_ANGLE_WAIT_FW)) {
-        quadplane.hold_stabilize(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01f);
+        quadplane.hold_stabilize(throttle);
         quadplane.motors_output(true);
 
         if ((quadplane.options & QuadPlane::OPTION_TAILSIT_Q_ASSIST_MOTORS_ONLY) != 0) {
@@ -315,10 +319,10 @@ void Tailsitter::output(void)
             tilt_right = 0.0f;
             if (vectored_hover_gain > 0) {
                 const float hover_throttle = motors->get_throttle_hover();
-                const float throttle = motors->get_throttle();
+                const float output_throttle = motors->get_throttle();
                 float throttle_scaler = throttle_scale_max;
-                if (is_positive(throttle)) {
-                    throttle_scaler = constrain_float(hover_throttle / throttle, gain_scaling_min, throttle_scale_max);
+                if (is_positive(output_throttle)) {
+                    throttle_scaler = constrain_float(hover_throttle / output_throttle, gain_scaling_min, throttle_scale_max);
                 }
                 tilt_left = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft) * vectored_hover_gain * throttle_scaler;
                 tilt_right = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight) * vectored_hover_gain * throttle_scaler;

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -87,6 +87,7 @@ public:
     AP_Float transition_rate_fw;
     AP_Int8 transition_angle_vtol;
     AP_Float transition_rate_vtol;
+    AP_Float transition_throttle_vtol;
     AP_Int8 input_type;
     AP_Float vectored_forward_gain;
     AP_Float vectored_hover_gain;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -352,7 +352,8 @@ float AP_MotorsMulticopter::apply_thrust_curve_and_volt_scaling(float thrust) co
     return constrain_float(throttle_ratio * battery_scale, 0.0f, 1.0f);
 }
 
-// inverse of above
+// inverse of above, tested with AP_Motors/examples/expo_inverse_test
+// used to calculate equivelent motor throttle level to direct ouput, used in tailsitter transtions
 float AP_MotorsMulticopter::remove_thrust_curve_and_volt_scaling(float throttle) const
 {
     float battery_scale = 1.0;
@@ -440,7 +441,8 @@ float AP_MotorsMulticopter::thrust_to_actuator(float thrust_in) const
     return _spin_min + (_spin_max - _spin_min) * apply_thrust_curve_and_volt_scaling(thrust_in);
 }
 
-// inverse of above
+// inverse of above, tested with AP_Motors/examples/expo_inverse_test
+// used to calculate equivelent motor throttle level to direct ouput, used in tailsitter transtions
 float AP_MotorsMulticopter::actuator_to_thrust(float actuator) const
 {
     actuator = (actuator - _spin_min) /  (_spin_max - _spin_min);

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -338,20 +338,37 @@ float AP_MotorsMulticopter::get_current_limit_max_throttle()
 // apply_thrust_curve_and_volt_scaling - returns throttle in the range 0 ~ 1
 float AP_MotorsMulticopter::apply_thrust_curve_and_volt_scaling(float thrust) const
 {
-    float throttle_ratio = thrust;
+    float battery_scale = 1.0;
+    if (is_positive(_batt_voltage_filt.get())) {
+        battery_scale = 1.0 / _batt_voltage_filt.get();
+    }
     // apply thrust curve - domain -1.0 to 1.0, range -1.0 to 1.0
     float thrust_curve_expo = constrain_float(_thrust_curve_expo, -1.0f, 1.0f);
     if (is_zero(thrust_curve_expo)) {
         // zero expo means linear, avoid floating point exception for small values
-        return _lift_max * thrust;
+        return _lift_max * thrust * battery_scale;
     }
-    if (is_positive(_batt_voltage_filt.get())) {
-        throttle_ratio = ((thrust_curve_expo - 1.0f) + safe_sqrt((1.0f - thrust_curve_expo) * (1.0f - thrust_curve_expo) + 4.0f * thrust_curve_expo * _lift_max * thrust)) / (2.0f * thrust_curve_expo * _batt_voltage_filt.get());
-    } else {
-        throttle_ratio = ((thrust_curve_expo - 1.0f) + safe_sqrt((1.0f - thrust_curve_expo) * (1.0f - thrust_curve_expo) + 4.0f * thrust_curve_expo * _lift_max * thrust)) / (2.0f * thrust_curve_expo);
-    }
+    float throttle_ratio = ((thrust_curve_expo - 1.0f) + safe_sqrt((1.0f - thrust_curve_expo) * (1.0f - thrust_curve_expo) + 4.0f * thrust_curve_expo * _lift_max * thrust)) / (2.0f * thrust_curve_expo);
+    return constrain_float(throttle_ratio * battery_scale, 0.0f, 1.0f);
+}
 
-    return constrain_float(throttle_ratio, 0.0f, 1.0f);
+// inverse of above
+float AP_MotorsMulticopter::remove_thrust_curve_and_volt_scaling(float throttle) const
+{
+    float battery_scale = 1.0;
+    if (is_positive(_batt_voltage_filt.get())) {
+        battery_scale = 1.0 / _batt_voltage_filt.get();
+    }
+    // apply thrust curve - domain -1.0 to 1.0, range -1.0 to 1.0
+    float thrust_curve_expo = constrain_float(_thrust_curve_expo, -1.0f, 1.0f);
+    if (is_zero(thrust_curve_expo)) {
+        // zero expo means linear, avoid floating point exception for small values
+        return  throttle / (_lift_max * battery_scale);
+    }
+    float thrust = ((throttle / battery_scale) * (2.0f * thrust_curve_expo)) - (thrust_curve_expo - 1.0f);
+    thrust = (thrust * thrust) - ((1.0f - thrust_curve_expo) * (1.0f - thrust_curve_expo));
+    thrust /=  4.0f * thrust_curve_expo * _lift_max;
+    return constrain_float(thrust, 0.0f, 1.0f);
 }
 
 // update_lift_max from battery voltage - used for voltage compensation
@@ -417,10 +434,17 @@ int16_t AP_MotorsMulticopter::output_to_pwm(float actuator)
 }
 
 // converts desired thrust to linearized actuator output in a range of 0~1
-float AP_MotorsMulticopter::thrust_to_actuator(float thrust_in)
+float AP_MotorsMulticopter::thrust_to_actuator(float thrust_in) const
 {
     thrust_in = constrain_float(thrust_in, 0.0f, 1.0f);
     return _spin_min + (_spin_max - _spin_min) * apply_thrust_curve_and_volt_scaling(thrust_in);
+}
+
+// inverse of above
+float AP_MotorsMulticopter::actuator_to_thrust(float actuator) const
+{
+    actuator = (actuator - _spin_min) /  (_spin_max - _spin_min);
+    return constrain_float(remove_thrust_curve_and_volt_scaling(actuator), 0.0f, 1.0f);
 }
 
 // adds slew rate limiting to actuator output

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -83,12 +83,15 @@ public:
     // get minimum or maximum pwm value that can be output to motors
     int16_t             get_pwm_output_min() const;
     int16_t             get_pwm_output_max() const;
-    
+
     // parameter check for MOT_PWM_MIN/MAX, returns true if parameters are valid
     bool check_mot_pwm_params() const;
 
     // converts desired thrust to linearized actuator output in a range of 0~1
-    float               thrust_to_actuator(float thrust_in);
+    float               thrust_to_actuator(float thrust_in) const;
+
+    // inverse of above
+    float               actuator_to_thrust(float actuator) const;
 
     // set thrust compensation callback
     FUNCTOR_TYPEDEF(thrust_compensation_fn_t, void, float *, uint8_t);
@@ -122,6 +125,8 @@ protected:
 
     // apply_thrust_curve_and_volt_scaling - returns throttle in the range 0 ~ 1
     float               apply_thrust_curve_and_volt_scaling(float thrust) const;
+    // inverse of above
+    float               remove_thrust_curve_and_volt_scaling(float throttle) const;
 
     // update_lift_max_from_batt_voltage - used for voltage compensation
     void                update_lift_max_from_batt_voltage();

--- a/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
+++ b/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
@@ -1,0 +1,97 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Motors/AP_Motors.h>
+
+/* run with:
+    ./waf configure --board linux
+    ./waf build --targets examples/expo_inverse_test
+    ./build/linux/examples/expo_inverse_test
+*/
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class AP_MotorsMulticopter_test : public AP_MotorsMulticopter {
+public:
+
+    AP_MotorsMulticopter_test(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMulticopter(loop_rate, speed_hz)
+    {
+    };
+
+    // have to have these functions as they are pure virtual
+    void init(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+    void output_test_seq(uint8_t motor_seq, int16_t pwm) override {};
+    const char* get_frame_string() const override { return "TEST"; }
+    void output_armed_stabilizing() override {};
+    void output_to_motors() override {};
+
+    // helper function to allow setting of expo
+    void set_expo(float v) { _thrust_curve_expo.set(v); }
+
+};
+
+AP_MotorsMulticopter_test motors{1};
+
+/*
+ *  rotation tests
+ */
+void setup(void)
+{
+    hal.console->begin(115200);
+    hal.console->printf("\n\nMotors expo inverse test\n\n");
+
+    const float expo_step = 0.01;
+    const float throttle_step = 0.01;
+
+    double max_diff = 0.0;
+    float max_diff_throttle = 0;
+    float max_diff_expo = 0;
+
+    float expo = -1.0;
+    while (expo < 1.0+expo_step*0.5) {
+        hal.console->printf("expo: %0.4f\n",expo);
+        motors.set_expo(expo);
+
+        float throttle = 0.0;
+        while (throttle < 1.0+throttle_step*0.5) {
+
+            const float throttle_out = motors.actuator_to_thrust(motors.thrust_to_actuator(throttle));
+            const double diff = fabsf(throttle_out - throttle);
+            if (diff > max_diff) {
+                max_diff_throttle = throttle;
+                max_diff_expo = expo;
+                max_diff = diff;
+            }
+
+            hal.console->printf("\tthrottle: %0.4f, error %0.8f\n", throttle, diff);
+
+            throttle += throttle_step;
+        }
+        hal.console->printf("\n");
+        expo += expo_step;
+    }
+
+    hal.console->printf("\nMotors expo inverse done, max error of %0.8f at expo %0.4f, throttle %0.4f\n\n", max_diff, max_diff_expo, max_diff_throttle);
+}
+
+void loop(void) {}
+
+AP_HAL_MAIN();

--- a/libraries/AP_Motors/examples/expo_inverse_test/wscript
+++ b/libraries/AP_Motors/examples/expo_inverse_test/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )


### PR DESCRIPTION
Team effort by @Hwurzburg and myself. Combination of https://github.com/ArduPilot/ardupilot/pull/18428 and https://github.com/ArduPilot/ardupilot/pull/18419

Firstly this fixes a bug where tailsitter was applying throttle scaling twice when in a Qassist transition.

Secondly it adds a param to hard code throttle level for transition to VTOL. For copter tailsitters like the H wing where throttle mix will bump the throttle to keep attitude control you can set the throttle to 0 and gain very little height. 

@lthall In order to maintain the current tailsitter behavior I have had to add inverse functions for thrust to throttle scaling to AP_MotorsMulticopter. In the process for that I have made a small tidy up to the normal `apply_thrust_curve_and_volt_scaling` function and added battery scaling to the expo = 0 case. 
