### PR TITLE
Fix RC channel init ordering error message

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -59,8 +59,8 @@ void Tracker::init_ardupilot()
     serial_manager.set_blocking_writes_all(false);
 
     // initialise rc channels including setting mode
-    rc().init();
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
+    rc().init();
 
     // initialise servos
     init_servos();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -80,8 +80,8 @@ void Copter::init_ardupilot()
     allocate_motors();
 
     // initialise rc channels including setting mode
-    rc().init();
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM_AIRMODE);
+    rc().init();
 
     // sets up motors and output to escs
     init_rc_out();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -35,12 +35,12 @@ void Plane::init_ardupilot()
     pitchController.convert_pid();
 
     // initialise rc channels including setting mode
-    rc().init();
 #if HAL_QUADPLANE_ENABLED
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, (quadplane.enabled() && (quadplane.options & QuadPlane::OPTION_AIRMODE_UNUSED) && (rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRMODE) == nullptr)) ? RC_Channel::AUX_FUNC::ARMDISARM_AIRMODE : RC_Channel::AUX_FUNC::ARMDISARM);
 #else
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
 #endif
+    rc().init();
 
     relay.init();
 

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -62,8 +62,9 @@ void Sub::init_ardupilot()
 #endif
 
     // initialise rc channels including setting mode
-    rc().init();
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
+    rc().init();
+
 
     init_rc_in();               // sets up rc channels from radio
     init_rc_out();              // sets up motors and output to escs

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -48,8 +48,8 @@ void Blimp::init_ardupilot()
     allocate_motors();
 
     // initialise rc channels including setting mode
-    rc().init();
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
+    rc().init();
 
     // sets up motors and output to escs
     init_rc_out();

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -130,8 +130,8 @@ void Rover::init_ardupilot()
     set_mode(*initial_mode, ModeReason::INITIALISED);
 
     // initialise rc channels
-    rc().init();
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
+    rc().init();
 
     rover.g2.sailboat.init();
 


### PR DESCRIPTION
This fixes a bug I added in https://github.com/ArduPilot/ardupilot/pull/18478 

Because the param conversion was done after init we were getting stuck in a board config loop on SITL. The moves the param conversion to be after. 

None issue IRL as you don't get trapped in the board config error here:
https://github.com/ArduPilot/ardupilot/blob/a24a8c110b53371a02ad31603835ca8afc4e1270/libraries/RC_Channel/RC_Channel.cpp#L514-L517

Not sure how I manged to miss this in the original PR, Sorry