### PR TITLE
GCS_Common : Mavlink wrap when battery percentage is above 100

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -281,6 +281,8 @@ public:
     void send_generator_status() const;
     virtual void send_winch_status() const {};
     void send_water_depth() const;
+    int8_t battery_remaining_pct(const uint8_t instance) const;
+
 #if HAL_HIGH_LATENCY2_ENABLED
     void send_high_latency() const;
 #endif // HAL_HIGH_LATENCY2_ENABLED


### PR DESCRIPTION
This fixes the issue #15858 
Even if calculated percentage exceeds 100, we report it to be 100 on MAVLink.
