### PR TITLE
AP_BLHeli: use correct enum for rover PWM type

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -9,7 +9,7 @@
 // check if we should enter esc calibration mode
 void Copter::esc_calibration_startup_check()
 {
-    if (motors->get_pwm_type() == AP_Motors::PWM_TYPE_BRUSHED) {
+    if (motors->is_brushed_pwm_type()) {
         // ESC cal not valid for brushed motors
         return;
     }
@@ -153,7 +153,7 @@ void Copter::esc_calibration_setup()
     // clear esc flag for next time
     g.esc_calibrate.set_and_save(ESCCAL_NONE);
 
-    if (motors->get_pwm_type() >= AP_Motors::PWM_TYPE_ONESHOT) {
+    if (motors->is_normal_pwm_type()) {
         // run at full speed for oneshot ESCs (actually done on push)
         motors->set_update_rate(g.rc_speed);
     } else {

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -574,7 +574,7 @@ case AP_Motors::MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX:
     }
 
     // brushed 16kHz defaults to 16kHz pulses
-    if (motors->get_pwm_type() == AP_Motors::PWM_TYPE_BRUSHED) {
+    if (motors->is_brushed_pwm_type()) {
         g.rc_speed.set_default(16000);
     }
     

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1339,7 +1339,7 @@ void AP_BLHeli::init(void)
     // setting the digital mask changes the min/max PWM values
     // it's important that this is NOT done for non-digital channels as otherwise
     // PWM min can result in motors turning. set for individual overrides first
-    if (mask && otype >= AP_HAL::RCOutput::MODE_PWM_DSHOT150) {
+    if (mask && hal.rcout->is_dshot_protocol(otype)) {
         digital_mask = mask;
     }
 

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1367,7 +1367,7 @@ void AP_BLHeli::init(void)
     if (motors) {
         uint16_t motormask = motors->get_motor_mask();
         // set the rest of the digital channels
-        if (motors->get_pwm_type() >= AP_Motors::PWM_TYPE_DSHOT150) {
+        if (motors->is_digital_pwm_type()) {
             digital_mask |= motormask;
         }
         mask |= motormask;

--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -52,3 +52,19 @@ void AP_HAL::RCOutput::append_to_banner(char banner_msg[], uint8_t banner_msg_le
         hal.util->snprintf(banner_msg, banner_msg_len, "%s %s:%u-%u", banner_msg_temp, mode_str, (unsigned)low_ch, (unsigned)high_ch);
     }
 }
+
+/*
+  true when the output mode is of type dshot
+*/
+bool AP_HAL::RCOutput::is_dshot_protocol(const enum output_mode mode)
+{
+    switch (mode) {
+    case MODE_PWM_DSHOT150:
+    case MODE_PWM_DSHOT300:
+    case MODE_PWM_DSHOT600:
+    case MODE_PWM_DSHOT1200:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -202,6 +202,10 @@ public:
         MODE_NEOPIXEL,  // same as MODE_PWM_DSHOT at 800kHz but it's an LED
         MODE_PROFILED,  // same as MODE_PWM_DSHOT using separate clock and data
     };
+    // true when the output mode is of type dshot
+    // static to allow use in the ChibiOS thread stuff
+    static bool is_dshot_protocol(const enum output_mode mode);
+
 
     // https://github.com/bitdump/BLHeli/blob/master/BLHeli_32%20ARM/BLHeli_32%20Firmware%20specs/Digital_Cmd_Spec.txt
     enum BLHeliDshotCommand : uint8_t {

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -186,7 +186,9 @@ public:
     
     /*
       output modes. Allows for support of PWM, oneshot and dshot 
-     */
+    */
+    // this enum is used by BLH_OTYPE and ESC_PWM_TYPE on AP_Periph
+    // double check params are still correct when changing
     enum output_mode {
         MODE_PWM_NONE,
         MODE_PWM_NORMAL,

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2018,22 +2018,6 @@ void RCOutput::set_failsafe_pwm(uint32_t chmask, uint16_t period_us)
 }
 
 /*
-  true when the output mode is of type dshot
-*/
-bool RCOutput::is_dshot_protocol(const enum output_mode mode)
-{
-    switch (mode) {
-    case MODE_PWM_DSHOT150:
-    case MODE_PWM_DSHOT300:
-    case MODE_PWM_DSHOT600:
-    case MODE_PWM_DSHOT1200:
-        return true;
-    default:
-        return false;
-    }
-}
-
-/*
     returns the bitrate in Hz of the given output_mode
 */
 uint32_t RCOutput::protocol_bitrate(const enum output_mode mode)

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -600,7 +600,6 @@ private:
     const uint16_t buffer_length, bool choose_high, uint32_t pulse_time_us);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);
     void set_group_mode(pwm_group &group);
-    static bool is_dshot_protocol(const enum output_mode mode);
     static uint32_t protocol_bitrate(const enum output_mode mode);
     void print_group_setup_error(pwm_group &group, const char* error_string);
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -208,6 +208,25 @@ void AP_Motors::set_limit_flag_pitch_roll_yaw(bool flag)
     limit.yaw = flag;
 }
 
+// returns true if the configured PWM type is digital and should have fixed endpoints
+bool AP_Motors::is_digital_pwm_type() const
+{
+    switch (_pwm_type) {
+        case PWM_TYPE_DSHOT150:
+        case PWM_TYPE_DSHOT300:
+        case PWM_TYPE_DSHOT600:
+        case PWM_TYPE_DSHOT1200:
+            return true;
+        case PWM_TYPE_NORMAL:
+        case PWM_TYPE_ONESHOT:
+        case PWM_TYPE_ONESHOT125:
+        case PWM_TYPE_BRUSHED:
+        case PWM_TYPE_PWM_RANGE:
+            break;
+    }
+    return false;
+}
+
 namespace AP {
     AP_Motors *motors()
     {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -219,16 +219,14 @@ public:
     // This function is overriden in motors_heli class.   Always true for multicopters.
     virtual bool init_targets_on_arming() const { return true; }
 
-    enum pwm_type { PWM_TYPE_NORMAL     = 0,
-                    PWM_TYPE_ONESHOT    = 1,
-                    PWM_TYPE_ONESHOT125 = 2,
-                    PWM_TYPE_BRUSHED    = 3,
-                    PWM_TYPE_DSHOT150   = 4,
-                    PWM_TYPE_DSHOT300   = 5,
-                    PWM_TYPE_DSHOT600   = 6,
-                    PWM_TYPE_DSHOT1200  = 7,
-                    PWM_TYPE_PWM_RANGE  = 8 };
-    pwm_type            get_pwm_type(void) const { return (pwm_type)_pwm_type.get(); }
+    // returns true if the configured PWM type is digital and should have fixed endpoints
+    bool is_digital_pwm_type() const;
+
+    // returns true is pwm type is brushed
+    bool is_brushed_pwm_type() const { return _pwm_type == PWM_TYPE_BRUSHED; }
+
+    // returns true is pwm type is normal
+    bool is_normal_pwm_type() const { return (_pwm_type == PWM_TYPE_NORMAL) || (_pwm_type == PWM_TYPE_PWM_RANGE); }
 
     MAV_TYPE get_frame_mav_type() const { return _mav_type; }
 
@@ -299,6 +297,16 @@ protected:
     float               _thrust_boost_ratio;    // choice between highest and second highest motor output for output mixing (0 ~ 1). Zero is normal operation
 
     MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
+
+    enum pwm_type { PWM_TYPE_NORMAL     = 0,
+                    PWM_TYPE_ONESHOT    = 1,
+                    PWM_TYPE_ONESHOT125 = 2,
+                    PWM_TYPE_BRUSHED    = 3,
+                    PWM_TYPE_DSHOT150   = 4,
+                    PWM_TYPE_DSHOT300   = 5,
+                    PWM_TYPE_DSHOT600   = 6,
+                    PWM_TYPE_DSHOT1200  = 7,
+                    PWM_TYPE_PWM_RANGE  = 8 };
 
 private:
 

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -1004,6 +1004,24 @@ bool AP_MotorsUGV::active() const
     return false;
 }
 
+// returns true if the configured PWM type is digital and should have fixed endpoints
+bool AP_MotorsUGV::is_digital_pwm_type() const
+{
+    switch (_pwm_type) {
+        case PWM_TYPE_DSHOT150:
+        case PWM_TYPE_DSHOT300:
+        case PWM_TYPE_DSHOT600:
+        case PWM_TYPE_DSHOT1200:
+            return true;
+        case PWM_TYPE_NORMAL:
+        case PWM_TYPE_ONESHOT:
+        case PWM_TYPE_ONESHOT125:
+        case PWM_TYPE_BRUSHED_WITH_RELAY:
+        case PWM_TYPE_BRUSHED_BIPOLAR:
+            break;
+    }
+    return false;
+}
 
 namespace AP {
     AP_MotorsUGV *motors_ugv()

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -12,18 +12,6 @@ public:
     // singleton support
     static AP_MotorsUGV    *get_singleton(void) { return _singleton; }
 
-    enum pwm_type {
-        PWM_TYPE_NORMAL = 0,
-        PWM_TYPE_ONESHOT = 1,
-        PWM_TYPE_ONESHOT125 = 2,
-        PWM_TYPE_BRUSHED_WITH_RELAY = 3,
-        PWM_TYPE_BRUSHED_BIPOLAR = 4,
-        PWM_TYPE_DSHOT150 = 5,
-        PWM_TYPE_DSHOT300 = 6,
-        PWM_TYPE_DSHOT600 = 7,
-        PWM_TYPE_DSHOT1200 = 8
-    };
-
     enum motor_test_order {
         MOTOR_TEST_THROTTLE = 1,
         MOTOR_TEST_STEERING = 2,
@@ -120,8 +108,8 @@ public:
     // return the motor mask
     uint16_t get_motor_mask() const { return _motor_mask; }
 
-    // returns the configured PWM type
-    uint8_t get_pwm_type() const { return _pwm_type; }
+    // returns true if the configured PWM type is digital and should have fixed endpoints
+    bool is_digital_pwm_type() const;
 
     // structure for holding motor limit flags
     struct AP_MotorsUGV_limit {
@@ -134,7 +122,20 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
-protected:
+private:
+
+    enum pwm_type {
+        PWM_TYPE_NORMAL = 0,
+        PWM_TYPE_ONESHOT = 1,
+        PWM_TYPE_ONESHOT125 = 2,
+        PWM_TYPE_BRUSHED_WITH_RELAY = 3,
+        PWM_TYPE_BRUSHED_BIPOLAR = 4,
+        PWM_TYPE_DSHOT150 = 5,
+        PWM_TYPE_DSHOT300 = 6,
+        PWM_TYPE_DSHOT600 = 7,
+        PWM_TYPE_DSHOT1200 = 8
+    };
+
     // sanity check parameters
     void sanity_check_parameters();
 


### PR DESCRIPTION
Fixes #18729

The AP motors enum is not the same as the rover one.

This is rover:
https://github.com/ArduPilot/ardupilot/blob/d853d16c42acc21ce762a8db8299926f752b71a4/libraries/AP_Motors/AP_Motors_Class.h#L222-L230

This is AP motors:
https://github.com/ArduPilot/ardupilot/blob/d853d16c42acc21ce762a8db8299926f752b71a4/libraries/AR_Motors/AP_MotorsUGV.h#L15-L25

Rover has `PWM_TYPE_BRUSHED_BIPOLAR` slotted in at 4 so it was showing up as digital when compared the to the AP motors enum. 

The short term fix is to use the right enum. But we really should only have one. This mistake could well exist in other places too, although I could not see any after a very quick look. 

I would guess this also means its impossible to override to `PWM_TYPE_BRUSHED_BIPOLAR` on rover using the `BLH` params. 