### PR TITLE
Add ESC_TELEMETRY_1_TO_4 to the mavlink_id_to_ap_message_id table

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -873,6 +873,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_EFI_STATUS,            MSG_EFI_STATUS},
         { MAVLINK_MSG_ID_GENERATOR_STATUS,      MSG_GENERATOR_STATUS},
         { MAVLINK_MSG_ID_WINCH_STATUS,          MSG_WINCH_STATUS},
+        { MAVLINK_MSG_ID_ESC_TELEMETRY_1_TO_4,  MSG_ESC_TELEMETRY},
         { MAVLINK_MSG_ID_WATER_DEPTH,           MSG_WATER_DEPTH},
         { MAVLINK_MSG_ID_HIGH_LATENCY2,         MSG_HIGH_LATENCY2},
         { MAVLINK_MSG_ID_AIS_VESSEL,            MSG_AIS_VESSEL},


### PR DESCRIPTION
Tested with mavros, works fine, and will automatically trigger the 5_TO_8 and 9_TO_12 messages if necessary.

```
Binary           text          data         bss          total
---------------  ------------  -----------  -----------  ------------
ardusub          8 (+0.0005%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0004%)
arduplane        8 (+0.0005%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0004%)
blimp            8 (+0.0006%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0005%)
arducopter-heli  8 (+0.0005%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0004%)
antennatracker   8 (+0.0006%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0005%)
ardurover        8 (+0.0005%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0004%)
arducopter       8 (+0.0005%)  0 (0.0000%)  0 (0.0000%)  8 (+0.0004%)
```
