### PR TITLE
AP_HAL: AnalogSource: return bool for set pin

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
@@ -41,11 +41,10 @@ bool AP_Airspeed_Analog::init()
 // read the airspeed sensor
 bool AP_Airspeed_Analog::get_differential_pressure(float &pressure)
 {
-    if (_source == nullptr) {
+    // allow pin to change
+    if (_source == nullptr || !_source->set_pin(get_pin())) {
         return false;
     }
-    // allow pin to change
-    _source->set_pin(get_pin());
     pressure = _source->voltage_average_ratiometric() * VOLTS_TO_PASCAL / get_psi_range();
     return true;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -58,8 +58,6 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
     _volt_pin_analog_source = hal.analogin->channel(_volt_pin);
     _curr_pin_analog_source = hal.analogin->channel(_curr_pin);
 
-    // always healthy
-    _state.healthy = true;
 }
 
 // read - read the voltage and current
@@ -67,7 +65,7 @@ void
 AP_BattMonitor_Analog::read()
 {
     // this copes with changing the pin at runtime
-    _volt_pin_analog_source->set_pin(_volt_pin);
+    _state.healthy = _volt_pin_analog_source->set_pin(_volt_pin);
 
     // get voltage
     _state.voltage = _volt_pin_analog_source->voltage_average() * _volt_multiplier;
@@ -79,7 +77,7 @@ AP_BattMonitor_Analog::read()
         float dt = tnow - _state.last_time_micros;
 
         // this copes with changing the pin at runtime
-        _curr_pin_analog_source->set_pin(_curr_pin);
+        _state.healthy &= _curr_pin_analog_source->set_pin(_curr_pin);
 
         // read current
         _state.current_amps = (_curr_pin_analog_source->voltage_average() - _curr_amp_offset) * _curr_amp_per_volt;

--- a/libraries/AP_HAL/AnalogIn.h
+++ b/libraries/AP_HAL/AnalogIn.h
@@ -9,7 +9,7 @@ class AP_HAL::AnalogSource {
 public:
     virtual float read_average() = 0;
     virtual float read_latest() = 0;
-    virtual void set_pin(uint8_t p) = 0;
+    virtual bool set_pin(uint8_t p) WARN_IF_UNUSED = 0;
 
     // return a voltage from 0.0 to 5.0V, scaled
     // against a reference voltage

--- a/libraries/AP_HAL/examples/AnalogIn/AnalogIn.cpp
+++ b/libraries/AP_HAL/examples/AnalogIn/AnalogIn.cpp
@@ -46,7 +46,7 @@ void loop(void) {
     //increment the pin number
     pin = (pin+1) % 16;
     //set pin corresponding to the new pin value
-    chan->set_pin(pin);
+    IGNORE_RETURN(chan->set_pin(pin));
     //give a delay of 100ms
     hal.scheduler->delay(100);
 }

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -140,11 +140,26 @@ float AnalogSource::voltage_latest()
     return _pin_scaler() * read_latest();
 }
 
-void AnalogSource::set_pin(uint8_t pin)
+bool AnalogSource::set_pin(uint8_t pin)
 {
     if (_pin == pin) {
-        return;
+        return true;
     }
+    bool found_pin = false;
+    if (_pin == ANALOG_SERVO_VRSSI_PIN) {
+        found_pin = true;
+    } else {
+        for (uint8_t i=0; i<ADC_GRP1_NUM_CHANNELS; i++) {
+            if (AnalogIn::pin_config[i].channel == pin) {
+                found_pin = true;
+                break;
+            }
+        }
+    }
+    if (!found_pin) {
+        return false;
+    }
+
     WITH_SEMAPHORE(_semaphore);
     _pin = pin;
     _sum_value = 0;
@@ -153,6 +168,7 @@ void AnalogSource::set_pin(uint8_t pin)
     _latest_value = 0;
     _value = 0;
     _value_ratiometric = 0;
+    return true;
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -32,7 +32,7 @@ public:
     AnalogSource(int16_t pin);
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override WARN_IF_UNUSED;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override;

--- a/libraries/AP_HAL_Empty/AnalogIn.cpp
+++ b/libraries/AP_HAL_Empty/AnalogIn.cpp
@@ -22,8 +22,9 @@ float AnalogSource::read_latest() {
     return _v;
 }
 
-void AnalogSource::set_pin(uint8_t p)
-{}
+bool AnalogSource::set_pin(uint8_t p) {
+    return true;
+}
 
 AnalogIn::AnalogIn()
 {}

--- a/libraries/AP_HAL_Empty/AnalogIn.h
+++ b/libraries/AP_HAL_Empty/AnalogIn.h
@@ -7,7 +7,7 @@ public:
     AnalogSource(float v);
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override { return voltage_average(); }

--- a/libraries/AP_HAL_Linux/AnalogIn_ADS1115.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_ADS1115.cpp
@@ -6,12 +6,13 @@ AnalogSource_ADS1115::AnalogSource_ADS1115(int16_t pin):
 {
 }
 
-void AnalogSource_ADS1115::set_pin(uint8_t pin)
+bool AnalogSource_ADS1115::set_pin(uint8_t pin)
 {
     if (_pin == pin) {
-        return;
+        return true;
     }
     _pin = pin;
+    return true;
 }
 
 float AnalogSource_ADS1115::read_average()

--- a/libraries/AP_HAL_Linux/AnalogIn_ADS1115.h
+++ b/libraries/AP_HAL_Linux/AnalogIn_ADS1115.h
@@ -11,7 +11,7 @@ public:
     AnalogSource_ADS1115(int16_t pin);
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override;

--- a/libraries/AP_HAL_Linux/AnalogIn_IIO.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_IIO.cpp
@@ -98,10 +98,10 @@ float AnalogSource_IIO::voltage_latest()
     return _latest;
 }
 
-void AnalogSource_IIO::set_pin(uint8_t pin)
+bool AnalogSource_IIO::set_pin(uint8_t pin)
 {
     if (_pin == pin) {
-        return;
+        return true;
     }
 
     WITH_SEMAPHORE(_semaphore);
@@ -112,6 +112,7 @@ void AnalogSource_IIO::set_pin(uint8_t pin)
     _latest = 0;
     _value = 0;
     select_pin();
+    return true;
 }
 
 AnalogIn_IIO::AnalogIn_IIO()

--- a/libraries/AP_HAL_Linux/AnalogIn_IIO.h
+++ b/libraries/AP_HAL_Linux/AnalogIn_IIO.h
@@ -27,7 +27,7 @@ public:
     AnalogSource_IIO(int16_t pin, float initial_value, float voltage_scaling);
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override { return voltage_average(); }

--- a/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
@@ -42,15 +42,16 @@ AnalogSource_Navio2::AnalogSource_Navio2(uint8_t pin)
     set_channel(pin);
 }
 
-void AnalogSource_Navio2::set_pin(uint8_t pin)
+bool AnalogSource_Navio2::set_pin(uint8_t pin)
 {
     if (_pin == pin) {
-        return;
+        return true;
     }
 
     set_channel(pin);
 
     _pin = pin;
+    return true;
 }
 
 float AnalogSource_Navio2::read_average()

--- a/libraries/AP_HAL_Linux/AnalogIn_Navio2.h
+++ b/libraries/AP_HAL_Linux/AnalogIn_Navio2.h
@@ -12,7 +12,7 @@ public:
     AnalogSource_Navio2(uint8_t pin);
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override;

--- a/libraries/AP_HAL_SITL/AnalogIn.cpp
+++ b/libraries/AP_HAL_SITL/AnalogIn.cpp
@@ -58,8 +58,9 @@ float ADCSource::read_latest() {
     }
 }
 
-void ADCSource::set_pin(uint8_t pin) {
+bool ADCSource::set_pin(uint8_t pin) {
     _pin = pin;
+    return true;
 }
 
 void AnalogIn::init() {

--- a/libraries/AP_HAL_SITL/AnalogIn.h
+++ b/libraries/AP_HAL_SITL/AnalogIn.h
@@ -14,7 +14,7 @@ public:
     /* implement AnalogSource virtual api: */
     float read_average() override;
     float read_latest() override;
-    void set_pin(uint8_t p) override;
+    bool set_pin(uint8_t p) override;
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override {

--- a/libraries/AP_LeakDetector/AP_LeakDetector_Analog.cpp
+++ b/libraries/AP_LeakDetector/AP_LeakDetector_Analog.cpp
@@ -11,8 +11,7 @@ AP_LeakDetector_Analog::AP_LeakDetector_Analog(AP_LeakDetector &_leak_detector, 
 
 void AP_LeakDetector_Analog::read()
 {
-    if (source != NULL && leak_detector._pin[state.instance] >= 0) {
-        source->set_pin(leak_detector._pin[state.instance]);
+    if (source != NULL && leak_detector._pin[state.instance] >= 0 && source->set_pin(leak_detector._pin[state.instance])) {
         state.status = source->voltage_average() > 2.0f;
         state.status = state.status != leak_detector._default_reading[state.instance];
     } else {

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -176,10 +176,9 @@ uint8_t AP_RSSI::read_receiver_rssi_uint8()
 // read the RSSI value from an analog pin - returns float in range 0.0 to 1.0
 float AP_RSSI::read_pin_rssi()
 {
-    if (!rssi_analog_source) {
+    if (!rssi_analog_source || !rssi_analog_source->set_pin(rssi_analog_pin)) {
         return 0;
     }
-    rssi_analog_source->set_pin(rssi_analog_pin);
     float current_analog_voltage = rssi_analog_source->voltage_average();
 
     return scale_and_constrain_float_rssi(current_analog_voltage, rssi_analog_pin_range_low, rssi_analog_pin_range_high);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
@@ -63,12 +63,11 @@ bool AP_RangeFinder_analog::detect(AP_RangeFinder_Params &_params)
  */
 void AP_RangeFinder_analog::update_voltage(void)
 {
-   if (source == nullptr) {
+   if (source == nullptr || !source->set_pin(params.pin)) {
        state.voltage_mv = 0;
+       set_status(RangeFinder::Status::NotConnected);
        return;
    }
-   // cope with changed settings
-   source->set_pin(params.pin);
    if (params.ratiometric) {
        state.voltage_mv = source->voltage_average_ratiometric() * 1000U;
    } else {

--- a/libraries/AP_Scripting/examples/analog_input_and_GPIO.lua
+++ b/libraries/AP_Scripting/examples/analog_input_and_GPIO.lua
@@ -6,7 +6,9 @@
 -- some are used by the main AP code, ie battery monitors
 -- assign them like this in the init, not in the main loop
 local analog_in = analog:channel()
-analog_in:set_pin(13) -- typically 13 is the battery input
+if not analog_in:set_pin(13) then -- typically 13 is the battery input
+  gcs:send_text(0, "Invalid analog pin")
+end
 
 -- load a input pwm pin
 local pwm_in = PWMSource()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -383,7 +383,7 @@ ap_object AP_HAL::I2CDevice method read_registers boolean uint8_t 0 UINT8_MAX &u
 ap_object AP_HAL::I2CDevice method set_address void uint8_t 0 UINT8_MAX
 
 
-ap_object AP_HAL::AnalogSource method set_pin void uint8_t 0 UINT8_MAX
+ap_object AP_HAL::AnalogSource method set_pin boolean uint8_t 0 UINT8_MAX
 ap_object AP_HAL::AnalogSource method voltage_average float
 ap_object AP_HAL::AnalogSource method voltage_latest float
 ap_object AP_HAL::AnalogSource method voltage_average_ratiometric float

--- a/libraries/AP_WindVane/AP_WindVane_Analog.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Analog.cpp
@@ -26,7 +26,10 @@ AP_WindVane_Analog::AP_WindVane_Analog(AP_WindVane &frontend) :
 
 void AP_WindVane_Analog::update_direction()
 {
-    _dir_analog_source->set_pin(_frontend._dir_analog_pin);
+    if (!_dir_analog_source->set_pin(_frontend._dir_analog_pin)) {
+        // pin invalid, don't have health monitoring to report yet
+        return;
+    }
     _current_analog_voltage = _dir_analog_source->voltage_latest();
 
     const float voltage_ratio = linear_interpolate(0.0f, 1.0f, _current_analog_voltage, _frontend._dir_analog_volt_min, _frontend._dir_analog_volt_max);

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
@@ -32,14 +32,20 @@ void AP_WindVane_ModernDevice::update_speed()
     // only read temp pin if defined, sensor will do OK assuming constant temp
     float temp_ambient = 28.0f; // equations were generated at this temp in above data sheet
     if (is_positive(_frontend._speed_sensor_temp_pin.get())) {
-        _temp_analog_source->set_pin(_frontend._speed_sensor_temp_pin.get());
+        if (!_temp_analog_source->set_pin(_frontend._speed_sensor_temp_pin.get())) {
+            // pin invalid, don't have health monitoring to report yet
+            return;
+        }
         analog_voltage = _temp_analog_source->voltage_average();
         temp_ambient = (analog_voltage - 0.4f) / 0.0195f; // deg C
         // constrain to reasonable range to avoid deviating from calibration too much and potential divide by zero
         temp_ambient = constrain_float(temp_ambient, 10.0f, 40.0f);
     }
 
-    _speed_analog_source->set_pin(_frontend._speed_sensor_speed_pin.get());
+    if (!_speed_analog_source->set_pin(_frontend._speed_sensor_speed_pin.get())) {
+        // pin invalid, don't have health monitoring to report yet
+        return;
+    }
     _current_analog_voltage = _speed_analog_source->voltage_average();
 
     // apply voltage offset and make sure not negative


### PR DESCRIPTION
Allows to check if a valid ADC pin has been selected. 
