### PR TITLE
Plane: Quadplane: check attitude relax before running controllers, do…

### DIFF
--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -31,8 +31,6 @@ void ModeQAcro::run()
         attitude_control->set_throttle_out(0, true, 0);
         quadplane.relax_attitude_control();
     } else {
-        quadplane.check_attitude_relax();
-
         quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // convert the input to the desired body frame rate

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -44,8 +44,6 @@ void ModeQLoiter::run()
         plane.mode_qloiter._enter();
     }
 
-    quadplane.check_attitude_relax();
-
     if (quadplane.should_relax()) {
         loiter_nav->soften_for_landing();
     }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -233,7 +233,6 @@ private:
     // use multicopter rate controller
     void multicopter_attitude_rate_update(float yaw_rate_cds);
 
-    void check_attitude_relax(void);
     float get_pilot_throttle(void);
     void control_hover(void);
     void relax_attitude_control();


### PR DESCRIPTION
…n't run controls if not going to output

Possibly due to https://github.com/ArduPilot/ardupilot/pull/18375 or possibly something else we were no longer relaxing correctly on tailsitters and probably other quad-planes too. This makes the change that I should probably have include in that PR. We now always relax if the controller has not been in active for more than 0.1 seconds. To make sure that works I have moved `rate_controller_run()` down in the function so it is after all the early returns that used run the control but never output to motors. 

