### PR TITLE
AP_Proximity: lower SF45B update rate

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
@@ -29,7 +29,7 @@ static const uint32_t PROXIMITY_SF45B_TIMEOUT_MS = 200;
 static const uint32_t PROXIMITY_SF45B_REINIT_INTERVAL_MS = 5000;    // re-initialise sensor after this many milliseconds
 static const float PROXIMITY_SF45B_COMBINE_READINGS_DEG = 5.0f;     // combine readings from within this many degrees to improve efficiency
 static const uint32_t PROXIMITY_SF45B_STREAM_DISTANCE_DATA_CM = 5;
-static const uint8_t PROXIMITY_SF45B_DESIRED_UPDATE_RATE = 8;       // 1:48hz, 2:55hz, 3:64hz, 4:77hz, 5:97hz, 6:129hz, 7:194hz, 8:388hz
+static const uint8_t PROXIMITY_SF45B_DESIRED_UPDATE_RATE = 6;       // 1:48hz, 2:55hz, 3:64hz, 4:77hz, 5:97hz, 6:129hz, 7:194hz, 8:388hz
 static const uint32_t PROXIMITY_SF45B_DESIRED_FIELDS = ((uint32_t)1 << 0 | (uint32_t)1 << 8);   // first return (unfiltered), yaw angle
 static const uint16_t PROXIMITY_SF45B_DESIRED_FIELD_COUNT = 2;      // DISTANCE_DATA_CM message should contain two fields
 


### PR DESCRIPTION
I was seeing very jump proximity readings from the SF45B. The angles seems not to match the distance. At a lower data rate it comes good. I have no idea if there has been some hardware/firmware change in the SF45B that has caused this. Maybe someone has a contact at LightWare. 

I used this to generate the following plots. 
https://github.com/IamPete1/ardupilot/commit/6026a532860de2eda7e1cd35013b7d4c9c570343

The lidar remains fixed looking at a wall throughout. 

![image](https://user-images.githubusercontent.com/33176108/134786108-52aca15f-2f0b-41c3-b255-ca0423e5f3b8.png)

![image](https://user-images.githubusercontent.com/33176108/134786112-2630691c-71f6-4205-b407-baa4c00a4a30.png)

![image](https://user-images.githubusercontent.com/33176108/134786114-6f9b0cce-4375-4459-9e13-4a2f226f967c.png)

![image](https://user-images.githubusercontent.com/33176108/134786118-dd2ca915-0313-4baa-935d-e5b9f258aa92.png)

![image](https://user-images.githubusercontent.com/33176108/134786123-01b0b23c-17b8-41fb-8dc9-194dad83ae5f.png)

![image](https://user-images.githubusercontent.com/33176108/134786126-7f75bf5a-0403-43f5-9bbc-26e645d629ef.png)

![image](https://user-images.githubusercontent.com/33176108/134786130-999fe4e5-cf84-4216-ae1f-61f84061dd35.png)

![image](https://user-images.githubusercontent.com/33176108/134786132-695b7f09-b6d9-4e23-b72a-c39153ef9acc.png)

Were currently use the highest rate, 8. It is clear that that is just wrong. 6 seems the fastest with good data, so this PR changes it to that. 