### PR TITLE
Fixed tailsitter auto landing bug and adjust Swan-K1 defaults

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2091,6 +2091,17 @@ void QuadPlane::poscontrol_init_approach(void)
 }
 
 /*
+  log the QPOS message
+ */
+void QuadPlane::log_QPOS(void)
+{
+    AP::logger().WriteStreaming("QPOS", "TimeUS,State,Dist", "QBf",
+                                AP_HAL::micros64(),
+                                poscontrol.get_state(),
+                                plane.auto_state.wp_distance);
+}
+
+/*
   change position control state
  */
 void QuadPlane::PosControlState::set_state(enum position_control_state s)
@@ -2116,6 +2127,7 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
             // reset throttle descent control
             qp.thr_ctrl_land = false;
         }
+        qp.log_QPOS();
     }
     state = s;
     last_state_change_ms = AP_HAL::millis();
@@ -2551,10 +2563,7 @@ void QuadPlane::vtol_position_controller(void)
     if (now_ms - poscontrol.last_log_ms >= 40) {
         // log poscontrol at 25Hz
         poscontrol.last_log_ms = now_ms;
-        AP::logger().WriteStreaming("QPOS", "TimeUS,State,Dist", "QBf",
-                           AP_HAL::micros64(),
-                           poscontrol.get_state(),
-                           plane.auto_state.wp_distance);
+        log_QPOS();
     }
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2802,11 +2802,10 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
         return false;
     }
     attitude_control->reset_rate_controller_I_terms();
-    
+
     plane.set_next_WP(cmd.content.location);
     // initially aim for current altitude
     plane.next_WP_loc.alt = plane.current_loc.alt;
-    poscontrol.set_state(QPOS_POSITION1);
 
     // initialise the position controller
     pos_control->init_xy_controller();

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -249,6 +249,7 @@ private:
     bool should_relax(void);
     void motors_output(bool run_rate_controller = true);
     void Log_Write_QControl_Tuning();
+    void log_QPOS(void);
     float landing_descent_rate_cms(float height_above_ground);
     
     // setup correct aux channels for frame class

--- a/libraries/AP_HAL_ChibiOS/hwdef/Swan-K1/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Swan-K1/defaults.parm
@@ -40,8 +40,11 @@ ARSPD_FBW_MAX  25
 ARSPD_FBW_MIN  8
 ARSPD_RATIO    1.9
 LIM_ROLL_CD    4000
+
+# the HWing can become unstable at high speeds. Limit pitch angle
+# to prevent overspeed
 LIM_PITCH_MAX  4500
-LIM_PITCH_MIN  -3000
+LIM_PITCH_MIN  -1500
 
 # setup left 3-pos switch for QHOVER, QLOITER and FBWA
 FLTMODE1 18
@@ -102,6 +105,9 @@ Q_M_THST_HOVER        0.45
 Q_M_BAT_VOLT_MAX   16.8
 Q_M_BAT_VOLT_MIN   13.2
 Q_TAILSIT_RAT_VT 30
+Q_A_RATE_Y_MAX 100
+Q_A_RATE_R_MAX 100
+Q_A_RATE_P_MAX 100
 
 Q_WP_ACCEL 250
 Q_WP_ACCEL_Z 300


### PR DESCRIPTION
This fixes an issue that caused a Swan-K1 crash, where the demanded body frame roll rate went very high. The problem was a call to attitude_control->reset_yaw_target_and_rate(); due to an unnecessary set_state to QPOS_POSITION1 on a VTOL_LAND waypoint.
It also adjusts the Swan-K1 parameters to prevent buildup of too much speed due to a steep dive
