### PR TITLE
Copter: reset land_repo_active flag in Auto mode

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -50,6 +50,9 @@ bool ModeAuto::init(bool ignore_checks)
         // clear guided limits
         copter.mode_guided.limit_clear();
 
+        // reset flag indicating if pilot has applied roll or pitch inputs during landing
+        copter.ap.land_repo_active = false;
+
 #if PRECISION_LANDING == ENABLED
         // initialise precland state machine
         copter.precland_statemachine.init();


### PR DESCRIPTION
This resets land_repo_active when switching into Auto mode.

PrecLand works in Land/RTL/Auto modes.
land_repo_active is reset in init() of Land and RTL.

It should be a unified behavior in Auto as well.
Referenced issue #17970

I tested this in SITL.