### PR TITLE
autotest: add test for HIGH_LATENCY2

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5695,6 +5695,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
              "Set modes via mavproxy switch",
              self.test_setting_modes_via_mavproxy_switch),
 
+            ("HIGH_LATENCY2",
+             "Set sending of HIGH_LATENCY2",
+             self.HIGH_LATENCY2),
+
             ("MAVProxy_SetModeUsingMode",
              "Set modes via mavproxy mode command",
              self.test_setting_modes_via_mavproxy_mode_command),


### PR DESCRIPTION
Split from https://github.com/ArduPilot/ardupilot/pull/17962

Just adds a few easy tests for the `HIGH_LATENCY2` support
