### PR TITLE
AP_Stats: Ignore fraudulent posts

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -52,6 +52,7 @@ AP_Stats::AP_Stats(void)
 
 void AP_Stats::copy_variables_from_parameters()
 {
+    bootcount = params.bootcount;
     flttime = params.flttime;
     runtime = params.runtime;
     reset = params.reset;
@@ -69,6 +70,7 @@ void AP_Stats::init()
 
 void AP_Stats::flush()
 {
+    params.bootcount.set_and_save_ifchanged(bootcount);
     params.flttime.set_and_save_ifchanged(flttime);
     params.runtime.set_and_save_ifchanged(runtime);
 }

--- a/libraries/AP_Stats/AP_Stats.h
+++ b/libraries/AP_Stats/AP_Stats.h
@@ -15,6 +15,7 @@ public:
     // these variables are periodically written into the actual
     // parameters.  If you add a variable here, make sure to update
     // init() to set initial values from the parameters!
+    uint32_t bootcount; // total boot count
     uint32_t flttime; // seconds in flight (or driving)
     uint32_t runtime; // total wallclock time spent running ArduPilot (seconds)
     uint32_t reset;   // last time AP_Stats parameters were reset (in seconds since AP_Stats Jan 1st 2016)


### PR DESCRIPTION
I was able to set the BOOT COUNT in APM PLANNER2.
I was not able to set FLIGHT TIME and RUN TIME.
I think that BOOT COUNT is the same as FLIGHT TIME and RUN TIME.