### PR TITLE
Tools: fix missing warning on Clang

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -270,9 +270,7 @@ class Board:
             '-Werror=parentheses',
             '-DARDUPILOT_BUILD',
             '-Wuninitialized',
-            '-Wmaybe-uninitialized',
             '-Warray-bounds',
-            '-Wduplicated-cond',
         ]
 
         if 'clang++' in cfg.env.COMPILER_CXX:
@@ -315,6 +313,8 @@ class Board:
             if self.cc_version_gte(cfg, 7, 4):
                 env.CXXFLAGS += [
                     '-Werror=implicit-fallthrough',
+                    '-Wmaybe-uninitialized',
+                    '-Wduplicated-cond',
                 ]
 
         if cfg.options.Werror:


### PR DESCRIPTION
Clang complains about some warning from https://github.com/ArduPilot/ardupilot/pull/18415, so I move them to GCC only