### PR TITLE
AP_Periph: fix GCS/mavlink for all configured MAVLink serial ports

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -111,6 +111,7 @@ void AP_Periph_FW::init()
 
 #if HAL_GCS_ENABLED
     gcs().setup_console();
+    gcs().setup_uarts();
     gcs().send_text(MAV_SEVERITY_INFO, "AP_Periph GCS Initialised!");
 #endif
 


### PR DESCRIPTION
AP_Periph GCS support was only initializing the console (serial0) for mavlink support. Now it will init any serial port that is _protocol 1 or 2.