### PR TITLE
AP_Periph: Baro uplink

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -111,6 +111,7 @@ void AP_Periph_FW::init()
 
 #if HAL_GCS_ENABLED
     gcs().setup_console();
+    gcs().setup_uarts();
     gcs().send_text(MAV_SEVERITY_INFO, "AP_Periph GCS Initialised!");
 #endif
 

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -50,6 +50,9 @@
 #error "Battery MPPT PacketDigital driver requires at least two CAN Ports"
 #endif
 
+#if defined(HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK) && !defined(HAL_PERIPH_ENABLE_BARO)
+#error "HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK needs HAL_PERIPH_ENABLE_BARO"
+#endif
 
 #include "Parameters.h"
 
@@ -120,6 +123,9 @@ public:
 
 #ifdef HAL_PERIPH_ENABLE_BARO
     AP_Baro baro;
+    #ifdef HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK
+    uint32_t baro_uplink_last_ms;
+    #endif
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_BATTERY

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -198,6 +198,31 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Values: 0:Disabled, 1:Enabled
     // @User: Standard
     GSCALAR(baro_enable, "BARO_ENABLE", 1),
+
+#ifdef HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK
+    // @Param: BARO_UPLINK_SEC
+    // @DisplayName: Barometer Uplink Seconds Interval
+    // @Description: Barometer base-station uplink update interval in seconds. At this interval, it will set a remote system's ground pressure with it's own ground pressure.
+    // @Range: 0 1000
+    // @Units: s
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(baro_uplink_sec, "BARO_UPLINK_SEC", 0),
+
+    // @Param: BARO_UPLINK_ID
+    // @DisplayName: Barometer Uplink SYSID
+    // @Description: Barometer base-station uplink update target MAVLink SYSID
+    // @Range: 0 255
+    // @User: Advanced
+    GSCALAR(baro_uplink_id, "BARO_UPLINK_ID", 1),
+
+    // @Param: BARO_UPLINK_NAME
+    // @DisplayName: Barometer Uplink Param Name
+    // @Description: Barometer base-station uplink update param names to update.
+    // @Values: 0:GND_ABS_PRESS, 1:BARO_ABS_PRESS
+    // @User: Advanced
+    GSCALAR(baro_uplink_name, "BARO_UPLINK_NAME", 0), // 0 for "GND_xxxx", 1 for "BARO_xxxxx"
+#endif // HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK
 #endif
 
 #ifdef AP_PERIPH_HAVE_LED_WITHOUT_NOTIFY

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -49,6 +49,9 @@ public:
         k_param_sysid_this_mav,
         k_param_serial_manager,
         k_param_gps_mb_only_can_port,
+        k_param_baro_uplink_sec,
+        k_param_baro_uplink_id,
+        k_param_baro_uplink_name,
     };
 
     AP_Int16 format_version;
@@ -67,6 +70,11 @@ public:
 #endif
 #ifdef HAL_PERIPH_ENABLE_BARO
     AP_Int8 baro_enable;
+#ifdef HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK
+    AP_Int16 baro_uplink_sec;
+    AP_Int32 baro_uplink_id;
+    AP_Int8 baro_uplink_name;
+#endif
 #endif
 #if !defined(HAL_NO_FLASH_SUPPORT) && !defined(HAL_NO_ROMFS_SUPPORT)
     AP_Int8 flash_bootloader;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -77,7 +77,6 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // NOTE: Index numbers 0 and 1 were for the old integer
     // ground temperature and pressure
 
-#ifndef HAL_BUILD_AP_PERIPH
     // @Param: 1_GND_PRESS
     // @DisplayName: Ground Pressure
     // @Description: calibrated ground pressure in Pascals
@@ -97,6 +96,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_GND_TEMP", 3, AP_Baro, _user_ground_temperature, 0),
 
+#ifndef HAL_BUILD_AP_PERIPH
     // index 4 reserved for old AP_Int8 version in legacy FRAM
     //AP_GROUPINFO("ALT_OFFSET", 4, AP_Baro, _alt_offset, 0),
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph-heavy/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-periph-heavy/hwdef.dat
@@ -26,8 +26,10 @@ define HAL_PERIPH_ENABLE_BARO
 define HAL_PERIPH_ENABLE_RC_OUT
 define HAL_PERIPH_ENABLE_NOTIFY
 define COMPASS_CAL_ENABLED 1
+define HAL_PERIPH_ENABLE_BARO_OFFSET_UPLINK
 
 define HAL_INS_ENABLED 1
+define HAL_GCS_ENABLED 1
 
 # use the app descriptor needed by MissionPlanner for CAN upload
 env APP_DESCRIPTOR MissionPlanner

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -533,6 +533,7 @@ protected:
     bool try_send_mission_message(enum ap_message id);
     void send_hwstatus();
     void handle_data_packet(const mavlink_message_t &msg);
+    void send_param_set(const char* name, const float value, const uint8_t target_system = 0);
 
     // these two methods are called after current_loc is updated:
     virtual int32_t global_position_int_alt() const;
@@ -964,6 +965,7 @@ public:
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_named_float(const char *name, float value) const;
+    void send_param_set_message(const char* name, const float value, const uint8_t target_system = 0);
 
     void send_parameter_value(const char *param_name,
                               ap_var_type param_type,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2136,6 +2136,13 @@ void GCS::send_mission_item_reached_message(uint16_t mission_index)
     }
 }
 
+void GCS::send_param_set_message(const char* name, const float value, const uint8_t target_system)
+{
+    for (uint8_t i=0; i<num_gcs(); i++) {
+        chan(i)->send_param_set(name, value, target_system);
+    }
+}
+
 void GCS::setup_console()
 {
     AP_HAL::UARTDriver *uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_MAVLink, 0);
@@ -4644,6 +4651,13 @@ void GCS_MAVLINK::send_hwstatus()
         chan,
         hal.analogin->board_voltage()*1000,
         0);
+}
+
+void GCS_MAVLINK::send_param_set(const char* name, const float value, const uint8_t target_system)
+{
+    mavlink_msg_param_set_send(
+        chan,
+        target_system, MAV_COMP_ID_AUTOPILOT1, name, value, MAV_PARAM_TYPE_REAL32);
 }
 
 void GCS_MAVLINK::send_rpm() const


### PR DESCRIPTION
This adds a new AP_Periph feature to allow a ground-based AP_Periph device to set another vehicle's ground pressure param, assuming you have all the data links set up to allow data to flow that way (like an IP network). This allows a fairly accurate ground reference without needing a lidar or RTK GPS.

This PR includes PR https://github.com/ArduPilot/ardupilot/pull/18796