### PR TITLE
Tools:install-prereqs-ubuntu.sh use $APT_GET for pkg-config install

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -107,7 +107,7 @@ fi
 if [ "$ARM_PKG_CONFIG_NOT_PRESENT" -eq 1 ]; then
     INSTALL_PKG_CONFIG=""
     # No need to install Ubuntu's pkg-config-arm-linux-gnueabihf, instead install the base pkg-config.
-    sudo apt-get install pkg-config
+    $APT_GET install pkg-config
     if [ -f /usr/share/pkg-config-crosswrapper ]; then
         # We are on non-Ubuntu so simulate effect of installing pkg-config-arm-linux-gnueabihf.
         sudo ln -s /usr/share/pkg-config-crosswrapper /usr/bin/arm-linux-gnueabihf-pkg-config


### PR DESCRIPTION
While writing a script to automate dev env install locally I notice this is not abiding by the $ASSUME_YES like the other apt-get install commands.