### PR TITLE
AP_BARO: baro filter fix

### DIFF
--- a/libraries/AP_Baro/AP_Baro_Backend.cpp
+++ b/libraries/AP_Baro/AP_Baro_Backend.cpp
@@ -86,11 +86,10 @@ bool AP_Baro_Backend::pressure_ok(float press)
     } else {
         const float d = fabsf(_mean_pressure - press) / (_mean_pressure + press);  // diff divide by mean value in percent ( with the * 200.0f on later line)
         float koeff = FILTER_KOEF;
-
-        if (d * 200.0f > range) {  // check the difference from mean value outside allowed range
-            // printf("\nBaro pressure error: mean %f got %f\n", (double)_mean_pressure, (double)press );
+        if (d  > (range * 0.000005f)) {  // check the difference from mean value outside allowed range
+            //printf("\nBaro pressure error: mean %f got %f\n", (double)_mean_pressure, (double)press );
             ret = false;
-            koeff /= (d * 10.0f);  // 2.5 and more, so one bad sample never change mean more than 4%
+            koeff *= (d * 10.0f);  // 2.5 and more, so one bad sample never change mean more than 4%
             _error_count++;
         }
         _mean_pressure = _mean_pressure * (1 - koeff) + press * koeff; // complimentary filter 1/k


### PR DESCRIPTION

Example:
two real values from baros -with jumps- are:
99545.718750, 99445.000000 (pressure)

do the [math and compute](https://github.com/ArduPilot/ardupilot/blob/aa05629ef61fb7adf85839b370948c784296bcbb/libraries/AP_Baro/AP_Baro_Backend.cpp#L87) 
`d = fabsf (_mean_pressure - press) / (_mean_pressure + press);`

for the sake of example lets assume
`_mean_pressure = 99545.718750`
and 
`press = 99445.000000`
then d = 100.71875 / 198990.71875 = 0.000506148

the next line is

**`if (d * 200.0f > range) {`** 

range is from 1 to 100 ..... d **no ways reaches even** 1

https://github.com/ArduPilot/ardupilot/blob/aa05629ef61fb7adf85839b370948c784296bcbb/libraries/AP_Baro/AP_Baro_Backend.cpp#L87

I believe the correct 
**` if (d  > (range * 0.000005f)) { `**  which even not enough and could be

=====
another thing is:
koeff /= (d * 10.0f);

if d is << 0 then koeff will be higher instead of being smaller.
so I converted:

koeff *= (d * 10.0f);

Please advise.
 