### PR TITLE
AP_AccelCal: update_status() - reorder logic

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -325,6 +325,13 @@ void AP_AccelCal::update_status() {
     }
 
     for(uint8_t i=0 ; (cal = get_calibrator(i))  ; i++) {
+        if (cal->get_status() == ACCEL_CAL_NOT_STARTED) {
+            _status = ACCEL_CAL_NOT_STARTED;    // we haven't started if all the calibrators haven't
+            return;
+        }
+    }
+
+    for(uint8_t i=0 ; (cal = get_calibrator(i))  ; i++) {
         if (cal->get_status() == ACCEL_CAL_FAILED) {
             _status = ACCEL_CAL_FAILED;         //fail if even one of the calibration has
             return;
@@ -345,12 +352,6 @@ void AP_AccelCal::update_status() {
         }
     }
 
-    for(uint8_t i=0 ; (cal = get_calibrator(i))  ; i++) {
-        if (cal->get_status() == ACCEL_CAL_NOT_STARTED) {
-            _status = ACCEL_CAL_NOT_STARTED;    // we haven't started if all the calibrators haven't
-            return;
-        }
-    }
 
     _status = ACCEL_CAL_SUCCESS;    // we have succeeded calibration if all the calibrators have
     return;


### PR DESCRIPTION
Move the 'not started' check up, since it need to verify all calibrators are started. Currently it would not get there if any calibrators were 'collecting' or 'waiting for orientation'.

Is possible I am misunderstanding as I am newer.

