### PR TITLE
HAL_ChibiOS: optimisation for AP_HAL::micros() with 32 bit timers

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -55,13 +55,14 @@ static void show_sizes(void)
 #define FIFTYTIMES(x) do { TENTIMES(x); TENTIMES(x); TENTIMES(x); TENTIMES(x); TENTIMES(x); } while (0)
 
 #define TIMEIT(name, op, count) do { \
-    uint32_t us_end, us_start; \
-    us_start = AP_HAL::micros(); \
+    uint16_t us_end, us_start; \
+    us_start = AP_HAL::micros16(); \
     for (uint8_t i = 0; i < count; i++) { \
         FIFTYTIMES(op); \
     } \
-    us_end = AP_HAL::micros(); \
-    hal.console->printf("%-10s %7.4f usec/call\n", name, double(us_end - us_start) / double(count * 50.0)); \
+    us_end = AP_HAL::micros16(); \
+    uint16_t dt_us = us_end - us_start; \
+    hal.console->printf("%-10s %7.4f usec/call\n", name, double(dt_us) / double(count * 50.0)); \
     hal.scheduler->delay(10); \
 } while (0)
 
@@ -101,7 +102,9 @@ static void show_timings(void)
     TIMEIT("nop", asm volatile("nop"::), 255);
 
     TIMEIT("micros()", AP_HAL::micros(), 200);
+    TIMEIT("micros16()", AP_HAL::micros16(), 200);
     TIMEIT("millis()", AP_HAL::millis(), 200);
+    TIMEIT("millis16()", AP_HAL::millis16(), 200);
     TIMEIT("micros64()", AP_HAL::micros64(), 200);
 
     TIMEIT("fadd", v_out += v_f, 100);

--- a/libraries/AP_HAL/system.cpp
+++ b/libraries/AP_HAL/system.cpp
@@ -5,6 +5,11 @@ uint16_t WEAK AP_HAL::millis16()
     return millis() & 0xFFFF;
 }
 
+uint16_t WEAK AP_HAL::micros16()
+{
+    return micros() & 0xFFFF;
+}
+
 void WEAK AP_HAL::dump_stack_trace()
 {
     // stack dump not available on this platform

--- a/libraries/AP_HAL/system.h
+++ b/libraries/AP_HAL/system.h
@@ -12,6 +12,7 @@ void init();
 
 void panic(const char *errormsg, ...) FMT_PRINTF(1, 2) NORETURN;
 
+uint16_t micros16();
 uint32_t micros();
 uint32_t millis();
 uint16_t millis16();

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1727,7 +1727,7 @@ bool RCOutput::serial_write_bytes(const uint8_t *bytes, uint16_t len)
  */
 void RCOutput::serial_bit_irq(void)
 {
-    uint32_t now = AP_HAL::micros();
+    uint16_t now = AP_HAL::micros16();
     uint8_t bit = palReadLine(irq.line);
     bool send_signal = false;
 
@@ -1746,7 +1746,7 @@ void RCOutput::serial_bit_irq(void)
             irq.bitmask = 0;
         }
     } else {
-        systime_t dt = now - irq.byte_start_tick;
+        uint16_t dt = now - irq.byte_start_tick;
         uint8_t bitnum = (dt+(irq.bit_time_tick/2)) / irq.bit_time_tick;
 
         if (bitnum > 10) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -332,7 +332,7 @@ private:
         // serial output
         struct {
             // expected time per bit
-            uint32_t bit_time_us;
+            uint16_t bit_time_us;
 
             // channel to output to within group (0 to 3)
             uint8_t chan;
@@ -411,7 +411,7 @@ private:
         ioline_t line;
 
         // time the current byte started
-        uint32_t byte_start_tick;
+        uint16_t byte_start_tick;
 
         // number of bits we have read in this byte
         uint8_t nbits;
@@ -423,7 +423,7 @@ private:
         uint16_t byteval;
 
         // expected time per bit in micros
-        uint32_t bit_time_tick;
+        uint16_t bit_time_tick;
 
         // the bit value of the last bit received
         uint8_t last_bit;

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -267,6 +267,17 @@ uint32_t micros()
 #endif
 }
 
+uint16_t micros16()
+{
+#if CH_CFG_ST_RESOLUTION == 32 && CH_CFG_ST_FREQUENCY==1000000U
+    return st_lld_get_counter() & 0xFFFF;
+#elif CH_CFG_ST_RESOLUTION == 16 && CH_CFG_ST_FREQUENCY==1000000U
+    return st_lld_get_counter();
+#else
+    return hrt_micros32() & 0xFFFF;
+#endif
+}
+    
 uint32_t millis()
 {
     return hrt_millis32();

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -259,7 +259,12 @@ void panic(const char *errormsg, ...)
 
 uint32_t micros()
 {
+#if CH_CFG_ST_RESOLUTION == 32 && CH_CFG_ST_FREQUENCY==1000000U
+    // special case optimisation for 32 bit timers
+    return st_lld_get_counter();
+#else
     return hrt_micros32();
+#endif
 }
 
 uint32_t millis()


### PR DESCRIPTION
most ChibiOS boards have a 32 bit system timer. This optimisation reduces the cost of AP_HAL::micros() from 0.3us to 0.06us, which is significant in interrupt handlers and for accurate timing. It takes advantage of the timer being 32 bit with 1MHz clock
This may help for R/C decoding and for blheli pass-thru parsing
Speed testing:
 - H7 (CubeOrange) micros() time drops from 0.3us to 0.06us
 - F404 (KakuteF4) micros16() costs 0.12us, whereas micros() costs 0.82us (16 bit timer)
 - F765 (CUAVv5Nano) old micros() costs 0.58us, new micros() and micros16() cost 0.095

Update: I've added AP_HAL::micros16() which is fast for both 16 bit and 32 bit timers. I've changed blheli pass-thru to use it for the IRQ, which makes the bit timing more accurate. I've tested it on a Wraith32 4-in-1 ESC and successfully updated BLHeli32 fw on all 4 ESCs with no errors with passthru
![image](https://user-images.githubusercontent.com/831867/135705811-f893018b-472a-4799-bfc6-dde128545b2e.png)
