### PR TITLE
AP_Hal: system: panic is WEAK, fixing MP SITL exe build

### DIFF
--- a/libraries/AP_HAL/system.h
+++ b/libraries/AP_HAL/system.h
@@ -10,7 +10,7 @@ namespace AP_HAL {
 
 void init();
 
-void panic(const char *errormsg, ...) FMT_PRINTF(1, 2) NORETURN;
+void WEAK panic(const char *errormsg, ...) FMT_PRINTF(1, 2) NORETURN;
 
 uint16_t micros16();
 uint32_t micros();


### PR DESCRIPTION
This fixes the MP SITL build, it has been stuck since the 27th https://firmware.ardupilot.org/Tools/MissionPlanner/sitl/

Seems to have been broken by the changes to panic in https://github.com/ArduPilot/ardupilot/pull/18404

I was seeing this error:
```
lib/libAntennaTracker_libs.a(AP_InternalError.cpp.0.o):AP_InternalError.cpp:(.text$_ZN16AP_InternalError5errorENS_7error_tEt.part.1+0x30): undefined reference to `AP_HAL::panic(char const*, ...)'
lib/libAntennaTracker_libs.a(GCS_MAVLink.cpp.0.o):GCS_MAVLink.cpp:(.text$_mav_finalize_message_chan_send+0x331): undefined reference to `AP_HAL::panic(char const*, ...)'
lib/libAntennaTracker_libs.a(GCS_MAVLink.cpp.0.o):GCS_MAVLink.cpp:(.text$_mav_finalize_message_chan_send+0x415): undefined reference to `AP_HAL::panic(char const*, ...)'
lib/libAntennaTracker_libs.a(GCS_MAVLink.cpp.0.o):GCS_MAVLink.cpp:(.text$_mav_finalize_message_chan_send+0x467): undefined reference to `AP_HAL::panic(char const*, ...)'
lib/libAntennaTracker_libs.a(GCS_MAVLink.cpp.0.o):GCS_MAVLink.cpp:(.text$_mav_finalize_message_chan_send+0x47f): undefined reference to `AP_HAL::panic(char const*, ...)'
lib/libAntennaTracker_libs.a(GCS_MAVLink.cpp.0.o):GCS_MAVLink.cpp:(.text$_mavlink_resend_uart+0x1ae): more undefined references to `AP_HAL::panic(char const*, ...)' follow
collect2: error: ld returned 1 exit status
```

I'm not sure if this is the correct fix, but it does fix. 