### PR TITLE
HAL_SITL: fixed cygwin build

### DIFF
--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -25,7 +25,11 @@ void init()
     gettimeofday(&state.start_time, nullptr);
 }
 
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
+void panic(const char *errormsg, ...)
+#else
 void WEAK panic(const char *errormsg, ...)
+#endif
 {
     va_list ap;
 


### PR DESCRIPTION
cygwin does not handle panic being weak, it gets a link error