### PR TITLE
Support MAVLINK_MSG_ID_SET_ATTITUDE_TARGET

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -401,7 +401,7 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     Quaternion q;
     q.from_euler(radians(roll_deg),radians(pitch_deg),radians(yaw_deg));
 
-    mode_guided.set_angle(q, climb_rate_ms*100, use_yaw_rate, radians(yaw_rate_degs), false);
+    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false);
     return true;
 }
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1109,6 +1109,14 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
             attitude_quat.zero();
         } else {
             attitude_quat = Quaternion(packet.q[0],packet.q[1],packet.q[2],packet.q[3]);
+
+            // Do not accept the attitude_quaternion
+            // if its magnitude is not close to unit length +/- 1E-3
+            // this limit is somewhat greater than sqrt(FLT_EPSL)
+            if (!attitude_quat.is_unit_length()) {
+                // The attitude quaternion is ill-defined
+                break;
+            }
         }
 
         // check if the message's thrust field should be interpreted as a climb rate or as thrust

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -872,7 +872,15 @@ public:
 
     bool requires_terrain_failsafe() const override { return true; }
 
-    void set_angle(const Quaternion &q, float climb_rate_cms_or_thrust, bool use_yaw_rate, float yaw_rate_rads, bool use_thrust);
+    // Sets guided's angular target submode: Using a rotation quaternion, angular velocity, and climbrate or thrust (depends on user option)
+    // attitude_quat: IF zero: ang_vel (angular velocity) must be provided even if all zeroes
+    //                IF non-zero: attitude_control is performed using both the attitude quaternion and angular velocity
+    // ang_vel: angular velocity (rad/s)
+    // climb_rate_cms_or_thrust: represents either the climb_rate (cm/s) or thrust scaled from [0, 1], unitless
+    // use_thrust: IF true: climb_rate_cms_or_thrust represents thrust
+    //             IF false: climb_rate_cms_or_thrust represents climb_rate (cm/s)
+    void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust);
+
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool terrain_alt = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool get_wp(Location &loc) const override;

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -622,9 +622,9 @@ void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_
 
     // log target
     copter.Log_Write_GuidedTarget(guided_mode,
-                           Vector3f(ToDeg(roll_rad) * 100.0f, ToDeg(pitch_rad) * 100.0f, ToDeg(pitch_rad) * 100.0f),
+                           Vector3f{ToDeg(roll_rad), ToDeg(pitch_rad), ToDeg(yaw_rad)} * 100.0,
                            false,
-                           Vector3f(0.0f, 0.0f, climb_rate_cms_or_thrust), Vector3f());
+                           ang_vel, Vector3f{0.0, 0.0, climb_rate_cms_or_thrust});
 }
 
 // takeoff_run - takeoff in guided mode

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4099,9 +4099,9 @@ class AutoTestCopter(AutoTest):
             1, # target compid
             0, # bitmask of things to ignore
             mavextra.euler_to_quat([0, math.radians(pitch), 0]), # att
-            0, # roll rate (rad/s)
-            1, # pitch rate
-            0, # yaw rate
+            0, # roll rate  (rad/s)
+            0, # pitch rate (rad/s)
+            0, # yaw rate   (rad/s)
             0.5) # thrust, 0 to 1, translated to a climb/descent rate
 
     def setup_servo_mount(self, roll_servo=5, pitch_servo=6, yaw_servo=7):
@@ -4222,6 +4222,10 @@ class AutoTestCopter(AutoTest):
                          0,
                          0,
                          )
+
+            # Delay here to allow the attitude to command to timeout and level out the copter a bit
+            self.delay_sim_time(3)
+
             start = self.mav.location()
             self.progress("start=%s" % str(start))
             (t_lat, t_lon) = mavextra.gps_offset(start.lat, start.lng, 10, 20)
@@ -4251,9 +4255,9 @@ class AutoTestCopter(AutoTest):
                 1, # target compid
                 0, # bitmask of things to ignore
                 mavextra.euler_to_quat([0, 0, 0]), # att
-                1, # roll rate (rad/s)
-                1, # pitch rate
-                1, # yaw rate
+                0, # roll rate  (rad/s)
+                0, # pitch rate (rad/s)
+                0, # yaw rate   (rad/s)
                 0.5) # thrust, 0 to 1, translated to a climb/descent rate
 
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOUNT_CONFIGURE,

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -149,7 +149,8 @@ public:
     void inertial_frame_reset();
 
     // Command a Quaternion attitude with feedforward and smoothing
-    virtual void input_quaternion(Quaternion attitude_desired_quat);
+    // attitude_desired_quat: is updated on each time_step (_dt) by the integral of the angular velocity
+    virtual void input_quaternion(Quaternion& attitude_desired_quat, Vector3f ang_vel_target);
 
     // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
@@ -295,7 +296,7 @@ public:
     // calculates the velocity correction from an angle error. The angular velocity has acceleration and
     // deceleration limits including basic jerk limiting using smoothing_gain
     static float input_shaping_angle(float error_angle, float input_tc, float accel_max, float target_ang_vel, float desired_ang_vel, float max_ang_vel, float dt);
-    static float input_shaping_angle(float error_angle, float smoothing_gain, float accel_max, float target_ang_vel, float dt){ return input_shaping_angle(error_angle,  smoothing_gain,  accel_max,  target_ang_vel,  0.0f,  0.0f,  dt); }
+    static float input_shaping_angle(float error_angle, float input_tc, float accel_max, float target_ang_vel, float dt){ return input_shaping_angle(error_angle,  input_tc,  accel_max,  target_ang_vel,  0.0f,  0.0f,  dt); }
 
     // limits the acceleration and deceleration of a velocity request
     static float input_shaping_ang_vel(float target_ang_vel, float desired_ang_vel, float accel_max, float dt);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
@@ -145,8 +145,9 @@ void AC_AttitudeControl_Multi_6DoF::input_angle_step_bf_roll_pitch_yaw(float rol
 }
 
 // Command a Quaternion attitude with feedforward and smoothing
-// not used anywhere in current code, panic in SITL so this implementaiton is not overlooked
-void AC_AttitudeControl_Multi_6DoF::input_quaternion(Quaternion attitude_desired_quat) {
+// attitude_desired_quat: is updated on each time_step (_dt) by the integral of the angular velocity
+// not used anywhere in current code, panic in SITL so this implementation is not overlooked
+void AC_AttitudeControl_Multi_6DoF::input_quaternion(Quaternion& attitude_desired_quat, Vector3f ang_vel_target) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     AP_HAL::panic("input_quaternion not implemented AC_AttitudeControl_Multi_6DoF");
 #endif
@@ -154,7 +155,7 @@ void AC_AttitudeControl_Multi_6DoF::input_quaternion(Quaternion attitude_desired
     _motors.set_lateral(0.0f);
     _motors.set_forward(0.0f);
 
-    AC_AttitudeControl_Multi::input_quaternion(attitude_desired_quat);
+    AC_AttitudeControl_Multi::input_quaternion(attitude_desired_quat, ang_vel_target);
 }
 
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
@@ -19,8 +19,9 @@ public:
     }
 
     // Command a Quaternion attitude with feedforward and smoothing
+    // attitude_desired_quat: is updated on each time_step (_dt) by the integral of the angular velocity
     // not used anywhere in current code, panic so this implementaiton is not overlooked
-    void input_quaternion(Quaternion attitude_desired_quat) override;
+    void input_quaternion(Quaternion& attitude_desired_quat, Vector3f ang_vel_target) override;
     /*
         override input functions to attitude controller and convert desired angles into thrust angles and substitute for osset angles
     */

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -130,8 +130,21 @@ public:
     // create eulers from a quaternion
     Vector3<T>    to_vector312(void) const;
 
+    T length_squared(void) const;
     T length(void) const;
     void normalize();
+
+    // Checks if each element of the quaternion is zero
+    bool is_zero(void) const;
+
+    // zeros the quaternion to [0, 0, 0, 0], an invalid quaternion
+    // See initialize() if you want the zero rotation quaternion
+    void zero(void);
+
+    // Checks if the quaternion is unit_length within a tolerance
+    // Returns True: if its magnitude is close to unit length +/- 1E-3
+    // This limit is somewhat greater than sqrt(FLT_EPSL)
+    bool is_unit_length(void) const;
 
     // initialise the quaternion to no rotation
     void initialise()

--- a/libraries/AP_Math/tests/test_quaternion.cpp
+++ b/libraries/AP_Math/tests/test_quaternion.cpp
@@ -163,4 +163,90 @@ TEST(QuaternionTest, QuatenionInverseRotationFormulaEquivalence) {
     }
 }
 
+// Test zero()
+TEST(QuaternionTest, Quaternion_zero)
+{
+    Quaternion q {0.0, 0.0, 0.0, 0.0};
+    q.zero();
+    EXPECT_TRUE(q.is_zero());
+
+    q = Quaternion{0.8365163, 0.48296291, 0.22414387, -0.12940952};
+    q.zero();
+    EXPECT_TRUE(q.is_zero());
+
+    // unit length
+    q = Quaternion{1.0, 0.0, 0.0, 0.0};
+    q.zero();
+    EXPECT_TRUE(q.is_zero());
+}
+
+// Tests is_zero()
+TEST(QuaternionTest, Quaternion_is_zero)
+{
+    Quaternion q {0.0, 0.0, 0.0, 0.0};
+    EXPECT_TRUE(q.is_zero());
+
+    q = Quaternion{0.8365163, 0.48296291, 0.22414387, -0.12940952};
+    EXPECT_FALSE(q.is_zero());
+
+    q = Quaternion{0.9, 0.0, 0.0, 0.0};
+    EXPECT_FALSE(q.is_zero());
+}
+
+// Tests is_unit_length()
+TEST(QuaternionTest, Quaternion_is_unit_length)
+{
+    // zero length
+    Quaternion q {0.0, 0.0, 0.0, 0.0};
+    EXPECT_FALSE(q.is_unit_length());
+
+    // Length == 1.0 - 0.0009, slightly within the tolerance
+    q = Quaternion{0.8361398, 0.4827455, 0.2240430, -0.1293512};
+    EXPECT_TRUE(q.is_unit_length());
+
+    // unit length
+    q  = Quaternion{0.8365163, 0.48296291, 0.22414387, -0.12940952};
+    EXPECT_TRUE(q.is_unit_length());
+
+    // unit length
+    q = Quaternion{1.0, 0.0, 0.0, 0.0};
+    EXPECT_TRUE(q.is_unit_length());
+
+    // Length == 1.0 + 0.0009, slightly within the tolerance
+    q = Quaternion{0.8368926, 0.4831802, 0.2242447, -0.1294677};
+    EXPECT_TRUE(q.is_unit_length());
+
+    // Length == 1.2
+    q = Quaternion{1.00382, 0.579555, 0.268973, -0.155291};
+    EXPECT_FALSE(q.is_unit_length());
+}
+
+// Tests length_squared()
+TEST(QuaternionTest, Quaternion_length_squared)
+{
+    // zero length
+    Quaternion q {0.0, 0.0, 0.0, 0.0};
+    EXPECT_FLOAT_EQ(q.length_squared(), 0.0);
+
+    // Length == 1.0 - 0.0009, slightly within the tolerance
+    q = Quaternion{0.8361398, 0.4827455, 0.2240430, -0.1293512};
+    EXPECT_FLOAT_EQ(q.length_squared(), 1.0 - 0.0009);
+
+    // unit length
+    q  = Quaternion{0.8365163, 0.48296291, 0.22414387, -0.12940952};
+    EXPECT_FLOAT_EQ(q.length_squared(), 1.0);
+
+    // unit length
+    q = Quaternion{1.0, 0.0, 0.0, 0.0};
+    EXPECT_FLOAT_EQ(q.length_squared(), 1.0);
+
+    // Length == 1.0 + 0.0009, slightly within the tolerance
+    q = Quaternion{0.8368926, 0.4831802, 0.2242447, -0.1294677};
+    EXPECT_FLOAT_EQ(q.length_squared(), 1.0 + 0.0009);
+
+    // Length == 1.2
+    q = Quaternion{1.00382, 0.579555, 0.268973, -0.155291};
+    EXPECT_FLOAT_EQ(q.length_squared(), 1.44);
+}
+
 AP_GTEST_MAIN()


### PR DESCRIPTION
This PR supports the full Support MAVLINK_MSG_ID_SET_ATTITUDE_TARGET message as it is specified. It now supports
- quaternion attitude
- quaternion attitude + roll and/or pitch and/or yaw rate
- thrust or climb rate (climb rate is not to spec and must be turned off using GUID_OPTIONS)
- roll and/or pitch and/or yaw rate.

We need to look at how we support the old but incorrect behaviour of attitude roll/pitch + rate yaw.

I also need to add the getter message associated with the setter message.

Closes https://github.com/ArduPilot/ardupilot/issues/14610