### PR TITLE
AP_HAL_ChibiOS: always check flow control after alt config setup

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -414,12 +414,7 @@ void AP_SerialManager::init()
         auto *uart = hal.serial(i);
 
         if (uart != nullptr) {
-
-            // see if special options have been requested
-            if (state[i].protocol != SerialProtocol_None) {
-                set_options(i);
-            }
-
+            set_options(i);
             switch (state[i].protocol) {
                 case SerialProtocol_None:
                     break;


### PR DESCRIPTION
This fixes a race where flow control could be left enabled when the flow control pins are not there. 

This could happen if `set_flow_control` is called before `set_options`. The fix is to disable flow control if the RTS pin is not there rather than just doing a early return and also reset the flow control state after changing pin mapping.

In order to make sure the serial port stops using pins we now always call `set_options` in `AP_SerialManager::init()` even if the serial port is not setup with a protocol.

Follow up to https://github.com/ArduPilot/ardupilot/pull/18753 thanks to some testing from @kniuk