### PR TITLE
AP_Airspeed move into AP_Vehicle

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -49,7 +49,6 @@
 #include <AP_Motors/AP_Motors.h>            // AP Motors library
 #include <AP_Stats/AP_Stats.h>              // statistics library
 #include <Filter/Filter.h>                  // Filter library
-#include <AP_Airspeed/AP_Airspeed.h>        // needed for AHRS build
 #include <AP_Vehicle/AP_Vehicle.h>          // needed for AHRS build
 #include <AP_InertialNav/AP_InertialNav.h>  // inertial navigation library
 #include <AC_WPNav/AC_WPNav.h>              // ArduCopter waypoint navigation library

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -65,7 +65,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(update_GPS_10Hz,        10,    400,  33),
     SCHED_TASK(navigate,               10,    150,  36),
     SCHED_TASK(update_compass,         10,    200,  39),
-    SCHED_TASK(read_airspeed,          10,    100,  42),
+    SCHED_TASK(calc_airspeed_errors,   10,    100,  42),
     SCHED_TASK(update_alt,             10,    200,  45),
     SCHED_TASK(adjust_altitude_target, 10,    200,  48),
 #if ADVANCED_FAILSAFE == ENABLED

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1404,18 +1404,6 @@ uint8_t GCS_MAVLINK_Plane::high_latency_wind_direction() const
     // need to convert -180->180 to 0->360/2
     return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
 }
-
-int8_t GCS_MAVLINK_Plane::high_latency_air_temperature() const
-{
-    // return units are degC
-    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
-    float air_temperature;
-    if (airspeed != nullptr && airspeed->enabled() && airspeed->get_temperature(air_temperature)) {
-        return air_temperature;
-    }
-
-    return INT8_MIN;
-}
 #endif // HAL_HIGH_LATENCY2_ENABLED
 
 MAV_VTOL_STATE GCS_MAVLINK_Plane::vtol_state() const

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -69,7 +69,6 @@ private:
     uint8_t high_latency_tgt_airspeed() const override;
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;
-    int8_t high_latency_air_temperature() const override;
 #endif // HAL_HIGH_LATENCY2_ENABLED
 
     MAV_VTOL_STATE vtol_state() const override;

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -8,18 +8,6 @@ uint8_t GCS_Plane::sysid_this_mav() const
 
 void GCS_Plane::update_vehicle_sensor_status_flags(void)
 {
-    // airspeed
-    const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
-    if (airspeed && airspeed->enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
-    }
-    if (airspeed && airspeed->enabled() && airspeed->use()) {
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
-    }
-    if (airspeed && airspeed->all_healthy()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
-    }
-
     // reverse thrust
     if (plane.have_reverse_thrust()) {
         control_sensors_present |= MAV_SYS_STATUS_REVERSE_MOTOR;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -890,9 +890,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),
 
-    // @Group: ARSPD
-    // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
-    GOBJECT(airspeed,                               "ARSPD",   AP_Airspeed),
+    // Airspeed was here
 
     // @Group: NAVL1_
     // @Path: ../libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -1490,6 +1488,14 @@ void Plane::load_parameters(void)
         AP_Param::convert_class(info.old_key, &efi, efi.var_info, old_index, old_top_element, false);
     }
 #endif
+
+    // PARAMETER_CONVERSION - Added: Jan-2022
+    {
+        const uint16_t old_key = g.k_param_airspeed;
+        const uint16_t old_index = 0;       // Old parameter index in the tree
+        const uint16_t old_top_element = 0; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
+        AP_Param::convert_class(old_key, &airspeed, airspeed.var_info, old_index, old_top_element, true);
+    }
 
     hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
 }

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -196,7 +196,7 @@ public:
         k_param_sonar_enabled_old,  // unused
         k_param_ahrs,  // AHRS group
         k_param_barometer,   // barometer ground calibration
-        k_param_airspeed,  // AP_Airspeed parameters
+        k_param_airspeed,           // only used for parameter conversion; AP_Airspeed parameters moved to AP_Vehicle
         k_param_curr_amp_offset,
         k_param_NavEKF,  // deprecated - remove
         k_param_mission, // mission library

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -41,7 +41,6 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
 #include <Filter/Filter.h>                     // Filter library
 #include <AP_Camera/AP_Camera.h>          // Photo or video camera
-#include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Stats/AP_Stats.h>     // statistics library
@@ -399,9 +398,6 @@ private:
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Plane::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
-
-    // Airspeed Sensors
-    AP_Airspeed airspeed;
 
     // ACRO controller state
     struct {
@@ -1047,7 +1043,6 @@ private:
 
     // sensors.cpp
     void read_rangefinder(void);
-    void read_airspeed(void);
 
     // system.cpp
     void init_ardupilot() override;

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -140,11 +140,20 @@ float Plane::mode_auto_target_airspeed_cm()
 
 void Plane::calc_airspeed_errors()
 {
+    // Get the airspeed_estimate, update smoothed airspeed estimate
+    // NOTE:  we use the airspeed estimate function not direct sensor
+    //        as TECS may be using synthetic airspeed
     float airspeed_measured = 0;
+    if (ahrs.airspeed_estimate(airspeed_measured)) {
+        smoothed_airspeed = smoothed_airspeed * 0.8f + airspeed_measured * 0.2f;
+    }
 
-    // we use the airspeed estimate function not direct sensor as TECS
-    // may be using synthetic airspeed
-    ahrs.airspeed_estimate(airspeed_measured);
+    // low pass filter speed scaler, with 1Hz cutoff, at 10Hz
+    const float speed_scaler = calc_speed_scaler();
+    const float cutoff_Hz = 2.0;
+    const float dt = 0.1;
+    surface_speed_scaler += calc_lowpass_alpha_dt(dt, cutoff_Hz) * (speed_scaler - surface_speed_scaler);
+
 
     // FBW_B/cruise airspeed target
     if (!failsafe.rc_failsafe && (control_mode == &mode_fbwb || control_mode == &mode_cruise)) {

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -33,28 +33,3 @@ void Plane::read_rangefinder(void)
 
     rangefinder_height_update();
 }
-
-/*
-  ask airspeed sensor for a new value
- */
-void Plane::read_airspeed(void)
-{
-    airspeed.update(should_log(MASK_LOG_IMU));
-
-    // we calculate airspeed errors (and thus target_airspeed_cm) even
-    // when airspeed is disabled as TECS may be using synthetic
-    // airspeed for a quadplane transition
-    calc_airspeed_errors();
-    
-    // update smoothed airspeed estimate
-    float aspeed;
-    if (ahrs.airspeed_estimate(aspeed)) {
-        smoothed_airspeed = smoothed_airspeed * 0.8f + aspeed * 0.2f;
-    }
-
-    // low pass filter speed scaler, with 1Hz cutoff, at 10Hz
-    const float speed_scaler = calc_speed_scaler();
-    const float cutoff_Hz = 2.0;
-    const float dt = 0.1;
-    surface_speed_scaler += calc_lowpass_alpha_dt(dt, cutoff_Hz) * (speed_scaler - surface_speed_scaler);
-}

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -80,11 +80,12 @@ void Plane::init_ardupilot()
     log_init();
 #endif
 
-    // initialise airspeed sensor
-    airspeed.init();
-
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
+
+#if AP_AIRSPEED_ENABLED
+    airspeed.set_log_bit(MASK_LOG_IMU);
+#endif
 
     // GPS Initialization
     gps.set_log_gps_bit(MASK_LOG_GPS);
@@ -407,14 +408,6 @@ void Plane::startup_INS_ground(void)
     //-----------------------------
     barometer.set_log_baro_bit(MASK_LOG_IMU);
     barometer.calibrate();
-
-    if (airspeed.enabled()) {
-        // initialize airspeed sensor
-        // --------------------------
-        airspeed.calibrate(true);
-    } else {
-        gcs().send_text(MAV_SEVERITY_WARNING,"No airspeed sensor present");
-    }
 }
 
 // sets notify object flight mode information

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -98,7 +98,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
 #ifdef USERHOOK_SUPERSLOWLOOP
     SCHED_TASK(userhook_SuperSlowLoop, 1,     75,  90),
 #endif
-    SCHED_TASK(read_airspeed,         10,    100,  93),
 };
 
 void Sub::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -657,9 +657,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(scripting, "SCR_", 18, ParametersG2, AP_Scripting),
 #endif
 
-    // @Group: ARSPD
-    // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
-    AP_SUBGROUPINFO(airspeed, "ARSPD", 19, ParametersG2, AP_Airspeed),
+    // 19 was airspeed
 
     AP_GROUPEND
 };
@@ -667,8 +665,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 /*
   constructor for g2 object
  */
-ParametersG2::ParametersG2():
-    airspeed()
+ParametersG2::ParametersG2()
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -730,6 +727,20 @@ void Sub::load_parameters()
     AP_Param::set_by_name("MNT_RC_IN_TILT", 8);
     // We should ignore this parameter since ROVs are neutral buoyancy
     AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
+
+// PARAMETER_CONVERSION - Added: JAN-2022
+#if AP_AIRSPEED_ENABLED
+    // Find G2's Top Level Key
+    AP_Param::ConversionInfo info;
+    if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
+        return;
+    }
+
+    const uint16_t old_index = 19;          // Old parameter index in the tree
+    const uint16_t old_top_element = 4051;  // Old group element in the tree for the first subgroup element
+    AP_Param::convert_class(info.old_key, &airspeed, airspeed.var_info, old_index, old_top_element, false);
+#endif
+
 }
 
 void Sub::convert_old_parameters()

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -338,10 +338,6 @@ public:
 #if AP_SCRIPTING_ENABLED
     AP_Scripting scripting;
 #endif // AP_SCRIPTING_ENABLED
-
-    // Airspeed
-    AP_Airspeed airspeed;
-
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -578,7 +578,6 @@ private:
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
     void log_init(void);
-    void read_airspeed();
 
     void failsafe_leak_check();
     void failsafe_internal_pressure_check();

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -70,11 +70,3 @@ bool Sub::rangefinder_alt_ok() const
 {
     return (rangefinder_state.enabled && rangefinder_state.alt_healthy);
 }
-
-/*
-  ask airspeed sensor for a new value, duplicated from plane
- */
-void Sub::read_airspeed()
-{
-    g2.airspeed.update(should_log(MASK_LOG_IMU));
-}

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -85,6 +85,10 @@ void Sub::init_ardupilot()
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 
+#if AP_AIRSPEED_ENABLED
+    airspeed.set_log_bit(MASK_LOG_IMU);
+#endif
+
 #if AP_OPTICALFLOW_ENABLED
     // initialise optical flow sensor
     optflow.init(MASK_LOG_OPTFLOW);
@@ -154,8 +158,6 @@ void Sub::init_ardupilot()
 #if AP_SCRIPTING_ENABLED
     g2.scripting.init();
 #endif // AP_SCRIPTING_ENABLED
-
-    g2.airspeed.init();
 
     // we don't want writes to the serial port to cause us to pause
     // mid-flight, so set the serial ports non-blocking once we are

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -42,7 +42,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Stats/AP_Stats.h>     // statistics library
 #include <Filter/Filter.h>             // Filter library
-#include <AP_Airspeed/AP_Airspeed.h>        // needed for AHRS build
 #include <AP_Vehicle/AP_Vehicle.h>         // needed for AHRS build
 #include <AP_InertialNav/AP_InertialNav.h>     // inertial navigation library
 #include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -574,9 +574,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // 32 to 36 were old sailboat params
 
-    // @Group: ARSPD
-    // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
-    AP_SUBGROUPINFO(airspeed, "ARSPD", 37, ParametersG2, AP_Airspeed),
+    // 37 was airspeed
 
     // @Param: MIS_DONE_BEHAVE
     // @DisplayName: Mission done behave
@@ -711,7 +709,6 @@ ParametersG2::ParametersG2(void)
     avoid(),
     follow(),
     windvane(),
-    airspeed(),
     wp_nav(attitude_control, rover.L1_controller),
     sailboat()
 {
@@ -842,5 +839,18 @@ void Rover::load_parameters(void)
     AP_Param::set_default_by_name("BRD_SAFETYOPTION", AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF|
                                                       AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON|
                                                       AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_ARMED);
+#endif
+
+// PARAMETER_CONVERSION - Added: JAN-2022
+#if AP_AIRSPEED_ENABLED
+    // Find G2's Top Level Key
+    AP_Param::ConversionInfo info;
+    if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
+        return;
+    }
+
+    const uint16_t old_index = 37;          // Old parameter index in the tree
+    const uint16_t old_top_element = 4069;  // Old group element in the tree for the first subgroup element
+    AP_Param::convert_class(info.old_key, &airspeed, airspeed.var_info, old_index, old_top_element, false);
 #endif
 }

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -371,9 +371,6 @@ public:
     // windvane
     AP_WindVane windvane;
 
-    // Airspeed
-    AP_Airspeed airspeed;
-
     // mission behave
     AP_Int8 mis_done_behave;
 

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -130,7 +130,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #if ADVANCED_FAILSAFE == ENABLED
     SCHED_TASK(afs_fs_check,           10,    200, 129),
 #endif
-    SCHED_TASK(read_airspeed,          10,    100, 132),
 #if HAL_AIS_ENABLED
     SCHED_TASK_CLASS(AP_AIS, &rover.g2.ais, update, 5, 100, 135),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -27,7 +27,6 @@
 #include <AC_PID/AC_PID.h>
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_AHRS/AP_AHRS.h>                        // ArduPilot Mega DCM Library
-#include <AP_Airspeed/AP_Airspeed.h>                // needed for AHRS build
 #include <AP_Baro/AP_Baro.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>          // Battery monitor library
 #include <AP_Beacon/AP_Beacon.h>
@@ -352,7 +351,6 @@ private:
     void compass_save(void);
     void update_wheel_encoder();
     void read_rangefinders(void);
-    void read_airspeed();
 
     // Steering.cpp
     void set_servos(void);

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -93,11 +93,3 @@ void Rover::read_rangefinders(void)
     rangefinder.update();
     Log_Write_Depth();
 }
-
-/*
-  ask airspeed sensor for a new value, duplicated from plane
- */
-void Rover::read_airspeed(void)
-{
-    g2.airspeed.update(should_log(MASK_LOG_IMU));
-}

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -42,8 +42,6 @@ void Rover::init_ardupilot()
 
     rssi.init();
 
-    g2.airspeed.init();
-
     g2.windvane.init(serial_manager);
 
     // init baro before we start the GCS, so that the CLI baro test works
@@ -67,6 +65,10 @@ void Rover::init_ardupilot()
     // initialise compass
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
+
+#if AP_AIRSPEED_ENABLED
+    airspeed.set_log_bit(MASK_LOG_IMU);
+#endif
 
     // initialise rangefinder
     rangefinder.set_log_rfnd_bit(MASK_LOG_RANGEFINDER);

--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -181,6 +181,7 @@ void AP_Periph_FW::init()
 
 #ifdef HAL_PERIPH_ENABLE_AIRSPEED
     if (airspeed.enabled()) {
+        // Note: logging of ARSPD is not enabled currently. To enable, call airspeed.set_log_bit();
         airspeed.init();
     }
 #endif

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -2138,7 +2138,7 @@ void AP_Periph_FW::can_airspeed_update(void)
         return;
     }
     last_airspeed_update_ms = now;
-    airspeed.update(false);
+    airspeed.update();
     if (!airspeed.healthy()) {
         // don't send any data
         return;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -58,9 +58,11 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),
 
+#if AP_AIRSPEED_ENABLED
     // @Group: ARSPD_
     // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
     GOBJECT(airspeed,                               "ARSP_",   AP_Airspeed),
+#endif
 
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -46,7 +46,7 @@ public:
     virtual uint8_t get_mode() const override { return 0; }
 
     AP_Vehicle::FixedWing aparm;
-    AP_Airspeed airspeed;
+
     AP_Int32 unused; // logging is magic for Replay; this is unused
     struct LogStructure log_structure[256] = {
     };

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -18,6 +18,7 @@ SOURCE_EXTS = [
 ]
 
 COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
+    'AP_Airspeed',
     'AP_AccelCal',
     'AP_ADC',
     'AP_AHRS',

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -821,6 +821,8 @@ Vector3f AP_AHRS::wind_estimate(void) const
 bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
 {
     bool ret = false;
+
+#if AP_AIRSPEED_ENABLED
     if (airspeed_sensor_enabled()) {
         uint8_t idx = get_active_airspeed_index();
         airspeed_ret = AP::airspeed()->get_airspeed(idx);
@@ -838,6 +840,7 @@ bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
 
         return true;
     }
+#endif
 
     if (!get_wind_estimation_enabled()) {
         return false;
@@ -2887,6 +2890,7 @@ bool AP_AHRS::get_vel_innovations_and_variances_for_source(uint8_t source, Vecto
 //get the index of the active airspeed sensor, wrt the primary core
 uint8_t AP_AHRS::get_active_airspeed_index() const
 {
+#if AP_AIRSPEED_ENABLED
     const auto *airspeed = AP::airspeed();
     if (airspeed == nullptr) {
         return 0;
@@ -2901,8 +2905,13 @@ uint8_t AP_AHRS::get_active_airspeed_index() const
         }
     }
 #endif
+
     // for the rest, let the primary airspeed sensor be used
     return airspeed->get_primary();
+#else
+
+    return 0;
+#endif // AP_AIRSPEED_ENABLED
 }
 
 // get the index of the current primary IMU

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -157,15 +157,23 @@ public:
     // return true if airspeed comes from an airspeed sensor, as
     // opposed to an IMU estimate
     bool airspeed_sensor_enabled(void) const {
+    #if AP_AIRSPEED_ENABLED
         const AP_Airspeed *_airspeed = AP::airspeed();
         return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
+    #else
+        return false;
+    #endif
     }
 
     // return true if airspeed comes from a specific airspeed sensor, as
     // opposed to an IMU estimate
     bool airspeed_sensor_enabled(uint8_t airspeed_index) const {
+    #if AP_AIRSPEED_ENABLED
         const AP_Airspeed *_airspeed = AP::airspeed();
         return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
+    #else
+        return false;
+    #endif
     }
 
     // return a ground vector estimate in meters/second, in North/East order

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -716,12 +716,14 @@ AP_AHRS_DCM::drift_correction(float deltat)
             // not enough time has accumulated
             return;
         }
-        float airspeed;
+
+        float airspeed = _last_airspeed;
+#if AP_AIRSPEED_ENABLED
         if (airspeed_sensor_enabled()) {
             airspeed = AP::airspeed()->get_airspeed();
-        } else {
-            airspeed = _last_airspeed;
         }
+#endif
+
         // use airspeed to estimate our ground velocity in
         // earth frame by subtracting the wind
         velocity = _dcm_matrix.colx() * airspeed;
@@ -1025,12 +1027,18 @@ void AP_AHRS_DCM::estimate_wind(void)
         }
 
         _last_wind_time = now;
-    } else if (now - _last_wind_time > 2000 && airspeed_sensor_enabled()) {
+
+        return;
+    }
+
+#if AP_AIRSPEED_ENABLED
+    if (now - _last_wind_time > 2000 && airspeed_sensor_enabled()) {
         // when flying straight use airspeed to get wind estimate if available
         const Vector3f airspeed = _dcm_matrix.colx() * AP::airspeed()->get_airspeed();
         const Vector3f wind = velocity - (airspeed * get_EAS2TAS());
         _wind = _wind * 0.92f + wind * 0.08f;
     }
+#endif
 }
 
 
@@ -1064,13 +1072,15 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
 
 bool AP_AHRS_DCM::airspeed_estimate(float &airspeed_ret) const
 {
+#if AP_AIRSPEED_ENABLED
     const auto *airspeed = AP::airspeed();
-    if (airspeed == nullptr) {
-        // airspeed_estimate will also make this nullptr check and act
-        // appropriately when we call it with a dummy sensor ID.
-        return airspeed_estimate(0, airspeed_ret);
+    if (airspeed != nullptr) {
+        return airspeed_estimate(airspeed->get_primary(), airspeed_ret);
     }
-    return airspeed_estimate(airspeed->get_primary(), airspeed_ret);
+#endif
+    // airspeed_estimate will also make this nullptr check and act
+    // appropriately when we call it with a dummy sensor ID.
+    return airspeed_estimate(0, airspeed_ret);
 }
 
 // return an airspeed estimate:
@@ -1079,15 +1089,12 @@ bool AP_AHRS_DCM::airspeed_estimate(float &airspeed_ret) const
 //  - otherwise from a cached wind-triangle estimate value (but returning false)
 bool AP_AHRS_DCM::airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret) const
 {
-    if (airspeed_sensor_enabled(airspeed_index)) {
-        airspeed_ret = AP::airspeed()->get_airspeed(airspeed_index);
-    } else if (AP::ahrs().get_wind_estimation_enabled() && have_gps()) {
-        // estimate it via GPS speed and wind
-        airspeed_ret = _last_airspeed;
-    } else {
-        // give the last estimate, but return false. This is used by
-        // dead-reckoning code
-        airspeed_ret = _last_airspeed;
+    // airspeed_ret: will always be filled-in by get_unconstrained_airspeed_estimate which fills in airspeed_ret in this order:
+    //               airspeed as filled-in by an enabled airsped sensor
+    //               if no airspeed sensor: airspeed estimated using the GPS speed & wind_speed_estimation
+    //               Or if none of the above, fills-in using the previous airspeed estimate
+    // Return false: if we are using the previous airspeed estimate
+    if (!get_unconstrained_airspeed_estimate(airspeed_index, airspeed_ret)) {
         return false;
     }
 
@@ -1104,6 +1111,32 @@ bool AP_AHRS_DCM::airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret)
     }
 
     return true;
+}
+
+// airspeed_ret: will always be filled-in by get_unconstrained_airspeed_estimate which fills in airspeed_ret in this order:
+//               airspeed as filled-in by an enabled airsped sensor
+//               if no airspeed sensor: airspeed estimated using the GPS speed & wind_speed_estimation
+//               Or if none of the above, fills-in using the previous airspeed estimate
+// Return false: if we are using the previous airspeed estimate
+bool AP_AHRS_DCM::get_unconstrained_airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret) const
+{
+#if AP_AIRSPEED_ENABLED
+    if (airspeed_sensor_enabled(airspeed_index)) {
+        airspeed_ret = AP::airspeed()->get_airspeed(airspeed_index);
+        return true;
+    }
+#endif
+
+    if (AP::ahrs().get_wind_estimation_enabled() && have_gps()) {
+        // estimated via GPS speed and wind
+        airspeed_ret = _last_airspeed;
+        return true;
+    }
+
+    // Else give the last estimate, but return false.
+    // This is used by the dead-reckoning code
+    airspeed_ret = _last_airspeed;
+    return false;
 }
 
 bool AP_AHRS::set_home(const Location &loc)

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -163,6 +163,13 @@ private:
     // DCM matrix from the eulers.  Called internally we may.
     void            reset(bool recover_eulers);
 
+    // airspeed_ret: will always be filled-in by get_unconstrained_airspeed_estimate which fills in airspeed_ret in this order:
+    //               airspeed as filled-in by an enabled airsped sensor
+    //               if no airspeed sensor: airspeed estimated using the GPS speed & wind_speed_estimation
+    //               Or if none of the above, fills-in using the previous airspeed estimate
+    // Return false: if we are using the previous airspeed estimate
+    bool get_unconstrained_airspeed_estimate(uint8_t airspeed_index, float &airspeed_ret) const;
+
     // primary representation of attitude of board used for all inertial calculations
     Matrix3f _dcm_matrix;
 

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -273,7 +273,8 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 #endif // AIRSPEED_MAX_SENSORS
 
     // Note that 21, 22 and 23 are used above by the _OPTIONS, _WIND_MAX and _WIND_WARN parameters.  Do not use them!!
-    
+
+    // NOTE: Index 63 is used by AIRSPEED_TYPE, Do not use it!: AP_Param converts an index of 0 to 63 so that the index may be bit shifted
     AP_GROUPEND
 };
 
@@ -597,7 +598,7 @@ void AP_Airspeed::read(uint8_t i)
 }
 
 // read all airspeed sensors
-void AP_Airspeed::update(bool log)
+void AP_Airspeed::update()
 {
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
         read(i);
@@ -624,8 +625,8 @@ void AP_Airspeed::update(bool log)
 
     check_sensor_failures();
 
-#ifndef HAL_BUILD_AP_PERIPH
-    if (log) {
+#if HAL_LOGGING_ENABLED
+    if (_log_bit != (uint32_t)-1 && AP::logger().should_log(_log_bit)) {
         Log_Airspeed();
     }
 #endif

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -16,6 +16,19 @@
  *   AP_Airspeed.cpp - airspeed (pitot) driver
  */
 
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
+#include "AP_Airspeed.h"
+
+// Dummy the AP_Airspeed class to allow building Airspeed only for plane, rover, sub, and copter & heli 2MB boards
+// This could be removed once the build system allows for APM_BUILD_TYPE in header files
+#ifndef AP_AIRSPEED_DUMMY_METHODS_ENABLED
+#define AP_AIRSPEED_DUMMY_METHODS_ENABLED ((APM_BUILD_COPTER_OR_HELI && BOARD_FLASH_SIZE <= 1024) || \
+                                            APM_BUILD_TYPE(APM_BUILD_AntennaTracker) || APM_BUILD_TYPE(APM_BUILD_Blimp))
+#endif
+
+#if !AP_AIRSPEED_DUMMY_METHODS_ENABLED
+
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/I2CDevice.h>
@@ -25,7 +38,6 @@
 #include <AP_Logger/AP_Logger.h>
 #include <utility>
 #include <AP_Vehicle/AP_Vehicle.h>
-#include "AP_Airspeed.h"
 #include "AP_Airspeed_MS4525.h"
 #include "AP_Airspeed_MS5525.h"
 #include "AP_Airspeed_SDP3X.h"
@@ -715,6 +727,24 @@ bool AP_Airspeed::all_healthy(void) const
     }
     return true;
 }
+
+#else  // build type is not appropriate; provide a dummy implementation:
+const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
+
+void AP_Airspeed::update() {};
+bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) { return false; }
+void AP_Airspeed::calibrate(bool in_startup) {}
+bool AP_Airspeed::use(uint8_t i) const { return false; }
+
+#if HAL_MSP_AIRSPEED_ENABLED
+void AP_Airspeed::handle_msp(const MSP::msp_airspeed_data_message_t &pkt) {}
+#endif
+
+bool AP_Airspeed::all_healthy(void) const { return false; }
+void AP_Airspeed::init(void) {};
+AP_Airspeed::AP_Airspeed() {}
+
+#endif // #if AP_AIRSPEED_DUMMY_METHODS_ENABLED
 
 // singleton instance
 AP_Airspeed *AP_Airspeed::_singleton;

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Description: Type of airspeed sensor
     // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X,7:I2C-DLVR-5in,8:DroneCAN,9:I2C-DLVR-10in,10:I2C-DLVR-20in,11:I2C-DLVR-30in,12:I2C-DLVR-60in,13:NMEA water speed,14:MSP,15:ASP5033
     // @User: Standard
-    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),     // NOTE: Index 0 is actually used as index 63 here
 
     // @Param: _DEVID
     // @DisplayName: Airspeed ID

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -49,19 +49,23 @@ extern const AP_HAL::HAL &hal;
  #ifndef ARSPD_DEFAULT_PIN
  #define ARSPD_DEFAULT_PIN 1
  #endif
-#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
- #define ARSPD_DEFAULT_TYPE TYPE_ANALOG
- #define ARSPD_DEFAULT_PIN 1
-#elif APM_BUILD_TYPE(APM_BUILD_Rover) || APM_BUILD_TYPE(APM_BUILD_ArduSub) 
+#elif APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+ // The HAL_BOARD_SITL setting is required because of current probe process for MS4525 will
+ // connect and find the SIM_DLVR sensors & fault as there is no way to tell them apart
+ #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+  #define ARSPD_DEFAULT_TYPE TYPE_ANALOG
+  #define ARSPD_DEFAULT_PIN 1
+ #else
+  #define ARSPD_DEFAULT_TYPE TYPE_I2C_MS4525
+  #ifdef HAL_DEFAULT_AIRSPEED_PIN
+      #define ARSPD_DEFAULT_PIN HAL_DEFAULT_AIRSPEED_PIN
+  #else
+     #define ARSPD_DEFAULT_PIN 15
+  #endif
+ #endif //CONFIG_HAL_BOARD
+#else   // All Other Vehicle Types
  #define ARSPD_DEFAULT_TYPE TYPE_NONE
  #define ARSPD_DEFAULT_PIN 15
-#else
- #define ARSPD_DEFAULT_TYPE TYPE_I2C_MS4525
-#ifdef HAL_DEFAULT_AIRSPEED_PIN
- #define ARSPD_DEFAULT_PIN HAL_DEFAULT_AIRSPEED_PIN
-#else
- #define ARSPD_DEFAULT_PIN 15
-#endif
 #endif
 
 #ifndef HAL_AIRSPEED_BUS_DEFAULT

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -7,6 +7,11 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_MSP/msp.h>
 
+#ifndef AP_AIRSPEED_ENABLED
+#define AP_AIRSPEED_ENABLED 1
+#endif
+
+
 class AP_Airspeed_Backend;
 
 #ifndef AIRSPEED_MAX_SENSORS
@@ -52,13 +57,16 @@ public:
 
     void init(void);
 
+    // indicate which bit in LOG_BITMASK indicates we should log airspeed readings
+    void set_log_bit(uint32_t log_bit) { _log_bit = log_bit; }
+
 #if AP_AIRSPEED_AUTOCAL_ENABLE
     // inflight ratio calibration
     void set_calibration_enabled(bool enable) {calibration_enabled = enable;}
 #endif //AP_AIRSPEED_AUTOCAL_ENABLE
 
     // read the analog source and update airspeed
-    void update(bool log);
+    void update(void);
 
     // calibrate the airspeed. This must be called on startup if the
     // altitude/climb_rate/acceleration interfaces are ever used
@@ -250,6 +258,8 @@ private:
     // current primary sensor
     uint8_t primary;
     uint8_t num_sensors;
+
+    uint32_t _log_bit = -1;     // stores which bit in LOG_BITMASK is used to indicate we should log airspeed readings
 
     void read(uint8_t i);
     // return the differential pressure in Pascal for the last airspeed reading for the requested instance

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -65,6 +65,7 @@ void setup()
     board_config.init();
 
     // initialize airspeed
+    // Note airspeed.set_log_bit(LOG_BIT) would need to be called in order to enable logging
     airspeed.init();
 
     airspeed.calibrate(false);
@@ -80,7 +81,7 @@ void loop(void)
 
         // current system time in milliseconds
         timer = AP_HAL::millis();
-        airspeed.update(false);
+        airspeed.update();
         airspeed.get_temperature(temperature);
 
         // print temperature and airspeed to console

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -226,6 +226,7 @@ bool AP_Arming::barometer_checks(bool report)
 
 bool AP_Arming::airspeed_checks(bool report)
 {
+#if AP_AIRSPEED_ENABLED
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_AIRSPEED)) {
         const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
@@ -240,6 +241,7 @@ bool AP_Arming::airspeed_checks(bool report)
             }
         }
     }
+#endif
 
     return true;
 }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -468,6 +468,7 @@ float AP_Baro::get_external_temperature(const uint8_t instance) const
     }
     
 #ifndef HAL_BUILD_AP_PERIPH
+#if AP_AIRSPEED_ENABLED
     // if we don't have an external temperature then try to use temperature
     // from the airspeed sensor
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
@@ -477,6 +478,7 @@ float AP_Baro::get_external_temperature(const uint8_t instance) const
             return temperature;
         }
     }
+#endif
 #endif
     
     // if we don't have an external temperature and airspeed temperature

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -129,10 +129,12 @@ void AP_DAL::init_sensors(void)
         alloc_failed |= (_rangefinder = new AP_DAL_RangeFinder) == nullptr;
     }
 
+#if AP_AIRSPEED_ENABLED
     auto *aspeed = AP::airspeed();
     if (aspeed != nullptr && aspeed->get_num_sensors() > 0) {
         alloc_failed |= (_airspeed = new AP_DAL_Airspeed) == nullptr;
     }
+#endif
 
     auto *bcn = AP::beacon();
     if (bcn != nullptr && bcn->enabled()) {

--- a/libraries/AP_DAL/AP_DAL_Airspeed.cpp
+++ b/libraries/AP_DAL/AP_DAL_Airspeed.cpp
@@ -5,13 +5,16 @@
 
 AP_DAL_Airspeed::AP_DAL_Airspeed()
 {
+#if AP_AIRSPEED_ENABLED
     for (uint8_t i=0; i<ARRAY_SIZE(_RASI); i++) {
         _RASI[i].instance = i;
     }
+#endif
 }
 
 void AP_DAL_Airspeed::start_frame()
 {
+#if AP_AIRSPEED_ENABLED
     const auto *airspeed = AP::airspeed();
     if (airspeed == nullptr) {
         return;
@@ -31,4 +34,5 @@ void AP_DAL_Airspeed::start_frame()
         RASI.airspeed = airspeed->get_airspeed(i);
         WRITE_REPLAY_BLOCK_IFCHANGED(RASI, RASI, old_RASI);
     }
+#endif
 }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
@@ -130,10 +130,12 @@ MAV_RESULT AP_Frsky_MAVliteMsgHandler::handle_command_preflight_calibration_baro
     AP::baro().update_calibration();
     gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr) {
         airspeed->calibrate(false);
     }
+#endif
 
     return MAV_RESULT_ACCEPTED;
 }

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -161,6 +161,7 @@ void AP_Hott_Telem::send_EAM(void)
         msg.electric_sec = t % 60U;
     }
 
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed && airspeed->healthy()) {
         msg.speed = uint16_t(airspeed->get_airspeed() * 3.6 + 0.5);
@@ -168,6 +169,10 @@ void AP_Hott_Telem::send_EAM(void)
         WITH_SEMAPHORE(ahrs.get_semaphore());
         msg.speed = uint16_t(ahrs.groundspeed() * 3.6 + 0.5);
     }
+#else
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+    msg.speed = uint16_t(ahrs.groundspeed() * 3.6 + 0.5);
+#endif
 
     send_packet((const uint8_t *)&msg, sizeof(msg));
 }

--- a/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
+++ b/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
@@ -121,11 +121,13 @@ void AP_LTM_Telem::send_Sframe(void)
     const uint16_t amp = (uint16_t) roundf(current * 100.0f);                          // current sensor (expects value in hundredth of A)
 
     // airspeed in m/s if available and enabled - even if not used - otherwise send 0
-    const AP_Airspeed *aspeed = AP::airspeed();
     uint8_t airspeed = 0; // airspeed sensor (m/s)
+#if AP_AIRSPEED_ENABLED
+    const AP_Airspeed *aspeed = AP::airspeed();
     if (aspeed && aspeed->enabled()) {
         airspeed = (uint8_t) roundf(aspeed->get_airspeed());
     }
+#endif
 
     const uint8_t flightmode = AP_Notify::flags.flight_mode; // flight mode
 

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -567,7 +567,7 @@ void AP_MSP_Telem_Backend::msp_handle_baro(const MSP::msp_baro_data_message_t &p
 
 void AP_MSP_Telem_Backend::msp_handle_airspeed(const MSP::msp_airspeed_data_message_t &pkt)
 {
-#if HAL_MSP_AIRSPEED_ENABLED
+#if HAL_MSP_AIRSPEED_ENABLED && AP_AIRSPEED_ENABLED
     auto *airspeed = AP::airspeed();
     if (airspeed) {
         airspeed->handle_msp(pkt);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1973,6 +1973,7 @@ void AP_OSD_Screen::draw_btemp(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_atemp(uint8_t x, uint8_t y)
 {
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (!airspeed) {
         return;
@@ -1984,6 +1985,7 @@ void AP_OSD_Screen::draw_atemp(uint8_t x, uint8_t y)
     } else {
         backend->write(x, y, false, "--%c", u_icon(TEMPERATURE));
     }
+#endif
 }
 
 void AP_OSD_Screen::draw_bat2_vlt(uint8_t x, uint8_t y)
@@ -2007,6 +2009,7 @@ void AP_OSD_Screen::draw_bat2used(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_aspd1(uint8_t x, uint8_t y)
 {
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (!airspeed) {
         return;
@@ -2017,10 +2020,12 @@ void AP_OSD_Screen::draw_aspd1(uint8_t x, uint8_t y)
     } else {
         backend->write(x, y, false, "%c ---%c", SYMBOL(SYM_ASPD), u_icon(SPEED));
     }
+#endif
 }
 
 void AP_OSD_Screen::draw_aspd2(uint8_t x, uint8_t y)
 {
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (!airspeed) {
         return;
@@ -2031,6 +2036,7 @@ void AP_OSD_Screen::draw_aspd2(uint8_t x, uint8_t y)
     } else {
         backend->write(x, y, false, "%c ---%c", SYMBOL(SYM_ASPD), u_icon(SPEED));
     }
+#endif
 }
 
 void AP_OSD_Screen::draw_clk(uint8_t x, uint8_t y)

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -433,13 +433,18 @@ void AP_Spektrum_Telem::calc_airspeed()
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
 
-    const AP_Airspeed *airspeed = AP::airspeed();
     float speed = 0.0f;
+#if AP_AIRSPEED_ENABLED
+    const AP_Airspeed *airspeed = AP::airspeed();
     if (airspeed && airspeed->healthy()) {
         speed = roundf(airspeed->get_airspeed() * 3.6);
     } else {
         speed = roundf(AP::ahrs().groundspeed() * 3.6);
     }
+#else
+    speed = roundf(AP::ahrs().groundspeed() * 3.6);
+#endif
+
     _telem.speed.airspeed = htobe16(uint16_t(speed));           // 1 km/h increments
     _max_speed = MAX(speed, _max_speed);
     _telem.speed.maxAirspeed = htobe16(uint16_t(_max_speed));   // 1 km/h increments

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -67,6 +67,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(efi, "EFI", 9, AP_Vehicle, AP_EFI),
 #endif
 
+#if AP_AIRSPEED_ENABLED
+    // @Group: ARSPD
+    // @Path: ../AP_Airspeed/AP_Airspeed.cpp
+    AP_SUBGROUPINFO(airspeed, "ARSPD", 10, AP_Vehicle, AP_Airspeed),
+#endif
+
     AP_GROUPEND
 };
 
@@ -145,6 +151,18 @@ void AP_Vehicle::setup()
 
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
+
+#if AP_AIRSPEED_ENABLED
+    airspeed.init();
+    if (airspeed.enabled()) {
+        airspeed.calibrate(true);
+    } 
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+    else {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"No airspeed sensor present or enabled");
+    }
+#endif
+#endif  // AP_AIRSPEED_ENABLED
 
 #if !APM_BUILD_TYPE(APM_BUILD_Replay)
     SRV_Channels::init();
@@ -256,6 +274,9 @@ SCHED_TASK_CLASS arguments:
 
  */
 const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
+#if AP_AIRSPEED_ENABLED
+    SCHED_TASK_CLASS(AP_Airspeed,  &vehicle.airspeed,       update,                   10, 100, 41),    // NOTE: the priority number here should be right before Plane's calc_airspeed_errors
+#endif
 #if HAL_RUNCAM_ENABLED
     SCHED_TASK_CLASS(AP_RunCam,    &vehicle.runcam,         update,                   50, 50, 200),
 #endif
@@ -485,7 +506,6 @@ void AP_Vehicle::accel_cal_update()
 #endif
 #endif // HAL_INS_ENABLED
 }
-
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -367,6 +367,10 @@ protected:
     AP_EFI efi;
 #endif
 
+#if AP_AIRSPEED_ENABLED
+    AP_Airspeed airspeed;
+#endif
+
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Scheduler::Task scheduler_tasks[];
 

--- a/libraries/AP_WindVane/AP_WindVane_Airspeed.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Airspeed.cpp
@@ -17,8 +17,10 @@
 
 void AP_WindVane_Airspeed::update_speed()
 {
+#if AP_AIRSPEED_ENABLED
     const AP_Airspeed* airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr) {
         _frontend._speed_apparent_raw = airspeed->get_raw_airspeed();
     }
+#endif
 }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -264,6 +264,20 @@ void GCS::update_sensor_status_flags()
     }
 #endif
 
+    // airspeed
+#if AP_AIRSPEED_ENABLED
+    const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    if (airspeed && airspeed->enabled()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
+        if (airspeed->use()) {
+            control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
+        }
+        if (airspeed->all_healthy()) {
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
+        }
+    }
+#endif
+
 #if HAL_VISUALODOM_ENABLED
     const AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom && visual_odom->enabled()) {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -593,7 +593,7 @@ protected:
     virtual uint8_t high_latency_tgt_airspeed() const { return 0; }
     virtual uint8_t high_latency_wind_speed() const { return 0; }
     virtual uint8_t high_latency_wind_direction() const { return 0; }
-    virtual int8_t high_latency_air_temperature() const { return 0; }
+    int8_t high_latency_air_temperature() const;
 #endif // HAL_HIGH_LATENCY2_ENABLED
 
     static constexpr const float magic_force_arm_value = 2989.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1825,6 +1825,7 @@ void GCS_MAVLINK::send_scaled_pressure_instance(uint8_t instance, void (*send_fn
     }
 
     float press_diff = 0; // pascal
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr &&
         airspeed->enabled(instance)) {
@@ -1839,6 +1840,7 @@ void GCS_MAVLINK::send_scaled_pressure_instance(uint8_t instance, void (*send_fn
         }
         have_data = true;
     }
+#endif
 
     if (!have_data) {
         return;
@@ -2729,10 +2731,13 @@ void GCS_MAVLINK::send_accelcal_vehicle_position(uint32_t position)
 
 float GCS_MAVLINK::vfr_hud_airspeed() const
 {
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr && airspeed->healthy()) {
         return airspeed->get_airspeed();
     }
+#endif
+
     // because most vehicles don't have airspeed sensors, we return a
     // different sort of speed estimate in the relevant field for
     // comparison's sake.
@@ -3871,10 +3876,12 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro()
     AP::baro().update_calibration();
     gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 
+#if AP_AIRSPEED_ENABLED
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr) {
         airspeed->calibrate(false);
     }
+#endif
 
     return MAV_RESULT_ACCEPTED;
 }
@@ -5986,12 +5993,14 @@ void GCS_MAVLINK::send_high_latency2() const
 
 int8_t GCS_MAVLINK::high_latency_air_temperature() const
 {
+#if AP_AIRSPEED_ENABLED
     // return units are degC
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     float air_temperature;
     if (airspeed != nullptr && airspeed->enabled() && airspeed->get_temperature(air_temperature)) {
         return air_temperature;
     }
+#endif
 
     return INT8_MIN;
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5983,4 +5983,16 @@ void GCS_MAVLINK::send_high_latency2() const
         0, // Field for custom payload.
         0); // Field for custom payload.
 }
+
+int8_t GCS_MAVLINK::high_latency_air_temperature() const
+{
+    // return units are degC
+    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    float air_temperature;
+    if (airspeed != nullptr && airspeed->enabled() && airspeed->get_temperature(air_temperature)) {
+        return air_temperature;
+    }
+
+    return INT8_MIN;
+}
 #endif // HAL_HIGH_LATENCY2_ENABLED

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1041,6 +1041,7 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
         break;
 
     case AUX_FUNC::DISABLE_AIRSPEED_USE: {
+#if AP_AIRSPEED_ENABLED
         AP_Airspeed *airspeed = AP::airspeed();
         if (airspeed == nullptr) {
             break;
@@ -1055,6 +1056,7 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
             airspeed->force_disable_use(false);
             break;
         }
+#endif
         break;
     }
 


### PR DESCRIPTION
This moves AP_Airspeed into AP_Vehicle as a basis for next adding airspeed into copter in this PR https://github.com/ArduPilot/ardupilot/pull/18813

I could use a little help with the #ifdefs as I couldn't figure out a way to get everything I wanted without putting vehicle specific defines in AP_Airspeed.??

The biggest being Airspeed must be enabled for all vehicles & boards it is currently enabled on. And then be able to exclude APM_BUILD_ArduCopter being built-in by default.