### PR TITLE
autotest: add test for Plane flying with a very slow GPS

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3084,6 +3084,24 @@ class AutoTestPlane(AutoTest):
 
         self.fly_mission("ap-circuit.txt", mission_timeout=1200)
 
+    def DCMFallback(self):
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        self.takeoff(50)
+        self.context_collect('STATUSTEXT')
+        self.set_parameter("EK3_POS_I_GATE", 25)
+        self.set_parameter("SIM_GPS_HZ", 1)
+        self.wait_statustext("DCM Active", check_context=True)
+        self.wait_statustext("EKF3 Active", check_context=True)
+        self.wait_statustext("DCM Active", check_context=True)
+        self.wait_statustext("EKF3 Active", check_context=True)
+        self.wait_statustext("DCM Active", check_context=True)
+        self.wait_statustext("EKF3 Active", check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+
+        self.fly_home_land_and_disarm()
+
     def ForcedDCM(self):
 
         self.wait_ready_to_arm()
@@ -3313,6 +3331,10 @@ class AutoTestPlane(AutoTest):
             ("ForcedDCM",
              "Switch to DCM mid-flight",
              self.ForcedDCM),
+
+            ("DCMFallback",
+             "Really annoy the EKF and force fallback",
+             self.DCMFallback),
 
             ("MAVFTP",
              "Test MAVProxy can talk FTP to autopilot",


### PR DESCRIPTION
It's a team effort to get back home after this test:

```
AT-0011.8: Waiting for Distance=100.00 with accuracy 9999900.00
AT-0011.8: Distance=593.64 (want 100.000000 +- 9999900.000000)
AT-0011.8: Attained Distance=593.636213
AT-0011.8: AP: Mission: 8 WP
AT-0011.9: Waiting for wp=8 current=8
AT-0011.9: Waiting for DISARM
AT-0011.9: Waiting for disarm (0.00s so far of allowed 120.00)
AT-0011.9: AP: EKF2 IMU0 yaw aligned to GPS velocity
AT-0011.9: AP: EKF2 IMU1 yaw aligned to GPS velocity
AT-0011.9: AP: EKF3 IMU0 yaw aligned to GPS velocity
AT-0011.9: AP: EKF3 IMU1 yaw aligned to GPS velocity
AT-0012.1: Waiting for disarm (1.80s so far of allowed 120.00)
AT-0012.3: Waiting for disarm (3.80s so far of allowed 120.00)
AT-0012.4: AP: AHRS: DCM active
AT-0012.6: Waiting for disarm (5.80s so far of allowed 120.00)
AT-0012.8: Waiting for disarm (7.80s so far of allowed 120.00)
AT-0013.1: Waiting for disarm (9.80s so far of allowed 120.00)
AT-0013.2: AP: AHRS: EKF3 active
AT-0013.3: Waiting for disarm (11.80s so far of allowed 120.00)
AT-0013.6: Waiting for disarm (13.80s so far of allowed 120.00)
AT-0013.7: AP: EKF3 lane switch 0
AT-0013.9: AP: AHRS: DCM active
AT-0013.9: Waiting for disarm (15.80s so far of allowed 120.00)
AT-0014.1: Waiting for disarm (17.80s so far of allowed 120.00)
AT-0014.4: Waiting for disarm (19.80s so far of allowed 120.00)
AT-0014.6: Waiting for disarm (21.80s so far of allowed 120.00)
AT-0014.7: AP: AHRS: EKF3 active
AT-0014.9: Waiting for disarm (23.80s so far of allowed 120.00)
AT-0015.0: AP: EKF3 lane switch 1
AT-0015.1: Waiting for disarm (25.80s so far of allowed 120.00)
AT-0015.2: AP: Reached waypoint #8 dist 22m
AT-0015.2: AP: Mission: 9 WP
AT-0015.4: Waiting for disarm (27.80s so far of allowed 120.00)
AT-0015.5: AP: AHRS: DCM active
AT-0015.6: Waiting for disarm (29.80s so far of allowed 120.00)
AT-0015.9: Waiting for disarm (31.80s so far of allowed 120.00)
AT-0016.1: Waiting for disarm (33.80s so far of allowed 120.00)
AT-0016.4: AP: AHRS: EKF3 active
AT-0016.4: Waiting for disarm (35.80s so far of allowed 120.00)
AT-0016.4: AP: Reached waypoint #9 dist 51m
AT-0016.4: AP: Mission: 10 WP
AT-0016.6: Waiting for disarm (37.80s so far of allowed 120.00)
AT-0016.9: Waiting for disarm (39.80s so far of allowed 120.00)
AT-0017.0: AP: AHRS: DCM active
```

... all the cores, all the estimators and the GSF....
