### PR TITLE
Sub: Motor-test: change disarm method on motor test timeout

### DIFF
--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -70,7 +70,7 @@ bool Sub::verify_motor_test()
 
     if (!pass) {
         ap.motor_test = false;
-        motors.armed(false); // disarm motors
+        AP::arming().disarm(AP_Arming::Method::MOTORTEST);
         last_do_motor_test_fail_ms = AP_HAL::millis();
         return false;
     }


### PR DESCRIPTION
Fix #18851 

`motors.armed(false)` seems to disarm the motors while keeping some of the vehicle armed. This works, but I'm not sure of how correct this is.

