### PR TITLE
AP_Airspeed: do not cal if backend does not exist

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -486,6 +486,10 @@ void AP_Airspeed::calibrate(bool in_startup)
         if (in_startup && param[i].skip_cal) {
             continue;
         }
+        if (sensor[i] == nullptr) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Airspeed %u not initalized, cannot cal", i+1);
+            continue;
+        }
         state[i].cal.start_ms = AP_HAL::millis();
         state[i].cal.count = 0;
         state[i].cal.sum = 0;


### PR DESCRIPTION
if airspeed init fails, either due to unattached or unhealthy from start...then cal is still started but never completes...this corrects that....I think...
while there is a message that it failed init, it occurs so early it never could appear on a telem GCS (telem hasnt started), or by reconnecting over USB....so the cal started message appears but never completes or shows unhealthy because pointer is null on reads....again, I think...this messages later in the ground start that the cal cannot be done on the sensor

will test on a system that sometimes does not init on power up due to timing or brownout