### PR TITLE
AP_AHRS: make ExternalAHRS an AP_AHRS_Backend

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -471,7 +471,7 @@ class SizeCompareBranches(object):
 
     def elf_diff_results(self, result_master, result_branch):
         master_branch = result_master["branch"]
-        branch = result_master["branch"]
+        branch = result_branch["branch"]
         for vehicle in result_master["vehicle"].keys():
             elf_filename = result_master["vehicle"][vehicle]["elf_filename"]
             master_elf_dir = result_master["vehicle"][vehicle]["elf_dir"]

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -235,6 +235,9 @@ void AP_AHRS::init()
 
     // init backends
     dcm.init();
+#if HAL_EXTERNAL_AHRS_ENABLED
+    external.init();
+#endif
 
 #if !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
     // convert to new custom rotaton
@@ -296,6 +299,9 @@ void AP_AHRS::reset_gyro_drift(void)
     
     // update DCM
     dcm.reset_gyro_drift();
+#if HAL_EXTERNAL_AHRS_ENABLED
+    external.reset_gyro_drift();
+#endif
 
     // reset the EKF gyro bias states
 #if HAL_NAVEKF2_AVAILABLE
@@ -623,26 +629,11 @@ void AP_AHRS::update_EKF3(void)
 #if HAL_EXTERNAL_AHRS_ENABLED
 void AP_AHRS::update_external(void)
 {
-    AP::externalAHRS().update();
+    external.update();
+    external.get_results(external_estimates);
 
     if (active_EKF_type() == EKFType::EXTERNAL) {
-        Quaternion quat;
-        if (!AP::externalAHRS().get_quaternion(quat)) {
-            return;
-        }
-        quat.rotation_matrix(_dcm_matrix);
-        _dcm_matrix = _dcm_matrix * get_rotation_vehicle_body_to_autopilot_body();
-        _dcm_matrix.to_euler(&roll, &pitch, &yaw);
-
-        update_cd_values();
-        update_trig();
-
-        _gyro_drift.zero();
-
-        _gyro_estimate = AP::externalAHRS().get_gyro();
-
-        Vector3f accel = AP::externalAHRS().get_accel();
-        _accel_ef = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * accel;
+        copy_estimates_from_backend_estimates(external_estimates);
     }
 }
 #endif // HAL_EXTERNAL_AHRS_ENABLED
@@ -655,6 +646,10 @@ void AP_AHRS::reset()
     dcm.reset();
 #if AP_AHRS_SIM_ENABLED
     sim.reset();
+#endif
+
+#if HAL_EXTERNAL_AHRS_ENABLED
+    external.reset();
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
@@ -699,7 +694,7 @@ bool AP_AHRS::get_location(Location &loc) const
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
-        return AP::externalAHRS().get_location(loc);
+        return external.get_location(loc);
     }
 #endif
     }
@@ -747,7 +742,7 @@ bool AP_AHRS::wind_estimate(Vector3f &wind) const
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return false;
+        return external.wind_estimate(wind);
 #endif
     }
     return false;
@@ -983,7 +978,6 @@ bool AP_AHRS::use_compass(void)
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        // fall through
         break;
 #endif
     }
@@ -1027,7 +1021,7 @@ bool AP_AHRS::get_quaternion(Quaternion &quat) const
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
         // we assume the external AHRS isn't trimmed with the autopilot!
-        return AP::externalAHRS().get_quaternion(quat);
+        return external.get_quaternion(quat);
 #endif
     }
 
@@ -1076,11 +1070,9 @@ bool AP_AHRS::get_secondary_attitude(Vector3f &eulers) const
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
         // External is secondary
-        Quaternion quat;
-        if (!AP::externalAHRS().get_quaternion(quat)) {
-            return false;
-        }
-        quat.to_euler(eulers.x, eulers.y, eulers.z);
+        eulers[0] = external_estimates.roll_rad;
+        eulers[1] = external_estimates.pitch_rad;
+        eulers[2] = external_estimates.yaw_rad;
         return true;
     }
 #endif
@@ -1137,7 +1129,7 @@ bool AP_AHRS::get_secondary_quaternion(Quaternion &quat) const
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
         // External is secondary
-        return AP::externalAHRS().get_quaternion(quat);
+        return external.get_quaternion(quat);
 #endif
     }
 
@@ -1184,7 +1176,7 @@ bool AP_AHRS::get_secondary_position(Location &loc) const
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
         // External is secondary
-        return AP::externalAHRS().get_location(loc);
+        return external.get_location(loc);
 #endif
     }
 
@@ -1219,7 +1211,7 @@ Vector2f AP_AHRS::groundspeed_vector(void)
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
-        return AP::externalAHRS().get_groundspeed_vector();
+        return external.groundspeed_vector();
     }
 #endif
     }
@@ -1327,7 +1319,7 @@ bool AP_AHRS::get_velocity_NED(Vector3f &vec) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().get_velocity_NED(vec);
+        return external.get_velocity_NED(vec);
 #endif
     }
     return dcm.get_velocity_NED(vec);
@@ -1422,7 +1414,7 @@ bool AP_AHRS::get_vert_pos_rate(float &velocity) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().get_speed_down(velocity);
+        return external.get_vert_pos_rate(velocity);
 #endif
     }
     // since there is no default case above, this is unreachable
@@ -1504,16 +1496,7 @@ bool AP_AHRS::get_relative_position_NED_origin(Vector3f &vec) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
-        auto &extahrs = AP::externalAHRS();
-        Location loc, orgn;
-        if (extahrs.get_origin(orgn) &&
-            extahrs.get_location(loc)) {
-            const Vector2f diff2d = orgn.get_distance_NE(loc);
-            vec = Vector3f(diff2d.x, diff2d.y,
-                           -(loc.alt - orgn.alt)*0.01);
-            return true;
-        }
-        return false;
+        return external.get_relative_position_NED_origin(vec);
     }
 #endif
     }
@@ -1568,15 +1551,8 @@ bool AP_AHRS::get_relative_position_NE_origin(Vector2f &posNE) const
     }
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
-    case EKFType::EXTERNAL: {
-        Location loc, orgn;
-        if (!get_location(loc) ||
-            !get_origin(orgn)) {
-            return false;
-        }
-        posNE = orgn.get_distance_NE(loc);
-        return true;
-    }
+    case EKFType::EXTERNAL:
+        return external.get_relative_position_NE_origin(posNE);
 #endif
     }
     // since there is no default case above, this is unreachable
@@ -1631,15 +1607,8 @@ bool AP_AHRS::get_relative_position_D_origin(float &posD) const
         return sim.get_relative_position_D_origin(posD);
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
-    case EKFType::EXTERNAL: {
-        Location orgn, loc;
-        if (!get_origin(orgn) ||
-            !get_location(loc)) {
-            return false;
-        }
-        posD = -(loc.alt - orgn.alt)*0.01;
-        return true;
-    }
+    case EKFType::EXTERNAL:
+        return external.get_relative_position_D_origin(posD);
 #endif
     }
     // since there is no default case above, this is unreachable
@@ -1959,7 +1928,7 @@ bool AP_AHRS::healthy(void) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().healthy();
+        return external.healthy();
 #endif
     }
 
@@ -2008,7 +1977,7 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return ret;
+        return external.pre_arm_check(requires_position, failure_msg, failure_msg_len);
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
@@ -2060,7 +2029,7 @@ bool AP_AHRS::initialised(void) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().initialised();
+        return external.initialised();
 #endif
     }
     return false;
@@ -2091,8 +2060,7 @@ bool AP_AHRS::get_filter_status(nav_filter_status &status) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        AP::externalAHRS().get_filter_status(status);
-        return true;
+        return external.get_filter_status(status);
 #endif
     }
 
@@ -2400,7 +2368,7 @@ uint32_t AP_AHRS::getLastYawResetAngle(float &yawAng)
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return 0;
+        return external.getLastYawResetAngle(yawAng);
 #endif
     }
     return 0;
@@ -2565,7 +2533,7 @@ void AP_AHRS::send_ekf_status_report(GCS_MAVLINK &link) const
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
-        AP::externalAHRS().send_status_report(link);
+        external.send_ekf_status_report(link);
         break;
     }
 #endif
@@ -2606,7 +2574,7 @@ bool AP_AHRS::get_origin(EKFType type, Location &ret) const
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().get_origin(ret);
+        return external.get_origin(ret);
 #endif
     }
     return false;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -31,6 +31,7 @@
 
 #include "AP_AHRS_DCM.h"
 #include "AP_AHRS_SIM.h"
+#include "AP_AHRS_External.h"
 
 // forward declare view class
 class AP_AHRS_View;
@@ -809,6 +810,11 @@ private:
     AP_AHRS_SIM sim;
 #endif
     struct AP_AHRS_Backend::Estimates sim_estimates;
+#endif
+
+#if HAL_EXTERNAL_AHRS_ENABLED
+    AP_AHRS_External external;
+    struct AP_AHRS_Backend::Estimates external_estimates;
 #endif
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -1,0 +1,136 @@
+#include "AP_AHRS_External.h"
+
+#if HAL_EXTERNAL_AHRS_ENABLED
+
+#include <AP_ExternalAHRS/AP_ExternalAHRS.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+// true if the AHRS has completed initialisation
+bool AP_AHRS_External::initialised(void) const
+{
+    return AP::externalAHRS().initialised();
+}
+
+void AP_AHRS_External::update()
+{
+    AP::externalAHRS().update();
+}
+
+bool AP_AHRS_External::healthy() const {
+    return AP::externalAHRS().healthy();
+}
+
+void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
+{
+    Quaternion quat;
+    if (!AP::externalAHRS().get_quaternion(quat)) {
+        return;
+    }
+    quat.rotation_matrix(results.dcm_matrix);
+    results.dcm_matrix = results.dcm_matrix * AP::ahrs().get_rotation_vehicle_body_to_autopilot_body();
+    results.dcm_matrix.to_euler(&results.roll_rad, &results.pitch_rad, &results.yaw_rad);
+
+    results.gyro_drift.zero();
+    results.gyro_estimate = AP::externalAHRS().get_gyro();
+
+    const Vector3f accel = AP::externalAHRS().get_accel();
+    const Vector3f accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;
+    results.accel_ef = accel_ef;
+}
+
+
+bool AP_AHRS_External::get_location(struct Location &loc) const
+{
+    return AP::externalAHRS().get_location(loc);
+}
+
+bool AP_AHRS_External::get_quaternion(Quaternion &quat) const
+{
+    return AP::externalAHRS().get_quaternion(quat);
+}
+
+Vector2f AP_AHRS_External::groundspeed_vector()
+{
+    return AP::externalAHRS().get_groundspeed_vector();
+}
+
+
+bool AP_AHRS_External::get_relative_position_NED_origin(Vector3f &vec) const
+{
+    auto &extahrs = AP::externalAHRS();
+    Location loc, orgn;
+    if (extahrs.get_origin(orgn) &&
+        extahrs.get_location(loc)) {
+        const Vector2f diff2d = orgn.get_distance_NE(loc);
+        vec = Vector3f(diff2d.x, diff2d.y,
+                       -(loc.alt - orgn.alt)*0.01);
+        return true;
+    }
+    return false;
+}
+
+bool AP_AHRS_External::get_relative_position_NE_origin(Vector2f &posNE) const
+{
+    auto &extahrs = AP::externalAHRS();
+
+    Location loc, orgn;
+    if (!extahrs.get_location(loc) ||
+        !extahrs.get_origin(orgn)) {
+        return false;
+    }
+    posNE = orgn.get_distance_NE(loc);
+    return true;
+}
+
+bool AP_AHRS_External::get_relative_position_D_origin(float &posD) const
+{
+    auto &extahrs = AP::externalAHRS();
+
+    Location orgn, loc;
+    if (!extahrs.get_origin(orgn) ||
+        !extahrs.get_location(loc)) {
+        return false;
+    }
+    posD = -(loc.alt - orgn.alt)*0.01;
+    return true;
+}
+
+bool AP_AHRS_External::get_velocity_NED(Vector3f &vec) const
+{
+    return AP::externalAHRS().get_velocity_NED(vec);
+}
+
+bool AP_AHRS_External::get_vert_pos_rate(float &velocity) const
+{
+    return AP::externalAHRS().get_speed_down(velocity);
+}
+
+bool AP_AHRS_External::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
+{
+    return AP::externalAHRS().pre_arm_check(failure_msg, failure_msg_len);
+}
+
+bool AP_AHRS_External::get_filter_status(nav_filter_status &status) const
+{
+    AP::externalAHRS().get_filter_status(status);
+    return true;
+}
+
+void AP_AHRS_External::send_ekf_status_report(GCS_MAVLINK &link) const
+{
+    AP::externalAHRS().send_status_report(link);
+}
+
+bool AP_AHRS_External::get_origin(Location &ret) const
+{
+    return AP::externalAHRS().get_origin(ret);
+}
+
+void AP_AHRS_External::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const
+{
+    // lower gains in VTOL controllers when flying on DCM
+    ekfGndSpdLimit = 50.0;
+    ekfNavVelGainScaler = 0.5;
+}
+
+#endif

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -1,0 +1,93 @@
+#pragma once
+
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  External based AHRS (Attitude Heading Reference System) interface for
+ *  ArduPilot
+ *
+ */
+
+#include "AP_AHRS_Backend.h"
+
+#if HAL_EXTERNAL_AHRS_ENABLED
+
+class AP_AHRS_External : public AP_AHRS_Backend {
+public:
+
+    using AP_AHRS_Backend::AP_AHRS_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_AHRS_External);
+
+    // reset the current gyro drift estimate
+    //  should be called if gyro offsets are recalculated
+    void reset_gyro_drift() override {}
+
+    // Methods
+    bool            initialised() const override;
+    void            update() override;
+    void            get_results(Estimates &results) override;
+    void            reset() override {}
+
+    // dead-reckoning support
+    virtual bool get_location(struct Location &loc) const override;
+
+    // return a wind estimation vector, in m/s
+    bool wind_estimate(Vector3f &ret) const override {
+        return false;
+    }
+
+    // return a ground vector estimate in meters/second, in North/East order
+    Vector2f groundspeed_vector() override;
+
+    bool            use_compass() override {
+        // this is actually never called at the moment; we use dcm's
+        // return value.
+        return true;
+    }
+
+    // return the quaternion defining the rotation from NED to XYZ (body) axes
+    bool get_quaternion(Quaternion &quat) const override WARN_IF_UNUSED;
+
+    void estimate_wind(void);
+
+    // is the AHRS subsystem healthy?
+    bool healthy() const override;
+
+    bool get_velocity_NED(Vector3f &vec) const override;
+
+    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
+    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
+    bool get_vert_pos_rate(float &velocity) const override;
+
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    // requires_position should be true if horizontal position configuration should be checked (not used)
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
+
+    // relative-origin functions for fallback in AP_InertialNav
+    bool get_origin(Location &ret) const override;
+    bool get_relative_position_NED_origin(Vector3f &vec) const override;
+    bool get_relative_position_NE_origin(Vector2f &posNE) const override;
+    bool get_relative_position_D_origin(float &posD) const override;
+
+    bool get_filter_status(nav_filter_status &status) const override;
+    void send_ekf_status_report(class GCS_MAVLINK &link) const override;
+
+    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
+};
+
+#endif


### PR DESCRIPTION
This starts to make all our existing backends inherit from AP_AHRS_Backend - rather than just AP_AHRS_DCM.

Future PRs make SITL and the EKFs backends as well.

 - [ ] We should probably test this on an actual ExternalAHRS, rather than trusting the simulated one.
