### PR TITLE
HAL_ChibiOS: add missing return to Dual CDC get_usb_baud()

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg_dualcdc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg_dualcdc.c
@@ -310,6 +310,7 @@ uint32_t get_usb_baud(uint16_t endpoint_id)
       if (endpoint_id == ep_index[i]) {
           uint32_t rate;
           memcpy(&rate, &linecoding[i].dwDTERate[0], sizeof(rate));
+          return rate;
       }
   }
   return 0;


### PR DESCRIPTION
Addresses accidental deletion of `return` in PR #18847.