### PR TITLE
AP_Gererator: IE Fuel Cell: reset health timer at init

### DIFF
--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -28,6 +28,7 @@ void AP_Generator_IE_FuelCell::init()
         return;
     }
     _uart->begin(AP::serialmanager().find_baudrate(AP_SerialManager::SerialProtocol_Generator, 0));
+    _health_warn_last_ms = AP_HAL::millis();
 }
 
 // Update fuelcell, expected to be called at 20hz


### PR DESCRIPTION
This change means you get the first health warning 20 seconds after init, not 20 seconds after boot. If you have a boot delay or long gyro cal, you currently get `Generator: Not healthy` followed by a immediate `Generator: Running` or other state update.