### PR TITLE
AP_HAL_Linux: small fixes to cpu affinity

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -297,8 +297,9 @@ void _usage(void)
     printf("\t                   --module-directory %s\n", AP_MODULE_DEFAULT_DIRECTORY);
     printf("\t                   -M %s\n", AP_MODULE_DEFAULT_DIRECTORY);
 #endif
-    printf("\tcpu affinity       --cpu-affinity 0,3 or 0,3\n");
-    printf("\t                   -c 0,3  or range -c 1,3\n");
+    printf("\tcpu affinity:\n");
+    printf("\t                   --cpu-affinity 1 (single cpu) or 1,3 (multiple cpus) or 1-3 (range of cpus)\n");
+    printf("\t                   -c 1 (single cpu) or 1,3 (multiple cpus) or 1-3 (range of cpus)\n");
 }
 
 void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
@@ -306,7 +307,7 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
 #if AP_MODULE_SUPPORTED
     const char *module_path = AP_MODULE_DEFAULT_DIRECTORY;
 #endif
-    
+
     int opt;
     const struct GetOptLong::option options[] = {
         {"uartA",         true,  0, 'A'},
@@ -383,6 +384,7 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         case 'c':
             cpu_set_t cpu_affinity;
             if (!utilInstance.parse_cpu_set(gopt.optarg, &cpu_affinity)) {
+                fprintf(stderr, "Could not parse cpu affinity: %s\n", gopt.optarg);
                 exit(1);
             }
             Linux::Scheduler::from(scheduler)->set_cpu_affinity(cpu_affinity);

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -306,7 +306,7 @@ bool Util::get_random_vals(uint8_t* data, size_t size)
     return true;
 }
 
-bool Util::parse_cpu_set(const char *str, cpu_set_t *cpu_set)  const
+bool Util::parse_cpu_set(const char *str, cpu_set_t *cpu_set) const
 {
     unsigned long cpu1, cpu2;
     char *endptr, sep;
@@ -316,7 +316,6 @@ bool Util::parse_cpu_set(const char *str, cpu_set_t *cpu_set)  const
     do {
         cpu1 = strtoul(str, &endptr, 10);
         if (str == endptr) {
-            fprintf(stderr, "Invalid option for cpu-affinity: %s missing cpu number\n", str);
             return false;
         }
 
@@ -328,13 +327,11 @@ bool Util::parse_cpu_set(const char *str, cpu_set_t *cpu_set)  const
         }
 
         if (sep != '-') {
-            fprintf(stderr, "Invalid option for cpu-affinity: %s did you means separator - e.g. 1-3\n", str);
             return false;
         }
 
         cpu2 = strtoul(str, &endptr, 10);
         if (str == endptr) {
-            fprintf(stderr, "Invalid option for cpu-affinity: %s missing end cpu number\n", str);
             return false;
         }
 

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -58,7 +58,7 @@ public:
         return custom_defaults;
     }
 
-    /* Parse cpu set in the form 0,2 or 0-2 or 0:2*/
+    /* Parse cpu set in the form 0; 0,2; or 0-2 */
     bool parse_cpu_set(const char *s, cpu_set_t *cpu_set) const;
 
     bool is_chardev_node(const char *path);


### PR DESCRIPTION
  - Do not mention x:y form in the comment since it's not supported
  - Give more detail in the help output regarding the meaning of each form
  - No prints in the helper parse function, let the caller print it