### PR TITLE
Copter: fix tradheli landing detector bug

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -5,7 +5,7 @@
 #if FRAME_CONFIG == HELI_FRAME
 
 #ifndef HELI_DYNAMIC_FLIGHT_SPEED_MIN
- #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      500     // we are in "dynamic flight" when the speed is over 5m/s for 2 seconds
+ #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      250     // we are in "dynamic flight" when the speed is over 2.5m/s for 2 seconds
 #endif
 
 // counter to control dynamic flight profile

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -61,8 +61,11 @@ void Copter::update_land_detector()
     } else {
 
 #if FRAME_CONFIG == HELI_FRAME
-        // check that collective pitch is below mid collective (zero thrust) position
-        bool motor_at_lower_limit = (motors->get_below_mid_collective() && fabsf(ahrs.get_roll()) < M_PI/2.0f);
+        // check for both manual collective modes and modes that use altitude hold. For manual collective (called throttle 
+        // because multi's use throttle), check that collective pitch is below mid collective (zero thrust) position.  For modes 
+        // that use altitude hold, check that the pilot is commanding a descent and collective is at min allowed for altitude hold modes.
+        bool motor_at_lower_limit = ((flightmode->has_manual_throttle() && motors->get_below_mid_collective() && fabsf(ahrs.get_roll()) < M_PI/2.0f) 
+                                    || (motors->limit.throttle_lower && pos_control->get_vel_desired_cms().z < 0.0f));
 #else
         // check that the average throttle output is near minimum (less than 12.5% hover throttle)
         bool motor_at_lower_limit = motors->limit.throttle_lower && attitude_control->is_throttle_mix_min();


### PR DESCRIPTION
There is a higher probability for an in-flight motor shutdown in Auto or Guided flight modes. This is occurring because the autopilot declares land complete in flight which initiates the auto shutdown and disarm sequence. The root cause of this was determined to be due to the new integrator management implementation. That PR changed the landing detector logic which overrided the suppression of the land complete declaration when the aircraft was not in a landing state in auto or guided modes.

This PR fixes this bug