### PR TITLE
SITL: use enumeration in place of O_RDWR for I2C register defs

### DIFF
--- a/libraries/SITL/SIM_BattMonitor_SMBus.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus.cpp
@@ -5,17 +5,17 @@
 SITL::SIM_BattMonitor_SMBus::SIM_BattMonitor_SMBus() :
     SMBusDevice()
 {
-    add_register("Temperature", SMBusBattDevReg::TEMP, O_RDONLY);
-    add_register("Voltage", SMBusBattDevReg::VOLTAGE, O_RDONLY);
-    add_register("Current", SMBusBattDevReg::CURRENT, O_RDONLY);
-    add_register("Remaining Capacity", SMBusBattDevReg::REMAINING_CAPACITY, O_RDONLY);
-    add_register("Full Charge Capacity", SMBusBattDevReg::FULL_CHARGE_CAPACITY, O_RDONLY);
-    add_register("Cycle_Count", SMBusBattDevReg::CYCLE_COUNT, O_RDONLY);
-    add_register("Specification Info", SMBusBattDevReg::SPECIFICATION_INFO, O_RDONLY);
-    add_register("Serial", SMBusBattDevReg::SERIAL, O_RDONLY);
-    add_block("Manufacture Name", SMBusBattDevReg::MANUFACTURE_NAME, O_RDONLY);
-    add_block("Device Name", SMBusBattDevReg::DEVICE_NAME, O_RDONLY);
-    add_register("Manufacture Data", SMBusBattDevReg::MANUFACTURE_DATA, O_RDONLY);
+    add_register("Temperature", SMBusBattDevReg::TEMP, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Voltage", SMBusBattDevReg::VOLTAGE, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Current", SMBusBattDevReg::CURRENT, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Remaining Capacity", SMBusBattDevReg::REMAINING_CAPACITY, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Full Charge Capacity", SMBusBattDevReg::FULL_CHARGE_CAPACITY, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Cycle_Count", SMBusBattDevReg::CYCLE_COUNT, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Specification Info", SMBusBattDevReg::SPECIFICATION_INFO, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Serial", SMBusBattDevReg::SERIAL, SITL::I2CRegisters::RegMode::RDONLY);
+    add_block("Manufacture Name", SMBusBattDevReg::MANUFACTURE_NAME, SITL::I2CRegisters::RegMode::RDONLY);
+    add_block("Device Name", SMBusBattDevReg::DEVICE_NAME, SITL::I2CRegisters::RegMode::RDONLY);
+    add_register("Manufacture Data", SMBusBattDevReg::MANUFACTURE_DATA, SITL::I2CRegisters::RegMode::RDONLY);
 
     set_register(SMBusBattDevReg::TEMP, (int16_t)((15 + C_TO_KELVIN)*10));
      // see update for voltage

--- a/libraries/SITL/SIM_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Generic.cpp
@@ -9,46 +9,46 @@ void SITL::SIM_BattMonitor_SMBus_Generic::init()
 {
     switch (cellcount()) {
     case 14:
-        add_register("Cell14", SMBusBattGenericDevReg::CELL14, O_RDONLY);
+        add_register("Cell14", SMBusBattGenericDevReg::CELL14, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 13:
-        add_register("Cell13", SMBusBattGenericDevReg::CELL13, O_RDONLY);
+        add_register("Cell13", SMBusBattGenericDevReg::CELL13, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 12:
-        add_register("Cell12", SMBusBattGenericDevReg::CELL12, O_RDONLY);
+        add_register("Cell12", SMBusBattGenericDevReg::CELL12, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 11:
-        add_register("Cell11", SMBusBattGenericDevReg::CELL11, O_RDONLY);
+        add_register("Cell11", SMBusBattGenericDevReg::CELL11, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 10:
-        add_register("Cell10", SMBusBattGenericDevReg::CELL10, O_RDONLY);
+        add_register("Cell10", SMBusBattGenericDevReg::CELL10, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 9:
-        add_register("Cell9", SMBusBattGenericDevReg::CELL9, O_RDONLY);
+        add_register("Cell9", SMBusBattGenericDevReg::CELL9, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 8:
-        add_register("Cell8", SMBusBattGenericDevReg::CELL8, O_RDONLY);
+        add_register("Cell8", SMBusBattGenericDevReg::CELL8, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 7:
-        add_register("Cell7", SMBusBattGenericDevReg::CELL7, O_RDONLY);
+        add_register("Cell7", SMBusBattGenericDevReg::CELL7, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 6:
-        add_register("Cell6", SMBusBattGenericDevReg::CELL6, O_RDONLY);
+        add_register("Cell6", SMBusBattGenericDevReg::CELL6, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 5:
-        add_register("Cell5", SMBusBattGenericDevReg::CELL5, O_RDONLY);
+        add_register("Cell5", SMBusBattGenericDevReg::CELL5, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 4:
-        add_register("Cell4", SMBusBattGenericDevReg::CELL4, O_RDONLY);
+        add_register("Cell4", SMBusBattGenericDevReg::CELL4, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 3:
-        add_register("Cell3", SMBusBattGenericDevReg::CELL3, O_RDONLY);
+        add_register("Cell3", SMBusBattGenericDevReg::CELL3, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 2:
-        add_register("Cell2", SMBusBattGenericDevReg::CELL2, O_RDONLY);
+        add_register("Cell2", SMBusBattGenericDevReg::CELL2, SITL::I2CRegisters::RegMode::RDONLY);
         FALLTHROUGH;
     case 1:
-        add_register("Cell1", SMBusBattGenericDevReg::CELL1, O_RDONLY);
+        add_register("Cell1", SMBusBattGenericDevReg::CELL1, SITL::I2CRegisters::RegMode::RDONLY);
         return;
     default:
         AP_HAL::panic("Bad cellcount %u", cellcount());

--- a/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
@@ -4,7 +4,7 @@
 SITL::Rotoye::Rotoye() :
     SIM_BattMonitor_SMBus_Generic()
 {
-    add_register("External Temperature", SMBusBattRotoyeDevReg::TEMP_EXT, O_RDONLY);
+    add_register("External Temperature", SMBusBattRotoyeDevReg::TEMP_EXT, SITL::I2CRegisters::RegMode::RDONLY);
 
     set_register(SMBusBattRotoyeDevReg::SERIAL, (uint16_t)39);
 }

--- a/libraries/SITL/SIM_I2CDevice.cpp
+++ b/libraries/SITL/SIM_I2CDevice.cpp
@@ -1,14 +1,14 @@
 #include "SIM_I2CDevice.h"
 #include <AP_HAL/utility/sparse-endian.h>
 
-void SITL::I2CRegisters::add_register(const char *name, uint8_t reg, int8_t mode)
+void SITL::I2CRegisters::add_register(const char *name, uint8_t reg, RegMode mode)
 {
     // ::fprintf(stderr, "Adding register %u (0x%02x) (%s)\n", reg, reg, name);
     regname[reg] = name;
-    if (mode == O_RDONLY || mode == O_RDWR) {
+    if (mode == RegMode::RDONLY || mode == RegMode::RDWR) {
         readable_registers.set((uint8_t)reg);
     }
-    if (mode == O_WRONLY || mode == O_RDWR) {
+    if (mode == RegMode::WRONLY || mode == RegMode::RDWR) {
         writable_registers.set((uint8_t)reg);
     }
 }

--- a/libraries/SITL/SIM_I2CDevice.h
+++ b/libraries/SITL/SIM_I2CDevice.h
@@ -14,11 +14,19 @@ class I2CRegEnum {
 
 class I2CRegisters {
 
+public:
+
+    enum class RegMode {
+        RDONLY = 11,
+        WRONLY = 22,
+        RDWR = 33,
+    };
+
 protected:
 
     virtual int rdwr(I2C::i2c_rdwr_ioctl_data *&data) = 0;
 
-    void add_register(const char *name, uint8_t reg, int8_t mode);
+    void add_register(const char *name, uint8_t reg, RegMode mode);
 
     const char *regname[256];
     Bitmask<256> writable_registers;

--- a/libraries/SITL/SIM_Invensense_v3.cpp
+++ b/libraries/SITL/SIM_Invensense_v3.cpp
@@ -103,14 +103,16 @@ int SITL::InvensenseV3::rdwr_fifo(I2C::i2c_rdwr_ioctl_data *&data)
     return -1;
 }
 
-void SITL::InvensenseV3::add_fifo(const char *name, uint8_t reg, int8_t mode)
+void SITL::InvensenseV3::add_fifo(const char *name, uint8_t reg, I2CRegisters::RegMode mode)
 {
     // ::fprintf(stderr, "Adding fifo %u (0x%02x) (%s)\n", reg, reg, name);
     fifoname[reg] = name;
-    if (mode == O_RDONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::RDONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         readable_fifos.set((uint8_t)reg);
     }
-    if (mode == O_WRONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::WRONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         writable_fifos.set((uint8_t)reg);
     }
 
@@ -155,7 +157,7 @@ bool SITL::InvensenseV3::write_to_fifo(uint8_t fifo, uint8_t *value, uint8_t val
 
 
 
-void SITL::InvensenseV3::add_block(const char *name, uint8_t addr, uint8_t len, int8_t mode)
+void SITL::InvensenseV3::add_block(const char *name, uint8_t addr, uint8_t len, I2CRegisters::RegMode mode)
 {
     // ::fprintf(stderr, "Adding block %u (0x%02x) (%s)\n", addr, addr, name);
     blockname[addr] = name;
@@ -164,10 +166,12 @@ void SITL::InvensenseV3::add_block(const char *name, uint8_t addr, uint8_t len, 
     if (block_values[addr] == nullptr) {
         AP_HAL::panic("Allocation failed for block (len=%u)", len);
     }
-    if (mode == O_RDONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::RDONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         readable_blocks.set((uint8_t)addr);
     }
-    if (mode == O_WRONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::WRONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         writable_blocks.set((uint8_t)addr);
     }
 }

--- a/libraries/SITL/SIM_Invensense_v3.h
+++ b/libraries/SITL/SIM_Invensense_v3.h
@@ -25,19 +25,19 @@ class InvensenseV3 : public I2CDevice, protected I2CRegisters_8Bit
 {
 public:
     void init() override {
-        add_register("WHOAMI", InvensenseV3DevReg::WHOAMI, O_RDONLY);
-        add_register("FIFO_CONFIG", InvensenseV3DevReg::FIFO_CONFIG, O_RDWR);
-        add_register("FIFO_CONFIG1", InvensenseV3DevReg::FIFO_CONFIG1, O_RDWR);
-        add_register("INTF_CONFIG0", InvensenseV3DevReg::INTF_CONFIG0, O_RDWR);
-        add_register("SIGNAL_PATH_RESET", InvensenseV3DevReg::SIGNAL_PATH_RESET, O_RDWR);
-        add_register("PWR_MGMT0", InvensenseV3DevReg::PWR_MGMT0, O_RDWR);
-        add_register("GYRO_CONFIG0", InvensenseV3DevReg::GYRO_CONFIG0, O_RDWR);
-        add_register("ACCDEL_CONFIG0", InvensenseV3DevReg::ACCEL_CONFIG0, O_RDWR);
+        add_register("WHOAMI", InvensenseV3DevReg::WHOAMI, I2CRegisters::RegMode::RDONLY);
+        add_register("FIFO_CONFIG", InvensenseV3DevReg::FIFO_CONFIG, I2CRegisters::RegMode::RDWR);
+        add_register("FIFO_CONFIG1", InvensenseV3DevReg::FIFO_CONFIG1, I2CRegisters::RegMode::RDWR);
+        add_register("INTF_CONFIG0", InvensenseV3DevReg::INTF_CONFIG0, I2CRegisters::RegMode::RDWR);
+        add_register("SIGNAL_PATH_RESET", InvensenseV3DevReg::SIGNAL_PATH_RESET, I2CRegisters::RegMode::RDWR);
+        add_register("PWR_MGMT0", InvensenseV3DevReg::PWR_MGMT0, I2CRegisters::RegMode::RDWR);
+        add_register("GYRO_CONFIG0", InvensenseV3DevReg::GYRO_CONFIG0, I2CRegisters::RegMode::RDWR);
+        add_register("ACCDEL_CONFIG0", InvensenseV3DevReg::ACCEL_CONFIG0, I2CRegisters::RegMode::RDWR);
 
         // sample count!
-        add_block("FIFO_COUNTH", InvensenseV3DevReg::FIFO_COUNTH, 2, O_RDONLY);
+        add_block("FIFO_COUNTH", InvensenseV3DevReg::FIFO_COUNTH, 2, I2CRegisters::RegMode::RDONLY);
 
-        add_fifo("FIFO_DATA", InvensenseV3DevReg::FIFO_DATA, O_RDONLY);
+        add_fifo("FIFO_DATA", InvensenseV3DevReg::FIFO_DATA, I2CRegisters::RegMode::RDONLY);
     }
 
     void update(const class Aircraft &aircraft) override;
@@ -54,7 +54,7 @@ private:
 
     void assert_register_values();
 
-    void add_fifo(const char *name, uint8_t reg, int8_t mode);
+    void add_fifo(const char *name, uint8_t reg, I2CRegisters::RegMode mode);
     bool write_to_fifo(uint8_t fifo, uint8_t *value, uint8_t valuelen);
 
     int rdwr_fifo(I2C::i2c_rdwr_ioctl_data *&data);
@@ -79,7 +79,7 @@ private:
     // block support
     // for things that are larger than a register....
     int rdwr_block(I2C::i2c_rdwr_ioctl_data *&data);
-    void add_block(const char *name, uint8_t addr, uint8_t len, int8_t mode);
+    void add_block(const char *name, uint8_t addr, uint8_t len, I2CRegisters::RegMode mode);
     void set_block(uint8_t addr, uint8_t *value, uint8_t valuelen);
 
     const char *blockname[256];

--- a/libraries/SITL/SIM_SMBusDevice.cpp
+++ b/libraries/SITL/SIM_SMBusDevice.cpp
@@ -37,14 +37,16 @@ int SITL::SMBusDevice::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
     return -1;
 }
 
-void SITL::SMBusDevice::add_block(const char *name, uint8_t reg, int8_t mode)
+void SITL::SMBusDevice::add_block(const char *name, uint8_t reg, I2CRegisters::RegMode mode)
 {
     // ::fprintf(stderr, "Adding block %u (0x%02x) (%s)\n", reg, reg, name);
     blockname[reg] = name;
-    if (mode == O_RDONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::RDONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         readable_blocks.set((uint8_t)reg);
     }
-    if (mode == O_WRONLY || mode == O_RDWR) {
+    if (mode == I2CRegisters::RegMode::WRONLY ||
+        mode == I2CRegisters::RegMode::RDWR) {
         writable_blocks.set((uint8_t)reg);
     }
 }

--- a/libraries/SITL/SIM_SMBusDevice.h
+++ b/libraries/SITL/SIM_SMBusDevice.h
@@ -32,14 +32,13 @@ protected:
     int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
 
     void set_block(uint8_t block, uint8_t *value, uint8_t valuelen);
-    void add_block(const char *name, uint8_t reg, int8_t mode);
+    void add_block(const char *name, uint8_t reg, I2CRegisters::RegMode mode);
 
     void set_block(uint8_t block, const char *value) {
         set_block(block, (uint8_t*)value, strlen(value));
     }
 
-
-    void add_register(const char *name, uint8_t reg, int8_t mode) {
+    void add_register(const char *name, uint8_t reg, I2CRegisters::RegMode mode) {
         I2CRegisters_16Bit::add_register(name, reg, mode);
     }
 

--- a/libraries/SITL/SIM_ToshibaLED.h
+++ b/libraries/SITL/SIM_ToshibaLED.h
@@ -14,10 +14,10 @@ class ToshibaLED : public I2CDevice, protected I2CRegisters_8Bit
 {
 public:
     void init() override {
-        add_register("PWM0", ToshibaLEDDevReg::PWM0, O_WRONLY);
-        add_register("PWM1", ToshibaLEDDevReg::PWM1, O_WRONLY);
-        add_register("PWM2", ToshibaLEDDevReg::PWM2, O_WRONLY);
-        add_register("ENABLE", ToshibaLEDDevReg::ENABLE, O_WRONLY);
+        add_register("PWM0", ToshibaLEDDevReg::PWM0, I2CRegisters::RegMode::WRONLY);
+        add_register("PWM1", ToshibaLEDDevReg::PWM1, I2CRegisters::RegMode::WRONLY);
+        add_register("PWM2", ToshibaLEDDevReg::PWM2, I2CRegisters::RegMode::WRONLY);
+        add_register("ENABLE", ToshibaLEDDevReg::ENABLE, I2CRegisters::RegMode::WRONLY);
     }
 
     void update(const class Aircraft &aircraft) override;


### PR DESCRIPTION
Swiping `O_RDWR` / `O_WRONLY` / `O_RDONLY` was really just a convenient shortcut which this now undoes.
