### PR TITLE
Plane/SpdHgtCtrl/TECS: we should never talk directly to TECS

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1459,18 +1459,18 @@ void QuadPlane::update_transition(void)
         // set a single loop pitch limit in TECS
         if (plane.ahrs.groundspeed() < 3) {
             // until we have some ground speed limit to zero pitch
-            plane.TECS_controller.set_pitch_max_limit(0);
+            plane.SpdHgt_Controller->set_pitch_max_limit(0);
         } else {
-            plane.TECS_controller.set_pitch_max_limit(transition_pitch_max);
+            plane.SpdHgt_Controller->set_pitch_max_limit(transition_pitch_max);
         }
     } else if (transition_state < TRANSITION_DONE) {
-        plane.TECS_controller.set_pitch_max_limit((transition_pitch_max+1)*2);
+        plane.SpdHgt_Controller->set_pitch_max_limit((transition_pitch_max+1)*2);
     }
     if (transition_state < TRANSITION_DONE) {
         // during transition we ask TECS to use a synthetic
         // airspeed. Otherwise the pitch limits will throw off the
         // throttle calculation which is driven by pitch
-        plane.TECS_controller.use_synthetic_airspeed();
+        plane.SpdHgt_Controller->use_synthetic_airspeed();
     }
     
     switch (transition_state) {
@@ -2871,7 +2871,7 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
         return false;
     }
     transition_state = tailsitter.enabled() ? TRANSITION_ANGLE_WAIT_FW : TRANSITION_AIRSPEED_WAIT;
-    plane.TECS_controller.set_pitch_max_limit(transition_pitch_max);
+    plane.SpdHgt_Controller->set_pitch_max_limit(transition_pitch_max);
 
     // todo: why are you doing this, I want to delete it.
     set_alt_target_current();

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -74,6 +74,12 @@ public:
     // set propulsion failed flag
     virtual void set_propulsion_failed_flag(bool propulsion_failed) = 0;
 
+    // set pitch max limit in degrees
+    virtual void set_pitch_max_limit(int8_t pitch_limit) = 0;
+
+    // force use of synthetic airspeed for one loop
+    virtual void use_synthetic_airspeed(void) = 0;
+
 	// add new controllers to this enum. Users can then
 	// select which controller to use by setting the
 	// SPDHGT_CONTROLLER parameter

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -123,12 +123,12 @@ public:
 
 
     // set pitch max limit in degrees
-    void set_pitch_max_limit(int8_t pitch_limit) {
+    void set_pitch_max_limit(int8_t pitch_limit) override {
         _pitch_max_limit = pitch_limit;
     }
 
     // force use of synthetic airspeed for one loop
-    void use_synthetic_airspeed(void) {
+    void use_synthetic_airspeed(void) override {
         _use_synthetic_airspeed_once = true;
     }
 


### PR DESCRIPTION
Removes some (all?) remaining instances of directly interacting with TECS.