### PR TITLE
GCS_MAVLink: unify DO_SET_CAM_TRIG_DIST for missions and cmd_long

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3037,6 +3037,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_camera(const mavlink_command_long_t &pack
         break;
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
         camera->set_trigger_distance(packet.param1);
+        if (is_equal(packet.param3, 1.0f)) {
+            camera->take_picture();
+        }
         result = MAV_RESULT_ACCEPTED;
         break;
     default:


### PR DESCRIPTION
PR https://github.com/ArduPilot/ardupilot/pull/13791, merged March 2020, added DO_SET_CAM_TRIG_DIST instant trigger capability to match [mavlink spec](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1061) but it only added it to mission int. This PR adds it to command_long too.
