### PR TITLE
HAL_ChibiOS: use a 16 bit sysinterval_t on 16 bit timers

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
@@ -99,7 +99,7 @@ extern "C" {
  * @note    Allowed values are 16, 32 or 64 bits.
  */
 #if !defined(CH_CFG_INTERVALS_SIZE)
-#define CH_CFG_INTERVALS_SIZE               32
+#define CH_CFG_INTERVALS_SIZE               CH_CFG_ST_RESOLUTION
 #endif
 
 /**

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -33,6 +33,7 @@ static_assert(sizeof(systime_t) == 2, "expected 16 bit systime_t");
 #elif CH_CFG_ST_RESOLUTION == 32
 static_assert(sizeof(systime_t) == 4, "expected 32 bit systime_t");
 #endif
+static_assert(sizeof(systime_t) == sizeof(sysinterval_t), "expected systime_t same size as sysinterval_t");
 
 #if defined(HAL_EXPECTED_SYSCLOCK)
 #ifdef STM32_SYS_CK


### PR DESCRIPTION
prevent mixed size subtraction errors.

@MichelleRos can you please test this on BraveHeart to see if it changes the 68ms delay bug

note: while this is marked for 4.1 backport, I think we should have it in master for at least 4 weeks before considering it for stable