### PR TITLE
Copter: fix takeoff end report on EXTEND_STATE

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -270,7 +270,7 @@ void ModeGuided::posvelaccel_control_start()
 
 bool ModeGuided::is_taking_off() const
 {
-    return guided_mode == SubMode::TakeOff;
+    return guided_mode == SubMode::TakeOff && !takeoff_complete;
 }
 
 // initialise guided mode's angle controller


### PR DESCRIPTION
regression from https://github.com/ArduPilot/ardupilot/pull/18700.
thanks to @arduouspilot on discuss to notice this, see https://discuss.ardupilot.org/t/extended-sys-state-never-changes-once-guided-takeoff-is-started/76996/3

Tested on SITL by sending takeoff cmd on guided, at the end of the takeoff, we are now switching landed_state to 2 to notify that the takeoff sequence end