### PR TITLE
Copter: Send ESC telemetry over mavlink while doing compassmot

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -224,6 +224,10 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
                                                motor_compensation[0].x,
                                                motor_compensation[0].y,
                                                motor_compensation[0].z);
+#if HAL_WITH_ESC_TELEM
+            // send ESC telemetry to monitor ESC and motor temperatures
+            AP::esc_telem().send_esc_telemetry_mavlink(gcs_chan.get_chan());
+#endif
         }
     }
 


### PR DESCRIPTION
compassmot can be used to bypass all PID control loops (this avoids forwarding IMU noise to the motors) while stress-testing the ESCs+motors.
So that temperatures can be monitored in real-time during those long tests, send ESC telemetry as well.