### PR TITLE
HAL_ChibiOS: make it clear how to enable parameter backup on CubeBlack

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
@@ -90,3 +90,9 @@ PA8 nVDD_5V_PERIPH_EN OUTPUT HIGH
 # means sensors off, then it is pulled HIGH in peripheral_power_enable()
 undef PE3
 PE3 VDD_3V3_SENSORS_EN OUTPUT LOW
+
+# if you want to enable parameter backup/restore then uncomment the following two lines
+# Note: this will use 16k more RAM, so ensure you have enough by looking at MEMINFO messages
+# in MAVLink2 or in PM message in logs
+# undef HAL_STORAGE_SIZE
+# define HAL_STORAGE_SIZE 32768


### PR DESCRIPTION
uses 16k more ram, but allows auto-restore of corrupted params