### PR TITLE
Compass: use GSF for in-flight compass learning

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3132,6 +3132,31 @@ enum Rotation AP_AHRS::get_view_rotation(void) const
     return _view?_view->get_rotation():ROTATION_NONE;
 }
 
+// check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
+const EKFGSF_yaw *AP_AHRS::get_yaw_estimator(void) const
+{
+    switch (active_EKF_type()) {
+#if HAL_NAVEKF2_AVAILABLE
+    case EKFType::TWO:
+        return EKF2.get_yawEstimator();
+#endif
+    case EKFType::NONE:
+#if HAL_NAVEKF3_AVAILABLE
+    case EKFType::THREE:
+        return EKF3.get_yawEstimator();
+#endif
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    case EKFType::SIM:
+#endif
+#if HAL_EXTERNAL_AHRS_ENABLED
+    case EKFType::EXTERNAL:
+#endif
+        return nullptr;
+    }
+    // since there is no default case above, this is unreachable
+    return nullptr;
+}
+
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -53,6 +53,9 @@ class AP_AHRS_View;
 
 #include <AP_NMEA_Output/AP_NMEA_Output.h>
 
+// fwd declare GSF estimator
+class EKFGSF_yaw;
+
 class AP_AHRS {
     friend class AP_AHRS_View;
 public:
@@ -593,6 +596,9 @@ public:
 
     // get the view's rotation, or ROTATION_NONE
     enum Rotation get_view_rotation(void) const;
+
+    // get access to an EKFGSF_yaw estimator
+    const EKFGSF_yaw *get_yaw_estimator(void) const;
 
 private:
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -336,7 +336,8 @@ public:
       fast compass calibration given vehicle position and yaw
      */
     MAV_RESULT mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
-                                 float lat_deg, float lon_deg);
+                                 float lat_deg, float lon_deg,
+                                 bool force_use=false);
 
 #if HAL_MSP_COMPASS_ENABLED
     void handle_msp(const MSP::msp_compass_data_message_t &pkt);

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -483,7 +483,7 @@ bool Compass::get_uncorrected_field(uint8_t instance, Vector3f &field) const
   This assumes that the compass is correctly scaled in milliGauss
 */
 MAV_RESULT Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
-                                      float lat_deg, float lon_deg)
+                                      float lat_deg, float lon_deg, bool force_use)
 {
     _reset_compass_id();
     if (is_zero(lat_deg) && is_zero(lon_deg)) {
@@ -526,7 +526,7 @@ MAV_RESULT Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
             // skip this compass
             continue;
         }
-        if (!use_for_yaw(i)) {
+        if (!force_use && !use_for_yaw(i)) {
             continue;
         }
         if (!healthy(i)) {

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -1,37 +1,25 @@
-#include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>
 
 #include <AP_Compass/AP_Compass.h>
-#include <AP_Declination/AP_Declination.h>
-#include <AP_Logger/AP_Logger.h>
 
 #include "Compass_learn.h"
 #include <GCS_MAVLink/GCS.h>
-
-#include <stdio.h>
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_NavEKF/EKFGSF_yaw.h>
 
 #if COMPASS_LEARN_ENABLED
 
 extern const AP_HAL::HAL &hal;
-
-static const uint8_t COMPASS_LEARN_NUM_SAMPLES = 30;
-static const uint8_t COMPASS_LEARN_BEST_ERROR_THRESHOLD = 50;
-static const uint8_t COMPASS_LEARN_WORST_ERROR_THRESHOLD = 65;
 
 // constructor
 CompassLearn::CompassLearn(Compass &_compass) :
     compass(_compass)
 {
     gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: Initialised");
-    for (Compass::Priority i(0); i<compass.get_count(); i++) {
-        if (compass._use_for_yaw[Compass::Priority(i)]) {
-            // reset scale factors, we can't learn scale factors in
-            // flight
-            compass.set_and_save_scale_factor(uint8_t(i), 0.0);
-        }
-    }
 }
+
+// accuracy threshold applied for GSF yaw estimate
+#define YAW_ACCURACY_THRESHOLD_DEG 5.0
 
 /*
   update when new compass sample available
@@ -39,230 +27,42 @@ CompassLearn::CompassLearn(Compass &_compass) :
 void CompassLearn::update(void)
 {
     const AP_Vehicle *vehicle = AP::vehicle();
-    if (converged || compass.get_learn_type() != Compass::LEARN_INFLIGHT ||
-        !hal.util->get_soft_armed() || vehicle->get_time_flying_ms() < 3000) {
+    if (compass.get_learn_type() != Compass::LEARN_INFLIGHT ||
+        !hal.util->get_soft_armed() ||
+        vehicle->get_time_flying_ms() < 3000) {
         // only learn when flying and with enough time to be clear of
         // the ground
         return;
     }
 
-    const AP_AHRS &ahrs = AP::ahrs();
-    if (!have_earth_field) {
-        Location loc;
-        if (!ahrs.get_position(loc)) {
-            // need to wait till we have a global position
-            return;
-        }
-
-        // setup the expected earth field in mGauss at this location
-        mag_ef = AP_Declination::get_earth_field_ga(loc) * 1000;
-        have_earth_field = true;
-
-        // form eliptical correction matrix and invert it. This is
-        // needed to remove the effects of the eliptical correction
-        // when calculating new offsets
-        const Vector3f &diagonals = compass.get_diagonals(0);
-        const Vector3f &offdiagonals = compass.get_offdiagonals(0);
-        mat = Matrix3f(
-            diagonals.x, offdiagonals.x, offdiagonals.y,
-            offdiagonals.x,    diagonals.y, offdiagonals.z,
-            offdiagonals.y, offdiagonals.z,    diagonals.z
-            );
-        if (!mat.invert()) {
-            // if we can't invert, use the identity matrix
-            mat.identity();
-        }
-
-        // set initial error to field intensity
-        float intensity = mag_ef.length();
-        for (uint16_t i=0; i<num_sectors; i++) {
-            errors[i] = intensity;
-        }
-
-        gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: have earth field");
-        hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&CompassLearn::io_timer, void));
+    const auto &ahrs = AP::ahrs();
+    const auto *gsf = ahrs.get_yaw_estimator();
+    if (gsf == nullptr) {
+        // no GSF available
+        return;
+    }
+    if (degrees(fabsf(ahrs.get_pitch())) > 50) {
+        // we don't want to be too close to nose up, or yaw gets
+        // problematic. Tailsitters need to wait till they are in
+        // forward flight
+        return;
     }
 
     AP_Notify::flags.compass_cal_running = true;
 
-    if (sample_available) {
-        // last sample still being processed by IO thread
+    ftype yaw_rad, yaw_variance;
+    if (!gsf->getYawData(yaw_rad, yaw_variance) ||
+        !is_positive(yaw_variance) ||
+        yaw_variance >= sq(radians(YAW_ACCURACY_THRESHOLD_DEG))) {
+        // not converged
         return;
     }
 
-    Vector3f field = compass.get_field(0);
-    Vector3f field_change = field - last_field;
-    if (field_change.length() < min_field_change) {
-        return;
-    }
-
-    {
-        WITH_SEMAPHORE(sem);
-        // give a sample to the backend to process
-        new_sample.field = field;
-        new_sample.offsets = compass.get_offsets(0);
-        new_sample.attitude = Vector3f(ahrs.roll, ahrs.pitch, ahrs.yaw);
-        sample_available = true;
-        last_field = field;
-        num_samples++;
-    }
-
-    if (sample_available) {
-        // @LoggerMessage: COFS
-        // @Description: Current compass learn offsets
-        // @Field: TimeUS: Time since system startup
-        // @Field: OfsX: best learnt offset, x-axis
-        // @Field: OfsY: best learnt offset, y-axis
-        // @Field: OfsZ: best learnt offset, z-axis
-        // @Field: Var: error of best offset vector
-        // @Field: Yaw: best learnt yaw
-        // @Field: WVar: error of best learn yaw
-        // @Field: N: number of samples used
-        AP::logger().WriteStreaming("COFS", "TimeUS,OfsX,OfsY,OfsZ,Var,Yaw,WVar,N", "QffffffI",
-                                               AP_HAL::micros64(),
-                                               (double)best_offsets.x,
-                                               (double)best_offsets.y,
-                                               (double)best_offsets.z,
-                                               (double)best_error,
-                                               (double)best_yaw_deg,
-                                               (double)worst_error,
-                                               num_samples);
-    }
-
-    if (!converged) {
-        WITH_SEMAPHORE(sem);
-
-        // set offsets to current best guess
-        compass.set_offsets(0, best_offsets);
-
-        // set non-primary offsets to match primary
-        Vector3f field_primary = compass.get_field(0);
-        for (uint8_t i=1; i<compass.get_count(); i++) {
-            if (!compass._use_for_yaw[Compass::Priority(i)]) {
-                continue;
-            }
-            Vector3f field2 = compass.get_field(i);
-            Vector3f new_offsets = compass.get_offsets(i) + (field_primary - field2);
-            compass.set_offsets(i, new_offsets);
-        }
-
-        // stop updating the offsets once converged
-        if (num_samples > COMPASS_LEARN_NUM_SAMPLES &&
-            best_error < COMPASS_LEARN_BEST_ERROR_THRESHOLD &&
-            worst_error > COMPASS_LEARN_WORST_ERROR_THRESHOLD) {
-            // set the offsets and enable compass for EKF use. Let the
-            // EKF learn the remaining compass offset error
-            for (uint8_t i=0; i<compass.get_count(); i++) {
-                if (compass._use_for_yaw[Compass::Priority(i)]) {
-                    compass.save_offsets(i);
-                    compass.set_and_save_scale_factor(i, 0.0);
-                }
-            }
-            compass.set_learn_type(Compass::LEARN_NONE, true);
-            // setup so use can trigger it again
-            converged = false;
-            sample_available = false;
-            num_samples = 0;
-            have_earth_field = false;
-            for (auto &v : predicted_offsets) {
-                v.zero();
-            }
-            worst_error = 0;
-            best_error = 0;
-            best_yaw_deg = 0;
-            best_offsets.zero();
-            gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: finished");
-            AP_Notify::flags.compass_cal_running = false;
-            AP_Notify::events.compass_cal_saved = true;
-        }
-    }
-}
-
-/*
-  we run the math intensive calculations in the IO thread
- */
-void CompassLearn::io_timer(void)
-{
-    if (!sample_available) {
-        return;
-    }
-
-    struct sample s;
-
-    {
-        WITH_SEMAPHORE(sem);
-        s = new_sample;
-        sample_available = false;
-    }
-
-    process_sample(s);
-}
-
-/*
-  process a new compass sample
- */
-void CompassLearn::process_sample(const struct sample &s)
-{
-    uint16_t besti = 0;
-    float bestv = 0, worstv=0;
-
-    /*
-      we run through the 72 possible yaw error values, and for each
-      one we calculate a value for the compass offsets if that yaw
-      error is correct. 
-     */
-    for (uint16_t i=0; i<num_sectors; i++) {
-        float yaw_err_deg = i*(360/num_sectors);
-
-        // form rotation matrix for the euler attitude
-        Matrix3f dcm;
-        dcm.from_euler(s.attitude.x, s.attitude.y, wrap_2PI(s.attitude.z + radians(yaw_err_deg)));
-
-        // calculate the field we would expect to get if this yaw error is correct
-        Vector3f expected_field = dcm.transposed() * mag_ef;
-
-        // calculate a value for the compass offsets for this yaw error
-        Vector3f v1 = mat * s.field;
-        Vector3f v2 = mat * expected_field;
-        Vector3f offsets = (v2 - v1) + s.offsets;
-        float delta = (offsets - predicted_offsets[i]).length();
-
-        if (num_samples == 1) {
-            predicted_offsets[i] = offsets;
-        } else {
-            // lowpass the predicted offsets and the error
-            const float learn_rate = 0.92f;
-            predicted_offsets[i] = predicted_offsets[i] * learn_rate + offsets * (1-learn_rate);
-            errors[i] = errors[i] * learn_rate + delta * (1-learn_rate);
-        }
-
-        // keep track of the current best prediction
-        if (i == 0 || errors[i] < bestv) {
-            besti = i;
-            bestv = errors[i];
-        }
-        // also keep the worst error. This is used as part of the convergence test
-        if (i == 0 || errors[i] > worstv) {
-            worstv = errors[i];
-        }
-    }
-
-    WITH_SEMAPHORE(sem);
-
-    // pass the current estimate to the front-end
-    best_offsets = predicted_offsets[besti];
-    best_error = bestv;
-    worst_error = worstv;
-    best_yaw_deg = wrap_360(degrees(s.attitude.z) + besti * (360/num_sectors));
-
-    // send current learn state to gcs
-    const uint32_t now = AP_HAL::millis();
-    if (!converged && now - last_learn_progress_sent_ms >= 5000) {
-        float percent = (MIN(num_samples / COMPASS_LEARN_NUM_SAMPLES, 1.0f) + 
-                         MIN(COMPASS_LEARN_BEST_ERROR_THRESHOLD / (best_error + 1.0f), 1.0f) + 
-                         MIN(worst_error / COMPASS_LEARN_WORST_ERROR_THRESHOLD, 1.0f)) / 3.0f * 100.f;
-        gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: %d%%", (int) percent);
-        last_learn_progress_sent_ms = now;
+    const auto result = compass.mag_cal_fixed_yaw(degrees(yaw_rad), (1U<<HAL_COMPASS_MAX_SENSORS)-1, 0, 0, true);
+    if (result == MAV_RESULT_ACCEPTED) {
+        AP_Notify::flags.compass_cal_running = false;
+        compass.set_learn_type(Compass::LEARN_NONE, true);
+        gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: Finished");
     }
 }
 

--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -3,7 +3,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 
 /*
-  compass learning using magnetic field tables from AP_Declination
+  compass learning using magnetic field tables from AP_Declination and GSF
  */
 
 class CompassLearn {
@@ -15,46 +15,4 @@ public:
 
 private:
     Compass &compass;
-    bool have_earth_field;
-
-    // 5 degree resolution
-    static const uint16_t num_sectors = 72; 
-    
-    Vector3f predicted_offsets[num_sectors];
-    float errors[num_sectors];
-    uint32_t num_samples;
-
-    // earth field
-    Vector3f mag_ef;
-
-    // semaphore for access to shared data with IO thread
-    HAL_Semaphore sem;
-    
-    struct sample {
-        // milliGauss body field and offsets
-        Vector3f field;
-        Vector3f offsets;
-
-        // euler radians attitude
-        Vector3f attitude;
-    };
-
-    Matrix3f mat;
-    
-    struct sample new_sample;
-    bool sample_available;
-    Vector3f last_field;
-    static const uint32_t min_field_change = 60;
-
-    Vector3f best_offsets;
-    float best_error;
-    float best_yaw_deg;
-    float worst_error;
-    bool converged;
-
-    // notification
-    uint32_t last_learn_progress_sent_ms;
-
-    void io_timer(void);
-    void process_sample(const struct sample &s);
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1595,3 +1595,12 @@ void NavEKF2::writeExtNavVelData(const Vector3f &vel, float err, uint32_t timeSt
         }
     }
 }
+
+// get a yaw estimator instance
+const EKFGSF_yaw *NavEKF2::get_yawEstimator(void) const
+{
+    if (core) {
+        return core[primary].get_yawEstimator();
+    }
+    return nullptr;
+}

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -29,6 +29,7 @@
 #include <AP_NavEKF/AP_Nav_Common.h>
 
 class NavEKF2_core;
+class EKFGSF_yaw;
 
 class NavEKF2 {
     friend class NavEKF2_core;
@@ -305,6 +306,9 @@ public:
     // Writes the default equivalent airspeed in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed);
 
+    // get a yaw estimator instance
+    const EKFGSF_yaw *get_yawEstimator(void) const;
+    
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -327,6 +327,9 @@ public:
 
     void Log_Write(uint64_t time_us);
 
+    // get a yaw estimator instance
+    const EKFGSF_yaw *get_yawEstimator(void) const { return yawEstimator; }
+    
 private:
     EKFGSF_yaw *yawEstimator;
     AP_DAL &dal;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -2011,3 +2011,12 @@ bool NavEKF3::isVibrationAffected(int8_t instance) const
     }
     return false;
 }
+
+// get a yaw estimator instance
+const EKFGSF_yaw *NavEKF3::get_yawEstimator(void) const
+{
+    if (core) {
+        return core[primary].get_yawEstimator();
+    }
+    return nullptr;
+}

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -27,6 +27,7 @@
 #include <AP_NavEKF/AP_NavEKF_Source.h>
 
 class NavEKF3_core;
+class EKFGSF_yaw;
 
 class NavEKF3 {
     friend class NavEKF3_core;
@@ -357,6 +358,9 @@ public:
     // returns true when the state estimates for the selected core are significantly degraded by vibration
     // if instance < 0, the primary instance will be used
     bool isVibrationAffected(int8_t instance) const;
+
+    // get a yaw estimator instance
+    const EKFGSF_yaw *get_yawEstimator(void) const;
 
 private:
     uint8_t num_cores; // number of allocated cores

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -421,6 +421,9 @@ public:
     // returns true when the state estimates are significantly degraded by vibration
     bool isVibrationAffected() const { return badIMUdata; }
 
+    // get a yaw estimator instance
+    const EKFGSF_yaw *get_yawEstimator(void) const { return yawEstimator; }
+
 private:
     EKFGSF_yaw *yawEstimator;
     AP_DAL &dal;


### PR DESCRIPTION
This makes inflight compass learning much faster, much more accurate and a lot less flash space
saves 2.1k of flash on F405
The method is to wait for GSF to converge with a max variance of 5 degrees (compared to 15 degrees for normal GSF threshold), then use the GSF yaw to predict the mag field using WMM tables. This field is rotated to body frame and used to create the compass offsets.
This method should work for just about any vehicle type, and will get pretty good offsets within a few seconds of takeoff as long as you have good GPS lock.