### PR TITLE
Ap hygrometer

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -116,6 +116,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if HAL_EFI_ENABLED
     SCHED_TASK(efi_update,             10,    200),
 #endif
+    SCHED_TASK(update_hygrometer,       3,    100),
 };
 
 void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -232,6 +232,33 @@ void GCS_MAVLINK_Plane::send_position_target_global_int()
         0.0f); // yaw_rate
 }
 
+int16_t GCS_MAVLINK_Plane::hygrometer_temp() const
+{
+    static float temperature = 0;
+
+    plane.hygrometer.get_temperature(temperature);
+    return (int16_t)(100*temperature);
+
+}
+
+uint16_t GCS_MAVLINK_Plane::hygrometer_humi() const
+{
+    static float humidity = 0;
+
+    plane.hygrometer.get_humidity(humidity);
+    return (uint16_t)(100*humidity);
+
+}
+
+uint8_t GCS_MAVLINK_Plane::hygrometer_id() const
+{
+    static uint8_t id = 0;
+
+    plane.hygrometer.get_id(id);
+    return id;
+
+}
+
 
 float GCS_MAVLINK_Plane::vfr_hud_airspeed() const
 {
@@ -516,6 +543,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -61,6 +61,9 @@ private:
     float vfr_hud_airspeed() const override;
     int16_t vfr_hud_throttle() const override;
     float vfr_hud_climbrate() const override;
+    int16_t hygrometer_temp() const override;
+    uint16_t hygrometer_humi() const override;
+    uint8_t hygrometer_id() const override;
     
 #if HAL_HIGH_LATENCY2_ENABLED
     int16_t high_latency_target_altitude() const override;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -995,6 +995,10 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_Vehicle/AP_Vehicle.cpp
     { AP_PARAM_GROUP, "", Parameters::k_param_vehicle, (const void *)&plane, {group_info : AP_Vehicle::var_info} },
 
+    // @Group: HYGRO
+    // @Path: ../libraries/AP_Hygrometer/AP_Hygrometer.cpp
+    GOBJECT(hygrometer, "HYGRO",   AP_Hygrometer),
+
     AP_VAREND
 };
 
@@ -1225,7 +1229,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15
     AP_GROUPINFO("ONESHOT_MASK", 32, ParametersG2, oneshot_mask, 0),
-    
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -351,6 +351,8 @@ public:
         k_param_gcs5,          // stream rates
         k_param_gcs6,          // stream rates
         k_param_fence,         // vehicle fence
+
+        k_param_hygrometer = 262,
     };
 
     AP_Int16 format_version;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -46,6 +46,7 @@
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Stats/AP_Stats.h>     // statistics library
 #include <AP_Beacon/AP_Beacon.h>
+#include <AP_Hygrometer/AP_Hygrometer.h>
 
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <APM_Control/APM_Control.h>
@@ -413,6 +414,9 @@ private:
 
     // Airspeed Sensors
     AP_Airspeed airspeed;
+
+    // Hygrometer Sensors
+    AP_Hygrometer hygrometer;
 
     // ACRO controller state
     struct {
@@ -1037,6 +1041,7 @@ private:
     void read_rangefinder(void);
     void read_airspeed(void);
     void rpm_update(void);
+    void update_hygrometer(void);
 
     // system.cpp
     void init_ardupilot() override;

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -65,3 +65,8 @@ void Plane::rpm_update(void)
         }
     }
 }
+
+void Plane::update_hygrometer(void)
+{
+    hygrometer.update_hygrometer_log(1);
+}

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -83,6 +83,9 @@ void Plane::init_ardupilot()
     // initialise airspeed sensor
     airspeed.init();
 
+    // initialise hygrometer sensor
+    hygrometer.init();
+
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -107,6 +107,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_ExternalAHRS',
     'AP_VideoTX',
     'AP_FETtecOneWire',
+    'AP_Torqeedo',
     'AP_Hygrometer',
 ]
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -107,6 +107,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_ExternalAHRS',
     'AP_VideoTX',
     'AP_FETtecOneWire',
+    'AP_Hygrometer',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_Hygrometer/AP_Hygrometer.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.cpp
@@ -1,0 +1,199 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+#include "AP_Hygrometer.h"
+#include "AP_Hygrometer_Backend.h"
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include "AP_Hygrometer_UAVCAN.h"
+#endif
+
+
+#ifdef HAL_HYGROMETER_TYPE_DEFAULT
+ #define HYGRO_DEFAULT_TYPE HAL_HYGROMETER_TYPE_DEFAULT
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+ #define HYGRO_DEFAULT_TYPE TYPE_NONE
+#elif APM_BUILD_TYPE(APM_BUILD_Rover) || APM_BUILD_TYPE(APM_BUILD_ArduSub) 
+ #define HYGRO_DEFAULT_TYPE TYPE_NONE
+#else
+ #define HYGRO_DEFAULT_TYPE TYPE_UAVCAN
+#endif
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Hygrometer::var_info[] = {
+
+    // @Param: _TYPE
+    // @DisplayName: Hygrometer type
+    // @Description: Type of hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Hygrometer, param[0].type, HYGRO_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+
+
+#if HYGROMETER_MAX_SENSORS > 1
+    // @Param: _PRIMARY
+    // @DisplayName: Primary hygrometer sensor
+    // @Description: This selects which hygrometer sensor will be the primary if multiple sensors are found
+    // @Values: 0:FirstSensor,1:2ndSensor
+    // @User: Advanced
+    AP_GROUPINFO("_PRIMARY", 1, AP_Hygrometer, primary_sensor, 0),
+#endif
+
+#if HYGROMETER_MAX_SENSORS > 1
+    // @Param: 2_TYPE
+    // @DisplayName: Second Hygrometer type
+    // @Description: Type of 2nd hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("2_TYPE", 2, AP_Hygrometer, param[1].type, 0, AP_PARAM_FLAG_ENABLE),
+
+
+#endif // HYGROMETER_MAX_SENSORS
+
+    AP_GROUPEND
+};
+
+
+void AP_Hygrometer::init(void)
+{
+    if (sensor[0] != nullptr) {
+        // already initialised
+        return;
+    }
+    
+    for (uint8_t i=0; i<HYGROMETER_MAX_SENSORS; i++) {
+
+         switch ((enum hygrometer_type)param[i].type.get()) {
+             case TYPE_NONE:
+                // nothing to do
+                break;
+             case TYPE_UAVCAN:
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS    
+printf("case uavcan\n");
+    sensor[i] = AP_Hygrometer_UAVCAN::probe(*this, i);
+#endif
+                break;
+         }
+        if (sensor[i] && !sensor[i]->init()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Hygrometer %u init failed", i + 1);
+            delete sensor[i];
+            sensor[i] = nullptr;
+        }
+        if (sensor[i] != nullptr) {
+            num_sensors = i+1;
+        }
+    }
+}
+
+
+AP_Hygrometer::AP_Hygrometer()
+{
+
+}
+
+bool AP_Hygrometer::get_humidity(uint8_t i, float &humidity)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_humidity(humidity);
+    }
+
+    return false;
+}
+
+bool AP_Hygrometer::get_temperature(uint8_t i, float &temperature)
+{
+    if (!enabled(i)) {
+        return false;
+
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_temperature(temperature);
+    }
+
+    return false;
+}
+
+bool AP_Hygrometer::get_id(uint8_t i, uint8_t &id)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_id(id);
+    }
+    return false;
+}
+
+
+void AP_Hygrometer::Log_Hygrometer()
+{
+    const uint64_t now = AP_HAL::micros64();
+    for (uint8_t i=0; i<HYGROMETER_MAX_SENSORS; i++) {
+        if (!enabled(i)) {
+            continue;
+        }
+        float temperature,humidity;
+        if (!get_temperature(i, temperature)) {
+            temperature = 0;
+        }
+        if (!get_humidity(i, humidity)) {
+            humidity = 0;
+        }
+
+        state[i].temperature = temperature;
+        state[i].humidity = humidity;
+
+            printf(" temperature[%d] = %f\n",i,temperature);
+            printf(" humidity[%d] = %f\n",i,humidity);
+
+
+
+        const struct log_HYGRO pkt{
+            LOG_PACKET_HEADER_INIT(LOG_HYGRO_MSG),
+            time_us       : now,
+            instance      : i,
+            temperature   : (int16_t)(state[i].temperature * 100.0f),
+            humidity      : (uint16_t)(state[i].humidity * 100.0f),
+            primary       : get_primary()
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    }
+}
+
+
+//update the log
+void AP_Hygrometer::update_hygrometer_log(bool log)
+{
+
+#ifndef HAL_NO_GCS
+    // debugging until we get MAVLink support for 2nd hygrometer sensor
+    if (enabled(1)) {
+        gcs().send_named_float("HY2_T", get_temperature_log(1));
+        gcs().send_named_float("HY2_H", get_humidity_log(1));
+    }
+#endif
+
+#ifndef HAL_BUILD_AP_PERIPH
+    if (log) {
+        Log_Hygrometer();
+    }
+#endif
+}

--- a/libraries/AP_Hygrometer/AP_Hygrometer.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stdint.h>
+#include "stdio.h"
+#include <AP_Param/AP_Param.h>
+
+#ifndef HYGROMETER_MAX_SENSORS
+#define HYGROMETER_MAX_SENSORS  2
+#endif
+
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer
+{
+public:
+    friend class AP_Hygrometer_Backend;
+
+    // constructor
+    AP_Hygrometer();
+
+    void init(void);
+
+    bool get_temperature(uint8_t i, float &temperature);
+    bool get_temperature(float &temperature) { return get_temperature(primary, temperature); }
+
+    bool get_humidity(uint8_t i, float &humidity);
+    bool get_humidity(float &humidity) { return get_humidity(primary, humidity); }
+
+    bool get_id(uint8_t i, uint8_t &id); 
+    bool get_id(uint8_t &id) { return get_id(primary, id); }
+
+    // return true if hygrometer is enabled
+    bool enabled(uint8_t i) const {
+        if (i < HYGROMETER_MAX_SENSORS) {
+             return param[i].type.get() != TYPE_NONE;
+        }
+        return false;
+    }
+    bool enabled(void) const { return enabled(primary); }
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    enum hygrometer_type {
+        TYPE_NONE=0,
+        TYPE_UAVCAN=1,
+    };
+
+    // get current primary sensor
+    uint8_t get_primary(void) const { return primary; }
+
+
+     
+    float get_temperature_log(uint8_t i) const {
+        return state[i].temperature;
+    }
+
+    float get_humidity_log(uint8_t i) const {
+        return state[i].humidity;
+    }
+
+    void update_hygrometer_log(bool log);
+    void Log_Hygrometer(void);
+
+private:
+
+    AP_Int8 primary_sensor;
+
+    struct {
+        AP_Int8  type;
+    } param[HYGROMETER_MAX_SENSORS];
+
+    struct {
+        float temperature;
+        float humidity;
+
+    }state[HYGROMETER_MAX_SENSORS];
+
+    // current primary sensor
+    uint8_t primary;
+    uint8_t num_sensors;
+
+    AP_Hygrometer_Backend *sensor[HYGROMETER_MAX_SENSORS];
+};

--- a/libraries/AP_Hygrometer/AP_Hygrometer_Backend.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_Backend.cpp
@@ -1,0 +1,29 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "AP_Hygrometer_Backend.h"
+#include "AP_Hygrometer.h"
+
+AP_Hygrometer_Backend::AP_Hygrometer_Backend(AP_Hygrometer &_frontend, uint8_t _instance) :
+    frontend(_frontend),
+    instance(_instance)
+{
+}
+
+
+AP_Hygrometer_Backend::~AP_Hygrometer_Backend(void)
+{
+}

--- a/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Hygrometer.h"
+
+class AP_Hygrometer_Backend
+{
+public:
+    AP_Hygrometer_Backend(AP_Hygrometer &frontend, uint8_t instance);
+    virtual ~AP_Hygrometer_Backend();
+
+    // probe and initialise the sensor
+    virtual bool init(void) = 0;
+
+    virtual bool get_humidity(float &humidity) = 0;
+
+    virtual bool get_temperature(float &temperature) = 0;
+
+    virtual bool get_id(uint8_t &id) = 0;
+
+private:
+    AP_Hygrometer &frontend;
+    uint8_t instance;
+};

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
@@ -1,0 +1,189 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+
+#include "AP_Hygrometer_UAVCAN.h"
+#include "AP_Hygrometer.h"
+#include <cuav/equipment/hygrometer/Hygrometer.hpp>
+#include <AP_CANManager/AP_CANManager.h>
+
+#define LOG_TAG "Hygrometer"
+#define C_TO_KELVIN 273.15f
+
+UC_REGISTRY_BINDER(HygrometerCb, cuav::equipment::hygrometer::Hygrometer);
+
+AP_Hygrometer_UAVCAN::DetectedModules AP_Hygrometer_UAVCAN::_detected_modules[] = {0};
+HAL_Semaphore AP_Hygrometer_UAVCAN::_sem_registry;
+
+
+AP_Hygrometer_UAVCAN::AP_Hygrometer_UAVCAN(AP_Hygrometer &_frontend, uint8_t _instance) :
+    AP_Hygrometer_Backend(_frontend, _instance)
+{}
+
+
+void AP_Hygrometer_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
+{
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+
+    auto* node = ap_uavcan->get_node();
+
+    uavcan::Subscriber<cuav::equipment::hygrometer::Hygrometer, HygrometerCb> *hygrometer_listener;
+    hygrometer_listener = new uavcan::Subscriber<cuav::equipment::hygrometer::Hygrometer, HygrometerCb>(*node);
+
+    const int hygrometer_listener_res = hygrometer_listener->start(HygrometerCb(ap_uavcan, &handle_hygrometer));
+
+    if (hygrometer_listener_res < 0) {
+        AP_HAL::panic("UAVCAN hygrometer subscriber start problem\n");
+    }
+}
+
+
+AP_Hygrometer_Backend* AP_Hygrometer_UAVCAN::probe(AP_Hygrometer &_frontend, uint8_t _instance)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* backend = nullptr;
+
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver == nullptr && _detected_modules[i].ap_uavcan != nullptr) {
+            backend = new AP_Hygrometer_UAVCAN(_frontend, _instance);
+            if (backend == nullptr) {
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Failed register UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            } else {
+                _detected_modules[i].driver = backend;
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Registered UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            }
+            break;
+        }
+    }
+    return backend;
+}
+
+
+AP_Hygrometer_UAVCAN* AP_Hygrometer_UAVCAN::get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id)
+{
+    if (ap_uavcan == nullptr) {
+        return nullptr;
+    }
+
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver != nullptr &&
+            _detected_modules[i].ap_uavcan == ap_uavcan &&
+            _detected_modules[i].node_id == node_id ) {
+            return _detected_modules[i].driver;
+        }
+    }
+
+    bool detected = false;
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].ap_uavcan == ap_uavcan && _detected_modules[i].node_id == node_id) {
+            detected = true;
+            break;
+        }
+    }
+
+    if (!detected) {
+        for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+            if (_detected_modules[i].ap_uavcan == nullptr) {
+                _detected_modules[i].ap_uavcan = ap_uavcan;
+                _detected_modules[i].node_id = node_id;
+                break;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+
+void AP_Hygrometer_UAVCAN::handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* driver = get_uavcan_backend(ap_uavcan, node_id);
+
+    if (driver != nullptr) {
+        WITH_SEMAPHORE(driver->_sem_hygrometer);
+        driver->_humidity = cb.msg->humidity;
+        if (!isnan(cb.msg->temperature))  {
+            driver->_temperature = cb.msg->temperature - C_TO_KELVIN;
+        }
+        driver->_id = cb.msg->id;
+        driver->_last_sample_time_ms = AP_HAL::millis();
+    }
+}
+
+
+bool AP_Hygrometer_UAVCAN::get_humidity(float &humidity)
+{
+
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+
+    humidity = _humidity;
+    return true;
+}
+
+
+bool AP_Hygrometer_UAVCAN::get_temperature(float &temperature)
+{
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+
+    temperature = _temperature;
+    return true;
+}
+
+
+bool AP_Hygrometer_UAVCAN::get_id(uint8_t &id)
+{
+
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+
+    id = _id;
+    return true;
+}
+
+bool AP_Hygrometer_UAVCAN::init()
+{
+    // always returns true
+    return true;
+}
+
+#endif // HAL_ENABLE_LIBUAVCAN_DRIVERS

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <AP_UAVCAN/AP_UAVCAN.h>
+
+#include "AP_Hygrometer_Backend.h"
+
+class HygrometerCb;
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer_UAVCAN : public AP_Hygrometer_Backend{
+public:
+    // constructor
+    AP_Hygrometer_UAVCAN(AP_Hygrometer &_frontend, uint8_t _instance);
+
+    bool init(void) override;
+
+    bool get_humidity(float &humidity) override;
+    bool get_temperature(float &temperature) override;
+    bool get_id(uint8_t &id) override;
+
+    static void handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb);
+
+    static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
+
+    static AP_Hygrometer_Backend* probe(AP_Hygrometer &_frontend, uint8_t _instance);
+
+private:
+    float _humidity;
+    float _temperature;
+    uint8_t _id;
+    uint32_t _last_sample_time_ms;
+
+    static  AP_Hygrometer_UAVCAN* get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id);
+
+    HAL_Semaphore _sem_hygrometer;
+
+    // Module Detection Registry
+    static struct DetectedModules {
+        AP_UAVCAN* ap_uavcan;
+        uint8_t node_id;
+        AP_Hygrometer_UAVCAN *driver;
+    } _detected_modules[HYGROMETER_MAX_SENSORS];
+
+    static HAL_Semaphore _sem_registry;
+};

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -478,6 +478,16 @@ struct PACKED log_ARSP {
     uint8_t primary;
 };
 
+struct PACKED log_HYGRO {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    int16_t temperature;
+    uint16_t   humidity;
+    uint8_t primary;
+};
+
+
 struct PACKED log_MAV_Stats {
     LOG_PACKET_HEADER;
     uint64_t timestamp;
@@ -870,6 +880,14 @@ struct PACKED log_STAK {
 // @Field: flags: compact representation of some stage of the channel
 // @Field: ss: stream slowdown is the number of ms being added to each message to fit within bandwidth
 // @Field: tf: times buffer was full when a message was going to be sent
+
+// @LoggerMessage: HYGRO
+// @Description: Hygrometer sensor data
+// @Field: TimeUS: Time since system startup
+// @Field: I: Hygrometer sensor instance number
+// @Field: Temp: Current temperature
+// @Field: Humi: Current humidity
+// @Field: Pri: True if sensor is the primary sensor
 
 // @LoggerMessage: MAVC
 // @Description: MAVLink command we have just executed
@@ -1318,7 +1336,9 @@ LOG_STRUCTURE_FROM_VISUALODOM \
       "PSCD", "Qffffffff", "TimeUS,TPD,PD,DVD,TVD,VD,DAD,TAD,AD", "smmnnnooo", "F00000000" }, \
     { LOG_STAK_MSG, sizeof(log_STAK), \
       "STAK", "QBBHHN", "TimeUS,Id,Pri,Total,Free,Name", "s#----", "F-----", true }, \
-LOG_STRUCTURE_FROM_AIS \
+LOG_STRUCTURE_FROM_AIS, \
+    { LOG_HYGRO_MSG, sizeof(log_HYGRO), \
+      "HYGR", "QBcCB", "TimeUS,I,Temp,Humi,Pri", "s#O%-", "F-BB-", true } \
 
 // message types 0 to 63 reserved for vehicle specific use
 
@@ -1396,6 +1416,7 @@ enum LogMessages : uint8_t {
     LOG_IDS_FROM_PRECLAND,
     LOG_IDS_FROM_AIS,
     LOG_STAK_MSG,
+    LOG_HYGRO_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -57,6 +57,7 @@
 #include <AP_ADSB/AP_ADSB.h>
 #include "AP_UAVCAN_DNA_Server.h"
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Hygrometer/AP_Hygrometer_UAVCAN.h>
 
 #define LED_DELAY_US 50000
 
@@ -292,6 +293,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     AP_Airspeed_UAVCAN::subscribe_msgs(this);
     AP_OpticalFlow_HereFlow::subscribe_msgs(this);
     AP_RangeFinder_UAVCAN::subscribe_msgs(this);
+    AP_Hygrometer_UAVCAN::subscribe_msgs(this);
 
     act_out_array[driver_index] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*_node);
     act_out_array[driver_index]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(2));

--- a/libraries/AP_UAVCAN/dsdl/cuav/equipment/hygrometer/20400.Hygrometer.uavcan
+++ b/libraries/AP_UAVCAN/dsdl/cuav/equipment/hygrometer/20400.Hygrometer.uavcan
@@ -1,0 +1,7 @@
+#
+# support for hygrometer sensors on UAVCAN
+#
+
+float16 temperature
+float16 humidity
+uint8 id

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -283,6 +283,7 @@ public:
     void send_rc_channels() const;
     void send_rc_channels_raw() const;
     void send_raw_imu();
+    void send_hygrometer();
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature, int16_t temperature_press_diff));
     void send_scaled_pressure();
@@ -577,6 +578,10 @@ protected:
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
+
+    virtual int16_t hygrometer_temp() const;
+    virtual uint16_t hygrometer_humi() const;
+    virtual uint8_t hygrometer_id() const;
 
 #if HAL_HIGH_LATENCY2_ENABLED
     virtual int16_t high_latency_target_altitude() const { return 0; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -890,6 +890,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_WATER_DEPTH,           MSG_WATER_DEPTH},
         { MAVLINK_MSG_ID_HIGH_LATENCY2,         MSG_HIGH_LATENCY2},
         { MAVLINK_MSG_ID_AIS_VESSEL,            MSG_AIS_VESSEL},
+        { MAVLINK_MSG_ID_HYGROMETER_SENSOR,     MSG_HYGROMETER_STATUS},
             };
 
     for (uint8_t i=0; i<ARRAY_SIZE(map); i++) {
@@ -2699,6 +2700,29 @@ void GCS_MAVLINK::send_accelcal_vehicle_position(uint32_t position)
     }
 }
 
+int16_t GCS_MAVLINK::hygrometer_temp() const
+{
+    return 0;
+}
+
+uint16_t GCS_MAVLINK::hygrometer_humi() const
+{
+    return 0;
+}
+
+uint8_t GCS_MAVLINK::hygrometer_id() const
+{
+    return 0;
+}
+
+void GCS_MAVLINK::send_hygrometer()
+{
+    mavlink_msg_hygrometer_sensor_send(
+        chan,
+        hygrometer_id(),
+        hygrometer_temp(),
+        hygrometer_humi());
+}
 
 float GCS_MAVLINK::vfr_hud_airspeed() const
 {
@@ -5105,6 +5129,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_RAW_IMU:
         CHECK_PAYLOAD_SIZE(RAW_IMU);
         send_raw_imu();
+        break;
+
+    case MSG_HYGROMETER_STATUS:
+        CHECK_PAYLOAD_SIZE(HYGROMETER_SENSOR);
+        send_hygrometer();
         break;
 
     case MSG_SCALED_IMU:

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -80,5 +80,6 @@ enum ap_message : uint8_t {
     MSG_HIGH_LATENCY2,
     MSG_AIS_VESSEL,
     MSG_MCU_STATUS,
+    MSG_HYGROMETER_STATUS,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
The flight controller receive the hygrometer message from CAN device and flight controller send hygrometer message to the ground station.

We can use 2 hygrometer sensors by setting parameter of HYGROx_TYPE: 0:None,1:UAVCAN.

background:
CUAV developed a new airspeed sensor that can be heated.The airspeed sensor heats up according to the set temperature, so as to prevent airspeed failure due to ice on the head of the airspeed sensor when the fixed-wing UAV is used in high and cold places.The temperature and humidity sensor is used to detect the temperature and humidity of the pitot tube head. If the measured temperature is lower than the set temperature, the airspeed sensor will enable heating to prevent ice.

The value shows in MissionPlanner.
![1634172970072_1B98CE1F-5E3E-438e-AB70-DDB813E36C55](https://user-images.githubusercontent.com/69180601/137289415-0692196c-692e-48f3-8e49-d4dbb84c68d3.png)
The log:
[AP_Hygrometer.zip](https://github.com/ArduPilot/ardupilot/files/7344778/AP_Hygrometer.zip)

