### PR TITLE
AP_HAL_ChibiOS: account for TXFIFO when doing flow control detection

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1135,9 +1135,18 @@ void UARTDriver::write_pending_bytes(void)
             // remaining queue space
             uint32_t space = qSpaceI(&((SerialDriver*)sdef.serial)->oqueue);
             uint32_t used = SERIAL_BUFFERS_SIZE - space;
+
+#if !defined(USART_CR1_FIFOEN)
             // threshold is 8 for the GCS_Common code to unstick SiK radios, which
             // sends 6 bytes with flow control disabled
             const uint8_t threshold = 8;
+#else
+            // account for TX FIFO buffer
+            uint8_t threshold = 12;
+            if (_last_options & OPTION_NOFIFO) {
+                threshold = 8;
+            }
+#endif
             if (_total_written > used && _total_written - used > threshold) {
                 _flow_control = FLOW_CONTROL_ENABLE;
                 return;


### PR DESCRIPTION
Fixes issue of detecting flow control for MCUs with FIFO buffer. Since the bytes were getting popped from tx queue to peripherals FIFO false detection as flow control as enabled was being made but no data was getting on the line successfully. The issue was detected in Lightware SF20 Telem 1 and 2 on CubeOrange.