### PR TITLE
Fix ftp burst read

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -55,6 +55,7 @@ int AP_Filesystem_Param::open(const char *fname, int flags)
     r.open = true;
     r.start = 0;
     r.count = 0;
+    r.read_size = 0;
     r.writebuf = nullptr;
     if (!read_only) {
         // setup for upload


### PR DESCRIPTION
Fixes #18934 

This totally fixes parameter download problems with mavproxy - it's amazing. Now instantaneous for me!