### PR TITLE
AP_Compass: added COMPASS_BAT_MASK for which batteries to compensate

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -152,6 +152,13 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT",    7, Compass, _state._priv_instance[0].motor_compensation, 0),
+
+    // @Param: BAT_MASK
+    // @DisplayName: Motor interference compensation battery index
+    // @Description: The mask battery numbers that are used for motor compensation of compasses. Total current is sum of current from the selected batteries
+    // @Bitmask: 0:FirstBattery,1:2ndBattery,2:3rdBattery,3:4thBattery,4:5thBattery,5:6thBattery,6:7thBattery,7:8thBattery,8:9thBattery
+    // @User: Advanced
+    AP_GROUPINFO("BAT_MASK", 52, Compass, _motor_comp_batmask, 1),
 #endif
 
     // @Param: ORIENT

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -470,6 +470,9 @@ private:
     // 0 = disabled, 1 = enabled for throttle, 2 = enabled for current
     AP_Int8     _motor_comp_type;
 
+    // motor compensation battery mask
+    AP_Int16     _motor_comp_batmask;
+    
     // automatic compass orientation on calibration
     AP_Int8     _rotate_auto;
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -103,10 +103,17 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
         state.motor_offset = mot * _compass._thr;
     } else if (_compass._motor_comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
         AP_BattMonitor &battery = AP::battery();
-        float current;
-        if (battery.current_amps(current)) {
-            state.motor_offset = mot * current;
+        float current_sum = 0;
+        for (uint8_t b=0; b<AP_BATT_MONITOR_MAX_INSTANCES; b++) {
+            const uint16_t mask = 1U<<b;
+            if (mask & uint16_t(_compass._motor_comp_batmask)) {
+                float current;
+                if (battery.current_amps(current, b)) {
+                    current_sum += current;
+                }
+            }
         }
+        state.motor_offset = mot * current_sum;
     }
 
     /*


### PR DESCRIPTION
this allows selection of batteries that need to be used for compass motor compensation with current

note: we also need to add use of this parameter in MAVExplorer magfit tool