### PR TITLE
AP_UAVCAN: hide -Wcast-function-type warning on GCC11

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -72,6 +72,11 @@ class ParamExecuteOpcodeCb;
 #define DISABLE_W_CAST_FUNCTION_TYPE_PUSH
 #define DISABLE_W_CAST_FUNCTION_TYPE_POP
 #endif
+#if defined(__GNUC__) && (__GNUC__ >= 11)
+#define DISABLE_W_CAST_FUNCTION_TYPE_WITH_VOID (void*)
+#else
+#define DISABLE_W_CAST_FUNCTION_TYPE_WITH_VOID
+#endif
 
 /*
     Frontend Backend-Registry Binder: Whenever a message of said DataType_ from new node is received,
@@ -84,7 +89,7 @@ class ParamExecuteOpcodeCb;
             ClassName_() : RegistryBinder() {} \
             DISABLE_W_CAST_FUNCTION_TYPE_PUSH \
             ClassName_(AP_UAVCAN* uc,  CN_Registry ffunc) : \
-                RegistryBinder(uc, (Registry)ffunc) {} \
+                RegistryBinder(uc, (Registry)DISABLE_W_CAST_FUNCTION_TYPE_WITH_VOID ffunc) {} \
             DISABLE_W_CAST_FUNCTION_TYPE_POP \
     }
 
@@ -95,7 +100,7 @@ class ParamExecuteOpcodeCb;
             ClassName_() : ClientCallRegistryBinder() {} \
             DISABLE_W_CAST_FUNCTION_TYPE_PUSH \
             ClassName_(AP_UAVCAN* uc,  CN_Registry ffunc) : \
-                ClientCallRegistryBinder(uc, (ClientCallRegistry)ffunc) {} \
+                ClientCallRegistryBinder(uc, (ClientCallRegistry)DISABLE_W_CAST_FUNCTION_TYPE_WITH_VOID ffunc) {} \
             DISABLE_W_CAST_FUNCTION_TYPE_POP \
     }
 


### PR DESCRIPTION
This is a temp fix to hide those kind of warning on GCC11

```
In file included from ../../libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h:5,
                 from ../../libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:5:
../../libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp: In constructor ‘AirspeedCb::AirspeedCb(AP_UAVCAN*, AirspeedCb::CN_Registry)’:
../../libraries/AP_UAVCAN/AP_UAVCAN.h:87:36: warning: cast between incompatible function types from ‘AirspeedCb::CN_Registry’ {aka ‘void (*)(AP_UAVCAN*, unsigned char, const AirspeedCb&)’} to ‘AP_UAVCAN::RegistryBinder<uavcan::equipment::air_data::RawAirData_<0> >::Registry’ {aka ‘void (*)(AP_UAVCAN*, unsigned char, const AP_UAVCAN::RegistryBinder<uavcan::equipment::air_data::RawAirData_<0> >&)’} [-Wcast-function-type]
   87 |                 RegistryBinder(uc, (Registry)ffunc) {} \
      |                                    ^~~~~~~~~~~~~~~
../../libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp:17:1: note: in expansion of macro ‘UC_REGISTRY_BINDER’
   17 | UC_REGISTRY_BINDER(AirspeedCb, uavcan::equipment::air_data::RawAirData);
      | ^~~~~~~~~~~~~~~~~~

```