### PR TITLE
Correct division-by-zero in Copter compassmot

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -160,6 +160,9 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
         throttle_pct = (float)channel_throttle->get_control_in() / 1000.0f;
         throttle_pct = constrain_float(throttle_pct,0.0f,1.0f);
 
+        // record maximum throttle
+        throttle_pct_max = MAX(throttle_pct_max, throttle_pct);
+
         if (!battery.current_amps(current)) {
             current = 0;
         }
@@ -211,9 +214,6 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
                     interference_pct[i] = motor_compensation[i].length() * (current_amps_max/throttle_pct_max) / (float)arming.compass_magfield_expected() * 100.0f;
                 }
             }
-
-            // record maximum throttle
-            throttle_pct_max = MAX(throttle_pct_max, throttle_pct);
         }
 
         if (AP_HAL::millis() - last_send_time > 500) {


### PR DESCRIPTION
compassmot is responsible for calibrating magnetic field compensation values which are then used to account for interference from motors.

This appears to be a long-standing problem where a zero-throttle is present.  My guess is that we always get this division-by-zero on actual hardware, it is simply ignored.  This test will fail with an arithmetic error before the patch against compassmot.cpp but not get the error in that place afterwards.

This test exposes several other problems, some actual bugs, some probably simulation.
 - the throttle comes through via mavlink as 0-1000 whereas the mavlink message definition states this is a percentage
 - the compensation values look way too low to be a useful test
 - the long you run the motor compensation test the larger the values become.  I'm not even sure the final values are bounded.
 - this exposes a problem in the EKF GSF (@priseborough ) - stack trace is below

I am invoking the test suite in this way to provoke the below stack trace: `./Tools/autotest/autotest.py build.Copter test.Copter.CompassMot --gdb`

```
#0  is_positive<double> (fVal1=1.008727614231422e+43) at ../../libraries/AP_Math/AP_Math.h:66
#1  0x0000555555869f17 in EKFGSF_yaw::updateRotMat (this=0x2, R=..., g=...) at ../../libraries/AP_NavEKF/EKFGSF_yaw.cpp:617
#2  0x0000555555867fc0 in EKFGSF_yaw::predictAHRS (this=0x555555c9fda0, mdl_idx=2 '\002') at ../../libraries/AP_NavEKF/EKFGSF_yaw.cpp:240
#3  0x00005555558684b8 in EKFGSF_yaw::predict (this=0x555555c9fda0, mdl_idx=0 '\000') at ../../libraries/AP_NavEKF/EKFGSF_yaw.cpp:314
#4  0x0000555555867931 in EKFGSF_yaw::update (this=0x555555c9fda0, delAng=..., delVel=..., delAngDT=1.008727614231422e+43, delVelDT=0.0010737157259629025, runEKF=80, TAS=3057831268.1328344) at ../../libraries/AP_NavEKF/EKFGSF_yaw.cpp:97
#5  0x00005555556595d5 in NavEKF3_core::runYawEstimatorPrediction (this=0x555555c9b3c0) at ../../libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp:734
#6  0x0000555555674eb6 in NavEKF3_core::UpdateFilter (this=0x7fffffffd280, predict=2) at ../../libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:677
#7  0x0000555555655acd in NavEKF3::UpdateFilter (this=0x555555c08008 <copter+9672>) at ../../libraries/AP_NavEKF3/AP_NavEKF3.cpp:894
#8  0x00005555555e1d1b in AP_AHRS::update_EKF3 (this=0x555555c07e70 <copter+9264>) at ../../libraries/AP_AHRS/AP_AHRS.cpp:541
#9  0x00005555555e13bb in AP_AHRS::update (this=0x555555c07e70 <copter+9264>, skip_ins_update=true) at ../../libraries/AP_AHRS/AP_AHRS.cpp:327
#10 0x00005555555aab07 in Copter::read_AHRS (this=0x555555c05a40 <copter>) at ../../ArduCopter/Copter.cpp:658
#11 0x00005555555a9537 in Copter::fast_loop (this=0x555555c05a40 <copter>) at ../../ArduCopter/Copter.cpp:234
#12 0x00005555555abf19 in Functor<void>::method_wrapper<AP_Vehicle, &AP_Vehicle::fast_loop> (obj=0x555555c05a40 <copter>) at ../../libraries/AP_HAL/utility/functor.h:88
#13 0x0000555555650846 in Functor<void>::operator() (this=0x555555c05d30 <copter+752>) at ../../libraries/AP_HAL/utility/functor.h:54
#14 0x00005555556940ed in AP_Scheduler::loop (this=0x555555c05cf8 <copter+696>) at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:285
#15 0x0000555555699325 in AP_Vehicle::loop (this=0x555555c05a40 <copter>) at ../../libraries/AP_Vehicle/AP_Vehicle.cpp:182
#16 0x00005555557b4ee4 in HAL_SITL::run (this=0x555555c1a5c0 <AP_HAL::get_HAL()::hal>, argc=11, argv=0x7fffffffd9f8, callbacks=0x555555c05a40 <copter>) at ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:257
#17 0x00005555555abc8f in main (argc=11, argv=0x7fffffffd9f8) at ../../ArduCopter/Copter.cpp:723
```
