### PR TITLE
Tools: Add intelhex to Cygwin install scripts

### DIFF
--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -19,7 +19,7 @@ Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (5/8)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink intelhex'"
 
 Write-Output "Downloading APM source (6/8)"
 Copy-Item "APM_install.sh" -Destination "C:\cygwin64\home"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -19,7 +19,7 @@ Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (5/7)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'pip install empy pyserial pymavlink intelhex'"
 
 Write-Output "Installing ARM GCC Compiler 10-2020-Q4-Major (6/7)"
 & $PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe /S /P /R


### PR DESCRIPTION
Adding missing package. Allows users to build bootloaders in Cygwin.