### PR TITLE
DevEnv: Add C++ and Lua recommended extensions for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "sumneko.lua",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "streetsidesoftware.code-spell-checker",
+        "chiehyu.vscode-astyle"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cSpell.language": "en-GB",
+    "astyle.astylerc": "${workspaceFolder}/Tools/CodeStyle/astylerc"
+}


### PR DESCRIPTION
Right now this is a short list. VSCode will read this list and suggest these extensions when a the repository is opened for the first time. It is not required, but will make it easier for a new user to start coding more easily.

@hendjoshsr71 @IamPete1 Thoughts?