### PR TITLE
SITL: correct compilation when MAX_CONNECTED_MAGS is reduced

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -370,12 +370,24 @@ const AP_Param::GroupInfo SIM::var_mag[] = {
     AP_GROUPINFO("MAG1_SCALING",  10, SIM,  mag_scaling[0], 1),
     AP_GROUPINFO("MAG1_DEVID",    11, SIM,  mag_devid[0], 97539),
     AP_GROUPINFO("MAG2_DEVID",    12, SIM,  mag_devid[1], 131874),
+#if MAX_CONNECTED_MAGS > 2
     AP_GROUPINFO("MAG3_DEVID",    13, SIM,  mag_devid[2], 263178),
+#endif
+#if MAX_CONNECTED_MAGS > 3
     AP_GROUPINFO("MAG4_DEVID",    14, SIM,  mag_devid[3], 97283),
+#endif
+#if MAX_CONNECTED_MAGS > 4
     AP_GROUPINFO("MAG5_DEVID",    15, SIM,  mag_devid[4], 97795),
+#endif
+#if MAX_CONNECTED_MAGS > 5
     AP_GROUPINFO("MAG6_DEVID",    16, SIM,  mag_devid[5], 98051),
+#endif
+#if MAX_CONNECTED_MAGS > 6
     AP_GROUPINFO("MAG7_DEVID",    17, SIM,  mag_devid[6], 0),
+#endif
+#if MAX_CONNECTED_MAGS > 7
     AP_GROUPINFO("MAG8_DEVID",    18, SIM,  mag_devid[7], 0),
+#endif
     AP_GROUPINFO("MAG1_FAIL",     26, SIM,  mag_fail[0], 0),
 #if HAL_COMPASS_MAX_SENSORS > 1
     AP_GROUPINFO("MAG2_OFS",      19, SIM,  mag_ofs[1], 0),


### PR DESCRIPTION
For example, when building AP_Periph with reduced mag count

This array is defined against `MAX_CONNECTED_MAGS`:

```
    AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
```

so we should limit indexing based on `MAX_CONNECTED_MAGS`.
