### PR TITLE
Plane: Quadplane: continue in mode loiter to Qland on failsafe, as wi…

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -68,9 +68,6 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
     case Mode::Number::AVOID_ADSB:
     case Mode::Number::GUIDED:
     case Mode::Number::LOITER:
-#if HAL_QUADPLANE_ENABLED
-    case Mode::Number::LOITER_ALT_QLAND:
-#endif
     case Mode::Number::THERMAL:
         if(g.fs_action_short != FS_ACTION_SHORT_BESTGUESS) {
             failsafe.saved_mode_number = control_mode->mode_number();
@@ -89,6 +86,7 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
 #if HAL_QUADPLANE_ENABLED
     case Mode::Number::QLAND:
     case Mode::Number::QRTL:
+    case Mode::Number::LOITER_ALT_QLAND:
 #endif
     case Mode::Number::INITIALISING:
         break;
@@ -115,9 +113,6 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
     case Mode::Number::TRAINING:
     case Mode::Number::CIRCLE:
     case Mode::Number::LOITER:
-#if HAL_QUADPLANE_ENABLED
-    case Mode::Number::LOITER_ALT_QLAND:
-#endif
     case Mode::Number::THERMAL:
         if(g.fs_action_long == FS_ACTION_LONG_PARACHUTE) {
 #if PARACHUTE == ENABLED
@@ -170,6 +165,7 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
 #if HAL_QUADPLANE_ENABLED
     case Mode::Number::QLAND:
     case Mode::Number::QRTL:
+    case Mode::Number::LOITER_ALT_QLAND:
 #endif
     case Mode::Number::TAKEOFF:
     case Mode::Number::INITIALISING:
@@ -220,7 +216,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
         case Failsafe_Action_Land: {
             bool already_landing = flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND;
 #if HAL_QUADPLANE_ENABLED
-            if (control_mode == &mode_qland) {
+            if (control_mode == &mode_qland || control_mode == &mode_lotier_qland) {
                 already_landing = true;
             }
 #endif
@@ -241,7 +237,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
         case Failsafe_Action_RTL: {
             bool already_landing = flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND;
 #if HAL_QUADPLANE_ENABLED
-            if (control_mode == &mode_qland ||
+            if (control_mode == &mode_qland || control_mode == &mode_lotier_qland ||
                 quadplane.in_vtol_land_sequence()) {
                 already_landing = true;
             }


### PR DESCRIPTION
…th Qland

This change to treat loiter to Qland mode the same as Qland if there is a failsafe trigger. 