### PR TITLE
SITL: add simulated MCP9600

### DIFF
--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -27,6 +27,7 @@
 #include "SIM_BattMonitor_SMBus_Rotoye.h"
 #include "SIM_Airspeed_DLVR.h"
 #include "SIM_Temperature_TSYS01.h"
+#include "SIM_Temperature_MCP9600.h"
 #include "SIM_ICM40609.h"
 #include "SIM_MS5525.h"
 #include "SIM_MS5611.h"
@@ -55,6 +56,7 @@ static Maxell maxell;
 static Rotoye rotoye;
 static Airspeed_DLVR airspeed_dlvr;
 static TSYS01 tsys01;
+static MCP9600 mcp9600;
 static ICM40609 icm40609;
 static MS5525 ms5525;
 static MS5611 ms5611;
@@ -65,6 +67,7 @@ struct i2c_device_at_address {
     I2CDevice &device;
 } i2c_devices[] {
     { 0, 0x70, maxsonari2cxl },
+    { 0, 0x60, mcp9600 }, // 0x60 is low address
     { 0, 0x71, maxsonari2cxl_2 },
     { 1, 0x01, icm40609 },
     { 1, 0x55, toshibaled },

--- a/libraries/SITL/SIM_I2CDevice.h
+++ b/libraries/SITL/SIM_I2CDevice.h
@@ -32,6 +32,33 @@ protected:
     Bitmask<256> writable_registers;
     Bitmask<256> readable_registers;
 
+    void set_debug(bool value) { debug = value; }
+    bool get_debug() const { return debug; }
+
+private:
+    bool debug;
+};
+
+class I2CRegisters_ConfigurableLength : public I2CRegisters {
+public:
+    void add_register(const char *name, uint8_t reg, uint8_t len, RegMode mode);
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+    void set_register(uint8_t reg, uint8_t *data, uint8_t len);
+    void set_register(uint8_t reg, uint16_t value);
+    void set_register(uint8_t reg, int16_t value);
+    void set_register(uint8_t reg, uint8_t value);
+    void set_register(uint8_t reg, int8_t value);
+
+    // void get_reg_value(uint8_t reg, int8_t &value) const;
+    void get_reg_value(uint8_t reg, uint8_t &value) const;
+    // void get_reg_value(uint8_t reg, int16_t &value) const;
+    // void get_reg_value(uint8_t reg, uint16_t &value) const;
+    // void get_reg_value(uint8_t reg, uint8_t *value, uint8_t len) const;
+
+protected:
+
+    uint32_t reg_data[256];  // OK, so not *that* configurable ATM....
+    uint8_t reg_data_len[256];
 };
 
 class I2CRegisters_16Bit : public I2CRegisters {

--- a/libraries/SITL/SIM_Temperature_MCP9600.cpp
+++ b/libraries/SITL/SIM_Temperature_MCP9600.cpp
@@ -1,0 +1,48 @@
+#include "SIM_Temperature_MCP9600.h"
+
+using namespace SITL;
+
+#include <GCS_MAVLink/GCS.h>
+#include <signal.h>
+
+void MCP9600::init()
+{
+    set_debug(true);
+
+    add_register("WHOAMI", MCP9600DevReg::WHOAMI, 2, I2CRegisters::RegMode::RDONLY);
+    set_register(MCP9600DevReg::WHOAMI, (uint16_t)0x40);
+
+    add_register("SENSOR_CONFIG", MCP9600DevReg::SENSOR_CONFIG, 1, I2CRegisters::RegMode::RDWR);
+    set_register(MCP9600DevReg::SENSOR_CONFIG, (uint8_t)0x00);
+
+    add_register("HOT_JUNC", MCP9600DevReg::HOT_JUNC, 2, I2CRegisters::RegMode::RDONLY);
+}
+
+void MCP9600::update(const class Aircraft &aircraft)
+{
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_temperature_update_ms < 100) {  // 10Hz
+        return;
+    }
+    last_temperature_update_ms = now_ms;
+
+    uint8_t config;
+    get_reg_value(MCP9600DevReg::SENSOR_CONFIG, config);
+    if (config == 0) {
+        // unconfigured; FIXME lack of fidelity
+        return;
+    }
+    if ((config & 0b111) != 1) {  // FIXME: this is just the default config
+        AP_HAL::panic("Unexpected filter configuration");
+    }
+    if ((config >> 4) != 0) {  // this is a K-type thermocouple, the default in the driver
+        AP_HAL::panic("Unexpected thermocouple configuration");
+    }
+    static constexpr uint16_t factor = (1/0.0625);
+    set_register(MCP9600DevReg::HOT_JUNC, uint16_t(htobe16(some_temperature + degrees(sinf(now_ms)) * factor)));
+}
+
+int MCP9600::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
+{
+    return I2CRegisters_ConfigurableLength::rdwr(data);
+}

--- a/libraries/SITL/SIM_Temperature_MCP9600.h
+++ b/libraries/SITL/SIM_Temperature_MCP9600.h
@@ -1,0 +1,38 @@
+#include "SIM_I2CDevice.h"
+
+/*
+  Simulator for the MCP9600 temperature sensor
+
+  DataSheet; https://www.microchip.com/content/dam/mchp/documents/OTH/ProductDocuments/DataSheets/MCP960X-Data-Sheet-20005426.pdf
+
+*/
+
+namespace SITL {
+
+class MCP9600DevReg : public I2CRegEnum {
+public:
+    static constexpr uint8_t HOT_JUNC        { 0x00 };
+    static constexpr uint8_t SENSOR_CONFIG   { 0x05 };
+    static constexpr uint8_t WHOAMI          { 0x20 };
+};
+
+class MCP9600 : public I2CDevice, private I2CRegisters_ConfigurableLength
+{
+public:
+
+    void init() override;
+
+    void update(const class Aircraft &aircraft) override;
+
+    int rdwr(I2C::i2c_rdwr_ioctl_data *&data) override;
+
+private:
+
+    // should be a call on aircraft:
+    float some_temperature = 26.5;
+    float last_temperature = -1000.0f;
+
+    uint32_t last_temperature_update_ms;
+};
+
+} // namespace SITL


### PR DESCRIPTION
Adds a really bad simulation of this sensor.

I had to add a Configurable_Register class to help simulated devices have "pointer" based registers; the MCP9600 has blocks you can read of lengths 1 through 3....

I also improved the debug diagnostics available in the simulated I2CDevice class.

I didn't actually read the datasheet much for this; really should improve the fidelity of the device by actually looking at the initial config and adding support for filtering and other thermocouples.
