### PR TITLE
AP_BatteryMoniter: add mask param to sum battery backend.

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -322,7 +322,7 @@ AP_BattMonitor::init()
     if (drivers[instance] && state[instance].var_info) {
         Type type = get_type(instance);
         if((type == Type::ANALOG_VOLTAGE_AND_CURRENT) || (type == Type::ANALOG_VOLTAGE_ONLY) ||
-            (type == Type::FuelFlow) || (type == Type::FuelLevel_PWM)) {
+            (type == Type::FuelFlow) || (type == Type::FuelLevel_PWM) || (type == Type::Sum)) {
             backend_analog_var_info[instance] = state[instance].var_info;
             AP_Param::load_object_from_eeprom(drivers[instance], backend_analog_var_info[instance]);
         }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -44,7 +44,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: _
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_analog_var_info[0]),
+    // @Group: _
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_var_info[0]),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
     // @Group: 2_
@@ -53,7 +57,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 2_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_analog_var_info[1]),
+    // @Group: 2_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_var_info[1]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 2
@@ -63,7 +71,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 3_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_analog_var_info[2]),
+    // @Group: 3_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_var_info[2]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 3
@@ -73,7 +85,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 4_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_analog_var_info[3]),
+    // @Group: 4_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_var_info[3]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 4
@@ -83,7 +99,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 5_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_analog_var_info[4]),
+    // @Group: 5_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_var_info[4]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 5
@@ -93,7 +113,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 6_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_analog_var_info[5]),
+    // @Group: 6_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_var_info[5]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 6
@@ -103,7 +127,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 7_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_analog_var_info[6]),
+    // @Group: 7_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_var_info[6]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 7
@@ -113,7 +141,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 8_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_analog_var_info[7]),
+    // @Group: 8_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_var_info[7]),
 #endif
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 8
@@ -123,71 +155,17 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
     // @Group: 9_
     // @Path: AP_BattMonitor_Analog.cpp
-    AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_analog_var_info[8]),
-#endif
-
-#if HAL_BATTMON_SMBUS_ENABLE
-    // @Group: _
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[0], "_", 32, AP_BattMonitor, backend_smbus_var_info[0]),
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 1
-    // @Group: 2_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[1], "2_", 33, AP_BattMonitor, backend_smbus_var_info[1]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 2
-    // @Group: 3_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[2], "3_", 34, AP_BattMonitor, backend_smbus_var_info[2]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 3
-    // @Group: 4_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[3], "4_", 35, AP_BattMonitor, backend_smbus_var_info[3]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 4
-    // @Group: 5_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[4], "5_", 36, AP_BattMonitor, backend_smbus_var_info[4]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 5
-    // @Group: 6_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[5], "6_", 37, AP_BattMonitor, backend_smbus_var_info[5]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 6
-    // @Group: 7_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[6], "7_", 38, AP_BattMonitor, backend_smbus_var_info[6]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 7
-    // @Group: 8_
-    // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[7], "8_", 39, AP_BattMonitor, backend_smbus_var_info[7]),
-#endif
-
-#if AP_BATT_MONITOR_MAX_INSTANCES > 8
     // @Group: 9_
     // @Path: AP_BattMonitor_SMBus.cpp
-    AP_SUBGROUPVARPTR(drivers[8], "9_", 40, AP_BattMonitor, backend_smbus_var_info[8]),
+    // @Group: 9_
+    // @Path: AP_BattMonitor_Sum.cpp
+    AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
-#endif // HAL_BATTMON_SMBUS_ENABLE
 
     AP_GROUPEND
 };
 
-const AP_Param::GroupInfo *AP_BattMonitor::backend_analog_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
-
-#if HAL_BATTMON_SMBUS_ENABLE
-const AP_Param::GroupInfo *AP_BattMonitor::backend_smbus_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
-#endif
+const AP_Param::GroupInfo *AP_BattMonitor::backend_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
 
 // Default constructor.
 // Note that the Vector/Matrix constructors already implicitly zero
@@ -320,19 +298,9 @@ AP_BattMonitor::init()
 
     // if the backend has some local parameters then make those available in the tree
     if (drivers[instance] && state[instance].var_info) {
-        Type type = get_type(instance);
-        if((type == Type::ANALOG_VOLTAGE_AND_CURRENT) || (type == Type::ANALOG_VOLTAGE_ONLY) ||
-            (type == Type::FuelFlow) || (type == Type::FuelLevel_PWM) || (type == Type::Sum)) {
-            backend_analog_var_info[instance] = state[instance].var_info;
-            AP_Param::load_object_from_eeprom(drivers[instance], backend_analog_var_info[instance]);
-        }
-#if HAL_BATTMON_SMBUS_ENABLE
-        else if ((type == Type::MAXELL) || (type == Type::NeoDesign) || (type == Type::Rotoye) || (type == Type::SMBus_Generic) ||
-            (type == Type::SOLO)   || (type == Type::SUI3)      || (type == Type::SUI6)) {
-            backend_smbus_var_info[instance] = state[instance].var_info;
-            AP_Param::load_object_from_eeprom(drivers[instance], backend_smbus_var_info[instance]);
-        }
-#endif
+        backend_var_info[instance] = state[instance].var_info;
+        AP_Param::load_object_from_eeprom(drivers[instance], backend_var_info[instance]);
+
         // param count could have changed
         AP_Param::invalidate_count();
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -145,8 +145,7 @@ public:
         const struct AP_Param::GroupInfo *var_info;
     };
 
-    static const struct AP_Param::GroupInfo *backend_analog_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
-    static const struct AP_Param::GroupInfo *backend_smbus_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
+    static const struct AP_Param::GroupInfo *backend_var_info[AP_BATT_MONITOR_MAX_INSTANCES];
 
     // Return the number of battery monitor instances
     uint8_t num_instances(void) const { return _num_instances; }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -43,6 +43,8 @@ const AP_Param::GroupInfo AP_BattMonitor_Analog::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("AMP_OFFSET", 5, AP_BattMonitor_Analog, _curr_amp_offset, AP_BATT_CURR_AMP_OFFSET_DEFAULT),
 
+    // Param indexes must be less than 10 to avoid conflict with other battery monitor param tables loaded by pointer
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -6,13 +6,15 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_BattMonitor_SMBus::var_info[] = {
 
+    // Param indexes must be between 10 and 19 to avoid conflict with other battery monitor param tables loaded by pointer
+
     // @Param: I2C_BUS
     // @DisplayName: Battery monitor I2C bus number
     // @Description: Battery monitor I2C bus number
     // @Range: 0 3
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("I2C_BUS", 1, AP_BattMonitor_SMBus, _bus, 0),
+    AP_GROUPINFO("I2C_BUS", 10, AP_BattMonitor_SMBus, _bus, 0),
 
     // @Param: I2C_ADDR
     // @DisplayName: Battery monitor I2C address
@@ -20,7 +22,9 @@ const AP_Param::GroupInfo AP_BattMonitor_SMBus::var_info[] = {
     // @Range: 0 127
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("I2C_ADDR", 2, AP_BattMonitor_SMBus, _address, AP_BATTMONITOR_SMBUS_I2C_ADDR),
+    AP_GROUPINFO("I2C_ADDR", 11, AP_BattMonitor_SMBus, _address, AP_BATTMONITOR_SMBUS_I2C_ADDR),
+
+    // Param indexes must be between 10 and 19 to avoid conflict with other battery monitor param tables loaded by pointer
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -14,12 +14,16 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_BattMonitor_Sum::var_info[] = {
 
+    // Param indexes must be between 20 and 29 to avoid conflict with other battery monitor param tables loaded by pointer
+
     // @Param: SUM_MASK
     // @DisplayName: Battery Sum mask
     // @Description: 0: sum of remaining battery monitors, If none 0 sum of specified monitors. Current will be summed and voltages averaged.
     // @Bitmask: 0:monitor 1, 1:monitor 2, 2:monitor 3, 3:monitor 4, 4:monitor 5, 5:monitor 6, 6:monitor 7, 7:monitor 8, 8:monitor 9
     // @User: Standard
-    AP_GROUPINFO("SUM_MASK", 1, AP_BattMonitor_Sum, _sum_mask, 0),
+    AP_GROUPINFO("SUM_MASK", 20, AP_BattMonitor_Sum, _sum_mask, 0),
+
+    // Param indexes must be between 20 and 29 to avoid conflict with other battery monitor param tables loaded by pointer
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -12,6 +12,18 @@
  */
 extern const AP_HAL::HAL& hal;
 
+const AP_Param::GroupInfo AP_BattMonitor_Sum::var_info[] = {
+
+    // @Param: SUM_MASK
+    // @DisplayName: Battery Sum mask
+    // @Description: 0: sum of remaining battery monitors, If none 0 sum of specified monitors. Current will be summed and voltages averaged.
+    // @Bitmask: 0:monitor 1, 1:monitor 2, 2:monitor 3, 3:monitor 4, 4:monitor 5, 5:monitor 6, 6:monitor 7, 7:monitor 8, 8:monitor 9
+    // @User: Standard
+    AP_GROUPINFO("SUM_MASK", 1, AP_BattMonitor_Sum, _sum_mask, 0),
+
+    AP_GROUPEND
+};
+
 /// Constructor
 AP_BattMonitor_Sum::AP_BattMonitor_Sum(AP_BattMonitor &mon,
                                        AP_BattMonitor::BattMonitor_State &mon_state,
@@ -20,6 +32,8 @@ AP_BattMonitor_Sum::AP_BattMonitor_Sum(AP_BattMonitor &mon,
     AP_BattMonitor_Backend(mon, mon_state, params),
     _instance(instance)
 {
+    AP_Param::setup_object_defaults(this, var_info);
+    _state.var_info = var_info;
 }
 
 // read - read the voltage and current
@@ -31,7 +45,19 @@ AP_BattMonitor_Sum::read()
     float current_sum = 0;
     uint8_t current_count = 0;
 
-    for (uint8_t i=_instance+1; i<_mon.num_instances(); i++) {
+    for (uint8_t i=0; i<_mon.num_instances(); i++) {
+        if (i == _instance) {
+            // never include self
+            continue;
+        }
+        if ((_sum_mask == 0) && (i <= _instance)) {
+            // sum of remaining, skip lower instances
+            continue;
+        }
+        if ((_sum_mask != 0) && ((_sum_mask & 1U<<i) == 0)) {
+            // mask param, skip if mask bit not set
+            continue;
+        }
         if (!_mon.healthy(i)) {
             continue;
         }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.h
@@ -21,7 +21,11 @@ public:
 
     void init(void) override {}
 
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
+
+    AP_Int16  _sum_mask;
     uint8_t _instance;
     bool _has_current;
 };


### PR DESCRIPTION
Adds mask parameter to sum battery backed. This allows https://github.com/ArduPilot/ardupilot/pull/18938 except we can report the reading used, and it works for all other used cases too. 

Of course compass will still need a param, but now it can just be a battery index not a mask. 

Could even re-use `COMPASS_MOTCT` something like:

0:Disabled
1:Use Throttle,
2:Use Current form batt mon 1
3: bat mon 2
4: bat mon 4
ect


