### PR TITLE
AP_RangeFinder_NMEA: add hondex custom message support

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
@@ -124,7 +124,7 @@ bool AP_RangeFinder_NMEA::decode_latest_term()
         }
         const uint8_t checksum = (nibble_high << 4u) | nibble_low;
         if (checksum == _checksum) {
-            if ((_sentence_type == SONAR_DBT || _sentence_type == SONAR_DPT) && !is_negative(_distance_m)) {
+            if ((_sentence_type == SONAR_DBT || _sentence_type == SONAR_DPT || _sentence_type == SONAR_HDED) && !is_negative(_distance_m)) {
                 // return true if distance is valid
                 return true;
             }
@@ -155,6 +155,8 @@ bool AP_RangeFinder_NMEA::decode_latest_term()
             _sentence_type = SONAR_DPT;
         } else if (strcmp(term_type, "MTW") == 0) {
             _sentence_type = SONAR_MTW;
+        } else if (strcmp(term_type, "ED") == 0) {
+            _sentence_type = SONAR_HDED;
         } else {
             _sentence_type = SONAR_UNKNOWN;
         }
@@ -175,6 +177,11 @@ bool AP_RangeFinder_NMEA::decode_latest_term()
         // parse MTW (mean water temperature) messages
         if (_term_number == 1) {
             _temp_unvalidated = strtof(_term, NULL);
+        }
+    } else if (_sentence_type == SONAR_HDED) {
+        // parse HDED (Hondex custom message)
+        if (_term_number == 4) {
+            _distance_m = strtof(_term, NULL);
         }
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
@@ -38,7 +38,8 @@ private:
         SONAR_UNKNOWN = 0,
         SONAR_DBT,
         SONAR_DPT,
-        SONAR_MTW   // mean water temperature
+        SONAR_MTW,  // mean water temperature
+        SONAR_HDED, // hondex custom sonar message
     };
 
     // get a distance reading


### PR DESCRIPTION
This adds support for the Hondex HE-8S fish finder's custom HDEX message.  It probably also works for other Hondex underwater sonar as well but this hasn't been tested.

In case it is of interest here is some sample data

$HDED,015,0,0,005.3,D8D8D8D8D8D8D8D8D8D8D8D8D8B8B9BABABBBCBCBDBDBCBBC0C3C0BCBEBFBFBFBDBAB4A4B1B4B4B3B0ACA7A19B9D9E9F9F9E9D9B9895918C88827D797979797978777573706D68809CAAACAA9597958C8D818282776A6C6852515354524E5C5E5B5057575654524F4F4B41444F514F4937383F444D4E4C3B403C444538474743474847413D3B4143433E59849FACB4B5B19B9C9A93948886877A76766D6062615D6565635E575C5C5C5E5E5658595963635D595A5C5C5B515155535256554D514E38484D4E4C443F39434645424D5A768996A1A8A8A29D9E989191847A7D7D78717063686A695D5654555F5F64696967615E5F6365645E686864575C5C5B5C5F5E515A5E5E556263615A534B4E4A48525556606F7C7E96A5AEAEAA90948E8F8E8178807F787B776A6B6663615C66675E596D72716565656A6961625F605F5F5F5C62625B5B5758535D5D5661615E55545959515D5D57576A78838D979DA09F9792938B80807574636D6E6E6B627274715B5C5A4B5A5D6A6D6C5C616C6C6764616068676259575A5C525D5D54565453565D5D57525552535E6060596D77777A7C8F9CA3A29C898B83807F75746D6D6266646B6C6A6A655D696B6354626C6C5E5B676C6C60576267655B5C5B5B555F605F625F60605759594B*45

.. and here is the description of the message:

- header : "$HDED"
- 1st term (e.g. "015") : sonar range (in meters)
- 2nd term (e.g. "0") : "0" = 50kHz data, "1" = 200kHz data
- 3rd term (e.g. "0") : "0" = standard sensitivity, "1" = high sensitivty
- 4th term (e.g.  "005.3") : depth (in meters), 0.1m accuracy, term is fixed length of 5 bytes
- 5th term (e.g.  "D8D8D8...") : echo data in hexidecimal. 472 elements of two bytes each.  In standard sensitivity mode 0x40 ~ 0xD8 are valid values.  In high sensitivity mode 0x28 to 0xC0 are valid values.
- 6th term (e.g. "45") : checksum

Other information about this driver and sonar:

- We do not consume the massive 5th term of raw echo data
- NMEA data is provided a 9600 baud over RS232 so an [RS232-to-serial converter](https://www.sparkfun.com/products/8780) is required (just like the [Echologger ECT400](https://ardupilot.org/rover/docs/common-echologger-ect400.html)) 

This has been tested on real hardware although the distances were always zero because I did not have a transducer attached and I couldn't immediately figure out how to pipe the above sample data into the driver.