### PR TITLE
AP_Baro_KellerLD : update pressure offset value based on sensor mode

### DIFF
--- a/libraries/AP_Baro/AP_Baro_KellerLD.h
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.h
@@ -64,7 +64,16 @@ private:
     } _accum;
 
     uint8_t _instance;
-    
+
+    enum class SensorMode {
+        PR_MODE = 0,    // Vented gauge
+        PA_MODE = 1,    // Sealed gauge
+        PAA_MODE = 2,   // Absolute
+        UNDEFINED = 3,  
+    };
+
+    // to store sensor mode
+    SensorMode _p_mode;
     // Model-specific offset/calibration values stored in device ROM
     //  pressure offset used in pressure calculation
     float _p_mode_offset;


### PR DESCRIPTION
This fixes the issue #18968. 
Earlier we were directly setting the _p_mode_offset property based on sensor mode, which is wrong. When in PR-mode, the offset needs to be regularly updated with the value of pressure inside the vent.
Now, we first set a property `_p_mode` with the mode we were getting from the device (we now have an enum for sensor modes) and then set or update the `_p_mode_offset` as required.