### PR TITLE
AP_AccelCal: accept ack only from initial source sysid/compid

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -183,7 +183,7 @@ void AP_AccelCal::update()
     }
 }
 
-void AP_AccelCal::start(GCS_MAVLINK *gcs)
+void AP_AccelCal::start(GCS_MAVLINK *gcs, uint8_t sysid, uint8_t compid)
 {
     if (gcs == nullptr || _started) {
         return;
@@ -201,6 +201,8 @@ void AP_AccelCal::start(GCS_MAVLINK *gcs)
     _started = true;
     _saving = false;
     _gcs = gcs;
+    _sysid = sysid;
+    _compid = compid;
     _use_gcs_snoop = true;
     _last_position_request_ms = 0;
     _step = 0;
@@ -362,8 +364,12 @@ bool AP_AccelCal::client_active(uint8_t client_num)
 }
 
 #if HAL_GCS_ENABLED
-void AP_AccelCal::handle_command_ack(const mavlink_command_ack_t &packet)
+void AP_AccelCal::handle_command_ack(const mavlink_command_ack_t &packet, uint8_t src_sysid, uint8_t src_compid)
 {
+    if(_sysid != src_sysid || _compid != src_compid) {
+        return;
+    }
+
     if (!_waiting_for_mavlink_ack) {
         return;
     }

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -28,7 +28,7 @@ public:
     { update_status(); }
 
     // start all the registered calibrations
-    void start(GCS_MAVLINK *gcs);
+    void start(GCS_MAVLINK *gcs, uint8_t sysid, uint8_t compid);
 
     // called on calibration cancellation
     void cancel();
@@ -46,7 +46,7 @@ public:
     static void register_client(AP_AccelCal_Client* client);
 
 #if HAL_GCS_ENABLED
-    void handle_command_ack(const mavlink_command_ack_t &packet);
+    void handle_command_ack(const mavlink_command_ack_t &packet, uint8_t src_sysid, uint8_t src_compid);
 #endif
 
     // true if we are in a calibration process
@@ -54,6 +54,8 @@ public:
 
 private:
     class GCS_MAVLINK *_gcs;
+    uint8_t _sysid;
+    uint8_t _compid;
     bool _use_gcs_snoop;
     bool _waiting_for_mavlink_ack = false;
     uint32_t _last_position_request_ms;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4089,7 +4089,7 @@ void GCS_MAVLINK::handle_command_ack(const mavlink_message_t &msg)
 
     AP_AccelCal *accelcal = AP::ins().get_acal();
     if (accelcal != nullptr) {
-        accelcal->handle_command_ack(packet);
+        accelcal->handle_command_ack(packet, msg.sysid, msg.compid);
     }
 #if AP_GENERATOR_LOWEHEISER_ENABLED
     // this might be an ACK from a loweheiser generator:
@@ -4858,7 +4858,7 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
         }
         // start accel cal
         AP::ins().acal_init();
-        AP::ins().get_acal()->start(this);
+        AP::ins().get_acal()->start(this, msg.sysid, msg.compid);
         return MAV_RESULT_ACCEPTED;
     }
 #endif


### PR DESCRIPTION
when AP is connected with a gremsy gimbal, and attempting to do an accel calibration, the calibration will fail based on the acceptance of mavlink ACK's from the gimbal, without the user having time to physically rotate the Autopilot