### PR TITLE
AP_Param: Class Conversion Function

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1895,35 +1895,6 @@ void AP_Param::convert_old_parameters(const struct ConversionInfo *conversion_ta
     flush();
 }
 
-/*
-  move old class variables for a class that was sub-classed to one that isn't
-  For example, used when the AP_MotorsTri class changed from having its own parameter table
-  plus a subgroup for AP_MotorsMulticopter to just inheriting the AP_MotorsMulticopter var_info
-
-  This does not handle nesting beyond the single level shift
-*/
-void AP_Param::convert_parent_class(uint8_t param_key, void *object_pointer,
-                                    const struct AP_Param::GroupInfo *group_info)
-{
-    for (uint8_t i=0; group_info[i].type != AP_PARAM_NONE; i++) {
-        struct ConversionInfo info;
-        info.old_key = param_key;
-        info.type = (ap_var_type)group_info[i].type;
-        info.new_name = nullptr;
-        info.old_group_element = uint16_t(group_info[i].idx)<<6;
-        uint8_t old_value[type_size(info.type)];
-        AP_Param *ap = (AP_Param *)&old_value[0];
-        
-        if (!AP_Param::find_old_parameter(&info, ap)) {
-            // the parameter wasn't set in the old eeprom
-            continue;
-        }
-
-        uint8_t *new_value = group_info[i].offset + (uint8_t *)object_pointer;
-        memcpy(new_value, old_value, sizeof(old_value));
-    }
-}
-
 // move all parameters from a class to a new location
 // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
 void AP_Param::convert_class(uint16_t param_key, void *object_pointer,

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -444,6 +444,12 @@ public:
     static void         convert_parent_class(uint8_t param_key, void *object_pointer,
                                              const struct AP_Param::GroupInfo *group_info);
 
+    // move all parameters from a class to a new location
+    // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
+    static void         convert_class(uint16_t param_key, void *object_pointer,
+                                        const struct AP_Param::GroupInfo *group_info,
+                                        uint16_t old_index, uint16_t old_top_element, bool is_top_level);
+
     /*
       fetch a parameter value based on the index within a group. This
       is used to find the old value of a parameter that has been

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -440,10 +440,6 @@ public:
     };
     static void         convert_old_parameter(const struct ConversionInfo *info, float scaler, uint8_t flags=0);
 
-    // move old class variables for a class that was sub-classed to one that isn't
-    static void         convert_parent_class(uint8_t param_key, void *object_pointer,
-                                             const struct AP_Param::GroupInfo *group_info);
-
     // move all parameters from a class to a new location
     // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
     static void         convert_class(uint16_t param_key, void *object_pointer,


### PR DESCRIPTION
This is a function to convert & move a whole class's parameter tree from either a sub-group or if it had its own top-level key.

Also removes an unused function that I swiped a lot of the code from.

Tested and worked with my AP_Airspeed PR in SITL and on my cube orange, 

I'm not sure if this method is 100% though and I wasn't  sure about including this bit of code from `AP_Param::convert_old_parameter()`
```cpp
    // see if they are the same type and no scaling applied
    if (ptype == info->type && is_equal(scaler, 1.0f) && flags == 0) {
        // copy the value over only if the new parameter does not already
        // have the old value (via a default).
        if (memcmp(ap2, ap, sizeof(old_value)) != 0) {
            memcpy(ap2, ap, sizeof(old_value));
            // and save
            ap2->save();
        }
```