### PR TITLE
GCS_MAVLink: add board ID to AUTOPILOT_VERSION mavlink msg

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2335,7 +2335,11 @@ void GCS_MAVLINK::send_autopilot_version() const
 {
     uint32_t flight_sw_version;
     uint32_t middleware_sw_version = 0;
+#ifdef APJ_BOARD_ID
+    uint32_t board_version { APJ_BOARD_ID << 16 };
+#else
     uint32_t board_version = 0;
+#endif
     char flight_custom_version[MAVLINK_MSG_AUTOPILOT_VERSION_FIELD_FLIGHT_CUSTOM_VERSION_LEN]{};
     char middleware_custom_version[MAVLINK_MSG_AUTOPILOT_VERSION_FIELD_MIDDLEWARE_CUSTOM_VERSION_LEN]{};
     char os_custom_version[MAVLINK_MSG_AUTOPILOT_VERSION_FIELD_OS_CUSTOM_VERSION_LEN]{};


### PR DESCRIPTION
Co-authored-by: durka

This patch was originally proposed as scope-creep on https://github.com/ArduPilot/ardupilot/pull/18988 by durka

This is not what this field is meant for:
```
<field type="uint32_t" name="board_version">HW / board version (last 8 bytes should be silicon ID, if any)</field>
```

(this field also has super-secret magic compression)

PX4Firmware just shove the USB product ID into this field (again), which isn't useful.

This PR shoves the board ID into the field.  I think we could potentially shift the 16-bit board ID 16 bits left and add a comment to the field indicating the top bits are `APJ_BOARD_ID`.  Problem here is that the mavlink spec should probably not be referencing an outside document...
