### PR TITLE
ArduCopter: fix few broken frames 

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6817,9 +6817,6 @@ class AutoTestCopter(AutoTest):
         vinfo = vehicleinfo.VehicleInfo()
         copter_vinfo_options = vinfo.options[self.vehicleinfo_key()]
         known_broken_frames = {
-            'cwx': "missing defaults file",
-            'deca-cwx': 'missing defaults file',
-            'djix': "missing defaults file",
             'heli-compound': "wrong binary, different takeoff regime",
             'heli-dual': "wrong binary, different takeoff regime",
             'heli': "wrong binary, different takeoff regime",

--- a/Tools/autotest/default_params/copter-cwx.parm
+++ b/Tools/autotest/default_params/copter-cwx.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE     14

--- a/Tools/autotest/default_params/copter-deca-cwx.parm
+++ b/Tools/autotest/default_params/copter-deca-cwx.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE     14

--- a/Tools/autotest/default_params/copter-djix.parm
+++ b/Tools/autotest/default_params/copter-djix.parm
@@ -1,0 +1,1 @@
+FRAME_TYPE  13

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -105,7 +105,11 @@ class VehicleInfo(object):
             },
             "deca-cwx": {
                 "waf_target": "bin/arducopter",
-                "default_params_filename": "default_params/copter.parm",
+                "default_params_filename": [
+                    "default_params/copter.parm",
+                    "default_params/copter-deca.parm",
+                    "default_params/copter-deca-cwx.parm"
+                 ],
             },
             "tri": {
                 "waf_target": "bin/arducopter",

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -1181,8 +1181,9 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motors(motors, ARRAY_SIZE(motors));
                     break;
                 }
-                case MOTOR_FRAME_TYPE_X: {
-                    _frame_type_string = "X";
+                case MOTOR_FRAME_TYPE_X:
+                case MOTOR_FRAME_TYPE_CW_X: {
+                    _frame_type_string = "X/CW_X";
                     static const AP_MotorsMatrix::MotorDef motors[] {
                         {   18, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   1 },
                         {   54, AP_MOTORS_MATRIX_YAW_FACTOR_CW,    2 },


### PR DESCRIPTION
This fixes few copter frames which were broken because of missing defaults.