### PR TITLE
Move EFI from Plane up to AP_Vehicle

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -113,9 +113,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if LANDING_GEAR_ENABLED == ENABLED
     SCHED_TASK(landing_gear_update, 5, 50),
 #endif
-#if HAL_EFI_ENABLED
-    SCHED_TASK(efi_update,             10,    200),
-#endif
 };
 
 void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
@@ -335,13 +332,6 @@ void Plane::compass_save()
          */
         compass.save_offsets();
     }
-}
-
-void Plane::efi_update(void)
-{
-#if HAL_EFI_ENABLED
-    g2.efi.update();
-#endif
 }
 
 #if AP_AIRSPEED_AUTOCAL_ENABLE

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1142,11 +1142,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DSPOILER_AILMTCH", 21, ParametersG2, crow_flap_aileron_matching, 100),
 
-#if HAL_EFI_ENABLED
-    // @Group: EFI
-    // @Path: ../libraries/AP_EFI/AP_EFI.cpp
-    AP_SUBGROUPINFO(efi, "EFI", 22, ParametersG2, AP_EFI),
-#endif
+
+    // 22 was EFI
 
     // @Param: FWD_BAT_VOLT_MAX
     // @DisplayName: Forward throttle battery voltage compensation maximum voltage
@@ -1468,6 +1465,22 @@ void Plane::load_parameters(void)
 #endif
 
     g.use_reverse_thrust.convert_parameter_width(AP_PARAM_INT16);
+
+
+    // PARAMETER_CONVERSION - Added: Oct-2021
+#if HAL_EFI_ENABLED
+    {
+        // Find G2's Top Level Key
+        AP_Param::ConversionInfo info;
+        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
+            return;
+        }
+
+        const uint16_t old_index = 22;       // Old parameter index in g2
+        const uint16_t old_top_element = 86; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
+        AP_Param::convert_class(info.old_key, &efi, efi.var_info, old_index, old_top_element, false);
+    }
+#endif
 
     hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
 }

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -538,11 +538,6 @@ public:
     AP_Float fwd_thr_batt_voltage_min;
     AP_Int8  fwd_thr_batt_idx;
 
-#if HAL_EFI_ENABLED
-    // EFI Engine Monitor
-    AP_EFI efi;
-#endif
-
 #if OFFBOARD_GUIDED == ENABLED
     // guided yaw heading PID
     AC_PID guidedHeading{5000.0,  0.0,   0.0, 0 ,  10.0,   5.0,  5.0 ,  5.0  , 0.2};

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -81,7 +81,6 @@
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_ICEngine/AP_ICEngine.h>
-#include <AP_EFI/AP_EFI.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Landing/AP_Landing.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -86,11 +86,6 @@ void Plane::init_ardupilot()
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 
-// init EFI monitoring
-#if HAL_EFI_ENABLED
-    g2.efi.init();
-#endif
-
     // GPS Initialization
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init(serial_manager);

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -61,6 +61,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(externalAHRS, "EAHRS", 8, AP_Vehicle, AP_ExternalAHRS),
 #endif
 
+#if HAL_EFI_ENABLED
+    // @Group: EFI
+    // @Path: ../AP_EFI/AP_EFI.cpp
+    AP_SUBGROUPINFO(efi, "EFI", 9, AP_Vehicle, AP_EFI),
+#endif
+
     AP_GROUPEND
 };
 
@@ -174,6 +180,12 @@ void AP_Vehicle::setup()
 #if HAL_GENERATOR_ENABLED
     generator.init();
 #endif
+
+// init EFI monitoring
+#if HAL_EFI_ENABLED
+    efi.init();
+#endif
+
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 }
 
@@ -243,6 +255,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
     SCHED_TASK(publish_osd_info, 1, 10),
 #endif
     SCHED_TASK(accel_cal_update,      10,    100),
+#if HAL_EFI_ENABLED
+    SCHED_TASK_CLASS(AP_EFI,       &vehicle.efi,            update,                   10, 200),
+#endif
 };
 
 void AP_Vehicle::get_common_scheduler_tasks(const AP_Scheduler::Task*& tasks, uint8_t& num_tasks)

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -25,6 +25,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Button/AP_Button.h>
+#include <AP_EFI/AP_EFI.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Generator/AP_Generator.h>
 #include <AP_Logger/AP_Logger.h>
@@ -352,6 +353,11 @@ protected:
     
 #if HAL_SMARTAUDIO_ENABLED
     AP_SmartAudio smartaudio;
+#endif
+
+#if HAL_EFI_ENABLED
+    // EFI Engine Monitor
+    AP_EFI efi;
 #endif
 
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This work sponsored by Harris Aerial.

This simply moves the AP_EFI object from Plane up to AP_Vehicle.

This makes use of @hendjoshsr71 's parameter conversion PR here: https://github.com/ArduPilot/ardupilot/pull/18994/files - parameter conversion seems to work.
