### PR TITLE
AP_Rangefinder: Use default address for TFMiniPlus I2C unless specified

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -413,15 +413,20 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
                 }
             }
         break;
-    case Type::BenewakeTFminiPlus:
+    case Type::BenewakeTFminiPlus: {
+        uint8_t addr = TFMINI_ADDR_DEFAULT;
+        if (params[instance].address != 0) {
+            addr = params[instance].address;
+        }
         FOREACH_I2C(i) {
             if (_add_backend(AP_RangeFinder_Benewake_TFMiniPlus::detect(state[instance], params[instance],
-                                                                        hal.i2c_mgr->get_device(i, params[instance].address)),
+                                                                        hal.i2c_mgr->get_device(i, addr)),
                     instance)) {
                 break;
             }
         }
         break;
+    }
     case Type::PX4_PWM:
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 #ifndef HAL_BUILD_AP_PERIPH

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMini.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMini.h
@@ -2,6 +2,8 @@
 
 #include "AP_RangeFinder_Benewake.h"
 
+#define TFMINI_ADDR_DEFAULT              0x10        // TFMini default device id
+
 class AP_RangeFinder_Benewake_TFMini : public AP_RangeFinder_Benewake
 {
 public:


### PR DESCRIPTION
This fixes the issue #13419. If RNGFNDx_ADDR is set to 0, this automatically uses default i2c address for TFMini/TFMiniPlus.
I could not simulate the i2c version of TFMini on SITL. If anyone could help me do that, I can test if it works fine.
