### PR TITLE
Scripting: allow for aerobatics in AUTO mode in plane

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -501,6 +501,15 @@ void Plane::stabilize()
             plane.stabilize_pitch(speed_scaler);
         }
 #endif
+#if ENABLE_SCRIPTING
+    } else if (control_mode == &mode_auto &&
+               mission.get_current_nav_cmd().id == MAV_CMD_NAV_SCRIPT_TIME) {
+        // scripting is in control of roll and pitch rates and throttle
+        const float aileron = rollController.get_rate_out(nav_scripting.roll_rate_dps, speed_scaler);
+        const float elevator = pitchController.get_rate_out(nav_scripting.pitch_rate_dps, speed_scaler);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, aileron);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, elevator);
+#endif
     } else {
         if (allow_stick_mixing && g.stick_mixing == StickMixing::FBW && control_mode != &mode_stabilize) {
             stabilize_stick_mixing_fbw();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -521,6 +521,18 @@ private:
         float terrain_correction;
     } auto_state;
 
+#if ENABLE_SCRIPTING
+    // support for scripting nav commands, with verify
+    struct {
+        uint16_t id;
+        float roll_rate_dps;
+        float pitch_rate_dps;
+        float throttle_pct;
+        uint32_t start_ms;
+        bool done;
+    } nav_scripting;
+#endif
+
     struct {
         // roll pitch yaw commanded from external controller in centidegrees
         Vector3l forced_rpy_cd;
@@ -932,6 +944,12 @@ private:
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     float get_wp_radius() const;
 
+#if ENABLE_SCRIPTING
+    // nav scripting support
+    void do_nav_script_time(const AP_Mission::Mission_Command& cmd);
+    bool verify_nav_script_time(const AP_Mission::Mission_Command& cmd);
+#endif
+
     // commands.cpp
     void set_guided_WP(void);
     void update_home();
@@ -1118,6 +1136,17 @@ private:
     bool have_reverse_thrust(void) const;
     float get_throttle_input(bool no_deadzone=false) const;
     float get_adjusted_throttle_input(bool no_deadzone=false) const;
+
+#ifdef ENABLE_SCRIPTING
+    // support for NAV_SCRIPT_TIME mission command
+    bool nav_scripting_active(void) const;
+    bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) override;
+    void nav_script_time_done(uint16_t id) override;
+
+    // command throttle percentage and roll, pitch, yaw target
+    // rates. For use with scripting controllers
+    bool set_target_throttle_rate_rpy(float throttle_pct, float roll_rate_dps, float pitch_rate_dps, float yaw_rate_dps) override;
+#endif
 
     enum Failsafe_Action {
         Failsafe_Action_None      = 0,

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -86,6 +86,13 @@ void ModeAuto::update()
         } else {
             plane.calc_throttle();
         }
+#if ENABLE_SCRIPTING
+    } else if (nav_cmd_id == MAV_CMD_NAV_SCRIPT_TIME) {
+        // NAV_SCRIPTING has a desired roll and pitch rate and desired throttle
+        plane.nav_roll_cd = plane.ahrs.roll_sensor;
+        plane.nav_pitch_cd = plane.ahrs.pitch_sensor;
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.nav_scripting.throttle_pct);
+#endif
     } else {
         // we are doing normal AUTO flight, the special cases
         // are for takeoff and landing

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -221,6 +221,14 @@ public:
         float p3;
     };
 
+    // Scripting NAV command (with verify)
+    struct PACKED nav_script_time_Command {
+        uint8_t command;
+        uint8_t timeout_s;
+        float arg1;
+        float arg2;
+    };
+    
     union Content {
         // jump structure
         Jump_Command jump;
@@ -291,6 +299,9 @@ public:
         // do scripting
         scripting_Command scripting;
 
+        // nav scripting
+        nav_script_time_Command nav_script_time;
+        
         // location
         Location location{};      // Waypoint location
     };

--- a/libraries/AP_Scripting/examples/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/plane_aerobatics.lua
@@ -1,0 +1,169 @@
+-- perform simple aerobatic manoeuvres in AUTO mode
+
+local running = false
+
+local roll_stage = 0
+
+local ROLL_TCONST = param:get('RLL2SRV_TCONST') * 0.5
+local PITCH_TCONST = param:get('PTCH2SRV_TCONST') * 0.5
+local TRIM_THROTTLE = param:get('TRIM_THROTTLE') * 1.0
+
+local scr_user1_param = Parameter()
+local scr_user2_param = Parameter()
+local scr_user3_param = Parameter()
+assert(scr_user1_param:init('SCR_USER1'), 'could not find SCR_USER1 parameter')
+assert(scr_user2_param:init('SCR_USER2'), 'could not find SCR_USER2 parameter')
+assert(scr_user3_param:init('SCR_USER3'), 'could not find SCR_USER3 parameter')
+
+local last_roll_err = 0.0
+local last_id = 0
+
+-- find our rudder channel
+local RUDDER_CHAN = SRV_Channels:find_channel(21)
+local RUDDER_TRIM = param:get("SERVO" .. RUDDER_CHAN + 1 .. "_TRIM")
+local RUDDER_REVERSED = param:get("SERVO" .. RUDDER_CHAN + 1 .. "_REVERSED")
+local RUDDER_MIN = param:get("SERVO" .. RUDDER_CHAN + 1 .. "_MIN")
+local RUDDER_MAX = param:get("SERVO" .. RUDDER_CHAN + 1 .. "_MAX")
+local RUDDER_THROW = (RUDDER_MAX - RUDDER_MIN) * 0.5
+
+-- constrain a value between limits
+function constrain(v, vmin, vmax)
+   if v < vmin then
+      v = vmin
+   end
+   if v > vmax then
+      v = vmax
+   end
+   return v
+end
+
+-- a controller to target a zero roll angle, coping with inverted flight
+-- output is a body frame roll rate, with convergence over time tconst in seconds
+function roll_zero_controller(tconst)
+   local roll_deg = math.deg(ahrs:get_roll())
+   local pitch_deg = math.deg(ahrs:get_pitch())
+   local roll_err = 0.0
+   if math.abs(pitch_deg) > 85 then
+      -- close to 90 we retain the last roll rate
+      roll_err = last_roll_err
+   elseif roll_deg > 90 then
+      roll_err = 180 - roll_deg
+   elseif roll_deg < -90 then
+      roll_err = (-180) - roll_deg
+   else
+      roll_err = -roll_deg
+   end
+   last_roll_err = roll_err
+   return roll_err / tconst
+end
+
+-- a controller to target a zero pitch angle
+-- output is a body frame pitch rate, with convergence over time tconst in seconds
+function pitch_controller(target_pitch_deg, tconst)
+   local roll_deg = math.deg(ahrs:get_roll())
+   local pitch_deg = math.deg(ahrs:get_pitch())
+   local pitch_rate = (target_pitch_deg - pitch_deg) * math.cos(math.rad(roll_deg)) / tconst
+   RUDDER_GAIN = scr_user1_param:get()
+   local rudder = pitch_deg * RUDDER_GAIN * math.sin(math.rad(roll_deg)) / tconst
+   return pitch_rate, rudder
+end
+
+-- a controller for throttle to account for pitch
+function throttle_controller(tconst)
+   local pitch_rad = ahrs:get_pitch()
+   local thr_ff = scr_user3_param:get()
+   local throttle = TRIM_THROTTLE + math.sin(pitch_rad) * thr_ff
+   return constrain(throttle, 0.0, 100.0)
+end
+
+function do_axial_roll(arg1, arg2)
+   -- constant roll rate axial roll
+   if not running then
+      running = true
+      roll_stage = 0
+      gcs:send_text(0, string.format("Starting roll"))
+   end
+   local roll_rate = arg1
+   local throttle = arg2
+   local pitch_deg = math.deg(ahrs:get_pitch())
+   local roll_deg = math.deg(ahrs:get_roll())
+   if roll_stage == 0 then
+      if roll_deg > 45 then
+         roll_stage = 1
+      end
+   elseif roll_stage == 1 then
+      if roll_deg > -5 and roll_deg < 5 then
+         running = false
+         -- we're done
+         gcs:send_text(0, string.format("Finished roll r=%.1f p=%.1f", roll_deg, pitch_deg))
+         vehicle:nav_script_time_done(last_id)
+         roll_stage = 2
+         return
+      end
+   end
+   if roll_stage < 2 then
+      target_pitch = scr_user2_param:get()
+      pitch_rate, rudder = pitch_controller(target_pitch, PITCH_TCONST)
+      vehicle:set_target_throttle_rate_rpy(throttle, roll_rate, pitch_rate, 0)
+      if RUDDER_REVERSED == 1 then
+         rudder = -rudder
+      end
+      local rudder_out = math.floor(RUDDER_TRIM + RUDDER_THROW * rudder)
+      rudder_out = constrain(rudder_out, RUDDER_MIN, RUDDER_MAX)
+      SRV_Channels:set_output_pwm_chan_timeout(RUDDER_CHAN, rudder_out, 50)
+   end
+end
+
+local loop_stage = 0
+
+function do_loop(arg1, arg2)
+   -- do one loop with controllable pitch rate and throttle
+   if not running then
+      running = true
+      loop_stage = 0
+      gcs:send_text(0, string.format("Starting loop"))
+   end
+   local pitch_rate = arg1
+   local throttle = throttle_controller()
+   local pitch_deg = math.deg(ahrs:get_pitch())
+   local roll_deg = math.deg(ahrs:get_roll())
+   if loop_stage == 0 then
+      if pitch_deg > 60 then
+         loop_stage = 1
+      end
+   elseif loop_stage == 1 then
+      if math.abs(roll_deg) < 90 and pitch_deg > -5 and pitch_deg < 5 then
+         running = false
+         -- we're done
+         gcs:send_text(0, string.format("Finished loop p=%.1f", pitch_deg))
+         vehicle:nav_script_time_done(last_id)
+         loop_stage = 2
+         return
+      end
+   end
+   if loop_stage < 2 then
+      local roll_rate = roll_zero_controller(ROLL_TCONST)
+      vehicle:set_target_throttle_rate_rpy(throttle, roll_rate, pitch_rate, 0)
+   end
+end
+
+function update()
+   id, cmd, arg1, arg2 = vehicle:nav_script_time()
+   if id then
+      if id ~= last_id then
+         -- we've started a new command
+         running = false
+         last_id = id
+      end
+      if cmd == 1 then
+         do_axial_roll(arg1, arg2)
+      elseif cmd == 2 then
+         do_loop(arg1, arg2)
+      end
+   else
+      running = false
+   end
+   return update, 10
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -218,6 +218,9 @@ singleton AP_Vehicle method get_wp_distance_m boolean float'Null
 singleton AP_Vehicle method get_wp_bearing_deg boolean float'Null
 singleton AP_Vehicle method get_wp_crosstrack_error_m boolean float'Null
 singleton AP_Vehicle method get_pan_tilt_norm boolean float'Null float'Null
+singleton AP_Vehicle method nav_script_time boolean uint16_t'Null uint8_t'Null float'Null float'Null
+singleton AP_Vehicle method nav_script_time_done void uint16_t'skip_check
+singleton AP_Vehicle method set_target_throttle_rate_rpy boolean float -100 100 float'skip_check float'skip_check float'skip_check
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -201,6 +201,10 @@ public:
     virtual bool set_target_velaccel_NED(const Vector3f& target_vel, const Vector3f& target_accel, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) { return false; }
     virtual bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) { return false; }
 
+    // command throttle percentage and roll, pitch, yaw target
+    // rates. For use with scripting controllers
+    virtual bool set_target_throttle_rate_rpy(float throttle_pct, float roll_rate_dps, float pitch_rate_dps, float yaw_rate_dps) { return false; }
+
     // get target location (for use by scripting)
     virtual bool get_target_location(Location& target_loc) { return false; }
 
@@ -210,6 +214,11 @@ public:
 
     // set steering and throttle (-1 to +1) (for use by scripting with Rover)
     virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
+
+    // support for NAV_SCRIPT_TIME mission command
+    virtual bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) { return false; }
+    virtual void nav_script_time_done(uint16_t id) {}
+
 #endif // ENABLE_SCRIPTING
 
 


### PR DESCRIPTION
This allows for a NAV_SCRIPTING command that is a verify mission item implemented in a script. It is implemented in plane to allow for aerobatics controlled by a lua script.
The mission item has:
 - a command ID (interpreted by the script)
 - a timeout in seconds
 - two script controlled float arguments

This is an example mission:
![image](https://user-images.githubusercontent.com/831867/138655668-be432e35-cf26-464b-a09e-4263b3ceffc9.png)
That mission works with libraries/AP_Scripting/examples/plane_aerobatics.lua. That script implements both loops and rolls

the passes arguments 2, 10, 80, 90 to the script in WP 4. The params are:
 - 2 == an integer argument the script interprets to know what manoeuvrer to do. For the example script 1 is an axial roll, 2 is a loop
 - 10 is the timeout in seconds. If the script doesn't complete the mission item in that time then the mission continues with the next item
 - 80 and 90 are float arguments interpreted by the script. In this case it is the pitch rate and the throttle level

Demo video:
https://www.youtube.com/watch?v=rqFUpj78fKE

Link to related mavlink PR: https://github.com/ArduPilot/mavlink/pull/228