### PR TITLE
Report CRSF link quality in place of RSSI

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -270,6 +270,9 @@ private:
     uint32_t _new_baud_rate;
     bool _crsf_v3_active;
 
+    bool _use_lq_for_rssi;
+    int16_t derive_scaled_lq_value(uint8_t uplink_lq);
+
     volatile struct LinkStatus _link_status;
 
     AP_HAL::UARTDriver *_uart;

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -171,6 +171,12 @@ void AP_CRSF_Telem::process_rf_mode_changes()
     if (_telem_last_report_ms == 0 && !uart->is_dma_enabled()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "CRSF: running on non-DMA serial port");
     }
+    // note if option was set to show LQ in place of RSSI
+    bool current_lq_as_rssi_active = bool(rc().use_crsf_lq_as_rssi());
+    if(_telem_last_report_ms == 0 || _noted_lq_as_rssi_active != current_lq_as_rssi_active){
+        _noted_lq_as_rssi_active = current_lq_as_rssi_active;
+        gcs().send_text(MAV_SEVERITY_INFO, "CRSF: RSSI now displays %s", current_lq_as_rssi_active ? " as LQ" : "normally");
+    }
     // report a change in RF mode or a chnage of more than 10Hz if we haven't done so in the last 5s
     if ((now - _telem_last_report_ms > 5000) &&
         (_telem_rf_mode != current_rf_mode || abs(int16_t(_telem_last_avg_rate) - int16_t(_scheduler.avg_packet_rate)) > 25)) {

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -351,6 +351,8 @@ private:
     bool _vtx_power_change_pending;
     bool _vtx_options_change_pending;
 
+    bool _noted_lq_as_rssi_active;
+
     static AP_CRSF_Telem *singleton;
 };
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -507,6 +507,10 @@ public:
         return _options & uint32_t(Option::MULTI_RECEIVER_SUPPORT);
     }
 
+    bool use_crsf_lq_as_rssi(void) const {
+        return get_singleton() != nullptr && (_options & uint32_t(Option::USE_CRSF_LQ_AS_RSSI)) != 0;
+    }
+
     // returns true if overrides should time out.  If true is returned
     // then returned_timeout_ms will contain the timeout in
     // milliseconds, with 0 meaning overrides are disabled.
@@ -570,6 +574,7 @@ protected:
         CRSF_CUSTOM_TELEMETRY   = (1U << 8), // use passthrough data for crsf telemetry
         SUPPRESS_CRSF_MESSAGE   = (1U << 9), // suppress CRSF mode/rate message for ELRS systems
         MULTI_RECEIVER_SUPPORT  = (1U << 10), // allow multiple receivers
+        USE_CRSF_LQ_AS_RSSI     = (1U << 11), // returns CRSF link quality as RSSI value, instead of RSSI
     };
 
     void new_override_received() {

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:CRSF RSSI shows Link Quality
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
For comment. It adds RC_OPTION bitmask 11
If set the CRSF protocol will return CRSF link quality in place of RSSI, i.e RSSI reported will not actually be RSSI but LQ.

This is the first time I have seen the code and am not sure of the structure, so for comment only really. Maybe a real contributor wants to re-factor the code for inclusion?

It also sends GCS message to note the value being reported as RSSI when RF Mode changes (again, slotted it in here to change the existing code as little as possible)