### PR TITLE
AP_WheelEncoder: quadrature spelling changed

### DIFF
--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -174,7 +174,7 @@ void AP_WheelEncoder::init(void)
 
         case WheelEncoder_TYPE_SITL_QUADRATURE:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-            drivers[i] = new AP_WheelEncoder_SITL_Qaudrature(*this, i, state[i]);
+            drivers[i] = new AP_WheelEncoder_SITL_Quadrature(*this, i, state[i]);
 #endif
             break;
             

--- a/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.cpp
@@ -22,7 +22,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-void AP_WheelEncoder_SITL_Qaudrature::update(void)
+void AP_WheelEncoder_SITL_Quadrature::update(void)
 {
     const auto *_sitl = AP::sitl();
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.h
@@ -20,7 +20,7 @@
 #include <AP_Math/AP_Math.h>
 #include <SITL/SITL.h>
 
-class AP_WheelEncoder_SITL_Qaudrature : public AP_WheelEncoder_Backend
+class AP_WheelEncoder_SITL_Quadrature : public AP_WheelEncoder_Backend
 {
 public:
     // constructor


### PR DESCRIPTION
Made changes in 
- `libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.h`
- `libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.cpp`
- `libraries/AP_WheelEncoder/AP_WheelEncoder.cpp`

Changes done:
Qaudrature -> Quadrature