### PR TITLE
AP_ADSB: bugfix vertical velocity sign was backwards

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
@@ -69,7 +69,7 @@ void AP_ADSB_uAvionix_MAVLink::send_dynamic_out(const mavlink_channel_t chan) co
     const int32_t latitude = _frontend._my_loc.lat;
     const int32_t longitude = _frontend._my_loc.lng;
     const int32_t altGNSS = _frontend._my_loc.alt * 10; // convert cm to mm
-    const int16_t velVert = gps_velocity.z * 1E2; // convert m/s to cm/s
+    const int16_t velVert = -1.0f * gps_velocity.z * 1E2; // convert m/s to cm/s
     const int16_t nsVog = gps_velocity.x * 1E2; // convert m/s to cm/s
     const int16_t ewVog = gps_velocity.y * 1E2; // convert m/s to cm/s
     const uint8_t fixType = gps.status(); // this lines up perfectly with our enum

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -364,7 +364,7 @@ void AP_ADSB_uAvionix_UCP::send_GPS_Data()
     msg.verticalVelocityFOM_mmps = msg.horizontalVelocityFOM_mmps;
 
     // Velocities
-    msg.verticalVelocity_cmps = fix_is_good ? velocity.z * 1E2 : INT16_MAX;
+    msg.verticalVelocity_cmps = fix_is_good ? -1.0f * velocity.z * 1E2 : INT16_MAX;
     msg.northVelocity_mmps = fix_is_good ? velocity.x * 1E3 : INT32_MAX;
     msg.eastVelocity_mmps = fix_is_good ? velocity.y * 1E3 : INT32_MAX;
 


### PR DESCRIPTION
AP_ADSB: bugfix vertical velocity sign was backwards and GPS altitude should always be from GPS