### PR TITLE
Stricter lua bindings build processing

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -57,6 +57,11 @@ _vehicle_macros = ['SKETCHNAME', 'SKETCH', 'APM_BUILD_DIRECTORY',
                    'AP_NavEKF3_core.h', 'lua_generated_bindings.h']
 _macros_re = re.compile(r'\b(%s)\b' % '|'.join(_vehicle_macros))
 
+# some cpp files are not available at the time we run this check so need to be
+# unilaterally added
+_vehicle_cpp_need_macros = ['lua_generated_bindings.cpp']
+_macros_cpp_re = re.compile(r'\b(%s)\b' % '|'.join(_vehicle_cpp_need_macros))
+
 def _remove_comments(s):
     return c_preproc.re_cpp.sub(c_preproc.repl, s)
 
@@ -66,14 +71,9 @@ def _depends_on_vehicle(bld, source_node):
 
     if not bld.env.BUILDROOT:
         bld.env.BUILDROOT = bld.bldnode.make_node('').abspath()
-    if path.startswith(bld.env.BUILDROOT) or path.startswith("build.tmp.binaries/"):
-        _depends_on_vehicle_cache[path] = False
 
-    if path.startswith("build/") or path.startswith(bld.env.BUILDROOT):
-        # allow vehicle dependend #if in cpp generated in build/
-        # only scripting bindings currently
+    if _macros_cpp_re.search(path) is not None:
         _depends_on_vehicle_cache[path] = True
-
 
     if path not in _depends_on_vehicle_cache:
         try:


### PR DESCRIPTION
The custom build server was failing on APM_BUILD_TYPE definitions for the lua generated bindings. It turns out that this is because the file does not exist at the point that the checks for APM_BUILD_TYPE are made. This PR explicitly enables the appropriate defines for that file which solves the custom build issue and is a better solution all round.