### PR TITLE
AP_ADSB: add OPTION bit to Prefer_ARHS_for_Location instead of GPS

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -78,6 +78,7 @@ public:
         Ping200X_Send_GPS               = (1<<0),
         Squawk_7400_FS_RC               = (1<<1),
         Squawk_7400_FS_GCS              = (1<<2),
+        Prefer_ARHS_for_Location        = (1<<3),
     };
 
     // for holding parameters


### PR DESCRIPTION
Add ADSB_OPTION bit to Prefer_ARHS_for_Location instead of GPS. Current behavior always uses AHRS but ADSB-Out expects gps position and gps altitude. The AHRS default is GPS position and Baro altitude and that causes a lot of error at higher altitudes, especially because of reasons https://github.com/ArduPilot/ardupilot/pull/17984 is trying to address.

I pulled this out of https://github.com/ArduPilot/ardupilot/pull/19049 as a separate PR.
