### PR TITLE
hwdef: fixed reported flash on boards with storage at end of flash

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
@@ -110,6 +110,9 @@ define HAL_STORAGE_SIZE 16384
 # H743 has 16 pages of 128k each
 define STORAGE_FLASH_PAGE 14
 
+# reserve space for flash storage in last 2 sectors
+FLASH_RESERVE_END_KB 256
+
 # enable logging to dataflash
 define HAL_LOGGING_DATAFLASH
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
@@ -24,6 +24,9 @@ FLASH_RESERVE_START_KB 128
 define STORAGE_FLASH_PAGE 14
 define HAL_STORAGE_SIZE 32768
 
+# reserve space for flash storage in last 2 sectors
+FLASH_RESERVE_END_KB 256
+
 # one I2C bus
 I2C_ORDER I2C1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
@@ -180,6 +180,9 @@ define HAL_STORAGE_SIZE 16384
 # H743 has 16 pages of 128k each
 define STORAGE_FLASH_PAGE 14
 
+# reserve space for flash storage in last 2 sectors
+FLASH_RESERVE_END_KB 256
+
 # spi devices
 SPIDEV mpu6000   SPI1 DEVID1 IMU1_CS      MODE3  1*MHZ  4*MHZ
 SPIDEV icm20602  SPI4 DEVID1 IMU2_CS      MODE3  1*MHZ  4*MHZ

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef.dat
@@ -12,10 +12,12 @@ define CAN_APP_NODE_NAME "org.ardupilot.ap_periph_ZubaxGNSS"
 # bootloader starts firmware at 34k
 FLASH_RESERVE_START_KB 34
 
-
 # store parameters in last 2 pages
 define STORAGE_FLASH_PAGE 126
 define HAL_STORAGE_SIZE 800
+
+# reserve space for flash storage in last 2 sectors
+FLASH_RESERVE_END_KB 2
 
 # board ID for firmware load
 APJ_BOARD_ID 1005


### PR DESCRIPTION
this was in hwdef-bl.dat but had been left out of hwdef.dat which led
to flash_free being wrong in apj file