### PR TITLE
Rover: prevent arming if RC/throttle failsafe is triggered

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -89,7 +89,8 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
             & motor_checks(report)
             & oa_check(report)
             & parameter_checks(report)
-            & mode_checks(report));
+            & mode_checks(report)
+            & pilot_throttle_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -183,6 +184,19 @@ bool AP_Arming_Rover::parameter_checks(bool report)
     if (!is_positive(rover.g2.wp_nav.get_default_speed())) {
         check_failed(ARMING_CHECK_PARAMETERS, report, "WP_SPEED too low");
         return false;
+    }
+
+    return true;
+}
+
+// check throttle is above failsafe throttle
+bool AP_Arming_Rover::pilot_throttle_checks(bool report)
+{
+    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
+        if (rover.g.fs_throttle_enabled != FS_THR_DISABLED && rover.channel_throttle->get_radio_in() < rover.g.fs_throttle_value) {
+            check_failed(ARMING_CHECK_RC, report, "Throttle below failsafe");
+            return false;
+        }
     }
 
     return true;

--- a/Rover/AP_Arming.h
+++ b/Rover/AP_Arming.h
@@ -32,5 +32,6 @@ protected:
     bool parameter_checks(bool report);
     bool mode_checks(bool report);
     bool motor_checks(bool report);
+    bool pilot_throttle_checks(bool report);
 
 };

--- a/Rover/radio.cpp
+++ b/Rover/radio.cpp
@@ -152,5 +152,6 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 500) {
         failed = true;
     }
+    AP_Notify::flags.failsafe_radio = failed;
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, "Radio", failed);
 }


### PR DESCRIPTION
This fixes the issue #18991. We use `AP_Arming::manual_transmitter_checks()` as a part of pre-arm checks to check if rc failsafe is triggered. This method uses `AP_Notify::flags.failsafe_radio` to know if RC failsafe is on/off. We were not setting this flag when RC failsafe is triggered which was allowing it to pass this test even when RC failsafe on. I also added a similar method that we use in copter to check pilot throttle and prevent arming if throttle is below failsafe value.

I tested this on sitl. The steps I followed to test this are:-
- param set SIM_RC_FAIL 1
- arm throttle
<img width="1440" alt="Screenshot 2021-10-28 at 11 12 34 PM" src="https://user-images.githubusercontent.com/67995771/139310578-2837e93e-5a97-4927-a411-779cb0d4938f.png">
<img width="1440" alt="Screenshot 2021-10-28 at 11 12 42 PM" src="https://user-images.githubusercontent.com/67995771/139310668-aab793da-6c25-4a8c-a0a8-23912a387e51.png">
This didn't allow the rover to arm. To be sure if it allows it to arm when failsafe is cleared, I did:
- param set SIM_RC_FAIL 0
- arm throttle

The rover was successfully armed. 
<img width="1440" alt="Screenshot 2021-10-28 at 11 12 59 PM" src="https://user-images.githubusercontent.com/67995771/139310783-44d93d5a-1c44-4c28-a1b4-a12aa87e94fb.png">
<img width="1440" alt="Screenshot 2021-10-28 at 11 13 07 PM" src="https://user-images.githubusercontent.com/67995771/139310827-c84de48b-cdb4-4d0f-9980-e7bc03c1fc34.png">

Thanks @hendjoshsr71 for helping with initial debugging.