### PR TITLE
Plane: suppress D/P term when on the ground

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -141,7 +141,8 @@ float Plane::stabilize_roll_get_roll_out(float speed_scaler)
     if (control_mode == &mode_stabilize && channel_roll->get_control_in() != 0) {
         disable_integrator = true;
     }
-    return rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, speed_scaler, disable_integrator);
+    return rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, speed_scaler, disable_integrator,
+                                        ground_mode && !(plane.g2.flight_options & FlightOptions::DISABLE_GROUND_PID_SUPPRESSION));
 }
 
 /*
@@ -197,7 +198,8 @@ float Plane::stabilize_pitch_get_pitch_out(float speed_scaler)
         demanded_pitch = landing.get_pitch_cd();
     }
 
-    return pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, speed_scaler, disable_integrator);
+    return pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, speed_scaler, disable_integrator,
+                                         ground_mode && !(plane.g2.flight_options & FlightOptions::DISABLE_GROUND_PID_SUPPRESSION));
 }
 
 /*
@@ -402,7 +404,7 @@ void Plane::stabilize_acro(float speed_scaler)
         // 'stabilze' to true, which disables the roll integrator
         SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, rollController.get_servo_out(roll_error_cd,
                                                                                              speed_scaler,
-                                                                                             true));
+                                                                                             true, false));
     } else {
         /*
           aileron stick is non-zero, use pure rate control until the
@@ -426,7 +428,7 @@ void Plane::stabilize_acro(float speed_scaler)
         nav_pitch_cd = acro_state.locked_pitch_cd;
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pitchController.get_servo_out(nav_pitch_cd - ahrs.pitch_sensor,
                                                                                                speed_scaler,
-                                                                                               false));
+                                                                                               false, false));
     } else {
         /*
           user has non-zero pitch input, use a pure rate controller

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1075,7 +1075,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor., 7:EnableDefaultAirspeed for takeoff, 8: Remove the TRIM_PITCH_CD on the GCS horizon, 9: Remove the TRIM_PITCH_CD on the OSD horizon, 10: Adjust mid-throttle to be TRIM_THROTTLE in non-auto throttle modes except MANUAL
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB, 4: Climb to ALT_HOLD_RTL before turning for RTL, 5: Enable yaw damper in acro mode, 6: Surpress speed scaling during auto takeoffs to be 1 or less to prevent oscillations without airpseed sensor., 7:EnableDefaultAirspeed for takeoff, 8: Remove the TRIM_PITCH_CD on the GCS horizon, 9: Remove the TRIM_PITCH_CD on the OSD horizon, 10: Adjust mid-throttle to be TRIM_THROTTLE in non-auto throttle modes except MANUAL, 11:Disable suppression of fixed wing rate gains in ground mode
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -601,6 +601,9 @@ private:
     // time since started flying in any mode in milliseconds
     uint32_t started_flying_ms;
 
+    // ground mode is true when disarmed and not flying
+    bool ground_mode;
+
     // Navigation control variables
     // The instantaneous desired bank angle.  Hundredths of a degree
     int32_t nav_roll_cd;
@@ -683,7 +686,6 @@ private:
         // The amount of time we should stay in a loiter for the Loiter Time command.  Milliseconds.
         uint32_t time_max_ms;
     } loiter;
-
 
     // Conditional command
     // A value used in condition commands (eg delay, change alt, etc.)

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -165,6 +165,7 @@ enum FlightOptions {
     GCS_REMOVE_TRIM_PITCH_CD = (1 << 8),
     OSD_REMOVE_TRIM_PITCH_CD = (1 << 9),
     CENTER_THROTTLE_TRIM = (1<<10),
+    DISABLE_GROUND_PID_SUPPRESSION = (1<<11),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -174,6 +174,9 @@ void Plane::update_is_flying_5Hz(void)
 
     // tell AHRS flying state
     set_likely_flying(new_is_flying);
+
+    // conservative ground mode value for rate D suppression
+    ground_mode = !is_flying() && !hal.util->get_soft_armed();
 }
 
 /*

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -16,7 +16,7 @@ public:
     AP_PitchController &operator=(const AP_PitchController&) = delete;
 
 	float get_rate_out(float desired_rate, float scaler);
-	float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator);
+    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
 	void reset_I();
 
@@ -56,6 +56,6 @@ private:
 
     AP_Logger::PID_Info _pid_info;
 
-    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed);
+    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
     float   _get_coordination_rate_offset(float &aspeed, bool &inverted) const;
 };

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -129,7 +129,7 @@ AP_RollController::AP_RollController(const AP_Vehicle::FixedWing &parms)
 /*
   AC_PID based rate controller
 */
-float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator)
+float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode)
 {
     const AP_AHRS &_ahrs = AP::ahrs();
 
@@ -187,6 +187,10 @@ float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool di
 
     // sum components
     float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D;
+    if (ground_mode) {
+        // when on ground suppress D term to prevent oscillations
+        out -= pinfo.D + 0.5*pinfo.P;
+    }
 
     // remember the last output to trigger the I limit
     _last_out = out;
@@ -209,7 +213,7 @@ float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool di
 */
 float AP_RollController::get_rate_out(float desired_rate, float scaler)
 {
-    return _get_rate_out(desired_rate, scaler, false);
+    return _get_rate_out(desired_rate, scaler, false, false);
 }
 
 /*
@@ -221,7 +225,7 @@ float AP_RollController::get_rate_out(float desired_rate, float scaler)
  3) boolean which is true when stabilise mode is active
  4) minimum FBW airspeed (metres/sec)
 */
-float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool disable_integrator)
+float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode)
 {
     if (gains.tau < 0.05f) {
         gains.tau.set(0.05f);
@@ -238,7 +242,7 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
         desired_rate = gains.rmax_pos;
     }
 
-    return _get_rate_out(desired_rate, scaler, disable_integrator);
+    return _get_rate_out(desired_rate, scaler, disable_integrator, ground_mode);
 }
 
 void AP_RollController::reset_I()

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -16,7 +16,7 @@ public:
     AP_RollController &operator=(const AP_RollController&) = delete;
 
 	float get_rate_out(float desired_rate, float scaler);
-	float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator);
+    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
 	void reset_I();
 
@@ -61,5 +61,5 @@ private:
 
     AP_Logger::PID_Info _pid_info;
 
-    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator);
+    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode);
 };


### PR DESCRIPTION
This prevents PID oscillations while on the ground, which are quite common. 
We define ground_mode as being both disarmed and the is_flying test being false.
When in ground mode we remove D term, and halve P term
