### PR TITLE
Plane/SRV_Channel: use servo limit flags to limit I build up.

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1068,7 +1068,6 @@ private:
     void set_landing_gear(void);
     void dspoiler_update(void);
     void airbrake_update(void);
-    void servo_output_mixers(void);
     void landing_neutral_control_surface_servos(void);
     void servos_output(void);
     void servos_auto_trim(void);
@@ -1079,8 +1078,8 @@ private:
     void throttle_slew_limit(SRV_Channel::Aux_servo_function_t func);
     bool suppress_throttle(void);
     void update_throttle_hover();
-    void channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
-                                SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out) const;
+    bool channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
+                                SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out, float priority_ratio) const;
     void flaperon_update(int8_t flap_percent);
 
     // is_flying.cpp

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -990,6 +990,20 @@ void Plane::servos_output(void)
     if (g2.servo_channels.auto_trim_enabled()) {
         servos_auto_trim();
     }
+
+    // set limit flags
+    bool roll_limit = SRV_Channels::get_output_limit(SRV_Channel::k_aileron);
+    roll_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_elevon_left);
+    roll_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_elevon_right);
+    rollController.set_I_limit(roll_limit);
+
+    bool pitch_limit = SRV_Channels::get_output_limit(SRV_Channel::k_elevator);
+    pitch_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_elevon_left);
+    pitch_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_elevon_right);
+    pitch_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_vtail_left);
+    pitch_limit |= SRV_Channels::get_output_limit(SRV_Channel::k_vtail_right);
+    pitchController.set_I_limit(pitch_limit);
+
 }
 
 void Plane::update_throttle_hover() {

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -176,8 +176,8 @@ void Plane::channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, S
         in1 *= (100 + g.mixing_offset) * 0.01;
     }
     
-    float out1 = constrain_float((in2 - in1) * g.mixing_gain, -4500, 4500);
-    float out2 = constrain_float((in2 + in1) * g.mixing_gain, -4500, 4500);
+    float out1 = (in2 - in1) * g.mixing_gain;
+    float out2 = (in2 + in1) * g.mixing_gain;
     SRV_Channels::set_output_scaled(func1_out, out1);
     SRV_Channels::set_output_scaled(func2_out, out2);
 }
@@ -194,8 +194,8 @@ void Plane::flaperon_update(int8_t flap_percent)
       or from auto flaps.
      */
     float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
-    float flaperon_left  = constrain_float(aileron + flap_percent * 45, -4500, 4500);
-    float flaperon_right = constrain_float(aileron - flap_percent * 45, -4500, 4500);
+    float flaperon_left  = aileron + flap_percent * 45;
+    float flaperon_right = aileron - flap_percent * 45;
     SRV_Channels::set_output_scaled(SRV_Channel::k_flaperon_left, flaperon_left);
     SRV_Channels::set_output_scaled(SRV_Channel::k_flaperon_right, flaperon_right);
 }
@@ -243,12 +243,12 @@ void Plane::dspoiler_update(void)
 
     if (rudder > 0) {
         // apply rudder to right wing
-        dspoiler_outer_right = constrain_float(dspoiler_outer_right + rudder, -4500, 4500);
-        dspoiler_inner_right = constrain_float(dspoiler_inner_right - rudder, -4500, 4500);
+        dspoiler_outer_right = dspoiler_outer_right + rudder;
+        dspoiler_inner_right = dspoiler_inner_right - rudder;
     } else {
         // apply rudder to left wing
-        dspoiler_outer_left = constrain_float(dspoiler_outer_left - rudder, -4500, 4500);
-        dspoiler_inner_left = constrain_float(dspoiler_inner_left + rudder, -4500, 4500);
+        dspoiler_outer_left = dspoiler_outer_left - rudder;
+        dspoiler_inner_left = dspoiler_inner_left + rudder;
     }
 
     // limit flap throw used for aileron
@@ -286,10 +286,10 @@ void Plane::dspoiler_update(void)
                 outer_flap_scaled = constrain_float(outer_flap_scaled - 50, 0,50) * 2;
             }
             // scale flaps so when weights are 100 they give full up or down
-            dspoiler_outer_left  = constrain_float(dspoiler_outer_left  + outer_flap_scaled * weight_outer * 0.45, -4500, 4500);
-            dspoiler_inner_left  = constrain_float(dspoiler_inner_left  - inner_flap_scaled * weight_inner * 0.45, -4500, 4500);
-            dspoiler_outer_right = constrain_float(dspoiler_outer_right + outer_flap_scaled * weight_outer * 0.45, -4500, 4500);
-            dspoiler_inner_right = constrain_float(dspoiler_inner_right - inner_flap_scaled * weight_inner * 0.45, -4500, 4500);
+            dspoiler_outer_left  = dspoiler_outer_left  + outer_flap_scaled * weight_outer * 0.45;
+            dspoiler_inner_left  = dspoiler_inner_left  - inner_flap_scaled * weight_inner * 0.45;
+            dspoiler_outer_right = dspoiler_outer_right + outer_flap_scaled * weight_outer * 0.45;
+            dspoiler_inner_right = dspoiler_inner_right - inner_flap_scaled * weight_inner * 0.45;
         }
     }
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -189,6 +189,10 @@ bool Plane::channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, S
         float overflow1 = overflow * (1-priority_ratio);
         float overflow2 = overflow * priority_ratio;
 
+        // don't remove more than original input
+        overflow1 = MIN(fabs(in1),overflow1);
+        overflow2 = MIN(fabs(in2),overflow2);
+
         // remove overflow
         in1 -= is_positive(in1) ? overflow1 : -overflow1;
         in2 -= is_positive(in2) ? overflow2 : -overflow2;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -28,7 +28,10 @@ public:
         _pid_info.I *= 0.995f;
         rate_pid.set_integrator(rate_pid.get_i() * 0.995);
     }
-    
+
+    // set I limit flag to preven integrator windup
+    void set_I_limit(bool b) { _limit_I = b; }
+
     void autotune_start(void);
     void autotune_restore(void);
 
@@ -50,9 +53,9 @@ private:
     bool failed_autotune_alloc;
 	AP_Int16 _max_rate_neg;
 	AP_Float _roll_ff;
-    float _last_out;
     AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;
+    bool _limit_I;
 
     AP_Logger::PID_Info _pid_info;
 

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -28,7 +28,10 @@ public:
         _pid_info.I *= 0.995f;
         rate_pid.set_integrator(rate_pid.get_i() * 0.995);
     }
-    
+
+    // set I limit flag to preven integrator windup
+    void set_I_limit(bool b) { _limit_I = b; }
+
     void autotune_start(void);
     void autotune_restore(void);
 
@@ -55,9 +58,9 @@ private:
     AP_AutoTune::ATGains gains;
     AP_AutoTune *autotune;
     bool failed_autotune_alloc;
-	float _last_out;
     AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;
+    bool _limit_I;
 
     AP_Logger::PID_Info _pid_info;
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -261,6 +261,9 @@ public:
     // used by DO_SET_SERVO commands
     void ignore_small_rcin_changes() { ign_small_rcin_changes = true; }
 
+    // return limit flag, true if scaled value is larger than given range/angle, set on calc_pwm call
+    bool get_output_limit() { return limited; }
+
 private:
     AP_Int16 servo_min;
     AP_Int16 servo_max;
@@ -284,11 +287,17 @@ private:
     // high point of angle or range output
     uint16_t high_out;
 
-    // convert a 0..range_max to a pwm
-    uint16_t pwm_from_range(float scaled_value) const;
+    // true if scaled value is larger than given range
+    bool limited;
 
-    // convert a -angle_max..angle_max to a pwm
-    uint16_t pwm_from_angle(float scaled_value) const;
+    // constrain float, setting limit flag
+    float constrain_scaled(float scaled, float low, float high);
+
+    // convert a 0..range_max to a pwm, setting limit flag
+    uint16_t pwm_from_range(float scaled_value);
+
+    // convert a -angle_max..angle_max to a pwm, setting limit flag
+    uint16_t pwm_from_angle(float scaled_value);
 
     // convert a scaled output to a pwm value
     void calc_pwm(float output_scaled);
@@ -358,6 +367,9 @@ public:
 
     // get pwm output for the first channel of the given function type.
     static bool get_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t &value);
+
+    // get limit flag for given output, true if assigned and scaled value is larger than given range/angle
+    static bool get_output_limit(SRV_Channel::Aux_servo_function_t function);
 
     // get normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max)
     // Value is taken from pwm value.  Returns zero on error.

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -538,6 +538,17 @@ float SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t function
     return 0;
 }
 
+// get limit flag for given output, true if assigned and scaled value is larger than given range/angle
+bool SRV_Channels::get_output_limit(SRV_Channel::Aux_servo_function_t function)
+{
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        if (channels[i].function == function) {
+            return channels[i].get_output_limit();
+        }
+    }
+    return false;
+}
+
 /*
   get mask of output channels for a function
  */


### PR DESCRIPTION
This uses actual servo output to set the plane I limit flags. Should be no difference on aileron elevator planes. For things like flying wings where there is some mixing gain we were setting the limit too soon. For example with mixing gain of 0.5, the default we were limiting the elevator I term at half total elevon travel. We would also have been limiting too late for the case that the mixing gain was set to larger than one. 

This does make a change to remove constraints, this means that larger output values get further down before being constrained, again this means you get more travel.

There is a change in behavior, I think it is a improvement, we will have to think about how it will effect peoples setups. 

I was not sure if we should limit I when both control surfaces hit the limit or just one. For example do both Vtails have to be on the limit or just one. Currently it is just one, this makes it easier for vehicles that have combinations. 

There are a few other places the new limit flags can be used, tailsiters in VTOL, rovers. 

This change does make mixing gain irrelevant for stabilized flight, but it still does stuff for manual where the stick inputs are still constrained to +-4500.