### PR TITLE
Remove pilot_throttle_checks() method from rover and copter

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -58,7 +58,6 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
 
     return parameter_checks(display_failure)
         & motor_checks(display_failure)
-        & pilot_throttle_checks(display_failure)
         & oa_checks(display_failure)
         & gcs_failsafe_check(display_failure)
         & winch_checks(display_failure)
@@ -340,25 +339,6 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         }
     }
 #endif
-
-    return true;
-}
-
-bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
-{
-    // check throttle is above failsafe throttle
-    // this is near the bottom to allow other failures to be displayed before checking pilot throttle
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
-        if (copter.g.failsafe_throttle != FS_THR_DISABLED && copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {
-            #if FRAME_CONFIG == HELI_FRAME
-            const char *failmsg = "Collective below Failsafe";
-            #else
-            const char *failmsg = "Throttle below Failsafe";
-            #endif
-            check_failed(ARMING_CHECK_RC, display_failure, "%s", failmsg);
-            return false;
-        }
-    }
 
     return true;
 }

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -45,7 +45,6 @@ protected:
     // NOTE! the following check functions *DO NOT* call into AP_Arming!
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
-    bool pilot_throttle_checks(bool display_failure);
     bool oa_checks(bool display_failure);
     bool mandatory_gps_checks(bool display_failure);
     bool gcs_failsafe_check(bool display_failure);

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -89,8 +89,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
             & motor_checks(report)
             & oa_check(report)
             & parameter_checks(report)
-            & mode_checks(report)
-            & pilot_throttle_checks(report));
+            & mode_checks(report));
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
@@ -184,19 +183,6 @@ bool AP_Arming_Rover::parameter_checks(bool report)
     if (!is_positive(rover.g2.wp_nav.get_default_speed())) {
         check_failed(ARMING_CHECK_PARAMETERS, report, "WP_SPEED too low");
         return false;
-    }
-
-    return true;
-}
-
-// check throttle is above failsafe throttle
-bool AP_Arming_Rover::pilot_throttle_checks(bool report)
-{
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
-        if (rover.g.fs_throttle_enabled != FS_THR_DISABLED && rover.channel_throttle->get_radio_in() < rover.g.fs_throttle_value) {
-            check_failed(ARMING_CHECK_RC, report, "Throttle below failsafe");
-            return false;
-        }
     }
 
     return true;

--- a/Rover/AP_Arming.h
+++ b/Rover/AP_Arming.h
@@ -32,6 +32,5 @@ protected:
     bool parameter_checks(bool report);
     bool mode_checks(bool report);
     bool motor_checks(bool report);
-    bool pilot_throttle_checks(bool report);
 
 };


### PR DESCRIPTION
As pointed out by @rmackay9 [here](https://github.com/ArduPilot/ardupilot/pull/19064#issuecomment-955161112), the dedicated RC failsafe methods in both the vehicles take care of below acceptable throttle, making `pilot_throttle_checks()` method redundant. 

I tested it on sitl on both these vehicles by setting throttle channel input to 900 (`rc 3 900`) and as expected that triggered rc failsafe. Below are some screenshots.
<img width="1440" alt="Screenshot 2021-10-30 at 9 31 57 PM" src="https://user-images.githubusercontent.com/67995771/139540721-f700e9ef-6dee-4414-9c3e-ba38e3a38c7c.png">
<img width="1440" alt="Screenshot 2021-10-30 at 9 34 21 PM" src="https://user-images.githubusercontent.com/67995771/139540729-5f6f75e7-b6be-4d9f-be27-a75367a53cfa.png">

