### PR TITLE
ChibiOS: get crash dump info on main thread lockup

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -443,6 +443,17 @@ void Scheduler::_monitor_thread(void *arg)
             INTERNAL_ERROR(AP_InternalError::error_t::main_loop_stuck);
         }
 
+#if AP_CRASHDUMP_ENABLED
+        if (loop_delay >= 1800 && using_watchdog) {
+            // we are about to watchdog, better to trigger a hardfault
+            // now and get a crash dump file
+            void *ptr = (void*)0xE000FFFF;
+            typedef void (*fptr)();
+            fptr gptr = (fptr) (void *)ptr;
+            gptr();
+        }
+#endif
+
 #if HAL_LOGGING_ENABLED
     if (log_wd_counter++ == 10 && hal.util->was_watchdog_reset()) {
         log_wd_counter = 0;


### PR DESCRIPTION
works on F7 and H7, but on F7 the resulting crash_dump.bin is only 45k, too small to find the bug