### PR TITLE
AP_Hygrometer: add hygrometer sensor 

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -440,6 +440,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -516,6 +516,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -330,6 +330,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -478,6 +478,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -108,6 +108,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_VideoTX',
     'AP_FETtecOneWire',
     'AP_Torqeedo',
+    'AP_Hygrometer',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_Hygrometer/AP_Hygrometer.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.cpp
@@ -1,0 +1,200 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Hygrometer.h"
+
+#if HAL_HYGROMETER_ENABLED
+
+#include <AP_Logger/AP_Logger.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+#include "AP_Hygrometer_Backend.h"
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include "AP_Hygrometer_UAVCAN.h"
+#endif
+
+#define HYGRO_DEFAULT_TYPE 0
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Hygrometer::var_info[] = {
+
+    // @Param: _TYPE
+    // @DisplayName: Hygrometer type
+    // @Description: Type of hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_TYPE", 1, AP_Hygrometer, param[0].type, HYGRO_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+
+
+#if HYGROMETER_MAX_SENSORS > 1
+    // @Param: _PRIMARY
+    // @DisplayName: Primary hygrometer sensor
+    // @Description: This selects which hygrometer sensor will be the primary if multiple sensors are found
+    // @Values: 0:FirstSensor,1:2ndSensor
+    // @User: Advanced
+    AP_GROUPINFO("_PRIMARY", 2, AP_Hygrometer, primary_sensor, 0),
+#endif
+
+#if HYGROMETER_MAX_SENSORS > 1
+    // @Param: 2_TYPE
+    // @DisplayName: Second Hygrometer type
+    // @Description: Type of 2nd hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("2_TYPE", 3, AP_Hygrometer, param[1].type, 0, AP_PARAM_FLAG_ENABLE),
+
+
+#endif // HYGROMETER_MAX_SENSORS
+
+    AP_GROUPEND
+};
+
+void AP_Hygrometer::init(void)
+{
+    for (uint8_t i=0; i<HYGROMETER_MAX_SENSORS; i++) {
+         switch ((enum Type)param[i].type.get()) {
+             case Type::NONE:
+                // nothing to do
+                break;
+             case Type::UAVCAN:
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS    
+    sensor[i] = AP_Hygrometer_UAVCAN::probe(*this, i, state[i], param[i]);
+#endif
+                break;
+         }
+        if (sensor[i] && !sensor[i]->init()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Hygrometer %u init failed", i + 1);
+            delete sensor[i];
+            sensor[i] = nullptr;
+        }
+        if (sensor[i] != nullptr) {
+            num_sensors = i+1;
+        }
+    }
+}
+
+AP_Hygrometer::AP_Hygrometer()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AP_Hygrometer must be singleton");
+    }
+    _singleton = this;
+}
+
+bool AP_Hygrometer::get_humidity(uint8_t i, float &humidity)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_humidity(humidity);
+    }
+
+    return false;
+}
+
+bool AP_Hygrometer::get_temperature(uint8_t i, float &temperature)
+{
+    if (!enabled(i)) {
+        return false;
+
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_temperature(temperature);
+    }
+
+    return false;
+}
+
+bool AP_Hygrometer::get_id(uint8_t i, uint8_t &id)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i]) {
+        return sensor[i]->get_id(id);
+    }
+    return false;
+}
+
+inline void AP_Hygrometer::Log_HYGR()
+{
+    const uint64_t now = AP_HAL::micros64();
+    for (uint8_t i=0; i<HYGROMETER_MAX_SENSORS; i++) {
+        if (!enabled(i)) {
+            continue;
+        }
+        float temperature,humidity;
+        if (!get_temperature(i, temperature)) {
+            temperature = 0;
+        }
+        if (!get_humidity(i, humidity)) {
+            humidity = 0;
+        }
+
+        state[i].temperature = temperature;
+        state[i].humidity = humidity;
+
+        const struct log_HYGRO pkt{
+            LOG_PACKET_HEADER_INIT(LOG_HYGRO_MSG),
+            time_us       : now,
+            instance      : i,
+            temperature   : state[i].temperature,
+            humidity      : state[i].humidity,
+            primary       : get_primary()
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    }
+}
+
+//update the log
+void AP_Hygrometer::update()
+{
+#if HAL_LOGGING_ENABLED
+        Log_HYGR();
+#endif
+}
+
+AP_Hygrometer_Backend *AP_Hygrometer::get_backend(uint8_t id) const 
+{
+    if (id >= HYGROMETER_MAX_SENSORS) {
+        return nullptr;
+    }
+    if (sensor[id] == nullptr) {
+        return nullptr;
+    }
+    if (sensor[id]->type() == Type::NONE) {
+        return nullptr;
+    }
+
+    return sensor[id];
+};
+
+// singleton instance
+AP_Hygrometer *AP_Hygrometer::_singleton;
+
+namespace AP {
+
+AP_Hygrometer *hygrometer()
+{
+    return AP_Hygrometer::get_singleton();
+}
+
+};
+
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_HYGROMETER_ENABLED
+#define HAL_HYGROMETER_ENABLED (BOARD_FLASH_SIZE > 1024)
+#endif
+
+#if HAL_HYGROMETER_ENABLED
+
+#include <stdint.h>
+#include "stdio.h"
+#include <AP_Param/AP_Param.h>
+#include <AP_Logger/AP_Logger.h>
+
+#ifndef HYGROMETER_MAX_SENSORS
+#define HYGROMETER_MAX_SENSORS  2
+#endif
+
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer
+{
+public:
+    friend class AP_Hygrometer_Backend;
+
+    // constructor
+    AP_Hygrometer();
+
+    void init(void);
+
+    bool get_temperature(uint8_t i, float &temperature) WARN_IF_UNUSED;
+    bool get_temperature(float &temperature) { return get_temperature(primary, temperature); }
+
+    bool get_humidity(uint8_t i, float &humidity);
+    bool get_humidity(float &humidity) { return get_humidity(primary, humidity); }
+
+    bool get_id(uint8_t i, uint8_t &id); 
+    bool get_id(uint8_t &id) { return get_id(primary, id); }
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    enum class Type {
+        NONE=0,
+        UAVCAN=1,
+    };
+
+    struct State {
+        float temperature;
+        float humidity;
+    };
+
+    struct Param {
+         AP_Enum<Type> type;
+    };
+
+        // return true if hygrometer is enabled
+    bool enabled(uint8_t i) const {
+        if (i < HYGROMETER_MAX_SENSORS) {
+             return (Type)param[i].type.get() != Type::NONE;
+        }
+        return false;
+    }
+    bool enabled(void) const { return enabled(primary); }
+
+    // get current primary sensor
+    uint8_t get_primary(void) const { return primary; }
+
+    static AP_Hygrometer *get_singleton() { return _singleton; }
+
+    AP_Hygrometer_Backend *get_backend(uint8_t id) const ;
+
+    void update(void);
+    void Log_HYGR(void);
+
+private:
+
+    static AP_Hygrometer *_singleton;
+
+    AP_Int8 primary_sensor;
+
+    Param param[HYGROMETER_MAX_SENSORS];
+
+    State state[HYGROMETER_MAX_SENSORS];
+
+    // current primary sensor
+    uint8_t primary;
+    uint8_t num_sensors;
+
+    AP_Hygrometer_Backend *sensor[HYGROMETER_MAX_SENSORS];
+};
+
+namespace AP {
+
+AP_Hygrometer *hygrometer();
+
+};
+
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_Backend.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_Backend.cpp
@@ -1,0 +1,30 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Hygrometer.h"
+
+#if HAL_HYGROMETER_ENABLED
+
+#include "AP_Hygrometer_Backend.h"
+
+AP_Hygrometer_Backend::AP_Hygrometer_Backend(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params) :
+    frontend(_frontend),
+    instance(_instance),
+    state(_state),
+    params(_params)
+{
+}
+
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#if HAL_HYGROMETER_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Hygrometer.h"
+
+class AP_Hygrometer_Backend
+{
+public:
+    AP_Hygrometer_Backend(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params);
+    
+    virtual ~AP_Hygrometer_Backend(void) { }
+   
+    float get_humidity() const { return state.humidity; }
+    float get_temperature() const { return state.temperature; }
+
+    AP_Hygrometer::Type type() const { return (AP_Hygrometer::Type)params.type.get(); }
+
+    // probe and initialise the sensor
+    virtual bool init(void) = 0;
+
+    virtual bool get_humidity(float &humidity) = 0;
+
+    virtual bool get_temperature(float &temperature) = 0;
+
+    virtual bool get_id(uint8_t &id) = 0;
+
+protected:
+    AP_Hygrometer::State &state;
+
+    AP_Hygrometer::Param &params;
+
+private:
+    AP_Hygrometer &frontend;
+    uint8_t instance;
+};
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
@@ -1,0 +1,181 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Hygrometer.h"
+
+#if HAL_HYGROMETER_ENABLED
+
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Hygrometer_UAVCAN.h"
+#include <dronecan/sensors/hygrometer/Hygrometer.hpp>
+#include <AP_CANManager/AP_CANManager.h>
+
+#define LOG_TAG "Hygrometer"
+#define C_TO_KELVIN 273.15f
+
+UC_REGISTRY_BINDER(HygrometerCb, dronecan::sensors::hygrometer::Hygrometer);
+
+AP_Hygrometer_UAVCAN::DetectedModules AP_Hygrometer_UAVCAN::_detected_modules[] = {0};
+HAL_Semaphore AP_Hygrometer_UAVCAN::_sem_registry;
+
+AP_Hygrometer_UAVCAN::AP_Hygrometer_UAVCAN(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params) :
+    AP_Hygrometer_Backend(_frontend, _instance, _state, _params)
+{}
+
+void AP_Hygrometer_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
+{
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+
+    auto* node = ap_uavcan->get_node();
+
+    uavcan::Subscriber<dronecan::sensors::hygrometer::Hygrometer, HygrometerCb> *hygrometer_listener;
+    hygrometer_listener = new uavcan::Subscriber<dronecan::sensors::hygrometer::Hygrometer, HygrometerCb>(*node);
+
+    const int hygrometer_listener_res = hygrometer_listener->start(HygrometerCb(ap_uavcan, &handle_hygrometer));
+
+    if (hygrometer_listener_res < 0) {
+        AP_HAL::panic("UAVCAN hygrometer subscriber start problem\n");
+    }
+}
+
+AP_Hygrometer_Backend* AP_Hygrometer_UAVCAN::probe(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* backend = nullptr;
+
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver == nullptr && _detected_modules[i].ap_uavcan != nullptr) {
+            backend = new AP_Hygrometer_UAVCAN(_frontend, _instance, _state, _params);
+            if (backend == nullptr) {
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Failed register UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            } else {
+                _detected_modules[i].driver = backend;
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Registered UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            }
+            break;
+        }
+    }
+    return backend;
+}
+
+AP_Hygrometer_UAVCAN* AP_Hygrometer_UAVCAN::get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id)
+{
+    if (ap_uavcan == nullptr) {
+        return nullptr;
+    }
+
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver != nullptr &&
+            _detected_modules[i].ap_uavcan == ap_uavcan &&
+            _detected_modules[i].node_id == node_id ) {
+            return _detected_modules[i].driver;
+        }
+    }
+
+    bool detected = false;
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].ap_uavcan == ap_uavcan && _detected_modules[i].node_id == node_id) {
+            detected = true;
+            break;
+        }
+    }
+
+    if (!detected) {
+        for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+            if (_detected_modules[i].ap_uavcan == nullptr) {
+                _detected_modules[i].ap_uavcan = ap_uavcan;
+                _detected_modules[i].node_id = node_id;
+                break;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+void AP_Hygrometer_UAVCAN::handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* driver = get_uavcan_backend(ap_uavcan, node_id);
+
+    if (driver != nullptr) {
+        WITH_SEMAPHORE(driver->_sem_hygrometer);
+        driver->_humidity = cb.msg->humidity;
+        if (!isnan(cb.msg->temperature))  {
+            driver->_temperature = cb.msg->temperature - C_TO_KELVIN;
+        }
+        driver->_id = cb.msg->id;
+        driver->_last_sample_time_ms = AP_HAL::millis();
+    }
+}
+
+bool AP_Hygrometer_UAVCAN::get_humidity(float &humidity)
+{
+
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+    humidity = _humidity;
+    return true;
+}
+
+bool AP_Hygrometer_UAVCAN::get_temperature(float &temperature)
+{
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+    temperature = _temperature;
+    return true;
+}
+
+bool AP_Hygrometer_UAVCAN::get_id(uint8_t &id)
+{
+
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+
+    id = _id;
+    return true;
+}
+
+bool AP_Hygrometer_UAVCAN::init()
+{
+    // always returns true
+    return true;
+}
+
+#endif // HAL_ENABLE_LIBUAVCAN_DRIVERS
+
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "AP_Hygrometer.h"
+
+#if HAL_HYGROMETER_ENABLED
+
+#include <AP_UAVCAN/AP_UAVCAN.h>
+#include "AP_Hygrometer_Backend.h"
+
+class HygrometerCb;
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer_UAVCAN : public AP_Hygrometer_Backend{
+public:
+    // constructor
+    AP_Hygrometer_UAVCAN(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params);
+
+    bool init(void) override;
+
+    bool get_humidity(float &humidity) override;
+    bool get_temperature(float &temperature) override;
+    bool get_id(uint8_t &id) override;
+
+    static void handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb);
+
+    static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
+
+    // static AP_Hygrometer_Backend* probe(AP_Hygrometer &_frontend, uint8_t _instance);
+    static AP_Hygrometer_Backend* probe(AP_Hygrometer &_frontend, uint8_t _instance, AP_Hygrometer::State &_state, AP_Hygrometer::Param &_params);
+
+private:
+    float _humidity;
+    float _temperature;
+    uint8_t _id;
+    uint32_t _last_sample_time_ms;
+
+    static  AP_Hygrometer_UAVCAN* get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id);
+
+    HAL_Semaphore _sem_hygrometer;
+
+    // Module Detection Registry
+    static struct DetectedModules {
+        AP_UAVCAN* ap_uavcan;
+        uint8_t node_id;
+        AP_Hygrometer_UAVCAN *driver;
+    } _detected_modules[HYGROMETER_MAX_SENSORS];
+
+    static HAL_Semaphore _sem_registry;
+};
+
+#endif // HAL_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/LogStructure.h
+++ b/libraries/AP_Hygrometer/LogStructure.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_HYGROMETER \
+    LOG_HYGRO_MSG
+
+// @LoggerMessage: HYGR
+// @Description: Hygrometer sensor data
+// @Field: TimeUS: Time since system startup
+// @Field: I: Hygrometer sensor instance number
+// @Field: Temp: Current temperature
+// @Field: Humi: Current humidity
+// @Field: Pri: True if sensor is the primary sensor
+struct PACKED log_HYGRO {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    float temperature;
+    float humidity;
+    uint8_t primary;
+};
+
+#define LOG_STRUCTURE_FROM_HYGROMETER \
+    { LOG_HYGRO_MSG, sizeof(log_HYGRO), \
+      "HYGR", "QBffB", "TimeUS,I,Temp,Humi,Pri", "s#O%-", "F-00-", true }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -134,6 +134,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AC_Avoidance/LogStructure.h>
 #include <AP_ESC_Telem/LogStructure.h>
 #include <AP_AIS/LogStructure.h>
+#include <AP_Hygrometer/LogStructure.h>
 
 // structure used to define logging format
 struct PACKED LogStructure {
@@ -1328,7 +1329,8 @@ LOG_STRUCTURE_FROM_VISUALODOM \
       "STAK", "QBBHHN", "TimeUS,Id,Pri,Total,Free,Name", "s#----", "F-----", true }, \
     { LOG_FILE_MSG, sizeof(log_File), \
       "FILE",   "NhhZ",       "FileName,Offset,Length,Data", "----", "----" }, \
-LOG_STRUCTURE_FROM_AIS \
+LOG_STRUCTURE_FROM_AIS, \
+LOG_STRUCTURE_FROM_HYGROMETER
 
 // message types 0 to 63 reserved for vehicle specific use
 
@@ -1407,6 +1409,7 @@ enum LogMessages : uint8_t {
     LOG_IDS_FROM_AIS,
     LOG_STAK_MSG,
     LOG_FILE_MSG,
+    LOG_IDS_FROM_HYGROMETER,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -57,6 +57,7 @@
 #include <AP_ADSB/AP_ADSB.h>
 #include "AP_UAVCAN_DNA_Server.h"
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Hygrometer/AP_Hygrometer_UAVCAN.h>
 
 #define LED_DELAY_US 50000
 
@@ -292,6 +293,9 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     AP_Airspeed_UAVCAN::subscribe_msgs(this);
     AP_OpticalFlow_HereFlow::subscribe_msgs(this);
     AP_RangeFinder_UAVCAN::subscribe_msgs(this);
+#if HAL_HYGROMETER_ENABLED
+    AP_Hygrometer_UAVCAN::subscribe_msgs(this);
+#endif // HAL_HYGROMETER_ENABLED
 
     act_out_array[driver_index] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*_node);
     act_out_array[driver_index]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(2));

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -61,6 +61,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(externalAHRS, "EAHRS", 8, AP_Vehicle, AP_ExternalAHRS),
 #endif
 
+#if HAL_HYGROMETER_ENABLED
+    // @Group: HYGRO
+    // @Path: ../libraries/AP_Hygrometer/AP_Hygrometer.cpp
+    AP_SUBGROUPINFO(hygrometer, "HYGRO", 9, AP_Vehicle, AP_Hygrometer),
+#endif
+
     AP_GROUPEND
 };
 
@@ -174,6 +180,10 @@ void AP_Vehicle::setup()
 #if HAL_GENERATOR_ENABLED
     generator.init();
 #endif
+
+#if HAL_HYGROMETER_ENABLED
+    hygrometer.init();
+#endif
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 }
 
@@ -241,6 +251,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if OSD_ENABLED
     SCHED_TASK(publish_osd_info, 1, 10),
+#endif
+#if HAL_HYGROMETER_ENABLED
+    SCHED_TASK_CLASS(AP_Hygrometer, &vehicle.hygrometer,      update,                   3,  100),
 #endif
     SCHED_TASK(accel_cal_update,      10,    100),
 };

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -46,6 +46,7 @@
 #include <AP_Frsky_Telem/AP_Frsky_Parameters.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_VideoTX/AP_SmartAudio.h>
+#include <AP_Hygrometer/AP_Hygrometer.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif
@@ -352,6 +353,10 @@ protected:
     
 #if HAL_SMARTAUDIO_ENABLED
     AP_SmartAudio smartaudio;
+#endif
+
+#if HAL_HYGROMETER_ENABLED
+    AP_Hygrometer hygrometer;
 #endif
 
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -283,6 +283,8 @@ public:
     void send_rc_channels() const;
     void send_rc_channels_raw() const;
     void send_raw_imu();
+    void send_hygrometer();
+    void send_hygrometer(const class AP_Hygrometer_Backend *sensor, const uint8_t instance) const;
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature, int16_t temperature_press_diff));
     void send_scaled_pressure();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -50,6 +50,8 @@
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <AP_AIS/AP_AIS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_Hygrometer/AP_Hygrometer.h>
+#include <AP_Hygrometer/AP_Hygrometer_Backend.h>
 
 #include <stdio.h>
 
@@ -891,6 +893,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_HIGH_LATENCY2,         MSG_HIGH_LATENCY2},
         { MAVLINK_MSG_ID_AIS_VESSEL,            MSG_AIS_VESSEL},
         { MAVLINK_MSG_ID_UAVIONIX_ADSB_OUT_STATUS, MSG_UAVIONIX_ADSB_OUT_STATUS},
+        { MAVLINK_MSG_ID_HYGROMETER_SENSOR,     MSG_HYGROMETER_STATUS},
             };
 
     for (uint8_t i=0; i<ARRAY_SIZE(map); i++) {
@@ -2747,6 +2750,34 @@ void GCS_MAVLINK::send_vfr_hud()
         vfr_hud_alt(),
         vfr_hud_climbrate());
 }
+
+#if HAL_HYGROMETER_ENABLED   
+void GCS_MAVLINK::send_hygrometer(const class AP_Hygrometer_Backend *sensor, const uint8_t instance) const
+{
+    mavlink_msg_hygrometer_sensor_send(
+        chan,
+        instance,                                // hygrometer instance, use 0 for first sensor          
+        100*sensor->get_temperature(),           // temperature the sensor measure, unit: Centi Degree(cdegC)
+        100*sensor->get_humidity());             // humidity the sensor measure, unit: Centi Percent(c%)
+}
+
+void GCS_MAVLINK::send_hygrometer()
+{
+    const AP_Hygrometer *hygrometer {AP::hygrometer()};
+    if (hygrometer == nullptr) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < HYGROMETER_MAX_SENSORS; i++) {
+        AP_Hygrometer_Backend *sensor = hygrometer->get_backend(i);
+        if (sensor == nullptr) {
+            continue;
+        }
+
+        send_hygrometer(sensor, i);
+    }
+}
+#endif // HAL_HYGROMETER_ENABLED 
 
 /*
   handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
@@ -5263,7 +5294,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         send_high_latency2();
 #endif // HAL_HIGH_LATENCY2_ENABLED
         break;
-
+    case MSG_HYGROMETER_STATUS:
+#if HAL_HYGROMETER_ENABLED   
+        CHECK_PAYLOAD_SIZE(HYGROMETER_SENSOR);
+        send_hygrometer();
+#endif // HAL_HYGROMETER_ENABLED 
 
     case MSG_UAVIONIX_ADSB_OUT_STATUS:
         CHECK_PAYLOAD_SIZE(UAVIONIX_ADSB_OUT_STATUS);

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -81,5 +81,6 @@ enum ap_message : uint8_t {
     MSG_AIS_VESSEL,
     MSG_MCU_STATUS,
     MSG_UAVIONIX_ADSB_OUT_STATUS,
+    MSG_HYGROMETER_STATUS,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
The flight controller receive the hygrometer message from CAN device and flight controller send hygrometer message to the ground station.

background:
CUAV developed a new airspeed sensor that can be heated.The airspeed sensor heats up according to the set temperature, so as to prevent airspeed failure due to ice on the head of the airspeed sensor when the fixed-wing UAV is used in high and cold places.The temperature and humidity sensor is used to detect the temperature and humidity of the pitot tube head. If the measured temperature is lower than the set temperature, the airspeed sensor will enable heating to prevent ice.

The value shows in MissionPlanner.
![lQLPDhrQcGhJCznNAhzNAaaw9Ik0twoGiU8Bgr_Y7EAcAA_422_540](https://user-images.githubusercontent.com/69180601/139632528-44a10d54-3aa4-4a12-bfd6-3b55f1f7a09c.png)

Logging:
[hygrometer_log.zip](https://github.com/ArduPilot/ardupilot/files/7451226/hygrometer_log.zip)
 
parameters for setting:
HYGROx_TYPE:  0 for none , 1 for uavcan. Note: HYGRO2_TYPE can be set after HYGRO1_TYPE is set to 1;
HYGRO_PRIMARY: to select the primary one.
![image](https://user-images.githubusercontent.com/69180601/139632782-e7e4c0ee-de23-4651-bc9b-29afc218fcad.png)
