### PR TITLE
Copter: Change the flight mode at startup to the initial flight mode

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -15,6 +15,7 @@ static void failsafe_check_static()
 
 void Copter::init_ardupilot()
 {
+    flightmode = mode_from_mode_num((enum Mode::Number)g.initial_mode.get());
 
 #if STATS_ENABLED == ENABLED
     // initialise stats module


### PR DESCRIPTION
The flight mode at startup is not set to INIT_MODE.
In fact, it changes from STABLIZE mode to INIT_MODE.
I will implement the flight mode setting in the first process of the initialization method of ARDUPILOT.

AFTER
![Screenshot from 2021-11-03 10-37-49](https://user-images.githubusercontent.com/646194/139999680-a5588d27-936b-4a1a-9214-e30064071384.png)

BEFORE
![Screenshot from 2021-11-03 10-37-05](https://user-images.githubusercontent.com/646194/139999707-67a76fd4-cae4-41c3-8fea-4c4c4bd4d393.png)