### PR TITLE
AP_Compass: never override custom orientation in calibration

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -207,7 +207,7 @@ bool Compass::_accept_calibration(uint8_t i)
         set_and_save_offdiagonals(i,offdiag);
         set_and_save_scale_factor(i,scale_factor);
 
-        if (_get_state(prio).external && _rotate_auto >= 2) {
+        if (cal_report.check_orientation && _get_state(prio).external && _rotate_auto >= 2) {
             set_and_save_orientation(i, cal_report.orientation);
         }
 

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -324,6 +324,7 @@ void CompassCalibrator::update_cal_report()
     cal_report.orientation_confidence = _orientation_confidence;
     cal_report.original_orientation = _orig_orientation;
     cal_report.orientation = _orientation_solution;
+    cal_report.check_orientation = _check_orientation;
 }
 
 // running method for use in thread

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -67,6 +67,7 @@ public:
         Rotation original_orientation;
         Rotation orientation;
         float scale_factor;
+        bool check_orientation;
     } cal_report;
 
     // Structure setup to set calibration run settings


### PR DESCRIPTION
Currently with `COMPASS_AUTO_ROT` > 1 custom rotations will always be reset  to 0.

We are not running the orientation code, but we still set the param.

https://github.com/ArduPilot/ardupilot/blob/6a12d3f5d91633bcd4ac984fff247f02957c19dd/libraries/AP_Compass/AP_Compass_Calibration.cpp#L85

We could also just check if the old orientation is custom, but then we end up having to check the special case in two places. 