### PR TITLE
Plane: quadplane: limit pitch for all transitions into position control modes

### DIFF
--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -76,18 +76,10 @@ void ModeQLoiter::run()
     plane.nav_roll_cd = loiter_nav->get_roll();
     plane.nav_pitch_cd = loiter_nav->get_pitch();
 
-    if (now - quadplane.last_pidz_init_ms < (uint32_t)quadplane.transition_time_ms*2 && !quadplane.tailsitter.enabled()) {
-        // we limit pitch during initial transition
-        float pitch_limit_cd = linear_interpolate(quadplane.loiter_initial_pitch_cd, quadplane.aparm.angle_max,
-                                                  now,
-                                                  quadplane.last_pidz_init_ms, quadplane.last_pidz_init_ms+quadplane.transition_time_ms*2);
-        if (plane.nav_pitch_cd > pitch_limit_cd) {
-            plane.nav_pitch_cd = pitch_limit_cd;
-            pos_control->set_externally_limited_xy();
-        }
+    if (quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
+        pos_control->set_externally_limited_xy();
     }
-    
-    
+
     // call attitude controller with conservative smoothing gain of 4.0f
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -273,6 +273,7 @@ private:
     float transition_threshold(void);
 
     AP_Int16 transition_time_ms;
+    AP_Int16 back_trans_pitch_limit_ms;
 
     // transition deceleration, m/s/s
     AP_Float transition_decel;

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -50,6 +50,8 @@ public:
 
     virtual MAV_VTOL_STATE get_mav_vtol_state() const = 0;
 
+    virtual bool set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd) { return false; }
+
 protected:
 
     // refences for convenience
@@ -69,11 +71,7 @@ public:
 
     void VTOL_update() override;
 
-    void force_transistion_complete() override {
-        transition_state = TRANSITION_DONE; 
-        transition_start_ms = 0;
-        transition_low_airspeed_ms = 0;
-    };
+    void force_transistion_complete() override;
 
     bool complete() const override { return transition_state == TRANSITION_DONE; }
 
@@ -91,6 +89,8 @@ public:
 
     MAV_VTOL_STATE get_mav_vtol_state() const override;
 
+    bool set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd) override;
+
 protected:
 
     enum {
@@ -105,6 +105,10 @@ protected:
 
     // last throttle value when active
     float last_throttle;
+
+    // time and pitch angle whe last in a vtol or FW control mode
+    uint32_t last_fw_mode_ms;
+    int32_t last_fw_nav_pitch_cd;
 
 };
 


### PR DESCRIPTION
A step towards making transitions to VTOL more consistent between modes. All position control modes now get the Q_Loiter pitch up limit and the QPOS1 pitch down limit. These limits decay to angle max over twice the transition time. 

SLT and tiltrotor only.
