### PR TITLE
AP_Compass: update MMMC5XX3 driver to support mmc5983 (and only mmc5983)

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -64,7 +64,7 @@ public:
         DEVTYPE_IST8308 = 0x10,
         DEVTYPE_RM3100 = 0x11,
         DEVTYPE_RM3100_2 = 0x12, // unused, past mistake
-        DEVTYPE_MMC5883 = 0x13,
+        DEVTYPE_MMC5983 = 0x13,
         DEVTYPE_AK09918 = 0x14,
     };
 

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.h
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.h
@@ -29,13 +29,13 @@
 class AP_Compass_MMC5XX3 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     void read() override;
 
-    static constexpr const char *name = "MMC5883";
+    static constexpr const char *name = "MMC5983";
 
 private:
     AP_Compass_MMC5XX3(AP_HAL::OwnPtr<AP_HAL::Device> dev,
@@ -68,7 +68,7 @@ private:
     uint32_t refill_start_ms;
     uint32_t last_sample_ms;
     
-    uint16_t data0[3];
+    uint8_t data0[6];
     
     enum Rotation rotation;
 };


### PR DESCRIPTION
MMC5883 is EOL and no "real" boards use it.

 - Registers changed
 - Product ID changed
 - Data is now Big endian
 - Results are now 18 bits instead of 16, but we only consume 16.
 - Added SPI support