### PR TITLE
AP_OSD: fix code causing errors while compiling out OSD

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -97,13 +97,16 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
     if (!displaying_stats_screen()) {
         telem.get_highest_motor_temperature(highest_temperature);
     } else {
+#if OSD_ENABLED
         AP_OSD *osd = AP::osd();
         if (osd == nullptr) {
             return MSP_RESULT_ERROR;
         }
         WITH_SEMAPHORE(osd->get_semaphore());
         highest_temperature = osd->get_stats_info().max_esc_temp;
+#endif
     }
+
     const struct PACKED {
         uint8_t temp;
         uint16_t rpm;

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -217,12 +217,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     AP_SUBGROUPINFO(param_screen[1], "6_", 22, AP_OSD, AP_OSD_ParamScreen),
 #endif
 
+#if OSD_ENABLED
     // additional tables to go beyond 63 limit
     AP_SUBGROUPINFO2(screen[0], "1_", 27, AP_OSD, AP_OSD_Screen),
     AP_SUBGROUPINFO2(screen[1], "2_", 28, AP_OSD, AP_OSD_Screen),
     AP_SUBGROUPINFO2(screen[2], "3_", 29, AP_OSD, AP_OSD_Screen),
     AP_SUBGROUPINFO2(screen[3], "4_", 30, AP_OSD, AP_OSD_Screen),
-
+#endif
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -380,7 +380,7 @@ public:
     static const uint8_t NUM_PARAMS = 9;
     static const uint8_t SAVE_PARAM = NUM_PARAMS + 1;
 
-#if HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT
+#if OSD_ENABLED && (HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT)
     void draw(void) override;
 #endif
 #if HAL_GCS_ENABLED


### PR DESCRIPTION
This solves the issue #19071. I tested it with `define OSD_ENABLED 0` and  `define OSD_ENABLED 1`. The code got compiled and worked fine.