### PR TITLE
GIT_HUB: actions ELF_DIFF fix per board generation and add copter ouput

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -111,12 +111,15 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -U weasyprint elf_diff anytree
-          python3 -m elf_diff --bin_prefix=arm-none-eabi- $GITHUB_WORKSPACE/master_bin/arduplane $GITHUB_WORKSPACE/pr_bin/arduplane
-          tar cf multipage_pair_report.tar multipage_pair_report
+          python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=plane $GITHUB_WORKSPACE/master_bin/arduplane $GITHUB_WORKSPACE/pr_bin/arduplane
+          python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=copter $GITHUB_WORKSPACE/master_bin/arducopter $GITHUB_WORKSPACE/pr_bin/arducopter
+          mkdir elf_diff
+          tar cf elf_diff/plane.tar plane
+          tar cf elf_diff/copter.tar copter
 
       - name: Archive elf_diff output
         uses: actions/upload-artifact@v2
         with:
-           name: elf_diff
-           path: multipage_pair_report.tar
+           name: ELF_DIFF_${{matrix.config}}
+           path: elf_diff
            retention-days: 14

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -9,6 +9,11 @@ pip3 install --user elf_diff weasyprint
 
 AP_FLAKE8_CLEAN
 
+How to use?
+Starting in the ardupilot directory.
+~/ardupilot $ python Tools/scripts/size_compare_branches.py --branch=[PR_BRANCH_NAME] --vehicle=copter
+
+Output is placed into ../ELF_DIFF_[VEHICLE_NAME]
 '''
 
 import optparse
@@ -159,6 +164,7 @@ class SizeCompareBranches(object):
             '--bin_prefix=arm-none-eabi-',
             "--old_alias", "%s %s" % (self.master_branch, binary_filename),
             "--new_alias", "%s %s" % (self.branch, binary_filename),
+            "--html_dir", "../ELF_DIFF_%s" % (self.vehicle),
             os.path.join(outdir_1, self.board, "bin", binary_filename),
             os.path.join(outdir_2, self.board, "bin", binary_filename)
         ]


### PR DESCRIPTION
Fixes the ELF_DIFF github actions create an artifact per board
Adds a copter ELF_DIFF as well

Makes a tweek to where and how the size_compare scripts outputs so it doesn't get placed into `ardupilot` and thus making sourcetree / vscode unhappy with 7000+ files changes :)
