### PR TITLE
Copter: Remove WP Delay in ZIGZAG Mode by S-Curve

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1699,7 +1699,6 @@ private:
         SIDEWAYS,       // moving to sideways
     } auto_stage;
 
-    uint32_t reach_wp_time_ms = 0;  // time since vehicle reached destination (or zero if not yet reached)
     Destination ab_dest_stored;     // store the current destination
     bool is_auto;                   // enable zigzag auto feature which is automate both AB and sideways
     uint16_t line_count = 0;        // current line number

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -26,14 +26,6 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     AP_GROUPINFO("SPRAYER", 2, ModeZigZag, _spray_enabled, 0),
 #endif // SPRAYER_ENABLED == ENABLED
 
-    // @Param: WP_DELAY
-    // @DisplayName: The delay for zigzag waypoint
-    // @Description: Waiting time after reached the destination
-    // @Units: s
-    // @Range: 0 127
-    // @User: Advanced
-    AP_GROUPINFO("WP_DELAY", 3, ModeZigZag, _wp_delay, 0),
-
     // @Param: SIDE_DIST
     // @DisplayName: Sideways distance in ZigZag auto
     // @Description: The distance to move sideways in ZigZag mode
@@ -203,7 +195,6 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
                     ab_dest_stored = ab_dest;
                     // spray on while moving to A or B
                     spray(true);
-                    reach_wp_time_ms = 0;
                     if (is_auto == false || line_num == ZIGZAG_LINE_INFINITY) {
                         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
                     } else {
@@ -228,7 +219,6 @@ void ModeZigZag::move_to_side()
                 auto_stage = AutoState::SIDEWAYS;
                 current_dest = next_dest;
                 current_terr_alt = terr_alt;
-                reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
                 gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }
@@ -404,12 +394,7 @@ bool ModeZigZag::reached_destination()
         return false;
     }
 
-    // wait at time which is set in zigzag_wp_delay
-    uint32_t now = AP_HAL::millis();
-    if (reach_wp_time_ms == 0) {
-        reach_wp_time_ms = now;
-    }
-    return ((now - reach_wp_time_ms) >= (uint16_t)constrain_int16(_wp_delay, 0, 127) * 1000);
+    return true;
 }
 
 // calculate next destination according to vector A-B and current position
@@ -544,7 +529,6 @@ void ModeZigZag::run_auto()
             wp_nav->wp_and_spline_init();
             if (wp_nav->set_wp_destination(current_dest, current_terr_alt)) {
                 stage = AUTO;
-                reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
                 gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }


### PR DESCRIPTION
rebase #17596.
I would remove the delay setting in #19143.
I want to take advantage of the fact that the S-curve does not require a delay.