### PR TITLE
SITL: send sv_info from both GPS instances

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3159,6 +3159,7 @@ class AutoTestPlane(AutoTest):
         self.context_collect('STATUSTEXT')
         self.set_parameter("EK3_POS_I_GATE", 0)
         self.set_parameter("SIM_GPS_HZ", 1)
+        self.set_parameter("GPS_DELAY_MS", 300)
         self.wait_statustext("DCM Active", check_context=True, timeout=60)
         self.wait_statustext("EKF3 Active", check_context=True)
         self.wait_statustext("DCM Active", check_context=True)

--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -310,7 +310,7 @@ void GPS::update_ubx(const struct gps_data *d)
     const uint8_t MSG_SVINFO = 0x30;
     const uint8_t MSG_RELPOSNED = 0x3c;
 
-    static uint32_t _next_nav_sv_info_time = 0;
+    uint32_t _next_nav_sv_info_time = 0;
 
     uint16_t time_week;
     uint32_t time_week_ms;


### PR DESCRIPTION
Without sv_info we don't get the correct ublox type, meaning we get the wrong lag time, meaning EKF2 gets rather more annoyed than it should when we do loops in SITL.

In master the lag is 0.22 (ublox-type-unknown), after this it is 0.12.
