### PR TITLE
hwdef: require BRD_ALT_CONFIG=1 for CUAVv5Nano RCIN uart

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5Nano/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5Nano/hwdef.dat
@@ -15,9 +15,6 @@ PE3 VDD_3V3_SENSORS_EN OUTPUT LOW
 # order of UARTs (and USB).
 SERIAL_ORDER OTG1 USART2 USART3 USART1 UART4 USART6 UART7 OTG2
 
-# enable TX on USART6 (disabled for fmuv5 with iomcu)
-PG14 USART6_TX USART6 NODMA
-
 # disable the IOMCU UART
 undef IOMCU_UART
 undef UART8_TX
@@ -40,6 +37,13 @@ PB11 TIM2_CH4 TIM2 PWM(11) GPIO(60)
 undef PG9
 undef USART6_RX
 PI5 TIM8_CH1 TIM8 RCININT PULLDOWN LOW
+PG14 GRCIN_TX INPUT FLOAT
+
+# alternative RC input as a USART. PI5 and PG14 are both connected
+# to the same RCIN port
+PI5 GRCIN INPUT FLOAT ALT(1)
+PG14 USART6_TX USART6 NODMA ALT(1)
+
 
 # setup for supplied power brick
 undef HAL_BATT_VOLT_SCALE

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -558,9 +558,9 @@ class generic_pin(object):
     def periph_instance(self):
         '''return peripheral instance'''
         if self.periph_type() == 'PERIPH_TYPE::GPIO':
-            result = re.match(r'[A-Z_]*([0-9]*)', self.label)
+            result = re.match(r'[A-Z_]*([0-9]+)', self.label)
         else:
-            result = re.match(r'[A-Z_]*([0-9]*)', self.type)
+            result = re.match(r'[A-Z_]*([0-9]+)', self.type)
         if result:
             return int(result.group(1))
         return 0


### PR DESCRIPTION
This fixes a problem with the uart competing with RCININT
