### PR TITLE
ChibiOS: disable unused UART pins

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -142,4 +142,7 @@ public:
 
     // return true requested baud on USB port
     virtual uint32_t get_usb_baud(void) const { return 0; }
+
+    // disable TX/RX pins for unusued uart
+    virtual void disable_rxtx(void) const {}
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1834,4 +1834,15 @@ void usb_initialise(void)
 }
 #endif
 
+// disable TX/RX pins for unusued uart
+void UARTDriver::disable_rxtx(void) const
+{
+    if (arx_line) {
+        palSetLineMode(arx_line, PAL_MODE_INPUT);
+    }
+    if (atx_line) {
+        palSetLineMode(atx_line, PAL_MODE_INPUT);
+    }
+}
+
 #endif //CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -46,6 +46,9 @@ public:
     bool tx_pending() override;
     uint32_t get_usb_baud() const override;
 
+    // disable TX/RX pins for unusued uart
+    void disable_rxtx(void) const override;
+    
     uint32_t available() override;
     uint32_t available_locked(uint32_t key) override;
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -558,9 +558,9 @@ class generic_pin(object):
     def periph_instance(self):
         '''return peripheral instance'''
         if self.periph_type() == 'PERIPH_TYPE::GPIO':
-            result = re.match(r'[A-Z_]*([0-9]*)', self.label)
+            result = re.match(r'[A-Z_]*([0-9]+)', self.label)
         else:
-            result = re.match(r'[A-Z_]*([0-9]*)', self.type)
+            result = re.match(r'[A-Z_]*([0-9]+)', self.type)
         if result:
             return int(result.group(1))
         return 0

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -417,6 +417,9 @@ void AP_SerialManager::init()
             set_options(i);
             switch (state[i].protocol) {
                 case SerialProtocol_None:
+                    // disable RX and TX pins in case they are shared
+                    // with another peripheral (eg. RCIN pin)
+                    uart->disable_rxtx();
                     break;
                 case SerialProtocol_Console:
                 case SerialProtocol_MAVLink:


### PR DESCRIPTION
This avoids an issue on boards where a uart shares an input pin with an RCIN timer. The uart, if unused, could cause pullup of the pin, disturbing RCIN.
This should fix an issue reported by CUAV

This has been tested by CUAV on a CUAV-X7 and confirmed it fixes the ground lift issue.
Also tested on a CUAVv5Nano and confirmed that F.Port still works with SERIAL5_PROTOCOL=23
