### PR TITLE
AP_GPS: Support integrated headings from SBF

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -114,18 +114,16 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: 1st GPS type
     // @Description: GPS type of 1st GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:DroneCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:DroneCAN-MovingBaseline-Base,23:DroneCAN-MovingBaseline-Rover,24:UnicoreNMEA,25:UnicoreMovingBaselineNMEA
+    // @Values: 0:None,1:AUTO,2:uBlox,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:DroneCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:DroneCAN-MovingBaseline-Base,23:DroneCAN-MovingBaseline-Rover,24:UnicoreNMEA,25:UnicoreMovingBaselineNMEA,26:SBF-Heading
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("_TYPE",    0, AP_GPS, _type[0], HAL_GPS_TYPE_DEFAULT),
 
 #if GPS_MAX_RECEIVERS > 1
     // @Param: _TYPE2
+    // @CopyFieldsFrom: _TYPE
     // @DisplayName: 2nd GPS type
     // @Description: GPS type of 2nd GPS
-    // @Values: 0:None,1:AUTO,2:uBlox,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:DroneCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:DroneCAN-MovingBaseline-Base,23:DroneCAN-MovingBaseline-Rover,24:UnicoreNMEA,25:UnicoreMovingBaselineNMEA
-    // @RebootRequired: True
-    // @User: Advanced
     AP_GROUPINFO("_TYPE2",   1, AP_GPS, _type[1], 0),
 #endif
 
@@ -631,6 +629,7 @@ void AP_GPS::send_blob_start(uint8_t instance)
     switch (_type[instance]) {
 #if AP_GPS_SBF_ENABLED
     case GPS_TYPE_SBF:
+    case GPS_TYPE_SBF_DUAL_ANTENNA:
 #endif //AP_GPS_SBF_ENABLED
 #if AP_GPS_GSOF_ENABLED
     case GPS_TYPE_GSOF:
@@ -780,6 +779,7 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
 #if AP_GPS_SBF_ENABLED
     // by default the sbf/trimble gps outputs no data on its port, until configured.
     case GPS_TYPE_SBF:
+    case GPS_TYPE_SBF_DUAL_ANTENNA:
         return new AP_GPS_SBF(*this, state[instance], _port[instance]);
 #endif //AP_GPS_SBF_ENABLED
 #if AP_GPS_GSOF_ENABLED

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -134,6 +134,7 @@ public:
 #if HAL_SIM_GPS_ENABLED
         GPS_TYPE_SITL = 100,
 #endif
+        GPS_TYPE_SBF_DUAL_ANTENNA = 26,
     };
 
     /// GPS status codes.  These are kept aligned with MAVLink by

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -162,9 +162,17 @@ AP_GPS_SBF::read(void)
                                 break;
                             case Config_State::SGA:
                             {
-                                const bool GNSSAttitude = get_type() == AP_GPS::GPS_Type::GPS_TYPE_SBF_DUAL_ANTENNA;
-                                if (asprintf(&config_string, "sga, %s\n",
-                                             GNSSAttitude ? "MovingBase" : "none")) {
+                                const char *targetGA = "none";
+                                if (get_type() == AP_GPS::GPS_Type::GPS_TYPE_SBF_DUAL_ANTENNA) {
+                                    targetGA = "MultiAntenna";
+                                }
+                                // We could set the UseBaseForYaw option to set the attitude here, and the attitude offset
+                                // which would generate an AttEuler message for us, and wouldn't require any extra handling
+                                // but by doing it in ArduPilot we can apply our constraints on baseline distances
+                                // if (driver_options() & DriverOptions::SBF_UseBaseForYaw) {
+                                //     targetGA = "MovingBase";
+                                // }
+                                if (asprintf(&config_string, "sga, %s\n", targetGA)) {
                                   config_string = nullptr;
                                 }
                                 break;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -73,6 +73,7 @@ private:
         SSO,
         Blob,
         SBAS,
+        SGA,
         Complete
     };
     Config_State config_step;
@@ -109,7 +110,9 @@ private:
         PVTGeodetic = 4007,
         ReceiverStatus = 4014,
         BaseVectorGeod = 4028,
-        VelCovGeodetic = 5908
+        VelCovGeodetic = 5908,
+        AttEuler = 5938,
+        AttEulerCov = 5939,
     };
 
     struct PACKED msg4007 // PVTGeodetic
@@ -217,12 +220,44 @@ private:
         float Cov_VuDt;
     };
 
+    struct PACKED msg5938 // AttEuler
+    {
+        uint32_t TOW;
+        uint16_t WNc;
+        uint8_t  NrSV;
+        uint8_t Error;
+        uint16_t Mode;
+        uint16_t Reserved;
+        float Heading;
+        float Pitch;
+        float Roll;
+        float PitchDot;
+        float RollDot;
+        float HeadingDot;
+    };
+
+    struct PACKED msg5939
+    {
+        uint32_t TOW;
+        uint16_t WNc;
+        uint8_t Reserved;
+        uint8_t Error;
+        float Cov_HeadHead;
+        float Cov_PitchPitch;
+        float Cov_RollRoll;
+        float Cov_HeadPitch;
+        float Cov_HeadRoll;
+        float Cov_PitchRoll;
+    };
+
     union PACKED msgbuffer {
         msg4007 msg4007u;
         msg4001 msg4001u;
         msg4014 msg4014u;
         msg4028 msg4028u;
         msg5908 msg5908u;
+        msg5938 msg5938u;
+        msg5939 msg5939u;
         uint8_t bytes[256];
     };
 


### PR DESCRIPTION
This is an alternate to #18615. (Basically it implements most of my PR requests on that PR). This also takes the step to actually configure GNSS Attitude as enabled via the config strings, as that was being ignored or manually done before. This may introduce a breakage if any older receivers (AsteRx-m is the minimum target here) don't support the command, which will have to be tested. I haven't had a chance to test it any of this PR yet though so that needs doing. (Otherwise I will probably get back to it in early December if no one else has beaten me to it).

Needed Tests:
- [x] Validate that normal SBF functionality isn't broken.
- [ ] Test that all expected units can handle `sga, None`
- [x] Test that heading works
- [x] Verify the yaw accuracy information is correct (I've seen early test data from a different incarnation of adding this, that was producing wildly inaccurate yaw accuracy).
- [ ] Consider if we should be setting the antenna locations to rigid instead of allowing the unit to compute them for us in auto (easier setup, but maybe not ideal, need to ask the manufacturer).