### PR TITLE
Plane: fixed a bug in POSITION1 speed thresholds

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -680,7 +680,6 @@ bool QuadPlane::setup(void)
     motors->set_update_rate(rc_speed);
     motors->set_interlock(true);
     attitude_control->parameter_sanity_check();
-    wp_nav->wp_and_spline_init();
 
     // setup the trim of any motors used by AP_Motors so I/O board
     // failsafe will disable motors
@@ -709,6 +708,9 @@ bool QuadPlane::setup(void)
     if (!transition) {
         AP_BoardConfig::allocation_error("transition");
     }
+
+    // init wp_nav variables after detaults are setup
+    wp_nav->wp_and_spline_init();
 
     transition->force_transistion_complete();
 
@@ -2282,7 +2284,7 @@ void QuadPlane::vtol_position_controller(void)
         float target_speed = stopping_speed;
 
         // maximum configured VTOL speed
-        const float wp_speed = pos_control->get_max_speed_xy_cms() * 0.01;
+        const float wp_speed = wp_nav->get_default_speed_xy() * 0.01;
         const float current_speed_sq = plane.ahrs.groundspeed_vector().length_squared();
         const float scaled_wp_speed = get_scaled_wp_speed(degrees(diff_wp.angle()));
 


### PR DESCRIPTION
we were comparing two different speeds in the threshold for going to
Q_WP_SPEED limit. The reason the two speeds were different was the
wp_nav init happened before the defaults were setup for quadplanes

this fixes both bugs
thanks to @lthall for helping me find this bug