### PR TITLE
Plane: Tailsitter transition starting points

### DIFF
--- a/ArduPlane/mode_manual.cpp
+++ b/ArduPlane/mode_manual.cpp
@@ -6,5 +6,8 @@ void ModeManual::update()
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.roll_in_expo(false));
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.pitch_in_expo(false));
     plane.steering_control.steering = plane.steering_control.rudder = plane.rudder_in_expo(false);
+
+    plane.nav_roll_cd = plane.ahrs.roll_sensor;
+    plane.nav_pitch_cd = plane.ahrs.pitch_sensor;
 }
 

--- a/ArduPlane/mode_stabilize.cpp
+++ b/ArduPlane/mode_stabilize.cpp
@@ -3,7 +3,7 @@
 
 void ModeStabilize::update()
 {
-    plane.nav_roll_cd = 0;
-    plane.nav_pitch_cd = 0;
+    plane.nav_roll_cd = plane.ahrs.roll_sensor;
+    plane.nav_pitch_cd = plane.ahrs.pitch_sensor;
 }
 

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -130,10 +130,7 @@ public:
 
     void VTOL_update() override;
 
-    void force_transistion_complete() override {
-        transition_state = TRANSITION_DONE; 
-        transition_start_ms = 0;
-    };
+    void force_transistion_complete() override;
 
     bool complete() const override { return transition_state == TRANSITION_DONE; }
 
@@ -158,9 +155,13 @@ private:
         TRANSITION_DONE
     } transition_state;
 
-    // timer start for transition
-    uint32_t transition_start_ms;
-    float transition_initial_pitch;
+    // for transition to VTOL flight
+    uint32_t vtol_transition_start_ms;
+    float vtol_transition_initial_pitch;
+
+    // for transition to FW flight
+    uint32_t fw_transition_start_ms;
+    float fw_transition_initial_pitch;
 
     // time when we were last in a vtol control mode
     uint32_t last_vtol_mode_ms;


### PR DESCRIPTION
This moves the tailsitter pitch starting point to be taken from the desired pitch angle rather than the measured pitch angle. This removes a potential step input. This is more noticeable when transitioning to VTOL because the fixed wing pitch up has no acceleration/jerk limit. The transition to FW is already smoothed by the attitude controllers controller built in limits.

I de-tuned the pitch to make the difference clearer.

Before:
![to_vtol_before](https://user-images.githubusercontent.com/33176108/140591418-e61b83f9-d571-4700-b513-ba354269a3f2.png)

After:
![to_vtol_after](https://user-images.githubusercontent.com/33176108/140591423-423388ba-2d0a-4d0a-b6d9-dd03d62ab089.png)

No more jump in desired pitch on mode switch, should help smooth out transitions. 

Tested with the built in copter-tailsitter and the CAT in realflight. 

To facilitate this change plane manual and stabilize modes now keep the desired pitch angles up to date with actual. Acro mode already does this. 
