### PR TITLE
fix flare rc switch action with flight option bit 10 active

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -190,11 +190,16 @@ float Plane::stabilize_pitch_get_pitch_out(float speed_scaler)
     if (control_mode == &mode_stabilize && channel_pitch->get_control_in() != 0) {
         disable_integrator = true;
     }
+    /* force landing pitch if:
+       - flare switch high
+       - throttle stick at zero thrust
+       - in fixed wing non auto-throttle mode
+    */
     if (!quadplane_in_transition &&
         !control_mode->is_vtol_mode() &&
-        channel_throttle->in_trim_dz() &&
         !control_mode->does_auto_throttle() &&
-        flare_mode == FlareMode::ENABLED_PITCH_TARGET) {
+        flare_mode == FlareMode::ENABLED_PITCH_TARGET &&
+        throttle_at_zero()) {
         demanded_pitch = landing.get_pitch_cd();
     }
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1205,6 +1205,7 @@ private:
     };
 
     FlareMode flare_mode;
+    bool throttle_at_zero(void) const;
 
     // expo handling
     float roll_in_expo(bool use_dz) const;

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -419,3 +419,15 @@ float Plane::rudder_in_expo(bool use_dz) const
 {
     return channel_expo(channel_rudder, g2.man_expo_roll, use_dz);
 }
+
+bool Plane::throttle_at_zero(void) const
+{
+/* true if throttle stick is at idle position...if throttle trim has been moved
+   to center stick area in conjunction with sprung throttle, cannot use in_trim, must use rc_min
+*/
+    if (((!(g2.flight_options & FlightOptions::CENTER_THROTTLE_TRIM) && channel_throttle->in_trim_dz()) ||
+        (g2.flight_options & FlightOptions::CENTER_THROTTLE_TRIM && channel_throttle->within_min_dz()))) {
+        return true;
+    }
+    return false;
+}

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -326,6 +326,15 @@ bool RC_Channel::in_trim_dz() const
     return is_bounded_int32(radio_in, radio_trim - dead_zone, radio_trim + dead_zone);
 }
 
+
+/*
+   return trues if input is within deadzone of min
+*/
+bool RC_Channel::within_min_dz() const
+{
+    return radio_in < radio_min + dead_zone;
+}
+
 void RC_Channel::set_override(const uint16_t v, const uint32_t timestamp_ms)
 {
     if (!rc().gcs_overrides_enabled()) {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -52,6 +52,9 @@ public:
     // ignores trim and deadzone
     float       norm_input_ignore_trim() const;
 
+    // returns true if input is within deadzone of min
+    bool        within_min_dz() const;
+
     uint8_t     percent_input() const;
     int16_t     pwm_to_range() const;
     int16_t     pwm_to_range_dz(uint16_t dead_zone) const;


### PR DESCRIPTION
found this while setting up a new tri-tiltrotor....unintended consequence of FLIGHT_OPTION bit 10 in conjunction with the FLARE rc option( RC trim in no longer zero thrust)...tested on TVBS and Convergence in RF SITL with and without the flight option enabled for flare switch

also fixes the QUADPLANE build option boundaries in this function