### PR TITLE
Review - Bandwidth limit option for mavlink uart by modifiying available txpace

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -506,6 +506,24 @@ const AP_Param::GroupInfo GCS_MAVLINK_Parameters::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("ADSB",   9, GCS_MAVLINK_Parameters, streamRates[9],  5),
+
+    // @Param: OPTIONS
+    // @DisplayName: Stream options
+    // @Description: Stream options
+    // @Values: 0:None, 1:Disable Streams, 2:QOS 4:Bandwidth override enable
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 10, GCS_MAVLINK_Parameters, streamOptions,  0),
+
+    // @Param: BW_OVERRIDE
+    // @DisplayName: Stream options
+    // @Description: Stream options
+    // @Units: bps
+    // @Range: 0 100000000
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("BW_OVERRIDE", 11, GCS_MAVLINK_Parameters, bandwidthOverride,  0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -125,6 +125,8 @@ public:
         return 57;
     }
 
+    virtual void set_bandwidth(uint32_t bandwidth) { return; }
+
     /*
       return true if this UART has DMA enabled on both RX and TX
      */

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -135,8 +135,13 @@ public:
         if (sdef.is_usb) {
             return 200;
         }
+        if(_bandwidth_Bps != 0){
+            return _bandwidth_Bps/1024;
+        }
         return _baudrate/(9*1024);
     }
+
+    void set_bandwidth(uint32_t bandwidth) override { _bandwidth_Bps=bandwidth ; }
 
     // request information on uart I/O for one uart
     void uart_info(ExpandingString &str) override;
@@ -177,6 +182,15 @@ private:
     uint32_t lock_read_key;
 
     uint32_t _baudrate;
+
+    // bandwidth in bytes per second
+    uint32_t _bandwidth_Bps;
+    uint32_t _last_remaining_update_ms;
+    uint32_t _bw_lim_bytes_remaining;
+
+#define UART_BW_LIMIT_MAX_TDELTA_MS		1000
+
+
 #if HAL_USE_SERIAL == TRUE
     SerialConfig sercfg;
 #endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -43,6 +43,12 @@
 #define HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED (HAVE_FILESYSTEM_SUPPORT && BOARD_FLASH_SIZE > 1024)
 #endif
 
+enum STREAM_OPTIONS_FLAG{
+	STREAM_OPTIONS_FLAG_DISABLE_STREAMS = 0x01,
+	STREAM_OPTIONS_FLAG_ALTERNATE_QOS 	= 0x02,
+	STREAM_OPTIONS_BANDWIDTH_OVERRIDE	= 0x04,
+};
+
 // macros used to determine if a message will fit in the space available.
 
 void gcs_out_of_space_to_send_count(mavlink_channel_t chan);
@@ -98,6 +104,8 @@ public:
 
     // saveable rate of each stream
     AP_Int16        streamRates[GCS_MAVLINK_NUM_STREAM_RATES];
+    AP_Int16		streamOptions;
+    AP_Int32		bandwidthOverride;
 };
 
 #if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
@@ -421,6 +429,7 @@ protected:
 
     // saveable rate of each stream
     AP_Int16        *streamRates;
+    AP_Int16		streamOptions;
 
     void handle_heartbeat(const mavlink_message_t &msg) const;
 


### PR DESCRIPTION
For telemetry radios that do not support radio_status message and have limited bandwidth compared to interface baud rate.

Option in HAL:UArtDriver to set bandwidth.  This only has a useful implementation in the ChibiOs driver and this only gets set by a mavlink user of the uart.

Whenever txspace is called and the option is activated, it checks for elapsed system time and increments the available buffer according to the set bandwidth.  There are checks on minimum and maximum increments.

When a message is sent to the uart the message size is removed from the available buffer space.

Result is a quite consistent bandwidth received over the telemetry link.  ON a radio limited to approx 100bytes/sec it reduces the packet loss from 50% to 15% for the same message rate settings.

It is mostly intended for low rate messaging since the extra processing overheads might not be acceptable.  Some optimization might help.  Keeping it simple as possible for now.

Review items
1. Testing is limited to one low rate radio so far.  Need to do the same with an FTDI cable.
2. The options parameter is a requirement for something else.  The bandwidth override only happens when the bandwidth value is moved from its default of zero.  The option parameter will be removed.
3. Mavlink gets some extra parameters on on the to contain the new option.  I need to check how to properly implement these.
4. I have some default parameters and lua script for testing with a specific board built.  Guidance on how to make this test properly would be good.
5. It might fit in the radio_status messaging scheme by actively modifying the bandwidth.  It is not my immediate intention to support this.
