### PR TITLE
ChibiOS: Support formatting of microSD card

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -70,6 +70,8 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
 #endif
 };
 
+extern const AP_HAL::HAL& hal;
+
 #define MAX_FD_PER_BACKEND 256U
 #define NUM_BACKENDS ARRAY_SIZE(backends)
 #define LOCAL_BACKEND backends[0]
@@ -267,6 +269,19 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
     }
     buf[i] = '\0';
     return i != 0;
+}
+
+// format filesystem
+bool AP_Filesystem::format(void)
+{
+#if AP_FILESYSTEM_FORMAT_ENABLED
+    if (hal.util->get_soft_armed()) {
+        return false;
+    }
+    return LOCAL_BACKEND.fs.format();
+#else
+    return false;
+#endif
 }
 
 namespace AP

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -42,6 +42,13 @@ struct dirent {
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
+
+#ifndef AP_FILESYSTEM_FORMAT_ENABLED
+// only enable for SDMMC filesystems for now as other types can't query
+// block size
+#define AP_FILESYSTEM_FORMAT_ENABLED (STM32_SDC_USE_SDMMC1==TRUE || STM32_SDC_USE_SDMMC2==TRUE)
+#endif
+
 #endif // HAL_BOARD_CHIBIOS
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_Filesystem_posix.h"
@@ -52,6 +59,10 @@ struct dirent {
 #endif
 
 #include "AP_Filesystem_backend.h"
+
+#ifndef AP_FILESYSTEM_FORMAT_ENABLED
+#define AP_FILESYSTEM_FORMAT_ENABLED 0
+#endif
 
 class AP_Filesystem {
 private:
@@ -96,6 +107,9 @@ public:
     // returns null-terminated string; cr or lf terminates line
     bool fgets(char *buf, uint8_t buflen, int fd);
 
+    // format filesystem
+    bool format(void);
+    
     /*
       load a full file. Use delete to free the data
      */

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -54,4 +54,11 @@ public:
 
     // unmount filesystem for reboot
     void unmount(void) override;
+
+    // format sdcard
+    bool format(void) override;
+
+private:
+    void format_handler(void);
+    bool format_pending;
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -73,6 +73,9 @@ public:
     // unmount filesystem for reboot
     virtual void unmount(void) {}
 
+    // format sdcard
+    virtual bool format(void) { return false; }
+    
     /*
       load a full file. Use delete to free the data
      */

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
@@ -44,7 +44,10 @@
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
 
-#define FF_USE_MKFS       0
+#ifndef FF_USE_MKFS
+// f_mkfs() only supported on SDC so far
+#define FF_USE_MKFS       HAL_USE_SDC
+#endif
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/mcuconf.h
@@ -52,3 +52,11 @@
 #else
 #error "Unsupported MCU"
 #endif
+
+#ifndef STM32_SDC_USE_SDMMC1
+#define STM32_SDC_USE_SDMMC1                FALSE
+#endif
+
+#ifndef STM32_SDC_USE_SDMMC2
+#define STM32_SDC_USE_SDMMC2                FALSE
+#endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
@@ -475,7 +475,3 @@
 
 // limit ISR count per byte
 #define STM32_I2C_ISR_LIMIT                 6
-
-#ifndef STM32_SDC_USE_SDMMC2
-#define STM32_SDC_USE_SDMMC2                FALSE
-#endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4_mcuconf.h
@@ -238,9 +238,6 @@
 /*
  * SDC driver system settings.
  */
-#ifndef STM32_SDC_USE_SDMMC1
-#define STM32_SDC_USE_SDMMC1                FALSE
-#endif
 #define STM32_SDC_SDMMC_UNALIGNED_SUPPORT   TRUE
 #define STM32_SDC_SDMMC_WRITE_TIMEOUT       1000
 #define STM32_SDC_SDMMC_READ_TIMEOUT        1000

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4655,6 +4655,14 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_do_set_roi_sysid(packet);
     case MAV_CMD_DO_SET_HOME:
         return handle_command_int_do_set_home(packet);
+    case MAV_CMD_STORAGE_FORMAT: {
+        if (!is_equal(packet.param1, 1.0f) ||
+            !is_equal(packet.param2, 1.0f)) {
+            return MAV_RESULT_UNSUPPORTED;
+        }
+        return AP::FS().format() ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
+    }
+
 #if AP_SCRIPTING_ENABLED
     case MAV_CMD_SCRIPTING:
         {


### PR DESCRIPTION
This supports formatting of the microSD card on ChibiOS. The card is then automatically remounted.
This only works on SDC sdcard interfaces (so not on MMC SPI interfaces) as the GET_BLOCK_SIZE ioctl() only works on SDC
MAVProxy implementation here: https://github.com/ArduPilot/MAVProxy/pull/961
using command "formatsdcard"
cost is about 5k on boards where this is enabled