### PR TITLE
UARTDriver: Option to bandwidth limit mavlink

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -507,19 +507,11 @@ const AP_Param::GroupInfo GCS_MAVLINK_Parameters::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ADSB",   9, GCS_MAVLINK_Parameters, streamRates[9],  5),
 
-    // @Param: OPTIONS
-    // @DisplayName: Stream options
-    // @Description: Stream options
-    // @Values: 0:None, 1:Disable Streams, 2:QOS 4:Bandwidth override enable
-    // @RebootRequired: True
-    // @User: Advanced
-    AP_GROUPINFO("OPTIONS", 10, GCS_MAVLINK_Parameters, streamOptions,  0),
-
     // @Param: BW_OVERRIDE
     // @DisplayName: Stream options
     // @Description: Stream options
-    // @Units: bps
-    // @Range: 0 100000000
+    // @Units: Bps
+    // @Range: 0 1000000
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("BW_OVERRIDE", 11, GCS_MAVLINK_Parameters, bandwidthOverride,  0),

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -506,6 +506,24 @@ const AP_Param::GroupInfo GCS_MAVLINK_Parameters::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("ADSB",   9, GCS_MAVLINK_Parameters, streamRates[9],  5),
+
+    // @Param: OPTIONS
+    // @DisplayName: Stream options
+    // @Description: Stream options
+    // @Values: 0:None, 1:Disable Streams, 2:QOS 4:Bandwidth override enable
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 10, GCS_MAVLINK_Parameters, streamOptions,  0),
+
+    // @Param: BW_OVERRIDE
+    // @DisplayName: Stream options
+    // @Description: Stream options
+    // @Units: bps
+    // @Range: 0 100000000
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("BW_OVERRIDE", 11, GCS_MAVLINK_Parameters, bandwidthOverride,  0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -125,6 +125,8 @@ public:
         return 57;
     }
 
+    virtual void set_bandwidth(uint32_t bandwidth) { return; }
+
     /*
       return true if this UART has DMA enabled on both RX and TX
      */

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -135,8 +135,13 @@ public:
         if (sdef.is_usb) {
             return 200;
         }
+        if(_bandwidth_Bps != 0){
+            return _bandwidth_Bps/1024;
+        }
         return _baudrate/(9*1024);
     }
+
+    void set_bandwidth(uint32_t bandwidth) override { _bandwidth_Bps=bandwidth ; }
 
     // request information on uart I/O for one uart
     void uart_info(ExpandingString &str) override;
@@ -177,6 +182,15 @@ private:
     uint32_t lock_read_key;
 
     uint32_t _baudrate;
+
+    // bandwidth in bytes per second
+    uint32_t _bandwidth_Bps;
+    uint32_t _last_remaining_update_ms;
+    uint32_t _bw_lim_bytes_remaining;
+
+#define UART_BW_LIMIT_MAX_TDELTA_MS		1000
+
+
 #if HAL_USE_SERIAL == TRUE
     SerialConfig sercfg;
 #endif

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -135,6 +135,8 @@ public:
         if (sdef.is_usb) {
             return 200;
         }
+
+        //if bandwidth setting is not zero then use baud rate.
         if(_bandwidth_Bps != 0){
             return _bandwidth_Bps/1024;
         }
@@ -185,8 +187,10 @@ private:
 
     // bandwidth in bytes per second
     uint32_t _bandwidth_Bps;
-    uint32_t _last_remaining_update_ms;
-    uint32_t _bw_lim_bytes_remaining;
+    //Last time that the space in the buffer was updated
+    uint32_t _last_txspace_update_ms;
+    //tx space remaining when bandwidth limiting
+    uint32_t _bandwidth_space_available;
 
 #define UART_BW_LIMIT_MAX_TDELTA_MS		1000
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -43,6 +43,12 @@
 #define HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED (HAVE_FILESYSTEM_SUPPORT && BOARD_FLASH_SIZE > 1024)
 #endif
 
+enum STREAM_OPTIONS_FLAG{
+	STREAM_OPTIONS_FLAG_DISABLE_STREAMS = 0x01,
+	STREAM_OPTIONS_FLAG_ALTERNATE_QOS 	= 0x02,
+	STREAM_OPTIONS_BANDWIDTH_OVERRIDE	= 0x04,
+};
+
 // macros used to determine if a message will fit in the space available.
 
 void gcs_out_of_space_to_send_count(mavlink_channel_t chan);
@@ -98,6 +104,8 @@ public:
 
     // saveable rate of each stream
     AP_Int16        streamRates[GCS_MAVLINK_NUM_STREAM_RATES];
+    AP_Int16		streamOptions;
+    AP_Int32		bandwidthOverride;
 };
 
 #if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
@@ -421,6 +429,7 @@ protected:
 
     // saveable rate of each stream
     AP_Int16        *streamRates;
+    AP_Int16		streamOptions;
 
     void handle_heartbeat(const mavlink_message_t &msg) const;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -43,12 +43,6 @@
 #define HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED (HAVE_FILESYSTEM_SUPPORT && BOARD_FLASH_SIZE > 1024)
 #endif
 
-enum STREAM_OPTIONS_FLAG{
-	STREAM_OPTIONS_FLAG_DISABLE_STREAMS = 0x01,
-	STREAM_OPTIONS_FLAG_ALTERNATE_QOS 	= 0x02,
-	STREAM_OPTIONS_BANDWIDTH_OVERRIDE	= 0x04,
-};
-
 // macros used to determine if a message will fit in the space available.
 
 void gcs_out_of_space_to_send_count(mavlink_channel_t chan);
@@ -104,7 +98,8 @@ public:
 
     // saveable rate of each stream
     AP_Int16        streamRates[GCS_MAVLINK_NUM_STREAM_RATES];
-    AP_Int16		streamOptions;
+
+    //Bandwidth override value
     AP_Int32		bandwidthOverride;
 };
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -100,6 +100,11 @@ GCS_MAVLINK::GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters,
     _port = &uart;
 
     streamRates = parameters.streamRates;
+
+    //Override port bandwidth if parameter value is not default zero
+    if(parameters.bandwidthOverride != 0){
+        _port->set_bandwidth(parameters.bandwidthOverride);
+    }
 }
 
 bool GCS_MAVLINK::init(uint8_t instance)


### PR DESCRIPTION
For use with telemetry not supporting radio_status that has baud rate significantly higher than its bandwidth.  This feature makes it possible to use available bandwidth without high packet loss.

A new SRx_BW_OVERRIDE parameter activates the feature when it is set to non zero.

Bandwidth limit done at uart driver level by modifying the result of txspace().  Available buffer space is limited according to bandwidth and time elapsed.

Only implemented for ChibiOs uarts.   Bandwidth only set by mavlink.

Written for low rate links.  Not optimized for efficiency at high message rates.  Minimum impact when not used.

