### PR TITLE
AP_RCProtocol: remove pointless 100kbaud speed change

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -303,7 +303,6 @@ void AP_RCProtocol::check_added_uart(void)
             if (added.phase > CONFIG_420000_8N1) {
                 added.phase = (enum config_phase)0;
             }
-            added.baudrate = (added.baudrate==100000)?115200:100000;
             added.opened = false;
         }
     }


### PR DESCRIPTION
added.opened is set to false.  Next time we check_added_uart, the baud
rate is unconditionally set in each of the phases.  Thus this line has
no effect except to confuse the reader

This line predates the addition of the baudrate set.
