### PR TITLE
AP_RangeFinder_LightWareSerial: handle LightWare lost signal flag output

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -19,6 +19,7 @@ protected:
 private:
     // get a reading
     bool get_reading(float &reading_m) override;
+    bool is_lost_signal_distance(int16_t distance_cm, int16_t distance_cm_max);
 
     char linebuf[10];           // legacy protocol buffer
     uint8_t linebuf_len;        // legacy protocol buffer length


### PR DESCRIPTION
This PR is in response to #18602. In short, several of the LightWare LiDAR sensors output an out-of-range-high value (flag) to indicate that the LiDAR has lost signal, and the current driver does not take this into account. Instead it only checks that the sensor's measured value is non-negative. This can lead to good measurements being summed together with out-of-range-high values resulting in an incorrect result.

Evidence from LightWare (see #18602) suggests that there are several possible out-of-range-high values that the LiDAR may output depending on the model of LiDAR. In this PR instead of checking for each of these flags, we note that for all of the flags listed in #18602, the value is at least 10 meters greater than the sensor's advertised maximum range, and we use this as an additional check to determine if a distance measurement is valid. As long as the end-user has configured the AP rangefinder parameters correctly for his/her specific rangefinder model, then the out-of-range-high outputs will be treated as invalid measurements and will not be summed with valid measurements.

I built and tested this change for the CubeBlack and tested it in hardware using a LightWare SF11/C. I used the default parameters listed [here](https://ardupilot.org/copter/docs/common-lightware-sf10-lidar.html#serial-connection) with RNGFND1_MAX_CM=12000. All indications are that the driver now correctly handles out-of-range-high value flags. Prior to the change, the "rangefinder1" field within the "Status" tab of MissionPlanner would output 13000 centimeters when I covered the receive side of the SF11/C--indicating that the sensor's output of 130.0 meters was being treated as a valid measurement. After the change, the same test results in a "rangfinder1" field value of 12100 centimeters--indicating that 'valid_count' on line 121 was correctly zero, the 'invalid_count' on line 127 was greater than zero, and the resulting output was the result of max_distance_cm() + LIGHTWARE_OUT_OF_RANGE_ADD_CM (12000 + 100 = 12100).