### PR TITLE
Param: removed param restored internal error

### DIFF
--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -65,7 +65,7 @@ public:
         gpio_isr                    = (1U << 25),  //0x2000000 33554432
         mem_guard                   = (1U << 26),  //0x4000000 67108864
         dma_fail                    = (1U << 27),  //0x8000000 134217728
-        params_restored             = (1U << 28),  //0x10000000 268435456
+        params_restored             = (1U << 28),  //0x10000000 268435456 UNUSED
         invalid_arg_or_result       = (1U << 29),  //0x20000000 536870912
         __LAST__                    = (1U << 30),  // used only for sanity check
     };

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -342,7 +342,6 @@ bool AP_Param::setup(void)
             hdr2.revision == k_EEPROM_revision &&
             _storage.copy_area(_storage_bak)) {
             // restored from backup
-            INTERNAL_ERROR(AP_InternalError::error_t::params_restored);
             return true;
         }
         // header doesn't match. We can't recover any variables. Wipe


### PR DESCRIPTION
this has been requested by multiple partners. The param restore is now  reliable and doesn't need an internal error
    
This error also happened when you load px4 firmware on a board then go back to ArduPilot (as that causes parameter corruption). That is not a good experience
