### PR TITLE
GCS_MAVLINK: fixed build of boards with APJ_BOARD_ID>32768

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2353,7 +2353,7 @@ void GCS_MAVLINK::send_autopilot_version() const
     uint32_t flight_sw_version;
     uint32_t middleware_sw_version = 0;
 #ifdef APJ_BOARD_ID
-    uint32_t board_version { APJ_BOARD_ID << 16 };
+    uint32_t board_version { uint32_t(APJ_BOARD_ID) << 16 };
 #else
     uint32_t board_version = 0;
 #endif


### PR DESCRIPTION
this impacts modalai_fc_v1