### PR TITLE
AP_Landing: Fix slope calculation.

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -282,13 +282,6 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
         aim_height = flare_alt*2;
     }
 
-    // calculate slope to landing point
-    bool is_first_calc = is_zero(slope);
-    slope = (sink_height - aim_height) / total_distance;
-    if (is_first_calc) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
-    }
-
     // time before landing that we will flare
     float flare_time = aim_height / SpdHgt_Controller->get_land_sinkrate();
 
@@ -311,6 +304,13 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     Location loc = next_WP_loc;
     loc.offset_bearing(land_bearing_cd * 0.01f, -flare_distance);
     loc.alt += aim_height*100;
+
+    // calculate slope to landing point
+    bool is_first_calc = is_zero(slope);
+    slope = (sink_height - aim_height) / (total_distance - flare_distance);
+    if (is_first_calc) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
+    }
 
     // calculate point along that slope 500m ahead
     loc.offset_bearing(land_bearing_cd * 0.01f, land_projection);


### PR DESCRIPTION
This corrects the calculation of landing slope using flare_distance.

This ensures that the calculated landing slope reflect the actual glidepath the aircraft has to track on final.

The main impact of this is on the printed message at the start of the approach. It's important that this is accurate to allow easy detection of an overly steep approach. Without this correction, the calculated slope is shallower than the actual glidepath to the target point. Therefore the printed slope may be fine, but the aircraft may nevertheless be unable to track the target path.