### PR TITLE
AP_Motors: Coax: remove servo outputs from motors mask, correct array indexing

### DIFF
--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -78,10 +78,10 @@ void AP_MotorsCoax::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _spin_up_ratio * _actuator_out[i] * AP_MOTORS_COAX_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[5], actuator_spin_up_to_ground_idle());
-            set_actuator_with_slew(_actuator[6], actuator_spin_up_to_ground_idle());
-            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[5]));
-            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[6]));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], actuator_spin_up_to_ground_idle());
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], actuator_spin_up_to_ground_idle());
+            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[AP_MOTORS_MOT_5]));
+            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[AP_MOTORS_MOT_6]));
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
@@ -90,10 +90,10 @@ void AP_MotorsCoax::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _actuator_out[i] * AP_MOTORS_COAX_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[5], thrust_to_actuator(_thrust_yt_ccw));
-            set_actuator_with_slew(_actuator[6], thrust_to_actuator(_thrust_yt_cw));
-            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[5]));
-            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[6]));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], thrust_to_actuator(_thrust_yt_ccw));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], thrust_to_actuator(_thrust_yt_cw));
+            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[AP_MOTORS_MOT_5]));
+            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[AP_MOTORS_MOT_6]));
             break;
     }
 }

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -103,10 +103,6 @@ void AP_MotorsCoax::output_to_motors()
 uint16_t AP_MotorsCoax::get_motor_mask()
 {
     uint32_t motor_mask =
-        1U << AP_MOTORS_MOT_1 |
-        1U << AP_MOTORS_MOT_2 |
-        1U << AP_MOTORS_MOT_3 |
-        1U << AP_MOTORS_MOT_4 |
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
     uint16_t mask = motor_mask_to_srv_channel_mask(motor_mask);


### PR DESCRIPTION
fixes in part [18201](https://github.com/ArduPilot/ardupilot/issues/18201), also need the same patch for single copter.
