### PR TITLE
corrected landing slope calculation

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -284,7 +284,7 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
 
     // calculate slope to landing point
     bool is_first_calc = is_zero(slope);
-    slope = (sink_height - aim_height) / total_distance;
+    slope = (sink_height - aim_height) / (total_distance - flare_distance);
     if (is_first_calc) {
         gcs().send_text(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
     }


### PR DESCRIPTION
This PR corrects calculation of gliding slope. Drawing below speaks for itself.
![landing](https://user-images.githubusercontent.com/57300765/141007657-870d67b0-60a0-4c28-b85c-2562624dee4c.jpg)
This PR is first of few upcoming PRs with changes to slope landing flare.