### PR TITLE
Copter: surface tracking timeout fix

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -290,8 +290,8 @@ private:
         Surface surface = Surface::GROUND;
         uint32_t last_update_ms;    // system time of last update to target_alt_cm
         uint32_t last_glitch_cleared_ms;    // system time of last handle glitch recovery
-        bool valid_for_logging;     // true if target_alt_cm is valid for logging
-        bool reset_target;          // true if target should be reset because of change in tracking_state
+        bool valid_for_logging;     // true if we have a desired target altitude
+        bool reset_target;          // true if target should be reset because of change in surface being tracked
     } surface_tracking;
 
 #if RPM_ENABLED == ENABLED


### PR DESCRIPTION
This resolves a bug in Copter's surface tracking's target altitude after a short-term glitch.

Some local variable renaming and commenting has also been added in the hopes of making the update_surface_offset method easier to understand.

This has been tested in SITL and below are screen shots before and after with some extra debug code added to trigger glitches.
![surface-track-timeout-fix-before-vs-after](https://user-images.githubusercontent.com/1498098/141034729-8ca7cfa8-0d15-4e84-b375-d55647467a73.png)

Thanks to @tatsuy for this report
