### PR TITLE
autotest: turn drain mav off when doing early-exit for being quiet

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2404,6 +2404,7 @@ class AutoTest(ABC):
         while mav.recv_match(blocking=False) is not None:
             count += 1
         if quiet:
+            self.in_drain_mav = False
             return
         tdelta = time.time() - tstart
         if tdelta == 0:


### PR DESCRIPTION
Should help to fix the blocked-on-terminal-output problems