### PR TITLE
AP_RCProtocol: move uart flow control set out of CRSF code

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -275,8 +275,6 @@ void AP_RCProtocol::check_added_uart(void)
             added.baudrate = CRSF_BAUDRATE;
             added.uart->configure_parity(0);
             added.uart->set_stop_bits(1);
-            added.uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-            added.uart->set_blocking_writes(false);
             added.uart->set_options(added.uart->get_options() & ~AP_HAL::UARTDriver::OPTION_RXINV);
             break;
         }
@@ -428,6 +426,7 @@ const char *AP_RCProtocol::protocol_name(void) const
 void AP_RCProtocol::add_uart(AP_HAL::UARTDriver* uart)
 {
     added.uart = uart;
+    added.uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
     // start with DSM
     added.baudrate = 115200U;
 }


### PR DESCRIPTION
11:32 AM] AndrewTridgell: @Peter Barker we should disable flow control when we first add the uart - none of the RC protocols use flow control
[11:32 AM] AndrewTridgell: the blocking writes call isn't needed
[11:32 AM] Peter Barker: Thanks, I'll make a patch.