### PR TITLE
AP_RCProtocol: Use a data structure to hold serial configurations for auto-detection

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -275,8 +275,6 @@ void AP_RCProtocol::check_added_uart(void)
             added.baudrate = CRSF_BAUDRATE;
             added.uart->configure_parity(0);
             added.uart->set_stop_bits(1);
-            added.uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-            added.uart->set_blocking_writes(false);
             added.uart->set_options(added.uart->get_options() & ~AP_HAL::UARTDriver::OPTION_RXINV);
             break;
         }
@@ -428,6 +426,7 @@ const char *AP_RCProtocol::protocol_name(void) const
 void AP_RCProtocol::add_uart(AP_HAL::UARTDriver* uart)
 {
     added.uart = uart;
+    added.uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
     // start with DSM
     added.baudrate = 115200U;
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -111,6 +111,16 @@ public:
     }
 #endif
 
+    class SerialConfig {
+    public:
+        void apply_to_uart(AP_HAL::UARTDriver *uart) const;
+
+        uint32_t baud;
+        uint8_t parity;
+        uint8_t stop_bits;
+        bool invert_rx;
+    };
+
 private:
     void check_added_uart(void);
 
@@ -125,20 +135,12 @@ private:
     uint32_t _last_input_ms;
     bool _valid_serial_prot;
 
-    enum config_phase {
-        CONFIG_115200_8N1 = 0,
-        CONFIG_115200_8N1I = 1,
-        CONFIG_100000_8E2I = 2,
-        CONFIG_420000_8N1 = 3,
-    };
-
     // optional additional uart
     struct {
         AP_HAL::UARTDriver *uart;
-        uint32_t baudrate;
         bool opened;
-        uint32_t last_baud_change_ms;
-        enum config_phase phase;
+        uint32_t last_config_change_ms;
+        uint8_t config_num;
     } added;
 
     // allowed RC protocols mask (first bit means "all")


### PR DESCRIPTION
More data structure, less code.

I think this makes it clearer as to what is going on, and makes it easier to add new serial configurations.
