### PR TITLE
Unbuffered write corrections

### DIFF
--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -398,8 +398,8 @@ void AP_Hott_Telem::send_packet(const uint8_t *b, uint8_t len)
  */
 void AP_Hott_Telem::loop(void)
 {
-    uart->begin(19200, 10, 10);
     uart->set_unbuffered_writes(true);
+    uart->begin(19200, 10, 10);
     uart->set_blocking_writes(true);
 
     while (true) {

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -65,9 +65,9 @@ AP_IOMCU *AP_IOMCU::singleton;
 void AP_IOMCU::init(void)
 {
     // uart runs at 1.5MBit
+    uart.set_unbuffered_writes(true);
     uart.begin(1500*1000, 128, 128);
     uart.set_blocking_writes(true);
-    uart.set_unbuffered_writes(true);
 
     AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
     if ((!boardconfig || boardconfig->io_enabled() == 1) && !hal.util->was_watchdog_reset()) {
@@ -101,9 +101,9 @@ void AP_IOMCU::thread_main(void)
     thread_ctx = chThdGetSelfX();
     chEvtSignal(thread_ctx, initial_event_mask);
 
+    uart.set_unbuffered_writes(true);
     uart.begin(1500*1000, 128, 128);
     uart.set_blocking_writes(true);
-    uart.set_unbuffered_writes(true);
 
     trigger_event(IOEVENT_INIT);
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -393,9 +393,9 @@ void AP_RCProtocol_SRXL2::_change_baud_rate(uint32_t baudrate)
 {
     AP_HAL::UARTDriver* uart = get_available_UART();
     if (uart != nullptr) {
+        uart->set_unbuffered_writes(true);
         uart->begin(baudrate);
         uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-        uart->set_unbuffered_writes(true);
         uart->set_blocking_writes(false);
     }
 }

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -465,20 +465,20 @@ void AP_SerialManager::init()
                 case SerialProtocol_Volz:
                                     // Note baudrate is hardcoded to 115200
                                     state[i].baud = AP_SERIALMANAGER_VOLZ_BAUD;   // update baud param in case user looks at it
+                                    uart->set_unbuffered_writes(true);
                                     uart->begin(map_baudrate(state[i].baud),
                                     		AP_SERIALMANAGER_VOLZ_BUFSIZE_RX,
 											AP_SERIALMANAGER_VOLZ_BUFSIZE_TX);
-                                    uart->set_unbuffered_writes(true);
                                     uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
                                     break;
                 case SerialProtocol_Sbus1:
                     state[i].baud = AP_SERIALMANAGER_SBUS1_BAUD / 1000;   // update baud param in case user looks at it
+                    uart->set_unbuffered_writes(true);
                     uart->begin(map_baudrate(state[i].baud),
                                          AP_SERIALMANAGER_SBUS1_BUFSIZE_RX,
                                          AP_SERIALMANAGER_SBUS1_BUFSIZE_TX);
                     uart->configure_parity(2);    // enable even parity
                     uart->set_stop_bits(2);
-                    uart->set_unbuffered_writes(true);
                     uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
                     break;
 
@@ -490,10 +490,10 @@ void AP_SerialManager::init()
                     break;
 
                 case SerialProtocol_Robotis:
+                    uart->set_unbuffered_writes(true);
                     uart->begin(map_baudrate(state[i].baud),
                                          AP_SERIALMANAGER_ROBOTIS_BUFSIZE_RX,
                                          AP_SERIALMANAGER_ROBOTIS_BUFSIZE_TX);
-                    uart->set_unbuffered_writes(true);
                     uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
                     break;
 

--- a/libraries/AP_Torqeedo/AP_Torqeedo.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.cpp
@@ -137,9 +137,9 @@ bool AP_Torqeedo::init_internals()
     if (_uart == nullptr) {
         return false;
     }
+    _uart->set_unbuffered_writes(true);
     _uart->begin(TORQEEDO_SERIAL_BAUD);
     _uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
-    _uart->set_unbuffered_writes(true);
 
     // if using tiller connection set on/off pin for 0.5 sec to turn on battery
     if (_type == ConnectionType::TYPE_TILLER) {


### PR DESCRIPTION
Using the `set_unbuffered_writes()` function we set the `unbuffered_writes` variable

This is used in write function, in uart_thread() and thead_init()
on uart_thread() it will change the thread priority.
On thead_init() it will set the thread priority on thread creation.

To prevent unnecessary complication by changing thread priority that is better to use `set_unbuffered_writes()` before  thead_init() so before begin function.