### PR TITLE
Add autotest for devo telemetry 

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3322,6 +3322,10 @@ class AutoTestPlane(AutoTest):
              "Test LTM serial output",
              self.test_ltm),
 
+            ("DEVO",
+             "Test DEVO serial output",
+             self.DEVO),
+
             ("AdvancedFailsafe",
              "Test Advanced Failsafe",
              self.test_advanced_failsafe),

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -48,10 +48,10 @@ void AP_DEVO_Telem::init()
 }
 
 
-uint32_t AP_DEVO_Telem::gpsDdToDmsFormat(float ddm)
+uint32_t AP_DEVO_Telem::gpsDdToDmsFormat(int32_t ddm)
 {
-    int32_t deg = (int32_t)ddm;
-    float mm = (ddm - deg) * 60.0f;
+    int32_t deg = (int32_t)(ddm * 1e-7);
+    float mm = (ddm * 1.0e-7 - deg) * 60.0f;
 
     mm = ((float)deg * 100.0f + mm) /100.0f;
 
@@ -105,7 +105,7 @@ void AP_DEVO_Telem::send_frames()
         */
         float alt;
         _ahrs.get_relative_position_D_home(alt);
-        devoPacket.alt   = alt * -100.0f; // coordinates was in NED, so it needs to change sign. Protocol requires in cm!
+        devoPacket.alt = alt * -100.0f; // coordinates was in NED, so it needs to change sign. Protocol requires in cm!
     }
 
 

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.h
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.h
@@ -31,7 +31,7 @@ public:
 
 private:
 
-    uint32_t gpsDdToDmsFormat(float ddm);
+    uint32_t gpsDdToDmsFormat(int32_t ddm);
 
     // tick - main call to send updates to transmitter
     void tick(void);


### PR DESCRIPTION
This adds an autotest for devo telemetry (issue #19174).
This also fixes the method `gpsDdToDmsFormat` in devo telemetry driver which returned 0 for valid values which lead `devoPacket` packet sending `lat` and `lon` as 0 always.