### PR TITLE
RC_Channel: Express option numbers in bits

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1269,7 +1269,7 @@ RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::aux_func_t op
 // duplicate_options_exist - returns true if any options are duplicated
 bool RC_Channels::duplicate_options_exist()
 {
-    uint8_t auxsw_option_counts[256] = {};
+    uint8_t auxsw_option_counts[uint32_t(RC_Channel::AUX_FUNC::AUX_FUNC_END) / 8 + 1] = {};
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
         const RC_Channel *c = channel(i);
         if (c == nullptr) {
@@ -1277,21 +1277,16 @@ bool RC_Channels::duplicate_options_exist()
             continue;
         }
         const uint16_t option = c->option.get();
-        if (option >= sizeof(auxsw_option_counts)) {
+        if (option == 0 || option >= uint16_t(RC_Channel::AUX_FUNC::AUX_FUNC_END)) {
             continue;
         }
-        auxsw_option_counts[option]++;
-    }
-
-    for (uint16_t i=0; i<sizeof(auxsw_option_counts); i++) {
-        if (i == 0) { // MAGIC VALUE! This is AUXSW_DO_NOTHING
-            continue;
-        }
-        if (auxsw_option_counts[i] > 1) {
+        if ((auxsw_option_counts[option / 8] & (1 << (option % 8))) == 0) {
+            auxsw_option_counts[option / 8] |= 1 << (option % 8);
+        } else {
             return true;
         }
     }
-   return false;
+    return false;
 }
 
 // convert option parameter from old to new

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -247,6 +247,9 @@ public:
         SCRIPTING_6 =        305,
         SCRIPTING_7 =        306,
         SCRIPTING_8 =        307,
+
+        // This AUX_FUNC_END is used in the array of the duplicate_options_exist method.
+        AUX_FUNC_END,
     };
     typedef enum AUX_FUNC aux_func_t;
 


### PR DESCRIPTION
I would change the number of arrays to the maximum value +1 to check for duplication of all channel options.