### PR TITLE
AP_BattMonitor: added VLT_OFFSET for analog

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -43,6 +43,13 @@ const AP_Param::GroupInfo AP_BattMonitor_Analog::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("AMP_OFFSET", 5, AP_BattMonitor_Analog, _curr_amp_offset, AP_BATT_CURR_AMP_OFFSET_DEFAULT),
 
+    // @Param: VLT_OFFSET
+    // @DisplayName: Volage offset
+    // @Description: Voltage offset on voltage pin. This allows for an offset due to a diode. This voltage is subtracted before the scaling is applied
+    // @Units: V
+    // @User: Advanced
+    AP_GROUPINFO("VLT_OFFSET", 6, AP_BattMonitor_Analog, _volt_offset, 0),
+    
     // Param indexes must be less than 10 to avoid conflict with other battery monitor param tables loaded by pointer
 
     AP_GROUPEND
@@ -70,7 +77,7 @@ AP_BattMonitor_Analog::read()
     _state.healthy = _volt_pin_analog_source->set_pin(_volt_pin);
 
     // get voltage
-    _state.voltage = _volt_pin_analog_source->voltage_average() * _volt_multiplier;
+    _state.voltage = (_volt_pin_analog_source->voltage_average() - _volt_offset) * _volt_multiplier;
 
     // read current
     if (has_current()) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -122,6 +122,7 @@ protected:
     AP_Float _volt_multiplier;          /// voltage on volt pin multiplied by this to calculate battery voltage
     AP_Float _curr_amp_per_volt;        /// voltage on current pin multiplied by this to calculate current in amps
     AP_Float _curr_amp_offset;          /// offset voltage that is subtracted from current pin before conversion to amps
+    AP_Float _volt_offset;              /// offset voltage that is subtracted from voltage pin before conversion
     AP_Int8  _volt_pin;                 /// board pin used to measure battery voltage
     AP_Int8  _curr_pin;                 /// board pin used to measure battery current
 };


### PR DESCRIPTION
useful for diode bias in voltage monitors

thanks to Charles from ASW and Jeff Wurzbach