### PR TITLE
AP_Mission: Have plane convert NAV_SPLINE points into NAV_WAYPOINT pts

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -962,7 +962,13 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_NAV_SPLINE_WAYPOINT:                   // MAV ID: 82
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+        // Spline is not supported by Plane, convert it to NAV_WAYPOINT
+        cmd.id = MAV_CMD_NAV_WAYPOINT;
+        cmd.p1 = 0;
+#else
         cmd.p1 = packet.param1;                         // delay at waypoint in seconds
+#endif
         break;
 
     case MAV_CMD_NAV_GUIDED_ENABLE:                     // MAV ID: 92


### PR DESCRIPTION
Have plane convert NAV_SPLINE points into NAV_WAYPOINT pts.

This makes it so even if a NAV_SPLINE_WAYPOINT is in a mission that is sent to the aircraft, it will convert it to NAV_WAYPOINT in the mavlink handler as it's received and will then get stored as a NAV_WAYPOINT onboard.