### PR TITLE
Tradheli: Using TX throttle and pitch curves for manual modes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -759,9 +759,7 @@ private:
     float get_pilot_desired_rotor_speed() const;
     void heli_update_rotor_speed_targets();
     void heli_update_autorotation();
-#if MODE_AUTOROTATE_ENABLED == ENABLED
     void heli_set_autorotation(bool autotrotation);
-#endif
     void update_collective_low_flag(int16_t throttle_control);
     float get_pilot_desired_throttle() const;
     // inertia.cpp

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -763,6 +763,7 @@ private:
     void heli_set_autorotation(bool autotrotation);
 #endif
     void update_collective_low_flag(int16_t throttle_control);
+    float get_pilot_desired_throttle() const;
     // inertia.cpp
     void read_inertia();
 

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -151,6 +151,18 @@ float Copter::get_pilot_desired_rotor_speed() const
     return 0.0f;
 }
 
+// get throttle from transmitter
+// returns -1 if throttle hasn't been defined
+float Copter::get_pilot_desired_throttle() const
+{
+    RC_Channel *rc_ptr = rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_INTERLOCK);
+    if (rc_ptr != nullptr) {
+        rc_ptr->set_range(1000);
+        return (float)rc_ptr->get_control_in() * 0.001f;
+    }
+    return -1.0f;
+}
+
 // heli_update_rotor_speed_targets - reads pilot input and passes new rotor speed targets to heli motors object
 void Copter::heli_update_rotor_speed_targets()
 {
@@ -159,6 +171,9 @@ void Copter::heli_update_rotor_speed_targets()
 
     // get rotor control method
     uint8_t rsc_control_mode = motors->get_rsc_mode();
+
+    // always reset desired throttle to keep from accidentally using manual throttle
+    motors->set_desired_throttle(-1.0f);
 
     switch (rsc_control_mode) {
         case ROTOR_CONTROL_MODE_SPEED_PASSTHROUGH:
@@ -173,6 +188,20 @@ void Copter::heli_update_rotor_speed_targets()
             break;
         case ROTOR_CONTROL_MODE_SPEED_SETPOINT:
         case ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT:
+            if (get_pilot_desired_throttle() >= 0.0f && flightmode->has_manual_throttle()) {
+                motors->set_desired_throttle(get_pilot_desired_throttle());
+            }
+            if (motors->get_interlock()) {
+#if RPM_ENABLED == ENABLED
+                float rpm = -1;
+                rpm_sensor.get_rpm(0, rpm);
+                motors->set_rpm(rpm);
+#endif
+                motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
+            }else{
+                motors->set_desired_rotor_speed(0.0f);
+            }
+            break;
         case ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT:
             // pass setpoint through as desired rotor speed. Needs work, this is pointless as it is
             // not used by closed loop control. Being used as a catch-all for other modes regardless

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -93,6 +93,9 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     virtual void set_desired_rotor_speed(float desired_speed) = 0;
 
+    // set_desired_throttle - sets target throttle as a number from 0 ~ 1
+    virtual void set_desired_throttle(float desired_throttle) = 0;
+
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
     virtual float get_desired_rotor_speed() const = 0;
 
@@ -154,10 +157,14 @@ public:
     // enum for heli optional features
     enum class HeliOption {
         USE_LEAKY_I                     = (1<<0),   // 1
+        USE_PILOT_THROTTLE              = (1<<1),   // 2
     };
 
     // use leaking integrator management scheme
     bool using_leaky_integrator() const { return heli_option(HeliOption::USE_LEAKY_I); }
+    
+    // use pilot desired throttle
+    bool using_pilot_throttle() const { return heli_option(HeliOption::USE_PILOT_THROTTLE); }
     
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -158,6 +158,7 @@ public:
     enum class HeliOption {
         USE_LEAKY_I                     = (1<<0),   // 1
         USE_PILOT_THROTTLE              = (1<<1),   // 2
+        ENABLE_BAILOUT                  = (1<<2),   // 3
     };
 
     // use leaking integrator management scheme
@@ -165,6 +166,9 @@ public:
     
     // use pilot desired throttle
     bool using_pilot_throttle() const { return heli_option(HeliOption::USE_PILOT_THROTTLE); }
+    
+    // allow autorotation bailout in manual modes
+    bool enable_bailout() const { return heli_option(HeliOption::ENABLE_BAILOUT); }
     
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -324,6 +324,17 @@ void AP_MotorsHeli_Dual::set_desired_rotor_speed(float desired_speed)
     _main_rotor.set_desired_speed(desired_speed);
 }
 
+// set_desired_throttle
+void AP_MotorsHeli_Dual::set_desired_throttle(float desired_throttle)
+{
+    // constrain and set desired throttle
+    // -1.0f is allowed because it indicates invalid pilot throttle or invalid flightmode
+    _main_rotor.set_desired_throttle(constrain_float(desired_throttle, -1.0f, 1.0f));
+
+    // indicates pilot desires using transmitter throttle in manual throttle modes
+    _main_rotor.use_pilot_desired_throttle(using_pilot_throttle());
+}
+
 // set_rotor_rpm - used for governor with speed sensor
 void AP_MotorsHeli_Dual::set_rpm(float rotor_rpm)
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -59,6 +59,9 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;
 
+    // set_desired_throttle - sets target throttle as a number from 0 ~ 1 with -1 signifying invalid
+    void set_desired_throttle(float desired_throttle) override;
+
     // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
     float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -103,6 +103,17 @@ void AP_MotorsHeli_Quad::set_desired_rotor_speed(float desired_speed)
     _main_rotor.set_desired_speed(desired_speed);
 }
 
+// set_desired_throttle
+void AP_MotorsHeli_Quad::set_desired_throttle(float desired_throttle)
+{
+    // constrain and set desired throttle
+    // -1.0f is allowed because it indicates invalid pilot throttle or invalid flightmode
+    _main_rotor.set_desired_throttle(constrain_float(desired_throttle, -1.0f, 1.0f));
+
+    // indicates pilot desires using transmitter throttle in manual throttle modes
+    _main_rotor.use_pilot_desired_throttle(using_pilot_throttle());
+}
+
 // set_rotor_rpm - used for governor with speed sensor
 void AP_MotorsHeli_Quad::set_rpm(float rotor_rpm)
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -41,6 +41,9 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;
 
+    // set_desired_throttle - sets target throttle as a number from 0 ~ 1 with -1 signifying invalid
+    void set_desired_throttle(float desired_throttle) override;
+
     // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
     float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -250,13 +250,26 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
             // set main rotor ramp to increase to full speed
             update_rotor_ramp(1.0f, dt);
 
-            if ((_control_mode == ROTOR_CONTROL_MODE_SPEED_PASSTHROUGH) || (_control_mode == ROTOR_CONTROL_MODE_SPEED_SETPOINT)) {
+            if (_control_mode == ROTOR_CONTROL_MODE_SPEED_PASSTHROUGH) {
                 // set control rotor speed to ramp slewed value between idle and desired speed
                 _control_output = get_idle_output() + (_rotor_ramp_output * (_desired_speed - get_idle_output()));
+            } else if (_control_mode == ROTOR_CONTROL_MODE_SPEED_SETPOINT) {
+                if (_use_pilot_throttle && _desired_throttle >= 0.0f) {
+                    // set control rotor speed to ramp slewed value between idle and desired speed
+                    _control_output = get_idle_output() + (_rotor_ramp_output * (_desired_throttle - get_idle_output()));
+                } else {
+                    // set control rotor speed to ramp slewed value between idle and desired speed
+                    _control_output = get_idle_output() + (_rotor_ramp_output * (_desired_speed - get_idle_output()));
+                }
             } else if (_control_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
-                // throttle output from throttle curve based on collective position
-                float desired_throttle = calculate_desired_throttle(_collective_in);
-                _control_output = get_idle_output() + (_rotor_ramp_output * (desired_throttle - get_idle_output()));
+                if (_use_pilot_throttle && _desired_throttle >= 0.0f) {
+                    // set control rotor speed to ramp slewed value between idle and desired speed
+                    _control_output = get_idle_output() + (_rotor_ramp_output * (_desired_throttle - get_idle_output()));
+                } else {
+                    // throttle output from throttle curve based on collective position
+                    float desired_throttle = calculate_desired_throttle(_collective_in);
+                    _control_output = get_idle_output() + (_rotor_ramp_output * (desired_throttle - get_idle_output()));
+                }
             } else if (_control_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
                 // governor provides two modes of throttle control - governor engaged
                 // or throttle curve if governor is out of range or sensor failed

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -170,7 +170,6 @@ const AP_Param::GroupInfo AP_MotorsHeli_RSC::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("GOV_RANGE", 17, AP_MotorsHeli_RSC, _governor_range, AP_MOTORS_HELI_RSC_GOVERNOR_RANGE_DEFAULT),
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     // @Param: AROT_PCT
     // @DisplayName: Autorotation Throttle Percentage for External Governor
     // @Description: The throttle percentage sent to external governors, signaling to enable fast spool-up, when bailing out of an autorotation.  Set 0 to disable. If also using a tail rotor of type DDVP with external governor then this value must lie within the autorotation window of both governors.
@@ -179,7 +178,6 @@ const AP_Param::GroupInfo AP_MotorsHeli_RSC::var_info[] = {
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("AROT_PCT", 18, AP_MotorsHeli_RSC, _ext_gov_arot_pct, 0),
-#endif
 
     AP_GROUPEND
 };

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -90,6 +90,12 @@ public:
     // set_desired_speed - this requires input to be 0-1
     void        set_desired_speed(float desired_speed) { _desired_speed = desired_speed; }
 
+    // set_desired_throttle - this requires input to be 0-1
+    void        set_desired_throttle(float desired_throttle) { _desired_throttle = desired_throttle; }
+
+    // use desired pilot throttle
+    void        use_pilot_desired_throttle(bool enable) { _use_pilot_throttle = enable; }
+
     // get_control_speed
     float       get_control_output() const { return _control_output; }
 
@@ -163,6 +169,8 @@ private:
     bool            _use_bailout_ramp;            // true if allowing RSC to quickly ramp up engine
     bool            _in_autorotation;              // true if vehicle is currently in an autorotation
     int16_t         _rsc_arot_bailout_pct;        // the throttle percentage sent to the external governor to signal that autorotation bailout ramp should be used
+    float           _desired_throttle;               // latest desired throttle from pilot
+    bool            _use_pilot_throttle;            // true if allowing to pass through pilot desired throttle
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -274,6 +274,17 @@ void AP_MotorsHeli_Single::set_desired_rotor_speed(float desired_speed)
     _tail_rotor.set_desired_speed(_direct_drive_tailspeed*0.01f);
 }
 
+// set_desired_throttle
+void AP_MotorsHeli_Single::set_desired_throttle(float desired_throttle)
+{
+    // constrain and set desired throttle
+    // -1.0f is allowed because it indicates invalid pilot throttle or invalid flightmode
+    _main_rotor.set_desired_throttle(constrain_float(desired_throttle, -1.0f, 1.0f));
+
+    // indicates pilot desires using transmitter throttle in manual throttle modes
+    _main_rotor.use_pilot_desired_throttle(using_pilot_throttle());
+}
+
 // set_rotor_rpm - used for governor with speed sensor
 void AP_MotorsHeli_Single::set_rpm(float rotor_rpm)
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -61,6 +61,9 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     void set_desired_rotor_speed(float desired_speed) override;
 
+    // set_desired_throttle - sets target throttle as a number from 0 ~ 1 with -1 signifying invalid
+    void set_desired_throttle(float desired_throttle) override;
+
     // set_rpm - for rotor speed governor
     void set_rpm(float rotor_rpm) override;
 


### PR DESCRIPTION
This PR enables users to use their transmitter throttle and pitch curves for manual modes while retaining the rotor speed control (RSC )modes for non-manual throttle modes.  It also adds the autorotational bailout feature to enable users to do practice autorotations where the ESC quick spool up can be activated when motor interlock enabled is switched on in an autorotation.  This PR will provide sport users with the ability to manage there head speed and collective setups in their radio.  This allows users to revert back to the setpoint or throttle curve RSC modes when switching to a non-manual throttle mode (the internal governor mode can't be used with this)

I would like @joshwelsh to review this as well.

@Gone4Dirt  and @joshwelsh  What do you think about removing the passthrough RSC mode altogether with this capability in place.  