### PR TITLE
Plane: fix bug causing wrong thr max and slew to be used during takeoff

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -552,6 +552,7 @@ void Plane::update_flight_stage(void)
 #endif
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_TAKEOFF);
+                return;
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
                 if (landing.is_commanded_go_around() || flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
                     // abort mode is sticky, it must complete while executing NAV_LAND


### PR DESCRIPTION
Fix bug introduced in 3d34e061fe which causes flight_stage to be FLIGHT_NORMAL instead of FLIGHT_TAKEOFF during takeoff stage causing itself at least the use of THR_MAX and THR_SLEWRATE instead of respectively TKOFF_THR_MAX and TKOFF_THR_SLEW and perhaps has other consequences.

Could be really bad if TKOFF_THR_MAX needs to be much higher than THR_MAX or if TKOFF_THR_SLEW needs to be much lower than THR_SLEWRATE and cause a crash on takeoff due to low airspeed or torque roll.