### PR TITLE
Harmonic notch filter on more than four motors

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -264,7 +264,7 @@ void Copter::update_dynamic_notch()
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(ins.get_num_gyro_dynamic_notches(), notches);
 
                 for (uint8_t i = 0; i < num_notches; i++) {
                     notches[i] =  MAX(ref_freq, notches[i]);
@@ -284,7 +284,7 @@ void Copter::update_dynamic_notch()
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(ins.get_num_gyro_dynamic_notches(), notches);
 
                 ins.update_harmonic_notch_frequencies_hz(peaks, notches);
             } else {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -491,7 +491,7 @@ void Plane::update_dynamic_notch()
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(ins.get_num_gyro_dynamic_notches(), notches);
 
                 for (uint8_t i = 0; i < num_notches; i++) {
                     notches[i] =  MAX(ref_freq, notches[i]);
@@ -515,7 +515,7 @@ void Plane::update_dynamic_notch()
             // set the harmonic notch filter frequency scaled on measured frequency
             if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(INS_MAX_NOTCHES, notches);
+                const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(ins.get_num_gyro_dynamic_notches(), notches);
 
                 ins.update_harmonic_notch_frequencies_hz(peaks, notches);
             } else {

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -249,20 +249,17 @@ void AP_GyroFFT::init(uint32_t target_looptime_us)
         return;
     }
 
-    // count the number of active harmonics
-    for (uint8_t i = 0; i < HNF_MAX_HARMONICS; i++) {
-        if (_ins->get_gyro_harmonic_notch_harmonics() & (1<<i)) {
-            _harmonics++;
-        }
-    }
-    _harmonics = constrain_int16(_harmonics, 1, FrequencyPeak::MAX_TRACKED_PEAKS);
+    const uint8_t harmonics = _ins->get_gyro_harmonic_notch_harmonics();
+    // count the number of active harmonics or dynamic notchs
+    _tracked_peaks = constrain_int16(MAX(__builtin_popcount(harmonics),
+        _ins->get_num_gyro_dynamic_notches()), 1, FrequencyPeak::MAX_TRACKED_PEAKS);
 
     // calculate harmonic multiplier. this assumes the harmonics configured on the 
     // harmonic notch reflect the multiples of the fundamental harmonic that should be tracked
     if (_harmonic_fit > 0) {
         uint8_t first_harmonic = 0;
         for (uint8_t i = 0; i < HNF_MAX_HARMONICS; i++) {
-            if (_ins->get_gyro_harmonic_notch_harmonics() & (1<<i)) {
+            if (harmonics & (1<<i)) {
                 if (first_harmonic == 0) {
                     first_harmonic = i + 1;
                 } else {
@@ -271,10 +268,14 @@ void AP_GyroFFT::init(uint32_t target_looptime_us)
                 }
             }
         }
+        // if no harmonic specified then select a simple 2x multiple
+        if (is_zero(_harmonic_multiplier)) {
+            _harmonic_multiplier = 2.0f;
+        }
     }
 
     // initialise the HAL DSP subsystem
-    _state = hal.dsp->fft_init(_window_size, _fft_sampling_rate_hz, _harmonics);
+    _state = hal.dsp->fft_init(_window_size, _fft_sampling_rate_hz);
     if (_state == nullptr) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Failed to initialize DSP engine");
         return;
@@ -374,7 +375,7 @@ void AP_GyroFFT::update()
     if (!_rpy_health.x && !_rpy_health.y) {
         _health = 0;
     } else {
-        _health = MIN(_global_state._health, _harmonics);
+        _health = MIN(_global_state._health, _ins->get_num_gyro_dynamic_notches());
     }
 }
 
@@ -765,7 +766,6 @@ float AP_GyroFFT::calculate_weighted_freq_hz(const Vector3f& energy, const Vecto
 // @Field: TimeUS: microseconds since system startup
 // @Field: PkAvg: peak noise frequency as an energy-weighted average of roll and pitch peak frequencies
 // @Field: BwAvg: bandwidth of weighted peak freqency where edges are determined by FFT_ATT_REF
-// @Field: DnF: dynamic harmonic notch centre frequency
 // @Field: SnX: signal-to-noise ratio on the roll axis
 // @Field: SnY: signal-to-noise ratio on the pitch axis
 // @Field: SnZ: signal-to-noise ratio on the yaw axis
@@ -778,22 +778,22 @@ float AP_GyroFFT::calculate_weighted_freq_hz(const Vector3f& energy, const Vecto
 // log gyro fft messages
 void AP_GyroFFT::write_log_messages()
 {
+    // still want to see the harmonic notch values
+    AP::vehicle()->write_notch_log_messages();
+
     if (!analysis_enabled()) {
-        // still want to see the harmonic notch values
-        AP::vehicle()->write_notch_log_messages();
         return;
     }
 
     AP::logger().WriteStreaming(
         "FTN1",
-        "TimeUS,PkAvg,BwAvg,DnF,SnX,SnY,SnZ,FtX,FtY,FtZ,FH,Tc",
-        "szzz---%%%-s",
-        "F----------F",
-        "QfffffffffBI",
+        "TimeUS,PkAvg,BwAvg,SnX,SnY,SnZ,FtX,FtY,FtZ,FH,Tc",
+        "szz---%%%-s",
+        "F---------F",
+        "QffffffffBI",
         AP_HAL::micros64(),
         get_weighted_noise_center_freq_hz(),
         get_weighted_noise_center_bandwidth_hz(),
-        _ins->get_gyro_dynamic_notch_center_freq_hz(),
         get_noise_signal_to_noise_db().x,
         get_noise_signal_to_noise_db().y,
         get_noise_signal_to_noise_db().z,
@@ -802,12 +802,10 @@ void AP_GyroFFT::write_log_messages()
         get_raw_noise_harmonic_fit().z,
         _health, _output_cycle_micros);
 
-    const float* notches = _ins->get_gyro_dynamic_notch_center_frequencies_hz();
-
-    log_noise_peak(0, FrequencyPeak::CENTER, notches[0]);
-    if (_harmonics > 1) {
-        log_noise_peak(1, FrequencyPeak::LOWER_SHOULDER, notches[1]);
-        log_noise_peak(2, FrequencyPeak::UPPER_SHOULDER, notches[2]);
+    log_noise_peak(0, FrequencyPeak::CENTER);
+    if (_tracked_peaks> 1) {
+        log_noise_peak(1, FrequencyPeak::LOWER_SHOULDER);
+        log_noise_peak(2, FrequencyPeak::UPPER_SHOULDER);
     }
 
 #if DEBUG_FFT
@@ -832,7 +830,6 @@ void AP_GyroFFT::write_log_messages()
 // @Field: PkX: noise frequency of the peak on roll
 // @Field: PkY: noise frequency of the peak on pitch
 // @Field: PkZ: noise frequency of the peak on yaw
-// @Field: DnF: dynamic harmonic notch centre frequency
 // @Field: BwX: bandwidth of the peak freqency on roll where edges are determined by FFT_ATT_REF
 // @Field: BwY: bandwidth of the peak freqency on pitch where edges are determined by FFT_ATT_REF
 // @Field: BwZ: bandwidth of the peak freqency on yaw where edges are determined by FFT_ATT_REF
@@ -841,15 +838,14 @@ void AP_GyroFFT::write_log_messages()
 // @Field: EnZ: power spectral density bin energy of the peak on roll
 
 // write a single log message
-void AP_GyroFFT::log_noise_peak(uint8_t id, FrequencyPeak peak, float notch) const
+void AP_GyroFFT::log_noise_peak(uint8_t id, FrequencyPeak peak) const
 {
-    AP::logger().WriteStreaming("FTN2", "TimeUS,Id,PkX,PkY,PkZ,DnF,BwX,BwY,BwZ,EnX,EnY,EnZ", "s#zzzzzzz---", "F-----------", "QBffffffffff",
+    AP::logger().WriteStreaming("FTN2", "TimeUS,Id,PkX,PkY,PkZ,BwX,BwY,BwZ,EnX,EnY,EnZ", "s#zzzzzz---", "F----------", "QBfffffffff",
         AP_HAL::micros64(),
         id,
         get_noise_center_freq_hz(peak).x,
         get_noise_center_freq_hz(peak).y,
         get_noise_center_freq_hz(peak).z,
-        notch,
         get_noise_center_bandwidth_hz(peak).x,
         get_noise_center_bandwidth_hz(peak).y,
         get_noise_center_bandwidth_hz(peak).z,
@@ -894,7 +890,7 @@ void AP_GyroFFT::calculate_noise(bool calibrating, const EngineConfig& config)
     FrequencyPeak tracked_peak = FrequencyPeak::CENTER;
 
     // record the tracked peak for harmonic fit, but only if we have more than one noise peak
-    if (num_peaks > 1 && _harmonics > 1 && !is_zero(get_tl_noise_center_freq_hz(FrequencyPeak::CENTER, _update_axis))) {
+    if (num_peaks > 1 && _tracked_peaks > 1 && !is_zero(get_tl_noise_center_freq_hz(FrequencyPeak::CENTER, _update_axis))) {
         if (get_tl_noise_center_freq_hz(FrequencyPeak::CENTER, _update_axis) > get_tl_noise_center_freq_hz(FrequencyPeak::LOWER_SHOULDER, _update_axis)
             // ignore the fit if there is too big a discrepancy between the energies
             && get_tl_center_freq_energy(FrequencyPeak::CENTER, _update_axis) < get_tl_center_freq_energy(FrequencyPeak::LOWER_SHOULDER, _update_axis) * FFT_HARMONIC_FIT_MULT) {
@@ -1019,7 +1015,8 @@ bool AP_GyroFFT::calculate_filtered_noise(FrequencyPeak target_peak, FrequencyPe
     const uint16_t nb = peak_data->_bin;
 
     if (freqs.is_valid(FrequencyPeak(source_peak))) {
-        update_tl_center_freq_energy(target_peak, _update_axis, _state->_freq_bins[nb]);
+        // total peak energy requires an integration, as an approximation use amplitude * noise width * 5/6
+        update_tl_center_freq_energy(target_peak, _update_axis, _state->_freq_bins[nb] * peak_data->_noise_width_hz * 0.8333f);
         update_tl_noise_center_bandwidth_hz(target_peak, _update_axis, peak_data->_noise_width_hz);
         update_tl_noise_center_freq_hz(target_peak, _update_axis, freqs.get_weighted_frequency(FrequencyPeak(source_peak)));
         _missed_cycles[_update_axis][target_peak] = 0;
@@ -1032,7 +1029,7 @@ bool AP_GyroFFT::calculate_filtered_noise(FrequencyPeak target_peak, FrequencyPe
     }
 
     // we failed to find a signal for more than FFT_MAX_MISSED_UPDATES cycles
-    update_tl_center_freq_energy(target_peak, _update_axis, _state->_freq_bins[nb]);     // use the actual energy detected rather than 0
+    update_tl_center_freq_energy(target_peak, _update_axis, _state->_freq_bins[nb] * peak_data->_noise_width_hz * 0.8333f);     // use the actual energy detected rather than 0
     update_tl_noise_center_bandwidth_hz(target_peak, _update_axis, _bandwidth_hover_hz);
     update_tl_noise_center_freq_hz(target_peak, _update_axis, config._fft_min_hz);
 

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -175,7 +175,7 @@ private:
         return (_thread_state._center_bandwidth_hz_filtered[peak][axis] = _center_bandwidth_filter[peak].apply(axis, value));
     }
     // write single log mesages
-    void log_noise_peak(uint8_t id, FrequencyPeak peak, float notch_freq) const;
+    void log_noise_peak(uint8_t id, FrequencyPeak peak) const;
     // calculate the peak noise frequency
     void calculate_noise(bool calibrating, const EngineConfig& config);
     // calculate noise peaks based on energy and history
@@ -276,8 +276,8 @@ private:
     uint8_t _current_sample_mode : 3;
     // harmonic multiplier for two highest peaks
     float _harmonic_multiplier;
-    // searched harmonics - inferred from harmonic notch harmonics
-    uint8_t _harmonics;
+    // number of tracked peaks
+    uint8_t _tracked_peaks;
     // engine health in tracked peaks
     uint8_t _health;
     // engine health on roll/pitch/yaw

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -272,3 +272,22 @@
 #ifndef HAL_WITH_MCU_MONITORING
 #define HAL_WITH_MCU_MONITORING defined(STM32H7)
 #endif
+
+#ifndef HAL_HNF_MAX_FILTERS
+// On an F7 The difference in CPU load between 1 notch and 24 notches is about 2%
+// The difference in CPU load between 1Khz backend and 2Khz backend is about 10%
+// So at 1Khz almost all notch combinations can be supported on F7 and certainly H7
+#if defined(STM32H7) || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+// Enough for a double-notch per motor on an octa using three IMUs and one harmonics
+// plus one static notch with one double-notch harmonics
+#define HAL_HNF_MAX_FILTERS 54
+#elif defined(STM32F7)
+// Enough for a notch per motor on an octa using three IMUs and one harmonics
+// plus one static notch with one harmonics
+#define HAL_HNF_MAX_FILTERS 27
+#else
+// Enough for a notch per motor on an octa quad using two IMUs and one harmonic
+// plus one static notch with one harmonic
+#define HAL_HNF_MAX_FILTERS 18
+#endif
+#endif

--- a/libraries/AP_HAL/DSP.cpp
+++ b/libraries/AP_HAL/DSP.cpp
@@ -28,11 +28,10 @@ extern const AP_HAL::HAL &hal;
 #define SQRT_2_3 0.816496580927726f
 #define SQRT_6   2.449489742783178f
 
-DSP::FFTWindowState::FFTWindowState(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics)
+DSP::FFTWindowState::FFTWindowState(uint16_t window_size, uint16_t sample_rate)
     : _window_size(window_size),
     _bin_count(window_size / 2),
-    _bin_resolution((float)sample_rate / (float)window_size),
-    _harmonics(harmonics)
+    _bin_resolution((float)sample_rate / (float)window_size)
 {
     // includes DC ad Nyquist components and needs to be large enough for intermediate steps
     _freq_bins = (float*)hal.util->malloc_type(sizeof(float) * (window_size), DSP_MEM_REGION);

--- a/libraries/AP_HAL/DSP.h
+++ b/libraries/AP_HAL/DSP.h
@@ -55,8 +55,6 @@ public:
         const uint16_t _bin_count;
         // size of the FFT window
         const uint16_t _window_size;
-        // number of harmonics of interest
-        const uint8_t _harmonics;
         // FFT data
         float* _freq_bins;
         // derivative real data scratch space
@@ -71,10 +69,10 @@ public:
         float _window_scale;
 
         virtual ~FFTWindowState();
-        FFTWindowState(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics);
+        FFTWindowState(uint16_t window_size, uint16_t sample_rate);
     };
     // initialise an FFT instance
-    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics) = 0;
+    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate) = 0;
     // start an FFT analysis with an ObjectBuffer
     virtual void fft_start(FFTWindowState* state, FloatBuffer& samples, uint16_t advance) = 0;
     // perform remaining steps of an FFT analysis

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -39,7 +39,7 @@ public:
 
 class DSPTest : public AP_HAL::DSP {
 public:
-    virtual FFTWindowState* fft_init(uint16_t w, uint16_t sample_rate, uint8_t harmonics) override { return nullptr; }
+    virtual FFTWindowState* fft_init(uint16_t w, uint16_t sample_rate) override { return nullptr; }
     virtual void fft_start(FFTWindowState* state, FloatBuffer& samples, uint16_t advance) override {}
     virtual uint16_t fft_analyse(FFTWindowState* state, uint16_t start_bin, uint16_t end_bin, float noise_att_cutoff) override { return 0; }
 protected:
@@ -65,7 +65,7 @@ void setup()
     hal.console->printf("DSP test\n");
     board_config.init();   
     serial_manager.init();
-    fft = hal.dsp->fft_init(WINDOW_SIZE, SAMPLE_RATE, 3);
+    fft = hal.dsp->fft_init(WINDOW_SIZE, SAMPLE_RATE);
     attenuation_cutoff = powf(10.0f, -attenuation_power_db / 10.0f);
 
     for(uint16_t i = 0; i < WINDOW_SIZE; i++) {

--- a/libraries/AP_HAL_ChibiOS/DSP.cpp
+++ b/libraries/AP_HAL_ChibiOS/DSP.cpp
@@ -49,9 +49,9 @@ extern const AP_HAL::HAL& hal;
 // important as frequency resolution. Referred to as [Heinz] throughout the code.
 
 // initialize the FFT state machine
-AP_HAL::DSP::FFTWindowState* DSP::fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics)
+AP_HAL::DSP::FFTWindowState* DSP::fft_init(uint16_t window_size, uint16_t sample_rate)
 {
-    DSP::FFTWindowStateARM* fft = new DSP::FFTWindowStateARM(window_size, sample_rate, harmonics);
+    DSP::FFTWindowStateARM* fft = new DSP::FFTWindowStateARM(window_size, sample_rate);
     if (fft == nullptr || fft->_hanning_window == nullptr || fft->_rfft_data == nullptr || fft->_freq_bins == nullptr || fft->_derivative_freq_bins == nullptr) {
         delete fft;
         return nullptr;
@@ -77,8 +77,8 @@ uint16_t DSP::fft_analyse(AP_HAL::DSP::FFTWindowState* state, uint16_t start_bin
 }
 
 // create an instance of the FFT state machine
-DSP::FFTWindowStateARM::FFTWindowStateARM(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics)
-    : AP_HAL::DSP::FFTWindowState::FFTWindowState(window_size, sample_rate, harmonics)
+DSP::FFTWindowStateARM::FFTWindowStateARM(uint16_t window_size, uint16_t sample_rate)
+    : AP_HAL::DSP::FFTWindowState::FFTWindowState(window_size, sample_rate)
 {
     if (_freq_bins == nullptr || _hanning_window == nullptr || _rfft_data == nullptr || _derivative_freq_bins == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to allocate %u bytes for window %u for DSP",

--- a/libraries/AP_HAL_ChibiOS/DSP.h
+++ b/libraries/AP_HAL_ChibiOS/DSP.h
@@ -29,7 +29,7 @@
 class ChibiOS::DSP : public AP_HAL::DSP {
 public:
     // initialise an FFT instance
-    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics) override;
+    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate) override;
     // start an FFT analysis with an ObjectBuffer
     virtual void fft_start(FFTWindowState* state, FloatBuffer& samples, uint16_t advance) override;
     // perform remaining steps of an FFT analysis
@@ -39,7 +39,7 @@ public:
     class FFTWindowStateARM : public AP_HAL::DSP::FFTWindowState {
         friend class ChibiOS::DSP;
     public:
-        FFTWindowStateARM(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics);
+        FFTWindowStateARM(uint16_t window_size, uint16_t sample_rate);
         virtual ~FFTWindowStateARM();
 
     private:

--- a/libraries/AP_HAL_Empty/DSP.h
+++ b/libraries/AP_HAL_Empty/DSP.h
@@ -21,7 +21,7 @@
 class Empty::DSP : public AP_HAL::DSP {
 #if HAL_WITH_DSP
 public:
-    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics) override { return nullptr; }
+    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate) override { return nullptr; }
     virtual void fft_start(FFTWindowState* state, FloatBuffer& samples, uint16_t advance) override {}
     virtual uint16_t fft_analyse(FFTWindowState* state, uint16_t start_bin, uint16_t end_bin, float noise_att_cutoff) override { return 0; }
 protected:

--- a/libraries/AP_HAL_SITL/DSP.cpp
+++ b/libraries/AP_HAL_SITL/DSP.cpp
@@ -35,9 +35,9 @@ extern const AP_HAL::HAL& hal;
 // important as frequency resolution. Referred to as [Heinz] throughout the code.
 
 // initialize the FFT state machine
-AP_HAL::DSP::FFTWindowState* DSP::fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics)
+AP_HAL::DSP::FFTWindowState* DSP::fft_init(uint16_t window_size, uint16_t sample_rate)
 {
-    DSP::FFTWindowStateSITL* fft = new DSP::FFTWindowStateSITL(window_size, sample_rate, harmonics);
+    DSP::FFTWindowStateSITL* fft = new DSP::FFTWindowStateSITL(window_size, sample_rate);
     if (fft == nullptr || fft->_hanning_window == nullptr || fft->_rfft_data == nullptr || fft->_freq_bins == nullptr || fft->_derivative_freq_bins == nullptr) {
         delete fft;
         return nullptr;
@@ -61,8 +61,8 @@ uint16_t DSP::fft_analyse(AP_HAL::DSP::FFTWindowState* state, uint16_t start_bin
 }
 
 // create an instance of the FFT state machine
-DSP::FFTWindowStateSITL::FFTWindowStateSITL(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics)
-    : AP_HAL::DSP::FFTWindowState::FFTWindowState(window_size, sample_rate, harmonics)
+DSP::FFTWindowStateSITL::FFTWindowStateSITL(uint16_t window_size, uint16_t sample_rate)
+    : AP_HAL::DSP::FFTWindowState::FFTWindowState(window_size, sample_rate)
 {
     if (_freq_bins == nullptr || _hanning_window == nullptr || _rfft_data == nullptr || _derivative_freq_bins == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to allocate window for DSP");

--- a/libraries/AP_HAL_SITL/DSP.h
+++ b/libraries/AP_HAL_SITL/DSP.h
@@ -27,7 +27,7 @@ typedef std::complex<float> complexf;
 class HALSITL::DSP : public AP_HAL::DSP {
 public:
     // initialise an FFT instance
-    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics) override;
+    virtual FFTWindowState* fft_init(uint16_t window_size, uint16_t sample_rate) override;
     // start an FFT analysis with an ObjectBuffer
     virtual void fft_start(FFTWindowState* state, FloatBuffer& samples, uint16_t advance) override;
     // perform remaining steps of an FFT analysis
@@ -38,7 +38,7 @@ public:
         friend class HALSITL::DSP;
 
     public:
-        FFTWindowStateSITL(uint16_t window_size, uint16_t sample_rate, uint8_t harmonics);
+        FFTWindowStateSITL(uint16_t window_size, uint16_t sample_rate);
         virtual ~FFTWindowStateSITL();
 
     private:

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -5,12 +5,16 @@
 #if HAL_INS_ENABLED
 #include <AP_HAL/I2CDevice.h>
 #include <AP_HAL/SPIDevice.h>
+#include <AP_HAL/DSP.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
+#if !APM_BUILD_TYPE(APM_BUILD_Rover)
+#include <AP_Motors/AP_Motors_Class.h>
+#endif
 
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_BMI160.h"
@@ -529,8 +533,8 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     AP_GROUPINFO("FAST_SAMPLE",  36, AP_InertialSensor, _fast_sampling_mask,   HAL_DEFAULT_INS_FAST_SAMPLE),
 
     // @Group: NOTCH_
-    // @Path: ../Filter/NotchFilter.cpp
-    AP_SUBGROUPINFO(_notch_filter, "NOTCH_",  37, AP_InertialSensor, NotchFilterParams),
+    // @Path: ../Filter/HarmonicNotchFilter.cpp
+    AP_SUBGROUPINFO(_notch_filter, "NOTCH_",  37, AP_InertialSensor, HarmonicNotchFilterParams),
 
     // @Group: LOG_
     // @Path: ../AP_InertialSensor/BatchSampler.cpp
@@ -869,12 +873,67 @@ AP_InertialSensor::init(uint16_t loop_rate)
     // configured value
     _calculated_harmonic_notch_freq_hz[0] = _harmonic_notch_filter.center_freq_hz();
     _num_calculated_harmonic_notch_frequencies = 1;
+    _num_dynamic_harmonic_notches = 1;
 
+    uint8_t num_filters = 0;
+    const bool double_notch = _harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch);
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+    if (_harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
+#if HAL_WITH_DSP
+        if (get_gyro_harmonic_notch_tracking_mode() == HarmonicNotchDynamicMode::UpdateGyroFFT) {
+            _num_dynamic_harmonic_notches = AP_HAL::DSP::MAX_TRACKED_PEAKS; // only 3 peaks supported currently
+        } else
+#endif
+        {
+            AP_Motors *motors = AP::motors();
+            _num_dynamic_harmonic_notches = __builtin_popcount(motors->get_motor_mask());
+        }
+        // avoid harmonics unless actually configured by the user
+        _harmonic_notch_filter.set_default_harmonics(1);
+    }
+#endif
+    // count number of used sensors
+    uint8_t sensors_used = 0;
+    for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
+        sensors_used += _use[i];
+    }
+
+    // calculate number of notches we might want to use for harmonic notch
+    if (_harmonic_notch_filter.enabled()) {
+        num_filters = __builtin_popcount( _harmonic_notch_filter.harmonics())
+            * _num_dynamic_harmonic_notches * (double_notch ? 2 : 1)
+            * sensors_used;
+    }
+    // add filters used by static notch
+    if (_notch_filter.enabled()) {
+        _notch_filter.set_default_harmonics(1);
+        num_filters +=  __builtin_popcount(_notch_filter.harmonics())
+            * (_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch) ? 2 : 1)
+            * sensors_used;
+    }
+
+    if (num_filters > HAL_HNF_MAX_FILTERS) {
+        AP_BoardConfig::config_error("Too many notches: %u > %u", num_filters, HAL_HNF_MAX_FILTERS);
+    }
+
+    // allocate notches
     for (uint8_t i=0; i<get_gyro_count(); i++) {
-        _gyro_harmonic_notch_filter[i].allocate_filters(_harmonic_notch_filter.harmonics(), _harmonic_notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch));
-        // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
-        _gyro_harmonic_notch_filter[i].init(_gyro_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz[0],
-             _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());
+        // only allocate notches for IMUs in use
+        if (_use[i]) {
+            if (_harmonic_notch_filter.enabled()) {
+                _gyro_harmonic_notch_filter[i].allocate_filters(_num_dynamic_harmonic_notches,
+                    _harmonic_notch_filter.harmonics(), double_notch);
+                // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
+                _gyro_harmonic_notch_filter[i].init(_gyro_raw_sample_rates[i], _calculated_harmonic_notch_freq_hz[0],
+                    _harmonic_notch_filter.bandwidth_hz(), _harmonic_notch_filter.attenuation_dB());
+            }
+            if (_notch_filter.enabled()) {
+                _gyro_notch_filter[i].allocate_filters(1, _notch_filter.harmonics(),
+                    _notch_filter.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch));
+                _gyro_notch_filter[i].init(_gyro_raw_sample_rates[i], _notch_filter.center_freq_hz(),
+                    _notch_filter.bandwidth_hz(), _notch_filter.attenuation_dB());
+            }
+        }
     }
 
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
@@ -912,7 +971,7 @@ AP_InertialSensor::detect_backends(void)
 
     _backends_detected = true;
 
-#if defined(HAL_CHIBIOS_ARCH_CUBE)
+#if defined(HAL_CHIBIOS_ARCH_CUBE) && INS_MAX_INSTANCES > 2
     // special case for Cubes, where the IMUs on the isolated
     // board could fail on some boards. If the user has INS_USE=1,
     // INS_USE2=1 and INS_USE3=0 then force INS_USE3 to 1. This is

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -17,7 +17,7 @@
 #define INS_MAX_INSTANCES 3
 #endif
 #define INS_MAX_BACKENDS  2*INS_MAX_INSTANCES
-#define INS_MAX_NOTCHES 4
+#define INS_MAX_NOTCHES 12
 #ifndef INS_VIBRATION_CHECK_INSTANCES
   #if HAL_MEM_CLASS >= HAL_MEM_CLASS_300
     #define INS_VIBRATION_CHECK_INSTANCES INS_MAX_INSTANCES
@@ -44,7 +44,6 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <Filter/LowPassFilter2p.h>
 #include <Filter/LowPassFilter.h>
-#include <Filter/NotchFilter.h>
 #include <Filter/HarmonicNotchFilter.h>
 #include <AP_Math/polyfit.h>
 
@@ -250,6 +249,9 @@ public:
 
     // harmonic notch current center frequency
     float get_gyro_dynamic_notch_center_freq_hz(void) const { return _calculated_harmonic_notch_freq_hz[0]; }
+
+    // number of dynamic harmonic notches
+    uint8_t get_num_gyro_dynamic_notches(void) const { return _num_dynamic_harmonic_notches; }
 
     // set of harmonic notch current center frequencies
     const float* get_gyro_dynamic_notch_center_frequencies_hz(void) const { return _calculated_harmonic_notch_freq_hz; }
@@ -498,12 +500,14 @@ private:
     bool _new_gyro_data[INS_MAX_INSTANCES];
 
     // optional notch filter on gyro
-    NotchFilterParams _notch_filter;
-    NotchFilterVector3f _gyro_notch_filter[INS_MAX_INSTANCES];
+    HarmonicNotchFilterParams _notch_filter;
+    HarmonicNotchFilterVector3f _gyro_notch_filter[INS_MAX_INSTANCES];
 
     // optional harmonic notch filter on gyro
     HarmonicNotchFilterParams _harmonic_notch_filter;
     HarmonicNotchFilterVector3f _gyro_harmonic_notch_filter[INS_MAX_INSTANCES];
+    // number of independent notches in the filter
+    uint8_t _num_dynamic_harmonic_notches;
     // the current center frequency for the notch
     float _calculated_harmonic_notch_freq_hz[INS_MAX_NOTCHES];
     uint8_t _num_calculated_harmonic_notch_frequencies;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -368,16 +368,26 @@ bool AP_Vehicle::is_crashed() const
 // @Description: Filter Tuning Messages
 // @Field: TimeUS: microseconds since system startup
 // @Field: NDn: number of active dynamic harmonic notches
-// @Field: DnF1: dynamic harmonic notch centre frequency for motor 1
-// @Field: DnF2: dynamic harmonic notch centre frequency for motor 2
-// @Field: DnF3: dynamic harmonic notch centre frequency for motor 3
-// @Field: DnF4: dynamic harmonic notch centre frequency for motor 4
+// @Field: NF1: dynamic harmonic notch centre frequency for motor 1
+// @Field: NF2: dynamic harmonic notch centre frequency for motor 2
+// @Field: NF3: dynamic harmonic notch centre frequency for motor 3
+// @Field: NF4: dynamic harmonic notch centre frequency for motor 4
+// @Field: NF5: dynamic harmonic notch centre frequency for motor 5
+// @Field: NF6: dynamic harmonic notch centre frequency for motor 6
+// @Field: NF7: dynamic harmonic notch centre frequency for motor 7
+// @Field: NF8: dynamic harmonic notch centre frequency for motor 8
+// @Field: NF9: dynamic harmonic notch centre frequency for motor 9
+// @Field: NF10: dynamic harmonic notch centre frequency for motor 10
+// @Field: NF11: dynamic harmonic notch centre frequency for motor 11
+// @Field: NF12: dynamic harmonic notch centre frequency for motor 12
 void AP_Vehicle::write_notch_log_messages() const
 {
     const float* notches = ins.get_gyro_dynamic_notch_center_frequencies_hz();
     AP::logger().Write(
-        "FTN", "TimeUS,NDn,DnF1,DnF2,DnF3,DnF4", "s-zzzz", "F-----", "QBffff", AP_HAL::micros64(), ins.get_num_gyro_dynamic_notch_center_frequencies(),
-            notches[0], notches[1], notches[2], notches[3]);
+        "FTN", "TimeUS,NDn,NF1,NF2,NF3,NF4,NF5,NF6,NF7,NF8,NF9,NF10,NF11,NF12", "s-zzzzzzzzzzzz", "F-------------", "QBffffffffffff", AP_HAL::micros64(), ins.get_num_gyro_dynamic_notch_center_frequencies(),
+            notches[0], notches[1], notches[2], notches[3],
+            notches[4], notches[5], notches[6], notches[7],
+            notches[8], notches[9], notches[10], notches[11]);
 }
 
 // run notch update at either loop rate or 200Hz

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -20,7 +20,6 @@
 #include "NotchFilter.h"
 
 #define HNF_MAX_HARMONICS 8
-#define HNF_MAX_HMNC_BITSET 0xF
 
 /*
   a filter that manages a set of notch filters targetted at a fundamental center frequency
@@ -31,7 +30,7 @@ class HarmonicNotchFilter {
 public:
     ~HarmonicNotchFilter();
     // allocate a bank of notch filters for this harmonic notch filter
-    void allocate_filters(uint8_t harmonics, bool double_notch);
+    void allocate_filters(uint8_t num_notches, uint8_t harmonics, bool double_notch);
     // initialize the underlying filters using the provided filter parameters
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
     // update the underlying filters' center frequencies using center_freq_hz as the fundamental
@@ -60,6 +59,8 @@ private:
     bool _double_notch;
     // number of allocated filters
     uint8_t _num_filters;
+    // pre-calculated number of harmonics
+    uint8_t _num_harmonics;
     // number of enabled filters
     uint8_t _num_enabled_filters;
     bool _initialised;
@@ -89,7 +90,9 @@ public:
     // set the fundamental center frequency of the harmonic notch
     void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
     // harmonics enabled on the harmonic notch
-    uint8_t harmonics(void) const { return hasOption(Options::DynamicHarmonic) ? HNF_MAX_HMNC_BITSET : _harmonics; }
+    uint8_t harmonics(void) const { return _harmonics; }
+    // has the user set the harmonics value
+    void set_default_harmonics(uint8_t hmncs) { _harmonics.set_default(hmncs); }
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
     // notch options


### PR DESCRIPTION
There are a number of issues with the current harmonic notch filter configuration:
- Can only have 4 notches per motor
- No account is made of the total number of notch filters vs CPU power
- Cannot have harmonics when using a notch-per-motor
- Cannot have harmonics on static notches

This PR addresses these issues by making the notch filters considerably more configurable whilst keeping more careful track of what is configured and preventing the user from selection options that might be dangerous