### PR TITLE
Allow notch update to be configurable

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -263,7 +263,7 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_GyroFFT,   &vehicle.gyro_fft,       update,                  400, 50, 205),
     SCHED_TASK_CLASS(AP_GyroFFT,   &vehicle.gyro_fft,       update_parameters,         1, 50, 210),
 #endif
-    SCHED_TASK(update_dynamic_notch,             LOOP_RATE,    200, 215),
+    SCHED_TASK(update_dynamic_notch_at_specified_rate,      LOOP_RATE,                    200, 215),
     SCHED_TASK_CLASS(AP_VideoTX,   &vehicle.vtx,            update,                    2, 100, 220),
     SCHED_TASK(send_watchdog_reset_statustext,         0.1,     20, 225),
 #if HAL_WITH_ESC_TELEM

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -383,12 +383,17 @@ void AP_Vehicle::write_notch_log_messages() const
 // run notch update at either loop rate or 200Hz
 void AP_Vehicle::update_dynamic_notch_at_specified_rate()
 {
+    if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::LoopRateUpdate)) {
+        update_dynamic_notch();
+        return;
+    }
+
+    // decimated update at 200Hz
     const uint32_t now = AP_HAL::millis();
 
-    if (ins.has_harmonic_option(HarmonicNotchFilterParams::Options::LoopRateUpdate)
-        || now - _last_notch_update_ms > 5) {
-        update_dynamic_notch();
+    if (now - _last_notch_update_ms > 5) {
         _last_notch_update_ms = now;
+        update_dynamic_notch();
     }
 }
 


### PR DESCRIPTION
This was a bug introduced by https://github.com/ArduPilot/ardupilot/commit/9bc9873e38551c02bc812fc48fd05276ddeeccb3
That change was supposed to make the rate configurable but instead made the update rate always the loop rate

@rmackay9 @tridge this bug is in 4.1