### PR TITLE
Copter: Suppress initialization access for optional devices

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -146,11 +146,15 @@ void Copter::init_ardupilot()
     barometer.set_log_baro_bit(MASK_LOG_IMU);
     barometer.calibrate();
 
+#if RANGEFINDER_ENABLED == ENABLED
     // initialise rangefinder
     init_rangefinder();
+#endif
 
+#if HAL_PROXIMITY_ENABLED
     // init proximity sensor
     init_proximity();
+#endif
 
 #if BEACON_ENABLED == ENABLED
     // init beacons used for non-gps position estimation


### PR DESCRIPTION
Rangefinder and PROXIMITY are optional devices.
I would change the initialization of the optional devices to be done as specified.