### PR TITLE
AP_Notify: make the buzzer pin configurable on all boards

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -123,6 +123,15 @@ AP_Notify *AP_Notify::_singleton;
 #define NOTIFY_LED_LEN_DEFAULT 1
 #endif
 
+#ifndef HAL_BUZZER_PIN
+#define HAL_BUZZER_PIN -1
+#endif
+
+#ifndef HAL_BUZZER_ON
+#define HAL_BUZZER_ON 1
+#define HAL_BUZZER_OFF 0
+#endif
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Notify::var_info[] = {
 
@@ -165,14 +174,12 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     AP_GROUPINFO("OREO_THEME", 4, AP_Notify, _oreo_theme, 0),
 #endif
 
-#if !defined(HAL_BUZZER_PIN)
     // @Param: BUZZ_PIN
     // @DisplayName: Buzzer pin
     // @Description: Enables to connect active buzzer to arbitrary pin. Requires 3-pin buzzer or additional MOSFET!
     // @Values: 0:Disabled
     // @User: Advanced
-    AP_GROUPINFO("BUZZ_PIN", 5, AP_Notify, _buzzer_pin, 0),
-#endif
+    AP_GROUPINFO("BUZZ_PIN", 5, AP_Notify, _buzzer_pin, HAL_BUZZER_PIN),
 
     // @Param: LED_TYPES
     // @DisplayName: LED Driver Types
@@ -181,14 +188,12 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("LED_TYPES", 6, AP_Notify, _led_type, BUILD_DEFAULT_LED_TYPE),
 
-#if !defined(HAL_BUZZER_PIN)
     // @Param: BUZZ_ON_LVL
     // @DisplayName: Buzzer-on pin logic level
     // @Description: Specifies pin level that indicates buzzer should play
     // @Values: 0:LowIsOn,1:HighIsOn
     // @User: Advanced
-    AP_GROUPINFO("BUZZ_ON_LVL", 7, AP_Notify, _buzzer_level, 1),
-#endif
+    AP_GROUPINFO("BUZZ_ON_LVL", 7, AP_Notify, _buzzer_level, HAL_BUZZER_ON),
 
     // @Param: BUZZ_VOLUME
     // @DisplayName: Buzzer volume

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -21,32 +21,18 @@
 
 #include "AP_Notify.h"
 
-#ifndef HAL_BUZZER_ON
-  #if !defined(HAL_BUZZER_PIN)
-    #define HAL_BUZZER_ON (pNotify->get_buzz_level())
-    #define HAL_BUZZER_OFF (!pNotify->get_buzz_level())
-  #else
-    #define HAL_BUZZER_ON 1
-    #define HAL_BUZZER_OFF 0 
-  #endif
-#endif
-
-
-
 extern const AP_HAL::HAL& hal;
-
 
 bool Buzzer::init()
 {
     if (pNotify->buzzer_enabled() == false) {
         return false;
     }
-#if defined(HAL_BUZZER_PIN)
-    _pin = HAL_BUZZER_PIN;
-#else
     _pin = pNotify->get_buzz_pin();
-#endif
-    if(!_pin) return false;
+    if (_pin <= 0) {
+        // no buzzer
+        return false;
+    }
 
     // setup the pin and ensure it's off
     hal.gpio->pinMode(_pin, HAL_GPIO_OUTPUT);
@@ -147,7 +133,8 @@ void Buzzer::on(bool turn_on)
     _flags.on = turn_on;
 
     // pull pin high or low
-    hal.gpio->write(_pin, _flags.on? HAL_BUZZER_ON : HAL_BUZZER_OFF);
+    const uint8_t buzz_on = pNotify->get_buzz_level();
+    hal.gpio->write(_pin, _flags.on? buzz_on : !buzz_on);
 }
 
 /// play_pattern - plays the defined buzzer pattern


### PR DESCRIPTION
this allows any board to setup a buzzer pin on any available
GPIO. Previously the pin if set in hwdef.dat was not configurable