### PR TITLE
AP_TECS: Height Demand model limiting based on command saturation.

### DIFF
--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -324,6 +324,14 @@ private:
     float _PITCHmaxf;
     float _PITCHminf;
 
+    // 1 if throttle is clipping at max value, -1 if clipping at min value, 0 otherwise
+    enum class ThrClipStatus  : int8_t {
+        MIN  = -1,
+        NONE =  0,
+        MAX  =  1,
+    };
+    ThrClipStatus _thr_clip_status;
+
     // Specific energy quantities
     float _SPE_dem;
     float _SKE_dem;


### PR DESCRIPTION
# Description:
This PR is in collaboration with @priseborough : [WIP Commit](https://github.com/priseborough/ardupilot/commit/9099cec8da2e87d96347fa52bc15cb882af0d852)

The TECS controller is an implementation of an EMF (Explicit Model Follower).  In this specific case, the Demanded Height is modeled through various constraints (slew rates, physical rates of change limits etc).  However, there is nothing to keep the model from "moving" when the commands (pitch attitude or throttle) are saturated.

# Issue: 
If the EMF Height Demand doesn't safety saturate when commands are saturated, the model will then lose its connection with reality.  This primarily happened on a test flight where the commanded descent rate was higher than the aircraft could achieve in a pure glide (0% throttle).  The model continued to model the demanded height well below the aircraft.

![Screen_Shot_2021-10-25_at_10 12 05_AM](https://user-images.githubusercontent.com/7753691/141843143-6a4a752c-8524-403a-93f5-f173157ad3e5.png)

# Justification for Fix: 
## Safety of Flight
If an aircraft is improperly configured with max descent and climb parameters and the demanded height model is allowed to bifurcate too far from reality, the pilot will not be able to keep the aircraft from descending towards original commanded height.  Specific scenario that occurred was a new level-off altitude was requested for traffic avoidance flying below the UAS in the descent.  New level-off altitude was commanded at current altitude and UAS continued to descend for another 300m.  Pilot always needs confidence that a new commanded level-off altitude will take immediately. 

## Safety Backstop for poor aircraft parameter configuration
One could make the claim that the aircraft was just improperly configured (i.e. demanded descent rate was too high for the aircraft given its glide slope).  Tuning this parameter does mitigate most of the issue for most aircraft, however in aircraft with high L/D and thermic conditions, the aircraft can and often does experience positive rates of climb due to thermals which again totally breaks the model.  In the picture above, you can see that the desired descent rate was maintained at higher altitudes but the closer it got to takeoff altitude, the less the aircraft was able to maintain its descent rate.  The aircraft's ability to descend is also a function of airspeed as well as angle of bank, therefore the model would have to also be aware of these states to properly account for aircraft min and max performance given the state.  This added complication would not be needed if model is simply constrained when commands are saturated.

# Methods for Replicating:

1.  At significant altitude (8,000m AGL), start a descent with a [TECS_SINK_MAX](https://ardupilot.org/plane/docs/parameters.html#tecs-sink-max-maximum-descent-rate-metres-sec) that is greater than the aircraft can achieve by a factor of 2x (to exaggerate the experiment).
2.  Set [TECS_CLMB_MAX](https://ardupilot.org/plane/docs/parameters.html#tecs-clmb-max-maximum-climb-rate-metres-sec) = 0.1 m/s to exaggerate the model's inability to recover back to reality
3.  Setup mavproxy plot (or other method to monitor throttle %)
4.  Set Target Altitude to 1000m AGL (i.e. `changealt 1000`)
5.  At 1,500m AGL set a new target altitude to 1,500m (i.e. `changealt 1500`)
6.  Observe that throttle % doesn't increase immediately and aircraft will descend significantly through target altitude

Note:  This bug doesn't occur if you don't do step 5.  If you simply let the aircraft descend to it's original target altitude, the bug isn't observed because the model isn't allowed to go below the target altitude.  So the model and reality eventually converge.  Therefore the ideal worst case scenario is to send a `changealt` command when the model is at its furthest divergence from reality.  In the picture above, you can see that the model recovers at the rate of `TECS_CLMB_MAX` and this is when throttle % comes back in off of 0%.  

Note:  It should be noted that the above steps to replicate only test the command saturate on throttle being 0%.  This same phenomenon occurs when any of the TECS commands saturate:
-  Desired Climb rate higher than aircraft can achieve (throttle at 100%)
-  Desired Descent rate higher than aircraft can achieve (throttle at 0%)
-  Airspeed higher than commanded (Max pitch command with high throttle)
-  Airspeed lower than commanded (Min pitch command with low to zero throttle)

# Suggested Fix:
Constrain the model integration math when either the pitch commands or the throttle commands are at their limits.

In the figure below, you can see that the Demanded Height model vs actual Height are following each other.  
Realtime confirmation in SITL can be done by observing throttle % perturbing from 0% by +-2% as well as any subsequent change in altitude commands to level off will have throttle immediately respond back to trim.

![Screen_Shot_2021-10-30_at_10 37 22_PM](https://user-images.githubusercontent.com/7753691/141846743-5d778ef4-1df0-4b81-aaa6-8929053f162e.png)

