### PR TITLE
AP_BattMonitor: remove old parameter conversion to allow setting BATT_MONITOR to 0

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -256,7 +256,6 @@ private:
     uint32_t    _log_battery_bit;
     uint8_t     _num_instances;                                     /// number of monitors
 
-    void convert_params(void);
     void convert_dynamic_param_groups(uint8_t instance);
 
     /// returns the failsafe state of the battery


### PR DESCRIPTION
Closes https://github.com/ArduPilot/ardupilot/issues/19224

From a user on Discord: The user would like to disable `BATT_MONITOR 0` on their Matek M9N as they are using power modules without monitoring. However, upon reboot `BATT_MONITOR` gets set to `4` due to the following lines. 

The param conversion code, `AP_BattMonitor::convert_params(void)`, hasn't been changed in nearly 4 years. And first entered stable versions here from my git archeology:  
Rover 3.3.0
Copter 3.6.0
Plane 3.9.0

Just want to see what timeline & # of stable releases since is reasonable in terms of keeping this param_conversion around?