### PR TITLE
AP_Frsky_Telem: added frame 0x500D for waypoint data

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
@@ -421,7 +421,7 @@ uint16_t AP_Frsky_SPort::prep_number(int32_t number, uint8_t digits, uint8_t pow
             res = abs_number<<1;
         } else if (abs_number < 10240) {
             res = ((uint16_t)roundf(abs_number * 0.1f)<<1)|0x1;
-        } else { // transmit max possible value (0x3FF x 10^1 = 10240)
+        } else { // transmit max possible value (0x3FF x 10^1 = 10230)
             res = 0x7FF;
         }
         if (number < 0) { // if number is negative, add sign bit in front
@@ -436,7 +436,7 @@ uint16_t AP_Frsky_SPort::prep_number(int32_t number, uint8_t digits, uint8_t pow
             res = ((uint16_t)roundf(abs_number * 0.01f)<<2)|0x2;
         } else if (abs_number < 1024000) {
             res = ((uint16_t)roundf(abs_number * 0.001f)<<2)|0x3;
-        } else { // transmit max possible value (0x3FF x 10^3 = 127000)
+        } else { // transmit max possible value (0x3FF x 10^3 = 1023000)
             res = 0xFFF;
         }
         if (number < 0) { // if number is negative, add sign bit in front

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.h
@@ -29,9 +29,9 @@ protected:
 
     void send_sport_frame(uint8_t frame, uint16_t appid, uint32_t data);
 
-    struct PACKED {
-        bool send_latitude; // sizeof(bool) = 4 ?
-        bool send_airspeed; // toggles 0x5005 between airspeed and groundspeed
+    struct {
+        bool send_latitude;
+        bool send_airspeed;     // toggles 0x5005 between airspeed and groundspeed
         uint32_t gps_lng_sample;
         uint8_t new_byte;
     } _passthrough;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
@@ -74,6 +74,7 @@ public:
 #endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
         TERRAIN =       14, // 0x500B terrain data
         WIND =          15, // 0x500C wind data
+        WAYPOINT =      16, // 0x500D waypoint data
         WFQ_LAST_ITEM       // must be last
     };
 
@@ -110,6 +111,7 @@ private:
     uint32_t calc_rpm(void);
     uint32_t calc_terrain(void);
     uint32_t calc_wind(void);
+    uint32_t calc_waypoint(void);
 
     // use_external_data is set when this library will
     // be providing data to another transport, such as FPort


### PR DESCRIPTION
this adds current waypoint info similar to NAV_CONTROLLER_OUTPUT.

new 0x500D frame with:
- current WP number
- current WP distance
- current WP bearing

The telemetry consumer will be responsable for rendering the telemetry data only when appropriate such as mavproxy does, i.e for the following modes: AUTO, GUIDED, LOITER, RTL, QRTL, QLOITER, QLAND, FOLLOW, ZIGZAG