### PR TITLE
Tools: reserve board id for sierra-F405

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -150,6 +150,7 @@ AP_HW_KakuteH7                       1048
 AP_HW_ICSI_Kestrel                   1049
 AP_HW_SierraL431                     1050
 AP_HW_NucleoL476                     1051
+AP_HW_SierraF405                     1052
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/19232 so the ID doesn't get swiped by someone else
