### PR TITLE
Rover: fix NTUN.yaw units

### DIFF
--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -310,7 +310,7 @@ const LogStructure Rover::log_structure[] = {
 // @Field: XTrack: the vehicle's current distance from the current travel segment
 
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),
-      "NTUN", "QfffHf", "TimeUS,WpDist,WpBrg,DesYaw,Yaw,XTrack", "smhhdm", "F000B0" },
+      "NTUN", "QfffHf", "TimeUS,WpDist,WpBrg,DesYaw,Yaw,XTrack", "smhhhm", "F000B0" },
     
 // @LoggerMessage: STER
 // @Description: Steering related messages


### PR DESCRIPTION
This is a minor fix to the NTUN message's "Yaw" field's units.  After this change the units are "degheading" (instead of just "deg") which better matches the WPBrg and DesYaw fields.

Below are before and after screen shots and we can see there is only one scale now on the left in the "After" screen shot.
![ntun-yaw-before-vs-after](https://user-images.githubusercontent.com/1498098/141981351-db24fe10-35fa-40c9-9876-0831278d2175.png)

