### PR TITLE
Rover: reduce some attitude control limits

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -20,15 +20,15 @@
 #include <AP_GPS/AP_GPS.h>
 
 // attitude control default definition
-#define AR_ATTCONTROL_STEER_ANG_P       2.50f
+#define AR_ATTCONTROL_STEER_ANG_P       2.00f
 #define AR_ATTCONTROL_STEER_RATE_FF     0.20f
 #define AR_ATTCONTROL_STEER_RATE_P      0.20f
 #define AR_ATTCONTROL_STEER_RATE_I      0.20f
 #define AR_ATTCONTROL_STEER_RATE_IMAX   1.00f
 #define AR_ATTCONTROL_STEER_RATE_D      0.00f
 #define AR_ATTCONTROL_STEER_RATE_FILT   10.00f
-#define AR_ATTCONTROL_STEER_RATE_MAX    360.0f
-#define AR_ATTCONTROL_STEER_ACCEL_MAX   180.0f
+#define AR_ATTCONTROL_STEER_RATE_MAX    120.0f
+#define AR_ATTCONTROL_STEER_ACCEL_MAX   120.0f
 #define AR_ATTCONTROL_THR_SPEED_P       0.20f
 #define AR_ATTCONTROL_THR_SPEED_I       0.20f
 #define AR_ATTCONTROL_THR_SPEED_IMAX    1.00f
@@ -50,7 +50,7 @@
 #define AR_ATTCONTROL_DT                0.02f
 
 // throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
-#define AR_ATTCONTROL_THR_ACCEL_MAX     2.00f
+#define AR_ATTCONTROL_THR_ACCEL_MAX     1.00f
 
 // minimum speed in m/s
 #define AR_ATTCONTROL_STEER_SPEED_MIN   1.0f

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -19,6 +19,45 @@
 #include "AR_AttitudeControl.h"
 #include <AP_GPS/AP_GPS.h>
 
+// attitude control default definition
+#define AR_ATTCONTROL_STEER_ANG_P       2.50f
+#define AR_ATTCONTROL_STEER_RATE_FF     0.20f
+#define AR_ATTCONTROL_STEER_RATE_P      0.20f
+#define AR_ATTCONTROL_STEER_RATE_I      0.20f
+#define AR_ATTCONTROL_STEER_RATE_IMAX   1.00f
+#define AR_ATTCONTROL_STEER_RATE_D      0.00f
+#define AR_ATTCONTROL_STEER_RATE_FILT   10.00f
+#define AR_ATTCONTROL_STEER_RATE_MAX    360.0f
+#define AR_ATTCONTROL_STEER_ACCEL_MAX   180.0f
+#define AR_ATTCONTROL_THR_SPEED_P       0.20f
+#define AR_ATTCONTROL_THR_SPEED_I       0.20f
+#define AR_ATTCONTROL_THR_SPEED_IMAX    1.00f
+#define AR_ATTCONTROL_THR_SPEED_D       0.00f
+#define AR_ATTCONTROL_THR_SPEED_FILT    10.00f
+#define AR_ATTCONTROL_PITCH_THR_P       1.80f
+#define AR_ATTCONTROL_PITCH_THR_I       1.50f
+#define AR_ATTCONTROL_PITCH_THR_D       0.03f
+#define AR_ATTCONTROL_PITCH_THR_IMAX    1.0f
+#define AR_ATTCONTROL_PITCH_THR_FILT    10.0f
+#define AR_ATTCONTROL_BAL_SPEED_FF      1.0f
+#define AR_ATTCONTROL_DT                0.02f
+#define AR_ATTCONTROL_TIMEOUT_MS        200
+#define AR_ATTCONTROL_HEEL_SAIL_P       1.0f
+#define AR_ATTCONTROL_HEEL_SAIL_I       0.1f
+#define AR_ATTCONTROL_HEEL_SAIL_D       0.0f
+#define AR_ATTCONTROL_HEEL_SAIL_IMAX    1.0f
+#define AR_ATTCONTROL_HEEL_SAIL_FILT    10.0f
+#define AR_ATTCONTROL_DT                0.02f
+
+// throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
+#define AR_ATTCONTROL_THR_ACCEL_MAX     2.00f
+
+// minimum speed in m/s
+#define AR_ATTCONTROL_STEER_SPEED_MIN   1.0f
+
+// speed (in m/s) at or below which vehicle is considered stopped (_STOP_SPEED parameter default)
+#define AR_ATTCONTROL_STOP_SPEED_DEFAULT    0.1f
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -4,46 +4,6 @@
 #include <AC_PID/AC_PID.h>
 #include <AC_PID/AC_P.h>
 
-// attitude control default definition
-#define AR_ATTCONTROL_STEER_ANG_P       2.50f
-#define AR_ATTCONTROL_STEER_RATE_FF     0.20f
-#define AR_ATTCONTROL_STEER_RATE_P      0.20f
-#define AR_ATTCONTROL_STEER_RATE_I      0.20f
-#define AR_ATTCONTROL_STEER_RATE_IMAX   1.00f
-#define AR_ATTCONTROL_STEER_RATE_D      0.00f
-#define AR_ATTCONTROL_STEER_RATE_FILT   10.00f
-#define AR_ATTCONTROL_STEER_RATE_MAX    360.0f
-#define AR_ATTCONTROL_STEER_ACCEL_MAX   180.0f
-#define AR_ATTCONTROL_THR_SPEED_P       0.20f
-#define AR_ATTCONTROL_THR_SPEED_I       0.20f
-#define AR_ATTCONTROL_THR_SPEED_IMAX    1.00f
-#define AR_ATTCONTROL_THR_SPEED_D       0.00f
-#define AR_ATTCONTROL_THR_SPEED_FILT    10.00f
-#define AR_ATTCONTROL_PITCH_THR_P       1.80f
-#define AR_ATTCONTROL_PITCH_THR_I       1.50f
-#define AR_ATTCONTROL_PITCH_THR_D       0.03f
-#define AR_ATTCONTROL_PITCH_THR_IMAX    1.0f
-#define AR_ATTCONTROL_PITCH_THR_FILT    10.0f
-#define AR_ATTCONTROL_BAL_SPEED_FF      1.0f
-#define AR_ATTCONTROL_DT                0.02f
-#define AR_ATTCONTROL_TIMEOUT_MS        200
-#define AR_ATTCONTROL_HEEL_SAIL_P       1.0f
-#define AR_ATTCONTROL_HEEL_SAIL_I       0.1f
-#define AR_ATTCONTROL_HEEL_SAIL_D       0.0f
-#define AR_ATTCONTROL_HEEL_SAIL_IMAX    1.0f
-#define AR_ATTCONTROL_HEEL_SAIL_FILT    10.0f
-#define AR_ATTCONTROL_DT                0.02f
-
-// throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
-#define AR_ATTCONTROL_THR_ACCEL_MAX     2.00f
-
-// minimum speed in m/s
-#define AR_ATTCONTROL_STEER_SPEED_MIN   1.0f
-
-// speed (in m/s) at or below which vehicle is considered stopped (_STOP_SPEED parameter default)
-#define AR_ATTCONTROL_STOP_SPEED_DEFAULT    0.1f
-
-
 class AR_AttitudeControl {
 public:
 


### PR DESCRIPTION
This PR reduces some default ATC parameter values to be closer to the majority of frames our users use.

- ATC_STR_ANG_P default reduced from 2.5 to 2.  This P gain is used during pivot turns.  2.0 means a 1 degree error is converted into a 1deg/sec turn rate.  In my experience most users need to reduce this to closer to 1.5.  For now we just reduce it to 2.0
- ATC_STR_RAT_MAX is reduced from 360 deg/sec to 120 deg/sec.  This limits the maximum turn rate of a vehicle at any speed.  360 deg/sec was insanely fast.  Even 120 deg/sec is still quite fast.
- ATC_STR_ACC_MAX is reduced from 180 deg/sec/sec to 120 deg/sec/sec.  This parameter controls how quickly the vehicle can get to any desired rotation rate.  So on this imaginary default vehicle it would take 1 sec for the vehicle to reach its maximum rotation rate of 120deg/sec.
- ATC_ACCEL_MAX is reduced from 2m/s/s to 1m/s/s.  This controls how quickly a vehicle can accelerate or decelerate in the forward/back direction.  This is perhaps the most controversion change of them all.  If this value is too low the user will complain of sluggish throttle control when driving in Acro mode.  Also the vehicle may not stop quickly enough which also can be dangerous as it may hit things.

These new values are based on experience helping users tune new vehicle.  These are very often some of the first changes I make when helping them.  All feedback welcome though if others have different suggestions

By the way, I tested these in SITL and the changes are hard to notice.

Below are before and after Desired vs Actual speed
![before-and-after-throttle-response](https://user-images.githubusercontent.com/1498098/141984635-f00f8397-2c23-4950-98ce-b9b70c37e1b9.png)

Here is before and after desired and actual turn rate
![before-and-after-steering-turn-rate](https://user-images.githubusercontent.com/1498098/141984657-fedbad0d-a590-4eeb-baf4-6aee958d3eb4.png)

