### PR TITLE
Rover: Auto's init stops vehicle, updates mission on each loop

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -85,7 +85,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AC_Fence,            &rover.g2.fence,         update,         10,  100,  33),
     SCHED_TASK(update_wheel_encoder,   50,    200,  36),
     SCHED_TASK(update_compass,         10,    200,  39),
-    SCHED_TASK(update_mission,         50,    200,  42),
     SCHED_TASK(update_logging1,        10,    200,  45),
     SCHED_TASK(update_logging2,        10,    200,  48),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&rover._gcs,       update_receive,                    400,    500,  51),
@@ -406,16 +405,6 @@ void Rover::update_current_mode(void)
     }
 
     control_mode->update();
-}
-
-// update mission including starting or stopping commands. called by scheduler at 10Hz
-void Rover::update_mission(void)
-{
-    if (control_mode == &mode_auto) {
-        if (ahrs.home_is_set() && mode_auto.mission.num_commands() > 1) {
-            mode_auto.mission.update();
-        }
-    }
 }
 
 // vehicle specific waypoint info helpers

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -279,7 +279,6 @@ private:
     void update_logging2(void);
     void one_second_loop(void);
     void update_current_mode(void);
-    void update_mission(void);
 
     // balance_bot.cpp
     void balancebot_pitch_control(float &throttle);

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -331,6 +331,7 @@ private:
         MIS_DONE_BEHAVE_MANUAL    = 3
     };
 
+    bool waiting_to_start;  // true if waiting for EKF origin before starting mission
     bool auto_triggered;        // true when auto has been triggered to start
 
     // HeadingAndSpeed sub mode variables

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -11,11 +11,6 @@ bool ModeAuto::_enter()
         return false;
     }
 
-    // init location target
-    if (!g2.wp_nav.set_desired_location(rover.current_loc)) {
-        return false;
-    }
-
     // initialise waypoint speed
     g2.wp_nav.set_desired_speed_to_default();
 
@@ -24,6 +19,15 @@ bool ModeAuto::_enter()
 
     // clear guided limits
     rover.mode_guided.limit_clear();
+
+    // initialise submode to stop or loiter
+    if (rover.is_boat()) {
+        if (!start_loiter()) {
+            start_stop();
+        }
+    } else {
+        start_stop();
+    }
 
     // restart mission processing
     mission.start_or_resume();

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -29,8 +29,9 @@ bool ModeAuto::_enter()
         start_stop();
     }
 
-    // restart mission processing
-    mission.start_or_resume();
+    // set flag to start mission
+    waiting_to_start = true;
+
     return true;
 }
 
@@ -44,6 +45,19 @@ void ModeAuto::_exit()
 
 void ModeAuto::update()
 {
+    // start or update mission
+    if (waiting_to_start) {
+        // don't start the mission until we have an origin
+        Location loc;
+        if (ahrs.get_origin(loc)) {
+            // start/resume the mission (based on MIS_RESTART parameter)
+            mission.start_or_resume();
+            waiting_to_start = false;
+        }
+    } else {
+        mission.update();
+    }
+
     switch (_submode) {
         case Auto_WP:
         {

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -24,7 +24,7 @@ extern const AP_HAL::HAL& hal;
 #define AR_WPNAV_RADIUS_DEFAULT         2.0f
 #define AR_WPNAV_OVERSHOOT_DEFAULT      2.0f
 #define AR_WPNAV_PIVOT_ANGLE_DEFAULT    60
-#define AR_WPNAV_PIVOT_ANGLE_ACCURACY   10      // vehicle will pivot to within this many degrees of destination
+#define AR_WPNAV_PIVOT_ANGLE_ACCURACY   5   // vehicle will pivot to within this many degrees of destination
 #define AR_WPNAV_PIVOT_RATE_DEFAULT     90
 
 const AP_Param::GroupInfo AR_WPNav::var_info[] = {
@@ -327,7 +327,7 @@ void AR_WPNav::update_pivot_active_flag()
 
     uint32_t now = AP_HAL::millis();
 
-    // if within 10 degrees of the target heading, set start time of pivot steering
+    // if within 5 degrees of the target heading, set start time of pivot steering
     if (_pivot_active && yaw_error < AR_WPNAV_PIVOT_ANGLE_ACCURACY && _pivot_start_ms == 0) {
         _pivot_start_ms = now;
     }


### PR DESCRIPTION
This makes some minor improvements to Rover's Auto mode

- Auto mode's init switches the vehicle into Hold or Loiter.  Previously it was setting wp_nav's destination to the current_loc but *not* setting the submode which is certainly bad behaviour.  This has the additional benefit that users can switch to Auto (while disarmed) sooner after startup because the wp_nav.set_desired_location() is not called and thus can't fail
- Auto mode's update takes responsibility for calling mission.update which means it runs at the main loop rate instead of always 50hz.  This also allows us to *not* update it until the origin has been set.  This doesn't matter much now but it will once SCurves are added
![before-vs-after-command-exec-order](https://user-images.githubusercontent.com/1498098/142089741-f8f8ecaf-4f0c-4040-821f-794899331457.png)
- Pivot turns complete when the vehicle is within 5deg of the heading towards the next waypoints instead of 10deg.  This makes very little difference but surely is a small improvement
![before-after-pivot-accuracy](https://user-images.githubusercontent.com/1498098/142091572-05cf4c91-9727-4b40-a899-bf9143bdfb4a.png)

