### PR TITLE
Plane: tailsitter rate limit second half of VTOL transition. 

### DIFF
--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -64,6 +64,8 @@ void ModeQStabilize::set_tailsitter_roll_pitch(const float roll_input, const flo
 
     // angle max for tailsitter pitch
     plane.nav_pitch_cd = pitch_input * plane.quadplane.aparm.angle_max;
+
+    plane.quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd);
 }
 
 // set the desired roll and pitch for normal quadplanes, also limited by forward flight limtis

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1864,7 +1864,8 @@ void QuadPlane::motors_output(bool run_rate_controller)
         return;
     }
 
-    if (tailsitter.in_vtol_transition() && !assisted_flight) {
+    const uint32_t now = AP_HAL::millis();
+    if (tailsitter.in_vtol_transition(now) && !assisted_flight) {
         /*
           don't run the motor outputs while in tailsitter->vtol
           transition. That is taken care of by the fixed wing
@@ -1873,7 +1874,6 @@ void QuadPlane::motors_output(bool run_rate_controller)
         return;
     }
 
-    const uint32_t now = AP_HAL::millis();
     if (run_rate_controller) {
         if (now - last_att_control_ms > 100) {
             // relax if have been inactive
@@ -2319,7 +2319,7 @@ void QuadPlane::vtol_position_controller(void)
     case QPOS_POSITION1: {
         setup_target_position();
 
-        if (tailsitter.enabled() && tailsitter.in_vtol_transition()) {
+        if (tailsitter.enabled() && tailsitter.in_vtol_transition(now_ms)) {
             break;
         }
 
@@ -2488,7 +2488,7 @@ void QuadPlane::vtol_position_controller(void)
         }
         break;
     case QPOS_POSITION1:
-        if (tailsitter.in_vtol_transition()) {
+        if (tailsitter.in_vtol_transition(now_ms)) {
             pos_control->relax_z_controller(0);
             break;
         }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -892,7 +892,7 @@ void QuadPlane::run_z_controller(void)
         // never run Z controller in tailsitter transtion
         return;
     }
-    if (!pos_control->is_active_z()) {
+    if ((now - last_pidz_active_ms) > 20) {
         // set vertical speed and acceleration limits
         pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_velocity_z_max_up, pilot_accel_z);
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -884,6 +884,9 @@ void QuadPlane::hold_stabilize(float throttle_in)
 // run the multicopter Z controller
 void QuadPlane::run_z_controller(void)
 {
+    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED ) {
+        return;
+    }
     const uint32_t now = AP_HAL::millis();
     if (tailsitter.in_vtol_transition(now)) {
         // never run Z controller in tailsitter transtion

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -885,6 +885,10 @@ void QuadPlane::hold_stabilize(float throttle_in)
 void QuadPlane::run_z_controller(void)
 {
     const uint32_t now = AP_HAL::millis();
+    if (tailsitter.in_vtol_transition(now)) {
+        // never run Z controller in tailsitter transtion
+        return;
+    }
     if (!pos_control->is_active_z()) {
         // set vertical speed and acceleration limits
         pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_velocity_z_max_up, pilot_accel_z);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -906,7 +906,7 @@ void QuadPlane::relax_attitude_control()
 {
     // disable roll and yaw control for vectored tailsitters
     // if not a vectored tailsitter completely disable attitude control
-    attitude_control->relax_attitude_controllers(tailsitter._is_vectored);
+    attitude_control->relax_attitude_controllers(!tailsitter.relax_pitch());
 }
 
 /*

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -757,6 +757,11 @@ void Tailsitter_Transition::VTOL_update()
         if (!quadplane.tailsitter.transition_vtol_complete()) {
             return;
         }
+        // transition to VTOL complete, if armed set vtol rate limit starting point
+        if (hal.util->get_soft_armed()) {
+            vtol_limit_start_ms = now;
+            vtol_limit_initial_pitch = quadplane.ahrs_view->pitch_sensor;
+        }
     }
     restart();
 }
@@ -795,6 +800,38 @@ void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& na
         // still in FW, reset transition starting point
         force_transistion_complete();
     }
+}
+
+bool Tailsitter_Transition::set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd)
+{
+    if (vtol_limit_start_ms == 0) {
+        return false;
+    }
+    // prevent pitching towards 0 too quickly
+    const float pitch_change_cd = (AP_HAL::millis() - vtol_limit_start_ms) * tailsitter.transition_rate_vtol * 0.1;
+    if (pitch_change_cd > fabsf(vtol_limit_initial_pitch)) {
+        // limit has passed 0, nothing to do
+        vtol_limit_start_ms = 0;
+        return false;
+    }
+    // continue limiting while limit angle is larger than desired angle
+    if (is_negative(vtol_limit_initial_pitch)) {
+        const float pitch_limit = vtol_limit_initial_pitch + pitch_change_cd;
+        if (nav_pitch_cd > pitch_limit) {
+            nav_pitch_cd = pitch_limit;
+            nav_roll_cd = 0;
+            return true;
+        }
+    } else {
+        const float pitch_limit = vtol_limit_initial_pitch - pitch_change_cd;
+        if (nav_pitch_cd < pitch_limit) {
+            nav_pitch_cd = pitch_limit;
+            nav_roll_cd = 0;
+            return true;
+        }
+    }
+    vtol_limit_start_ms = 0;
+    return false;
 }
 
 // setup for the transition back to fixed wing

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -685,6 +685,14 @@ void Tailsitter::speed_scaling(void)
     }
 }
 
+// return true if pitch control should be relaxed
+// on vectored belly sitters the pitch control is not relaxed in order to keep motors pointing and avoid risk of props hitting the ground
+// always relax after a transition
+bool Tailsitter::relax_pitch()
+{
+    return !enabled() || !_is_vectored || (transition->vtol_limit_start_ms != 0);
+}
+
 /*
   update for transition from quadplane to fixed wing mode
  */

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -150,6 +150,8 @@ public:
 
     MAV_VTOL_STATE get_mav_vtol_state() const override;
 
+    bool set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd) override;
+
 private:
 
     enum {
@@ -161,6 +163,10 @@ private:
     // for transition to VTOL flight
     uint32_t vtol_transition_start_ms;
     float vtol_transition_initial_pitch;
+
+    // for rate limit of VTOL flight
+    uint32_t vtol_limit_start_ms;
+    float vtol_limit_initial_pitch;
 
     // for transition to FW flight
     uint32_t fw_transition_start_ms;

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -62,9 +62,8 @@ public:
     // return the transition_angle_vtol value
     int8_t get_transition_angle_vtol() const;
 
-
-    // true when flying a tilt-vectored tailsitter
-    bool _is_vectored;
+    // return true if pitch control should be relaxed
+    bool relax_pitch();
 
     // tailsitter speed scaler
     float last_spd_scaler = 1.0f; // used to slew rate limiting with TAILSITTER_GSCL_ATT_THR option
@@ -110,6 +109,9 @@ public:
 private:
 
     bool setup_complete;
+
+    // true when flying a tilt-vectored tailsitter
+    bool _is_vectored;
 
     // refences for convenience
     QuadPlane& quadplane;


### PR DESCRIPTION
This now applys a pitch up rate limit to the second half of the transition into VTOL flight. Rather than just pulling up to `Q_TAILSIT_ANG_VT` and dumping to the VTOL controller, the pitch up rate is now limited as the same `Q_TAILSIT_RAT_VT` that the first half of the transition is done at. Once the desired pitch angle is larger than the pitch up limit the limit is removed. 
The limit it applied in all modes, except QACRO.

In addition we now no longer run the Z controller in tailsitter VTOL transition or if the throttle state is not unlimited. We always do a full pitch relax on transition entry (if not in Qassist) and pass the current time to `tailsitter.in_vtol_transition` that already have the time available in the function, this should reduce the chances of a race condition. 

The result of these changes are a much smoother transition from the FW pull up to the VTOL flight. You can still see the step as we swap from the FW to VTOL controller, but it is much smoother. This also enables lower `Q_TAILSIT_ANG_VT` values without a very aggressive pitch up.