### PR TITLE
Copter: Delay the start of radio fail-safe actions

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -247,6 +247,15 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(failsafe_throttle_value, "FS_THR_VALUE",      FS_THR_VALUE_DEFAULT),
 
+    // @Param: FS_RADIO_ACTD
+    // @DisplayName: Failsafe Radio Action Delay
+    // @Description: Failsafe Radio Action Delay
+    // @Range: 0 30000
+    // @Units: ms
+    // @Increment: 1
+    // @User: Standard
+    GSCALAR(failsafe_radio_action_delay, "FS_RADIO_ACTD", 0),
+
     // @Param: THR_DZ
     // @DisplayName: Throttle deadzone
     // @Description: The deadzone above and below mid throttle in PWM microseconds. Used in AltHold, Loiter, PosHold flight modes

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -289,7 +289,7 @@ public:
         k_param_rc_8_old,
         k_param_rc_10_old,
         k_param_rc_11_old,
-        k_param_throttle_min,           // remove
+        k_param_throttle_min = 180,     // remove
         k_param_throttle_max,           // remove
         k_param_failsafe_throttle,
         k_param_throttle_fs_action,     // remove
@@ -299,6 +299,7 @@ public:
         k_param_radio_tuning,
         k_param_radio_tuning_high_old,   // unused
         k_param_radio_tuning_low_old,    // unused
+        k_param_failsafe_radio_action_delay,
         k_param_rc_speed = 192,
         k_param_failsafe_battery_enabled, // unused - moved to AP_BattMonitor
         k_param_throttle_mid,           // remove
@@ -427,6 +428,7 @@ public:
     AP_Int8         failsafe_throttle;
     AP_Int16        failsafe_throttle_value;
     AP_Int16        throttle_deadzone;
+    AP_Int16        failsafe_radio_action_delay;
 
     // Flight modes
     //


### PR DESCRIPTION
Radio fail-safe actions are performed during flight operations.
The operator is confused by the different flight operations.
I interrupt the flight operation to indicate to the operator that the aircraft is abnormal.
The operator knows that the aircraft operation is now possible by operating the flight mode switch.
If the radio fail continues to occur, the fail-safe action will be implemented after the specified time.
I will notify the GCS of the message and have the GCS display and audibly notify me.