### PR TITLE
AP_InertialSensor: change VIBE logging units to m/s/s

### DIFF
--- a/libraries/AP_InertialSensor/LogStructure.h
+++ b/libraries/AP_InertialSensor/LogStructure.h
@@ -119,7 +119,7 @@ struct PACKED log_Vibe {
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QBffffffIIfBBHH", "TimeUS,I,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz", "s#EEEooo--O--zz", "F-000000-----00" , true }, \
     { LOG_VIBE_MSG, sizeof(log_Vibe), \
-      "VIBE", "QBfffI", "TimeUS,IMU,VibeX,VibeY,VibeZ,Clip", "s#----", "F-----" , true }, \
+      "VIBE", "QBfffI", "TimeUS,IMU,VibeX,VibeY,VibeZ,Clip", "s#ooo-", "F-000-" , true }, \
     { LOG_ISBH_MSG, sizeof(log_ISBH), \
       "ISBH", "QHBBHHQf", "TimeUS,N,type,instance,mul,smp_cnt,SampleUS,smp_rate", "s-----sz", "F-----F-" },  \
     { LOG_ISBD_MSG, sizeof(log_ISBD), \


### PR DESCRIPTION
Although filtered, the vibration levels are in m/s/s so let's set the units to match.  This improves display of the values in MP (and perhaps other log viewing applications) which may not align the scale unless the units are set (fyi @meee1)

Unaligned scales with no units
![image](https://user-images.githubusercontent.com/1498098/142300668-c565e1b7-4802-4fe8-a641-f93c3f76c9a6.png)

Aligned scales with units
![image](https://user-images.githubusercontent.com/1498098/142300690-3d2bde2a-0577-4899-ac2b-b24bc91e204a.png)


