### PR TITLE
Plane: add radius for GUIDED mode

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -604,7 +604,7 @@ const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] = {
  */
 bool GCS_MAVLINK_Plane::handle_guided_request(AP_Mission::Mission_Command &cmd)
 {
-    return plane.control_mode->handle_guided_request(cmd.content.location);
+    return plane.control_mode->handle_guided_request(cmd.content.location, cmd.p1);
 }
 
 /*

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -119,8 +119,8 @@ public:
     // method for mode specific target altitude profiles
     virtual bool update_target_altitude() { return false; }
 
-    // handle a guided target request from GCS
-    virtual bool handle_guided_request(Location target_loc) { return false; }
+    // handle a guided target request from GCS. A radius of Zero indicates to use WP_LOITER_RAD
+    virtual bool handle_guided_request(const Location target_loc, const uint16_t radius = 0) { return false; }
 
 protected:
 
@@ -224,11 +224,15 @@ public:
     bool does_auto_throttle() const override { return true; }
 
     // handle a guided target request from GCS
-    bool handle_guided_request(Location target_loc) override;
+    bool handle_guided_request(const Location target_loc, const uint16_t radius = 0) override;
 
 protected:
 
     bool _enter() override;
+
+private:
+    // adjustable radius for guided. A radius of Zero indicates to use WP_LOITER_RAD
+    uint16_t loiter_radius_m;
 };
 
 class ModeCircle: public Mode
@@ -287,8 +291,8 @@ public:
     const char *name() const override { return "Loiter to QLAND"; }
     const char *name4() const override { return "L2QL"; }
 
-    // handle a guided target request from GCS
-    bool handle_guided_request(Location target_loc) override;
+    // handle a guided target request from GCS. Radius is unused.
+    bool handle_guided_request(const Location target_loc, const uint16_t radius = 0) override;
 
 protected:
     bool _enter() override;

--- a/ArduPlane/mode_LoiterAltQLand.cpp
+++ b/ArduPlane/mode_LoiterAltQLand.cpp
@@ -42,7 +42,7 @@ void ModeLoiterAltQLand::switch_qland()
     }
 }
 
-bool ModeLoiterAltQLand::handle_guided_request(Location target_loc)
+bool ModeLoiterAltQLand::handle_guided_request(const Location target_loc, const uint16_t radius)
 {
     plane.guided_WP_loc = target_loc;
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -39,13 +39,14 @@ void ModeGuided::update()
 
 void ModeGuided::navigate()
 {
-    // Zero indicates to use WP_LOITER_RAD
-    plane.update_loiter(0);
+    // A radius of Zero indicates to use WP_LOITER_RAD
+    plane.update_loiter(loiter_radius_m);
 }
 
-bool ModeGuided::handle_guided_request(Location target_loc)
+bool ModeGuided::handle_guided_request(const Location target_loc, const uint16_t radius)
 {
     plane.guided_WP_loc = target_loc;
+    loiter_radius_m = radius;
 
     // add home alt if needed
     if (plane.guided_WP_loc.relative_alt) {


### PR DESCRIPTION
Allow setting a radius specifically for mode GUIDED via mavlink. A radius of Zero indicates to use WP_LOITER_RAD which is the existing behavior