### PR TITLE
Add support for DISTANCE_SENSOR.signal_quality

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -64,6 +64,10 @@ public:
     // get temperature reading in C.  returns true on success and populates temp argument
     virtual bool get_temp(float &temp) const { return false; }
 
+    // 0 is no return value, 100 is perfect.  false means signal
+    // quality is not available
+    virtual bool get_signal_quality_pct(uint8_t &quality_pct) const { return false; }
+
 protected:
 
     // update status based on distance measurement

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -119,12 +119,14 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
     // return average of all valid readings
     if (valid_count > 0) {
         reading_m = sum / valid_count;
+        no_signal = false;
         return true;
     }
 
     // all readings were invalid so return out-of-range-high value
     if (invalid_count > 0) {
         reading_m = MIN(MAX(LIGHTWARE_DIST_MAX_CM, distance_cm_max + LIGHTWARE_OUT_OF_RANGE_ADD_CM), UINT16_MAX) * 0.01f;
+        no_signal = true;
         return true;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -16,6 +16,11 @@ protected:
         return MAV_DISTANCE_SENSOR_LASER;
     }
 
+    bool get_signal_quality_pct(uint8_t &quality_pct) const override {
+        quality_pct = no_signal ? 0 : 100;
+        return true;
+    }
+
 private:
     // get a reading
     bool get_reading(float &reading_m) override;
@@ -35,4 +40,6 @@ private:
     } protocol_state;
     uint8_t legacy_valid_count;
     uint8_t binary_valid_count;
+
+    bool no_signal = false;
 };

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -341,6 +341,15 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         return;
     }
 
+    uint8_t quality_pct = 0;
+    uint8_t quality;
+    if (sensor->get_signal_quality_pct(quality_pct)) {
+        // mavlink defines this field as 0 is unknown, 1 is invalid, 100 is perfect
+        quality = MAX(quality_pct, 1);
+    } else {
+        quality = 0;
+    }
+
     mavlink_msg_distance_sensor_send(
         chan,
         AP_HAL::millis(),                        // time since system boot TODO: take time of measurement
@@ -354,7 +363,7 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         0,                                       // horizontal FOV
         0,                                       // vertical FOV
         (const float *)nullptr,                  // quaternion of sensor orientation for MAV_SENSOR_ROTATION_CUSTOM
-        0);                                      // Signal quality of the sensor. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.
+        quality);                                // Signal quality of the sensor. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.
 }
 // send any and all distance_sensor messages.  This starts by sending
 // any distance sensors not used by a Proximity sensor, then sends the

--- a/libraries/SITL/SIM_RF_LightWareSerial.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerial.cpp
@@ -50,5 +50,10 @@ void RF_LightWareSerial::update(float range)
 
 uint32_t RF_LightWareSerial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
+    if (alt_cm > 10000) {
+        // out-of-range-high
+        alt_cm = 13000;  // from datasheet
+    }
+
     return snprintf((char*)buffer, buflen, "%0.2f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
 }

--- a/libraries/SITL/SIM_RF_LightWareSerial.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerial.cpp
@@ -50,5 +50,5 @@ void RF_LightWareSerial::update(float range)
 
 uint32_t RF_LightWareSerial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
-    return snprintf((char*)buffer, buflen, "%f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
+    return snprintf((char*)buffer, buflen, "%0.2f\r", alt_cm / 100.0f); // note tragic lack of snprintf return checking
 }


### PR DESCRIPTION
Adds a callback onto the rangefinder backend to get a signal quality as a percentage.

Rescales this in GCS_MAVLink to account for field definition.

Adds test for same the functionality by flying a quadcopter up and up and up.

This attempts to interpret the Lightware "out of range magic values", as we recently changed in master.

Modifies the Lightware rangefinder simulation to return `13000` when out of range
