### PR TITLE
AP_Devo_Telem: compile out devo telemetry

### DIFF
--- a/AntennaTracker/GCS_Tracker.cpp
+++ b/AntennaTracker/GCS_Tracker.cpp
@@ -60,5 +60,7 @@ void GCS_Tracker::update_vehicle_sensor_status_flags()
 
 // avoid building/linking LTM:
 void AP_LTM_Telem::init() {};
+#if AP_DEVO_TELEM_ENABLED
 // avoid building/linking Devo:
 void AP_DEVO_Telem::init() {};
+#endif

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -98,5 +98,7 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
 
 // avoid building/linking LTM:
 void AP_LTM_Telem::init() {};
+#if AP_DEVO_TELEM_ENABLED
 // avoid building/linking Devo:
 void AP_DEVO_Telem::init() {};
+#endif

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -110,8 +110,10 @@ bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reaso
 
 // avoid building/linking LTM:
 void AP_LTM_Telem::init() {};
+#if AP_DEVO_TELEM_ENABLED
 // avoid building/linking Devo:
 void AP_DEVO_Telem::init() {};
+#endif
 
 void ReplayVehicle::init_ardupilot(void)
 {

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -686,6 +686,8 @@ class DEVO(Telem):
 
         self.HEADER = 0xAA
         self.frame_length = 20
+
+        # frame is 'None' until we receive a frame with VALID header and checksum
         self.frame = None
         self.bad_chars = 0
 
@@ -11029,14 +11031,19 @@ switch value'''
 
         tstart = self.get_sim_time_cached()
         while True:
+            self.drain_mav()
             now = self.get_sim_time_cached()
             if now - tstart > 10:
-                raise AutoTestTimeoutException("Failed to get devo data")
+                if devo.frame is not None:
+                    # we received some frames but could not find correct values
+                    raise AutoTestTimeoutException("Failed to get correct data")
+                else:
+                    # No frames received. Devo telemetry is compiled out?
+                    break
 
             devo.update()
             frame = devo.frame
             if frame is None:
-                self.progress("No data received")
                 continue
 
             m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -17,19 +17,21 @@
    DEVO Telemetry library
 */
 
-#define DEVOM_SYNC_BYTE        0xAA
 
-
-#define AP_SERIALMANAGER_DEVO_TELEM_BAUD        38400
-#define AP_SERIALMANAGER_DEVO_BUFSIZE_RX        0
-#define AP_SERIALMANAGER_DEVO_BUFSIZE_TX        32
 
 #include "AP_Devo_Telem.h"
+
+#if AP_DEVO_TELEM_ENABLED
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <GCS_MAVLink/GCS.h>
+
+#define DEVOM_SYNC_BYTE        0xAA
+#define AP_SERIALMANAGER_DEVO_TELEM_BAUD        38400
+#define AP_SERIALMANAGER_DEVO_BUFSIZE_RX        0
+#define AP_SERIALMANAGER_DEVO_BUFSIZE_TX        32
 
 extern const AP_HAL::HAL& hal;
 
@@ -133,3 +135,4 @@ void AP_DEVO_Telem::tick(void)
         send_frames();
     }
 }
+#endif

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.h
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.h
@@ -18,6 +18,11 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
+#ifndef AP_DEVO_TELEM_ENABLED
+    #define AP_DEVO_TELEM_ENABLED   0
+#endif
+
+#if AP_DEVO_TELEM_ENABLED
 class AP_DEVO_Telem {
 public:
     //constructor
@@ -43,3 +48,4 @@ private:
     uint32_t _last_frame_ms;
 
 };
+#endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1049,6 +1049,9 @@ public:
 #if !HAL_MINIMIZE_FEATURES
     // LTM backend
     AP_LTM_Telem ltm_telemetry;
+#endif
+
+#if AP_DEVO_TELEM_ENABLED
     // Devo backend
     AP_DEVO_Telem devo_telemetry;
 #endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2223,6 +2223,9 @@ void GCS::setup_uarts()
     }
 #if !HAL_MINIMIZE_FEATURES
     ltm_telemetry.init();
+#endif
+
+#if AP_DEVO_TELEM_ENABLED
     devo_telemetry.init();
 #endif
 }


### PR DESCRIPTION
Devo telemetry is one of the most rarely used features (almost never used since added) we should compile it out from our code. @peterbarker Can you please review it?