### PR TITLE
Tools: fixed cygwin build for rover

### DIFF
--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -13,7 +13,11 @@ mkdir artifacts
 
 (
     python ./waf --color yes --toolchain i686-pc-cygwin --board sitl configure 2>&1
-    python ./waf plane rover copter sub heli 2>&1
+    python ./waf plane 2>&1
+    python ./waf copter 2>&1
+    python ./waf heli 2>&1
+    python ./waf rover 2>&1
+    python ./waf sub 2>&1
 ) | tee artifacts/build.txt
 
 i686-pc-cygwin-g++ -print-sysroot


### PR DESCRIPTION
fixes issue caused by header vehicle dependencies by compiling each vehicle separately