### PR TITLE
AP_RangFinder: various maxbotix serial sonar

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -477,6 +477,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #endif
         break;
     case Type::MBSER:
+    case Type::MBSER_CM:
+    case Type::MBSER_MM:
         if (AP_RangeFinder_MaxsonarSerialLV::detect(serial_instance)) {
             _add_backend(new AP_RangeFinder_MaxsonarSerialLV(state[instance], params[instance]), instance, serial_instance++);
         }

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -89,6 +89,8 @@ public:
         MSP = 32,
         USD1_CAN = 33,
         Benewake_CAN = 34,
+        MBSER_CM = 35,
+        MBSER_MM = 36,
         SIM = 100,
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
@@ -69,7 +69,7 @@ bool AP_RangeFinder_MaxsonarSerialLV::get_reading(float &reading_m)
         return false;
     }
 
-    // This sonar gives the metrics in inches, so we have to transform this to meters
+    // Maxbotix serial sonar may give the metrics in inches, cm or mm, so we have to transform this to meters
     reading_m = unit_conversion * (float(sum) / count);
 
     return true;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
@@ -24,6 +24,20 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_RangeFinder_MaxsonarSerialLV::AP_RangeFinder_MaxsonarSerialLV(
+    RangeFinder::RangeFinder_State &_state,
+    AP_RangeFinder_Params &_params):
+    AP_RangeFinder_Backend_Serial(_state, _params)
+{
+    if (_backend_type == RangeFinder::Type::MBSER) {
+        unit_conversion = 0.0254f;
+    } else if (_backend_type == RangeFinder::Type::MBSER_CM) {
+        unit_conversion = 0.01f;
+    } else if (_backend_type == RangeFinder::Type::MBSER_MM) {
+        unit_conversion = 0.001f;
+    }
+}
+
 // read - return last value measured by sensor
 bool AP_RangeFinder_MaxsonarSerialLV::get_reading(float &reading_m)
 {
@@ -56,7 +70,7 @@ bool AP_RangeFinder_MaxsonarSerialLV::get_reading(float &reading_m)
     }
 
     // This sonar gives the metrics in inches, so we have to transform this to meters
-    reading_m = (2.54f * 0.01f) * (float(sum) / count);
+    reading_m = unit_conversion * (float(sum) / count);
 
     return true;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
@@ -8,7 +8,7 @@ class AP_RangeFinder_MaxsonarSerialLV : public AP_RangeFinder_Backend_Serial
 
 public:
 
-    using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
+    AP_RangeFinder_MaxsonarSerialLV(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
 
 protected:
 
@@ -24,4 +24,5 @@ private:
 
     char linebuf[10];
     uint8_t linebuf_len = 0;
+    float unit_conversion = 0.0254f;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -6,7 +6,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:USD1_Serial,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:DroneCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,100:SITL
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:USD1_Serial,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:DroneCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,35:MaxbotixSerialCM,36:MaxbotixSerialMM,100:SITL
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_RangeFinder_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 


### PR DESCRIPTION
fix #7885 and fix #16749

Maxbotix serial sonar may report reading in inch, cm or mm. Current implementation assume it gives the metrics in inches. 
This PR add 2 additional rangfinder type: 35 for MaxbotixSerial cm reading and 36 for MaxbotixSerial mm reading.

P.S: some Maxbotix serial sonar (MB1240, for example) may need to set InvertRX in SERIALx_OPTIONS 

Test ok in MB1240 (cm reading)