### PR TITLE
AP_Compass: added AP_RM3100_REVERSAL_MASK

### DIFF
--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -208,6 +208,22 @@ void AP_Compass_RM3100::timer()
     magy >>= 8;
     magz >>= 8;
 
+#ifdef AP_RM3100_REVERSAL_MASK
+    // some RM3100 builds get the polarity wrong on one or more of the
+    // elements. By setting AP_RM3100_REVERSAL_MASK in hwdef.dat you
+    // can fix it without modifying the hardware
+    const uint8_t mask = AP_RM3100_REVERSAL_MASK;
+    if (mask & 1U) {
+        magx = -magx;
+    }
+    if (mask & 2U) {
+        magy = -magy;
+    }
+    if (mask & 4U) {
+        magz = -magz;
+    }
+#endif
+
     {
         // apply scaler and store in field vector
          Vector3f field{


### PR DESCRIPTION
this allows for fixing setups where the RM3100 has been installed on a
board with one or more axes reversed