### PR TITLE
Copter: Allow guided mode velaccel control on landed

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -788,7 +788,9 @@ void ModeGuided::velaccel_control_run()
     }
 
     // if not armed set throttle to zero and exit immediately
-    if (is_disarmed_or_landed()) {
+    // Unless there is an AllowArmingFromTX bit in GUID_OPTIONS
+    bool allow_arming_on_ground = copter.g2.guided_options & (uint32_t)Options::AllowArmingFromTX;
+    if (is_disarmed_or_landed() && !allow_arming_on_ground) {
         // do not spool down tradheli when on the ground with motor interlock enabled
         make_safe_ground_handling(copter.is_tradheli() && motors->get_interlock());
         return;


### PR DESCRIPTION
When I test copter-wall-climber.lua with Copter-4.1.1, the vehicle does not fly. If there is an AllowArmingFromTX bit flag in the GUID_OPTIONS, I would like to arm it on the ground so that it can be controlled by the Lua script set_target_velaccel_NED / set_target_velocity_NED. I would be grateful if you could give me some advice.