### PR TITLE
Plane: limited VFWD integrator to cruise throttle

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3141,7 +3141,7 @@ float QuadPlane::forward_throttle_pct()
 
     // inhibit reverse throttle and allow petrol engines with min > 0
     int8_t fwd_throttle_min = plane.have_reverse_thrust() ? 0 : plane.aparm.throttle_min;
-    vel_forward.integrator = constrain_float(vel_forward.integrator, fwd_throttle_min, plane.aparm.throttle_max);
+    vel_forward.integrator = constrain_float(vel_forward.integrator, fwd_throttle_min, plane.aparm.throttle_cruise);
 
     if (in_vtol_land_approach()) {
         // when we are doing horizontal positioning in a VTOL land


### PR DESCRIPTION
in some situations (such as when landing approach is disabled) the
vfwd integrator can wind up to extreme values. This can put a huge
load on an electric quadplane as it is running both forward and vtol
motors, and the downforce from being nose down can be extreme.

It should never need to go above the cruise throttle in any reasonable
situation, so limit it to cruise to ensure we don't apply too much
forward throttle