### PR TITLE
SITL: NFC comment for sim_i2c parameters

### DIFF
--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -68,9 +68,9 @@ struct i2c_device_at_address {
     uint8_t addr;
     I2CDevice &device;
 } i2c_devices[] {
-    { 0, 0x70, maxsonari2cxl },
+    { 0, 0x70, maxsonari2cxl },   // RNGFNDx_TYPE = 2, RNGFNDx_ADDR = 112
     { 0, 0x60, mcp9600 }, // 0x60 is low address
-    { 0, 0x71, maxsonari2cxl_2 },
+    { 0, 0x71, maxsonari2cxl_2 }, // RNGFNDx_TYPE = 2, RNGFNDx_ADDR = 113
     { 1, 0x01, icm40609 },
 #if AP_SIM_TOSHIBALED_ENABLED
     { 1, 0x55, toshibaled },
@@ -78,12 +78,12 @@ struct i2c_device_at_address {
     { 1, 0x38, ignored }, // NCP5623
     { 1, 0x39, ignored }, // NCP5623C
     { 1, 0x40, ignored }, // KellerLD
-    { 1, 0x76, ms5525 },
+    { 1, 0x76, ms5525 },  // MS5525: ARSPD_TYPE = 4
     { 1, 0x77, tsys01 },
-    { 1, 0x0B, rotoye },
-    { 2, 0x0B, maxell },
-    { 2, 0x28, airspeed_dlvr },
-    { 2, 0x77, ms5611 },
+    { 1, 0x0B, rotoye },  // Rotoye: BATTx_MONITOR 19
+    { 2, 0x0B, maxell },  // Maxell: BATTx_MONITOR 16
+    { 2, 0x28, airspeed_dlvr }, // ARSPD_TYPE = 7 5inch H2O sensor
+    { 2, 0x77, ms5611 },        // MS5611: BARO_PROBE_EXT = 2
 };
 
 void I2C::init()


### PR DESCRIPTION
This just adds some comments to SITL_I2C.cpp for the params needed to use the simulated sensors. Useful for testing outside of autotests. 