### PR TITLE
Logging fixes for AP_Periph

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -373,7 +373,7 @@ void AP_BattMonitor::convert_dynamic_param_groups(uint8_t instance)
 // read - For all active instances read voltage & current; log BAT, BCL, POWR
 void AP_BattMonitor::read()
 {
-#ifndef HAL_BUILD_AP_PERIPH
+#if HAL_LOGGING_ENABLED
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger != nullptr && logger->should_log(_log_battery_bit)) {
         logger->Write_Power();
@@ -384,8 +384,8 @@ void AP_BattMonitor::read()
         if (drivers[i] != nullptr && get_type(i) != Type::NONE) {
             drivers[i]->read();
             drivers[i]->update_resistance_estimate();
-            
-#ifndef HAL_BUILD_AP_PERIPH
+
+#if HAL_LOGGING_ENABLED
             if (logger != nullptr && logger->should_log(_log_battery_bit)) {
                 const uint64_t time_us = AP_HAL::micros64();
                 drivers[i]->Log_Write_BAT(i, time_us);

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -310,7 +310,7 @@ void RangeFinder::update(void)
             drivers[i]->update();
         }
     }
-#ifndef HAL_BUILD_AP_PERIPH
+#if HAL_LOGGING_ENABLED
     Log_RFND();
 #endif
 }


### PR DESCRIPTION
battery and rangefinder monitoring weren't working on Periph.

log status wasn't being represented appropriately over mavlink.
