### PR TITLE
AP_HAL_SITL: remove incorrect use of ARRAY_SIZE

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -319,6 +319,7 @@ class Board:
                     '-Werror=implicit-fallthrough',
                     '-Wmaybe-uninitialized',
                     '-Wduplicated-cond',
+                    '-Werror=sizeof-pointer-div',
                 ]
 
         if cfg.options.Werror:

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -317,8 +317,8 @@ class Board:
             if self.cc_version_gte(cfg, 7, 4):
                 env.CXXFLAGS += [
                     '-Werror=implicit-fallthrough',
-                    '-Wmaybe-uninitialized',
-                    '-Wduplicated-cond',
+                    '-Werror=maybe-uninitialized',
+                    '-Werror=duplicated-cond',
                     '-Werror=sizeof-pointer-div',
                 ]
 

--- a/libraries/AP_HAL_SITL/SPIDevice.cpp
+++ b/libraries/AP_HAL_SITL/SPIDevice.cpp
@@ -106,9 +106,6 @@ SPIBus *SPIDeviceManager::buses;
 
 SPIDeviceManager::SPIDeviceManager()
 {
-    for (uint8_t i=0; i<ARRAY_SIZE(buses); i++) {
-        buses[i].bus = i;
-    }
 }
 
 static const struct SPIDriverInfo {


### PR DESCRIPTION
This was changed to a linked list.

Also adds a compiler check (which was just warning rather than failing).
