### PR TITLE
AP_Periph: correct compilation when both periph-adsb and GCS enabled

### DIFF
--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -25,6 +25,8 @@
 
 extern const AP_HAL::HAL &hal;
 
+# if !HAL_GCS_ENABLED
+
 #include "include/mavlink/v2.0/protocol.h"
 #include "include/mavlink/v2.0/mavlink_types.h"
 #include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
@@ -33,6 +35,7 @@ extern const AP_HAL::HAL &hal;
 #include "include/mavlink/v2.0/mavlink_helpers.h"
 #pragma GCC diagnostic pop
 
+#endif
 
 /*
   init ADSB support


### PR DESCRIPTION
Get lots of these otherwise:

```
/home/pbarker/gcc/gcc-arm-none-eabi-10.3-2021.07/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: lib/libAP_Periph_libs.a(GCS_MAVLink.cpp.0.o): in function `mavlink_parse_char':
GCS_MAVLink.cpp:(.text.mavlink_parse_char+0x0): multiple definition of `mavlink_parse_char'; Tools/AP_Periph/adsb.cpp.41.o:adsb.cpp:(.text.mavlink_parse_char+0x0): first defined here
/home/pbarker/gcc/gcc-arm-none-eabi-10.3-2021.07/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: lib/libAP_Periph_libs.a(GCS_MAVLink.cpp.0.o): in function `put_bitfield_n_by_index':
GCS_MAVLink.cpp:(.text.put_bitfield_n_by_index+0x0): multiple definition of `put_bitfield_n_by_index'; Tools/AP_Periph/adsb.cpp.41.o:adsb.cpp:(.text.put_bitfield_n_by_index+0x0): first defined here
```
