### PR TITLE
Ground effect

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1223,6 +1223,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15
     AP_GROUPINFO("ONESHOT_MASK", 32, ParametersG2, oneshot_mask, 0),
     
+    // @Group: GNDEF_
+    // @Path: ../libraries/AP_GroundEffectControl/GroundEffectController.cpp
+    AP_SUBGROUPINFO(ground_effect_controller, "GNDEF", 33, ParametersG2, GroundEffectController),
+
     AP_GROUPEND
 };
 
@@ -1234,6 +1238,7 @@ ParametersG2::ParametersG2(void) :
 #if HAL_BUTTON_ENABLED
     ,button_ptr(&plane.button)
 #endif
+    ,ground_effect_controller{plane.ahrs, plane.rangefinder}
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -554,6 +554,8 @@ public:
     AP_Int8         man_expo_rudder;
 
     AP_Int32        oneshot_mask;
+
+    GroundEffectController ground_effect_controller;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -46,6 +46,7 @@
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Stats/AP_Stats.h>     // statistics library
 #include <AP_Beacon/AP_Beacon.h>
+#include <AP_GroundEffectControl/AP_GroundEffectController.h>
 
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <APM_Control/APM_Control.h>
@@ -307,6 +308,9 @@ private:
 
     // This is used to enable the inverted flight feature
     bool inverted_flight;
+
+    // This is used to enable the ground effect sub-mode of fbwa
+    bool ground_effect_submode;
 
     // last time we ran roll/pitch stabilization
     uint32_t last_stabilize_ms;

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -375,6 +375,12 @@ case AUX_FUNC::ARSPD_CALIBRATE:
         plane.autotune_enable(ch_flag == AuxSwitchPos::HIGH);
         break;
 
+    case AUX_FUNC::GROUND_EFFECT:
+        if(!plane.g2.ground_effect_controller.user_request_enable(ch_flag == AuxSwitchPos::HIGH)){
+            gcs().send_text(MAV_SEVERITY_NOTICE, "GND EFFECT FAILED");
+        }
+        break;
+
     default:
         return RC_Channel::do_aux_function(ch_option, ch_flag);
     }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -50,6 +50,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         break;
 
     case MAV_CMD_NAV_WAYPOINT:                  // Navigate to Waypoint
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
         do_nav_wp(cmd);
         break;
 
@@ -233,6 +234,7 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
         return verify_takeoff();
 
     case MAV_CMD_NAV_WAYPOINT:
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
         return verify_nav_wp(cmd);
 
     case MAV_CMD_NAV_LAND:

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -93,6 +93,13 @@ void ModeAuto::update()
         plane.nav_pitch_cd = plane.ahrs.pitch_sensor;
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.nav_scripting.throttle_pct);
 #endif
+    } else if (nav_cmd_id == MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT) {
+        plane.g2.ground_effect_controller.update();
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.g2.ground_effect_controller.get_throttle());
+        plane.nav_pitch_cd = plane.g2.ground_effect_controller.get_pitch();
+        plane.calc_nav_roll();
+        uint32_t roll_limit_cd = plane.g2.ground_effect_controller.get_auto_lim_roll_cd();
+        plane.nav_roll_cd = constrain_int32(plane.nav_roll_cd, -roll_limit_cd, roll_limit_cd);
     } else {
         // we are doing normal AUTO flight, the special cases
         // are for takeoff and landing

--- a/ArduPlane/mode_fbwa.cpp
+++ b/ArduPlane/mode_fbwa.cpp
@@ -12,8 +12,23 @@ void ModeFBWA::update()
     } else {
         plane.nav_pitch_cd = -(pitch_input * plane.pitch_limit_min_cd);
     }
-    plane.adjust_nav_pitch_throttle();
+    
+    if(plane.g2.ground_effect_controller.enabled_by_user()){
+        plane.g2.ground_effect_controller.update();
+        // If the rc throttle input is zero (within dead zone), supress throttle
+        // This allows the user to stop flight by reflexively cutting the throttle
+        if(plane.channel_throttle->in_trim_dz()){
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
+        } else {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.g2.ground_effect_controller.get_throttle());
+        }
+        plane.nav_pitch_cd += plane.g2.ground_effect_controller.get_pitch(); // Note that this stacks
+    } else {
+        plane.adjust_nav_pitch_throttle();
+    }
+    
     plane.nav_pitch_cd = constrain_int32(plane.nav_pitch_cd, plane.pitch_limit_min_cd, plane.aparm.pitch_limit_max_cd.get());
+
     if (plane.fly_inverted()) {
         plane.nav_pitch_cd = -plane.nav_pitch_cd;
     }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -555,8 +555,8 @@ void Plane::set_servos_controlled(void)
     } else if (control_mode == &mode_stabilize ||
                control_mode == &mode_training ||
                control_mode == &mode_acro ||
-               control_mode == &mode_fbwa ||
-               control_mode == &mode_autotune) {
+               control_mode == &mode_autotune ||
+               (control_mode == &mode_fbwa && !plane.g2.ground_effect_controller.enabled_by_user())) {
         // a manual throttle mode
         if (failsafe.throttle_counter) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0.0);

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -108,6 +108,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_VideoTX',
     'AP_FETtecOneWire',
     'AP_Torqeedo',
+    'AP_GroundEffectControl'
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_GroundEffectControl/AP_GroundEffectController.cpp
+++ b/libraries/AP_GroundEffectControl/AP_GroundEffectController.cpp
@@ -1,0 +1,178 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//	Code by Sebastian Quilter
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_GroundEffectController.h"
+#include <AP_AHRS/AP_AHRS.h>
+
+extern const AP_HAL::HAL& hal;
+
+constexpr uint32_t RESET_TIMEOUT_MICROS{1000000};
+
+const AP_Param::GroupInfo GroundEffectController::var_info[] = {
+    // @Param: P
+    // @DisplayName: P gain
+    // @Description: P gain. A 1 meter error from desired alt changes throttle by this many percent.
+    // @Range: 0.0 200.0
+    // @User: Standard
+
+    // @Param: I
+    // @DisplayName: I gain
+    // @Description: I gain
+    // @User: Standard
+
+    // @Param: D
+    // @DisplayName: D gain
+    // @Description: D gain
+    // @User: Standard
+
+    // @Param: IMAX
+    // @DisplayName: IMax
+    // @Description: Maximum integrator value
+    // @User: Standard
+    AP_SUBGROUPINFO(_throttle_pid, "_THR_", 1, GroundEffectController, PID),
+
+    // @Param: P
+    // @DisplayName: P gain
+    // @Description: P gain. A 1 meter error from desired alt changes sets the vehicle pitch to this value.
+    // @User: Standard
+
+    // @Param: I
+    // @DisplayName: I gain
+    // @Description: I gain
+    // @User: Standard
+
+    // @Param: D
+    // @DisplayName: D gain
+    // @Description: D gain
+    // @User: Standard
+
+    // @Param: IMAX
+    // @DisplayName: IMax
+    // @Description: Maximum integrator value
+    // @User: Standard
+    AP_SUBGROUPINFO(_pitch_pid, "_PITCH_", 2, GroundEffectController, PID),
+
+	// @Param: THR_REF
+	// @DisplayName: Ground Effect desired throttle (percentage)
+	// @Description:
+	// @Range: 0.0 100.0
+	// @Increment: 0.01
+    // @User: Standard
+	AP_GROUPINFO("_THR_REF",   3, GroundEffectController, _THR_REF,   35.0),
+
+	// @Param: THR_MIN
+	// @DisplayName: Ground Effect minimum throttle (percentage)
+	// @Description:
+	// @Range: 0.0 100.0
+	// @Increment: 0.01
+    // @User: Standard
+	AP_GROUPINFO("_THR_MIN",   4, GroundEffectController, _THR_MIN,   20.0),
+
+    // @Param: THR_MAX
+	// @DisplayName: Ground Effect maximum throttle (percentage)
+	// @Description:
+	// @Range: 0.0 100.0
+	// @Increment: 0.01
+    // @User: Standard
+	AP_GROUPINFO("_THR_MAX",   5, GroundEffectController, _THR_MAX,   50.0),
+
+	// @Param: ALT_REF
+	// @DisplayName: Ground Effect desired altitude (meters)
+	// @Description:
+	// @Range: 0.0 1.0
+	// @Increment: 0.01
+    // @User: Standard
+	AP_GROUPINFO("_ALT_REF",   6, GroundEffectController, _ALT_REF,   0.45),
+
+	// @Param: CUTOFF_FREQ
+	// @DisplayName: Rangefinder Complementary Filter Cutoff Frequency
+	// @Description: Lower values will trust the rangefinder less.
+	// @Range: 0.0 2.0
+	// @Increment: 0.01
+    // @User: Advanced
+	AP_GROUPINFO("_CUTOFF_FRQ",   7, GroundEffectController, _CUTOFF_FREQ,   0.1),
+
+	// @Param: LIM_ROLL
+	// @DisplayName: Max roll angle (degrees)
+	// @Description: Max roll allowed in auto mode while going towards a ground effect waypoint. 0 to disable.
+	// @Range: 0.0 45.0
+	// @Increment: 0.01
+    // @User: Advanced
+	AP_GROUPINFO("_LIM_ROLL",   8, GroundEffectController, _LIM_ROLL,   10.0), /* TODO gotta choose a good value here */
+
+    AP_GROUPEND
+};
+
+bool GroundEffectController::user_request_enable(bool enable)
+{
+    if(enable){
+        if(!_rangefinder.has_orientation(ROTATION_PITCH_270)){
+            _enabled = false;
+            return false;
+        }
+    }
+
+    _enabled = enable;
+    return true;
+}
+
+void GroundEffectController::reset()
+{
+    _altFilter.set_cutoff_frequency(_CUTOFF_FREQ);
+    _altFilter.reset();
+
+    _pitch_pid.reset_I();
+    _throttle_pid.reset_I();
+    return;
+}
+
+int32_t GroundEffectController::get_auto_lim_roll_cd()
+{
+    if(_LIM_ROLL <= 0.0001f){
+        return INT32_MAX;
+    }
+    return int32_t(_LIM_ROLL*100.0);
+}
+
+void GroundEffectController::update()
+{
+    uint32_t time = AP_HAL::micros();
+    if(time - _last_time_called > RESET_TIMEOUT_MICROS){
+        reset();
+    }
+    _last_time_called = time;
+
+    if(_rangefinder.status_orient(ROTATION_PITCH_270) == RangeFinder::Status::Good) {
+        _last_good_rangefinder_reading = _rangefinder.distance_orient(ROTATION_PITCH_270);
+    }
+
+    // DCM altitude is not good. If EKF alt is not available, just use raw rangefinder data
+    float alt_error, ahrs_negative_alt;
+    if(_ahrs.get_active_AHRS_type() > 0 && _ahrs.get_relative_position_D_origin(ahrs_negative_alt)){
+        _altFilter.apply(_last_good_rangefinder_reading, -ahrs_negative_alt, time);
+        alt_error = _ALT_REF - _altFilter.get();
+    } else {
+        alt_error = _ALT_REF - _last_good_rangefinder_reading;
+    }
+
+    _pitch = _pitch_pid.get_pid(alt_error);
+    _throttle = _throttle_pid.get_pid(alt_error) + _THR_REF;
+    _throttle = constrain_int16(_throttle, _THR_MIN, _THR_MAX);
+
+    return;
+}

--- a/libraries/AP_GroundEffectControl/AP_GroundEffectController.h
+++ b/libraries/AP_GroundEffectControl/AP_GroundEffectController.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <PID/PID.h>
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <Filter/ComplementaryFilter.h>
+
+class GroundEffectController {
+public:
+    GroundEffectController(AP_AHRS& ahrs, RangeFinder& rangefinder)
+        : _ahrs{ahrs}
+        , _rangefinder{rangefinder}
+        , _enabled{false}
+        {
+            AP_Param::setup_object_defaults(this, var_info);
+        };
+
+    /* Do not allow copies */
+    GroundEffectController(const GroundEffectController &other) = delete;
+    GroundEffectController &operator=(const GroundEffectController&) = delete;
+
+    bool user_request_enable(bool enable);
+
+    bool enabled_by_user() { return _enabled; }
+
+    void update();
+
+	void reset();
+
+    const       AP_Logger::PID_Info& get_pid_info(void) const { return _pid_info; }
+
+	static const struct AP_Param::GroupInfo var_info[];
+
+    int32_t get_auto_lim_roll_cd();
+
+    int32_t get_pitch() { return _pitch; }
+
+    int16_t get_throttle() { return _throttle; }
+
+private:
+    PID _pitch_pid{120.0, 0.0, 0.0, 1000};
+    PID _throttle_pid{64, 0.0, 20.0, 1000};
+
+	AP_Float _THR_REF;
+    AP_Float _THR_MIN;
+    AP_Float _THR_MAX;
+    AP_Float _ALT_REF;
+    AP_Float _CUTOFF_FREQ;
+    AP_Float _LIM_ROLL;
+
+    AP_Logger::PID_Info _pid_info;
+
+    uint32_t _last_time_called;
+
+    AP_AHRS& _ahrs;
+    RangeFinder& _rangefinder;
+    ComplementaryFilter _altFilter;
+
+    float _last_good_rangefinder_reading;
+
+    bool _enabled;
+    int32_t _pitch;
+    int16_t _throttle;
+};

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -409,7 +409,8 @@ bool AP_Mission::is_nav_cmd(const Mission_Command& cmd)
     // NAV commands all have ids below MAV_CMD_NAV_LAST, plus some exceptions
     return (cmd.id <= MAV_CMD_NAV_LAST ||
             cmd.id == MAV_CMD_NAV_SET_YAW_SPEED ||
-            cmd.id == MAV_CMD_NAV_SCRIPT_TIME);
+            cmd.id == MAV_CMD_NAV_SCRIPT_TIME ||
+            cmd.id == MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT);
 }
 
 /// get_next_nav_cmd - gets next "navigation" command found at or after start_index
@@ -743,6 +744,7 @@ bool AP_Mission::stored_in_location(uint16_t id)
 {
     switch (id) {
     case MAV_CMD_NAV_WAYPOINT:
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
     case MAV_CMD_NAV_LOITER_UNLIM:
     case MAV_CMD_NAV_LOITER_TURNS:
     case MAV_CMD_NAV_LOITER_TIME:
@@ -832,6 +834,7 @@ MAV_MISSION_RESULT AP_Mission::sanity_check_params(const mavlink_mission_item_in
     uint8_t nan_mask;
     switch (packet.command) {
     case MAV_CMD_NAV_WAYPOINT:
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
         nan_mask = ~(1 << 3); // param 4 can be nan
         break;
     case MAV_CMD_NAV_LAND:
@@ -891,7 +894,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         // this is reserved for storing 16 bit command IDs
         return MAV_MISSION_INVALID;
 
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
     case MAV_CMD_NAV_WAYPOINT: {                        // MAV ID: 16
+    
         /*
           the 15 byte limit means we can't fit both delay and radius
           in the cmd structure. When we expand the mission structure
@@ -1360,6 +1365,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         return false;
 
     case MAV_CMD_NAV_WAYPOINT:                          // MAV ID: 16
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
         // acceptance radius in meters
 
@@ -2350,7 +2356,8 @@ const char *AP_Mission::Mission_Command::type() const
         return "Go Around";
     case MAV_CMD_NAV_SCRIPT_TIME:
         return "NavScriptTime";
-
+    case MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT:
+        return "GroundEffectWP";
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Mission command with ID %u has no string", id);

--- a/libraries/AP_Terrain/TerrainMission.cpp
+++ b/libraries/AP_Terrain/TerrainMission.cpp
@@ -68,7 +68,8 @@ void AP_Terrain::update_mission_data(void)
         // we only want nav waypoint commands. That should be enough to
         // prefill the terrain data and makes many things much simpler
         while ((cmd.id != MAV_CMD_NAV_WAYPOINT &&
-                cmd.id != MAV_CMD_NAV_SPLINE_WAYPOINT) ||
+                cmd.id != MAV_CMD_NAV_SPLINE_WAYPOINT && 
+                cmd.id != MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT) ||
                (cmd.content.location.lat == 0 && cmd.content.location.lng == 0)) {
             next_mission_index++;
             if (!mission.read_cmd_from_storage(next_mission_index, cmd)) {

--- a/libraries/Filter/ComplementaryFilter.cpp
+++ b/libraries/Filter/ComplementaryFilter.cpp
@@ -1,0 +1,90 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ComplementaryFilter.h"
+
+/*
+  complementary filter. Used to combine a reading that is long term
+  stable but has high freq noise with another reading that has less
+  high frequency noise and poor long term stability.
+ */
+
+/*
+  set crossover frequency between low frequency and high frequency
+  components
+ */
+void ComplementaryFilter::set_cutoff_frequency(float freq_hz)
+{
+    cutoff_freq = freq_hz;
+}
+
+/*
+  reset the filter to initial values
+ */
+void ComplementaryFilter::reset()
+{
+    lp.reset();
+    hp.reset();
+}
+
+/*
+  apply a low freqency and high freqency input to give a complementary
+  filter result where signal below the cutoff comes from the low_freq
+  input and above the cutoff from high freqency input. We take a
+  timestamp on each input as the input data may vary somewhat in
+  frequency
+ */
+float ComplementaryFilter::apply(float low_freq, float high_freq, uint32_t time_us)
+{
+    if (!is_positive(cutoff_freq)) {
+        reset();
+        return low_freq;
+    }
+    const uint32_t dt_us = time_us - last_sample_us;
+
+    if (dt_us > 1e6) {
+        // if we have not updated for 1s then assume we've had a
+        // sensor outage and reset
+        reset();
+    }
+    last_sample_us = time_us;
+
+    const float dt = MIN(dt_us * 1.0e-6, 1);
+
+    // keep a low pass filter of the sample rate. Rapidly changing
+    // sample frequency in bi-quad filters leads to very nasty spikes
+    if (!is_positive(sample_freq)) {
+        sample_freq = 1.0/dt;
+    } else {
+        sample_freq = 0.99 * sample_freq + 0.01 * (1.0/dt);
+    }
+
+    lp.compute_params(sample_freq, cutoff_freq, params);
+
+    float hp_out = hp.apply(high_freq, params);
+    float lp_out = lp.apply(low_freq, params);
+
+    out = (high_freq - hp_out) + lp_out;
+
+    return out;
+}
+
+/*
+  return the current value
+ */
+float ComplementaryFilter::get(void)
+{
+    return out;
+}

--- a/libraries/Filter/ComplementaryFilter.h
+++ b/libraries/Filter/ComplementaryFilter.h
@@ -1,0 +1,45 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <AP_Math/AP_Math.h>
+#include "LowPassFilter2p.h"
+
+/*
+  complementary filter. Used to combine a reading that is long term
+  stable but has high freq noise with another reading that has less
+  high frequency noise and poor long term stability.
+ */
+
+class ComplementaryFilter
+{
+public:
+    void set_cutoff_frequency(float freq_hz);
+    void reset();
+    float apply(float low_freq, float high_freq, uint32_t time_us);
+    float get(void);
+
+private:
+    uint32_t last_sample_us;
+    float cutoff_freq;
+    float sample_freq;
+    // use 2-pole low pass filters to get a reasonably sharp cutoff
+    DigitalBiquadFilter<float>::biquad_params params;
+    DigitalBiquadFilter<float> lp, hp;
+    float out;
+};
+
+

--- a/libraries/Filter/LowPassFilter2p.cpp
+++ b/libraries/Filter/LowPassFilter2p.cpp
@@ -125,3 +125,4 @@ template class LowPassFilter2p<long>;
 template class LowPassFilter2p<float>;
 template class LowPassFilter2p<Vector2f>;
 template class LowPassFilter2p<Vector3f>;
+template class DigitalBiquadFilter<float>;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -226,6 +226,7 @@ public:
         TRIM_TO_CURRENT_SERVO_RC = 155, // trim to current servo and RC
         TORQEEDO_CLEAR_ERR = 156, // clear torqeedo error
         EMERGENCY_LANDING_EN = 157, //Force long FS action to FBWA for landing out of range
+        GROUND_EFFECT      = 158, // Use ground effect controller in FBWA
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input


### PR DESCRIPTION
Adds a new feature to plane: ground effect mode.

This "mode" will control throttle (and optionally, pitch) in order to keep a plane within a few cm of the ground. Usually this works best over water. This can be enabled with a switch in fbwa, and waypoint missions can be flown in ground effect too. It requires a downward-facing rangefinder, preferably one that is good for short ranges.

Note: a definition for `MAV_CMD_NAV_WAYPOINT_GROUND_EFFECT` needs to be added to mavlink. I can submit the PR for that too, but I'm unsure what number would be best.