### PR TITLE
waf: only enable `-Wsizeof-pointer-div` for gcc v8.4 or greater

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -319,6 +319,9 @@ class Board:
                     '-Werror=implicit-fallthrough',
                     '-Werror=maybe-uninitialized',
                     '-Werror=duplicated-cond',
+                ]
+            if self.cc_version_gte(cfg, 8, 4):
+                env.CXXFLAGS += [
                     '-Werror=sizeof-pointer-div',
                 ]
 


### PR DESCRIPTION
Addresses #19362 

The `-Wsizeof-pointer-div` option doesn't exist in `gcc` v7.5, which is the version used by Ubuntu 18.04 LTS. It does exist in `gcc` v8.4.