### PR TITLE
Correct autotest running under Valgrind

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2456,13 +2456,13 @@ class AutoTest(ABC):
     def reset_SITL_commandline(self):
         self.progress("Resetting SITL commandline to default")
         self.stop_SITL()
-        self.start_SITL(wipe=True)
-        self.set_streamrate(self.sitl_streamrate())
-        self.apply_default_parameters()
         try:
             del self.valgrind_restart_customisations
         except Exception:
             pass
+        self.start_SITL(wipe=True)
+        self.set_streamrate(self.sitl_streamrate())
+        self.apply_default_parameters()
         self.progress("Reset SITL commandline to default")
 
     def stop_SITL(self):

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9520,8 +9520,10 @@ switch value'''
         self.start_subtest("parameter download")
         target_system = self.sysid_thismav()
         target_component = 1
+        self.progress("First Download:")
         (parameters, seq_id) = self.download_parameters(target_system, target_component)
         self.reboot_sitl()
+        self.progress("Second download:")
         (parameters2, seq2_id) = self.download_parameters(target_system, target_component)
 
         delta = self.dictdiff(parameters, parameters2)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2720,6 +2720,8 @@ class AutoTest(ABC):
         self.set_parameter("ARSPD_TYPE", 7)
         self.reboot_sitl()
 
+        self.wait_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS, True, True, True, verbose=True, timeout=30)
+
         # should not be getting HIGH_LATENCY2 by default
         m = self.mav.recv_match(type='HIGH_LATENCY2', blocking=True, timeout=2)
         if m is not None:


### PR DESCRIPTION
autotest should be able to run end-to-end under Valgrind; it currently doesn't, but this gets us closer by fixing one Tracker issue and one Rover issue.
