### PR TITLE
AP_Hygrometer: add new driver of hygrometer

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -483,6 +483,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -536,6 +536,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -338,6 +338,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -522,6 +522,7 @@ static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_SCALED_PRESSURE,
     MSG_SCALED_PRESSURE2,
     MSG_SCALED_PRESSURE3,
+    MSG_HYGROMETER_STATUS,
 };
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -109,7 +109,8 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_VideoTX',
     'AP_FETtecOneWire',
     'AP_Torqeedo',
-    'AP_CustomRotations'
+    'AP_CustomRotations',
+    'AP_Hygrometer',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_Hygrometer/AP_Hygrometer.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.cpp
@@ -59,7 +59,6 @@ void AP_Hygrometer::init(void)
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
         case Type::UAVCAN:
             sensor[i] = AP_Hygrometer_UAVCAN::probe(param[i]);
-            printf("sensor[%d] = 0x%x\n",i,sensor[i]);
             break;
 #endif
         }

--- a/libraries/AP_Hygrometer/AP_Hygrometer.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.cpp
@@ -1,0 +1,209 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Hygrometer.h"
+
+#if AP_HYGROMETER_ENABLED
+
+#include <AP_Logger/AP_Logger.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+#include "AP_Hygrometer_Backend.h"
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include "AP_Hygrometer_UAVCAN.h"
+#endif
+
+#define HYGRO_DEFAULT_TYPE 0
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Hygrometer::var_info[] = {
+
+    // @Param: _TYPE
+    // @DisplayName: Hygrometer type
+    // @Description: Type of hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_TYPE", 1, AP_Hygrometer, param[0].type, HYGRO_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+
+#if AP_HYGROMETER_MAX_SENSORS > 1
+    // @Param: 2_TYPE
+    // @DisplayName: Second Hygrometer type
+    // @Description: Type of 2nd hygrometer sensor
+    // @Values: 0:None,1:UAVCAN
+    // @User: Standard
+    AP_GROUPINFO("2_TYPE", 2, AP_Hygrometer, param[1].type, 0),
+#endif // AP_HYGROMETER_MAX_SENSORS
+
+    AP_GROUPEND
+};
+
+void AP_Hygrometer::init(void)
+{
+    for (uint8_t i=0; i<AP_HYGROMETER_MAX_SENSORS; i++) {
+        switch ((enum Type)param[i].type.get()) {
+        case Type::NONE:
+            break;
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+        case Type::UAVCAN:
+            sensor[i] = AP_Hygrometer_UAVCAN::probe(param[i]);
+            printf("sensor[%d] = 0x%x\n",i,sensor[i]);
+            break;
+#endif
+        }
+
+        if (sensor[i] == nullptr) {
+            continue;
+        }
+        if (!sensor[i]->init()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Hygrometer %u init failed", i + 1);
+            delete sensor[i];
+            sensor[i] = nullptr;
+            continue;
+        }
+        num_sensors = i+1;
+    }
+}
+
+AP_Hygrometer::AP_Hygrometer()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AP_Hygrometer must be singleton");
+    }
+    _singleton = this;
+}
+
+bool AP_Hygrometer::get_humidity(uint8_t i, float &humidity)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i] == nullptr) {
+        return false;
+    }
+
+    return sensor[i]->get_humidity(humidity);
+}
+
+bool AP_Hygrometer::get_temperature(uint8_t i, float &temperature)
+{
+    if (!enabled(i)) {
+        return false;
+    }
+    if (sensor[i] == nullptr) {
+        return false;
+    }
+
+    return sensor[i]->get_temperature(temperature);
+}
+
+inline void AP_Hygrometer::Log_HYGR()
+{
+    const uint64_t now = AP_HAL::micros64();
+
+    for (uint8_t i=0; i < num_sensors; i++) {
+        const struct log_HYGRO pkt {
+            LOG_PACKET_HEADER_INIT(LOG_HYGRO_MSG),
+                time_us       : now,
+                instance      : i,
+                temperature   : state[i].temperature,
+                humidity      : state[i].humidity,
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    }
+}
+
+// update the log
+void AP_Hygrometer::update()
+{
+    // copy data from backends
+    WITH_SEMAPHORE(_rsem);
+
+    for (uint8_t i=0; i < num_sensors; i++) {
+        if (!enabled(i)) {
+            continue;
+        }
+        float temperature,humidity;
+        if (!get_temperature(i, temperature)) {
+            temperature = AP::logger().quiet_nanf();
+        }
+        if (!get_humidity(i, humidity)) {
+            humidity = AP::logger().quiet_nanf();
+        }
+
+        state[i].temperature = temperature;
+        state[i].humidity = humidity;
+    }
+
+#if HAL_LOGGING_ENABLED
+    Log_HYGR();
+#endif
+}
+
+float AP_Hygrometer::get_temperature(uint8_t instance)
+{
+    if (!enabled(instance)) {
+        return false;
+    }
+    if (sensor[instance] == nullptr) {
+        return false;
+    }
+
+    return state[instance].temperature;
+}
+
+float AP_Hygrometer::get_humidity(uint8_t instance)
+{
+    if (!enabled(instance)) {
+        return false;
+    }
+    if (sensor[instance] == nullptr) {
+        return false;
+    }
+    
+    return state[instance].humidity;
+}
+
+AP_Hygrometer_Backend *AP_Hygrometer::get_backend(uint8_t id) const
+{
+    if (id >= num_sensors) {
+        return nullptr;
+    }
+    if (sensor[id] == nullptr) {
+        return nullptr;
+    }
+    if (sensor[id]->type() == Type::NONE) {
+        return nullptr;
+    }
+
+    return sensor[id];
+};
+
+// singleton instance
+AP_Hygrometer *AP_Hygrometer::_singleton;
+
+namespace AP
+{
+
+AP_Hygrometer *hygrometer()
+{
+    return AP_Hygrometer::get_singleton();
+}
+
+};
+
+#endif // AP_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_HYGROMETER_ENABLED
+#define AP_HYGROMETER_ENABLED (BOARD_FLASH_SIZE > 1024)
+#endif
+
+#if AP_HYGROMETER_ENABLED
+
+#include <stdint.h>
+#include "stdio.h"
+#include <AP_Param/AP_Param.h>
+#include <AP_Logger/AP_Logger.h>
+
+#ifndef AP_HYGROMETER_MAX_SENSORS
+#define AP_HYGROMETER_MAX_SENSORS  2
+#endif
+
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer
+{
+public:
+    friend class AP_Hygrometer_Backend;
+
+    // constructor
+    AP_Hygrometer();
+
+    void init(void);
+
+    bool get_temperature(uint8_t i, float &temperature) WARN_IF_UNUSED;
+    bool get_humidity(uint8_t i, float &humidity) WARN_IF_UNUSED;
+
+    float get_humidity(uint8_t instance);
+
+    float get_temperature(uint8_t instance);
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    enum class Type {
+        NONE=0,
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+        UAVCAN=1,
+#endif
+    };
+
+    struct State {
+        float temperature;
+        float humidity;
+    };
+
+    struct Param {
+        AP_Enum<Type> type;
+    };
+
+    // return true if hygrometer is enabled
+    bool enabled(uint8_t i) const
+    {
+        if (i < num_sensors) {
+            return (Type)param[i].type.get() != Type::NONE;
+        }
+        return false;
+    }
+
+    static AP_Hygrometer *get_singleton() { return _singleton; }
+
+    AP_Hygrometer_Backend *get_backend(uint8_t id) const;
+
+    // allow threads to lock against hygrometer update
+    HAL_Semaphore &get_semaphore(void) { return _rsem; }
+
+    void update(void);
+    void Log_HYGR(void);
+
+private:
+
+    static AP_Hygrometer *_singleton;
+
+    Param param[AP_HYGROMETER_MAX_SENSORS];
+
+    State state[AP_HYGROMETER_MAX_SENSORS];
+
+    uint8_t num_sensors;
+
+    // semaphore for API access from threads
+    HAL_Semaphore _rsem;
+
+    AP_Hygrometer_Backend *sensor[AP_HYGROMETER_MAX_SENSORS];
+};
+
+namespace AP
+{
+
+AP_Hygrometer *hygrometer();
+
+};
+
+#endif // AP_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_Backend.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#if AP_HYGROMETER_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Hygrometer.h"
+
+class AP_Hygrometer_Backend
+{
+public:
+    AP_Hygrometer_Backend(AP_Hygrometer::Param &_params) : params(_params) { }
+
+    virtual ~AP_Hygrometer_Backend(void) { }
+
+    AP_Hygrometer::Type type() const {
+        return (AP_Hygrometer::Type)params.type.get();
+    }
+
+    // probe and initialise the sensor
+    virtual bool init(void) = 0;
+
+    virtual bool get_humidity(float &humidity) = 0;
+
+    virtual bool get_temperature(float &temperature) = 0;
+
+protected:
+    AP_Hygrometer::Param &params;
+};
+#endif // AP_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
@@ -25,7 +25,6 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 #define LOG_TAG "Hygrometer"
-#define C_TO_KELVIN 273.15f
 
 UC_REGISTRY_BINDER(HygrometerCb, dronecan::sensors::hygrometer::Hygrometer);
 
@@ -131,7 +130,7 @@ void AP_Hygrometer_UAVCAN::handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_
     WITH_SEMAPHORE(driver->_sem_hygrometer);
     driver->_humidity = cb.msg->humidity;
     if (!isnan(cb.msg->temperature))  {
-        driver->_temperature = cb.msg->temperature - C_TO_KELVIN;
+        driver->_temperature = KELVIN_TO_C(cb.msg->temperature);
     }
     driver->_last_sample_time_ms = AP_HAL::millis();
 }

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.cpp
@@ -1,0 +1,165 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Hygrometer.h"
+
+#if AP_HYGROMETER_ENABLED
+
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Hygrometer_UAVCAN.h"
+#include <dronecan/sensors/hygrometer/Hygrometer.hpp>
+#include <AP_CANManager/AP_CANManager.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
+#define LOG_TAG "Hygrometer"
+#define C_TO_KELVIN 273.15f
+
+UC_REGISTRY_BINDER(HygrometerCb, dronecan::sensors::hygrometer::Hygrometer);
+
+AP_Hygrometer_UAVCAN::DetectedModules AP_Hygrometer_UAVCAN::_detected_modules[];
+HAL_Semaphore AP_Hygrometer_UAVCAN::_sem_registry;
+
+AP_Hygrometer_UAVCAN::AP_Hygrometer_UAVCAN(AP_Hygrometer::Param &_params) :
+    AP_Hygrometer_Backend(_params)
+{}
+
+void AP_Hygrometer_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
+{
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+
+    auto* node = ap_uavcan->get_node();
+
+    uavcan::Subscriber<dronecan::sensors::hygrometer::Hygrometer, HygrometerCb> *hygrometer_listener;
+    hygrometer_listener = new uavcan::Subscriber<dronecan::sensors::hygrometer::Hygrometer, HygrometerCb>(*node);
+    if(hygrometer_listener == nullptr) {
+        AP_BoardConfig::allocation_error("AP_Hygrometer_UAVCAN: hygrometer_listener");
+    }
+    const int hygrometer_listener_res = hygrometer_listener->start(HygrometerCb(ap_uavcan, &handle_hygrometer));
+    if (hygrometer_listener_res < 0) {
+        AP_HAL::panic("UAVCAN hygrometer subscriber start problem");
+    }
+}
+
+AP_Hygrometer_Backend* AP_Hygrometer_UAVCAN::probe(AP_Hygrometer::Param &_params)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* backend = nullptr;
+
+    for (uint8_t i = 0; i < AP_HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver == nullptr && _detected_modules[i].ap_uavcan != nullptr) {
+            backend = new AP_Hygrometer_UAVCAN(_params);
+            if (backend == nullptr) {
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Failed register UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            } else {
+                _detected_modules[i].driver = backend;  
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Registered UAVCAN Hygrometer Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+            }
+            break;
+        }
+    }
+    return backend;
+}
+
+AP_Hygrometer_UAVCAN* AP_Hygrometer_UAVCAN::get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id)
+{
+    if (ap_uavcan == nullptr) {
+        return nullptr;
+    }
+
+    for (uint8_t i = 0; i < AP_HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].driver != nullptr &&
+            _detected_modules[i].ap_uavcan == ap_uavcan &&
+            _detected_modules[i].node_id == node_id ) {
+            return _detected_modules[i].driver;
+        }
+    }
+
+    bool detected = false;
+    for (uint8_t i = 0; i < AP_HYGROMETER_MAX_SENSORS; i++) {
+        if (_detected_modules[i].ap_uavcan == ap_uavcan && _detected_modules[i].node_id == node_id) {
+            detected = true;
+            break;
+        }
+    }
+
+    if (!detected) {
+        for (uint8_t i = 0; i < AP_HYGROMETER_MAX_SENSORS; i++) {
+            if (_detected_modules[i].ap_uavcan == nullptr) {
+                _detected_modules[i].ap_uavcan = ap_uavcan;
+                _detected_modules[i].node_id = node_id;
+                break;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+void AP_Hygrometer_UAVCAN::handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb)
+{
+    WITH_SEMAPHORE(_sem_registry);
+
+    AP_Hygrometer_UAVCAN* driver = get_uavcan_backend(ap_uavcan, node_id);
+
+    if (driver == nullptr) {
+        return;
+    }
+    WITH_SEMAPHORE(driver->_sem_hygrometer);
+    driver->_humidity = cb.msg->humidity;
+    if (!isnan(cb.msg->temperature))  {
+        driver->_temperature = cb.msg->temperature - C_TO_KELVIN;
+    }
+    driver->_last_sample_time_ms = AP_HAL::millis();
+}
+
+bool AP_Hygrometer_UAVCAN::get_humidity(float &humidity)
+{
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+    humidity = _humidity;
+
+    return true;
+}
+
+bool AP_Hygrometer_UAVCAN::get_temperature(float &temperature)
+{
+    WITH_SEMAPHORE(_sem_hygrometer);
+
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 200) {
+        return false;
+    }
+    temperature = _temperature;
+
+    return true;
+}
+
+#endif // HAL_ENABLE_LIBUAVCAN_DRIVERS
+
+#endif // AP_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
+++ b/libraries/AP_Hygrometer/AP_Hygrometer_UAVCAN.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "AP_Hygrometer.h"
+
+#if AP_HYGROMETER_ENABLED
+
+#include <AP_UAVCAN/AP_UAVCAN.h>
+#include "AP_Hygrometer_Backend.h"
+
+class HygrometerCb;
+class AP_Hygrometer_Backend;
+
+class AP_Hygrometer_UAVCAN : public AP_Hygrometer_Backend
+{
+public:
+    // constructor
+    AP_Hygrometer_UAVCAN(AP_Hygrometer::Param &_params);
+
+    bool init(void) override { return true; }
+
+    bool get_humidity(float &humidity) override;
+    bool get_temperature(float &temperature) override;
+
+    static void handle_hygrometer(AP_UAVCAN* ap_uavcan, uint8_t node_id, const HygrometerCb &cb);
+
+    static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
+
+    static AP_Hygrometer_Backend* probe(AP_Hygrometer::Param &_params);
+
+private:
+    float _humidity;
+    float _temperature;
+    uint32_t _last_sample_time_ms;
+
+    static  AP_Hygrometer_UAVCAN* get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id);
+
+    HAL_Semaphore _sem_hygrometer;
+
+    // Module Detection Registry
+    static struct DetectedModules {
+        AP_UAVCAN* ap_uavcan;
+        uint8_t node_id;
+        AP_Hygrometer_UAVCAN *driver;
+    } _detected_modules[AP_HYGROMETER_MAX_SENSORS];
+
+    static HAL_Semaphore _sem_registry;
+};
+
+#endif // AP_HYGROMETER_ENABLED

--- a/libraries/AP_Hygrometer/LogStructure.h
+++ b/libraries/AP_Hygrometer/LogStructure.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_HYGROMETER \
+    LOG_HYGRO_MSG
+
+// @LoggerMessage: HYGR
+// @Description: Hygrometer sensor data
+// @Field: TimeUS: Time since system startup
+// @Field: I: Hygrometer sensor instance number
+// @Field: Temperature: Current temperature
+// @Field: Humidity: Current humidity
+struct PACKED log_HYGRO {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    float temperature;
+    float humidity;
+};
+
+#define LOG_STRUCTURE_FROM_HYGROMETER \
+    { LOG_HYGRO_MSG, sizeof(log_HYGRO), \
+      "HYGR", "QBff", "TimeUS,I,Temperature,Humidity", "s#O%", "F-00", true }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -139,6 +139,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_AIS/LogStructure.h>
 #include <AP_HAL_ChibiOS/LogStructure.h>
 #include <AP_RPM/LogStructure.h>
+#include <AP_Hygrometer/LogStructure.h>
 
 // structure used to define logging format
 // It is packed on ChibiOS to save flash space; however, this causes problems
@@ -1286,7 +1287,8 @@ LOG_STRUCTURE_FROM_AIS, \
     { LOG_VER_MSG, sizeof(log_VER), \
       "VER",   "QBHBBBBIZH", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ", "s---------", "F---------", false }, \
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt), \
-      "MOTB", "QffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,FailFlags", "s-----", "F-----" , true }
+      "MOTB", "QffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,FailFlags", "s-----", "F-----" , true }, \
+LOG_STRUCTURE_FROM_HYGROMETER
 
 // message types 0 to 63 reserved for vehicle specific use
 
@@ -1369,6 +1371,7 @@ enum LogMessages : uint8_t {
     LOG_VIDEO_STABILISATION_MSG,
     LOG_MOTBATT_MSG,
     LOG_VER_MSG,
+    LOG_IDS_FROM_HYGROMETER,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -58,6 +58,7 @@
 #include "AP_UAVCAN_DNA_Server.h"
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Notify/AP_Notify.h>
+#include <AP_Hygrometer/AP_Hygrometer_UAVCAN.h>
 
 #define LED_DELAY_US 50000
 
@@ -328,6 +329,9 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     AP_OpticalFlow_HereFlow::subscribe_msgs(this);
 #endif
     AP_RangeFinder_UAVCAN::subscribe_msgs(this);
+#if AP_HYGROMETER_ENABLED
+    AP_Hygrometer_UAVCAN::subscribe_msgs(this);
+#endif // AP_HYGROMETER_ENABLED
 
     act_out_array[driver_index] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*_node);
     act_out_array[driver_index]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(2));

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -80,6 +80,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     // @Path: ../AP_CustomRotations/AP_CustomRotations.cpp
     AP_SUBGROUPINFO(custom_rotations, "CUST_ROT", 11, AP_Vehicle, AP_CustomRotations),
 
+#if AP_HYGROMETER_ENABLED
+    // @Group: HYGRO
+    // @Path: ../libraries/AP_Hygrometer/AP_Hygrometer.cpp
+    AP_SUBGROUPINFO(hygrometer, "HYGRO", 12, AP_Vehicle, AP_Hygrometer),
+#endif
+
     AP_GROUPEND
 };
 
@@ -211,6 +217,10 @@ void AP_Vehicle::setup()
     efi.init();
 #endif
 
+#if AP_HYGROMETER_ENABLED
+    hygrometer.init();
+#endif
+
     custom_rotations.init();
 
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
@@ -303,6 +313,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if HAL_EFI_ENABLED
     SCHED_TASK_CLASS(AP_EFI,       &vehicle.efi,            update,                   10, 200, 250),
+#endif
+#if AP_HYGROMETER_ENABLED
+    SCHED_TASK_CLASS(AP_Hygrometer, &vehicle.hygrometer,      update,                  3,  100, 251),
 #endif
 };
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -51,6 +51,7 @@
 #include <AP_VideoTX/AP_SmartAudio.h>
 #include <SITL/SITL.h>
 #include <AP_CustomRotations/AP_CustomRotations.h>
+#include <AP_Hygrometer/AP_Hygrometer.h>
 
 class AP_Vehicle : public AP_HAL::HAL::Callbacks {
 
@@ -379,6 +380,10 @@ protected:
 
 #if AP_AIRSPEED_ENABLED
     AP_Airspeed airspeed;
+#endif
+
+#if AP_HYGROMETER_ENABLED
+    AP_Hygrometer hygrometer;
 #endif
 
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -277,6 +277,7 @@ public:
     void send_rc_channels() const;
     void send_rc_channels_raw() const;
     void send_raw_imu();
+    void send_hygrometer();
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature, int16_t temperature_press_diff));
     void send_scaled_pressure();

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -82,5 +82,6 @@ enum ap_message : uint8_t {
     MSG_MCU_STATUS,
     MSG_UAVIONIX_ADSB_OUT_STATUS,
     MSG_ATTITUDE_TARGET,
+    MSG_HYGROMETER_STATUS,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
The flight controller receive the hygrometer message from CAN device and flight controller send hygrometer message to the ground station.

background:
CUAV developed a new airspeed sensor that can be heated.The airspeed sensor heats up according to the set temperature, so as to prevent airspeed failure due to ice on the head of the airspeed sensor when the fixed-wing UAV is used in high and cold places.The temperature and humidity sensor is used to detect the temperature and humidity of the pitot tube head. If the measured temperature is lower than the set temperature, the airspeed sensor will enable heating to prevent ice.

![1637907979915_0CE47D6B-D58F-44ea-BDE7-F50121475ABE](https://user-images.githubusercontent.com/69180601/143541211-dedea493-a26c-4d47-8dd9-5906902ac8e3.png)

![1637908646536_629D9D29-389A-4b14-B086-50DC2ED267A5](https://user-images.githubusercontent.com/69180601/143541228-d957776d-8067-4797-927c-a18b5ae1232f.png)

![1637908659110_8DCE4D08-65CB-4ee6-AC0B-E9A400387A78](https://user-images.githubusercontent.com/69180601/143541240-edb99812-f777-4388-8b47-346ccaa934e7.png)

logfiles: plane ,rover, copter , sub 

[log.zip](https://github.com/ArduPilot/ardupilot/files/7606947/log.zip)

parameters for setting:
HYGROx_TYPE: 0 for none , 1 for uavcan. 
Note: HYGRO2_TYPE can be set after HYGRO1_TYPE is set to 1;

previous pr:
https://github.com/ArduPilot/ardupilot/pull/19101 
https://github.com/ArduPilot/ardupilot/pull/19294
