### PR TITLE
Plane: tiltrotor: transition improvements

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2365,7 +2365,8 @@ void QuadPlane::vtol_position_controller(void)
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,
                                                                       desired_auto_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
-        if (plane.auto_state.wp_distance < position2_dist_threshold) {
+        if ((plane.auto_state.wp_distance < position2_dist_threshold) && tiltrotor.tilt_angle_achieved()) {
+            // if continuous tiltrotor only advance to position 2 once tilts have finished moving
             poscontrol.set_state(QPOS_POSITION2);
             poscontrol.pilot_correction_done = false;
             gcs().send_text(MAV_SEVERITY_INFO,"VTOL position2 started v=%.1f d=%.1f",

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2200,7 +2200,8 @@ void QuadPlane::vtol_position_controller(void)
 
         const float stop_distance = stopping_distance();
 
-        if (poscontrol.get_state() == QPOS_AIRBRAKE) {
+        if (poscontrol.get_state() == QPOS_AIRBRAKE && !(tiltrotor.enabled() && !tiltrotor.has_vtol_motor() && (tiltrotor.current_tilt >= tiltrotor.get_fully_forward_tilt()))) {
+            // don't ouput VTOL throttle on tiltrotors if there are no fixed VTOL motors and the tilt is still forward
             hold_hover(0);
         }
 

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -186,6 +186,8 @@ void Tiltrotor::slew(float newtilt)
     float max_change = tilt_max_change(newtilt<current_tilt, newtilt > get_fully_forward_tilt());
     current_tilt = constrain_float(newtilt, current_tilt-max_change, current_tilt+max_change);
 
+    angle_achieved = is_equal(newtilt, current_tilt);
+
     // translate to 0..1000 range and output
     SRV_Channels::set_output_scaled(SRV_Channel::k_motor_tilt, 1000 * current_tilt);
 }

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -107,6 +107,22 @@ void Tiltrotor::setup()
 
     _is_vectored = tilt_mask != 0 && type == TILT_TYPE_VECTORED_YAW;
 
+    // true if a fixed forward motor is configured, either throttle, throttle left  or throttle right.
+    // bicopter tiltrotors use throttle left and right as tilting motors, so they don't count in that case.
+    _have_fw_motor = SRV_Channels::function_assigned(SRV_Channel::k_throttle) ||
+                    ((SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) || SRV_Channels::function_assigned(SRV_Channel::k_throttleRight))
+                        && (type != TILT_TYPE_BICOPTER));
+
+
+    // check if there are any perminant VTOL motors
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; ++i) {
+        if (motors->is_motor_enabled(i) && ((tilt_mask & (1U<<1)) == 0)) {
+            // enabled motor not set in tilt mask
+            _have_vtol_motor = true;
+            break;
+        }
+    }
+
     if (quadplane.motors_var_info == AP_MotorsMatrix::var_info && _is_vectored) {
         // we will be using vectoring for yaw
         motors->disable_yaw_torque();

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -57,6 +57,10 @@ public:
 
     bool is_vectored() const { return enabled() && _is_vectored; }
 
+    bool has_fw_motor() const { return _have_fw_motor; }
+
+    bool has_vtol_motor() const { return _have_vtol_motor; }
+
     bool motors_active() const { return enabled() && _motors_active; }
 
     AP_Int8 enable;
@@ -89,6 +93,12 @@ public:
 private:
 
     bool setup_complete;
+
+    // true if a fixed forward motor is setup
+    bool _have_fw_motor;
+
+    // true if all motors tilt with no fixed VTOL motor
+    bool _have_vtol_motor;
 
     // refences for convenience
     QuadPlane& quadplane;

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -63,6 +63,10 @@ public:
 
     bool motors_active() const { return enabled() && _motors_active; }
 
+    // true if the tilts have completed slewing
+    // always return true if not enabled or not a continuous type
+    bool tilt_angle_achieved() const { return !enabled() || (type != TILT_TYPE_CONTINUOUS) || angle_achieved; }
+
     AP_Int8 enable;
     AP_Int16 tilt_mask;
     AP_Int16 max_rate_up_dps;
@@ -99,6 +103,10 @@ private:
 
     // true if all motors tilt with no fixed VTOL motor
     bool _have_vtol_motor;
+
+    // true if the current tilt angle is equal to the desired
+    // with slow tilt rates the tilt angle can lag
+    bool angle_achieved;
 
     // refences for convenience
     QuadPlane& quadplane;

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -110,5 +110,8 @@ protected:
     uint32_t last_fw_mode_ms;
     int32_t last_fw_nav_pitch_cd;
 
+    // tiltrotor tilt angle when airspeed wait transition stage completes
+    float airspeed_reached_tilt;
+
 };
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -88,7 +88,12 @@ public:
     void reset_pitch_I(void) {
         _integSEB_state = 0.0f;
     }
-    
+
+    // reset throttle integrator
+    void reset_throttle_I(void) {
+        _integTHR_state = 0.0;
+    }
+
     // return landing sink rate
     float get_land_sinkrate(void) const {
         return _land_sink;


### PR DESCRIPTION
This adds a couple of tiltrotor enhancements developed for Pterodynamics. Most of these improvements came about because the Pterodynamics vehicle is limited by the time it takes to move the wing rather than the time to get up to speed. 

- Resetting TECS throttle I if there is no motor pointing forwards, In the airspeed wait portion of the transition are ignoring forward throttle so TECS builds a large I term. 
- Smooth interpolation between VTOL throttle and FW as the tilts move forwards in the transition timer stage
- Not outputting VTOL throttle in QPos air-break if there are no VTOL motors. 
- Not advancing to Qpos2 until wing has finished tilting.