### PR TITLE
Tradheli: fix bug for auto missions using continue after land

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -443,7 +443,7 @@ void AP_MotorsHeli::output_logic()
                 _spool_state = SpoolState::SPOOLING_UP;
                 break;
             }
-            if (!rotor_speed_above_critical()){
+            if (_heliflags.rotor_spooldown_complete){
                 _spool_state = SpoolState::GROUND_IDLE;
             }
             break;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -250,6 +250,7 @@ protected:
         uint8_t land_complete           : 1;    // true if aircraft is landed
         uint8_t takeoff_collective      : 1;    // true if collective is above 30% between H_COL_MID and H_COL_MAX
         uint8_t below_land_min_coll     : 1;    // true if collective is below H_COL_LAND_MIN
+        uint8_t rotor_spooldown_complete : 1;    // true if the rotors have spooled down completely
     } _heliflags;
 
     // parameters

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -517,6 +517,8 @@ void AP_MotorsHeli_Dual::update_motor_control(RotorControlState state)
 
     // Check if rotors are run-up
     _heliflags.rotor_runup_complete = _main_rotor.is_runup_complete();
+    // Check if rotors are spooled down
+    _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -220,6 +220,8 @@ void AP_MotorsHeli_Quad::update_motor_control(RotorControlState state)
 
     // Check if rotors are run-up
     _heliflags.rotor_runup_complete = _main_rotor.is_runup_complete();
+    // Check if rotors are spooled down
+    _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -382,6 +382,8 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     if (_runup_complete && (get_rotor_speed() <= get_critical_speed())) {
         _runup_complete = false;
     }
+    // if rotor estimated speed is zero, then spooldown has been completed
+    if (get_rotor_speed() <= 0.0f) { _spooldown_complete = true; } else { _spooldown_complete = false; }
 }
 
 // get_rotor_speed - gets rotor speed either as an estimate, or (ToDO) a measured value

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -105,6 +105,9 @@ public:
     // is_runup_complete
     bool        is_runup_complete() const { return _runup_complete; }
 
+    // is_spooldown_complete
+    bool        is_spooldown_complete() const { return _spooldown_complete; }
+
     // set_ramp_time
     void        set_ramp_time(int8_t ramp_time) { _ramp_time = ramp_time; }
 
@@ -163,6 +166,7 @@ private:
     bool            _use_bailout_ramp;            // true if allowing RSC to quickly ramp up engine
     bool            _in_autorotation;              // true if vehicle is currently in an autorotation
     int16_t         _rsc_arot_bailout_pct;        // the throttle percentage sent to the external governor to signal that autorotation bailout ramp should be used
+    bool            _spooldown_complete;          // flag for determining if spooldown is complete
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -404,6 +404,9 @@ void AP_MotorsHeli_Single::update_motor_control(RotorControlState state)
 
     // Check if both rotors are run-up, tail rotor controller always returns true if not enabled
     _heliflags.rotor_runup_complete = ( _main_rotor.is_runup_complete() && _tail_rotor.is_runup_complete() );
+
+    // Check if both rotors are spooled down, tail rotor controller always returns true if not enabled
+    _heliflags.rotor_spooldown_complete = ( _main_rotor.is_spooldown_complete() );
 }
 
 //


### PR DESCRIPTION
With the recent capability in Copter 4.1 for helicopters to be able to land and then takeoff during an auto mission, it was discovered that the rotor was not allowed to spool up completely before the takeoff was initiated by the autopilot resulting in the aircraft spinning until it regained tail rotor effectiveness.
**How the autopilot determines runup complete and setting ground idle**
The reason for the premature takeoff is due to how the autopilot determines when spool up is complete. The run up time (H_RUNUP_TIME) is what it uses during spool up to determine run up complete (ie rotor at flight capable RPM). The autopilot counts up from when the motor interlock switch is enabled. When it reaches runup time it declares runup complete and the autopilot raises the collective to take off. When the motor interlock is disabled, the autopilot counts down until it reaches the critical speed (H_RSC_CRITICAL) and at that point declares that the rotor is below critical and the autopilot allows disarming if in an auto mode like RTL or. LAND.
**What happens in an auto mission with continue after land**
What happens in the continue after land situation is the aircraft lands and waits for rotor speed below critical. Once that occurs, the autopilot initiates spool up. But only counts up from the critical speed instead of counting from zero. So it you had the runup time set to 10 seconds and the critical speed at 50%, the autopilot would only count 5 seconds to declare below critical rotor speed and then count up 5 seconds (instead of the full 10 seconds) to declare runup complete. For heli’s that use the governor of the ESC (H_RSC_MODE set to 2), this may not be enough time for the ESC to complete its spool up and thus the autopilot will try to take off before the ESC is ready.

**How it was fixed in this PR**
Ground Idle for heli's has always been set once the rotor speed went below the critical rotor speed determined based on the runup time.  The critical rotor speed is not the speed at which the ground idle should be set because in most cases, the rotor is still spinning 700 to 1000 RPM.  It would be more appropriate to make the autopilot wait the full length of the runup time before declaring ground idle.  This forces the autopilot to use the full runup time for the subsequent spool up and launch.  The code already protects the user from going into other non-manual throttle modes while the aircraft is spooling down or spooling up.  which should keep users from switching into auto or loiter and trying to takeoff before the rotor is ready for flight.  Thus the change in this PR was to force the autopilot to wait the length of the runup time before declaring ground idle.

**Testing**
This PR was tested in SITL with Realflight.  Want to test it in an actual heli before merging