### PR TITLE
Tradheli: make bailout in SITL only enabled with AROT_ENABLE

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -207,8 +207,8 @@ void Copter::heli_update_autorotation()
 {
 #if MODE_AUTOROTATE_ENABLED == ENABLED
     // check if flying and interlock disengaged
-    if (!ap.land_complete && !motors->get_interlock()) {
-        if (!flightmode->has_manual_throttle() && g2.arot.is_enable()) {
+    if (!ap.land_complete && !motors->get_interlock() && g2.arot.is_enable()) {
+        if (!flightmode->has_manual_throttle()) {
             // set autonomous autorotation flight mode
             set_mode(Mode::Number::AUTOROTATE, ModeReason::AUTOROTATION_START);
         }
@@ -220,7 +220,7 @@ void Copter::heli_update_autorotation()
 
     // sets autorotation flags through out libraries
     heli_set_autorotation(heli_flags.in_autorotation);
-    if (!ap.land_complete) {
+    if (!ap.land_complete && g2.arot.is_enable()) {
         motors->set_enable_bailout(true);
     } else {
         motors->set_enable_bailout(false);


### PR DESCRIPTION
When the autonomous autorotation code was first merged in master, it was limited to only working in SITL.  There was the autonomous autorotation library that is turned on with the enable parameter and there was a manual bailout feature that allowed users to practice manual autorotations and get immediate throttle response when enabling motor interlock while in flight.  This manual bailout feature was not selectable for enabling and was alway on in SITL.  This makes the code not representative of the code in actual flight controllers and can affect the proper testing of code changes in SITL.

This PR makes the manual bailout feature only enabled when the autonomous autorotation feature is enabled.  This only affects SITL.
