### PR TITLE
AP_Terrain: cast result of labs to unsigned

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -62,7 +62,7 @@
 // we allow for a 2cm discrepancy in the grid corners. This is to
 // account for different rounding in terrain DAT file generators using
 // different programming languages
-#define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= unsigned(margin.get()*100))
+#define TERRAIN_LATLON_EQUAL(v1, v2) (unsigned(labs((v1)-(v2))) <= unsigned(margin.get()*100))
 
 #if TERRAIN_DEBUG
 #include <assert.h>


### PR DESCRIPTION
Fixes:

```
../../libraries/AP_Terrain/TerrainGCS.cpp: In member function ‘void AP_Terrain::
handle_terrain_data(const mavlink_message_t&)’:
../../libraries/AP_Terrain/AP_Terrain.h:65:55: error: comparison between signed
and unsigned integer expressions [-Werror=sign-compare]
 #define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= unsigned(margin.get()*
100))
                                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
~~~~
../../libraries/AP_Terrain/AP_Terrain.h:65:55: note: in definition of macro ‘TER
RAIN_LATLON_EQUAL’
 #define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= unsigned(margin.get()*
100))
                                                       ^~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors

In file included from ../../libraries/AP_Terrain/TerrainUtil.cpp:24:0:
../../libraries/AP_Terrain/TerrainUtil.cpp: In member function ‘AP_Terrain::grid
_cache& AP_Terrain::find_grid_cache(const AP_Terrain::grid_info&)’:
../../libraries/AP_Terrain/AP_Terrain.h:65:55: error: comparison between signed
and unsigned integer expressions [-Werror=sign-compare]
 #define TERRAIN_LATLON_EQUAL(v1, v2) (labs((v1)-(v2)) <= unsigned(margin.get()*
100))
                                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
~~~~
```

The return value of labs is signed

Tested as far as ensuring examples compile for navio.
