### PR TITLE
autotest: correct MAVFTP test for autotest server

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11348,7 +11348,15 @@ switch value'''
             mavproxy.send("module load ftp\n")
             mavproxy.expect(["Loaded module ftp", "module ftp already loaded"])
             mavproxy.send("ftp list\n")
-            mavproxy.expect(" D libraries")  # one line from the ftp list output
+            some_directory = None
+            for entry in sorted(os.listdir()):
+                if os.path.isdir(entry):
+                    some_directory = entry
+                    break
+            if some_directory is None:
+                raise NotAchievedException("No directories?!")
+            expected_line = " D %s" % some_directory
+            mavproxy.expect(expected_line)  # one line from the ftp list output
         except Exception as e:
             self.print_exception_caught(e)
             ex = e


### PR DESCRIPTION
The autotest server runs autotest.py from a directory one-up from the
ArduPilot root directory, whereas most people run it from the root
directory.  The test wasn't taking that into account, looking for a
directory which doesn't necessarily exist.

Changed to os.listdir() to find a directory to look for in the MAVFTP
output.

Tested by running the test from both the root directory and one-up-from-root-directory
