### PR TITLE
autotest: Add diagnostics to Replay

### DIFF
--- a/Tools/Replay/check_replay.py
+++ b/Tools/Replay/check_replay.py
@@ -75,7 +75,9 @@ def check_log(logfile, progress=print, ekf2_only=False, ekf3_only=False, verbose
     if verbose:
         for mtype in counts.keys():
             progress("%s %u/%u %d" % (mtype, counts[mtype], base_counts[mtype], base_counts[mtype]-counts[mtype]))
-    if count == 0 or abs(count - base_count) > 100:
+    count_delta = abs(count - base_count)
+    if count == 0 or count_delta > 100:
+        progress("count=%u count_delta=%u" % (count, count_delta))
         failure += 1
     if failure != 0 or errors != 0:
         return False

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7059,9 +7059,14 @@ class AutoTestCopter(AutoTest):
         self.progress("Building Replay")
         util.build_SITL('tool/Replay', clean=False, configure=False)
 
-        self.test_replay_bit(self.test_replay_gps_bit)
-        self.test_replay_bit(self.test_replay_beacon_bit)
-        self.test_replay_bit(self.test_replay_optical_flow_bit)
+        bits = [
+            ('GPS', self.test_replay_gps_bit),
+            ('Beacon', self.test_replay_beacon_bit),
+            ('OpticalFlow', self.test_replay_optical_flow_bit),
+        ]
+        for (name, func) in bits:
+            self.start_subtest("%s" % name)
+            self.test_replay_bit(func)
 
     def test_replay_bit(self, bit):
 


### PR DESCRIPTION
We're getting intermittent Replay failures on the autotest server; adding some diagnostics to help pin things down.

It looks like were are processing a non-replay logfile as a Replay logfile - that should probably cause the replay tool itself to exit(1)
