### PR TITLE
Cubes Define EKx_IMU_MASK and Change INS_USE check to apply for all Cubes

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
@@ -4,7 +4,7 @@
 
 include ../fmuv3/hwdef.dat
 
-define HAL_CHIBIOS_ARCH_CUBEBLACK 1
+define HAL_CHIBIOS_ARCH_CUBE 1
 
 env OPTIMIZE -O2
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
@@ -306,6 +306,9 @@ define HAL_IMUHEAT_P_DEFAULT 50
 define HAL_IMUHEAT_I_DEFAULT 0.07
 define HAL_IMU_TEMP_MARGIN_LOW_DEFAULT 5
 
+# Enable all IMUs to be used and therefore three active EKF Lanes
+define HAL_EKF_IMU_MASK_DEFAULT 7
+
 # Enable FAT filesystem support (needs a microSD defined via SDMMC).
 define HAL_OS_FATFS_IO 1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
@@ -1,5 +1,7 @@
 # hw definition file for processing by chibios_hwdef.py
 
+define HAL_CHIBIOS_ARCH_CUBE 1
+
 # USB setup
 USB_VENDOR 0x2DAE # ONLY FOR USE BY HEX! NOBODY ELSE
 USB_PRODUCT 0x1016

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubePurple/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubePurple/hwdef.dat
@@ -4,6 +4,8 @@
 
 include ../fmuv3/hwdef.dat
 
+define HAL_CHIBIOS_ARCH_CUBE 1
+
 # USB setup
 USB_VENDOR 0x2DAE # ONLY FOR USE BY HEX! NOBODY ELSE
 USB_PRODUCT 0x1015

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeSolo/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeSolo/hwdef.dat
@@ -5,6 +5,8 @@
 
 include ../fmuv3/hwdef.dat
 
+define HAL_CHIBIOS_ARCH_CUBE 1
+
 env OPTIMIZE -O2
 
 SPIDEV icm20948_ext   SPI4 DEVID1  MPU_EXT_CS   MODE3  4*MHZ  8*MHZ

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -443,6 +443,9 @@ define HAL_WITH_RAMTRON 1
 define HAL_HAVE_IMU_HEATER 1
 define HAL_IMU_TEMP_MARGIN_LOW_DEFAULT 5
 
+# Enable all IMUs to be used and therefore three active EKF Lanes
+define HAL_EKF_IMU_MASK_DEFAULT 7
+
 # enable FAT filesystem support (needs a microSD defined via SDIO)
 define HAL_OS_FATFS_IO 1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -1,6 +1,8 @@
 # The CUBE Yellow is a variant of The CUBE Black from ProfiCNC/Hex
 # with a STM32F777 MCU
 
+define HAL_CHIBIOS_ARCH_CUBE 1
+
 # MCU class and specific type
 MCU STM32F7xx STM32F777xx
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -912,8 +912,8 @@ AP_InertialSensor::detect_backends(void)
 
     _backends_detected = true;
 
-#if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
-    // special case for CubeBlack, where the IMUs on the isolated
+#if defined(HAL_CHIBIOS_ARCH_CUBE)
+    // special case for Cubes, where the IMUs on the isolated
     // board could fail on some boards. If the user has INS_USE=1,
     // INS_USE2=1 and INS_USE3=0 then force INS_USE3 to 1. This is
     // done as users loading past parameter files may end up with

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -117,6 +117,11 @@
 
 #endif // APM_BUILD_DIRECTORY
 
+// This allows boards to default to using a specified number of IMUs and EKF lanes
+#ifndef HAL_EKF_IMU_MASK_DEFAULT
+#define HAL_EKF_IMU_MASK_DEFAULT 3       // Default to using two IMUs
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 // Define tuning parameters
@@ -408,7 +413,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU,3:FourthIMU,4:FifthIMU,5:SixthIMU
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("IMU_MASK",     33, NavEKF2, _imuMask, 3),
+    AP_GROUPINFO("IMU_MASK",     33, NavEKF2, _imuMask, HAL_EKF_IMU_MASK_DEFAULT),
     
     // @Param: CHECK_SCALE
     // @DisplayName: GPS accuracy check scaler (%)

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -125,6 +125,11 @@
 #define EK3_PRIMARY_DEFAULT 0
 #endif
 
+// This allows boards to default to using a specified number of IMUs and EKF lanes
+#ifndef HAL_EKF_IMU_MASK_DEFAULT
+#define HAL_EKF_IMU_MASK_DEFAULT 3       // Default to using two IMUs
+#endif
+
 // Define tuning parameters
 const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
@@ -402,7 +407,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU,3:FourthIMU,4:FifthIMU,5:SixthIMU
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("IMU_MASK",     33, NavEKF3, _imuMask, 3),
+    AP_GROUPINFO("IMU_MASK",     33, NavEKF3, _imuMask, HAL_EKF_IMU_MASK_DEFAULT),
     
     // @Param: CHECK_SCALE
     // @DisplayName: GPS accuracy check scaler (%)


### PR DESCRIPTION
This PR sets the default `EKF_IMU_MASK` to use all three IMUs and changes the `INS_USEx` check to apply to all cubes.  This was discussed on discord with @proficnc. [Here](https://discord.com/channels/674039678562861068/780728024756781056/914278885804355625)
It also sets the `INS_USE` check that was for only cubeblack to be for all cubes.

Should this be set as the default via the hwdef? 
"The answer from Cubepilot is ABSOLUTELY YES!  But the pull request for this was rejected."

I couldn't find the PR discussed. 

My one thought is  that enabling this for F4s in this manner  might cause a bunch of support issues on updating. The user would need to go in and switch back to `EK3_IMU_MASK 3` on an update if there resources are constrained. 
