### PR TITLE
autotest: disable flightgear output

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -311,6 +311,7 @@ def start_SITL(binary,
                disable_breakpoints=False,
                customisations=[],
                lldb=False,
+               enable_fgview_output=False,
                supplementary=False):
 
     if model is None and not supplementary:
@@ -407,6 +408,8 @@ def start_SITL(binary,
             cmd.extend(['--unhide-groups'])
         # somewhere for MAVProxy to connect to:
         cmd.append('--uartC=tcp:2')
+        if not enable_fgview_output:
+            cmd.append("--disable-fgview");
 
     cmd.extend(customisations)
 


### PR DESCRIPTION
burning CPU for no good reason

This PR provides a measurable improvement to the user time of autotest.  It does so by omitting the output from autotest to flightgear - an option never used by autotest users, I would wager.  If there are complaints we can add a command-line option to re-add the functionality but AFAIK that would simply be more noise.

The ByteSwap() call within the fg output code appeared to be the bit consuming time.

master:
```
real	0m28.333s
user	0m14.988s
sys	0m3.151s

real	0m28.340s
user	0m15.191s
sys	0m2.991s

real	0m28.327s
user	0m15.337s
sys	0m2.808s
```

pr/autotest-disable-fgview:
```
real	0m28.328s
user	0m14.482s
sys	0m1.530s

real	0m28.315s
user	0m14.158s
sys	0m1.469s

real	0m28.318s
user	0m14.677s
sys	0m1.398s
```