### PR TITLE
hwdef: enable UART7 on Swan-K1

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Swan-K1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Swan-K1/hwdef.dat
@@ -5,7 +5,7 @@
 include ../fmuv5/hwdef.dat
 
 # order of UARTs (and USB). Telem2 is UART4 on the mini, USART3 is not available
-SERIAL_ORDER OTG1 USART2 UART4 USART1 USART6 OTG2
+SERIAL_ORDER OTG1 USART2 UART4 USART1 USART6 UART7 OTG2
 
 # enable TX on USART6 (disabled for fmuv5 with iomcu)
 PG14 USART6_TX USART6 NODMA


### PR DESCRIPTION
useful extra UART for debug or extra sensor or MSP
