### PR TITLE
Added logging of crash_dump.bin

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1377,6 +1377,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         "@SYS/memory.txt",
         "@SYS/threads.txt",
         "@ROMFS/hwdef.dat",
+        "@SYS/storage.bin",
         "@SYS/crash_dump.bin",
     };
     for (const auto *name : log_content_filenames) {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1377,6 +1377,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         "@SYS/memory.txt",
         "@SYS/threads.txt",
         "@ROMFS/hwdef.dat",
+        "@SYS/crash_dump.bin",
     };
     for (const auto *name : log_content_filenames) {
         AP::logger().log_file_content(name);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -559,6 +559,8 @@ private:
         struct file_list *head, *tail;
         int fd;
         uint32_t offset;
+        bool fast;
+        uint8_t counter;
         HAL_Semaphore sem;
     } file_content;
     void file_content_update(void);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -558,7 +558,7 @@ private:
     struct {
         struct file_list *head, *tail;
         int fd;
-        uint16_t offset;
+        uint32_t offset;
         HAL_Semaphore sem;
     } file_content;
     void file_content_update(void);

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -690,8 +690,8 @@ struct PACKED log_STAK {
 struct PACKED log_File {
     LOG_PACKET_HEADER;
     char filename[16];
-    uint16_t offset;
-    uint16_t length;
+    uint32_t offset;
+    uint8_t length;
     char data[64];
 };
 
@@ -1344,7 +1344,7 @@ LOG_STRUCTURE_FROM_VISUALODOM \
     { LOG_STAK_MSG, sizeof(log_STAK), \
       "STAK", "QBBHHN", "TimeUS,Id,Pri,Total,Free,Name", "s#----", "F-----", true }, \
     { LOG_FILE_MSG, sizeof(log_File), \
-      "FILE",   "NhhZ",       "FileName,Offset,Length,Data", "----", "----" }, \
+      "FILE",   "NIBZ",       "FileName,Offset,Length,Data", "----", "----" }, \
 LOG_STRUCTURE_FROM_AIS, \
     { LOG_SCRIPTING_MSG, sizeof(log_Scripting), \
       "SCR",   "QNIii", "TimeUS,Name,Runtime,Total_mem,Run_mem", "s-sbb", "F-F--", true }


### PR DESCRIPTION
This gives logging of crash dumps on arming. We needed some special handling to make it fast enough to be usable as the files are large.
I have also fixed MAVExplorer to handle binary FILE messages
