### PR TITLE
AP_Compass: add batt index param per instance and refactor

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -457,10 +457,7 @@ void Copter::update_batt_compass(void)
     // read battery before compass because it may be used for motor interference compensation
     battery.read();
 
-    if(AP::compass().available()) {
-        // update compass with throttle value - used for compassmot
-        compass.set_throttle(motors->get_throttle());
-        compass.set_voltage(battery.voltage());
+    if (AP::compass().available()) {
         compass.read();
     }
 }

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -55,7 +55,6 @@ void Copter::motor_test_output()
         switch (motor_test_throttle_type) {
 
             case MOTOR_TEST_COMPASS_CAL:
-                compass.set_voltage(battery.voltage());
                 compass.per_motor_calibration_update();
                 FALLTHROUGH;
 

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -185,8 +185,6 @@ void Sub::update_batt_compass()
     battery.read();
 
     if (AP::compass().available()) {
-        // update compass with throttle value - used for compassmot
-        compass.set_throttle(motors.get_throttle());
         compass.read();
     }
 }

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -153,8 +153,6 @@ void Blimp::update_batt_compass(void)
     battery.read();
 
     if (AP::compass().available()) {
-        // update compass with throttle value - used for compassmot
-        compass.set_voltage(battery.voltage());
         compass.read();
     }
 }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1946,7 +1946,6 @@ void Compass::motor_compensation_type(const uint8_t comp_type)
 {
     if (_motor_comp_type <= AP_COMPASS_MOT_COMP_CURRENT && _motor_comp_type != (int8_t)comp_type) {
         _motor_comp_type = (int8_t)comp_type;
-        _thr = 0; // set current  throttle to zero
         for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             set_motor_compensation(i, Vector3f(0,0,0)); // clear out invalid compensation vectors
         }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -282,13 +282,6 @@ public:
         }
     }
 
-#if COMPASS_MOT_ENABLED
-    /// Set the battery voltage for per-motor compensation
-    void set_voltage(float voltage) {
-        _per_motor.set_voltage(voltage);
-    }
-#endif
-    
     /// Returns True if the compasses have been configured (i.e. offsets saved)
     ///
     /// @returns                    True if compass has been configured

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -245,11 +245,6 @@ public:
     ///
     void motor_compensation_type(const uint8_t comp_type);
 
-    /// get the motor compensation value.
-    uint8_t get_motor_compensation_type() const {
-        return _motor_comp_type;
-    }
-
     /// Set the motor compensation factor x/y/z values.
     ///
     /// @param  i                   instance of compass

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -269,13 +269,6 @@ public:
     const Vector3f &get_motor_offsets(uint8_t i) const { return _get_state(Priority(i)).motor_offset; }
     const Vector3f &get_motor_offsets(void) const { return get_motor_offsets(_first_usable); }
 
-    /// Set the throttle as a percentage from 0.0 to 1.0
-    /// @param thr_pct              throttle expressed as a percentage from 0 to 1.0
-    void set_throttle(float thr_pct) {
-        if (_motor_comp_type == AP_COMPASS_MOT_COMP_THROTTLE) {
-            _thr = thr_pct;
-        }
-    }
 
     /// Returns True if the compasses have been configured (i.e. offsets saved)
     ///
@@ -467,9 +460,6 @@ private:
     AP_Float    _custom_roll;
     AP_Float    _custom_pitch;
     AP_Float    _custom_yaw;
-    
-    // throttle expressed as a percentage from 0 ~ 1.0, used for motor compensation
-    float       _thr;
 
     struct mag_state {
         bool        healthy;

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -104,7 +104,7 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     } else if (_compass._motor_comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
         AP_BattMonitor &battery = AP::battery();
         float current;
-        if (battery.current_amps(current)) {
+        if (battery.current_amps(current, state.params.motor_comp_batt_index)) {
             state.motor_offset = mot * current;
         }
     }

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -98,7 +98,7 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     state.motor_offset.zero();
     if (_compass._per_motor.enabled() && i == 0) {
         // per-motor correction is only valid for first compass
-        _compass._per_motor.compensate(state.motor_offset);
+        _compass._per_motor.compensate(state.motor_offset, state.params.motor_comp_batt_index);
     } else if (_compass._motor_comp_type == AP_COMPASS_MOT_COMP_THROTTLE) {
         state.motor_offset = mot * _compass._thr;
     } else if (_compass._motor_comp_type == AP_COMPASS_MOT_COMP_CURRENT) {

--- a/libraries/AP_Compass/AP_Compass_Params.cpp
+++ b/libraries/AP_Compass/AP_Compass_Params.cpp
@@ -130,6 +130,13 @@ const AP_Param::GroupInfo AP_Compass_Params::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT",    9, AP_Compass_Params, motor_compensation, 0),
+
+    // @Param: BAT_IDX
+    // @DisplayName: Motor interference compensation battry moniter index
+    // @Description: Motor interference compensation source battry moniter index
+    // @Values: 0:First battery, 1:Second battery
+    // @User: Advanced
+    AP_GROUPINFO("BAT_IDX", 10, AP_Compass_Params, motor_comp_batt_index, 0),
 #endif
 
     AP_GROUPEND

--- a/libraries/AP_Compass/AP_Compass_Params.h
+++ b/libraries/AP_Compass/AP_Compass_Params.h
@@ -29,6 +29,7 @@ public:
 
     // factors multiplied by throttle and added to compass outputs
     AP_Vector3f motor_compensation;
+    AP_Int8 motor_comp_batt_index;
 
 };
 

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -5,6 +5,7 @@
 #include "AP_Compass.h"
 #include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -212,9 +213,12 @@ void Compass_PerMotor::calibration_end(void)
 /*
   calculate total offset for per-motor compensation
  */
-void Compass_PerMotor::compensate(Vector3f &offset)
+void Compass_PerMotor::compensate(Vector3f &offset, uint8_t batt_index)
 {
     offset.zero();
+
+    // simple low-pass on voltage
+    voltage = 0.9f * voltage + 0.1f * AP::battery().voltage(batt_index);
 
     if (running) {
         // don't compensate while calibrating

--- a/libraries/AP_Compass/Compass_PerMotor.h
+++ b/libraries/AP_Compass/Compass_PerMotor.h
@@ -19,15 +19,10 @@ public:
         return enable.get() != 0;
     }
     
-    void set_voltage(float _voltage) {
-        // simple low-pass on voltage
-        voltage = 0.9f * voltage + 0.1f * _voltage;
-    }
-
     void calibration_start(void);
     void calibration_update(void);
     void calibration_end(void);
-    void compensate(Vector3f &offset);
+    void compensate(Vector3f &offset, uint8_t batt_index);
     
 private:
     Compass &compass;


### PR DESCRIPTION
This adds a per instance compass param for battery monitor index to use for compensation. This is used for both current in the current compensation and voltage in the per motor. This removes the need to set the voltage from the vehicle. 

I have also made the change to grab throttle directly from AP_Motors/AP_MotorsUGV for throttle compensation. This means that throttle compensation now works on rover and quadpane (VTOL motors only). 

https://github.com/ArduPilot/ardupilot/pull/18938

All compasses still have to use the same type of compensation. I was originally thinking to add battery indexes as part of the existing COMPASS_MOTCH param, but with the work Andy is doing in https://github.com/ArduPilot/ardupilot/pull/19080 that would add another set of options that would also need a battery index.