### PR TITLE
Rover: control turn rate while stopping, Guided stops initially

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -331,7 +331,7 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
     g2.motors.set_throttle(throttle_out);
 }
 
-// performs a controlled stop with steering centered
+// performs a controlled stop without turning
 bool Mode::stop_vehicle()
 {
     // call throttle controller and convert output to -100 to +100 range
@@ -353,8 +353,12 @@ bool Mode::stop_vehicle()
     // send to motor
     g2.motors.set_throttle(throttle_out);
 
-    // do not attempt to steer
-    g2.motors.set_steering(0.0f);
+    // do not turn while slowing down
+    float steering_out = 0.0;
+    if (!stopped) {
+        steering_out = attitude_control.get_steering_out_rate(0.0, g2.motors.limit.steer_left, g2.motors.limit.steer_right, rover.G_Dt);
+    }
+    g2.motors.set_steering(steering_out * 4500.0);
 
     // return true once stopped
     return stopped;

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -407,6 +407,9 @@ public:
     // vehicle start loiter
     bool start_loiter();
 
+    // start stopping
+    void start_stop();
+
     // guided limits
     void limit_set(uint32_t timeout_ms, float horiz_max);
     void limit_clear();
@@ -420,7 +423,8 @@ protected:
         Guided_HeadingAndSpeed,
         Guided_TurnRateAndSpeed,
         Guided_Loiter,
-        Guided_SteeringAndThrottle
+        Guided_SteeringAndThrottle,
+        Guided_Stop
     };
 
     bool _enter() override;

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -3,11 +3,14 @@
 
 bool ModeGuided::_enter()
 {
-    // set desired location to reasonable stopping point
-    if (!g2.wp_nav.set_desired_location_to_stopping_location()) {
-        return false;
+    // initialise submode to stop or loiter
+    if (rover.is_boat()) {
+        if (!start_loiter()) {
+            start_stop();
+        }
+    } else {
+        start_stop();
     }
-    _guided_mode = Guided_WP;
 
     // initialise waypoint speed
     g2.wp_nav.set_desired_speed_to_default();
@@ -129,6 +132,10 @@ void ModeGuided::update()
             break;
         }
 
+        case Guided_Stop:
+            stop_vehicle();
+            break;
+
         default:
             gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
             break;
@@ -147,6 +154,7 @@ float ModeGuided::get_distance_to_destination() const
     case Guided_Loiter:
         return rover.mode_loiter.get_distance_to_destination();
     case Guided_SteeringAndThrottle:
+    case Guided_Stop:
         return 0.0f;
     }
 
@@ -164,6 +172,7 @@ bool ModeGuided::reached_destination() const
     case Guided_TurnRateAndSpeed:
     case Guided_Loiter:
     case Guided_SteeringAndThrottle:
+    case Guided_Stop:
         return true;
     }
 
@@ -188,6 +197,7 @@ bool ModeGuided::set_desired_speed(float speed)
     case Guided_Loiter:
         return rover.mode_loiter.set_desired_speed(speed);
     case Guided_SteeringAndThrottle:
+    case Guided_Stop:
         // no speed control
         return false;
     }
@@ -212,6 +222,7 @@ bool ModeGuided::get_desired_location(Location& destination) const
         // get destination from loiter
         return rover.mode_loiter.get_desired_location(destination);
     case Guided_SteeringAndThrottle:
+    case Guided_Stop:
         // no desired location in this submode
         break;
     }
@@ -296,6 +307,13 @@ bool ModeGuided::start_loiter()
         return true;
     }
     return false;
+}
+
+
+// start stopping vehicle as quickly as possible
+void ModeGuided::start_stop()
+{
+    _guided_mode = Guided_Stop;
 }
 
 // set guided timeout and movement limits


### PR DESCRIPTION
This includes two related changes:

1. stop_vehicle attempts to keep the vehicle's turn rate zero while it is stopping (previously it would just center the steering control).  This should be good behaviour for vehicles that are stopping from a high speed and have imperfectly set steering trim (they turn slightly when the steering is centered).  The steering is centered once the vehicle has stopped to avoid the steering twitching while the vehicle is stopped.  This stop_vehicle() method is called from various places in Auto, Follow, Guided, RTL and SmartRTL (all modes which have position control).
2. Guided mode initially stops the vehicle using the above mentioned "stop_vehicle" method instead of attempting to move to a stopping point.  This has two benefits:
    - users can enter Guided mode slightly earlier in the startup because wp_nav.set_desired_location_to_stopping_location() is not called and thus cannot fail.
    - the vehicle may stop in a straighter line if the vehicle enters Guided mode from a high speed because we are directly calling the low level turn rate controller instead of relying on the higher level navigation controller.

Below is a before vs after screenshot from SITL showing a vehicle with slightly bad steering trim that was driven forward at throttle of 1800 in Manual mode and then switched into Guided mode.  We can see that the "After" stops in a straighter line.  "Before" actually never reached the target location.

![guided-stop-before-vs-after](https://user-images.githubusercontent.com/1498098/144416634-4c33e2fb-1cb3-4a76-ae5a-dbae2d8a80f6.png)
