### PR TITLE
AP_RangeFinder: fixed support for multiple Benewake_CAN CAN lidars

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
@@ -5,14 +5,18 @@
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
 
-class AP_RangeFinder_Benewake_CAN : public AP_RangeFinder_Backend, public CANSensor {
+class Benewake_MultiCAN;
+
+class AP_RangeFinder_Benewake_CAN : public AP_RangeFinder_Backend {
 public:
+    friend class Benewake_MultiCAN;
+
     AP_RangeFinder_Benewake_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
 
     void update() override;
 
-    // handler for incoming frames
-    void handle_frame(AP_HAL::CANFrame &frame) override;
+    // handler for incoming frames. Return true if consumed
+    bool handle_frame(AP_HAL::CANFrame &frame);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -20,6 +24,7 @@ protected:
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
         return MAV_DISTANCE_SENSOR_RADAR;
     }
+
 private:
     float _distance_sum_cm;
     uint32_t _distance_count;
@@ -27,6 +32,26 @@ private:
 
     AP_Int32 snr_min;
     AP_Int32 receive_id;
+
+    static Benewake_MultiCAN *multican;
+    AP_RangeFinder_Benewake_CAN *next;
 };
+
+// a class to allow for multiple Benewake_CAN backends with one
+// CANSensor driver
+class Benewake_MultiCAN : public CANSensor {
+public:
+    Benewake_MultiCAN() : CANSensor("Benewake") {
+        register_driver(AP_CANManager::Driver_Type_Benewake);
+    }
+
+    // handler for incoming frames
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+
+    HAL_Semaphore sem;
+    AP_RangeFinder_Benewake_CAN *drivers;
+};
+
 #endif //HAL_MAX_CAN_PROTOCOL_DRIVERS
+
 


### PR DESCRIPTION
we need to instantiate only one CANSensor object
this has been tested with 3 CAN lidars by Ibrahim from Benewake

