### PR TITLE
Plane: fixed reset of steering locked course

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -650,6 +650,13 @@ void Plane::calc_nav_yaw_ground(void)
         return;
     }
 
+    // if we haven't been steering for 1s then clear locked course
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - steer_state.last_steer_ms > 1000) {
+        steer_state.locked_course = false;
+    }
+    steer_state.last_steer_ms = now_ms;
+
     float steer_rate = (rudder_input()/4500.0f) * g.ground_steer_dps;
     if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF ||
         flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
@@ -666,6 +673,7 @@ void Plane::calc_nav_yaw_ground(void)
             steer_state.locked_course_err = 0;
         }
     }
+
     if (!steer_state.locked_course) {
         // use a rate controller at the pilot specified rate
         steering_control.steering = steerController.get_steering_out_rate(steer_rate);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -432,6 +432,7 @@ private:
         // when ground steering is active, and for steering in auto-takeoff
         bool locked_course;
         float locked_course_err;
+        uint32_t last_steer_ms;
     } steer_state;
 
     // flight mode specific

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -30,6 +30,7 @@ bool Mode::enter()
 
     // zero locked course
     plane.steer_state.locked_course_err = 0;
+    plane.steer_state.locked_course = false;
 
     // reset crash detection
     plane.crash_state.is_crashed = false;


### PR DESCRIPTION
reset when we have not been steering for 1s, to ensure that an old
locked course is not used
fixes this issue:
https://discuss.ardupilot.org/t/the-plane-turn-to-one-side-as-soon-as-touch-down-with-nose-wheel-setting-ground-streering/77346/2
