### PR TITLE
Plane: check for VTOL takeoff in AUTO

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -163,10 +163,15 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
         ret = false;
     }
 
-    if (((plane.quadplane.options & QuadPlane::OPTION_ONLY_ARM_IN_QMODE_OR_AUTO) != 0) &&
-            !plane.control_mode->is_vtol_mode() && (plane.control_mode != &plane.mode_auto) && (plane.control_mode != &plane.mode_guided)) {
-        check_failed(display_failure,"not in Q mode");
-        ret = false;
+    if ((plane.quadplane.options & QuadPlane::OPTION_ONLY_ARM_IN_QMODE_OR_AUTO) != 0) {
+        if (!plane.control_mode->is_vtol_mode() && (plane.control_mode != &plane.mode_auto) && (plane.control_mode != &plane.mode_guided)) {
+            check_failed(display_failure,"not in Q mode");
+            ret = false;
+        }
+        if ((plane.control_mode == &plane.mode_auto) && !plane.quadplane.is_vtol_takeoff(plane.mission.get_current_nav_cmd().id)) {
+            check_failed(display_failure,"not in VTOL takeoff");
+            ret = false;
+        }
     }
 
     return ret;


### PR DESCRIPTION
if the "only arm in Q modes" bit is set in Q_OPTIONS then check that
in AUTO mode we are in a VTOL takeoff WP