### PR TITLE
AP_Notify: Notification of alarm patterns to GCS

### DIFF
--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -145,6 +145,9 @@ void AP_ToneAlarm::play_tone(const uint8_t tone_index)
 {
     uint32_t tnow_ms = AP_HAL::millis();
     const Tone &tone_requested = _tones[tone_index];
+    
+    // Notification of alarm patterns to GCS
+    mavlink_msg_play_tune_send(mavlink_channel_t(0), 0, 0, nullptr, tone_requested.str);
 
     if (tone_requested.continuous) {
         _cont_tone_playing = tone_index;


### PR DESCRIPTION
I am using HERELINK.
I am using QGC's voice notification.
I fly a vehicle too far.
I cannot hear the vehicle alarm.
I can know the status of the vehicle by sounding the alarm on the GCS.
I send the alarm pattern to the GCS via MAVLINK message.
I got the idea from SITL's alarm simulator.