### PR TITLE
Plane: use EKF accel bias in yaw controller

### DIFF
--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -196,6 +196,10 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
     // Get the accln vector (m/s^2)
     float accel_y = AP::ins().get_accel().y;
 
+    // subtract current bias estimate from EKF
+    const Vector3f &abias = _ahrs.get_accel_bias();
+    accel_y -= abias.y;
+
     // Subtract the steady turn component of rate from the measured rate
     // to calculate the rate relative to the turn requirement in degrees/sec
     float rate_hp_in = ToDeg(omega_z - rate_offset);

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -411,6 +411,7 @@ void AP_AHRS::copy_estimates_from_backend_estimates(const AP_AHRS_Backend::Estim
         _accel_ef_ekf[i] = results.accel_ef[i];
     }
     _accel_ef_ekf_blended = results.accel_ef_blended;
+    _accel_bias = results.accel_bias;
 
     update_cd_values();
     update_trig();
@@ -494,7 +495,7 @@ void AP_AHRS::update_EKF2(void)
             }
 
             // get z accel bias estimate from active EKF (this is usually for the primary IMU)
-            float abias = 0;
+            float &abias = _accel_bias.z;
             EKF2.getAccelZBias(-1,abias);
 
             // This EKF is currently using primary_imu, and abias applies to only that IMU
@@ -571,7 +572,7 @@ void AP_AHRS::update_EKF3(void)
             }
 
             // get 3-axis accel bias festimates for active EKF (this is usually for the primary IMU)
-            Vector3f abias;
+            Vector3f &abias = _accel_bias;
             EKF3.getAccelBias(-1,abias);
 
             // This EKF uses the primary IMU

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -547,6 +547,13 @@ public:
         return AP::ins().get_accel();
     }
 
+    // return primary accel bias. This should be subtracted from
+    // get_accel() vector to get best current body frame accel
+    // estimate
+    const Vector3f &get_accel_bias(void) const {
+        return _accel_bias;
+    }
+    
     /*
      * AHRS is used as a transport for vehicle-takeoff-expected and
      * vehicle-landing-expected:
@@ -708,6 +715,8 @@ private:
     Vector3f _gyro_estimate;
     Vector3f _accel_ef_ekf[INS_MAX_INSTANCES];
     Vector3f _accel_ef_ekf_blended;
+    Vector3f _accel_bias;
+
     const uint16_t startup_delay_ms = 1000;
     uint32_t start_time_ms;
     uint8_t _ekf_flags; // bitmask from Flags enumeration

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -61,6 +61,7 @@ public:
         Vector3f gyro_drift;
         Vector3f accel_ef[INS_MAX_INSTANCES];  // must be INS_MAX_INSTANCES
         Vector3f accel_ef_blended;
+        Vector3f accel_bias;
     };
 
     // init sets up INS board orientation


### PR DESCRIPTION
This fixes the fixed wing yaw controller to use the EKF estimate of IMU bias
Without this we can build up quite a lot of side-slip

SITL test with 0.3m/s/s Y accel bias, without this PR:
![image](https://user-images.githubusercontent.com/831867/144826056-78d345c0-1da8-48cf-b132-4d8a9aade969.png)
with this PR:
![image](https://user-images.githubusercontent.com/831867/144826129-7180a314-0d5b-4f17-98c6-40338397dda6.png)
