### PR TITLE
Guided corner fix

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -350,10 +350,10 @@ void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_offset_z, float
         accel_z_cmss *= POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_up_cms;
     }
 
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     // calculate the horizontal and vertical velocity limits to travel directly to the destination defined by pos
     float vel_max_xy_cms = 0.0f;
@@ -524,7 +524,7 @@ void AC_PosControl::input_accel_xy(const Vector3f& accel)
     // check for ekf xy position reset
     handle_ekf_xy_reset();
 
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
     shape_accel_xy(accel, _accel_desired, _jerk_max_xy_cmsss, _dt);
 }
 
@@ -535,12 +535,12 @@ void AC_PosControl::input_accel_xy(const Vector3f& accel)
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     shape_vel_accel_xy(vel, accel, _vel_desired.xy(), _accel_desired.xy(),
         _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_vel_accel_xy(vel, accel, _dt, Vector2f());
+    update_vel_accel_xy(vel, accel, _dt, Vector2f(), Vector2f());
 }
 
 /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
@@ -550,12 +550,12 @@ void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, boo
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     shape_pos_vel_accel_xy(pos, vel, accel, _pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(),
                            _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f());
+    update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f(), Vector2f(), Vector2f());
 }
 
 /// stop_pos_xy_stabilisation - sets the target to the current position to remove any position corrections from the system
@@ -626,7 +626,7 @@ void AC_PosControl::update_xy_controller()
     } else {
         _vehicle_horiz_vel = _inav.get_velocity_xy_cms();
     }
-    Vector2f accel_target = _pid_vel_xy.update_all(Vector2f{_vel_target.x, _vel_target.y}, _vehicle_horiz_vel, Vector2f(_limit_vector.x, _limit_vector.y));
+    Vector2f accel_target = _pid_vel_xy.update_all(_vel_target.xy(), _vehicle_horiz_vel, _limit_vector.xy());
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
     accel_target *= ahrsControlScaleXY;
 
@@ -798,7 +798,7 @@ void AC_PosControl::input_accel_z(float accel)
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_accel(accel, _accel_desired.z, _jerk_max_z_cmsss, _dt);
 }
@@ -824,14 +824,14 @@ void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool ignore_desce
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_vel_accel(vel, accel,
                     _vel_desired.z, _accel_desired.z,
                     -constrain_float(accel_z_cmss, 0.0f, 750.0f), accel_z_cmss,
                     _jerk_max_z_cmsss, _dt, limit_output);
 
-    update_vel_accel(vel, accel, _dt, 0);
+    update_vel_accel(vel, accel, _dt, 0.0, 0.0);
 }
 
 /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
@@ -881,7 +881,7 @@ void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, b
     }
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_pos_vel_accel(pos, vel, accel,
                         _pos_target.z, _vel_desired.z, _accel_desired.z,
@@ -890,7 +890,7 @@ void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, b
                         _jerk_max_z_cmsss, _dt, limit_output);
 
     postype_t posp = pos;
-    update_pos_vel_accel(posp, vel, accel, _dt, 0);
+    update_pos_vel_accel(posp, vel, accel, _dt, 0.0, 0.0, 0.0);
     pos = posp;
 }
 
@@ -907,7 +907,7 @@ void AC_PosControl::update_pos_offset_z(float pos_offset_z)
 {
 
     postype_t p_offset_z = _pos_offset_z;
-    update_pos_vel_accel(p_offset_z, _vel_offset_z, _accel_offset_z, _dt, MIN(_limit_vector.z, 0.0f));
+    update_pos_vel_accel(p_offset_z, _vel_offset_z, _accel_offset_z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
     _pos_offset_z = p_offset_z;
 
     // input shape the terrain offset

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -26,7 +26,7 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     // prevent altitude target from breeching altitude limits
     if (is_negative(_alt_min) && _alt_min < _alt_max && _alt_max < 100 && _pos_target.z < _alt_min) {
@@ -38,5 +38,5 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
         -accel_z_cms, accel_z_cms,
         _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_vel_accel(vel, accel, _dt, _limit_vector.z);
+    update_vel_accel(vel, accel, _dt, 0.0, 0.0);
 }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -476,7 +476,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     float vel_time_scalar = 1.0;
     if (is_positive(_wp_desired_speed_xy_cms)) {
-        update_vel_accel(_terrain_vel, _terrain_accel, dt, false);
+        update_vel_accel(_terrain_vel, _terrain_accel, dt, 0.0, 0.0);
         shape_vel_accel( _wp_desired_speed_xy_cms * offset_z_scaler, 0.0,
             _terrain_vel, _terrain_accel,
             -_wp_accel_cmss, _wp_accel_cmss, _pos_control.get_shaping_jerk_xy_cmsss(), dt, true);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -25,19 +25,29 @@ typedef Vector3f Vector3p;
   common controller helper functions
  */
 
-// update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
-// update_vel_accel - single axis projection.
-void update_vel_accel(float& vel, float accel, float dt, float limit);
+// update_vel_accel - single axis projection of velocity, vel, forwards in time based on a time step of dt and acceleration of accel.
+// the velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// vel_error - specifies the direction of the velocity error useded in limit handling
+void update_vel_accel(float& vel, float accel, float dt, float limit, float vel_error);
 
 // update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit);
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit, float pos_error, float vel_error);
 
-// update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
+// update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+// the velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& vel_error);
 
-// update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
+// update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+// the position and velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& pos_error, const Vector2f& vel_error);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.


### PR DESCRIPTION
This PR fixes a number of problems with the guided implementation when handling corners and controller saturation. The PR:

- prevents the target moving behind the actual position when saturated,
- prevents the velocity growing to maximum when saturated,
- reserves up to 1/sqrt(2) acceleration for the cross axis corrections but only when needed,
- does breaking at 1/sqrt(2) acceleration to provide enough left over acceleration to start a corner if needed without overshooting.
- 
This shows the improvement between what we have now and this PR:
![image](https://user-images.githubusercontent.com/100896/144940892-d02c8a93-49fc-4bbd-9bd9-df1bb55186a9.png)

Thanks to Ferruccio Vicari for his help and testing.