### PR TITLE
AP_NMEA_Output: remove pointless intermediate res variables

### DIFF
--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -167,24 +167,15 @@ void AP_NMEA_Output::update()
             continue;
         }
 
-        if (gga_res != -1) {
-            _uart[i]->write(gga);
-            _uart[i]->write(gga_end);
-        }
+        _uart[i]->write(gga);
+        _uart[i]->write(gga_end);
 
-        if (rmc_res != -1) {
-            _uart[i]->write(rmc);
-            _uart[i]->write(rmc_end);
-        }
+        _uart[i]->write(rmc);
+        _uart[i]->write(rmc_end);
     }
 
-    if (gga_res != -1) {
-        free(gga);
-    }
-
-    if (rmc_res != -1) {
-        free(rmc);
-    }
+    free(gga);
+    free(rmc);
 }
 
 #endif  // HAL_NMEA_OUTPUT_ENABLED


### PR DESCRIPTION
I've tested this as far as ensuring NMEA ouptut in SITL still works.

I believe this old structure remains from when we used to *not* return if any allocations failed.
