### PR TITLE
AP_AHRS: mark type column in ORGN as instance

### DIFF
--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -148,7 +148,7 @@ struct PACKED log_Rate {
     { LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
         "ATT", "QccccCCCCB", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw,AEKF", "sddddhhdh-", "FBBBBBBBB-" , true }, \
     { LOG_ORGN_MSG, sizeof(log_ORGN), \
-        "ORGN","QBLLe","TimeUS,Type,Lat,Lng,Alt", "s-DUm", "F-GGB" }, \
+        "ORGN","QBLLe","TimeUS,Type,Lat,Lng,Alt", "s#DUm", "F-GGB" }, \
     { LOG_POS_MSG, sizeof(log_POS), \
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \


### PR DESCRIPTION
As discussed on DevCall this-morning, adding `#` to the message definition to make the type an instance column.

Tested in SITL:

![image](https://user-images.githubusercontent.com/7077857/144974413-98a58eea-1d10-412b-8f83-20be956ba47a.png)
