### PR TITLE
Make RPM logging independant of RCIN mask

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -155,9 +155,7 @@ void Copter::rpm_update(void)
 #if RPM_ENABLED == ENABLED
     rpm_sensor.update();
     if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        if (should_log(MASK_LOG_RCIN)) {
-            logger.Write_RPM(rpm_sensor);
-        }
+        logger.Write_RPM(rpm_sensor);
     }
 #endif
 }

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -60,8 +60,6 @@ void Plane::rpm_update(void)
 {
     rpm_sensor.update();
     if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        if (should_log(MASK_LOG_RC)) {
-            logger.Write_RPM(rpm_sensor);
-        }
+        logger.Write_RPM(rpm_sensor);
     }
 }

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -79,9 +79,7 @@ void Sub::rpm_update(void)
 {
     rpm_sensor.update();
     if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        if (should_log(MASK_LOG_RCIN)) {
-            logger.Write_RPM(rpm_sensor);
-        }
+        logger.Write_RPM(rpm_sensor);
     }
 }
 #endif

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -109,8 +109,6 @@ void Rover::rpm_update(void)
 {
     rpm_sensor.update();
     if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        if (should_log(MASK_LOG_RC)) {
-            logger.Write_RPM(rpm_sensor);
-        }
+        logger.Write_RPM(rpm_sensor);
     }
 }


### PR DESCRIPTION
This PR removes the RCIN mask should log check.

It is in no way intuative to users that RPM logging is tied to RCIN in the logging bit mask.  We already have RPM enable (which defaults to not enabled).  If a user configures RPM then its safe to assume it should be logged.   