### PR TITLE
Tidy SITL rangefinder calculations

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -74,7 +74,6 @@ void SITL_State::_sitl_setup(const char *home_str)
     if (_sitl != nullptr) {
         // setup some initial values
         _update_airspeed(0);
-        _update_rangefinder(0);
         if (enable_gimbal) {
             gimbal = new SITL::Gimbal(_sitl->state);
         }
@@ -165,7 +164,7 @@ void SITL_State::_fdm_input_step(void)
 
     if (_sitl != nullptr) {
         _update_airspeed(_sitl->state.airspeed);
-        _update_rangefinder(_sitl->state.range);
+        _update_rangefinder();
     }
 
     // trigger all APM timers.

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -139,7 +139,7 @@ private:
     void _setup_adc(void);
 
     void set_height_agl(void);
-    void _update_rangefinder(float range_value);
+    void _update_rangefinder();
     void _set_signal_handlers(void) const;
 
     void _update_airspeed(float airspeed);
@@ -279,6 +279,11 @@ private:
 
     // simulated GPS devices
     SITL::GPS *gps[2];  // constrained by # of parameter sets
+
+    // returns a voltage between 0V to 5V which should appear as the
+    // voltage from the sensor
+    float _sonar_pin_voltage() const;
+
 };
 
 #endif // defined(HAL_BUILD_AP_PERIPH)

--- a/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
+++ b/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
@@ -19,58 +19,36 @@ extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
 
+// returns a voltage between 0V to 5V which should appear as the
+// voltage from the sensor
+float SITL_State::_sonar_pin_voltage() const
+{
+    // Use glitch defines as the probablility between 0-1 that any
+    // given sonar sample will read as max distance
+    if (!is_zero(_sitl->sonar_glitch) &&
+        _sitl->sonar_glitch >= (rand_float() + 1.0f) / 2.0f) {
+        // glitched
+        return 5.0f;
+    }
+
+    const float altitude = sitl_model->rangefinder_range();
+    if (altitude == INFINITY) {
+        return 5.0f;
+    }
+
+    // Altitude in in m, scaler in meters/volt
+    const float voltage = altitude / _sitl->sonar_scale;
+
+    // constrain to 0-5V
+    return constrain_float(voltage, 0.0f, 5.0f);
+}
+
 /*
   setup the rangefinder with new input
  */
-void SITL_State::_update_rangefinder(float range_value)
+void SITL_State::_update_rangefinder()
 {
-    float altitude = range_value;
-    if (is_equal(range_value, -1.0f)) {  // Use SITL altitude as reading by default
-        altitude = _sitl->height_agl;
-    }
-
-    // sensor position offset in body frame
-    const Vector3f relPosSensorBF = _sitl->rngfnd_pos_offset;
-
-    // adjust altitude for position of the sensor on the vehicle if position offset is non-zero
-    if (!relPosSensorBF.is_zero()) {
-        // get a rotation matrix following DCM conventions (body to earth)
-        Matrix3f rotmat;
-        _sitl->state.quaternion.rotation_matrix(rotmat);
-        // rotate the offset into earth frame
-        const Vector3f relPosSensorEF = rotmat * relPosSensorBF;
-        // correct the altitude at the sensor
-        altitude -= relPosSensorEF.z;
-    }
-
-    float voltage = 5.0f;  // Start the reading at max value = 5V
-    // If the attidude is non reversed for SITL OR we are using rangefinder from external simulator,
-    // We adjust the reading with noise, glitch and scaler as the reading is on analog port.
-    if ((fabs(_sitl->state.rollDeg) < 90.0 && fabs(_sitl->state.pitchDeg) < 90.0) || !is_equal(range_value, -1.0f)) {
-        if (is_equal(range_value, -1.0f)) {  // disable for external reading that already handle this
-            // adjust for apparent altitude with roll
-            altitude /= cosf(radians(_sitl->state.rollDeg)) * cosf(radians(_sitl->state.pitchDeg));
-        }
-        // Add some noise on reading
-        altitude += _sitl->sonar_noise * rand_float();
-
-        // Altitude in in m, scaler in meters/volt
-        voltage = altitude / _sitl->sonar_scale;
-        // constrain to 0-5V
-        voltage = constrain_float(voltage, 0.0f, 5.0f);
-
-        // Use glitch defines as the probablility between 0-1 that any given sonar sample will read as max distance
-        if (!is_zero(_sitl->sonar_glitch) && _sitl->sonar_glitch >= (rand_float() + 1.0f) / 2.0f) {
-            voltage = 5.0f;
-        }
-    }
-
-    // if not populated also fill out the STIL rangefinder array
-    if (is_equal(_sitl->state.rangefinder_m[0],-1.0f)) {
-        _sitl->state.rangefinder_m[0] = altitude;
-    }
-
-    sonar_pin_value = 1023 * (voltage / 5.0f);
+    sonar_pin_value = 1023 * (_sonar_pin_voltage() / 5.0f);
 }
 
 #endif

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -507,16 +507,17 @@ float Aircraft::rangefinder_range() const
         altitude -= relPosSensorEF.z;
     }
 
-    // If the attidude is non reversed for SITL OR we are using rangefinder from external simulator,
-    // We adjust the reading with noise, glitch and scaler as the reading is on analog port.
-    if ((fabs(sitl->state.rollDeg) < 90.0 && fabs(sitl->state.pitchDeg) < 90.0) || !is_equal(range, -1.0f)) {
-        if (is_equal(range, -1.0f)) {  // disable for external reading that already handle this
-            // adjust for apparent altitude with roll
-            altitude /= cosf(radians(sitl->state.rollDeg)) * cosf(radians(sitl->state.pitchDeg));
+    if (is_equal(range, -1.0f)) {  // disable for external reading that already handle this
+        if (fabs(sitl->state.rollDeg) >= 90.0 || fabs(sitl->state.pitchDeg) >= 90.0) {
+            // not going to hit the ground....
+            return INFINITY;
         }
-        // Add some noise on reading
-        altitude += sitl->sonar_noise * rand_float();
+
+        // adjust for apparent altitude with roll
+        altitude /= cosf(radians(sitl->state.rollDeg)) * cosf(radians(sitl->state.pitchDeg));
     }
+    // Add some noise on reading
+    altitude += sitl->sonar_noise * rand_float();
 
     return altitude;
 }

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -192,7 +192,9 @@ protected:
     float rpm[12];
     uint8_t rcin_chan_count;
     float rcin[12];
-    float range = -1.0f;                 // externally supplied rangefinder value, assumed to have been corrected for vehicle attitude
+
+    virtual float rangefinder_beam_width() const { return 0; }
+    virtual float perpendicular_distance_to_rangefinder_surface() const;
 
     struct {
         // data from simulated laser scanner, if available

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -65,6 +65,12 @@ Submarine::Submarine(const char *frame_str) :
     lock_step_scheduled = true;
 }
 
+float Submarine::perpendicular_distance_to_rangefinder_surface() const
+{
+    const float floor_depth = calculate_sea_floor_depth(position);
+    return floor_depth - position.z;
+}
+
 // calculate rotational and linear accelerations
 void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
@@ -88,9 +94,8 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
         rot_accel += t.rotational * thrust * frame_property.thruster_mount_radius / frame_property.moment_of_inertia;
     }
 
-    float floor_depth = calculate_sea_floor_depth(position);
-    range = floor_depth - position.z;
     // Limit movement at the sea floor
+    const float floor_depth = calculate_sea_floor_depth(position);
     if (position.z > floor_depth && body_accel.z > -GRAVITY_MSS) {
     	body_accel.z = -GRAVITY_MSS;
     }
@@ -138,7 +143,7 @@ void Submarine::calculate_buoyancy_torque(Vector3f &torque)
  * @param position
  * @return float
  */
-float Submarine::calculate_sea_floor_depth(const Vector3d &/*position*/)
+float Submarine::calculate_sea_floor_depth(const Vector3d &/*position*/) const
 {
     return 50;
 }

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -89,8 +89,12 @@ protected:
 
     bool on_ground() const override;
 
+    float rangefinder_beam_width() const override { return 10; }
+
+    float perpendicular_distance_to_rangefinder_surface() const override;
+
     // calculate sea floor depth based for terrain follow
-    float calculate_sea_floor_depth(const Vector3d &/*position*/);
+    float calculate_sea_floor_depth(const Vector3d &/*position*/) const;
     // calculate rotational and linear accelerations
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     // calculate buoyancy


### PR DESCRIPTION
We were duplicating the range calculations.

This splits things such that the voltage calculation made by AP_HAL_SITL is separate but dependant on the altitude coming from the simulated analogue rangefinder.
