### PR TITLE
Copter: Guided Mavlink Target Input loosen force_set restriction only for acceleration commands

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1160,8 +1160,9 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
         bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
 
-        // force_set true, do not accept command
-        if (force_set) {
+        // Force inputs are not supported
+        // Do not accept command if force_set is true and acc_ignore is false
+        if (force_set && !acc_ignore) {
             break;
         }
 
@@ -1254,8 +1255,9 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
         bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
 
-        // force_set true, do not accept command
-        if (force_set) {
+        // Force inputs are not supported
+        // Do not accept command if force_set is true and acc_ignore is false
+        if (force_set && !acc_ignore) {
             break;
         }
 


### PR DESCRIPTION
#18720 was a bit too  restrictive considering how much pre-existing code is out there utilizing Force_Set `True` when acceleration targets aren't being commanded.   See this comment https://github.com/ArduPilot/ardupilot/issues/19462#issuecomment-989863780

This only rejects commands for when force_set is true & accelerations are to be commanded. 

Tested in SITL with:
`mode guided`
`module load message`
`arm throttle`
`takeoff 10`
`message SET_POSITION_TARGET_LOCAL_NED 0 1 0 1 4039 0 0 0 2 -2 -1 0 0 0 0 0`

Note above TYPE_MASK: sets ignore POS, ACCEL, Yaw, & Yaw Rate.  Sets Force_Set TRUE and allows Velocity commands