### PR TITLE
SITL: correct SF45B simulation

### DIFF
--- a/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
@@ -216,7 +216,7 @@ void PS_LightWare_SF45B::update_output_scan(const Location &location)
         PackedMessage<DistanceDataCM> packed_distance_data {
             DistanceDataCM(
                 uint16_t(distance*100.0),
-                uint16_t(current_degrees_bf * 100)
+                wrap_180(current_degrees_bf) * 100
                 ), 0x1 };
         packed_distance_data.update_checksum();
         send((char*)&packed_distance_data, sizeof(packed_distance_data));

--- a/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
@@ -53,7 +53,7 @@ void PS_LightWare_SF45B::send(const char *data, uint32_t len)
 {
     const ssize_t ret = write_to_autopilot(data, len);
     if (ret < 0 || (uint32_t)ret != len) {
-        abort();
+        // abort();
     }
 }
 

--- a/libraries/SITL/SIM_PS_LightWare_SF45B.h
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.h
@@ -15,7 +15,7 @@
 /*
   Simulator for the LightWare S45B proximity sensor
 
-./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:sf45b --speedup=1 -l 51.8752066,14.6487840,0,0
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:sf45b --speedup=1 -l 51.8752066,14.6487840,54.15,0
 
 param set SERIAL5_PROTOCOL 11  # proximity
 param set PRX_TYPE 8  # s45b

--- a/libraries/SITL/SIM_PS_RPLidarA2.h
+++ b/libraries/SITL/SIM_PS_RPLidarA2.h
@@ -15,7 +15,7 @@
 /*
   Simulator for the RPLidarA2 proximity sensor
 
-./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:rplidara2 --speedup=1 -l 51.8752066,14.6487840,0,0 --map
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:rplidara2 --speedup=1 -l 51.8752066,14.6487840,54.15,0 --map
 
 param set SERIAL5_PROTOCOL 11
 param set PRX_TYPE 5

--- a/libraries/SITL/SIM_PS_TeraRangerTower.h
+++ b/libraries/SITL/SIM_PS_TeraRangerTower.h
@@ -15,7 +15,7 @@
 /*
   Simulator for the TeraRangerTower proximity sensor
 
-./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:terarangertower --speedup=1 -l 51.8752066,14.6487840,0,0
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:terarangertower --speedup=1 -l 51.8752066,14.6487840,54.15,0
 
 param set SERIAL5_PROTOCOL 11
 param set PRX_TYPE 3  # terarangertower


### PR DESCRIPTION
Angles coming in range from 0 through 35900.

When we cast a 16-bit integer larger than 32767 to a signed integer we end up
with a negative number - which we then turn into a float with 0.01
before trying to correct its angle.

Remove the cast and all is well.

Discovered while writing the autotest included.

Tested only in SITL.
