### PR TITLE
AP_BattMonitor: use SOC 127 as an invalid SOC flag

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -183,7 +183,7 @@ void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
     const float current = use_input_value ? cb.msg->input_current : cb.msg->output_current;
 
     // use an invalid soc so we use the library calculated one
-    const uint8_t soc = 101;
+    const uint8_t soc = 127;
 
     // convert C to Kelvin
     const float temperature_K = isnanf(cb.msg->temperature) ? 0 : cb.msg->temperature + C_TO_KELVIN;
@@ -264,9 +264,10 @@ bool AP_BattMonitor_UAVCAN::capacity_remaining_pct(uint8_t &percentage) const
 {
     if ((uint32_t(_params._options.get()) & uint32_t(AP_BattMonitor_Params::Options::Ignore_UAVCAN_SoC)) ||
         _mppt.is_detected ||
-        _soc > 100) {
+        _soc == 127) {
         // a UAVCAN battery monitor may not be able to supply a state of charge. If it can't then
         // the user can set the option to use current integration in the backend instead.
+        // SOC of 127 is used as an invalid SOC flag ie system configuration errors or SOC estimation unavailable
         return AP_BattMonitor_Backend::capacity_remaining_pct(percentage);
     }
 


### PR DESCRIPTION
As discussed here, https://github.com/ArduPilot/ardupilot/pull/19404#discussion_r763693256

Using soc = 101 for an invalid soc is pre-existing, but I'm not a fan of it. Technically, of course the battery can never get above 100 soc by definition both in current UAVCAN standard and of course reality. But if the system is misconfigured (wrong voltages, capacity, etc.) it could end up above 101 SOC.

I just looked some code for a UAVCAN battery monitor and it just sends out 100 if it computes SOC above 100. Instead IMO a device should send a "hey this is isn't right state using 127". Just a thought as we look to future DroneCan messages.

Since we can't really change the in-use UAVCAN standard I didn't propose that. I imagine the change would look like this in `1092.BatteryInfo.UAVCAN`

```cpp
#
# Relative State of Charge (SOC) estimate, in percent.
# http://en.wikipedia.org/wiki/State_of_charge
#
uint7 STATE_OF_CHARGE_INVALID = 127     # Use this constant if SOC cannot be estimated or if the SOC estimation is in an error state
uint7 state_of_charge_pct               # Percent of the full charge [0, 100]. This field is required
uint7 state_of_charge_pct_stdev         # SOC error standard deviation; use best guess if unknown
```