### PR TITLE
DevEnv: Add AP VSCode extension to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "streetsidesoftware.code-spell-checker",
-        "chiehyu.vscode-astyle"
+        "chiehyu.vscode-astyle",
+        "ardupilot-org.ardupilot-devenv"
     ]
 }


### PR DESCRIPTION
Adds Sid's VSCode extension to the recommendations list. Should be helpful to get up and running before memorizing waf options.