### PR TITLE
Motors/Scripting: add support for setting a custom frame string

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -534,8 +534,9 @@ void Plane::Log_Write_Vehicle_Startup_Messages()
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.initialised) {
-        logger.Write_MessageF("QuadPlane Frame: %s/%s", quadplane.motors->get_frame_string(),
-                                                        quadplane.motors->get_type_string());
+        char frame_and_type_string[30];
+        quadplane.motors->get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
+        logger.Write_MessageF("QuadPlane %s", frame_and_type_string);
     }
 #endif
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -727,7 +727,9 @@ bool QuadPlane::setup(void)
     // param count will have changed
     AP_Param::invalidate_count();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised, class: %s, type: %s", motors->get_frame_string(), motors->get_type_string());
+    char frame_and_type_string[30];
+    motors->get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
+    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised, %s", frame_and_type_string);
     initialised = true;
     return true;
 }

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -29,8 +29,6 @@ public:
         SUB_FRAME_CUSTOM
     } sub_frame_t;
 
-    const char* get_frame_string() const override { return _frame_class_string; };
-
     // Override parent
     void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
 

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -49,8 +49,6 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t            get_motor_mask() override;
 
-    const char* get_frame_string() const override { return "COAX"; }
-
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
@@ -58,4 +56,6 @@ protected:
     float               _actuator_out[NUM_ACTUATORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range
     float               _thrust_yt_ccw;
     float               _thrust_yt_cw;
+
+    const char* _get_frame_string() const override { return "COAX"; }
 };

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -159,8 +159,6 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
-    const char* get_frame_string() const override { return "HELI"; }
-
 protected:
 
     // manual servo modes (used for setup)
@@ -226,6 +224,8 @@ protected:
 
     // updates the takeoff collective flag indicating that current collective is greater than collective required to indicate takeoff.
     void update_takeoff_collective_flag(float coll_out);
+
+    const char* _get_frame_string() const override { return "HELI"; }
 
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -95,8 +95,6 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
-    const char* get_frame_string() const override { return "HELI_DUAL"; }
-
 protected:
 
     // init_outputs
@@ -110,6 +108,8 @@ protected:
 
     // move_actuators - moves swash plate to attitude of parameters passed in
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out)  override;
+
+    const char* _get_frame_string() const override { return "HELI_DUAL"; }
 
     //  objects we depend upon
     AP_MotorsHeli_Swash        _swashplate1;        // swashplate1

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -74,8 +74,6 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
-    const char* get_frame_string() const override { return "HELI_QUAD"; }
-
 protected:
 
     // init_outputs
@@ -89,6 +87,8 @@ protected:
 
     // move_actuators - moves swash plate to attitude of parameters passed in
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out)  override;
+
+    const char* _get_frame_string() const override { return "HELI_QUAD"; }
 
     // rate factors
     float _rollFactor[AP_MOTORS_HELI_QUAD_NUM_MOTORS];

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -76,9 +76,6 @@ public:
     // return the pitch factor of any motor
     float               get_pitch_factor(uint8_t i) override { return _pitch_factor[i]; }
 
-    const char*         get_frame_string() const override { return _frame_class_string; }
-    const char*         get_type_string() const override { return _frame_type_string; }
-
     // disable the use of motor torque to control yaw. Used when an external mechanism such
     // as vectoring is used for yaw control
     void                disable_yaw_torque(void) override;
@@ -133,6 +130,9 @@ protected:
 
     // call vehicle supplied thrust compensation if set
     void                thrust_compensation(void) override;
+
+    const char*         _get_frame_string() const override { return _frame_class_string; }
+    const char*         get_type_string() const override { return _frame_type_string; }
 
     float               _roll_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to roll
     float               _pitch_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to pitch

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.h
@@ -37,14 +37,14 @@ public:
     // if the expected number of motors have been setup then set as initalized
     bool init(uint8_t expected_num_motors) override;
 
-    const char* get_frame_string() const override { return "6DoF scripting"; }
-
 protected:
     // output - sends commands to the motors
     void output_armed_stabilizing() override;
 
     // nothing to do for setup, scripting will mark as initalized when done
     void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+
+    const char* _get_frame_string() const override { return "6DoF scripting"; }
 
     float _forward_factor[AP_MOTORS_MAX_NUM_MOTORS];      // each motors contribution to forward thrust
     float _right_factor[AP_MOTORS_MAX_NUM_MOTORS];        // each motors contribution to right thrust

--- a/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h
@@ -43,13 +43,13 @@ public:
     // output - sends commands to the motors
     void output_to_motors() override;
 
-    const char* get_frame_string() const override { return "Dynamic Matrix"; }
-
 protected:
 
     // Do not apply thrust compensation, this is used by Quadplane tiltrotors
     // assume the compensation is done in the mixer and should not be done by quadplane
     void thrust_compensation(void) override {};
+
+    const char* _get_frame_string() const override { return "Dynamic Matrix"; }
 
 private:
 

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -49,11 +49,11 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t            get_motor_mask() override;
 
-    const char* get_frame_string() const override { return "SINGLE"; }
-
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
+
+    const char* _get_frame_string() const override { return "SINGLE"; }
 
     int16_t             _throttle_radio_output;   // total throttle pwm value, summed onto throttle channel minimum, typically ~1100-1900
     float               _actuator_out[NUM_ACTUATORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -33,11 +33,11 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t get_motor_mask() override;
 
-    const char* get_frame_string() const override { return "TAILSITTER"; }
-
 protected:
     // calculate motor outputs
     void output_armed_stabilizing() override;
+
+    const char* _get_frame_string() const override { return "TAILSITTER"; }
 
     // calculated outputs
     float _throttle; // 0..1

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -54,15 +54,15 @@ public:
     // using copter motors for forward flight
     float               get_roll_factor(uint8_t i) override;
 
-    const char* get_frame_string() const override { return "TRI"; }
-
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
 
     // call vehicle supplied thrust compensation if set
     void                thrust_compensation(void) override;
-    
+
+    const char* _get_frame_string() const override { return "TRI"; }
+
     // parameters
 
     float           _pivot_angle;                       // Angle of yaw pivot

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -52,7 +52,11 @@ void AP_Motors::get_frame_and_type_string(char *buffer, uint8_t buflen) const
 {
     const char *frame_str = get_frame_string();
     const char *type_str = get_type_string();
-    if (type_str != nullptr && strlen(type_str)) {
+    if (type_str != nullptr && strlen(type_str)
+#if AP_SCRIPTING_ENABLED
+        && custom_frame_string == nullptr
+#endif
+    ) {
         hal.util->snprintf(buffer, buflen, "Frame: %s/%s", frame_str, type_str);
     } else {
         hal.util->snprintf(buffer, buflen, "Frame: %s", frame_str);
@@ -226,6 +230,31 @@ bool AP_Motors::is_digital_pwm_type() const
     }
     return false;
 }
+
+// return string corresponding to frame_class
+const char* AP_Motors::get_frame_string() const
+{
+#if AP_SCRIPTING_ENABLED
+    if (custom_frame_string != nullptr) {
+        return custom_frame_string;
+    }
+#endif
+    return _get_frame_string();
+}
+
+#if AP_SCRIPTING_ENABLED
+// set custom frame string
+void AP_Motors::set_frame_string(const char * str) {
+    if (custom_frame_string != nullptr) {
+        return;
+    }
+    const size_t len = strlen(str)+1;
+    custom_frame_string = new char[len];
+    if (custom_frame_string != nullptr) {
+        strncpy(custom_frame_string, str, len);
+    }
+}
+#endif
 
 namespace AP {
     AP_Motors *motors()

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -73,7 +73,7 @@ public:
     };
 
     // return string corresponding to frame_class
-    virtual const char* get_frame_string() const = 0;
+    const char* get_frame_string() const;
 
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,
@@ -95,8 +95,6 @@ public:
         MOTOR_FRAME_TYPE_Y4 = 19, //Y4 Quadrotor frame
     };
 
-    // return string corresponding to frame_type
-    virtual const char* get_type_string() const { return ""; }
 
     // returns a formatted string into buffer, e.g. "QUAD/X"
     void get_frame_and_type_string(char *buffer, uint8_t buflen) const;
@@ -256,6 +254,10 @@ public:
     // direct motor write
     virtual void        rc_write(uint8_t chan, uint16_t pwm);
 
+#if AP_SCRIPTING_ENABLED
+    void set_frame_string(const char * str);
+#endif
+
 protected:
     // output functions that should be overloaded by child classes
     virtual void        output_armed_stabilizing() = 0;
@@ -330,6 +332,17 @@ protected:
                     PWM_TYPE_DSHOT600   = 6,
                     PWM_TYPE_DSHOT1200  = 7,
                     PWM_TYPE_PWM_RANGE  = 8 };
+
+    // return string corresponding to frame_class
+    virtual const char* _get_frame_string() const = 0;
+
+    // return string corresponding to frame_type
+    virtual const char* get_type_string() const { return ""; }
+
+#if AP_SCRIPTING_ENABLED
+    // Custom frame string set from scripting
+    char* custom_frame_string;
+#endif
 
 private:
 

--- a/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
+++ b/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
@@ -39,7 +39,7 @@ public:
     void init(motor_frame_class frame_class, motor_frame_type frame_type) override {};
     void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {};
     void output_test_seq(uint8_t motor_seq, int16_t pwm) override {};
-    const char* get_frame_string() const override { return "TEST"; }
+    const char* _get_frame_string() const override { return "TEST"; }
     void output_armed_stabilizing() override {};
     void output_to_motors() override {};
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -646,6 +646,15 @@ function RC_Channel_ud:norm_input() end
 
 
 -- desc
+---@class motors
+motors = {}
+
+-- desc
+---@param param1 string
+function motors:set_frame_string(param1) end
+
+
+-- desc
 ---@class periph
 periph = {}
 

--- a/libraries/AP_Scripting/examples/MotorMatrix_fault_tolerant_hex.lua
+++ b/libraries/AP_Scripting/examples/MotorMatrix_fault_tolerant_hex.lua
@@ -33,3 +33,5 @@ add_motor(AP_MOTORS_MOT_5,  30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1)
 add_motor(AP_MOTORS_MOT_6,-150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4)
 
 assert(MotorsMatrix:init(6), "Failed to init MotorsMatrix")
+
+motors:set_frame_string("fault tolerant hex")

--- a/libraries/AP_Scripting/examples/MotorMatrix_setup.lua
+++ b/libraries/AP_Scripting/examples/MotorMatrix_setup.lua
@@ -7,3 +7,5 @@ MotorsMatrix:add_motor_raw(2, 0, 1,-1, 1)
 MotorsMatrix:add_motor_raw(3, 0,-1,-1, 3)
 
 assert(MotorsMatrix:init(4), "Failed to init MotorsMatrix")
+
+motors:set_frame_string("scripting plus example")

--- a/libraries/AP_Scripting/examples/Motor_mixer_dynamic_setup.lua
+++ b/libraries/AP_Scripting/examples/Motor_mixer_dynamic_setup.lua
@@ -43,5 +43,7 @@ assert(Motors_dynamic:init(4), "Failed to init Motors_dynamic")
 -- at any time we can then re-load new factors
 Motors_dynamic:load_factors(factors)
 
+motors:set_frame_string("Dynamic example")
+
 -- if doing changes in flight it is a good idea to us pcall to protect the script from crashing
 -- see 'protected_call.lua' example

--- a/libraries/AP_Scripting/examples/Motors_6DoF.lua
+++ b/libraries/AP_Scripting/examples/Motors_6DoF.lua
@@ -9,3 +9,6 @@ Motors_6DoF:add_motor(4, -0.205533, -0.035715,  0.359267, -0.048371,  0.010753, 
 Motors_6DoF:add_motor(5,  0.143881, -0.227449,  0.375220, -0.046098,  0.811593,  0.431718, true, 6)
 
 assert(Motors_6DoF:init(6),'unable to setup 6 motors')
+
+motors:set_frame_string("6DoF example")
+

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -452,3 +452,9 @@ singleton AP_Periph_FW depends defined(HAL_BUILD_AP_PERIPH)
 singleton AP_Periph_FW alias periph
 singleton AP_Periph_FW method get_yaw_earth float
 singleton AP_Periph_FW method get_vehicle_state uint32_t
+
+include AP_Motors/AP_Motors_Class.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
+singleton AP::motors() depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
+singleton AP::motors() literal
+singleton AP::motors() alias motors
+singleton AP::motors() method set_frame_string void string


### PR DESCRIPTION
This allows scripting to set a custom frame string to go with its ability to setup custom frames. I have also made a small quadplane change to use the `get_frame_and_type_string` method rather than getting each individually.