### PR TITLE
AP_SerialManager: remove unused extern bool reference

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -422,8 +422,6 @@ void AP_SerialManager::init_console()
 #endif
 }
 
-extern bool g_nsh_should_exit;
-
 // init - // init - initialise serial ports
 void AP_SerialManager::init()
 {


### PR DESCRIPTION
This isn't used - or even defined.