### PR TITLE
AP_NavEKF3: allow boards to override NavEKF3 features

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 // define for when to include all features
 #define EK3_FEATURE_ALL APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) || APM_BUILD_TYPE(APM_BUILD_Replay)


### PR DESCRIPTION
defines created by the hwdef system weren't visible in here
