### PR TITLE
AP_HAL_SITL: use is_equal to compare floats in _sonar_pin_voltage()

### DIFF
--- a/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
+++ b/libraries/AP_HAL_SITL/sitl_rangefinder.cpp
@@ -32,7 +32,7 @@ float SITL_State::_sonar_pin_voltage() const
     }
 
     const float altitude = sitl_model->rangefinder_range();
-    if (altitude == INFINITY) {
+    if (is_equal(altitude, INFINITY)) {
         return 5.0f;
     }
 


### PR DESCRIPTION
Comparing floats with == or != throws error, we should use is_equal() instead
<img width="1151" alt="Screenshot 2021-12-11 at 11 40 32 PM" src="https://user-images.githubusercontent.com/67995771/145687859-939e5bf7-4251-40c8-98ca-61c85ef4aadb.png">

