### PR TITLE
Create and use Enum16

### DIFF
--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -1032,3 +1032,12 @@ public:
         return (eclass)_value;
     }
 };
+
+template<typename eclass>
+class AP_Enum16 : public AP_Int16
+{
+public:
+    operator const eclass () const {
+        return (eclass)_value;
+    }
+};

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -270,7 +270,7 @@ private:
     AP_Int16 servo_trim;
     // reversal, following convention that 1 means reversed, 0 means normal
     AP_Int8 reversed;
-    AP_Int16 function;
+    AP_Enum16<Aux_servo_function_t> function;
 
     // a pending output value as PWM
     uint16_t output_pwm;

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -317,7 +317,8 @@ void SRV_Channels::calc_pwm(void)
             channels[i].set_override(true);
             override_counter[i]--;
         }
-        channels[i].calc_pwm(functions[channels[i].function].output_scaled);
+        const uint16_t function_num = channels[i].function.get();
+        channels[i].calc_pwm(functions[function_num].output_scaled);
     }
 }
 


### PR DESCRIPTION
Similar to Enum8, this allows for better type-safety and less casting.

Tested in SITL.

I also flashed this onto a CubeBlack and did a very small amount of testing - ensure RC passthrough still worked.
