### PR TITLE
HAL_ChibiOS: reduce rebuild on re-configure

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -494,7 +494,7 @@ def write_dma_header(f, peripheral_list, mcu_type, dma_exclude=[],
     if len(shared_set) == 0:
         f.write("#define SHARED_DMA_MASK 0\n")
     else:
-        f.write("#define SHARED_DMA_MASK (%s)\n" % '|'.join(list(shared_set)))
+        f.write("#define SHARED_DMA_MASK (%s)\n" % '|'.join(sorted(list(shared_set))))
 
     # now generate UARTDriver.cpp DMA config lines
     f.write("\n\n// generated UART DMA configuration lines\n")


### PR DESCRIPTION
this fixes an unnecessary change in hwdef.h based on set to list conversion, and avoids changing timestamp on hwdef.h if unchanged
