### PR TITLE
GCS_MAVLink: Don't start with MAVLink1 messages on a MAVLink2 connection

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -160,22 +160,11 @@ bool GCS_MAVLINK::init(uint8_t instance)
     if (mavlink_protocol == AP_SerialManager::SerialProtocol_MAVLink2) {
         // load signing key
         load_signing_key();
-
-        if (status->signing == nullptr) {
-            // if signing is off start by sending MAVLink1.
-            status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-        }
     } else if (status) {
         // user has asked to only send MAVLink1
         status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
     }
-
-    if (chan == MAVLINK_COMM_0) {
-        // Always start with MAVLink1 on first port for now, to allow for recovery
-        // after experiments with MAVLink2
-        status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-    }
-
+    
     return true;
 }
 


### PR DESCRIPTION
Currently, ArduPilot will default to MAVLink1 messages on a ``SERIALn_PROTOCOL=2``, until a valid MAVLink2 message is received from the GCS. Then AP will switch to sending MAVLink2 messages.

Note that if MAVLink signing is enabled, ArduPilot will send MAVLink2 messages from the beginning anyway.

This PR makes this behaviour more consistent, so ArduPilot will in all cases (where ``SERIALn_PROTOCOL=2``) send MAVLink2 messages from the beginning.

Looking at the comments around the code, it seems this came from the time period where MAVLink2 was new, and provided a fallback to ensure a GCS could always communicate with ArduPilot. Given how long we've been using MAVLink2 without issues, I suspect this is no longer an issue.

I recently encountered this whilst troubleshooting a custom GCS, where the GCS would auto-detect the MAVLink version by looking at the incoming protocol markers. So the GCS always auto-detected MAVLink1, despite ``SERIALn_PROTOCOL=2``.

This will also be an issue for any GCS links over high-latency/low-bandwidth connections, where the GCS may not be sending packets often.

I've tested this PR against MAVProxy, QGC and Mission Planner with no problems.

I note this is a change to how ArduPilot interacts with GCS's and related systems, so I'd be interested in any cases where this breaks any existing functionality _and_ it's not fixable via setting ``SERIALn_PROTOCOL=1``.