### PR TITLE
AP_Vehicle: declare get_control_output only if scripting is enabled

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -219,8 +219,6 @@ public:
     virtual bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) { return false; }
     virtual void nav_script_time_done(uint16_t id) {}
 
-#endif // AP_SCRIPTING_ENABLED
-
 
     // control outputs enumeration
     enum class ControlOutput {
@@ -238,6 +236,8 @@ public:
     // get control output (for use in scripting)
     // returns true on success and control_value is set to a value in the range -1 to +1
     virtual bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) { return false; }
+
+#endif // AP_SCRIPTING_ENABLED
 
     // write out harmonic notch log messages
     void write_notch_log_messages() const;


### PR DESCRIPTION
It's right there in the comments - this should only be defined if
scripting is enabled.

Rover overrides this but that is protected by AP_SCRIPTING_ENABLED.

Tested only that it compiles.
