### PR TITLE
TECS: fix throttle excursions when demanded air speed changes

### DIFF
--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -185,6 +185,7 @@ private:
     AP_Int8  _land_pitch_max;
     AP_Float _maxSinkRate_approach;
     AP_Int32 _options;
+    AP_Float _vel_rate_acc;
 
     enum {
         OPTION_GLIDER_ONLY=(1<<0),
@@ -249,6 +250,8 @@ private:
 
     // Current true airspeed demand
     float _TAS_dem;
+
+    float current_vel_rate;
 
     // Equivalent airspeed demand
     float _EAS_dem;
@@ -381,7 +384,7 @@ private:
     void _update_speed(float load_factor);
 
     // Update the demanded airspeed
-    void _update_speed_demand(void);
+    void _update_speed_demand(float dt);
 
     // Update the demanded height
     void _update_height_demand(void);


### PR DESCRIPTION
Fix throttle excursions when demanded air speed changes by limiting the airspeed's jerk.

Before:
![before](https://user-images.githubusercontent.com/4030264/146098532-9b28fc82-a39f-4105-bb57-add538888cda.png)

After:
![after](https://user-images.githubusercontent.com/4030264/146098543-5004e8fb-7d86-47b9-ad16-a7a1ed92e1db.png)

