### PR TITLE
AP_HAL_Linux: RPI-CM4 detection

### DIFF
--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -36,10 +36,19 @@ int UtilRPI::_check_rpi_version()
     char buffer[MAX_SIZE_LINE];
     int hw;
 
+    memset(buffer, 0, MAX_SIZE_LINE);
     FILE *f = fopen("/sys/firmware/devicetree/base/model", "r");
     if (f != nullptr && fgets(buffer, MAX_SIZE_LINE, f) != nullptr) {
-        int ret = sscanf(buffer + 12, "%d", &_rpi_version);
         fclose(f);
+        
+        int ret = strncmp(buffer, "Raspberry Pi Compute Module 4", 28);
+        if (ret == 0) {
+             _rpi_version = 4; // compute module 4 e.g. Raspberry Pi Compute Module 4 Rev 1.0.
+             printf("%s. (intern: %d)\n", buffer, _rpi_version);
+             return _rpi_version;
+        }
+        
+        ret = sscanf(buffer + 12, "%d", &_rpi_version);
         if (ret != EOF) {
             if (_rpi_version > 3)  {
                 _rpi_version = 4;


### PR DESCRIPTION
Although CM4 is identical to RPI-4 but the ID is different
/sys/firmware/devicetree/base/model  for CM4 returns
**Raspberry Pi Compute Module 4 Rev 1.0.** 
while for RPI-4 returns somthing like
**Raspberry Pi 4 Model B Rev 1.2.**

This is directly related to [issue 19037](https://github.com/ArduPilot/ardupilot/issues/19037)

The issue corrupted DMA & PCM initialization logic and that what caused the issue.
