### PR TITLE
Gyroflow logging

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -287,6 +287,10 @@ void Copter::fast_loop()
     }
 
     AP_Vehicle::fast_loop();
+
+    if (should_log(MASK_LOG_VIDEO_STABILISATION)) {
+        ahrs.write_video_stabilisation();
+    }
 }
 
 #if AP_SCRIPTING_ENABLED

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -322,7 +322,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,17:MOTBATT,18:IMU_FAST,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,17:MOTBATT,18:IMU_FAST,19:IMU_RAW,20:VideoStabilization
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -143,6 +143,7 @@ enum LoggingParameters {
 #define MASK_LOG_MOTBATT                (1UL<<17)
 #define MASK_LOG_IMU_FAST               (1UL<<18)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
+#define MASK_LOG_VIDEO_STABILISATION    (1UL<<20)
 #define MASK_LOG_ANY                    0xFFFF
 
 // Radio failsafe definitions (FS_THR parameter)

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -189,6 +189,10 @@ void Plane::ahrs_update()
     // update inertial_nav for quadplane
     quadplane.inertial_nav.update();
 #endif
+
+    if (should_log(MASK_LOG_VIDEO_STABILISATION)) {
+        ahrs.write_video_stabilisation();
+    }
 }
 
 /*

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -618,7 +618,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what on-board log types to enable. This value is made up of the sum of each of the log types you want to be saved. It is usually best just to enable all log types by setting this to 65535. The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Sonar=16384, Arming=32768, FullLogs=65535
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,19:IMU_RAW,20:ATTITUDE_FULLRATE
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,19:IMU_RAW,20:ATTITUDE_FULLRATE,21:VideoStabilization
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",    DEFAULT_LOG_BITMASK),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -118,6 +118,7 @@ enum log_messages {
 // #define MASK_LOG_ARM_DISARM             (1<<15)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
 #define MASK_LOG_ATTITUDE_FULLRATE      (1U<<20)
+#define MASK_LOG_VIDEO_STABILISATION    (1UL<<21)
 
 // altitude control algorithms
 enum {

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -19,7 +19,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in on-board logger. This value is made up of the sum of each of the log types you want to be saved. On boards supporting microSD cards or other large block-storage devices it is usually best just to enable all log types by setting this to 65535. The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Rangefinder=16384, Arming=32768, FullLogs=65535
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:THR,5:NTUN,7:IMU,8:CMD,9:CURRENT,10:RANGEFINDER,11:COMPASS,12:CAMERA,13:STEERING,14:RC,15:ARM/DISARM,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:THR,5:NTUN,7:IMU,8:CMD,9:CURRENT,10:RANGEFINDER,11:COMPASS,12:CAMERA,13:STEERING,14:RC,15:ARM/DISARM,19:IMU_RAW,20:VideoStabilization
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -289,6 +289,10 @@ void Rover::ahrs_update()
     if (should_log(MASK_LOG_IMU)) {
         AP::ins().Write_IMU();
     }
+
+    if (should_log(MASK_LOG_VIDEO_STABILISATION)) {
+        ahrs.write_video_stabilisation();
+    }
 }
 
 /*

--- a/Rover/defines.h
+++ b/Rover/defines.h
@@ -45,6 +45,8 @@ enum LoggingParameters {
 #define MASK_LOG_RC             (1<<14)
 // #define MASK_LOG_ARM_DISARM     (1<<15)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
+#define MASK_LOG_VIDEO_STABILISATION (1UL<<20)
+
 
 // for mavlink SET_POSITION_TARGET messages
 #define MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE      ((1<<0) | (1<<1))

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -432,6 +432,7 @@ public:
     };
     void Write_Origin(LogOriginType origin_type, const Location &loc) const; 
     void Write_POS(void) const;
+    void write_video_stabilisation() const;
 
     // return a smoothed and corrected gyro vector in radians/second
     // using the latest ins data (which may not have been consumed by

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -97,6 +97,29 @@ void AP_AHRS::Write_POS() const
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
+// Write a packet for video stabilisation
+void AP_AHRS::write_video_stabilisation() const
+{
+    Quaternion current_attitude;
+    get_quat_body_to_ned(current_attitude);
+    Vector3f accel = get_accel() - get_accel_bias();
+    const struct log_Video_Stabilisation pkt {
+        LOG_PACKET_HEADER_INIT(LOG_VIDEO_STABILISATION_MSG),
+        time_us         : AP_HAL::micros64(),
+        gyro_x          : _gyro_estimate.x,
+        gyro_y          : _gyro_estimate.y,
+        gyro_z          : _gyro_estimate.z,
+        accel_x         : accel.x,
+        accel_y         : accel.y,
+        accel_z         : accel.z,
+        Q1              : current_attitude.q1,
+        Q2              : current_attitude.q2,
+        Q3              : current_attitude.q3,
+        Q4              : current_attitude.q4,
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
 // Write an attitude view packet
 void AP_AHRS_View::Write_AttitudeView(const Vector3f &targets) const
 {

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -153,7 +153,7 @@ struct PACKED log_Rate {
 // @Field: Q3: Estimated attitude quaternion component 3
 // @Field: Q4: Estimated attitude quaternion component 4
 
-struct PACKED log_Gyroflow {
+struct PACKED log_Video_Stabilisation {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     float gyro_x;
@@ -182,6 +182,6 @@ struct PACKED log_Gyroflow {
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \
         "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" , true }, \
-    { LOG_GYROFLOW_MSG, sizeof(log_Gyroflow), \
+    { LOG_VIDEO_STABILISATION_MSG, sizeof(log_Video_Stabilisation), \
         "VSTB", "Qffffffffff",  "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,Q1,Q2,Q3,Q4", "sEEEooo????", "F000000????" },
 

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -139,6 +139,35 @@ struct PACKED log_Rate {
     float   accel_out;
 };
 
+// @LoggerMessage: VSTB
+// @Description: Log message for video stabilisation software such as Gyroflow
+// @Field: TimeUS: Time since system startup
+// @Field: GyrX: measured rotation rate about X axis
+// @Field: GyrY: measured rotation rate about Y axis
+// @Field: GyrZ: measured rotation rate about Z axis
+// @Field: AccX: acceleration along X axis
+// @Field: AccY: acceleration along Y axis
+// @Field: AccZ: acceleration along Z axis
+// @Field: Q1: Estimated attitude quaternion component 1
+// @Field: Q2: Estimated attitude quaternion component 2
+// @Field: Q3: Estimated attitude quaternion component 3
+// @Field: Q4: Estimated attitude quaternion component 4
+
+struct PACKED log_Gyroflow {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float gyro_x;
+    float gyro_y;
+    float gyro_z;
+    float accel_x;
+    float accel_y;
+    float accel_z;
+    float Q1;
+    float Q2;
+    float Q3;
+    float Q4;
+};
+
 
 #define LOG_STRUCTURE_FROM_AHRS \
     { LOG_AHR2_MSG, sizeof(log_AHRS), \
@@ -152,4 +181,7 @@ struct PACKED log_Rate {
     { LOG_POS_MSG, sizeof(log_POS), \
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \
-        "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" , true },
+        "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" , true }, \
+    { LOG_GYROFLOW_MSG, sizeof(log_Gyroflow), \
+        "VSTB", "Qffffffffff",  "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,Q1,Q2,Q3,Q4", "sEEEooo????", "F000000????" },
+

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1427,6 +1427,7 @@ enum LogMessages : uint8_t {
     LOG_STAK_MSG,
     LOG_FILE_MSG,
     LOG_SCRIPTING_MSG,
+    LOG_VIDEO_STABILISATION_MSG,
 
     _LOG_LAST_MSG_
 };


### PR DESCRIPTION
This adds a log with fields dedicated to the info Gyroflow needs. It is logged in the fast loop on copter and in ahrs update on plane and rover. 

https://github.com/ElvinC/gyroflow

Of course all the info is already available, but for Gyroflow the faster the better, this is significantly less overhead than enabling fast attitude logging which is the only other way to get 400 hz filtered gyro data. It is not enabled by defualt.

Not sure how people feel about logging directly in the fast loops, we do it for IMU on plane already, but not copter. 

https://github.com/ArduPilot/ardupilot/issues/19376
