### PR TITLE
AP_InertialSensor: added support for ICM-20608-D sensor

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -911,7 +911,8 @@ bool AP_InertialSensor_Invensense::_check_whoami(void)
     case MPU_WHOAMI_MPU9255:
         _mpu_type = Invensense_MPU9250;
         return true;
-    case MPU_WHOAMI_20608:
+    case MPU_WHOAMI_20608D:    
+    case MPU_WHOAMI_20608G:
         _mpu_type = Invensense_ICM20608;
         return true;
     case MPU_WHOAMI_20602:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
@@ -178,7 +178,8 @@
 
 // WHOAMI values
 #define MPU_WHOAMI_6000			0x68
-#define MPU_WHOAMI_20608		0xaf
+#define MPU_WHOAMI_20608D		0xae
+#define MPU_WHOAMI_20608G		0xaf
 #define MPU_WHOAMI_20602		0x12
 #define MPU_WHOAMI_20601		0xac
 #define MPU_WHOAMI_6500			0x70


### PR DESCRIPTION
ICM-20608 chip has two versions: ICM-20608D and ICM-20608G. The current driver without the whoamI value of ICM-20608D, so that ICM-20608D cannot be detected it doesn't work.