### PR TITLE
AP_ADSB: add link to UCP protocol in the UCP driver

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -19,6 +19,9 @@
 
 #include "AP_ADSB_uAvionix_UCP.h"
 
+// This driver implements the UCP protocol from uAvionix which is a variant of the GDL90 protocol by Garmin
+// https://uavionix.com/downloads/ping200X/uAvionix-UCP-Transponder-ICD-Rev-Q.pdf
+
 #if HAL_ADSB_UCP_ENABLED
 
 #include <AP_SerialManager/AP_SerialManager.h>


### PR DESCRIPTION
Non-functional change: Added this text to the top of AP_ADSB_uAvionix_UCP.cpp
```
// This driver implements the UCP protocol from uAvionix which is a variant of the GDL90 protocol by Garmin
// https://uavionix.com/downloads/ping200X/uAvionix-UCP-Transponder-ICD-Rev-Q.pdf

```
