### PR TITLE
AP_Periph: fixed temperature reporting

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1561,7 +1561,7 @@ void AP_Periph_FW::esc_telem_update()
             pkt.current = nan;
         }
         int16_t temperature;
-        if (esc_telem.get_motor_temperature(i, temperature)) {
+        if (esc_telem.get_temperature(i, temperature)) {
             pkt.temperature = temperature*0.01 + C_TO_KELVIN;
         } else {
             pkt.temperature = nan;


### PR DESCRIPTION
more common to have ESC temp than motor temp, so report ESC
temperature