### PR TITLE
add ToneAlarm for EKF active and require EKF active for RGBLed solid green

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -112,7 +112,7 @@ uint32_t RGBLed::get_colour_sequence(void) const
         return sequence_trim_or_esc;
     }
 
-    // radio and battery failsafe patter: flash yellow
+    // radio and battery failsafe pattern: flash yellow
     // gps failsafe pattern : flashing yellow and blue
     // ekf_bad pattern : flashing yellow and red
     if (AP_Notify::flags.failsafe_radio ||
@@ -138,8 +138,9 @@ uint32_t RGBLed::get_colour_sequence(void) const
 
     // solid green or blue if armed
     if (AP_Notify::flags.armed) {
-        // solid green if armed with GPS 3d lock
-        if (AP_Notify::flags.gps_status >= AP_GPS::GPS_OK_FIX_3D) {
+        // solid green if armed with GPS 3d lock and EKF active
+        if (AP_Notify::flags.gps_status >= AP_GPS::GPS_OK_FIX_3D &&
+            AP_Notify::flags.gps_fusion > 0) {
             return sequence_armed;
         }
         // solid blue if armed with no GPS lock

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -97,7 +97,9 @@ const AP_ToneAlarm::Tone AP_ToneAlarm::_tones[] {
 #define AP_NOTIFY_TONE_NO_SDCARD 30
     { "MNBGG", false },
 #define AP_NOTIFY_TONE_EKF_ALERT 31
-    { "MBNT255>A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8", true },
+    { "MBNT255>A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8P8A#8A#8A#8A#8", false },
+#define AP_NOTIFY_TONE_EKF_ACTIVE 32
+    { "MFT100L8>G#6G#6G#6G#6G#6G#6G#6G#6", true },
 };
 
 bool AP_ToneAlarm::init()
@@ -341,6 +343,16 @@ void AP_ToneAlarm::update()
                 play_tone(AP_NOTIFY_TONE_LOUD_POS_FEEDBACK);
             } else {
                 play_tone(AP_NOTIFY_TONE_QUIET_POS_FEEDBACK);
+            }
+        }
+    }
+
+    // notify the user when EKF is using GPS if this occurs after arming
+    if (AP_Notify::flags.armed) {
+        if (flags.gps_fusion != AP_Notify::flags.gps_fusion) {
+            flags.gps_fusion = AP_Notify::flags.gps_fusion;
+            if (flags.gps_fusion) {
+                play_tone(AP_NOTIFY_TONE_EKF_ACTIVE);
             }
         }
     }

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -57,6 +57,7 @@ private:
         uint16_t failsafe_battery      : 1;    // 1 if battery failsafe
         uint16_t parachute_release     : 1;    // 1 if parachute is being released
         uint16_t pre_arm_check         : 1;    // 0 = failing checks, 1 = passed
+        uint16_t gps_fusion            : 1;    // 0 = EKF not using GPS, 1 = EKF active
         uint16_t failsafe_radio        : 1;    // 1 if radio failsafe
         uint16_t failsafe_gcs          : 1;    // 1 if gcs failsafe
         uint16_t failsafe_ekf          : 1;    // 1 if ekf failsafe


### PR DESCRIPTION
This aids in use of Plane as a "blackbox" logger: don't want to fly before EKF is fusing GPS, and there's currently no audible or visible indication of this without a GCS.

Pilot should wait for the new tone (8 beeps) and solid green RGB LED before flying.

Impact to non-GPS setups? Won't get the green LED if EKF is not using GPS and ???
