### PR TITLE
AC_Fence: Clarify the fence breach

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -316,7 +316,11 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
 
     // check no limits are currently breached
     if (_breached_fences) {
-        fail_msg =  "vehicle outside fence";
+        //GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "### _breached_fences %d", _breached_fences);
+        static char text[37];
+        memset(text, 0, sizeof(text));
+        hal.util->snprintf(text, sizeof(text), "vehicle outside fence (FENCE_TYPE %1d)", _breached_fences>>1);
+        fail_msg = text;
         return false;
     }
 


### PR DESCRIPTION
I saw the message "vehicle outside fence".
I don't know which fence I went over.
I know that there are multiple fences.
I want to know which fence I'm over.

I know by this correspondence that it is fence 4.
I can see that it is a polygon fence.

AFTER
![Screenshot from 2021-12-18 08-08-45](https://user-images.githubusercontent.com/646194/146619835-ad7264ea-cd6b-4e6c-aace-1a4f1fb0f328.png)

BEFORE
![Screenshot from 2021-12-18 08-26-57](https://user-images.githubusercontent.com/646194/146619816-fe51ab30-e5e0-406c-b590-7f4c3824c63f.png)