### PR TITLE
AP_BoardConfig: disable STLink debug pins by default (4.0 version)

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -244,7 +244,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Board options
     // @Description: Board specific option flags
-    // @Bitmask: 0:Enable hardware watchdog
+    // @Bitmask: 0:Enable hardware watchdog, 3:Enable Debug Pins
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 
@@ -337,6 +337,7 @@ void AP_BoardConfig::set_default_safety_ignore_mask(uint16_t mask)
 void AP_BoardConfig::init_safety()
 {
     board_init_safety();
+    board_init_debug();
 }
 
 /*

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -164,6 +164,7 @@ public:
 
     enum board_options {
         BOARD_OPTION_WATCHDOG = (1 << 0),
+        BOARD_OPTION_DEBUG_ENABLE = (1 << 3),
     };
 
     // return true if watchdog enabled
@@ -210,6 +211,7 @@ private:
 #endif // AP_FEATURE_BOARD_DETECT
 
     void board_init_safety(void);
+    void board_init_debug(void);
 
     void board_setup_uart(void);
     void board_setup_sbus(void);

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -47,6 +47,22 @@ void AP_BoardConfig::board_init_safety()
 }
 
 
+/*
+  init debug pins. We set debug pins as input if BRD_OPTIONS bit for debug enable is not set
+  this prevents possible ESD issues on the debug pins
+ */
+void AP_BoardConfig::board_init_debug()
+{
+    if ((_options & BOARD_OPTION_DEBUG_ENABLE) == 0) {
+#ifdef HAL_GPIO_PIN_JTCK_SWCLK
+        palSetLineMode(HAL_GPIO_PIN_JTCK_SWCLK, PAL_MODE_INPUT);
+#endif
+#ifdef HAL_GPIO_PIN_JTMS_SWDIO
+        palSetLineMode(HAL_GPIO_PIN_JTMS_SWDIO, PAL_MODE_INPUT);
+#endif
+    }
+}
+
 #if AP_FEATURE_BOARD_DETECT
 
 AP_BoardConfig::px4_board_type AP_BoardConfig::px4_configured_board;


### PR DESCRIPTION
    
this avoids leaving the debug pins in a state where they may be
vulnerable to ESD issues