### PR TITLE
HAL_ChibiOS: set SWD pins pulled up and low by default

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -368,6 +368,15 @@ class generic_pin(object):
              self.label.endswith('_CTS') or
              self.label.endswith('_RTS'))):
             v = "PULLUP"
+
+        if (self.type.startswith('SWD') and
+            'SWDIO' in self.label):
+            v = "PULLUP"
+
+        if (self.type.startswith('SWD') and
+            'SWCLK' in self.label):
+            v = "PULLDOWN"
+
         # generate pullups for SDIO and SDMMC
         if (self.type.startswith('SDIO') or
             self.type.startswith('SDMMC')) and (


### PR DESCRIPTION
This PR ensures SWDIO and SWCLK  are pulled up and down respectively as should be the case by default.

![image](https://user-images.githubusercontent.com/5697288/146623919-0909f54e-0d41-4f78-a325-3c723ea0d8e5.png)
