### PR TITLE
Reduce number of log IDs allocated to vehicles, rearrange

### DIFF
--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -34,6 +34,8 @@ enum class PWMDisarmed {
 #define MASK_LOG_CURRENT                (1<<6)
 #define MASK_LOG_ANY                    0xFFFF
 
-//  Logging messages
-#define LOG_V_BAR_MSG                   0x04
-#define LOG_V_POS_MSG                   0x05
+//  Logging messages - only 32 messages are available to the vehicle here.
+enum log_messages {
+    LOG_V_BAR_MSG,
+    LOG_V_POS_MSG,
+};

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -108,7 +108,7 @@ enum DevOptions {
     DevOptionVFR_HUDRelativeAlt = 2,
 };
 
-//  Logging parameters
+//  Logging parameters - only 32 messages are available to the vehicle here.
 enum LoggingParameters {
      LOG_CONTROL_TUNING_MSG,
      LOG_DATA_INT16_MSG,

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -79,7 +79,7 @@ enum tuning_pid_bits {
 
 static_assert(TUNING_BITS_END <= (1 << 24) + 1, "Tuning bit mask is too large to be set by MAVLink");
 
-// Logging message types
+// Logging message types - only 32 messages are available to the vehicle here.
 enum log_messages {
     LOG_CTUN_MSG,
     LOG_NTUN_MSG,

--- a/ArduSub/defines.h
+++ b/ArduSub/defines.h
@@ -82,7 +82,7 @@ enum RTLState {
     RTL_Land
 };
 
-//  Logging parameters
+//  Logging parameters - only 32 messages are available to the vehicle here.
 enum LoggingParameters {
     LOG_CONTROL_TUNING_MSG,
     LOG_DATA_INT16_MSG,

--- a/Blimp/defines.h
+++ b/Blimp/defines.h
@@ -124,7 +124,7 @@ enum DevOptions {
     DevOptionSetAttitudeTarget_ThrustAsThrust = 4,
 };
 
-//  Logging parameters
+//  Logging parameters - only 32 messages are available to the vehicle here.
 enum LoggingParameters {
     LOG_CONTROL_TUNING_MSG,
     LOG_DATA_INT16_MSG,

--- a/Rover/defines.h
+++ b/Rover/defines.h
@@ -17,12 +17,14 @@
 #define FAILSAFE_EVENT_THROTTLE (1<<0)
 #define FAILSAFE_EVENT_GCS      (1<<1)
 
-//  Logging parameters
-#define LOG_THR_MSG             0x01
-#define LOG_NTUN_MSG            0x02
-#define LOG_STARTUP_MSG         0x06
-#define LOG_STEERING_MSG        0x0D
-#define LOG_GUIDEDTARGET_MSG    0x0E
+//  Logging parameters - only 32 messages are available to the vehicle here.
+enum LoggingParameters {
+    LOG_THR_MSG,
+    LOG_NTUN_MSG,
+    LOG_STARTUP_MSG,
+    LOG_STEERING_MSG,
+    LOG_GUIDEDTARGET_MSG,
+};
 
 #define TYPE_GROUNDSTART_MSG    0x01
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1353,7 +1353,7 @@ LOG_STRUCTURE_FROM_AIS, \
 
 // message types for common messages
 enum LogMessages : uint8_t {
-    LOG_PARAMETER_MSG = 64,
+    LOG_PARAMETER_MSG = 32,
     LOG_IDS_FROM_NAVEKF2,
     LOG_IDS_FROM_NAVEKF3,
     LOG_MESSAGE_MSG,
@@ -1377,14 +1377,6 @@ enum LogMessages : uint8_t {
 
     LOG_IDS_FROM_GPS,
 
-    // LOG_MODE_MSG is used as a check for duplicates. Do not add between this and LOG_FORMAT_MSG
-    LOG_MODE_MSG,
-
-    LOG_FORMAT_MSG = 128, // this must remain #128
-
-    LOG_IDS_FROM_DAL,
-    LOG_IDS_FROM_INERTIALSENSOR,
-
     LOG_PIDR_MSG,
     LOG_PIDP_MSG,
     LOG_PIDY_MSG,
@@ -1401,9 +1393,18 @@ enum LogMessages : uint8_t {
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,
     LOG_MULT_MSG,
-
     LOG_RALLY_MSG,
+
+    // LOG_MODE_MSG is used as a check for duplicates. Do not add between this and LOG_FORMAT_MSG
+    LOG_MODE_MSG,
+
+    LOG_FORMAT_MSG = 128, // this must remain #128
+
+    LOG_IDS_FROM_DAL,
+    LOG_IDS_FROM_INERTIALSENSOR,
+
     LOG_IDS_FROM_VISUALODOM,
+    LOG_IDS_FROM_AVOIDANCE,
     LOG_BEACON_MSG,
     LOG_PROXIMITY_MSG,
     LOG_DF_FILE_STATS,
@@ -1416,7 +1417,6 @@ enum LogMessages : uint8_t {
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,
     LOG_ARM_DISARM_MSG,
-    LOG_IDS_FROM_AVOIDANCE,
     LOG_WINCH_MSG,
     LOG_PSCN_MSG,
     LOG_PSCE_MSG,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1431,5 +1431,6 @@ enum LogMessages : uint8_t {
     _LOG_LAST_MSG_
 };
 
-static_assert(_LOG_LAST_MSG_ <= 255, "Too many message formats");
+// we reserve ID #255 for future expansion
+static_assert(_LOG_LAST_MSG_ < 255, "Too many message formats");
 static_assert(LOG_MODE_MSG < 128, "Duplicate message format IDs");


### PR DESCRIPTION
With the following patch:
```
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -286,6 +286,9 @@ extern AP_IOMCU iomcu;
 
 void Plane::one_second_loop()
 {
+
+    gcs().send_text(MAV_SEVERITY_INFO, "SCR=%u MODE=%u CMDH=%u", LOG_SCRIPTING_MSG, LOG_MODE_MSG, LOG_CMDH_MSG);
+
     // make it possible to change control channel ordering at runtime
     set_control_channels();
```

I get the following output:
```
AP: SCR=197 MODE=112 CMDH=16
```

Which means we have 57 ids "after the break" - available for `logger.Log_write(...)` and  `logger.LogWriteStreaming(...)` to use.  We don't have that many calls - and if anyone's using more in scripting then they're almost certainly doing something very wrong...

This also introduces a gap before `FMT` - before this patch `MODE` was 127.  That's very silly as anybody adding a logging message to e.g. NavEKF3 would get a compilation failure as it would push `MODE` past `FMT`!

Also adds a comment to warn people of the 32-id limit.  Plane's the largest user of vehicle-specific IDs with 17 defined.

Also corrected a bad sanity check.

Tidied the vehicle definitions up to remove absolute setting of specific IDs (not needed), and to make enumerations in the two vehicles where we were using defines.

Tested only with the autotest suite and a very small amount in SITL.

Edit: I flashed Rover onto CubeBlack and had a look at a produced log.  All looked in order.
