### PR TITLE
RC_Channel: added RC_SWITCH_TYPE parameter

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -412,12 +412,31 @@ bool RC_Channel::read_6pos_switch(int8_t& position)
         return false;  // This is an error condition
     }
 
-    if      (pulsewidth < 1231) position = 0;
-    else if (pulsewidth < 1361) position = 1;
-    else if (pulsewidth < 1491) position = 2;
-    else if (pulsewidth < 1621) position = 3;
-    else if (pulsewidth < 1750) position = 4;
-    else position = 5;
+    switch (rc().get_switch_type()) {
+    case RC_Channels::SwitchType::OpenTX6Pos: {
+        // 6 position buttons on OpenTX radios such as Radiomaster T16S
+        // 1: 1100, 2: 1260 3: 1420, 4: 1580, 5: 1740, 6: 1900
+        constexpr uint16_t step = 160;
+        uint16_t base = 1100 + step/2;
+        for (position=0; position < 5; position++) {
+            if (pulsewidth < base) {
+                break;
+            }
+            base += step;
+        }
+        break;
+    }
+
+    case RC_Channels::SwitchType::Original:
+    default:
+        if      (pulsewidth < 1231) position = 0;
+        else if (pulsewidth < 1361) position = 1;
+        else if (pulsewidth < 1491) position = 2;
+        else if (pulsewidth < 1621) position = 3;
+        else if (pulsewidth < 1750) position = 4;
+        else position = 5;
+        break;
+    }
 
     if (!debounce_completed(position)) {
         return false;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -556,6 +556,17 @@ public:
     void calibrating(bool b) { gcs_is_calibrating = b; }
     bool calibrating() { return gcs_is_calibrating; }
 
+    // RC_SWITCH_TYPE options
+    enum class SwitchType {
+        Original = 0,
+        OpenTX6Pos = 1,
+    };
+
+    // return RC_SWITCH_TYPE
+    RC_Channels::SwitchType get_switch_type(void) const {
+        return _switch_type;
+    }
+
 protected:
 
     enum class Option {
@@ -588,6 +599,7 @@ private:
     AP_Float _override_timeout;
     AP_Int32  _options;
     AP_Int32  _protocols;
+    AP_Enum<SwitchType> _switch_type;
 
     RC_Channel *flight_mode_channel() const;
 

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -98,6 +98,13 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @User: Advanced
     // @Bitmask: 0:All,1:PPM,2:IBUS,3:SBUS,4:SBUS_NI,5:DSM,6:SUMD,7:SRXL,8:SRXL2,9:CRSF,10:ST24,11:FPORT,12:FPORT2,13:FastSBUS
     AP_GROUPINFO("_PROTOCOLS", 34, RC_CHANNELS_SUBCLASS, _protocols, 1),
+
+    // @Param: _SWITCH_TYPE
+    // @DisplayName: Flight mode switch type
+    // @Description: Choose mapping from PWM to 6 flight modes
+    // @User: Advanced
+    // @Values: 0:Original,1:OpenTX6Pos
+    AP_GROUPINFO("_SWITCH_TYPE", 35, RC_CHANNELS_SUBCLASS, _switch_type, uint8_t(SwitchType::Original)),
     
     AP_GROUPEND
 };


### PR DESCRIPTION
this makes setting up the flight mode switch on the widely used OpenTX
radios with 6 mode buttons much easier