### PR TITLE
Copter: 4.1.3-rc2 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,15 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.3-rc2 21-Dec-2021
+Changes from 4.1.3-rc1
+1) Suport for IIM-42652, ICM-40605 and ICM-20608-D IMUs
+2) Bug fixes
+    a) Autotune twitches at no more than ATC_RATE_R/P/Y_MAX param value
+    b) SmartAudio high CPU load fix (previously it could starve other threads of CPU)
+    c) Debug pins disabled by default to prevent rare inflight reset due to electrostatic discharge
+    d) EKF3 reset causing bad accel biases fixed
+    e) RC protocol detection fix that forced PH4-mini users to powerup autopilot before transmitter
+------------------------------------------------------------------
 Copter 4.1.3-rc1 18-Dec-2021
 Changes from 4.1.2
 1) Enhancements:

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.3-rc1"
+#define THISFIRMWARE "ArduCopter V4.1.3-rc2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC+2
 
 #define FW_MAJOR 4
 #define FW_MINOR 1

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,19 @@
+Release 4.1.6beta1 21st December 2021
+-------------------------------------
+
+This is a minor release with some important bug fixes:
+
+ - disable the STLink debug pins after boot by default to prevent ESD
+   from triggering CPU changes or a reset
+ - support ICM-20608-D, IIM-42652 and ICM-40605 sensors
+ - fixed missing covarience reset row in EKF3
+ - fixed failure to detect inverted RC input on uarts when transmitter
+   is on at boot
+ - fixed QAUTOTUNE to obey maximum attitude rate limits
+ - fixed a bug in smartaudio support that increased CPU usage
+
+Happy flying!
+
 Release 4.1.5 13th December 2021
 --------------------------------
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.1.5"
+#define THISFIRMWARE "ArduPlane V4.1.6beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,6,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 6
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is just the release notes and version update for the 4.1.3 release as the commits for the change have already been added to the Copter-4.1 branch.  This brings the branch up-to-date with the Plane-4.1.6-beta1 which is why it also includes the Plane release notes and version update.

The changes included in this release can be seen in the [4.1.3-rc2 column of this project](https://github.com/ArduPilot/ardupilot/projects/19).