### PR TITLE
Rover: 4.1.3-rc2 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,15 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.3-rc2 21-Dec-2021
+Changes from 4.1.3-rc1
+1) Suport for IIM-42652, ICM-40605 and ICM-20608-D IMUs
+2) Bug fixes
+    a) Autotune twitches at no more than ATC_RATE_R/P/Y_MAX param value
+    b) SmartAudio high CPU load fix (previously it could starve other threads of CPU)
+    c) Debug pins disabled by default to prevent rare inflight reset due to electrostatic discharge
+    d) EKF3 reset causing bad accel biases fixed
+    e) RC protocol detection fix that forced PH4-mini users to powerup autopilot before transmitter
+------------------------------------------------------------------
 Copter 4.1.3-rc1 18-Dec-2021
 Changes from 4.1.2
 1) Enhancements:

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.3-rc1"
+#define THISFIRMWARE "ArduCopter V4.1.3-rc2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC+2
 
 #define FW_MAJOR 4
 #define FW_MINOR 1

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,19 @@
+Release 4.1.6beta1 21st December 2021
+-------------------------------------
+
+This is a minor release with some important bug fixes:
+
+ - disable the STLink debug pins after boot by default to prevent ESD
+   from triggering CPU changes or a reset
+ - support ICM-20608-D, IIM-42652 and ICM-40605 sensors
+ - fixed missing covarience reset row in EKF3
+ - fixed failure to detect inverted RC input on uarts when transmitter
+   is on at boot
+ - fixed QAUTOTUNE to obey maximum attitude rate limits
+ - fixed a bug in smartaudio support that increased CPU usage
+
+Happy flying!
+
 Release 4.1.5 13th December 2021
 --------------------------------
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.1.5"
+#define THISFIRMWARE "ArduPlane V4.1.6beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,6,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 6
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,14 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.1.3-rc2 21-Dec-2021
+Changes from 4.1.3-rc1
+1) Suport for IIM-42652, ICM-40605 and ICM-20608-D IMUs
+2) Bug fixes
+    a) SmartAudio high CPU load fix (previously it could starve other threads of CPU)
+    b) Debug pins disabled by default to prevent rare inflight reset due to electrostatic discharge
+    c) EKF3 reset causing bad accel biases fixed
+    d) RC protocol detection fix that forced PH4-mini users to powerup autopilot before transmitter
+------------------------------------------------------------------
 Rover 4.1.3-rc1 18-Dec-2021
 Changes from 4.1.2
 1) CUAV-X7 servo voltage detection support

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.1.3-rc1"
+#define THISFIRMWARE "ArduRover V4.1.3-rc2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_RC+2
 
 #define FW_MAJOR 4
 #define FW_MINOR 1

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -113,6 +113,9 @@ public:
     // get the pitch angular velocity limit in radians/s
     float get_ang_vel_pitch_max_rads() const { return radians(_ang_vel_pitch_max); }
 
+    // get the yaw angular velocity limit in radians/s
+    float get_ang_vel_yaw_max_rads() const { return radians(_ang_vel_yaw_max); }
+    
     // get the yaw slew limit
     float get_slew_yaw_cds() const { return _slew_yaw; }
 

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -527,8 +527,12 @@ void AC_AutoTune::control_attitude()
 
         float target_max_rate;
         switch (axis) {
-        case ROLL:
+        case ROLL: {
             target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, step_scaler*AUTOTUNE_TARGET_RATE_RLLPIT_CDS);
+            const float roll_rate_max_cds = degrees(attitude_control->get_ang_vel_roll_max_rads()) * 100;
+            if (is_positive(roll_rate_max_cds)) {
+                target_max_rate = MIN(target_max_rate, roll_rate_max_cds);
+            }
             target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_roll())*100.0f, AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, target_max_rate);
             target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_roll())*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_CD, AUTOTUNE_TARGET_ANGLE_RLLPIT_CD);
             abort_angle = AUTOTUNE_TARGET_ANGLE_RLLPIT_CD;
@@ -536,8 +540,13 @@ void AC_AutoTune::control_attitude()
             start_angle = ahrs_view->roll_sensor;
             rotation_rate_filt.set_cutoff_frequency(attitude_control->get_rate_roll_pid().filt_D_hz()*2.0f);
             break;
-        case PITCH:
+        }
+        case PITCH: {
             target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, step_scaler*AUTOTUNE_TARGET_RATE_RLLPIT_CDS);
+            const float pitch_rate_max_cds = degrees(attitude_control->get_ang_vel_pitch_max_rads()) * 100;
+            if (is_positive(pitch_rate_max_cds)) {
+                target_max_rate = MIN(target_max_rate, pitch_rate_max_cds);
+            }
             target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_pitch())*100.0f, AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, target_max_rate);
             target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_pitch())*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_CD, AUTOTUNE_TARGET_ANGLE_RLLPIT_CD);
             abort_angle = AUTOTUNE_TARGET_ANGLE_RLLPIT_CD;
@@ -545,8 +554,13 @@ void AC_AutoTune::control_attitude()
             start_angle = ahrs_view->pitch_sensor;
             rotation_rate_filt.set_cutoff_frequency(attitude_control->get_rate_pitch_pid().filt_D_hz()*2.0f);
             break;
-        case YAW:
+        }
+        case YAW: {
             target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, step_scaler*AUTOTUNE_TARGET_RATE_YAW_CDS);
+            const float yaw_rate_max_cds = degrees(attitude_control->get_ang_vel_yaw_max_rads()) * 100;
+            if (is_positive(yaw_rate_max_cds)) {
+                target_max_rate = MIN(target_max_rate, yaw_rate_max_cds);
+            }
             target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_yaw()*0.75f)*100.0f, AUTOTUNE_TARGET_MIN_RATE_YAW_CDS, target_max_rate);
             target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_yaw()*0.75f)*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_YAW_CD, AUTOTUNE_TARGET_ANGLE_YAW_CD);
             abort_angle = AUTOTUNE_TARGET_ANGLE_YAW_CD;
@@ -554,6 +568,7 @@ void AC_AutoTune::control_attitude()
             start_angle = ahrs_view->yaw_sensor;
             rotation_rate_filt.set_cutoff_frequency(AUTOTUNE_Y_FILT_FREQ);
             break;
+        }
         }
         if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
             rotation_rate_filt.reset(start_rate);

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -45,7 +45,7 @@
 // detect if any port is configured as Sagetech
 bool AP_ADSB_Sagetech::detect()
 {
-    return (AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_ADSB, 0) != nullptr);
+    return AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_ADSB, 0);
 }
 
 // Init, called once after class is constructed

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -269,7 +269,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Board options
     // @Description: Board specific option flags
-    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters
+    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters, 3:Enable Debug Pins
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 
@@ -362,6 +362,7 @@ void AP_BoardConfig::set_default_safety_ignore_mask(uint16_t mask)
 void AP_BoardConfig::init_safety()
 {
     board_init_safety();
+    board_init_debug();
 }
 
 /*

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -176,6 +176,7 @@ public:
         BOARD_OPTION_WATCHDOG = (1 << 0),
         DISABLE_FTP = (1<<1),
         ALLOW_SET_INTERNAL_PARM = (1<<2),
+        BOARD_OPTION_DEBUG_ENABLE = (1<<3),
     };
 
     // return true if ftp is disabled
@@ -237,6 +238,7 @@ private:
 #endif // AP_FEATURE_BOARD_DETECT
 
     void board_init_safety(void);
+    void board_init_debug(void);
 
     void board_setup_uart(void);
     void board_setup_sbus(void);

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -46,6 +46,24 @@ void AP_BoardConfig::board_init_safety()
 #endif
 }
 
+/*
+  init debug pins. We set debug pins as input if BRD_OPTIONS bit for debug enable is not set
+  this prevents possible ESD issues on the debug pins
+ */
+void AP_BoardConfig::board_init_debug()
+{
+#ifndef HAL_BUILD_AP_PERIPH
+    if ((_options & BOARD_OPTION_DEBUG_ENABLE) == 0) {
+#ifdef HAL_GPIO_PIN_JTCK_SWCLK
+        palSetLineMode(HAL_GPIO_PIN_JTCK_SWCLK, PAL_MODE_INPUT);
+#endif
+#ifdef HAL_GPIO_PIN_JTMS_SWDIO
+        palSetLineMode(HAL_GPIO_PIN_JTMS_SWDIO, PAL_MODE_INPUT);
+#endif
+    }
+#endif // HAL_BUILD_AP_PERIPH
+}
+
 
 #if AP_FEATURE_BOARD_DETECT
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -121,6 +121,8 @@ public:
         DEVTYPE_INS_ICM40609 = 0x33,
         DEVTYPE_INS_ICM42688 = 0x34,
         DEVTYPE_INS_ICM42605 = 0x35,
+        DEVTYPE_INS_ICM40605 = 0x36,
+        DEVTYPE_INS_IIM42652 = 0x37,
     };
 
 protected:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -911,7 +911,8 @@ bool AP_InertialSensor_Invensense::_check_whoami(void)
     case MPU_WHOAMI_MPU9255:
         _mpu_type = Invensense_MPU9250;
         return true;
-    case MPU_WHOAMI_20608:
+    case MPU_WHOAMI_20608D:    
+    case MPU_WHOAMI_20608G:
         _mpu_type = Invensense_ICM20608;
         return true;
     case MPU_WHOAMI_20602:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense_registers.h
@@ -178,7 +178,8 @@
 
 // WHOAMI values
 #define MPU_WHOAMI_6000			0x68
-#define MPU_WHOAMI_20608		0xaf
+#define MPU_WHOAMI_20608D		0xae
+#define MPU_WHOAMI_20608G		0xaf
 #define MPU_WHOAMI_20602		0x12
 #define MPU_WHOAMI_20601		0xac
 #define MPU_WHOAMI_6500			0x70

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -19,6 +19,8 @@
    ICM-40609
    ICM-42688
    ICM-42605
+   ICM-40605
+   IIM-42652
 
   Note that this sensor includes 32kHz internal sampling and an
   anti-aliasing filter, which means this driver can be a lot simpler
@@ -62,9 +64,11 @@ static const float GYRO_SCALE = (0.0174532f / 16.4f);
 #define INV3REG_BANK_SEL      0x76
 
 // WHOAMI values
+#define INV3_ID_ICM40605      0x33
 #define INV3_ID_ICM40609      0x3b
 #define INV3_ID_ICM42605      0x42
 #define INV3_ID_ICM42688      0x47
+#define INV3_ID_IIM42652      0x6f
 
 // run output data at 2kHz
 #define INV3_ODR 2000
@@ -127,7 +131,7 @@ void AP_InertialSensor_Invensensev3::fifo_reset()
     // FIFO_MODE stop-on-full
     register_write(INV3REG_FIFO_CONFIG, 0x80);
     // FIFO partial disable, enable accel, gyro, temperature
-    register_write(INV3REG_FIFO_CONFIG1, 0x07);
+    register_write(INV3REG_FIFO_CONFIG1, fifo_config1);
     // little-endian, fifo count in records, last data hold for ODR mismatch
     register_write(INV3REG_INTF_CONFIG0, 0xC0);
     register_write(INV3REG_SIGNAL_PATH_RESET, 2);
@@ -143,23 +147,39 @@ void AP_InertialSensor_Invensensev3::start()
     // initially run the bus at low speed
     dev->set_speed(AP_HAL::Device::SPEED_LOW);
 
-    // always use FIFO
-    fifo_reset();
-
     // grab the used instances
     enum DevTypes devtype;
     switch (inv3_type) {
+    case Invensensev3_Type::IIM42652:
+        devtype = DEVTYPE_INS_IIM42652;
+        fifo_config1 = 0x07;
+        temp_sensitivity = 1.0 / 2.07;
+        break;
     case Invensensev3_Type::ICM42688:
         devtype = DEVTYPE_INS_ICM42688;
+        fifo_config1 = 0x07;
+        temp_sensitivity = 1.0 / 2.07;
         break;
     case Invensensev3_Type::ICM42605:
         devtype = DEVTYPE_INS_ICM42605;
+        fifo_config1 = 0x07;
+        temp_sensitivity = 1.0 / 2.07;
+        break;
+    case Invensensev3_Type::ICM40605:
+        devtype = DEVTYPE_INS_ICM40605;
+        fifo_config1 = 0x0F;
+        temp_sensitivity = 1.0 * 128 / 115.49;
         break;
     case Invensensev3_Type::ICM40609:
     default:
         devtype = DEVTYPE_INS_ICM40609;
+        temp_sensitivity = 1.0 / 2.07;
+        fifo_config1 = 0x07;
         break;
     }
+
+    // always use FIFO
+    fifo_reset();
 
     if (!_imu.register_gyro(gyro_instance, INV3_ODR, dev->get_bus_id_devtype(devtype)) ||
         !_imu.register_accel(accel_instance, INV3_ODR, dev->get_bus_id_devtype(devtype))) {
@@ -343,6 +363,14 @@ bool AP_InertialSensor_Invensensev3::check_whoami(void)
         inv3_type = Invensensev3_Type::ICM42605;
         accel_scale = (GRAVITY_MSS / 2048);
         return true;
+    case INV3_ID_ICM40605:
+        inv3_type = Invensensev3_Type::ICM40605;
+        accel_scale = (GRAVITY_MSS / 2048);
+        return true;
+    case INV3_ID_IIM42652:
+        inv3_type = Invensensev3_Type::IIM42652;
+        accel_scale = (GRAVITY_MSS / 2048);
+        return true;
     }
     // not a value WHOAMI result
     return false;
@@ -368,7 +396,9 @@ bool AP_InertialSensor_Invensensev3::hardware_init(void)
         _clip_limit = 29.5f * GRAVITY_MSS;
         break;
     case Invensensev3_Type::ICM42688:
+    case Invensensev3_Type::IIM42652:
     case Invensensev3_Type::ICM42605:
+    case Invensensev3_Type::ICM40605:
         _clip_limit = 15.5f * GRAVITY_MSS;
         break;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
@@ -33,6 +33,8 @@ public:
         ICM40609 = 0,
         ICM42688,
         ICM42605,
+        ICM40605,
+        IIM42652,
     };
 
     // acclerometers on Invensense sensors will return values up to 32G
@@ -63,8 +65,11 @@ private:
     uint8_t gyro_instance;
     uint8_t accel_instance;
 
+    // reset FIFO configure1 register
+    uint8_t fifo_config1;
+
     // temp scaling for FIFO temperature
-    const float temp_sensitivity = 1.0f/2.07;
+    float temp_sensitivity;
     const float temp_zero = 25; // degC
     
     const enum Rotation rotation;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1923,6 +1923,7 @@ void NavEKF3_core::ConstrainVariances()
             }
             // reset all delta velocity bias covariances
             zeroCols(P,13,15);
+            zeroRows(P,13,15);
             // restore all delta velocity bias variances
             for (uint8_t i=0; i<=2; i++) {
                 P[i+13][i+13] = delVelBiasVar[i];

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
@@ -39,7 +39,7 @@ AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial(AP_Proximity &_frontend
 // configured serial port
 bool AP_Proximity_Backend_Serial::detect()
 {
-    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
+    return AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
 }
 
 #endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -296,7 +296,7 @@ void AP_RCProtocol::check_added_uart(void)
             process_byte(uint8_t(b), added.baudrate);
         }
     }
-    if (!_detected_with_bytes) {
+    if (searching) {
         if (now - added.last_baud_change_ms > 1000) {
             // flip baudrates if not detected once a second
             added.phase = (enum config_phase)(uint8_t(added.phase) + 1);

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -56,8 +56,8 @@ AP_CRSF_Telem::~AP_CRSF_Telem(void)
 bool AP_CRSF_Telem::init(void)
 {
     // sanity check that we are using a UART for RC input
-    if (!AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_RCIN, 0)
-        && !AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_CRSF, 0)) {
+    if (!AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_RCIN, 0)
+        && !AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_CRSF, 0)) {
         return false;
     }
     return AP_RCTelemetry::init();

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -68,7 +68,7 @@ AP_Spektrum_Telem::~AP_Spektrum_Telem(void)
 bool AP_Spektrum_Telem::init(void)
 {
     // sanity check that we are using a UART for RC input
-    if (!AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_RCIN, 0)) {
+    if (!AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_RCIN, 0)) {
         return false;
     }
     return AP_RCTelemetry::init();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
@@ -53,7 +53,7 @@ uint32_t AP_RangeFinder_Backend_Serial::initial_baudrate(const uint8_t serial_in
 */
 bool AP_RangeFinder_Backend_Serial::detect(uint8_t serial_instance)
 {
-    return AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+    return AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
 }
 
 

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -578,6 +578,12 @@ AP_HAL::UARTDriver *AP_SerialManager::find_serial(enum SerialProtocol protocol, 
     return port;
 }
 
+// have_serial - return true if we have the given serial protocol configured
+bool AP_SerialManager::have_serial(enum SerialProtocol protocol, uint8_t instance) const
+{
+    return find_protocol_instance(protocol, instance) != nullptr;
+}
+
 // find_baudrate - searches available serial ports for the first instance that allows the given protocol
 //  instance should be zero if searching for the first instance, 1 for the second, etc
 //  returns baudrate on success, 0 if a serial port cannot be found

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -169,8 +169,12 @@ public:
     // find_serial - searches available serial ports that allows the given protocol
     //  instance should be zero if searching for the first instance, 1 for the second, etc
     //  returns uart on success, nullptr if a serial port cannot be found
+    // note that the SERIALn_OPTIONS are applied if the port is found
     AP_HAL::UARTDriver *find_serial(enum SerialProtocol protocol, uint8_t instance) const;
 
+    // have_serial - return true if we have the corresponding serial protocol configured
+    bool have_serial(enum SerialProtocol protocol, uint8_t instance) const;
+    
     // find_baudrate - searches available serial ports for the first instance that allows the given protocol
     //  instance should be zero if searching for the first instance, 1 for the second, etc
     //  returns the baudrate of that protocol on success, 0 if a serial port cannot be found

--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -115,7 +115,7 @@ void AP_SmartAudio::loop()
         }
 
         // nothing going on so give CPU to someone else
-        if (!_is_waiting_response && !_initialised) {
+        if (!_is_waiting_response || !_initialised) {
             hal.scheduler->delay(100);
         }
 


### PR DESCRIPTION
This is the Rover-4.1.3-rc2 release which is equivalent to the [Copter-4.1.3-rc2](https://github.com/ArduPilot/ardupilot/pull/19586) and Plane-4.1.6-beta1 releases.