### PR TITLE
Copter: Constrain vertical speed in loiter_to_alt_run

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1032,6 +1032,7 @@ void ModeAuto::loiter_to_alt_run()
         pos_control->get_pos_z_p().kP(),
         pos_control->get_max_accel_z_cmss(),
         G_Dt);
+    target_climb_rate = constrain_float(target_climb_rate, pos_control->get_max_speed_down_cms(), pos_control->get_max_speed_up_cms());
 
     // get avoidance adjusted climb rate
     target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);


### PR DESCRIPTION
This PR addresses one of the issues here:
https://github.com/ArduPilot/ardupilot/issues/16478

In particular:
loiter-to-alt moves too quickly (4.0 issue)