### PR TITLE
Copter: Guided: When yaw is not specified use default yaw behaviour.

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -1023,6 +1023,8 @@ void ModeGuided::set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, fl
         auto_yaw.set_yaw_angle_rate(yaw_cd * 0.01f, 0.0f);
     } else if (use_yaw_rate) {
         auto_yaw.set_rate(yaw_rate_cds);
+    } else {
+        auto_yaw.set_mode_to_default(false);
     }
 }
 


### PR DESCRIPTION
This PR sets the guided yaw behaviour to that defined by WP_YAW_BEHAVIOR if it is not specified in the messages:
MAVLINK_MSG_ID_SET_POSITION_TARGET_LOCAL_NED
MAVLINK_MSG_ID_SET_POSITION_TARGET_GLOBAL_INT