### PR TITLE
hwdef: enable telem3 (SERIAL5) TX on Pix32v5

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pix32v5/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pix32v5/hwdef.dat
@@ -13,6 +13,9 @@ define HAL_IMU_TEMP_DEFAULT 45
 define HAL_IMUHEAT_P_DEFAULT 50
 define HAL_IMUHEAT_I_DEFAULT 0.07
 
+# USART6 is available for telem3
+PG14 USART6_TX USART6 NODMA
+
 # offset the internal compass for EM impact of the IMU heater
 # this is in sensor frame mGauss
 define HAL_IST8310_I2C_HEATER_OFFSET Vector3f(-3,14,-6)


### PR DESCRIPTION
this is now safe as we disable the TX/RX pins on ports with
SERIALn_PROTOCOL = -1

as this board defaults to protocol -1 for SERIAL5, we can enable this
if the user wishes to use telem3
tested and confirmed working on a Pix32v5