### PR TITLE
Blimp: remove pilot_throttle_checks()

### DIFF
--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -48,7 +48,6 @@ bool AP_Arming_Blimp::run_pre_arm_checks(bool display_failure)
     return fence_checks(display_failure)
            & parameter_checks(display_failure)
            & motor_checks(display_failure)
-           & pilot_throttle_checks(display_failure)
            & gcs_failsafe_check(display_failure)
            & alt_checks(display_failure)
            & AP_Arming::pre_arm_checks(display_failure);
@@ -146,21 +145,6 @@ bool AP_Arming_Blimp::motor_checks(bool display_failure)
     // further checks enabled with parameters
     if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
         return true;
-    }
-
-    return true;
-}
-
-bool AP_Arming_Blimp::pilot_throttle_checks(bool display_failure)
-{
-    // check throttle is above failsafe throttle
-    // this is near the bottom to allow other failures to be displayed before checking pilot throttle
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
-        if (blimp.g.failsafe_throttle != FS_THR_DISABLED && blimp.channel_down->get_radio_in() < blimp.g.failsafe_throttle_value) {
-            const char *failmsg = "Throttle below Failsafe";
-            check_failed(ARMING_CHECK_RC, display_failure, "%s", failmsg);
-            return false;
-        }
     }
 
     return true;

--- a/Blimp/AP_Arming.h
+++ b/Blimp/AP_Arming.h
@@ -44,7 +44,6 @@ protected:
     // NOTE! the following check functions *DO NOT* call into AP_Arming!
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
-    bool pilot_throttle_checks(bool display_failure);
     bool oa_checks(bool display_failure);
     bool mandatory_gps_checks(bool display_failure);
     bool gcs_failsafe_check(bool display_failure);


### PR DESCRIPTION
This is in continuation to the PR #19083. We have already removed this method in Rover and copter. This PR removes this form Blimp too. I have tested it and it worked well. Here's a screenshot
@rmackay9 If you could review please
<img width="1680" alt="Screenshot 2021-12-24 at 9 38 30 PM" src="https://user-images.githubusercontent.com/67995771/147364075-d118430a-6aa2-485b-aa88-7fe81236e481.png">
 