### PR TITLE
GCS_MAVLINK: prevent build error with -O3

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5221,13 +5221,17 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         break;
 
     case MSG_SCALED_IMU2:
+#if INS_MAX_INSTANCES > 1
         CHECK_PAYLOAD_SIZE(SCALED_IMU2);
         send_scaled_imu(1, mavlink_msg_scaled_imu2_send);
+#endif
         break;
 
     case MSG_SCALED_IMU3:
+#if INS_MAX_INSTANCES > 2
         CHECK_PAYLOAD_SIZE(SCALED_IMU3);
         send_scaled_imu(2, mavlink_msg_scaled_imu3_send);
+#endif
         break;
 
     case MSG_SCALED_PRESSURE:


### PR DESCRIPTION
and less than 3 IMUs
an alternative to #19602 that fixes the actual issue
