### PR TITLE
AP_BattMonitor: fixed a segv with BATT_MONITOR=14

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
@@ -22,12 +22,14 @@ AP_BattMonitor_SMBus_SUI::AP_BattMonitor_SMBus_SUI(AP_BattMonitor &mon,
       cell_count(_cell_count)
 {
     _pec_supported = false;
-    _dev->set_retries(2);
 }
 
 void AP_BattMonitor_SMBus_SUI::init(void)
 {
     AP_BattMonitor_SMBus::init();
+    if (_dev) {
+        _dev->set_retries(2);
+    }
     if (_dev && timer_handle) {
         // run twice as fast for two phases
         _dev->adjust_periodic_callback(timer_handle, 50000);


### PR DESCRIPTION
this causes a hang on boot on some boards
this was reported as "bricking" the board when the wrong param was set here:
https://www.youtube.com/watch?v=Y83w_n1lo2g&t=23s