### PR TITLE
AP_Proximity: Add parameter to allow manually setting range to sensors

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -174,6 +174,22 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_FILT", 18, AP_Proximity, _filt_freq, 0.25f),
 
+    // @Param: _MIN
+    // @DisplayName: Proximity minimum range
+    // @Description: Minimum expected range for Proximity Sensor. Setting this to 0 will set value to manufacturer reported range.
+    // @Units: m
+    // @Range: 0 500
+    // @User: Advanced
+    AP_GROUPINFO("_MIN", 19, AP_Proximity, _min_m, 0.0f),
+
+    // @Param: _MAX
+    // @DisplayName: Proximity maximum range
+    // @Description: Maximum expected range for Proximity Sensor. Setting this to 0 will set value to manufacturer reported range.
+    // @Units: m
+    // @Range: 0 500
+    // @User: Advanced
+    AP_GROUPINFO("_MAX", 20, AP_Proximity, _max_m, 0.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -191,6 +191,8 @@ private:
     AP_Int8 _raw_log_enable;                            // enable logging raw distances
     AP_Int8 _ign_gnd_enable;                           // true if land detection should be enabled
     AP_Float _filt_freq;                               // cutoff frequency for low pass filter
+    AP_Float _max_m;                                   // Proximity maximum range
+    AP_Float _min_m;                                   // Proximity minimum range
 
     void detect_instance(uint8_t instance);
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -89,19 +89,20 @@ protected:
 
     // correct an angle (in degrees) based on the orientation and yaw correction parameters
     float correct_angle_for_orientation(float angle_degrees) const;
-    
-    // check if a reading should be ignored because it falls into an ignore area
-    // angles should be in degrees and in the range of 0 to 360
-    bool ignore_reading(uint16_t angle_deg, float distance_m) const;
+
+    // check if a reading should be ignored because it falls into an ignore area (check_for_ign_area should be sent as false if this check is not needed)
+    // pitch is the vertical body-frame angle (in degrees) to the obstacle (0=directly ahead, 90 is above the vehicle)
+    // yaw is the horizontal body-frame angle (in degrees) to the obstacle (0=directly ahead of the vehicle, 90 is to the right of the vehicle)
+    // Also checks if obstacle is near land or out of range
+    // angles should be in degrees and in the range of 0 to 360, distance should be in meteres
+    bool ignore_reading(float pitch, float yaw, float distance_m, bool check_for_ign_area = true) const;
+    bool ignore_reading(float yaw, float distance_m, bool check_for_ign_area = true) const { return ignore_reading(0.0f, yaw, distance_m, check_for_ign_area); }
 
     // get alt from rangefinder in meters. This reading is corrected for vehicle tilt
     bool get_rangefinder_alt(float &alt_m) const;
 
     // Check if Obstacle defined by body-frame yaw and pitch is near ground
-    bool check_obstacle_near_ground(float yaw, float pitch, float distance) const;
-    bool check_obstacle_near_ground(float yaw, float distance) const { return check_obstacle_near_ground(yaw, 0.0f, distance); };
-    // Check if Obstacle defined by Vector3f is near ground. The vector is assumed to be body frame FRD
-    bool check_obstacle_near_ground(const Vector3f &obstacle) const;
+    bool check_obstacle_near_ground(float pitch, float yaw, float distance) const;
 
     // database helpers. All angles are in degrees
     static bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -50,7 +50,7 @@ void AP_Proximity_RangeFinder::update(void)
                 const float distance = sensor->distance();
                 _distance_min = sensor->min_distance_cm() * 0.01f;
                 _distance_max = sensor->max_distance_cm() * 0.01f;
-                if ((distance <= _distance_max) && (distance >= _distance_min) && !check_obstacle_near_ground(angle, distance)) {
+                if ((distance <= _distance_max) && (distance >= _distance_min) && !ignore_reading(angle, distance, false)) {
                     boundary.set_face_attributes(face, angle, distance);
                     // update OA database
                     database_push(angle, distance);

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -101,7 +101,7 @@ bool AP_Proximity_SITL::get_distance_to_fence(float angle_deg, float &distance) 
         }
     }
     distance = min_dist;
-    if (check_obstacle_near_ground(angle_deg, distance)) {
+    if (ignore_reading(angle_deg, distance, false)) {
         // obstacle near land, lets ignore it
         return false;
     }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -93,10 +93,10 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
 
 // process reply
 void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_t distance_cm)
-{   
+{
     // Get location on 3-D boundary based on angle to the object
     const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
-    if ((distance_cm != 0xffff) && !check_obstacle_near_ground(angle_deg, distance_cm * 0.001f)) {
+    if ((distance_cm != 0xffff) && !ignore_reading(angle_deg, distance_cm * 0.001f, false)) {
         boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
         database_push(angle_deg, ((float) distance_cm) / 1000);

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -151,7 +151,7 @@ void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint
     const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
     //check for target too far, target too close and sensor not connected
     const bool valid = (distance_cm != 0xffff) && (distance_cm > 0x0001);
-    if (valid && !check_obstacle_near_ground(angle_deg, distance_cm * 0.001f)) {
+    if (valid && !ignore_reading(angle_deg, distance_cm * 0.001f, false)) {
         boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
         database_push(angle_deg, ((float) distance_cm) / 1000);


### PR DESCRIPTION
This pull request forces all drivers to pass through the function "ignore_reading" which is a convenience function to filter out values depending on: 
1. If they are within range (as specified by min/max newly added params)
2. If they are detected to be above ground
3. If they are not in ignore area as set by params

Having such a function is good so that we can pass the raw readings through any kind of other filter required in the future. 