### PR TITLE
hwdef: set AP_OPTICALFLOW_ENABLED 0 for SkyViper-v2450

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -68,3 +68,4 @@ env BUILD_ABIN True
 # Disable un-needed hardware drivers
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
+define AP_OPTICALFLOW_ENABLED 0


### PR DESCRIPTION
Saves some bytes (not that that's a big issue on SkyViper), but also tests that OF being compiled out works.
