### PR TITLE
AC_PosControl: remove duplicate xy I set and contrain accel target to…

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -446,11 +446,6 @@ void AC_PosControl::set_correction_speed_accel_xy(float speed_cms, float accel_c
 void AC_PosControl::init_xy_controller()
 {
     init_xy();
-
-    // set resultant acceleration to current attitude target
-    Vector3f accel_target;
-    lean_angles_to_accel_xy(accel_target.x, accel_target.y);
-    _pid_vel_xy.set_integrator(accel_target - _accel_desired);
 }
 
 /// init_xy_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
@@ -502,6 +497,7 @@ void AC_PosControl::init_xy()
     _accel_desired.xy().limit_length(_accel_max_xy_cmss);
 
     lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    _accel_target.xy().limit_length(_accel_max_xy_cmss);
 
     // initialise I terms from lean angles
     _pid_vel_xy.reset_filter();

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -408,7 +408,7 @@ protected:
     void accel_to_lean_angles(float accel_x_cmss, float accel_y_cmss, float& roll_target, float& pitch_target) const;
 
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
-    void lean_angles_to_accel_xy(float& accel_x_cmss, float& accel_y_cmss) const;
+    void lean_angles_to_accel_xy(float& accel_x_cmss, float& accel_y_cmss, bool limit_angle_max) const;
 
     // calculate_yaw_and_rate_yaw - calculate the vehicle yaw and rate of yaw.
     bool calculate_yaw_and_rate_yaw();


### PR DESCRIPTION
… max accel

Firstly this removes the set integrator call from `void AC_PosControl::init_xy_controller()` it is a duplicate of the one already done in     `init_xy()`

Secondly this constrains the value of `_accel_target` to `_accel_max_xy_cmss`, this prevents huge integrator terms being set in the `_pid_vel_xy.set_integrator(_accel_target - _accel_desired);` call.

This happens when the controller is init at large lean angles, the return of `lean_angles_to_accel_xy` will give up to 10g (9800 cm/s^2). This is constrained to the I max value of course, 1000 by default, but it still takes ages to decay down. 

This should help with a issue in tailsitter transition seen here:

![image](https://user-images.githubusercontent.com/33176108/147712673-62afe05e-3c75-4c17-959c-5aa940c90d21.png)

Huge I value is dominant term for 20 seconds or so. Of course lower I max and larger I would make the issue much less severe. 

@lthall I'm a little puzzled by the initialisation of the I term in this way, why not just zero? 

I think we should at least also constrain the lean angles in the calculation to be within the position controller max lean angle.

https://github.com/ArduPilot/ardupilot/blob/7c8794b0bd41f9d06d0944e7951f9454600c3fe7/libraries/AC_AttitudeControl/AC_PosControl.cpp#L1206

Not yet tested this to confirm it does fix/help the tailsitter issue, so just a draft for now.

Original Log from @robustini here: https://discord.com/channels/674039678562861068/783141293445480470/925687163117510676 and vid of the issue here: https://discord.com/channels/674039678562861068/783141293445480470/921090429879975996