### PR TITLE
Tidy Notch filter logging

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -686,10 +686,9 @@ void Copter::update_altitude()
 
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
+        write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
-#else
-        write_notch_log_messages();
 #endif
     }
 }

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -686,7 +686,7 @@ void Copter::update_altitude()
 
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
-        write_notch_log_messages();
+        AP::ins().write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
 #endif

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -243,13 +243,12 @@ void Plane::update_logging2(void)
 {
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
+        write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
-#else
-        write_notch_log_messages();
 #endif
     }
-    
+
     if (should_log(MASK_LOG_NTUN)) {
         Log_Write_Nav_Tuning();
         Log_Write_Guided();

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -243,7 +243,7 @@ void Plane::update_logging2(void)
 {
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
-        write_notch_log_messages();
+        AP::ins().write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
 #endif

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -323,7 +323,7 @@ void Sub::update_altitude()
 
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
-        write_notch_log_messages();
+        AP::ins().write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
 #endif

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -323,10 +323,9 @@ void Sub::update_altitude()
 
     if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
+        write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
-#else
-        write_notch_log_messages();
 #endif
     }
 }

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -260,7 +260,7 @@ void Blimp::update_altitude()
     read_barometer();
 
     if (should_log(MASK_LOG_CTUN)) {
-        write_notch_log_messages();
+        AP::ins().write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
 #endif

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -260,10 +260,9 @@ void Blimp::update_altitude()
     read_barometer();
 
     if (should_log(MASK_LOG_CTUN)) {
+        write_notch_log_messages();
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
-#else
-        write_notch_log_messages();
 #endif
     }
 }

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -777,9 +777,6 @@ float AP_GyroFFT::calculate_weighted_freq_hz(const Vector3f& energy, const Vecto
 // log gyro fft messages
 void AP_GyroFFT::write_log_messages()
 {
-    // still want to see the harmonic notch values
-    AP::vehicle()->write_notch_log_messages();
-
     if (!analysis_enabled()) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -276,6 +276,9 @@ public:
         return _harmonic_notch_filter.hasOption(option);
     }
 
+    // write out harmonic notch log messages
+    void write_notch_log_messages() const;
+
     // indicate which bit in LOG_BITMASK indicates raw logging enabled
     void set_log_raw_bit(uint32_t log_raw_bit) { _log_raw_bit = log_raw_bit; }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -128,3 +128,29 @@ bool AP_InertialSensor::BatchSampler::Write_ISBD() const
 
     return AP::logger().WriteBlock_first_succeed(&pkt, sizeof(pkt));
 }
+
+// @LoggerMessage: FTN
+// @Description: Filter Tuning Messages
+// @Field: TimeUS: microseconds since system startup
+// @Field: NDn: number of active dynamic harmonic notches
+// @Field: NF1: dynamic harmonic notch centre frequency for motor 1
+// @Field: NF2: dynamic harmonic notch centre frequency for motor 2
+// @Field: NF3: dynamic harmonic notch centre frequency for motor 3
+// @Field: NF4: dynamic harmonic notch centre frequency for motor 4
+// @Field: NF5: dynamic harmonic notch centre frequency for motor 5
+// @Field: NF6: dynamic harmonic notch centre frequency for motor 6
+// @Field: NF7: dynamic harmonic notch centre frequency for motor 7
+// @Field: NF8: dynamic harmonic notch centre frequency for motor 8
+// @Field: NF9: dynamic harmonic notch centre frequency for motor 9
+// @Field: NF10: dynamic harmonic notch centre frequency for motor 10
+// @Field: NF11: dynamic harmonic notch centre frequency for motor 11
+// @Field: NF12: dynamic harmonic notch centre frequency for motor 12
+void AP_InertialSensor::write_notch_log_messages() const
+{
+    const float* notches = get_gyro_dynamic_notch_center_frequencies_hz();
+    AP::logger().Write(
+        "FTN", "TimeUS,NDn,NF1,NF2,NF3,NF4,NF5,NF6,NF7,NF8,NF9,NF10,NF11,NF12", "s-zzzzzzzzzzzz", "F-------------", "QBffffffffffff", AP_HAL::micros64(), get_num_gyro_dynamic_notch_center_frequencies(),
+            notches[0], notches[1], notches[2], notches[3],
+            notches[4], notches[5], notches[6], notches[7],
+            notches[8], notches[9], notches[10], notches[11]);
+}

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -148,7 +148,7 @@ bool AP_InertialSensor::BatchSampler::Write_ISBD() const
 void AP_InertialSensor::write_notch_log_messages() const
 {
     const float* notches = get_gyro_dynamic_notch_center_frequencies_hz();
-    AP::logger().Write(
+    AP::logger().WriteStreaming(
         "FTN", "TimeUS,NDn,NF1,NF2,NF3,NF4,NF5,NF6,NF7,NF8,NF9,NF10,NF11,NF12", "s-zzzzzzzzzzzz", "F-------------", "QBffffffffffff", AP_HAL::micros64(), get_num_gyro_dynamic_notch_center_frequencies(),
             notches[0], notches[1], notches[2], notches[3],
             notches[4], notches[5], notches[6], notches[7],

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -364,32 +364,6 @@ bool AP_Vehicle::is_crashed() const
     return AP::arming().last_disarm_method() == AP_Arming::Method::CRASH;
 }
 
-// @LoggerMessage: FTN
-// @Description: Filter Tuning Messages
-// @Field: TimeUS: microseconds since system startup
-// @Field: NDn: number of active dynamic harmonic notches
-// @Field: NF1: dynamic harmonic notch centre frequency for motor 1
-// @Field: NF2: dynamic harmonic notch centre frequency for motor 2
-// @Field: NF3: dynamic harmonic notch centre frequency for motor 3
-// @Field: NF4: dynamic harmonic notch centre frequency for motor 4
-// @Field: NF5: dynamic harmonic notch centre frequency for motor 5
-// @Field: NF6: dynamic harmonic notch centre frequency for motor 6
-// @Field: NF7: dynamic harmonic notch centre frequency for motor 7
-// @Field: NF8: dynamic harmonic notch centre frequency for motor 8
-// @Field: NF9: dynamic harmonic notch centre frequency for motor 9
-// @Field: NF10: dynamic harmonic notch centre frequency for motor 10
-// @Field: NF11: dynamic harmonic notch centre frequency for motor 11
-// @Field: NF12: dynamic harmonic notch centre frequency for motor 12
-void AP_Vehicle::write_notch_log_messages() const
-{
-    const float* notches = ins.get_gyro_dynamic_notch_center_frequencies_hz();
-    AP::logger().Write(
-        "FTN", "TimeUS,NDn,NF1,NF2,NF3,NF4,NF5,NF6,NF7,NF8,NF9,NF10,NF11,NF12", "s-zzzzzzzzzzzz", "F-------------", "QBffffffffffff", AP_HAL::micros64(), ins.get_num_gyro_dynamic_notch_center_frequencies(),
-            notches[0], notches[1], notches[2], notches[3],
-            notches[4], notches[5], notches[6], notches[7],
-            notches[8], notches[9], notches[10], notches[11]);
-}
-
 // run notch update at either loop rate or 200Hz
 void AP_Vehicle::update_dynamic_notch_at_specified_rate()
 {

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -239,8 +239,6 @@ public:
 
 #endif // AP_SCRIPTING_ENABLED
 
-    // write out harmonic notch log messages
-    void write_notch_log_messages() const;
     // update the harmonic notch
     virtual void update_dynamic_notch() {};
 


### PR DESCRIPTION
This was a bit weird, with the vehicle calling the library and the library calling the vehicle.  This makes it less weird.

Tested in SITL by running the GyroFFT test and checking the logs still contained the `FTN` message.

Better still would be to pass the log-bitmask-bit (e.g. `MASK_LOG_CTUN`) into the AP_InertialSensor library and have it do the relevant logging.  It's a pattern we use elsewhere.
