### PR TITLE
AP_Arming: Implement ARMING_REQUIRE 3 aka AUTO_ARM_FORCE_CHECKS

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -12,7 +12,7 @@ public:
     {
         // default REQUIRE parameter to 1 (Copter does not have an
         // actual ARMING_REQUIRE parameter)
-        require.set_default((uint8_t)Required::YES_MIN_PWM);
+        set_arming_required_default(Required::YES_MIN_PWM);
     }
 
     /* Do not allow copies */

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -23,7 +23,7 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
  */
 bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 {
-    if (armed || require == (uint8_t)Required::NO) {
+    if (armed || arming_required() == Required::NO) {
         // if we are already armed or don't need any arming checks
         // then skip the checks
         return true;

--- a/Blimp/AP_Arming.h
+++ b/Blimp/AP_Arming.h
@@ -12,7 +12,7 @@ public:
     {
         // default REQUIRE parameter to 1 (Blimp does not have an
         // actual ARMING_REQUIRE parameter)
-        require.set_default((uint8_t)Required::YES_MIN_PWM);
+        set_arming_required_default(Required::YES_MIN_PWM);
     }
 
     /* Do not allow copies */

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -125,9 +125,10 @@ public:
     Method last_disarm_method() const { return _last_disarm_method; } 
 
 protected:
-
+    void set_arming_required_default(Required default_require) {
+        require.set_default((uint8_t)default_require);
+    }
     // Parameters
-    AP_Int8                 require;
     AP_Int32                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
@@ -213,6 +214,8 @@ protected:
 private:
 
     static AP_Arming *_singleton;
+
+    AP_Int8                 require;
 
     bool ins_accels_consistent(const AP_InertialSensor &ins);
     bool ins_gyros_consistent(const AP_InertialSensor &ins);

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -79,7 +79,8 @@ public:
     enum class Required {
         NO           = 0,
         YES_MIN_PWM  = 1,
-        YES_ZERO_PWM = 2
+        YES_ZERO_PWM = 2,
+        AUTO_ARM_FORCE_CHECKS = 3
     };
 
     void init(void);
@@ -222,6 +223,11 @@ private:
 
     // check if we should keep logging after disarming
     void check_forced_logging(const AP_Arming::Method method);
+
+    // arm() in a low priority thread for AUTO_ARM_FORCE_CHECKS
+    void low_priority_arm();
+    bool low_priority_arm_initialized{false};
+    uint32_t last_arm_trial{0};
 
     enum MIS_ITEM_CHECK {
         MIS_ITEM_CHECK_LAND          = (1 << 0),


### PR DESCRIPTION
This mode tries to automatically arm as soon as all checks are passed
    It runs on a low priority thread to avoid imu_reset/possible watchdog
    reset when INS_FAST_SAMPLE is enabled

I tried to keep changes as minimal as possible that's why I used is_armed() as a start point.

Suggestions are welcome.