### PR TITLE
AP_Scripting: AP_Param: remove name helper functions and use alias

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
@@ -217,7 +217,7 @@ void AP_Frsky_MAVliteMsgHandler::handle_param_set(const AP_Frsky_MAVlite_Message
     }
     if ((parameter_flags & AP_PARAM_FLAG_INTERNAL_USE_ONLY) || vp->is_read_only()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Param write denied (%s)", param_name);
-    } else if (!AP_Param::set_and_save(param_name, param_value)) {
+    } else if (!AP_Param::set_and_save_by_name(param_name, param_value)) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Param write failed (%s)", param_name);
     }
     // let's read back the last value, either the readonly one or the updated one

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -291,8 +291,6 @@ public:
     /// @param  value           The new value
     /// @return                 true if the variable is found
     static bool set_by_name(const char *name, float value);
-    // name helper for scripting
-    static bool set(const char *name, float value) { return set_by_name(name, value); };
 
     /// gat a value by name, used by scripting
     ///
@@ -308,8 +306,6 @@ public:
     /// @return                 true if the variable is found
     static bool set_and_save_by_name(const char *name, float value);
     static bool set_and_save_by_name_ifchanged(const char *name, float value);
-    // name helper for scripting
-    static bool set_and_save(const char *name, float value) { return set_and_save_by_name(name, value); };
 
     /// Find a variable by index.
     ///

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -294,8 +294,10 @@ singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHAN
 include AP_Param/AP_Param.h
 singleton AP_Param alias param
 singleton AP_Param method get boolean string float'Null
-singleton AP_Param method set boolean string float'skip_check
-singleton AP_Param method set_and_save boolean string float'skip_check
+singleton AP_Param method set_by_name boolean string float'skip_check
+singleton AP_Param method set_by_name alias set
+singleton AP_Param method set_and_save_by_name boolean string float'skip_check
+singleton AP_Param method set_and_save_by_name alias set_and_save
 
 include AP_Scripting/AP_Scripting_helpers.h
 userdata Parameter method init boolean string


### PR DESCRIPTION
We now (for ages) support function alias in scripting so we can remove the helper functions in param.

I think these are the only ones, there might be some where we would have liked to give the function a more verbose name for the `c++` but didn't because of a scripting user. I don't think its worth going back and changing those, but we don't have to add anymore in the future.  