### PR TITLE
Tool: ardupilotwaf fix duplicate reporting from build summary

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -518,8 +518,9 @@ def _select_programs_from_group(bld):
         else:
             bld.targets = tg.name
 
-        for tg in _grouped_programs[group][1:]:
-            bld.targets += ',' + tg.name
+        if len(_grouped_programs[group]) > 2:
+            for tg in _grouped_programs[group][1:]:
+                bld.targets += ',' + tg.name
 
 def options(opt):
     opt.ap_groups = {


### PR DESCRIPTION
This removes the duplicates on master that seem to have been around a long time when using `./waf plane copter` found by @peterbarker 

Checked `./waf build` , `./waf tests`,  `./waf examples`, `./waf copter` `./waf copter plane tracker` build without duplicates and look good

Master:
![image](https://user-images.githubusercontent.com/69225461/147866152-c4cffe75-b99f-495e-84da-5bcb844ecd1c.png)

After PR:
![image](https://user-images.githubusercontent.com/69225461/147866808-7af0a626-f23d-4d64-bb6e-8d2ceaa116b2.png)


Note: there is another preexisting issue this PR does not fix: `./waf tests examples` 
Instead of outputting the summary for tests then examples it just repeats the summary for tests

