### PR TITLE
AP_Scripting: generator: use depends for singleton strings

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2010,7 +2010,9 @@ void emit_sandbox(void) {
   struct userdata *single = parsed_singletons;
   fprintf(source, "const char *singletons[] = {\n");
   while (single) {
+    start_dependency(source, single->dependency);
     fprintf(source, "    \"%s\",\n", single->alias ? single->alias : single->sanatized_name);
+    end_dependency(source, single->dependency);
     single = single->next;
   }
   fprintf(source, "};\n\n");


### PR DESCRIPTION
The correct dependency was not being added for the singlton name strings table. This fixes.

On master the generated table looks like this:
```
const char *singletons[] = {
    "periph",
    "ins",
    "Motors_dynamic",
    "analog",
    "gpio",
    "Motors_6DoF",
    "attitude_control",
    "frsky_sport",
    "MotorsMatrix",
    "quadplane",
    "LED",
    "button",
    "RPM",
    "mission",
    "param",
    "esc_telem",
    "optical_flow",
    "baro",
    "serial",
    "rc",
    "SRV_Channels",
    "serialLED",
    "vehicle",
    "onvif",
    "gcs",
    "relay",
    "terrain",
    "rangefinder",
    "proximity",
    "notify",
    "gps",
    "battery",
    "arming",
    "ahrs",
};
```
With this patch:
```
const char *singletons[] = {
#if defined(HAL_BUILD_AP_PERIPH)
    "periph",
#endif // defined(HAL_BUILD_AP_PERIPH)
    "ins",
#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
    "Motors_dynamic",
#endif // APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
    "analog",
    "gpio",
#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
    "Motors_6DoF",
#endif // APM_BUILD_TYPE(APM_BUILD_ArduCopter)
#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
    "attitude_control",
#endif // APM_BUILD_TYPE(APM_BUILD_ArduCopter)
    "frsky_sport",
#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
    "MotorsMatrix",
#endif // APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
#if APM_BUILD_TYPE(APM_BUILD_ArduPlane) && HAL_QUADPLANE_ENABLED
    "quadplane",
#endif // APM_BUILD_TYPE(APM_BUILD_ArduPlane) && HAL_QUADPLANE_ENABLED
    "LED",
#if HAL_BUTTON_ENABLED == 1
    "button",
#endif // HAL_BUTTON_ENABLED == 1
    "RPM",
    "mission",
    "param",
#if HAL_WITH_ESC_TELEM == 1
    "esc_telem",
#endif // HAL_WITH_ESC_TELEM == 1
#if AP_OPTICALFLOW_ENABLED
    "optical_flow",
#endif // AP_OPTICALFLOW_ENABLED
    "baro",
    "serial",
    "rc",
    "SRV_Channels",
    "serialLED",
    "vehicle",
#if ENABLE_ONVIF == 1
    "onvif",
#endif // ENABLE_ONVIF == 1
    "gcs",
    "relay",
#if defined(AP_TERRAIN_AVAILABLE) && AP_TERRAIN_AVAILABLE == 1
    "terrain",
#endif // defined(AP_TERRAIN_AVAILABLE) && AP_TERRAIN_AVAILABLE == 1
    "rangefinder",
#if HAL_PROXIMITY_ENABLED == 1
    "proximity",
#endif // HAL_PROXIMITY_ENABLED == 1
    "notify",
    "gps",
    "battery",
    "arming",
    "ahrs",
};
```

Everything else worked as expected, so were just saving the flash cost of the strings.