### PR TITLE
Build system: GH action to make *_bl.hex uploadable to FC

### DIFF
--- a/.github/workflows/manual_firmware_build.yml
+++ b/.github/workflows/manual_firmware_build.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'MatekF405-Wing,MatekF405-CAN,MatekF765-Wing,MambaF405v2'
       projects:
-        description: 'Boards to build (e.g. `arducopter,arduplane,rover,antennatracker,ardusub,AP_Periph` )'
+        description: 'Projects to build (e.g. `arducopter,arduplane,rover,antennatracker,ardusub,AP_Periph` )'
         required: true
         default: 'arduplane'
 
@@ -60,13 +60,14 @@ jobs:
           PATH="/github/home/.local/bin:$PATH"
           mkdir -p $BUILDLOGS/binaries
           mkdir -p $BUILD_BINARIES_PATH
-          # latest tag would use newer compiled, but it's not installed here (linked)...
+          # P.S.: 'latest' tags would use newer compiler, but it's not installed or linked in current build environment
           ./Tools/scripts/build_binaries.py --tags beta --boards ${{ github.event.inputs.boards }} --projects ${{ github.event.inputs.projects }} --skip-history yes --require-checkout no
-          tar -cvf /tmp/buildlogs/built_binaries.tar /tmp/buildlogs/binaries/Plane/
+          # FIXME: we probably want to upload other projects too?
+          tar -cvf $BUILDLOGS/built_arduplane_binaries.tar $BUILDLOGS/binaries/Plane/
           ccache -s
           ccache -z
-      - name: 'Upload'
+      - name: 'Upload build artefacts to Github'
         uses: actions/upload-artifact@v2
         with:
           name: arduplane build files tar of ${{ github.event.inputs.boards }}
-          path: /tmp/buildlogs/built_binaries.tar
+          path: $BUILDLOGS/built_arduplane_binaries.tar

--- a/.github/workflows/manual_firmware_build.yml
+++ b/.github/workflows/manual_firmware_build.yml
@@ -1,0 +1,72 @@
+name: Manual Firmware build (produce downloadable *_with_bl.hex ready to upload to FC)
+
+on:
+  workflow_dispatch:
+    inputs:
+      boards:
+        description: 'Boards to build (see `Tools/scripts/board_list.py` for a full list)'
+        required: true
+        default: 'MatekF405-Wing,MatekF405-CAN,MatekF765-Wing,MambaF405v2'
+      projects:
+        description: 'Boards to build (e.g. `arducopter,arduplane,rover,antennatracker,ardusub,AP_Periph` )'
+        required: true
+        default: 'arduplane'
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: 'macos-latest'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install Prerequisites
+        shell: bash
+        run: |
+          Tools/environment_install/install-prereqs-mac.sh -y
+          source ~/.bash_profile
+      # Put ccache into github cache for faster build
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        run: |
+          NOW=$(date -u +"%F-%T")
+          echo "::set-output name=timestamp::${NOW}"
+      - name: ccache cache files
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{github.workflow}}-ccache-manual-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+          restore-keys: ${{github.workflow}}-ccache-manual # restore ccache from either previous build on this branch or on master
+      - name: setup ccache
+        run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 6" >> ~/.ccache/ccache.conf
+          echo "max_size = 400M" >> ~/.ccache/ccache.conf
+          ccache -s
+          ccache -z
+      - name: manual build for ${{ github.event.inputs.boards }}
+        env:
+          BUILDLOGS: /tmp/buildlogs
+          BUILD_BINARIES_PATH: /tmp/ardu-build-dir
+        shell: bash
+        run: |
+          source ~/.bash_profile
+          PATH="/github/home/.local/bin:$PATH"
+          mkdir -p $BUILDLOGS/binaries
+          mkdir -p $BUILD_BINARIES_PATH
+          # latest tag would use newer compiled, but it's not installed here (linked)...
+          ./Tools/scripts/build_binaries.py --tags beta --boards ${{ github.event.inputs.boards }} --projects ${{ github.event.inputs.projects }} --skip-history yes --require-checkout no
+          tar -cvf /tmp/buildlogs/built_binaries.tar /tmp/buildlogs/binaries/Plane/
+          ccache -s
+          ccache -z
+      - name: 'Upload'
+        uses: actions/upload-artifact@v2
+        with:
+          name: arduplane build files tar of ${{ github.event.inputs.boards }}
+          path: /tmp/buildlogs/built_binaries.tar

--- a/.github/workflows/manual_firmware_build.yml
+++ b/.github/workflows/manual_firmware_build.yml
@@ -63,6 +63,8 @@ jobs:
           # P.S.: 'latest' tags would use newer compiler, but it's not installed or linked in current build environment
           ./Tools/scripts/build_binaries.py --tags beta --boards ${{ github.event.inputs.boards }} --projects ${{ github.event.inputs.projects }} --skip-history yes --require-checkout no
           # FIXME: we probably want to upload other projects too?
+          echo "listing files in BUILDLOGS/binaries/"
+          ls -lh $BUILDLOGS/binaries
           tar -cvf $BUILDLOGS/built_arduplane_binaries.tar $BUILDLOGS/binaries/Plane/
           ccache -s
           ccache -z

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -80,13 +80,10 @@ ALL_PROJECTS = [
 
 
 class build_binaries(object):
-    def __init__(self, tags, boards=None, projects=ALL_PROJECTS, require_checkout=True, skip_history=False):
+    def __init__(self, tags, selected_boards=[], projects=ALL_PROJECTS, require_checkout=True, skip_history=False):
         self.tags = tags
         self.require_checkout = require_checkout
-        if boards:
-            self.selected_boards = boards
-        else:
-            self.selected_boards = [] # build all boards
+        self.selected_boards = selected_boards # P.S. build all boards when selected_boards=[]
         self.projects = projects
         self.dirty = False
         binaries_history_filepath = os.path.join(self.buildlogs_dirpath(),
@@ -366,11 +363,13 @@ is bob we will attempt to checkout bob-AVR'''
     def addfwversion(self, destdir, src):
         '''write version information into destdir'''
         self.addfwversion_gitversion(destdir, src)
+        # FIXME: this seem to sometimes result in utf-8/encoding issues. at least add traceback for now
         try:
             self.addfwversion_firmwareversiontxt(destdir, src)
         except:
             import traceback
             traceback.print_stack()
+            raise
 
     def read_string_from_filepath(self, filepath):
         '''returns content of filepath as a string'''
@@ -793,12 +792,10 @@ if __name__ == '__main__':
         tags = ["stable", "beta", "latest"]
 
     boards = flatten_comma_opts(cmd_opts.boards)
-    projects = flatten_comma_opts(cmd_opts.projects)
+    projects = flatten_comma_opts(cmd_opts.projects) or ALL_PROJECTS
     require_checkout = cmd_opts.require_checkout == "yes"
     skip_history = cmd_opts.skip_history == "yes"
-    if len(projects) == 0:
-        projects = ALL_PROJECTS
     projects = filter_valid_projects(projects)
 
-    bb = build_binaries(tags, boards=boards, projects=projects, require_checkout=require_checkout, skip_history=skip_history)
+    bb = build_binaries(tags, selected_boards=boards, projects=projects, require_checkout=require_checkout, skip_history=skip_history)
     bb.run()


### PR DESCRIPTION
Add a manual Github Action which can build *_bl.hex files uploadable to Flight Controller.
The action can be used on custom branches, and thus very useful for live testing of PRs on real FC before merging them to master on a manual selection of FC models (thus rather fast build).

The build firmware `*_bl.hex` files are uploaded to Github and can be downloaded with one click.

Changes:
- fix utf-8 encode/decode in  `Tools/scripts/build_binaries.py` (might need more ❤️ , tried to keep changes minimal for now)
- make history optional for now (missing size cmd)
- upload built files to Github