### PR TITLE
Fix log various

### DIFF
--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -71,7 +71,7 @@ void LoggerMessageWriter_DFLogStart::reset()
     ap = AP_Param::first(&token, &type, &param_default);
 }
 
-bool LoggerMessageWriter_DFLogStart::out_of_time_for_writing_messages() const
+bool LoggerMessageWriter_DFLogStart::out_of_time_for_writing_messages_df() const
 {
     if (stage == Stage::FORMATS) {
         // write out the FMT messages as fast as we can
@@ -99,7 +99,7 @@ bool LoggerMessageWriter_DFLogStart::check_process_limit(uint32_t start_us)
 
 void LoggerMessageWriter_DFLogStart::process()
 {
-    if (out_of_time_for_writing_messages()) {
+    if (out_of_time_for_writing_messages_df()) {
         return;
     }
     // allow any stage to run for max 1ms, to prevent a long loop on arming

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -14,7 +14,7 @@ public:
         _logger_backend = backend;
     }
 
-    bool out_of_time_for_writing_messages() const;
+    virtual bool out_of_time_for_writing_messages() const;
 
 protected:
     bool _finished = false;
@@ -124,7 +124,7 @@ public:
 #endif
     }
 
-    bool out_of_time_for_writing_messages() const;
+    bool out_of_time_for_writing_messages() const override;
 
     void reset() override;
     void process() override;

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -110,7 +110,7 @@ public:
         {
         }
 
-    virtual void set_logger_backend(class AP_Logger_Backend *backend) override {
+    void set_logger_backend(class AP_Logger_Backend *backend) override final {
         LoggerMessageWriter::set_logger_backend(backend);
         _writesysinfo.set_logger_backend(backend);
 #if AP_MISSION_ENABLED
@@ -124,7 +124,7 @@ public:
 #endif
     }
 
-    bool out_of_time_for_writing_messages() const override;
+    bool out_of_time_for_writing_messages() const override final;
 
     void reset() override;
     void process() override;

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -14,7 +14,7 @@ public:
         _logger_backend = backend;
     }
 
-    virtual bool out_of_time_for_writing_messages() const;
+    bool out_of_time_for_writing_messages() const;
 
 protected:
     bool _finished = false;
@@ -124,7 +124,7 @@ public:
 #endif
     }
 
-    bool out_of_time_for_writing_messages() const override final;
+    bool out_of_time_for_writing_messages_df() const;
 
     void reset() override;
     void process() override;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -479,7 +479,7 @@ public:
 
     // returns a mask indicating which channels have overrides.  Bit 0
     // is RC channel 1.  Beware this is not a cheap call.
-    static uint16_t get_override_mask();
+    uint16_t get_override_mask() const;
 
     class RC_Channel *find_channel_for_option(const RC_Channel::aux_func_t option);
     bool duplicate_options_exist();

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -114,7 +114,7 @@ void RC_Channels::clear_overrides(void)
     // copter and plane, RC_Channels needs to control failsafes to resolve this
 }
 
-uint16_t RC_Channels::get_override_mask(void)
+uint16_t RC_Channels::get_override_mask(void) const
 {
     uint16_t ret = 0;
     RC_Channels &_rc = rc();


### PR DESCRIPTION
This bring a bunch of small fix on AP_Logger, mostly warning reported by clang
Switch NULL to nullptr
Correct on instantiation order
Make explicit comparison for strncmp
Make out_of_time_for_writing_messages() explicitly virtual
