### PR TITLE
T-Motor Alpha ESC telemetry input support

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -108,6 +108,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_VideoTX',
     'AP_FETtecOneWire',
     'AP_Torqeedo',
+    'AP_TMotorESC',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1106,7 +1106,7 @@ bool AP_Arming::fettec_checks(bool display_failure) const
         return true;
     }
 
-    // check camera is ready
+    // check ESCs are ready
     char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     if (!f->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
         check_failed(ARMING_CHECK_ALL, display_failure, "FETtec: %s", fail_msg);

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -43,6 +43,7 @@
 #include <AP_OSD/AP_OSD.h>
 #include <AP_Button/AP_Button.h>
 #include <AP_FETtecOneWire/AP_FETtecOneWire.h>
+#include <AP_TMotorESC/AP_TMotorESC.h>
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
   #include <AP_CANManager/AP_CANManager.h>
@@ -1116,6 +1117,24 @@ bool AP_Arming::fettec_checks(bool display_failure) const
     return true;
 }
 
+bool AP_Arming::tmotor_esc_checks(bool display_failure) const
+{
+#if AP_TMOTOR_ESC_ENABLED
+    const AP_TMotorESC *f = AP_TMotorESC::get_singleton();
+    if (f == nullptr) {
+        return true;
+    }
+
+    // check ESCs are ready
+    char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    if (!f->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
+        check_failed(ARMING_CHECK_ALL, display_failure, "TMotor: %s", fail_msg);
+        return false;
+    }
+#endif
+    return true;
+}
+
 // request an auxiliary authorisation id.  This id should be used in subsequent calls to set_aux_auth_passed/failed
 // returns true on success
 bool AP_Arming::get_aux_auth_id(uint8_t& auth_id)
@@ -1280,7 +1299,12 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  proximity_checks(report)
         &  camera_checks(report)
         &  osd_checks(report)
+#if AP_FETTEC_ONEWIRE_ENABLED
         &  fettec_checks(report)
+#endif
+#if AP_TMOTOR_ESC_ENABLED
+        &  tmotor_esc_checks(report)
+#endif
         &  visodom_checks(report)
         &  aux_auth_checks(report)
         &  disarm_switch_checks(report)

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -188,6 +188,8 @@ protected:
 
     bool fettec_checks(bool display_failure) const;
 
+    bool tmotor_esc_checks(bool display_failure) const;
+
     virtual bool proximity_checks(bool report) const;
 
     bool servo_checks(bool report) const;

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -141,7 +141,7 @@ void AP_FETtecOneWire::init()
 
     // initialise ESC ids.  This enforces that the FETtec ESC ids
     // inside FETtec ESCs need to be contiguous and start at ID 1
-    // which required by fast-throttle commands.
+    // which is required by fast-throttle commands.
     uint8_t esc_offset = 0;  // offset into our device-driver dynamically-allocated array of ESCs
     uint8_t esc_id = 1;      // ESC ids inside FETtec protocol are one-indexed
     uint8_t servo_chan_offset = 0;  // offset into _motor_mask_parameter array

--- a/libraries/AP_FETtecOneWire/README.md
+++ b/libraries/AP_FETtecOneWire/README.md
@@ -4,7 +4,7 @@ FETtec OneWire is an [ESC](https://en.wikipedia.org/wiki/Electronic_speed_contro
 It is a (bidirectional) [digital full-duplex asynchronous serial communication protocol](https://en.wikipedia.org/wiki/Asynchronous_serial_communication) running at 500Kbit/s Baudrate. It requires three wire (RX, TX and GND) connection (albeit the name OneWire) regardless of the number of ESCs connected.
 Unlike bidirectional-Dshot, the FETtec OneWire protocol does not need one DMA channel per ESC for bidirectional communication. 
 
-For purchase, connection and configuration information please see the [Ardupilot FETtec OneWire wiki page](https://ardupilot.org/copter/docs/common-fettec-onewire.html).
+For purchase, connection and configuration information please see the [ArduPilot FETtec OneWire wiki page](https://ardupilot.org/copter/docs/common-fettec-onewire.html).
 
 ## Features of this device driver
 
@@ -39,9 +39,9 @@ For purchase, connection and configuration information please see the [Ardupilot
   - fly a copter over a simulated serial link connection
 
 
-## Ardupilot to ESC protocol
+## ArduPilot to ESC protocol
 
-The FETtec OneWire protocol supports up to 24 ESCs. As most copters only use at most 12 motors, Ardupilot's implementation supports only 12 (`ESC_TELEM_MAX_ESCS`)to save memory.
+The FETtec OneWire protocol supports up to 24 ESCs. As most copters only use at most 12 motors, ArduPilot's implementation supports only 12 (`ESC_TELEM_MAX_ESCS`)to save memory.
 
 There are two types of messages sent to the ESCs configuration and fast-throttle messages:
 
@@ -95,7 +95,7 @@ The signal is used to transfer the eleven bit throttle signals with as few bytes
 All motors wait for the complete message with all throttle signals before changing their output.
 
 If telemetry is requested the ESCs will answer them in the ESC-ID order.
-See *ESC to Ardupilot Protocol* section below and comments in `AP_FETtecOneWire.cpp` for details.
+See *ESC to ArduPilot Protocol* section below and comments in `AP_FETtecOneWire.cpp` for details.
 
 
 ### Timing
@@ -103,13 +103,13 @@ See *ESC to Ardupilot Protocol* section below and comments in `AP_FETtecOneWire.
 Four ESCs need 90us for the fast-throttle request and telemetry reception. With four ESCs 11kHz update would be possible.
 Each additional ESC adds 11 extra fast-throttle command bits, so the update rate is lowered by each additional ESC.
 If you use 8 ESCs, it needs 160us including telemetry response, so 5.8kHz update rate would be possible.
-The FETtec Ardupilot device driver limits the message transmit period to `_min_fast_throttle_period_us` according to the number of ESCs used.
+The FETtec ArduPilot device driver limits the message transmit period to `_min_fast_throttle_period_us` according to the number of ESCs used.
 The update() function has an extra invocation period limit so that even at very high loop rates the the ESCs will still operate correctly albeit doing some decimation.
 The current update rate for Copter is 400Hz (~2500us) and for other vehicles is 50Hz (~20000us) so we are bellow device driver limit.
 
 **Note:** The FETtec ESCs firmware requires at least a 4Hz fast-throttle update rate (max. 250ms between messages) otherwise the FETtec ESC disarm (stop) the motors.
 
-## ESC to Ardupilot protocol
+## ESC to ArduPilot protocol
 
 OneWire ESC telemetry information is sent back to the autopilot:
 
@@ -120,7 +120,7 @@ OneWire ESC telemetry information is sent back to the autopilot:
 - Temperature (°C/10)
 - CRC errors (ArduPilot->ESC) counter
 
-This information is used by Ardupilot to:
+This information is used by ArduPilot to:
 
 - log the status of each ESC to the SDCard or internal Flash, for post flight analysis
 - send the status of each ESC to the ground station or companion computer for real-time monitoring
@@ -137,8 +137,8 @@ The data is forwarded to the `AP_ESC_Telem` class that distributes it to other p
 
 There are two public top level functions `update()` and `pre_arm_check()`.
 And these two call all other private internal functions.
-A single (per ESC) state variable (`_escs[i]._state`) is used in both the RX and TX state machnines.
-Here is the callgraph:
+A single (per ESC) state variable (`_escs[i]._state`) is used in both the RX and TX state machines.
+Here is the call graph:
 
 ```
 update()

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -135,3 +135,4 @@ define HAL_BARO_20789_I2C_ADDR_PRESS 0x63
 # Disable un-needed hardware drivers
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
+define AP_TMOTOR_ESC_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -138,3 +138,4 @@ define AP_PARAM_MAX_EMBEDDED_PARAM 8192
 # Disable un-needed hardware drivers
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
+define AP_TMOTOR_ESC_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -68,3 +68,4 @@ env BUILD_ABIN True
 # Disable un-needed hardware drivers
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
+define AP_TMOTOR_ESC_ENABLED 0

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -137,7 +137,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:MegaSquirt EFI, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41: TMotorESC
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -156,6 +156,7 @@ public:
         SerialProtocol_AIS = 40,
         SerialProtocol_CoDevESC = 41,
         SerialProtocol_MSP_DisplayPort = 42,
+        SerialProtocol_TMotorESC = 43,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 

--- a/libraries/AP_TMotorESC/AP_TMotorESC.cpp
+++ b/libraries/AP_TMotorESC/AP_TMotorESC.cpp
@@ -1,0 +1,509 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Initial protocol implementation by Amilcar Lucas, IAV GmbH */
+
+#include <AP_Math/AP_Math.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <SRV_Channel/SRV_Channel.h>
+#include <GCS_MAVLink/GCS.h>
+
+#include "AP_TMotorESC.h"
+#if AP_TMOTOR_ESC_ENABLED
+
+extern const AP_HAL::HAL& hal;
+
+// Set to 0 when no ESC hardware is available and you want to test the UART send function
+#ifndef HAL_AP_TMOTOR_CONFIGURE_ESCS
+#define HAL_AP_TMOTOR_CONFIGURE_ESCS 1
+#endif
+
+#define HAL_AP_TMOTOR_HALF_DUPLEX 0
+
+#if HAL_AP_TMOTOR_HALF_DUPLEX
+static constexpr uint32_t HALF_DUPLEX_BAUDRATE = 2000000;
+#endif
+static constexpr uint32_t FULL_DUPLEX_BAUDRATE =  500000;
+
+const AP_Param::GroupInfo AP_TMotorESC::var_info[] {
+
+#if HAL_WITH_ESC_TELEM
+    // @Param: POLES
+    // @DisplayName: Nr. electrical poles
+    // @Description: Number of motor electrical poles
+    // @Range: 2 50
+    // @User: Standard
+    AP_GROUPINFO("POLES", 3, AP_TMotorESC, _pole_count_parameter, 14),
+#endif
+
+    AP_GROUPEND
+};
+
+AP_TMotorESC *AP_TMotorESC::_singleton;
+
+AP_TMotorESC::AP_TMotorESC()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AP_TMotorESC must be singleton");
+    }
+#endif
+    _singleton = this;
+}
+
+/**
+  initialize the serial port
+
+*/
+void AP_TMotorESC::init_uart()
+{
+    if (_uart != nullptr) {
+        return;
+    }
+    const AP_SerialManager& serial_manager = AP::serialmanager();
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_TMotorESC, 0);
+    if (_uart == nullptr) {
+        return; // no serial port available, so nothing to do here
+    }
+    _uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+    _uart->set_unbuffered_writes(true);
+    _uart->set_blocking_writes(false);
+
+    uint32_t uart_baud { FULL_DUPLEX_BAUDRATE };
+#if HAL_AP_TMOTOR_HALF_DUPLEX
+    if (_uart->get_options() & _uart->OPTION_HDPLEX) { //Half-Duplex is enabled
+        _use_hdplex = true;
+        uart_baud = HALF_DUPLEX_BAUDRATE;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TME using Half-Duplex");
+    } else {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TME using Full-Duplex");
+    }
+#endif
+
+    _uart->begin(uart_baud);
+}
+
+/// initialize the device driver: configure serial port, wake-up and configure ESCs
+void AP_TMotorESC::init()
+{
+    init_uart();
+    if (_uart == nullptr) {
+        return; // no serial port available, so nothing to do here
+    }
+
+    // we have a uart and the desired ESC combination id valid, allocate some memory:
+    _escs = new ESC[_esc_count];
+    if (_escs == nullptr) {
+        return;
+    }
+
+    // initialise ESC ids.  This enforces that the TMotor ESC ids
+    // inside TMotor ESCs need to be contiguous and start at ID 1
+    uint8_t esc_offset = 0;  // offset into our device-driver dynamically-allocated array of ESCs
+    uint8_t esc_id = 1;      // ESC ids inside TMotor protocol are one-indexed
+    uint8_t servo_chan_offset = 0;  // offset into _motor_mask_parameter array
+    for (uint32_t mask = 0xff; mask != 0; mask >>= 1, servo_chan_offset++) {
+        if (mask & 0x1) {
+            _escs[esc_offset].servo_ofs = servo_chan_offset;
+            _escs[esc_offset].id = esc_id++;
+            esc_offset++;
+        }
+    }
+
+    gcs().send_text(MAV_SEVERITY_INFO, "TMotor: allocated %u motors", _esc_count);
+
+#if HAL_AP_TMOTOR_HALF_DUPLEX
+    if (_use_hdplex == true) { //Half-Duplex is enabled
+        uart_baud = HALF_DUPLEX_BAUDRATE;
+    }
+#endif
+
+    _init_done = true;
+}
+
+/**
+    transmits data to ESCs
+    @param bytes  bytes to transmit
+    @param length number of bytes to transmit
+    @return false there's no space in the UART for this message
+*/
+bool AP_TMotorESC::transmit(const uint8_t* bytes, const uint8_t length)
+{
+    const uint32_t now = AP_HAL::micros();
+    if (now - _last_transmit_us < 400) {
+        // in case the SRV_Channels::push() is running at very high rates, limit the period
+        // this function gets executed because TMotor needs a time gap between frames
+        // this also prevents one loop to do multiple actions, like reinitialize an ESC and sending a fast-throttle command without a gap.
+        _period_too_short++;
+        return false;
+    }
+    _last_transmit_us = now;
+    if (length > _uart->txspace()) {
+        return false;
+    }
+
+    _uart->write(bytes, length);
+#if HAL_AP_TMOTOR_HALF_DUPLEX
+    if (_use_hdplex) {
+        _ignore_own_bytes += length;
+    }
+#endif
+    return true;
+}
+
+/**
+    transmits a config request to ESCs
+    @param bytes  bytes to transmit
+    @param length number of bytes to transmit
+    @return false if vehicle is armed or if transmit(bytes, length) would return false
+*/
+bool AP_TMotorESC::transmit_config_request(const uint8_t* bytes, const uint8_t length)
+{
+    if (hal.util->get_soft_armed()) {
+        return false;
+    }
+    return transmit(bytes, length);
+}
+
+/// shifts data to start of buffer based on magic header bytes
+void AP_TMotorESC::move_frame_source_in_receive_buffer(const uint8_t search_start_pos)
+{
+    uint8_t i;
+    for (i=search_start_pos; i<_receive_buf_used; i++) {
+        // FIXME: full-duplex should add MASTER here as we see our own data
+        if ((FrameSource)u.receive_buf[i] == FrameSource::BOOTLOADER ||
+            (FrameSource)u.receive_buf[i] == FrameSource::ESC) {
+            break;
+        }
+    }
+    consume_bytes(i);
+}
+
+/// cut n bytes from start of buffer
+void AP_TMotorESC::consume_bytes(const uint8_t n)
+{
+    if (n == 0) {
+        return;
+    }
+    // assure the length of the memmove is positive
+    if (_receive_buf_used < n) {
+        return;
+    }
+    memmove(u.receive_buf, &u.receive_buf[n], _receive_buf_used-n);
+    _receive_buf_used = _receive_buf_used - n;
+}
+
+/// returns true if the first message in the buffer is OK
+bool AP_TMotorESC::buffer_contains_ok(const uint8_t length)
+{
+    if (length != sizeof(u.packed_ok)) {
+        _message_invalid_in_state_count++;
+        return false;
+    }
+    if ((MsgType)u.packed_ok.msg.msgid != MsgType::OK) {
+        return false;
+    }
+    return true;
+}
+
+void AP_TMotorESC::handle_message(ESC &esc, const uint8_t length)
+{
+    // only accept messages from the bootloader when we could
+    // legitimately get a message from the bootloader.  Swipes the OK
+    // message for convenience
+    const FrameSource frame_source = (FrameSource)u.packed_ok.frame_source;
+    if (frame_source != FrameSource::ESC) {
+        if (esc.state != ESCState::WAITING_OK_FOR_RUNNING_SW_TYPE) {
+            return;
+        }
+    }
+
+    switch (esc.state) {
+    case ESCState::UNINITIALISED:
+    case ESCState::WANT_SEND_OK_TO_GET_RUNNING_SW_TYPE:
+        return;
+    case ESCState::WAITING_OK_FOR_RUNNING_SW_TYPE:
+        // "OK" is the only valid response
+        if (!buffer_contains_ok(length)) {
+            return;
+        }
+        switch (frame_source) {
+        case FrameSource::MASTER:
+            // probably half-duplex; should be caught before we get here
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            break;
+        case FrameSource::BOOTLOADER:
+            esc.set_state(ESCState::WANT_SEND_START_FW);
+            esc.is_awake = true;
+            break;
+        case FrameSource::ESC:
+#if HAL_WITH_ESC_TELEM
+            esc.set_state(ESCState::WANT_SEND_SET_TLM_TYPE);
+#else
+            esc.set_state(ESCState::WANT_SEND_SET_FAST_COM_LENGTH);
+#endif
+            esc.is_awake = true;
+            break;
+        }
+        break;
+
+    case ESCState::WANT_SEND_START_FW:
+        return;
+    case ESCState::WAITING_OK_FOR_START_FW:
+        if (buffer_contains_ok(length)) {
+#if HAL_WITH_ESC_TELEM
+            esc.set_state(ESCState::WANT_SEND_SET_TLM_TYPE);
+#else
+            esc.set_state(ESCState::RUNNING);
+#endif
+        }
+        break;
+
+#if HAL_WITH_ESC_TELEM
+    case ESCState::WANT_SEND_SET_TLM_TYPE:
+        return;
+    case ESCState::WAITING_SET_TLM_TYPE_OK:
+        if (buffer_contains_ok(length)) {
+            esc.set_state(ESCState::RUNNING);
+        }
+        break;
+#endif
+
+    case ESCState::RUNNING:
+        // we only expect telemetry messages in this state
+#if HAL_WITH_ESC_TELEM
+        if (!esc.telem_expected) {
+            esc.unexpected_telem++;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            AP_HAL::panic("unexpected telemetry");
+#endif
+            return;
+        }
+        esc.telem_expected = false;
+        return handle_message_telem(esc);
+#else
+        return;
+#endif  // HAL_WITH_ESC_TELEM
+
+    }
+}
+
+#if HAL_WITH_ESC_TELEM
+void AP_TMotorESC::handle_message_telem(ESC &esc)
+{
+    // the following two methods are coming from AP_ESC_Telem:
+    const TLM &tlm = u.packed_tlm.msg;
+
+    // update rpm and error rate
+    float error_rate_pct = 0;
+    update_rpm(esc.servo_ofs,
+               tlm.rpm*(100*2/_pole_count_parameter),
+               error_rate_pct);
+
+    // update power and temperature telem data
+    TelemetryData t {};
+    t.temperature_cdeg = tlm.temp * 100;
+    t.voltage = tlm.voltage * 0.01f;
+    t.current = tlm.current * 0.01f;
+    t.consumption_mah = tlm.consumption_mah;
+    update_telem_data(
+        esc.servo_ofs,
+        t,
+        TelemetryType::TEMPERATURE|
+          TelemetryType::VOLTAGE|
+          TelemetryType::CURRENT|
+          TelemetryType::CONSUMPTION);
+
+    esc.last_telem_us = AP_HAL::micros();
+}
+#endif  // HAL_WITH_ESC_TELEM
+
+// reads data from the UART, calling handle_message on any message found
+void AP_TMotorESC::read_data_from_uart()
+{
+    /*
+    a frame looks like:
+    byte 1 = frame header (0x02 = bootloader, 0x03 = ESC firmware)
+    byte 2 = sender ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = answer type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+
+#if HAL_AP_TMOTOR_HALF_DUPLEX
+    //ignore own bytes
+    if (_use_hdplex) {
+        while (_ignore_own_bytes > 0 && _uart->available()) {
+            _ignore_own_bytes--;
+            _uart->read();
+        }
+    }
+#endif
+
+    uint32_t bytes_to_read = MIN(_uart->available(), 128U);
+    uint32_t last_bytes_to_read = 0;
+    while (bytes_to_read &&
+           bytes_to_read != last_bytes_to_read) {
+        last_bytes_to_read = bytes_to_read;
+
+        // read as much from the uart as we can:
+        const uint8_t space = ARRAY_SIZE(u.receive_buf) - _receive_buf_used;
+        const uint32_t nbytes = _uart->read(&u.receive_buf[_receive_buf_used], space);
+        _receive_buf_used += nbytes;
+        bytes_to_read -= nbytes;
+
+        move_frame_source_in_receive_buffer();
+
+        // borrow the "OK" message to retrieve the frame length from the buffer:
+        const uint8_t frame_length = u.packed_ok.frame_length;
+        if (_receive_buf_used < frame_length) {
+            continue;
+        }
+
+        if (crc8_dvb_update(0, u.receive_buf, frame_length-1) != u.receive_buf[frame_length-1]) {
+            // bad message; shift away this frame_source byte to try to find
+            // another message
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            AP_HAL::panic("bad message");
+#endif
+            crc_rec_err_cnt++;
+            move_frame_source_in_receive_buffer(1);
+            continue;
+        }
+
+        // borrow the "OK" message to retrieve the frame_source from the buffer:
+        const FrameSource frame_source = (FrameSource)u.packed_ok.frame_source;
+        if (frame_source == FrameSource::MASTER) {
+            // this is our own message - we'd best be running in
+            // half-duplex or we're in trouble!
+            consume_bytes(frame_length);
+            continue;
+        }
+
+        // borrow the "OK" message to retrieve the esc id from the buffer:
+        const uint8_t esc_id = u.packed_ok.esc_id;
+        bool handled = false;
+        // FIXME: we could scribble down the last ESC we sent a
+        // message to here and use it rather than doing this linear
+        // search:
+        for (uint8_t i=0; i<_esc_count; i++) {
+            auto &esc = _escs[i];
+            if (esc.id != esc_id) {
+                continue;
+            }
+            handle_message(esc, frame_length);
+            handled = true;
+            break;
+        }
+        if (!handled) {
+            _unknown_esc_message++;
+        }
+
+        consume_bytes(frame_length);
+    }
+}
+
+bool AP_TMotorESC::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const
+{
+    if (_uart == nullptr) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "No uart");
+        return false;
+    }
+#if HAL_WITH_ESC_TELEM
+    if (_pole_count_parameter < 2) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "Invalid pole count %u", uint8_t(_pole_count_parameter));
+        return false;
+    }
+    uint8_t no_telem = 0;
+    const uint32_t now = AP_HAL::micros();
+#endif
+
+    uint8_t not_running = 0;
+    for (uint8_t i=0; i<_esc_count; i++) {
+        auto &esc = _escs[i];
+        if (esc.state != ESCState::RUNNING) {
+            not_running++;
+            continue;
+        }
+#if HAL_WITH_ESC_TELEM
+        if (now - esc.last_telem_us > max_telem_interval_us) {
+            no_telem++;
+        }
+#endif
+    }
+    if (not_running != 0) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "%u of %u ESCs are not running", not_running, _esc_count);
+        return false;
+    }
+    if (!_init_done) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "Not initialised");
+        return false;
+    }
+#if HAL_WITH_ESC_TELEM
+    if (no_telem != 0) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "%u of %u ESCs are not sending telemetry", no_telem, _esc_count);
+        return false;
+    }
+#endif
+
+    return true;
+}
+
+/// periodically called from SRV_Channels::push()
+void AP_TMotorESC::update()
+{
+    if (!_init_done) {
+        init();
+        return; // the rest of this function can only run after fully initted
+    }
+
+    // read all data from incoming serial:
+    read_data_from_uart();
+
+    const uint32_t now = AP_HAL::micros();
+
+#if HAL_WITH_ESC_TELEM
+    if (!hal.util->get_soft_armed()) {
+
+        // if we haven't seen an ESC in a while, the user might
+        // have power-cycled them.  Try re-initialising.
+        for (uint8_t i=0; i<_esc_count; i++) {
+            auto &esc = _escs[i];
+            if (!esc.telem_requested || now - esc.last_telem_us < 1000000U ) {
+                // telem OK
+                continue;
+            }
+            _running_mask &= ~(1 << esc.servo_ofs);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "No telem from esc id=%u. Resetting it.", esc.id);
+            //GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "unknown %u, invalid %u, too short %u, unexpected: %u, crc_err %u", _unknown_esc_message, _message_invalid_in_state_count, _period_too_short, esc.unexpected_telem, crc_rec_err_cnt);
+            esc.set_state(ESCState::WANT_SEND_OK_TO_GET_RUNNING_SW_TYPE);
+            esc.telem_requested = false;
+        }
+    }
+#endif  // HAL_WITH_ESC_TELEM
+
+    if (now - _last_transmit_us < 700U) {
+        // in case the SRV_Channels::push() is running at very high rates, limit the period
+        // this function gets executed because TMotor needs a time gap between frames
+        _period_too_short++;
+        return;
+    }
+
+}
+
+#endif  // AP_TMOTOR_ESC_ENABLED

--- a/libraries/AP_TMotorESC/AP_TMotorESC.h
+++ b/libraries/AP_TMotorESC/AP_TMotorESC.h
@@ -1,0 +1,306 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Initial protocol implementation by Amilcar Lucas, IAV GmbH */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifndef AP_TMOTOR_ESC_ENABLED
+#define AP_TMOTOR_ESC_ENABLED !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024
+#endif
+
+
+#if AP_TMOTOR_ESC_ENABLED
+
+#define TME_DEBUGGING 0
+#if TME_DEBUGGING
+#include <stdio.h>
+#define tme_debug(fmt, args ...)  do {::fprintf(stderr,"TMotor: %s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
+#else
+#define tme_debug(fmt, args ...)
+#endif
+
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
+#include <AP_Param/AP_Param.h>
+
+#include <AP_Math/AP_Math.h>
+#include <AP_Math/crc.h>
+
+class AP_TMotorESC : public AP_ESC_Telem_Backend
+{
+
+public:
+    AP_TMotorESC();
+
+    /// Do not allow copies
+    AP_TMotorESC(const AP_TMotorESC &other) = delete;
+    AP_TMotorESC &operator=(const AP_TMotorESC&) = delete;
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    static AP_TMotorESC *get_singleton() {
+        return _singleton;
+    }
+
+    /// periodically called from SRV_Channels::push()
+    void update();
+
+    /// called from AP_Arming; should return false if arming should be
+    /// disallowed
+    bool pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const;
+
+private:
+    static AP_TMotorESC *_singleton;
+    AP_HAL::UARTDriver *_uart;
+
+#if HAL_WITH_ESC_TELEM
+    AP_Int8 _pole_count_parameter;
+#endif
+
+    static constexpr uint8_t FRAME_OVERHEAD = 6;          ///< message frame overhead (header+tail bytes)
+    static constexpr uint8_t MAX_RECEIVE_LENGTH = 12;     ///< max receive message payload length in bytes
+
+    /**
+        initialize the device driver: configure serial port, wake-up and configure ESCs
+    */
+    void init();
+
+    /**
+        initialize the serial port
+    */
+    void init_uart();
+
+    // states configured ESCs can be in:
+    enum class ESCState : uint8_t {
+        UNINITIALISED = 5,  // when we haven't tried to send anything to the ESC
+
+        WANT_SEND_OK_TO_GET_RUNNING_SW_TYPE = 10,
+        WAITING_OK_FOR_RUNNING_SW_TYPE = 11,
+
+        WANT_SEND_START_FW = 20,
+        WAITING_OK_FOR_START_FW = 21,
+
+#if HAL_WITH_ESC_TELEM
+        WANT_SEND_SET_TLM_TYPE = 60,
+        WAITING_SET_TLM_TYPE_OK = 61,
+#endif
+
+        RUNNING = 100,
+    };
+
+    class ESC {
+    public:
+
+#if HAL_WITH_ESC_TELEM
+        uint32_t last_telem_us;              ///< last time we got telemetry from this ESC
+        uint16_t unexpected_telem;
+        uint16_t error_count_at_throttle_count_overflow;            ///< overflow counter for error counter from the ESCs.
+        bool telem_expected;                 ///< this ESC is fully configured and is now expected to send us telemetry
+        bool telem_requested;                ///< this ESC is fully configured and at some point was requested to send us telemetry
+#endif
+
+        uint8_t id;         ///< ESC ID
+        uint8_t servo_ofs;  ///< offset into ArduPilot servo array
+        bool is_awake;
+        void set_state(ESCState _state) {
+            tme_debug("Moving ESC.id=%u from state=%u to state=%u", (unsigned)id, (unsigned)state, (unsigned)_state);
+            state = _state;
+        };
+        ESCState state = ESCState::UNINITIALISED;
+    };
+
+    uint32_t _last_not_running_warning_ms;  ///< last time we warned the user their ESCs are stuffed
+    int32_t _running_mask;                  ///< a bitmask of the actively running ESCs
+    uint32_t _last_transmit_us;             ///< last time the transmit() function sent data
+    ESC *_escs;
+    uint8_t _esc_count;                ///< number of allocated ESCs
+
+    bool _init_done;     ///< device driver is initialized; ESCs may still need to be configured
+
+    enum class FrameSource : uint8_t {
+        MASTER     = 0x01,  ///< master is always 0x01
+        BOOTLOADER = 0x02,
+        ESC        = 0x03,
+    };
+
+    enum class MsgType : uint8_t
+    {
+        OK                  = 0,
+        BL_PAGE_CORRECT     = 1,  ///< Bootloader only
+        NOT_OK              = 2,
+        BL_START_FW         = 3,  ///< Bootloader only - exit the boot loader and start the standard firmware
+        BL_PAGES_TO_FLASH   = 4,  ///< Bootloader only
+        SET_TLM_TYPE        = 27, ///< telemetry operation mode
+    };
+
+    /**
+    a frame looks like:
+    byte 1 = frame header (master is always 0x01)
+    byte 2 = target ID (5bit)
+    byte 3 & 4 = frame type (always 0x00, 0x00 used for bootloader. here just for compatibility)
+    byte 5 = frame length over all bytes
+    byte 6 - X = request type, followed by the payload
+    byte X+1 = 8bit CRC
+    */
+    template <typename T>
+    class PACKED PackedMessage {
+    public:
+        PackedMessage(uint8_t _esc_id, T _msg) :
+            esc_id(_esc_id),
+            msg(_msg)
+        {
+            update_checksum();
+        }
+        uint8_t frame_source { (uint8_t)FrameSource::MASTER };
+        uint8_t esc_id;
+        uint16_t frame_type { 0 };  // bootloader only, always zero
+        uint8_t frame_length {sizeof(T) + FRAME_OVERHEAD};  // all bytes including frame_source and checksum
+        T msg;
+        uint8_t checksum;
+
+        void update_checksum() {
+            checksum = crc8_dvb_update(0, (const uint8_t*)this, frame_length-1);
+        }
+    };
+
+    class PACKED OK {
+    public:
+        uint8_t msgid { (uint8_t)MsgType::OK };
+    };
+
+    class PACKED START_FW {
+    public:
+        uint8_t msgid { (uint8_t)MsgType::BL_START_FW };
+    };
+
+/*
+ * Messages, methods and states for dealing with ESC telemetry
+ */
+#if HAL_WITH_ESC_TELEM
+    void handle_message_telem(ESC &esc);
+
+    /// the ESC at this offset into _escs should be the next to send a
+    /// telemetry request for:
+    uint8_t _esc_ofs_to_request_telem_from;
+
+    class PACKED SET_TLM_TYPE {
+    public:
+        SET_TLM_TYPE(uint8_t _tlm_type) :
+            tlm_type{_tlm_type}
+        { }
+        uint8_t msgid { (uint8_t)MsgType::SET_TLM_TYPE };
+        uint8_t tlm_type;
+    };
+
+    class PACKED TLM {
+    public:
+        TLM(int8_t _temp, uint16_t _voltage, uint16_t _current, int16_t _rpm, uint16_t _consumption_mah, uint16_t _tx_err_count) :
+            temp{_temp},
+            voltage{_voltage},
+            current{_current},
+            rpm{_rpm},
+            consumption_mah{_consumption_mah},
+            tx_err_count{_tx_err_count}
+        { }
+        int8_t temp;              // centi-degrees
+        uint16_t voltage;         // centi-Volt
+        uint16_t current;         // centi-Ampere  (signed?)
+        int16_t rpm;              // centi-rpm
+        uint16_t consumption_mah; // mili-Ampere.hour
+        uint16_t tx_err_count;    // CRC error count, as perceived from the ESC receiving side
+    };
+
+#endif  // HAL_WITH_ESC_TELEM
+
+    /*
+     * Methods and data for transmitting data to the ESCSs:
+     */
+
+    /**
+        transmits data to ESCs
+        @param bytes  bytes to transmit
+        @param length number of bytes to transmit
+        @return false there's no space in the UART for this message
+    */
+    bool transmit(const uint8_t* bytes, const uint8_t length);
+
+    template <typename T>
+    bool transmit(const PackedMessage<T> &msg) {
+        return transmit((const uint8_t*)&msg, sizeof(msg));
+    }
+
+    /**
+        transmits configuration request data to ESCs
+        @param bytes  bytes to transmit
+        @param length number of bytes to transmit
+        @return false if vehicle armed or there's no space in the UART for this message
+    */
+    bool transmit_config_request(const uint8_t* bytes, const uint8_t length);
+
+    template <typename T>
+    bool transmit_config_request(const PackedMessage<T> &msg) {
+        return transmit_config_request((const uint8_t*)&msg, sizeof(msg));
+    }
+
+    /*
+     * Methods and data for receiving data from the ESCs:
+     */
+
+    // FIXME: this should be tighter - and probably calculated.  Note
+    // that we can't request telemetry faster than the loop interval,
+    // which is 20ms on Plane, so that puts a constraint here.  When
+    // using fast-throttle with 12 ESCs on Plane you could expect
+    // 240ms between telem updates.  Why you have a Plane with 12 ESCs
+    // is a bit of a puzzle.
+    static const uint32_t max_telem_interval_us = 100000;
+
+    void handle_message(ESC &esc, const uint8_t length);
+
+    /**
+        reads data from the UART, calling handle_message on any message found
+    */
+    void read_data_from_uart();
+    union MessageUnion {
+        MessageUnion() { }
+        PackedMessage<OK> packed_ok;
+#if HAL_WITH_ESC_TELEM
+        PackedMessage<TLM> packed_tlm;
+#endif
+        uint8_t receive_buf[FRAME_OVERHEAD + MAX_RECEIVE_LENGTH];
+    } u;
+
+    static_assert(sizeof(u.packed_ok) <= sizeof(u.receive_buf),"packed_ok does not fit in receive_buf. MAX_RECEIVE_LENGTH too small?");
+#if HAL_WITH_ESC_TELEM
+    static_assert(sizeof(u.packed_tlm) <= sizeof(u.receive_buf),"packed_tlm does not fit in receive_buf. MAX_RECEIVE_LENGTH too small?");
+#endif
+
+    uint16_t _unknown_esc_message;
+    uint16_t _message_invalid_in_state_count;
+    uint16_t _period_too_short;
+    uint16_t crc_rec_err_cnt;
+    uint8_t _receive_buf_used;
+
+    /// shifts data to start of buffer based on magic header bytes
+    void move_frame_source_in_receive_buffer(const uint8_t search_start_pos = 0);
+
+    /// cut n bytes from start of buffer
+    void consume_bytes(const uint8_t n);
+
+    /// returns true if the first message in the buffer is OK
+    bool buffer_contains_ok(const uint8_t length);
+};
+#endif // AP_TMOTOR_ESC_ENABLED

--- a/libraries/AP_TMotorESC/README.md
+++ b/libraries/AP_TMotorESC/README.md
@@ -1,0 +1,58 @@
+# T-Motor Alpha ESC serial telemetry input
+
+This library decodes the T-Motor manufactured Alpha [ESC](https://en.wikipedia.org/wiki/Electronic_speed_control)'s serial telemetry communication protocol.
+It is a (unidirectional) [digital asynchronous serial communication protocol](https://en.wikipedia.org/wiki/Asynchronous_serial_communication) running at XXX bit/s Baudrate. It requires three wires (RX, TX and GND) connection.
+
+## Features of this device driver
+
+- use ArduPilot's coding guidelines and naming conventions
+- Use the AP_ESC_Telem base class to:
+  - copy ESC telemetry data into MAVLink telemetry
+  - save ESC telemetry data in dataflash logs
+  - use RPM telemetry for dynamic notch filter frequencies
+  - sum the current telemetry info from all ESCs and use it as virtual battery current monitor sensor
+  - average the voltage telemetry info and use it as virtual battery voltage monitor sensor
+  - average the temperature telemetry info and use it as virtual battery temperature monitor sensor
+- pre-arm checks:
+  - Check that UART is available
+  - check that the ESCs are periodically sending telemetry data
+
+## ESC to ArduPilot protocol
+
+ESC telemetry information is sent back to the autopilot:
+
+- Electronic rotations per minute (eRPM/100) (must be divided by number of motor poles to translate to propeller RPM)
+- Input voltage (V/10)
+- Current draw (A/10)
+- Power consumption (mAh)
+- Temperature (°C/10)
+- CRC errors (ArduPilot->ESC) counter
+
+This information is used by ArduPilot to:
+
+- log the status of each ESC to the SDCard or internal Flash, for post flight analysis
+- send the status of each ESC to the ground station or companion computer for real-time monitoring
+- Optionally dynamically change the center frequency of the notch filters used to reduce frame vibration noise in the gyros
+- Optionally measure battery voltage and power consumption
+
+
+## Function structure
+
+There are two public top level functions `update()` and `pre_arm_check()`.
+And these two call all other private internal functions.
+A single (per ESC) state variable (`_escs[i]._state`) is used in both the RX and TX state machines.
+Here is the call graph:
+
+```
+update()
+  init()
+    init_uart()
+  read_data_from_uart()
+    move_frame_source_in_receive_buffer()
+      consume_bytes()
+    consume_bytes()
+    handle_message()             <-- RX state machine
+      buffer_contains_ok()
+      handle_message_telem()
+pre_arm_check()
+```

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -22,6 +22,7 @@
 #include <AP_SBusOut/AP_SBusOut.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_FETtecOneWire/AP_FETtecOneWire.h>
+#include <AP_TMotorESC/AP_TMotorESC.h>
 
 #ifndef NUM_SERVO_CHANNELS
 #if defined(HAL_BUILD_AP_PERIPH) && defined(HAL_PWM_COUNT)
@@ -584,6 +585,11 @@ private:
     AP_FETtecOneWire fetteconwire;
     static AP_FETtecOneWire *fetteconwire_ptr;
 #endif  // AP_FETTEC_ONEWIRE_ENABLED
+
+#if AP_TMOTOR_ESC_ENABLED
+    AP_TMotorESC tmotor_esc;
+    static AP_TMotorESC *tmotor_esc_ptr;
+#endif  // AP_TMOTOR_ESC_ENABLED
 
     static uint16_t disabled_mask;
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -53,6 +53,10 @@ AP_RobotisServo *SRV_Channels::robotis_ptr;
 AP_FETtecOneWire *SRV_Channels::fetteconwire_ptr;
 #endif
 
+#if AP_TMOTOR_ESC_ENABLED
+AP_TMotorESC *SRV_Channels::tmotor_esc_ptr;
+#endif
+
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
 
 #if HAL_SUPPORT_RCOUT_SERIAL
@@ -233,7 +237,15 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("_GPIO_MASK",  26, SRV_Channels, gpio_mask, 0),
-    
+
+#ifndef HAL_BUILD_AP_PERIPH
+#if AP_TMOTOR_ESC_ENABLED
+    // @Group: _TME_
+    // @Path: ../AP_TMotorESC/AP_TMotorESC.cpp
+    AP_SUBGROUPINFO(tmotor_esc, "_TME_",  27, SRV_Channels, AP_TMotorESC),
+#endif
+#endif // HAL_BUILD_AP_PERIPH
+
     AP_GROUPEND
 };
 
@@ -255,6 +267,10 @@ SRV_Channels::SRV_Channels(void)
 
 #if AP_FETTEC_ONEWIRE_ENABLED
     fetteconwire_ptr = &fetteconwire;
+#endif
+
+#if AP_TMOTOR_ESC_ENABLED
+    tmotor_esc_ptr = &tmotor_esc;
 #endif
 
 #ifndef HAL_BUILD_AP_PERIPH
@@ -391,6 +407,10 @@ void SRV_Channels::push()
 
 #if AP_FETTEC_ONEWIRE_ENABLED
     fetteconwire_ptr->update();
+#endif
+
+#if AP_TMOTOR_ESC_ENABLED
+    tmotor_esc_ptr->update();
 #endif
 
 #if HAL_CANMANAGER_ENABLED


### PR DESCRIPTION
This is work in progress. I'm trying to help [Khang Pham](https://discuss.ardupilot.org/u/kylepham/summary) by providing a [starting point](https://discuss.ardupilot.org/t/how-to-make-cube-orange-understand-data-frame-in-mavlink-format-by-using-stm32f407-through-uart/79866).

The important lines of code are in the AP_TMotorESC/AP_TMotorESC.cpp file, mainly lines 313 and 323

For simplicity reasons I did This PR on top of #19665, so you can ignore the first two commits.

So far this is basically a copy-paste-delete exercise of the AP_FETtec_OneWire device driver.
Code must be added to actually decode the TMotor ESC telemetry data.