### PR TITLE
Revert "AP_GPS: drop default GPS lag to 0.1s"

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1469,7 +1469,7 @@ void AP_GPS::Write_AP_Logger_Log_Startup_messages()
 bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
     // always enusre a lag is provided
-    lag_sec = 0.1f;
+    lag_sec = 0.22f;
 
     if (instance >= GPS_MAX_INSTANCES) {
         return false;


### PR DESCRIPTION
This reverts commit 1e60d2557b9dbb386afffc98236466d35995d136.