### PR TITLE
AC_Autotune: remove most GCS messages

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -157,6 +157,20 @@ const char *AC_AutoTune::type_string() const
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
 }
 
+// return current axis string
+const char *AC_AutoTune::axis_string() const
+{
+    switch (axis) {
+    case ROLL:
+        return "Roll";
+    case PITCH:
+        return "Pitch";
+    case YAW:
+        return "Yaw";
+    }
+    return "";
+}
+
 // run - runs the autotune flight mode
 // should be called at 100hz or more
 void AC_AutoTune::run()

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -152,7 +152,7 @@ const char *AC_AutoTune::type_string() const
     case TUNE_COMPLETE:
         return "Tune Complete";
     }
-    return "unknown tune type";
+    return "";
     // this should never happen
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
 }
@@ -309,7 +309,6 @@ void AC_AutoTune::control_attitude()
 
         // if we have been level for a sufficient amount of time (0.5 seconds) move onto tuning step
         if (now - step_start_time_ms > AUTOTUNE_REQUIRED_LEVEL_TIME_MS) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Start Test");
             // initiate variables for next step
             step = TESTING;
             step_start_time_ms = now;

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -292,22 +292,6 @@ private:
     // directly updates attitude controller with targets
     void control_attitude();
 
-    // convert latest level issue to string for reporting
-    const char *level_issue_string() const;
-
-    enum struct LevelIssue {
-        NONE,
-        ANGLE_ROLL,
-        ANGLE_PITCH,
-        ANGLE_YAW,
-        RATE_ROLL,
-        RATE_PITCH,
-        RATE_YAW,
-    };
-
-    // check if current is greater than maximum and update level_problem structure
-    bool check_level(const enum LevelIssue issue, const float current, const float maximum);
-
     // returns true if vehicle is close to level
     bool currently_level();
 
@@ -332,11 +316,5 @@ private:
 
     // time in ms of last pilot override warning
     uint32_t last_pilot_override_warning;
-
-    struct {
-        LevelIssue issue{LevelIssue::NONE};
-        float maximum;
-        float current;
-    } level_problem;
 
 };

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -171,6 +171,9 @@ protected:
     // convert tune type to string for reporting
     const char *type_string() const;
 
+    // return current axis string
+    const char *axis_string() const;
+
     // Functions added for heli autotune
 
     // Add additional updating gain functions specific to heli

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -267,20 +267,8 @@ void AC_AutoTune_Heli::do_gcs_announcements()
     if (now - announce_time < AUTOTUNE_ANNOUNCE_INTERVAL_MS) {
         return;
     }
-    char axis_char = '?';
-    switch (axis) {
-    case ROLL:
-        axis_char = 'R';
-        break;
-    case PITCH:
-        axis_char = 'P';
-        break;
-    case YAW:
-        axis_char = 'Y';
-        break;
-    }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: (%c) %s", axis_char, type_string());
+    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: %s %s", axis_string(), type_string());
     send_step_string();
     switch (tune_type) {
     case RD_UP:

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -111,63 +111,7 @@ void AC_AutoTune_Multi::do_gcs_announcements()
     if (now - announce_time < AUTOTUNE_ANNOUNCE_INTERVAL_MS) {
         return;
     }
-    float tune_rp = 0.0f;
-    float tune_rd = 0.0f;
-    float tune_sp = 0.0f;
-    float tune_accel = 0.0f;
-    char axis_char = '?';
-    switch (axis) {
-    case ROLL:
-        tune_rp = tune_roll_rp;
-        tune_rd = tune_roll_rd;
-        tune_sp = tune_roll_sp;
-        tune_accel = tune_roll_accel;
-        axis_char = 'R';
-        break;
-    case PITCH:
-        tune_rp = tune_pitch_rp;
-        tune_rd = tune_pitch_rd;
-        tune_sp = tune_pitch_sp;
-        tune_accel = tune_pitch_accel;
-        axis_char = 'P';
-        break;
-    case YAW:
-        tune_rp = tune_yaw_rp;
-        tune_rd = tune_yaw_rLPF;
-        tune_sp = tune_yaw_sp;
-        tune_accel = tune_yaw_accel;
-        axis_char = 'Y';
-        break;
-    }
-
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: (%c) %s", axis_char, type_string());
-    send_step_string();
-    if (!is_zero(lean_angle)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: lean=%f target=%f", (double)lean_angle, (double)target_angle);
-    }
-    if (!is_zero(rotation_rate)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: rotation=%f target=%f", (double)(rotation_rate*0.01f), (double)(target_rate*0.01f));
-    }
-    switch (tune_type) {
-    case RD_UP:
-    case RD_DOWN:
-    case RP_UP:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: p=%f d=%f", (double)tune_rp, (double)tune_rd);
-        break;
-    case SP_DOWN:
-    case SP_UP:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: p=%f accel=%f", (double)tune_sp, (double)tune_accel);
-        break;
-    case RFF_UP:
-    case MAX_GAINS:
-        // this should never happen
-        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-        break;
-    case TUNE_COMPLETE:
-        break;
-    }
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: success %u/%u", counter, AUTOTUNE_SUCCESS_COUNT);
-
+    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: %s %s %u%%", axis_string(), type_string(), (counter * (100/AUTOTUNE_SUCCESS_COUNT)) );
     announce_time = now;
 }
 


### PR DESCRIPTION
Extract from https://github.com/ArduPilot/ardupilot/pull/15267, this removes the majority of autotune messages. We now just get the axis and stage

![image](https://user-images.githubusercontent.com/33176108/148111271-34e90e1e-daa0-4b12-88da-5179c01ecb12.png)

Current master is rather spammy:

![image](https://user-images.githubusercontent.com/33176108/148111448-d67792d6-cc46-4da2-be65-21c6fa827fdb.png)

All the information removed form the GSC messages is still in the `ATUN` and `ATDE` log messages at a higher rate. 
