### PR TITLE
AP_NavEKF2: don't include log structures if not enabled

### DIFF
--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_Logger/LogStructure.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #define LOG_IDS_FROM_NAVEKF2 \
     LOG_NKF0_MSG,  \
@@ -283,6 +284,9 @@ struct PACKED log_NKT {
     float delVelDT_max;
 };
 
+#if !HAL_NAVEKF2_AVAILABLE
+#define LOG_STRUCTURE_FROM_NAVEKF2
+#else
 #define LOG_STRUCTURE_FROM_NAVEKF2        \
     { LOG_NKF0_MSG, sizeof(log_NKF0), \
       "NKF0","QBBccCCcccccccc","TimeUS,C,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD", "s#-m---mmmmmmmm", "F--B---BBBBBBBB" , true }, \
@@ -299,3 +303,4 @@ struct PACKED log_NKT {
     { LOG_NKQ_MSG, sizeof(log_NKQ), "NKQ", "QBffff", "TimeUS,C,Q1,Q2,Q3,Q4", "s#????", "F-????" , true }, \
     { LOG_NKT_MSG, sizeof(log_NKT),   \
       "NKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000", true },
+#endif


### PR DESCRIPTION
A idea for some flash saving, probably nothing massive but we might make up to a couple of K if we do this throughout. 