### PR TITLE
Rover: set speed control FF from cruise speed and throttle

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -206,7 +206,7 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
 
     // speed to throttle PID
     if (g.gcs_pid_mask & 2) {
-        pid_info = &g2.attitude_control.get_throttle_speed_pid().get_pid_info();
+        pid_info = &g2.attitude_control.get_throttle_speed_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info->target,
                                     pid_info->actual,

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -19,7 +19,7 @@ void Rover::Log_Write_Attitude()
 
     // log steering rate controller
     logger.Write_PID(LOG_PIDS_MSG, g2.attitude_control.get_steering_rate_pid().get_pid_info());
-    logger.Write_PID(LOG_PIDA_MSG, g2.attitude_control.get_throttle_speed_pid().get_pid_info());
+    logger.Write_PID(LOG_PIDA_MSG, g2.attitude_control.get_throttle_speed_pid_info());
 
     // log pitch control for balance bots
     if (is_balancebot()) {

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -637,6 +637,10 @@ float AR_AttitudeControl::get_throttle_out_speed(float desired_speed, bool motor
     throttle_out += _throttle_speed_pid.get_ff();
     throttle_out += throttle_base;
 
+    // update PID info for reporting purposes
+    _throttle_speed_pid_info = _throttle_speed_pid.get_pid_info();
+    _throttle_speed_pid_info.FF += throttle_base;
+
     // clear local limit flags used to stop i-term build-up as we stop reversed outputs going to motors
     _throttle_limit_low = false;
     _throttle_limit_high = false;

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -80,9 +80,9 @@ public:
     // low level control accessors for reporting and logging
     AC_P& get_steering_angle_p() { return _steer_angle_p; }
     AC_PID& get_steering_rate_pid() { return _steer_rate_pid; }
-    AC_PID& get_throttle_speed_pid() { return _throttle_speed_pid; }
     AC_PID& get_pitch_to_throttle_pid() { return _pitch_to_throttle_pid; }
     AC_PID& get_sailboat_heel_pid() { return _sailboat_heel_pid; }
+    const AP_Logger::PID_Info& get_throttle_speed_pid_info() const { return _throttle_speed_pid_info; }
 
     // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
     bool get_forward_speed(float &speed) const;
@@ -143,6 +143,7 @@ private:
     uint32_t _stop_last_ms;         // system time the vehicle was at a complete stop
     bool     _throttle_limit_low;   // throttle output was limited from going too low (used to reduce i-term buildup)
     bool     _throttle_limit_high;  // throttle output was limited from going too high (used to reduce i-term buildup)
+    AP_Logger::PID_Info _throttle_speed_pid_info;   // local copy of throttle_speed controller's PID info to allow reporting of unusual FF
 
     // balancebot pitch control
     uint32_t _balance_last_ms = 0;


### PR DESCRIPTION
This PR helps diagnosing the speed controller performance by ensuring the PIDA message's FF value is populated.  This is done by AR_AttitudeControl maintaining a local copy of the speed controller's PID_info with the only difference being that the copy's FF is both the actual FF and the "base throttle" (calculated from desired speed, cruise_speed and cruise_throttle.

Below is a screen shot showing the PIDA message output for P and I (which are unchanged) and FF (populated in "After").
![rover-speed-control-FFPI-before-vs-after](https://user-images.githubusercontent.com/1498098/148163875-ba5eafa7-6eab-40ce-b38c-cf4b6ad9a8b3.png)
