### PR TITLE
Move RPM sensor logging into AP_RPM

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -184,7 +184,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 
     SCHED_TASK_CLASS(AP_Scheduler,         &copter.scheduler,           update_logging, 0.1,  75, 126),
 #if RPM_ENABLED == ENABLED
-    SCHED_TASK(rpm_update,            40,    200, 129),
+    SCHED_TASK_CLASS(AP_RPM,               &copter.rpm_sensor,          update,          40, 200, 129),
 #endif
     SCHED_TASK_CLASS(Compass, &copter.compass, cal_update, 100, 100, 132),
     SCHED_TASK_CLASS(AP_TempCalibration,   &copter.g2.temp_calibration, update,          10, 100, 135),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -861,7 +861,6 @@ private:
     void read_rangefinder(void);
     bool rangefinder_alt_ok() const;
     bool rangefinder_up_ok() const;
-    void rpm_update();
     void update_optical_flow(void);
     void compass_cal_update(void);
 

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -145,17 +145,3 @@ bool Copter::get_rangefinder_height_interpolated_cm(int32_t& ret)
     ret += inertial_alt_cm - rangefinder_state.inertial_alt_cm;
     return true;
 }
-
-
-/*
-  update RPM sensors
- */
-void Copter::rpm_update(void)
-{
-#if RPM_ENABLED == ENABLED
-    rpm_sensor.update();
-    if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        logger.Write_RPM(rpm_sensor);
-    }
-#endif
-}

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -90,7 +90,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(one_second_loop,         1,    400,  90),
     SCHED_TASK(three_hz_loop,           3,     75,  93),
     SCHED_TASK(check_long_failsafe,     3,    400,  96),
-    SCHED_TASK(rpm_update,             10,    100,  99),
+    SCHED_TASK_CLASS(AP_RPM,           &plane.rpm_sensor,     update,     10, 100,  99),
 #if AP_AIRSPEED_AUTOCAL_ENABLE
     SCHED_TASK(airspeed_ratio_update,   1,    100,  102),
 #endif // AP_AIRSPEED_AUTOCAL_ENABLE

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1048,7 +1048,6 @@ private:
     // sensors.cpp
     void read_rangefinder(void);
     void read_airspeed(void);
-    void rpm_update(void);
 
     // system.cpp
     void init_ardupilot() override;

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -58,14 +58,3 @@ void Plane::read_airspeed(void)
     const float dt = 0.1;
     surface_speed_scaler += calc_lowpass_alpha_dt(dt, cutoff_Hz) * (speed_scaler - surface_speed_scaler);
 }
-
-/*
-  update RPM sensors
- */
-void Plane::rpm_update(void)
-{
-    rpm_sensor.update();
-    if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        logger.Write_RPM(rpm_sensor);
-    }
-}

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -76,7 +76,7 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_InertialSensor,   &sub.ins,          periodic,           400,  50,  60),
     SCHED_TASK_CLASS(AP_Scheduler,        &sub.scheduler,    update_logging,     0.1,  75,  63),
 #if RPM_ENABLED == ENABLED
-    SCHED_TASK(rpm_update,            10,    200,  66),
+    SCHED_TASK_CLASS(AP_RPM,              &sub.rpm_sensor,   update               10, 200,  66),
 #endif
     SCHED_TASK_CLASS(Compass,             &sub.compass,      cal_update,         100, 100,  69),
     SCHED_TASK(terrain_update,        10,    100,  72),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -406,9 +406,6 @@ private:
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
     void update_poscon_alt_max();
     void rotate_body_frame_to_NE(float &x, float &y);
-#if RPM_ENABLED == ENABLED
-    void rpm_update();
-#endif
     void Log_Write_Control_Tuning();
     void Log_Write_Attitude();
     void Log_Write_MotBatt();

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -72,19 +72,6 @@ bool Sub::rangefinder_alt_ok() const
 }
 
 /*
-  update RPM sensors
- */
-#if RPM_ENABLED == ENABLED
-void Sub::rpm_update(void)
-{
-    rpm_sensor.update();
-    if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        logger.Write_RPM(rpm_sensor);
-    }
-}
-#endif
-
-/*
   ask airspeed sensor for a new value, duplicated from plane
  */
 void Sub::read_airspeed()

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -416,8 +416,6 @@ private:
     void read_rangefinder(void);
     bool rangefinder_alt_ok();
     bool rangefinder_up_ok();
-    void rpm_update();
-    void update_optical_flow(void);
 
     // RC_Channel.cpp
     void save_trim();

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -96,7 +96,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #if GRIPPER_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Gripper,          &rover.g2.gripper,       update,         10,   75,  69),
 #endif
-    SCHED_TASK(rpm_update,             10,    100,  72),
+    SCHED_TASK_CLASS(AP_RPM,              &rover.rpm_sensor,       update,         10,  100,  72),
 #if HAL_MOUNT_ENABLED
     SCHED_TASK_CLASS(AP_Mount,            &rover.camera_mount,     update,         50,  200,  75),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -351,7 +351,6 @@ private:
     void update_wheel_encoder();
     void read_rangefinders(void);
     void read_airspeed();
-    void rpm_update(void);
 
     // Steering.cpp
     void set_servos(void);

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -101,14 +101,3 @@ void Rover::read_airspeed(void)
 {
     g2.airspeed.update(should_log(MASK_LOG_IMU));
 }
-
-/*
-  update RPM sensors
- */
-void Rover::rpm_update(void)
-{
-    rpm_sensor.update();
-    if (rpm_sensor.enabled(0) || rpm_sensor.enabled(1)) {
-        logger.Write_RPM(rpm_sensor);
-    }
-}

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -20,6 +20,8 @@
 #include "RPM_HarmonicNotch.h"
 #include "RPM_ESC_Telem.h"
 
+#include <AP_Logger/AP_Logger.h>
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -185,6 +187,10 @@ void AP_RPM::update(void)
 
             drivers[i]->update();
         }
+    }
+
+    if (enabled(0) || enabled(1)) {
+        AP::logger().Write_RPM(*this);
     }
 }
 


### PR DESCRIPTION
We could potentially move the message definition back into here too.

Tested by running the Helicopter autotests and noting that `RPM` is still present in the logs:

![image](https://user-images.githubusercontent.com/7077857/148296206-ffbf640e-d3e1-4791-b607-54558f44f6d6.png)
