### PR TITLE
AP_HAL_Linux: set external i2c bus mask for Navigator

### DIFF
--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -194,6 +194,10 @@
     #define HAL_BARO_PROBE_LIST PROBE_BARO_I2C(BMP280, 1, 0x76)
     #define HAL_BARO_EXTERNAL_BUS_DEFAULT 6
     #define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+    // I2C6 is the only i2c one exposed on a header
+    #define HAL_LINUX_I2C_EXTERNAL_BUS_MASK 1 << 6
+    // We don't want any probing on the internal buses
+    #define HAL_LINUX_I2C_INTERNAL_BUS_MASK 0
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BLUE
     #define HAL_GPIO_A_LED_PIN 66
     #define HAL_GPIO_B_LED_PIN 67


### PR DESCRIPTION
This fixes an issue where the internal Compass was being re-detected as an external one