### PR TITLE
Update BUILD.md to include git submodule update

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,6 +6,7 @@ Clone the project from GitHub:
 ```sh
 git clone --recursive https://github.com/ArduPilot/ardupilot.git
 cd ardupilot
+git submodule update --init --recursive
 ```
 
 Ardupilot is gradually moving from the make-based build system to


### PR DESCRIPTION
If you follow the existing build instructions, a newly cloned local repo will not build. It will fail at ./waf configure with this error:
  File "Tools/ardupilotwaf/chibios.py", line 345, in setup_canmgr_build
    cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath(),

It's essential to do a git submodule update --init --recursive in order to create functional local repo