### PR TITLE
AP_Mount: Add mount_mode to MOUNT_STATUS

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -104,7 +104,7 @@ void AP_Mount_Alexmos::send_mount_status(mavlink_channel_t chan)
     }
 
     get_angles();
-    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y*100, _current_angle.x*100, _current_angle.z*100);
+    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y*100, _current_angle.x*100, _current_angle.z*100, _state._mode);
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -116,7 +116,7 @@ void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
 void AP_Mount_SToRM32::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.  To-Do: retrieve actual gimbal attitude and send these instead
-    mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100);
+    mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100, _state._mode);
 }
 
 // search for gimbal in GCS_MAVLink routing table

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -150,7 +150,7 @@ void AP_Mount_SToRM32_serial::set_mode(enum MAV_MOUNT_MODE mode)
 void AP_Mount_SToRM32_serial::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.
-    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y, _current_angle.x, _current_angle.z);
+    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y, _current_angle.x, _current_angle.z, _state._mode);
 }
 
 bool AP_Mount_SToRM32_serial::can_send(bool with_control) {

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -136,7 +136,7 @@ void AP_Mount_Servo::check_servo_map()
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_Servo::send_mount_status(mavlink_channel_t chan)
 {
-    mavlink_msg_mount_status_send(chan, 0, 0, _angle_bf_output_deg.y*100, _angle_bf_output_deg.x*100, _angle_bf_output_deg.z*100);
+    mavlink_msg_mount_status_send(chan, 0, 0, _angle_bf_output_deg.y*100, _angle_bf_output_deg.x*100, _angle_bf_output_deg.z*100, _state._mode);
 }
 
 // stabilize - stabilizes the mount relative to the Earth's frame

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -116,7 +116,7 @@ void AP_Mount_SoloGimbal::set_mode(enum MAV_MOUNT_MODE mode)
 void AP_Mount_SoloGimbal::send_mount_status(mavlink_channel_t chan)
 {
     if (_gimbal.aligned()) {
-        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100);
+        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100, _state._mode);
     }
     
     // block heartbeat from transmitting to the GCS

--- a/libraries/SITL/SIM_Gimbal.cpp
+++ b/libraries/SITL/SIM_Gimbal.cpp
@@ -28,6 +28,14 @@
 
 extern const AP_HAL::HAL& hal;
 
+#define GIMBAL_DEBUG 0
+
+#if GIMBAL_DEBUG
+#define debug(fmt, args...)  do { printf("GIMBAL: " fmt, ##args); } while(0)
+#else
+#define debug(fmt, args...)  do { } while(0)
+#endif
+
 namespace SITL {
 
 Gimbal::Gimbal(const struct sitl_fdm &_fdm) :
@@ -287,7 +295,7 @@ void Gimbal::send_report(void)
                 case MAVLINK_MSG_ID_HEARTBEAT: {
                     mavlink_heartbeat_t pkt;
                     mavlink_msg_heartbeat_decode(&msg, &pkt);
-                    printf("Gimbal: got HB type=%u autopilot=%u base_mode=0x%x\n", pkt.type, pkt.autopilot, pkt.base_mode);
+                    debug("got HB type=%u autopilot=%u base_mode=0x%x\n", pkt.type, pkt.autopilot, pkt.base_mode);
                     if (!seen_heartbeat) {
                         seen_heartbeat = true;
                         vehicle_component_id = msg.compid;
@@ -336,7 +344,7 @@ void Gimbal::send_report(void)
                     break;
                 }
                 default:
-                    printf("Gimbal got unexpected msg %u\n", msg.msgid);
+                    debug("got unexpected msg %u\n", msg.msgid);
                     break;
                 }
             }


### PR DESCRIPTION
Partner Request via Discord

This adds mount_mode to the output of mount_status

Companion ArduPilot/mavlink PR here https://github.com/ArduPilot/mavlink/pull/236

This also pulls the mavlink submodule forward.

Edits the SITL_GIMBAL to not spam the console with messages when not desired