### PR TITLE
Tools: use define for define rather than default...

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -12,7 +12,7 @@ class Feature:
         self.label = label
         self.define = define
         self.description = description
-        self.define = default
+        self.default = default
         self.dependency = dependency
 
 # list of build options to offer

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -37,7 +37,7 @@ BUILD_OPTIONS = [
     Feature('Ident', 'AIS', 'HAL_AIS_ENABLED', 'Enable AIS', 0, None),
 
     Feature('Telemetry', 'CRSF', 'HAL_CRSF_TELEM_ENABLED', 'Enable CRSF Telemetry', 0, None),
-    Feature('Telemetry', 'CRSFText', ' HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED', 'Enable CRSF Text Param Selection', 0, 'CRSF'),
+    Feature('Telemetry', 'CRSFText', 'HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED', 'Enable CRSF Text Param Selection', 0, 'CRSF'),
     Feature('Telemetry', 'HIGHLAT2', 'HAL_HIGH_LATENCY2_ENABLED', 'Enable HighLatency2 Support', 0, None),
     Feature('Telemetry', 'HOTT', 'HAL_HOTT_TELEM_ENABLED', 'Enable HOTT Telemetry', 0, None),
     Feature('Telemetry', 'SPEKTRUM', 'HAL_SPEKTRUM_TELEM_ENABLED', 'Enable Spektrum Telemetry', 0, None),


### PR DESCRIPTION
Fixes the CustomBuild server's use of ArduPilot's build_options.py script.

... now with bonus bugfix
