### PR TITLE
AP_Logger_File: fix a SITL crash on arm64 when no speedup was specified on the command line

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -1016,7 +1016,8 @@ bool AP_Logger_File::io_thread_alive() const
     // SITL speedup options, so we allow for it here.
     SITL::SIM *sitl = AP::sitl();
     if (sitl != nullptr) {
-        timeout_ms *= sitl->speedup;
+        /* sitl->speedup may be -1 to indicate "default" so we check explicitly */
+        timeout_ms *= sitl->speedup > 0 ? sitl->speedup : 1;
     }
 #endif
     return (AP_HAL::millis() - _io_timer_heartbeat) < timeout_ms;


### PR DESCRIPTION
This PR fixes an issue with the SITL on arm64 (Apple M1) processors when the `--speedup` parameter is not specified on the command line.

More details about the problem can be found in https://github.com/ArduPilot/ardupilot/issues/19588 . In a nutshell: `sitl->speedup` remains -1 if the user does not specify an explicit speedup factor at startup, and this translates to `timeout_ms` being negative in `AP_Logger_File::io_thread_alive()` . I'm not sure why it results in a crash with an `illegal hardware instruction` later as `timeout_ms` is only involved in a comparison with `AP_HAL::millis() - _io_timer_heartbeat`, but it happens consistently with both `gcc-11` and `clang` on macOS when targeting `arm64` so I think it's not a compiler bug.

The original problem does not arise when compiling for Intel or when using any other platform (not macOS), but `timeout_ms` is still negative in these cases.

This PR is just a stopgap measure; I think that the original problem is how `sitl->speedup` can remain -1 in the first place. I have found that `SIM_Aircraft.cpp` updates `sitl->speedup` from its _own_ `speedup` parameter, but it does so only if it is not set to 1 (which it is by default), and I don't understand why, so I did not mess around with that part of the code. For your reference, this is what `SIM_Aircraft::fill_fdm()` does:

```
if (is_equal(last_speedup, -1.0f) && !is_equal(get_speedup(), 1.0f)) {
    sitl->speedup = get_speedup();
}
```

_Footnote_: `master` does not compile right now on Apple M1 without further modifications as it complains about unaligned pointers in `LogStructure`. I temporarily worked around that in my tests by removing `PACKED` from `LogStructure`.