### PR TITLE
Copter: Notify that the radio failsafe is disabled

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -710,7 +710,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     // Throttle Failsafe check
     if (copter.g.failsafe_throttle == FS_THR_DISABLED) {
-        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FS_THR_ENABLE is disabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Throttle failsafe is disabled");
     }
     
     // superclass method should always be the last thing called; it

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -708,6 +708,11 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         return false;
     }
 
+    // Throttle Failsafe check
+    if (copter.g.failsafe_throttle == FS_THR_DISABLED) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FS_THR_ENABLE is disabled");
+    }
+    
     // superclass method should always be the last thing called; it
     // has side-effects which would need to be cleaned up if one of
     // our arm checks failed


### PR DESCRIPTION
Disables the radio fail-safe during automatic flight.
This vehicle can be operated with a radio.
The operator does not get passively that the radio failsafe is disabled.
I learned that when the radio receiver of the radio is abnormal, it notifies the active PWM.
When I manually operate the vehicle, it notifies me that the radio failsafe is disabled.
I notify the message to the GCS, which in turn notifies the operator by voice and displays the message.

https://ardupilot.org/copter/docs/radio-failsafe.html#receiver-configuration-for-low-throttle-method

AFTER
![Screenshot from 2022-01-08 06-52-31](https://user-images.githubusercontent.com/646194/148617218-edb0cddb-bdf5-45d3-be75-e5d75a567ef6.png)

