### PR TITLE
AC_AttitudeControl: fix relax z controller integrator bug

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -447,6 +447,7 @@ protected:
     float       _jerk_max_xy_cmsss;       // Jerk limit of the xy kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
     float       _jerk_max_z_cmsss;        // Jerk limit of the z kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
     float       _vel_z_control_ratio = 2.0f;    // confidence that we have control in the vertical axis
+    float       _throttle_setting;      // throttle setting memory while relaxing z controller
 
     // output from controller
     float       _roll_target;           // desired roll angle in centi-degrees calculated by position controller


### PR DESCRIPTION
This is intended to fix the growth of the z PID integrator when the z controller is relaxed.  A user with significant vertical vibration in a heli found that the collective was responding to this vibration when in loiter with the aircraft landed and rotors turning.  The discuss thread that discusses this issue is [here](https://discuss.ardupilot.org/t/how-to-turn-off-the-cyclic-blade-pitch-and-collective-pitch-when-the-helicopter-is-on-the-ground/80038)
