### PR TITLE
AP_HAL_ChibiOS: do not emit config for more ports than we use in hwdef

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1525,8 +1525,6 @@ def get_UART_ORDER():
         # in bootloader SERIAL_ORDER is treated the same as UART_ORDER
         return serial_order
     map = [ 0, 3, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
-    while len(serial_order) < 4:
-        serial_order += ['EMPTY']
     uart_order = []
     global uart_serial_num
     for i in range(len(serial_order)):


### PR DESCRIPTION
The number of serial ports in the device list here flows through to SERIALMANAGER_NUM_PORTS and that (at least) increases the size of AP_SerialManager::var_info

Saves 108 bytes on Hitec-Airspeed, which defines a single serial port but we end up with 4 entries in the list.

Marked Draft because I'm really just taking a punt here :-)

