### PR TITLE
.github: add size-test targets to f103-GPS and Hitec-Airspeed

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -21,7 +21,9 @@ jobs:
         config: [
             Durandal,
             MatekF405,
-            Pixhawk1-1M
+            Pixhawk1-1M,
+            Hitec-Airspeed,  # see special code for Periph below (3 places!)
+            f103-GPS  # see special code for Periph below (3 places!)
         ]
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +61,12 @@ jobs:
           PATH="/github/home/.local/bin:$PATH"
           cd master
           ./waf configure --board ${{matrix.config}}
-          ./waf
+          if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
+             [ "${{matrix.config}}" = "f103-GPS" ]; then
+            ./waf AP_Periph
+          else
+            ./waf
+          fi
           mkdir -p $GITHUB_WORKSPACE/master_bin
           cp -r build/${{matrix.config}}/bin/* $GITHUB_WORKSPACE/master_bin/
 
@@ -82,7 +89,12 @@ jobs:
           git rebase ardupilot/master
           git submodule update --init --recursive --depth=1
           ./waf configure --board ${{matrix.config}}
-          ./waf
+          if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
+             [ "${{matrix.config}}" = "f103-GPS" ]; then
+            ./waf AP_Periph
+          else
+            ./waf
+          fi
           mkdir $GITHUB_WORKSPACE/pr_bin
           cp -r build/${{matrix.config}}/bin/* $GITHUB_WORKSPACE/pr_bin/
 
@@ -112,8 +124,13 @@ jobs:
         run: |
           python3 -m pip install -U weasyprint elf_diff anytree
           mkdir elf_diff
-          python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=elf_diff/plane $GITHUB_WORKSPACE/master_bin/arduplane $GITHUB_WORKSPACE/pr_bin/arduplane
-          python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=elf_diff/copter $GITHUB_WORKSPACE/master_bin/arducopter $GITHUB_WORKSPACE/pr_bin/arducopter
+          if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
+             [ "${{matrix.config}}" = "f103-GPS" ]; then
+             python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=elf_diff/AP_Periph $GITHUB_WORKSPACE/master_bin/AP_Periph $GITHUB_WORKSPACE/pr_bin/AP_Periph
+          else
+             python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=elf_diff/plane $GITHUB_WORKSPACE/master_bin/arduplane $GITHUB_WORKSPACE/pr_bin/arduplane
+             python3 -m elf_diff --bin_prefix=arm-none-eabi- --html_dir=elf_diff/copter $GITHUB_WORKSPACE/master_bin/arducopter $GITHUB_WORKSPACE/pr_bin/arducopter
+          fi
           zip -r elf_diff.zip elf_diff
 
       - name: Archive elf_diff output


### PR DESCRIPTION
MatekF405 isn't our closest.

Basing this change on https://firmware.ardupilot.org/Tools/BuildSizes/builds.html - but ignoring BeastF7v2 as I expect that will get fixed shortly... ( @andyp1per )
