### PR TITLE
AC_AttitudeControl: always use smaller of slew yaw and rate max

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -124,9 +124,9 @@ void Mode::AutoYaw::set_fixed_yaw(float angle_deg, float turn_rate_ds, int8_t di
     // get turn speed
     if (!is_positive(turn_rate_ds)) {
         // default to default slew rate
-        _fixed_yaw_slewrate_cds = copter.attitude_control->get_slew_yaw_cds();
+        _fixed_yaw_slewrate_cds = copter.attitude_control->get_slew_yaw_max_degs() * 100.0;
     } else {
-        _fixed_yaw_slewrate_cds = MIN(copter.attitude_control->get_slew_yaw_cds(), turn_rate_ds * 100.0);
+        _fixed_yaw_slewrate_cds = MIN(copter.attitude_control->get_slew_yaw_max_degs(), turn_rate_ds) * 100.0;
     }
 
     // set yaw mode

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -116,9 +116,9 @@ public:
 
     // get the yaw angular velocity limit in radians/s
     float get_ang_vel_yaw_max_rads() const { return radians(_ang_vel_yaw_max); }
-    
-    // get the yaw slew limit
-    float get_slew_yaw_cds() const { return _slew_yaw; }
+
+    // get the slew yaw rate limit in deg/s
+    float get_slew_yaw_max_degs() const;
 
     // get the rate control input smoothing time constant
     float get_input_tc() const { return _input_tc; }
@@ -373,7 +373,7 @@ protected:
     virtual float get_roll_trim_rad() { return 0;}
 
     // Return the yaw slew rate limit in radians/s
-    float get_slew_yaw_rads() { return radians(_slew_yaw * 0.01f); }
+    float get_slew_yaw_max_rads() const { return radians(get_slew_yaw_max_degs()); }
 
     // Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes
     AP_Float            _slew_yaw;


### PR DESCRIPTION
We had a error on line 581:
https://github.com/ArduPilot/ardupilot/blob/c8780792d4cf3fd7f5f2890f30ebe33536ce64cc/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp#L571

This was throwing away max slew yaw because `_ang_vel_yaw_max` defaults to zero. The same bug as was fixed in https://github.com/ArduPilot/ardupilot/pull/18341

This adds some new methods to get max yaw rate and uses them in attitude control and copter auto yaw. Except for the bug fix above this should be no change in behavior.