### PR TITLE
AP_Scripting: special case handling of copy method

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -325,6 +325,10 @@ local Vector2f_ud = {}
 ---@return Vector2f_ud
 function Vector2f() end
 
+-- copy
+---@return Vector2f_ud
+function Vector2f_ud:copy() end
+
 -- get field
 ---@return number
 function Vector2f_ud:y() end
@@ -371,6 +375,10 @@ local Vector3f_ud = {}
 
 ---@return Vector3f_ud
 function Vector3f() end
+
+-- copy
+---@return Vector3f_ud
+function Vector3f_ud:copy() end
 
 -- get field
 ---@return number
@@ -437,6 +445,10 @@ local Location_ud = {}
 
 ---@return Location_ud
 function Location() end
+
+-- copy
+---@return Location_ud
+function Location_ud:copy() end
 
 -- get field
 ---@return boolean

--- a/libraries/AP_Scripting/examples/copy_userdata.lua
+++ b/libraries/AP_Scripting/examples/copy_userdata.lua
@@ -1,0 +1,27 @@
+--[[
+ An example of using the copy() method on userdata
+--]]
+
+
+local loc1 = Location()
+loc1:lat(-35)
+loc1:lng(-122)
+
+-- if we did this as loc2 = loc1 then it actually takes a reference
+-- by using copy() we get the intended behaviour
+local loc2 = loc1:copy()
+loc2:offset(3000,5000)
+
+local diff = loc1:get_distance_NE(loc2)
+gcs:send_text(0,string.format("locdiff=(%.2f,%.2f)", diff:x(), diff:y()))
+
+local v1 = Vector2f()
+v1:x(-35)
+v1:y(-122)
+
+local v2 = v1:copy()
+v2:x(v2:x()+100)
+v2:y(v2:y()+300)
+
+local diff = v2 - v1
+gcs:send_text(0,string.format("vdiff=(%.2f,%.2f)", diff:x(), diff:y()))

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -18,6 +18,8 @@ userdata Location method get_bearing float Location
 userdata Location method get_distance_NED Vector3f Location
 userdata Location method get_distance_NE Vector2f Location
 userdata Location method change_alt_frame boolean Location::AltFrame'enum Location::AltFrame::ABSOLUTE Location::AltFrame::ABOVE_TERRAIN
+userdata Location method copy Location
+
 
 include AP_AHRS/AP_AHRS.h
 
@@ -119,6 +121,7 @@ userdata Vector3f operator -
 userdata Vector3f method dot float Vector3f
 userdata Vector3f method cross Vector3f Vector3f
 userdata Vector3f method scale Vector3f float'skip_check
+userdata Vector3f method copy Vector3f
 
 userdata Vector2f field x float'skip_check read write
 userdata Vector2f field y float'skip_check read write
@@ -130,6 +133,8 @@ userdata Vector2f method is_zero boolean
 userdata Vector2f method rotate void float'skip_check
 userdata Vector2f operator +
 userdata Vector2f operator -
+userdata Vector2f method copy Vector2f
+
 
 include AP_Notify/AP_Notify.h
 singleton AP_Notify alias notify

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1692,7 +1692,12 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       static_cast = FALSE;
       break;
     case TYPE_USERDATA:
-      fprintf(source, "    const %s &data = %s%s%s(", method->return_type.data.ud.name, ud_name, ud_access, method->name);
+      if (strcmp(method->name, "copy") == 0) {
+          // special case for copy method
+          fprintf(source, "    const %s data = (*%s", method->return_type.data.ud.name, ud_name);
+      } else {
+          fprintf(source, "    const %s &data = %s%s%s(", method->return_type.data.ud.name, ud_name, ud_access, method->name);
+      }
       static_cast = FALSE;
       break;
     case TYPE_AP_OBJECT:


### PR DESCRIPTION
allow for each copy() of Location, Vector2f and Vector3f without
adding special methods to each type in C++