### PR TITLE
Plane: add support for MAV_CMD_DO_AUTOTUNE by Axis

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -965,9 +965,9 @@ private:
     void read_control_switch();
     uint8_t readSwitch(void) const;
     void reset_control_switch();
-    void autotune_start(void);
-    void autotune_restore(void);
-    void autotune_enable(bool enable);
+    void autotune_start(uint8_t = 255);
+    void autotune_restore(uint8_t = 255);
+    void autotune_enable(bool enable, uint8_t = 255);
     bool fly_inverted(void);
     uint8_t get_mode() const override { return (uint8_t)control_mode->mode_number(); }
     Mode *mode_from_mode_num(const enum Mode::Number num);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -157,7 +157,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         break;
 
     case MAV_CMD_DO_AUTOTUNE_ENABLE:
-        autotune_enable(cmd.p1);
+        autotune_enable(cmd.p1, cmd.content.axis_to_tune.masked_value);
         break;
 
 #if HAL_MOUNT_ENABLED

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -159,34 +159,46 @@ void Plane::reset_control_switch()
 /*
   called when entering autotune
  */
-void Plane::autotune_start(void)
+void Plane::autotune_start(uint8_t tune_type)
 {
     gcs().send_text(MAV_SEVERITY_INFO, "Started autotune");
-    rollController.autotune_start();
-    pitchController.autotune_start();
-    yawController.autotune_start();
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_ROLL)) {
+        rollController.autotune_start();
+    }
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_PITCH)) {
+        pitchController.autotune_start();
+    }
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_YAW)) {
+        yawController.autotune_start();
+    }
 }
 
 /*
   called when exiting autotune
  */
-void Plane::autotune_restore(void)
+void Plane::autotune_restore(uint8_t tune_type)
 {
-    rollController.autotune_restore();
-    pitchController.autotune_restore();
-    yawController.autotune_restore();
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_ROLL)) {
+        rollController.autotune_restore();
+    }
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_PITCH)) {
+        pitchController.autotune_restore();
+    }
+    if (tune_type & (1U<<AP_AutoTune::AUTOTUNE_YAW)) {
+        yawController.autotune_restore();
+    }
     gcs().send_text(MAV_SEVERITY_INFO, "Stopped autotune");
 }
 
 /*
   enable/disable autotune for AUTO modes
  */
-void Plane::autotune_enable(bool enable)
+void Plane::autotune_enable(bool enable, uint8_t tune_type)
 {
     if (enable) {
-        autotune_start();
+        autotune_start(tune_type);
     } else {
-        autotune_restore();
+        autotune_restore(tune_type);
     }
 }
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1104,6 +1104,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
 
     case MAV_CMD_DO_AUTOTUNE_ENABLE:                    // MAV ID: 211
         cmd.p1 = packet.param1;                         // disable=0 enable=1
+        cmd.content.axis_to_tune.masked_value = packet.param2;
         break;
 
     case MAV_CMD_NAV_ALTITUDE_WAIT:                     // MAV ID: 83
@@ -1571,6 +1572,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     case MAV_CMD_DO_AUTOTUNE_ENABLE:
         packet.param1 = cmd.p1;                         // disable=0 enable=1
+        packet.param2 = cmd.content.axis_to_tune.masked_value;
         break;
 
     case MAV_CMD_DO_SET_REVERSE:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -60,6 +60,12 @@ class AP_Mission
 {
 
 public:
+
+    // autotune bitmasked roll/pitch/yaw
+    struct PACKED Axis_To_Tune {
+        uint8_t masked_value ;
+    };
+
     // jump command structure
     struct PACKED Jump_Command {
         uint16_t target;        // target command id
@@ -304,6 +310,9 @@ public:
         
         // location
         Location location{};      // Waypoint location
+
+        // autotune axis
+        Axis_To_Tune axis_to_tune ;
     };
 
     // command structure


### PR DESCRIPTION
In reference, the issue #19702 . MAV_CMD_DO_AUTOTUNE_ENABLE.param2 can be used to trigger autotuning for the plane. This may not be fully completed, please suggest changes.

Closes #19702