### PR TITLE
Call mavlink_parse_char without r_msg/r_status

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -335,6 +335,14 @@ public:
         return _locked;
     }
 
+    // return the parse buffer for supplied channel.  Caller must do
+    // range-checking on chan.
+    mavlink_message_t *get_channel_buffer(mavlink_channel_t _chan);
+
+    // return the parse status object for supplied channel.  Caller
+    // must do range-checking on chan.
+    mavlink_status_t *get_channel_status(mavlink_channel_t _chan);
+
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1450,12 +1450,8 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
     }
 
     // receive new packets
-    mavlink_message_t msg;
-    mavlink_status_t status;
     uint32_t tstart_us = AP_HAL::micros();
     uint32_t now_ms = AP_HAL::millis();
-
-    status.packet_rx_drop_count = 0;
 
     const uint16_t nbytes = _port->available();
     for (uint16_t i=0; i<nbytes; i++)
@@ -1487,9 +1483,11 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
         bool parsed_packet = false;
 
         // Try to get a new message
-        if (mavlink_parse_char(chan, c, &msg, &status)) {
-            hal.util->persistent_data.last_mavlink_msgid = msg.msgid;
-            packetReceived(status, msg);
+        if (mavlink_parse_char(chan, c, NULL, NULL)) {
+            const mavlink_message_t *msg = GCS_MAVLINK::get_channel_buffer(chan);
+            const mavlink_status_t *status = GCS_MAVLINK::get_channel_status(chan);
+            hal.util->persistent_data.last_mavlink_msgid = msg->msgid;
+            packetReceived(*status, *msg);
             parsed_packet = true;
             gcs_alternative_active[chan] = false;
             alternative.last_mavlink_ms = now_ms;

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -47,6 +47,19 @@ mavlink_system_t mavlink_system = {7,1};
 // routing table
 MAVLink_routing GCS_MAVLINK::routing;
 
+// return the parse buffer for supplied channel.  Caller must do
+// range-checking on chan.
+mavlink_message_t *GCS_MAVLINK::get_channel_buffer(mavlink_channel_t _chan)
+{
+    return mavlink_get_channel_buffer(chan);
+}
+// return the parse status object for supplied channel.  Caller must
+// do range-checking on chan.
+mavlink_status_t *GCS_MAVLINK::get_channel_status(mavlink_channel_t _chan)
+{
+    return mavlink_get_channel_status(chan);
+}
+
 // set a channel as private. Private channels get sent heartbeats, but
 // don't get broadcast packets or forwarded packets
 void GCS_MAVLINK::set_channel_private(mavlink_channel_t _chan)

--- a/libraries/GCS_MAVLink/examples/mavlink-performance/mavlink-performance.cpp
+++ b/libraries/GCS_MAVLink/examples/mavlink-performance/mavlink-performance.cpp
@@ -1,0 +1,106 @@
+//
+// Simple test for the GCS_MAVLink decode performance
+//
+
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
+#include <AP_Common/AP_FWVersion.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+AP_SerialManager _serialmanager;
+GCS_Dummy _gcs;
+
+extern mavlink_system_t mavlink_system;
+
+const AP_Param::GroupInfo GCS_MAVLINK_Parameters::var_info[] = {
+    AP_GROUPEND
+};
+
+void setup(void)
+{
+    hal.console->printf("routing test startup...");
+    gcs().init();
+    gcs().setup_console();
+}
+
+uint32_t get_rate(bool with_objects);
+uint32_t get_rate(bool with_objects)
+{
+    mavlink_message_t msg;
+
+    // heartbeat
+    mavlink_heartbeat_t heartbeat = {};
+    mavlink_msg_heartbeat_encode(3, 1, &msg, &heartbeat);
+    uint8_t heartbeat_buf[128];
+    const uint16_t heartbeat_buf_len = mavlink_msg_to_send_buffer(heartbeat_buf, &msg);
+
+    // attitude
+    mavlink_attitude_t attitude = {};
+    mavlink_msg_attitude_encode(3, 1, &msg, &attitude);
+    uint8_t attitude_buf[128];
+    const uint16_t attitude_buf_len = mavlink_msg_to_send_buffer(attitude_buf, &msg);
+
+    const uint64_t tstart = AP_HAL::micros64();
+
+    mavlink_status_t status;
+    mavlink_message_t buffer;
+
+    const uint32_t iterations = 1 << 16;
+    uint32_t heartbeats_received = 0;
+    uint32_t attitudes_received = 0;
+    for (uint32_t iter=0; iter < iterations; iter++) {
+        for (uint16_t i=0; i<heartbeat_buf_len; i++) {
+            if (with_objects) {
+                if (mavlink_parse_char(1, heartbeat_buf[i], &buffer, &status)) {
+                    heartbeats_received++;
+                }
+            } else {
+                if (mavlink_parse_char(1, heartbeat_buf[i], NULL, NULL)) {
+                    heartbeats_received++;
+                }
+            }
+        }
+        for (uint16_t i=0; i<attitude_buf_len; i++) {
+            if (with_objects) {
+                if (mavlink_parse_char(1, attitude_buf[i], &buffer, &status)) {
+                    attitudes_received++;
+                }
+            } else {
+                if (mavlink_parse_char(1, attitude_buf[i], NULL, NULL)) {
+                    attitudes_received++;
+                }
+            }
+        }
+    }
+
+    const uint64_t tdelta = AP_HAL::micros64() - tstart;
+
+    if (heartbeats_received != iterations) {
+        hal.console->printf("Did not get correct number of heartbeats: want=%u got=%u", (unsigned)iterations, (unsigned)heartbeats_received);
+    }
+    if (attitudes_received != iterations) {
+        hal.console->printf("Did not get correct number of attitudes: want=%u got=%u", (unsigned)iterations, (unsigned)attitudes_received);
+    }
+
+    const uint32_t bytes_decoded = iterations * (heartbeat_buf_len + attitude_buf_len);
+    hal.console->printf("dec=%u t=%" PRIu64 "\n", (unsigned)bytes_decoded, tdelta);
+    const uint64_t x = bytes_decoded * 1000000LL;
+    return x/tdelta;
+}
+
+void loop(void)
+{
+    hal.console->printf("Decode rate    (with return-objects): %u bytes/s\n", (unsigned)get_rate(true));
+    hal.console->printf("Decode rate (without return-objects): %u bytes/s\n", (unsigned)get_rate(false));
+
+    hal.scheduler->delay(1000);
+}
+
+AP_HAL_MAIN();

--- a/libraries/GCS_MAVLink/examples/mavlink-performance/wscript
+++ b/libraries/GCS_MAVLink/examples/mavlink-performance/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )


### PR DESCRIPTION
We don't use the values that are returned inside these two objects, but passing them into the mavlink API causes a chunk of work to be done (particularly filling `r_status` in for every character that's passed in.

Also included is an example which calls the API with/without objects.  It returns this on a `Pixhaw1-1M` here:

```
Decode rate    (with return-objects): 494354 bytes/s
dec=2228224 t=2869610
Decode rate (without return-objects): 776490 bytes/s
dec=2228224 t=4509092
Decode rate    (with return-objects): 494162 bytes/s
dec=2228224 t=2870253
Decode rate (without return-objects): 776316 bytes/s
dec=2228224 t=4509270
Decode rate    (with return-objects): 494142 bytes/s
dec=2228224 t=2870199
Decode rate (without return-objects): 776330 bytes/s
dec=2228224 t=4509244
Decode rate    (with return-objects): 494145 bytes/s
dec=2228224 t=2870286
```

That's a signficant change.
