### PR TITLE
AP_Param: fix convert_class when index is 0

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1908,7 +1908,14 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
         info.old_key = param_key;
         info.type = (ap_var_type)group_info[i].type;
         info.new_name = nullptr;
-        info.old_group_element = (uint16_t(group_info[i].idx)<<group_shift) + old_index;
+
+        uint16_t idx = group_info[i].idx;
+        if (group_shift != 0 && idx == 0) {
+            // Note: Index 0 is treated as 63 for group bit shifting purposes. See group_id()
+            idx = 63;
+        }
+
+        info.old_group_element = (idx << group_shift) + old_index;
 
         uint8_t old_value[type_size(info.type)];
         AP_Param *ap = (AP_Param *)&old_value[0];


### PR DESCRIPTION
This fixes an error I had in this function when the index of the parameter group starts with a zero and it is not a top element group.

Found while confirming rover and sub AP_Airspeed conversion was working correctly in my PR. All of it was working fine but the first element... somehow how missed in previous testing. 

This doesn't effect the only current user of this function the plane EFI conversion. 