### PR TITLE
AP_Compass: use AK09915 at 200Hz continuous mode

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -369,7 +369,10 @@ bool AP_Compass_AK09916::_check_id()
 }
 
 bool AP_Compass_AK09916::_setup_mode() {
-    return _bus->register_write(REG_CNTL2, 0x08, true); //Continuous Mode 2
+    if (_devtype == DEVTYPE_AK09915) {
+        return _bus->register_write(REG_CNTL2, 0xA, true); //Continuous Mode 5 - 200Hz
+    }
+    return _bus->register_write(REG_CNTL2, 0x08, true); //Continuous Mode 4 - 100Hz
 }
 
 bool AP_Compass_AK09916::_reset()


### PR DESCRIPTION
AK09915 supports a new "continuous measurement mode 5" at 200hz:

https://datasheetspdf.com/pdf-file/1074994/AKM/AK09915/1

![image](https://user-images.githubusercontent.com/4013804/148824431-a78d55e0-9fd3-4cd3-9dce-577fe99004e6.png)


Also, the previous comment was wrong. 0x08 is mode 4