### PR TITLE
AP_OSD: Added new per screen PARAMs for HD OSD options

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -1217,6 +1217,12 @@ void AP_MSP_Telem_Backend::msp_displayport_write_string(uint8_t col, uint8_t row
 
     msp_send_packet(MSP_DISPLAYPORT, MSP::MSP_V1, &packet, 4 + len, false);
 }
+
+void AP_MSP_Telem_Backend::msp_displayport_set_options(const uint8_t font_index, const uint8_t screen_resolution)
+{
+    const uint8_t subcmd[] = { msp_displayport_subcmd_e::MSP_DISPLAYPORT_SET_OPTIONS, font_index, screen_resolution };
+    msp_send_packet(MSP_DISPLAYPORT, MSP::MSP_V1, subcmd, sizeof(subcmd), false);
+}
 #endif //HAL_WITH_MSP_DISPLAYPORT
 bool AP_MSP_Telem_Backend::displaying_stats_screen() const
 {

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.h
@@ -88,6 +88,7 @@ public:
     virtual void msp_displayport_clear_screen();
     virtual void msp_displayport_draw_screen();
     virtual void msp_displayport_write_string(uint8_t col, uint8_t row, bool blink, const char *string);
+    virtual void msp_displayport_set_options(const uint8_t font_index, const uint8_t screen_resolution);
 #endif
 protected:
     enum msp_packet_type : uint8_t {

--- a/libraries/AP_MSP/msp.h
+++ b/libraries/AP_MSP/msp.h
@@ -104,6 +104,7 @@ typedef enum : uint8_t {
     MSP_DISPLAYPORT_CLEAR_SCREEN = 2,
     MSP_DISPLAYPORT_WRITE_STRING = 3,
     MSP_DISPLAYPORT_DRAW_SCREEN = 4,
+    MSP_DISPLAYPORT_SET_OPTIONS = 5,
 } msp_displayport_subcmd_e;
 
 typedef struct PACKED {

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -94,7 +94,14 @@ public:
 
 protected:
     bool check_option(uint32_t option);
-
+#ifdef HAL_WITH_MSP_DISPLAYPORT
+    virtual uint8_t get_txt_resolution() const {
+        return 0;
+    }
+    virtual uint8_t get_font_index() const {
+        return 0;
+    }
+#endif
     enum unit_type {
         ALTITUDE=0,
         SPEED=1,
@@ -134,6 +141,14 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Param::GroupInfo var_info2[];
 
+#ifdef HAL_WITH_MSP_DISPLAYPORT
+    uint8_t get_txt_resolution() const override {
+        return txt_resolution;
+    }
+    uint8_t get_font_index() const override {
+        return font_index;
+    }
+#endif
 private:
     friend class AP_MSP;
     friend class AP_MSP_Telem_Backend;
@@ -214,6 +229,12 @@ private:
     AP_OSD_Setting batt_bar{true, 1, 1};
     AP_OSD_Setting arming{true, 1, 1};
 
+#ifdef HAL_WITH_MSP_DISPLAYPORT
+    // Per screen HD resolution options (currently supported only by DisplayPort)
+    AP_Int8 txt_resolution;
+    AP_Int8 font_index;
+#endif
+
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
     void draw_avgcellvolt(uint8_t x, uint8_t y);
@@ -280,7 +301,6 @@ private:
     void draw_fence(uint8_t x, uint8_t y);
 #endif
     void draw_rngf(uint8_t x, uint8_t y);
-
 
     struct {
         bool load_attempted;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -60,6 +60,14 @@ void AP_OSD_MSP_DisplayPort::osd_thread_run_once()
 
 void AP_OSD_MSP_DisplayPort::clear(void)
 {
+    // check if we need to enable some options
+    // but only for actual OSD screens
+    if (_osd.get_current_screen() < AP_OSD_NUM_DISPLAY_SCREENS) {
+        const uint8_t txt_resolution = _osd.screen[_osd.get_current_screen()].get_txt_resolution();
+        const uint8_t font_index = _osd.screen[_osd.get_current_screen()].get_font_index();
+        _displayport->msp_displayport_set_options(font_index, txt_resolution);
+    }
+
     // clear remote MSP screen
     _displayport->msp_displayport_clear_screen();
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1022,6 +1022,21 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(link_quality, "LINK_Q", 1, AP_OSD_Screen, AP_OSD_Setting),
 
+#if HAL_WITH_MSP_DISPLAYPORT
+    // @Param: TXT_RES
+    // @DisplayName: Sets the overlay text resolution (MSP DisplayPort only)
+    // @Description: Sets the overlay text resolution for this screen to either LD 30x16 or HD 50x18 (MSP DisplayPort only)
+    // @Values: 0:30x16,1:50x18
+    // @User: Standard
+    AP_GROUPINFO("TXT_RES", 3, AP_OSD_Screen, txt_resolution, 0),
+
+    // @Param: FONT
+    // @DisplayName: Sets the font index for this screen (MSP DisplayPort only)
+    // @Description: Sets the font index for this screen (MSP DisplayPort only)
+    // @Range: 0 15
+    // @User: Standard
+    AP_GROUPINFO("FONT", 4, AP_OSD_Screen, font_index, 0),
+#endif
     AP_GROUPEND
 };
 


### PR DESCRIPTION
This adds
 OSDn_HD_RES_EN to enable HD resoloution
 OSDn_HD_FONT for HD font index selection

Notes:
- settings are per screen (future OSD fw will even allow the use of custom font tables)
- resolution refers to the size of text frame buffer not to the actual pixel resolution.
Latest HDZERO MSP DisplayPort firmware supports 2 text resolutions 30x16 and 50x18 switchable with MSP sub command 5

What follows is an example of the same OSD settings applied to 30x16 and 50x18, same coordinates draw on different screen positions due to higher resolutin.

Low resolution DisplayPort has 30 cols and 16 rows i.e. 30x16
![image](https://user-images.githubusercontent.com/30294218/149034281-7deb95ec-0463-40a9-a737-33f54c2f45a5.png)

High resolution DisplayPort has 50 cols and 18 rows i.e 50x18
![image](https://user-images.githubusercontent.com/30294218/149034704-fdcd6372-e2ed-4f74-a891-84497c5a7a40.png)
