### PR TITLE
hwdef: fixed flash double reserve

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef-bl.dat
@@ -15,8 +15,9 @@ FLASH_SIZE_KB 2048
 # bootloader starts at zero offset
 FLASH_RESERVE_START_KB 0
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
+# use last 2 pages for flash storage
+# H743 has 16 pages of 128k each
+STORAGE_FLASH_PAGE 14
 
 # the location where the bootloader will put the firmware
 # the H743 has 128k sectors

--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/hwdef.dat
@@ -110,9 +110,6 @@ define HAL_STORAGE_SIZE 16384
 # H743 has 16 pages of 128k each
 STORAGE_FLASH_PAGE 14
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
-
 # enable logging to dataflash
 define HAL_LOGGING_DATAFLASH_ENABLED 1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef-bl.dat
@@ -18,8 +18,8 @@ FLASH_RESERVE_START_KB 0
 # the location where the bootloader will put the firmware
 FLASH_BOOTLOADER_LOAD_KB 128
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
+STORAGE_FLASH_PAGE 14
+define HAL_STORAGE_SIZE 32768
 
 # order of UARTs (and USB)
 SERIAL_ORDER OTG1

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
@@ -24,9 +24,6 @@ FLASH_RESERVE_START_KB 128
 STORAGE_FLASH_PAGE 14
 define HAL_STORAGE_SIZE 32768
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
-
 # one I2C bus
 I2C_ORDER I2C1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/hwdef-bl.dat
@@ -18,8 +18,8 @@ FLASH_RESERVE_START_KB 0
 # the location where the bootloader will put the firmware
 FLASH_BOOTLOADER_LOAD_KB 128
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
+STORAGE_FLASH_PAGE 14
+define HAL_STORAGE_SIZE 32768
 
 # order of UARTs (and USB)
 SERIAL_ORDER OTG1

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/hwdef.dat
@@ -27,9 +27,6 @@ define HAL_STORAGE_SIZE 32768
 # enable logging to dataflash
 define HAL_LOGGING_DATAFLASH_ENABLED 1
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
-
 # one I2C bus
 I2C_ORDER I2C1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef-bl.dat
@@ -15,8 +15,9 @@ FLASH_SIZE_KB 2048
 # bootloader starts at zero offset
 FLASH_RESERVE_START_KB 0
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
+# use last 2 pages for flash storage
+# H743 has 16 pages of 128k each
+STORAGE_FLASH_PAGE 14
 
 # the location where the bootloader will put the firmware
 # the H743 has 128k sectors

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
@@ -180,9 +180,6 @@ define HAL_STORAGE_SIZE 16384
 # H743 has 16 pages of 128k each
 STORAGE_FLASH_PAGE 14
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 256
-
 # spi devices
 SPIDEV mpu6000   SPI1 DEVID1 IMU1_CS      MODE3  1*MHZ  4*MHZ
 SPIDEV icm20602  SPI4 DEVID1 IMU2_CS      MODE3  1*MHZ  4*MHZ

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef-bl.dat
@@ -26,9 +26,9 @@ define CH_CFG_ST_FREQUENCY 1000
 
 FLASH_SIZE_KB 256
 
-# reserve space for params
-FLASH_RESERVE_END_KB 2
-
+# store parameters in last 2 pages
+STORAGE_FLASH_PAGE 126
+define HAL_STORAGE_SIZE 800
 
 # USART3 for debug
 #STDOUT_SERIAL SD3

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZubaxGNSS/hwdef.dat
@@ -16,9 +16,6 @@ FLASH_RESERVE_START_KB 34
 STORAGE_FLASH_PAGE 126
 define HAL_STORAGE_SIZE 800
 
-# reserve space for flash storage in last 2 sectors
-FLASH_RESERVE_END_KB 2
-
 # board ID for firmware load
 APJ_BOARD_ID 1005
 
@@ -31,10 +28,6 @@ OSCILLATOR_HZ 16000000
 define CH_CFG_ST_FREQUENCY 1000
 
 FLASH_SIZE_KB 256
-
-
-# reserve space for params
-FLASH_RESERVE_END_KB 2
 
 # USART3 for debug
 STDOUT_SERIAL SD3

--- a/libraries/AP_HAL_ChibiOS/hwdef/mindpx-v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mindpx-v2/hwdef.dat
@@ -20,9 +20,6 @@ FLASH_SIZE_KB 2048
 # space to reserve for bootloader and storage at start of flash
 FLASH_RESERVE_START_KB 16
 
-# space to reserve for storage at end of flash
-FLASH_RESERVE_END_KB 0
-
 # serial port for stdout disabled, uses USB instead
 # STDOUT_SERIAL SD7
 # STDOUT_BAUDRATE 57600


### PR DESCRIPTION
fixes #19765, an alternative to #19768

the advantage of this approach is it is less error prone, as the
actual position and size of the storage sectors is calculated