### PR TITLE
AP_Hal_Linux: PCA9685: do not shutdown

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -173,8 +173,6 @@ bool RCOutput_PCA9685::force_safety_on() {
     }
     /* Shutdown before sleeping. */
     _dev->write_register(PCA9685_RA_ALL_LED_OFF_H, PCA9685_ALL_LED_OFF_H_SHUT);
-    /* Put PCA9685 to sleep */
-    _dev->write_register(PCA9685_RA_MODE1, PCA9685_MODE1_SLEEP_BIT);
 
     _dev->get_semaphore()->give();
     return true;


### PR DESCRIPTION
Sleeping causes the current pulses to be cut short, often causing ESCs to interpret this pulse and briefly spin thrusters (often pretty violently) when Ardupilot is stopped.

We can alternatively add a delay to wait until all the pulses are over, but that will delay the shutdown and depends on the current PWM frequency. Is there an issue in keeping the PCA running?

Before:
![image (18)](https://user-images.githubusercontent.com/4013804/149206819-3e52c4ba-e771-49f6-ad85-9322b9f5667b.png)

After:
![image (17)](https://user-images.githubusercontent.com/4013804/149206810-7a77c402-a1f1-4650-a9b8-a2e610ea9be5.png)

credits to @jaxxzer for digging into this