### PR TITLE
AP_RangFinder: support various maxbotix serial sonar

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.cpp
@@ -24,6 +24,14 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_RangeFinder_MaxsonarSerialLV::AP_RangeFinder_MaxsonarSerialLV(
+    RangeFinder::RangeFinder_State &_state,
+    AP_RangeFinder_Params &_params):
+    AP_RangeFinder_Backend_Serial(_state, _params)
+{
+    params.scaling.set_default(0.0254f);
+}
+
 // read - return last value measured by sensor
 bool AP_RangeFinder_MaxsonarSerialLV::get_reading(float &reading_m)
 {
@@ -56,7 +64,7 @@ bool AP_RangeFinder_MaxsonarSerialLV::get_reading(float &reading_m)
     }
 
     // This sonar gives the metrics in inches, so we have to transform this to meters
-    reading_m = (2.54f * 0.01f) * (float(sum) / count);
+    reading_m = params.scaling * (float(sum) / count);
 
     return true;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
@@ -8,7 +8,7 @@ class AP_RangeFinder_MaxsonarSerialLV : public AP_RangeFinder_Backend_Serial
 
 public:
 
-    using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
+    AP_RangeFinder_MaxsonarSerialLV(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
 
     // @Param: SCALING
     // @DisplayName: Rangefinder scaling
-    // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
+    // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts. For Maxbotix serial sonar this is unit conversion to meters.
     // @Units: m/V
     // @Increment: 0.001
     // @User: Standard


### PR DESCRIPTION
fix #7885 and fix #16749
replace #19323

[> It was suggested on the Devcall we use scaling factor parameter instead
](https://github.com/ArduPilot/ardupilot/pull/19323#issuecomment-1009464248)

This PR use RNGFNDx_SCALING as unit conversion factor. 
It is tested on maxbotix MB1240 (FC is Matek H743) with RNGFND1_SCALING = 0.01 (MB1240 report reading in cm)
