### PR TITLE
AP_Logger: Allow log rotate if armed while disarmed logging is enabled

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -654,6 +654,9 @@ void AP_Logger::set_vehicle_armed(const bool armed_state)
         // get a set of @SYS files logged:
         file_content_prepare_for_arming = true;
 #endif
+        if (_params.log_disarmed && _params.file_disarm_rot) {
+            FOR_EACH_BACKEND(vehicle_was_disarmed());
+        }
     } else {
         // went from armed to disarmed
         FOR_EACH_BACKEND(vehicle_was_disarmed());


### PR DESCRIPTION
Allows efficient log analysis when disarmed time is long

As log size would be very large then.

Found it very useful for cases when one is doing RC calibration or waiting for good GPS fix before taking off, so once everything is ready, vehicle is armed and safety switch is disabled a new fresh log file is started.. holding only what's really important to analyze for the flight while the disarmed log is till there.