### PR TITLE
RC_Channel: make AUXF.function an instance

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -908,7 +908,7 @@ bool RC_Channel::run_aux_function(aux_func_t ch_option, AuxSwitchPos pos, AuxFun
     AP::logger().Write(
         "AUXF",
         "TimeUS,function,pos,source,result",
-        "s----",
+        "s#---",
         "F----",
         "QHBBB",
         AP_HAL::micros64(),


### PR DESCRIPTION
Super simple change that brakes up the AUXF logs to make them a little easier to see what is happening on each channel. e.g. 
![image](https://user-images.githubusercontent.com/34512430/149419202-746f8575-d0c6-4ea6-b09d-0571ba26c5d8.png)
