### PR TITLE
AP_HAL_Linux: supporting RPI-Zero 2 W

### DIFF
--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -48,6 +48,13 @@ int UtilRPI::_check_rpi_version()
              return _rpi_version;
         }
         
+        ret = strncmp(buffer, "Raspberry Pi Zero 2", 19);
+        if (ret == 0) {
+             _rpi_version = 2; // Raspberry PI Zero 2 W e.g. Raspberry Pi Zero 2 Rev 1.0.
+             printf("%s. (intern: %d)\n", buffer, _rpi_version);
+             return _rpi_version;
+        }
+        
         ret = sscanf(buffer + 12, "%d", &_rpi_version);
         if (ret != EOF) {
             if (_rpi_version > 3)  {


### PR DESCRIPTION
At last I got my RPI-Zero 2 W.
Similar to CM4 it reports a new string from "/sys/firmware/devicetree/base/model" that makes UtilRPI::_check_rpi_version() report it wrong.

It returns "Raspberry Pi Zero 2 Rev 1.0" and its addresses should be handled as RPI-2 addresses.

This PR fixes this issue.