### PR TITLE
AP_Common: support AP_CUSTOM_FIRMWARE_STRING

### DIFF
--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -28,6 +28,7 @@ public:
     const uint32_t os_sw_version;
     const char *fw_string;
     const char *fw_hash_str;
+    const char *fw_string_original;
     const char *fw_short_string;
     const char *middleware_name;
     const char *middleware_hash_str;

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -23,6 +23,17 @@
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
+/*
+  allow vendors to set AP_CUSTOM_FIRMWARE_STRING in hwdef.dat
+ */
+#ifdef AP_CUSTOM_FIRMWARE_STRING
+#define ACTIVE_FWSTR AP_CUSTOM_FIRMWARE_STRING
+#define ORIGINAL_FWSTR THISFIRMWARE
+#else
+#define ACTIVE_FWSTR THISFIRMWARE
+#define ORIGINAL_FWSTR nullptr
+#endif
+
 const AP_FWVersion AP_FWVersion::fwver{
     // Version header struct
     .header = 0x61706677766572fb, // First 7 MSBs: "apfwver", LSB is the checksum of the previous string: 0xfb
@@ -43,13 +54,14 @@ const AP_FWVersion AP_FWVersion::fwver{
    .os_sw_version = 0,
 #endif
 #ifndef GIT_VERSION
-    .fw_string = THISFIRMWARE,
+    .fw_string = ACTIVE_FWSTR,
     .fw_hash_str = "",
 #else
-    .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
+    .fw_string = ACTIVE_FWSTR " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-    .fw_short_string = THISFIRMWARE,
+    .fw_string_original = ORIGINAL_FWSTR,
+    .fw_short_string = ACTIVE_FWSTR,
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
 #ifdef CHIBIOS_GIT_VERSION

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -211,9 +211,18 @@ void LoggerMessageWriter_WriteSysInfo::process() {
     switch(stage) {
 
     case Stage::FIRMWARE_STRING:
+#ifdef AP_CUSTOM_FIRMWARE_STRING
+        // also log original firmware string if different
+        if (! _logger_backend->Write_MessageF("%s [%s]",
+                                              fwver.fw_string,
+                                              fwver.fw_string_original)) {
+            return; // call me again
+        }
+#else
         if (! _logger_backend->Write_Message(fwver.fw_string)) {
             return; // call me again
         }
+#endif
         stage = Stage::GIT_VERSIONS;
         FALLTHROUGH;
 


### PR DESCRIPTION
this allows vendors to setup a custom firmware string in hwdef.dat,
which makes maintaining a vehicle specific firmware easier

update: the original fw string is now logged:
```
1970-01-01 10:00:09.95: MSG {TimeUS : 9956814, Message : MyFw 1.7 (82a962d3) [ArduPlane V4.2.0dev]}
1970-01-01 10:00:09.95: MSG {TimeUS : 9956822, Message : ChibiOS: 93e6e03d}
1970-01-01 10:00:09.95: MSG {TimeUS : 9956836, Message : CubeOrange 0029002B 34385115 31373439}
```