### PR TITLE
AP_BatteryMonitor: add current scaler for UAVCAN

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -22,6 +22,8 @@ public:
     /// Constructor
     AP_BattMonitor_UAVCAN(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, BattMonitor_UAVCAN_Type type, AP_BattMonitor_Params &params);
 
+    static const struct AP_Param::GroupInfo var_info[];
+
     void init() override {}
 
     /// Read the battery voltage and current.  Should be called at 10hz
@@ -54,7 +56,6 @@ public:
 private:
     void handle_battery_info(const BattInfoCb &cb);
     void handle_battery_info_aux(const BattInfoAuxCb &cb);
-
     void update_interim_state(const float voltage, const float current, const float temperature_K, const uint8_t soc);
 
     static bool match_battery_id(uint8_t instance, uint8_t battery_id) {
@@ -94,7 +95,7 @@ private:
     bool _has_battery_info_aux;
     uint8_t _instance;                  // instance of this battery monitor
     uavcan::Node<0> *_node;             // UAVCAN node id
-
+    AP_Float _cur_mult;                 // scaling multiplier applied to current reports for adjustment
     // MPPT variables
     struct {
         bool is_detected;               // true if this UAVCAN device is a Packet Digital MPPT


### PR DESCRIPTION
This allows tweaking UAVCAN PMs that do not provide a param for current adjustment (ie CUAV for example) and also allows lower capacity monitors to be used in parallel battery setups by attaching to one of the paralleled batteries

tested on CUAV UAVCAN power module

thanks to @hendjoshsr71 for helping me debug the constructs