### PR TITLE
AP_NavEKF2, AP_NavEKF3, AP_EFI : correct typo

### DIFF
--- a/libraries/AP_EFI/AP_EFI_Serial_MS.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_MS.cpp
@@ -162,7 +162,7 @@ bool AP_EFI_Serial_MS::read_incoming_realtime_data()
     float duty_cycle = (internal_state.cylinder_status[0].injection_time_ms * internal_state.engine_speed_rpm)/600.0f;
     uint32_t current_time = AP_HAL::millis();
     // Super Simplified integration method - Error Analysis TBD
-    // This calcualtion gives erroneous results when the engine isn't running
+    // This calculation gives erroneous results when the engine isn't running
     if (internal_state.engine_speed_rpm > RPM_THRESHOLD) {
         internal_state.fuel_consumption_rate_cm3pm = duty_cycle*get_coef1() - get_coef2();
         internal_state.estimated_consumed_fuel_volume_cm3 += internal_state.fuel_consumption_rate_cm3pm * (current_time - internal_state.last_updated_ms)/60000.0f;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -322,7 +322,7 @@ void NavEKF2_core::FuseRngBcnStatic()
                 // calculate the delta to the estimated receiver position
                 ftype delta = receiverPos.z - bcnMidPosD;
 
-                // calcuate the two hypothesis for our vertical position
+                // calculate the two hypothesis for our vertical position
                 ftype receiverPosDownMax;
                 ftype receiverPosDownMin;
                 if (delta >= 0.0f) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_RngBcnFusion.cpp
@@ -323,18 +323,18 @@ void NavEKF2_core::FuseRngBcnStatic()
                 ftype delta = receiverPos.z - bcnMidPosD;
 
                 // calcuate the two hypothesis for our vertical position
-                ftype receverPosDownMax;
-                ftype receverPosDownMin;
+                ftype receiverPosDownMax;
+                ftype receiverPosDownMin;
                 if (delta >= 0.0f) {
-                    receverPosDownMax = receiverPos.z;
-                    receverPosDownMin = receiverPos.z - 2.0f * delta;
+                    receiverPosDownMax = receiverPos.z;
+                    receiverPosDownMin = receiverPos.z - 2.0f * delta;
                 } else {
-                    receverPosDownMax = receiverPos.z - 2.0f * delta;
-                    receverPosDownMin = receiverPos.z;
+                    receiverPosDownMax = receiverPos.z - 2.0f * delta;
+                    receiverPosDownMin = receiverPos.z;
                 }
 
-                bcnPosOffsetMax = stateStruct.position.z - receverPosDownMin;
-                bcnPosOffsetMin = stateStruct.position.z - receverPosDownMax;
+                bcnPosOffsetMax = stateStruct.position.z - receiverPosDownMin;
+                bcnPosOffsetMin = stateStruct.position.z - receiverPosDownMax;
             } else {
                 // We are using the beacons as the primary height reference, so don't modify their vertical position
                 bcnPosOffset = 0.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -360,19 +360,19 @@ void NavEKF3_core::FuseRngBcnStatic()
                 // calculate the delta to the estimated receiver position
                 ftype delta = receiverPos.z - bcnMidPosD;
 
-                // calcuate the two hypothesis for our vertical position
-                ftype receverPosDownMax;
-                ftype receverPosDownMin;
+                // calculate the two hypothesis for our vertical position
+                ftype receiverPosDownMax;
+                ftype receiverPosDownMin;
                 if (delta >= 0.0f) {
-                    receverPosDownMax = receiverPos.z;
-                    receverPosDownMin = receiverPos.z - 2.0f * delta;
+                    receiverPosDownMax = receiverPos.z;
+                    receiverPosDownMin = receiverPos.z - 2.0f * delta;
                 } else {
-                    receverPosDownMax = receiverPos.z - 2.0f * delta;
-                    receverPosDownMin = receiverPos.z;
+                    receiverPosDownMax = receiverPos.z - 2.0f * delta;
+                    receiverPosDownMin = receiverPos.z;
                 }
 
-                bcnPosDownOffsetMax = stateStruct.position.z - receverPosDownMin;
-                bcnPosDownOffsetMin = stateStruct.position.z - receverPosDownMax;
+                bcnPosDownOffsetMax = stateStruct.position.z - receiverPosDownMin;
+                bcnPosDownOffsetMin = stateStruct.position.z - receiverPosDownMax;
             } else {
                 // We are using the beacons as the primary height reference, so don't modify their vertical position
                 bcnPosOffsetNED.z = 0.0f;


### PR DESCRIPTION
variable :
`receverPosDownMax` -> `receiverPosDownMax`
`receverPosDownMin` -> `receiverPosDownMin`

comment : 
`calcuate` -> `calculate`
`calcualtion` -> `calculation`

Other files have similar symptoms, so will modify them together.

If it is intentionally abbreviated, please close it.