### PR TITLE
AP_InertialSensor: add and use AP_SIM_INS_ENABLED

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1011,13 +1011,16 @@ AP_InertialSensor::detect_backends(void)
     }
 #endif
 
-#if defined(HAL_INS_PROBE_LIST)
-    // IMUs defined by IMU lines in hwdef.dat
-    HAL_INS_PROBE_LIST;
-#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if AP_SIM_INS_ENABLED
     for (uint8_t i=0; i<AP::sitl()->imu_count; i++) {
         ADD_BACKEND(AP_InertialSensor_SITL::detect(*this, i==1?INS_SITL_SENSOR_B:INS_SITL_SENSOR_A));
     }
+    return;
+#endif
+
+#if defined(HAL_INS_PROBE_LIST)
+    // IMUs defined by IMU lines in hwdef.dat
+    HAL_INS_PROBE_LIST;
 #if defined(HAL_SITL_INVENSENSEV3)
     ADD_BACKEND(AP_InertialSensor_Invensensev3::probe(*this, hal.i2c_mgr->get_device(1, 1), ROTATION_NONE));
 #endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -47,6 +47,10 @@
 #include <Filter/HarmonicNotchFilter.h>
 #include <AP_Math/polyfit.h>
 
+#ifndef AP_SIM_INS_ENABLED
+#define AP_SIM_INS_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif
+
 class AP_InertialSensor_Backend;
 class AuxiliaryBus;
 class AP_AHRS;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -3,7 +3,7 @@
 #include <SITL/SITL.h>
 #include <stdio.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if AP_SIM_INS_ENABLED
 
 const extern AP_HAL::HAL& hal;
 
@@ -347,4 +347,4 @@ void AP_InertialSensor_SITL::start()
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
 }
 
-#endif // HAL_BOARD_SITL
+#endif // AP_SIM_INS_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include <SITL/SITL.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_InertialSensor.h"
+
+#if AP_SIM_INS_ENABLED
+
 #include "AP_InertialSensor_Backend.h"
 
 // simulated sensor rates in Hz. This matches a pixhawk1
 const uint16_t INS_SITL_SENSOR_A[] = { 1000, 1000 };
 const uint16_t INS_SITL_SENSOR_B[] = { 760, 800 };
+
+#include <SITL/SITL.h>
 
 class AP_InertialSensor_SITL : public AP_InertialSensor_Backend
 {
@@ -47,4 +49,4 @@ private:
 
     static uint8_t bus_id;
 };
-#endif // CONFIG_HAL_BOARD
+#endif // AP_SIM_INS_ENABLED


### PR DESCRIPTION
This PR accomplishes two things:
 - creates AP_SIM_INS_ENABLED
 - in the case that AP_SIM_INS_ENABLED is true and we are on real hardware (future PR), we do not instantiate any backends other than the SITL backends (through the use of an early-return) - EXCEPT for ExternalAHRS backends, to allow them to be instantiated while connected to a simulation (while providing conflicting data, it does allow for testing the protocols)
