### PR TITLE
SITL: add compilation option AP_SIM_CRSF_ENABLED

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -323,12 +323,14 @@ SITL::SerialDevice *SITL_State::create_serial_sim(const char *name, const char *
     //     }
     //     frsky_sport = new SITL::Frsky_SPortPassthrough();
     //     return frsky_sportpassthrough;
+#if AP_SIM_CRSF_ENABLED
     } else if (streq(name, "crsf")) {
         if (crsf != nullptr) {
             AP_HAL::panic("Only one crsf at a time");
         }
         crsf = new SITL::CRSF();
         return crsf;
+#endif
 #if HAL_SIM_PS_RPLIDARA2_ENABLED
     } else if (streq(name, "rplidara2")) {
         if (rplidara2 != nullptr) {
@@ -615,9 +617,11 @@ void SITL_State::_fdm_input_local(void)
     //     frsky_sportpassthrough->update();
     // }
 
+#if AP_SIM_CRSF_ENABLED
     if (crsf != nullptr) {
         crsf->update();
     }
+#endif
 
 #if HAL_SIM_PS_RPLIDARA2_ENABLED
     if (rplidara2 != nullptr) {

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -262,8 +262,10 @@ private:
     SITL::PS_TeraRangerTower *terarangertower;
 #endif
 
+#if AP_SIM_CRSF_ENABLED
     // simulated CRSF devices
     SITL::CRSF *crsf;
+#endif
 
     // simulated VectorNav system:
     SITL::VectorNav *vectornav;

--- a/libraries/SITL/SIM_CRSF.cpp
+++ b/libraries/SITL/SIM_CRSF.cpp
@@ -18,6 +18,8 @@
 
 #include "SIM_CRSF.h"
 
+#if AP_SIM_CRSF_ENABLED
+
 using namespace SITL;
 
 extern const AP_HAL::HAL& hal;
@@ -80,3 +82,5 @@ void CRSF::update()
         return;
     }
 }
+
+#endif  // AP_SIM_CRSF_ENABLED

--- a/libraries/SITL/SIM_CRSF.h
+++ b/libraries/SITL/SIM_CRSF.h
@@ -27,6 +27,14 @@ rc 3 1600
 
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_SIM_CRSF_ENABLED
+#define AP_SIM_CRSF_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif
+
+#if AP_SIM_CRSF_ENABLED
+
 #include "SIM_Aircraft.h"
 #include <SITL/SITL.h>
 #include "SIM_SerialDevice.h"
@@ -58,3 +66,5 @@ protected:
 };
 
 }
+
+#endif  // AP_SIM_CRSF_ENABLED


### PR DESCRIPTION
This allows for the feature to be compiled out.

Tested by enabling/disabling the option
