### PR TITLE
AP_Baro: create and use HAL_SIM_BARO_ENABLED

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -257,8 +257,8 @@ void AP_Baro::calibrate(bool save)
         BARO_SEND_TEXT(MAV_SEVERITY_INFO, "Baro: skipping calibration after WDG reset");
         return;
     }
-    
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#if AP_SIM_BARO_ENABLED
     if (AP::sitl()->baro_count == 0) {
         return;
     }
@@ -628,7 +628,7 @@ void AP_Baro::init(void)
     default:
         break;
     }
-#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#elif AP_SIM_BARO_ENABLED
     SITL::SIM *sitl = AP::sitl();
     if (sitl == nullptr) {
         AP_HAL::panic("No SITL pointer");
@@ -681,7 +681,7 @@ void AP_Baro::init(void)
 #endif
 
 #if !defined(HAL_BARO_ALLOW_INIT_NO_BARO) // most boards requires external baro
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if AP_SIM_BARO_ENABLED
     if (sitl->baro_count == 0) {
         return;
     }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -7,6 +7,10 @@
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 
+#ifndef AP_SIM_BARO_ENABLED
+#define AP_SIM_BARO_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif
+
 #ifndef HAL_MSP_BARO_ENABLED
 #define HAL_MSP_BARO_ENABLED HAL_MSP_SENSORS_ENABLED
 #endif

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -1,9 +1,9 @@
+#include "AP_Baro_SITL.h"
+
+#if AP_SIM_BARO_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-
-#include "AP_Baro_SITL.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -182,4 +182,4 @@ float AP_Baro_SITL::wind_pressure_correction(void)
     return error * 0.5 * SSL_AIR_DENSITY * AP::baro().get_air_density_ratio();
 }
 
-#endif  // CONFIG_HAL_BOARD
+#endif  // AP_SIM_BARO_ENABLED

--- a/libraries/AP_Baro/AP_Baro_SITL.h
+++ b/libraries/AP_Baro/AP_Baro_SITL.h
@@ -2,9 +2,11 @@
 
 #include "AP_Baro_Backend.h"
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#include <SITL/SITL.h>
+#if AP_SIM_BARO_ENABLED
+
 #include <AP_Math/vectorN.h>
+
+#include <SITL/SITL.h>
 
 class AP_Baro_SITL : public AP_Baro_Backend {
 public:
@@ -47,4 +49,4 @@ private:
     float _last_altitude;
 
 };
-#endif  // CONFIG_HAL_BOARD
+#endif  // AP_SIM_BARO_ENABLED


### PR DESCRIPTION
~~This PR also pulls the detection code for simulated sensors out of the `#if`/`#else if` block it was in, while preserving the detection of ExternalAHRS barometers.~~

That proved to be problematic due to the i2c-sensor-simulation and accompanying autotest.
