### PR TITLE
CRSFv3 power cycle

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -309,6 +309,13 @@ void AP_RCProtocol::check_added_uart(void)
             }
             added.opened = false;
         }
+    // power loss on CRSF requires re-bootstrap because the baudrate is reset to the default. The CRSF side will
+    // drop back down to 416k if it has received 200 incorrect characters (or none at all)
+    } else if (_detected_protocol != AP_RCProtocol::NONE
+        // protocols that want to be able to renegotiate should return false in is_rx_active()
+        && !backend[_detected_protocol]->is_rx_active()
+        && now - added.last_config_change_ms > 1000) {
+        added.opened = false;
     }
 }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -85,6 +85,11 @@ public:
     bool have_UART(void) const {
         return frontend.added.uart != nullptr;
     }
+
+    // is the receiver active, used to detect power loss and baudrate changes
+    virtual bool is_rx_active() const {
+        return true;
+    }
     
 protected:
     struct Channels11Bit_8Chan {


### PR DESCRIPTION
This allows the CRSFv3 connection to be renegotiated on power loss to the RX

This also fixes a problem with bootstrap spam from CRSF

Flight tested on 6.16 tracer with 3" quad