### PR TITLE
diff binaries as part of CI

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -70,6 +70,23 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/master_bin
           cp -r build/${{matrix.config}}/bin/* $GITHUB_WORKSPACE/master_bin/
 
+          # build a set of binaries without symbols so we can check if
+          #  the binaries have changed.
+          echo [`date`] Building master with no versions
+
+          NO_VERSIONS_DIR="$GITHUB_WORKSPACE/master_bin_no_versions"
+          mkdir "$NO_VERSIONS_DIR"
+
+          if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
+             [ "${{matrix.config}}" = "f103-GPS" ]; then
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf AP_Periph
+          else
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf
+          fi
+          cp -r build/${{matrix.config}}/bin/* "$NO_VERSIONS_DIR"
+
+          echo [`date`] Built master with no versions
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -98,6 +115,23 @@ jobs:
           mkdir $GITHUB_WORKSPACE/pr_bin
           cp -r build/${{matrix.config}}/bin/* $GITHUB_WORKSPACE/pr_bin/
 
+          # build a set of binaries without symbols so we can check if
+          #  the binaries have changed.
+          echo [`date`] Building PR with no versions
+
+          NO_VERSIONS_DIR="$GITHUB_WORKSPACE/pr_bin_no_versions"
+          mkdir "$NO_VERSIONS_DIR"
+
+          if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
+             [ "${{matrix.config}}" = "f103-GPS" ]; then
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf AP_Periph
+          else
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf
+          fi
+          cp -r build/${{matrix.config}}/bin/* "$NO_VERSIONS_DIR"
+
+          echo [`date`] Built PR with no versions
+
           # build MatekF405 Plane without quadplane
           if [ "${{matrix.config}}" = "MatekF405" ]; then
             PLANE_BINARY="build/MatekF405/bin/arduplane.bin"
@@ -118,6 +152,11 @@ jobs:
           cd pr/
           python3 -m pip install -U tabulate
           Tools/scripts/pretty_diff_size.py -m $GITHUB_WORKSPACE/master_bin -s $GITHUB_WORKSPACE/pr_bin
+
+      - name: Checksum compare with Master
+        shell: bash
+        run: |
+          diff -r $GITHUB_WORKSPACE/master_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.elf --exclude=*.apj || true
 
       - name: elf_diff compare with Master
         shell: bash

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -205,7 +205,7 @@ class set_app_descriptor(Task.Task):
         desc_len = 16
         crc1 = to_unsigned(crc32(bytearray(img[:offset])))
         crc2 = to_unsigned(crc32(bytearray(img[offset+desc_len:])))
-        githash = to_unsigned(int('0x' + self.generator.bld.git_head_hash(short=True),16))
+        githash = to_unsigned(int('0x' + os.environ.get('GIT_VERSION', self.generator.bld.git_head_hash(short=True)),16))
         desc = struct.pack('<IIII', crc1, crc2, len(img), githash)
         img = img[:offset] + desc + img[offset+desc_len:]
         Logs.info("Applying %s APP_DESCRIPTOR %08x%08x" % (self.env.APP_DESCRIPTOR, crc1, crc2))

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -13,8 +13,8 @@ cxx_compiler=${CXX:-g++}
 
 export BUILDROOT=/tmp/ci.build
 rm -rf $BUILDROOT
-export GIT_VERSION="ci_test"
-export CHIBIOS_GIT_VERSION="ci_test"
+export GIT_VERSION="abcdef"
+export CHIBIOS_GIT_VERSION="12345667"
 export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
 autotest_args=""
 


### PR DESCRIPTION
This will allow us to be assured that there's no changes from a PR, at least for things we test in CI; if the binaries are identical the functionality is identical.

I've tested the changes to the waf build by creating another commit on top of this PR and ensured that the output files have the same checksum before/after (they don't on master).

The binaries on this PR won't match master (i.e. the diff will show differences) as master doesn't have the patches to use a known git hash.
