### PR TITLE
Rover/Scripting: Add lua script bindings to allow using guided "set turn rate and speed" command 

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -204,6 +204,19 @@ bool Rover::set_steering_and_throttle(float steering, float throttle)
     return true;
 }
 
+// set desired turn rate (degrees/sec) and speed (m/s). Used for scripting
+bool Rover::set_desired_turn_rate_and_speed(float turn_rate, float speed)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!control_mode->in_guided_mode()) {
+        return false;
+    }
+
+    // set turn rate and speed. Turn rate is expected in centidegrees/s and speed in meters/s
+    mode_guided.set_desired_turn_rate_and_speed(turn_rate * 100.0f, speed);
+    return true;
+}
+
 // get control output (for use in scripting)
 // returns true on success and control_value is set to a value in the range -1 to +1
 bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value)

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -271,6 +271,8 @@ private:
     bool set_target_location(const Location& target_loc) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_steering_and_throttle(float steering, float throttle) override;
+    // set desired turn rate (degrees/sec) and speed (m/s). Used for scripting
+    bool set_desired_turn_rate_and_speed(float turn_rate, float speed) override;
     bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) override;
 #endif // AP_SCRIPTING_ENABLED
     void stats_update();

--- a/libraries/AP_Scripting/examples/rover-set-turn-rate.lua
+++ b/libraries/AP_Scripting/examples/rover-set-turn-rate.lua
@@ -1,0 +1,58 @@
+-- This scirpt uses Rover's turn rate controller to make the vehicle move in circles of fixed radius
+
+-- Edit these variables
+local rad_xy_m = 0.5                -- circle radius in xy plane in m
+local target_speed_xy_mps = 0.5     -- target speed in m/s
+local rc_channel_switch = 7         -- switch this channel to "high" to get the script working
+local cw_turn = true                -- change this to false for ccw circle instead of default cw
+
+
+
+-- Fixed variables
+local omega_radps = target_speed_xy_mps/rad_xy_m
+local rover_guided_mode_num = 15
+local direction = 1
+if not cw_turn then
+    direction = -1
+end
+
+
+-- Script Start --
+
+gcs:send_text(0,"Script started")
+gcs:send_text(0,"Trajectory period: " .. tostring(2 * math.rad(180) / omega_radps))
+
+local circle_active = false
+local last_mode = 0
+
+
+function update()
+
+    if not circle_active then
+        last_mode = vehicle:get_mode()
+    end
+
+    if arming:is_armed() and rc:get_pwm(rc_channel_switch) > 1700 and not circle_active then
+        -- set guided mode since rc switch is now high
+        vehicle:set_mode(rover_guided_mode_num)
+        circle_active = true
+    elseif arming:is_armed() and rc:get_pwm(rc_channel_switch) < 1200 and circle_active then
+        -- set back to last mode since rc switch is low
+        vehicle:set_mode(last_mode)
+        circle_active = false
+    end
+
+    if circle_active then
+        --target turn rate in degrees including direction
+        local target_turn_rate = math.deg(omega_radps * direction)
+
+        -- send guided message
+        if not vehicle:set_desired_turn_rate_and_speed(target_turn_rate, target_speed_xy_mps) then
+            gcs:send_text(0, "Failed to send target ")
+        end
+    end
+
+    return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -227,6 +227,7 @@ singleton AP_Vehicle method get_pan_tilt_norm boolean float'Null float'Null
 singleton AP_Vehicle method nav_script_time boolean uint16_t'Null uint8_t'Null float'Null float'Null
 singleton AP_Vehicle method nav_script_time_done void uint16_t'skip_check
 singleton AP_Vehicle method set_target_throttle_rate_rpy boolean float -100 100 float'skip_check float'skip_check float'skip_check
+singleton AP_Vehicle method set_desired_turn_rate_and_speed boolean float'skip_check float'skip_check
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED alias serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -215,6 +215,9 @@ public:
     // set steering and throttle (-1 to +1) (for use by scripting with Rover)
     virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
 
+    // set turn rate in deg/sec and speed in meters/sec (for use by scripting with Rover)
+    virtual bool set_desired_turn_rate_and_speed(float turn_rate, float speed) { return false; }
+
     // support for NAV_SCRIPT_TIME mission command
     virtual bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) { return false; }
     virtual void nav_script_time_done(uint16_t id) {}


### PR DESCRIPTION
I have also added an example script that uses the guided turn rate and speed to command the vehicle to move in circles of a fixed radius.

![rover_circ](https://user-images.githubusercontent.com/36970042/149656010-d7438662-3ac5-475f-b90c-1343096f09d2.png)

Tested on real vehicles and SITL