### PR TITLE
AP_HAL:RPI read cpu by revision

### DIFF
--- a/libraries/AP_HAL_Linux/Util_RPI.h
+++ b/libraries/AP_HAL_Linux/Util_RPI.h
@@ -17,7 +17,7 @@ public:
 
 protected:
     // Called in the constructor once
-    int _check_rpi_version();
+    int _check_rpi_version_by_rev();
 
 private:
     int _rpi_version = 0;


### PR DESCRIPTION
This is based on @lucasdemarchi  feedback on [PR 19786]( https://github.com/ArduPilot/ardupilot/pull/19786)

Solid review value exists in /proc/cpuinfo

The pr make use of 
UtilRPI::UtilRPI::_check_rpi_version_by_rev() and if no valid review found it calls the current method _check_rpi_version()

I tested it on RPI-Z W , RPI-Z 2W, RPI-4 & CM4.

