### PR TITLE
Allow compilation with EKF2/EKF3 compiled out (cast-to-void version)

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -54,6 +54,10 @@ def get_defines(feature, options):
 
 def test_feature(feature, options):
     defines = get_defines(feature, options)
+    test_compile_with_defines(defines)
+
+
+def test_compile_with_defines(defines):
     extra_hwdef_filepath = "/tmp/extra.hwdef"
     write_defines_to_file(defines, extra_hwdef_filepath)
     util.waf_configure(
@@ -64,12 +68,12 @@ def test_feature(feature, options):
         try:
             util.waf_build(t)
         except Exception:
-            print("Failed to build (%s) with (%s) disabled" %
-                  (t, feature.label))
+            print("Failed to build (%s) with everything disabled" %
+                  (t,))
             raise
 
 
-def run():
+def run_disable_in_turn():
     options = get_build_options_from_ardupilot_tree()
     count = 1
     for feature in options:
@@ -77,6 +81,19 @@ def run():
               (feature.label, feature.define, count, len(options)))
         test_feature(feature, options)
         count += 1
+
+
+def run_disable_all():
+    options = get_build_options_from_ardupilot_tree()
+    defines = {}
+    for feature in options:
+        defines[feature.define] = 0
+    test_compile_with_defines(defines)
+
+
+def run():
+    run_disable_all()
+    run_disable_in_turn()
 
 
 if __name__ == '__main__':

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2027,6 +2027,11 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         ret = false;
     }
 
+#if !HAL_NAVEKF2_AVAILABLE && !#if HAL_NAVEKF3_AVAILABLE
+    // allow compilation without EKF2/EKF3 compiled in
+    (void)ret;
+#endif
+
     switch (ekf_type()) {
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2027,7 +2027,7 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         ret = false;
     }
 
-#if !HAL_NAVEKF2_AVAILABLE && !#if HAL_NAVEKF3_AVAILABLE
+#if !HAL_NAVEKF2_AVAILABLE && !HAL_NAVEKF3_AVAILABLE
     // allow compilation without EKF2/EKF3 compiled in
     (void)ret;
 #endif


### PR DESCRIPTION
Suggested in today's DevCall as an alternative to https://github.com/ArduPilot/ardupilot/pull/19787 - I think we should merge the other one, 'though
