### PR TITLE
Copter: add ARMING_OPTION to hide prearm messages

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -11,7 +11,8 @@ void AP_Arming_Copter::update(void)
     static uint8_t pre_arm_display_counter = PREARM_DISPLAY_PERIOD/2;
     pre_arm_display_counter++;
     bool display_fail = false;
-    if (pre_arm_display_counter >= PREARM_DISPLAY_PERIOD) {
+    if ((_arming_options & uint32_t(AP_Arming::ArmingOptions::DISABLE_PREARM_DISPLAY)) == 0 &&
+        pre_arm_display_counter >= PREARM_DISPLAY_PERIOD) {
         display_fail = true;
         pre_arm_display_counter = 0;
     }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -128,6 +128,13 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
+    // @Param: OPTIONS
+    // @DisplayName: Arming options
+    // @Description: Options that can be applied to change arming behaviour
+    // @Values: 0:None,1:Disable prearm display
+    // @User: Advanced
+    AP_GROUPINFO_FRAME("OPTIONS", 9,   AP_Arming, _arming_options, 0, AP_PARAM_FRAME_COPTER),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1523,8 +1523,7 @@ bool AP_Arming::disarm_switch_checks(bool display_failure) const
 {
     const RC_Channel *chan = rc().find_channel_for_option(RC_Channel::AUX_FUNC::DISARM);
     if (chan != nullptr &&
-        chan->get_aux_switch_pos() == RC_Channel::AuxSwitchPos::HIGH &&
-        (checks_to_perform & ARMING_CHECK_ALL)) {
+        chan->get_aux_switch_pos() == RC_Channel::AuxSwitchPos::HIGH) {
         check_failed(display_failure, "Disarm Switch on");
         return false;
     }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -122,7 +122,12 @@ public:
 
     // method that was last used for disarm; invalid unless the
     // vehicle has been disarmed at least once.
-    Method last_disarm_method() const { return _last_disarm_method; } 
+    Method last_disarm_method() const { return _last_disarm_method; }
+
+    // enum for ARMING_OPTIONS parameter
+    enum class ArmingOptions : int32_t {
+        DISABLE_PREARM_DISPLAY   = (1U << 0),
+    };
 
 protected:
 
@@ -131,7 +136,8 @@ protected:
     AP_Int32                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
-    AP_Int32                 _required_mission_items;
+    AP_Int32                _required_mission_items;
+    AP_Int32                _arming_options;
 
     // internal members
     bool                    armed;


### PR DESCRIPTION
There are two changes.
~~1. move disarm_switch_checks from pre_arm_checks to arm_checks
it's affected for all vehicle types~~
1. add ARMING_OPTION to hide prearm messages
pre arm checks display the message every 30 seconds but that was unnecessary.
![image](https://user-images.githubusercontent.com/16643069/150068718-c2f14630-398f-402f-bf14-eb37774bede6.png)

2. check disarm switch even arming checks are disabled
it's affected for only copter
In current master, the user can arm when arming checks are disabled and disarm switch is High.
but, Estop does not allow users to arm even if arming check is disabled.
I felt that it should be the same as EStop, or it makes users confusing.

3. turn the LED yellow when the vehicle can't be armed

note: disarm switch is like EStop+Disarm immediately #14244

I tested the followings in SITL:
```
param set RC9_OPTION 81
param set ARMING_CHECK 1
rc 9 2000      // LED is yellow
arm throttle // cannot arm
rc 9 1000      // LED is green
arm throttle // arming
rc 9 2000 // disarm by Disarm Switch

param set ARMING_CHECK 0    // LED is yellow (in master, it was green)
arm throttle // cannot arm in this branch (in master, the vehicle can arm)
rc 9 1000      // LED is green
arm throttle // arming
rc 9 2000 // disarm by Disarm Switch
```