### PR TITLE
AP_AccelCal: remove unused calc_mean_squared_residuals

### DIFF
--- a/libraries/AP_AccelCal/AccelCalibrator.cpp
+++ b/libraries/AP_AccelCal/AccelCalibrator.cpp
@@ -392,13 +392,6 @@ float AccelCalibrator::calc_residual(const Vector3f& sample, const struct param_
 }
 
 // calculated the total mean squared fitness of all the collected samples using parameters
-// converged to LSq estimator so far
-float AccelCalibrator::calc_mean_squared_residuals() const
-{
-    return calc_mean_squared_residuals(_param.s);
-}
-
-// calculated the total mean squared fitness of all the collected samples using parameters
 // supplied
 float AccelCalibrator::calc_mean_squared_residuals(const struct param_t& params) const
 {

--- a/libraries/AP_AccelCal/AccelCalibrator.h
+++ b/libraries/AP_AccelCal/AccelCalibrator.h
@@ -137,7 +137,6 @@ private:
 
     // Function related to Gauss Newton Least square regression process
     float calc_residual(const Vector3f& sample, const struct param_t& params) const;
-    float calc_mean_squared_residuals() const;
     float calc_mean_squared_residuals(const struct param_t& params) const;
     void calc_jacob(const Vector3f& sample, const struct param_t& params, VectorP& ret) const;
     void run_fit(uint8_t max_iterations, float& fitness);


### PR DESCRIPTION
This removes an apparently unused method of the AP_AccelCal class.

I've done a full search and this method (which does not take an argument) doesn't seem to be used anywhere.

