### PR TITLE
AP_AHRS: Change the judgment order

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2036,11 +2036,11 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         return ret;
 #endif
     case EKFType::NONE:
-        return dcm.pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret;
+        return ret && dcm.pre_arm_check(requires_position, failure_msg, failure_msg_len);
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL:
-        return AP::externalAHRS().pre_arm_check(failure_msg, failure_msg_len) && ret;
+        return ret && AP::externalAHRS().pre_arm_check(failure_msg, failure_msg_len);
 #endif
         
 #if HAL_NAVEKF2_AVAILABLE


### PR DESCRIPTION
Change the decision order.
If the value of RET is FALSE, there is no need to run pre_arm_check.