### PR TITLE
AC_PosControl: constrain init vel Z to limits

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -740,7 +740,7 @@ void AC_PosControl::init_z_controller()
 {
     _pos_target.z = _inav.get_position_z_up_cm();
 
-    const float &curr_vel_z = _inav.get_velocity_z_up_cms();
+    const float curr_vel_z = constrain_float(_inav.get_velocity_z_up_cms(), _vel_max_down_cms, _vel_max_up_cms);
     _vel_desired.z = curr_vel_z;
     // with zero position error _vel_target = _vel_desired
     _vel_target.z = curr_vel_z;


### PR DESCRIPTION
When trying to recover a diving plane into a Q mode initialising with -40m/s means that it takes rather too long to stop. In this case nearly 20 nearly seconds due to the low Z accel limit we typically see on Q planes. 

![image](https://user-images.githubusercontent.com/33176108/150231323-ad9990f6-ae90-488d-80e7-03a058f87794.png)
