### PR TITLE
HAL_SITL: fixed mapping of --serial ports in SITL

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -451,9 +451,11 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         case CMDLINE_SERIAL6:
         case CMDLINE_SERIAL7:
         case CMDLINE_SERIAL8:
-        case CMDLINE_SERIAL9:
-            _uart_path[opt - CMDLINE_SERIAL0] = gopt.optarg;
+        case CMDLINE_SERIAL9: {
+            static const uint8_t mapping[] = { 0, 2, 3, 1, 4, 5, 6, 7, 8, 9 };
+            _uart_path[mapping[opt - CMDLINE_SERIAL0]] = gopt.optarg;
             break;
+        }
         case CMDLINE_RTSCTS:
             _use_rtscts = true;
             break;


### PR DESCRIPTION
uart paths are still in uartABCD order