### PR TITLE
RC_Channel: add RC_OPTIONS bit to clear RC override by RC input change

### DIFF
--- a/ArduSub/RC_Channel_Sub.cpp
+++ b/ArduSub/RC_Channel_Sub.cpp
@@ -52,6 +52,20 @@ bool RC_Channels_Sub::has_valid_input() const
     return RC_Channels::has_valid_input();
 }
 
+bool RC_Channels_Sub::has_pilot_input_for_override_clear()
+{
+    if (channel_outside_trim_dz(get_forward_channel()) ||
+        channel_outside_trim_dz(get_lateral_channel()) ||
+        channel_outside_trim_dz(get_yaw_channel())) {
+        return true;
+    }
+    // Sub throttle (=vertical) is biased away from trim by the GCS, so use movement-since-override-start
+    if (throttle_moved_since_override_start()) {
+        return true;
+    }
+    return false;
+}
+
 
 // do_aux_function - implement the function invoked by auxiliary switches
 bool RC_Channel_Sub::do_aux_function(const AuxFuncTrigger &trigger)

--- a/ArduSub/RC_Channel_Sub.h
+++ b/ArduSub/RC_Channel_Sub.h
@@ -26,6 +26,9 @@ public:
     bool in_rc_failsafe() const override;
     // returns true if throttle arming checks should be run
     bool arming_check_throttle() const override;
+
+    bool has_pilot_input_for_override_clear() override;
+
     RC_Channel_Sub obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Sub *channel(const uint8_t chan) override {
         if (chan >= ARRAY_SIZE(obj_channels)) {

--- a/Rover/RC_Channel_Rover.cpp
+++ b/Rover/RC_Channel_Rover.cpp
@@ -81,6 +81,21 @@ RC_Channel * RC_Channels_Rover::get_arming_channel(void) const
     return rover.channel_steer;
 }
 
+bool RC_Channels_Rover::has_pilot_input_for_override_clear()
+{
+    if (channel_outside_trim_dz(get_roll_channel())) {  // steering
+        return true;
+    }
+    // throttle may be non-centered (e.g. forward-only), so use movement-since-override-start
+    if (throttle_moved_since_override_start()) {
+        return true;
+    }
+    if (rover.g2.motors.is_omni() && channel_outside_trim_dz(get_lateral_channel())) {
+        return true;
+    }
+    return false;
+}
+
 void RC_Channel_Rover::do_aux_function_change_mode(Mode &mode,
         const AuxSwitchPos ch_flag)
 {

--- a/Rover/RC_Channel_Rover.h
+++ b/Rover/RC_Channel_Rover.h
@@ -37,6 +37,8 @@ public:
 
     RC_Channel *get_arming_channel(void) const override;
 
+    bool has_pilot_input_for_override_clear() override;
+
     RC_Channel_Rover obj_channels[NUM_RC_CHANNELS];
 
     RC_Channel_Rover *channel(const uint8_t chan) override {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -16663,6 +16663,66 @@ RTL_ALT_M 111
         self.do_set_mode_via_command_int('RTL')
         self.wait_disarmed()
 
+    def RCOverridesClearByPilotInput(self):
+        '''Test RC_OPTIONS bit 14 on Copter: roll/pitch/yaw/throttle each clear overrides'''
+        self.set_parameters({
+            "MAV_GCS_SYSID": self.mav.source_system,
+            "RC12_OPTION": 46,  # RC_OVERRIDE_ENABLE aux switch
+        })
+        self.reboot_sitl()
+
+        self.set_rc(12, 2000)
+        self.delay_sim_time(0.2)
+
+        bit_clear_by_rc = 1 << 14
+
+        self.start_subtest("RC_OPTIONS bit off: pilot input does not clear overrides")
+        rc_options = int(self.get_parameter("RC_OPTIONS"))
+        self.set_parameter("RC_OPTIONS", rc_options & ~bit_clear_by_rc)
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=1, trigger_pwm=1700,
+            override_ch=3, override_pwm=1300,
+            expect_clear=False,
+        )
+
+        rc_options = int(self.get_parameter("RC_OPTIONS"))
+        self.set_parameter("RC_OPTIONS", rc_options | bit_clear_by_rc)
+
+        self.start_subtest("Override held while every stick stays at trim")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=None, trigger_pwm=None,
+            override_ch=3, override_pwm=1300,
+            expect_clear=False,
+        )
+
+        self.start_subtest("Roll input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=1, trigger_pwm=1700,
+            override_ch=3, override_pwm=1300,
+            expect_clear=True,
+        )
+
+        self.start_subtest("Pitch input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=2, trigger_pwm=1700,
+            override_ch=1, override_pwm=1700,
+            expect_clear=True,
+        )
+
+        self.start_subtest("Throttle input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=3, trigger_pwm=1700,
+            override_ch=1, override_pwm=1700,
+            expect_clear=True,
+        )
+
+        self.start_subtest("Yaw input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=4, trigger_pwm=1700,
+            override_ch=1, override_pwm=1700,
+            expect_clear=True,
+        )
+
     def MISSION_OPTION_CLEAR_MISSION_AT_BOOT(self):
         '''check functionality of mission-clear-at-boot option'''
         self.upload_simple_relhome_mission([
@@ -17391,6 +17451,7 @@ return update, 1000
             self.EK3_RNG_USE_HGT,
             self.NoRC,
             self.RCOverridesNoRCReceiver,
+            self.RCOverridesClearByPilotInput,
             self.TerrainDBPreArm,
             self.ThrottleGainBoost,
             self.ScriptMountPOI,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1185,6 +1185,66 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.disarm_vehicle()
 
+    def RCOverridesClearByPilotInput(self):
+        '''Test RC_OPTIONS bit 14 on Rover: steering/throttle clear, pitch/yaw do not'''
+        self.set_parameters({
+            "MAV_GCS_SYSID": self.mav.source_system,
+            "RC12_OPTION": 46,  # RC_OVERRIDE_ENABLE aux switch
+        })
+        self.reboot_sitl()
+
+        self.set_rc(12, 2000)
+        self.delay_sim_time(0.2)
+
+        bit_clear_by_rc = 1 << 14
+
+        self.start_subtest("RC_OPTIONS bit off: pilot input does not clear overrides")
+        rc_options = int(self.get_parameter("RC_OPTIONS"))
+        self.set_parameter("RC_OPTIONS", rc_options & ~bit_clear_by_rc)
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=1, trigger_pwm=1700,
+            override_ch=3, override_pwm=1700,
+            expect_clear=False,
+        )
+
+        rc_options = int(self.get_parameter("RC_OPTIONS"))
+        self.set_parameter("RC_OPTIONS", rc_options | bit_clear_by_rc)
+
+        self.start_subtest("Override held while every stick stays at trim")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=None, trigger_pwm=None,
+            override_ch=1, override_pwm=1700,
+            expect_clear=False,
+        )
+
+        self.start_subtest("Steering input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=1, trigger_pwm=1700,
+            override_ch=3, override_pwm=1700,
+            expect_clear=True,
+        )
+
+        self.start_subtest("Throttle input clears overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=3, trigger_pwm=1700,
+            override_ch=1, override_pwm=1700,
+            expect_clear=True,
+        )
+
+        self.start_subtest("Pitch input does not clear overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=2, trigger_pwm=1700,
+            override_ch=3, override_pwm=1700,
+            expect_clear=False,
+        )
+
+        self.start_subtest("Yaw input does not clear overrides")
+        self._check_rc_overrides_cleared_by_pilot_input(
+            trigger_ch=4, trigger_pwm=1700,
+            override_ch=3, override_pwm=1700,
+            expect_clear=False,
+        )
+
     def MANUAL_CONTROL(self):
         '''Test mavlink MANUAL_CONTROL'''
         self.set_parameters({
@@ -7337,6 +7397,7 @@ return update()
             self.RCOverrides,
             self.RCOverridesCancel,
             Test(self.RCOverrideEnableChannel, speedup=10),
+            self.RCOverridesClearByPilotInput,
             self.MANUAL_CONTROL,
             self.Sprayer,
             self.AC_Avoidance,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8404,6 +8404,79 @@ class TestSuite(abc.ABC):
             raise NotAchievedException("Expected %s to be %u got %u" %
                                        (channel, value, m_value))
 
+    def _rc_overrides_send_single(self, chan, pwm):
+        '''Send RC_CHANNELS_OVERRIDE targeting a single channel; others are UINT16_MAX (ignore)'''
+        channels = [65535] * 18
+        channels[chan-1] = pwm
+        self.mav.mav.rc_channels_override_send(
+            self.mav.target_system,
+            1,
+            *channels,
+        )
+
+    def _rc_overrides_release_single(self, chan):
+        '''Release RC override on a single channel by sending 0; others are UINT16_MAX (ignore)'''
+        channels = [65535] * 18
+        channels[chan-1] = 0
+        self.mav.mav.rc_channels_override_send(
+            self.mav.target_system,
+            1,
+            *channels,
+        )
+
+    def _check_rc_overrides_cleared_by_pilot_input(self,
+                                                   trigger_ch,
+                                                   trigger_pwm,
+                                                   override_ch,
+                                                   override_pwm,
+                                                   expect_clear):
+        '''Verify whether moving trigger_ch clears an active override on override_ch (RC_OPTIONS bit 14).
+
+        Pass trigger_ch=None to skip the pilot-input step. Caller must have set
+        RC12_OPTION=46 and rebooted; this helper toggles ch12 to recover from a
+        previous clear-by-pilot.'''
+        if trigger_ch is not None and trigger_ch == override_ch:
+            raise ValueError("trigger_ch must differ from override_ch")
+
+        self.context_push()
+        self.context_collect("STATUSTEXT")
+        try:
+            # disable auto-expiry so the test does not race the 3s timeout
+            self.set_parameter("RC_OVERRIDE_TIME", -1)
+
+            # toggle ch12 to recover override-enable after a prior clear-by-pilot
+            self.set_rc(12, 1000)
+            self.delay_sim_time(0.2)
+            self.set_rc(12, 2000)
+            self.delay_sim_time(0.5)
+
+            self.set_rc_from_map({1: 1500, 2: 1500, 3: 1500, 4: 1500})
+            self.delay_sim_time(0.5)
+
+            self._rc_overrides_send_single(override_ch, override_pwm)
+            self.wait_rc_channel_value(override_ch, override_pwm, timeout=5)
+
+            if trigger_ch is not None:
+                self.set_rc(trigger_ch, trigger_pwm)
+
+            if expect_clear:
+                self.wait_statustext(
+                    "RC overrides cleared by pilot input",
+                    timeout=5,
+                    check_context=True,
+                )
+                self.wait_rc_channel_value(override_ch, 1500, timeout=3)
+            else:
+                # re-send override since it may have just expired
+                self.delay_sim_time(1.0)
+                self._rc_overrides_send_single(override_ch, override_pwm)
+                self.wait_rc_channel_value(override_ch, override_pwm, timeout=2)
+        finally:
+            self._rc_overrides_release_single(override_ch)
+            self.set_rc_from_map({1: 1500, 2: 1500, 3: 1500, 4: 1500})
+            self.delay_sim_time(0.2)
+            self.context_pop()
+
     def send_do_reposition(self,
                            loc,
                            frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT):

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -303,10 +303,11 @@ bool RC_Channel::get_reverse(void) const
 // read input from hal.rcin or overrides
 bool RC_Channel::update(void)
 {
+    raw_radio_in = hal.rcin->read(ch_in);
     if (has_override() && !rc().option_is_enabled(RC_Channels::Option::IGNORE_OVERRIDES)) {
         radio_in = override_value;
     } else if (rc().has_had_rc_receiver() && !rc().option_is_enabled(RC_Channels::Option::IGNORE_RECEIVER)) {
-        radio_in = hal.rcin->read(ch_in);
+        radio_in = raw_radio_in;
     } else {
         return false;
     }
@@ -509,6 +510,13 @@ bool RC_Channel::in_trim_dz() const
     return is_bounded_int32(radio_in, radio_trim - dead_zone, radio_trim + dead_zone);
 }
 
+/*
+  return true if raw input is within deadzone of trim
+*/
+bool RC_Channel::in_raw_trim_dz() const
+{
+    return is_bounded_int32(raw_radio_in, radio_trim - dead_zone, radio_trim + dead_zone);
+}
 
 /*
    return trues if input is within deadzone of min
@@ -531,6 +539,11 @@ void RC_Channel::set_override(const uint16_t v, const uint32_t timestamp_ms)
         return;
     }
 
+    // store throttle pwm at the start of an override session
+    if (!rc().has_active_overrides()) {
+        rc().set_override_start_throttle(rc().get_throttle_channel().get_raw_radio_in());
+    }
+
     last_override_time = timestamp_ms != 0 ? timestamp_ms : AP_HAL::millis();
     override_value = v;
     rc().new_override_received();
@@ -540,6 +553,10 @@ void RC_Channel::clear_override()
 {
     last_override_time = 0;
     override_value = 0;
+    // only forget the throttle override-start pwm once no overrides remain
+    if (!rc().has_active_overrides()) {
+        rc().set_override_start_throttle(-1);
+    }
 }
 
 bool RC_Channel::has_override() const

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -525,8 +525,10 @@ protected:
 
 private:
 
-    // pwm is stored here
+    // pwm is stored here; if an override is active, override_value is stored instead
     int16_t     radio_in;
+    // stores the raw pwm value read from hal.rcin
+    int16_t     raw_radio_in;
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;
@@ -544,6 +546,10 @@ private:
     // overrides
     uint16_t override_value;
     uint32_t last_override_time;
+
+    // return true if raw input is within deadzone of trim
+    bool in_raw_trim_dz() const;
+    int16_t get_raw_radio_in() const { return raw_radio_in; }
 
     float pwm_to_angle() const;
     float pwm_to_angle_dz(uint16_t dead_zone) const;
@@ -667,6 +673,7 @@ public:
         USE_CRSF_LQ_AS_RSSI     = (1U << 11), // returns CRSF link quality as RSSI value, instead of RSSI
         CRSF_FM_DISARM_STAR     = (1U << 12), // when disarmed, add a star at the end of the flight mode in CRSF telemetry
         ELRS_420KBAUD           = (1U << 13), // use 420kbaud for ELRS protocol
+        CLEAR_OVERRIDES_BY_RC   = (1U << 14), // clear MAVLink overrides when the pilot moves the RC sticks (per-vehicle definition)
     };
 
     bool option_is_enabled(Option option) const {
@@ -760,12 +767,21 @@ public:
 
     bool seen_neutral_rudder() const { return have_seen_neutral_rudder; }
 
+    // returns true when pilot input should clear an active MAVLink override; vehicles override to define which axes count
+    virtual bool has_pilot_input_for_override_clear();
+
 protected:
 
     void new_override_received() {
         has_new_overrides = true;
         _has_had_override = true;
     }
+
+    // returns true if the channel's raw pwm is outside its trim deadzone
+    static bool channel_outside_trim_dz(const RC_Channel &ch);
+
+    // returns true if throttle moved beyond deadzone since override start
+    bool throttle_moved_since_override_start() const;
 
 private:
     static RC_Channels *_singleton;
@@ -776,6 +792,7 @@ private:
     bool has_new_overrides;
     bool _has_had_rc_receiver; // true if we have had a direct detach RC receiver, does not include overrides
     bool _has_had_override; // true if we have had an override on any channel
+    int16_t override_start_throttle; // throttle value at the moment an override was activated
 
     AP_Float _override_timeout;
     AP_Int32  _options;
@@ -814,6 +831,9 @@ private:
     // check for arm/disarm command based on rudder stick position:
     void rudder_arm_disarm_check();
 
+    // returns true if pilot stick input has exited any deadzone (or throttle moved)
+    bool should_ignore_overrides(void);
+    void set_override_start_throttle(int16_t pwm) { override_start_throttle = pwm; }
 };
 
 RC_Channels &rc();

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -31,6 +31,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Math/AP_Math.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_RCMapper/AP_RCMapper.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include "RC_Channel.h"
 
@@ -39,7 +40,8 @@ extern const AP_HAL::HAL& hal;
 /*
   channels group object constructor
  */
-RC_Channels::RC_Channels(void)
+RC_Channels::RC_Channels(void) :
+    override_start_throttle(-1)
 {
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);
@@ -106,9 +108,53 @@ bool RC_Channels::read_input(void)
 
     if (success) {
         rudder_arm_disarm_check();
+
+        // check if RC overrides should be ignored based on RC_OPTIONS and any pilot input change during active overrides
+        if (should_ignore_overrides()) {
+            set_gcs_overrides_enabled(false);
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "RC overrides cleared by pilot input");
+        }
     }
 
     return success;
+}
+
+bool RC_Channels::should_ignore_overrides(void)
+{
+    if (!rc().option_is_enabled(Option::CLEAR_OVERRIDES_BY_RC) || !has_active_overrides()) {
+        return false;
+    }
+    return has_pilot_input_for_override_clear();
+}
+
+bool RC_Channels::channel_outside_trim_dz(const RC_Channel &ch)
+{
+    return !ch.in_raw_trim_dz();
+}
+
+bool RC_Channels::throttle_moved_since_override_start() const
+{
+    if (override_start_throttle < 0) {
+        return false;
+    }
+
+    const RC_Channel &thr = get_throttle_channel();
+    return abs(thr.get_raw_radio_in() - override_start_throttle) > thr.get_dead_zone();
+}
+
+bool RC_Channels::has_pilot_input_for_override_clear()
+{
+    if (channel_outside_trim_dz(get_roll_channel()) ||
+        channel_outside_trim_dz(get_pitch_channel()) ||
+        channel_outside_trim_dz(get_yaw_channel())) {
+        return true;
+    }
+
+    if (throttle_moved_since_override_start()) {
+        return true;
+    }
+
+    return false;
 }
 
 uint8_t RC_Channels::get_valid_channel_count(void)

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -93,7 +93,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:Use Link Quality for RSSI with CRSF, 12:Annotate CRSF flight mode with * on disarm, 13: Use 420kbaud for ELRS protocol
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:Use Link Quality for RSSI with CRSF, 12:Annotate CRSF flight mode with * on disarm, 13: Use 420kbaud for ELRS protocol, 14: Clear MAVLink overrides on any stick input
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // _PROTOCOLS copied to AP_Periph/Parameters.cpp


### PR DESCRIPTION
This PR introduces a new option to clear the RC override, allowing the pilot to regain control by operating roll, pitch, throttle, or yaw during an RC override situation. While this functionality was previously possible using RCx_OPTION(46), the new option provides a more direct and safer method for pilots to cancel overrides using basic RC inputs.

## Required parameters
The following settings are required
`RC_OPTIONS = 16384` (bit 14, `CLEAR_OVERRIDES_BY_RC`) enables the feature
`RCx_OPTION = 46` (`RC_OVERRIDE_ENABLE`) Re-enable RC overrides

## Per-vehicle behavior
Vehicles override `RC_Channels::has_pilot_input_for_override_clear()` to define which axes count as pilot input:

| Vehicle | Axes that clear an active override |
|---|---|
| Copter / Plane / Blimp | roll, pitch, yaw out of trim deadzone, or throttle moved beyond deadzone since the override began |
| Rover | steering (rcmap roll), throttle; plus lateral on omni rovers |
| Sub | forward, lateral, yaw, plus throttle (= vertical) |

## Testing
Tested manually in SITL with Copter, Rover, and Plane.
Added autotest:
`RCOverridesClearByPilotInput` on Copter (all four primary axes each clear) and Rover (steering/throttle clear; pitch/yaw must not), plus held-while-neutral and bit-off regression checks.