### PR TITLE
Rename AP_AHRS::get_position(Location&) to AP_AHRS::get_location(Location&)

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -96,7 +96,7 @@ void Tracker::one_second_loop()
     if (!ahrs.home_is_set()) {
         // set home to current location
         Location temp_loc;
-        if (ahrs.get_position(temp_loc)) {
+        if (ahrs.get_location(temp_loc)) {
             if (!set_home(temp_loc)){
                 // fail silently
             }

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -34,7 +34,7 @@ void Tracker::update_tracker_position()
     Location temp_loc;
 
     // REVISIT: what if we lose lock during a mission and the antenna is moving?
-    if (ahrs.get_position(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
         stationary = false;
         current_loc = temp_loc;
     }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1491,7 +1491,7 @@ int16_t GCS_MAVLINK_Copter::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
     struct Location global_position_current;
-    UNUSED_RESULT(ahrs.get_position(global_position_current));
+    UNUSED_RESULT(ahrs.get_location(global_position_current));
 
     //return units are m
     if (copter.ap.initialised) {

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -179,7 +179,7 @@ bool AP_Avoidance_Copter::handle_avoidance_vertical(const AP_Avoidance::Obstacle
     // decide on whether we should climb or descend
     bool should_climb = false;
     Location my_loc;
-    if (AP::ahrs().get_position(my_loc)) {
+    if (AP::ahrs().get_location(my_loc)) {
         should_climb = my_loc.alt > obstacle->_location.alt;
     }
 

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -24,7 +24,7 @@ void Copter::set_home_to_current_location_inflight() {
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             return;
@@ -40,7 +40,7 @@ void Copter::set_home_to_current_location_inflight() {
 bool Copter::set_home_to_current_location(bool lock) {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_position(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }

--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -8,7 +8,7 @@ void Copter::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_position(loc);
+    ahrs.get_location(loc);
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -396,7 +396,7 @@ void Plane::update_GPS_50Hz(void)
     gps.update();
 
     // get position from AHRS
-    have_position = ahrs.get_position(current_loc);
+    have_position = ahrs.get_location(current_loc);
     ahrs.get_relative_position_D_home(relative_altitude);
     relative_altitude *= -1.0f;
 }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1340,7 +1340,7 @@ int16_t GCS_MAVLINK_Plane::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
     struct Location global_position_current;
-    UNUSED_RESULT(ahrs.get_position(global_position_current));
+    UNUSED_RESULT(ahrs.get_location(global_position_current));
 
 #if HAL_QUADPLANE_ENABLED
     const QuadPlane &quadplane = plane.quadplane;

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -122,7 +122,7 @@ void Plane::update_home()
     }
     if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         Location loc;
-        if(ahrs.get_position(loc) && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+        if(ahrs.get_location(loc) && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
             // we take the altitude directly from the GPS as we are
             // about to reset the baro calibration. We can't use AHRS
             // altitude or we can end up perpetuating a bias in

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2542,7 +2542,7 @@ void QuadPlane::vtol_position_controller(void)
             }
         }
         if (plane.control_mode == &plane.mode_guided || vtol_loiter_auto) {
-            plane.ahrs.get_position(plane.current_loc);
+            plane.ahrs.get_location(plane.current_loc);
             int32_t target_altitude_cm;
             if (!plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME,target_altitude_cm)) {
                 break;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -803,7 +803,7 @@ int16_t GCS_MAVLINK_Sub::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
     struct Location global_position_current;
-    UNUSED_RESULT(ahrs.get_position(global_position_current));
+    UNUSED_RESULT(ahrs.get_location(global_position_current));
 
     //return units are m
     if (sub.control_mode == AUTO || sub.control_mode == GUIDED) {

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -25,7 +25,7 @@ void Sub::set_home_to_current_location_inflight()
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             // ignore this failure
@@ -38,7 +38,7 @@ bool Sub::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_position(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
 
         // Make home always at the water's surface.
         // This allows disarming and arming again at depth.

--- a/ArduSub/inertia.cpp
+++ b/ArduSub/inertia.cpp
@@ -8,7 +8,7 @@ void Sub::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_position(loc);
+    ahrs.get_location(loc);
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -25,7 +25,7 @@ void Blimp::set_home_to_current_location_inflight()
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;
-    if (ahrs.get_position(temp_loc) && ahrs.get_origin(ekf_origin)) {
+    if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
         temp_loc.alt = ekf_origin.alt;
         if (!set_home(temp_loc, false)) {
             return;
@@ -38,7 +38,7 @@ bool Blimp::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
-    if (ahrs.get_position(temp_loc)) {
+    if (ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }

--- a/Blimp/inertia.cpp
+++ b/Blimp/inertia.cpp
@@ -8,7 +8,7 @@ void Blimp::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_position(loc);
+    ahrs.get_location(loc);
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -45,7 +45,7 @@ void Rover::Log_Write_Depth()
 
     // get position
     Location loc;
-    IGNORE_RETURN(ahrs.get_position(loc));
+    IGNORE_RETURN(ahrs.get_location(loc));
 
     for (uint8_t i=0; i<rangefinder.num_sensors(); i++) {
         const AP_RangeFinder_Backend *s = rangefinder.get_backend(i);

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -263,7 +263,7 @@ void Rover::ahrs_update()
     ahrs.update();
 
     // update position
-    have_position = ahrs.get_position(current_loc);
+    have_position = ahrs.get_location(current_loc);
 
     // set home from EKF if necessary and possible
     if (!ahrs.home_is_set()) {

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -4,7 +4,7 @@
 bool Rover::set_home_to_current_location(bool lock)
 {
     Location temp_loc;
-    if (ahrs.have_inertial_nav() && ahrs.get_position(temp_loc)) {
+    if (ahrs.have_inertial_nav() && ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {
             return false;
         }
@@ -64,7 +64,7 @@ void Rover::update_home()
     }
 
     Location loc{};
-    if (!ahrs.get_position(loc)) {
+    if (!ahrs.get_location(loc)) {
         return;
     }
 

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -196,7 +196,7 @@ bool AC_PolyFence_loader::load_point_from_eeprom(uint16_t i, Vector2l& point) co
 bool AC_PolyFence_loader::breached() const
 {
     struct Location loc;
-    if (!AP::ahrs().get_position(loc)) {
+    if (!AP::ahrs().get_location(loc)) {
         return false;
     }
 

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -70,7 +70,7 @@ bool AC_WPNav_OA::update_wpnav()
     // run path planning around obstacles
     AP_OAPathPlanner *oa_ptr = AP_OAPathPlanner::get_singleton();
     Location current_loc;
-    if ((oa_ptr != nullptr) && AP::ahrs().get_position(current_loc)) {
+    if ((oa_ptr != nullptr) && AP::ahrs().get_location(current_loc)) {
 
         // backup _origin and _destination when not doing oa
         if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -322,7 +322,7 @@ void AP_ADSB::update(void)
 
     const uint32_t now = AP_HAL::millis();
 
-    if (!AP::ahrs().get_position(_my_loc)) {
+    if (!AP::ahrs().get_location(_my_loc)) {
         _my_loc.zero();
     }
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -718,11 +718,11 @@ void AP_AHRS::reset()
 }
 
 // dead-reckoning support
-bool AP_AHRS::get_position(struct Location &loc) const
+bool AP_AHRS::get_location(struct Location &loc) const
 {
     switch (active_EKF_type()) {
     case EKFType::NONE:
-        return dcm.get_position(loc);
+        return dcm.get_location(loc);
 
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
@@ -763,7 +763,7 @@ bool AP_AHRS::get_position(struct Location &loc) const
 
     // fall back to position from DCM
     if (!always_use_EKF()) {
-        return dcm.get_position(loc);
+        return dcm.get_location(loc);
     }
     return false;
 }
@@ -1170,7 +1170,7 @@ bool AP_AHRS::get_secondary_position(struct Location &loc) const
 
     case EKFType::NONE:
         // return DCM position
-        dcm.get_position(loc);
+        dcm.get_location(loc);
         return true;
 
 #if HAL_NAVEKF2_AVAILABLE
@@ -1539,7 +1539,7 @@ bool AP_AHRS::get_relative_position_NED_origin(Vector3f &vec) const
             return false;
         }
         Location loc, orgn;
-        if (!get_position(loc) ||
+        if (!get_location(loc) ||
             !get_origin(orgn)) {
             return false;
         }
@@ -1613,7 +1613,7 @@ bool AP_AHRS::get_relative_position_NE_origin(Vector2f &posNE) const
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM: {
         Location loc, orgn;
-        if (!get_position(loc) ||
+        if (!get_location(loc) ||
             !get_origin(orgn)) {
             return false;
         }
@@ -1624,7 +1624,7 @@ bool AP_AHRS::get_relative_position_NE_origin(Vector2f &posNE) const
 #if HAL_EXTERNAL_AHRS_ENABLED
     case EKFType::EXTERNAL: {
         Location loc, orgn;
-        if (!get_position(loc) ||
+        if (!get_location(loc) ||
             !get_origin(orgn)) {
             return false;
         }
@@ -1698,7 +1698,7 @@ bool AP_AHRS::get_relative_position_D_origin(float &posD) const
     case EKFType::EXTERNAL: {
         Location orgn, loc;
         if (!get_origin(orgn) ||
-            !get_position(loc)) {
+            !get_location(loc)) {
             return false;
         }
         posD = -(loc.alt - orgn.alt)*0.01;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -105,7 +105,7 @@ public:
     void            reset();
 
     // dead-reckoning support
-    bool get_position(struct Location &loc) const;
+    bool get_location(struct Location &loc) const;
 
     // get latest altitude estimate above ground level in meters and validity flag
     bool get_hagl(float &hagl) const WARN_IF_UNUSED;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -116,7 +116,7 @@ public:
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
-    virtual bool get_position(struct Location &loc) const WARN_IF_UNUSED = 0;
+    virtual bool get_location(struct Location &loc) const WARN_IF_UNUSED = 0;
 
     // get latest altitude estimate above ground level in meters and validity flag
     virtual bool get_hagl(float &height) const WARN_IF_UNUSED { return false; }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1044,7 +1044,7 @@ void AP_AHRS_DCM::estimate_wind(void)
 
 // return our current position estimate using
 // dead-reckoning or GPS
-bool AP_AHRS_DCM::get_position(struct Location &loc) const
+bool AP_AHRS_DCM::get_location(struct Location &loc) const
 {
     loc.lat = _last_lat;
     loc.lng = _last_lng;
@@ -1239,7 +1239,7 @@ bool AP_AHRS_DCM::get_relative_position_NED_origin(Vector3f &posNED) const
         return false;
     }
     Location loc;
-    if (!AP_AHRS_DCM::get_position(loc)) {
+    if (!AP_AHRS_DCM::get_location(loc)) {
         return false;
     }
     posNED = origin.get_distance_NED(loc);

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -62,7 +62,7 @@ public:
     }
 
     // dead-reckoning support
-    virtual bool get_position(struct Location &loc) const override;
+    virtual bool get_location(struct Location &loc) const override;
 
     // status reporting
     float           get_error_rp() const {

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -80,7 +80,7 @@ void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 void AP_AHRS::Write_POS() const
 {
     Location loc;
-    if (!get_position(loc)) {
+    if (!get_location(loc)) {
         return;
     }
     float home, origin;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -85,8 +85,8 @@ public:
       wrappers around ahrs functions which pass-thru directly. See
       AP_AHRS.h for description of each function
      */
-    bool get_position(struct Location &loc) const WARN_IF_UNUSED {
-        return ahrs.get_position(loc);
+    bool get_location(struct Location &loc) const WARN_IF_UNUSED {
+        return ahrs.get_location(loc);
     }
 
     Vector3f wind_estimate(void) {

--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -292,7 +292,7 @@ bool AP_AIS::get_vessel_index(uint32_t mmsi, uint16_t &index, uint32_t lat, uint
     }
 
     struct Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -541,7 +541,7 @@ bool AP_Arming::gps_checks(bool report)
         // check AHRS and GPS are within 10m of each other
         const Location gps_loc = gps.location();
         Location ahrs_loc;
-        if (AP::ahrs().get_position(ahrs_loc)) {
+        if (AP::ahrs().get_location(ahrs_loc)) {
             const float distance = gps_loc.get_distance(ahrs_loc);
             if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
                 check_failed(ARMING_CHECK_GPS, report, "GPS and AHRS differ by %4.1fm", (double)distance);
@@ -757,7 +757,7 @@ bool AP_Arming::mission_checks(bool report)
         }
         if (_required_mission_items & MIS_ITEM_CHECK_RALLY) {
             Location ahrs_loc;
-            if (!AP::ahrs().get_position(ahrs_loc)) {
+            if (!AP::ahrs().get_location(ahrs_loc)) {
                 check_failed(ARMING_CHECK_MISSION, report, "Can't check rally without position");
                 return false;
             }

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -457,7 +457,7 @@ void AP_Avoidance::check_for_threats()
     const AP_AHRS &_ahrs = AP::ahrs();
 
     Location my_loc;
-    if (!_ahrs.get_position(my_loc)) {
+    if (!_ahrs.get_location(my_loc)) {
         // if we don't know our own location we can't determine any threat level
         return;
     }
@@ -542,7 +542,7 @@ void AP_Avoidance::handle_avoidance_local(AP_Avoidance::Obstacle *threat)
             action = (MAV_COLLISION_ACTION)_fail_action.get();
             Location my_loc;
             if (action != MAV_COLLISION_ACTION_NONE && _fail_altitude_minimum > 0 &&
-                AP::ahrs().get_position(my_loc) && ((my_loc.alt*0.01f) < _fail_altitude_minimum)) {
+                AP::ahrs().get_location(my_loc) && ((my_loc.alt*0.01f) < _fail_altitude_minimum)) {
                 // disable avoidance when close to ground, report only
                 action = MAV_COLLISION_ACTION_REPORT;
 			}
@@ -617,7 +617,7 @@ bool AP_Avoidance::get_vector_perpendicular(const AP_Avoidance::Obstacle *obstac
     }
 
     Location my_abs_pos;
-    if (!AP::ahrs().get_position(my_abs_pos)) {
+    if (!AP::ahrs().get_location(my_abs_pos)) {
         // we should not get to here!  If we don't know our position
         // we can't know if there are any threats, for starters!
         return false;

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -368,7 +368,7 @@ void AP_Camera::update()
 
     const AP_AHRS &ahrs = AP::ahrs();
     Location current_loc;
-    if (!ahrs.get_position(current_loc)) {
+    if (!ahrs.get_location(current_loc)) {
         // completely ignore this failure!  AHRS will provide its best guess.
     }
 
@@ -502,7 +502,7 @@ void AP_Camera::take_picture()
 void AP_Camera::prep_mavlink_msg_camera_feedback(uint64_t timestamp_us)
 {
     const AP_AHRS &ahrs = AP::ahrs();
-    if (!ahrs.get_position(feedback.location)) {
+    if (!ahrs.get_location(feedback.location)) {
         // completely ignore this failure!  AHRS will provide its best guess.
     }
     feedback.timestamp_us = timestamp_us;

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -7,7 +7,7 @@ void AP_Camera::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
     const AP_AHRS &ahrs = AP::ahrs();
 
     Location current_loc;
-    if (!ahrs.get_position(current_loc)) {
+    if (!ahrs.get_location(current_loc)) {
         // completely ignore this failure!  AHRS will provide its best guess.
     }
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1718,7 +1718,7 @@ void Compass::try_set_initial_location()
     }
 
     Location loc;
-    if (!AP::ahrs().get_position(loc)) {
+    if (!AP::ahrs().get_location(loc)) {
         return;
     }
     _initial_location_set = true;

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -489,7 +489,7 @@ MAV_RESULT Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
     if (is_zero(lat_deg) && is_zero(lon_deg)) {
         Location loc;
         // get AHRS position. If unavailable then try GPS location
-        if (!AP::ahrs().get_position(loc)) {
+        if (!AP::ahrs().get_location(loc)) {
             if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
                 gcs().send_text(MAV_SEVERITY_ERROR, "Mag: no position available");
                 return MAV_RESULT_FAILED;

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -96,7 +96,7 @@ void AP_DEVO_Telem::send_frames()
     const AP_GPS &gps = AP::gps();
     Location loc;
 
-    if (_ahrs.get_position(loc)) {
+    if (_ahrs.get_location(loc)) {
         devoPacket.lat = gpsDdToDmsFormat(loc.lat);
         devoPacket.lon = gpsDdToDmsFormat(loc.lng);
         devoPacket.speed = (int16_t)(gps.ground_speed() * DEVO_SPEED_FACTOR * 100.0f);  // * 100 for cm

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -179,7 +179,7 @@ bool AP_Follow::get_target_dist_and_vel_ned(Vector3f &dist_ned, Vector3f &dist_w
 {
     // get our location
     Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         clear_dist_and_bearing_to_target();
          return false;
     }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.cpp
@@ -77,7 +77,7 @@ void AP_Frsky_Backend::calc_nav_alt(void)
 
     AP_AHRS &_ahrs = AP::ahrs();
     WITH_SEMAPHORE(_ahrs.get_semaphore());
-    if (_ahrs.get_position(loc)) {
+    if (_ahrs.get_location(loc)) {
         current_height = loc.alt*0.01f;
         if (!loc.relative_alt) {
             // loc.alt has home altitude added, remove it
@@ -109,7 +109,7 @@ void AP_Frsky_Backend::calc_gps_position(void)
 
     Location loc;
 
-    if (_ahrs.get_position(loc)) {
+    if (_ahrs.get_location(loc)) {
         float lat = format_gps(fabsf(loc.lat/10000000.0f));
         _SPort_data.latdddmm = lat;
         _SPort_data.latmmmm = (lat - _SPort_data.latdddmm) * 10000;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -610,7 +610,7 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_home(void)
     {
         AP_AHRS &_ahrs = AP::ahrs();
         WITH_SEMAPHORE(_ahrs.get_semaphore());
-        got_position = _ahrs.get_position(loc);
+        got_position = _ahrs.get_location(loc);
         home_loc = _ahrs.get_home();
     }
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-joey/scripts/mode.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-joey/scripts/mode.lua
@@ -10,7 +10,7 @@ local MODE_LAND = 9
 local counter = 0
 
 function update()
-  local pos = ahrs:get_position()
+  local pos = ahrs:get_location()
 
   if (vehicle:get_mode() == MODE_AUTO or vehicle:get_mode() == MODE_LOITER) then
     setfence(true)

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -217,7 +217,7 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
     float K_L1 = 4.0f * _L1_damping * _L1_damping;
 
     // Get current position and velocity
-    if (_ahrs.get_position(_current_loc) == false) {
+    if (_ahrs.get_location(_current_loc) == false) {
         // if no GPS loc available, maintain last nav/target_bearing
         _data_is_stale = true;
         return;
@@ -349,7 +349,7 @@ void AP_L1_Control::update_loiter(const struct Location &center_WP, float radius
     float K_L1 = 4.0f * _L1_damping * _L1_damping;
 
     //Get current position and velocity
-    if (_ahrs.get_position(_current_loc) == false) {
+    if (_ahrs.get_location(_current_loc) == false) {
         // if no GPS loc available, maintain last nav/target_bearing
         _data_is_stale = true;
         return;

--- a/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
+++ b/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
@@ -74,7 +74,7 @@ void AP_LTM_Telem::send_Gframe(void)
         ahrs.get_relative_position_D_home(alt_ahrs);
         alt = (int32_t) roundf(-alt_ahrs * 100.0); // altitude (cm)
         Location loc;
-        if (ahrs.get_position(loc)) {
+        if (ahrs.get_location(loc)) {
             lat = loc.lat;
             lon = loc.lng;
             gndspeed = (uint8_t) roundf(gps.ground_speed());

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -290,7 +290,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
             height_above_target = -height_above_target;
         } else {
             Location position;
-            if (landing.ahrs.get_position(position)) {
+            if (landing.ahrs.get_location(position)) {
                 height_above_target = (position.alt - landing_point.alt + approach_alt_offset * 100) * 1e-2f;
             } else {
                 height_above_target = approach_alt_offset;
@@ -487,7 +487,7 @@ bool AP_Landing_Deepstall::terminate(void) {
         landing.flags.in_progress = true;
         stage = DEEPSTALL_STAGE_LAND;
 
-        if(landing.ahrs.get_position(landing_point)) {
+        if(landing.ahrs.get_location(landing_point)) {
             build_approach_path(true);
         } else {
             hold_level = true;
@@ -613,7 +613,7 @@ bool AP_Landing_Deepstall::verify_breakout(const Location &current_loc, const Lo
 float AP_Landing_Deepstall::update_steering()
 {
     Location current_loc;
-    if ((!landing.ahrs.get_position(current_loc) || !landing.ahrs.healthy()) && !hold_level) {
+    if ((!landing.ahrs.get_location(current_loc) || !landing.ahrs.healthy()) && !hold_level) {
         // panic if no position source is available
         // continue the stall but target just holding the wings held level as deepstall should be a minimal
         // energy configuration on the aircraft, and if a position isn't available aborting would be worse

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -180,7 +180,7 @@ void AP_MSP_Telem_Backend::update_home_pos(home_state_t &home_state)
     WITH_SEMAPHORE(_ahrs.get_semaphore());
     Location loc;
     float alt;
-    if (_ahrs.get_position(loc) && _ahrs.home_is_set()) {
+    if (_ahrs.get_location(loc) && _ahrs.home_is_set()) {
         const Location &home_loc = _ahrs.get_home();
         home_state.home_distance_m = home_loc.get_distance(loc);
         home_state.home_bearing_cd = loc.get_bearing_to(home_loc);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2027,7 +2027,7 @@ uint16_t AP_Mission::get_landing_sequence_start()
 {
     struct Location current_loc;
 
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         return 0;
     }
 
@@ -2086,7 +2086,7 @@ bool AP_Mission::jump_to_abort_landing_sequence(void)
     struct Location current_loc;
 
     uint16_t abort_index = 0;
-    if (AP::ahrs().get_position(current_loc)) {
+    if (AP::ahrs().get_location(current_loc)) {
         float min_distance = FLT_MAX;
 
         for (uint16_t i = 1; i < num_commands(); i++) {
@@ -2153,7 +2153,7 @@ bool AP_Mission::is_best_land_sequence(void)
 
     // get our current location
     Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         // we don't know where we are!!
         return false;
     }
@@ -2397,7 +2397,7 @@ void AP_Mission::reset_wp_history(void)
 // store the latest reported position incase of mission exit and rewind resume
 void AP_Mission::update_exit_position(void)
 {
-    if (!AP::ahrs().get_position(_exit_position)) {
+    if (!AP::ahrs().get_location(_exit_position)) {
         _exit_position.lat = 0;
         _exit_position.lng = 0;
     }

--- a/libraries/AP_Module/AP_Module.cpp
+++ b/libraries/AP_Module/AP_Module.cpp
@@ -177,7 +177,7 @@ void AP_Module::call_hook_AHRS_update(const AP_AHRS &ahrs)
         state.origin.altitude = loc.alt*0.01f;
     }
 
-    if (ahrs.get_position(loc)) {
+    if (ahrs.get_location(loc)) {
         state.position.available = true;
         state.position.latitude = loc.lat;
         state.position.longitude = loc.lng;

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -198,7 +198,7 @@ bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad
 bool AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
 {
     Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         return false;
     }
     const float GPS_vector_x = Location::diff_longitude(target.lng,current_loc.lng)*cosf(ToRad((current_loc.lat+target.lat)*0.00000005f))*0.01113195f;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -95,9 +95,9 @@ void AP_NMEA_Output::update()
 
     auto &ahrs = AP::ahrs();
 
-    // get location (note: get_position from AHRS always returns true after having GPS position once)
+    // get location (note: get_location from AHRS always returns true after having GPS position once)
     Location loc;
-    bool pos_valid = ahrs.get_position(loc);
+    bool pos_valid = ahrs.get_location(loc);
 
     // format latitude
     char lat_string[13];

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -370,7 +370,7 @@ void AP_OSD::update_stats()
         AP_AHRS &ahrs = AP::ahrs();
         WITH_SEMAPHORE(ahrs.get_semaphore());
         v = ahrs.groundspeed_vector();
-        home_is_set = ahrs.get_position(loc) && ahrs.home_is_set();
+        home_is_set = ahrs.get_location(loc) && ahrs.home_is_set();
         if (home_is_set) {
             home_loc = ahrs.get_home();
         }

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1559,7 +1559,7 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
     Location loc;
-    if (ahrs.get_position(loc) && ahrs.home_is_set()) {
+    if (ahrs.get_location(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
         float distance = home_loc.get_distance(loc);
         int32_t angle = wrap_360_cd(loc.get_bearing_to(home_loc) - ahrs.yaw_sensor);

--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -32,7 +32,7 @@ An example script is given below:
 
 ```lua
 function update () -- periodic function that will be called
-  current_pos = ahrs:get_position()
+  current_pos = ahrs:get_location()
   home = ahrs:get_home()
   if current_pos and home then
     distance = current_pos:get_distance(ahrs:get_home()) -- calculate the distance from home

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1880,7 +1880,7 @@ function ahrs:get_home() end
 
 -- desc
 ---@return Location_ud|nil
-function ahrs:get_position() end
+function ahrs:get_location() end
 
 -- desc
 ---@return number

--- a/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
+++ b/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
@@ -160,7 +160,7 @@ function update() -- this is the loop which periodically runs
   local alt = 0
 
   -- try and get true position, but don't fail for no GPS lock
-  local position = ahrs:get_position()
+  local position = ahrs:get_location()
   if position then
     lat = position:lat()*10^-7
     lng = position:lng()*10^-7

--- a/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
+++ b/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
@@ -4,7 +4,7 @@
 function update ()
 
     if ahrs:home_is_set() then
-        ahrs:set_home(ahrs:get_position())
+        ahrs:set_home(ahrs:get_location())
         gcs:send_text(0, "Home position reset")
     end
 

--- a/libraries/AP_Scripting/examples/copter-fast-descent.lua
+++ b/libraries/AP_Scripting/examples/copter-fast-descent.lua
@@ -66,7 +66,7 @@ function update()
 
   if (stage == 0) then            -- Stage0: initialise
     local home = ahrs:get_home()
-    local curr_loc = ahrs:get_position()
+    local curr_loc = ahrs:get_location()
     if home and curr_loc then
       circle_center_pos = ahrs:get_relative_position_NED_origin()
       circle_radius_rate_ms = 0   -- reset circle radius expandion rate to zero

--- a/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
+++ b/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
@@ -38,7 +38,7 @@ function update()
         end
       elseif (stage == 2) then      -- Stage2: check if vehicle has reached target altitude
         local home = ahrs:get_home()
-        local curr_loc = ahrs:get_position()
+        local curr_loc = ahrs:get_location()
         if home and curr_loc then
           local vec_from_home = home:get_distance_NED(curr_loc)
           gcs:send_text(0, "alt above home: " .. tostring(math.floor(-vec_from_home:z())))

--- a/libraries/AP_Scripting/examples/easter-egg.lua
+++ b/libraries/AP_Scripting/examples/easter-egg.lua
@@ -26,7 +26,7 @@ function find_next_point ()
     target:lng(top_left:lng())
     target:offset(math.random()*-100, math.random()*10)
     gcs:send_text(6, string.format("New target %d %d", target:lat(), target:lng()))
-    local current = ahrs:get_position()
+    local current = ahrs:get_location()
     if current then
         last_distance = current:get_distance(target)
     end
@@ -35,7 +35,7 @@ function find_next_point ()
 end
 
 function update ()
-    local current = ahrs:get_position()
+    local current = ahrs:get_location()
     if current then
         local dist = target:get_distance(current)
         local now = millis()

--- a/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
+++ b/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
@@ -96,7 +96,7 @@ end
 -- check if we should switch to QLAND
 function check_qland()
   local target = vehicle:get_target_location()
-  local pos = ahrs:get_position()
+  local pos = ahrs:get_location()
   if not target or not pos then
     -- we can't estimate distance
     return

--- a/libraries/AP_Scripting/examples/mission-edit-demo.lua
+++ b/libraries/AP_Scripting/examples/mission-edit-demo.lua
@@ -7,7 +7,7 @@ demostage = 0
 eventcounter = 0
 
 function update () -- periodic function that will be called
-    current_pos = ahrs:get_position()
+    current_pos = ahrs:get_location()
 
   -- adds new/extra mission item at the end by copying the last one and modifying it
   -- get number of last mission item
@@ -257,7 +257,7 @@ function stage7 ()
 end
 
 function wait_for_home()
-  current_pos = ahrs:get_position()
+  current_pos = ahrs:get_location()
   if current_pos == nil then
      return wait_for_home, 1000
   end

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -93,7 +93,7 @@ local timer_active = true
 -- otherwise returns the time in seconds to get back
 local function time_to_home()
   local home = ahrs:get_home()
-  local position = ahrs:get_position()
+  local position = ahrs:get_location()
   local wind = ahrs:wind_estimate()
 
   if home and position and wind then
@@ -201,7 +201,7 @@ function track_return_time()
   end
 
   local home = ahrs:get_home()
-  local position = ahrs:get_position()
+  local position = ahrs:get_location()
   if home and position then
     local now = millis()
 
@@ -373,7 +373,7 @@ function update()
 
         -- Print the return distance
         --[[local home = ahrs:get_home()
-        local position = ahrs:get_position()
+        local position = ahrs:get_location()
         if home and position then
           return_distance = position:get_distance(home)
         end

--- a/libraries/AP_Scripting/examples/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/plane_aerobatics.lua
@@ -161,7 +161,7 @@ local function height_controller(kP_param,kI_param,KnifeEdge_param,Imax)
    local PI = PI_controller(kP:get(), kI:get(), Imax)
 
    function self.update(target)
-      local target_pitch = PI.update(initial_height, ahrs:get_position():alt()*0.01)
+      local target_pitch = PI.update(initial_height, ahrs:get_location():alt()*0.01)
       local roll_rad = ahrs:get_roll()
       local ke_add = math.abs(math.sin(roll_rad)) * KnifeEdge:get()
       target_pitch = target_pitch + ke_add
@@ -371,7 +371,7 @@ function update()
          running = false
          last_id = id
          initial_yaw_deg = math.deg(ahrs:get_yaw())
-         initial_height = ahrs:get_position():alt()*0.01
+         initial_height = ahrs:get_location():alt()*0.01
 
          -- work out yaw between previous WP and next WP
          local cnum = mission:get_current_nav_index()

--- a/libraries/AP_Scripting/examples/set-target-location.lua
+++ b/libraries/AP_Scripting/examples/set-target-location.lua
@@ -35,7 +35,7 @@ function update()
         -- change to land mode when within 2m of home
         if not (mode == copter_land_mode_num) then
           local home = ahrs:get_home()
-          local curr_loc = ahrs:get_position()
+          local curr_loc = ahrs:get_location()
           if home and curr_loc then
             local home_dist = curr_loc:get_distance(home)   -- get horizontal distance to home
             if (home_dist < wp_radius) then                 -- change to land mode if close

--- a/libraries/AP_Scripting/examples/set-target-velocity.lua
+++ b/libraries/AP_Scripting/examples/set-target-velocity.lua
@@ -31,7 +31,7 @@ function update()
         end
       elseif (stage == 2) then      -- Stage2: check if vehicle has reached target altitude
         local home = ahrs:get_home()
-        local curr_loc = ahrs:get_position()
+        local curr_loc = ahrs:get_location()
         if home and curr_loc then
           local vec_from_home = home:get_distance_NED(curr_loc)
           gcs:send_text(0, "alt above home: " .. tostring(math.floor(-vec_from_home:z())))
@@ -41,7 +41,7 @@ function update()
           end
         end
       elseif (stage >= 3 and stage <= 6) then   -- fly a square using velocity controller
-        local curr_loc = ahrs:get_position()
+        local curr_loc = ahrs:get_location()
         local target_vel = Vector3f()           -- create velocity vector
         if (bottom_left_loc and curr_loc) then
           local dist_NE = bottom_left_loc:get_distance_NE(curr_loc)

--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -69,7 +69,7 @@ function update()
         end
     else 
         -- calculate test starting location in NED
-        local cur_loc = ahrs:get_position()        
+        local cur_loc = ahrs:get_location()        
         if cur_loc then
              test_start_location = cur_loc.get_vector_from_origin_NEU(cur_loc)             
              if test_start_location then

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -28,7 +28,8 @@ singleton AP_AHRS semaphore
 singleton AP_AHRS method get_roll float
 singleton AP_AHRS method get_pitch float
 singleton AP_AHRS method get_yaw float
-singleton AP_AHRS method get_position boolean Location'Null
+singleton AP_AHRS method get_location boolean Location'Null
+singleton AP_AHRS method get_location alias get_position
 singleton AP_AHRS method get_home Location
 singleton AP_AHRS method get_gyro Vector3f
 singleton AP_AHRS method get_accel Vector3f

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -193,7 +193,7 @@ bool AP_Terrain::height_terrain_difference_home(float &terrain_difference, bool 
     }
 
     Location loc;
-    if (!ahrs.get_position(loc)) {
+    if (!ahrs.get_location(loc)) {
         // we don't know where we are
         return false;
     }
@@ -279,7 +279,7 @@ float AP_Terrain::lookahead(float bearing, float distance, float climb_ratio)
     }
 
     Location loc;
-    if (!AP::ahrs().get_position(loc)) {
+    if (!AP::ahrs().get_location(loc)) {
         // we don't know where we are
         return 0;
     }
@@ -329,7 +329,7 @@ void AP_Terrain::update(void)
 
     // update the cached current location height
     Location loc;
-    bool pos_valid = ahrs.get_position(loc);
+    bool pos_valid = ahrs.get_location(loc);
     bool terrain_valid = pos_valid && height_amsl(loc, height, false);
     if (pos_valid && terrain_valid) {
         last_current_loc_height = height;
@@ -365,7 +365,7 @@ void AP_Terrain::log_terrain_data()
         return;
     }
     Location loc;
-    if (!AP::ahrs().get_position(loc)) {
+    if (!AP::ahrs().get_location(loc)) {
         // we don't know where we are
         return;
     }

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -113,7 +113,7 @@ void AP_Terrain::send_request(mavlink_channel_t chan)
     schedule_disk_io();
 
     Location loc;
-    if (!AP::ahrs().get_position(loc)) {
+    if (!AP::ahrs().get_location(loc)) {
         // we don't know where we are. Send a report and request any cached blocks.
         // this allows for download of mission items when we have no GPS lock
         loc = {};
@@ -227,7 +227,7 @@ void AP_Terrain::send_terrain_report(mavlink_channel_t chan, const Location &loc
     uint16_t spacing = 0;
     Location current_loc;
     const AP_AHRS &ahrs = AP::ahrs();
-    if (ahrs.get_position(current_loc) &&
+    if (ahrs.get_location(current_loc) &&
         height_amsl(ahrs.get_home(), home_terrain_height, false) &&
         height_amsl(loc, terrain_height, false)) {
         // non-zero spacing indicates we have data

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -108,7 +108,7 @@ void AR_WPNav::update(float dt)
     // exit immediately if no current location, origin or destination
     Location current_loc;
     float speed;
-    if (!hal.util->get_soft_armed() || !_orig_and_dest_valid || !AP::ahrs().get_position(current_loc) || !_atc.get_forward_speed(speed)) {
+    if (!hal.util->get_soft_armed() || !_orig_and_dest_valid || !AP::ahrs().get_location(current_loc) || !_atc.get_forward_speed(speed)) {
         _desired_speed_limited = _atc.get_desired_speed_accel_limited(0.0f, dt);
         _desired_turn_rate_rads = 0.0f;
         return;
@@ -263,7 +263,7 @@ bool AR_WPNav::set_desired_location_NED(const Vector3f& destination, float next_
 bool AR_WPNav::get_stopping_location(Location& stopping_loc)
 {
     Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
+    if (!AP::ahrs().get_location(current_loc)) {
         return false;
     }
 
@@ -350,7 +350,7 @@ void AR_WPNav::update_distance_and_bearing_to_destination()
 {
     // if no current location leave distance unchanged
     Location current_loc;
-    if (!_orig_and_dest_valid || !AP::ahrs().get_position(current_loc)) {
+    if (!_orig_and_dest_valid || !AP::ahrs().get_location(current_loc)) {
         _distance_to_destination = 0.0f;
         _wp_bearing_cd = 0.0f;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2765,7 +2765,7 @@ void GCS_MAVLINK::send_vfr_hud()
     AP_AHRS &ahrs = AP::ahrs();
 
     // return values ignored; we send stale data
-    UNUSED_RESULT(ahrs.get_position(global_position_current_loc));
+    UNUSED_RESULT(ahrs.get_location(global_position_current_loc));
 
     mavlink_msg_vfr_hud_send(
         chan,
@@ -4900,7 +4900,7 @@ void GCS_MAVLINK::send_global_position_int()
 {
     AP_AHRS &ahrs = AP::ahrs();
 
-    UNUSED_RESULT(ahrs.get_position(global_position_current_loc)); // return value ignored; we send stale data
+    UNUSED_RESULT(ahrs.get_location(global_position_current_loc)); // return value ignored; we send stale data
 
     Vector3f vel;
     if (!ahrs.get_velocity_NED(vel)) {
@@ -4997,7 +4997,7 @@ void GCS_MAVLINK::send_water_depth() const
     // get position
     const AP_AHRS &ahrs = AP::ahrs();
     Location loc;
-    IGNORE_RETURN(ahrs.get_position(loc));
+    IGNORE_RETURN(ahrs.get_location(loc));
 
     for (uint8_t i=0; i<rangefinder->num_sensors(); i++) {
         const AP_RangeFinder_Backend *s = rangefinder->get_backend(i);
@@ -5917,7 +5917,7 @@ void GCS_MAVLINK::send_high_latency2() const
 {
     AP_AHRS &ahrs = AP::ahrs();
     Location global_position_current;
-    UNUSED_RESULT(ahrs.get_position(global_position_current));
+    UNUSED_RESULT(ahrs.get_location(global_position_current));
 #if !defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_BATTERY)
     const int8_t battery_remaining = battery_remaining_pct(AP_BATT_PRIMARY_INSTANCE);
 #endif


### PR DESCRIPTION
When I removed the old get_location I said I'd do this rename at some stage.

Well, that's now....

We're trying to canonicalise on "Location" always meaning "lat,lng,alt,frame" and "position" being x, y, z in metres from origin.
