### PR TITLE
Plane: Add radius to MAV_CMD_DO_REPOSITION

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -725,6 +725,11 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_do_reposition(const mavlink_com
 
         plane.set_guided_WP(requested_position);
 
+        // Loiter radius for planes. Positive radius in meters, direction is controlled by Yaw (param4) value, parsed above
+        if (!isnan(packet.param3) && packet.param3 > 0) {
+            plane.mode_guided.set_radius_and_direction(packet.param3, requested_position.loiter_ccw);
+        }
+
         return MAV_RESULT_ACCEPTED;
     }
     return MAV_RESULT_FAILED;

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -224,9 +224,14 @@ public:
     // handle a guided target request from GCS
     bool handle_guided_request(Location target_loc) override;
 
+    void set_radius_and_direction(const float radius, const bool direction_is_ccw);
+
 protected:
 
     bool _enter() override;
+
+private:
+    float active_radius_m;
 };
 
 class ModeCircle: public Mode

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -20,6 +20,9 @@ bool ModeGuided::_enter()
     }
 #endif
 
+    // set guided radius to WP_LOITER_RAD on mode change.
+    active_radius_m = 0;
+
     plane.set_guided_WP(loc);
     return true;
 }
@@ -39,8 +42,7 @@ void ModeGuided::update()
 
 void ModeGuided::navigate()
 {
-    // Zero indicates to use WP_LOITER_RAD
-    plane.update_loiter(0);
+    plane.update_loiter(active_radius_m);
 }
 
 bool ModeGuided::handle_guided_request(Location target_loc)
@@ -54,4 +56,11 @@ bool ModeGuided::handle_guided_request(Location target_loc)
     plane.set_guided_WP(target_loc);
 
     return true;
+}
+
+void ModeGuided::set_radius_and_direction(const float radius, const bool direction_is_ccw)
+{
+    // constrain to (uint16_t) range for update_loiter()
+    active_radius_m = constrain_int32(fabsf(radius), 0, UINT16_MAX);
+    plane.loiter.direction = direction_is_ccw ? -1 : 1;
 }


### PR DESCRIPTION
mavlink change: https://github.com/ArduPilot/mavlink/pull/240

Replaced https://github.com/ArduPilot/ardupilot/pull/19297

This adds an adjustable radius for Guided mode vis the . This does not effect any other vehicle since the concept of radius does not apply to any vehicle that has a guided mode.

It's fully backwards compatible to existing command.

param3: was unused, now it's the positive-only radius. Ignore if <= 0
param4: controls radius, as stated in existing mavlink spec. Added option to ignore yaw if not == 0 or == 1.

This also lays the groundwork to easily add a new param GUIDED_LOIT_RAD in the future [which is requested](https://github.com/ArduPilot/ardupilot/pull/19297#issuecomment-1002163538) by @pompecukor


Behavior:
when entering guided mode, it uses WP_LOITER_RAD like usual. If the DO_REPOS command is received and the radius is > 0, then it overwrites the radius with this new one. Any change away and back to guided will reset you back to WP_LOITER_RAD. This is consistent with how DO_CHANGE_SPEED behaves.

This has been discussed with @peterbarker and @WickedShell