### PR TITLE
AP_ROMFS: Enable/fix mavlink ftp ListDirectory for @ROMFS top level

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -61,6 +61,7 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
     { nullptr, fs_local },
 #ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
     { "@ROMFS/", fs_romfs },
+    { "@ROMFS", fs_romfs },
 #endif
     { "@PARAM/", fs_param },
     { "@SYS/", fs_sys },

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -171,10 +171,13 @@ struct dirent *AP_Filesystem_ROMFS::readdir(void *dirp)
         return nullptr;
     }
     const uint32_t plen = strlen(dir[idx].path);
-    if (strncmp(name, dir[idx].path, plen) != 0 || name[plen] != '/') {
-        return nullptr;
+    if (plen > 0) {
+        // strip leading directory name from name if it exists
+        if (strncmp(name, dir[idx].path, plen) != 0 || name[plen] != '/') {
+            return nullptr;
+        }
+        name += plen + 1;
     }
-    name += plen + 1;
     dir[idx].de.d_type = DT_REG;
     strncpy(dir[idx].de.d_name, name, sizeof(dir[idx].de.d_name));
     return &dir[idx].de;

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -131,8 +131,7 @@ const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
 {
     const size_t dlen = strlen(dirname);
     for ( ; ofs < ARRAY_SIZE(files); ofs++) {
-        if (strncmp(dirname, files[ofs].filename, dlen) == 0 &&
-            files[ofs].filename[dlen] == '/') {
+        if (strncmp(dirname, files[ofs].filename, dlen) == 0 || dlen == 0) {
             // found one
             return files[ofs++].filename;
         }


### PR DESCRIPTION
The AP_ROMFS had a dir list method added a while back, but it does not work to show the top level files in the ROMFS. For example, the mavproxy command "ftp list @ROMFS" or "ftp list @ROMFS/" doesn't work. The existing code expects a directory name after the backend @ROMFS/ string, e.g @ROMFS/models. 

With the suggested change, "ftp list @ROMFS" will return a list of all files in the romfs embedded file. The previous behavior is retained as well and "ftp list @ROMFS/models" will only list the files with a name starting with models/ and stripping the directory part.