### PR TITLE
AP_Bootloader: fixed ID conflict

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -112,7 +112,7 @@ AP_HW_CUAV_X7_PRO                    1010
 AP_HW_SUCCEXF4                       1011
 AP_HW_LIGHTSPARKMINI                 1012
 AP_HW_MATEKH743                      1013
-AP_HW_MRO_MAXXIUM                    1014
+AP_HW_MATEKF405_GPS                  1014
 AP_HW_MRO_NEXUS                      1015
 AP_HW_HITEC_MOSAIC                   1016
 AP_HW_MRO_PIXRACER_PRO               1017


### PR DESCRIPTION
AP_HW_MRO_MAXXIUM seems to be unused
@pkocmoud can you check this? Is the Maxxium ID actually used?

fixes #19850