### PR TITLE
AP_OpticalFlow: add easier calibration method

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1999,6 +1999,89 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    # fly_optical_flow_calibration - test optical flow calibration
+    def fly_optical_flow_calibration(self):
+        ex = None
+        self.context_push()
+        try:
+
+            self.set_parameter("SIM_FLOW_ENABLE", 1)
+            self.set_parameter("FLOW_TYPE", 10)
+            self.set_analog_rangefinder_parameters()
+
+            # RC9 starts/stops calibration
+            self.set_parameter("RC9_OPTION", 158)
+
+            # initialise flow scaling parameters to incorrect values
+            self.set_parameter("FLOW_FXSCALER", -200)
+            self.set_parameter("FLOW_FYSCALER", 200)
+
+            self.reboot_sitl()
+
+            # ensure calibration is off
+            self.set_rc(9, 1000)
+
+            # takeoff to 10m in loiter
+            self.takeoff(10, mode="LOITER", require_absolute=True, timeout=720)
+
+            # start calibration
+            self.set_rc(9, 2000)
+
+            tstart = self.get_sim_time()
+            timeout = 90
+            veh_dir_tstart = self.get_sim_time()
+            veh_dir = 0
+            while self.get_sim_time_cached() - tstart < timeout:
+                # roll and pitch vehicle until samples collected
+                # change direction of movement every 2 seconds
+                if self.get_sim_time_cached() - veh_dir_tstart > 2:
+                    veh_dir_tstart = self.get_sim_time()
+                    veh_dir = veh_dir + 1
+                    if veh_dir > 3:
+                        veh_dir = 0
+                if veh_dir == 0:
+                    # move right
+                    self.set_rc(1, 1800)
+                    self.set_rc(2, 1500)
+                if veh_dir == 1:
+                    # move left
+                    self.set_rc(1, 1200)
+                    self.set_rc(2, 1500)
+                if veh_dir == 2:
+                    # move forward
+                    self.set_rc(1, 1500)
+                    self.set_rc(2, 1200)
+                if veh_dir == 3:
+                    # move back
+                    self.set_rc(1, 1500)
+                    self.set_rc(2, 1800)
+
+            # return sticks to center
+            self.set_rc(1, 1500)
+            self.set_rc(2, 1500)
+
+            # stop calibration (not actually necessary)
+            self.set_rc(9, 1000)
+
+            # check scaling parameters have been restored to values near zero
+            flow_scalar_x = self.get_parameter("FLOW_FXSCALER")
+            flow_scalar_y = self.get_parameter("FLOW_FYSCALER")
+            if ((flow_scalar_x > 30) or (flow_scalar_x < -30)):
+                raise NotAchievedException("FlowCal failed to set FLOW_FXSCALER correctly")
+            if ((flow_scalar_y > 30) or (flow_scalar_y < -30)):
+                raise NotAchievedException("FlowCal failed to set FLOW_FYSCALER correctly")
+
+        except Exception as e:
+            self.print_exception_caught(e)
+            ex = e
+
+        self.context_pop()
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
+        if ex is not None:
+            raise ex
+
     def fly_autotune(self):
         """Test autotune mode"""
 
@@ -8018,6 +8101,10 @@ class AutoTestCopter(AutoTest):
             ("OpticalFlowLimits",
              "Fly Optical Flow limits",
              self.fly_optical_flow_limits),  # 27s
+
+            ("OpticalFlowCalibration",
+             "Fly Optical Flow calibration",
+             self.fly_optical_flow_calibration),
 
             ("MotorFail",
              "Fly motor failure test",

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2152,6 +2152,15 @@ void  AP_AHRS::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &ra
 #endif
 }
 
+// retrieve latest corrected optical flow samples (used for calibration)
+bool AP_AHRS::getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const
+{
+#if HAL_NAVEKF3_AVAILABLE
+    return EKF3.getOptFlowSample(timeStamp_ms, flowRate, bodyRate, losPred);
+#endif
+    return false;
+}
+
 // write body frame odometry measurements to the EKF
 void  AP_AHRS::writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, uint16_t delay_ms, const Vector3f &posOffset)
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -240,6 +240,9 @@ public:
     // write optical flow measurements to EKF
     void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
 
+    // retrieve latest corrected optical flow samples (used for calibration)
+    bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;
+
     // write body odometry measurements to the EKF
     void writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, uint16_t delay_ms, const Vector3f &posOffset);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1518,6 +1518,16 @@ void NavEKF3::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &raw
     }
 }
 
+// retrieve latest corrected optical flow samples (used for calibration)
+bool NavEKF3::getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const
+{
+    // return optical flow samples from primary core
+    if (core) {
+        return core[primary].getOptFlowSample(timeStamp_ms, flowRate, bodyRate, losPred);
+    }
+    return false;
+}
+
 // write yaw angle sensor measurements
 void NavEKF3::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type)
 {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -198,6 +198,9 @@ public:
     // posOffset is the XYZ flow sensor position in the body frame in m
     void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
 
+    // retrieve latest corrected optical flow samples (used for calibration)
+    bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;
+
     /*
      * Write body frame linear and angular displacement measurements from a visual odometry sensor
      *

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -737,6 +737,28 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
             }
         }
     }
+
+    // store optical flow rates for use in external calibration
+    flowCalSample.timestamp_ms = imuSampleTime_ms;
+    flowCalSample.flowRate.x = ofDataDelayed.flowRadXY.x;
+    flowCalSample.flowRate.y = ofDataDelayed.flowRadXY.y;
+    flowCalSample.bodyRate.x = ofDataDelayed.bodyRadXYZ.x;
+    flowCalSample.bodyRate.y = ofDataDelayed.bodyRadXYZ.y;
+    flowCalSample.losPred.x = losPred[0];
+    flowCalSample.losPred.y = losPred[1];
+}
+
+// retrieve latest corrected optical flow samples (used for calibration)
+bool NavEKF3_core::getOptFlowSample(uint32_t& timestamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const
+{
+    if (flowCalSample.timestamp_ms != 0) {
+        timestamp_ms = flowCalSample.timestamp_ms;
+        flowRate = flowCalSample.flowRate;
+        bodyRate = flowCalSample.bodyRate;
+        losPred = flowCalSample.losPred;
+        return true;
+    }
+    return false;
 }
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -248,6 +248,9 @@ public:
     // posOffset is the XYZ flow sensor position in the body frame in m
     void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
 
+    // retrieve latest corrected optical flow samples (used for calibration)
+    bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;
+
     /*
      * Write body frame linear and angular displacement measurements from a visual odometry sensor
      *
@@ -1186,6 +1189,12 @@ private:
     ftype prevPosE;                 // east position at last measurement
     ftype varInnovRng;              // range finder observation innovation variance (m^2)
     ftype innovRng;                 // range finder observation innovation (m)
+    struct {
+        uint32_t timestamp_ms;      // system timestamp of last correct optical flow sample (used for calibration)
+        Vector2f flowRate;          // latest corrected optical flow flow rate (used for calibration)
+        Vector2f bodyRate;          // latest corrected optical flow body rate (used for calibration)
+        Vector2f losPred;           // EKF estimated component of flowRate that comes from vehicle movement (not rotation)
+    } flowCalSample;
 
     ftype hgtMea;                   // height measurement derived from either baro, gps or range finder data (m)
     bool inhibitGndState;           // true when the terrain position state is to remain constant

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -13,6 +13,7 @@
 #include "AP_OpticalFlow_MSP.h"
 #include "AP_OpticalFlow_UPFLOW.h"
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -182,6 +183,21 @@ void OpticalFlow::update(void)
 
     // only healthy if the data is less than 0.5s old
     _flags.healthy = (AP_HAL::millis() - _last_update_ms < 500);
+
+    // update calibrator and save resulting scaling
+    if (_calibrator != nullptr) {
+        if (_calibrator->update()) {
+            // apply new calibration values
+            const Vector2f new_scaling = _calibrator->get_scalars();
+            const float flow_scalerx_as_multiplier = (1.0 + (_flowScalerX / 1000.0)) * new_scaling.x;
+            const float flow_scalery_as_multiplier = (1.0 + (_flowScalerY / 1000.0)) * new_scaling.y;
+            _flowScalerX.set_and_save_ifchanged((flow_scalerx_as_multiplier - 1.0) * 1000.0);
+            _flowScalerY.set_and_save_ifchanged((flow_scalery_as_multiplier - 1.0) * 1000.0);
+            _flowScalerX.notify();
+            _flowScalerY.notify();
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FlowCal: FLOW_FXSCALER=%d, FLOW_FYSCALER=%d", (int)_flowScalerX, (int)_flowScalerY);
+        }
+    }
 }
 
 void OpticalFlow::handle_msg(const mavlink_message_t &msg)
@@ -209,6 +225,29 @@ void OpticalFlow::handle_msp(const MSP::msp_opflow_data_message_t &pkt)
     }
 }
 #endif //HAL_MSP_OPTICALFLOW_ENABLED
+
+// start calibration
+void OpticalFlow::start_calibration()
+{
+    if (_calibrator == nullptr) {
+        _calibrator = new AP_OpticalFlow_Calibrator();
+        if (_calibrator == nullptr) {
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "FlowCal: failed to start");
+            return;
+        }
+    }
+    if (_calibrator != nullptr) {
+        _calibrator->start();
+    }
+}
+
+// stop calibration
+void OpticalFlow::stop_calibration()
+{
+    if (_calibrator != nullptr) {
+        _calibrator->stop();
+    }
+}
 
 void OpticalFlow::update_state(const OpticalFlow_state &state)
 {

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -34,7 +34,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-
+#include "AP_OpticalFlow_Calibrator.h"
 
 class OpticalFlow_backend;
 
@@ -110,6 +110,10 @@ public:
         return _pos_offset;
     }
 
+    // start or stop calibration
+    void start_calibration();
+    void stop_calibration();
+
     // parameter var info table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -141,6 +145,9 @@ private:
 
     void Log_Write_Optflow();
     uint32_t _log_bit = -1;     // bitmask bit which indicates if we should log.  -1 means we always log
+
+    // calibrator
+    AP_OpticalFlow_Calibrator *_calibrator;
 
 };
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.cpp
@@ -1,0 +1,320 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "AP_OpticalFlow_Calibrator.h"
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
+
+const uint32_t AP_OPTICALFLOW_CAL_TIMEOUT_SEC = 120;        // calibration timesout after 120 seconds
+const uint32_t AP_OPTICALFLOW_CAL_STATUSINTERVAL_SEC = 3;   // status updates printed at 3 second intervals
+const float AP_OPTICALFLOW_CAL_YAW_MAX_RADS = radians(20);  // maximum yaw rotation (must be low to ensure good scaling)
+const float AP_OPTICALFLOW_CAL_ROLLPITCH_MIN_RADS = radians(20);    // minimum acceptable roll or pitch rotation
+const float AP_OPTICALFLOW_CAL_SCALE_MIN = 0.20f;           // min acceptable scaling value.  If resulting scaling is below this then the calibration fails
+const float AP_OPTICALFLOW_CAL_SCALE_MAX = 4.0f;            // max acceptable scaling value.  If resulting scaling is above this then the calibration fails
+const float AP_OPTICALFLOW_CAL_FITNESS_THRESH = 0.5f;       // min acceptable fitness
+const float AP_OPTICALFLOW_CAL_RMS_FAILED = 1.0e30f;        // calc_mean_squared_residuals returns this value when it fails to calculate a good value
+
+extern const AP_HAL::HAL& hal;
+
+// start the calibration
+void AP_OpticalFlow_Calibrator::start()
+{
+    // exit immediately if already running
+    if (_cal_state == CalState::RUNNING) {
+        return;
+    }
+
+    _cal_state = CalState::RUNNING;
+    _start_time_ms = AP_HAL::millis();
+
+    // clear samples buffers
+    _cal_data[0].num_samples = 0;
+    _cal_data[1].num_samples = 0;
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FlowCal: Started");
+}
+
+void AP_OpticalFlow_Calibrator::stop()
+{
+    // exit immediately if already stopped
+    if (_cal_state == CalState::NOT_STARTED) {
+        return;
+    }
+
+    _cal_state = CalState::NOT_STARTED;
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FlowCal: Stopped");
+}
+
+// update the state machine and calculate scaling
+bool AP_OpticalFlow_Calibrator::update()
+{
+    // prefix for reporting
+    const char* prefix_str = "FlowCal:";
+
+    // while running add samples
+    if (_cal_state == CalState::RUNNING) {
+        uint32_t now_ms = AP_HAL::millis();
+        uint32_t timestamp_ms;
+        Vector2f flow_rate, body_rate, los_pred;
+        if (AP::ahrs().getOptFlowSample(timestamp_ms, flow_rate, body_rate, los_pred)) {
+            add_sample(timestamp_ms, flow_rate, body_rate, los_pred);
+
+            // while collecting samples display percentage complete
+            if (now_ms - _last_report_ms > AP_OPTICALFLOW_CAL_STATUSINTERVAL_SEC * 1000UL) {
+                _last_report_ms = now_ms;
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s x:%d%% y:%d%%",
+                                prefix_str,
+                                (int)((_cal_data[0].num_samples * 100.0 / AP_OPTICALFLOW_CAL_MAX_SAMPLES)),
+                                (int)((_cal_data[1].num_samples * 100.0 / AP_OPTICALFLOW_CAL_MAX_SAMPLES)));
+            }
+
+            // advance state once sample buffers are full
+            if (sample_buffers_full()) {
+                _cal_state = CalState::READY_TO_CALIBRATE;
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s samples collected", prefix_str);
+            }
+        }
+
+        // check for timeout
+        if (now_ms - _start_time_ms > AP_OPTICALFLOW_CAL_TIMEOUT_SEC * 1000UL) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s timeout", prefix_str);
+            _cal_state = CalState::FAILED;
+        }
+    }
+
+    // start calibration
+    if (_cal_state == CalState::READY_TO_CALIBRATE) {
+        // run calibration and mark failure or success
+        if (run_calibration()) {
+            _cal_state = CalState::SUCCESS;
+            return true;
+        } else {
+            _cal_state = CalState::FAILED;
+        }
+    }
+
+    // return indicating calibration is not complete
+    return false;
+}
+
+// get final scaling values
+// scaling values used during sample collection should be multiplied by these scalars
+Vector2f AP_OpticalFlow_Calibrator::get_scalars()
+{
+    // return best scaling values
+    return Vector2f{_cal_data[0].best_scalar, _cal_data[1].best_scalar};
+}
+
+// add new sample to the calibrator
+void AP_OpticalFlow_Calibrator::add_sample(uint32_t timestamp_ms, const Vector2f& flow_rate, const Vector2f& body_rate, const Vector2f& los_pred)
+{
+    // return immediately if not running
+    if (_cal_state != CalState::RUNNING) {
+        return;
+    }
+
+    // check for duplicates
+    if (timestamp_ms == _last_sample_timestamp_ms) {
+        return;
+    }
+    _last_sample_timestamp_ms = timestamp_ms;
+
+    // check yaw rotation is low
+    const Vector3f gyro = AP::ahrs().get_gyro();
+    if (fabsf(gyro.z) > AP_OPTICALFLOW_CAL_YAW_MAX_RADS) {
+        return;
+    }
+
+    // check enough roll or pitch movement and record sample
+    const bool rates_x_sufficient = (fabsf(body_rate.x) >= AP_OPTICALFLOW_CAL_ROLLPITCH_MIN_RADS) && (fabsf(flow_rate.x) >= AP_OPTICALFLOW_CAL_ROLLPITCH_MIN_RADS);
+    if (rates_x_sufficient && (_cal_data[0].num_samples < ARRAY_SIZE(_cal_data[0].samples))) {
+        log_sample(0, _cal_data[0].num_samples, flow_rate.x, body_rate.x, los_pred.x);
+        _cal_data[0].samples[_cal_data[0].num_samples].flow_rate = flow_rate.x;
+        _cal_data[0].samples[_cal_data[0].num_samples].body_rate = body_rate.x;
+        _cal_data[0].samples[_cal_data[0].num_samples].los_pred = los_pred.x;
+        _cal_data[0].num_samples++;
+    }
+    const bool rates_y_sufficient = (fabsf(body_rate.y) >= AP_OPTICALFLOW_CAL_ROLLPITCH_MIN_RADS) && (fabsf(flow_rate.y) >= AP_OPTICALFLOW_CAL_ROLLPITCH_MIN_RADS);
+    if (rates_y_sufficient && (_cal_data[1].num_samples < ARRAY_SIZE(_cal_data[1].samples))) {
+        log_sample(1, _cal_data[1].num_samples, flow_rate.y, body_rate.y, los_pred.y);
+        _cal_data[1].samples[_cal_data[1].num_samples].flow_rate = flow_rate.y;
+        _cal_data[1].samples[_cal_data[1].num_samples].body_rate = body_rate.y;
+        _cal_data[1].samples[_cal_data[1].num_samples].los_pred = los_pred.y;
+        _cal_data[1].num_samples++;
+    }
+}
+
+// returns true once the sample buffer is full
+bool AP_OpticalFlow_Calibrator::sample_buffers_full() const
+{
+    return ((_cal_data[0].num_samples >= ARRAY_SIZE(_cal_data[0].samples)) && (_cal_data[1].num_samples >= ARRAY_SIZE(_cal_data[1].samples)));
+}
+
+// run calibration algorithm for both axis
+// returns true on success and updates _cal_data[0,1].best_scale and best_scale_fitness
+bool AP_OpticalFlow_Calibrator::run_calibration()
+{
+    // run calibration for x and y axis
+    const bool calx_res = calc_scalars(0, _cal_data[0].best_scalar, _cal_data[0].best_scalar_fitness);
+    const bool caly_res = calc_scalars(1, _cal_data[1].best_scalar, _cal_data[1].best_scalar_fitness);
+
+    return calx_res && caly_res;
+}
+
+// Run Gauss Newton fitting algorithm for all samples of the given axis
+// returns a scalar and fitness (lower numbers mean a better result) in the arguments provided
+bool AP_OpticalFlow_Calibrator::calc_scalars(uint8_t axis, float& scalar, float& fitness)
+{
+    // prefix for reporting
+    const char* prefix_str = "FlowCal:";
+    const char* axis_str = axis == 0 ? "x" : "y";
+
+    // check we have samples
+    // this should never fail because this method should only be called once the sample buffer is full
+    const uint8_t num_samples = _cal_data[axis].num_samples;
+    if (num_samples == 0) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s failed because no samples", prefix_str);
+        return false;
+    }
+
+    // calculate total absolute residual from all samples
+    float total_abs_residual = 0;
+    for (uint8_t i = 0; i < num_samples; i++) {
+        const sample_t& samplei = _cal_data[axis].samples[i];
+        total_abs_residual += fabsf(calc_sample_residual(samplei, 1.0));
+    }
+
+    // if there are no residuals then scaling is perfect
+    if (is_zero(total_abs_residual)) {
+        scalar = 1.0;
+        fitness = 0;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s perfect scalar%s of 1.0", prefix_str, axis_str);
+        return true;
+    }
+
+    // for each sample calculate the residual and scalar that best reduces the residual
+    float best_scalar_total = 0;
+    for (uint8_t i = 0; i < num_samples; i++) {
+        float sample_best_scalar;
+        const sample_t& samplei = _cal_data[axis].samples[i];
+        if (!calc_sample_best_scalar(samplei, sample_best_scalar)) {
+            // failed to find the best scalar for a single sample
+            // this should never happen because of checks when capturing samples
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s failed because of zero flow rate", prefix_str);
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            return false;
+        }
+        const float sample_residual = calc_sample_residual(samplei, 1.0);
+        best_scalar_total += sample_best_scalar * fabsf(sample_residual) / total_abs_residual;
+    }
+
+    // check for out of range results
+    if (best_scalar_total < AP_OPTICALFLOW_CAL_SCALE_MIN) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s scalar%s:%4.3f too low (<%3.1f)", prefix_str, axis_str, (double)best_scalar_total, (double)AP_OPTICALFLOW_CAL_SCALE_MIN);
+        return false;
+    }
+    if (best_scalar_total > AP_OPTICALFLOW_CAL_SCALE_MAX) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s scalar%s:%4.3f too high (>%3.1f)", prefix_str, axis_str, (double)best_scalar_total, (double)AP_OPTICALFLOW_CAL_SCALE_MAX);
+        return false;
+    }
+
+    // check for poor fitness
+    float fitness_new = calc_mean_squared_residuals(axis, best_scalar_total);
+    if (fitness_new > AP_OPTICALFLOW_CAL_FITNESS_THRESH) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s scalar%s:%4.3f fit:%4.3f too high (>%3.1f)", prefix_str, axis_str, (double)scalar, (double)fitness_new, (double)AP_OPTICALFLOW_CAL_FITNESS_THRESH);
+        return false;
+    }
+
+    // success if fitness has improved
+    float fitness_orig = calc_mean_squared_residuals(axis, 1.0);
+    if (fitness_new <= fitness_orig) {
+        scalar = best_scalar_total;
+        fitness = fitness_new;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s scalar%s:%4.3f fit:%4.2f", prefix_str, axis_str, (double)scalar, (double)fitness);
+        return true;
+    }
+
+    // failed to find a better scalar than 1.0
+    scalar = 1.0;
+    fitness = fitness_orig;
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s no better scalar%s:%4.3f (fit:%4.3f > orig:%4.3f)", prefix_str, axis_str, (double)best_scalar_total, (double)fitness_new, (double)fitness_orig);
+    return false;
+}
+
+// calculate a single sample's residual
+float AP_OpticalFlow_Calibrator::calc_sample_residual(const sample_t& sample, float scalar) const
+{
+    return (sample.body_rate + ((sample.flow_rate * scalar) - sample.los_pred));
+}
+
+// calculate the scalar that minimises the residual for a single sample
+// returns true on success and populates the best_scalar argument
+bool AP_OpticalFlow_Calibrator::calc_sample_best_scalar(const sample_t& sample, float& best_scalar) const
+{
+    // if sample's flow_rate is zero scalar has no effect
+    // this should never happen because samples should have been checked before being added
+    if (is_zero(sample.flow_rate)) {
+        return false;
+    }
+    best_scalar = (sample.los_pred - sample.body_rate) / sample.flow_rate;
+    return true;
+}
+
+// calculate mean squared residual for all samples of a single axis (0 or 1) given a scalar parameter
+float AP_OpticalFlow_Calibrator::calc_mean_squared_residuals(uint8_t axis, float scalar) const
+{
+    // sanity check axis
+    if (axis >= 2) {
+        return AP_OPTICALFLOW_CAL_RMS_FAILED;
+    }
+
+    // calculate and sum residuals of each sample
+    float sum = 0.0f;
+    uint16_t num_samples = 0;
+    for (uint8_t i = 0; i < _cal_data[axis].num_samples; i++) {
+        sum += sq(calc_sample_residual(_cal_data[axis].samples[i], scalar));
+        num_samples++;
+    }
+
+    // return a huge residual if no samples
+    if (num_samples == 0) {
+        return AP_OPTICALFLOW_CAL_RMS_FAILED;
+    }
+
+    sum /= num_samples;
+    return sum;
+}
+
+// log all samples
+void AP_OpticalFlow_Calibrator::log_sample(uint8_t axis, uint8_t sample_num, float flow_rate, float body_rate, float los_pred)
+{
+    // @LoggerMessage: OFCA
+    // @Description: Optical Flow Calibration sample
+    // @Field: TimeUS: Time since system startup
+    // @Field: Axis: Axis (X=0 Y=1)
+    // @Field: Num: Sample number
+    // @Field: FRate: Flow rate
+    // @Field: BRate: Body rate
+    // @Field: LPred: Los pred
+
+    AP::logger().Write("OFCA", "TimeUS,Axis,Num,FRate,BRate,LPred", "QBBfff",
+        AP_HAL::micros64(),
+        (unsigned)axis,
+        (unsigned)sample_num,
+        (double)flow_rate,
+        (double)body_rate,
+        (double)los_pred);
+}

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+
+#define AP_OPTICALFLOW_CAL_MAX_SAMPLES 50  // number of samples required before calibration begins
+
+class AP_OpticalFlow_Calibrator {
+public:
+    AP_OpticalFlow_Calibrator() {};
+
+    // start or stop the calibration
+    void start();
+    void stop();
+
+    // update the state machine and calculate scaling
+    // returns true if new scaling values have been found
+    bool update();
+
+    // get final scaling values
+    // scaling values used during sample collection should be multiplied by these scalars
+    Vector2f get_scalars();
+
+private:
+
+    // single sample for a single axis
+    struct sample_t {
+        float flow_rate;
+        float body_rate;
+        float los_pred;
+    };
+
+    // attempt to add a new sample to the buffer
+    void add_sample(uint32_t timestamp_ms, const Vector2f& flow_rate, const Vector2f& body_rate, const Vector2f& los_pred);
+
+    // returns true once the sample buffer is full
+    bool sample_buffers_full() const;
+
+    // run calibration algorithm for both axis
+    // returns true on success and updates _cal_data[0,1].best_scale and best_scale_fitness
+    bool run_calibration();
+
+    // Run fitting algorithm for all samples of the given axis
+    // returns a scalar and fitness (lower numbers mean a better result) in the arguments provided
+    bool calc_scalars(uint8_t axis, float& scalar, float& fitness);
+
+    // calculate a single sample's residual given a scalar parameter
+    float calc_sample_residual(const sample_t& sample, float scalar) const;
+
+    // calculate the scalar that minimises the residual for a single sample
+    // returns true on success and populates the best_scalar argument
+    bool calc_sample_best_scalar(const sample_t& sample, float& best_scalar) const;
+
+    // calculate mean squared residual for all samples of a single axis (0 or 1) given a scalar parameter
+    float calc_mean_squared_residuals(uint8_t axis, float scalar) const;
+
+    // log a sample
+    void log_sample(uint8_t axis, uint8_t sample_num, float flow_rate, float body_rate, float los_pred);
+
+    // calibration states
+    enum class CalState {
+        NOT_STARTED = 0,
+        RUNNING,            // collecting samples
+        READY_TO_CALIBRATE, // ready to calibrate (may wait until vehicle is disarmed)
+        SUCCESS,
+        FAILED
+    } _cal_state;
+
+    // local variables
+    uint32_t _start_time_ms;                                // time the calibration was started
+    struct {
+        sample_t samples[AP_OPTICALFLOW_CAL_MAX_SAMPLES];   // buffer of sensor samples
+        uint8_t num_samples;                                // number of samples in samples buffer
+        float best_scalar;                                  // best scaling value found so far
+        float best_scalar_fitness;                          // fitness (rms of error) of best scaling value
+    } _cal_data[2];                                         // x and y axis
+    uint32_t _last_sample_timestamp_ms;                     // system time of last sample's timestamp, used to ignore duplicates
+    uint32_t _last_report_ms;                               // system time of last status report
+};

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -41,6 +41,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AC_Fence/AC_Fence.h>
+#include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mount/AP_Mount.h>
@@ -96,9 +97,9 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
-    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 75:SurfaceTrackingUpDown, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:VisOdom Align, 81:Disarm, 83:ZigZag Auto, 84:Air Mode, 85:Generator, 90:EKF Pos Source, 94:VTX Power, 99:AUTO RTL, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 151:Turtle, 152:simple heading reset, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with AirMode  (4.2 and higher), 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 75:SurfaceTrackingUpDown, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:VisOdom Align, 81:Disarm, 83:ZigZag Auto, 84:Air Mode, 85:Generator, 90:EKF Pos Source, 94:VTX Power, 99:AUTO RTL, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 151:Turtle, 152:simple heading reset, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with AirMode  (4.2 and higher), 158:Optflow Calibration, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
     // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim (4.1 and lower), 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 27:Retract Mount, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 81:Disarm, 90:EKF Pos Source, 94:VTX Power, 97:Windvane home heading direction offset, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 153:ArmDisarm (4.2 and higher), 155: set steering trim to current servo and RC, 156:Torqeedo Clear Err, 201:Roll, 202:Pitch, 207:MainSail, 208:Flap, 211:Walking Height, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
-    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 11:Fence, 16:ModeAuto, 22:Parachute Release, 24:Auto Mission Reset, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Plane Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm (4.1 and lower), 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 52: ModeACRO, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 81:Disarm, 82:QAssist 3pos, 84:Air Mode, 85:Generator, 86: Non Auto Terrain Follow Disable, 87:Crow Select, 88:Soaring Enable, 89:Landing Flare, 90:EKF Pos Source, 91:Airspeed Ratio Calibration, 92:FBWA, 94:VTX Power, 95:FBWA taildragger takeoff mode, 96:trigger re-reading of mode switch, 98: ModeTraining, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 107: EnableFixedWingAutotune, 108: ModeQRTL, 150: CRUISE, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with Quadplane AirMode (4.2 and higher), 155: set roll pitch and yaw trim to current servo and RC, 157: Force FS Action to FBWA, 208:Flap, 209: Forward Throttle, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 11:Fence, 16:ModeAuto, 22:Parachute Release, 24:Auto Mission Reset, 27:Retract Mount, 28:Relay On/Off, 29:Landing Gear, 30:Lost Plane Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm (4.1 and lower), 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 52: ModeACRO, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 81:Disarm, 82:QAssist 3pos, 84:Air Mode, 85:Generator, 86: Non Auto Terrain Follow Disable, 87:Crow Select, 88:Soaring Enable, 89:Landing Flare, 90:EKF Pos Source, 91:Airspeed Ratio Calibration, 92:FBWA, 94:VTX Power, 95:FBWA taildragger takeoff mode, 96:trigger re-reading of mode switch, 98: ModeTraining, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 107: EnableFixedWingAutotune, 108: ModeQRTL, 150: CRUISE, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with Quadplane AirMode (4.2 and higher), 155: set roll pitch and yaw trim to current servo and RC, 157: Force FS Action to FBWA, 158:Optflow Calibration, 208:Flap, 209: Forward Throttle, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
     // @Values{Blimp}: 0:Do Nothing, 18:Land, 46:RC Override Enable, 65:GPS Disable, 81:Disarm, 90:EKF Pos Source, 100:KillIMU1, 101:KillIMU2, 153:ArmDisarm
     // @User: Standard
     AP_GROUPINFO_FRAME("OPTION",  6, RC_Channel, option, 0, AP_PARAM_FRAME_COPTER|AP_PARAM_FRAME_ROVER|AP_PARAM_FRAME_PLANE|AP_PARAM_FRAME_BLIMP),
@@ -499,6 +500,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::SCRIPTING_7:
     case AUX_FUNC::SCRIPTING_8:
     case AUX_FUNC::VTX_POWER:
+    case AUX_FUNC::OPTFLOW_CAL:
         break;
     case AUX_FUNC::AVOID_ADSB:
     case AUX_FUNC::AVOID_PROXIMITY:
@@ -1115,6 +1117,22 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
             break;
         }
         break;
+
+    case AUX_FUNC::OPTFLOW_CAL: {
+#if AP_OPTICALFLOW_ENABLED
+        OpticalFlow *optflow = AP::opticalflow();
+        if (optflow == nullptr) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "OptFlow Cal: failed sensor not enabled");
+            break;
+        }
+        if (ch_flag == AuxSwitchPos::HIGH) {
+            optflow->start_calibration();
+        } else {
+            optflow->stop_calibration();
+        }
+#endif
+        break;
+    }
 
 #if !HAL_MINIMIZE_FEATURES
     case AUX_FUNC::KILL_IMU1:

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -227,6 +227,7 @@ public:
         TRIM_TO_CURRENT_SERVO_RC = 155, // trim to current servo and RC
         TORQEEDO_CLEAR_ERR = 156, // clear torqeedo error
         EMERGENCY_LANDING_EN = 157, //Force long FS action to FBWA for landing out of range
+        OPTFLOW_CAL =        158, // optical flow calibration
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input


### PR DESCRIPTION
This adds an an optical flow calibrator and resolves issue https://github.com/ArduPilot/ardupilot/issues/16631.  The hope is users will run this calibrator on the bench or even in the air and it will more easily capture better X and Y scaling values than they could using our [currently recommended method](https://ardupilot.org/copter/docs/common-optical-flow-sensor-setup.html#calibrating-the-sensor) which is quite laborious.

Some details of this change:

1. AP_AHRS and AP_NavEKF3 have been enhanced to store the last optical flow "sample".  This is the flow rate (e.g. the motion the camera sees), body rate (the rotation from the gyros) and "los pred" (the portion of the flow rate which can be attributed to change in position of the vehicle (i.e. not it's rotation)).  These samples are stored at the "delayed horizon" because this is when "los pred" is available.
2. AP_OpticalFlow::update() has been extended to polls the AHRS for new samples and when they are available they are pushed into the new AP_OpticalFlow_Calibrator class
3. AP_OpticalFlow stores samples with both body and flow rate > 20deg/sec.  Once 50 samples for X and Y axis have been stored the calibration procedure runs.  These samples are also logged for debugging (I have a spreadsheet that duplicates what this library does).
4. The calibration routine is run on each axis (x and y) like this:
    - the "residual" for each sample is calculated.  This is the difference between body rate and flow rate.
    - a scalar for each sample is calculated that would cause the flow rate to equal the body rate (note: scalars always adjust the flow rate).  i.e. would result in no residual.
    - The best scalar for the entire set of samples is the sum of the individual sample scalars weighted by their residual vs the total residual (of the full set of samples).  This means the scalar from samples with a higher residual have a larger impact.
    - the "fitnesses" using the new scalars (one for x, one for y) is checked vs the original scalars to ensure there's has been improvement.  note: a lower fitness is better.  note2: the "fitness" is calculated using a "mean squared" of the residuals not just the sum of the residuals which I think explains why every now and then the new scalars are **not** an improvement and the calibration fails.
    - unlike some more complicated calibrators (e.g. accel cal, compass cal) there is no iterative process.  I don't think we need to iterate because there is only one variable for each axis and I can't see how repeating the calibration would change the final number we come up with.

This calibrator can be tested in SITL by doing the following:

- cd ArduCopter
- ../Tools/autotest/sim_vehicle.py --map --console
- param load ../Tools/autotest/default_params/copter-optflow.parm (this may need to be repeated a few times because of enable parameters, then restart SITL)
- param set RC9_OPTION 158
- param set FLOW_FXSCALER 200 (need to set these to bad values initially so calibration can fix them)
- param set FLOW_FYSCALER -200
- loiter
- arm throttle
- rc 3 1800 (climb to about 10m)
- cause the vehicle to roll and pitch using rc sticks by entering values like below
    - rc 1 1000
    - rc 1 2000
    - rc 1 1500
    - rc 2 1000
    - rc 2 2000
    - rc 2 1500 
- after 50 x-axis and 50 y-axis samples are collected the calibration will run and FLOW_FXSCALER and FLOW_FYSCALER should be retuned to values near 0 as shown below:

![image](https://user-images.githubusercontent.com/1498098/150929388-8bad6bdd-8a00-4db2-9600-85547cea8e6e.png)

This has been tested fairly thoroughly in SITL and in bench testing including testing that the calibration fails if the FLOW_YAW_ORIENT parameter is incorrect.

I've also added an autotest that can be run like this:

- cd ArduCopter
- ../Tools/autotest/autotest.py build.Copter test.Copter.OpticalFlowCalibration --map

Update on testing:
- [x] Tested on a real vehicle:
    - 1st test: FLOW_FXSCALER=-129, FYSCALER=-125
    - 2nd test:  FLOW_FXSCALER=-98, FYSCALER = -111
- [x] Confirm the calibration can all be run in one iteration of the main loop without causing problems.  The calibration takes 1.7ms on a classic Pixhawk1 (STM32 F4?) and in a real flight test it was lost amongst the noise of "normal" long running loops.
- [x] Calibrator consumes about 2.1K of RAM which is consumed by a calloc when the calibration is first started by the user

The design of this calibrator is based on a discussion with @priseborough but there is certainly a chance that I misunderstood his suggestion.