### PR TITLE
Copter: improve PILOT_SPEED_DN param description

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -899,9 +899,9 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: PILOT_SPEED_DN
     // @DisplayName: Pilot maximum vertical speed descending
-    // @Description: The maximum vertical descending velocity the pilot may request in cm/s
+    // @Description: The maximum vertical descending velocity the pilot may request in cm/s.  If 0 PILOT_SPEED_UP value is used.
     // @Units: cm/s
-    // @Range: 50 500
+    // @Range: 0 500
     // @Increment: 10
     // @User: Standard
     AP_GROUPINFO("PILOT_SPEED_DN", 24, ParametersG2, pilot_speed_dn, 0),


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/19839 by improving the human-readable description to specify what happens when the param is set to zero.  Also the range includes 0 so users don't see an error in the GCS if they try to change it to zero as shown below.

![image](https://user-images.githubusercontent.com/1498098/150964347-248e137b-c4eb-4e78-83e7-e304d5e905cb.png)
