### PR TITLE
Copter: fix sanity checks for takeoff altitude

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -258,12 +258,9 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     }
 
     // sanity check target
-    if (alt_target < copter.current_loc.alt) {
-        dest.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
-    }
-    // Note: if taking off from below home this could cause a climb to an unexpectedly high altitude
-    if (alt_target < 100) {
-        dest.set_alt_cm(100, Location::AltFrame::ABOVE_HOME);
+    float alt_target_min_cm = copter.current_loc.alt + (copter.ap.land_complete ? 100 : 0);
+    if (alt_target < alt_target_min_cm ) {
+        dest.set_alt_cm(alt_target_min_cm , Location::AltFrame::ABOVE_HOME);
     }
 
     // set waypoint controller target


### PR DESCRIPTION
This PR fixed the accidental setting of the target to 100cm in the TAKEOFF command.

We can reproduce the problem in SITL.
1. run SITL at CMAC
2. create and write mission
 TAKEOFF Alt:20m, Frame: Absolute
3. takeoff manually
arm throttle
takeoff 10
4. switch to auto mode

The copter will descend because the altitude target is 100cm.
Absolute's 20m altitude target is a user setting error.
But, if the target is lower than the current altitude, it needs to set the target to the current altitude instead of 100cm.