### PR TITLE
Add AP_GPS_BACKEND_DEFAULT_ENABLED and have SkyViper-v2450 use just ublox and mav

### DIFF
--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -25,7 +25,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_ERB_ENABLED
-  #define AP_GPS_ERB_ENABLED 1
+  #define AP_GPS_ERB_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_ERB_ENABLED

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -23,7 +23,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_GSOF_ENABLED
-  #define AP_GPS_GSOF_ENABLED 1
+  #define AP_GPS_GSOF_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_GSOF_ENABLED

--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -26,7 +26,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_MAV_ENABLED
-  #define AP_GPS_MAV_ENABLED 1
+  #define AP_GPS_MAV_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif 
 
 #if AP_GPS_MAV_ENABLED

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -47,7 +47,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_NMEA_ENABLED
-  #define AP_GPS_NMEA_ENABLED 1
+  #define AP_GPS_NMEA_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_NMEA_ENABLED

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -23,7 +23,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_NOVA_ENABLED
-  #define AP_GPS_NOVA_ENABLED 1
+  #define AP_GPS_NOVA_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_NOVA_ENABLED

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -23,7 +23,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_SBF_ENABLED
-  #define AP_GPS_SBF_ENABLED 1
+  #define AP_GPS_SBF_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_SBF_ENABLED

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -25,7 +25,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_SBP_ENABLED
-  #define AP_GPS_SBP_ENABLED 1
+  #define AP_GPS_SBP_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_SBP_ENABLED

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -25,7 +25,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_SBP2_ENABLED
-   #define AP_GPS_SBP2_ENABLED 1
+   #define AP_GPS_SBP2_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_SBP2_ENABLED

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -26,7 +26,7 @@
 #include "GPS_Backend.h"
 
 #ifndef AP_GPS_SIRF_ENABLED
-  #define AP_GPS_SIRF_ENABLED 1
+  #define AP_GPS_SIRF_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
 #endif
 
 #if AP_GPS_SIRF_ENABLED

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -22,6 +22,10 @@
 #include <AP_RTC/JitterCorrection.h>
 #include "AP_GPS.h"
 
+#ifndef AP_GPS_BACKEND_DEFAULT_ENABLED
+#define AP_GPS_BACKEND_DEFAULT_ENABLED 1
+#endif
+
 #ifndef AP_GPS_DEBUG_LOGGING_ENABLED
 // enable this to log all bytes from the GPS. Also needs a call to
 // log_data() in each backend

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -97,3 +97,8 @@ define HAL_WITH_ESC_TELEM 0
 define LANDING_GEAR_ENABLED 0
 define MODE_TURTLE_ENABLED 0
 define WINCH_ENABLED 0
+
+# SkyViper has only one physical GPS but can also take from mavlink:
+define AP_GPS_BACKEND_DEFAULT_ENABLED 0
+define AP_GPS_UBLOX_ENABLED 1
+define AP_GPS_MAV_ENABLED 1


### PR DESCRIPTION
```
bin/arducopter   1210144      2876   193816               1213020          867740
bin/arducopter   1227756      2876   193820               1230632          850124
```

Currently there are several backends which can't be removed, but when they'll stop being used on SkyViper-v2450.

The UBLOX define in the SkyViper hwdef doesn't do anything but is correctly named and might stop breakage when we do stop add the option in for the UBLOX support.
