### PR TITLE
Copter: 4.1.4-rc1 beta release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,25 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.4-rc1 27-Jan-2022
+Changes from 4.1.3
+1) Benewake CAN Lidar support
+2) CAN GPS default lag dropped to 0.1 seconds (was 0.22 seconds)
+3) Bug fixes
+    a) Compass custom orientation is never overwritten during calibration
+    b) EKF logging gaps fixed (some messages were occasionally being skipped)
+    c) Guided mode cornering improvements
+    d) IMU logging fix for IREG message (records IMU register changes)
+    e) LOITER_TO_ALT mission command's climb rate fixed (could climb or descend too quickly)
+    f) Position controller init fix to avoid twitch on vehicles with high vibrations
+    g) Position controller init fix to better handle high speed entry to flight mode
+    h) Position controller priortises reducing cross track error
+    i) Position controller relax fix
+    j) SBUS RC frame gap increased to better handle some new receivers
+    k) SERVOx_FUNCTION protection to avoid memory overwrite if set too high
+    l) SD card init triggering watchdog fixed
+    m) Spline path max lateral acceleration reduced (vehicle stays on path better but may be slower)
+    n) Takeoff bug fix if taking off below home or frame specified as MSL
+------------------------------------------------------------------
 Copter 4.1.3 31-Dec-2021 / 4.1.3-rc2 21-Dec-2021
 Changes from 4.1.3-rc1
 1) Suport for IIM-42652, ICM-40605 and ICM-20608-D IMUs

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -979,6 +979,7 @@ void ModeAuto::loiter_to_alt_run()
         pos_control->get_pos_z_p().kP(),
         pos_control->get_max_accel_z_cmss(),
         G_Dt);
+    target_climb_rate = constrain_float(target_climb_rate, pos_control->get_max_speed_down_cms(), pos_control->get_max_speed_up_cms());
 
     // get avoidance adjusted climb rate
     target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -207,12 +207,9 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     }
 
     // sanity check target
-    if (alt_target < copter.current_loc.alt) {
-        dest.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
-    }
-    // Note: if taking off from below home this could cause a climb to an unexpectedly high altitude
-    if (alt_target < 100) {
-        dest.set_alt_cm(100, Location::AltFrame::ABOVE_HOME);
+    float alt_target_min_cm = copter.current_loc.alt + (copter.ap.land_complete ? 100 : 0);
+    if (alt_target < alt_target_min_cm ) {
+        dest.set_alt_cm(alt_target_min_cm , Location::AltFrame::ABOVE_HOME);
     }
 
     // set waypoint controller target

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -207,7 +207,7 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     }
 
     // sanity check target
-    float alt_target_min_cm = copter.current_loc.alt + (copter.ap.land_complete ? 100 : 0);
+    int32_t alt_target_min_cm = copter.current_loc.alt + (copter.ap.land_complete ? 100 : 0);
     if (alt_target < alt_target_min_cm ) {
         dest.set_alt_cm(alt_target_min_cm , Location::AltFrame::ABOVE_HOME);
     }

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.3"
+#define THISFIRMWARE "ArduCopter V4.1.4-rc1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,4,FIRMWARE_VERSION_TYPE_RC
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 4
+#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1,11 +1,11 @@
 #include "Plane.h"
 
 /*
-  get a speed scaling number for control surfaces. This is applied to
-  PIDs to change the scaling of the PID with speed. At high speed we
-  move the surfaces less, and at low speeds we move them more.
+  calculate speed scaling number for control surfaces. This is applied
+  to PIDs to change the scaling of the PID with speed. At high speed
+  we move the surfaces less, and at low speeds we move them more.
  */
-float Plane::get_speed_scaler(void)
+float Plane::calc_speed_scaler(void)
 {
     float aspeed, speed_scaler;
     if (ahrs.airspeed_estimate(aspeed)) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -394,6 +394,9 @@ private:
     // Difference between current altitude and desired altitude.  Centimeters
     int32_t altitude_error_cm;
 
+    // speed scaler for control surfaces, updated at 10Hz
+    float surface_speed_scaler = 1.0;
+
     // Battery Sensors
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Plane::handle_battery_failsafe, void, const char*, const int8_t),
@@ -844,7 +847,8 @@ private:
     void calc_throttle();
     void calc_nav_roll();
     void calc_nav_pitch();
-    float get_speed_scaler(void);
+    float calc_speed_scaler(void);
+    float get_speed_scaler(void) const { return surface_speed_scaler; }
     bool stick_mixing_enabled(void);
     void stabilize_roll(float speed_scaler);
     void stabilize_pitch(float speed_scaler);

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,5 @@
-Release 4.1.6beta1 21st December 2021
--------------------------------------
+Release 4.1.6 3rd January 2022
+------------------------------
 
 This is a minor release with some important bug fixes:
 
@@ -11,6 +11,10 @@ This is a minor release with some important bug fixes:
    is on at boot
  - fixed QAUTOTUNE to obey maximum attitude rate limits
  - fixed a bug in smartaudio support that increased CPU usage
+ - added lowpass filter to speed scaling to prevent sudden surface
+   movement on VTOL arming
+ - fixed hang when BATT_MONITOR is set to 14
+ - fixed gaps in EKF3 logging of variances and timing
 
 Happy flying!
 

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -410,10 +410,10 @@ float Plane::roll_in_expo(bool use_dz) const
 
 float Plane::pitch_in_expo(bool use_dz) const
 {
-    return channel_expo(channel_pitch, g2.man_expo_roll, use_dz);
+    return channel_expo(channel_pitch, g2.man_expo_pitch, use_dz);
 }
 
 float Plane::rudder_in_expo(bool use_dz) const
 {
-    return channel_expo(channel_rudder, g2.man_expo_roll, use_dz);
+    return channel_expo(channel_rudder, g2.man_expo_rudder, use_dz);
 }

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -65,6 +65,12 @@ void Plane::read_airspeed(void)
     if (ahrs.airspeed_estimate(aspeed)) {
         smoothed_airspeed = smoothed_airspeed * 0.8f + aspeed * 0.2f;
     }
+
+    // low pass filter speed scaler, with 1Hz cutoff, at 10Hz
+    const float speed_scaler = calc_speed_scaler();
+    const float cutoff_Hz = 2.0;
+    const float dt = 0.1;
+    surface_speed_scaler += calc_lowpass_alpha_dt(dt, cutoff_Hz) * (speed_scaler - surface_speed_scaler);
 }
 
 /*

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.1.6beta1"
+#define THISFIRMWARE "ArduPlane V4.1.6"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,6,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,1,6,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
 #define FW_PATCH 6
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -182,9 +182,9 @@ void AC_AttitudeControl::reset_rate_controller_I_terms()
 // reset rate controller I terms smoothly to zero in 0.5 seconds
 void AC_AttitudeControl::reset_rate_controller_I_terms_smoothly()
 {
-    get_rate_roll_pid().reset_I_smoothly();
-    get_rate_pitch_pid().reset_I_smoothly();
-    get_rate_yaw_pid().reset_I_smoothly();
+    get_rate_roll_pid().relax_integrator(0.0, AC_ATTITUDE_RATE_RELAX_TC);;
+    get_rate_pitch_pid().relax_integrator(0.0, AC_ATTITUDE_RATE_RELAX_TC);;
+    get_rate_yaw_pid().relax_integrator(0.0, AC_ATTITUDE_RATE_RELAX_TC);;
 }
 
 // The attitude controller works around the concept of the desired attitude, target attitude

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -25,6 +25,7 @@
 #define AC_ATTITUDE_RATE_CONTROLLER_TIMEOUT             1.0f    // body-frame rate controller timeout in seconds
 #define AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX          1.0f    // body-frame rate controller maximum output (for roll-pitch axis)
 #define AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX         1.0f    // body-frame rate controller maximum output (for yaw axis)
+#define AC_ATTITUDE_RATE_RELAX_TC                       0.16f   // This is used to decay the rate I term to 5% in half a second.
 
 #define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(30.0f) // Thrust angle error above which yaw corrections are limited
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -658,13 +658,13 @@ void AC_PosControl::update_xy_controller()
     // Acceleration Controller
 
     // limit acceleration using maximum lean angles
-    _limit_vector.x = 0.0f;
-    _limit_vector.y = 0.0f;
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max(), get_lean_angle_max_cd());
     float accel_max = GRAVITY_MSS * 100.0f * tanf(ToRad(angle_max * 0.01f));
-    if (_accel_target.limit_length_xy(accel_max)) {
-        _limit_vector.x = _accel_target.x;
-        _limit_vector.y = _accel_target.y;
+    // Define the limit vector before we constrain _accel_target 
+    _limit_vector.xy() = _accel_target.xy();
+    if (!limit_accel_xy(_vel_desired.xy(), _accel_target.xy(), accel_max)) {
+        // _accel_target was not limited so we can zero the xy limit vector
+        _limit_vector.xy().zero();
     }
 
     // update angle targets that will be passed to stabilize controller

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -355,10 +355,10 @@ void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_offset_z, float
         accel_z_cmss *= POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_up_cms;
     }
 
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     // calculate the horizontal and vertical velocity limits to travel directly to the destination defined by pos
     float vel_max_xy_cms = 0.0f;
@@ -536,7 +536,7 @@ void AC_PosControl::input_accel_xy(const Vector3f& accel)
     // check for ekf xy position reset
     handle_ekf_xy_reset();
 
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
     shape_accel_xy(accel, _accel_desired, _jerk_max_xy_cmsss, _dt);
 }
 
@@ -547,12 +547,12 @@ void AC_PosControl::input_accel_xy(const Vector3f& accel)
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     shape_vel_accel_xy(vel, accel, _vel_desired.xy(), _accel_desired.xy(),
         _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_vel_accel_xy(vel, accel, _dt, Vector2f());
+    update_vel_accel_xy(vel, accel, _dt, Vector2f(), Vector2f());
 }
 
 /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
@@ -562,12 +562,12 @@ void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, boo
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy());
+    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     shape_pos_vel_accel_xy(pos, vel, accel, _pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(),
                            _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f());
+    update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f(), Vector2f(), Vector2f());
 }
 
 /// stop_pos_xy_stabilisation - sets the target to the current position to remove any position corrections from the system
@@ -647,7 +647,7 @@ void AC_PosControl::update_xy_controller()
         _vehicle_horiz_vel.x = _inav.get_velocity().x;
         _vehicle_horiz_vel.y = _inav.get_velocity().y;
     }
-    Vector2f accel_target = _pid_vel_xy.update_all(Vector2f{_vel_target.x, _vel_target.y}, _vehicle_horiz_vel, Vector2f(_limit_vector.x, _limit_vector.y));
+    Vector2f accel_target = _pid_vel_xy.update_all(_vel_target.xy(), _vehicle_horiz_vel, _limit_vector.xy());
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
     accel_target *= ekfNavVelGainScaler;
 
@@ -824,7 +824,7 @@ void AC_PosControl::input_accel_z(float accel)
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_accel(accel, _accel_desired.z, _jerk_max_z_cmsss, _dt);
 }
@@ -850,14 +850,14 @@ void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool ignore_desce
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_vel_accel(vel, accel,
                     _vel_desired.z, _accel_desired.z,
                     -constrain_float(accel_z_cmss, 0.0f, 750.0f), accel_z_cmss,
                     _jerk_max_z_cmsss, _dt, limit_output);
 
-    update_vel_accel(vel, accel, _dt, 0);
+    update_vel_accel(vel, accel, _dt, 0.0, 0.0);
 }
 
 /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
@@ -907,7 +907,7 @@ void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, b
     }
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_pos_vel_accel(pos, vel, accel,
                         _pos_target.z, _vel_desired.z, _accel_desired.z,
@@ -916,7 +916,7 @@ void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, b
                         _jerk_max_z_cmsss, _dt, limit_output);
 
     postype_t posp = pos;
-    update_pos_vel_accel(posp, vel, accel, _dt, 0);
+    update_pos_vel_accel(posp, vel, accel, _dt, 0.0, 0.0, 0.0);
     pos = posp;
 }
 
@@ -933,7 +933,7 @@ void AC_PosControl::update_pos_offset_z(float pos_offset_z)
 {
 
     postype_t p_offset_z = _pos_offset_z;
-    update_pos_vel_accel(p_offset_z, _vel_offset_z, _accel_offset_z, _dt, MIN(_limit_vector.z, 0.0f));
+    update_pos_vel_accel(p_offset_z, _vel_offset_z, _accel_offset_z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
     _pos_offset_z = p_offset_z;
 
     // input shape the terrain offset

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -509,15 +509,16 @@ void AC_PosControl::init_xy()
     _vel_target.y = curr_vel.y;
 
 
-    const Vector3f &curr_accel = _ahrs.get_accel_ef_blended() * 100.0f;
-    _accel_desired.xy() = curr_accel.xy();
-    _accel_desired.xy().limit_length(_accel_max_xy_cmss);
+    // Set desired accel to zero because raw acceleration is prone to noise
+    _accel_desired.xy().zero();
 
     lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
 
     // initialise I terms from lean angles
     _pid_vel_xy.reset_filter();
-    _pid_vel_xy.set_integrator(_accel_target - _accel_desired);
+    // initialise the I term to _accel_target - _accel_desired
+    // _accel_desired is zero and can be removed from the equation
+    _pid_vel_xy.set_integrator(_accel_target);
 
     // initialise ekf xy reset handler
     init_ekf_xy_reset();

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -34,7 +34,7 @@
 
 #define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
 
-#define POSCONTROL_RELAX_TC                     0.16f   // This is used to decay the relevant variable to 5% in half a second.
+#define POSCONTROL_RELAX_TC                     0.16f   // This is used to decay the I term to 5% in half a second.
 
 class AC_PosControl
 {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -420,6 +420,9 @@ protected:
     // calculate_yaw_and_rate_yaw - calculate the vehicle yaw and rate of yaw.
     bool calculate_yaw_and_rate_yaw();
 
+    // calculate_overspeed_gain - calculated increased maximum acceleration and jerk if over speed condition is detected
+    float calculate_overspeed_gain();
+
     /// initialise and check for ekf position resets
     void init_ekf_xy_reset();
     void handle_ekf_xy_reset();

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -33,7 +33,7 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
     }
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z);
+    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     // prevent altitude target from breeching altitude limits
     if (is_negative(_alt_min) && _alt_min < _alt_max && _alt_max < 100 && _pos_target.z < _alt_min) {
@@ -45,5 +45,5 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
         -accel_z_cms, accel_z_cms,
         _jerk_max_xy_cmsss, _dt, limit_output);
 
-    update_vel_accel(vel, accel, _dt, _limit_vector.z);
+    update_vel_accel(vel, accel, _dt, 0.0, 0.0);
 }

--- a/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Sub.cpp
@@ -23,14 +23,9 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
             sqrt_controller(_alt_max-_pos_target.z, 0.0f, _accel_max_z_cmss, 0.0f));
     }
 
-    // calculated increased maximum acceleration if over speed
-    float accel_z_cms = _accel_max_z_cmss;
-    if (_vel_desired.z < _vel_max_down_cms && !is_zero(_vel_max_down_cms)) {
-        accel_z_cms *= POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_down_cms;
-    }
-    if (_vel_desired.z > _vel_max_up_cms && !is_zero(_vel_max_up_cms)) {
-        accel_z_cms *= POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_up_cms;
-    }
+    // calculated increased maximum acceleration and jerk if over speed
+    float accel_max_z_cmss = _accel_max_z_cmss * calculate_overspeed_gain();
+    float jerk_max_xy_cmsss = _jerk_max_xy_cmsss * calculate_overspeed_gain();
 
     // adjust desired alt if motors have not hit their limits
     update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
@@ -42,8 +37,8 @@ void AC_PosControl_Sub::input_vel_accel_z(float &vel, const float accel, bool fo
 
     shape_vel_accel(vel, accel,
         _vel_desired.z, _accel_desired.z,
-        -accel_z_cms, accel_z_cms,
-        _jerk_max_xy_cmsss, _dt, limit_output);
+        -accel_max_z_cmss, accel_max_z_cmss,
+        jerk_max_xy_cmsss, _dt, limit_output);
 
     update_vel_accel(vel, accel, _dt, 0.0, 0.0);
 }

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -58,9 +58,6 @@ public:
     // reset_I - reset the integrator
     void reset_I();
 
-    // reset_I - reset the integrator smoothly to zero within 0.5 seconds
-    void reset_I_smoothly();
-
     // reset_filter - input filter will be reset to the next value provided to set_input()
     void reset_filter() {
         _flags._reset_filter = true;
@@ -111,6 +108,7 @@ public:
     void set_integrator(float target, float measurement, float i);
     void set_integrator(float error, float i);
     void set_integrator(float i);
+    void relax_integrator(float integrator, float time_constant);
 
     // set slew limiter scale factor
     void set_slew_limit_scale(int8_t scale) { _slew_limit_scale = scale; }
@@ -156,8 +154,6 @@ protected:
     float _error;             // error value to enable filtering
     float _derivative;        // derivative value to enable filtering
     int8_t _slew_limit_scale;
-    uint16_t _reset_counter;  // loop counter for reset decay
-    uint64_t _reset_last_update; //time in microseconds of last update to reset_I
 
     AP_Logger::PID_Info _pid_info;
 };

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -129,17 +129,18 @@ Vector2f AC_PID_2D::update_all(const Vector3f &target, const Vector3f &measureme
 //  If the limit is set the integral is only allowed to reduce in the direction of the limit
 void AC_PID_2D::update_i(const Vector2f &limit)
 {
-    Vector2f limit_direction = limit;
+    _pid_info_x.limit = false;
+    _pid_info_y.limit = false;
+    
     Vector2f delta_integrator = (_error * _ki) * _dt;
-    if (!is_zero(limit_direction.length_squared())) {
-        // zero delta_vel if it will increase the velocity error
-        limit_direction.normalize();
-        if (is_positive(delta_integrator * limit)) {
-            delta_integrator.zero();
-        }
+    float integrator_length = _integrator.length();
+    _integrator += delta_integrator;
+    // do not let integrator increase in length if delta_integrator is in the direction of limit
+    if (is_positive(delta_integrator * limit) && _integrator.limit_length(integrator_length)) {
+        _pid_info_x.limit = true;
+        _pid_info_y.limit = true;
     }
 
-    _integrator += delta_integrator;
     _integrator.limit_length(_kimax);
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -475,7 +475,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     float vel_time_scalar = 1.0;
     if (is_positive(_wp_desired_speed_xy_cms)) {
-        update_vel_accel(_terrain_vel, _terrain_accel, dt, false);
+        update_vel_accel(_terrain_vel, _terrain_accel, dt, 0.0, 0.0);
         shape_vel_accel( _wp_desired_speed_xy_cms * offset_z_scaler, 0.0,
             _terrain_vel, _terrain_accel,
             -_wp_accel_cmss, _wp_accel_cmss, _pos_control.get_shaping_jerk_xy_cmsss(), dt, true);

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -925,6 +925,7 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CANManager::Driver_Type_USD1:
                 case AP_CANManager::Driver_Type_MPPT_PacketDigital:
                 case AP_CANManager::Driver_Type_None:
+                case AP_CANManager::Driver_Type_Benewake:
                     break;
             }
         }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_SUI.cpp
@@ -23,12 +23,14 @@ AP_BattMonitor_SMBus_SUI::AP_BattMonitor_SMBus_SUI(AP_BattMonitor &mon,
       cell_count(_cell_count)
 {
     _pec_supported = false;
-    _dev->set_retries(2);
 }
 
 void AP_BattMonitor_SMBus_SUI::init(void)
 {
     AP_BattMonitor_SMBus::init();
+    if (_dev) {
+        _dev->set_retries(2);
+    }
     if (_dev && timer_handle) {
         // run twice as fast for two phases
         _dev->adjust_periodic_callback(timer_handle, 50000);

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -32,8 +32,8 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Param: PROTOCOL
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
-    // @Values{Copter,Plane,Sub,Rover}: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,8:KDECAN,9:PacketDigitalCAN
-    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,9:PacketDigital
+    // @Values{Copter,Plane,Sub,Rover}: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,8:KDECAN,9:PacketDigitalCAN,11:Benewake
+    // @Values: 0:Disabled,1:UAVCAN,3:ToshibaCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,9:PacketDigital,11:Benewake
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_UAVCAN),

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -61,6 +61,7 @@ public:
         Driver_Type_USD1 = 7,
         Driver_Type_KDECAN = 8,
         Driver_Type_MPPT_PacketDigital = 9,
+        Driver_Type_Benewake = 11,
     };
 
     void init(void);

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -200,7 +200,7 @@ bool Compass::_accept_calibration(uint8_t i)
         set_and_save_offdiagonals(i,offdiag);
         set_and_save_scale_factor(i,scale_factor);
 
-        if (_get_state(prio).external && _rotate_auto >= 2) {
+        if (cal_report.check_orientation && _get_state(prio).external && _rotate_auto >= 2) {
             set_and_save_orientation(i, cal_report.orientation);
         }
 

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -321,6 +321,7 @@ void CompassCalibrator::update_cal_report()
     cal_report.orientation_confidence = _orientation_confidence;
     cal_report.original_orientation = _orig_orientation;
     cal_report.orientation = _orientation_solution;
+    cal_report.check_orientation = _check_orientation;
 }
 
 // running method for use in thread

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -67,6 +67,7 @@ public:
         Rotation original_orientation;
         Rotation orientation;
         float scale_factor;
+        bool check_orientation;
     } cal_report;
 
     // Structure setup to set calibration run settings

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -56,6 +56,7 @@ int AP_Filesystem_Param::open(const char *fname, int flags)
     r.start = 0;
     r.count = 0;
     r.read_size = 0;
+    r.file_size = 0;
     r.writebuf = nullptr;
     if (!read_only) {
         // setup for upload

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1410,7 +1410,7 @@ void AP_GPS::Write_AP_Logger_Log_Startup_messages()
 bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
     // always enusre a lag is provided
-    lag_sec = 0.22f;
+    lag_sec = 0.1f;
 
     if (instance >= GPS_MAX_INSTANCES) {
         return false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -609,7 +609,7 @@ bool AP_InertialSensor_Backend::should_log_imu_raw() const
 // log an unexpected change in a register for an IMU
 void AP_InertialSensor_Backend::log_register_change(uint32_t bus_id, const AP_HAL::Device::checkreg &reg)
 {
-    AP::logger().Write("IREG", "TimeUS,DevID,Bank,Reg,Val", "QUBBB",
+    AP::logger().Write("IREG", "TimeUS,DevID,Bank,Reg,Val", "QIBBB",
                        AP_HAL::micros64(),
                        bus_id,
                        reg.bank,

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -130,7 +130,8 @@ void AP_Logger_File::periodic_1Hz()
         erase.was_logging) {
         // restart logging after an erase if needed
         erase.was_logging = false;
-        start_new_log();
+        // setup to open the log in the backend thread
+        start_new_log_pending = true;
     }
     
     if (_initialised &&
@@ -138,15 +139,8 @@ void AP_Logger_File::periodic_1Hz()
         _write_fd == -1 && _read_fd == -1 &&
         logging_enabled() &&
         !recent_open_error()) {
-        // retry logging open. This allows for booting with
-        // LOG_DISARMED=1 with a bad microSD or no microSD. Once a
-        // card is inserted then logging starts
-        // this also allows for logging to start after forced arming
-        if (!hal.util->get_soft_armed()) {
-            start_new_log();
-        } else {
-            start_new_log_pending = true;
-        }
+        // setup to open the log in the backend thread
+        start_new_log_pending = true;
     }
 
     if (!io_thread_alive()) {

--- a/libraries/AP_Math/SplineCurve.cpp
+++ b/libraries/AP_Math/SplineCurve.cpp
@@ -26,7 +26,7 @@ extern const AP_HAL::HAL &hal;
 
 #define SPLINE_FACTOR           4.0f    // defines shape of curves.  larger numbers result in longer spline curves, lower numbers take a direct path
 #define TANGENTIAL_ACCEL_SCALER 0.5f    // the proportion of the maximum accel that can be used for tangential acceleration (aka in the direction of travel along the track)
-#define LATERAL_ACCEL_SCALER    1.0f    // the proportion of the maximum accel that can be used for lateral acceleration (aka crosstrack acceleration)
+#define LATERAL_ACCEL_SCALER    0.5f    // the proportion of the maximum accel that can be used for lateral acceleration (aka crosstrack acceleration)
 
 // limit the maximum speed along the track to that which will achieve a cornering (aka lateral) acceleration of LATERAL_SPEED_SCALER * acceleration limit
 

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -58,7 +58,6 @@ void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const V
     Vector2f delta_vel = accel * dt;
     if (!is_zero(limit.length_squared())) {
         // zero delta_vel if it will increase the velocity error
-        limit.normalize();
         if (is_positive(delta_vel * limit)) {
             delta_vel.zero();
         }
@@ -75,7 +74,6 @@ void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel
 
     if (!is_zero(limit.length_squared())) {
         // zero delta_vel if it will increase the velocity error
-        limit.normalize();
         if (is_positive(delta_pos * limit)) {
             delta_pos.zero();
         }

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -29,9 +29,9 @@
 #define CORNER_ACCELERATION_RATIO   1.0/safe_sqrt(2.0)   // acceleration reduction to enable zero overshoot corners
 
 // update_vel_accel - single axis projection of velocity, vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// vel_error - specifies the direction of the velocity error useded in limit handling
+// the velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_vel_accel(float& vel, float accel, float dt, float limit, float vel_error)
 {
     const float delta_vel = accel * dt;
@@ -42,9 +42,9 @@ void update_vel_accel(float& vel, float accel, float dt, float limit, float vel_
 }
 
 // update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the position and velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_pos_vel_accel(postype_t& pos, float& vel, float accel, float dt, float limit, float pos_error, float vel_error)
 {
     // move position and velocity forward by dt if it does not increase error when limited.
@@ -58,9 +58,9 @@ void update_pos_vel_accel(postype_t& pos, float& vel, float accel, float dt, flo
 }
 
 // update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& vel_error)
 {
     // increase velocity by acceleration * dt if it does not increase error when limited.
@@ -77,9 +77,9 @@ void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const V
 }
 
 // update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the position and velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error used in limit handling.
 void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& pos_error, const Vector2f& vel_error)
 {
     // move position and velocity forward by dt.
@@ -100,12 +100,12 @@ void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     acceleration limits - accel_min, accel_max,
-     time constant - tc.
+    acceleration limits - accel_min, accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to accel_input.
 */
 void shape_accel(float accel_input, float& accel,
                  float jerk_max, float dt)
@@ -141,17 +141,16 @@ void shape_accel_xy(const Vector3f& accel_input, Vector3f& accel,
     accel.y = accel_2f.y;
 }
 
-
 /* shape_vel_accel and shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     maximum velocity - vel_max,
-     maximum acceleration - accel_max,
-     time constant - tc.
+    maximum velocity - vel_max,
+    maximum acceleration - accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input.
  The accel_max limit can be removed by setting it to zero.
 */
 void shape_vel_accel(float vel_input, float accel_input,
@@ -246,13 +245,13 @@ void shape_vel_accel_xy(const Vector2f &vel_input, const Vector2f& accel_input,
 /* shape_pos_vel_accel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     maximum velocity - vel_max,
-     maximum acceleration - accel_max,
-     time constant - tc.
+    maximum velocity - vel_max,
+    maximum acceleration - accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input.
  The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
 void shape_pos_vel_accel(postype_t pos_input, float vel_input, float accel_input,
@@ -324,7 +323,45 @@ void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input
     shape_vel_accel_xy(vel_target, accel_input, vel, accel, accel_max, jerk_max, dt, limit_total_accel);
 }
 
-// proportional controller with piecewise sqrt sections to constrain second derivative
+/* limit_accel_xy limits the acceleration to prioritise acceleration perpendicular to the provided velocity vector.
+ Input parameters are:
+    vel is the velocity vector used to define the direction acceleration limit is biased in.
+    accel is the acceleration vector to be limited.
+    accel_max is the maximum length of the acceleration vector after being limited.
+ Returns true when accel vector has been limited.
+*/
+bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
+{
+    // check accel_max is defined
+    if (!is_positive(accel_max)) {
+        return false;
+    }
+    // limit acceleration to accel_max while prioritizing cross track acceleration
+    if (accel.length_squared() > sq(accel_max)) {
+        if (vel.is_zero()) {
+            // We do not have a direction of travel so do a simple vector length limit
+            accel.limit_length(accel_max);
+        } else {
+            // calculate acceleration in the direction of and perpendicular to the velocity input
+            const Vector2f vel_input_unit = vel.normalized();
+            // acceleration in the direction of travel
+            float accel_dir = vel_input_unit * accel;
+            // cross track acceleration
+            Vector2f accel_cross = accel - (vel_input_unit * accel_dir);
+            if (accel_cross.limit_length(accel_max)) {
+                accel_dir = 0.0;
+            } else {
+                float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
+                accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
+            }
+            accel = accel_cross + vel_input_unit * accel_dir;
+        }
+        return true;
+    }
+    return false;
+}
+
+// sqrt_controller calculates the correction based on a proportional controller with piecewise sqrt sections to constrain second derivative.
 float sqrt_controller(float error, float p, float second_ord_lim, float dt)
 {
     float correction_rate;
@@ -359,7 +396,7 @@ float sqrt_controller(float error, float p, float second_ord_lim, float dt)
     }
 }
 
-// proportional controller with piecewise sqrt sections to constrain second derivative
+// sqrt_controller calculates the correction based on a proportional controller with piecewise sqrt sections to constrain second derivative.
 Vector2f sqrt_controller(const Vector2f& error, float p, float second_ord_lim, float dt)
 {
     const float error_length = error.length();
@@ -371,7 +408,8 @@ Vector2f sqrt_controller(const Vector2f& error, float p, float second_ord_lim, f
     return error * (correction_length / error_length);
 }
 
-// inverse of the sqrt controller.  calculates the input (aka error) to the sqrt_controller required to achieve a given output
+// inv_sqrt_controller calculates the inverse of the sqrt controller.
+// This function calculates the input (aka error) to the sqrt_controller required to achieve a given output.
 float inv_sqrt_controller(float output, float p, float D_max)
 {
     if (is_positive(D_max) && is_zero(p)) {
@@ -384,7 +422,7 @@ float inv_sqrt_controller(float output, float p, float D_max)
         return 0.0;
     }
 
-    // calculate the velocity at which we switch from calculating the stopping point using a linear function to a sqrt function
+    // calculate the velocity at which we switch from calculating the stopping point using a linear function to a sqrt function.
     const float linear_velocity = D_max / p;
 
     if (fabsf(output) < linear_velocity) {
@@ -397,13 +435,13 @@ float inv_sqrt_controller(float output, float p, float D_max)
     return is_positive(output) ? stopping_dist : -stopping_dist;
 }
 
-// calculate the stopping distance for the square root controller based deceleration path
+// stopping_distance calculates the stopping distance for the square root controller based deceleration path.
 float stopping_distance(float velocity, float p, float accel_max)
 {
     return inv_sqrt_controller(velocity, p, accel_max);
 }
 
-// calculate the maximum acceleration or velocity in a given direction
+// kinematic_limit calculates the maximum acceleration or velocity in a given direction.
 // based on horizontal and vertical limits.
 float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float max_z_neg)
 {

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -37,7 +37,7 @@ void update_vel_accel(float& vel, float accel, float dt, float limit)
     }
 }
 
-// update_pos_vel_accel - single axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+// update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
 void update_pos_vel_accel(postype_t& pos, float& vel, float accel, float dt, float limit)
 {
@@ -52,7 +52,7 @@ void update_pos_vel_accel(postype_t& pos, float& vel, float accel, float dt, flo
 
 // update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the velocity is not moved in the direction of limit if limit is not set to zero
-void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit)
 {
     // increase velocity by acceleration * dt if it does not increase error when limited.
     Vector2f delta_vel = accel * dt;
@@ -68,7 +68,7 @@ void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2
 
 // update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit)
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit)
 {
     // move position and velocity forward by dt.
     Vector2f delta_pos = vel * dt + accel * 0.5f * sq(dt);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -25,19 +25,29 @@ typedef Vector3f Vector3p;
   common controller helper functions
  */
 
-// update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
-// update_vel_accel - single axis projection.
-void update_vel_accel(float& vel, float accel, float dt, float limit);
+// update_vel_accel - single axis projection of velocity, vel, forwards in time based on a time step of dt and acceleration of accel.
+// the velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// vel_error - specifies the direction of the velocity error useded in limit handling
+void update_vel_accel(float& vel, float accel, float dt, float limit, float vel_error);
 
 // update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
 // the position and velocity is not moved in the direction of limit if limit is not set to zero
-void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit);
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit, float pos_error, float vel_error);
 
-// update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
+// update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+// the velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& vel_error);
 
-// update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
+// update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
+// the position and velocity is not moved in the direction of limit if limit is not set to zero
+// limit - specifies if the system is unable to continue to accelerate
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& pos_error, const Vector2f& vel_error);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -26,78 +26,82 @@ typedef Vector3f Vector3p;
  */
 
 // update_vel_accel - single axis projection of velocity, vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// vel_error - specifies the direction of the velocity error useded in limit handling
+// the velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_vel_accel(float& vel, float accel, float dt, float limit, float vel_error);
 
 // update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the position and velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit, float pos_error, float vel_error);
 
 // update_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& vel_error);
 
 // update_pos_vel_accel - dual axis projection of position and velocity, pos and vel, forwards in time based on a time step of dt and acceleration of accel.
-// the position and velocity is not moved in the direction of limit if limit is not set to zero
-// limit - specifies if the system is unable to continue to accelerate
-// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling
+// the position and velocity is not moved in the direction of limit if limit is not set to zero.
+// limit - specifies if the system is unable to continue to accelerate.
+// pos_error and vel_error - specifies the direction of the velocity error useded in limit handling.
 void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit, const Vector2f& pos_error, const Vector2f& vel_error);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     acceleration limits - accel_min, accel_max,
-     time constant - tc.
+    acceleration limits - accel_min, accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to accel_input.
 */
 void shape_accel(float accel_input, float& accel,
                  float jerk_max, float dt);
 
+// 2D version
 void shape_accel_xy(const Vector2f& accel_input, Vector2f& accel,
                     float jerk_max, float dt);
 
 void shape_accel_xy(const Vector3f& accel_input, Vector3f& accel,
                     float jerk_max, float dt);
 
-/* shape_vel calculates a jerk limited path from the current velocity and acceleration to an input velocity.
- The function takes the current velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
+/* shape_vel_accel and shape_vel_xy calculate a jerk limited path from the current position, velocity and acceleration to an input velocity.
+ The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     velocity limits - vel_min, vel_max,
-     acceleration limits - accel_min, accel_max,
-     time constant - tc.
+    maximum velocity - vel_max,
+    maximum acceleration - accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to vel_input and accel_input.
+ The accel_max limit can be removed by setting it to zero.
 */
 void shape_vel_accel(float vel_input, float accel_input,
                      float vel, float& accel,
                      float accel_min, float accel_max,
                      float jerk_max, float dt, bool limit_total_accel);
 
+// 2D version
 void shape_vel_accel_xy(const Vector2f &vel_input1, const Vector2f& accel_input,
                         const Vector2f& vel, Vector2f& accel,
                         float accel_max, float jerk_max, float dt, bool limit_total_accel);
 
-/* shape_pos_vel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
+/* shape_pos_vel_accel calculate a jerk limited path from the current position, velocity and acceleration to an input position and velocity.
  The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
  The kinematic path is constrained by :
-     maximum velocity - vel_max,
-     maximum acceleration - accel_max,
-     time constant - tc.
+    maximum velocity - vel_max,
+    maximum acceleration - accel_max,
+    time constant - tc.
  The time constant defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
  The time constant also defines the time taken to achieve the maximum acceleration.
  The time constant must be positive.
- The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input
+ The function alters the variable accel to follow a jerk limited kinematic path to pos_input, vel_input and accel_input.
+ The vel_max, vel_correction_max, and accel_max limits can be removed by setting the desired limit to zero.
 */
 void shape_pos_vel_accel(const postype_t pos_input, float vel_input, float accel_input,
                          const postype_t pos, float vel, float& accel,
@@ -105,23 +109,34 @@ void shape_pos_vel_accel(const postype_t pos_input, float vel_input, float accel
                          float accel_min, float accel_max,
                          float jerk_max, float dt, bool limit_total_accel);
 
+// 2D version
 void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input, const Vector2f& accel_input,
                             const Vector2p& pos, const Vector2f& vel, Vector2f& accel,
                             float vel_max, float accel_max,
                             float jerk_max, float dt, bool limit_total_accel);
 
-// proportional controller with piecewise sqrt sections to constrain second derivative
+/* limit_accel_xy limits the acceleration to prioritise acceleration perpendicular to the provided velocity vector.
+ Input parameters are:
+    vel is the velocity vector used to define the direction acceleration limit is biased in.
+    accel is the acceleration vector to be limited.
+    accel_max is the maximum length of the acceleration vector after being limited.
+ Returns true when accel vector has been limited.
+*/
+bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max);
+
+// sqrt_controller calculates the correction based on a proportional controller with piecewise sqrt sections to constrain second derivative.
 float sqrt_controller(float error, float p, float second_ord_lim, float dt);
 
-// proportional controller with piecewise sqrt sections to constrain second derivative
+// sqrt_controller calculates the correction based on a proportional controller with piecewise sqrt sections to constrain second derivative.
 Vector2f sqrt_controller(const Vector2f& error, float p, float second_ord_lim, float dt);
 
-// inverse of the sqrt controller.  calculates the input (aka error) to the sqrt_controller required to achieve a given output
+// inv_sqrt_controller calculates the inverse of the sqrt controller.
+// This function calculates the input (aka error) to the sqrt_controller required to achieve a given output.
 float inv_sqrt_controller(float output, float p, float D_max);
 
-// calculate the stopping distance for the square root controller based deceleration path
+// stopping_distance calculates the stopping distance for the square root controller based deceleration path.
 float stopping_distance(float velocity, float p, float accel_max);
 
-// calculate the maximum acceleration or velocity in a given direction
+// kinematic_limit calculates the maximum acceleration or velocity in a given direction.
 // based on horizontal and vertical limits.
 float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float max_z_neg);

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -29,15 +29,15 @@ typedef Vector3f Vector3p;
 // update_vel_accel - single axis projection.
 void update_vel_accel(float& vel, float accel, float dt, float limit);
 
-// update_vel_accel projects the velocity, vel, forward in time based on a time step of dt and acceleration of accel.
-// update_vel_accel - single axis projection.
+// update_pos_vel_accel - single axis projection of position and velocity forward in time based on a time step of dt and acceleration of accel.
+// the position and velocity is not moved in the direction of limit if limit is not set to zero
 void update_pos_vel_accel(postype_t & pos, float& vel, float accel, float dt, float limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
+void update_vel_accel_xy(Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
 
 // update_pos_vel_accel_xy - dual axis projection operating on the x, y axis of Vector2f or Vector3f inputs.
-void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, Vector2f limit);
+void update_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, float dt, const Vector2f& limit);
 
 /* shape_accel calculates a jerk limited path from the current acceleration to an input acceleration.
  The function takes the current acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -273,7 +273,6 @@ void NavEKF3_core::Log_Write_BodyOdom(uint64_t time_us)
         return;
     }
 
-    static uint32_t lastUpdateTime_ms = 0;
     const uint32_t updateTime_ms = MAX(bodyOdmDataDelayed.time_ms,wheelOdmDataDelayed.time_ms);
     if (updateTime_ms > lastUpdateTime_ms) {
         const struct log_XKFD pkt11{
@@ -293,14 +292,13 @@ void NavEKF3_core::Log_Write_BodyOdom(uint64_t time_us)
 }
 #endif
 
-void NavEKF3_core::Log_Write_State_Variances(uint64_t time_us) const
+void NavEKF3_core::Log_Write_State_Variances(uint64_t time_us)
 {
     if (core_index != frontend->primary) {
         // log only primary instance for now
         return;
     }
 
-    static uint32_t lastEkfStateVarLogTime_ms = 0;
     if (AP::dal().millis() - lastEkfStateVarLogTime_ms > 490) {
         lastEkfStateVarLogTime_ms = AP::dal().millis();
         const struct log_XKV pktv1{
@@ -394,7 +392,6 @@ void NavEKF3_core::Log_Write(uint64_t time_us)
 void NavEKF3_core::Log_Write_Timing(uint64_t time_us)
 {
     // log EKF timing statistics every 5s
-    static uint32_t lastTimingLogTime_ms = 0;
     if (AP::dal().millis() - lastTimingLogTime_ms <= 5000) {
         return;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -2182,7 +2182,6 @@ void NavEKF3_core::verifyTiltErrorVariance()
     }
 
     tiltErrorVarianceAlt = MIN(tiltErrorVarianceAlt, sq(radians(30.0f)));
-    static uint32_t lastLogTime_ms = 0;
     if (imuSampleTime_ms - lastLogTime_ms > 500) {
         lastLogTime_ms = imuSampleTime_ms;
         const struct log_XKTV msg {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1479,6 +1479,12 @@ private:
     bool EKFGSF_run_filterbank;             // true when the filter bank is active
     uint8_t EKFGSF_yaw_valid_count;         // number of updates since the last invalid yaw estimate
 
+    // logging timestamps
+    uint32_t lastLogTime_ms;
+    uint32_t lastUpdateTime_ms;
+    uint32_t lastEkfStateVarLogTime_ms;
+    uint32_t lastTimingLogTime_ms;
+
     // bits in EK3_AFFINITY
     enum ekf_affinity {
         EKF_AFFINITY_GPS  = (1U<<0),
@@ -1519,7 +1525,7 @@ private:
     void Log_Write_Quaternion(uint64_t time_us) const;
     void Log_Write_Beacon(uint64_t time_us);
     void Log_Write_BodyOdom(uint64_t time_us);
-    void Log_Write_State_Variances(uint64_t time_us) const;
+    void Log_Write_State_Variances(uint64_t time_us);
     void Log_Write_Timing(uint64_t time_us);
     void Log_Write_GSF(uint64_t time_us);
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
@@ -170,7 +170,7 @@ void AP_RCProtocol_SBUS::process_pulse(uint32_t width_s0, uint32_t width_s1)
 // support byte input
 void AP_RCProtocol_SBUS::_process_byte(uint32_t timestamp_us, uint8_t b)
 {
-    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 4000U);
     byte_input.last_byte_us = timestamp_us;
 
     if (have_frame_gap) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -48,6 +48,7 @@
 #include "AP_RangeFinder_SITL.h"
 #include "AP_RangeFinder_MSP.h"
 #include "AP_RangeFinder_USD1_CAN.h"
+#include "AP_RangeFinder_Benewake_CAN.h"
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
@@ -63,7 +64,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 	AP_SUBGROUPINFO(params[0], "1_", 25, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 1_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[0], "1_",  57, RangeFinder, backend_var_info[0]),
 
 #if RANGEFINDER_MAX_INSTANCES > 1
@@ -72,7 +73,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[1], "2_", 27, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 2_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_",  58, RangeFinder, backend_var_info[1]),
 #endif
 
@@ -82,7 +83,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[2], "3_", 29, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 3_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_",  59, RangeFinder, backend_var_info[2]),
 #endif
 
@@ -92,7 +93,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[3], "4_", 31, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 4_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_",  60, RangeFinder, backend_var_info[3]),
 #endif
 
@@ -102,7 +103,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[4], "5_", 33, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 5_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_",  34, RangeFinder, backend_var_info[4]),
 #endif
 
@@ -112,7 +113,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[5], "6_", 35, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 6_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_",  36, RangeFinder, backend_var_info[5]),
 #endif
 
@@ -122,7 +123,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[6], "7_", 37, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 7_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_",  38, RangeFinder, backend_var_info[6]),
 #endif
 
@@ -132,7 +133,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[7], "8_", 39, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 8_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_",  40, RangeFinder, backend_var_info[7]),
 #endif
 
@@ -142,7 +143,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[8], "9_", 41, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 9_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_",  42, RangeFinder, backend_var_info[8]),
 #endif
 
@@ -152,7 +153,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[9], "A_", 43, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: A_
-    // @Path: AP_RangeFinder_Wasp.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Benewake_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[9], "A_",  44, RangeFinder, backend_var_info[9]),
 #endif
     
@@ -573,6 +574,9 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     case Type::USD1_CAN:
         _add_backend(new AP_RangeFinder_USD1_CAN(state[instance], params[instance]), instance);
+        break;
+    case Type::Benewake_CAN:
+        _add_backend(new AP_RangeFinder_Benewake_CAN(state[instance], params[instance]), instance);
         break;
 #endif
     case Type::NONE:

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -88,6 +88,7 @@ public:
         GYUS42v2 = 31,
         MSP = 32,
         USD1_CAN = 33,
+        Benewake_CAN = 34,
         SITL = 100,
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Benewake_CAN::var_info[] = {
   constructor
  */
 AP_RangeFinder_Benewake_CAN::AP_RangeFinder_Benewake_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
-    CANSensor("Benewake", 3072),
+    CANSensor("Benewake"),
     AP_RangeFinder_Backend(_state, _params)
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.cpp
@@ -1,0 +1,79 @@
+#include <AP_HAL/AP_HAL.h>
+#include "AP_RangeFinder_Benewake_CAN.h"
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+const AP_Param::GroupInfo AP_RangeFinder_Benewake_CAN::var_info[] = {
+
+    // @Param: RECV_ID
+    // @DisplayName: CAN receive ID
+    // @Description: The receive ID of the CAN frames. A value of zero means all IDs are accepted.
+    // @Range: 0 65535
+    // @User: Advanced
+    AP_GROUPINFO("RECV_ID", 10, AP_RangeFinder_Benewake_CAN, receive_id, 0),
+
+    // @Param: SNR_MIN
+    // @DisplayName: Minimum signal strength
+    // @Description: Minimum signal strength (SNR) to accept distance
+    // @Range: 0 65535
+    // @User: Advanced
+    AP_GROUPINFO("SNR_MIN", 11, AP_RangeFinder_Benewake_CAN, snr_min, 0),
+
+    AP_GROUPEND
+};
+
+
+/*
+  constructor
+ */
+AP_RangeFinder_Benewake_CAN::AP_RangeFinder_Benewake_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
+    CANSensor("Benewake", 3072),
+    AP_RangeFinder_Backend(_state, _params)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    register_driver(AP_CANManager::Driver_Type_Benewake);
+    state.var_info = var_info;
+}
+
+// update state
+void AP_RangeFinder_Benewake_CAN::update(void)
+{
+    WITH_SEMAPHORE(_sem);
+    const uint32_t now = AP_HAL::millis();
+    if (_distance_count == 0 && now - state.last_reading_ms > 500) {
+        // no new data.
+        set_status(RangeFinder::Status::NoData);
+    } else if (_distance_count != 0) {
+        state.distance_cm = (_distance_sum_cm / _distance_count);
+        state.last_reading_ms = AP_HAL::millis();
+        _distance_sum_cm = 0;
+        _distance_count = 0;
+        update_status();
+    }
+}
+
+// handler for incoming frames. These come in at 100Hz
+void AP_RangeFinder_Benewake_CAN::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(_sem);
+    const uint16_t id = frame.id & AP_HAL::CANFrame::MaskStdID;
+    if (receive_id != 0 && id != uint16_t(receive_id.get())) {
+        // incorrect receive ID
+        return;
+    }
+    if (last_recv_id != -1 && id != last_recv_id) {
+        // changing ID
+        return;
+    }
+    last_recv_id = id;
+    const uint16_t dist_cm = (frame.data[1]<<8) | frame.data[0];
+    const uint16_t snr = (frame.data[3]<<8) | frame.data[2];
+    if (snr_min != 0 && snr < uint16_t(snr_min.get())) {
+        // too low signal strength
+        return;
+    }
+    _distance_sum_cm += dist_cm;
+    _distance_count++;
+}
+
+#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
@@ -5,7 +5,7 @@
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
 
-class AP_RangeFinder_Benewake_CAN : public CANSensor, public AP_RangeFinder_Backend {
+class AP_RangeFinder_Benewake_CAN : public AP_RangeFinder_Backend, public CANSensor {
 public:
     AP_RangeFinder_Benewake_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "AP_RangeFinder_Backend.h"
+#include <AP_CANManager/AP_CANSensor.h>
+
+#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+
+class AP_RangeFinder_Benewake_CAN : public CANSensor, public AP_RangeFinder_Backend {
+public:
+    AP_RangeFinder_Benewake_CAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
+
+    void update() override;
+
+    // handler for incoming frames
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+    virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
+private:
+    float _distance_sum_cm;
+    uint32_t _distance_count;
+    int32_t last_recv_id = -1;
+
+    AP_Int32 snr_min;
+    AP_Int32 receive_id;
+};
+#endif //HAL_MAX_CAN_PROTOCOL_DRIVERS
+

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -6,7 +6,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,100:SITL
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:UAVCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,100:SITL
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_RangeFinder_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -175,15 +175,15 @@ void SRV_Channels::update_aux_servo_function(void)
     }
     function_mask.clearall();
 
-    for (uint8_t i = 0; i < SRV_Channel::k_nr_aux_servo_functions; i++) {
+    for (uint16_t i = 0; i < SRV_Channel::k_nr_aux_servo_functions; i++) {
         functions[i].channel_mask = 0;
     }
 
     // set auxiliary ranges
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        if ((uint8_t)channels[i].function.get() < SRV_Channel::k_nr_aux_servo_functions) {
+        if ((uint16_t)channels[i].function.get() < SRV_Channel::k_nr_aux_servo_functions) {
             channels[i].aux_servo_function_setup();
-            function_mask.set((uint8_t)channels[i].function.get());
+            function_mask.set((uint16_t)channels[i].function.get());
             functions[channels[i].function.get()].channel_mask |= 1U<<i;
         }
     }
@@ -204,7 +204,7 @@ void SRV_Channels::enable_aux_servos()
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         SRV_Channel &c = channels[i];
         // see if it is a valid function
-        if ((uint8_t)c.function.get() < SRV_Channel::k_nr_aux_servo_functions) {
+        if ((uint16_t)c.function.get() < SRV_Channel::k_nr_aux_servo_functions) {
             hal.rcout->enable_ch(c.ch_num);
         }
 
@@ -505,7 +505,7 @@ bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t fun
     channels[channel].type_setup = false;
     channels[channel].function.set(function);
     channels[channel].aux_servo_function_setup();
-    function_mask.set((uint8_t)function);
+    function_mask.set((uint16_t)function);
     functions[function].channel_mask |= 1U<<channel;
     return true;
 }
@@ -598,9 +598,9 @@ void SRV_Channels::set_default_function(uint8_t chan, SRV_Channel::Aux_servo_fun
 {
     if (chan < NUM_SERVO_CHANNELS) {
         int8_t old = channels[chan].function;
-        channels[chan].function.set_default((uint8_t)function);
+        channels[chan].function.set_default((uint16_t)function);
         if (old != channels[chan].function && channels[chan].function == function) {
-            function_mask.set((uint8_t)function);
+            function_mask.set((uint16_t)function);
         }
     }
 }


### PR DESCRIPTION
PR for the Copter-4.1.4-rc1 beta release which will likely be our last release before starting 4.2 beta testing.

This has been "double rebased" on the Plane-4.1 branch (which is Plane-4.1.6) plus any PRs marked for back porting that did not cause serious merge conflicts.

Please see the "4.1.4-rc1" and "Skipped" columns of the Copter-4.1 project https://github.com/ArduPilot/ardupilot/projects/19 to see the PRs that I could and could not include.

@tridge if you could check that the Benewake CAN lidar works that would be greatly appreciated.  I had a little merge conflict that I think I resolved correctly (distance_m vs distance_cm).

The Rover-4.1.4-rc1 release will look identical to this one.
