### PR TITLE
ardupilotwaf: grouped_program use nested dicts

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -295,7 +295,8 @@ def ap_program(bld,
         tg.env.STLIB += [kw['use']]
 
     for group in program_groups:
-        _grouped_programs.setdefault(group, []).append(tg)
+        _grouped_programs.setdefault(group, {}).update({tg.name : tg})
+
 
 @conf
 def ap_example(bld, **kw):
@@ -507,21 +508,20 @@ def _select_programs_from_group(bld):
             groups = ['bin']
 
     if 'all' in groups:
-        groups = _grouped_programs.keys()
+        groups = list(_grouped_programs.keys())
+        groups.remove('bin')       # Remove `bin` so as not to duplicate all items in bin
 
     for group in groups:
         if group not in _grouped_programs:
             bld.fatal('Group %s not found' % group)
 
-        tg = _grouped_programs[group][0]
-        if bld.targets:
-            bld.targets += ',' + tg.name
-        else:
-            bld.targets = tg.name
+        target_names = _grouped_programs[group].keys()
 
-        if len(_grouped_programs[group]) > 2:
-            for tg in _grouped_programs[group][1:]:
-                bld.targets += ',' + tg.name
+        for name in target_names:
+            if bld.targets:
+                bld.targets += ',' + name
+            else:
+                bld.targets = name
 
 def options(opt):
     opt.ap_groups = {


### PR DESCRIPTION
This updates the `_grouped_programs` dictionary to be a nested dictionary so we don't insert duplicates like we were doing before with the list. Thus why we were getting duplicates on `build_summary.py`.

It also fixes the duplicated outputs when `./waf all` was used

Checked `./waf all`, `./waf build` , `./waf tests`, `./waf examples`, `./waf copter` `./waf copter plane tracker` build without duplicates and look good

And now `./waf iofirmware` ......


It also fixes the kludge I added in #19651 that silently broke the building of the second target for iofirmware.