### PR TITLE
AP_Baro.cpp: Atmospheric Model Correction

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -402,10 +402,10 @@ float AP_Baro::get_altitude_difference(float base_pressure, float pressure) cons
 // 1976 standard atmospheric model
 float AP_Baro::get_sealevel_pressure(float pressure) const
 {
-    const float standard_day_temp = C_TO_KELVIN(15); //15 degrees Celsius converted to Kelvin
+    float temp    = C_TO_KELVIN(get_ground_temperature());
     float p0_sealevel;
 
-    p0_sealevel = 8.651154799255761e30f*pressure*powF((769231.0f-(5000.0f*_field_elevation_active)/standard_day_temp),-5.255993146184937f);
+    p0_sealevel = 8.651154799255761e30f*pressure*powF((769231.0f-(5000.0f*_field_elevation_active)/temp),-5.255993146184937f);
 
     return p0_sealevel;
 }
@@ -932,7 +932,7 @@ void AP_Baro::update(void)
     }
 
     const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _field_elevation_last_ms >= 1000 && fabs(_field_elevation_active-_field_elevation) > 1.0) {
+    if (now_ms - _field_elevation_last_ms >= 1000 && fabsf(_field_elevation_active-_field_elevation) > 1.0) {
       if (!AP::arming().is_armed()) {
         _field_elevation_last_ms = now_ms;
         _field_elevation_active = _field_elevation;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -941,7 +941,7 @@ void AP_Baro::update(void)
         BARO_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer Field Elevation Set: %.0fm",_field_elevation_active);
       }
       else {
-        _field_elevation.set_and_save(_field_elevation_active);
+        _field_elevation.set(_field_elevation_active);
         _field_elevation.notify();
         BARO_SEND_TEXT(MAV_SEVERITY_ALERT, "Failed to Set Field Elevation: Armed");
       }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -930,7 +930,7 @@ void AP_Baro::update(void)
             }
         }
     }
-
+#ifndef HAL_BUILD_AP_PERIPH
     const uint32_t now_ms = AP_HAL::millis();
     if (now_ms - _field_elevation_last_ms >= 1000 && fabsf(_field_elevation_active-_field_elevation) > 1.0) {
       if (!AP::arming().is_armed()) {
@@ -946,6 +946,7 @@ void AP_Baro::update(void)
         BARO_SEND_TEXT(MAV_SEVERITY_ALERT, "Failed to Set Field Elevation: Armed");
       }
     }
+#endif
 
     // logging
 #if HAL_LOGGING_ENABLED

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -404,7 +404,8 @@ float AP_Baro::get_sealevel_pressure(float pressure) const
 {
     float temp    = C_TO_KELVIN(get_ground_temperature());
     float p0_sealevel;
-
+    // This is an exact calculation that is within +-2.5m of the standard
+    // atmosphere tables in the troposphere (up to 11,000 m amsl).
     p0_sealevel = 8.651154799255761e30f*pressure*powF((769231.0f-(5000.0f*_field_elevation_active)/temp),-5.255993146184937f);
 
     return p0_sealevel;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -134,15 +134,6 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Values: 1.0:Freshwater,1.024:Saltwater
     AP_GROUPINFO_FRAME("_SPEC_GRAV", 8, AP_Baro, _specific_gravity, 1.0, AP_PARAM_FRAME_SUB),
 
-    // @Param: _FIELD_ELV
-    // @DisplayName: field elevation
-    // @Description: User provided field elevation in meters. This is used to improve the calculation of the altitude the vehicle is at. This parameter is not persistent and will be reset to 0 every time the vehicle is rebooted. A value of 0 means no correction for takeoff height above sea level is performed.
-    // @Units: m
-    // @Increment: 0.1
-    // @Volatile: True
-    // @User: Advanced
-    AP_GROUPINFO("_FIELD_ELV", 22, AP_Baro, _field_elevation, 0),
-
 #if BARO_MAX_INSTANCES > 1
     // @Param: 2_GND_PRESS
     // @DisplayName: Ground Pressure
@@ -229,8 +220,17 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Path: AP_Baro_Wind.cpp
     AP_SUBGROUPINFO(sensors[2].wind_coeff, "3_WCF_", 20, AP_Baro, WindCoeff),
 #endif
+#ifndef HAL_BUILD_AP_PERIPH
+    // @Param: _FIELD_ELV
+    // @DisplayName: field elevation
+    // @Description: User provided field elevation in meters. This is used to improve the calculation of the altitude the vehicle is at. This parameter is not persistent and will be reset to 0 every time the vehicle is rebooted. A value of 0 means no correction for takeoff height above sea level is performed.
+    // @Units: m
+    // @Increment: 0.1
+    // @Volatile: True
+    // @User: Advanced
+    AP_GROUPINFO("_FIELD_ELV", 22, AP_Baro, _field_elevation, 0),
 #endif
-
+#endif
     AP_GROUPEND
 };
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -50,6 +50,7 @@
 
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Arming/AP_Arming.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define INTERNAL_TEMPERATURE_CLAMP 35.0f
@@ -132,6 +133,15 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Description: This sets the specific gravity of the fluid when flying an underwater ROV.
     // @Values: 1.0:Freshwater,1.024:Saltwater
     AP_GROUPINFO_FRAME("_SPEC_GRAV", 8, AP_Baro, _specific_gravity, 1.0, AP_PARAM_FRAME_SUB),
+
+    // @Param: _FIELD_ELV
+    // @DisplayName: field elevation
+    // @Description: User provided field elevation in meters. This is used to improve the calculation of the altitude the vehicle is at. This parameter is not persistent and will be reset to 0 every time the vehicle is rebooted. A value of 0 means no correction for takeoff height above sea level is performed.
+    // @Units: m
+    // @Increment: 0.1
+    // @Volatile: True
+    // @User: Advanced
+    AP_GROUPINFO("_FIELD_ELV", 22, AP_Baro, _field_elevation, 0),
 
 #if BARO_MAX_INSTANCES > 1
     // @Param: 2_GND_PRESS
@@ -241,6 +251,7 @@ AP_Baro::AP_Baro()
     _singleton = this;
 
     AP_Param::setup_object_defaults(this, var_info);
+    _field_elevation_active = _field_elevation;
 }
 
 // calibrate the barometer. This must be called at least once before
@@ -318,7 +329,8 @@ void AP_Baro::calibrate(bool save)
             sensors[i].calibrated = false;
         } else {
             if (save) {
-                sensors[i].ground_pressure.set_and_save(sum_pressure[i] / count[i]);
+                float p0_sealevel = get_sealevel_pressure(sum_pressure[i] / count[i]);
+                sensors[i].ground_pressure.set_and_save(p0_sealevel);
             }
         }
     }
@@ -353,7 +365,7 @@ void AP_Baro::update_calibration()
     }
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (healthy(i)) {
-            float corrected_pressure = get_pressure(i) + sensors[i].p_correction;
+            float corrected_pressure = get_sealevel_pressure(get_pressure(i) + sensors[i].p_correction);
             sensors[i].ground_pressure.set(corrected_pressure);
         }
 
@@ -380,9 +392,22 @@ float AP_Baro::get_altitude_difference(float base_pressure, float pressure) cons
 
     // This is an exact calculation that is within +-2.5m of the standard
     // atmosphere tables in the troposphere (up to 11,000 m amsl).
-    ret = 153.8462f * temp * (1.0f - expf(0.190259f * logf(scaling)));
+    ret = 153.8462f * temp * (1.0f - expf(0.190259f * logf(scaling)))-_field_elevation_active;
 
     return ret;
+}
+
+// return sea level pressure where in which the current measured pressure
+// at field elevation returns the same altitude under the
+// 1976 standard atmospheric model
+float AP_Baro::get_sealevel_pressure(float pressure) const
+{
+    const float standard_day_temp = C_TO_KELVIN(15); //15 degrees Celsius converted to Kelvin
+    float p0_sealevel;
+
+    p0_sealevel = 8.651154799255761e30f*pressure*powF((769231.0f-(5000.0f*_field_elevation_active)/standard_day_temp),-5.255993146184937f);
+
+    return p0_sealevel;
 }
 
 
@@ -524,10 +549,12 @@ void AP_Baro::init(void)
 {
     init_done = true;
 
-    // ensure that there isn't a previous ground temperature saved
-    if (!is_zero(_user_ground_temperature)) {
-        _user_ground_temperature.set_and_save(0.0f);
-        _user_ground_temperature.notify();
+    // always set field elvation to zero on reboot in the case user
+    // fails to update.  TBD automate sanity checking error bounds on
+    // on previously saved value at new location etc.
+    if (!is_zero(_field_elevation)) {
+        _field_elevation.set_and_save(0.0f);
+        _field_elevation.notify();
     }
 
     // zero bus IDs before probing
@@ -902,6 +929,22 @@ void AP_Baro::update(void)
                 break;
             }
         }
+    }
+
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _field_elevation_last_ms >= 1000 && fabs(_field_elevation_active-_field_elevation) > 1.0) {
+      if (!AP::arming().is_armed()) {
+        _field_elevation_last_ms = now_ms;
+        _field_elevation_active = _field_elevation;
+        AP::ahrs().resetHeightDatum();
+        update_calibration();
+        BARO_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer Field Elevation Set: %.0fm",_field_elevation_active);
+      }
+      else {
+        _field_elevation.set_and_save(_field_elevation_active);
+        _field_elevation.notify();
+        BARO_SEND_TEXT(MAV_SEVERITY_ALERT, "Failed to Set Field Elevation: Armed");
+      }
     }
 
     // logging

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -114,6 +114,10 @@ public:
     // pressure in Pascal
     float get_altitude_difference(float base_pressure, float pressure) const;
 
+    // get sea level pressure relative to 1976 standard atmosphere model
+    // pressure in Pascal
+    float get_sealevel_pressure(float pressure) const;
+
     // get scale factor required to convert equivalent to true airspeed
     float get_EAS2TAS(void);
 
@@ -270,6 +274,9 @@ private:
 
     AP_Float                            _alt_offset;
     float                               _alt_offset_active;
+    AP_Float                            _field_elevation;       // field elevation in meters
+    float                               _field_elevation_active;
+    uint32_t                            _field_elevation_last_ms;
     AP_Int8                             _primary_baro; // primary chosen by user
     AP_Int8                             _ext_bus; // bus number for external barometer
     float                               _last_altitude_EAS2TAS;


### PR DESCRIPTION
# Description:
This Pull Request correctly estimates altitude from takeoff (or Field Elevation) where the takeoff altitude is anything other than sea level (i.e. 0 ft msl).  A new parameter is added `BARO_FIELD_ELV` in order to accomplish the re-baseline of the standard day 1976 atmospheric model.  This parameter is set to 0 on every boot and (in its current form) is required to be manually set before launch by the pilot.

# Issue: Incorrect dP/dh when not at Sea Level
The current altitude model sufficiently estimates altitude, however only if your starting condition is at sea level.  Because the change in pressure vs change in height (dP/dh) is a function of the current altitude, the assumption that the starting condition is always sea level results in incorrect altitude measurements.  This error will also be a function of temperature, therefore this algorithm, utilizes `BARO_FIELD_ELV` and the currently measured barometric pressure, to ensure that the temperature based error is zero when at Field Elevation (or Takeoff/arming elevation) in accordance with how General Aviation models altitude.  

# Justification for Fix:
Currently there is no way to fly a standardized altitude in accordance with General aviation standards.  General aviation flies a non-temperature compensated altitude baselined at Field Elevation and assuming 15C standard day temperature.  If the `BARO_FIELD_ELV` and `BARO_GND_TEMP = 15` are used, then the aircraft is flying the same altitude model as air traffic control is expecting.  

NOTE: It should be noted that the altitude reported/calculated is Feet Above Launch/Takeoff, so manual calculation of MSL is as simple as adding `BARO_FIELD_ELV` to the altitude reported by ArduPilot.  However, utilizing this method will ensure that the barometric gradient that you are flying is in accordance with General Aviation.

# Method of replication:
* Set `BARO_GND_TEMP = 15
* Fly with calibrated/certified barometric sensor like the [Ping 200x](https://uavionix.com/products/ping200x/)
* Note that the altitude error between Ardupilot and the Ping 200x is a function of temperature and altitude
