### PR TITLE
Copter/Blimp: Classify an enum

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -88,18 +88,18 @@ enum class AirMode {
     AIRMODE_ENABLED,
 };
 
-enum PayloadPlaceStateType {
-    PayloadPlaceStateType_FlyToLocation,
-    PayloadPlaceStateType_Calibrating_Hover_Start,
-    PayloadPlaceStateType_Calibrating_Hover,
-    PayloadPlaceStateType_Descending_Start,
-    PayloadPlaceStateType_Descending,
-    PayloadPlaceStateType_Releasing_Start,
-    PayloadPlaceStateType_Releasing,
-    PayloadPlaceStateType_Released,
-    PayloadPlaceStateType_Ascending_Start,
-    PayloadPlaceStateType_Ascending,
-    PayloadPlaceStateType_Done,
+enum class PayloadPlaceStateType {
+    FlyToLocation,
+    Calibrating_Hover_Start,
+    Calibrating_Hover,
+    Descending_Start,
+    Descending,
+    Releasing_Start,
+    Releasing,
+    Released,
+    Ascending_Start,
+    Ascending,
+    Done,
 };
 
 // bit options for DEV_OPTIONS parameter

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -566,7 +566,7 @@ private:
     State state = State::FlyToLocation;
 
     struct {
-        PayloadPlaceStateType state = PayloadPlaceStateType_Calibrating_Hover_Start; // records state of place (descending, releasing, released, ...)
+        PayloadPlaceStateType state = PayloadPlaceStateType::Calibrating_Hover_Start; // records state of place (descending, releasing, released, ...)
         uint32_t hover_start_timestamp; // milliseconds
         float hover_throttle_level;
         uint32_t descend_start_timestamp; // milliseconds

--- a/Blimp/defines.h
+++ b/Blimp/defines.h
@@ -103,20 +103,6 @@ enum GuidedMode {
     Guided_Angle,
 };
 
-enum PayloadPlaceStateType {
-    PayloadPlaceStateType_FlyToLocation,
-    PayloadPlaceStateType_Calibrating_Hover_Start,
-    PayloadPlaceStateType_Calibrating_Hover,
-    PayloadPlaceStateType_Descending_Start,
-    PayloadPlaceStateType_Descending,
-    PayloadPlaceStateType_Releasing_Start,
-    PayloadPlaceStateType_Releasing,
-    PayloadPlaceStateType_Released,
-    PayloadPlaceStateType_Ascending_Start,
-    PayloadPlaceStateType_Ascending,
-    PayloadPlaceStateType_Done,
-};
-
 // bit options for DEV_OPTIONS parameter
 enum DevOptions {
     DevOptionADSBMAVLink = 1,


### PR DESCRIPTION
Classify the enum PayloadPlaceStateType
Since "PayloadPlaceStateType" is appended to all definition names, shorten the definition name by making it a class.