### PR TITLE
Copter: Pause/Continue Concept with SCurves

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1005,31 +1005,24 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_pause_continue(const mavlink_command_int_t &packet)
 {
-#if MODE_AUTO_ENABLED
-    if (copter.flightmode->mode_number() != Mode::Number::AUTO) {
-        // only supported in AUTO mode
+    // requested pause
+    if ((uint8_t) packet.param1 == 0) {
+        if (copter.flightmode->pause()) {
+            return MAV_RESULT_ACCEPTED;
+        }
+        send_text(MAV_SEVERITY_INFO, "Failed to pause");
         return MAV_RESULT_FAILED;
     }
 
-    // requested pause from GCS
-    if ((int8_t) packet.param1 == 0) {
-        // copter.mode_auto.mission.stop();
-        copter.mode_auto.pause_mission();
-        gcs().send_text(MAV_SEVERITY_INFO, "Paused mission");
-        return MAV_RESULT_ACCEPTED;
+    // requested resume
+    if ((uint8_t) packet.param1 == 1) {
+        if (copter.flightmode->resume()) {
+            return MAV_RESULT_ACCEPTED;
+        }
+        send_text(MAV_SEVERITY_INFO, "Failed to resume");
+        return MAV_RESULT_FAILED;
     }
-
-    // requested resume from GCS
-    if ((int8_t) packet.param1 == 1) {
-        // copter.mode_auto.mission.resume();
-        copter.mode_auto.continue_mission();
-        gcs().send_text(MAV_SEVERITY_INFO, "Resumed mission");
-        return MAV_RESULT_ACCEPTED;
-    }
-#endif
-
-    // fail pause or continue
-    return MAV_RESULT_FAILED;
+    return MAV_RESULT_DENIED;
 }
 
 void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1013,15 +1013,16 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_pause_continue(const mavlink_comma
 
     // requested pause from GCS
     if ((int8_t) packet.param1 == 0) {
-        copter.mode_auto.mission.stop();
-        copter.mode_auto.loiter_start();
+        // copter.mode_auto.mission.stop();
+        copter.mode_auto.pause_mission();
         gcs().send_text(MAV_SEVERITY_INFO, "Paused mission");
         return MAV_RESULT_ACCEPTED;
     }
 
     // requested resume from GCS
     if ((int8_t) packet.param1 == 1) {
-        copter.mode_auto.mission.resume();
+        // copter.mode_auto.mission.resume();
+        copter.mode_auto.continue_mission();
         gcs().send_text(MAV_SEVERITY_INFO, "Resumed mission");
         return MAV_RESULT_ACCEPTED;
     }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -110,6 +110,10 @@ public:
     // returns true if pilot's yaw input should be used to adjust vehicle's heading
     virtual bool use_pilot_yaw() const {return true; }
 
+    // pause and resume a mode
+    virtual bool pause() { return false; };
+    virtual bool resume() { return false; };
+
 protected:
 
     // helper functions
@@ -419,6 +423,10 @@ public:
     // Auto
     SubMode mode() const { return _mode; }
 
+    // pause continue in auto mode
+    bool pause() override;
+    bool resume() override;
+
     bool loiter_start();
     void rtl_start();
     void takeoff_start(const Location& dest_loc);
@@ -427,9 +435,6 @@ public:
     void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
     void nav_guided_start();
-    
-    void pause_mission();
-    void continue_mission();
 
     bool is_landing() const override;
 
@@ -973,6 +978,10 @@ public:
 
     bool use_pilot_yaw() const override;
 
+    // pause continue in guided mode
+    bool pause() override;
+    bool resume() override;
+
 protected:
 
     const char *name() const override { return "GUIDED"; }
@@ -1016,6 +1025,9 @@ private:
     SubMode guided_mode = SubMode::TakeOff;
     bool send_notification;     // used to send one time notification to ground station
     bool takeoff_complete;      // true once takeoff has completed (used to trigger retracting of landing gear)
+
+    // guided mode is paused or not
+    bool _paused;
 };
 
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1008,6 +1008,7 @@ private:
     void pos_control_run();
     void accel_control_run();
     void velaccel_control_run();
+    void pause_control_run();
     void posvelaccel_control_run();
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -427,6 +427,9 @@ public:
     void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
     void nav_guided_start();
+    
+    void pause_mission();
+    void continue_mission();
 
     bool is_landing() const override;
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -673,18 +673,6 @@ void ModeAuto::exit_mission()
     }
 }
 
-// pause_mission - Prevent aircraft from progressing along the track
-void ModeAuto::pause_mission()
-{
-        wp_nav->set_pause();
-}
-
-// continue_mission - Allow aircraft to progress along the track
-void ModeAuto::continue_mission()
-{
-        wp_nav->set_continue();
-}
-
 // do_guided - start guided mode
 bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 {
@@ -2077,5 +2065,29 @@ bool ModeAuto::verify_nav_script_time()
     return false;
 }
 #endif
+
+// pause - Prevent aircraft from progressing along the track
+bool ModeAuto::pause()
+{
+    // do not pause if already paused or not in the WP sub mode or already reached to the destination
+    if(wp_nav->paused() || _mode != SubMode::WP || wp_nav->reached_wp_destination()) {
+        return false;
+    }
+
+    wp_nav->set_pause();
+    return true;
+}
+
+// resume - Allow aircraft to progress along the track
+bool ModeAuto::resume()
+{
+    // do not resume if not paused before
+    if(!wp_nav->paused()) {
+        return false;
+    }
+
+    wp_nav->set_resume();
+    return true;
+}
 
 #endif

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -673,6 +673,18 @@ void ModeAuto::exit_mission()
     }
 }
 
+// pause_mission - Prevent aircraft from progressing along the track
+void ModeAuto::pause_mission()
+{
+        wp_nav->set_pause();
+}
+
+// continue_mission - Allow aircraft to progress along the track
+void ModeAuto::continue_mission()
+{
+        wp_nav->set_continue();
+}
+
 // do_guided - start guided mode
 bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -40,6 +40,10 @@ bool ModeGuided::init(bool ignore_checks)
     guided_vel_target_cms.zero();
     guided_accel_target_cmss.zero();
     send_notification = false;
+
+    // clear pause state when entering guided mode
+    _paused = false;
+
     return true;
 }
 
@@ -47,10 +51,11 @@ bool ModeGuided::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeGuided::run()
 {
-    // if (paused) {
-    //     pause_control_run();
-    //     return;
-    // }
+    // run pause control if the vehicle is paused
+    if (_paused) {
+        pause_control_run();
+        return;
+    }
 
     // call the correct auto controller
     switch (guided_mode) {
@@ -854,7 +859,7 @@ void ModeGuided::velaccel_control_run()
     }
 }
 
-// velaccel_control_run - runs the guided velocity and acceleration controller
+// pause_control_run - runs the guided mode pause controller
 // called from guided_run
 void ModeGuided::pause_control_run()
 {
@@ -1197,6 +1202,20 @@ float ModeGuided::crosstrack_error() const
 uint32_t ModeGuided::get_timeout_ms() const
 {
     return MAX(copter.g2.guided_timeout, 0.1) * 1000;
+}
+
+// pause guide mode
+bool ModeGuided::pause()
+{
+    _paused = true;
+    return true;
+}
+
+// resume guided mode
+bool ModeGuided::resume()
+{
+    _paused = false;
+    return true;
 }
 
 #endif

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11856,3 +11856,25 @@ switch value'''
         '''load a file from Tools/autotest/default_params'''
         filepath = util.reltopdir(os.path.join("Tools", "autotest", "default_params", filename))
         self.repeatedly_apply_parameter_file(filepath)
+
+    def send_pause_command(self):
+        '''pause AUTO/GUIDED modes'''
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_PAUSE_CONTINUE,
+                     0, # 0: pause, 1: continue
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0) # param7
+
+    def send_resume_command(self):
+        '''resume AUTO/GUIDED modes'''
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_PAUSE_CONTINUE,
+                     1, # 0: pause, 1: continue
+                     0, # param2
+                     0, # param3
+                     0, # param4
+                     0, # param5
+                     0, # param6
+                     0) # param7

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -57,6 +57,13 @@ public:
     /// set current target horizontal speed during wp navigation
     void set_speed_xy(float speed_cms);
 
+    /// set pause or resume during wp navigation
+    void set_pause() { _paused = true; }
+    void set_resume() { _paused = false; }
+
+    /// get paused status
+    bool paused() { return _paused; }
+
     /// set current target climb or descent rate during wp navigation
     void set_speed_up(float speed_up_cms);
     void set_speed_down(float speed_down_cms);
@@ -258,8 +265,9 @@ protected:
     Vector3f    _origin;                // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination;           // target destination in cm from ekf origin
     float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
-    float       _terrain_vel;            // maximum horizontal velocity used to ensure the aircraft can maintain height above terrain
-    float       _terrain_accel;          // acceleration value used to change _terrain_vel
+    float       _offset_vel;            // horizontal velocity reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
+    float       _offset_accel;          // horizontal acceleration reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
+    bool        _paused;                // flag for pausing waypoint controller
 
     // terrain following variables
     bool        _terrain_alt;   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin


### PR DESCRIPTION
This is the concept implementation of adding support to pausing and continuing (with MAV_CMD_DO_PAUSE_CONTINUE command) for Copter in GUIDED and AUTO modes.

Testing Pause/Continue for Copter in GUIDED mode:
`./Tools/autotest/autotest.py build.Copter test.Copter.PAUSE_CONTINUE_GUIDED --map`

Testing Pause/Continue for Copter in AUTO mode:
`./Tools/autotest/autotest.py build.Copter test.Copter.PAUSE_CONTINUE --map`