### PR TITLE
SITL: correct compilation if INS_TEMPERATURE_CAL_ENABLE is off

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -46,6 +46,7 @@ static float calculate_noise(float noise, float noise_variation) {
 
 float AP_InertialSensor_SITL::get_temperature(void)
 {
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
     if (!is_zero(sitl->imu_temp_fixed)) {
         // user wants fixed temperature
         return sitl->imu_temp_fixed;
@@ -60,6 +61,9 @@ float AP_InertialSensor_SITL::get_temperature(void)
     const float T1 = sitl->imu_temp_end;
     const float tconst = sitl->imu_temp_tconst;
     return T1 - (T1 - T0) * expf(-tsec / tconst);
+#else
+    return 20.0f;
+#endif
 }
 
 /*
@@ -69,8 +73,6 @@ void AP_InertialSensor_SITL::generate_accel()
 {
     Vector3f accel_accum;
     uint8_t nsamples = enable_fast_sampling(accel_instance) ? 4 : 1;
-
-    float T = get_temperature();
 
     for (uint8_t j = 0; j < nsamples; j++) {
 
@@ -173,7 +175,10 @@ void AP_InertialSensor_SITL::generate_accel()
             accel.x = accel.y = accel.z = sitl->accel_fail[accel_instance];
         }
 
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
+        const float T = get_temperature();
         sitl->imu_tcal[gyro_instance].sitl_apply_accel(T, accel);
+#endif
 
         _notify_new_accel_sensor_rate_sample(accel_instance, accel);
 
@@ -256,7 +261,9 @@ void AP_InertialSensor_SITL::generate_gyro()
 
         Vector3f gyro = Vector3f(p, q, r);
 
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
         sitl->imu_tcal[gyro_instance].sitl_apply_gyro(get_temperature(), gyro);
+#endif
 
         // add in gyro scaling
         Vector3f scale = sitl->gyro_scale[gyro_instance];

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -432,10 +432,12 @@ const AP_Param::GroupInfo SIM::var_sfml_joystick[] = {
 
 // INS SITL parameters
 const AP_Param::GroupInfo SIM::var_ins[] = {
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_GROUPINFO("IMUT_START",    1, SIM, imu_temp_start,  25),
     AP_GROUPINFO("IMUT_END",      2, SIM, imu_temp_end, 45),
     AP_GROUPINFO("IMUT_TCONST",   3, SIM, imu_temp_tconst, 300),
     AP_GROUPINFO("IMUT_FIXED",    4, SIM, imu_temp_fixed, 0),
+#endif
     AP_GROUPINFO("ACC1_BIAS",     5, SIM, accel_bias[0], 0),
 #if INS_MAX_INSTANCES > 1
     AP_GROUPINFO("ACC2_BIAS",     6, SIM, accel_bias[1], 0),
@@ -493,6 +495,7 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     AP_GROUPINFO("JSON_MASTER",     27, SIM, ride_along_master, 0),
 
     // the IMUT parameters must be last due to the enable parameters
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SIM, AP_InertialSensor::TCal),
 #if INS_MAX_INSTANCES > 1
     AP_SUBGROUPINFO(imu_tcal[1], "IMUT2_", 62, SIM, AP_InertialSensor::TCal),
@@ -500,6 +503,7 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
 #if INS_MAX_INSTANCES > 2
     AP_SUBGROUPINFO(imu_tcal[2], "IMUT3_", 63, SIM, AP_InertialSensor::TCal),
 #endif
+#endif  // HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -451,12 +451,14 @@ public:
     float get_apparent_wind_dir() const{return state.wind_vane_apparent.direction;}
     float get_apparent_wind_spd() const{return state.wind_vane_apparent.speed;}
 
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
     // IMU temperature calibration params
     AP_Float imu_temp_start;
     AP_Float imu_temp_end;
     AP_Float imu_temp_tconst;
     AP_Float imu_temp_fixed;
     AP_InertialSensor::TCal imu_tcal[INS_MAX_INSTANCES];
+#endif
 
     // IMU control parameters
     AP_Float gyro_noise[INS_MAX_INSTANCES];  // in degrees/second


### PR DESCRIPTION
Compilation fails because we do this in SITL.h: `AP_InertialSensor::TCal` - that isn't defined if tcal isn't enabled

... we probably shouldn't be using `AP_InertialSensor::TCal` in SITL.h
