### PR TITLE
Copter: Glitch check is not required if GNSS is not used

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -284,6 +284,10 @@ void Copter::failsafe_terrain_on_event()
 // check for gps glitch failsafe
 void Copter::gpsglitch_check()
 {
+    if (copter.gps.num_sensors() < 1) {
+        return;  // copter that do not use GNSS do not need a glitch check.
+    }
+
     // get filter status
     nav_filter_status filt_status = inertial_nav.get_filter_status();
     bool gps_glitching = filt_status.flags.gps_glitching;


### PR DESCRIPTION
I think the GPS glitch check is unnecessary if you are not using GNSS.
I think it is better to finish the process immediately if there is no GPS sensor.