### PR TITLE
Copter: Change multiple if statements to swtich statements

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -997,19 +997,22 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_pause_continue(const mavlink_comma
         return MAV_RESULT_FAILED;
     }
 
-    // requested pause from GCS
-    if ((int8_t) packet.param1 == 0) {
+    switch (int8_t(packet.param1)) {
+    case 0:
+        // requested pause from GCS
         copter.mode_auto.mission.stop();
         copter.mode_auto.loiter_start();
         gcs().send_text(MAV_SEVERITY_INFO, "Paused mission");
         return MAV_RESULT_ACCEPTED;
-    }
 
-    // requested resume from GCS
-    if ((int8_t) packet.param1 == 1) {
+    case 1:
+        // requested resume from GCS
         copter.mode_auto.mission.resume();
         gcs().send_text(MAV_SEVERITY_INFO, "Resumed mission");
         return MAV_RESULT_ACCEPTED;
+
+    default:
+        break;
     }
 #endif
 


### PR DESCRIPTION
I saw the same variable being processed differently depending on its value.
This process can be replaced by a SWITCH statement.