### PR TITLE
AP_OpticalFlow: Change division to multiplication

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -189,8 +189,8 @@ void OpticalFlow::update(void)
         if (_calibrator->update()) {
             // apply new calibration values
             const Vector2f new_scaling = _calibrator->get_scalars();
-            const float flow_scalerx_as_multiplier = (1.0 + (_flowScalerX / 1000.0)) * new_scaling.x;
-            const float flow_scalery_as_multiplier = (1.0 + (_flowScalerY / 1000.0)) * new_scaling.y;
+            const float flow_scalerx_as_multiplier = (1.0 + (_flowScalerX * 0.001)) * new_scaling.x;
+            const float flow_scalery_as_multiplier = (1.0 + (_flowScalerY * 0.001)) * new_scaling.y;
             _flowScalerX.set_and_save_ifchanged((flow_scalerx_as_multiplier - 1.0) * 1000.0);
             _flowScalerY.set_and_save_ifchanged((flow_scalery_as_multiplier - 1.0) * 1000.0);
             _flowScalerX.notify();


### PR DESCRIPTION
Most of the ArduPilot is used with the STM32 system.
The STM32 takes fewer clocks to multiply than to divide.
I have changed the division to multiplication.