### PR TITLE
Add developer code of coduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+ArduPilot Developer Code of Conduct
+===================================
+
+Rev 1.0 Jan 2nd 2018
+
+Our Aim
+-------
+
+ArduPilot aims to enable the creation and use of trusted, autonomous,
+unmanned vehicle systems for the peaceful benefit of all.
+
+Our Team
+--------
+
+The ArduPilot team is global. It consists of the Development Team plus
+many contributors, from many fields and many places. By choosing to be
+part of the ArduPilot Development Team, you choose to accept this Code
+of Conduct.
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+developers and maintainers pledge to:
+
+-   Endeavour to make participation in our project and our community a
+    harassment-free experience for everyone, regardless of age, body
+    size, disability, ethnicity, gender identity and expression, level
+    of experience, nationality, personal appearance, race, religion, or
+    sexual identity and orientation.
+-   Endeavour to understand the intent of development activities they
+    undertake, where there may be reason to think that the vehicle may
+    be used as a weapon or in an application where it is effectively in
+    control of human life.
+-   Not knowingly support or facilitate the weaponization of systems
+    using ArduPilot
+-   ArduPilot is NOT certified for use in applications where ArduPilot
+    is effectively in control of human lives. Members of the development
+    team must not knowingly assist in projects where ArduPilot will be
+    in control of human lives. “In control of human lives” includes but
+    isn’t limited to manned aircraft.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to achieving the aims of ArduPilot
+include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by contributors include:
+
+-   The use of sexualized language or imagery and unwelcome sexual
+    attention or advances
+-   Trolling, insulting/derogatory comments, and personal or political
+    attacks
+-   Public or private harassment
+-   Publishing others’ private information, such as a physical or
+    electronic address, without explicit permission
+-   Modifying ArduPilot code to intentionally support weaponization
+-   Knowingly designing, testing or using weaponized systems running
+    ArduPilot
+-   Other conduct which could reasonably be considered inappropriate in
+    a public or professional setting
+
+Our Responsibilities
+--------------------
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the ArduPilot project or its
+community. Examples of representing the ArduPilot project or community
+include using an official project e-mail address, posting via an
+official social media account, or acting as an appointed representative
+at an online or offline event. Representation of the ArduPilot project
+may be further defined and clarified by project maintainers.
+
+In addition, the rules regarding weaponization and manned vehicles using
+ArduPilot apply regardless of whether you are representing the ArduPilot
+project at the time.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior, and
+other actions not consistent with this Code of Conduct may be reported
+by contacting the project team at <ardupilot.devel@gmail.com>. All
+complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to
+the reporter of an incident. Further details of specific enforcement
+policies may be posted separately. Project maintainers who do not follow
+or enforce the Code of Conduct in good faith may face temporary or
+permanent repercussions as determined by other members of the project’s
+leadership team.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the Contributor Covenant, version
+1.4, available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>


### PR DESCRIPTION
This was generated by coverting the document on the Wiki like this:

```
pandoc ~/rc/ardupilot_wiki/dev/source/docs/developer-code-of-conduct.rst -f rst -t markdown -o CODE_OF_CONDUCT.md
```

Based this on a snippet from the github interface which hints that their options are simply templates that can be adjusted, and that this is some sort of useful standard for projects to adopt:

![image](https://user-images.githubusercontent.com/7077857/151647253-1fabcc39-1cb6-4284-8b69-7c89878b2d12.png)
