### PR TITLE
AP_Terrain: avoid direct use of Location alt field

### DIFF
--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -243,10 +243,10 @@ void AP_Terrain::send_terrain_report(mavlink_channel_t chan, const Location &loc
     uint16_t pending, loaded;
     get_statistics(pending, loaded);
 
-    float current_height;
+    float current_height = 0.0f;
     if (spacing == 0 && !(extrapolate && have_current_loc_height)) {
         current_height = 0;
-    } else {
+    } else if (!current_loc.is_zero()) {
         int32_t height_above_home_cm = 0;
         UNUSED_RESULT(current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, height_above_home_cm));
         current_height = height_above_home_cm * 0.01f;  // cm -> m

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -247,11 +247,9 @@ void AP_Terrain::send_terrain_report(mavlink_channel_t chan, const Location &loc
     if (spacing == 0 && !(extrapolate && have_current_loc_height)) {
         current_height = 0;
     } else {
-        if (current_loc.relative_alt) {
-            current_height = current_loc.alt*0.01f;
-        } else {
-            current_height = (current_loc.alt - ahrs.get_home().alt)*0.01f;
-        }
+        int32_t height_above_home_cm = 0;
+        UNUSED_RESULT(current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, height_above_home_cm));
+        current_height = height_above_home_cm * 0.01f;  // cm -> m
     }
     current_height += home_terrain_height - terrain_height;
 


### PR DESCRIPTION
I'm really not sure about this whole returning of zero for above-home height if we don't know what it is.  Perhaps we'd be better off not sending `TERRAIN_REPORT` in that case - or a nan in the relevant mavlink field?  Separate issue.

