### PR TITLE
SRC_Channels: correct RC channel define to SERVO channel

### DIFF
--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -462,7 +462,7 @@ void SRV_Channels::zero_rc_outputs()
      * undesired/unexpected behavior
      */
     cork();
-    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         hal.rcout->write(i, 0);
     }
     push();


### PR DESCRIPTION
Defines are currently both 16, so no change in behavior we were just using the wrong one. The `zero_rc_outputs` function is only used on sub in any case. 