### PR TITLE
libraries: Change the word(NFC)

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -388,7 +388,7 @@ void AP_ESC_Telem::update()
                 //   voltage is in Volt
                 //   current is in Ampere
                 //   esc_temp is in centi-degrees Celsius
-                //   current_tot is in mili-Ampere hours
+                //   current_tot is in milli-Ampere hours
                 //   motor_temp is in centi-degrees Celsius
                 //   error_rate is in percentage
                 const struct log_Esc pkt{

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -20,7 +20,7 @@ public:
         float consumption_mah;      // milli-Ampere.hours
         uint32_t usage_s;           // usage seconds
         int16_t  motor_temp_cdeg;   // centi-degrees C, negative values allowed
-        uint32_t last_update_ms;    // last update time in miliseconds, determines whether active
+        uint32_t last_update_ms;    // last update time in milliseconds, determines whether active
         uint16_t types;             // telemetry types present
         uint16_t count;             // number of times updated
     };

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -372,7 +372,7 @@ private:
         uint16_t voltage;         // centi-Volt
         uint16_t current;         // centi-Ampere  (signed?)
         int16_t rpm;              // centi-rpm
-        uint16_t consumption_mah; // mili-Ampere.hour
+        uint16_t consumption_mah; // milli-Ampere.hour
         uint16_t tx_err_count;    // CRC error count, as perceived from the ESC receiving side
     };
 

--- a/libraries/AP_IRLock/AP_IRLock_SITL_Gazebo.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_SITL_Gazebo.cpp
@@ -66,7 +66,7 @@ bool AP_IRLock_SITL_Gazebo::update()
       reply packet sent from simulator to ArduPilot
      */
     struct irlock_packet {
-        uint64_t timestamp;  // in miliseconds
+        uint64_t timestamp;  // in milliseconds
         uint16_t num_targets;
         float pos_x;
         float pos_y;

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -317,7 +317,7 @@ void AP_ToshibaCAN::loop()
                         t.voltage = float(be16toh(reply_data.voltage_mv)) * 0.001f;  // millivolts to volts
                         t.current = MAX((int16_t)be16toh(reply_data.current_ma), 0) * (4.0f * 0.001f); // milli-amps to amps
                         if (diff_ms <= 1000) {
-                            // convert centi-amps miliseconds to mAh
+                            // convert centi-amps milliseconds to mAh
                             _telemetry[esc_id].current_tot_mah += t.current * diff_ms * amp_ms_to_mah;
                         }
                         t.consumption_mah = _telemetry[esc_id].current_tot_mah;


### PR DESCRIPTION
I think mili is a typo.
I'll change it to milli.