### PR TITLE
Build ArduPilot against all.xml rather than ardupilotmega.xml

### DIFF
--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -29,7 +29,7 @@ extern const AP_HAL::HAL &hal;
 
 #include "include/mavlink/v2.0/protocol.h"
 #include "include/mavlink/v2.0/mavlink_types.h"
-#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
+#include "include/mavlink/v2.0/all/mavlink.h"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #include "include/mavlink/v2.0/mavlink_helpers.h"

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -6375,7 +6375,7 @@ Also, ignores heartbeats not from our target system'''
                 source_system=250,
                 source_component=250,
                 autoreconnect=True,
-                dialect="ardupilotmega",  # if we don't pass this in we end up with the wrong mavlink version...
+                dialect="all",  # if we don't pass this in we end up with the wrong mavlink version...
             )
         except Exception as msg:
             self.progress("Failed to start mavlink connection on %s: %s" %

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -34,7 +34,7 @@
 #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 #endif
 
-#include "include/mavlink/v2.0/ardupilotmega/version.h"
+#include "include/mavlink/v2.0/all/version.h"
 
 #define MAVLINK_MAX_PAYLOAD_LEN 255
 
@@ -67,7 +67,7 @@ void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len);
 uint16_t comm_get_txspace(mavlink_channel_t chan);
 
 #define MAVLINK_USE_CONVENIENCE_FUNCTIONS
-#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
+#include "include/mavlink/v2.0/all/mavlink.h"
 
 // lock and unlock a channel, for multi-threaded mavlink send
 void comm_send_lock(mavlink_channel_t chan);

--- a/wscript
+++ b/wscript
@@ -606,7 +606,7 @@ def _build_dynamic_sources(bld):
     if not bld.env.BOOTLOADER:
         bld(
             features='mavgen',
-            source='modules/mavlink/message_definitions/v1.0/ardupilotmega.xml',
+            source='modules/mavlink/message_definitions/v1.0/all.xml',
             output_dir='libraries/GCS_MAVLink/include/mavlink/v2.0/',
             name='mavlink',
             # this below is not ideal, mavgen tool should set this, but that's not


### PR DESCRIPTION
This has the advantage that we will understand and forward packets that we don't understand but are contained in all.xml.

This has the drawback that those checksums aren't free - there is a cost to being able to undersand (and thus route) mavlink messages.
