### PR TITLE
Move logging of Event::SET_HOME up to AP_AHRS

### DIFF
--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -78,9 +78,6 @@ bool Copter::set_home(const Location& loc, bool lock)
 
     // init inav and compass declination
     if (!home_was_set) {
-        // record home is set
-        AP::logger().Write_Event(LogEvent::SET_HOME);
-
 #if MODE_AUTO_ENABLED == ENABLED
         // log new home position which mission library will pull from ahrs
         if (should_log(MASK_LOG_CMD)) {

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -70,9 +70,6 @@ bool Sub::set_home(const Location& loc, bool lock)
 
     // init inav and compass declination
     if (!home_was_set) {
-        // record home is set
-        AP::logger().Write_Event(LogEvent::SET_HOME);
-
         // log new home position which mission library will pull from ahrs
         if (should_log(MASK_LOG_CMD)) {
             AP_Mission::Mission_Command temp_cmd;

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -63,17 +63,9 @@ bool Blimp::set_home(const Location& loc, bool lock)
         return false;
     }
 
-    const bool home_was_set = ahrs.home_is_set();
-
     // set ahrs home (used for RTL)
     if (!ahrs.set_home(loc)) {
         return false;
-    }
-
-    // init inav and compass declination
-    if (!home_was_set) {
-        // record home is set
-        AP::logger().Write_Event(LogEvent::SET_HOME);
     }
 
     // lock home position

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -25,6 +25,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -1156,6 +1157,13 @@ bool AP_AHRS::set_home(const Location &loc)
     if (!tmp.change_alt_frame(Location::AltFrame::ABSOLUTE)) {
         return false;
     }
+
+#if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+    if (!_home_is_set) {
+        // record home is set
+        AP::logger().Write_Event(LogEvent::SET_HOME);
+    }
+#endif
 
     _home = tmp;
     _home_is_set = true;


### PR DESCRIPTION
Tested in SITL.  Event is still logged:
```
MAV> messages SET_HOME
MAV> 2022-01-30 16:53:02.426 Event: DATA_SET_HOME

```
