### PR TITLE
Plane: disable TECS use during NAV_SCRIPT_TIME

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -173,9 +173,9 @@ public:
 
     bool allows_throttle_nudging() const override { return true; }
 
-    bool does_auto_navigation() const override { return true; }
+    bool does_auto_navigation() const override;
 
-    bool does_auto_throttle() const override { return true; }
+    bool does_auto_throttle() const override;
 
 protected:
 

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -112,3 +112,19 @@ void ModeAuto::navigate()
     }
 }
 
+
+bool ModeAuto::does_auto_navigation() const
+{
+#if AP_SCRIPTING_ENABLED
+   return (!plane.nav_scripting_active());
+#endif
+   return true;
+}
+
+bool ModeAuto::does_auto_throttle() const
+{
+#if AP_SCRIPTING_ENABLED
+   return (!plane.nav_scripting_active());
+#endif
+   return true;
+}


### PR DESCRIPTION
allows TECS to resume immediately in height control at the end of a NAV_SCRIPT_TIME segment

tested in SITL on long aerobatics script mission which showed the issue....TECS now responds in height control immediately after end of NAV_SCRIPT_TIME period where before it would not begin again until the next normal waypoint is reached.....

thanks to Tridge for teaching me how to do this