### PR TITLE
AP_Math: spline lateral scaler reduced to 0.5

### DIFF
--- a/libraries/AP_Math/SplineCurve.cpp
+++ b/libraries/AP_Math/SplineCurve.cpp
@@ -26,7 +26,7 @@ extern const AP_HAL::HAL &hal;
 
 #define SPLINE_FACTOR           4.0f    // defines shape of curves.  larger numbers result in longer spline curves, lower numbers take a direct path
 #define TANGENTIAL_ACCEL_SCALER 0.5f    // the proportion of the maximum accel that can be used for tangential acceleration (aka in the direction of travel along the track)
-#define LATERAL_ACCEL_SCALER    1.0f    // the proportion of the maximum accel that can be used for lateral acceleration (aka crosstrack acceleration)
+#define LATERAL_ACCEL_SCALER    0.5f    // the proportion of the maximum accel that can be used for lateral acceleration (aka crosstrack acceleration)
 
 // limit the maximum speed along the track to that which will achieve a cornering (aka lateral) acceleration of LATERAL_SPEED_SCALER * acceleration limit
 


### PR DESCRIPTION
This change reduces the maximum lateral acceleration used when creating a spline path.

This is important because it path will more likely be within the vehicle's acceleration limits so it is more likely to stay on the path.  Staying on the path is more important than before because PR https://github.com/ArduPilot/ardupilot/pull/19508 causes the vehicle to more aggressively get back on the path if it strays too far.

Below are screen shots of the vehicle path using 4.1.4-rc1 with a spline mission and we see in the "before" the vehicle was not flying a smooth path.  Instead it aggressively turns to hit waypoint 3.  In "after" we see a nice smooth path.
![accel05-before-vs-after](https://user-images.githubusercontent.com/1498098/151728142-9f4bf12b-5ca5-4e1c-ad35-9458ec818ef3.png)

