### PR TITLE
Removed terrain home correction

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -628,8 +628,8 @@ void Plane::rangefinder_terrain_correction(float &height)
         return;
     }
     float terrain_amsl1, terrain_amsl2;
-    if (!terrain.height_amsl(current_loc, terrain_amsl1, false) ||
-        !terrain.height_amsl(next_WP_loc, terrain_amsl2, false)) {
+    if (!terrain.height_amsl(current_loc, terrain_amsl1) ||
+        !terrain.height_amsl(next_WP_loc, terrain_amsl2)) {
         return;
     }
     float correction = (terrain_amsl1 - terrain_amsl2);

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -140,7 +140,7 @@ bool Location::get_alt_cm(AltFrame desired_frame, int32_t &ret_alt_cm) const
         if (terrain == nullptr) {
             return false;
         }
-        if (!terrain->height_amsl(*this, alt_terr_cm, true)) {
+        if (!terrain->height_amsl(*this, alt_terr_cm)) {
             return false;
         }
         // convert terrain alt to cm

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -906,7 +906,7 @@ void SITL_State::set_height_agl(void)
 
         AP_Terrain *_terrain = AP_Terrain::get_singleton();
         if (_terrain != nullptr &&
-            _terrain->height_amsl(location, terrain_height_amsl, false)) {
+            _terrain->height_amsl(location, terrain_height_amsl)) {
             _sitl->height_agl = _sitl->state.altitude - terrain_height_amsl;
             return;
         }

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1446,9 +1446,8 @@ function terrain:height_terrain_difference_home(extrapolate) end
 
 -- desc
 ---@param loc Location_ud
----@param corrected boolean
 ---@return number|nil
-function terrain:height_amsl(loc, corrected) end
+function terrain:height_amsl(loc) end
 
 -- desc
 ---@return integer

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -173,7 +173,7 @@ singleton AP_Terrain alias terrain
 singleton AP_Terrain method enabled boolean
 singleton AP_Terrain enum TerrainStatusDisabled TerrainStatusUnhealthy TerrainStatusOK
 singleton AP_Terrain method status uint8_t
-singleton AP_Terrain method height_amsl boolean Location float'Null boolean
+singleton AP_Terrain method height_amsl boolean Location float'Null
 singleton AP_Terrain method height_terrain_difference_home boolean float'Null boolean
 singleton AP_Terrain method height_above_terrain boolean float'Null boolean
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -96,7 +96,7 @@ AP_Terrain::AP_Terrain(const AP_Mission &_mission) :
 
   This function costs about 20 microseconds on Pixhawk
  */
-bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
+bool AP_Terrain::height_amsl(const Location &loc, float &height)
 {
     if (!allocate()) {
         return false;
@@ -108,10 +108,6 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
     if (loc.lat == home_loc.lat &&
         loc.lng == home_loc.lng) {
         height = home_height;
-        // apply correction which assumes home altitude is at terrain altitude
-        if (corrected) {
-            height += (ahrs.get_home().alt * 0.01f) - home_height;
-        }
         return true;
     }
 
@@ -162,11 +158,6 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
         home_loc = loc;
     }
 
-    // apply correction which assumes home altitude is at terrain altitude
-    if (corrected) {
-        height += (ahrs.get_home().alt * 0.01f) - home_height;
-    }
-
     return true;
 }
 
@@ -187,7 +178,7 @@ bool AP_Terrain::height_terrain_difference_home(float &terrain_difference, bool 
     const AP_AHRS &ahrs = AP::ahrs();
 
     float height_home, height_loc;
-    if (!height_amsl(ahrs.get_home(), height_home, false)) {
+    if (!height_amsl(ahrs.get_home(), height_home)) {
         // we don't know the height of home
         return false;
     }
@@ -198,7 +189,7 @@ bool AP_Terrain::height_terrain_difference_home(float &terrain_difference, bool 
         return false;
     }
 
-    if (!height_amsl(loc, height_loc, false)) {
+    if (!height_amsl(loc, height_loc)) {
         if (!extrapolate || !have_current_loc_height) {
             // we don't know the height of the given location
             return false;
@@ -284,7 +275,7 @@ float AP_Terrain::lookahead(float bearing, float distance, float climb_ratio)
         return 0;
     }
     float base_height;
-    if (!height_amsl(loc, base_height, false)) {
+    if (!height_amsl(loc, base_height)) {
         // we don't know our current terrain height
         return 0;
     }
@@ -298,7 +289,7 @@ float AP_Terrain::lookahead(float bearing, float distance, float climb_ratio)
         climb += climb_ratio * grid_spacing;
         distance -= grid_spacing;
         float height;
-        if (height_amsl(loc, height, false)) {
+        if (height_amsl(loc, height)) {
             float rise = (height - base_height) - climb;
             if (rise > lookahead_estimate) {
                 lookahead_estimate = rise;
@@ -325,12 +316,12 @@ void AP_Terrain::update(void)
 
     // try to ensure the home location is populated
     float height;
-    height_amsl(ahrs.get_home(), height, false);
+    height_amsl(ahrs.get_home(), height);
 
     // update the cached current location height
     Location loc;
     bool pos_valid = ahrs.get_location(loc);
-    bool terrain_valid = pos_valid && height_amsl(loc, height, false);
+    bool terrain_valid = pos_valid && height_amsl(loc, height);
     if (pos_valid && terrain_valid) {
         last_current_loc_height = height;
         have_current_loc_height = true;
@@ -373,7 +364,7 @@ void AP_Terrain::log_terrain_data()
     float current_height = 0;
     uint16_t pending, loaded;
 
-    height_amsl(loc, terrain_height, false);
+    height_amsl(loc, terrain_height);
     height_above_terrain(current_height, true);
     get_statistics(pending, loaded);
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -122,12 +122,8 @@ public:
       find the terrain height in meters above sea level for a location
 
       return false if not available
-
-      if corrected is true then terrain alt is adjusted so that
-      the terrain altitude matches the home altitude at the home location
-      (i.e. we assume home is at the terrain altitude)
      */
-    bool height_amsl(const Location &loc, float &height, bool corrected);
+    bool height_amsl(const Location &loc, float &height);
 
     /* 
        find difference between home terrain height and the terrain

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -228,8 +228,8 @@ void AP_Terrain::send_terrain_report(mavlink_channel_t chan, const Location &loc
     Location current_loc;
     const AP_AHRS &ahrs = AP::ahrs();
     if (ahrs.get_location(current_loc) &&
-        height_amsl(ahrs.get_home(), home_terrain_height, false) &&
-        height_amsl(loc, terrain_height, false)) {
+        height_amsl(ahrs.get_home(), home_terrain_height) &&
+        height_amsl(loc, terrain_height)) {
         // non-zero spacing indicates we have data
         spacing = grid_spacing;
     } else if (extrapolate && have_current_loc_height) {
@@ -238,7 +238,7 @@ void AP_Terrain::send_terrain_report(mavlink_channel_t chan, const Location &loc
         terrain_height = last_current_loc_height;
     } else {
         // report terrain height if we can, but can't give current_height
-        height_amsl(loc, terrain_height, false);
+        height_amsl(loc, terrain_height);
     }
     uint16_t pending, loaded;
     get_statistics(pending, loaded);

--- a/libraries/AP_Terrain/TerrainMission.cpp
+++ b/libraries/AP_Terrain/TerrainMission.cpp
@@ -88,7 +88,7 @@ void AP_Terrain::update_mission_data(void)
 
         // we have a mission command to check
         float height;
-        if (!height_amsl(cmd.content.location, height, false)) {
+        if (!height_amsl(cmd.content.location, height)) {
             // if we can't get data for a mission item then return and
             // check again next time
             return;
@@ -149,7 +149,7 @@ void AP_Terrain::update_rally_data(void)
         loc.lat = rp.lat;
         loc.lng = rp.lng;
         float height;
-        if (!height_amsl(loc, height, false)) {
+        if (!height_amsl(loc, height)) {
             // if we can't get data for a rally item then return and
             // check again next time
             return;

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -107,8 +107,8 @@ float Aircraft::ground_height_difference() const
     if (sitl &&
         terrain != nullptr &&
         sitl->terrain_enable &&
-        terrain->height_amsl(home, h1, false) &&
-        terrain->height_amsl(location, h2, false)) {
+        terrain->height_amsl(home, h1) &&
+        terrain->height_amsl(location, h2)) {
         h2 += local_ground_level;
         return h2 - h1;
     }

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -183,7 +183,7 @@ void ShipSim::send_report(void)
 #if AP_TERRAIN_AVAILABLE
     auto terrain = AP::terrain();
     float height;
-    if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height, true)) {
+    if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height)) {
         alt_mm = height * 1000;
     }
 #endif


### PR DESCRIPTION
The terrain home correction was an attempt to cope with the error between initial baro height and terrain height at that location. Only two places in the code used it, both of them incorrect, so it is best to remove it completely.
Where it badly broke down is if the user moved home, which is more common for people doing complex missions involving terrain.
