### PR TITLE
AP_BattMonitor: extend build options to backend modules

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
@@ -2,6 +2,9 @@
 #include "AP_BattMonitor_FuelFlow.h"
 #include <GCS_MAVLink/GCS.h>
 
+#if AP_BATTMON_FUEL_ENABLE
+
+
 /*
   "battery" monitor for liquid fuel flow systems that give a pulse on
   a pin for fixed volumes of fuel.
@@ -122,3 +125,4 @@ void AP_BattMonitor_FuelFlow::read()
     // map consumed_wh using fixed voltage of 1
     _state.consumed_wh = _state.consumed_mah;
 }
+#endif

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_PWM.cpp
@@ -2,6 +2,8 @@
 #include "AP_BattMonitor_FuelLevel_PWM.h"
 #include <GCS_MAVLink/GCS.h>
 
+#if AP_BATTMON_FUEL_ENABLE
+
 /*
   "battery" monitor for liquid fuel level systems that give a PWM value indicating quantity of remaining fuel.
 
@@ -62,3 +64,5 @@ void AP_BattMonitor_FuelLevel_PWM::read()
     // map consumed_wh using fixed voltage of 1
     _state.consumed_wh = _state.consumed_mah;
 }
+
+#endif

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -1,5 +1,7 @@
 #include "AP_BattMonitor_SMBus.h"
 
+#if AP_BATTMON_SMBUS_ENABLE
+
 #define AP_BATTMONITOR_SMBUS_PEC_POLYNOME 0x07 // Polynome for CRC generation
 
 extern const AP_HAL::HAL& hal;
@@ -211,3 +213,4 @@ uint8_t AP_BattMonitor_SMBus::get_PEC(const uint8_t i2c_addr, uint8_t cmd, bool 
     // return result
     return crc;
 }
+#endif


### PR DESCRIPTION
Can save 5.6k....completes all options that save space in AP_BattMonitor