### PR TITLE
AP_UAVCAN: add option to send ESC msg idx to match motor name idx

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -200,6 +200,7 @@ public:
         DNA_CLEAR_DATABASE        = (1U<<0),
         DNA_IGNORE_DUPLICATE_NODE = (1U<<1),
         CANFD_ENABLED             = (1U<<2),
+        ESC_IDX_MATCHES_MOTOR_NAME= (1U<<3),
     };
 
     // check if a option is set
@@ -275,9 +276,8 @@ private:
     ///// SRV output /////
     struct {
         uint16_t pulse;
-        bool esc_pending;
-        bool servo_pending;
-    } _SRV_conf[UAVCAN_SRV_NUMBER];
+        bool pending;
+    } _SRV_conf[UAVCAN_SRV_NUMBER], _ESC_conf[UAVCAN_SRV_NUMBER];
 
     uint8_t _SRV_armed;
     uint32_t _SRV_last_send_us;


### PR DESCRIPTION
This adds a new CAN_xx_UC_OPTIONS bit to map Servo X function MOTOR_N to the CAN ESC msg of the same N index. Default is off where we use the existing SRV X channel as the ESC X index. Note, this does not change the Actuator CAN msg at all.

Example:
```SERVO6_FUNCTION = MOTOR2```

Current:
This maps CAN ESC msg index 6

With Option bit:
This maps CAN ESC msg index 2
