### PR TITLE
Log ArduPilot version into dataflash in VER message

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -416,6 +416,7 @@ class Board:
 
     def build(self, bld):
         bld.ap_version_append_str('GIT_VERSION', bld.git_head_hash(short=True))
+        bld.ap_version_append_int('GIT_VERSION_INT', int("0x" + bld.git_head_hash(short=True), base=16))
         import time
         ltime = time.localtime()
         if bld.env.build_dates:

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -28,6 +28,7 @@ public:
     const uint32_t os_sw_version;
     const char *fw_string;
     const char *fw_hash_str;
+    const uint32_t fw_hash;
     const char *fw_string_original;
     const char *fw_short_string;
     const char *middleware_name;

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -60,6 +60,11 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_string = ACTIVE_FWSTR " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
+#ifndef GIT_VERSION_INT
+    .fw_hash = 0,
+#else
+   .fw_hash = GIT_VERSION_INT,
+#endif
     .fw_string_original = ORIGINAL_FWSTR,
     .fw_short_string = ACTIVE_FWSTR,
     .middleware_name = nullptr,

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -2,6 +2,7 @@
 
 #include "LoggerMessageWriter.h"
 
+#include "AP_Common/AP_FWVersion.h"
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 
@@ -518,6 +519,31 @@ bool AP_Logger_Backend::Write_Rally()
     return _startup_messagewriter->writeallrallypoints();
 }
 #endif
+
+
+bool AP_Logger_Backend::Write_VER()
+{
+    const AP_FWVersion &fwver = AP::fwversion();
+
+    log_VER pkt{
+        LOG_PACKET_HEADER_INIT(LOG_VER_MSG),
+        time_us  : AP_HAL::micros64(),
+        board_type : fwver.board_type,
+        board_subtype: fwver.board_subtype,
+        major: fwver.major,
+        minor: fwver.minor,
+        patch: fwver.patch,
+        fw_type: fwver.fw_type,
+        git_hash: fwver.fw_hash,
+    };
+    strncpy(pkt.fw_string, fwver.fw_string, ARRAY_SIZE(pkt.fw_string)-1);
+
+#ifdef APJ_BOARD_ID
+    pkt._APJ_BOARD_ID = APJ_BOARD_ID;
+#endif
+
+    return WriteCriticalBlock(&pkt, sizeof(pkt));
+}
 
 /*
   convert a list entry number back into a log number (which can then

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -130,6 +130,7 @@ public:
     bool Write_Parameter(const AP_Param *ap,
                              const AP_Param::ParamToken &token,
                              enum ap_var_type type);
+    bool Write_VER();
 
     uint32_t num_dropped(void) const {
         return _dropped;

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -714,6 +714,21 @@ struct PACKED log_MotBatt {
     uint8_t mot_fail_flags;
 };
 
+struct PACKED log_VER {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t board_type;
+    uint16_t board_subtype;
+    uint8_t major;
+    uint8_t minor;
+    uint8_t patch;
+    uint8_t fw_type;
+    uint32_t git_hash;
+    char fw_string[64];
+    uint16_t _APJ_BOARD_ID;
+};
+
+
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
@@ -1374,6 +1389,8 @@ LOG_STRUCTURE_FROM_VISUALODOM \
 LOG_STRUCTURE_FROM_AIS, \
     { LOG_SCRIPTING_MSG, sizeof(log_Scripting), \
       "SCR",   "QNIii", "TimeUS,Name,Runtime,Total_mem,Run_mem", "s-sbb", "F-F--", true }, \
+    { LOG_VER_MSG, sizeof(log_VER), \
+      "VER",   "QBHBBBBIZH", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ", "s---------", "F---------", false }, \
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt), \
       "MOTB", "QffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,FailFlags", "s-----", "F-----" , true }
 
@@ -1457,6 +1474,7 @@ enum LogMessages : uint8_t {
     LOG_SCRIPTING_MSG,
     LOG_VIDEO_STABILISATION_MSG,
     LOG_MOTBATT_MSG,
+    LOG_VER_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -242,9 +242,16 @@ void LoggerMessageWriter_WriteSysInfo::process() {
                 return; // call me again
             }
         }
-        stage = Stage::SYSTEM_ID;
+        stage = Stage::VER;
         FALLTHROUGH;
 
+    case Stage::VER: {
+        if (!_logger_backend->Write_VER()) {
+            return;
+        }
+        stage = Stage::SYSTEM_ID;
+        FALLTHROUGH;
+    }
     case Stage::SYSTEM_ID:
         char sysid[40];
         if (hal.util->get_system_id(sysid)) {

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -31,6 +31,7 @@ private:
     enum class Stage : uint8_t {
         FIRMWARE_STRING = 0,
         GIT_VERSIONS,
+        VER,  // i.e. the "VER" message
         SYSTEM_ID,
         PARAM_SPACE_USED,
         RC_PROTOCOL


### PR DESCRIPTION
Tested in SITL and also a CubeBlack on my desk:

```
pbarker@bluebottle:~/rc/ardupilot(pr/log-ver)$ mavlogdump.py ../log79.bin --t VER
1970-01-01 10:01:12.73: VER {TimeUS : 72738988, BT : 10, BST : 5001, Maj : 4, Min : 2, Pat : 0, FWT : 0, GH : 445699628, FWS : ArduRover V4.2.0-dev (1a90d62c), APJ : 9}
```
