### PR TITLE
Allow AP_Terrain to be constructed without passing AP_Mission in

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -510,8 +510,8 @@ private:
 #endif
 
     // terrain handling
-#if AP_TERRAIN_AVAILABLE && MODE_AUTO_ENABLED == ENABLED
-    AP_Terrain terrain{mode_auto.mission};
+#if AP_TERRAIN_AVAILABLE
+    AP_Terrain terrain;
 #endif
 
     // Precision Landing

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -665,10 +665,6 @@
   #error ModeAuto requires ModeRTL which is disabled
 #endif
 
-#if AP_TERRAIN_AVAILABLE && !MODE_AUTO_ENABLED
-  #error Terrain requires ModeAuto which is disabled
-#endif
-
 #if FRAME_CONFIG == HELI_FRAME && !MODE_ACRO_ENABLED
   #error Helicopter frame requires acro mode support which is disabled
 #endif

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -638,7 +638,7 @@ private:
 
     // terrain handling
 #if AP_TERRAIN_AVAILABLE
-    AP_Terrain terrain{mission};
+    AP_Terrain terrain;
 #endif
 
     AP_Landing landing{mission,ahrs,&TECS_controller,nav_controller,aparm,

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -363,7 +363,7 @@ private:
 
     // terrain handling
 #if AP_TERRAIN_AVAILABLE
-    AP_Terrain terrain{mission};
+    AP_Terrain terrain;
 #endif
 
     // used to allow attitude and depth control without a position system

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -18,7 +18,7 @@ public:
         FUNCTOR_BIND_MEMBER(&DummyVehicle::start_cmd, bool, const AP_Mission::Mission_Command &),
         FUNCTOR_BIND_MEMBER(&DummyVehicle::verify_cmd, bool, const AP_Mission::Mission_Command &),
         FUNCTOR_BIND_MEMBER(&DummyVehicle::mission_complete, void)};
-    AP_Terrain terrain{mission};
+    AP_Terrain terrain;
 };
 
 const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -72,8 +72,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
 };
 
 // constructor
-AP_Terrain::AP_Terrain(const AP_Mission &_mission) :
-    mission(_mission),
+AP_Terrain::AP_Terrain() :
     disk_io_state(DiskIoIdle),
     fd(-1)
 {

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -18,6 +18,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/Location.h>
 #include <AP_Filesystem/AP_Filesystem_Available.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef AP_TERRAIN_AVAILABLE
 #if HAVE_FILESYSTEM_SUPPORT && defined(HAL_BOARD_TERRAIN_DIRECTORY)
@@ -30,7 +31,6 @@
 #if AP_TERRAIN_AVAILABLE
 
 #include <AP_Param/AP_Param.h>
-#include <AP_Mission/AP_Mission.h>
 
 #define TERRAIN_DEBUG 0
 
@@ -83,11 +83,10 @@
 
 class AP_Terrain {
 public:
-    AP_Terrain(const AP_Mission &_mission);
+    AP_Terrain();
 
     /* Do not allow copies */
-    AP_Terrain(const AP_Terrain &other) = delete;
-    AP_Terrain &operator=(const AP_Terrain&) = delete;
+    CLASS_NO_COPY(AP_Terrain);
 
     static AP_Terrain *get_singleton(void) { return singleton; }
 
@@ -359,10 +358,6 @@ private:
     enum class Options {
         DisableDownload = (1U<<0),
     };
-
-    // reference to AP_Mission, so we can ask preload terrain data for 
-    // all waypoints
-    const AP_Mission &mission;
 
     // cache of grids in memory, LRU
     uint8_t cache_size = 0;

--- a/libraries/AP_Terrain/TerrainMission.cpp
+++ b/libraries/AP_Terrain/TerrainMission.cpp
@@ -19,6 +19,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Mission/AP_Mission.h>
 #include <AP_Rally/AP_Rally.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
@@ -34,12 +35,18 @@ extern const AP_HAL::HAL& hal;
  */
 void AP_Terrain::update_mission_data(void)
 {
-    if (last_mission_change_ms != mission.last_change_time_ms() ||
+#if HAL_MISSION_ENABLED
+    const AP_Mission *mission = AP::mission();
+    if (mission == nullptr) {
+        return;
+    }
+
+    if (last_mission_change_ms != mission->last_change_time_ms() ||
         last_mission_spacing != grid_spacing) {
         // the mission has changed - start again
         next_mission_index = 1;
         next_mission_pos = 0;
-        last_mission_change_ms = mission.last_change_time_ms();
+        last_mission_change_ms = mission->last_change_time_ms();
         last_mission_spacing = grid_spacing;
     }
     if (next_mission_index == 0) {
@@ -59,7 +66,7 @@ void AP_Terrain::update_mission_data(void)
     for (uint8_t i=0; i<20; i++) {
         // get next mission command
         AP_Mission::Mission_Command cmd;
-        if (!mission.read_cmd_from_storage(next_mission_index, cmd)) {
+        if (!mission->read_cmd_from_storage(next_mission_index, cmd)) {
             // nothing more to do
             next_mission_index = 0;
             return;
@@ -71,7 +78,7 @@ void AP_Terrain::update_mission_data(void)
                 cmd.id != MAV_CMD_NAV_SPLINE_WAYPOINT) ||
                (cmd.content.location.lat == 0 && cmd.content.location.lng == 0)) {
             next_mission_index++;
-            if (!mission.read_cmd_from_storage(next_mission_index, cmd)) {
+            if (!mission->read_cmd_from_storage(next_mission_index, cmd)) {
                 // nothing more to do
                 next_mission_index = 0;
                 next_mission_pos = 0;
@@ -105,6 +112,7 @@ void AP_Terrain::update_mission_data(void)
             next_mission_pos = 0;
         }
     }
+#endif  // HAL_MISSION_ENABLED
 }
 
 /*


### PR DESCRIPTION
... instead, use the singleton to access the mission if required.

This allows vehicles to be built without Mission but with Terrain.
