### PR TITLE
Plane: remove logging of STRT message

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -61,24 +61,6 @@ void Plane::Log_Write_Fast(void)
 }
 
 
-struct PACKED log_Startup {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t startup_type;
-    uint16_t command_total;
-};
-
-void Plane::Log_Write_Startup(uint8_t type)
-{
-    struct log_Startup pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG),
-        time_us         : AP_HAL::micros64(),
-        startup_type    : type,
-        command_total   : mission.num_commands()
-    };
-    logger.WriteCriticalBlock(&pkt, sizeof(pkt));
-}
-
 struct PACKED log_Control_Tuning {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -301,8 +283,6 @@ struct PACKED log_CMDI {
 // units and "Format characters" for field type information
 const struct LogStructure Plane::log_structure[] = {
     LOG_COMMON_STRUCTURES,
-    { LOG_STARTUP_MSG, sizeof(log_Startup),         
-      "STRT", "QBH",         "TimeUS,SType,CTot", "s--", "F--" },
 
 // @LoggerMessage: CTUN
 // @Description: Control Tuning information
@@ -525,7 +505,6 @@ void Plane::Log_Write_MavCmdI(const mavlink_command_int_t &mav_cmd)
 void Plane::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
-    Log_Write_Startup(TYPE_GROUNDSTART_MSG);
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.initialised) {
         char frame_and_type_string[30];
@@ -550,7 +529,6 @@ void Plane::log_init(void)
 
 void Plane::Log_Write_Attitude(void) {}
 void Plane::Log_Write_Fast(void) {}
-void Plane::Log_Write_Startup(uint8_t type) {}
 void Plane::Log_Write_Control_Tuning() {}
 void Plane::Log_Write_OFG_Guided() {}
 void Plane::Log_Write_Nav_Tuning() {}

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -878,7 +878,6 @@ private:
 
     void Log_Write_Fast(void);
     void Log_Write_Attitude(void);
-    void Log_Write_Startup(uint8_t type);
     void Log_Write_Control_Tuning();
     void Log_Write_OFG_Guided();
     void Log_Write_Guided(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -83,8 +83,6 @@ static_assert(TUNING_BITS_END <= (1 << 24) + 1, "Tuning bit mask is too large to
 enum log_messages {
     LOG_CTUN_MSG,
     LOG_NTUN_MSG,
-    LOG_STARTUP_MSG,
-    TYPE_GROUNDSTART_MSG,
     LOG_STATUS_MSG,
     LOG_QTUN_MSG,
     LOG_PIQR_MSG,


### PR DESCRIPTION
SType is always 3 - and we're just about to log the entire
mission so CTOT is pointless

... so `TYPE_GROUNDSTART_MSG` was coming from the message enumeration, which was weird.
