### PR TITLE
Plane: correct reporting of relative altitude as a global altitude

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -214,6 +214,11 @@ void GCS_MAVLINK_Plane::send_position_target_global_int()
     static constexpr uint16_t TYPE_MASK = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
                                           POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
                                           POSITION_TARGET_TYPEMASK_YAW_IGNORE | POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE | POSITION_TARGET_TYPEMASK_LAST_BYTE;
+    int32_t alt = 0;
+    if (!next_WP_loc.is_zero()) {
+        UNUSED_RESULT(next_WP_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt));
+    }
+
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms
@@ -221,7 +226,7 @@ void GCS_MAVLINK_Plane::send_position_target_global_int()
         TYPE_MASK, // ignore everything except the x/y/z components
         next_WP_loc.lat, // latitude as 1e7
         next_WP_loc.lng, // longitude as 1e7
-        next_WP_loc.alt * 0.01f, // altitude is sent as a float
+        alt * 0.01, // altitude is sent as a float
         0.0f, // vx
         0.0f, // vy
         0.0f, // vz


### PR DESCRIPTION
There's an expectation that `next_WP_loc` is in the absolute frame at the moment.

LoiterAltQLand wasn't obeying that, setting it above-home or above-terrain; this has the mode set the altitude in absolute frame, setting the terrain flag if appropriate.

The test included here fails on master:

```
AT-0022.0: AP: Battery 1 is low 12.59V used 429 mAh
Mode(25)> Mode Mode(25)
AP: Battery 1 is low 12.59V used 429 mAh
AT-0022.0: 2022-02-04 18:25:27.03: POSITION_TARGET_GLOBAL_INT (id=87) (link=None) (signed=False) (seq=158) (src=1/1)
    time_boot_ms: 109636ms
    coordinate_frame: 0 (MAV_FRAME_GLOBAL)
    type_mask: 65016
      ! POSITION_TARGET_TYPEMASK_X_IGNORE
      ! POSITION_TARGET_TYPEMASK_Y_IGNORE
      ! POSITION_TARGET_TYPEMASK_Z_IGNORE
        POSITION_TARGET_TYPEMASK_VX_IGNORE
        POSITION_TARGET_TYPEMASK_VY_IGNORE
        POSITION_TARGET_TYPEMASK_VZ_IGNORE
        POSITION_TARGET_TYPEMASK_AX_IGNORE
        POSITION_TARGET_TYPEMASK_AY_IGNORE
        POSITION_TARGET_TYPEMASK_AZ_IGNORE
      ! POSITION_TARGET_TYPEMASK_FORCE_SET
        POSITION_TARGET_TYPEMASK_YAW_IGNORE
        POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE
        [UNKNOWN]
        [UNKNOWN]
        [UNKNOWN]
        [UNKNOWN]
    lat_int: -27.27057deg
    lon_int: 151.2948922deg
    alt: 15.0m
    vx: 0.0m/s
    vy: 0.0m/s
    vz: 0.0m/s
    afx: 0.0m/s/s
    afy: 0.0m/s/s
    afz: 0.0m/s/s
    yaw: 0.0rad (0.0deg)
    yaw_rate: 0.0rad/s (0.0deg/s)

AT-0022.0: Sending param_request_read for (Q_RTL_ALT)
AT-0022.0: get_parameter(Q_RTL_ALT): PARAM_VALUE {param_id : Q_RTL_ALT, param_value : 15.0, param_type : 4, param_count : 1511, param_index : 65535}
AT-0022.0: Exception caught: Unexpected altitude; expected=359.000000 got=15.000000
Traceback (most recent call last):
  File "/home/pbarker/rc/ardupilot/Tools/autotest/common.py", line 6522, in run_one_test_attempt
    test_function()
  File "/home/pbarker/rc/ardupilot/Tools/autotest/quadplane.py", line 814, in LoiterAltQLand
    (expected_alt, m.alt))
common.NotAchievedException: Unexpected altitude; expected=359.000000 got=15.000000
```

but passes on this PR.

I haven't spotted any code paths which would make this instantly fatal - but something updating `plane.guided_WP_loc` but not updating its frame would potentially cause the plane to navigate to (e.g.) 15m absolute rather than 15m relative, which might be bad.
