### PR TITLE
AC_Autotune: print gains on axis completion 

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -454,6 +454,8 @@ void AC_AutoTune::control_attitude()
                 // we've reached the end of a D-up-down PI-up-down tune type cycle
                 next_tune_type(tune_type, true);
 
+                report_final_gains(axis);
+
                 // advance to the next axis
                 bool complete = false;
                 switch (axis) {

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -174,6 +174,9 @@ protected:
     // return current axis string
     const char *axis_string() const;
 
+    // report final gains for a given axis to GCS
+    virtual void report_final_gains(AxisType test_axis) const = 0;
+
     // Functions added for heli autotune
 
     // Add additional updating gain functions specific to heli

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -706,6 +706,31 @@ void AC_AutoTune_Heli::save_tuning_gains()
     reset();
 }
 
+// report final gains for a given axis to GCS
+void AC_AutoTune_Heli::report_final_gains(AxisType test_axis) const
+{
+    switch (test_axis) {
+        case ROLL:
+            report_axis_gains("Roll", tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel);
+            break;
+        case PITCH:
+            report_axis_gains("Pitch", tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel);
+            break;
+        case YAW:
+            report_axis_gains("Yaw", tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel);
+            break;
+    }
+}
+
+// report gain formating helper
+void AC_AutoTune_Heli::report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float rate_ff, float angle_P, float max_accel) const
+{
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.4f, I:%0.4f, D:%0.5f, FF:%0.4f",axis_string,rate_P,rate_I,rate_D,rate_ff);
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.2f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
+}
+
+
 void AC_AutoTune_Heli::rate_ff_test_init()
 {
     ff_test_phase = 0;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -110,6 +110,9 @@ protected:
     // send post test updates to user
     void do_post_test_gcs_announcements() override;
 
+    // report final gains for a given axis to GCS
+    void report_final_gains(AxisType test_axis) const override;
+
     // set the tuning test sequence
     void set_tune_sequence() override;
 
@@ -172,6 +175,9 @@ private:
 
     // exceeded_freq_range - ensures tuning remains inside frequency range
     bool exceeded_freq_range(float frequency);
+
+    // report gain formating helper
+    void report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float rate_ff, float angle_P, float max_accel) const;
 
     // updating rate FF variables
     // flag for completion of the initial direction for the feedforward test

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -440,6 +440,30 @@ void AC_AutoTune_Multi::save_tuning_gains()
     reset();
 }
 
+// report final gains for a given axis to GCS
+void AC_AutoTune_Multi::report_final_gains(AxisType test_axis) const
+{
+    switch (test_axis) {
+        case ROLL:
+            report_axis_gains("Roll", tune_roll_rp, tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL, tune_roll_rd, tune_roll_sp, tune_roll_accel);
+            break;
+        case PITCH:
+            report_axis_gains("Pitch", tune_pitch_rp, tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL, tune_pitch_rd, tune_pitch_sp, tune_pitch_accel);
+            break;
+        case YAW:
+            report_axis_gains("Yaw", tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, 0, tune_yaw_sp, tune_yaw_accel);
+            break;
+    }
+}
+
+// report gain formating helper
+void AC_AutoTune_Multi::report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float angle_P, float max_accel) const
+{
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.3f, I:%0.3f, D:%0.4f",axis_string,rate_P,rate_I,rate_D);
+    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.3f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
+}
+
 // twitching_test_rate - twitching tests
 // update min and max and test for end conditions
 void AC_AutoTune_Multi::twitching_test_rate(float rate, float rate_target_max, float &meas_rate_min, float &meas_rate_max)

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.h
@@ -68,6 +68,9 @@ protected:
     // send post test updates to user
     void do_post_test_gcs_announcements() override {};
 
+    // report final gains for a given axis to GCS
+    void report_final_gains(AxisType test_axis) const override;
+
     // update gains for the rate P up tune type
     void updating_rate_p_up_all(AxisType test_axis) override;
 
@@ -156,6 +159,9 @@ private:
     // updating_angle_p_up - increase P to ensure the target is reached
     // P is increased until we achieve our target within a reasonable time
     void updating_angle_p_up(float &tune_p, float tune_p_max, float tune_p_step_ratio, float angle_target, float meas_angle_max, float meas_rate_min, float meas_rate_max);
+
+    // report gain formating helper
+    void report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float angle_P, float max_accel) const;
 
     // parameters
     AP_Int8  axis_bitmask;        // axes to be tuned


### PR DESCRIPTION
This prints autotune gains after each axis has completed. This means if you don't save them by mistake you can enter them manually. 

Copter:

![image](https://user-images.githubusercontent.com/33176108/152618543-2401b81e-0b1c-44f9-a1f6-10fdd467d0f9.png)

Heli:

![image](https://user-images.githubusercontent.com/33176108/152618648-7cd3d562-a686-4b5c-a4ee-4a27f1b2f491.png)

The key thing to double check is that I am correctly printing the gains as they will be saved. 

