### PR TITLE
libraries: remove duplicated words from comments

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -300,7 +300,7 @@ public:
     }
 
     // get_variances - provides the innovations normalised using the innovation variance where a value of 0
-    // indicates perfect consistency between the measurement and the EKF solution and a value of of 1 is the maximum
+    // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
     virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {

--- a/libraries/AP_Airspeed/models/ADS_cal_EKF.m
+++ b/libraries/AP_Airspeed/models/ADS_cal_EKF.m
@@ -37,7 +37,7 @@ for i = 1:1000
     
     %% Calculate truth values
     % calculate ground velocity by simulating a wind relative
-    % circular path of of 60m radius and 16 m/s airspeed
+    % circular path of 60m radius and 16 m/s airspeed
     time = i*DT;
     radius = 60;
     TAS_truth = 16;


### PR DESCRIPTION
I found out that I have the same mistake as #19987.
I've changed it.