### PR TITLE
AP_Proximity: change variable type from float to uint8_t

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -309,7 +309,7 @@ void AP_Proximity_RPLidarA2::parse_response_data()
                 const float angle_deg = wrap_360(payload.sensor_scan.angle_q6/64.0f * angle_sign + frontend.get_yaw_correction(state.instance));
                 const float distance_m = (payload.sensor_scan.distance_q2/4000.0f);
 #if RP_DEBUG_LEVEL >= 2
-                const float quality = payload.sensor_scan.quality;
+                const uint8_t quality = payload.sensor_scan.quality;
                 Debug(2, "                                       D%02.2f A%03.1f Q%02d", distance_m, angle_deg, quality);
 #endif
                 _last_distance_received_ms = AP_HAL::millis();


### PR DESCRIPTION
Fix the compilation when RP_DEBUG_LEVEL is set to 3.

this is the error message.
```
../../libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp: In member function 'void AP_Proximity_RPLidarA2::parse_response_data()':
../../libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp:313:26: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
  313 |                 Debug(2, "                                       D%02.2f A%03.1f Q%02d", distance_m, angle_deg, quality);
```

I tested this with CubeBlack/RPLIDAR A2 and it worked.