### PR TITLE
Copter: Change -1 judgment in ZIGZAG mode to negative value judgment

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1711,7 +1711,6 @@ private:
     Destination ab_dest_stored;     // store the current destination
     bool is_auto;                   // enable zigzag auto feature which is automate both AB and sideways
     uint16_t line_count = 0;        // current line number
-    int16_t line_num = 0;           // target line number
     bool is_suspended;              // true if zigzag auto is suspended
 };
 


### PR DESCRIPTION
A setting value of -1 for ZIGZ_LINE_NUM does not indicate any specific behavior.
It converts all negative values to -1.
I think I can determine if they are negative values or not.