### PR TITLE
global: remove meaningless semicolons

### DIFF
--- a/ArduPlane/mode_thermal.cpp
+++ b/ArduPlane/mode_thermal.cpp
@@ -127,7 +127,7 @@ bool ModeThermal::exit_heading_aligned() const
     switch (plane.previous_mode->mode_number()) {
     case Mode::Number::AUTO: {
         //Get the lat/lon of next Nav waypoint after this one:
-        AP_Mission::Mission_Command current_nav_cmd = plane.mission.get_current_nav_cmd();;
+        AP_Mission::Mission_Command current_nav_cmd = plane.mission.get_current_nav_cmd();
         return plane.mode_loiter.isHeadingLinedUp(plane.next_WP_loc, current_nav_cmd.content.location);
     }
     case Mode::Number::FLY_BY_WIRE_B:

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -981,7 +981,7 @@ float QuadPlane::get_pilot_throttle()
         float thrust_curve_expo = constrain_float(throttle_expo, 0.0f, 1.0f);
 
         // this puts mid stick at hover throttle
-        return throttle_curve(thr_mid, thrust_curve_expo, throttle_in);;
+        return throttle_curve(thr_mid, thrust_curve_expo, throttle_in);
     } else {
         return throttle_in;
     }

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -119,7 +119,7 @@ void Sub::failsafe_ekf_check()
         last_ekf_good_ms = AP_HAL::millis();
         failsafe.ekf = false;
         AP_Notify::flags.ekf_bad = false;
-        return;;
+        return;
     }
 
     // Bad EKF for 2 solid seconds triggers failsafe

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -126,7 +126,7 @@ void AC_AutoTune_Heli::test_init()
                 // start with freq found for sweep where phase was 180 deg
                 } else if (!is_zero(sweep.ph180_freq)) {
                     freq_cnt = 12;
-                    test_freq[freq_cnt] = sweep.ph180_freq - 0.25f * 3.14159f * 2.0f;;
+                    test_freq[freq_cnt] = sweep.ph180_freq - 0.25f * 3.14159f * 2.0f;
                 // otherwise start at min freq to step up in dwell frequency until phase > 160 deg
                 } else {
                     freq_cnt = 0;
@@ -140,7 +140,7 @@ void AC_AutoTune_Heli::test_init()
             } else {
                 if (!is_zero(sweep.ph180_freq)) {
                     freq_cnt = 12;
-                    test_freq[freq_cnt] = sweep.ph180_freq - 0.25f * 3.14159f * 2.0f;;
+                    test_freq[freq_cnt] = sweep.ph180_freq - 0.25f * 3.14159f * 2.0f;
                     curr_test_freq = test_freq[freq_cnt];
                     start_freq = curr_test_freq;
                     stop_freq = curr_test_freq;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -356,7 +356,7 @@ void AP_BattMonitor::convert_dynamic_param_groups(uint8_t instance)
         };
 
     for (const auto & elem : conversion_table) {
-        info.old_group_element = token.group_element + ((elem.old_group_element - battmonitor_index) * 64);;
+        info.old_group_element = token.group_element + ((elem.old_group_element - battmonitor_index) * 64);
         info.type = elem.type;
 
         hal.util->snprintf(param_name, sizeof(param_name), "%s_%s", param_prefix, elem.new_name);

--- a/libraries/AP_Declination/AP_Declination.cpp
+++ b/libraries/AP_Declination/AP_Declination.cpp
@@ -72,7 +72,7 @@ bool AP_Declination::get_mag_field_ef(float latitude_deg, float longitude_deg, f
     /* calculate intensity */
 
     float data_sw = intensity_table[min_lat_index][min_lon_index];
-    float data_se = intensity_table[min_lat_index][min_lon_index + 1];;
+    float data_se = intensity_table[min_lat_index][min_lon_index + 1];
     float data_ne = intensity_table[min_lat_index + 1][min_lon_index + 1];
     float data_nw = intensity_table[min_lat_index + 1][min_lon_index];
 
@@ -86,7 +86,7 @@ bool AP_Declination::get_mag_field_ef(float latitude_deg, float longitude_deg, f
     /* calculate declination */
 
     data_sw = declination_table[min_lat_index][min_lon_index];
-    data_se = declination_table[min_lat_index][min_lon_index + 1];;
+    data_se = declination_table[min_lat_index][min_lon_index + 1];
     data_ne = declination_table[min_lat_index + 1][min_lon_index + 1];
     data_nw = declination_table[min_lat_index + 1][min_lon_index];
 
@@ -100,7 +100,7 @@ bool AP_Declination::get_mag_field_ef(float latitude_deg, float longitude_deg, f
     /* calculate inclination */
 
     data_sw = inclination_table[min_lat_index][min_lon_index];
-    data_se = inclination_table[min_lat_index][min_lon_index + 1];;
+    data_se = inclination_table[min_lat_index][min_lon_index + 1];
     data_ne = inclination_table[min_lat_index + 1][min_lon_index + 1];
     data_nw = inclination_table[min_lat_index + 1][min_lon_index];
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_MAVlite_Message.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_MAVlite_Message.h
@@ -28,7 +28,7 @@ public:
     }
 
     bool get_uint8(uint8_t &value, const uint8_t offset) const WARN_IF_UNUSED {
-        return get_bytes((uint8_t*)&value, offset, 1);;
+        return get_bytes((uint8_t*)&value, offset, 1);
     }
     bool set_uint8(const uint8_t value, const uint8_t offset) WARN_IF_UNUSED {
         return set_bytes((uint8_t*)&value, offset, 1);

--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -97,11 +97,11 @@ static inline uint64_t be64toh_ptr(const uint8_t *p) { return (uint64_t) p[7] | 
 static inline void put_le16_ptr(uint8_t *p, uint16_t v) { p[0] = (v&0xFF); p[1] = (v>>8); }
 static inline void put_le24_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; }
 static inline void put_le32_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; }
-static inline void put_le64_ptr(uint8_t *p, uint64_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; p[4] = (v>>24)&0xFF;p[5] = (v>>24)&0xFF;;p[6] = (v>>24)&0xFF;p[7] = (v>>24)&0xFF;}
+static inline void put_le64_ptr(uint8_t *p, uint64_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; p[4] = (v>>24)&0xFF;p[5] = (v>>24)&0xFF; p[6] = (v>>24)&0xFF;p[7] = (v>>24)&0xFF;}
 static inline void put_be16_ptr(uint8_t *p, uint16_t v) { p[1] = (v&0xFF); p[0] = (v>>8); }
 static inline void put_be24_ptr(uint8_t *p, uint32_t v) { p[2] = (v&0xFF); p[1] = (v>>8)&0xFF; p[0] = (v>>16)&0xFF; }
 static inline void put_be32_ptr(uint8_t *p, uint32_t v) { p[3] = (v&0xFF); p[2] = (v>>8)&0xFF; p[1] = (v>>16)&0xFF; p[0] = (v>>24)&0xFF; }
-static inline void put_be64_ptr(uint8_t *p, uint64_t v) { p[7] = (v&0xFF); p[6] = (v>>8)&0xFF; p[5] = (v>>16)&0xFF; p[4] = (v>>24)&0xFF; p[3] = (v>>32)&0xFF;p[2] = (v>>40)&0xFF;;p[1] = (v>>48)&0xFF;p[0] = (v>>56)&0xFF;}
+static inline void put_be64_ptr(uint8_t *p, uint64_t v) { p[7] = (v&0xFF); p[6] = (v>>8)&0xFF; p[5] = (v>>16)&0xFF; p[4] = (v>>24)&0xFF; p[3] = (v>>32)&0xFF;p[2] = (v>>40)&0xFF; p[1] = (v>>48)&0xFF;p[0] = (v>>56)&0xFF;}
 
 #undef __ap_bitwise
 #undef __ap_force

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -848,7 +848,7 @@ bool CANIface::init(const uint32_t bitrate, const CANIface::OperatingMode mode)
         Debug("Initing iface 0...");
         if (!can_ifaces[0]->init(bitrate, mode)) {
             Debug("Iface 0 init failed");
-            return false;;
+            return false;
         }
 
         Debug("Enabling CAN iface");

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2110,7 +2110,7 @@ bool AP_Param::parse_param_line(char *line, char **vname, float &value, bool &re
 // increments num_defaults for each default found in filename
 bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaults)
 {
-    int f = AP::FS().open(filename, O_RDONLY);;
+    int f = AP::FS().open(filename, O_RDONLY);
     if (f == -1) {
         return false;
     }
@@ -2140,7 +2140,7 @@ bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaul
 
 bool AP_Param::read_param_defaults_file(const char *filename, bool last_pass)
 {
-    int f = AP::FS().open(filename, O_RDONLY);;
+    int f = AP::FS().open(filename, O_RDONLY);
     if (f == -1) {
         AP_HAL::panic("AP_Param: Failed to re-open defaults file");
         return false;

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1936,7 +1936,7 @@ void emit_operators(struct userdata *data) {
     fprintf(source, "    %s *ud2 = check_%s(L, 2);\n", data->name, data->sanatized_name);
     // create a container for the result
     fprintf(source, "    new_%s(L);\n", data->sanatized_name);
-    fprintf(source, "    *check_%s(L, -1) = *ud %c *ud2;;\n", data->sanatized_name, op_sym);
+    fprintf(source, "    *check_%s(L, -1) = *ud %c *ud2;\n", data->sanatized_name, op_sym);
     // return the first pointer
     fprintf(source, "    return 1;\n");
     fprintf(source, "}\n\n");

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -320,7 +320,7 @@ static int lua_get_i2c_device(lua_State *L) {
 
     static_assert(SCRIPTING_MAX_NUM_I2C_DEVICE >= 0, "There cannot be a negative number of I2C devices");
     if (AP::scripting()->num_i2c_devices >= SCRIPTING_MAX_NUM_I2C_DEVICE) {
-        return luaL_argerror(L, 1, "no i2c devices available");;
+        return luaL_argerror(L, 1, "no i2c devices available");
     }
 
     AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] = new AP_HAL::OwnPtr<AP_HAL::I2CDevice>;

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -503,7 +503,7 @@ bool SoaringController::check_drift(Vector2f prev_wp, Vector2f next_wp)
         // as these are favourable (towards next wp)
         parallel = parallel>0 ? 0 : parallel;
 
-        return (powf(parallel,2)+powf(perpendicular,2)) > powf(max_drift,2);;
+        return (powf(parallel,2)+powf(perpendicular,2)) > powf(max_drift,2);
     }
 }
 


### PR DESCRIPTION
I don't think I need a double semicolon as a marker.
I have changed the tabular semicolon.

I'm not sure why the contributor used a double semicolon.
If you want to tell other contributors what this means, please add a comment.