### PR TITLE
AP_Motors/AR_Motors: Make enum pwm type a class

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Values: 0:Normal,1:OneShot,2:OneShot125,3:Brushed,4:DShot150,5:DShot300,6:DShot600,7:DShot1200,8:PWMRange
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, PWM_TYPE_NORMAL),
+    AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, int8_t(pwm_type::NORMAL)),
 
     // @Param: PWM_MIN
     // @DisplayName: PWM output minimum
@@ -517,7 +517,7 @@ void AP_MotorsMulticopter::update_throttle_range()
 {
     // if all outputs are digital adjust the range. We also do this for type PWM_RANGE, as those use the
     // scaled output, which is then mapped to PWM via the SRV_Channel library
-    if (SRV_Channels::have_digital_outputs(get_motor_mask()) || (_pwm_type == PWM_TYPE_PWM_RANGE)) {
+    if (SRV_Channels::have_digital_outputs(get_motor_mask()) || (_pwm_type == int8_t(pwm_type::PWM_RANGE))) {
         _pwm_min = 1000;
         _pwm_max = 2000;
     }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -126,32 +126,32 @@ void AP_Motors::rc_set_freq(uint32_t motor_mask, uint16_t freq_hz)
     hal.rcout->set_freq(mask, freq_hz);
 
     switch (pwm_type(_pwm_type.get())) {
-    case PWM_TYPE_ONESHOT:
+    case pwm_type::ONESHOT:
         if (freq_hz > 50 && mask != 0) {
             hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT);
         }
         break;
-    case PWM_TYPE_ONESHOT125:
+    case pwm_type::ONESHOT125:
         if (freq_hz > 50 && mask != 0) {
             hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT125);
         }
         break;
-    case PWM_TYPE_BRUSHED:
+    case pwm_type::BRUSHED:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_BRUSHED);
         break;
-    case PWM_TYPE_DSHOT150:
+    case pwm_type::DSHOT150:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT150);
         break;
-    case PWM_TYPE_DSHOT300:
+    case pwm_type::DSHOT300:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT300);
         break;
-    case PWM_TYPE_DSHOT600:
+    case pwm_type::DSHOT600:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT600);
         break;
-    case PWM_TYPE_DSHOT1200:
+    case pwm_type::DSHOT1200:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT1200);
         break;
-    case PWM_TYPE_PWM_RANGE:
+    case pwm_type::PWM_RANGE:
         /*
           this is a motor output type for multirotors which honours
           the SERVOn_MIN/MAX values per channel
@@ -215,17 +215,17 @@ void AP_Motors::set_limit_flag_pitch_roll_yaw(bool flag)
 // returns true if the configured PWM type is digital and should have fixed endpoints
 bool AP_Motors::is_digital_pwm_type() const
 {
-    switch (_pwm_type) {
-        case PWM_TYPE_DSHOT150:
-        case PWM_TYPE_DSHOT300:
-        case PWM_TYPE_DSHOT600:
-        case PWM_TYPE_DSHOT1200:
+    switch (pwm_type(_pwm_type.get())) {
+        case pwm_type::DSHOT150:
+        case pwm_type::DSHOT300:
+        case pwm_type::DSHOT600:
+        case pwm_type::DSHOT1200:
             return true;
-        case PWM_TYPE_NORMAL:
-        case PWM_TYPE_ONESHOT:
-        case PWM_TYPE_ONESHOT125:
-        case PWM_TYPE_BRUSHED:
-        case PWM_TYPE_PWM_RANGE:
+        case pwm_type::NORMAL:
+        case pwm_type::ONESHOT:
+        case pwm_type::ONESHOT125:
+        case pwm_type::BRUSHED:
+        case pwm_type::PWM_RANGE:
             break;
     }
     return false;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -244,10 +244,10 @@ public:
     bool is_digital_pwm_type() const;
 
     // returns true is pwm type is brushed
-    bool is_brushed_pwm_type() const { return _pwm_type == PWM_TYPE_BRUSHED; }
+    bool is_brushed_pwm_type() const { return _pwm_type == int8_t(pwm_type::BRUSHED); }
 
     // returns true is pwm type is normal
-    bool is_normal_pwm_type() const { return (_pwm_type == PWM_TYPE_NORMAL) || (_pwm_type == PWM_TYPE_PWM_RANGE); }
+    bool is_normal_pwm_type() const { return (_pwm_type == int8_t(pwm_type::NORMAL)) || (_pwm_type == int8_t(pwm_type::PWM_RANGE)); }
 
     MAV_TYPE get_frame_mav_type() const { return _mav_type; }
 
@@ -326,15 +326,16 @@ protected:
 
     MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
 
-    enum pwm_type { PWM_TYPE_NORMAL     = 0,
-                    PWM_TYPE_ONESHOT    = 1,
-                    PWM_TYPE_ONESHOT125 = 2,
-                    PWM_TYPE_BRUSHED    = 3,
-                    PWM_TYPE_DSHOT150   = 4,
-                    PWM_TYPE_DSHOT300   = 5,
-                    PWM_TYPE_DSHOT600   = 6,
-                    PWM_TYPE_DSHOT1200  = 7,
-                    PWM_TYPE_PWM_RANGE  = 8 };
+    enum class pwm_type : int8_t {
+                    NORMAL     = 0,
+                    ONESHOT    = 1,
+                    ONESHOT125 = 2,
+                    BRUSHED    = 3,
+                    DSHOT150   = 4,
+                    DSHOT300   = 5,
+                    DSHOT600   = 6,
+                    DSHOT1200  = 7,
+                    PWM_RANGE  = 8 };
 
     // return string corresponding to frame_class
     virtual const char* _get_frame_string() const = 0;

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @Values: 0:Normal,1:OneShot,2:OneShot125,3:BrushedWithRelay,4:BrushedBiPolar,5:DShot150,6:DShot300,7:DShot600,8:DShot1200
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("PWM_TYPE", 1, AP_MotorsUGV, _pwm_type, PWM_TYPE_NORMAL),
+    AP_GROUPINFO("PWM_TYPE", 1, AP_MotorsUGV, _pwm_type, int8_t(pwm_type::NORMAL)),
 
     // @Param: PWM_FREQ
     // @DisplayName: Motor Output PWM freq for brushed motors
@@ -143,7 +143,7 @@ void AP_MotorsUGV::init(uint8_t frtype)
 // setup output in case of main CPU failure
 void AP_MotorsUGV::setup_safety_output()
 {
-    if (_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) {
+    if (_pwm_type == int8_t(pwm_type::BRUSHED_WITH_RELAY)) {
         // set trim to min to set duty cycle range (0 - 100%) to servo range
         // ignore servo revese flag, it is used by the relay
         SRV_Channels::set_trim_to_min_for(SRV_Channel::k_throttle, true);
@@ -508,28 +508,28 @@ void AP_MotorsUGV::setup_pwm_type()
         _motor_mask |= SRV_Channels::get_output_channel_mask(SRV_Channels::get_motor_function(i));
     }
 
-    switch (_pwm_type) {
-    case PWM_TYPE_ONESHOT:
+    switch (pwm_type(_pwm_type.get())) {
+    case pwm_type::ONESHOT:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT);
         break;
-    case PWM_TYPE_ONESHOT125:
+    case pwm_type::ONESHOT125:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT125);
         break;
-    case PWM_TYPE_BRUSHED_WITH_RELAY:
-    case PWM_TYPE_BRUSHED_BIPOLAR:
+    case pwm_type::BRUSHED_WITH_RELAY:
+    case pwm_type::BRUSHED_BIPOLAR:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_BRUSHED);
         hal.rcout->set_freq(_motor_mask, uint16_t(_pwm_freq * 1000));
         break;
-    case PWM_TYPE_DSHOT150:
+    case pwm_type::DSHOT150:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT150);
         break;
-    case PWM_TYPE_DSHOT300:
+    case pwm_type::DSHOT300:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT300);
         break;
-    case PWM_TYPE_DSHOT600:
+    case pwm_type::DSHOT600:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT600);
         break;
-    case PWM_TYPE_DSHOT1200:
+    case pwm_type::DSHOT1200:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT1200);
         break;
     default:
@@ -846,7 +846,7 @@ void AP_MotorsUGV::output_throttle(SRV_Channel::Aux_servo_function_t function, f
     throttle = get_rate_controlled_throttle(function, throttle, dt);
 
     // set relay if necessary
-    if (_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) {
+    if (_pwm_type == int8_t(pwm_type::BRUSHED_WITH_RELAY)) {
         // find the output channel, if not found return
         const SRV_Channel *out_chan = SRV_Channels::get_channel_for(function);
         if (out_chan == nullptr) {
@@ -1007,17 +1007,17 @@ bool AP_MotorsUGV::active() const
 // returns true if the configured PWM type is digital and should have fixed endpoints
 bool AP_MotorsUGV::is_digital_pwm_type() const
 {
-    switch (_pwm_type) {
-        case PWM_TYPE_DSHOT150:
-        case PWM_TYPE_DSHOT300:
-        case PWM_TYPE_DSHOT600:
-        case PWM_TYPE_DSHOT1200:
+    switch (pwm_type(_pwm_type.get())) {
+        case pwm_type::DSHOT150:
+        case pwm_type::DSHOT300:
+        case pwm_type::DSHOT600:
+        case pwm_type::DSHOT1200:
             return true;
-        case PWM_TYPE_NORMAL:
-        case PWM_TYPE_ONESHOT:
-        case PWM_TYPE_ONESHOT125:
-        case PWM_TYPE_BRUSHED_WITH_RELAY:
-        case PWM_TYPE_BRUSHED_BIPOLAR:
+        case pwm_type::NORMAL:
+        case pwm_type::ONESHOT:
+        case pwm_type::ONESHOT125:
+        case pwm_type::BRUSHED_WITH_RELAY:
+        case pwm_type::BRUSHED_BIPOLAR:
             break;
     }
     return false;

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -124,16 +124,16 @@ public:
 
 private:
 
-    enum pwm_type {
-        PWM_TYPE_NORMAL = 0,
-        PWM_TYPE_ONESHOT = 1,
-        PWM_TYPE_ONESHOT125 = 2,
-        PWM_TYPE_BRUSHED_WITH_RELAY = 3,
-        PWM_TYPE_BRUSHED_BIPOLAR = 4,
-        PWM_TYPE_DSHOT150 = 5,
-        PWM_TYPE_DSHOT300 = 6,
-        PWM_TYPE_DSHOT600 = 7,
-        PWM_TYPE_DSHOT1200 = 8
+    enum class pwm_type : int8_t {
+        NORMAL = 0,
+        ONESHOT = 1,
+        ONESHOT125 = 2,
+        BRUSHED_WITH_RELAY = 3,
+        BRUSHED_BIPOLAR = 4,
+        DSHOT150 = 5,
+        DSHOT300 = 6,
+        DSHOT600 = 7,
+        DSHOT1200 = 8
     };
 
     // sanity check parameters


### PR DESCRIPTION
I make enum pwm_type a class.
I saw that all definition names have PWM_TYPE appended to them.
I clarify the definition name by making it a class.