### PR TITLE
CAN: support CAN over MAVLink using CAN_FRAME message

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -167,9 +167,11 @@ void AP_CANManager::init()
             // we have slcan bridge setup pass that on as can iface
             can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
             iface = &_slcan_interface;
+#ifdef HAL_BUILD_AP_PERIPH
         } else if(drv_type[drv_num] == Driver_Type_UAVCAN) {
-            // We do Message ID filtering when using UAVCAN without SLCAN
+            // setup for filtering on AP_Periph if using UAVCAN
             can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::FilteredMode);
+#endif
         } else {
             can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
         }

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -167,11 +167,6 @@ void AP_CANManager::init()
             // we have slcan bridge setup pass that on as can iface
             can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
             iface = &_slcan_interface;
-#ifdef HAL_BUILD_AP_PERIPH
-        } else if(drv_type[drv_num] == Driver_Type_UAVCAN) {
-            // setup for filtering on AP_Periph if using UAVCAN
-            can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::FilteredMode);
-#endif
         } else {
             can_initialised = hal.can[i]->init(_interfaces[i]._bitrate, AP_HAL::CANIface::NormalMode);
         }
@@ -385,6 +380,62 @@ void AP_CANManager::log_retrieve(ExpandingString &str) const
     }
     str.append(_log_buf, _log_pos);
 }
+
+#if HAL_GCS_ENABLED
+/*
+  handle MAV_CMD_CAN_FORWARD mavlink long command
+ */
+bool AP_CANManager::handle_can_forward(mavlink_channel_t chan, const mavlink_command_long_t &packet, const mavlink_message_t &msg)
+{
+    const int8_t bus = int8_t(packet.param1)-1;
+    if (bus == -1) {
+        for (auto can_iface : hal.can) {
+            if (can_iface) {
+                can_iface->register_frame_callback(nullptr);
+            }
+        }
+        return true;
+    }
+    if (bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+        return false;
+    }
+    if (!hal.can[bus]->register_frame_callback(
+            FUNCTOR_BIND_MEMBER(&AP_CANManager::can_frame_callback, void, uint8_t, const AP_HAL::CANFrame &))) {
+        return false;
+    }
+    can_forward.chan = chan;
+    can_forward.system_id = msg.sysid;
+    can_forward.component_id = msg.compid;
+    return true;
+}
+
+/*
+  handle a CAN_FRAME packet
+ */
+void AP_CANManager::handle_can_frame(const mavlink_message_t &msg) const
+{
+    mavlink_can_frame_t p;
+    mavlink_msg_can_frame_decode(&msg, &p);
+    if (p.bus >= HAL_NUM_CAN_IFACES || hal.can[p.bus] == nullptr) {
+        return;
+    }
+    const uint16_t timeout_us = 2000;
+    AP_HAL::CANFrame frame{p.id, p.data, p.len};
+    hal.can[p.bus]->send(frame, AP_HAL::native_micros64() + timeout_us, AP_HAL::CANIface::IsMAVCAN);
+}
+
+/*
+  handler for CAN frames from the registered callback, sending frames
+  out as CAN_FRAME messages
+ */
+void AP_CANManager::can_frame_callback(uint8_t bus, const AP_HAL::CANFrame &frame)
+{
+    if (HAVE_PAYLOAD_SPACE(can_forward.chan, CAN_FRAME)) {
+        mavlink_msg_can_frame_send(can_forward.chan, can_forward.system_id, can_forward.component_id,
+                                   bus, frame.dlc, frame.id, const_cast<uint8_t*>(frame.data));
+    }
+}
+#endif // HAL_GCS_ENABLED
 
 AP_CANManager& AP::can()
 {

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -24,6 +24,8 @@
 #include <AP_Param/AP_Param.h>
 #include "AP_SLCANIface.h"
 #include "AP_CANDriver.h"
+#include <GCS_MAVLink/GCS.h>
+//#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_CANManager
 {
@@ -107,6 +109,11 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+#if HAL_GCS_ENABLED
+    bool handle_can_forward(mavlink_channel_t chan, const mavlink_command_long_t &packet, const mavlink_message_t &msg);
+    void handle_can_frame(const mavlink_message_t &msg) const;
+#endif
+
 private:
 
     // Parameter interface for CANIfaces
@@ -161,6 +168,20 @@ private:
     uint32_t _log_pos;
 
     HAL_Semaphore _sem;
+
+#if HAL_GCS_ENABLED
+    /*
+      handler for CAN frames from the registered callback, sending frames
+      out as CAN_FRAME messages
+    */
+    void can_frame_callback(uint8_t bus, const AP_HAL::CANFrame &frame);
+
+    struct {
+        mavlink_channel_t chan;
+        uint8_t system_id;
+        uint8_t component_id;
+    } can_forward;
+#endif // HAL_GCS_ENABLED
 };
 
 namespace AP

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -112,7 +112,7 @@ bool SLCAN::CANIface::push_Frame(AP_HAL::CANFrame &frame)
     frm.frame = frame;
     frm.flags = 0;
     frm.timestamp_us = AP_HAL::native_micros64();
-    return rx_queue_.push(frm);
+    return add_to_rx_queue(frm);
 }
 
 /**

--- a/libraries/AP_CANManager/AP_SLCANIface.h
+++ b/libraries/AP_CANManager/AP_SLCANIface.h
@@ -100,10 +100,6 @@ public:
     bool init_passthrough(uint8_t i);
 
     void reset_params();
-    int8_t get_iface_num() const
-    {
-        return _iface_num;
-    }
 
     // Overriden methods
     bool set_event_handle(AP_HAL::EventHandle* evt_handle) override;
@@ -123,6 +119,15 @@ public:
 
     int16_t receive(AP_HAL::CANFrame& out_frame, uint64_t& rx_time,
                     AP_HAL::CANIface::CanIOFlags& out_flags) override;
+
+protected:
+    int8_t get_iface_num() const override {
+        return _iface_num;
+    }
+
+    bool add_to_rx_queue(const AP_HAL::CANIface::CanRxItem &frm) override {
+        return rx_queue_.push(frm);
+    }
 };
 
 }

--- a/libraries/AP_HAL/CANIface.h
+++ b/libraries/AP_HAL/CANIface.h
@@ -105,6 +105,7 @@ public:
     typedef uint16_t CanIOFlags;
     static const CanIOFlags Loopback = 1;
     static const CanIOFlags AbortOnError = 2;
+    static const CanIOFlags IsMAVCAN = 4;
 
     // Single Rx Frame with related info
     struct CanRxItem {
@@ -167,11 +168,11 @@ public:
     }
 
     // Put frame in queue to be sent, return negative if error occured, 0 if no space, and 1 if successful
-    virtual int16_t send(const CANFrame& frame, uint64_t tx_deadline, CanIOFlags flags) = 0;
+    virtual int16_t send(const CANFrame& frame, uint64_t tx_deadline, CanIOFlags flags);
 
     // Non blocking receive frame that pops the frames received inside the buffer, return negative if error occured, 
     // 0 if no frame available, 1 if successful
-    virtual int16_t receive(CANFrame& out_frame, uint64_t& out_ts_monotonic, CanIOFlags& out_flags) = 0;
+    virtual int16_t receive(CANFrame& out_frame, uint64_t& out_ts_monotonic, CanIOFlags& out_flags);
 
     //Configure filters so as to reject frames that are not going to be handled by us
     virtual bool configureFilters(const CanFilterConfig* filter_configs, uint16_t num_configs)
@@ -208,7 +209,19 @@ public:
 
     // return true if init was called and successful
     virtual bool is_initialized() const = 0;
+
+    FUNCTOR_TYPEDEF(FrameCb, void, uint8_t, const AP_HAL::CANFrame &);
+
+    // register a frame callback function
+    virtual bool register_frame_callback(FrameCb cb);
+
 protected:
+    virtual int8_t get_iface_num() const = 0;
+    virtual bool add_to_rx_queue(const CanRxItem &rx_item) = 0;
+
+    FrameCb frame_callback;
+    uint8_t frame_counter;
+    uint32_t last_callback_enable_ms;
     uint32_t bitrate_;
     OperatingMode mode_;
 };

--- a/libraries/AP_HAL/CANIface.h
+++ b/libraries/AP_HAL/CANIface.h
@@ -168,10 +168,12 @@ public:
     }
 
     // Put frame in queue to be sent, return negative if error occured, 0 if no space, and 1 if successful
+    // must be called on child class
     virtual int16_t send(const CANFrame& frame, uint64_t tx_deadline, CanIOFlags flags);
 
     // Non blocking receive frame that pops the frames received inside the buffer, return negative if error occured, 
     // 0 if no frame available, 1 if successful
+    // must be called on child class
     virtual int16_t receive(CANFrame& out_frame, uint64_t& out_ts_monotonic, CanIOFlags& out_flags);
 
     //Configure filters so as to reject frames that are not going to be handled by us

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -399,8 +399,9 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
 bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
                                 uint16_t num_configs)
 {
-#if defined(STM32G4)
-    // not supported yet
+    // only enable filters in AP_Periph. It makes no sense on the flight controller
+#if !defined(HAL_BUILD_AP_PERIPH) || defined(STM32G4)
+    // no filtering
     can_->CCCR &= ~FDCAN_CCCR_INIT; // Leave init mode
     uint32_t while_start_ms = AP_HAL::millis();
     while ((can_->CCCR & FDCAN_CCCR_INIT) == 1) {
@@ -525,7 +526,7 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
     }
     initialised_ = true;
     return true;
-#endif // defined(STM32G4)
+#endif // AP_Periph, STM32G4
 }
 
 uint16_t CANIface::getNumFilters() const

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.h
@@ -240,6 +240,15 @@ public:
     // CAN Peripheral register structure, pointing at base
     // register. Indexed by locical interface number
     static constexpr CanType* const Can[HAL_NUM_CAN_IFACES] = { HAL_CAN_BASE_LIST };
+
+protected:
+    bool add_to_rx_queue(const CanRxItem &rx_item) override {
+        return rx_queue_.push(rx_item);
+    }
+
+    int8_t get_iface_num(void) const override {
+        return self_index_;
+    }
 };
 
 

--- a/libraries/AP_HAL_ChibiOS/CANIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANIface.h
@@ -238,6 +238,15 @@ public:
 
     // CAN Peripheral register structure
     static constexpr bxcan::CanType* const Can[HAL_NUM_CAN_IFACES] = { HAL_CAN_BASE_LIST };
+
+protected:
+    bool add_to_rx_queue(const CanRxItem &rx_item) override {
+        return rx_queue_.push(rx_item);
+    }
+
+    int8_t get_iface_num(void) const override {
+        return self_index_;
+    }
 };
 #endif //HAL_NUM_CAN_IFACES
 #endif //# if defined(STM32H7XX) || defined(STM32G4)

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -384,6 +384,11 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
 bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
                                 uint16_t num_configs)
 {
+#if !defined(HAL_BUILD_AP_PERIPH)
+    // only do filtering for AP_Periph
+    can_->FMR &= ~bxcan::FMR_FINIT;
+    return true;
+#else
     if (mode_ != FilteredMode) {
         return false;
     }
@@ -451,6 +456,7 @@ bool CANIface::configureFilters(const CanFilterConfig* filter_configs,
     }
 
     return false;
+#endif // AP_Periph
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -362,7 +362,8 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
     txi.abort_on_error = (flags & AbortOnError) != 0;
     // setup frame initial state
     txi.pushed         = false;
-    return 1;
+
+    return AP_HAL::CANIface::send(frame, tx_deadline, flags);
 }
 
 int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_us, CanIOFlags& out_flags)
@@ -375,7 +376,8 @@ int16_t CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& out_timestamp_u
     out_frame    = rx_item.frame;
     out_timestamp_us = rx_item.timestamp_us;
     out_flags    = rx_item.flags;
-    return 1;
+
+    return AP_HAL::CANIface::receive(out_frame, out_timestamp_us, out_flags);
 }
 
 #if !defined(HAL_BOOTLOADER_BUILD)
@@ -481,7 +483,7 @@ void CANIface::handleTxMailboxInterrupt(uint8_t mailbox_index, bool txok, const 
         rx_item.timestamp_us = timestamp_us;
         rx_item.flags = AP_HAL::CANIface::Loopback;
         PERF_STATS(stats.tx_loopback);
-        rx_queue_.push(rx_item);
+        add_to_rx_queue(rx_item);
     }
 
     if (txok && !txi.pushed) {
@@ -569,7 +571,7 @@ void CANIface::handleRxInterrupt(uint8_t fifo_index, uint64_t timestamp_us)
     rx_item.frame = frame;
     rx_item.timestamp_us = timestamp_us;
     rx_item.flags = 0;
-    if (rx_queue_.push(rx_item)) {
+    if (add_to_rx_queue(rx_item)) {
         PERF_STATS(stats.rx_received);
     } else {
         PERF_STATS(stats.rx_overflow);

--- a/libraries/AP_HAL_Linux/CANSocketIface.h
+++ b/libraries/AP_HAL_Linux/CANSocketIface.h
@@ -142,9 +142,9 @@ private:
 
     bool _checkHWFilters(const can_frame& frame) const;
 
-    bool _hasReadyTx() const;
+    bool _hasReadyTx();
 
-    bool _hasReadyRx() const;
+    bool _hasReadyRx();
 
     void _poll(bool read, bool write);
 
@@ -190,6 +190,17 @@ private:
         uint32_t num_poll_tx_events;
         uint32_t num_poll_rx_events;
     } stats;
+
+protected:
+    bool add_to_rx_queue(const CanRxItem &rx_item) override {
+        _rx_queue.push(rx_item);
+        return true;
+    }
+
+    int8_t get_iface_num(void) const override {
+        return _self_index;
+    }
+    HAL_Semaphore sem;
 };
 
 }

--- a/libraries/AP_HAL_SITL/CANSocketIface.h
+++ b/libraries/AP_HAL_SITL/CANSocketIface.h
@@ -59,7 +59,6 @@ public:
     CANIface(int index)
       : _self_index(index)
       , _frames_in_socket_tx_queue(0)
-      , _max_frames_in_socket_tx_queue(2)
     { }
 
     static uint8_t next_interface;
@@ -145,9 +144,9 @@ private:
 
     bool _checkHWFilters(const can_frame& frame) const;
 
-    bool _hasReadyTx() const;
+    bool _hasReadyTx();
 
-    bool _hasReadyRx() const;
+    bool _hasReadyRx();
 
     void _poll(bool read, bool write);
 
@@ -164,7 +163,6 @@ private:
 
     const uint8_t _self_index;
 
-    const unsigned _max_frames_in_socket_tx_queue;
     unsigned _frames_in_socket_tx_queue;
     uint32_t _tx_frame_counter;
     AP_HAL::EventHandle *_evt_handle;
@@ -193,6 +191,18 @@ private:
         uint32_t num_poll_tx_events;
         uint32_t num_poll_rx_events;
     } stats;
+
+    HAL_Semaphore sem;
+
+protected:
+    bool add_to_rx_queue(const CanRxItem &rx_item) override {
+        _rx_queue.push(rx_item);
+        return true;
+    }
+
+    int8_t get_iface_num(void) const override {
+        return _self_index;
+    }
 };
 
 }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -357,9 +357,6 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
     }
     
     _led_conf.devices_count = 0;
-    if (enable_filters) {
-        configureCanAcceptanceFilters(*_node);
-    }
 
     /*
      * Informing other nodes that we're ready to work.

--- a/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.cpp
@@ -94,27 +94,6 @@ int16_t CanIface::receive(CanFrame& out_frame, MonotonicTime& out_ts_monotonic, 
 }
 
 /**
- * Configure the hardware CAN filters. @ref CanFilterConfig.
- *
- * @return 0 = success, negative for error.
- */
-int16_t CanIface::configureFilters(const CanFilterConfig* filter_configs, uint16_t num_configs)
-{
-    if (can_iface_ == UAVCAN_NULLPTR) {
-        return -1;
-    }
-    AP_HAL::CANIface::CanFilterConfig* hal_filter_configs = new AP_HAL::CANIface::CanFilterConfig[num_configs];
-    if (hal_filter_configs == nullptr) {
-        return -1;
-    }
-    for (uint16_t i = 0; i < num_configs; i++) {
-        hal_filter_configs[i].id = filter_configs[i].id;
-        hal_filter_configs[i].mask = filter_configs[i].mask;
-    }
-    return can_iface_->configureFilters(hal_filter_configs, num_configs);
-}
-
-/**
  * Number of available hardware filters.
  */
 uint16_t CanIface::getNumFilters() const

--- a/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_IfaceMgr.h
@@ -39,9 +39,11 @@ public:
     virtual int16_t receive(CanFrame& out_frame, MonotonicTime& out_ts_monotonic,
                             UtcTime& out_ts_utc, CanIOFlags& out_flags) override;
 
-    int16_t configureFilters(const CanFilterConfig* filter_configs,
-                             uint16_t num_configs) override;
-
+    virtual int16_t configureFilters(const CanFilterConfig* filter_configs,
+                                     uint16_t num_configs) override {
+        return 0;
+    }
+    
     uint16_t getNumFilters() const override;
 
     uint64_t getErrorCount() const override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -565,6 +565,13 @@ protected:
     MAV_RESULT handle_command_debug_trap(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_set_ekf_source_set(const mavlink_command_long_t &packet);
 
+    /*
+      handle MAV_CMD_CAN_FORWARD and CAN_FRAME messages for CAN over MAVLink
+     */
+    void can_frame_callback(uint8_t bus, const AP_HAL::CANFrame &);
+    MAV_RESULT handle_can_forward(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
+    void handle_can_frame(const mavlink_message_t &msg) const;
+
 #if AP_OPTICALFLOW_ENABLED
     void handle_optical_flow(const mavlink_message_t &msg);
 #endif


### PR DESCRIPTION
mavlink PR: https://github.com/ArduPilot/mavlink/pull/244
pydronecan PR: https://github.com/dronecan/pydronecan/pull/10

this allows for interaction with CAN nodes remotely via mavlink. This works with any MAVLink2 connection, including serial, UDP and TCP

@bugobliterator we need to discuss the interaction with filtering. I actually wonder what benefit filtering gives us in the flight controller main firmware? what packets do we really want to drop?

should we add filtering options to MAV_CMD_CAN_FORWARD so the client can request to get only low bandwidth packets like NodeStatus, NodeInfo and parameter packets? That would allow CAN config over slow mavlink radios

update: I've added code to disable filtering except for AP_Periph
