### PR TITLE
AR_AttitudeControl: get_turn_rate_from_heading applies acceleration limit

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -501,6 +501,12 @@ float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float ra
         desired_rate = constrain_float(desired_rate, -rate_max_rads, rate_max_rads);
     }
 
+    // if acceleration limit is provided, ensure rate can be slowed to zero in time to stop at heading_rad (i.e. avoid overshoot)
+    if (is_positive(_steer_accel_max)) {
+        const float steer_accel_rate_max_rads = safe_sqrt(2.0 * fabsf(yaw_error) * radians(_steer_accel_max));
+        desired_rate = constrain_float(desired_rate, -steer_accel_rate_max_rads, steer_accel_rate_max_rads);
+    }
+
     return desired_rate;
 }
 


### PR DESCRIPTION
This PR slightly improves Rover's pivot turns by removing the possibility that a high ATC_STR_ANG_P and low ATC_STR_ACC_MAX will cause the vehicle to overshoot during pivot turns.

- ATC_STR_ACC_MAX : maximum change in the turn rate / sec
- ATC_STR_ANG_P : P gain used to convert heading error to turn rate (only used in pivot turns and in Guided mode's velocity controller)

The issue is that a high ATC_STR_ANG_P causes the get_turn_rate_from_heading() to return a high desired turn rate even when the vehicle's heading is getting very close to the target heading.  Normally get_steering_out_rate() is next used to turn this desired turn rate into a steering output but this function uses ATC_STR_ACC_MAX to limit how quickly the turn rate can change and this leads to the desired turn rate not reducing to zero in time to stop at the desired heading.

The fix is to enhance get_turn_rate_from_heading() so that it limits the output rate (using ATC_STR_ACC_MAX) so that the vehicle's heading will always stop in time.

The issue can be reproduced in SITL by doing the following:

- start SITL with a skid-steering rover ("sim_vehicle.py --map --console -f rover-skid")
- param set ATC_STR_ANG_P 20  (a very high angle error to turn rate gain)
- param set ATC_STR_ACC_MAX 30 (a very low maximum acceleration)
- module load message (allows directly sending mavlink messages)
- GUIDED
- message SET_POSITION_TARGET_GLOBAL_INT 0 0 0 3 2535 0 0 0 0 0 0 0 0 0 3.141 0 (to pivot to the south, repeated send this command every second or so)

Below are before and after screen shots of the vehicle's heading.  We see "Before" overshoots horribly while "After" nicely stops at the target.
![rover-turn-acc-lim-before-vs-after](https://user-images.githubusercontent.com/1498098/152976779-c0d56659-1b3e-4aab-8daa-bd672f2cc103.png)

Most users will probably not notice any difference but there is a risk that users who have set ATC_STR_ACC_MAX too low will complain their pivot turns are too slow now.

