### PR TITLE
autotest: increase timeout in Baro-Drift test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3334,7 +3334,7 @@ function'''
         # Wait for landing waypoint (second attempt)
         self.wait_current_waypoint(9, timeout=1200)
 
-        self.wait_statustext("Auto disarmed", timeout=120)
+        self.wait_disarmed(timeout=180)
 
     def DCMFallback(self):
         self.reboot_sitl()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5906,7 +5906,12 @@ class AutoTest(ABC):
             if self.get_sim_time() - tstart > timeout:
                 raise AutoTestTimeoutException("Did not get wanted current waypoint")
             seq = self.mav.waypoint_current()
-            self.progress("Waiting for wp=%u current=%u" % (wpnum, seq))
+            wp_dist = None
+            try:
+                wp_dist = self.mav.messages['NAV_CONTROLLER_OUTPUT'].wp_dist
+            except (KeyError, AttributeError):
+                pass
+            self.progress("Waiting for wp=%u current=%u dist=%sm" % (wpnum, seq, wp_dist))
             if seq == wpnum:
                 break
 


### PR DESCRIPTION
timeout was being hit on the autotest server

Also wait_disarmed isntead of wait for statustext You get a bit more information about what's going on this way