### PR TITLE
Reset SITL if required on test failure rather than just rebooting

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -6570,8 +6570,12 @@ Also, ignores heartbeats not from our target system'''
             self.progress("Armed at end of test; force-rebooting SITL")
             self.disarm_vehicle(force=True)
             self.forced_post_test_sitl_reboots += 1
-            self.progress("Force-resetting SITL")
-            self.reboot_sitl() # that'll learn it
+            if reset_needed:
+                self.progress("Force-resetting SITL")
+                self.reset_SITL_commandline()
+            else:
+                self.progress("Force-rebooting SITL")
+                self.reboot_sitl() # that'll learn it
             passed = False
 
         if self._mavproxy is not None:

--- a/Tools/autotest/locations.txt
+++ b/Tools/autotest/locations.txt
@@ -86,3 +86,5 @@ CMAC_NZ_E=-43.47493266,172.318144,0,84  #Christchurch MAC, New Zealand, East tak
 CMAC_NZ_W=-43.47493266,172.318144,0,264  #Christchurch MAC, New Zealand, West takeoff
 OSPN=30.53202,-97.62892,199,7 #Old Settlers Park , Austin, TX, North takeof
 OSP=30.53202,-97.62892,199,187 #Old Settlers Park , Austin, TX, South takeof
+KalaupapaCliffs=21.16564233,-156.88680160,165.25,0
+LakeGeorgeLookout=-35.10122092,149.37517574,708.12,90


### PR DESCRIPTION
... this problem can show itself as "far from SITL home" if a test fails which was using customise-sitl-commandline to change home location.

... also adds a couple of convenient locations for testing terrain handling.
