### PR TITLE
AP_OpticalFlow, AP_NavEKF3: upwards facing optical flow support

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2164,13 +2164,15 @@ bool AP_AHRS::get_filter_status(nav_filter_status &status) const
 }
 
 // write optical flow data to EKF
-void  AP_AHRS::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
+void AP_AHRS::writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation)
 {
 #if HAL_NAVEKF2_AVAILABLE
-    EKF2.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    if (!upwardsOrientation) {
+        EKF2.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    }
 #endif
 #if HAL_NAVEKF3_AVAILABLE
-    EKF3.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    EKF3.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset, upwardsOrientation);
 #endif
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -235,7 +235,7 @@ public:
     bool get_vert_pos_rate(float &velocity) const;
 
     // write optical flow measurements to EKF
-    void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
+    void writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation);
 
     // retrieve latest corrected optical flow samples (used for calibration)
     bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -317,7 +317,7 @@ bool AP_DAL::ekf_low_time_remaining(EKFType etype, uint8_t core)
 }
 
 // log optical flow data
-void AP_DAL::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
+void AP_DAL::writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation)
 {
     end_frame();
 
@@ -327,6 +327,7 @@ void AP_DAL::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawF
     _ROFH.rawGyroRates = rawGyroRates;
     _ROFH.msecFlowMeas = msecFlowMeas;
     _ROFH.posOffset = posOffset;
+    _ROFH.upwardsOrientation = upwardsOrientation;
     WRITE_REPLAY_BLOCK_IFCHANGED(ROFH, _ROFH, old);
 }
 
@@ -436,8 +437,10 @@ void AP_DAL::handle_message(const log_RFRF &msg, NavEKF2 &ekf2, NavEKF3 &ekf3)
 void AP_DAL::handle_message(const log_ROFH &msg, NavEKF2 &ekf2, NavEKF3 &ekf3)
 {
     _ROFH = msg;
-    ekf2.writeOptFlowMeas(msg.rawFlowQuality, msg.rawFlowRates, msg.rawGyroRates, msg.msecFlowMeas, msg.posOffset);
-    ekf3.writeOptFlowMeas(msg.rawFlowQuality, msg.rawFlowRates, msg.rawGyroRates, msg.msecFlowMeas, msg.posOffset);
+    if (!msg.upwardsOrientation) {
+        ekf2.writeOptFlowMeas(msg.rawFlowQuality, msg.rawFlowRates, msg.rawGyroRates, msg.msecFlowMeas, msg.posOffset);
+    }
+    ekf3.writeOptFlowMeas(msg.rawFlowQuality, msg.rawFlowRates, msg.rawGyroRates, msg.msecFlowMeas, msg.posOffset, msg.upwardsOrientation);
 }
 
 /*

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -202,7 +202,7 @@ public:
     }
 
     // log optical flow data
-    void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
+    void writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation);
 
     // log external nav data
     void writeExtNavData(const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint16_t delay_ms, uint32_t resetTime_ms);

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -98,6 +98,7 @@ void AP_DAL_RangeFinder_Backend::start_frame(AP_RangeFinder_Backend *backend) {
     _RRNI.status = (uint8_t)backend->status();
     _RRNI.pos_offset = backend->get_pos_offset();
     _RRNI.distance_cm = backend->distance_cm();
+    _RRNI.last_reading_ms = backend->last_reading_ms();
     WRITE_REPLAY_BLOCK_IFCHANGED(RRNI, _RRNI, old);
 }
 

--- a/libraries/AP_DAL/AP_DAL_RangeFinder.h
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.h
@@ -63,6 +63,9 @@ public:
 
     const Vector3f &get_pos_offset() const { return _RRNI.pos_offset; }
 
+    // return system time of last successful read from the sensor
+    uint32_t last_reading_ms() const { return _RRNI.last_reading_ms; }
+
     // DAL methods:
     void start_frame(AP_RangeFinder_Backend *backend);
 

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -167,6 +167,7 @@ struct log_RRNH {
 // @LoggerMessage: RRNI
 // @Description: Replay Data Rangefinder Instance
 struct log_RRNI {
+    uint32_t last_reading_ms;
     Vector3f pos_offset;
     uint16_t distance_cm;
     uint8_t orientation;
@@ -395,7 +396,7 @@ struct log_RBOH {
     { LOG_RRNH_MSG, RLOG_SIZE(RRNH),                                   \
       "RRNH", "hhB", "GCl,MaxD,NumSensors", "???", "???" },  \
     { LOG_RRNI_MSG, RLOG_SIZE(RRNI),                                   \
-      "RRNI", "fffHBBB", "PX,PY,PZ,Dist,Orient,Status,I", "------#", "-------" }, \
+      "RRNI", "IfffHBBB", "LastReadingMS,PX,PY,PZ,Dist,Orient,Status,I", "-------#", "--------" }, \
     { LOG_RGPH_MSG, RLOG_SIZE(RGPH),                                   \
       "RGPH", "BB", "NumInst,Primary", "--", "--" },  \
     { LOG_RGPI_MSG, RLOG_SIZE(RGPI),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -308,6 +308,7 @@ struct log_ROFH {
     uint32_t msecFlowMeas;
     Vector3f posOffset;
     uint8_t rawFlowQuality;
+    uint8_t upwardsOrientation;
     uint8_t _end;
 };
 
@@ -414,7 +415,7 @@ struct log_RBOH {
     { LOG_RVOH_MSG, RLOG_SIZE(RVOH),                                   \
       "RVOH", "fffIBB", "OX,OY,OZ,Del,H,Ena", "------", "------" }, \
     { LOG_ROFH_MSG, RLOG_SIZE(ROFH),                                   \
-      "ROFH", "ffffIfffB", "FX,FY,GX,GY,Tms,PX,PY,PZ,Qual", "---------", "---------" }, \
+      "ROFH", "ffffIfffBB", "FX,FY,GX,GY,Tms,PX,PY,PZ,Qual,Up", "----------", "----------" }, \
     { LOG_REPH_MSG, RLOG_SIZE(REPH),                                   \
       "REPH", "fffffffffIIH", "PX,PY,PZ,Q1,Q2,Q3,Q4,PEr,AEr,TS,RT,D", "------------", "------------" }, \
     { LOG_REVH_MSG, RLOG_SIZE(REVH),                                   \

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1226,7 +1226,7 @@ bool NavEKF2::use_compass(void) const
 // posOffset is the XYZ flow sensor position in the body frame in m
 void NavEKF2::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
 {
-    AP::dal().writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    AP::dal().writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset, false);
 
     if (core) {
         for (uint8_t i=0; i<num_cores; i++) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1507,13 +1507,14 @@ bool NavEKF3::configuredToUseGPSForPosXY(void) const
 // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
 // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
 // posOffset is the XYZ flow sensor position in the body frame in m
-void NavEKF3::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
+// upwardsOrientation should be true if the sensor is facing upwards
+void NavEKF3::writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation)
 {
-    AP::dal().writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    AP::dal().writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset, upwardsOrientation);
 
     if (core) {
         for (uint8_t i=0; i<num_cores; i++) {
-            core[i].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+            core[i].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset, upwardsOrientation);
         }
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -196,7 +196,8 @@ public:
     // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
     // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
     // posOffset is the XYZ flow sensor position in the body frame in m
-    void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
+    // upwardsOrientation should be true if the sensor is facing upwards
+    void writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation);
 
     // retrieve latest corrected optical flow samples (used for calibration)
     bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -696,10 +696,10 @@ void  NavEKF3_core::updateFilterStatus(void)
     filterStatus.flags.attitude = !stateStruct.quat.is_nan() && filterHealthy;   // attitude valid (we need a better check)
     filterStatus.flags.horiz_vel = someHorizRefData && filterHealthy;      // horizontal velocity estimate valid
     filterStatus.flags.vert_vel = someVertRefData && filterHealthy;        // vertical velocity estimate valid
-    filterStatus.flags.horiz_pos_rel = ((doingFlowNav && gndOffsetValid) || doingWindRelNav || doingNormalGpsNav || doingBodyVelNav) && filterHealthy;   // relative horizontal position estimate valid
+    filterStatus.flags.horiz_pos_rel = ((doingFlowNav && terrainStateValid) || doingWindRelNav || doingNormalGpsNav || doingBodyVelNav) && filterHealthy;   // relative horizontal position estimate valid
     filterStatus.flags.horiz_pos_abs = doingNormalGpsNav && filterHealthy; // absolute horizontal position estimate valid
     filterStatus.flags.vert_pos = !hgtTimeout && filterHealthy && !hgtNotAccurate; // vertical position estimate valid
-    filterStatus.flags.terrain_alt = gndOffsetValid && filterHealthy;		// terrain height estimate valid
+    filterStatus.flags.terrain_alt = terrainStateValid && filterHealthy;     // terrain height estimate valid
     filterStatus.flags.const_pos_mode = (PV_AidingMode == AID_NONE) && filterHealthy;     // constant position mode
     filterStatus.flags.pred_horiz_pos_rel = filterStatus.flags.horiz_pos_rel; // EKF3 enters the required mode before flight
     filterStatus.flags.pred_horiz_pos_abs = filterStatus.flags.horiz_pos_abs; // EKF3 enters the required mode before flight

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -189,7 +189,7 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
         normInnov : (uint8_t)(MIN(100*MAX(flowTestRatio[0],flowTestRatio[1]),255)),  // normalised innovation variance ratio for optical flow observations fused by the main nav filter
         FIX : (int16_t)(1000*flowInnov[0]),  // optical flow LOS rate vector innovations from the main nav filter
         FIY : (int16_t)(1000*flowInnov[1]),  // optical flow LOS rate vector innovations from the main nav filter
-        AFI : (int16_t)(1000 * auxFlowObsInnov.length()),  // optical flow LOS rate innovation from terrain offset estimator
+        AFI : (int16_t)(1000 * terrainFlowInnov.length()),  // optical flow LOS rate innovation from terrain offset estimator
         HAGL : (int16_t)(100*(terrainState - stateStruct.position.z)),    // height above ground level
         offset : (int16_t)(100*terrainState),           // filter ground offset state error
         RI : (int16_t)(100*rngInnov),                   // range finder innovations

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -192,7 +192,7 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
         AFI : (int16_t)(1000 * auxFlowObsInnov.length()),  // optical flow LOS rate innovation from terrain offset estimator
         HAGL : (int16_t)(100*(terrainState - stateStruct.position.z)),    // height above ground level
         offset : (int16_t)(100*terrainState),           // filter ground offset state error
-        RI : (int16_t)(100*innovRng),                   // range finder innovations
+        RI : (int16_t)(100*rngInnov),                   // range finder innovations
         meaRng : (uint16_t)(100*rangeDataDelayed.rng),  // measured range
         errHAGL : (uint16_t)(100*sqrtF(terrainPopt)),   // note terrainPopt is constrained to be non-negative in EstimateTerrainOffset()
         angErr : (float)outputTrackError.x,             // output predictor angle error

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -194,7 +194,7 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
         offset : (int16_t)(100*terrainState),           // filter ground offset state error
         RI : (int16_t)(100*innovRng),                   // range finder innovations
         meaRng : (uint16_t)(100*rangeDataDelayed.rng),  // measured range
-        errHAGL : (uint16_t)(100*sqrtF(Popt)),          // note Popt is constrained to be non-negative in EstimateTerrainOffset()
+        errHAGL : (uint16_t)(100*sqrtF(terrainPopt)),   // note terrainPopt is constrained to be non-negative in EstimateTerrainOffset()
         angErr : (float)outputTrackError.x,             // output predictor angle error
         velErr : (float)outputTrackError.y,             // output predictor velocity error
         posErr : (float)outputTrackError.z              // output predictor position tracking error

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -192,7 +192,7 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
         AFI : (int16_t)(1000 * terrainFlowInnov.length()),  // optical flow LOS rate innovation from terrain offset estimator
         HAGL : (int16_t)(100*(terrainState - stateStruct.position.z)),    // height above ground level
         offset : (int16_t)(100*terrainState),           // filter ground offset state error
-        RI : (int16_t)(100*rngInnov),                   // range finder innovations
+        RI : (int16_t)(100*terrainRngInnov),            // range finder innovations
         meaRng : (uint16_t)(100*rangeDataDelayed.rng),  // measured range
         errHAGL : (uint16_t)(100*sqrtF(terrainPopt)),   // note terrainPopt is constrained to be non-negative in EstimateTerrainOffset()
         angErr : (float)outputTrackError.x,             // output predictor angle error

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -166,7 +166,7 @@ void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStam
 
 // write the raw optical flow measurements
 // this needs to be called externally.
-void NavEKF3_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset)
+void NavEKF3_core::writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation)
 {
     // limit update rate to maximum allowed by sensor buffers
     if ((imuSampleTime_ms - flowMeaTime_ms) < frontend->sensorIntervalMin_ms) {
@@ -197,6 +197,7 @@ void NavEKF3_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f
     if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {
         // correct flow sensor body rates for bias and write
         of_elements ofDataNew {};
+        ofDataNew.upwardsOrientation = upwardsOrientation;
         ofDataNew.bodyRadXYZ.x = rawGyroRates.x - flowGyroBias.x;
         ofDataNew.bodyRadXYZ.y = rawGyroRates.y - flowGyroBias.y;
         // the sensor interface doesn't provide a z axis rate so use the rate from the nav sensor instead

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -105,6 +105,53 @@ void NavEKF3_core::readRangeFinder(void)
     }
 }
 
+// Read upward facing range finder
+void NavEKF3_core::readRangeFinderUp()
+{
+    // return immediately if no rangefinder object
+    const auto *_rng = dal.rangefinder();
+    if (_rng == nullptr) {
+        return;
+    }
+
+    // search for upward facing rangefinder with good data
+    AP_DAL_RangeFinder_Backend* sensor = nullptr;
+    uint8_t sensorIndex;
+    bool sensorFound = false;
+    for (sensorIndex = 0; sensorIndex < RANGEFINDER_MAX_INSTANCES; sensorIndex++) {
+        sensor = _rng->get_backend(sensorIndex);
+        if ((sensor != nullptr) && (sensor->orientation() == ROTATION_PITCH_90) && (sensor->status() == AP_DAL_RangeFinder::Status::Good)) {
+            // found sensor, stop looking
+            sensorFound = true;
+            break;
+        }
+    }
+    if (!sensorFound || (sensor == nullptr)) {
+        return;
+    }
+
+    // return immediately if there has been no new sensor data
+    const uint32_t last_reading_ms = sensor->last_reading_ms();
+    if (lastRngUpMeasTime_ms == last_reading_ms) {
+        return;
+    }
+
+    // limit update rate to maximum allowed by data buffers
+    if ((last_reading_ms - lastRngUpMeasTime_ms) < frontend->sensorIntervalMin_ms) {
+        return;
+    }
+    lastRngUpMeasTime_ms = last_reading_ms;
+
+    // store reading to buffer
+    range_elements rngUpDataNew = {};
+    rngUpDataNew.rng = sensor->distance_cm() * 0.01;
+    rngUpDataNew.time_ms = last_reading_ms;
+    rngUpDataNew.sensor_idx = sensorIndex;
+
+    // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
+    storedRangeUp.push(rngUpDataNew);
+}
+
 void NavEKF3_core::writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, uint16_t delay_ms, const Vector3f &posOffset)
 {
 #if EK3_FEATURE_BODY_ODOM

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -40,14 +40,14 @@ void NavEKF3_core::SelectFlowFusion()
     // Constrain measurements to zero if takeoff is not detected and the height above ground
     // is insufficient to achieve acceptable focus. This allows the vehicle to be picked up
     // and carried to test optical flow operation
-    if (!takeOffDetected && ((terrainState - stateStruct.position.z) < 0.5f)) {
+    if (!takeOffDetected && !ofDataDelayed.upwardsOrientation && ((terrainState - stateStruct.position.z) < 0.5f)) {
         ofDataDelayed.flowRadXYcomp.zero();
         ofDataDelayed.flowRadXY.zero();
         flowDataValid = true;
     }
 
     // if have valid flow or range measurements, fuse data into a 1-state EKF to estimate terrain height
-    if (((flowDataToFuse && (frontend->_flowUse == FLOW_USE_TERRAIN)) || rangeDataToFuse) && tiltOK) {
+    if (((flowDataToFuse && !ofDataDelayed.upwardsOrientation && (frontend->_flowUse == FLOW_USE_TERRAIN)) || rangeDataToFuse) && tiltOK) {
         // Estimate the terrain offset (runs a one state EKF)
         EstimateTerrainOffset(ofDataDelayed);
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -132,10 +132,10 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             terrainRngInnov = predRngMeas - rangeDataDelayed.rng;
 
             // calculate the innovation consistency test ratio
-            auxRngTestRatio = sq(terrainRngInnov) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
+            terrainRngTestRatio = sq(terrainRngInnov) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
 
             // Check the innovation test ratio and don't fuse if too large
-            if (auxRngTestRatio < 1.0f) {
+            if (terrainRngTestRatio < 1.0f) {
                 // correct the state
                 terrainState -= K_RNG * terrainRngInnov;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -34,7 +34,7 @@ void NavEKF3_core::SelectFlowFusion()
     // Check if the optical flow data is still valid
     flowDataValid = ((imuSampleTime_ms - flowValidMeaTime_ms) < 1000);
     // check is the terrain offset estimate is still valid - if we are using range finder as the main height reference, the ground is assumed to be at 0
-    gndOffsetValid = ((imuSampleTime_ms - terrainValidTime_ms) < 5000) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER);
+    terrainStateValid = ((imuSampleTime_ms - terrainValidTime_ms) < 5000) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER);
     // Perform tilt check
     bool tiltOK = (prevTnb.c.z > frontend->DCM33FlowMin);
     // Constrain measurements to zero if takeoff is not detected and the height above ground

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -83,9 +83,9 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
 
     if ((!rangeDataToFuse && cantFuseFlowData) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER)) {
         // skip update
-        inhibitGndState = true;
+        inhibitTerrainState = true;
     } else {
-        inhibitGndState = false;
+        inhibitTerrainState = false;
 
         // propagate ground position state noise each time this is called using the difference in position since the last observations and an RMS gradient assumption
         // limit distance to prevent initialisation after bad gps causing bad numerical conditioning

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -129,15 +129,15 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             terrainState = MAX(terrainState, stateStruct.position[2] + rngOnGnd);
 
             // Calculate the measurement innovation
-            innovRng = predRngMeas - rangeDataDelayed.rng;
+            rngInnov = predRngMeas - rangeDataDelayed.rng;
 
             // calculate the innovation consistency test ratio
-            auxRngTestRatio = sq(innovRng) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
+            auxRngTestRatio = sq(rngInnov) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
 
             // Check the innovation test ratio and don't fuse if too large
             if (auxRngTestRatio < 1.0f) {
                 // correct the state
-                terrainState -= K_RNG * innovRng;
+                terrainState -= K_RNG * rngInnov;
 
                 // constrain the state
                 terrainState = MAX(terrainState, stateStruct.position[2] + rngOnGnd);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -129,15 +129,15 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             terrainState = MAX(terrainState, stateStruct.position[2] + rngOnGnd);
 
             // Calculate the measurement innovation
-            rngInnov = predRngMeas - rangeDataDelayed.rng;
+            terrainRngInnov = predRngMeas - rangeDataDelayed.rng;
 
             // calculate the innovation consistency test ratio
-            auxRngTestRatio = sq(rngInnov) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
+            auxRngTestRatio = sq(terrainRngInnov) / (sq(MAX(0.01f * (ftype)frontend->_rngInnovGate, 1.0f)) * varInnovRng);
 
             // Check the innovation test ratio and don't fuse if too large
             if (auxRngTestRatio < 1.0f) {
                 // correct the state
-                terrainState -= K_RNG * rngInnov;
+                terrainState -= K_RNG * terrainRngInnov;
 
                 // constrain the state
                 terrainState = MAX(terrainState, stateStruct.position[2] + rngOnGnd);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -88,7 +88,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
         inhibitGndState = false;
 
         // propagate ground position state noise each time this is called using the difference in position since the last observations and an RMS gradient assumption
-        // limit distance to prevent intialisation after bad gps causing bad numerical conditioning
+        // limit distance to prevent initialisation after bad gps causing bad numerical conditioning
         ftype distanceTravelledSq = sq(stateStruct.position[0] - prevPosN) + sq(stateStruct.position[1] - prevPosE);
         distanceTravelledSq = MIN(distanceTravelledSq, 100.0f);
         prevPosN = stateStruct.position[0];
@@ -100,7 +100,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
         Popt += Pincrement;
         timeAtLastAuxEKF_ms = imuSampleTime_ms;
 
-        // fuse range finder data
+        // fuse range finder data to calculate terrain offset
         if (rangeDataToFuse) {
             // reset terrain state if rangefinder data not fused for 5 seconds
             if (imuSampleTime_ms - gndHgtValidTime_ms > 5000) {
@@ -153,6 +153,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             }
         }
 
+        // fuse optical flow data to calculate terrain offset
         if (!cantFuseFlowData) {
 
             Vector3F relVelSensor;          // velocity of sensor relative to ground in sensor axes
@@ -280,7 +281,7 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
     Vector2 losPred;
 
     // Copy required states to local variable names
-    ftype q0  = stateStruct.quat[0];
+    ftype q0 = stateStruct.quat[0];
     ftype q1 = stateStruct.quat[1];
     ftype q2 = stateStruct.quat[2];
     ftype q3 = stateStruct.quat[3];
@@ -292,7 +293,7 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
     // constrain height above ground to be above range measured on ground
     ftype heightAboveGndEst = MAX((terrainState - pd), rngOnGnd);
 
-    // calculate range from ground plain to centre of sensor fov assuming flat earth
+    // calculate range from ground plane to centre of sensor fov assuming flat earth
     ftype range = constrain_ftype((heightAboveGndEst/prevTnb.c.z),rngOnGnd,1000.0f);
 
     // correct range for flow sensor offset body frame position offset
@@ -767,8 +768,3 @@ bool NavEKF3_core::getOptFlowSample(uint32_t& timestamp_ms, Vector2f& flowRate, 
     }
     return false;
 }
-
-/********************************************************
-*                   MISC FUNCTIONS                      *
-********************************************************/
-

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -181,7 +181,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             losPred.y = - relVelSensor.x / flowRngPred;
 
             // calculate innovations
-            auxFlowObsInnov = losPred - ofDataDelayed.flowRadXYcomp;
+            terrainFlowInnov = losPred - ofDataDelayed.flowRadXYcomp;
 
             // calculate observation jacobians 
             ftype t2 = q0*q0;
@@ -211,13 +211,13 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             K_OPT = terrainPopt * H_OPT / auxFlowObsInnovVar.y;
 
             // calculate the innovation consistency test ratio
-            const ftype auxFlowTestRatio_y = sq(auxFlowObsInnov.y) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.y);
+            const ftype auxFlowTestRatio_y = sq(terrainFlowInnov.y) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.y);
 
             // don't fuse if optical flow data is outside valid range
             if (auxFlowTestRatio_y < 1.0f) {
 
                 // correct the state
-                terrainState -= K_OPT * auxFlowObsInnov.y;
+                terrainState -= K_OPT * terrainFlowInnov.y;
 
                 // constrain the state
                 terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
@@ -246,13 +246,13 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             K_OPT = terrainPopt * H_OPT / auxFlowObsInnovVar.x;
 
             // calculate the innovation consistency test ratio
-            const ftype auxFlowTestRatio_x = sq(auxFlowObsInnov.x) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.x);
+            const ftype auxFlowTestRatio_x = sq(terrainFlowInnov.x) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.x);
 
             // don't fuse if optical flow data is outside valid range
             if (auxFlowTestRatio_x < 1.0f) {
 
                 // correct the state
-                terrainState -= K_OPT * auxFlowObsInnov.x;
+                terrainState -= K_OPT * terrainFlowInnov.x;
 
                 // constrain the state
                 terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -34,7 +34,7 @@ void NavEKF3_core::SelectFlowFusion()
     // Check if the optical flow data is still valid
     flowDataValid = ((imuSampleTime_ms - flowValidMeaTime_ms) < 1000);
     // check is the terrain offset estimate is still valid - if we are using range finder as the main height reference, the ground is assumed to be at 0
-    gndOffsetValid = ((imuSampleTime_ms - gndHgtValidTime_ms) < 5000) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER);
+    gndOffsetValid = ((imuSampleTime_ms - terrainValidTime_ms) < 5000) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER);
     // Perform tilt check
     bool tiltOK = (prevTnb.c.z > frontend->DCM33FlowMin);
     // Constrain measurements to zero if takeoff is not detected and the height above ground
@@ -103,7 +103,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
         // fuse range finder data to calculate terrain offset
         if (rangeDataToFuse) {
             // reset terrain state if rangefinder data not fused for 5 seconds
-            if (imuSampleTime_ms - gndHgtValidTime_ms > 5000) {
+            if (imuSampleTime_ms - terrainValidTime_ms > 5000) {
                 terrainState = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd) + stateStruct.position.z;
             }
 
@@ -149,7 +149,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
                 Popt = MAX(Popt,0.0f);
 
                 // record the time we last updated the terrain offset state
-                gndHgtValidTime_ms = imuSampleTime_ms;
+                terrainValidTime_ms = imuSampleTime_ms;
             }
         }
 
@@ -233,7 +233,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
                 Popt = MAX(Popt,1E-6f);
 
                 // record the time we last updated the terrain offset state
-                gndHgtValidTime_ms = imuSampleTime_ms;
+                terrainValidTime_ms = imuSampleTime_ms;
             }
 
             // fuse X axis data

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -89,10 +89,10 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
 
         // propagate ground position state noise each time this is called using the difference in position since the last observations and an RMS gradient assumption
         // limit distance to prevent initialisation after bad gps causing bad numerical conditioning
-        ftype distanceTravelledSq = sq(stateStruct.position[0] - prevPosN) + sq(stateStruct.position[1] - prevPosE);
+        ftype distanceTravelledSq = sq(stateStruct.position[0] - terrainPrevPosNE.x) + sq(stateStruct.position[1] - terrainPrevPosNE.y);
         distanceTravelledSq = MIN(distanceTravelledSq, 100.0f);
-        prevPosN = stateStruct.position[0];
-        prevPosE = stateStruct.position[1];
+        terrainPrevPosNE.x = stateStruct.position[0];
+        terrainPrevPosNE.y = stateStruct.position[1];
 
         // in addition to a terrain gradient error model, we also have the growth in uncertainty due to the copter's vertical velocity
         ftype timeLapsed = MIN(0.001f * (imuSampleTime_ms - timeAtLastAuxEKF_ms), 1.0f);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -211,10 +211,10 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             K_OPT = terrainPopt * H_OPT / auxFlowObsInnovVar.y;
 
             // calculate the innovation consistency test ratio
-            auxFlowTestRatio.y = sq(auxFlowObsInnov.y) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.y);
+            const ftype auxFlowTestRatio_y = sq(auxFlowObsInnov.y) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.y);
 
             // don't fuse if optical flow data is outside valid range
-            if (auxFlowTestRatio.y < 1.0f) {
+            if (auxFlowTestRatio_y < 1.0f) {
 
                 // correct the state
                 terrainState -= K_OPT * auxFlowObsInnov.y;
@@ -246,10 +246,10 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             K_OPT = terrainPopt * H_OPT / auxFlowObsInnovVar.x;
 
             // calculate the innovation consistency test ratio
-            auxFlowTestRatio.x = sq(auxFlowObsInnov.x) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.x);
+            const ftype auxFlowTestRatio_x = sq(auxFlowObsInnov.x) / (sq(MAX(0.01f * (ftype)frontend->_flowInnovGate, 1.0f)) * auxFlowObsInnovVar.x);
 
             // don't fuse if optical flow data is outside valid range
-            if (auxFlowTestRatio.x < 1.0f) {
+            if (auxFlowTestRatio_x < 1.0f) {
 
                 // correct the state
                 terrainState -= K_OPT * auxFlowObsInnov.x;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -123,7 +123,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             ftype K_RNG = terrainPopt/(SK_RNG*(R_RNG + terrainPopt/sq(SK_RNG)));
 
             // Calculate the innovation variance for data logging
-            varInnovRng = (R_RNG + terrainPopt/sq(SK_RNG));
+            const ftype varInnovRng = (R_RNG + terrainPopt/sq(SK_RNG));
 
             // constrain terrain height to be below the vehicle
             terrainState = MAX(terrainState, stateStruct.position[2] + rngOnGnd);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -264,7 +264,7 @@ bool NavEKF3_core::getHAGL(float &HAGL) const
 {
     HAGL = terrainState - outputDataNew.position.z - posOffsetNED.z;
     // If we know the terrain offset and altitude, then we have a valid height above ground estimate
-    return !hgtTimeout && gndOffsetValid && healthy();
+    return !hgtTimeout && terrainStateValid && healthy();
 }
 
 // Return the last calculated latitude, longitude and height in WGS-84

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -580,7 +580,7 @@ void NavEKF3_core::send_status_report(mavlink_channel_t chan) const
     // range finder is fitted for other applications
     float temp;
     if (((frontend->_useRngSwHgt > 0) && activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER) || (PV_AidingMode == AID_RELATIVE && flowDataValid)) {
-        temp = sqrtF(auxRngTestRatio);
+        temp = sqrtF(terrainRngTestRatio);
     } else {
         temp = 0.0f;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -135,6 +135,10 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if(dal.rangefinder() && !storedRange.init(MIN(2*obs_buffer_length , imu_buffer_length))) {
         return false;
     }
+    // upward facing rangefinder
+    if(dal.rangefinder() && !storedRangeUp.init(MIN(obs_buffer_length , imu_buffer_length))) {
+        return false;
+    }
     // Note: range beacon data is read one beacon at a time and can arrive at a high rate
     if(dal.beacon() && !storedRangeBeacon.init(imu_buffer_length+1)) {
         return false;
@@ -413,6 +417,7 @@ void NavEKF3_core::InitialiseVariables()
     storedBaro.reset();
     storedTAS.reset();
     storedRange.reset();
+    storedRangeUp.reset();
     storedOutput.reset();
     storedRangeBeacon.reset();
 #if EK3_FEATURE_BODY_ODOM
@@ -2013,6 +2018,8 @@ void NavEKF3_core::ConstrainStates()
     if (!inhibitTerrainState) {
         terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
     }
+    // constrain ceiling state to be above the vehicle
+    ceilingState = MAX(ceilingState, ceilingDistMin - stateStruct.position.z);
 }
 
 // calculate the NED earth spin vector in rad/sec

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -245,8 +245,8 @@ void NavEKF3_core::InitialiseVariables()
     rangeDataToFuse  = false;
     terrainPopt = 0.0f;
     terrainState = 0.0f;
-    prevPosN = stateStruct.position.x;
-    prevPosE = stateStruct.position.y;
+    terrainPrevPosNE.x = stateStruct.position.x;
+    terrainPrevPosNE.y = stateStruct.position.y;
     inhibitTerrainState = false;
     flowGyroBias.x = 0;
     flowGyroBias.y = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -247,7 +247,7 @@ void NavEKF3_core::InitialiseVariables()
     terrainState = 0.0f;
     prevPosN = stateStruct.position.x;
     prevPosE = stateStruct.position.y;
-    inhibitGndState = false;
+    inhibitTerrainState = false;
     flowGyroBias.x = 0;
     flowGyroBias.y = 0;
     PV_AidingMode = AID_NONE;
@@ -2010,7 +2010,7 @@ void NavEKF3_core::ConstrainStates()
     // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
     for (uint8_t i=22; i<=23; i++) statesArray[i] = constrain_ftype(statesArray[i],-100.0f,100.0f);
     // constrain the terrain state to be below the vehicle height unless we are using terrain as the height datum
-    if (!inhibitGndState) {
+    if (!inhibitTerrainState) {
         terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -209,7 +209,7 @@ void NavEKF3_core::InitialiseVariables()
     rngValidMeaTime_ms = imuSampleTime_ms;
     flowMeaTime_ms = 0;
     prevFlowFuseTime_ms = 0;
-    gndHgtValidTime_ms = 0;
+    terrainValidTime_ms = 0;
     ekfStartTime_ms = imuSampleTime_ms;
     lastGpsVelFail_ms = 0;
     lastGpsAidBadTime_ms = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -243,7 +243,7 @@ void NavEKF3_core::InitialiseVariables()
     memset(&nextP[0][0], 0, sizeof(nextP));
     flowDataValid = false;
     rangeDataToFuse  = false;
-    Popt = 0.0f;
+    terrainPopt = 0.0f;
     terrainState = 0.0f;
     prevPosN = stateStruct.position.x;
     prevPosE = stateStruct.position.y;
@@ -626,7 +626,7 @@ void NavEKF3_core::CovarianceInit()
 
 
     // optical flow ground height covariance
-    Popt = 0.25f;
+    terrainPopt = 0.25f;
 
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -265,7 +265,7 @@ void NavEKF3_core::InitialiseVariables()
     windStatesAligned = false;
     inhibitDelVelBiasStates = true;
     inhibitDelAngBiasStates = true;
-    gndOffsetValid =  false;
+    terrainStateValid =  false;
     validOrigin = false;
     gpsSpdAccuracy = 0.0f;
     gpsPosAccuracy = 0.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1199,7 +1199,6 @@ private:
     bool inhibitTerrainState;       // true when the terrain position state is to remain constant
     uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
     Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
-    Vector2F auxFlowTestRatio;      // sum of squares of optical flow innovation divided by fail threshold used by 1-state terrain offset estimator
     ftype R_LOS;                    // variance of optical flow rate measurements (rad/sec)^2
     ftype auxRngTestRatio;          // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
     Vector2F flowGyroBias;          // bias error of optical flow sensor gyro output

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1188,7 +1188,7 @@ private:
     ftype terrainState;             // terrain position state (m)
     Vector2F terrainPrevPosNE;      // position at last measurement in NE frame
     ftype varInnovRng;              // range finder observation innovation variance (m^2)
-    ftype innovRng;                 // range finder observation innovation (m)
+    ftype rngInnov;                 // range finder observation innovation (m)
     struct {
         uint32_t timestamp_ms;      // system timestamp of last correct optical flow sample (used for calibration)
         Vector2f flowRate;          // latest corrected optical flow flow rate (used for calibration)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1186,8 +1186,7 @@ private:
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)
     ftype terrainPopt;              // Optical flow terrain height state covariance (m^2)
     ftype terrainState;             // terrain position state (m)
-    ftype prevPosN;                 // north position at last measurement
-    ftype prevPosE;                 // east position at last measurement
+    Vector2F terrainPrevPosNE;      // position at last measurement in NE frame
     ftype varInnovRng;              // range finder observation innovation variance (m^2)
     ftype innovRng;                 // range finder observation innovation (m)
     struct {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1180,7 +1180,7 @@ private:
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)
     uint32_t rngValidMeaTime_ms;    // time stamp from latest valid range measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
-    uint32_t gndHgtValidTime_ms;    // time stamp from last terrain offset state update (msec)
+    uint32_t terrainValidTime_ms;   // time stamp from last terrain offset state update (msec)
     Vector2 flowVarInnov;           // optical flow innovations variances (rad/sec)^2
     Vector2 flowInnov;              // optical flow LOS innovations (rad/sec)
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1187,7 +1187,6 @@ private:
     ftype terrainPopt;              // Optical flow terrain height state covariance (m^2)
     ftype terrainState;             // terrain position state (m)
     Vector2F terrainPrevPosNE;      // position at last measurement in NE frame
-    ftype varInnovRng;              // range finder observation innovation variance (m^2)
     ftype rngInnov;                 // range finder observation innovation (m)
     struct {
         uint32_t timestamp_ms;      // system timestamp of last correct optical flow sample (used for calibration)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1188,7 +1188,7 @@ private:
     ftype terrainPopt;              // Optical flow terrain height state covariance (m^2)
     ftype terrainState;             // terrain position state (m)
     Vector2F terrainPrevPosNE;      // position at last measurement in NE frame
-    ftype rngInnov;                 // range finder observation innovation (m)
+    ftype terrainRngInnov;          // range finder observation innovation (m)
     struct {
         uint32_t timestamp_ms;      // system timestamp of last correct optical flow sample (used for calibration)
         Vector2f flowRate;          // latest corrected optical flow flow rate (used for calibration)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -828,8 +828,9 @@ private:
     void EstimateTerrainOffset(const of_elements &ofDataDelayed);
 
     // fuse optical flow measurements into the main filter
+    // flowNoise is the variance of of optical flow rate measurements in (rad/sec)^2
     // really_fuse should be true to actually fuse into the main filter, false to only calculate variances
-    void FuseOptFlow(const of_elements &ofDataDelayed, bool really_fuse);
+    void FuseOptFlow(const of_elements &ofDataDelayed, ftype flowNoise, bool really_fuse);
 
     // Control filter mode changes
     void controlFilterModes();
@@ -1199,7 +1200,6 @@ private:
     bool inhibitTerrainState;       // true when the terrain position state is to remain constant
     uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
     Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
-    ftype R_LOS;                    // variance of optical flow rate measurements (rad/sec)^2
     ftype auxRngTestRatio;          // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
     Vector2F flowGyroBias;          // bias error of optical flow sensor gyro output
     bool rangeDataToFuse;           // true when valid range finder height data has arrived at the fusion time horizon.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1200,7 +1200,7 @@ private:
     bool inhibitTerrainState;       // true when the terrain position state is to remain constant
     uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
     Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
-    ftype auxRngTestRatio;          // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
+    ftype terrainRngTestRatio;      // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
     Vector2F flowGyroBias;          // bias error of optical flow sensor gyro output
     bool rangeDataToFuse;           // true when valid range finder height data has arrived at the fusion time horizon.
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -829,6 +829,9 @@ private:
     // Estimate terrain offset using a single state EKF
     void EstimateTerrainOffset(const of_elements &ofDataDelayed);
 
+    // Estimate ceiling offset (i.e. ceiling's height above EKF origin) using an upward facing rangefinder
+    void EstimateCeilingOffset();
+
     // fuse optical flow measurements into the main filter
     // flowNoise is the variance of of optical flow rate measurements in (rad/sec)^2
     // really_fuse should be true to actually fuse into the main filter, false to only calculate variances
@@ -871,6 +874,9 @@ private:
     // Read the range finder and take new measurements if available
     // Apply a median filter to range finder data
     void readRangeFinder();
+
+    // Read upward facing range finder
+    void readRangeFinderUp();
 
     // check if the vehicle has taken off during optical flow navigation by looking at inertial and range finder data
     void detectOptFlowTakeoff(void);
@@ -1202,6 +1208,19 @@ private:
         Vector2f bodyRate;          // latest corrected optical flow body rate (used for calibration)
         Vector2f losPred;           // EKF estimated component of flowRate that comes from vehicle movement (not rotation)
     } flowCalSample;
+
+    // variables for upward facing optical flow and ceiling state estimation
+    EKF_obs_buffer_t<range_elements> storedRangeUp; // upward range finder data buffer
+    uint32_t lastRngUpMeasTime_ms;  // system time of last upward rangefinder measurement (time from sensor)
+    uint32_t ceilingValidTime_ms;   // system time from last ceiling offset state update
+    uint32_t ceilingResetTime_ms;   // system time of last ceiling state reset
+    Vector2F ceilingPrevPosNE;      // position (in NE frame) when ceiling state was last estimated
+    uint32_t ceilingPrevPosNETime_ms;   // system time that ceilingPrevPosNE was recorded
+    ftype ceilingState;             // ceiling height above EKF origin (m)
+    ftype ceilingPopt;              // ceiling height state covariance (m^2)
+    ftype ceilingRngInnov;          // range finder observation innovation (m) calculated during ceiling state estimation
+    ftype ceilingRngTestRatio;      // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
+    const float ceilingDistMin = 0.05;  // ceiling estimate's minimum height above vehicle
 
     ftype hgtMea;                   // height measurement derived from either baro, gps or range finder data (m)
     bool rangeDataToFuse;           // true when valid range finder height data has arrived at the fusion time horizon.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1215,7 +1215,7 @@ private:
                     };
     AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
     AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions
-    bool gndOffsetValid;            // true when the ground offset state can still be considered valid
+    bool terrainStateValid;         // true when the ground offset state can still be considered valid
     Vector3F delAngBodyOF;          // bias corrected delta angle of the vehicle IMU measured summed across the time since the last OF measurement
     ftype delTimeOF;                // time that delAngBodyOF is summed across
     bool flowFusionActive;          // true when optical flow fusion is active

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1174,21 +1174,26 @@ private:
     Vector3F gpsVelVarInnov;        // gps velocity innovation variances
     uint32_t gpsVelInnovTime_ms;    // system time that gps velocity innovations were recorded (to detect timeouts)
 
-    // variables added for optical flow fusion
+    // variables added for optical flow fusion and terrain estimation
     EKF_obs_buffer_t<of_elements> storedOF;    // OF data buffer
     bool flowDataValid;             // true while optical flow data is still fresh
-    Vector2F terrainFlowInnov;      // optical flow rate innovation from 1-state terrain offset estimator
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)
-    uint32_t rngValidMeaTime_ms;    // time stamp from latest valid range measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
-    uint32_t terrainValidTime_ms;   // time stamp from last terrain offset state update (msec)
+    uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
     Vector2 flowVarInnov;           // optical flow innovations variances (rad/sec)^2
     Vector2 flowInnov;              // optical flow LOS innovations (rad/sec)
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)
+    Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
+    Vector2F flowGyroBias;          // bias error of optical flow sensor gyro output
+    uint32_t terrainValidTime_ms;   // time stamp from last terrain offset state update (msec)
+    ftype terrainState;             // terrain height above EKF origin (m)
     ftype terrainPopt;              // Optical flow terrain height state covariance (m^2)
-    ftype terrainState;             // terrain position state (m)
     Vector2F terrainPrevPosNE;      // position at last measurement in NE frame
+    Vector2F terrainFlowInnov;      // optical flow rate innovation from 1-state terrain offset estimator
     ftype terrainRngInnov;          // range finder observation innovation (m)
+    ftype terrainRngTestRatio;      // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
+    bool inhibitTerrainState;       // true when the terrain position state is to remain constant
+    bool terrainStateValid;         // true when the ground offset state can still be considered valid
     struct {
         uint32_t timestamp_ms;      // system timestamp of last correct optical flow sample (used for calibration)
         Vector2f flowRate;          // latest corrected optical flow flow rate (used for calibration)
@@ -1197,11 +1202,6 @@ private:
     } flowCalSample;
 
     ftype hgtMea;                   // height measurement derived from either baro, gps or range finder data (m)
-    bool inhibitTerrainState;       // true when the terrain position state is to remain constant
-    uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
-    Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
-    ftype terrainRngTestRatio;      // square of range finder innovations divided by fail threshold used by main filter where >1.0 is a fail
-    Vector2F flowGyroBias;          // bias error of optical flow sensor gyro output
     bool rangeDataToFuse;           // true when valid range finder height data has arrived at the fusion time horizon.
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.
     bool gpsDataToFuse;             // true when valid GPS data has arrived at the fusion time horizon.
@@ -1212,7 +1212,6 @@ private:
                     };
     AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
     AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions
-    bool terrainStateValid;         // true when the ground offset state can still be considered valid
     Vector3F delAngBodyOF;          // bias corrected delta angle of the vehicle IMU measured summed across the time since the last OF measurement
     ftype delTimeOF;                // time that delAngBodyOF is summed across
     bool flowFusionActive;          // true when optical flow fusion is active
@@ -1225,6 +1224,7 @@ private:
     ftype storedRngMeas[2][3];              // Ringbuffer of stored range measurements for dual range sensors
     uint32_t storedRngMeasTime_ms[2][3];    // Ringbuffers of stored range measurement times for dual range sensors
     uint32_t lastRngMeasTime_ms;            // Timestamp of last range measurement
+    uint32_t rngValidMeaTime_ms;            // time stamp from latest valid range measurement (msec)
     uint8_t rngMeasIndex[2];                // Current range measurement ringbuffer index for dual range sensors
     bool terrainHgtStable;                  // true when the terrain height is stable enough to be used as a height reference
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1226,7 +1226,7 @@ private:
     uint32_t lastRngMeasTime_ms;            // Timestamp of last range measurement
     uint32_t rngValidMeaTime_ms;            // time stamp from latest valid range measurement (msec)
     uint8_t rngMeasIndex[2];                // Current range measurement ringbuffer index for dual range sensors
-    bool terrainHgtStable;                  // true when the terrain height is stable enough to be used as a height reference
+    bool terrainHgtStable;                  // flag set by external caller to true when the terrain height is stable enough to be used as a height reference
 
     // body frame odometry fusion
 #if EK3_FEATURE_BODY_ODOM

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1177,7 +1177,7 @@ private:
     // variables added for optical flow fusion
     EKF_obs_buffer_t<of_elements> storedOF;    // OF data buffer
     bool flowDataValid;             // true while optical flow data is still fresh
-    Vector2F auxFlowObsInnov;       // optical flow rate innovation from 1-state terrain offset estimator
+    Vector2F terrainFlowInnov;      // optical flow rate innovation from 1-state terrain offset estimator
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)
     uint32_t rngValidMeaTime_ms;    // time stamp from latest valid range measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -246,7 +246,8 @@ public:
     // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
     // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
     // posOffset is the XYZ flow sensor position in the body frame in m
-    void writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset);
+    // upwardsOrientation should be true if the sensor is pointing upwards
+    void writeOptFlowMeas(uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, uint32_t msecFlowMeas, const Vector3f &posOffset, bool upwardsOrientation);
 
     // retrieve latest corrected optical flow samples (used for calibration)
     bool getOptFlowSample(uint32_t& timeStamp_ms, Vector2f& flowRate, Vector2f& bodyRate, Vector2f& losPred) const;
@@ -563,6 +564,7 @@ private:
         Vector2F    flowRadXYcomp;  // motion compensated XY optical flow angular rates about the XY body axes (rad/sec)
         Vector3F    bodyRadXYZ;     // body frame XYZ axis angular rates averaged across the optical flow measurement interval (rad/sec)
         Vector3F    body_offset;    // XYZ position of the optical flow sensor in body frame (m)
+        bool        upwardsOrientation; // true if optical flow sensor is facing upwards
     };
 
     struct vel_odm_elements : EKF_obs_element_t {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1198,7 +1198,7 @@ private:
     } flowCalSample;
 
     ftype hgtMea;                   // height measurement derived from either baro, gps or range finder data (m)
-    bool inhibitGndState;           // true when the terrain position state is to remain constant
+    bool inhibitTerrainState;       // true when the terrain position state is to remain constant
     uint32_t prevFlowFuseTime_ms;   // time both flow measurement components passed their innovation consistency checks
     Vector2 flowTestRatio;          // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
     Vector2F auxFlowTestRatio;      // sum of squares of optical flow innovation divided by fail threshold used by 1-state terrain offset estimator

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1184,7 +1184,7 @@ private:
     Vector2 flowVarInnov;           // optical flow innovations variances (rad/sec)^2
     Vector2 flowInnov;              // optical flow LOS innovations (rad/sec)
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)
-    ftype Popt;                     // Optical flow terrain height state covariance (m^2)
+    ftype terrainPopt;              // Optical flow terrain height state covariance (m^2)
     ftype terrainState;             // terrain position state (m)
     ftype prevPosN;                 // north position at last measurement
     ftype prevPosE;                 // east position at last measurement

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -224,6 +224,13 @@ void OpticalFlow::handle_msp(const MSP::msp_opflow_data_message_t &pkt)
 }
 #endif //HAL_MSP_OPTICALFLOW_ENABLED
 
+// returns true if sensor is orientated to face upwards
+bool OpticalFlow::upwards_orientation() const
+{
+    const enum Rotation orient = get_orientation();
+    return (orient >= Rotation::ROTATION_ROLL_180 && orient <= ROTATION_ROLL_180_YAW_315);
+}
+
 // start calibration
 void OpticalFlow::start_calibration()
 {
@@ -257,7 +264,8 @@ void OpticalFlow::update_state(const OpticalFlow_state &state)
                                 _state.flowRate,
                                 _state.bodyRate,
                                 _last_update_ms,
-                                get_pos_offset());
+                                get_pos_offset(),
+                                upwards_orientation());
     Log_Write_Optflow();
 }
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -52,15 +52,6 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_FYSCALER", 2,  OpticalFlow,    _flowScalerY,   0),
 
-    // @Param: _ORIENT_YAW
-    // @DisplayName: Flow sensor yaw alignment
-    // @Description: Specifies the number of centi-degrees that the flow sensor is yawed relative to the vehicle. A sensor with its X-axis pointing to the right of the vehicle X axis has a positive yaw angle.
-    // @Units: cdeg
-    // @Range: -17999 +18000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("_ORIENT_YAW", 3,  OpticalFlow,    _yawAngle_cd,   0),
-
     // @Param: _POS_X
     // @DisplayName:  X position offset
     // @Description: X position of the optical flow sensor focal point in body frame. Positive X is forward of the origin.
@@ -92,6 +83,13 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @Range: 0 127
     // @User: Advanced
     AP_GROUPINFO("_ADDR", 5,  OpticalFlow, _address,   0),
+
+    // @Param: _ORIENT
+    // @DisplayName: Flow sensor orientation
+    // @Description: Flow sensor orientation
+    // @Values: 0:Downwards, 1:Downwards Yaw45, 2:Downwards Yaw90, 3:Downwards Yaw135, 4:Downwards Yaw180, 5:Downwards Yaw225, 6:Downwards Yaw270, 7:Downwards Yaw315, 8:Upwards, 9:Upwards Yaw45, 10:Upwards Yaw90, 11:Upwards Yaw135, 12:Upwards Yaw180, 13:Upwards Yaw225, 14:Upwards Yaw270, 15:Upwards Yaw315
+    // @User: Standard
+    AP_GROUPINFO("_ORIENT", 6, OpticalFlow, _orientation, 0),
 
     AP_GROUPEND
 };

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -102,6 +102,9 @@ public:
     // get user defined sensor orientation
     enum Rotation get_orientation() const { return (enum Rotation)_orientation.get(); }
 
+    // returns true if sensor is orientated to face upwards
+    bool upwards_orientation() const;
+
     struct OpticalFlow_state {
         uint8_t  surface_quality;   // image quality (below TBD you can't trust the dx,dy values returned)
         Vector2f flowRate;          // optical flow angular rate in rad/sec measured about the X and Y body axis. A RH rotation about a sensor axis produces a positive rate.

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -99,6 +99,9 @@ public:
     // last_update() - returns system time of last sensor update
     uint32_t last_update() const { return _last_update_ms; }
 
+    // get user defined sensor orientation
+    enum Rotation get_orientation() const { return (enum Rotation)_orientation.get(); }
+
     struct OpticalFlow_state {
         uint8_t  surface_quality;   // image quality (below TBD you can't trust the dx,dy values returned)
         Vector2f flowRate;          // optical flow angular rate in rad/sec measured about the X and Y body axis. A RH rotation about a sensor axis produces a positive rate.
@@ -131,9 +134,9 @@ private:
     AP_Int8  _type;                 // user configurable sensor type
     AP_Int16 _flowScalerX;          // X axis flow scale factor correction - parts per thousand
     AP_Int16 _flowScalerY;          // Y axis flow scale factor correction - parts per thousand
-    AP_Int16 _yawAngle_cd;          // yaw angle of sensor X axis with respect to vehicle X axis - centi degrees
     AP_Vector3f _pos_offset;        // position offset of the flow sensor in the body frame
     AP_Int8  _address;              // address on the bus (allows selecting between 8 possible I2C addresses for px4flow)
+    AP_Int8 _orientation;           // sensor orientation
 
     // method called by backend to update frontend state:
     void update_state(const OpticalFlow_state &state);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
@@ -34,19 +34,21 @@ void OpticalFlow_backend::_update_frontend(const struct OpticalFlow::OpticalFlow
     frontend.update_state(state);
 }
 
-// apply yaw angle to a vector
-void OpticalFlow_backend::_applyYaw(Vector2f &v)
+// rotate vector based on user supplied sensor orientation
+// resulting vector will be as if sensor was pointing dowards in default orientation
+void OpticalFlow_backend::apply_orientation(Vector2f &v) const
 {
-    float yawAngleRad = _yawAngleRad();
-    if (is_zero(yawAngleRad)) {
+    // skip rotation in the most common case
+    const enum Rotation orient = frontend.get_orientation();
+    if (orient == ROTATION_NONE) {
         return;
     }
-    float cosYaw = cosf(yawAngleRad);
-    float sinYaw = sinf(yawAngleRad);
-    float x = v.x;
-    float y = v.y;
-    v.x = cosYaw * x - sinYaw * y;
-    v.y = sinYaw * x + cosYaw * y;
+
+    // create a 3D vector, rotate and then copy only the xy portions
+    Vector3f v3d{v.x, v.y, 0};
+    v3d.rotate(orient);
+    v.x = v3d.x;
+    v.y = v3d.y;
 }
 
 #endif

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
@@ -53,11 +53,9 @@ protected:
     // get the flow scaling parameters
     Vector2f _flowScaler(void) const { return Vector2f(frontend._flowScalerX, frontend._flowScalerY); }
 
-    // get the yaw angle in radians
-    float _yawAngleRad(void) const { return radians(float(frontend._yawAngle_cd) * 0.01f); }
-
-    // apply yaw angle to a vector
-    void _applyYaw(Vector2f &v);
+    // rotate vector based on user supplied sensor orientation
+    // resulting vector will be as if sensor was pointing dowards in default orientation
+    void apply_orientation(Vector2f &v) const;
 
     // get ADDR parameter value
     uint8_t get_address(void) const { return frontend._address; }

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -189,7 +189,7 @@ void AP_OpticalFlow_CXOF::update(void)
         state.bodyRate = Vector2f(gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count);
 
         // we only apply yaw to flowRate as body rate comes from AHRS
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
@@ -94,8 +94,8 @@ void AP_OpticalFlow_HereFlow::_push_state(void)
                                 flowRate.y * flowScaleFactorY) * integralToRate;
     state.bodyRate = bodyRate * integralToRate;
     state.surface_quality = surface_quality;
-    _applyYaw(state.flowRate);
-    _applyYaw(state.bodyRate);
+    apply_orientation(state.flowRate);
+    apply_orientation(state.bodyRate);
     // hal.console->printf("DRV: %u %f %f\n", state.surface_quality, flowRate.length(), bodyRate.length());
     _update_frontend(state);
     new_data = false;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
@@ -69,7 +69,7 @@ void AP_OpticalFlow_MAV::update(void)
         state.bodyRate = { gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count };
 
         // we only apply yaw to flowRate as body rate comes from AHRS
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.cpp
@@ -74,7 +74,7 @@ void AP_OpticalFlow_MSP::update(void)
         state.flowRate *= -1;
 
         // we only apply yaw to flowRate as body rate comes from AHRS
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.cpp
@@ -78,7 +78,7 @@ void AP_OpticalFlow_Onboard::update()
         state.bodyRate.y = 1000000.0f / float(data_frame.delta_time) *
                            data_frame.gyro_y_integral;
 
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
     } else {
         state.flowRate.zero();
         state.bodyRate.zero();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -132,8 +132,8 @@ void AP_OpticalFlow_PX4Flow::timer(void)
                                   frame.pixel_flow_y_integral * flowScaleFactorY) * 1.0e-4 * integralToRate;
         state.bodyRate = Vector2f(frame.gyro_x_rate_integral, frame.gyro_y_rate_integral) * 1.0e-4 * integralToRate;
         
-        _applyYaw(state.flowRate);
-        _applyYaw(state.bodyRate);
+        apply_orientation(state.flowRate);
+        apply_orientation(state.bodyRate);
     }
 
     _update_frontend(state);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -345,7 +345,7 @@ void AP_OpticalFlow_Pixart::update(void)
         state.flowRate *= flow_pixel_scaling / dt;
 
         // we only apply yaw to flowRate as body rate comes from AHRS
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
 
         state.bodyRate = integral.gyro / dt;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
@@ -122,7 +122,7 @@ void AP_OpticalFlow_SITL::update(void)
         }
     }
 
-    _applyYaw(state.flowRate);
+    apply_orientation(state.flowRate);
     
     // copy results to front end
     _update_frontend(state);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.cpp
@@ -177,7 +177,7 @@ void AP_OpticalFlow_UPFLOW::update(void)
         state.bodyRate = Vector2f{gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count};
 
         // we only apply yaw to flowRate as body rate comes from AHRS
-        _applyYaw(state.flowRate);
+        apply_orientation(state.flowRate);
     } else {
         // first frame received in some time so cannot calculate flow values
         state.flowRate.zero();


### PR DESCRIPTION
This adds support for upwards facing optical flow by making the following changes:

- DAL's rangefinder data is extended to store the sensor time of the reading.  This is required so the EKF's "ceiling" estimate only processes each rangefinder reading once.
- DAL's optical flow data is extended to store whether the sensor is upward facing or downward facing.  We don't need to store the full orientation because the optical flow library rotates the sensor data for us but the EKF later needs to know whether to combine this data with an upwards or downwards facing lidar.
- EKF2 slightly modified to ignore upward facing flow data
- EKF3 extended to consume upward facing lidar data and estimate a "ceiling offset".  This is the ceiling's offset from the EKF origin and is calculated in a similar way to how the terrainOffset is calculated.
- AP_AHRS's writeOptFlowMeas method gets a new argument saying whether the optical flow is facing upwards or downwards
- EKF3's FuseOptFlow is modified to use the ceiling offset (instead of terrain offset) with upward facing optical flow
- OpticalFlow replaces the _ORIENT_YAW with a more standard _ORIENT parameter.  This reduces the number of downward facing orientations to just 4 but also allows 4 upwards facing orientations.  Optical flow uses this to set the new writeOptFlowMeas() method's upwards argument

This PR is built on this NFC PR: https://github.com/ArduPilot/ardupilot/pull/19878 so many of the commits will disappear after the other PR is merged.