### PR TITLE
Plane: Update auto_state.highest_airspeed only if armed

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -9,7 +9,7 @@ float Plane::calc_speed_scaler(void)
 {
     float aspeed, speed_scaler;
     if (ahrs.airspeed_estimate(aspeed)) {
-        if (aspeed > auto_state.highest_airspeed) {
+        if (aspeed > auto_state.highest_airspeed && hal.util->get_soft_armed()) {
             auto_state.highest_airspeed = aspeed;
         }
         if (aspeed > 0.0001f) {


### PR DESCRIPTION
This fixes a potential issue during takeoff.

If the airspeed gets a high reading during setup/ preflight, e.g. gust of wind or testing the pitot tube, then takeoff rotation could occur early, before airspeed has reached TKOFF_ROTATE_SPD, with potentially serious results.

