### PR TITLE
Copter: 4.1.5-rc1 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.5-rc1 10-Feb-2022
+Changes from 4.1.4
+1) Bug fixes
+    a) attitude control I-term always reset when landed (previously only reset after spool down)
+    b) revert SBUS RC frame gap change from 4.1.4
+------------------------------------------------------------------
 Copter 4.1.4 08-Feb-2022 / 4.1.4-rc1 27-Jan-2022
 Changes from 4.1.3
 1) Benewake CAN Lidar support

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -464,16 +464,15 @@ void Mode::make_safe_ground_handling(bool force_throttle_unlimited)
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
     }
 
-
+    // aircraft is landed, integrator terms must be reset regardless of spool state
+    attitude_control->reset_rate_controller_I_terms_smoothly();
+ 
     switch (motors->get_spool_state()) {
-
     case AP_Motors::SpoolState::SHUT_DOWN:
     case AP_Motors::SpoolState::GROUND_IDLE:
-        // relax controllers during idle states
-        attitude_control->reset_rate_controller_I_terms_smoothly();
+        // reset yaw targets and rates during idle states
         attitude_control->reset_yaw_target_and_rate();
         break;
-
     case AP_Motors::SpoolState::SPOOLING_UP:
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
     case AP_Motors::SpoolState::SPOOLING_DOWN:

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.4"
+#define THISFIRMWARE "ArduCopter V4.1.5-rc1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,4,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_RC
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 4
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 5
+#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.1.5-rc1 beta release which includes just two changes which can be seen in the Copter-4.1.5-rc1 column of the [project page](https://github.com/ArduPilot/ardupilot/projects/19)

- https://github.com/ArduPilot/ardupilot/pull/20044
- https://github.com/ArduPilot/ardupilot/pull/19983

