### PR TITLE
Rover: 4.1.5-rc1 beta release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.5-rc1 10-Feb-2022
+Changes from 4.1.4
+1) Bug fixes
+    a) attitude control I-term always reset when landed (previously only reset after spool down)
+    b) revert SBUS RC frame gap change from 4.1.4
+------------------------------------------------------------------
 Copter 4.1.4 08-Feb-2022 / 4.1.4-rc1 27-Jan-2022
 Changes from 4.1.3
 1) Benewake CAN Lidar support

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -464,16 +464,15 @@ void Mode::make_safe_ground_handling(bool force_throttle_unlimited)
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
     }
 
-
+    // aircraft is landed, integrator terms must be reset regardless of spool state
+    attitude_control->reset_rate_controller_I_terms_smoothly();
+ 
     switch (motors->get_spool_state()) {
-
     case AP_Motors::SpoolState::SHUT_DOWN:
     case AP_Motors::SpoolState::GROUND_IDLE:
-        // relax controllers during idle states
-        attitude_control->reset_rate_controller_I_terms_smoothly();
+        // reset yaw targets and rates during idle states
         attitude_control->reset_yaw_target_and_rate();
         break;
-
     case AP_Motors::SpoolState::SPOOLING_UP:
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
     case AP_Motors::SpoolState::SPOOLING_DOWN:

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.4"
+#define THISFIRMWARE "ArduCopter V4.1.5-rc1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,4,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_RC
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 4
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 5
+#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,9 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.1.5-rc1 10-Feb-2022
+Changes from 4.1.4
+1) Revert SBUS RC frame gap change from 4.1.4
+------------------------------------------------------------------
 Rover 4.1.4 08-Feb-2022 / 4.1.4-rc1 31-Jan-2022
 Changes from 4.1.3
 1) Benewake CAN Lidar support

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.1.4"
+#define THISFIRMWARE "ArduRover V4.1.5-rc1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,4,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_RC
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 4
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 5
+#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
@@ -170,7 +170,7 @@ void AP_RCProtocol_SBUS::process_pulse(uint32_t width_s0, uint32_t width_s1)
 // support byte input
 void AP_RCProtocol_SBUS::_process_byte(uint32_t timestamp_us, uint8_t b)
 {
-    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 4000U);
+    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
     byte_input.last_byte_us = timestamp_us;
 
     if (have_frame_gap) {


### PR DESCRIPTION
This is the Rover-4.1.5-rc1 beta release which is "double rebased" on the [Copter-4.1.5-rc1 release ](https://github.com/ArduPilot/ardupilot/pull/20045) and includes just one change relevant to rovers:

- https://github.com/ArduPilot/ardupilot/pull/20044
