### PR TITLE
AP_Common: Fix AP_FWVersion after structure change

### DIFF
--- a/Tools/scripts/firmware_version_decoder.py
+++ b/Tools/scripts/firmware_version_decoder.py
@@ -94,6 +94,7 @@ class FWVersion:
     os_software_version: int = 0
     firmware_string: str = ""
     firmware_hash_string: str = ""
+    firmware_hash: int = 0
     middleware_name: str = ""
     middleware_hash_string: str = ""
     os_name: str = ""
@@ -120,6 +121,7 @@ class FWVersion:
         board: {BoardType(self.board_type).name}
         board subtype: {BoardSubType(self.board_subtype).name}
         hash: {self.firmware_hash_string}
+        hash integer: 0x{self.firmware_hash:02x}
         version: {self.major}.{self.minor}.{self.patch}
         type: {FirmwareVersionType(self.firmware_type).name}
     os:
@@ -177,6 +179,8 @@ class Decoder:
         )
 
         self.fwversion.header_version = self.unpack("H")
+        major_version = self.fwversion.header_version >> 8
+
         self.pointer_size = self.unpack("B")
         self.fwversion.pointer_size = self.pointer_size
         self.unpack("B")  # reserved
@@ -192,6 +196,9 @@ class Decoder:
 
         self.fwversion.firmware_string = self.unpack_string_from_pointer()
         self.fwversion.firmware_hash_string = self.unpack_string_from_pointer()
+        if major_version >= 2:
+            self.fwversion.firmware_hash = self.unpack("I")
+
         self.fwversion.middleware_name = self.unpack_string_from_pointer()
         self.fwversion.middleware_hash_string = self.unpack_string_from_pointer()
         self.fwversion.os_name = self.unpack_string_from_pointer()

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -42,7 +42,7 @@
 const AP_FWVersion AP_FWVersion::fwver{
     // Version header struct
     .header = 0x61706677766572fb, // First 7 MSBs: "apfwver", LSB is the checksum of the previous string: 0xfb
-    .header_version = 0x0100U, // Major and minor version
+    .header_version = 0x0200U, // Major and minor version
     .pointer_size = static_cast<uint8_t>(sizeof(void*)),
     .reserved = 0,
     .vehicle_type = static_cast<uint8_t>(APM_BUILD_DIRECTORY),

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -34,6 +34,11 @@
 #define ORIGINAL_FWSTR nullptr
 #endif
 
+/**
+ * The version number should be used when the structure is updated
+ * Major: For breaking changes of the structure
+ * Minor: For new fields that does not brake the structure or corrections
+ */
 const AP_FWVersion AP_FWVersion::fwver{
     // Version header struct
     .header = 0x61706677766572fb, // First 7 MSBs: "apfwver", LSB is the checksum of the previous string: 0xfb

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -63,7 +63,7 @@ const AP_FWVersion AP_FWVersion::fwver{
 #ifndef GIT_VERSION_INT
     .fw_hash = 0,
 #else
-   .fw_hash = GIT_VERSION_INT,
+    .fw_hash = GIT_VERSION_INT,
 #endif
     .fw_string_original = ORIGINAL_FWSTR,
     .fw_short_string = ACTIVE_FWSTR,

--- a/libraries/AP_Common/tests/test_fwversion.cpp
+++ b/libraries/AP_Common/tests/test_fwversion.cpp
@@ -12,7 +12,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 TEST(AP_FWVersion, FWVersion)
 {
     EXPECT_EQ(AP::fwversion().header, 0x61706677766572fbu);
-    EXPECT_EQ(AP::fwversion().header_version, 0x0100U);
+    EXPECT_EQ(AP::fwversion().header_version, 0x0200U);
     EXPECT_EQ(AP::fwversion().pointer_size, static_cast<uint8_t>(sizeof(void*)));
     EXPECT_EQ(AP::fwversion().reserved, 0);
     EXPECT_EQ(AP::fwversion().vehicle_type, static_cast<uint8_t>(APM_BUILD_DIRECTORY));
@@ -26,6 +26,7 @@ TEST(AP_FWVersion, FWVersion)
     EXPECT_STREQ(AP::fwversion().fw_string, THISFIRMWARE);
     EXPECT_STREQ(AP::fwversion().fw_hash_str, "");
     EXPECT_STREQ(AP::fwversion().fw_short_string, THISFIRMWARE);
+    EXPECT_EQ(AP::fwversion().fw_hash, 0u);
     EXPECT_EQ(AP::fwversion().middleware_name, nullptr);
     EXPECT_EQ(AP::fwversion().middleware_hash_str, nullptr);
     EXPECT_EQ(AP::fwversion().os_name, nullptr);


### PR DESCRIPTION
The change happened on 8814486572e9ad2f1611711f14604a0f9bca2b90, that breaks the ABI of the interface. 

output:
```
FWVersion:                                                                                                                                                                                                                                                                       
    header:                                                                                                                                                                                                                                                                      
        magic: apfwver                                                                                                                                                                                                                                                           
        checksum: 0xfb                                                                                                                                                                                                                                                           
        version: 2.0                                                                                                                                                                                                                                                             
        pointer_size: 4                                                                                                                                                                                                                                                          
    firmware:                                                                                                                                                                                                                                                                    
        string: ArduSub V4.2.0dev (16c5e640)                                                                                                                                                                                                                                     
        vehicle: ArduSub                                                                                                                                                                                                                                                         
        board: LINUX                                                                                                                                                                                                                                                             
        board subtype: LINUX_NAVIGATOR                                                                                                                                                                                                                                           
        hash: 16c5e640                                                                                                                                                                                                                                                           
        hash integer: 0x16c5e640                                                                                                                                                                                                                                                 
        version: 4.2.0                                                                                                                                                                                                                                                           
        type: Dev                                                                                                                                                                                                                                                                
    os:                                                                                                                                                                                                                                                                          
        name:                                                                                                                                                                                                                                                                    
        hash:                                                                                                                                                                                                                                                                    
        software_version: 0/0/0                                                                                                                                                                                                                                                  
    middleware:                                                                                                                                                                                                                                                                  
        name:                                                                                                                                                                                                                                                                    
        hash: ArduSub V4.2.0dev                                                                                                                                                                                                                                                  
```