### PR TITLE
Validate built Navigator firmware using firmware_version_decoder.py

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -298,6 +298,7 @@ for t in $CI_BUILD_TARGET; do
         echo "Building navigator"
         $waf configure --board navigator --toolchain=arm-linux-musleabihf
         $waf sub --static
+        ./Tools/scripts/firmware_version_decoder.py -f build/navigator/bin/ardusub --expected-hash $GIT_VERSION
         continue
     fi
 

--- a/Tools/scripts/firmware_version_decoder.py
+++ b/Tools/scripts/firmware_version_decoder.py
@@ -197,7 +197,7 @@ class Decoder:
         self.fwversion.os_name = self.unpack_string_from_pointer()
         self.fwversion.os_hash_string = self.unpack_string_from_pointer()
 
-    def process(self, filename) -> None:
+    def process(self, filename) -> FWVersion:
         # We need the file open for ELFFile
         file = open(filename, "rb")
         data = file.read()
@@ -219,7 +219,7 @@ class Decoder:
 
         # Unpack struct and print it
         self.unpack_fwversion()
-        print(self.fwversion)
+        return self.fwversion
 
 
 if __name__ == "__main__":
@@ -235,7 +235,21 @@ if __name__ == "__main__":
         required=True,
         help="File that contains a valid ardupilot firmware in ELF format.",
     )
+    parser.add_argument(
+        "--expected-hash",
+        dest="expected_hash",
+        help="Expected git hash. The script fails if this doesn't match the git hash in the binary file. Used in CI",
+    )
     args = parser.parse_args()
 
     decoder = Decoder()
-    decoder.process(args.file)
+    try:
+        firmware_data = decoder.process(args.file)
+    except Exception as e:
+        print(f"Error decoding FWVersion: {type(e)}")
+        exit(-1)
+
+    print(firmware_data)
+    if args.expected_hash and args.expected_hash != firmware_data.firmware_hash_string:
+        print(f"Git hashes don't match! expected: {args.expected_hash}, got {firmware_data.firmware_hash_string}")
+        exit(-1)


### PR DESCRIPTION
depends on:
 - [x] #20047
 - [x] https://github.com/ArduPilot/ardupilot_dev_docker/pull/11