### PR TITLE
@SYS/timers.txt support and prescaler tweaks

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -36,6 +36,7 @@ static const SysFileList sysfs_file_list[] = {
     {"dma.txt"},
     {"memory.txt"},
     {"uarts.txt"},
+    {"timers.txt"},
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     {"can_log.txt"},
 #endif
@@ -110,6 +111,9 @@ int AP_Filesystem_Sys::open(const char *fname, int flags)
         hal.util->uart_info(*r.str);
     }
 #endif
+    if (strcmp(fname, "timers.txt") == 0) {
+        hal.util->timer_info(*r.str);
+    }
 #if HAL_CANMANAGER_ENABLED
     if (strcmp(fname, "can_log.txt") == 0) {
         AP::can().log_retrieve(*r.str);

--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -68,3 +68,35 @@ bool AP_HAL::RCOutput::is_dshot_protocol(const enum output_mode mode)
         return false;
     }
 }
+
+/*
+ * calculate the prescaler required to achieve the desire bitrate
+ */
+uint32_t AP_HAL::RCOutput::calculate_bitrate_prescaler(uint32_t timer_clock, uint32_t target_frequency, bool is_dshot)
+{
+    uint32_t prescaler;
+    if (is_dshot) {
+        // original prescaler calculation from betaflight. bi-dir dshot is incredibly sensitive to the bitrate
+        prescaler = uint32_t(lrintf((float) timer_clock / target_frequency + 0.01f) - 1);
+    } else {
+        // adjust frequency to give an allowed value given the clock, erring on the high side
+        prescaler = timer_clock / target_frequency;
+        while ((timer_clock / prescaler) < target_frequency && prescaler > 1) {
+            prescaler--;
+        }
+    }
+
+    // find the closest value
+    const uint32_t freq = timer_clock / prescaler;
+    const float delta = fabsf(float(freq) - target_frequency);
+    if (freq > target_frequency
+        && delta > fabsf(float(timer_clock / (prescaler+1)) - target_frequency)) {
+        prescaler++;
+    } else if (freq < target_frequency
+        && delta > fabsf(float(timer_clock / (prescaler-1)) - target_frequency)) {
+        prescaler--;
+    }
+
+    return prescaler;
+}
+

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -31,6 +31,8 @@
 
 class ByteBuffer;
 
+class ExpandingString;
+
 class AP_HAL::RCOutput {
 public:
     virtual void init() = 0;
@@ -309,6 +311,13 @@ public:
       trigger send of serial led
      */
     virtual void serial_led_send(const uint16_t chan) {}
+
+    virtual void timer_info(ExpandingString &str) {}
+
+    /*
+     * calculate the prescaler required to achieve the desire bitrate
+     */
+    static uint32_t calculate_bitrate_prescaler(uint32_t timer_clock, uint32_t target_frequency, bool is_dshot);
 
 protected:
 

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -184,6 +184,8 @@ public:
     // request information on uart I/O
     virtual void uart_info(ExpandingString &str) {}
 #endif
+    // request information on timer frequencies
+    virtual void timer_info(ExpandingString &str) {}
 
     // generate Random values
     virtual bool get_random_vals(uint8_t* data, size_t size) { return false; }

--- a/libraries/AP_HAL/tests/test_prescaler.cpp
+++ b/libraries/AP_HAL/tests/test_prescaler.cpp
@@ -1,0 +1,57 @@
+#include <AP_gtest.h>
+#include <AP_HAL/HAL.h>
+#include <AP_HAL/RCOutput.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class PrescalerParameterizedTestFixture :public ::testing::TestWithParam<uint32_t> {
+protected:
+    void test_prescaler(uint32_t clock, uint32_t target_rate, bool is_dshot)
+    {
+        const uint32_t prescaler = AP_HAL::RCOutput::calculate_bitrate_prescaler(clock, target_rate, is_dshot);
+        // we would like at most a 1% discrepancy in target versus actual
+        const float rate_delta = fabsf(float(clock / prescaler) - target_rate) / target_rate;
+        EXPECT_TRUE(rate_delta < 0.13f);
+    }
+};
+
+TEST_P(PrescalerParameterizedTestFixture, DShot150) {
+    test_prescaler(GetParam(), 150000 * 20, true);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, DShot300) {
+    test_prescaler(GetParam(), 300000 * 20, true);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, DShot600) {
+    test_prescaler(GetParam(), 600000 * 20, true);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, DShot1200) {
+    test_prescaler(GetParam(), 1200000 * 20, true);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, Passthrough) {
+    test_prescaler(GetParam(), 19200 * 10, false);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, NeoPixel) {
+    test_prescaler(GetParam(), 800000 * 20, false);
+}
+
+TEST_P(PrescalerParameterizedTestFixture, ProfiLED) {
+    test_prescaler(GetParam(), 1500000 * 20, false);
+}
+
+INSTANTIATE_TEST_CASE_P(
+        prescaler_Test,
+        PrescalerParameterizedTestFixture,
+        ::testing::Values(
+                200000000,  // H743
+                216000000,  // F745
+                108000000,  // F745
+                 84000000,  // F405
+                168000000   // F405
+        ));
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -248,6 +248,11 @@ public:
      */
     void rcout_thread();
 
+    /*
+     timer information
+     */
+    void timer_info(ExpandingString &str) override;
+
 private:
     enum class DshotState {
       IDLE = 0,
@@ -282,6 +287,7 @@ private:
         uint8_t chan[4]; // chan number, zero based, 255 for disabled
         PWMConfig pwm_cfg;
         PWMDriver* pwm_drv;
+        uint8_t timer_id;
         bool have_up_dma; // can we do DMAR outputs for DShot?
         uint8_t dma_up_stream_id;
         uint8_t dma_up_channel;
@@ -294,7 +300,6 @@ private:
 #endif
         uint8_t alt_functions[4];
         ioline_t pal_lines[4];
-
         // below this line is not initialised by hwdef.h
         enum output_mode current_mode;
         uint16_t frequency_hz;
@@ -597,7 +602,7 @@ private:
     void dma_cancel(pwm_group& group);
     bool mode_requires_dma(enum output_mode mode) const;
     bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high,
-                         const uint16_t buffer_length, bool choose_high, uint32_t pulse_time_us,
+                         const uint16_t buffer_length, uint32_t pulse_time_us,
                          bool is_dshot);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);
     void set_group_mode(pwm_group &group);

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -606,6 +606,14 @@ void Util::uart_info(ExpandingString &str)
 }
 #endif
 
+// request information on uart I/O
+#if HAL_USE_PWM == TRUE
+void Util::timer_info(ExpandingString &str)
+{
+    hal.rcout->timer_info(str);
+}
+#endif
+
 /**
  * This method will generate random values with set size. It will fall back to AP_Math's get_random16()
  * if True RNG fails or enough entropy is not present.

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -91,7 +91,9 @@ public:
     // request information on uart I/O
     virtual void uart_info(ExpandingString &str) override;
 #endif
-
+#if HAL_USE_PWM == TRUE
+    void timer_info(ExpandingString &str) override;
+#endif
     // returns random values
     bool get_random_vals(uint8_t* data, size_t size) override;
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1986,7 +1986,7 @@ def write_PWM_config(f, ordered_timers):
            {%s, NULL}, \\
            {%s, NULL}, \\
            {%s, NULL}  \\
-          }, 0, 0}, &PWMD%u, \\
+          }, 0, 0}, &PWMD%u, %u, \\
           HAL_PWM%u_DMA_CONFIG, \\%s
           { %u, %u, %u, %u }, \\
           { %s, %s, %s, %s }}\n''' %
@@ -1994,7 +1994,7 @@ def write_PWM_config(f, ordered_timers):
                  chan_list[0], chan_list[1], chan_list[2], chan_list[3],
                  pwm_clock, period,
                  chan_mode[0], chan_mode[1], chan_mode[2], chan_mode[3],
-                 n, n, hal_icu_cfg,
+                 n, n, n, hal_icu_cfg,
                  alt_functions[0], alt_functions[1], alt_functions[2], alt_functions[3],
                  pal_lines[0], pal_lines[1], pal_lines[2], pal_lines[3]))
     f.write('#define HAL_PWM_GROUPS %s\n\n' % ','.join(groups))

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1416,6 +1416,7 @@ void AP_Logger::prepare_at_arming_sys_file_logging()
         "@SYS/dma.txt",
         "@SYS/memory.txt",
         "@SYS/threads.txt",
+        "@SYS/timers.txt",
         "@ROMFS/hwdef.dat",
         "@SYS/storage.bin",
         "@SYS/crash_dump.bin",


### PR DESCRIPTION
- Add support for timer information via @SYS/timers.txt
- Change hwdef generation to include timer number in pwm_groups
- Add unit tests for PWM prescaler calculation
- Change PWM prescaler calculation to look for the closest possible frequency match rather than the highest, this appears to yield more accurate dshot rates.
- Tested all dshot rates + bi-dir. Tridge tested LEDs