### PR TITLE
Tools: disable Plane Landing-Drift test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3746,4 +3746,5 @@ function'''
     def disabled_tests(self):
         return {
             "Terrain-loiter": "Loading of terrain data is not reliable",
+            "Landing-Drift": "Flapping test. See https://github.com/ArduPilot/ardupilot/issues/20054",
         }


### PR DESCRIPTION
This test appears to be flapping so let's disable it for now.

I've raised an issue here so we hopefully won't forget to fix it as well. https://github.com/ArduPilot/ardupilot/issues/20054