### PR TITLE
BattMonitor: BATTx_CURR_MULT fix documentation & param index

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -47,6 +47,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: _
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_var_info[0]),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
@@ -60,6 +62,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 2_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_var_info[1]),
 #endif
 
@@ -74,6 +78,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 3_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_var_info[2]),
 #endif
 
@@ -88,6 +94,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 4_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_var_info[3]),
 #endif
 
@@ -102,6 +110,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 5_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_var_info[4]),
 #endif
 
@@ -116,6 +126,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 6_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_var_info[5]),
 #endif
 
@@ -130,6 +142,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 7_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_var_info[6]),
 #endif
 
@@ -144,6 +158,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 8_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_var_info[7]),
 #endif
 
@@ -158,6 +174,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_SMBus.cpp
     // @Group: 9_
     // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_UAVCAN.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -28,7 +28,10 @@ const AP_Param::GroupInfo AP_BattMonitor_UAVCAN::var_info[] = {
     // @Description: Multiplier applied to all current related reports to allow for adjustment if no UAVCAN param access or current splitting applications
     // @Range: .1 10
     // @User: Advanced
-    AP_GROUPINFO("CURR_MULT", 27, AP_BattMonitor_UAVCAN, _curr_mult, 1.0),
+    AP_GROUPINFO("CURR_MULT", 30, AP_BattMonitor_UAVCAN, _curr_mult, 1.0),
+
+    // Param indexes must be between 30 and 39 to avoid conflict with other battery monitor param tables loaded by pointer
+
     AP_GROUPEND
 };
 


### PR DESCRIPTION
BATTx_CURR_MULT isn't on the wiki because we forgot to add these bits to tell the generator to go look for them.

This also moves the param index from 27 to 30 to fit the pattern we used with the other varptr monitors. Since this has only been in master 17 days I think this should be fine. Since it clearly isn't worth conversion so either change like this or leave it be)