### PR TITLE
Copter/Plane:  Judge by return value

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -149,8 +149,7 @@ void Copter::thrust_loss_check()
     }
 
     // check for angle error over 30 degrees to ensure the aircraft has attitude control
-    const float angle_error = attitude_control->get_att_error_angle_deg();
-    if (angle_error >= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
+    if (attitude_control->get_att_error_angle_deg() >= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
         thrust_loss_counter = 0;
         return;
     }
@@ -294,8 +293,7 @@ void Copter::parachute_check()
     parachute.check_sink_rate();
 
     // check for angle error over 30 degrees
-    const float angle_error = attitude_control->get_att_error_angle_deg();
-    if (angle_error <= PARACHUTE_CHECK_ANGLE_DEVIATION_DEG) {
+    if (attitude_control->get_att_error_angle_deg() <= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
         if (control_loss_count > 0) {
             control_loss_count--;
         }

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -187,8 +187,7 @@ void Copter::update_throttle_mix()
         bool large_angle_request = angle_target.xy().length() > LAND_CHECK_LARGE_ANGLE_CD;
 
         // check for large external disturbance - angle error over 30 degrees
-        const float angle_error = attitude_control->get_att_error_angle_deg();
-        bool large_angle_error = (angle_error > LAND_CHECK_ANGLE_ERROR_DEG);
+        bool large_angle_error = (attitude_control->get_att_error_angle_deg() > LAND_CHECK_ANGLE_ERROR_DEG);
 
         // check for large acceleration - falling or high turbulence
         const bool accel_moving = (land_accel_ef_filter.get().length() > LAND_CHECK_ACCEL_MOVING);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3525,8 +3525,7 @@ void QuadPlane::update_throttle_mix(void)
         bool large_angle_request = angle_target.xy().length() > LAND_CHECK_LARGE_ANGLE_CD;
 
         // check for large external disturbance - angle error over 30 degrees
-        const float angle_error = attitude_control->get_att_error_angle_deg();
-        bool large_angle_error = (angle_error > LAND_CHECK_ANGLE_ERROR_DEG);
+        bool large_angle_error = (attitude_control->get_att_error_angle_deg() > LAND_CHECK_ANGLE_ERROR_DEG);
 
         // check for large acceleration - falling or high turbulence
         bool accel_moving = (throttle_mix_accel_ef_filter.get().length() > LAND_CHECK_ACCEL_MOVING);


### PR DESCRIPTION
The angle_error variable is used only once.
I make the decision in the return value of the method, which eliminates the need for this variable.