### PR TITLE
AP_AHRS: View: get_gyro_latest should include pitch trim.

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -84,9 +84,7 @@ void AP_AHRS_View::update()
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
 Vector3f AP_AHRS_View::get_gyro_latest(void) const {
-    Vector3f gyro_latest = ahrs.get_gyro_latest();
-    gyro_latest.rotate(rotation);
-    return gyro_latest;
+    return rot_view * ahrs.get_gyro_latest();
 }
 
 // rotate a 2D vector from earth frame to body frame


### PR DESCRIPTION
A long standing bug that means pitch trim is not applied to the latest gyro reading. This causes odd cross coupling effects if `Q_TRIM_PITCH` is none 0. Latest gyro should use the same rotation as smoothed uses here:

https://github.com/ArduPilot/ardupilot/blob/5bb7b04343eac451b00c5cba38af985fec4cfc90/libraries/AP_AHRS/AP_AHRS_View.cpp#L68

Flight tested on a Blackfly style tail sitter with 45 deg (ish) pitch trim. (IRL not SITL).

Spotted because the logged gyro in the `RATE` message was not the same as that in the `PIQ` messages, one was using "old" and the other latest. With this patch they match. 
