### PR TITLE
Rover: remove un-needed initialisations

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -150,9 +150,6 @@ constexpr int8_t Rover::_failsafe_priorities[7];
 Rover::Rover(void) :
     AP_Vehicle(),
     param_loader(var_info),
-    channel_steer(nullptr),
-    channel_throttle(nullptr),
-    channel_lateral(nullptr),
     logger{g.log_bitmask},
     modes(&g.mode1),
     control_mode(&mode_initializing)


### PR DESCRIPTION
These are zero anyway
