### PR TITLE
Copter: Change altitude hold to selection mode

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -42,6 +42,7 @@
 //#define MODE_ZIGZAG_ENABLED   DISABLED            // disable zigzag mode support
 //#define OSD_ENABLED           DISABLED            // disable on-screen-display support
 //#define LANDING_GEAR_ENABLED  DISABLED            // disable landing gear support
+//#define MODE_ALTHOLD_ENABLED  DISABLED            // disable alt hold mode support
 
 // features below are disabled by default on all boards
 //#define CAL_ALWAYS_REBOOT                         // flight controller will reboot after compass or accelerometer calibration completes

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -917,7 +917,9 @@ private:
     ModeAcro mode_acro;
 #endif
 #endif
+#if MODE_ALTHOLD_ENABLED == ENABLED
     ModeAltHold mode_althold;
+#endif
 #if MODE_AUTO_ENABLED == ENABLED
     ModeAuto mode_auto;
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -222,6 +222,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// Alt hold - fly vehicle in Altitude hold mode
+#ifndef MODE_ALTHOLD_ENABLED
+# define MODE_ALTHOLD_ENABLED ENABLED
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Auto mode - allows vehicle to trace waypoints and perform automated actions
 #ifndef MODE_AUTO_ENABLED
 # define MODE_AUTO_ENABLED ENABLED

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -41,9 +41,11 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             ret = &mode_stabilize;
             break;
 
+#if MODE_ALTHOLD_ENABLED == ENABLED
         case Mode::Number::ALT_HOLD:
             ret = &mode_althold;
             break;
+#endif
 
 #if MODE_AUTO_ENABLED == ENABLED
         case Mode::Number::AUTO:

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -1,5 +1,6 @@
 #include "Copter.h"
 
+#if MODE_ALTHOLD_ENABLED == ENABLED
 
 /*
  * Init and run calls for althold, flight mode
@@ -101,3 +102,5 @@ void ModeAltHold::run()
     // run the vertical position controller and set output throttle
     pos_control->update_z_controller();
 }
+
+#endif


### PR DESCRIPTION
I would change the altitude hold mode to an optional mode.
Automatic flight requires position control, altitude control, and attitude control.
I don't think altitude hold mode is essential.