### PR TITLE
AP_AHRS: Logging: VSTB use latest gyro

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -102,13 +102,14 @@ void AP_AHRS::write_video_stabilisation() const
 {
     Quaternion current_attitude;
     get_quat_body_to_ned(current_attitude);
-    Vector3f accel = get_accel() - get_accel_bias();
+    const Vector3f accel = get_accel() - get_accel_bias();
+    const Vector3f gyro_latest = get_gyro_latest();
     const struct log_Video_Stabilisation pkt {
         LOG_PACKET_HEADER_INIT(LOG_VIDEO_STABILISATION_MSG),
         time_us         : AP_HAL::micros64(),
-        gyro_x          : _gyro_estimate.x,
-        gyro_y          : _gyro_estimate.y,
-        gyro_z          : _gyro_estimate.z,
+        gyro_x          : gyro_latest.x,
+        gyro_y          : gyro_latest.y,
+        gyro_z          : gyro_latest.z,
         accel_x         : accel.x,
         accel_y         : accel.y,
         accel_z         : accel.z,


### PR DESCRIPTION
This gives better alignment between the timestamp, the accel and the gyo.

Note that the `RATE` message does not use the gyro reading that lines up with the targets, as the PID loops use gyro latest and `RATE` just uses gyro. Not a easy fix as using gyro latest at the time of logging will also not be the same as the value used when the PIDs were run. We could switch to using PID info for the rate message...