### PR TITLE
Plane: quadplane: combine `is_flying_vtol()` and `is_flying()` , smoothly relax I if not flying. 

### DIFF
--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -52,7 +52,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Plane::handle_avoidance(const AP_Avoidance::Ob
         case MAV_COLLISION_ACTION_HOVER:
             if (failsafe_state_change) {
 #if HAL_QUADPLANE_ENABLED
-                if (plane.quadplane.is_flying()) {
+                if (plane.quadplane.in_vtol_mode()) {
                     plane.set_mode(plane.mode_qloiter, ModeReason::AVOIDANCE);
                     break;
                 }

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -35,7 +35,7 @@ void Plane::update_is_flying_5Hz(void)
     }
 
 #if HAL_QUADPLANE_ENABLED
-    is_flying_bool = quadplane.is_flying();
+    is_flying_bool = quadplane.is_flying_vtol();
 #endif
     if (is_flying_bool) {
         // no need to look further

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1686,6 +1686,12 @@ void QuadPlane::update(void)
         }
         // todo: do you want to set the throttle at this point?
         pos_control->relax_z_controller(0);
+
+    } else if (!plane.is_flying()) {
+        // probbibly on the ground, relax rate I terms
+        // not a full relax, rate controllers will still work if is_flying is wrong
+        // smmoth reset will not cause any step change in output
+        attitude_control->reset_rate_controller_I_terms_smoothly();
     }
 
     const uint32_t now = AP_HAL::millis();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1043,24 +1043,6 @@ float QuadPlane::get_pilot_land_throttle(void) const
     return constrain_float(throttle_in, 0, 1);
 }
 
-// helper for is_flying()
-bool QuadPlane::is_flying(void)
-{
-    if (!available()) {
-        return false;
-    }
-    if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
-        return true;
-    }
-    if (motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
-        return true;
-    }
-    if (tailsitter.in_vtol_transition()) {
-        return true;
-    }
-    return false;
-}
-
 // crude landing detector to prevent tipover
 bool QuadPlane::should_relax(void)
 {
@@ -1092,8 +1074,11 @@ bool QuadPlane::is_flying_vtol(void) const
         // assume that with no motor outputs we're not flying in VTOL mode
         return false;
     }
-    if (motors->get_throttle() > 0.01f) {
-        // if we are demanding more than 1% throttle then don't consider aircraft landed
+    if (motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
+        // if we are demanding more than 1% throttle or not on the lower throttle limit then don't consider aircraft landed
+        return true;
+    }
+    if (tailsitter.in_vtol_transition()) {
         return true;
     }
     if (plane.control_mode->is_vtol_man_throttle() && air_mode_active()) {
@@ -3374,7 +3359,7 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
         gcs().send_text(MAV_SEVERITY_INFO, "Must be armed for takeoff");
         return false;
     }
-    if (is_flying()) {
+    if (is_flying_vtol()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Already flying - no takeoff");
         return false;
     }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -112,9 +112,6 @@ public:
     void update_throttle_hover();
     bool show_vtol_view() const;
 
-    // vtol help for is_flying()
-    bool is_flying(void);
-
     // return desired forward throttle percentage
     float forward_throttle_pct();
     float get_weathervane_yaw_rate_cds(void);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -141,7 +141,7 @@ bool Plane::suppress_throttle(void)
     }
 
 #if HAL_QUADPLANE_ENABLED
-    if (quadplane.is_flying()) {
+    if (quadplane.is_flying_vtol()) {
         throttle_suppressed = false;
         return false;
     }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -294,7 +294,7 @@ void Tailsitter::output(void)
     // handle forward flight modes and transition to VTOL modes
     if (!active() || in_vtol_transition()) {
         // get FW controller throttle demand and mask of motors enabled during forward flight
-        if (hal.util->get_soft_armed() && in_vtol_transition() && !quadplane.throttle_wait && quadplane.is_flying()) {
+        if (hal.util->get_soft_armed() && in_vtol_transition() && !quadplane.throttle_wait) {
             /*
               during transitions to vtol mode set the throttle to hover thrust, center the rudder
             */


### PR DESCRIPTION
Currently have both `is_flying_vtol()` and `is_flying()` they are very close to the same. This combines the methods, this makes is the is flying probability follow `is_flying_vtol()` rather than `is_flying()`, we then use that via `plane.is_flying()` to relax rate I terms. 