### PR TITLE
Plane: use correct "down" rangefinder on tailsitters

### DIFF
--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -133,13 +133,14 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
 #endif
 
     const RangeFinder *rangefinder = RangeFinder::get_singleton();
-    if (rangefinder && rangefinder->has_orientation(ROTATION_PITCH_270)) {
+    const Rotation rot_down = plane.rangefinder_down_orientation();
+    if (rangefinder && rangefinder->has_orientation(rot_down)) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         if (plane.g.rangefinder_landing) {
             control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
-        if (rangefinder->has_data_orient(ROTATION_PITCH_270)) {
-            control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;            
+        if (rangefinder->has_data_orient(rot_down)) {
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
 }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -851,6 +851,8 @@ private:
     float mission_alt_offset(void);
     float height_above_target(void);
     float lookahead_adjustment(void);
+    Rotation rangefinder_down_orientation() const;
+    float rangefinder_attitude_correction_factor(void) const;
     float rangefinder_correction(void);
     void rangefinder_height_update(void);
     void rangefinder_terrain_correction(float &height);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3256,7 +3256,7 @@ float QuadPlane::forward_throttle_pct()
         // approach the landing point when landing below the takeoff point
         vel_forward.last_pct = vel_forward.integrator;
     } else if ((in_vtol_land_final() && motors->limit.throttle_lower) ||
-              (plane.g.rangefinder_landing && (plane.rangefinder.status_orient(ROTATION_PITCH_270) == RangeFinder::Status::OutOfRangeLow))) {
+              (plane.g.rangefinder_landing && (plane.rangefinder.status_orient(plane.rangefinder_down_orientation()) == RangeFinder::Status::OutOfRangeLow))) {
         // we're in the settling phase of landing or using a rangefinder that is out of range low, disable fwd motor
         vel_forward.last_pct = 0;
         vel_forward.integrator = 0;

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -100,3 +100,12 @@ Vector2f AP_AHRS_View::body_to_earth2D(const Vector2f &bf) const
     return Vector2f(bf.x * trig.cos_yaw - bf.y * trig.sin_yaw,
                     bf.x * trig.sin_yaw + bf.y * trig.cos_yaw);
 }
+
+// get current rotation
+enum Rotation AP_AHRS_View::get_rotation(void) const {
+    if (is_zero(_pitch_trim_deg)) {
+        return rotation;
+    }
+    // return invalid rotation
+    return ROTATION_MAX;
+}

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -187,9 +187,7 @@ public:
 
 
     // get current rotation
-    enum Rotation get_rotation(void) const {
-        return rotation;
-    }
+    enum Rotation get_rotation(void) const;
 
 private:
     const enum Rotation rotation;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -189,6 +189,9 @@ public:
     // get current rotation
     enum Rotation get_rotation(void) const;
 
+    // pitch relative to normal AHRS
+    float get_relative_pitch_deg() const { return y_angle + _pitch_trim_deg; }
+
 private:
     const enum Rotation rotation;
     AP_AHRS &ahrs;


### PR DESCRIPTION
On a tailsitter in VTOL flight `ROTATION_PITCH_270` rangefinder is not down. This changes to use `ROTATION_YAW_180` in that case. It also takes into account `Q_TRIM_PITCH` if set. 

This does mean that were swapping the source for the rangefinder distance calculation depending on mode.  

In the longer term it would be nice to abstract the height above ground stuff to a library, copter has two instances (up and down), plane should probably also have two (FW and VTOL). There is also no reason we should only use one rangfinder, we should use the one that is closest to pointing down at the time, for example a plane in a 70 deg bank would get a better estimate from a `YAW_90`/`YAW_270` rangefinder than the normal `ROTATION_PITCH_270`. We could also use proximity sensors as a source of readings. 