### PR TITLE
Plane: quadplane: never reset yaw target rates when entering QPOS1

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2151,7 +2151,9 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
         // handle resets needed for when the state changes
         if (s == QPOS_POSITION1) {
             reached_wp_speed = false;
-            qp.attitude_control->reset_yaw_target_and_rate();
+            // never do a rate reset, if attitude control is not active it will be automaticaly reset before running, see: last_att_control_ms
+            // if it is active then the rate control should not be reset at all
+            qp.attitude_control->reset_yaw_target_and_rate(false);
             pos1_start_speed = plane.ahrs.groundspeed_vector().length();
         } else if (s == QPOS_POSITION2) {
             // POSITION2 changes target speed, so we need to change it


### PR DESCRIPTION
Should fix https://github.com/ArduPilot/ardupilot/issues/18782

We should never reset the rate controller. If its not being run then it will be again reset again anyway here:

https://github.com/ArduPilot/ardupilot/blob/87a369727a43d2d907c32b993619e7cf42662f25/ArduPlane/quadplane.cpp#L1912-L1916

If were running it already then this rate reset will give a step change in desired rate.

I think in the first case the rate reset is pointless and in the second case it is bad.

I have not tested extensively. 
