### PR TITLE
Rover: remove unnecessary constraint on steering sent to motors library

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -1055,7 +1055,7 @@ uint8_t GCS_MAVLINK_Rover::high_latency_tgt_heading() const
         // need to convert -180->180 to 0->360/2
         return wrap_360(control_mode->wp_bearing()) / 2;
     }
-    return 0;      
+    return 0;
 }
     
 uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist() const
@@ -1065,7 +1065,7 @@ uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist() const
         // return units are dm
         return MIN((control_mode->get_distance_to_destination()) / 10, UINT16_MAX);
     }
-    return 0;  
+    return 0;
 }
 
 uint8_t GCS_MAVLINK_Rover::high_latency_tgt_airspeed() const
@@ -1084,7 +1084,7 @@ uint8_t GCS_MAVLINK_Rover::high_latency_wind_speed() const
         // return units are m/s*5
         return MIN(rover.g2.windvane.get_true_wind_speed() * 5, UINT8_MAX);
     }
-    return 0; 
+    return 0;
 }
 
 uint8_t GCS_MAVLINK_Rover::high_latency_wind_direction() const
@@ -1093,6 +1093,6 @@ uint8_t GCS_MAVLINK_Rover::high_latency_wind_direction() const
         // return units are deg/2
         return wrap_360(degrees(rover.g2.windvane.get_true_wind_direction_rad())) / 2;
     }
-    return 0; 
+    return 0;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -227,7 +227,7 @@ bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &
         return true;
     case AP_Vehicle::ControlOutput::Walking_Height:
         control_value = constrain_float(g2.motors.get_walking_height(), -1.0f, 1.0f);
-        return true;    
+        return true;
     case AP_Vehicle::ControlOutput::Throttle:
         control_value = constrain_float(g2.motors.get_throttle() / 100.0f, -1.0f, 1.0f);
         return true;

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -496,7 +496,6 @@ void Mode::set_steering(float steering_value)
     if (allows_stick_mixing() && g2.stick_mixing > 0) {
         steering_value = channel_steer->stick_mixing((int16_t)steering_value);
     }
-    steering_value = constrain_float(steering_value, -4500.0f, 4500.0f);
     g2.motors.set_steering(steering_value);
 }
 


### PR DESCRIPTION
This resolves PR https://github.com/ArduPilot/ardupilot/issues/19535 by removing an unnecessary limitation in the Mode::set_steering() method which can lead to bad steering behaviour on Ackermann steering vehicles at low speeds (normally 1m/s ~ 3m/s).

In particular the bad behaviour was:

- vehicle does not reach the desired turn rate even though its steering servo still has travel remaining (i.e. it is not fully deflected)
- I-term build-up in the turn rate controller leading to the vehicle continuing to turn once the pilot (or autopilot) commands a zero turn rate (e.g. moves the sticks back to the center).

.. and this could occur in Acro, Steering, Follow, Loiter, Simple and even Auto and Guided although for these two modes it was only possible in Loiter-within-Auto and the seldom used HeadingAndSpeed and TurnRateAndSpeed sub modes.

The issue was recreated in SITL by doing the following:

- param set ATC_STR_RAT_FF 2.4 <-- to improve feed forward tuning
- param set GCS_PID_MASK 1 <-- to send steering rate control PID outputs to GCS for live viewing
- graph PID_TUNING.desired PID_TUNING.achieved
- graph PID_TUNING.FF PID_TUNING.P PID_TUNING.I
- graph SERVO_OUTPUT_RAW.servo1_raw
- acro
- arm throttle
- rc 3 1600 <- to request a speed of about 2.5m/s
- rc 1 1000 <- to request turn left at 120 deg/sec

Below are before-and-after screen shots from SITL of the above test
![before](https://user-images.githubusercontent.com/1498098/153830172-b67cad14-b7ea-4377-825a-dd9799eb5eb6.png)
![after](https://user-images.githubusercontent.com/1498098/153830227-cf3890b8-2ccc-4fb1-9b06-0d055ff17648.png)

The only slight downside is that in the logs, the STER.SteerOut value can be much larger than before.  Previously it was limited to +-4500 but now we can see very large values like 20K.  Still, I think this is fine.

Thanks very much to @mikerob for finding this issue and providing the fix!

