### PR TITLE
AR_Motors: remove redundant set of throttle limit flags

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -667,12 +667,6 @@ void AP_MotorsUGV::output_regular(bool armed, float ground_speed, float steering
                     const float throttle_scaler_inv = cosf(steering_angle_rad);
                     if (!is_zero(throttle_scaler_inv)) {
                         throttle /= throttle_scaler_inv;
-                        if (throttle >= 100.0f) {
-                            limit.throttle_upper = true;
-                        }
-                        if (throttle <= -100.0f) {
-                            limit.throttle_lower = true;
-                        }
                     }
                 }
             } else {


### PR DESCRIPTION
This PR has no function change.  It simply remove a few lines in the motors library that set the throttle limits for vectored thrust vehicles.  There is no need for these lines because it is done lower down in the method when set_limits_from_input() is called.  In fact the lines being removed are incorrect because they simply check vs +-100 when they should check vs +-MOT_THR_MAX.

This has been tested in SITL to confirm that the throttle limits are still set correctly for vectored thrust boats:

- sim_vehicle --map --console --f rover-vectored
- param set MOT_THR_MAX 50 <-- limits maximum throttle to 50% so we can more easily hit limits
- acro
- arm throttle
- rc 1 1200 <-- left rudder 60%
- rc 3 1600 <-- throttle 20%, results in the throttle_upper limit being set
- rc 3 1400 <-- throttle -20%, results in the throttle_lower limit being set

To do the above test I had to add some debug like below showing the amount that the throttle was scaled to because of the steering angle and an output of the four limits flags.

![image](https://user-images.githubusercontent.com/1498098/153859071-2e7bfd0c-a126-41c2-a8c2-4b80d2c59976.png)
