### PR TITLE
Copter: Add support for MAV_CMD_NAV_TAKEOFF with COMMAND_INT

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -36,6 +36,7 @@ protected:
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_pause_continue(const mavlink_command_int_t &packet);
+    MAV_RESULT handle_command_nav_takeoff(const mavlink_command_int_t &packet);
 
 #if HAL_MOUNT_ENABLED
     void handle_mount_message(const mavlink_message_t &msg) override;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -75,7 +75,7 @@ public:
     virtual const char *name() const = 0;
     virtual const char *name4() const = 0;
 
-    bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
+    bool do_user_takeoff(float takeoff_alt_cm);
     virtual bool is_taking_off() const;
     static void takeoff_stop() { takeoff.stop(); }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -22,7 +22,7 @@ bool Mode::do_user_takeoff_start(float takeoff_alt_cm)
 }
 
 // initiate user takeoff - called when MAVLink TAKEOFF command is received
-bool Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
+bool Mode::do_user_takeoff(float takeoff_alt_cm)
 {
     if (!copter.motors->armed()) {
         return false;
@@ -31,7 +31,7 @@ bool Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
         // can't takeoff again!
         return false;
     }
-    if (!has_user_takeoff(must_navigate)) {
+    if (!has_user_takeoff(true)) {
         // this mode doesn't support user takeoff
         return false;
     }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8624,6 +8624,72 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    def TakeoffCommandInt(self):
+        '''Test MAV_CMD_NAV_TAKEOFF in GUIDED mode with COMMAND_INT'''
+        self.start_subtest("Started test for MAV_CMD_NAV_TAKEOFF as COMMAND_INT with GLOBAL_RELATIVE_ALT!")
+        self.change_mode(mode="GUIDED")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.run_cmd_int(command=mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
+                         p1=0,
+                         p2=0,
+                         p3=0,
+                         p4=0,
+                         x=0,
+                         y=0,
+                         z=30,
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=10,
+                         target_sysid=1,
+                         target_compid=1,
+                         frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT)
+        self.wait_altitude(altitude_min=29.5, altitude_max=30.5, relative=True, timeout=30)
+        self.watch_altitude_maintained(altitude_min=29.5, altitude_max=30.5, minimum_duration=10)
+        self.land_and_disarm(timeout=30)
+
+        self.start_subtest("Started test for MAV_CMD_NAV_TAKEOFF as COMMAND_INT with GLOBAL!")
+        self.change_mode(mode="GUIDED")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.run_cmd_int(command=mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
+                         p1=0,
+                         p2=0,
+                         p3=0,
+                         p4=0,
+                         x=0,
+                         y=0,
+                         z=614,
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=10,
+                         target_sysid=1,
+                         target_compid=1,
+                         frame=mavutil.mavlink.MAV_FRAME_GLOBAL)
+        self.wait_altitude(altitude_min=613.5, altitude_max=614.5, relative=False, timeout=30)
+        self.watch_altitude_maintained(altitude_min=29.5, altitude_max=30.5, minimum_duration=10)
+        self.land_and_disarm(timeout=30)
+
+        self.install_terrain_handlers_context()
+        self.start_subtest("Started test for MAV_CMD_NAV_TAKEOFF as COMMAND_INT with GLOBAL_TERRAIN_ALT!")
+        self.change_mode(mode="GUIDED")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.run_cmd_int(command=mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
+                         p1=0,
+                         p2=0,
+                         p3=0,
+                         p4=0,
+                         x=0,
+                         y=0,
+                         z=30,
+                         want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+                         timeout=10,
+                         target_sysid=1,
+                         target_compid=1,
+                         frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.wait_altitude(altitude_min=29.5, altitude_max=30.5, relative=True, timeout=30)
+        self.watch_altitude_maintained(altitude_min=29.5, altitude_max=30.5, minimum_duration=10)
+        self.land_and_disarm(timeout=30)
+
     def ATTITUDE_FAST(self):
         '''ensure that when ATTITDE_FAST is set we get many messages'''
         self.context_push()
@@ -8986,6 +9052,7 @@ class AutoTestCopter(AutoTest):
              self.RichenPower,
              self.IE24,
              self.MAVLandedStateTakeoff,
+             self.TakeoffCommandInt,
         ])
         return ret
 


### PR DESCRIPTION
I added support to MAV_CMD_NAV_TAKEOFF with COMMAND_INT.
Can be tested with MAVProxy using:
`long MAV_CMD_NAV_TAKEOFF 0 0 0 0 0 0 10` Takeoff to 10 meters.
`command_int GLOBAL_RELATIVE_ALT MAV_CMD_NAV_TAKEOFF 0 0 0 0 0 0 0 0 10` Takeoff to 10 meters.
`command_int GLOBAL MAV_CMD_NAV_TAKEOFF 0 0 0 0 0 0 0 0 594` Takeoff to 594 AMSL (10 meters above home) meters.
`command_int GLOBAL_TERRAIN_ALT MAV_CMD_NAV_TAKEOFF 0 0 0 0 0 0 0 0 10` Takeoff to 10 meters terrain altitude.
If required, I can also write an autotest for this.