### PR TITLE
Add log analysis helper to show power status flag changes over time

### DIFF
--- a/Tools/scripts/powr_change.py
+++ b/Tools/scripts/powr_change.py
@@ -43,11 +43,14 @@ class POWRChange(object):
                 break
             if current is None:
                 current_flags = 0
+                current_accflags = 0
+                have_accflags = hasattr(m, "AccFlags")
             else:
                 current_flags = current.Flags
+                if have_accflags:
+                    current_accflags = current.AccFlags
+
             flags = m.Flags
-            if flags == current_flags:
-                continue
             line = ""
             for bit in range(0, 32):  # range?
                 mask = 1 << bit
@@ -57,6 +60,19 @@ class POWRChange(object):
                     line += " +%s" % self.bit_description(bit)
                 elif not new_bit_set and old_bit_set:
                     line += " -%s" % self.bit_description(bit)
+
+                if have_accflags:
+                    accflags = m.AccFlags
+                    old_acc_bit_set = current_accflags & mask
+                    new_acc_bit_set = accflags & mask
+
+                    if new_acc_bit_set and not old_acc_bit_set:
+                        line += " ACCFLAGS+%s" % self.bit_description(bit)
+                    elif not new_bit_set and old_bit_set:
+                        line += " ACCFLAGS-%s" % self.bit_description(bit)
+
+            if len(line) == 0:
+                continue
 
             current = m
 

--- a/Tools/scripts/powr_change.py
+++ b/Tools/scripts/powr_change.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+"""
+Parses a log file and shows how the power flags changed over time
+
+AP_FLAKE8_CLEAN
+
+"""
+
+from __future__ import print_function
+
+import optparse
+import sys
+import time
+
+from pymavlink import mavutil
+
+
+class POWRChange(object):
+    def __init__(self, master):
+        self.master = master
+
+    def progress(self, text):
+        '''emit text with possible timestamps etc'''
+        print("%u: %s" % (time.time(), text))
+
+    def bit_description(self, bit_number):
+        if 1 << bit_number not in mavutil.mavlink.enums["MAV_POWER_STATUS"]:
+            return "UNKNOWN_BIT[%u]" % bit_number
+
+        return mavutil.mavlink.enums["MAV_POWER_STATUS"][1 << bit_number].name
+
+    def run(self):
+
+        self.progress("Creating connection")
+        self.conn = mavutil.mavlink_connection(master)
+
+        desired_type = "POWR"
+        current = None
+        while True:
+            m = self.conn.recv_match(type=desired_type)
+            if m is None:
+                break
+            if current is None:
+                current_flags = 0
+            else:
+                current_flags = current.Flags
+            flags = m.Flags
+            if flags == current_flags:
+                continue
+            line = ""
+            for bit in range(0, 32):  # range?
+                mask = 1 << bit
+                old_bit_set = current_flags & mask
+                new_bit_set = flags & mask
+                if new_bit_set and not old_bit_set:
+                    line += " +%s" % self.bit_description(bit)
+                elif not new_bit_set and old_bit_set:
+                    line += " -%s" % self.bit_description(bit)
+
+            current = m
+
+            timestamp = getattr(m, '_timestamp', 0.0)
+            formatted_timestamp = "%s.%02u" % (
+                time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp)),
+                int(timestamp * 100.0) % 100)
+
+            print("%s: %s" % (formatted_timestamp, line))
+            current = m
+
+
+if __name__ == '__main__':
+    parser = optparse.OptionParser("powr_change.py [options]")
+
+    (opts, args) = parser.parse_args()
+
+    if len(args) < 1:
+        parser.print_help()
+        sys.exit(1)
+
+    master = args[0]
+
+    tester = POWRChange(master)
+    tester.run()


### PR DESCRIPTION
Similar to the EKF diagnostics script which was added a few weeks ago.

Sample output:
```
pbarker@bluebottle:~/rc/ardupilot/Tools/scripts(master)$ ./powr_change.py /tmp/00000109.BIN
1644894818: Creating connection
2022-02-14 00:30:25.91:  +MAV_POWER_STATUS_BRICK_VALID +MAV_POWER_STATUS_SERVO_VALID
2022-02-14 00:33:15.46:  +MAV_POWER_STATUS_CHANGED
2022-02-14 00:33:34.96:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:33:35.06:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:16.86:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:16.96:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:38.46:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:38.56:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:40.05:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:40.15:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:41.45:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:41.55:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:45.85:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:45.95:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:47.05:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:47.15:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:48.25:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:48.35:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:49.75:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:49.85:  -MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:34:51.05:  +MAV_POWER_STATUS_PERIPH_OVERCURRENT
2022-02-14 00:38:01.89:  -MAV_POWER_STATUS_CHANGED
pbarker@bluebottle:~/rc/ardupilot/Tools/scripts(master)$ 
```

And with AccFlags in the log:
```
pbarker@bluebottle:~/rc/ardupilot/Tools/scripts(pr/pwr-change)$ ./powr_change.py /tmp/2022-02-09-1720.BIN
1644895493: Creating connection
2022-02-10 12:09:33.27:  +MAV_POWER_STATUS_BRICK_VALID ACCFLAGS+MAV_POWER_STATUS_BRICK_VALID
pbarker@bluebottle:~/rc/ardupilot/Tools/scripts(pr/pwr-change)$ 
```
