### PR TITLE
AP_L1_Control: wrap nav_bearing in update_waypoint

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -313,7 +313,7 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
         Nu1 += _L1_xtrack_i;
 
         Nu = Nu1 + Nu2;
-        _nav_bearing = atan2f(AB.y, AB.x) + Nu1; // bearing (radians) from AC to L1 point
+        _nav_bearing = wrap_PI(atan2f(AB.y, AB.x) + Nu1);   // bearing (radians) from AC to L1 point
     }
 
     _prevent_indecision(Nu);


### PR DESCRIPTION
The L1 controller's update_waypoint method calculates the _nav_bearing but fails to wrap it so it may return values outside the  -180deg and +180deg range.

This has been lightly tested in SITL (with both Plane and Rover) to confirm that before this change the _nav_bearing could be larger than +- PI and after it can't (of course).  To see the difference though debug needed to be added because Rover's AR_WPNav (the only place in rover that uses this output) wraps the value back to a 0~360 deg range.  I'm happy to provide logs if required.

The issue can probably best be seen in Plane's NTUN logs and NAV_CONTROLLER_OUTPUT mavlink messages where it could return a number outside the +-PI range especially when doing a 180deg turn.

This falls out of this discussion of this issue https://github.com/ArduPilot/ardupilot/issues/20080

Thanks to @IamPete1 for finding this issue