### PR TITLE
Copter: fixed use of counter in RC failsafe

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -45,6 +45,9 @@ bool RC_Channels_Copter::has_valid_input() const
     if (copter.failsafe.radio_counter != 0) {
         return false;
     }
+    if (!copter.ap.rc_receiver_present) {
+        return false;
+    }
     return true;
 }
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -400,7 +400,7 @@ void Copter::notify_flight_mode() {
 void Mode::get_pilot_desired_lean_angles(float &roll_out, float &pitch_out, float angle_max, float angle_limit) const
 {
     // throttle failsafe check
-    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+    if (!rc().has_valid_input()) {
         roll_out = 0;
         pitch_out = 0;
         return;
@@ -936,7 +936,7 @@ Mode::AltHoldModeState Mode::get_alt_hold_state(float target_climb_rate_cms)
 float Mode::get_pilot_desired_yaw_rate(float yaw_in)
 {
     // throttle failsafe check
-    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+    if (!rc().has_valid_input()) {
         return 0.0f;
     }
 

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -17,7 +17,7 @@ void Copter::tuning()
     }
 
     // exit immediately when radio failsafe is invoked or transmitter has not been turned on
-    if (failsafe.radio || failsafe.radio_counter != 0 || rc6->get_radio_in() == 0) {
+    if (!rc().has_valid_input() || rc6->get_radio_in() == 0) {
         return;
     }
 


### PR DESCRIPTION
this fixes a bug where if all channels go low on receiver failsafe
then the copter will treat the low channels as pilot input until the
RC failsafe counter is reached

Thanks to Alex Burka from Exyn for reporting