### PR TITLE
AP_Logger: add LogMessage documentation for PIDN and PIDE

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -979,7 +979,7 @@ struct PACKED log_VER {
 // @Field: Name: parameter name
 // @Field: Value: parameter value
 
-// @LoggerMessage: PIDR,PIDP,PIDY,PIDA,PIDS
+// @LoggerMessage: PIDR,PIDP,PIDY,PIDA,PIDS,PIDN,PIDE
 // @Description: Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Altitude/Steering
 // @Field: TimeUS: Time since system startup
 // @Field: Tar: desired value


### PR DESCRIPTION
Not appearing on e.g. https://ardupilot.org/copter/docs/logmessages.html
