### PR TITLE
Copter: remove wp_nav from takeoff and landing

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -696,14 +696,6 @@ void Mode::land_run_horizontal_control()
 #endif
 
     if (!copter.ap.prec_land_active) {
-        if (copter.ap.prec_land_active) {
-            // precland isn't active anymore but was active a while back
-            // lets run an init again
-            // set target to stopping point
-            Vector2f stopping_point;
-            loiter_nav->get_stopping_point_xy(stopping_point);
-            loiter_nav->init_target(stopping_point);
-        }
         Vector2f accel;
         pos_control->input_vel_accel_xy(vel_correction, accel);
     }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -431,6 +431,39 @@ void Mode::get_pilot_desired_lean_angles(float &roll_out, float &pitch_out, floa
     // roll_out and pitch_out are returned
 }
 
+// transform pilot's roll or pitch input into a desired velocity
+Vector2f Mode::get_pilot_desired_velocity(float vel_max) const
+{
+    Vector2f vel;
+
+    // throttle failsafe check
+    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+        return vel;
+    }
+    // fetch roll and pitch inputs
+    float roll_out = channel_roll->get_control_in();
+    float pitch_out = channel_pitch->get_control_in();
+
+    // convert roll and pitch inputs to -1 to +1 range
+    float scaler = 1.0 / (float)ROLL_PITCH_YAW_INPUT_MAX;
+    roll_out *= scaler;
+    pitch_out *= scaler;
+
+    // convert roll and pitch inputs into velocity in NE frame
+    vel = Vector2f(-pitch_out, roll_out);
+    if (vel.is_zero()) {
+        return vel;
+    }
+    copter.rotate_body_frame_to_NE(vel.x, vel.y);
+
+    // Transform square input range to circular output
+    // vel_scaler is the vector to the edge of the +- 1.0 square in the direction of the current input
+    Vector2f vel_scaler = vel / MAX(fabsf(vel.x), fabsf(vel.y));
+    // We scale the output by the ratio of the distance to the square to the unit circle and multiply by vel_max
+    vel *= vel_max / vel_scaler.length();
+    return vel;
+}
+
 bool Mode::_TakeOff::triggered(const float target_climb_rate) const
 {
     if (!copter.ap.land_complete) {
@@ -598,13 +631,12 @@ void Mode::land_run_vertical_control(bool pause_descent)
 
 void Mode::land_run_horizontal_control()
 {
-    float target_roll = 0.0f;
-    float target_pitch = 0.0f;
+    Vector2f vel_correction;
     float target_yaw_rate = 0;
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {
-        loiter_nav->soften_for_landing();
+        pos_control->soften_for_landing_xy();
     }
 
     // process pilot inputs
@@ -621,11 +653,14 @@ void Mode::land_run_horizontal_control()
             // apply SIMPLE mode transform to pilot inputs
             update_simple_mode();
 
-            // convert pilot input to lean angles
-            get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+            // convert pilot input to reposition velocity
+            // use half maximum acceleration as the maximum velocity to ensure aircraft will
+            // stop from full reposition speed in less than 1 second.
+            const float max_pilot_vel = wp_nav->get_wp_acceleration() * 0.5;
+            vel_correction = get_pilot_desired_velocity(max_pilot_vel);
 
             // record if pilot has overridden roll or pitch
-            if (!is_zero(target_roll) || !is_zero(target_pitch)) {
+            if (!vel_correction.is_zero()) {
                 if (!copter.ap.land_repo_active) {
                     AP::logger().Write_Event(LogEvent::LAND_REPO_ACTIVE);
                 }
@@ -641,11 +676,11 @@ void Mode::land_run_horizontal_control()
     }
 
     // this variable will be updated if prec land target is in sight and pilot isn't trying to reposition the vehicle
-    bool doing_precision_landing = false;
+    copter.ap.prec_land_active = false;
 #if PRECISION_LANDING == ENABLED
-    doing_precision_landing = !copter.ap.land_repo_active && copter.precland.target_acquired();
+    copter.ap.prec_land_active = !copter.ap.land_repo_active && copter.precland.target_acquired();
     // run precision landing
-    if (doing_precision_landing) {
+    if (copter.ap.prec_land_active) {
         Vector2f target_pos, target_vel;
         if (!copter.precland.get_target_position_cm(target_pos)) {
             target_pos = inertial_nav.get_position_xy_cm();
@@ -657,12 +692,10 @@ void Mode::land_run_horizontal_control()
         Vector2p landing_pos = target_pos.topostype();
         // target vel will remain zero if landing target is stationary
         pos_control->input_pos_vel_accel_xy(landing_pos, target_vel, zero);
-        // run pos controller
-        pos_control->update_xy_controller();
     }
 #endif
 
-    if (!doing_precision_landing) {
+    if (!copter.ap.prec_land_active) {
         if (copter.ap.prec_land_active) {
             // precland isn't active anymore but was active a while back
             // lets run an init again
@@ -671,15 +704,12 @@ void Mode::land_run_horizontal_control()
             loiter_nav->get_stopping_point_xy(stopping_point);
             loiter_nav->init_target(stopping_point);
         }
-        // process roll, pitch inputs
-        loiter_nav->set_pilot_desired_acceleration(target_roll, target_pitch);
-
-        // run loiter controller
-        loiter_nav->update();
+        Vector2f accel;
+        pos_control->input_vel_accel_xy(vel_correction, accel);
     }
 
-    copter.ap.prec_land_active = doing_precision_landing;
-
+    // run pos controller
+    pos_control->update_xy_controller();
     Vector3f thrust_vector = pos_control->get_thrust_vector();
 
     if (g2.wp_navalt_min > 0) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -197,14 +197,22 @@ protected:
 
     virtual bool do_user_takeoff_start(float takeoff_alt_cm);
 
-    // method shared by both Guided and Auto for takeoff.  This is
-    // waypoint navigation but the user can control the yaw.
+    // method shared by both Guided and Auto for takeoff.
+    // position controller controls vehicle but the user can control the yaw.
     void auto_takeoff_run();
-    void auto_takeoff_set_start_alt(void);
+    void auto_takeoff_start(float complete_alt_cm, bool terrain_alt);
+    bool auto_takeoff_get_position(Vector3p& completion_pos);
 
     // altitude above-ekf-origin below which auto takeoff does not control horizontal position
     static bool auto_takeoff_no_nav_active;
     static float auto_takeoff_no_nav_alt_cm;
+
+    // auto takeoff variables
+    static float auto_take_off_start_alt_cm;    // start altitude expressed as cm above ekf origin
+    static float auto_take_off_complete_alt_cm; // completion altitude expressed as cm above ekf origin
+    static bool auto_takeoff_terrain_alt;       // true if altitudes are above terrain
+    static bool auto_takeoff_complete;          // true when takeoff is complete
+    static Vector3p auto_takeoff_complete_pos;  // target takeoff position as offset from ekf origin in cm
 
 public:
     // Navigation Yaw control
@@ -940,6 +948,8 @@ public:
 
     bool is_taking_off() const override;
 
+    // initialises position controller to implement take-off
+    // takeoff_alt_cm is interpreted as alt-above-home (in cm) or alt-above-terrain if a rangefinder is available
     bool do_user_takeoff_start(float takeoff_alt_cm) override;
 
     enum class SubMode {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -424,7 +424,6 @@ public:
     void takeoff_start(const Location& dest_loc);
     void wp_start(const Location& dest_loc);
     void land_start();
-    void land_start(const Vector2f& destination);
     void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
     void nav_guided_start();
@@ -495,7 +494,6 @@ private:
 
     Location loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const;
 
-    void payload_place_start(const Vector2f& destination);
     void payload_place_run();
     bool payload_place_run_should_run();
     void payload_place_run_loiter();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -90,6 +90,7 @@ public:
 
     // pilot input processing
     void get_pilot_desired_lean_angles(float &roll_out, float &pitch_out, float angle_max, float angle_limit) const;
+    Vector2f get_pilot_desired_velocity(float vel_max) const;
     float get_pilot_desired_yaw_rate(float yaw_in);
     float get_pilot_desired_throttle() const;
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -47,7 +47,7 @@ void ModeBrake::run()
 
     // relax stop target if we might be landed
     if (copter.ap.land_complete_maybe) {
-        loiter_nav->soften_for_landing();
+        pos_control->soften_for_landing_xy();
     }
 
     // use position controller to stop

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -180,7 +180,7 @@ void Mode::auto_takeoff_run()
 
     // handle takeoff completion
     bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_take_off_start_alt_cm) >= ((auto_take_off_complete_alt_cm  - auto_take_off_start_alt_cm) * 0.90);
-    bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * 0.5;
+    bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * 0.1;
     auto_takeoff_complete = reached_altitude && reached_climb_rate;
 
     // calculate completion for location in case it is needed for a smooth transition to wp_nav

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -4,6 +4,11 @@ Mode::_TakeOff Mode::takeoff;
 
 bool Mode::auto_takeoff_no_nav_active = false;
 float Mode::auto_takeoff_no_nav_alt_cm = 0;
+float Mode::auto_take_off_start_alt_cm = 0;
+float Mode::auto_take_off_complete_alt_cm = 0;
+bool Mode::auto_takeoff_terrain_alt = false;
+bool Mode::auto_takeoff_complete = false;
+Vector3p Mode::auto_takeoff_complete_pos;
 
 // This file contains the high-level takeoff logic for Loiter, PosHold, AltHold, Sport modes.
 //   The take-off can be initiated from a GCS NAV_TAKEOFF command which includes a takeoff altitude
@@ -93,13 +98,21 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
     }
 }
 
+// auto_takeoff_run - controls the vertical position controller during the process of taking off in auto modes
+// auto_takeoff_complete set to true when target altitude is within 10% of the take off altitude and less than 50% max climb rate
 void Mode::auto_takeoff_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !copter.ap.auto_armed) {
         // do not spool down tradheli when on the ground with motor interlock enabled
         make_safe_ground_handling(copter.is_tradheli() && motors->get_interlock());
-        wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
+        return;
+    }
+
+    // get terrain offset
+    float terr_offset = 0.0f;
+    if (auto_takeoff_terrain_alt && !wp_nav->get_terrain_offset(terr_offset)) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "auto takeoff: failed to get terrain offset");
         return;
     }
 
@@ -116,17 +129,18 @@ void Mode::auto_takeoff_run()
         }
     }
 
-    // aircraft stays in landed state until rotor speed runup has finished
+    // aircraft stays in landed state until rotor speed run up has finished
     if (motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         set_land_complete(false);
     } else {
         // motors have not completed spool up yet so relax navigation and position controllers
-        wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
+        pos_control->relax_velocity_controller_xy();
+        pos_control->update_xy_controller();
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         pos_control->update_z_controller();
         attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
+        attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), auto_yaw.rate_cds());
         return;
     }
 
@@ -135,49 +149,72 @@ void Mode::auto_takeoff_run()
         // check if vehicle has reached no_nav_alt threshold
         if (inertial_nav.get_position_z_up_cm() >= auto_takeoff_no_nav_alt_cm) {
             auto_takeoff_no_nav_active = false;
-            wp_nav->shift_wp_origin_and_destination_to_stopping_point_xy();
-        } else {
-            // shift the navigation target horizontally to our current position
-            wp_nav->shift_wp_origin_and_destination_to_current_pos_xy();
         }
-        // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
-        pos_control->set_externally_limited_xy();
+        pos_control->relax_velocity_controller_xy();
+    } else {
+        Vector2f vel;
+        Vector2f accel;
+        pos_control->input_vel_accel_xy(vel, accel);
     }
+    pos_control->update_xy_controller();
 
-    // run waypoint controller
-    copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
-
-    Vector3f thrustvector{0, 0, -GRAVITY_MSS * 100.0f};
-    if (!auto_takeoff_no_nav_active) {
-        thrustvector = wp_nav->get_thrust_vector();
-    }
-
-    // WP_Nav has set the vertical position control targets
+    // command the aircraft to the take off altitude
+    float pos_z = auto_take_off_complete_alt_cm + terr_offset;
+    float vel_z = 0.0;
+    copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0.0);
+    
     // run the vertical position controller and set output throttle
-    copter.pos_control->update_z_controller();
+    pos_control->update_z_controller();
 
     // call attitude controller
     if (auto_yaw.mode() == AUTO_YAW_HOLD) {
         // roll & pitch from position controller, yaw rate from pilot
-        attitude_control->input_thrust_vector_rate_heading(thrustvector, target_yaw_rate);
+        attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), target_yaw_rate);
     } else if (auto_yaw.mode() == AUTO_YAW_RATE) {
         // roll & pitch from position controller, yaw rate from mavlink command or mission item
-        attitude_control->input_thrust_vector_rate_heading(thrustvector, auto_yaw.rate_cds());
+        attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), auto_yaw.rate_cds());
     } else {
         // roll & pitch from position controller, yaw heading from GCS or auto_heading()
-        attitude_control->input_thrust_vector_heading(thrustvector, auto_yaw.yaw(), auto_yaw.rate_cds());
+        attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.yaw(), auto_yaw.rate_cds());
+    }
+
+    // handle takeoff completion
+    bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_take_off_start_alt_cm) >= ((auto_take_off_complete_alt_cm  - auto_take_off_start_alt_cm) * 0.90);
+    bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * 0.5;
+    auto_takeoff_complete = reached_altitude && reached_climb_rate;
+
+    // calculate completion for location in case it is needed for a smooth transition to wp_nav
+    if (auto_takeoff_complete) {
+        const Vector3p& complete_pos = copter.pos_control->get_pos_target_cm();
+        auto_takeoff_complete_pos = Vector3p{complete_pos.x, complete_pos.y, pos_z};
     }
 }
 
-void Mode::auto_takeoff_set_start_alt(void)
+void Mode::auto_takeoff_start(float complete_alt_cm, bool terrain_alt)
 {
+    auto_take_off_start_alt_cm = inertial_nav.get_position_z_up_cm();
+    auto_take_off_complete_alt_cm = complete_alt_cm;
+    auto_takeoff_terrain_alt = terrain_alt;
+    auto_takeoff_complete = false;
     if ((g2.wp_navalt_min > 0) && (is_disarmed_or_landed() || !motors->get_interlock())) {
         // we are not flying, climb with no navigation to current alt-above-ekf-origin + wp_navalt_min
-        auto_takeoff_no_nav_alt_cm = inertial_nav.get_position_z_up_cm() + g2.wp_navalt_min * 100;
+        auto_takeoff_no_nav_alt_cm = auto_take_off_start_alt_cm + g2.wp_navalt_min * 100;
         auto_takeoff_no_nav_active = true;
     } else {
         auto_takeoff_no_nav_active = false;
     }
+}
+
+// return takeoff final position if takeoff has completed successfully
+bool Mode::auto_takeoff_get_position(Vector3p& complete_pos)
+{
+    // only provide location if takeoff has completed
+    if (!auto_takeoff_complete) {
+        return false;
+    }
+
+    complete_pos = auto_takeoff_complete_pos;
+    return true;
 }
 
 bool Mode::is_taking_off() const

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -458,7 +458,6 @@ void AC_PosControl::relax_velocity_controller_xy()
 
     // decay resultant acceleration and therefore current attitude target to zero
     float decay = 1.0 - _dt / (_dt + POSCONTROL_RELAX_TC);
-
     _accel_target.xy() *= decay;
     _pid_vel_xy.set_integrator(_accel_target - _accel_desired);
 }
@@ -466,11 +465,11 @@ void AC_PosControl::relax_velocity_controller_xy()
 /// reduce response for landing
 void AC_PosControl::soften_for_landing_xy()
 {
-    // set target position to current position
-    _pos_target.xy() = _inav.get_position_xy_cm().topostype();
+    // decay position error to zero
+    _pos_target.xy() += (_inav.get_position_xy_cm().topostype() - _pos_target.xy()) * (_dt / (_dt + POSCONTROL_RELAX_TC));
 
-    // also prevent I term build up in xy velocity controller. Note
-    // that this flag is reset on each loop, in update_xy_controller()
+    // Prevent I term build up in xy velocity controller.
+    // Note that this flag is reset on each loop in update_xy_controller()
     set_externally_limited_xy();
 }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -463,9 +463,19 @@ void AC_PosControl::relax_velocity_controller_xy()
     _pid_vel_xy.set_integrator(_accel_target - _accel_desired);
 }
 
+/// reduce response for landing
+void AC_PosControl::soften_for_landing_xy()
+{
+    // set target position to current position
+    _pos_target.xy() = _inav.get_position_xy_cm().topostype();
+
+    // also prevent I term build up in xy velocity controller. Note
+    // that this flag is reset on each loop, in update_xy_controller()
+    set_externally_limited_xy();
+}
+
 /// init_xy_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
 ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
-///     This function is private and contains all the shared xy axis initialisation functions
 void AC_PosControl::init_xy_controller()
 {
     // set roll, pitch lean angle targets to current attitude

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -96,6 +96,9 @@ public:
     ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
     void relax_velocity_controller_xy();
 
+    /// reduce response for landing
+    void soften_for_landing_xy();
+
     // init_xy_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
     ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
     ///     This function is private and contains all the shared xy axis initialisation functions

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -132,14 +132,7 @@ void AC_Loiter::init_target()
 /// reduce response for landing
 void AC_Loiter::soften_for_landing()
 {
-    const Vector3f& curr_pos = _inav.get_position_neu_cm();
-
-    // set target position to current position
-    _pos_control.set_pos_target_xy_cm(curr_pos.x, curr_pos.y);
-
-    // also prevent I term build up in xy velocity controller. Note
-    // that this flag is reset on each loop, in update_xy_controller()
-    _pos_control.set_externally_limited_xy();
+    _pos_control.soften_for_landing_xy();
 }
 
 /// set pilot desired acceleration in centi-degrees

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -143,9 +143,9 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 
 /// wp_and_spline_init - initialise straight line and spline waypoint controllers
 ///     speed_cms should be a positive value or left at zero to use the default speed
-///     updates target roll, pitch targets and I terms based on vehicle lean angles
+///     stopping_point should be the vehicle's stopping point (equal to the starting point of the next segment) if know or left as zero
 ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-void AC_WPNav::wp_and_spline_init(float speed_cms)
+void AC_WPNav::wp_and_spline_init(float speed_cms, Vector3f stopping_point)
 {
     
     // sanity check parameters
@@ -185,13 +185,13 @@ void AC_WPNav::wp_and_spline_init(float speed_cms)
     _scurve_next_leg.init();
     _track_scalar_dt = 1.0f;
 
-    // set flag so get_yaw() returns current heading target
-    _flags.reached_destination = false;
+    _flags.reached_destination = true;
     _flags.fast_waypoint = false;
 
     // initialise origin and destination to stopping point
-    Vector3f stopping_point;
-    get_wp_stopping_point(stopping_point);
+    if (stopping_point.is_zero()) {
+        get_wp_stopping_point(stopping_point);
+    }
     _origin = _destination = stopping_point;
     _terrain_alt = false;
     _this_leg_is_spline = false;
@@ -199,6 +199,9 @@ void AC_WPNav::wp_and_spline_init(float speed_cms)
     // initialise the terrain velocity to the current maximum velocity
     _terrain_vel = _wp_desired_speed_xy_cms;
     _terrain_accel = 0.0;
+
+    // mark as active
+    _wp_last_update = AP_HAL::millis();
 }
 
 /// set_speed_xy - allows main code to pass target horizontal velocity for wp navigation

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -52,7 +52,7 @@ public:
     ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or omitted to use the default speed
     ///     updates target roll, pitch targets and I terms based on vehicle lean angles
     ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-    void wp_and_spline_init(float speed_cms = 0.0f);
+    void wp_and_spline_init(float speed_cms = 0.0f, Vector3f stopping_point = Vector3f{});
 
     /// set current target horizontal speed during wp navigation
     void set_speed_xy(float speed_cms);


### PR DESCRIPTION
This replaces PR https://github.com/ArduPilot/ardupilot/pull/19739 and the high level changes are:

1. Landing (in RTL, Land, Auto) now uses the position controller instead of the AC_Loiter controller.  Users will notice that repositioning the vehicle during landing responds quite differently because the pilot controls the vehicle's horizontal velocity instead of the vehicle's lean angle.  The maximum velocity is half the WP_ACCEL (defaults to 1) which is much less than Loiter's maximum speed.
2. Takeoff (in Auto, Guided) is also changed to use the position controller instead of WP_Nav.  Users should notice no real change in functionality except that Auto's takeoff gets support for terrain altitudes

Things still to test:

- [x] Confirm the frame for repositioning during landing (it appears to be NE frame instead of body frame)
- [x] Flight test Land's lowered repositioning speed (Leonard's happy, let's get some more feedback)
- [x] Confirm during takeoff the vehicle does not attempt to hold position below WP_NAVALT_MIN
- [x] Confirm precision landing still works (it should because SITL tests pass)