### PR TITLE
INS: only run harmonic notch on active gyro

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -930,9 +930,10 @@ AP_InertialSensor::init(uint16_t loop_rate)
         // calculate number of notches we might want to use for harmonic notch
         if (notch.params.enabled() || fft_enabled) {
             const bool double_notch = notch.params.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch);
+            const bool all_sensors = notch.params.hasOption(HarmonicNotchFilterParams::Options::EnableOnAllIMUs);
             num_filters += __builtin_popcount(notch.params.harmonics())
                 * notch.num_dynamic_notches * (double_notch ? 2 : 1)
-                * sensors_used;
+                * (all_sensors?sensors_used:1);
         }
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -174,6 +174,45 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._delta_angle_acc_dt[instance] = 0;
 }
 
+/*
+  apply harmonic notch and low pass gyro filters
+ */
+void AP_InertialSensor_Backend::apply_gyro_filters(const uint8_t instance, const Vector3f &gyro)
+{
+    Vector3f gyro_filtered = gyro;
+
+    // apply the harmonic notch filters
+    for (auto &notch : _imu.harmonic_notches) {
+        if (!notch.params.enabled()) {
+            continue;
+        }
+#ifndef HAL_BUILD_AP_PERIPH
+        // by default we only run the expensive notch filters on the
+        // currently active IMU we reset the inactive notch filters so
+        // that if we switch IMUs we're not left with old data
+        if (!notch.params.hasOption(HarmonicNotchFilterParams::Options::EnableOnAllIMUs) &&
+            instance != AP::ahrs().get_primary_gyro_index()) {
+            notch.filter[instance].reset();
+            continue;
+        }
+#endif
+        gyro_filtered = notch.filter[instance].apply(gyro_filtered);
+    }
+
+    // apply the low pass filter last to attentuate any notch induced noise
+    gyro_filtered = _imu._gyro_filter[instance].apply(gyro_filtered);
+
+    // if the filtering failed in any way then reset the filters and keep the old value
+    if (gyro_filtered.is_nan() || gyro_filtered.is_inf()) {
+        _imu._gyro_filter[instance].reset();
+        for (auto &notch : _imu.harmonic_notches) {
+            notch.filter[instance].reset();
+        }
+    } else {
+        _imu._gyro_filtered[instance] = gyro_filtered;
+    }
+}
+
 void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
                                                             const Vector3f &gyro,
                                                             uint64_t sample_us)
@@ -264,27 +303,9 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
             _imu._gyro_window[instance][2].push(scaled_gyro.z);
         }
 #endif
-        Vector3f gyro_filtered = gyro;
 
-        // apply the harmonic notch filter
-        for (auto &notch : _imu.harmonic_notches) {
-            if (notch.params.enabled()) {
-                gyro_filtered = notch.filter[instance].apply(gyro_filtered);
-            }
-        }
-
-        // apply the low pass filter last to attentuate any notch induced noise
-        gyro_filtered = _imu._gyro_filter[instance].apply(gyro_filtered);
-
-        // if the filtering failed in any way then reset the filters and keep the old value
-        if (gyro_filtered.is_nan() || gyro_filtered.is_inf()) {
-            _imu._gyro_filter[instance].reset();
-            for (auto &notch : _imu.harmonic_notches) {
-                notch.filter[instance].reset();
-            }
-        } else {
-            _imu._gyro_filtered[instance] = gyro_filtered;
-        }
+        // apply gyro filters
+        apply_gyro_filters(instance, gyro);
 
         _imu._new_gyro_data[instance] = true;
     }
@@ -383,27 +404,9 @@ void AP_InertialSensor_Backend::_notify_new_delta_angle(uint8_t instance, const 
             _imu._gyro_window[instance][2].push(scaled_gyro.z);
         }
 #endif
-        Vector3f gyro_filtered = gyro;
 
-        // apply the harmonic notch filters
-        for (auto &notch : _imu.harmonic_notches) {
-            if (notch.params.enabled()) {
-                gyro_filtered = notch.filter[instance].apply(gyro_filtered);
-            }
-        }
-
-        // apply the low pass filter last to attentuate any notch induced noise
-        gyro_filtered = _imu._gyro_filter[instance].apply(gyro_filtered);
-
-        // if the filtering failed in any way then reset the filters and keep the old value
-        if (gyro_filtered.is_nan() || gyro_filtered.is_inf()) {
-            _imu._gyro_filter[instance].reset();
-            for (auto &notch : _imu.harmonic_notches) {
-                notch.filter[instance].reset();
-            }
-        } else {
-            _imu._gyro_filtered[instance] = gyro_filtered;
-        }
+        // apply gyro filters
+        apply_gyro_filters(instance, gyro);
 
         _imu._new_gyro_data[instance] = true;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -140,6 +140,9 @@ protected:
     // rotate gyro vector, offset and publish
     void _publish_gyro(uint8_t instance, const Vector3f &gyro) __RAMFUNC__; /* front end */
 
+    // apply notch and lowpass gyro filters
+    void apply_gyro_filters(const uint8_t instance, const Vector3f &gyro);
+
     // this should be called every time a new gyro raw sample is
     // available - be it published or not the sample is raw in the
     // sense that it's not filtered yet, but it must be rotated and

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -85,7 +85,7 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @Param: OPTS
     // @DisplayName: Harmonic Notch Filter options
     // @Description: Harmonic Notch Filter options. Double-notches can provide deeper attenuation across a wider bandwidth than single notches and are suitable for larger aircraft. Dynamic harmonics attaches a harmonic notch to each detected noise frequency instead of simply being multiples of the base frequency, in the case of FFT it will attach notches to each of three detected noise peaks, in the case of ESC it will attach notches to each of four motor RPM values. Loop rate update changes the notch center frequency at the scheduler loop rate rather than at the default of 200Hz.
-    // @Bitmask: 0:Double notch,1:Dynamic harmonic,2:Update at loop rate
+    // @Bitmask: 0:Double notch,1:Dynamic harmonic,2:Update at loop rate,3:EnableOnAllIMUs
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("OPTS", 8, HarmonicNotchFilterParams, _options, 0),

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -84,7 +84,8 @@ public:
     enum class Options {
         DoubleNotch = 1<<0,
         DynamicHarmonic = 1<<1,
-        LoopRateUpdate = 2<<1,
+        LoopRateUpdate = 1<<2,
+        EnableOnAllIMUs = 1<<3,
     };
 
     HarmonicNotchFilterParams(void);

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -74,7 +74,7 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
 template <class T>
 T NotchFilter<T>::apply(const T &sample)
 {
-    if (!initialised) {
+    if (!initialised || need_reset) {
         // if we have not been initialised when return the input
         // sample as output and update delayed samples
         ntchsig2 = ntchsig1;
@@ -82,6 +82,7 @@ T NotchFilter<T>::apply(const T &sample)
         ntchsig = sample;
         signal2 = signal1;
         signal1 = sample;
+        need_reset = false;
         return sample;
     }
     ntchsig2 = ntchsig1;
@@ -96,8 +97,7 @@ T NotchFilter<T>::apply(const T &sample)
 template <class T>
 void NotchFilter<T>::reset()
 {
-    ntchsig2 = ntchsig1 = T();
-    signal2 = signal1 = T();
+    need_reset = true;
 }
 
 /*

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -77,11 +77,11 @@ T NotchFilter<T>::apply(const T &sample)
     if (!initialised || need_reset) {
         // if we have not been initialised when return the input
         // sample as output and update delayed samples
-        ntchsig2 = ntchsig1;
-        ntchsig1 = ntchsig;
-        ntchsig = sample;
-        signal2 = signal1;
         signal1 = sample;
+        signal2 = sample;
+        ntchsig = sample;
+        ntchsig1 = sample;
+        ntchsig2 = sample;
         need_reset = false;
         return sample;
     }

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -40,7 +40,7 @@ public:
 
 private:
 
-    bool initialised;
+    bool initialised, need_reset;
     float b0, b1, b2, a1, a2, a0_inv;
     T ntchsig, ntchsig1, ntchsig2, signal2, signal1;
 };

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -1,0 +1,68 @@
+#include <AP_gtest.h>
+
+#include <Filter/Filter.h>
+#include <Filter/NotchFilter.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+/*
+  test if a reset of a notch filter results in no glitch in the following samples
+  with constant input
+ */
+TEST(NotchFilterTest, ResetTest)
+{
+    NotchFilter<float> filter;
+    filter.init(1000, 60, 33, 41);
+    const float const_sample = -0.512;
+    filter.reset();
+    for (uint32_t i=0; i<100; i++) {
+        float v = filter.apply(const_sample);
+        EXPECT_FLOAT_EQ(v, const_sample);
+    }
+}
+
+/*
+  test with a sine input
+ */
+TEST(NotchFilterTest, SineTest)
+{
+    NotchFilter<float> filter;
+    const float test_freq = 47;
+    const float attenuation_dB = 43;
+    const float rate_hz = 2000;
+    double dt = 1.0 / rate_hz;
+    const uint32_t period_samples = rate_hz / test_freq;
+    const uint32_t periods = 1000;
+    const float test_amplitude = 0.7;
+    const float expected_ratio = powf(10, (attenuation_dB/2)/10.0);
+    double integral1_in = 0;
+    double integral1_out = 0;
+    double integral2_in = 0;
+    double integral2_out = 0;
+    filter.init(rate_hz, test_freq, test_freq*0.5, attenuation_dB);
+    filter.reset();
+    for (uint32_t i=0; i<periods * period_samples; i++) {
+        const double t = i * dt;
+        const double sample = sin(test_freq * t * 2 * M_PI) * test_amplitude;
+        const float v = filter.apply(sample);
+        if (i >= 2*period_samples) {
+            integral1_in += sample * dt;
+            integral2_in += fabsf(sample) * dt;
+            integral1_out += v * dt;
+            integral2_out += fabsf(v) * dt;
+        }
+    }
+
+    // we expect both absolute integrals to be zero
+    EXPECT_LE(fabsf(integral1_in), 0.01);
+    EXPECT_LE(fabsf(integral1_out), 0.01);
+
+    // we expect the output abs integral to be smaller than input
+    // integral by the attenuation
+    const float ratio1 = integral2_in / integral2_out;
+    ::printf("ratio1=%f expected_ratio=%f\n", ratio1, expected_ratio);
+    const float err_pct = 100 * fabsf(ratio1 - expected_ratio) / ratio1;
+    EXPECT_LE(err_pct, 1);
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
This should save quite a lot of CPU on multi-IMU systems by avoiding the cost of the harmonic notch calculations on inactive IMUs. 
Note that the EKF doesn't use the filtered data, and control loops only use the primary gyro
not tested yet outside of SITL