### PR TITLE
Clock H750 at 480Mhz when using 8Mhz, 16Mhz and 24Mhz crystals

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -19,7 +19,9 @@
 #pragma once
 
 // we want to cope with both revision XY chips and newer chips
+#ifndef STM32H750xx
 #define STM32_ENFORCE_H7_REV_XY
+#endif
 
 #ifndef STM32_LSECLK
 #define STM32_LSECLK 32768U
@@ -159,7 +161,11 @@
 
 #elif (STM32_HSECLK == 8000000U) || (STM32_HSECLK == 16000000U)
 // common clock tree for multiples of 8MHz crystals
+#ifdef STM32H750xx
+#define STM32_PLL1_DIVN_VALUE               120
+#else
 #define STM32_PLL1_DIVN_VALUE               100
+#endif
 #define STM32_PLL1_DIVP_VALUE               2
 #define STM32_PLL1_DIVQ_VALUE               8
 #define STM32_PLL1_DIVR_VALUE               2
@@ -175,7 +181,11 @@
 #define STM32_PLL3_DIVR_VALUE               9
 
 #elif STM32_HSECLK == 24000000U
+#ifdef STM32H750xx
+#define STM32_PLL1_DIVN_VALUE               120
+#else
 #define STM32_PLL1_DIVN_VALUE               100
+#endif
 #define STM32_PLL1_DIVP_VALUE               2
 #define STM32_PLL1_DIVQ_VALUE               8
 #define STM32_PLL1_DIVR_VALUE               2

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -61,7 +61,7 @@ mcu = {
         (0x38000000,  64, 1), # SRAM4.
     ],
 
-    'EXPECTED_CLOCK' : 400000000,
+    'EXPECTED_CLOCK' : 480000000,
 
     # this MCU has M7 instructions and hardware double precision
     'CORTEX'    : 'cortex-m7',


### PR DESCRIPTION
This saves a solid 5-6% on the SPRacing H7, which is really pretty significant

I was unable to find clock combinations to make this work with 24Mhz and 25Mhz crystals