### PR TITLE
Copter/Rover: add support for running lua scripts as part of missions

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -418,6 +418,32 @@ bool Copter::set_circle_rate(float rate_dps)
     return true;
 }
 
+// returns true if mode supports NAV_SCRIPT_TIME mission commands
+bool Copter::nav_scripting_enable(uint8_t mode)
+{
+    return mode == (uint8_t)mode_auto.mode_number();
+}
+
+// lua scripts use this to retrieve the contents of the active command
+bool Copter::nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2)
+{
+    if (flightmode != &mode_auto) {
+        return false;
+    }
+
+    return mode_auto.nav_script_time(id, cmd, arg1, arg2);
+}
+
+// lua scripts use this to indicate when they have complete the command
+void Copter::nav_script_time_done(uint16_t id)
+{
+    if (flightmode != &mode_auto) {
+        return;
+    }
+
+    return mode_auto.nav_script_time_done(id);
+}
+
 #endif // AP_SCRIPTING_ENABLED
 
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -653,6 +653,9 @@ private:
     bool set_target_angle_and_climbrate(float roll_deg, float pitch_deg, float yaw_deg, float climb_rate_ms, bool use_yaw_rate, float yaw_rate_degs) override;
     bool get_circle_radius(float &radius_m) override;
     bool set_circle_rate(float rate_dps) override;
+    bool nav_scripting_enable(uint8_t mode) override;
+    bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) override;
+    void nav_script_time_done(uint16_t id) override;
 #endif // AP_SCRIPTING_ENABLED
     void rc_loop();
     void throttle_loop();

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -165,7 +165,7 @@ bool Rover::set_target_location(const Location& target_loc)
         return false;
     }
 
-    return control_mode->set_desired_location(target_loc);
+    return mode_guided.set_desired_location(target_loc);
 }
 
 // set target velocity (for use by scripting)

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -248,6 +248,32 @@ bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &
     }
     return false;
 }
+
+// returns true if mode supports NAV_SCRIPT_TIME mission commands
+bool Rover::nav_scripting_enable(uint8_t mode)
+{
+    return mode == (uint8_t)mode_auto.mode_number();
+}
+
+// lua scripts use this to retrieve the contents of the active command
+bool Rover::nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2)
+{
+    if (control_mode != &mode_auto) {
+        return false;
+    }
+
+    return mode_auto.nav_script_time(id, cmd, arg1, arg2);
+}
+
+// lua scripts use this to indicate when they have complete the command
+void Rover::nav_script_time_done(uint16_t id)
+{
+    if (control_mode != &mode_auto) {
+        return;
+    }
+
+    return mode_auto.nav_script_time_done(id);
+}
 #endif // AP_SCRIPTING_ENABLED
 
 #if STATS_ENABLED == ENABLED

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -274,6 +274,9 @@ private:
     // set desired turn rate (degrees/sec) and speed (m/s). Used for scripting
     bool set_desired_turn_rate_and_speed(float turn_rate, float speed) override;
     bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) override;
+    bool nav_scripting_enable(uint8_t mode) override;
+    bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2) override;
+    void nav_script_time_done(uint16_t id) override;
 #endif // AP_SCRIPTING_ENABLED
     void stats_update();
     void ahrs_update();

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -255,7 +255,7 @@ public:
     bool is_autopilot_mode() const override { return true; }
 
     // return if external control is allowed in this mode (Guided or Guided-within-Auto)
-    bool in_guided_mode() const override { return _submode == Auto_Guided; }
+    bool in_guided_mode() const override { return _submode == Auto_Guided || _submode == Auto_NavScriptTime; }
 
     // return distance (in meters) to destination
     float get_distance_to_destination() const override;
@@ -270,6 +270,10 @@ public:
 
     // start RTL (within auto)
     void start_RTL();
+
+    // lua accessors for nav script time support
+    bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2);
+    void nav_script_time_done(uint16_t id);
 
     AP_Mission mission{
         FUNCTOR_BIND_MEMBER(&ModeAuto::start_command, bool, const AP_Mission::Mission_Command&),
@@ -294,7 +298,8 @@ protected:
         Auto_RTL,               // perform RTL within auto mode
         Auto_Loiter,            // perform Loiter within auto mode
         Auto_Guided,            // handover control to external navigation system from within auto mode
-        Auto_Stop               // stop the vehicle as quickly as possible
+        Auto_Stop,              // stop the vehicle as quickly as possible
+        Auto_NavScriptTime,     // accept targets from lua scripts while NAV_SCRIPT_TIME commands are executing
     } _submode;
 
 private:
@@ -330,6 +335,10 @@ private:
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_set_reverse(const AP_Mission::Mission_Command& cmd);
     void do_guided_limits(const AP_Mission::Mission_Command& cmd);
+#if AP_SCRIPTING_ENABLED
+    void do_nav_script_time(const AP_Mission::Mission_Command& cmd);
+    bool verify_nav_script_time();
+#endif
 
     bool waiting_to_start;  // true if waiting for EKF origin before starting mission
     bool auto_triggered;        // true when auto has been triggered to start
@@ -362,6 +371,18 @@ private:
     uint32_t nav_delay_time_max_ms;  // used for delaying the navigation commands
     uint32_t nav_delay_time_start_ms;
 
+#if AP_SCRIPTING_ENABLED
+    // nav_script_time command variables
+    struct {
+        bool done;          // true once lua script indicates it has completed
+        uint16_t id;        // unique id to avoid race conditions between commands and lua scripts
+        uint32_t start_ms;  // system time nav_script_time command was received (used for timeout)
+        uint8_t command;    // command number provided by mission command
+        uint8_t timeout_s;  // timeout (in seconds) provided by mission command
+        float arg1;         // 1st argument provided by mission command
+        float arg2;         // 2nd argument provided by mission command
+    } nav_scripting;
+#endif
 };
 
 

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -555,7 +555,7 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
         return verify_nav_guided_enable(cmd);
 
     case MAV_CMD_NAV_DELAY:
-       return verify_nav_delay(cmd);
+        return verify_nav_delay(cmd);
 
 #if AP_SCRIPTING_ENABLED
     case MAV_CMD_NAV_SCRIPT_TIME:

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -119,6 +119,10 @@ void ModeAuto::update()
         case Auto_Stop:
             stop_vehicle();
             break;
+
+        case Auto_NavScriptTime:
+            rover.mode_guided.update();
+            break;
     }
 }
 
@@ -147,6 +151,7 @@ float ModeAuto::get_distance_to_destination() const
     case Auto_Loiter:
         return rover.mode_loiter.get_distance_to_destination();
     case Auto_Guided:
+    case Auto_NavScriptTime:
         return rover.mode_guided.get_distance_to_destination();
     }
 
@@ -173,6 +178,7 @@ bool ModeAuto::get_desired_location(Location& destination) const
     case Auto_Loiter:
         return rover.mode_loiter.get_desired_location(destination);
     case Auto_Guided:
+    case Auto_NavScriptTime:
         return rover.mode_guided.get_desired_location(destination);\
     }
 
@@ -212,6 +218,7 @@ bool ModeAuto::reached_destination() const
         return rover.mode_loiter.reached_destination();
         break;
     case Auto_Guided:
+    case Auto_NavScriptTime:
         return rover.mode_guided.reached_destination();
         break;
     }
@@ -239,6 +246,7 @@ bool ModeAuto::set_desired_speed(float speed)
     case Auto_Loiter:
         return rover.mode_loiter.set_desired_speed(speed);
     case Auto_Guided:
+    case Auto_NavScriptTime:
         return rover.mode_guided.set_desired_speed(speed);
     }
     return false;
@@ -250,6 +258,31 @@ void ModeAuto::start_RTL()
     if (rover.mode_rtl.enter()) {
         _submode = Auto_RTL;
     }
+}
+
+// lua scripts use this to retrieve the contents of the active command
+bool ModeAuto::nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2)
+{
+#if AP_SCRIPTING_ENABLED
+    if (_submode == AutoSubMode::Auto_NavScriptTime) {
+        id = nav_scripting.id;
+        cmd = nav_scripting.command;
+        arg1 = nav_scripting.arg1;
+        arg2 = nav_scripting.arg2;
+        return true;
+    }
+#endif
+    return false;
+}
+
+// lua scripts use this to indicate when they have complete the command
+void ModeAuto::nav_script_time_done(uint16_t id)
+{
+#if AP_SCRIPTING_ENABLED
+    if ((_submode == AutoSubMode::Auto_NavScriptTime) && (id == nav_scripting.id)) {
+        nav_scripting.done = true;
+    }
+#endif
 }
 
 // check for triggering of start of auto mode
@@ -387,6 +420,12 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
         do_nav_delay(cmd);
         break;
 
+#if AP_SCRIPTING_ENABLED
+    case MAV_CMD_NAV_SCRIPT_TIME:
+        do_nav_script_time(cmd);
+        break;
+#endif
+
     // Conditional commands
     case MAV_CMD_CONDITION_DELAY:
         do_wait_delay(cmd);
@@ -517,6 +556,11 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_NAV_DELAY:
        return verify_nav_delay(cmd);
+
+#if AP_SCRIPTING_ENABLED
+    case MAV_CMD_NAV_SCRIPT_TIME:
+        return verify_nav_script_time();
+#endif
 
     case MAV_CMD_CONDITION_DELAY:
         return verify_wait_delay();
@@ -812,3 +856,35 @@ void ModeAuto::do_guided_limits(const AP_Mission::Mission_Command& cmd)
         cmd.p1 * 1000, // convert seconds to ms
         cmd.content.guided_limits.horiz_max);
 }
+
+#if AP_SCRIPTING_ENABLED
+// start accepting position, velocity and acceleration targets from lua scripts
+void ModeAuto::do_nav_script_time(const AP_Mission::Mission_Command& cmd)
+{
+    // call regular guided flight mode initialisation
+    if (rover.mode_guided.enter()) {
+        _submode = AutoSubMode::Auto_NavScriptTime;
+        nav_scripting.done = false;
+        nav_scripting.id++;
+        nav_scripting.start_ms = millis();
+        nav_scripting.command = cmd.content.nav_script_time.command;
+        nav_scripting.timeout_s = cmd.content.nav_script_time.timeout_s;
+        nav_scripting.arg1 = cmd.content.nav_script_time.arg1;
+        nav_scripting.arg2 = cmd.content.nav_script_time.arg2;
+    } else {
+        // for safety we set nav_scripting to done to protect against the mission getting stuck
+        nav_scripting.done = true;
+    }
+}
+
+// check if verify_nav_script_time command has completed
+bool ModeAuto::verify_nav_script_time()
+{
+    // if done or timeout then return true
+    if (nav_scripting.done ||
+        (AP_HAL::millis() - nav_scripting.start_ms) > (nav_scripting.timeout_s * 1000)) {
+        return true;
+    }
+    return false;
+}
+#endif

--- a/libraries/AP_Scripting/examples/copter-nav-script-time.lua
+++ b/libraries/AP_Scripting/examples/copter-nav-script-time.lua
@@ -1,0 +1,90 @@
+-- Copter perform a simple maneuver in response to a NAV_SCRIPT_TIME mission command while the vehicle is in Auto mode
+--
+-- Create a simple mission like below
+-- TAKEOFF, Alt:10m
+-- NAV_SCRIPT_TIME, command=0 (not used in this script), timeout=30 (seconds), arg1=5 (square width in meters), arg2=10 (square height in meters)
+-- RETURN-TO-LAUNCH
+--
+-- Arm the vehicle (in Loiter mode), switch to Auto and raise the throttle
+-- The vehicle should climb to 10m
+-- This lua script will be fly the vehicle in square pattern in clockwise direction at the current altitude
+-- "arg1" specifies the width (e.g. East-West) in meters
+-- "arg2" specifies the height (e.g. North-South) in meters
+-- Once the vehicle completes the square or the timeout expires the mission will continue and the vehicle should RTL home
+
+local running = false
+local last_id = -1          -- unique id used to detect if a new NAV_SCRIPT_TIME command has started
+local start_loc             -- vehicle's location when command starts (South-West corner of square)
+local target_loc            -- vehicle's target location
+local stage = 0             -- stage0: fly North arg2 meters
+                            -- stage1: fly East arg1 meters
+                            -- stage2: fly South arg2 meters
+                            -- stage3: fly West arg2 meters
+                            -- stage4: done
+local prev_stage = -1       -- previous stage, used to initate call to move to next corner
+
+function update()
+  id, cmd, arg1, arg2 = vehicle:nav_script_time()
+  if id then
+    -- handle start of new command
+    if id ~= last_id then
+      start_loc = ahrs:get_location()       -- initialise south-west corner of square
+      if start_loc then
+        running = true
+        last_id = id
+        stage = 0                           -- start heading North
+        prev_stage = -1
+      else
+        gcs:send_text(0, "nav-script-time: failed to get location")
+        running = false
+      end
+    end
+
+    -- set waypoint target according to stage
+    if (running and stage ~= prev_stage) then
+      prev_stage = stage
+      local corner_loc = start_loc:copy()   -- initialise target location to starting location
+      if (stage == 0) then
+        corner_loc:offset(arg2, 0)          -- North West corner
+      end
+      if (stage == 1) then
+        corner_loc:offset(arg2, arg1)       -- North East corner
+      end
+      if (stage == 2) then
+        corner_loc:offset(0, arg1)          -- South East corner
+      end
+      -- stage 3 is back to start_loc
+      if vehicle:set_target_location(corner_loc) then
+        target_loc = corner_loc
+      else
+        gcs:send_text(0, "nav-script-time: failed to set target")
+        vehicle:nav_script_time_done(last_id)
+        running = false
+      end
+    end
+
+    -- advance stage if we have reached within 1m of target
+    if running then
+      local curr_loc = ahrs:get_location()
+      if curr_loc then
+        local dist_m = curr_loc:get_distance(target_loc)
+        if (dist_m < 1.0) then
+          stage = stage + 1
+          if stage == 4 then
+            vehicle:nav_script_time_done(last_id)
+            running = false
+          end
+        end
+      else
+        gcs:send_text(0, "nav-script-time: failed to get location")
+      end
+    end
+  else
+    -- no active command
+    running = false
+  end
+
+  return update, 100                        -- update at 10hz
+end
+
+return update()


### PR DESCRIPTION
This adds support for the [NAV_SCRIPT_TIME](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml#L284) mission command to Copter and Rover including adding an example script that flies a square with width and height specified by arg1 and arg2 of the command.

This feature mostly re-uses the existing Guided-within-Auto feature so lua scripts can control the vehicle using all the same methods they can use when the vehicle is in Guided mode (e.g. target location, velocity, acceleration, etc).

A new Auto sub-mode called NAV_SCRIPT_TIME has been added which mostly separates the lua script control from the existing companion computer (or GCS) control.  With this separation:

- Lua scripts won't try and take control while a GUIDED_ENABLE command is being executed
- Lua scripts are not limited by the timeout and position limits set from GUIDED_LIMITS commands.  Lua scripts are instead only limited by the command's "timeout_s" value.

The separation is not 100% though because while Lua scripts can't interfere with companion computer control of the vehicle (while executing GUIDED_ENABLE commands), the opposite is not true.  E.g. companion computers could interfere and control the vehicle while NAV_SCRIPT_TIME commands are being executed.  With a bit more effort we could separate them completely but I don't think it's necessary at this stage.

This has been tested in SITL including confirming the following all worked as expected

1. Vehicle flew a square specified by arg1 and arg2 (Note existing bug https://github.com/ArduPilot/ardupilot/issues/20114)
2. Timeout triggered if mission takes longer than timeout_s
3. Interrupting the command works correctly
4. Multiple NAV_SCRIPT_TIME commands in a row

![copter-nav-script-time-support](https://user-images.githubusercontent.com/1498098/154623912-27df9b1e-9a01-4e49-8aab-ba94a480b4c8.png)

![image](https://user-images.githubusercontent.com/1498098/154892773-7f98aae4-2506-43d4-b14d-b7ea1db0179e.png)
