### PR TITLE
AP_Common: convert referenced location alt while sanitizing a location

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -355,9 +355,11 @@ bool Location::sanitize(const Location &defaultLoc)
 
     // convert relative alt=0 to mean current alt
     if (alt == 0 && relative_alt) {
-        relative_alt = false;
-        alt = defaultLoc.alt;
-        has_changed = true;
+        int32_t defaultLoc_alt;
+        if (defaultLoc.get_alt_cm(get_alt_frame(), defaultLoc_alt)) {
+            alt = defaultLoc_alt;
+            has_changed = true;
+        }
     }
 
     // limit lat/lng to appropriate ranges

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -317,24 +317,31 @@ TEST(Location, Distance)
 
 TEST(Location, Sanitize)
 {
+    // we will sanitize test_loc with test_default_loc
+    // test_home is just for reference
     const Location test_home{-35362938, 149165085, 100, Location::AltFrame::ABSOLUTE};
+    EXPECT_TRUE(vehicle.ahrs.set_home(test_home));
+    const Location test_default_loc{-35362938, 149165085, 200, Location::AltFrame::ABSOLUTE};
     Location test_loc;
     test_loc.set_alt_cm(0, Location::AltFrame::ABOVE_HOME);
-    EXPECT_TRUE(test_loc.sanitize(test_home));
-    EXPECT_TRUE(test_loc.same_latlon_as(test_home));
-    EXPECT_EQ(test_home.alt, test_loc.alt);
+    EXPECT_TRUE(test_loc.sanitize(test_default_loc));
+    EXPECT_TRUE(test_loc.same_latlon_as(test_default_loc));
+    int32_t default_loc_alt;
+    // we should compare test_loc alt and test_default_loc alt in same frame , in this case, ABOVE HOME
+    EXPECT_TRUE(test_default_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, default_loc_alt));
+    EXPECT_EQ(test_loc.alt, default_loc_alt);
     test_loc = Location(91*1e7, 0, 0, Location::AltFrame::ABSOLUTE);
-    EXPECT_TRUE(test_loc.sanitize(test_home));
-    EXPECT_TRUE(test_loc.same_latlon_as(test_home));
-    EXPECT_NE(test_home.alt, test_loc.alt);
+    EXPECT_TRUE(test_loc.sanitize(test_default_loc));
+    EXPECT_TRUE(test_loc.same_latlon_as(test_default_loc));
+    EXPECT_NE(test_default_loc.alt, test_loc.alt);
     test_loc = Location(0, 181*1e7, 0, Location::AltFrame::ABSOLUTE);
-    EXPECT_TRUE(test_loc.sanitize(test_home));
-    EXPECT_TRUE(test_loc.same_latlon_as(test_home));
-    EXPECT_NE(test_home.alt, test_loc.alt);
+    EXPECT_TRUE(test_loc.sanitize(test_default_loc));
+    EXPECT_TRUE(test_loc.same_latlon_as(test_default_loc));
+    EXPECT_NE(test_default_loc.alt, test_loc.alt);
     test_loc = Location(42*1e7, 42*1e7, 420, Location::AltFrame::ABSOLUTE);
-    EXPECT_FALSE(test_loc.sanitize(test_home));
-    EXPECT_FALSE(test_loc.same_latlon_as(test_home));
-    EXPECT_NE(test_home.alt, test_loc.alt);
+    EXPECT_FALSE(test_loc.sanitize(test_default_loc));
+    EXPECT_FALSE(test_loc.same_latlon_as(test_default_loc));
+    EXPECT_NE(test_default_loc.alt, test_loc.alt);
 }
 
 TEST(Location, Line)


### PR DESCRIPTION
While working on a PR, @peterbarker suggested me to use `sanitize()` method (I was duplicating this because I didn't know we already had this method) in the code. **Both the location to be sanitized and referenced location were in relative frame.** After the changes, I observed that the vehicle was crashing (on SITL) because we were copying altitude value from referenced location and setting `relative_alt = false` which was leading to that copied value being interpreted as absolute altitude (10 m above sea in my case) and hence the vehicle was crashing.
Hence, I propose to set the altitude of referenced location in with correct frame so that the altitude is same as of referenced location.

**Edit: As suggested by @peterbarker in the comment below, we should convert the value of `alt` before copying it to the location being sanitised instead of changing the alt frame to avoid any implications.**