### PR TITLE
GCS_MAVLink: stop taking semaphore aorund statustext queue loop

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2053,8 +2053,6 @@ void GCS_MAVLINK::service_statustext(void)
 {
     GCS::StatusTextQueue &_statustext_queue = gcs().statustext_queue();
 
-    WITH_SEMAPHORE(comm_chan_lock(chan));
-
     const uint8_t chan_bit = (1U<<chan);
     // note the lack of idx++ here.  We may remove the iteration item
     // from the queue as the last thing we do, in which case we don't


### PR DESCRIPTION
we're taking it in the loop