### PR TITLE
build: ccache efficiency part2

### DIFF
--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -1,0 +1,33 @@
+name: test ccache
+
+on: [push, pull_request, workflow_dispatch]
+# paths:
+# - "*"
+# - "!README.md" <-- don't rebuild on doc change
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    strategy:
+      fail-fast: false  # don't cancel if a job from the matrix fails
+      matrix:
+        toolchain: [
+            chibios,
+        ]
+        gcc: [10]
+    steps:
+      # git checkout the PR
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: ccache test
+        shell: bash
+        run: |
+          PATH="/usr/lib/ccache:/opt/gcc-arm-none-eabi-${{matrix.gcc}}/bin:$PATH"
+          Tools/scripts/build_tests/test_ccache.py --boards MatekF405,MatekF405-bdshot --min-cache-pct=75
+          Tools/scripts/build_tests/test_ccache.py --boards CubeOrange,Durandal --min-cache-pct=75
+

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -894,6 +894,9 @@ class chibios(Board):
             cfg.msg("Enabling ChibiOS asserts", "no")
 
 
+        if cfg.env.SAVE_TEMPS:
+            env.CXXFLAGS += [ '-S', '-save-temps=obj' ]
+
         if cfg.options.disable_watchdog:
             cfg.msg("Disabling Watchdog", "yes")
             env.CFLAGS += [ '-DDISABLE_WATCHDOG' ]

--- a/Tools/scripts/build_tests/test_ccache.py
+++ b/Tools/scripts/build_tests/test_ccache.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# test ccache efficiency building two similar boards
+# AP_FLAKE8_CLEAN
+
+import subprocess
+import re
+import argparse
+import sys
+import os
+
+parser = argparse.ArgumentParser(description='test ccache performance')
+parser.add_argument('--boards', default='MatekF405,MatekF405-bdshot', help='boards to test')
+parser.add_argument('--min-cache-pct', type=int, default=75, help='minimum acceptable ccache hit rate')
+
+args = parser.parse_args()
+
+
+def ccache_stats():
+    '''return hits/misses from ccache -s'''
+    hits = 0
+    miss = 0
+    stats = str(subprocess.Popen(["ccache", "-s"], stdout=subprocess.PIPE).communicate()[0], encoding='ascii')
+    for line in stats.split('\n'):
+        m = re.match(r"cache.hit\D*(\d+)$", line)
+        if m is not None:
+            hits += int(m.group(1))
+        m = re.match(r"cache.miss\D*(\d+)", line)
+        if m is not None:
+            miss += int(m.group(1))
+    return (hits, miss)
+
+
+def build_board(boardname):
+    subprocess.run(["./waf", "configure", "--board", boardname])
+    subprocess.run(["./waf", "clean", "copter"])
+
+
+boards = args.boards.split(",")
+if len(boards) != 2:
+    print(boards)
+    print("Must specify exactly 2 boards (comma separated)")
+    sys.exit(1)
+
+os.environ['CCACHE_DIR'] = os.path.join(os.getcwd(), 'build', 'ccache')
+subprocess.run(["ccache", "-C", "-z"])
+build_board(boards[0])
+subprocess.run(["ccache", "-z"])
+build_board(boards[1])
+subprocess.run(["ccache", "-s"])
+
+post = ccache_stats()
+hit_pct = 100 * post[0] / float(post[0]+post[1])
+print("ccache hit percentage: %.1f%%  %s" % (hit_pct, post))
+if hit_pct < args.min_cache_pct:
+    print("ccache hits too low, need %d%%" % args.min_cache_pct)
+    sys.exit(1)
+else:
+    print("ccache hits good")

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -77,6 +77,18 @@
 extern const AP_HAL::HAL& hal;
 AP_BoardConfig *AP_BoardConfig::_singleton;
 
+// constructor
+AP_BoardConfig::AP_BoardConfig()
+#if HAL_HAVE_IMU_HEATER
+    // initialise heater PI controller. Note we do this in the cpp file
+    // for ccache efficiency
+    : heater{{HAL_IMUHEAT_P_DEFAULT, HAL_IMUHEAT_I_DEFAULT, 70},}
+#endif
+{
+    _singleton = this;
+    AP_Param::setup_object_defaults(this, var_info);
+};
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -44,10 +44,7 @@ extern "C" typedef int (*main_fn_t)(int argc, char **);
 
 class AP_BoardConfig {
 public:
-    AP_BoardConfig() {
-        _singleton = this;
-        AP_Param::setup_object_defaults(this, var_info);
-    };
+    AP_BoardConfig();
 
     /* Do not allow copies */
     AP_BoardConfig(const AP_BoardConfig &other) = delete;
@@ -124,12 +121,10 @@ public:
 #endif
     }
 
-#ifdef HAL_PIN_ALT_CONFIG
     // get alternative config selection
     uint8_t get_alt_config(void) {
         return uint8_t(_alt_config.get());
     }
-#endif // HAL_PIN_ALT_CONFIG
 
     enum board_safety_button_option {
         BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF= (1 << 0),
@@ -254,9 +249,9 @@ private:
 
 #if HAL_HAVE_IMU_HEATER
     struct {
+        AC_PI pi_controller;
         AP_Int8 imu_target_temperature;
         uint32_t last_update_ms;
-        AC_PI pi_controller{HAL_IMUHEAT_P_DEFAULT, HAL_IMUHEAT_I_DEFAULT, 70};
         uint16_t count;
         float sum;
         float output;
@@ -282,9 +277,7 @@ private:
     AP_Float _vservo_min;
 #endif
 
-#ifdef HAL_GPIO_PWM_VOLT_PIN
     AP_Int8 _pwm_volt_sel;
-#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     AP_Int8 _sdcard_slowdown;
@@ -294,9 +287,7 @@ private:
 
     AP_Int32 _options;
 
-#ifdef HAL_PIN_ALT_CONFIG
     AP_Int8  _alt_config;
-#endif
 };
 
 namespace AP {

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -27,6 +27,10 @@
 
 #if HAL_NMEA_OUTPUT_ENABLED
 
+#ifndef NMEA_MAX_OUTPUTS
+#define NMEA_MAX_OUTPUTS 3
+#endif
+
 #include <AP_SerialManager/AP_SerialManager.h>
 
 class AP_NMEA_Output {
@@ -45,7 +49,7 @@ private:
     uint8_t _nmea_checksum(const char *str);
 
     uint8_t _num_outputs;
-    AP_HAL::UARTDriver* _uart[SERIALMANAGER_NUM_PORTS];
+    AP_HAL::UARTDriver* _uart[NMEA_MAX_OUTPUTS];
 
     uint32_t _last_run_ms;
 };

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -114,7 +114,6 @@ extern const AP_HAL::HAL& hal;
 #define SERIAL9_PROTOCOL SerialProtocol_None
 #endif // HAL_BUILD_AP_PERIPH
 
-
 const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
 #if SERIALMANAGER_NUM_PORTS > 0
     // @Param: 0_BAUD
@@ -807,7 +806,7 @@ void AP_SerialManager::disable_passthru(void)
 // accessor for AP_Periph to set baudrate and type
 void AP_SerialManager::set_protocol_and_baud(uint8_t sernum, enum SerialProtocol protocol, uint32_t baudrate)
 {
-    if (sernum <= ARRAY_SIZE(state)) {
+    if (sernum < SERIALMANAGER_NUM_PORTS) {
         state[sernum].protocol.set(protocol);
         state[sernum].baud.set(baudrate);
     }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -38,6 +38,19 @@
 #define SERIALMANAGER_NUM_PORTS 8
 #endif
 
+/*
+  array size for state[]. This needs to be at least
+  SERIALMANAGER_NUM_PORTS, but we want it to be the same length on
+  similar boards to get the ccache efficiency up. This wastes a small
+  amount of memory, but makes a huge difference to the build times
+ */
+#if SERIALMANAGER_NUM_PORTS > 10 || SERIALMANAGER_NUM_PORTS < 5
+#define SERIALMANAGER_MAX_PORTS SERIALMANAGER_NUM_PORTS
+#else
+#define SERIALMANAGER_MAX_PORTS 10
+#endif
+
+
  // console default baud rates and buffer sizes
 #ifdef HAL_SERIAL0_BAUD_DEFAULT
 # define AP_SERIALMANAGER_CONSOLE_BAUD          HAL_SERIAL0_BAUD_DEFAULT
@@ -223,12 +236,13 @@ public:
 private:
     static AP_SerialManager *_singleton;
 
-    // array of uart info
+    // array of uart info. See comment above about
+    // SERIALMANAGER_MAX_PORTS
     struct UARTState {
-        AP_Int8 protocol;
         AP_Int32 baud;
         AP_Int16 options;
-    } state[SERIALMANAGER_NUM_PORTS];
+        AP_Int8 protocol;
+    } state[SERIALMANAGER_MAX_PORTS];
 
     // pass-through serial support
     AP_Int8 passthru_port1;

--- a/wscript
+++ b/wscript
@@ -155,6 +155,11 @@ def options(opt):
         default=False,
         help='enable OS level asserts.')
 
+    g.add_option('--save-temps',
+        action='store_true',
+        default=False,
+        help='save compiler temporary files.')
+    
     g.add_option('--enable-malloc-guard',
         action='store_true',
         default=False,
@@ -387,6 +392,7 @@ def configure(cfg):
     cfg.env.BOOTLOADER = cfg.options.bootloader
     cfg.env.ENABLE_MALLOC_GUARD = cfg.options.enable_malloc_guard
     cfg.env.ENABLE_STATS = cfg.options.enable_stats
+    cfg.env.SAVE_TEMPS = cfg.options.save_temps
 
     cfg.env.HWDEF_EXTRA = cfg.options.extra_hwdef
     if cfg.env.HWDEF_EXTRA:


### PR DESCRIPTION
This adjusts some code to get the ccache efficiency up for less similar boards. It raises hit rate for CubeOrange vs Durandal from 30% to 83%, and also gets a good level of direct ccache hits
It also adds a CI test to ensure that we keep this high level of efficiency. For the first push I have a test that will deliberately fail to check failure is reported correctly
