### PR TITLE
Rover nav bearing

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -660,6 +660,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(ais, "AIS_",  50, ParametersG2, AP_AIS),
 #endif
 
+    // @Param: MIS_NAV_TYP
+    // @DisplayName: Mission navigation type
+    // @Description: Behaviour mission navigation class
+    // @Values: 0:Navigation by lateral acceleration 1: Navigation by yaw 
+    // @User: Standard
+    AP_GROUPINFO("MIS_NAV_TYP", 60, ParametersG2, mis_nav_type, 0),
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -411,6 +411,8 @@ public:
     // Automatic Identification System - for tracking sea-going vehicles
     AP_AIS ais;
 #endif
+
+    AP_Int8 mis_nav_type;
 };
 
 extern const AP_Param::Info var_info[];

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -437,6 +437,20 @@ void Mode::navigate_to_waypoint()
         const float turn_rate = g2.sailboat.tacking() ? g2.wp_nav.get_pivot_rate() : 0.0f;
         calc_steering_to_heading(desired_heading_cd, turn_rate);
     } else {
+        if(g2.mis_nav_type == 1){
+            // retrieve desired yaw from waypoint controller
+            float desired_yaw_cd = g2.wp_nav.nav_bearing_cd();
+
+            // if simple avoidance is active at very low speed do not attempt to turn
+            if (g2.avoid.limits_active() && (fabsf(attitude_control.get_desired_speed()) <= attitude_control.get_stop_speed())) {
+                desired_yaw_cd = ahrs.yaw_sensor;
+            }
+
+            // call steering angle controller
+            calc_steering_to_heading(desired_yaw_cd);
+            return;
+        }
+
         // retrieve turn rate from waypoint controller
         float desired_turn_rate_rads = g2.wp_nav.get_turn_rate_rads();
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -491,7 +491,19 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate
 // return a desired turn-rate given a desired heading in radians
 float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float rate_max_rads) const
 {
-    const float yaw_error = wrap_PI(heading_rad - AP::ahrs().yaw);
+    // get ground course
+    float ground_course_deg;
+    Vector2f ground_speed_vec = AP::ahrs().groundspeed_vector();
+    const float ground_speed_dir = ground_speed_vec.angle();
+    if (ground_speed_vec.length() < AR_ATTCONTROL_STEER_SPEED_MIN) {
+        // with zero ground speed use vehicle's heading
+        ground_course_deg = AP::ahrs().yaw;
+    } else {
+        ground_course_deg = ground_speed_dir;
+    }
+    ground_course_deg =  wrap_PI(ground_course_deg);
+
+    const float yaw_error = wrap_PI(heading_rad - ground_course_deg);
 
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
     float desired_rate = _steer_angle_p.get_p(yaw_error);

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -293,7 +293,7 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
         //Calculate Nu1 angle (Angle to L1 reference point)
         float sine_Nu1 = _crosstrack_error/MAX(_L1_dist, 0.1f);
         //Limit sine of Nu1 to provide a controlled track capture angle of 45 deg
-        sine_Nu1 = constrain_float(sine_Nu1, -0.7071f, 0.7071f);
+        sine_Nu1 = constrain_float(sine_Nu1, -1.0f, 1.0f);
         float Nu1 = asinf(sine_Nu1);
 
         // compute integral error component to converge to a crosstrack of zero when traveling


### PR DESCRIPTION
Using the course track can reduce the overshoot of turning instead of lateral acceleration.
In addition, when the boat is traveling in a place with high water velocity, it should to use the speed direction instead of the bow direction for adjustment 
![lataccel_turn](https://user-images.githubusercontent.com/48796694/155130711-b156e79f-700b-4e9f-8e95-60cced594a3e.png)
![yaw_turn](https://user-images.githubusercontent.com/48796694/155130718-ae7b2dce-e02d-4335-8d2c-818ffe61b73d.png)
