### PR TITLE
Copter/Rover: NAV_SCRIPT_TIME's timeout fixed

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2034,7 +2034,8 @@ bool ModeAuto::verify_nav_script_time()
 {
     // if done or timeout then return true
     if (nav_scripting.done ||
-        (AP_HAL::millis() - nav_scripting.start_ms) > (nav_scripting.timeout_s * 1000)) {
+        ((nav_scripting.timeout_s > 0) &&
+         (AP_HAL::millis() - nav_scripting.start_ms) > (nav_scripting.timeout_s * 1000))) {
         return true;
     }
     return false;

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -882,7 +882,8 @@ bool ModeAuto::verify_nav_script_time()
 {
     // if done or timeout then return true
     if (nav_scripting.done ||
-        (AP_HAL::millis() - nav_scripting.start_ms) > (nav_scripting.timeout_s * 1000)) {
+        ((nav_scripting.timeout_s > 0) &&
+         (AP_HAL::millis() - nav_scripting.start_ms) > (nav_scripting.timeout_s * 1000))) {
         return true;
     }
     return false;


### PR DESCRIPTION
This fixes a bug found in Copter and Rover's handling of the recently introduced NAV_SCRIPT_TIME mission command.

The bug is that we were not disabling the timeout if the "timeout_s" argument was zero.

This has been tested in SITL on Copter and Rover to confirm that the timeout works correctly when specified and is not invoked when set to zero.