### PR TITLE
AP_Radio: fix build for skyviper-journey

### DIFF
--- a/libraries/AP_Radio/AP_Radio_bk2425.cpp
+++ b/libraries/AP_Radio/AP_Radio_bk2425.cpp
@@ -36,6 +36,18 @@ extern const AP_HAL::HAL& hal;
 #define DebugMavlink(level, fmt, args...)   do { if ((level) <= get_debug_level()) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
 
 
+#if SUPPORT_BK_DEBUG_PINS
+#define DEBUG1_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG1))
+#define DEBUG1_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG1))
+#define DEBUG2_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG2))
+#define DEBUG2_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG2))
+#else
+#define DEBUG1_HIGH()       do {} while (0)
+#define DEBUG1_LOW()        do {} while (0)
+#define DEBUG2_HIGH()       do {} while (0)
+#define DEBUG2_LOW()        do {} while (0)
+#endif
+
 // object instance for trampoline
 AP_Radio_beken *AP_Radio_beken::radio_singleton;
 thread_t *AP_Radio_beken::_irq_handler_ctx;

--- a/libraries/AP_Radio/driver_bk2425.cpp
+++ b/libraries/AP_Radio/driver_bk2425.cpp
@@ -14,6 +14,33 @@ using namespace ChibiOS;
 
 extern const AP_HAL::HAL& hal;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#include <hal.h>
+#endif
+
+// This assumes we are using ChiBios instead of the pixhawk o/s for accessing GPIO
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412
+#define BEKEN_SELECT()      (dev->set_chip_select(true))
+#define BEKEN_DESELECT()    (dev->set_chip_select(false))
+#define BEKEN_CE_HIGH()     (palSetLine(HAL_GPIO_PIN_RADIO_CE)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_CE, 1))
+#define BEKEN_CE_LOW()      (palClearLine(HAL_GPIO_PIN_RADIO_CE)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_CE, 0))
+#define BEKEN_PA_HIGH()     (palSetLine(HAL_GPIO_PIN_RADIO_PA_CTL)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_PA_CTL, 1))
+#define BEKEN_PA_LOW()      (palClearLine(HAL_GPIO_PIN_RADIO_PA_CTL)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_PA_CTL, 0))
+#if SUPPORT_BK_DEBUG_PINS
+#define DEBUG1_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG1))
+#define DEBUG1_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG1))
+#define DEBUG2_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG2))
+#define DEBUG2_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG2))
+#else
+#define DEBUG1_HIGH()       do {} while (0)
+#define DEBUG1_LOW()        do {} while (0)
+#define DEBUG2_HIGH()       do {} while (0)
+#define DEBUG2_LOW()        do {} while (0)
+#endif
+#else
+#error This configuration is not supported.
+#endif
+
 // --------------------------------------------------------------------
 // Radio initialisation tables
 // --------------------------------------------------------------------

--- a/libraries/AP_Radio/driver_bk2425.h
+++ b/libraries/AP_Radio/driver_bk2425.h
@@ -317,29 +317,6 @@ enum {
 #define DEFAULT_OUTPUT_REG6 TOKENPASTE2(OUTPUT_POWER_REG6_,DEFAULT_OUTPUT_POWER)
 #define DEFAULT_OUTPUT_REG4 TOKENPASTE2(OUTPUT_POWER_REG4_,DEFAULT_OUTPUT_POWER)
 
-// This assumes we are using ChiBios instead of the pixhawk o/s for accessing GPIO
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412
-#define BEKEN_SELECT()      (dev->set_chip_select(true))
-#define BEKEN_DESELECT()    (dev->set_chip_select(false))
-#define BEKEN_CE_HIGH()     (palSetLine(HAL_GPIO_PIN_RADIO_CE)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_CE, 1))
-#define BEKEN_CE_LOW()      (palClearLine(HAL_GPIO_PIN_RADIO_CE)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_CE, 0))
-#define BEKEN_PA_HIGH()     (palSetLine(HAL_GPIO_PIN_RADIO_PA_CTL)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_PA_CTL, 1))
-#define BEKEN_PA_LOW()      (palClearLine(HAL_GPIO_PIN_RADIO_PA_CTL)) // (hal.gpio->write(HAL_CHIBIOS_GPIO_RADIO_PA_CTL, 0))
-#if SUPPORT_BK_DEBUG_PINS
-#define DEBUG1_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG1))
-#define DEBUG1_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG1))
-#define DEBUG2_HIGH()       (palSetLine(HAL_GPIO_PIN_DEBUG2))
-#define DEBUG2_LOW()        (palClearLine(HAL_GPIO_PIN_DEBUG2))
-#else
-#define DEBUG1_HIGH()       do {} while (0)
-#define DEBUG1_LOW()        do {} while (0)
-#define DEBUG2_HIGH()       do {} while (0)
-#define DEBUG2_LOW()        do {} while (0)
-#endif
-#else
-#error This configuration is not supported.
-#endif
-
 /** Parameters used by the fcc pretests */
 typedef struct FccParams_s {
     uint8_t fcc_mode; ///< The value (0..6) last set by the user that we are using. Non-zero iff we are sending test signals


### PR DESCRIPTION
Recent header changes killed this.  I duplicated the pin-debug stuff because I'm lazy (it's needed in two .cpp files and we don't want `PAL_LINE` in a header...
