### PR TITLE
Allow H7 480Mhz clock speed to be configured in hwdef

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7/hwdef.dat
@@ -11,6 +11,8 @@ APJ_BOARD_ID 1060
 # crystal frequency, setup to use external oscillator
 OSCILLATOR_HZ 8000000
 
+MCU_CLOCKRATE_MHZ 480
+
 env OPTIMIZE -O2
 
 STM32_ST_USE_TIMER 2

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -19,7 +19,7 @@
 #pragma once
 
 // we want to cope with both revision XY chips and newer chips
-#ifndef STM32H750xx
+#if !defined(HAL_CUSTOM_MCU_CLOCKRATE) || HAL_CUSTOM_MCU_CLOCKRATE <= 400000000
 #define STM32_ENFORCE_H7_REV_XY
 #endif
 
@@ -161,8 +161,12 @@
 
 #elif (STM32_HSECLK == 8000000U) || (STM32_HSECLK == 16000000U)
 // common clock tree for multiples of 8MHz crystals
-#ifdef STM32H750xx
+#ifdef HAL_CUSTOM_MCU_CLOCKRATE
+#if HAL_CUSTOM_MCU_CLOCKRATE == 480000000
 #define STM32_PLL1_DIVN_VALUE               120
+#else
+#error "Unable to configure custom clockrate"
+#endif
 #else
 #define STM32_PLL1_DIVN_VALUE               100
 #endif
@@ -181,8 +185,12 @@
 #define STM32_PLL3_DIVR_VALUE               9
 
 #elif STM32_HSECLK == 24000000U
-#ifdef STM32H750xx
+#ifdef HAL_CUSTOM_MCU_CLOCKRATE
+#if HAL_CUSTOM_MCU_CLOCKRATE == 480000000
 #define STM32_PLL1_DIVN_VALUE               120
+#else
+#error "Unable to configure custom clockrate"
+#endif
 #else
 #define STM32_PLL1_DIVN_VALUE               100
 #endif
@@ -201,6 +209,9 @@
 #define STM32_PLL3_DIVR_VALUE               9
 
 #elif STM32_HSECLK == 25000000U
+#ifdef HAL_CUSTOM_MCU_CLOCKRATE
+#error "Unable to configure custom clockrate"
+#endif
 #define STM32_PLL1_DIVN_VALUE               64
 #define STM32_PLL1_DIVP_VALUE               2
 #define STM32_PLL1_DIVQ_VALUE               10

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -61,7 +61,7 @@ mcu = {
         (0x38000000,  64, 1), # SRAM4.
     ],
 
-    'EXPECTED_CLOCK' : 480000000,
+    'EXPECTED_CLOCK' : 400000000,
 
     # this MCU has M7 instructions and hardware double precision
     'CORTEX'    : 'cortex-m7',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1037,7 +1037,11 @@ def write_mcu_config(f):
 #endif
 ''')
 
-    if get_mcu_config('EXPECTED_CLOCK', required=True):
+    if get_config('MCU_CLOCKRATE_MHZ', required=False):
+        clockrate = int(get_config('MCU_CLOCKRATE_MHZ'))
+        f.write('#define HAL_CUSTOM_MCU_CLOCKRATE %u\n' % (clockrate * 1000000))
+        f.write('#define HAL_EXPECTED_SYSCLOCK %u\n' % (clockrate * 1000000))
+    elif get_mcu_config('EXPECTED_CLOCK', required=True):
         f.write('#define HAL_EXPECTED_SYSCLOCK %u\n' % get_mcu_config('EXPECTED_CLOCK'))
 
     env_vars['CORTEX'] = cortex


### PR DESCRIPTION
This is a little bit more general. If vendors know they are not using rev X/Y then they should be allowed to get the higher clock speed.