### PR TITLE
Plane: Simplify and clarify failsafe messages

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -21,7 +21,7 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
     failsafe.state = fstype;
     failsafe.short_timer_ms = millis();
     failsafe.saved_mode_number = control_mode->mode_number();
-    gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe. Short event on: type=%u/reason=%u", fstype, static_cast<unsigned>(reason));
+    gcs().send_text(MAV_SEVERITY_WARNING, "RC Short Failsafe On");
     switch (control_mode->mode_number())
     {
     case Mode::Number::MANUAL:
@@ -102,7 +102,12 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
 void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason)
 {
     // This is how to handle a long loss of control signal failsafe.
-    gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe. Long event on: type=%u/reason=%u", fstype, static_cast<unsigned>(reason));
+    if (reason == ModeReason:: GCS_FAILSAFE) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe On");
+    }
+    else {
+        gcs().send_text(MAV_SEVERITY_WARNING, "RC Long Failsafe On");
+    }
     //  If the GCS is locked up we allow control to revert to RC
     RC_Channels::clear_overrides();
     failsafe.state = fstype;
@@ -186,7 +191,7 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
 void Plane::failsafe_short_off_event(ModeReason reason)
 {
     // We're back in radio contact
-    gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe. Short event off: reason=%u", static_cast<unsigned>(reason));
+    gcs().send_text(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
     failsafe.state = FAILSAFE_NONE;
     //restore entry mode if desired but check that our current mode is still due to failsafe
     if ( _last_reason == ModeReason::RADIO_FAILSAFE) { 
@@ -197,8 +202,13 @@ void Plane::failsafe_short_off_event(ModeReason reason)
 
 void Plane::failsafe_long_off_event(ModeReason reason)
 {
-    // We're back in radio contact
-    gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe. Long event off: reason=%u", static_cast<unsigned>(reason));
+    // We're back in radio contact with RC or GCS
+    if (reason == ModeReason:: GCS_FAILSAFE) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe Off");
+    }
+    else {
+        gcs().send_text(MAV_SEVERITY_WARNING, "RC Long Failsafe Cleared");
+    }
     failsafe.state = FAILSAFE_NONE;
 }
 

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -280,7 +280,7 @@ void Plane::control_failsafe()
         // throttle has dropped below the mark
         failsafe.throttle_counter++;
         if (failsafe.throttle_counter == 10) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe on");
+            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "on");
             failsafe.rc_failsafe = true;
             AP_Notify::flags.failsafe_radio = true;
         }
@@ -295,7 +295,7 @@ void Plane::control_failsafe()
             failsafe.throttle_counter = 3;
         }
         if (failsafe.throttle_counter == 1) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe off");
+            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "off");
         } else if(failsafe.throttle_counter == 0) {
             failsafe.rc_failsafe = false;
             AP_Notify::flags.failsafe_radio = false;

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1000,11 +1000,11 @@ class AutoTestPlane(AutoTest):
                 "FS_SHORT_ACTN": 3, # 3 means disabled
                 "SIM_RC_FAIL": 1,
             })
-            self.wait_statustext("Long event on", check_context=True)
+            self.wait_statustext("Long failsafe on", check_context=True)
             self.wait_mode("RTL")
 #            self.context_clear_collection("STATUSTEXT")
             self.set_parameter("SIM_RC_FAIL", 0)
-            self.wait_text("Long event off", check_context=True)
+            self.wait_text("Long Failsafe Cleared", check_context=True)
             self.change_mode("MANUAL")
 
             self.progress("Trying again with THR_FS_VALUE")
@@ -1012,7 +1012,7 @@ class AutoTestPlane(AutoTest):
                 "THR_FS_VALUE": 960,
                 "SIM_RC_FAIL": 2,
             })
-            self.wait_statustext("Long event on", check_context=True)
+            self.wait_statustext("Long Failsafe on", check_context=True)
             self.wait_mode("RTL")
         except Exception as e:
             self.print_exception_caught(e)


### PR DESCRIPTION
alternative to #20129 

In plane, short and long failsafe is very simple with only a few reasons....throttle failsafe is already separately annunciated, changing the short and long fs messages to this is clear and unambiguous in conjunction with the throttle failsafe message and is saving 44 bytes..more if Peter's throttle message change (which saves 12 bytes itself) is also incorporated...which I can do if desired