### PR TITLE
AP_Scripting: modify example script of README.md

### DIFF
--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -32,21 +32,24 @@ An example script is given below:
 
 ```lua
 function update () -- periodic function that will be called
-  current_pos = ahrs:get_location()
-  home = ahrs:get_home()
-  if current_pos and home then
-    distance = current_pos:get_distance(ahrs:get_home()) -- calculate the distance from home
+  local current_pos = ahrs:get_location() -- fetch the current position of the vehicle
+  local home = ahrs:get_home()            -- fetch the home position of the vehicle
+  if current_pos and home then            -- check that both a vehicle location, and home location are available
+    local distance = current_pos:get_distance(home) -- calculate the distance from home in meters
     if distance > 1000 then -- if more then 1000 meters away
       distance = 1000;      -- clamp the distance to 1000 meters
     end
     SRV_Channels:set_output_pwm(96, 1000 + distance) -- set the servo assigned function 96 (scripting3) to a proportional value
   end
 
-  return update, 1000 -- request to be rerun again 1000 milliseconds (1 second) from now
+  return update, 1000 -- request "update" to be rerun again 1000 milliseconds (1 second) from now
 end
 
-return update, 1000 -- request to be rerun again 1000 milliseconds (1 second) from now
+return update, 1000   -- request "update" to be the first time 1000 milliseconds (1 second) after script is loaded
 ```
+
+## Examples
+See the [code examples folder](https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/examples)
 
 ## Working with bindings
 


### PR DESCRIPTION
change the two things:
- avoid to call set_output_pwm before setting origin
- make get_home() once