### PR TITLE
External flash binaries should be published like internal flash binaries

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -266,6 +266,18 @@ class build_abin(Task.Task):
     def __str__(self):
         return self.outputs[0].path_from(self.generator.bld.bldnode)
 
+class build_normalized_bins(Task.Task):
+    '''Move external flash binaries to regular location if regular bin is zero length'''
+    color='CYAN'
+    always_run = True
+    def run(self):
+        if self.env.HAS_EXTERNAL_FLASH_SECTIONS and os.path.getsize(self.inputs[0].abspath()) == 0:
+                os.remove(self.inputs[0].abspath())
+                shutil.move(self.inputs[1].abspath(), self.inputs[0].abspath())
+
+    def keyword(self):
+        return "bin cleanup"
+
 class build_intel_hex(Task.Task):
     '''build an intel hex file for upload with DFU'''
     color='CYAN'
@@ -302,12 +314,15 @@ def chibios_firmware(self):
         abin_task = self.create_task('build_abin', src=link_output, tgt=abin_target)
         abin_task.set_run_after(generate_apj_task)
 
+    cleanup_task = self.create_task('build_normalized_bins', src=bin_target)
+    cleanup_task.set_run_after(generate_apj_task)
+
     bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % self.env.BOARD)
     if self.bld.env.HAVE_INTEL_HEX:
         if os.path.exists(bootloader_bin.abspath()):
             hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
             hex_task = self.create_task('build_intel_hex', src=[bin_target[0], bootloader_bin], tgt=hex_target)
-            hex_task.set_run_after(generate_bin_task)
+            hex_task.set_run_after(cleanup_task)
         else:
             print("Not embedding bootloader; %s does not exist" % bootloader_bin)
 


### PR DESCRIPTION
In order to bootstrap on SPRacingH7 we need to publish the external flash binary otherwise no-one will be able to load the firmware.

The change ensures that arduxxxx.bin is the binary with the code, whether internal or external