### PR TITLE
Copter: Add acceptance radius to NAV_WAYPOINT in auto mode

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -907,6 +907,16 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         acp = MIN(0xFF,acp);
 
         cmd.p1 = (passby << 8) | (acp & 0x00FF);
+#elif APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+        // hold time in seconds and acceptance radius in meters
+        uint16_t hold = packet.param1; // param 1 is hold time in seconds is held in low p1
+        uint16_t acp = packet.param2; // param 2 is acceptance radius in meters is held in high p1
+
+        // limit to 255 so it does not wrap during the shift or mask operation
+        hold = MIN(0xFF,hold);
+        acp = MIN(0xFF,acp);
+
+        cmd.p1 = (acp << 8) | (hold & 0x00FF);
 #else
         // delay at waypoint in seconds (this is for copters???)
         cmd.p1 = packet.param1;
@@ -1369,6 +1379,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
         packet.param2 = LOWBYTE(cmd.p1);        // param 2 is acceptance radius in meters is held in low p1
         packet.param3 = HIGHBYTE(cmd.p1);       // param 3 is pass by distance in meters is held in high p1
+#elif APM_BUILD_TYPE(APM_BUILD_ArduCopter)
+        // hold time in seconds and acceptance radius in meters
+        packet.param1 = LOWBYTE(cmd.p1); // param 1 is hold time in seconds is held in low p1
+        packet.param2 = HIGHBYTE(cmd.p1); // param 2 is acceptance radius in meters is held in high p1
 #else
         // delay at waypoint in seconds
         packet.param1 = cmd.p1;


### PR DESCRIPTION
I did this for [a forum discussion](https://discuss.ardupilot.org/t/copter-waypoints-accuracy/81855).
This significantly reduces the hold time to a maximum of 255 seconds.
But people who want more can do NAV_LOITER_TIME.
I tried my best to preserve the current implementation of hold time (except the value of itself 🙂).
For non-zero hold time values, the vehicle obeys the hold time and reaches the WP within WP_NAV_RADIUS and waits for the duration of hold time.
For zero hold time, the vehicle checks the acceptance radius, and if it is within this radius, goes to the next WP.
If hold time is less than WP_NAV_RADIUS, doesn't affect the current behavior.