### PR TITLE
Clean up some includes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -34,7 +34,6 @@
 #include <StorageManager/StorageManager.h>  // library for Management for hal.storage to allow for backwards compatible mapping of storage offsets to available storage
 
 // Application dependencies
-#include <GCS_MAVLink/GCS.h>                // Library for Interface definition for the various Ground Control System
 #include <AP_Logger/AP_Logger.h>            // ArduPilot Mega Flash Memory Library
 #include <AP_Math/AP_Math.h>                // ArduPilot Mega Vector/Matrix math Library
 #include <AP_AccelCal/AP_AccelCal.h>        // interface and maths for accelerometer calibration

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -13,7 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #pragma once
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class QuadPlane;
 class AP_MotorsMulticopter;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -32,7 +32,6 @@
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
 #include <AP_Declination/AP_Declination.h>     // ArduPilot Mega Declination Helper Library

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -34,7 +34,6 @@
 #include <StorageManager/StorageManager.h>
 
 // Application dependencies
-#include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>          // ArduPilot Mega Flash Memory Library
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
 // #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -25,6 +25,7 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_Filesystem/posix_compat.h>
+#include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/Scheduler.h>

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -4,9 +4,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AC_Fence/AC_PolyFence_loader.h>
-#include <AP_Common/Location.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
@@ -105,7 +103,7 @@ public:
     uint8_t check();
 
     // returns true if the destination is within fence (used to reject waypoints outside the fence)
-    bool check_destination_within_fence(const Location& loc);
+    bool check_destination_within_fence(const class Location& loc);
 
     /// get_breaches - returns bit mask of the fence types that have been breached
     uint8_t get_breaches() const { return _breached_fences; }

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AP_Math/AP_Math.h>
-#include <GCS_MAVLink/GCS.h>
 
 // This class constantly monitors what the status of the landing target is
 // If it is not in sight, depending on user parameters, it decides what measures can be taken to bring the target back in sight
@@ -17,8 +16,7 @@ public:
     };
 
     // Do not allow copies
-    AC_PrecLand_StateMachine(const AC_PrecLand_StateMachine &other) = delete;
-    AC_PrecLand_StateMachine &operator=(const AC_PrecLand_StateMachine&) = delete;
+    CLASS_NO_COPY(AC_PrecLand_StateMachine);
 
     // Initialize the state machine. This is called everytime vehicle switches mode
     void init();

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -22,9 +22,11 @@
 #include "AP_AHRS.h"
 #include "AP_AHRS_View.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_Module/AP_Module.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Notify/AP_Notify.h>

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -16,7 +16,7 @@
  */
 
 /*
- *  NavEKF based AHRS (Attitude Heading Reference System) interface for
+ *  AHRS (Attitude Heading Reference System) frontend interface for
  *  ArduPilot
  *
  */
@@ -36,13 +36,9 @@
 #define AP_AHRS_SIM_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 #endif
 
-#include "AP_AHRS.h"
-
 #if AP_AHRS_SIM_ENABLED
 #include <SITL/SITL.h>
 #endif
-
-#include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 
 #include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_NavEKF3/AP_NavEKF3.h>

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -16,10 +16,13 @@
 */
 #include "AP_AHRS.h"
 #include "AP_AHRS_View.h"
+
+#include <AP_Common/Location.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Compass/AP_Compass.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -22,11 +22,8 @@
 
 #include <AP_Math/AP_Math.h>
 #include <inttypes.h>
-#include <AP_Compass/AP_Compass.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
-#include <AP_Param/AP_Param.h>
-#include <AP_Common/Location.h>
 
 class OpticalFlow;
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
@@ -204,10 +201,10 @@ public:
     }
 
     //
-    virtual bool set_origin(const Location &loc) {
+    virtual bool set_origin(const struct Location &loc) {
         return false;
     }
-    virtual bool get_origin(Location &ret) const = 0;
+    virtual bool get_origin(struct Location &ret) const = 0;
 
     // return a position relative to origin in meters, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -25,6 +25,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -2,7 +2,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <Filter/Filter.h>
 #include <Filter/DerivativeFilter.h>
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -20,6 +20,7 @@
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
+#include <RC_Channel/RC_Channel.h>
 
 // very crude debounce method
 #define DEBOUNCE_MS 50

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define AP_CAMERA_TRIGGER_DEFAULT_DURATION  10      // default duration servo or relay is held open in 10ths of a second (i.e. 10 = 1 second)

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -19,11 +19,12 @@
  */
 #pragma once
 
-#include "AP_Compass.h"
-
+#include <AP_MSP/msp.h>
 #ifndef HAL_MSP_COMPASS_ENABLED
 #define HAL_MSP_COMPASS_ENABLED HAL_MSP_SENSORS_ENABLED
 #endif
+
+#include "AP_Compass.h"
 
 class Compass;  // forward declaration
 class AP_Compass_Backend

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -15,11 +15,9 @@
 
 #pragma once
 
-
-
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef HAL_EFI_ENABLED
 #define HAL_EFI_ENABLED !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024

--- a/libraries/AP_EFI/AP_EFI_Serial_Lutan.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_Lutan.cpp
@@ -16,9 +16,12 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_EFI_Serial_Lutan.h"
 #include <AP_HAL/utility/sparse-endian.h>
-#include <stdio.h>
 
 #if HAL_EFI_ENABLED
+
+#include <stdio.h>
+
+#include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_EFI/AP_EFI_Serial_MS.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_MS.cpp
@@ -17,6 +17,7 @@
 #include "AP_EFI_Serial_MS.h"
 
 #if HAL_EFI_ENABLED
+#include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -15,10 +15,11 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AC_PID/AC_P.h>
 #include <AP_RTC/JitterCorrection.h>
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -22,6 +22,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_RTC/AP_RTC.h>
 #include <climits>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 #include "AP_GPS_NOVA.h"
 #include "AP_GPS_ERB.h"

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -20,7 +20,6 @@
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
 #include "GPS_detect_state.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 
@@ -219,7 +218,7 @@ public:
     };
 
     /// Startup initialisation.
-    void init(const AP_SerialManager& serial_manager);
+    void init(const class AP_SerialManager& serial_manager);
 
     /// Update GPS state based on possible bytes received from the module.
     /// This routine must be called periodically (typically at 10Hz or

--- a/libraries/AP_Generator/AP_Generator.cpp
+++ b/libraries/AP_Generator/AP_Generator.cpp
@@ -21,6 +21,8 @@
 #include "AP_Generator_IE_2400.h"
 #include "AP_Generator_RichenPower.h"
 
+#include <GCS_MAVLink/GCS.h>
+
 const AP_Param::GroupInfo AP_Generator::var_info[] = {
 
     // @Param: TYPE

--- a/libraries/AP_Generator/AP_Generator.h
+++ b/libraries/AP_Generator/AP_Generator.h
@@ -9,7 +9,6 @@
 #if HAL_GENERATOR_ENABLED
 
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
 
 class AP_Generator_Backend;
@@ -62,7 +61,7 @@ public:
     bool idle(void);
     bool run(void);
 
-    void send_generator_status(const GCS_MAVLINK &channel);
+    void send_generator_status(const class GCS_MAVLINK &channel);
 
     // Parameter block
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -14,9 +14,11 @@
  */
 
 #include "AP_Generator_IE_FuelCell.h"
-#include <AP_SerialManager/AP_SerialManager.h>
 
 #if HAL_GENERATOR_ENABLED
+
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <GCS_MAVLink/GCS.h>
 
 // Initialize the fuelcell object and prepare it for use
 void AP_Generator_IE_FuelCell::init()

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
@@ -4,9 +4,6 @@
 
 #if HAL_GENERATOR_ENABLED
 
-#include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
-
 class AP_Generator_IE_FuelCell : public AP_Generator_Backend
 {
 

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -19,6 +19,8 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Notify/AP_Notify.h>
+#include <RC_Channel/RC_Channel.h>
+
 #include "AP_ICEngine.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <SITL/SITL.h>
-#include <GCS_MAVLink/GCS.h>
-
 /*
  This is a 'mock' implementation of an INS that does nothing and gives a level HUD, but does it successfully.   
  Its useful for boards that don't have any form of IMU accel/gyro etc connected just yet, but where u want to boot-up "successfully" anyway, 

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -17,6 +17,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Common/AP_FWVersion.h>

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -4,7 +4,6 @@
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
-#include <GCS_MAVLink/GCS.h>
 
 // default main rotor speed (ch8 out) as a number from 0 ~ 100
 #define AP_MOTORS_HELI_RSC_SETPOINT             70

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -14,8 +14,11 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
+
 #include "AP_MotorsTri.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Radio/AP_Radio.h
+++ b/libraries/AP_Radio/AP_Radio.h
@@ -18,9 +18,8 @@
  * base class for direct attached radios
  */
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_Radio_backend;
 

--- a/libraries/AP_Radio/AP_Radio_backend.h
+++ b/libraries/AP_Radio/AP_Radio_backend.h
@@ -21,6 +21,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Radio.h"
 
+#include <AP_Math/AP_Math.h>
+
 class AP_Radio_backend
 {
 public:

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_Notify/AP_Notify.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
 #include <AP_Math/crc.h>
 #include <AP_Param/AP_Param.h>
 

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -11,7 +11,7 @@
 #include <AP_Math/crc.h>
 #include "telem_structure.h"
 #include <AP_Notify/AP_Notify.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
 
 /*
   driver for CYRF6936 radio

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -17,7 +17,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_MSP/msp.h>
 #include "AP_RangeFinder_Params.h"
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -18,7 +18,8 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Mission/AP_Mission.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_HAL/I2CDevice.h>
 #include "AP_Scripting_CANSensor.h"
@@ -48,7 +49,7 @@ public:
 
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
-    void handle_mission_command(const AP_Mission::Mission_Command& cmd);
+    void handle_mission_command(const class AP_Mission::Mission_Command& cmd);
 
    // User parameters for inputs into scripts 
    AP_Float _user[6];

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -25,6 +25,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Button/AP_Button.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_EFI/AP_EFI.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Generator/AP_Generator.h>

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -9,6 +9,9 @@
 
 #include "AP_Volz_Protocol.h"
 #if NUM_SERVO_CHANNELS
+
+#include <AP_SerialManager/AP_SerialManager.h>
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_Volz_Protocol::var_info[] = {

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
@@ -34,10 +34,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Param/AP_Param.h>
-
-//#include <GCS_MAVLink/GCS.h>
 
 #define VOLZ_SCALE_VALUE 					(uint16_t)(VOLZ_EXTENDED_POSITION_MAX - VOLZ_EXTENDED_POSITION_MIN)	// Extended Position Data Format defines 100 as 0x0F80, which results in 1920 steps for +100 deg and 1920 steps for -100 degs meaning if you take movement a scaled between -1 ... 1 and multiply by 1920 you get the travel from center
 #define VOLZ_SET_EXTENDED_POSITION_CMD 		0xDC
@@ -56,8 +53,7 @@ public:
     AP_Volz_Protocol();
 
     /* Do not allow copies */
-    AP_Volz_Protocol(const AP_Volz_Protocol &other) = delete;
-    AP_Volz_Protocol &operator=(const AP_Volz_Protocol&) = delete;
+    CLASS_NO_COPY(AP_Volz_Protocol);
 
     static const struct AP_Param::GroupInfo var_info[];
     

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -23,7 +23,9 @@
 #include "AP_WindVane_SITL.h"
 #include "AP_WindVane_NMEA.h"
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 const AP_Param::GroupInfo AP_WindVane::var_info[] = {
 
@@ -369,6 +371,10 @@ void AP_WindVane::update()
 
 }
 
+void AP_WindVane::record_home_heading()
+{
+    _home_heading = AP::ahrs().yaw;
+}
 
 // to start direction calibration from mavlink or other
 bool AP_WindVane::start_direction_calibration()

--- a/libraries/AP_WindVane/AP_WindVane.h
+++ b/libraries/AP_WindVane/AP_WindVane.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <AP_Param/AP_Param.h>
-#include <AP_AHRS/AP_AHRS.h>
-#include <AP_SerialManager/AP_SerialManager.h>
+#include <Filter/Filter.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef WINDVANE_DEFAULT_PIN
 #define WINDVANE_DEFAULT_PIN -1                     // default wind vane sensor analog pin
@@ -58,7 +58,7 @@ public:
     bool wind_speed_enabled() const;
 
     // Initialize the Wind Vane object and prepare it for use
-    void init(const AP_SerialManager& serial_manager);
+    void init(const class AP_SerialManager& serial_manager);
 
     // update wind vane
     void update();
@@ -88,7 +88,7 @@ public:
     Sailboat_Tack get_current_tack() const { return _current_tack; }
 
     // record home heading for use as wind direction if no sensor is fitted
-    void record_home_heading() { _home_heading = AP::ahrs().yaw; }
+    void record_home_heading();
 
     // start calibration routine
     bool start_direction_calibration();

--- a/libraries/AP_WindVane/AP_WindVane_Analog.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Analog.cpp
@@ -15,6 +15,11 @@
 
 #include "AP_WindVane_Analog.h"
 
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
 #define WINDVANE_CALIBRATION_VOLT_DIFF_MIN  1.0f    // calibration routine's min voltage difference required for success
 
 // constructor

--- a/libraries/AP_WindVane/AP_WindVane_Analog.h
+++ b/libraries/AP_WindVane/AP_WindVane_Analog.h
@@ -16,11 +16,6 @@
 
 #include "AP_WindVane_Backend.h"
 
-#include <GCS_MAVLink/GCS.h>
-#include <AP_HAL/AP_HAL.h>
-
-extern const AP_HAL::HAL& hal;
-
 class AP_WindVane_Analog : public AP_WindVane_Backend
 {
 public:
@@ -33,7 +28,7 @@ public:
 
 private:
     // pin for reading analog voltage
-    AP_HAL::AnalogSource *_dir_analog_source;
+    class AP_HAL::AnalogSource *_dir_analog_source;
 
     float _current_analog_voltage;
     uint32_t  _cal_start_ms = 0;

--- a/libraries/AP_WindVane/AP_WindVane_Backend.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Backend.cpp
@@ -16,6 +16,8 @@
 #include "AP_WindVane.h"
 #include "AP_WindVane_Backend.h"
 
+#include <GCS_MAVLink/GCS.h>
+
 // base class constructor.
 AP_WindVane_Backend::AP_WindVane_Backend(AP_WindVane &frontend) :
         _frontend(frontend)

--- a/libraries/AP_WindVane/AP_WindVane_Backend.h
+++ b/libraries/AP_WindVane/AP_WindVane_Backend.h
@@ -16,9 +16,6 @@
 
 #include "AP_WindVane.h"
 
-#include <GCS_MAVLink/GCS.h>
-#include <Filter/Filter.h>
-
 class AP_WindVane_Backend
 {
 public:

--- a/libraries/AP_WindVane/AP_WindVane_Home.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Home.cpp
@@ -15,6 +15,8 @@
 
 #include "AP_WindVane_Home.h"
 
+#include <AP_AHRS/AP_AHRS.h>
+
 void AP_WindVane_Home::update_direction()
 {
     float direction_apparent_ef = _frontend._home_heading;

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
@@ -17,6 +17,8 @@
 // read wind speed from Modern Device rev p wind sensor
 // https://moderndevice.com/news/calibrating-rev-p-wind-sensor-new-regression/
 
+#include <GCS_MAVLink/GCS.h>
+
 // constructor
 AP_WindVane_ModernDevice::AP_WindVane_ModernDevice(AP_WindVane &frontend) :
     AP_WindVane_Backend(frontend)

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.h
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.h
@@ -16,7 +16,6 @@
 
 #include "AP_WindVane_Backend.h"
 
-#include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_WindVane/AP_WindVane_SITL.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_SITL.cpp
@@ -17,6 +17,9 @@
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
+#include <SITL/SITL.h>
+#include <AP_AHRS/AP_AHRS.h>
+
 void AP_WindVane_SITL::update_direction()
 {
     if (_frontend._direction_type == _frontend.WindVaneType::WINDVANE_SITL_TRUE) {

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -7,8 +7,14 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Arming/AP_Arming.h>
+#include <AP_VisualOdom/AP_VisualOdom.h>
+
+#include "MissionItemProtocol_Waypoints.h"
+#include "MissionItemProtocol_Rally.h"
+#include "MissionItemProtocol_Fence.h"
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -17,21 +17,14 @@
 #include <AP_Mission/AP_Mission.h>
 #include <stdint.h>
 #include "MAVLink_routing.h"
-#include <AP_Frsky_Telem/AP_Frsky_Telem.h>
-#include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <AP_RTC/JitterCorrection.h>
 #include <AP_Common/Bitmask.h>
 #include <AP_LTM_Telem/AP_LTM_Telem.h>
 #include <AP_Devo_Telem/AP_Devo_Telem.h>
-#include <RC_Channel/RC_Channel.h>
 #include <AP_Filesystem/AP_Filesystem_Available.h>
 #include <AP_GPS/AP_GPS.h>
-#include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 
-#include "MissionItemProtocol_Waypoints.h"
-#include "MissionItemProtocol_Rally.h"
-#include "MissionItemProtocol_Fence.h"
 #include "ap_message.h"
 
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
@@ -611,7 +604,7 @@ protected:
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;
 
-    void manual_override(RC_Channel *c, int16_t value_in, uint16_t offset, float scaler, const uint32_t tnow, bool reversed = false);
+    void manual_override(class RC_Channel *c, int16_t value_in, uint16_t offset, float scaler, const uint32_t tnow, bool reversed = false);
 
     uint8_t receiver_rssi() const;
 
@@ -1051,10 +1044,10 @@ public:
                               ap_var_type param_type,
                               float param_value);
 
-    static MissionItemProtocol_Waypoints *_missionitemprotocol_waypoints;
-    static MissionItemProtocol_Rally *_missionitemprotocol_rally;
-    static MissionItemProtocol_Fence *_missionitemprotocol_fence;
-    MissionItemProtocol *get_prot_for_mission_type(const MAV_MISSION_TYPE mission_type) const;
+    static class MissionItemProtocol_Waypoints *_missionitemprotocol_waypoints;
+    static class MissionItemProtocol_Rally *_missionitemprotocol_rally;
+    static class MissionItemProtocol_Fence *_missionitemprotocol_fence;
+    class MissionItemProtocol *get_prot_for_mission_type(const MAV_MISSION_TYPE mission_type) const;
     void try_send_queued_message_for_type(MAV_MISSION_TYPE type) const;
 
     void update_send();
@@ -1075,7 +1068,7 @@ public:
     bool out_of_time() const;
 
     // frsky backend
-    AP_Frsky_Telem *frsky;
+    class AP_Frsky_Telem *frsky;
 
 #if !HAL_MINIMIZE_FEATURES
     // LTM backend

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -18,6 +18,7 @@
 
 #include <AC_Fence/AC_Fence.h>
 #include <AP_ADSB/AP_ADSB.h>
+#include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Arming/AP_Arming.h>
@@ -49,6 +50,13 @@
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <AP_AIS/AP_AIS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_Frsky_Telem/AP_Frsky_Telem.h>
+#include <RC_Channel/RC_Channel.h>
+#include <AP_VisualOdom/AP_VisualOdom.h>
+
+#include "MissionItemProtocol_Waypoints.h"
+#include "MissionItemProtocol_Rally.h"
+#include "MissionItemProtocol_Fence.h"
 
 #include <stdio.h>
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -1,6 +1,8 @@
 #include "MissionItemProtocol_Fence.h"
 
 #include <AC_Fence/AC_Fence.h>
+#include <AP_InternalError/AP_InternalError.h>
+#include <GCS_MAVLink/GCS.h>
 
 /*
   public function to format mission item as mavlink_mission_item_int_t


### PR DESCRIPTION
Most notable, don't include `GCS_MAVLink/GCS.h` everywhere.  That header pulls a lot of stuff in - and there are only a handful of header files in the system that actually need anything more than the mavlink variable types (e.g. `mavlink_message_t`) out of it.

Several of the remaining uses of it I think show a flaw in the way we're doing our 
```
#ifndef FOO_FEATURE_ENABLED`
#define FOO_FEATURE_ENABLED XYZZY
#endif
```

idiom.  To get `HAL_GCS_ENABLED` those headers have to include the massive file and its many includes - probably most of the headers in the system, eventually.

We should consider either (a) moving to putting stuff in `AP_HAL/AP_HAL_Boards.h`, or doing something similar to `AP_Filesystem/AP_Filesystem_Available` - but with a better name.... perhaps `GCS_MAVLink/config.h`?

There's also (c), which is to stop guarding method definitions against the feature required.  So e.g. `AP_VisualOdom` uses `#if HAL_GCS_ENABLED` whereas `AP_OpticalFlow` does not, despite them being roughly equivalent in terms of why they're interested in that define.

This has only been tested for compilation / autotest suite.
