### PR TITLE
Plane: quadplane manual fwd throttle on elevator channel

### DIFF
--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -18,7 +18,13 @@ void ModeQStabilize::update()
     // be correct for tailsitters, so get_control_in() must be used instead.
     // normalize control_input to [-1,1]
     const float roll_input = (float)plane.channel_roll->get_control_in() / plane.channel_roll->get_range();
-    const float pitch_input = (float)plane.channel_pitch->get_control_in() / plane.channel_pitch->get_range();
+
+    float pitch_input = (float)plane.channel_pitch->get_control_in() / plane.channel_pitch->get_range();
+
+    if (plane.quadplane.rc_fwd_thr_ch != nullptr && plane.quadplane.rc_fwd_thr_ch->get_aux_switch_pos() != RC_Channel::AuxSwitchPos::LOW) {
+        // don't allow downward pitch
+        if (pitch_input < 0) pitch_input = 0;
+    }
 
     // then scale to target angles in centidegrees
     if (plane.quadplane.tailsitter.active()) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3167,13 +3167,14 @@ float QuadPlane::forward_throttle_pct()
         plane.control_mode == &plane.mode_qstabilize ||
         plane.control_mode == &plane.mode_qhover) {
 
-        if (rc_fwd_thr_ch == nullptr) {
+        // if manual forward throttle option channel is unassigned or OFF, return zero 
+        if (rc_fwd_thr_ch == nullptr || rc_fwd_thr_ch->get_aux_switch_pos() == RC_Channel::AuxSwitchPos::LOW) {
             return 0;
         } else {
-            // calculate fwd throttle demand from manual input
-            float fwd_thr = rc_fwd_thr_ch->percent_input();
+            // use down elevator input as percentage of forward throttle
+            float fwd_thr = -100*(float)plane.channel_pitch->get_control_in() / plane.channel_pitch->get_range();
 
-            // set forward throttle to fwd_thr_max * (manual input + mix): range [0,100]
+            // scale manual input to fwd_thr_max: range [0,100]%
             fwd_thr *= .01f * constrain_float(fwd_thr_max, 0, 100);
             return fwd_thr;
         }


### PR DESCRIPTION
Changes behavior of the "manual forward throttle" RCn_option (209) to be similar to that of the stock E-Flite Convergence in angle mode.

Instead of the option channel controlling forward throttle, it changes the behavior of stabilized Qmodes when the channel value is not LOW (>1200 usec PWM). In that case, the elevator channel becomes the forward throttle control when < 0  (forward stick is forward throttle with zero pitch and back stick is zero forward throttle with up elevator).  This allows forward flight with wings level and pitching up to slow down rapidly. 

If the option channel value is LOW (< 1200 usec), forward throttle is disabled and stabilized Qmodes behave normally.
