### PR TITLE
Nuke the vast majority of clang warnings

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -28,7 +28,7 @@ void Copter::update_throttle_hover()
 
     // calc average throttle if we are in a level hover.  accounts for heli hover roll trim
     if (throttle > 0.0f && fabsf(inertial_nav.get_velocity_z_up_cms()) < 60 &&
-        labs(ahrs.roll_sensor-attitude_control->get_roll_trim_cd()) < 500 && labs(ahrs.pitch_sensor) < 500) {
+        fabsf(ahrs.roll_sensor-attitude_control->get_roll_trim_cd()) < 500 && labs(ahrs.pitch_sensor) < 500) {
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);
 #if HAL_GYROFFT_ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1980,7 +1980,7 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // check if we have completed circling
-    return fabsf(copter.circle_nav->get_angle_total()/M_2PI) >= LOWBYTE(cmd.p1);
+    return fabsf(copter.circle_nav->get_angle_total()/float(M_2PI)) >= LOWBYTE(cmd.p1);
 }
 
 // verify_spline_wp - check if we have reached the next way point using spline

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -684,7 +684,7 @@ void ModeGuided::pos_control_run()
 
     float pos_offset_z_buffer = 0.0; // Vertical buffer size in m
     if (guided_pos_terrain_alt) {
-        pos_offset_z_buffer = MIN(copter.wp_nav->get_terrain_margin() * 100.0, 0.5 * fabsf(guided_pos_target_cm.z));
+        pos_offset_z_buffer = MIN(copter.wp_nav->get_terrain_margin() * 100.0, 0.5 * fabsF(guided_pos_target_cm.z));
     }
     pos_control->input_pos_xyz(guided_pos_target_cm, terr_offset, pos_offset_z_buffer);
 

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -201,15 +201,9 @@ private:
     // flag for finding the peak of the gain response
     bool find_peak;
 
-    // updating angle P up yaw
-    // counter value of previous good frequency
-    uint8_t sp_prev_good_frq_cnt;
-
     // updating rate P up
     // counter value of previous good frequency
     uint8_t rp_prev_good_frq_cnt;
-    // previous gain
-    float rp_prev_gain;
 
     // updating rate D up
     // counter value of previous good frequency

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -33,6 +33,13 @@
 // used to mark a function that may be unused in some builds
 #define UNUSED_FUNCTION __attribute__((unused))
 
+// used to mark an attribute that may be unused in some builds
+#ifdef __clang__
+#define UNUSED_PRIVATE_MEMBER __attribute__((unused))
+#else
+#define UNUSED_PRIVATE_MEMBER
+#endif
+
 // this can be used to optimize individual functions
 #define OPTIMIZE(level) __attribute__((optimize(level)))
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -49,7 +49,6 @@ private:
     int8_t port_num;
     bool port_opened;
     uint32_t baudrate;
-    uint16_t rate;
 
     void update_thread();
     bool check_uart();

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -193,7 +193,6 @@ private:
     };
 
     uint32_t _min_fast_throttle_period_us;  ///< minimum allowed fast-throttle command transmit period
-    uint32_t _last_not_running_warning_ms;  ///< last time we warned the user their ESCs are stuffed
     int32_t _motor_mask;                    ///< an un-mutable copy of the _motor_mask_parameter taken before _init_done goes true
     int32_t _reverse_mask;                  ///< a copy of the _reverse_mask_parameter taken while not armed
     int32_t _running_mask;                  ///< a bitmask of the actively running ESCs

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort.cpp
@@ -246,7 +246,7 @@ extern const AP_HAL::HAL& hal;
 bool AP_Frsky_SPortParser::should_process_packet(const uint8_t *packet, bool discard_duplicates)
 {
     // check for duplicate packets
-    if (discard_duplicates && _parse_state.last_packet != nullptr) {
+    if (discard_duplicates) {
         /*
           Note: the polling byte packet[0] should be ignored in the comparison
           because we might get the same packet with different polling bytes
@@ -323,10 +323,10 @@ bool AP_Frsky_SPortParser::get_packet(AP_Frsky_SPort::sport_packet_t &sport_pack
     }
 
     const AP_Frsky_SPort::sport_packet_t sp {
-        _parse_state.rx_buffer[0],
+        { _parse_state.rx_buffer[0],
         _parse_state.rx_buffer[1],
         le16toh_ptr(&_parse_state.rx_buffer[2]),
-        le32toh_ptr(&_parse_state.rx_buffer[4])
+        le32toh_ptr(&_parse_state.rx_buffer[4]) },
     };
 
     sport_packet = sp;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -857,10 +857,10 @@ bool AP_Frsky_SPort_Passthrough::set_telem_data(const uint8_t frame, const uint1
     // queue only Uplink packets
     if (frame == SPORT_UPLINK_FRAME || frame == SPORT_UPLINK_FRAME_RW) {
         const AP_Frsky_SPort::sport_packet_t sp {
-            0x00,   // this is ignored by process_sport_rx_queue() so no need for a real sensor ID
+            { 0x00,   // this is ignored by process_sport_rx_queue() so no need for a real sensor ID
             frame,
             appid,
-            data
+            data }
         };
 
         _SPort_bidir.rx_packet_queue.push_force(sp);

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -151,7 +151,7 @@ private:
         uint8_t footermagic1;
         uint8_t footermagic2;
     };
-    assert_storage_size<RichenPacket, 70> _assert_storage_size_RichenPacket;
+    assert_storage_size<RichenPacket, 70> _assert_storage_size_RichenPacket UNUSED_PRIVATE_MEMBER;
 
     union RichenUnion {
         uint8_t parse_buffer[70];

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -109,15 +109,15 @@ public:
 private:
     // the uartX ports must be contiguous in ram for the serial() method to work
     AP_HAL::UARTDriver* uartA;
-    AP_HAL::UARTDriver* uartB;
-    AP_HAL::UARTDriver* uartC;
-    AP_HAL::UARTDriver* uartD;
-    AP_HAL::UARTDriver* uartE;
-    AP_HAL::UARTDriver* uartF;
-    AP_HAL::UARTDriver* uartG;
-    AP_HAL::UARTDriver* uartH;
-    AP_HAL::UARTDriver* uartI;
-    AP_HAL::UARTDriver* uartJ;
+    AP_HAL::UARTDriver* uartB UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartC UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartD UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartE UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartF UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartG UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartH UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartI UNUSED_PRIVATE_MEMBER;
+    AP_HAL::UARTDriver* uartJ UNUSED_PRIVATE_MEMBER;
 
 public:
     AP_HAL::I2CDeviceManager* i2c_mgr;

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -31,9 +31,6 @@ private:
     AP_Float *fence_alt_max;
     Location current_loc;
 
-    // latest sector updated
-    uint8_t last_sector;
-
     // get distance in meters to fence in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
     bool get_distance_to_fence(float angle_deg, float &distance) const;
 

--- a/libraries/SITL/SIM_Buzzer.h
+++ b/libraries/SITL/SIM_Buzzer.h
@@ -40,11 +40,6 @@ public:
 
     AP_Int8  _enable;  // enable buzzer sim
     AP_Int8  _pin;
-    bool was_on;
-
-    uint32_t on_time;
-
-    bool prep_done;
 };
 
 }

--- a/libraries/SITL/SIM_EFI_MegaSquirt.h
+++ b/libraries/SITL/SIM_EFI_MegaSquirt.h
@@ -44,8 +44,6 @@ public:
 private:
     void send_table();
 
-    uint32_t time_send_ms;
-
     struct PACKED {
         uint16_t size;
         uint8_t command;

--- a/libraries/SITL/SIM_Helicopter.h
+++ b/libraries/SITL/SIM_Helicopter.h
@@ -62,7 +62,6 @@ private:
     float hover_throttle = 0.5f;
     float terminal_velocity = 80;
     float hover_lean = 3.2f;
-    float yaw_zero = 0.1f;
     float rotor_rot_accel = radians(20);
     float roll_rate_max = radians(1400);
     float pitch_rate_max = radians(1400);
@@ -70,10 +69,8 @@ private:
     float rsc_setpoint = 0.8f;
     float izz = 0.2f;
     float tr_dist = 0.85f;
-    float tr_accel_max = 50.0f; //rad/s/s
     float cyclic_scalar = 7.2; // converts swashplate servo ouputs to cyclic blade pitch
     float thrust_scale;
-    float tail_thrust_scale;
     Vector2f _tpp_angle;
     float torque_scale;
     float torque_mpog;

--- a/libraries/SITL/SIM_MS5XXX.h
+++ b/libraries/SITL/SIM_MS5XXX.h
@@ -23,10 +23,6 @@ private:
     // float pressure;
     // float temperature;
 
-    // time we last updated the measurements (simulated internal
-    // workings of sensor)
-    uint32_t last_update_ms;
-
     void reset();
 
     enum class Command : uint8_t {

--- a/libraries/SITL/SIM_RichenPower.h
+++ b/libraries/SITL/SIM_RichenPower.h
@@ -71,8 +71,6 @@ private:
 // So we set batt fs high 46s
 // Gennie keeps batts charged to 49v + typically
 
-    class SIM *_sitl;
-
     uint32_t last_sent_ms;
 
     void update_control_pin(const struct sitl_input &input);
@@ -122,7 +120,7 @@ private:
         uint8_t footermagic1;
         uint8_t footermagic2;
     };
-    assert_storage_size<RichenPacket, 70> _assert_storage_size_RichenPacket;
+    assert_storage_size<RichenPacket, 70> _assert_storage_size_RichenPacket UNUSED_PRIVATE_MEMBER;
 
     union RichenUnion {
         uint8_t parse_buffer[70];

--- a/libraries/SITL/SIM_Scrimmage.cpp
+++ b/libraries/SITL/SIM_Scrimmage.cpp
@@ -35,8 +35,7 @@ Scrimmage::Scrimmage(const char *_frame_str) :
     Aircraft(_frame_str),
     prev_timestamp_us(0),
     recv_sock(true),
-    send_sock(true),
-    frame_str(_frame_str)
+    send_sock(true)
 {
 }
 

--- a/libraries/SITL/SIM_Scrimmage.h
+++ b/libraries/SITL/SIM_Scrimmage.h
@@ -86,8 +86,6 @@ private:
     uint64_t prev_timestamp_us;
     SocketAPM recv_sock;
     SocketAPM send_sock;
-
-    const char *frame_str;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Temperature_MCP9600.h
+++ b/libraries/SITL/SIM_Temperature_MCP9600.h
@@ -30,7 +30,6 @@ private:
 
     // should be a call on aircraft:
     float some_temperature = 26.5;
-    float last_temperature = -1000.0f;
 
     uint32_t last_temperature_update_ms;
 };

--- a/libraries/SITL/SIM_VectorNav.h
+++ b/libraries/SITL/SIM_VectorNav.h
@@ -41,10 +41,6 @@ public:
     void update(void);
 
 private:
-    // TODO: make these parameters:
-    const uint8_t system_id = 17;
-    const uint8_t component_id = 18;
-
     uint32_t last_pkt1_us;
     uint32_t last_pkt2_us;
 


### PR DESCRIPTION
This removes most clang warnings on macos. Still warnings about std::move() but I am not sure how to fix those