### PR TITLE
AC_WPNav: rename circle_nav.set_radius to circle_nav.set_radius_cm

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -378,7 +378,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
 
     // set circle radius
     if (!is_zero(radius_m)) {
-        copter.circle_nav->set_radius(radius_m * 100.0f);
+        copter.circle_nav->set_radius_cm(radius_m * 100.0f);
     }
 
     // check our distance from edge of circle

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -52,7 +52,7 @@ void ModeCircle::run()
         const float radius_new = MAX(radius_current + radius_pilot_change,0);   // new radius target
 
         if (!is_equal(radius_current, radius_new)) {
-            copter.circle_nav->set_radius(radius_new);
+            copter.circle_nav->set_radius_cm(radius_new);
         }
 
         // update the orbicular rate target based on pilot roll stick inputs

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -180,7 +180,7 @@ void Sub::auto_circle_movetoedge_start(const Location &circle_center, float radi
 
     // set circle radius
     if (!is_zero(radius_m)) {
-        circle_nav.set_radius(radius_m * 100.0f);
+        circle_nav.set_radius_cm(radius_m * 100.0f);
     }
 
     // check our distance from edge of circle

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -138,7 +138,7 @@ void AC_Circle::set_rate(float deg_per_sec)
 }
 
 /// set_circle_rate - set circle rate in degrees per second
-void AC_Circle::set_radius(float radius_cm)
+void AC_Circle::set_radius_cm(float radius_cm)
 {
     _radius = constrain_float(radius_cm, 0, AC_CIRCLE_RADIUS_MAX);
 }

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -44,8 +44,8 @@ public:
     /// get_radius - returns radius of circle in cm
     float get_radius() const { return is_positive(_radius)?_radius:_radius_parm; }
 
-    /// set_radius - sets circle radius in cm
-    void set_radius(float radius_cm);
+    /// set_radius_cm - sets circle radius in cm
+    void set_radius_cm(float radius_cm);
 
     /// get_rate - returns target rate in deg/sec held in RATE parameter
     float get_rate() const { return _rate; }


### PR DESCRIPTION
This method accepts radius in cm. This renaming makes it easier to understand that we should pass the radius in cm.