### PR TITLE
Copter: fix ignore pilot yaw input when rtl_options is enabled

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -634,9 +634,13 @@ void Mode::land_run_horizontal_control()
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->norm_input_dz());
-        if (!is_zero(target_yaw_rate)) {
-            auto_yaw.set_mode(AUTO_YAW_HOLD);
+        target_yaw_rate = 0;
+        if (!copter.failsafe.radio && use_pilot_yaw()) {
+            // get pilot's desired yaw rate
+            target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->norm_input_dz());
+            if (!is_zero(target_yaw_rate)) {
+                auto_yaw.set_mode(AUTO_YAW_HOLD);
+            }
         }
     }
 


### PR DESCRIPTION
I found that copter was not ignoring the pilot's yaw input after setting RTL_OPTIONS to 4 (or enabled). Here is the proposed code fix, which I tested on SITL successfully.