### PR TITLE
AP_Param: try both native and AP::FS filesystems for posix systems

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -106,10 +106,10 @@ const AP_Filesystem::Backend &AP_Filesystem::backend_by_fd(int &fd) const
     return backends[idx];
 }
 
-int AP_Filesystem::open(const char *fname, int flags)
+int AP_Filesystem::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     const Backend &backend = backend_by_path(fname);
-    int fd = backend.fs.open(fname, flags);
+    int fd = backend.fs.open(fname, flags, allow_absolute_paths);
     if (fd < 0) {
         return -1;
     }

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -80,7 +80,7 @@ public:
     AP_Filesystem() {}
 
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags);
+    int open(const char *fname, int flags, bool allow_absolute_paths = false);
     int close(int fd);
     int32_t read(int fd, void *buf, uint32_t count);
     int32_t write(int fd, const void *buf, uint32_t count);

--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
@@ -21,7 +21,7 @@ class AP_Filesystem_ESP32 : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -279,7 +279,7 @@ static bool remount_file_system(void)
     return true;
 }
 
-int AP_Filesystem_FATFS::open(const char *pathname, int flags)
+int AP_Filesystem_FATFS::open(const char *pathname, int flags, bool allow_absolute_path)
 {
     int fileno;
     int fatfs_modes;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -20,7 +20,7 @@ class AP_Filesystem_FATFS : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -30,7 +30,7 @@ extern int errno;
 
 #define IDLE_TIMEOUT_MS 30000
 
-int AP_Filesystem_Mission::open(const char *fname, int flags)
+int AP_Filesystem_Mission::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     enum MAV_MISSION_TYPE mtype;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -23,7 +23,7 @@ class AP_Filesystem_Mission : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -26,7 +26,7 @@
 extern const AP_HAL::HAL& hal;
 extern int errno;
 
-int AP_Filesystem_Param::open(const char *fname, int flags)
+int AP_Filesystem_Param::open(const char *fname, int flags, bool allow_absolute_path)
 {
     if (!check_file_name(fname)) {
         errno = ENOENT;

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.h
@@ -24,7 +24,7 @@ class AP_Filesystem_Param : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -23,7 +23,7 @@
 
 #if defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
 
-int AP_Filesystem_ROMFS::open(const char *fname, int flags)
+int AP_Filesystem_ROMFS::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     if ((flags & O_ACCMODE) != O_RDONLY) {
         errno = EROFS;

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -21,7 +21,7 @@ class AP_Filesystem_ROMFS : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -60,7 +60,7 @@ int8_t AP_Filesystem_Sys::file_in_sysfs(const char *fname) {
     return -1;
 }
 
-int AP_Filesystem_Sys::open(const char *fname, int flags)
+int AP_Filesystem_Sys::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     if ((flags & O_ACCMODE) != O_RDONLY) {
         errno = EROFS;

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.h
@@ -23,7 +23,7 @@ class AP_Filesystem_Sys : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -43,7 +43,7 @@ class AP_Filesystem_Backend {
 
 public:
     // functions that closely match the equivalent posix calls
-    virtual int open(const char *fname, int flags) {
+    virtual int open(const char *fname, int flags, bool allow_absolute_paths = false) {
         return -1;
     }
     virtual int close(int fd) { return -1; }

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -49,10 +49,12 @@ static const char *map_filename(const char *fname)
     return fname;
 }
 
-int AP_Filesystem_Posix::open(const char *fname, int flags)
+int AP_Filesystem_Posix::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     FS_CHECK_ALLOWED(-1);
-    fname = map_filename(fname);
+    if (! allow_absolute_paths) {
+        fname = map_filename(fname);
+    }
     // we automatically add O_CLOEXEC as we always want it for ArduPilot FS usage
     return ::open(fname, flags | O_CLOEXEC, 0644);
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.h
@@ -29,7 +29,7 @@ class AP_Filesystem_Posix : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -33,6 +33,7 @@
 #include <StorageManager/StorageManager.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_InternalError/AP_InternalError.h>
+#include <AP_Filesystem/AP_Filesystem.h>
 #include <stdio.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     #include <SITL/SITL.h>
@@ -2109,8 +2110,9 @@ bool AP_Param::parse_param_line(char *line, char **vname, float &value, bool &re
 // increments num_defaults for each default found in filename
 bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaults)
 {
-    FILE *f = fopen(filename, "r");
-    if (f == nullptr) {
+    // try opening the file both in the posix filesystem and using AP::FS
+    int file_apfs = AP::FS().open(filename, O_RDONLY, true);
+    if (file_apfs == -1) {
         return false;
     }
     char line[100];
@@ -2118,7 +2120,7 @@ bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaul
     /*
       work out how many parameter default structures to allocate
      */
-    while (fgets(line, sizeof(line)-1, f)) {
+    while (AP::FS().fgets(line, sizeof(line)-1, file_apfs)) {
         char *pname;
         float value;
         bool read_only;
@@ -2131,23 +2133,23 @@ bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaul
         }
         num_defaults++;
     }
-
-    fclose(f);
+    AP::FS().close(file_apfs);
 
     return true;
 }
 
 bool AP_Param::read_param_defaults_file(const char *filename, bool last_pass)
 {
-    FILE *f = fopen(filename, "r");
-    if (f == nullptr) {
+    // try opening the file both in the posix filesystem and using AP::FS
+    int file_apfs = AP::FS().open(filename, O_RDONLY, true);
+    if (file_apfs == -1) {
         AP_HAL::panic("AP_Param: Failed to re-open defaults file");
         return false;
     }
 
     uint16_t idx = 0;
     char line[100];
-    while (fgets(line, sizeof(line)-1, f)) {
+    while (AP::FS().fgets(line, sizeof(line)-1, file_apfs)) {
         char *pname;
         float value;
         bool read_only;
@@ -2179,7 +2181,8 @@ bool AP_Param::read_param_defaults_file(const char *filename, bool last_pass)
             vp->set_float(value, var_type);
         }
     }
-    fclose(f);
+    AP::FS().close(file_apfs);
+
     return true;
 }
 


### PR DESCRIPTION
This is an alternative to switching completely to AP:FS() in order to use @ROMFS in linux boards.