### PR TITLE
AP_Airspeed:  use reading from correct airspeed sensor for health check

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -689,7 +689,7 @@ void AP_Airspeed::Log_Airspeed()
             offset        : get_offset(i),
             use           : use(i),
             healthy       : healthy(i),
-            health_prob   : get_health_failure_probability(i),
+            health_prob   : get_health_probability(i),
             primary       : get_primary()
         };
         AP::logger().WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -266,12 +266,12 @@ private:
     // returns 0 if the sensor is not enabled
     float get_pressure(uint8_t i);
 
-    // get the failure health probability
-    float get_health_failure_probability(uint8_t i) const {
+    // get the health probability
+    float get_health_probability(uint8_t i) const {
         return state[i].failures.health_probability;
     }
-    float get_health_failure_probability(void) const {
-        return get_health_failure_probability(primary);
+    float get_health_probability(void) const {
+        return get_health_probability(primary);
     }
 
     void update_calibration(uint8_t i, float raw_pressure);

--- a/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
@@ -28,8 +28,7 @@ void AP_Airspeed::check_sensor_ahrs_wind_max_failures(uint8_t i)
         return;
     }
 
-    const float aspeed = get_airspeed();
-    if (aspeed <= 0) {
+    if (state[i].airspeed <= 0) {
         // invalid estimate
         return;
     }
@@ -44,7 +43,7 @@ void AP_Airspeed::check_sensor_ahrs_wind_max_failures(uint8_t i)
         }
         return;
     }
-    const float speed_diff = fabsf(aspeed-gps.ground_speed());
+    const float speed_diff = fabsf(state[i].airspeed-gps.ground_speed());
 
     // update health_probability with LowPassFilter
     if (speed_diff > _wind_max) {

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -769,7 +769,7 @@ struct PACKED log_VER {
 // @Field: Offset: Offset from parameter
 // @Field: U: True if sensor is being used
 // @Field: H: True if sensor is healthy
-// @Field: Hfp: Probability sensor has failed
+// @Field: Hp: Probability sensor is healthy
 // @Field: Pri: True if sensor is the primary sensor
 
 // @LoggerMessage: BCN
@@ -1303,7 +1303,7 @@ LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \
-    { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBfB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hfp,Pri", "s#nPOPP----", "F-00B00----", true }, \
+    { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBfB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hp,Pri", "s#nPOPP----", "F-00B00----", true }, \
     LOG_STRUCTURE_FROM_BATTMONITOR \
     { LOG_MAG_MSG, sizeof(log_MAG), \
       "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F", true }, \


### PR DESCRIPTION
We were always using the primary airspeed via `get_airspeed()`.

This also changes the naming of the function and log to make it clear that the probability is a health probability not a fail probability. 