### PR TITLE
Tools: build_binaries.py: do not delete build dir if no hash change

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -412,12 +412,17 @@ is bob we will attempt to checkout bob-AVR'''
                     framesuffix = ""
                 else:
                     framesuffix = "-%s" % frame
+
+                old_githash = self.run_git(["rev-parse", "HEAD"]).rstrip()
+
                 if not self.checkout(vehicle, tag, board, frame, submodule_update=False):
                     msg = ("Failed checkout of %s %s %s %s" %
                            (vehicle, board, tag, frame,))
                     self.progress(msg)
                     self.error_strings.append(msg)
                     continue
+
+                new_githash = self.run_git(["rev-parse", "HEAD"]).rstrip()
 
                 self.progress("Building %s %s %s binaries %s" %
                               (vehicle, tag, board, frame))
@@ -438,10 +443,13 @@ is bob we will attempt to checkout bob-AVR'''
                 if self.skip_board_waf(board):
                     continue
 
-                if os.path.exists(self.buildroot):
+                changed_git_hash = (new_githash != old_githash)
+
+                if changed_git_hash and os.path.exists(self.buildroot):
                     shutil.rmtree(self.buildroot)
 
-                self.remove_tmpdir()
+                if changed_git_hash:
+                    self.remove_tmpdir()
 
                 githash = self.run_git(["rev-parse", "HEAD"]).rstrip()
 


### PR DESCRIPTION
In the case that we don't change git hashes we don't necessarily need to
remove the build directory.

This should mean that when we build latest we can keep the build
products around from the Copter build and reuse a bunch of products.


.... keeping any build directory around when we change git hashes is problematic (and has been for years) because of our dependency issues when adding/removing files.  Those problems only evidence themselves as build failures which didn't need to happen (I usually solve them with `rm -rf build` and then another configure/build)
