### PR TITLE
Rover: loiter: sailboats don't try and sail directly into the wind

### DIFF
--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -56,8 +56,20 @@ void ModeLoiter::update()
         _desired_speed *= yaw_error_ratio;
     }
 
+    // 0 turn rate is no limit
+    float turn_rate = 0.0;
+
+    // make sure sailboats don't try and sail directly into the wind
+    if (g2.sailboat.use_indirect_route(_desired_yaw_cd)) {
+        _desired_yaw_cd = g2.sailboat.calc_heading(_desired_yaw_cd);
+        if (g2.sailboat.tacking()) {
+            // use pivot turn rate for tacks
+            turn_rate = g2.wp_nav.get_pivot_rate();
+        }
+    }
+
     // run steering and throttle controllers
-    calc_steering_to_heading(_desired_yaw_cd);
+    calc_steering_to_heading(_desired_yaw_cd, turn_rate);
     calc_throttle(_desired_speed, true);
 }
 


### PR DESCRIPTION
This fixes a issue where sailboats would eventually get stuck while loitering. 

Master eventually tries to sail too close to the wind to get to the loiter point and drifts backwards:
![image](https://user-images.githubusercontent.com/33176108/156470027-098e9798-3303-4688-8fb3-37819023e045.png)

This PR does not, it keeps out of the no go zone:
![image](https://user-images.githubusercontent.com/33176108/156469863-ba85bdc7-9ae2-4eaf-a232-9310045eb417.png)

Original report:
https://discuss.ardupilot.org/t/sailboat-support/32060/840?u=iampete