### PR TITLE
Stop libraries including AP_Logger.h in their header files

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -128,8 +128,7 @@ void GCS_MAVLINK_Tracker::send_pid_tuning()
 
     // Pitch PID
     if (g.gcs_pid_mask & 1) {
-        const AP_Logger::PID_Info *pid_info;
-        pid_info = &g.pidPitch2Srv.get_pid_info();
+        const AP_PIDInfo *pid_info = &g.pidPitch2Srv.get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH,
                                     pid_info->target,
                                     pid_info->actual,
@@ -146,8 +145,7 @@ void GCS_MAVLINK_Tracker::send_pid_tuning()
 
     // Yaw PID
     if (g.gcs_pid_mask & 2) {
-        const AP_Logger::PID_Info *pid_info;
-        pid_info = &g.pidYaw2Srv.get_pid_info();
+        const AP_PIDInfo *pid_info = &g.pidYaw2Srv.get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_YAW,
                                     pid_info->target,
                                     pid_info->actual,

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -263,7 +263,7 @@ void GCS_MAVLINK_Copter::send_pid_tuning()
         if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
             return;
         }
-        const AP_Logger::PID_Info *pid_info = nullptr;
+        const AP_PIDInfo *pid_info = nullptr;
         switch (axes[i]) {
         case PID_TUNING_ROLL:
             pid_info = &copter.attitude_control->get_rate_roll_pid().get_pid_info();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -290,7 +290,7 @@ void GCS_MAVLINK_Plane::send_wind() const
 }
 
 // sends a single pid info over the provided channel
-void GCS_MAVLINK_Plane::send_pid_info(const AP_Logger::PID_Info *pid_info,
+void GCS_MAVLINK_Plane::send_pid_info(const AP_PIDInfo *pid_info,
                           const uint8_t axis, const float achieved)
 {
     if (pid_info == nullptr) {
@@ -322,7 +322,7 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
 
     const Parameters &g = plane.g;
 
-    const AP_Logger::PID_Info *pid_info;
+    const AP_PIDInfo *pid_info;
     if (g.gcs_pid_mask & TUNING_BITS_ROLL) {
         pid_info = &plane.rollController.get_pid_info();
 #if HAL_QUADPLANE_ENABLED

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -41,7 +41,7 @@ protected:
 
 private:
 
-    void send_pid_info(const AP_Logger::PID_Info *pid_info, const uint8_t axis, const float achieved);
+    void send_pid_info(const AP_PIDInfo *pid_info, const uint8_t axis, const float achieved);
 
     void handleMessage(const mavlink_message_t &msg) override;
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -18,6 +18,7 @@
 #include <AC_WPNav/AC_Loiter.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AC_Avoidance/AC_Avoid.h>
+#include <AP_Logger/LogStructure.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include "qautotune.h"
 #include "defines.h"

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -154,7 +154,7 @@ void GCS_MAVLINK_Sub::send_pid_tuning()
 
     const Vector3f &gyro = ahrs.get_gyro();
     if (g.gcs_pid_mask & 1) {
-        const AP_Logger::PID_Info &pid_info = attitude_control.get_rate_roll_pid().get_pid_info();
+        const AP_PIDInfo &pid_info = attitude_control.get_rate_roll_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ROLL,
                                     pid_info.target*0.01f,
                                     degrees(gyro.x),
@@ -169,7 +169,7 @@ void GCS_MAVLINK_Sub::send_pid_tuning()
         }
     }
     if (g.gcs_pid_mask & 2) {
-        const AP_Logger::PID_Info &pid_info = attitude_control.get_rate_pitch_pid().get_pid_info();
+        const AP_PIDInfo &pid_info = attitude_control.get_rate_pitch_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH,
                                     pid_info.target*0.01f,
                                     degrees(gyro.y),
@@ -184,7 +184,7 @@ void GCS_MAVLINK_Sub::send_pid_tuning()
         }
     }
     if (g.gcs_pid_mask & 4) {
-        const AP_Logger::PID_Info &pid_info = attitude_control.get_rate_yaw_pid().get_pid_info();
+        const AP_PIDInfo &pid_info = attitude_control.get_rate_yaw_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_YAW,
                                     pid_info.target*0.01f,
                                     degrees(gyro.z),
@@ -199,7 +199,7 @@ void GCS_MAVLINK_Sub::send_pid_tuning()
         }
     }
     if (g.gcs_pid_mask & 8) {
-        const AP_Logger::PID_Info &pid_info = sub.pos_control.get_accel_z_pid().get_pid_info();
+        const AP_PIDInfo &pid_info = sub.pos_control.get_accel_z_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info.target*0.01f,
                                     -(ahrs.get_accel_ef_blended().z + GRAVITY_MSS),

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -123,7 +123,7 @@ void GCS_MAVLINK_Blimp::send_pid_tuning()
         if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
             return;
         }
-        const AP_Logger::PID_Info *pid_info = nullptr;
+        const AP_PIDInfo *pid_info = nullptr;
         switch (axes[i]) {
         case PID_SEND::VELX:
             pid_info = &blimp.pid_vel_xy.get_pid_info_x();

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -185,7 +185,7 @@ void GCS_MAVLINK_Rover::send_pid_tuning()
     Parameters &g = rover.g;
     ParametersG2 &g2 = rover.g2;
 
-    const AP_Logger::PID_Info *pid_info;
+    const AP_PIDInfo *pid_info;
 
     // steering PID
     if (g.gcs_pid_mask & 1) {

--- a/libraries/AC_AttitudeControl/ControlMonitor.cpp
+++ b/libraries/AC_AttitudeControl/ControlMonitor.cpp
@@ -1,6 +1,7 @@
 #include "AC_AttitudeControl.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Logger/AP_Logger.h>
 
 /*
   code to monitor and report on the rate controllers, allowing for
@@ -24,15 +25,15 @@ void AC_AttitudeControl::control_monitor_filter_pid(float value, float &rms)
  */
 void AC_AttitudeControl::control_monitor_update(void)
 {
-    const AP_Logger::PID_Info &iroll  = get_rate_roll_pid().get_pid_info();
+    const AP_PIDInfo &iroll  = get_rate_roll_pid().get_pid_info();
     control_monitor_filter_pid(iroll.P + iroll.FF,  _control_monitor.rms_roll_P);
     control_monitor_filter_pid(iroll.D,             _control_monitor.rms_roll_D);
 
-    const AP_Logger::PID_Info &ipitch = get_rate_pitch_pid().get_pid_info();
+    const AP_PIDInfo &ipitch = get_rate_pitch_pid().get_pid_info();
     control_monitor_filter_pid(ipitch.P + ipitch.FF,  _control_monitor.rms_pitch_P);
     control_monitor_filter_pid(ipitch.D,             _control_monitor.rms_pitch_D);
 
-    const AP_Logger::PID_Info &iyaw   = get_rate_yaw_pid().get_pid_info();
+    const AP_PIDInfo &iyaw   = get_rate_yaw_pid().get_pid_info();
     control_monitor_filter_pid(iyaw.P + iyaw.D + iyaw.FF,  _control_monitor.rms_yaw);
 }
 

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1,6 +1,8 @@
 #include "AC_AutoTune.h"
-#include <GCS_MAVLink/GCS.h>
+
+#include <AP_Logger/AP_Logger.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500     // restart tuning if pilot has left sticks in middle for 2 seconds
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -19,6 +19,8 @@
 
 #include "AC_AutoTune_Heli.h"
 
+#include <AP_Logger/AP_Logger.h>
+
 #define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   5000U     // timeout for tuning mode's testing step
 
 #define AUTOTUNE_RD_STEP                  0.0005f     // minimum increment when increasing/decreasing Rate D term

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -1,5 +1,7 @@
 #include "AC_AutoTune_Multi.h"
 
+#include <AP_Logger/AP_Logger.h>
+
 /*
  * autotune support for multicopters
  *

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -7,13 +7,14 @@
 #include <AP_Param/AP_Param.h>
 #include <stdlib.h>
 #include <cmath>
-#include <AP_Logger/AP_Logger.h>
 #include <Filter/SlewLimiter.h>
 
 #define AC_PID_TFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_EFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_DFILT_HZ_DEFAULT  20.0f   // default input filter frequency
 #define AC_PID_RESET_TC          0.16f   // Time constant for integrator reset decay to zero
+
+#include "AP_PIDInfo.h"
 
 /// @class	AC_PID
 /// @brief	Copter PID control class
@@ -116,7 +117,7 @@ public:
     // return current slew rate of slew limiter. Will return 0 if SMAX is zero
     float get_slew_rate(void) const { return _slew_limiter.get_slew_rate(); }
 
-    const AP_Logger::PID_Info& get_pid_info(void) const { return _pid_info; }
+    const AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
@@ -155,5 +156,5 @@ protected:
     float _derivative;        // derivative value to enable filtering
     int8_t _slew_limit_scale;
 
-    AP_Logger::PID_Info _pid_info;
+    AP_PIDInfo _pid_info;
 };

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -7,7 +7,7 @@
 #include <AP_Param/AP_Param.h>
 #include <stdlib.h>
 #include <cmath>
-#include <AP_Logger/AP_Logger.h>
+#include <AC_PID/AP_PIDInfo.h>
 
 /// @class	AC_PID_2D
 /// @brief	Copter PID control class
@@ -75,8 +75,8 @@ public:
     void set_integrator(const Vector3f& i) { set_integrator(Vector2f{i.x, i.y}); }
     void set_integrator(const Vector2f& i);
 
-    const AP_Logger::PID_Info& get_pid_info_x(void) const { return _pid_info_x; }
-    const AP_Logger::PID_Info& get_pid_info_y(void) const { return _pid_info_y; }
+    const AP_PIDInfo& get_pid_info_x(void) const { return _pid_info_x; }
+    const AP_PIDInfo& get_pid_info_y(void) const { return _pid_info_y; }
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
@@ -100,6 +100,6 @@ protected:
     Vector2f    _integrator;    // integrator value
     bool        _reset_filter;  // true when input filter should be reset during next call to update_all
 
-    AP_Logger::PID_Info _pid_info_x;
-    AP_Logger::PID_Info _pid_info_y;
+    AP_PIDInfo _pid_info_x;
+    AP_PIDInfo _pid_info_y;
 };

--- a/libraries/AC_PID/AC_PID_Basic.h
+++ b/libraries/AC_PID/AC_PID_Basic.h
@@ -5,7 +5,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Logger/AP_Logger.h>
+#include "AP_PIDInfo.h"
 
 /// @class	AC_PID_Basic
 /// @brief	Copter PID control class
@@ -70,7 +70,7 @@ public:
     void set_integrator(float error, float i);
     void set_integrator(float i);
 
-    const AP_Logger::PID_Info& get_pid_info(void) const WARN_IF_UNUSED { return _pid_info; }
+    const AP_PIDInfo& get_pid_info(void) const WARN_IF_UNUSED { return _pid_info; }
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
@@ -94,5 +94,5 @@ protected:
     float _integrator;  // integrator value
     bool _reset_filter; // true when input filter should be reset during next call to set_input
 
-    AP_Logger::PID_Info _pid_info;
+    AP_PIDInfo _pid_info;
 };

--- a/libraries/AC_PID/AP_PIDInfo.h
+++ b/libraries/AC_PID/AP_PIDInfo.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// This structure provides information on the internal member data of
+// a PID.  It provides an abstract way to pass PID information around,
+// useful for logging and sending mavlink messages.
+
+// It is also used to pass PID information into controllers...
+
+struct AP_PIDInfo {
+    float target;
+    float actual;
+    float error;
+    float P;
+    float I;
+    float D;
+    float FF;
+    float Dmod;
+    float slew_rate;
+    bool  limit;
+};

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -7,6 +7,7 @@
 #include "AC_PrecLand_IRLock.h"
 #include "AC_PrecLand_SITL_Gazebo.h"
 #include "AC_PrecLand_SITL.h"
+#include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -3,6 +3,8 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include "AC_Circle.h"
 
+#include <AP_Logger/AP_Logger.h>
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AC_Circle::var_info[] = {

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -163,7 +163,7 @@ const char *AP_AutoTune::axis_string(void) const
 /*
   one update cycle of the autotuner
  */
-void AP_AutoTune::update(AP_Logger::PID_Info &pinfo, float scaler, float angle_err_deg)
+void AP_AutoTune::update(AP_PIDInfo &pinfo, float scaler, float angle_err_deg)
 {
     if (!running) {
         return;

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -5,6 +5,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AC_PID/AC_PID.h>
+#include <Filter/ModeFilter.h>
 
 class AP_AutoTune
 {
@@ -54,7 +55,7 @@ public:
 
     // update called whenever autotune mode is active. This is
     // called at the main loop rate
-    void update(AP_Logger::PID_Info &pid_info, float scaler, float angle_err_deg);
+    void update(AP_PIDInfo &pid_info, float scaler, float angle_err_deg);
 
     // are we running?
     bool running;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -3,7 +3,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include "AP_AutoTune.h"
-#include <AP_Logger/AP_Logger.h>
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
 
@@ -34,7 +33,7 @@ public:
     void autotune_start(void);
     void autotune_restore(void);
 
-    const AP_Logger::PID_Info& get_pid_info(void) const
+    const AP_PIDInfo& get_pid_info(void) const
     {
         return _pid_info;
     }
@@ -59,7 +58,7 @@ private:
     AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;
 
-    AP_Logger::PID_Info _pid_info;
+    AP_PIDInfo _pid_info;
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
     float _get_coordination_rate_offset(float &aspeed, bool &inverted) const;

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -3,7 +3,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include "AP_AutoTune.h"
-#include <AP_Logger/AP_Logger.h>
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
 
@@ -34,7 +33,7 @@ public:
     void autotune_start(void);
     void autotune_restore(void);
 
-    const AP_Logger::PID_Info& get_pid_info(void) const
+    const AP_PIDInfo& get_pid_info(void) const
     {
         return _pid_info;
     }
@@ -64,7 +63,7 @@ private:
     AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
     float angle_err_deg;
 
-    AP_Logger::PID_Info _pid_info;
+    AP_PIDInfo _pid_info;
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode);
 };

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -2,7 +2,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Vehicle/AP_Vehicle.h>
-#include <AP_Logger/AP_Logger.h>
+#include <AC_PID/AP_PIDInfo.h>
 
 class AP_SteerController {
 public:
@@ -44,7 +44,7 @@ public:
 
 	static const struct AP_Param::GroupInfo var_info[];
 
-    const AP_Logger::PID_Info& get_pid_info(void) const { return _pid_info; }
+    const class AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
     void set_reverse(bool reverse) {
         _reverse = reverse;
@@ -65,7 +65,7 @@ private:
 	AP_Float _deratefactor;
 	AP_Float _mindegree;
 
-    AP_Logger::PID_Info _pid_info {};
+    AP_PIDInfo _pid_info {};
 
     bool _reverse;
 };

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -2,7 +2,6 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Vehicle/AP_Vehicle.h>
-#include <AP_Logger/AP_Logger.h>
 #include <AC_PID/AC_PID.h>
 #include "AP_AutoTune.h"
 
@@ -36,7 +35,7 @@ public:
         _pid_info.I *= 0.995f;
     }
 
-    const AP_Logger::PID_Info& get_pid_info(void) const
+    const AP_PIDInfo& get_pid_info(void) const
     {
         return _pid_info;
     }
@@ -69,5 +68,5 @@ private:
     AP_AutoTune *autotune;
     bool failed_autotune_alloc;
     
-    AP_Logger::PID_Info _pid_info;
+    AP_PIDInfo _pid_info;
 };

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -82,7 +82,7 @@ public:
     AC_PID& get_steering_rate_pid() { return _steer_rate_pid; }
     AC_PID& get_pitch_to_throttle_pid() { return _pitch_to_throttle_pid; }
     AC_PID& get_sailboat_heel_pid() { return _sailboat_heel_pid; }
-    const AP_Logger::PID_Info& get_throttle_speed_pid_info() const { return _throttle_speed_pid_info; }
+    const AP_PIDInfo& get_throttle_speed_pid_info() const { return _throttle_speed_pid_info; }
 
     // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
     bool get_forward_speed(float &speed) const;
@@ -143,7 +143,7 @@ private:
     uint32_t _stop_last_ms;         // system time the vehicle was at a complete stop
     bool     _throttle_limit_low;   // throttle output was limited from going too low (used to reduce i-term buildup)
     bool     _throttle_limit_high;  // throttle output was limited from going too high (used to reduce i-term buildup)
-    AP_Logger::PID_Info _throttle_speed_pid_info;   // local copy of throttle_speed controller's PID info to allow reporting of unusual FF
+    AP_PIDInfo _throttle_speed_pid_info;   // local copy of throttle_speed controller's PID info to allow reporting of unusual FF
 
     // balancebot pitch control
     uint32_t _balance_last_ms = 0;

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -2,9 +2,10 @@
 /// @brief	Photo or video camera manager, with EEPROM-backed storage of constants.
 #pragma once
 
+#include <AP_Common/Location.h>
+#include <AP_Logger/LogStructure.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_Logger/AP_Logger.h>
 
 #define AP_CAMERA_TRIGGER_DEFAULT_DURATION  10      // default duration servo or relay is held open in 10ths of a second (i.e. 10 = 1 second)
 

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -3,6 +3,7 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Logger/AP_Logger.h>
 #include "GyroFrame.h"
 
 #if HAL_WITH_DSP

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -408,7 +408,7 @@ bool AP_Landing::override_servos(void) {
 
 // returns a PID_Info object if there is one available for the selected landing
 // type, otherwise returns a nullptr, indicating no data to be logged/sent
-const AP_Logger::PID_Info* AP_Landing::get_pid_info(void) const
+const AP_PIDInfo* AP_Landing::get_pid_info(void) const
 {
     switch (type) {
 #if HAL_LANDING_DEEPSTALL_ENABLED

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -109,7 +109,7 @@ public:
     void set_initial_slope(void) { initial_slope = slope; }
     bool is_expecting_impact(void) const;
     void Log(void) const;
-    const AP_Logger::PID_Info * get_pid_info(void) const;
+    const AP_PIDInfo * get_pid_info(void) const;
 
     // landing altitude offset (meters)
     float alt_offset;

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -26,6 +26,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Common/Location.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
 
 // table of user settable parameters for deepstall
 const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
@@ -448,13 +449,13 @@ bool AP_Landing_Deepstall::send_deepstall_message(mavlink_channel_t chan) const
     return true;
 }
 
-const AP_Logger::PID_Info& AP_Landing_Deepstall::get_pid_info(void) const
+const AP_PIDInfo& AP_Landing_Deepstall::get_pid_info(void) const
 {
     return ds_PID.get_pid_info();
 }
 
 void AP_Landing_Deepstall::Log(void) const {
-    const AP_Logger::PID_Info& pid_info = ds_PID.get_pid_info();
+    const AP_PIDInfo& pid_info = ds_PID.get_pid_info();
     struct log_DSTL pkt = {
         LOG_PACKET_HEADER_INIT(LOG_DSTL_MSG),
         time_us          : AP_HAL::micros64(),

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -100,7 +100,7 @@ private:
 
     bool send_deepstall_message(mavlink_channel_t chan) const;
 
-    const AP_Logger::PID_Info& get_pid_info(void) const;
+    const AP_PIDInfo& get_pid_info(void) const;
 
     //private helpers
     void build_approach_path(bool use_current_heading);

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -23,6 +23,7 @@
 #include <AP_LandingGear/AP_LandingGear.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_Logger/AP_Logger.h>
 
 void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
 {

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -48,6 +48,7 @@
 #define HAL_LOGGER_FILE_CONTENTS_ENABLED HAL_LOGGING_FILESYSTEM_ENABLED
 #endif
 
+#include <AC_PID/AC_PID.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_AHRS/AP_AHRS_DCM.h>
@@ -326,21 +327,7 @@ public:
     void WriteCritical(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
     void WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list, bool is_critical=false, bool is_streaming=false);
 
-    // This structure provides information on the internal member data of a PID for logging purposes
-    struct PID_Info {
-        float target;
-        float actual;
-        float error;
-        float P;
-        float I;
-        float D;
-        float FF;
-        float Dmod;
-        float slew_rate;
-        bool  limit;
-    };
-
-    void Write_PID(uint8_t msg_type, const PID_Info &info);
+    void Write_PID(uint8_t msg_type, const AP_PIDInfo &info);
 
     // returns true if logging of a message should be attempted
     bool should_log(uint32_t mask) const;

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -407,7 +407,7 @@ void AP_Logger::Write_ServoStatus(uint64_t time_us, uint8_t id, float position, 
 
 
 // Write a Yaw PID packet
-void AP_Logger::Write_PID(uint8_t msg_type, const PID_Info &info)
+void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
 {
     const struct log_PID pkt{
         LOG_PACKET_HEADER_INIT(msg_type),

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -7,6 +7,7 @@
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AC_Sprayer/AC_Sprayer.h>
 #include <AP_Scripting/AP_Scripting.h>
+#include <RC_Channel/RC_Channel.h>
 
 bool AP_Mission::start_command_do_aux_function(const AP_Mission::Mission_Command& cmd)
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -4,6 +4,7 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
+#include <AP_InternalError/AP_InternalError.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -4,6 +4,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_DAL/AP_DAL.h>
+#include <AP_InternalError/AP_InternalError.h>
 
 /********************************************************
 *              OPT FLOW AND RANGE FINDER                *

--- a/libraries/AP_Scripting/lua_repl.cpp
+++ b/libraries/AP_Scripting/lua_repl.cpp
@@ -10,6 +10,8 @@
 #include "lua/src/lauxlib.h"
 #include "lua/src/lualib.h"
 
+#include <AP_Logger/LogStructure.h>
+
 #if !defined(LUA_MAXINPUT)
 #define LUA_MAXINPUT    256
 #endif

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -16,6 +16,7 @@
 #include "lua_scripts.h"
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Scripting.h"
+#include <AP_Logger/AP_Logger.h>
 
 #include <AP_Scripting/lua_generated_bindings.h>
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -21,6 +21,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <Filter/AverageFilter.h>
 
 class AP_Landing;
 class AP_TECS {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -4,8 +4,10 @@
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Frsky_Telem/AP_Frsky_Parameters.h>
+#include <AP_Logger/AP_Logger.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_OSD/AP_OSD.h>
+#include <SRV_Channel/SRV_Channel.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 #include <AP_HAL_ChibiOS/sdcard.h>
 #endif

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -21,6 +21,8 @@
 
 #include "ModeReason.h" // reasons can't be defined in this header due to circular loops
 
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
 #include <AP_CANManager/AP_CANManager.h>
@@ -29,7 +31,6 @@
 #include <AP_EFI/AP_EFI.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Generator/AP_Generator.h>
-#include <AP_Logger/AP_Logger.h>
 #include <AP_Notify/AP_Notify.h>                    // Notify library
 #include <AP_Param/AP_Param.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>

--- a/libraries/AP_Winch/AP_Winch.h
+++ b/libraries/AP_Winch/AP_Winch.h
@@ -59,7 +59,7 @@ public:
     float get_rate_max() const { return MAX(config.rate_max, 0.0f); }
 
     // send status to ground station
-    void send_status(const GCS_MAVLINK &channel);
+    void send_status(const class GCS_MAVLINK &channel);
 
     // write log
     void write_log();

--- a/libraries/AP_Winch/AP_Winch_Backend.cpp
+++ b/libraries/AP_Winch/AP_Winch_Backend.cpp
@@ -1,5 +1,7 @@
 #include <AP_Winch/AP_Winch_Backend.h>
+
 #include <RC_Channel/RC_Channel.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 // setup rc input and output
 void AP_Winch_Backend::init()

--- a/libraries/AP_Winch/AP_Winch_Daiwa.cpp
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.cpp
@@ -1,4 +1,6 @@
 #include <AP_Winch/AP_Winch_Daiwa.h>
+
+#include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Winch/AP_Winch_PWM.cpp
+++ b/libraries/AP_Winch/AP_Winch_PWM.cpp
@@ -1,4 +1,6 @@
 #include "AP_Winch_PWM.h"
+
+#include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -3,6 +3,7 @@
 #include <AP_Arming/AP_Arming.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_WheelEncoder/AP_WheelRateControl.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 class AP_MotorsUGV {
 public:

--- a/libraries/AR_WPNav/AR_PivotTurn.cpp
+++ b/libraries/AR_WPNav/AR_PivotTurn.cpp
@@ -13,6 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include "AR_PivotTurn.h"

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -13,6 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
 #include "AR_WPNav.h"

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -13,6 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
 #include "AR_WPNav_OA.h"

--- a/libraries/PID/PID.h
+++ b/libraries/PID/PID.h
@@ -4,7 +4,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Logger/AP_Logger.h>
+#include <AC_PID/AC_PID.h>  // for AP_PIDInfo
 #include <stdlib.h>
 #include <cmath>
 
@@ -98,7 +98,7 @@ public:
 
     static const struct AP_Param::GroupInfo        var_info[];
 
-    const AP_Logger::PID_Info& get_pid_info(void) const { return _pid_info; }
+    const AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
 private:
     AP_Float        _kp;
@@ -113,7 +113,7 @@ private:
 
     float           _get_pid(float error, uint16_t dt, float scaler);
 
-    AP_Logger::PID_Info _pid_info {};
+    AP_PIDInfo _pid_info {};
 
     /// Low pass filter cut frequency for derivative calculation.
     ///

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -36,6 +36,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_LandingGear/AP_LandingGear.h>
+#include <AP_Logger/AP_Logger.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Avoidance/AP_Avoidance.h>


### PR DESCRIPTION
AP_Logger.h is a nexus of includes; while this is being improved over
time, there's no reason for the library headers to include AP_Logger.h
as the logger itself is access by singleton and the structures are in
LogStructure.h

This necessitated moving The PID_Info structure out of AP_Logger's
namespace.  This cleans up a pretty nasty bit - that structure is
definitely not simply used for logging, but also used to pass pid
information around to controllers!

There are a lot of patches in here because AP_Logger.h, acting as a
nexus, was providing transitive header file inclusion in many (some
unlikely!) places.
