### PR TITLE
Calculate throttle based harmonic notch using FFT averaging

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5052,9 +5052,11 @@ class AutoTestCopter(AutoTest):
                                        (tdelta, max_good_tdelta))
         self.progress("Vehicle returned")
 
-    def hover_and_check_matched_frequency_with_fft(self, dblevel=-15, minhz=200, maxhz=300, peakhz=None, reverse=None):
+    def hover_and_check_matched_frequency_with_fft(self, dblevel=-15, minhz=200, maxhz=300, peakhz=None,
+                                                   reverse=None, takeoff=True):
         # find a motor peak
-        self.takeoff(10, mode="ALT_HOLD")
+        if takeoff:
+            self.takeoff(10, mode="ALT_HOLD")
 
         hover_time = 15
         tstart = self.get_sim_time()
@@ -5587,6 +5589,158 @@ class AutoTestCopter(AutoTest):
         self.context_pop()
 
         # must reboot after we move away from EKF type 10 to EKF2 or EKF3
+        self.reboot_sitl()
+
+        if ex is not None:
+            raise ex
+
+    def fly_gyro_fft_average(self):
+        """Use dynamic harmonic notch to control motor noise setup via FFT averaging."""
+        # basic gyro sample rate test
+        self.progress("Flying with gyro FFT harmonic - Gyro sample rate")
+        self.context_push()
+        ex = None
+        try:
+            # Step 1
+            self.start_subtest("Hover to calculate approximate hover frequency and see that it is tracked")
+            # magic tridge EKF type that dramatically speeds up the test
+            self.set_parameters({
+                "AHRS_EKF_TYPE": 10,
+                "EK2_ENABLE": 0,
+                "EK3_ENABLE": 0,
+                "INS_LOG_BAT_MASK": 3,
+                "INS_LOG_BAT_OPT": 2,
+                "INS_GYRO_FILTER": 100,
+                "INS_FAST_SAMPLE": 0,
+                "INS_HNTCH_ATT": 100,
+                "LOG_BITMASK": 958,
+                "LOG_DISARMED": 0,
+                "SIM_DRIFT_SPEED": 0,
+                "SIM_DRIFT_TIME": 0,
+                "SIM_GYR1_RND": 20,  # enable a noisy gyro
+            })
+            # motor peak enabling FFT will also enable the arming
+            # check, self-testing the functionality
+            self.set_parameters({
+                "FFT_ENABLE": 1,
+                "FFT_WINDOW_SIZE": 64,  # not the default, but makes the test more reliable
+                "FFT_SNR_REF": 10,
+            })
+
+            # Step 1: inject actual motor noise and use the FFT to track it
+            self.set_parameters({
+                "SIM_VIB_MOT_MAX": 250, # gives a motor peak at about 175Hz
+                "RC7_OPTION" : 162,   # FFT tune
+            })
+
+            self.reboot_sitl()
+
+            # hover and engage FFT tracker
+            self.takeoff(10, mode="ALT_HOLD")
+
+            hover_time = 60
+            tstart = self.get_sim_time()
+            self.progress("Hovering for %u seconds" % hover_time)
+
+            # start the tune
+            self.set_rc(7, 2000)
+
+            while self.get_sim_time_cached() < tstart + hover_time:
+                self.mav.recv_match(type='ATTITUDE', blocking=True)
+            vfr_hud = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            tend = self.get_sim_time()
+
+            # finish the tune
+            self.set_rc(7, 1000)
+
+            psd = self.mavfft_fttd(1, 0, tstart * 1.0e6, tend * 1.0e6)
+
+            # batch sampler defaults give 1024 fft and sample rate of 1kz so roughly 1hz/bin
+            freq = psd["F"][numpy.argmax(psd["X"][50:450]) + 50] * (1000. / 1024.)
+
+            detected_ref = self.get_parameter("INS_HNTCH_REF")
+            detected_freq = self.get_parameter("INS_HNTCH_FREQ")
+            self.progress("FFT detected parameters were %fHz, ref %f" % (detected_freq, detected_ref))
+
+            # approximate the scaled frequency
+            scaled_freq_at_hover = math.sqrt((vfr_hud.throttle / 100.) / detected_ref) * detected_freq
+
+            # Check we matched
+            if abs(scaled_freq_at_hover - freq) / scaled_freq_at_hover > 0.05:
+                raise NotAchievedException("Detected frequency %fHz did not match required %fHz" %
+                                           (scaled_freq_at_hover, freq))
+
+            if self.get_parameter("INS_HNTCH_ENABLE") != 1:
+                raise NotAchievedException("Harmonic notch was not enabled")
+
+            # Step 2: now rerun the test and check that the peak is squashed
+            self.start_subtest("Verify that noise is suppressed by the harmonic notch")
+            self.hover_and_check_matched_frequency_with_fft(0, 100, 350, reverse=True, takeoff=False)
+
+            # Step 3: add a second harmonic and check the first is still tracked
+            self.start_subtest("Add a fixed frequency harmonic at twice the hover frequency "
+                               "and check the right harmonic is found")
+            self.set_parameters({
+                "SIM_VIB_FREQ_X": freq * 2,
+                "SIM_VIB_FREQ_Y": freq * 2,
+                "SIM_VIB_FREQ_Z": freq * 2,
+                "SIM_VIB_MOT_MULT": 0.25,  # halve the motor noise so that the higher harmonic dominates
+            })
+            self.reboot_sitl()
+
+            # hover and engage FFT tracker
+            self.takeoff(10, mode="ALT_HOLD")
+
+            hover_time = 60
+            tstart = self.get_sim_time()
+            self.progress("Hovering for %u seconds" % hover_time)
+
+            # start the tune
+            self.set_rc(7, 2000)
+
+            while self.get_sim_time_cached() < tstart + hover_time:
+                self.mav.recv_match(type='ATTITUDE', blocking=True)
+            vfr_hud = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            tend = self.get_sim_time()
+
+            # finish the tune
+            self.set_rc(7, 1000)
+
+            self.do_RTL()
+
+            detected_ref = self.get_parameter("INS_HNTCH_REF")
+            detected_freq = self.get_parameter("INS_HNTCH_FREQ")
+            self.progress("FFT detected parameters were %fHz, ref %f" % (detected_freq, detected_ref))
+
+            # approximate the scaled frequency
+            scaled_freq_at_hover = math.sqrt((vfr_hud.throttle / 100.) / detected_ref) * detected_freq
+
+            # Check we matched
+            if abs(scaled_freq_at_hover - freq) / scaled_freq_at_hover > 0.05:
+                raise NotAchievedException("Detected frequency %fHz did not match required %fHz" %
+                                           (scaled_freq_at_hover, freq))
+
+            if self.get_parameter("INS_HNTCH_ENABLE") != 1:
+                raise NotAchievedException("Harmonic notch was not enabled")
+
+            self.set_parameters({
+                "SIM_VIB_FREQ_X": 0,
+                "SIM_VIB_FREQ_Y": 0,
+                "SIM_VIB_FREQ_Z": 0,
+                "SIM_VIB_MOT_MULT": 1.0,
+            })
+            # prevent update parameters from messing with the settings when we pop the context
+            self.set_parameter("FFT_ENABLE", 0)
+            self.reboot_sitl()
+
+        except Exception as e:
+            self.print_exception_caught(e)
+            ex = e
+
+        self.context_pop()
+
+        # need a final reboot because weird things happen to your
+        # vehicle state when switching back from EKF type 10!
         self.reboot_sitl()
 
         if ex is not None:
@@ -8899,6 +9053,11 @@ class AutoTestCopter(AutoTest):
                  "Fly Gyro FFT Harmonic Matching",
                  self.fly_gyro_fft_harmonic,
                  attempts=8),
+
+            Test("GyroFFTAverage",
+                 "Fly Gyro FFT Averaging",
+                 self.fly_gyro_fft_average,
+                 attempts=1),
 
             Test("CompassReordering",
                  "Test Compass reordering when priorities are changed",

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -614,6 +614,14 @@ void AP_GyroFFT::update_freq_hover(float dt, float throttle_out)
     if (!analysis_enabled()) {
         return;
     }
+
+    // throttle averaging for average fft calculation
+    if (is_zero(_avg_throttle_out)) {
+        _avg_throttle_out = throttle_out;
+    } else {
+        _avg_throttle_out = constrain_float(_avg_throttle_out + (dt / (10.0f + dt)) * (throttle_out - _avg_throttle_out), 0.01f, 0.9f);
+    }
+
     // we have chosen to constrain the hover frequency to be within the range reachable by the third order expo polynomial.
     _freq_hover_hz = constrain_float(_freq_hover_hz + (dt / (10.0f + dt)) * (get_weighted_noise_center_freq_hz() - _freq_hover_hz), _fft_min_hz, _fft_max_hz);
     _bandwidth_hover_hz = constrain_float(_bandwidth_hover_hz + (dt / (10.0f + dt)) * (get_weighted_noise_center_bandwidth_hz() - _bandwidth_hover_hz), 0, _fft_max_hz * 0.5f);
@@ -631,6 +639,69 @@ void AP_GyroFFT::save_params_on_disarm()
     _freq_hover_hz.save();
     _bandwidth_hover_hz.save();
     _throttle_ref.save();
+}
+
+    // notch tuning
+void AP_GyroFFT::start_notch_tune()
+{
+    if (!analysis_enabled()) {
+        return;
+    }
+
+    if (!hal.dsp->fft_start_average(_state)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to start FFT averaging");
+    }
+    _avg_throttle_out = 0.0f;
+}
+
+void AP_GyroFFT::stop_notch_tune()
+{
+    if (!analysis_enabled()) {
+        return;
+    }
+
+    float freqs[FrequencyPeak::MAX_TRACKED_PEAKS] {};
+
+    uint16_t numpeaks = hal.dsp->fft_stop_average(_state, _config._fft_start_bin, _config._fft_end_bin, freqs);
+
+    if (numpeaks == 0) {
+        return;
+    }
+
+    float harmonic = freqs[0];
+    float harmonic_fit = 100.0f;
+
+    for (uint8_t i = 1; i < numpeaks; i++) {
+        if (freqs[i] < harmonic) {
+            const float fit = 100.0f * fabsf(harmonic - freqs[i] * _harmonic_multiplier) / harmonic;
+            if (isfinite(fit) && fit < _harmonic_fit && fit < harmonic_fit) {
+                harmonic = freqs[i];
+                harmonic_fit = fit;
+            }
+        }
+    }
+
+    gcs().send_text(MAV_SEVERITY_INFO, "FFT: Found peaks at %.1f/%.1f/%.1fHz", freqs[0], freqs[1], freqs[2]);
+    gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Selected %.1fHz with fit %.1f%%\n", harmonic, is_equal(harmonic_fit, 100.0f) ? 100.0f : 100.0f - harmonic_fit);
+
+    // if we don't have a throttle value then all bets are off
+    if (is_zero(_avg_throttle_out) || is_zero(harmonic)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to calculate notch: need stable hover");
+        return;
+    }
+
+    // pick a ref which means the notch covers all the way down to FFT_MINHZ
+    const float thr_ref = _avg_throttle_out * sq((float)_fft_min_hz.get() / harmonic);
+
+    if (!_ins->setup_throttle_gyro_harmonic_notch((float)_fft_min_hz.get(), thr_ref)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
+            (float)_fft_min_hz.get(), thr_ref);
+        // save results to FFT slots
+        _throttle_ref = thr_ref;
+        _freq_hover_hz = harmonic;
+    } else {
+        gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", (float)_fft_min_hz.get(), thr_ref);
+    }
 }
 
 // return the noise peak that is being tracked
@@ -704,7 +775,7 @@ float AP_GyroFFT::get_weighted_noise_center_freq_hz() const
     if (!_health) {
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
         AP_Motors* motors = AP::motors();
-        if (motors != nullptr) {
+        if (motors != nullptr && !is_zero(_throttle_ref)) {
             // FFT is not healthy, fallback to throttle-based estimate
             return constrain_float(_fft_min_hz * MAX(1.0f, sqrtf(motors->get_throttle_out() / _throttle_ref)), _fft_min_hz, _fft_max_hz);
         }

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -61,6 +61,8 @@ public:
     void update_thread();
     // start the update thread
     bool start_update_thread();
+    // is the subsystem enabled
+    bool enabled() const { return _enable; }
 
     // check at startup that standard frequencies can be detected
     bool pre_arm_check(char *failure_msg, const uint8_t failure_msg_len);
@@ -72,6 +74,9 @@ public:
     void save_params_on_disarm();
     // dynamically enable or disable the analysis through the aux switch
     void set_analysis_enabled(bool enabled) { _analysis_enabled = enabled; };
+    // notch tuning
+    void start_notch_tune();
+    void stop_notch_tune();
 
     // detected peak frequency filtered at 1/3 the update rate
     const Vector3f& get_noise_center_freq_hz() const { return get_noise_center_freq_hz(FrequencyPeak::CENTER); }
@@ -282,6 +287,8 @@ private:
     uint8_t _health;
     // engine health on roll/pitch/yaw
     Vector3<uint8_t> _rpy_health;
+    // averaged throttle output over averaging period
+    float _avg_throttle_out;
 
     // smoothing filter on the output
     MedianLowPassFilter3dFloat _center_freq_filter[FrequencyPeak::MAX_TRACKED_PEAKS];

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -47,6 +47,7 @@ protected:
     virtual void vector_max_float(const float* vin, uint16_t len, float* maxValue, uint16_t* maxIndex) const override {}
     virtual void vector_scale_float(const float* vin, float scale, float* vout, uint16_t len) const override {}
     virtual float vector_mean_float(const float* vin, uint16_t len) const override { return 0.0f; };
+    virtual void vector_add_float(const float* vin1, const float* vin2, float* vout, uint16_t len) const override {}
 public:
     void run_tests();
 } dsptest;

--- a/libraries/AP_HAL_ChibiOS/DSP.h
+++ b/libraries/AP_HAL_ChibiOS/DSP.h
@@ -61,6 +61,9 @@ protected:
         arm_mean_f32(vin, len, &mean_value);
         return mean_value;
     }
+    void vector_add_float(const float* vin1, const float* vin2, float* vout, uint16_t len) const override {
+        arm_add_f32(vin1, vin2, vout, len);
+    }
 
 private:
     // following are the six independent steps for calculating an FFT

--- a/libraries/AP_HAL_Empty/DSP.h
+++ b/libraries/AP_HAL_Empty/DSP.h
@@ -28,5 +28,6 @@ protected:
     virtual void vector_max_float(const float* vin, uint16_t len, float* maxValue, uint16_t* maxIndex) const override {}
     virtual void vector_scale_float(const float* vin, float scale, float* vout, uint16_t len) const override {}
     virtual float vector_mean_float(const float* vin, uint16_t len) const override { return 0.0f; };
+    virtual void vector_add_float(const float* vin1, const float* vin2, float* vout, uint16_t len) const override {};
 #endif // HAL_WITH_DSP
 };

--- a/libraries/AP_HAL_SITL/DSP.cpp
+++ b/libraries/AP_HAL_SITL/DSP.cpp
@@ -137,6 +137,13 @@ void DSP::vector_scale_float(const float* vin, float scale, float* vout, uint16_
     }
 }
 
+void DSP::vector_add_float(const float* vin1, const float* vin2, float* vout, uint16_t len) const
+{
+    for (uint16_t i = 0; i < len; i++) {
+        vout[i] = vin1[i] + vin2[i];
+    }
+}
+
 float DSP::vector_mean_float(const float* vin, uint16_t len) const
 {
     float mean_value = 0.0f;

--- a/libraries/AP_HAL_SITL/DSP.h
+++ b/libraries/AP_HAL_SITL/DSP.h
@@ -52,5 +52,6 @@ private:
     void vector_max_float(const float* vin, uint16_t len, float* maxValue, uint16_t* maxIndex) const override;
     void vector_scale_float(const float* vin, float scale, float* vout, uint16_t len) const override;
     float vector_mean_float(const float* vin, uint16_t len) const override;
+    void vector_add_float(const float* vin1, const float* vin2, float* vout, uint16_t len) const override;
     void calculate_fft(complexf* f, uint16_t length);
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -253,6 +253,9 @@ public:
     // get the accel filter rate in Hz
     uint16_t get_accel_filter_hz(void) const { return _accel_filter_cutoff; }
 
+    // setup the notch for throttle based tracking
+    bool setup_throttle_gyro_harmonic_notch(float center_freq_hz, float ref);
+
     // write out harmonic notch log messages
     void write_notch_log_messages() const;
 

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @Range: 0 4
     // @Values: 0:Disabled,1:Throttle,2:RPM Sensor,3:ESC Telemetry,4:Dynamic FFT,5:Second RPM Sensor
     // @User: Advanced
-    AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, 1),
+    AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, int8_t(HarmonicNotchDynamicMode::UpdateThrottle)),
 
     // @Param: OPTS
     // @DisplayName: Harmonic Notch Filter options
@@ -285,6 +285,19 @@ void HarmonicNotchFilter<T>::reset()
 HarmonicNotchFilterParams::HarmonicNotchFilterParams(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
+}
+
+/*
+  save changed parameters
+ */
+void HarmonicNotchFilterParams::save_params()
+{
+    _enable.save();
+    _center_freq_hz.save();
+    _bandwidth_hz.save();
+    _attenuation_dB.save();
+    _harmonics.save();
+    _reference.save();
 }
 
 /* 

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -90,17 +90,23 @@ public:
     HarmonicNotchFilterParams(void);
     // set the fundamental center frequency of the harmonic notch
     void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
+    // set the bandwidth of the harmonic notch
+    void set_bandwidth_hz(float bandwidth_hz) { _bandwidth_hz.set(bandwidth_hz); }
     // harmonics enabled on the harmonic notch
     uint8_t harmonics(void) const { return _harmonics; }
     // has the user set the harmonics value
     void set_default_harmonics(uint8_t hmncs) { _harmonics.set_default(hmncs); }
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
+    void set_reference(float ref) { _reference = ref; }
     // notch options
     bool hasOption(Options option) const { return _options & uint16_t(option); }
     // notch dynamic tracking mode
     HarmonicNotchDynamicMode tracking_mode(void) const { return HarmonicNotchDynamicMode(_tracking_mode.get()); }
     static const struct AP_Param::GroupInfo var_info[];
+
+    // save parameters
+    void save_params();
 
 private:
     // configured notch harmonics

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -54,6 +54,7 @@ public:
     float bandwidth_hz(void) const { return _bandwidth_hz; }
     float attenuation_dB(void) const { return _attenuation_dB; }
     uint8_t enabled(void) const { return _enable; }
+    void enable() { _enable.set(true); }
     
 protected:
     AP_Int8 _enable;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -224,7 +224,8 @@ public:
         OPTFLOW_CAL =        158, // optical flow calibration
         FORCEFLYING =        159, // enable or disable land detection for GPS based manual modes preventing land detection and maintainting set_throttle_mix_max
         WEATHER_VANE_ENABLE = 160, // enable/disable weathervaning
-        TURBINE_START =       161, // initialize turbine start sequence
+        TURBINE_START =      161, // initialize turbine start sequence
+        FFT_NOTCH_TUNE =     162, // FFT notch tuning function
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input
@@ -315,6 +316,7 @@ protected:
     void do_aux_function_relay(uint8_t relay, bool val);
     void do_aux_function_sprayer(const AuxSwitchPos ch_flag);
     void do_aux_function_generator(const AuxSwitchPos ch_flag);
+    void do_aux_function_fft_notch_tune(const AuxSwitchPos ch_flag);
 
     typedef int8_t modeswitch_pos_t;
     virtual void mode_switch_changed(modeswitch_pos_t new_pos) {


### PR DESCRIPTION
Users struggle with harmonic notch setup. On 2Mb boards we have the possibility of using the in-flight FFT to setup the throttle-based harmonic notch. Normally the in-flight FFT can struggle to track noise peaks in noisy builds, but if the FFT's are averaged over a factor of N then the noise is reduced by 1/sqrt(N). This PR introduces the ability to average FFTs in-flight controlled by RC input (function 163). The user hovers, engages 163, hovers for some period, disengages 163 and the lands. The function will setup the appropriate harmonic notch options and scaling factors such that if the user then reboots they will have an enabled and accurate throttle-based notch.

Setup procedure:

1. Enable the FFT - ```FFT_ENABLE = 1```
2. Reboot
3. Put function 162 on an RC switch, e.g. ```SERVO9_OPTION = 162```
4. Make sure the servo channel is low
5. Take off and hover
6. Set the servo channel to high
7. Hover for 30s or longer
8. Set the channel to low again. The notch will have been configured and engaged at this point so you may see improvements in flight performance. To see more improvements rerun autotune
9. You can repeat this procedure if you are not happy with the results