### PR TITLE
HAL_ChibiOS: fixed min/max inversion in MCU voltage logging

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -513,8 +513,9 @@ void AnalogIn::_timer_tick(void)
 
         _mcu_temperature = ((110 - 30) / (TS_CAL2 - TS_CAL1)) * (float(buf_adc3[1]) - TS_CAL1) + 30;
         _mcu_voltage = 3.3 * VREFINT_CAL / float(buf_adc3[2]+0.001);
-        _mcu_voltage_min = 3.3 * VREFINT_CAL / float(min_adc3[2]+0.001);
-        _mcu_voltage_max = 3.3 * VREFINT_CAL / float(max_adc3[2]+0.001);
+        // note min/max swap due to inversion
+        _mcu_voltage_min = 3.3 * VREFINT_CAL / float(max_adc3[2]+0.001);
+        _mcu_voltage_max = 3.3 * VREFINT_CAL / float(min_adc3[2]+0.001);
     }
 #endif
 }


### PR DESCRIPTION
The POWR log had MCU min/max voltage swapped