### PR TITLE
Clean up Heli Autotune to reduce flash size

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Copter.h"
+#include <AP_Math/chirp.h>
 class Parameters;
 class ParametersG2;
 
@@ -1481,6 +1482,8 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    Chirp chirp_input;
+
 protected:
 
     const char *name() const override { return "SYSTEMID"; }
@@ -1489,7 +1492,6 @@ protected:
 private:
 
     void log_data() const;
-    float waveform(float time);
 
     enum class AxisType {
         NONE = 0,           // none

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -95,6 +95,8 @@ bool ModeSystemId::init(bool ignore_checks)
     systemid_state = SystemIDModeState::SYSTEMID_STATE_TESTING;
     log_subsample = 0;
 
+    chirp_input.init(time_record, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
+
     gcs().send_text(MAV_SEVERITY_INFO, "SystemID Starting: axis=%d", (unsigned)axis);
 
     copter.Log_Write_SysID_Setup(axis, waveform_magnitude, frequency_start, frequency_stop, time_fade_in, time_const_freq, time_record, time_fade_out);
@@ -172,7 +174,8 @@ void ModeSystemId::run()
     }
 
     waveform_time += G_Dt;
-    waveform_sample = waveform(waveform_time - SYSTEM_ID_DELAY);
+    waveform_sample = chirp_input.update(waveform_time - SYSTEM_ID_DELAY, waveform_magnitude);
+    waveform_freq_rads = chirp_input.get_frequency_rads();
 
     switch (systemid_state) {
         case SystemIDModeState::SYSTEMID_STATE_STOPPED:
@@ -289,45 +292,6 @@ void ModeSystemId::log_data() const
 
     // Full rate logging of attitude, rate and pid loops
     copter.Log_Write_Attitude();
-}
-
-// init_test - initialises the test
-float ModeSystemId::waveform(float time)
-{
-    float wMin = 2 * M_PI * frequency_start;
-    float wMax = 2 * M_PI * frequency_stop;
-
-    float window;
-    float output;
-
-    float B = logf(wMax / wMin);
-
-    if (time <= 0.0f) {
-        window = 0.0f;
-    } else if (time <= time_fade_in) {
-        window = 0.5 - 0.5 * cosf(M_PI * time / time_fade_in);
-    } else if (time <= time_record - time_fade_out) {
-        window = 1.0;
-    } else if (time <= time_record) {
-        window = 0.5 - 0.5 * cosf(M_PI * (time - (time_record - time_fade_out)) / time_fade_out + M_PI);
-    } else {
-        window = 0.0;
-    }
-
-    if (time <= 0.0f) {
-        waveform_freq_rads = wMin;
-        output = 0.0f;
-    } else if (time <= time_const_freq) {
-        waveform_freq_rads = wMin;
-        output = window * waveform_magnitude * sinf(wMin * time - wMin * time_const_freq);
-    } else if (time <= time_record) {
-        waveform_freq_rads = wMin * expf(B * (time - time_const_freq) / (time_record - time_const_freq));
-        output = window * waveform_magnitude * sinf((wMin * (time_record - time_const_freq) / B) * (expf(B * (time - time_const_freq) / (time_record - time_const_freq)) - 1));
-    } else {
-        waveform_freq_rads = wMax;
-        output = 0.0f;
-    }
-    return output;
 }
 
 #endif

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -330,35 +330,20 @@ void AC_AutoTune_Heli::do_post_test_gcs_announcements() {
             gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ff=%f", (double)tune_rff);
             break;
         case RP_UP:
+        case RD_UP:
+        case SP_UP:
+        case MAX_GAINS:
             if (is_equal(start_freq,stop_freq)) {
                 // announce results of dwell
                 gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_p=%f", (double)(test_phase[freq_cnt]), (double)(tune_rp));
-            } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: max_freq=%f max_gain=%f", (double)(sweep.maxgain.freq), (double)(sweep.maxgain.gain));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph180_freq=%f ph180_gain=%f", (double)(sweep.ph180.freq), (double)(sweep.ph180.gain));
-            }
-            break;
-        case RD_UP:
-            // announce results of dwell
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]));
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_d=%f", (double)(test_phase[freq_cnt]), (double)(tune_rd));
-            break;
-        case SP_UP:
-            if (is_equal(start_freq,stop_freq)) {
-                // announce results of dwell and update
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: phase=%f angle_p=%f", (double)(test_phase[freq_cnt]), (double)(tune_sp));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: tune_accel=%f max_accel=%f", (double)(tune_accel), (double)(test_accel_max));
-            } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: max_freq=%f max_gain=%f", (double)(sweep.maxgain.freq), (double)(sweep.maxgain.gain));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph180_freq=%f ph180_gain=%f", (double)(sweep.ph180.freq), (double)(sweep.ph180.gain));
-            }
-            break;
-        case MAX_GAINS:
-            if (is_equal(start_freq,stop_freq)) {
-                // announce results of dwell and update
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f ph=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]), (double)(test_phase[freq_cnt]));
+                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f", (double)(test_phase[freq_cnt]));
+               if (tune_type == RP_UP) {
+                   gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: rate_p=%f", (double)(tune_rp));
+               } else if (tune_type == RD_UP) {
+               gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: rate_d=%f", (double)(tune_rd));
+               } else if (tune_type == SP_UP) {
+                   gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: angle_p=%f tune_accel=%f max_accel=%f", (double)(tune_sp), (double)(tune_accel), (double)(test_accel_max));
+               }
             } else {
                 gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: max_freq=%f max_gain=%f", (double)(sweep.maxgain.freq), (double)(sweep.maxgain.gain));
                 gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph180_freq=%f ph180_gain=%f", (double)(sweep.ph180.freq), (double)(sweep.ph180.gain));

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -919,42 +919,12 @@ void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float fi
     command_filt.set_cutoff_frequency(filt_freq);
     target_rate_filt.set_cutoff_frequency(filt_freq);
 
-    if (dwell_type == RATE) {
-        rotation_rate_filt.reset(0);
-        command_filt.reset(0);
-        target_rate_filt.reset(0);
-        rotation_rate = 0.0f;
-        command_out = 0.0f;
-        filt_target_rate = 0.0f;
-    } else {
-        switch (axis) {
-        case ROLL:
-            rotation_rate_filt.reset(((float)ahrs_view->roll_sensor) / 5730.0f);
-            command_filt.reset(motors->get_roll());
-            target_rate_filt.reset(((float)attitude_control->get_att_target_euler_cd().x) / 5730.0f);
-            rotation_rate = ((float)ahrs_view->roll_sensor) / 5730.0f;
-            command_out = motors->get_roll();
-            filt_target_rate = ((float)attitude_control->get_att_target_euler_cd().x) / 5730.0f;
-            break;
-        case PITCH:
-            rotation_rate_filt.reset(((float)ahrs_view->pitch_sensor) / 5730.0f);
-            command_filt.reset(motors->get_pitch());
-            target_rate_filt.reset(((float)attitude_control->get_att_target_euler_cd().y) / 5730.0f);
-            rotation_rate = ((float)ahrs_view->pitch_sensor) / 5730.0f;
-            command_out = motors->get_pitch();
-            filt_target_rate = ((float)attitude_control->get_att_target_euler_cd().y) / 5730.0f;
-            break;
-        case YAW:
-            // yaw angle will be centered on zero by removing trim heading
-            rotation_rate_filt.reset(0.0f);
-            command_filt.reset(motors->get_yaw());
-            target_rate_filt.reset(0.0f);
-            rotation_rate = 0.0f;
-            command_out = motors->get_yaw();
-            filt_target_rate = 0.0f;
-            break;
-        }
-    }
+    rotation_rate_filt.reset(0);
+    command_filt.reset(0);
+    target_rate_filt.reset(0);
+    rotation_rate = 0.0f;
+    command_out = 0.0f;
+    filt_target_rate = 0.0f;
 
     // filter at lower frequency to remove steady state
     filt_command_reading.set_cutoff_frequency(0.2f * start_frq);

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -150,10 +150,7 @@ private:
     void dwell_test_init(float start_frq, float filt_freq, DwellType dwell_type);
 
     // dwell test used to perform frequency dwells for rate gains
-    void dwell_test_run(uint8_t freq_resp_input, float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase);
-
-    // dwell test used to perform frequency dwells for angle gains
-    void angle_dwell_test_run(float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase);
+    void dwell_test_run(uint8_t freq_resp_input, float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase, DwellType dwell_type);
 
     // generates waveform for frequency sweep excitations
     float waveform(float time, float time_record, float waveform_magnitude, float wMin, float wMax);
@@ -286,8 +283,6 @@ private:
     AP_Float max_resp_gain;     // maximum response gain
     AP_Float vel_hold_gain;     // gain for velocity hold
 
-    // freqresp object for the rate frequency response tests
-    AC_AutoTune_FreqResp freqresp_rate;
-    // freqresp object for the angle frequency response tests
-    AC_AutoTune_FreqResp freqresp_angle;
+    // freqresp object for the frequency response tests
+    AC_AutoTune_FreqResp freqresp;
 };

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "AC_AutoTune.h"
+#include <AP_Math/chirp.h>
 
 class AC_AutoTune_Heli : public AC_AutoTune
 {
@@ -147,13 +148,10 @@ private:
     void rate_ff_test_run(float max_angle_cds, float target_rate_cds, float dir_sign);
 
     // initialize dwell test or angle dwell test variables
-    void dwell_test_init(float start_frq, float filt_freq, DwellType dwell_type);
+    void dwell_test_init(float start_frq, float stop_frq, float filt_freq, DwellType dwell_type);
 
     // dwell test used to perform frequency dwells for rate gains
     void dwell_test_run(uint8_t freq_resp_input, float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase, DwellType dwell_type);
-
-    // generates waveform for frequency sweep excitations
-    float waveform(float time, float time_record, float waveform_magnitude, float wMin, float wMax);
 
     // updating_rate_ff_up - adjust FF to ensure the target is reached
     // FF is adjusted until rate requested is acheived
@@ -275,6 +273,10 @@ private:
     };
     sweep_data sweep;
 
+    // fix the frequency sweep time to 23 seconds
+    const float sweep_time_ms = 23000;
+
+
     // parameters
     AP_Int8  axis_bitmask;        // axes to be tuned
     AP_Int8  seq_bitmask;       // tuning sequence bitmask
@@ -285,4 +287,6 @@ private:
 
     // freqresp object for the frequency response tests
     AC_AutoTune_FreqResp freqresp;
+
+    Chirp chirp_input;
 };

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -136,16 +136,23 @@ private:
     // max gain data for rate d tuning
     max_gain_data max_rate_d;
 
+    // dwell type identifies whether the dwell is ran on rate or angle
+    enum DwellType {
+        RATE    = 0,
+        ANGLE   = 1,
+    };
+
     // Feedforward test used to determine Rate FF gain
     void rate_ff_test_init();
     void rate_ff_test_run(float max_angle_cds, float target_rate_cds, float dir_sign);
 
+    // initialize dwell test or angle dwell test variables
+    void dwell_test_init(float start_frq, float filt_freq, DwellType dwell_type);
+
     // dwell test used to perform frequency dwells for rate gains
-    void dwell_test_init(float start_frq, float filt_freq);
     void dwell_test_run(uint8_t freq_resp_input, float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase);
 
     // dwell test used to perform frequency dwells for angle gains
-    void angle_dwell_test_init(float start_frq, float filt_freq);
     void angle_dwell_test_run(float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase);
 
     // generates waveform for frequency sweep excitations

--- a/libraries/AP_Math/chirp.cpp
+++ b/libraries/AP_Math/chirp.cpp
@@ -1,0 +1,87 @@
+/*
+ * chirp.cpp
+ *
+ * Copyright (C) Leonard Hall 2020
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+* This object generates a chirp signal based on the input variables.  A chirp is
+* a sine wave starting from the minimum frequency and ending at the maximum frequency.
+* The progression in frequency is not linear but designed to increase exponentially.
+* The chirp can be designed to dwell at the minimum frequency for a specified time
+* before sweeping through the frequencies and also can fade in the magnitude at the
+* beginning and fade out the magnitude at the end.  This object can also generate
+* constant frequency sine waves by setting the minimum and maximum frequency to the
+* same value.
+*/
+#include <AP_Math/AP_Math.h>
+#include "chirp.h"
+
+// constructor
+Chirp::Chirp() {}
+
+// initializes the chirp object
+void Chirp::init(float time_record, float frequency_start_hz, float frequency_stop_hz, float time_fade_in, float time_fade_out, float time_const_freq)
+{
+    // pass in variables to class
+    record = time_record;
+    wMin = M_2PI * frequency_start_hz;
+    wMax = M_2PI * frequency_stop_hz;
+    fade_in = time_fade_in;
+    fade_out = time_fade_out;
+    const_freq = time_const_freq;
+
+    B = logf(wMax / wMin);
+
+}
+
+// determine chirp signal output at the specified time and amplitude
+float Chirp::update(float time, float waveform_magnitude)
+{
+    magnitude = waveform_magnitude;
+    if (time <= 0.0f) {
+        window = 0.0f;
+    } else if (time <= fade_in) {
+        window = 0.5 - 0.5 * cosf(M_PI * time / fade_in);
+    } else if (time <= record - fade_out) {
+        window = 1.0;
+    } else if (time <= record) {
+        window = 0.5 - 0.5 * cosf(M_PI * (time - (record - fade_out)) / fade_out + M_PI);
+    } else {
+        window = 0.0;
+    }
+
+    if (time <= 0.0f) {
+        waveform_freq_rads = wMin;
+        output = 0.0f;
+    } else if (time <= const_freq) {
+        waveform_freq_rads = wMin;
+        output = window * magnitude * sinf(wMin * time - wMin * const_freq);
+    } else if (time <= record) {
+        // handles constant frequency dwells and chirps
+        if (is_equal(wMin, wMax)) {
+            waveform_freq_rads = wMin;
+            output = window * magnitude * sinf(wMin * time);
+        } else {
+            waveform_freq_rads = wMin * expf(B * (time - const_freq) / (record - const_freq));
+            output = window * magnitude * sinf((wMin * (record - const_freq) / B) * (expf(B * (time - const_freq) / (record - const_freq)) - 1));
+        }
+    } else {
+        waveform_freq_rads = wMax;
+        output = 0.0f;
+    }
+    return output;
+}

--- a/libraries/AP_Math/chirp.h
+++ b/libraries/AP_Math/chirp.h
@@ -1,0 +1,53 @@
+#pragma once
+
+class Chirp {
+
+public:
+
+    // constructor
+    Chirp();
+
+    // initializes the chirp object
+    void init(float time_record, float frequency_start_hz, float frequency_stop_hz, float time_fade_in, float time_fade_out, float time_const_freq);
+
+    // determine chirp signal output at the specified time and amplitude
+    float update(float time, float waveform_magnitude);
+
+    // accessor for the current waveform frequency
+    float get_frequency_rads() {return waveform_freq_rads; }
+
+private:
+    // Total chirp length in seconds
+    float record;
+
+    // Chirp oscillation amplitude
+    float magnitude;
+
+    // Chirp start frequency in rad/s
+    float wMin;
+
+    // Chirp end frequency in rad/s
+    float wMax;
+
+    // Amplitude fade in time in seconds
+    float fade_in;
+
+    // Amplitude fade out time in seconds
+    float fade_out;
+
+    // Time that chirp will remain at the min frequency before increasing to max frequency
+    float const_freq;
+
+    // frequency ratio
+    float B;
+
+    // current waveform frequency in rad/s
+    float waveform_freq_rads;
+
+    // current amplitude of chirp
+    float window;
+
+    // output of chirp signal at the requested time
+    float output;
+
+};


### PR DESCRIPTION
This PR reduces flash size for heli by streamlining some of the functions in heli autotune.  The functions that were streamlined include the GCS announcements and the dwell_test run and init methods.   My initial calculations is that it may save 1200 bytes.

Haven't completed testing but I will post once I am happy that it hasn't affected the autotune feature