### PR TITLE
Copter: If transition to ALT_HOLD is not possible, transition to STABILIZE

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -308,8 +308,9 @@ void ModeRTL::descent_run()
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             AP::logger().Write_Event(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
-            if (!copter.set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE)) {
-                copter.set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
+            if (!copter.set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE) ||
+                !copter.set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE)) {
+                    copter.set_mode(Mode::Number::STABILIZE, ModeReason::THROTTLE_LAND_ESCAPE);
             }
         }
 


### PR DESCRIPTION
There are cases where a transition to ALT_HOLD cannot be made.
In this case, the transition should be made to STABILIZE.