### PR TITLE
Plane: tailsitter: keep attitude controll throttle level upto date for smoother controller handover

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -312,6 +312,11 @@ void Tailsitter::output(void)
 
             // in assisted flight this is done in the normal motor output path
             if (!quadplane.assisted_flight) {
+
+                // keep attitude control throttle level upto date, this value should never be output to motors
+                // it is used to re-set the accel Z integrator term allowing for a smooth transfer of control
+                quadplane.attitude_control->set_throttle_out(throttle, false, 0);
+
                 // convert the hover throttle to the same output that would result if used via AP_Motors
                 // apply expo, battery scaling and SPIN min/max.
                 throttle = motors->thrust_to_actuator(throttle);


### PR DESCRIPTION
This means that init Z controller function sets the correct integrator term to remove a instantaneous throttle step.

https://github.com/ArduPilot/ardupilot/blob/37abfb98dcc00cdf0952180da9629b2403cf1ed7/libraries/AC_AttitudeControl/AC_PosControl.cpp#L762-L767

Untested, so just a draft.