### PR TITLE
AP_Motors: update no motor found warning message

### DIFF
--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -199,7 +199,7 @@ void AP_Motors::add_motor_num(int8_t motor_num)
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
         if (!SRV_Channels::find_channel(function, chan)) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: no SERVOx_FUNCTION set to Motor%u", motor_num + 1);
         }
     }
 }


### PR DESCRIPTION
Now gives a more usefull warning. 

Tempted to remove completely, it happens very early in the boot processes so is easy to miss. You will also get it if you change the frame class after boot or add a custom frame via scripting.

Might be better as a motors pre-arm check.... but not as part of this PR ;)