### PR TITLE
autotest: Re-enable Plane Landing-Drift test.

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3782,5 +3782,4 @@ function'''
     def disabled_tests(self):
         return {
             "Terrain-loiter": "Loading of terrain data is not reliable",
-            "Landing-Drift": "Flapping test. See https://github.com/ArduPilot/ardupilot/issues/20054",
         }


### PR DESCRIPTION
WIP to allow failed logs to be obtained