### PR TITLE
Tools: remove Solo Cubes and skyvipers from blacklist

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -116,13 +116,6 @@ class BoardList(object):
         # should probably have a line in the hwdef indicating they
         # shouldn't be auto-built...
         blacklist = [
-            # the following boards are hacked into build_binaries.py
-            # to be built for Copter only:
-            "CubeGreen-solo",
-            "CubeSolo",
-            "skyviper-journey",
-            "skyviper-v2450",
-
             # IOMCU:
             "iomcu",
             'iomcu_f103_8MHz',


### PR DESCRIPTION
autotest server will start to build these again.