### PR TITLE
Plane: Display Fence Breach message in GCS

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -50,6 +50,10 @@ void Plane::fence_check()
         // user disables/re-enables using the fence channel switch
         return;
     }
+    
+     if(new_breaches && plane.is_flying()) {
+         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+     }
 
     if (new_breaches || orig_breaches) {
         // if the user wants some kind of response and motors are armed


### PR DESCRIPTION
Send a "Geofence breach" message to the Ground Control Station. Without this when the fence is breached and if anything happens as a result, such as RTL, it will happen silently.