### PR TITLE
autotest: board_list.py: correct autobuild target name for Tracker

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -15,7 +15,7 @@ class Board(object):
         self.name = name
         self.is_ap_periph = False
         self.autobuild_targets = [
-            'AntennaTracker',
+            'Tracker',
             'Blimp',
             'Copter',
             'Heli',


### PR DESCRIPTION
We're using the shortened name throughout