### PR TITLE
Copter: fix auto takeoff when using terrain altitudes

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -212,8 +212,8 @@ protected:
     static float auto_takeoff_no_nav_alt_cm;
 
     // auto takeoff variables
-    static float auto_take_off_start_alt_cm;    // start altitude expressed as cm above ekf origin
-    static float auto_take_off_complete_alt_cm; // completion altitude expressed as cm above ekf origin
+    static float auto_takeoff_start_alt_cm;     // start altitude expressed as cm above ekf origin
+    static float auto_takeoff_complete_alt_cm;  // completion altitude expressed as cm above ekf origin
     static bool auto_takeoff_terrain_alt;       // true if altitudes are above terrain
     static bool auto_takeoff_complete;          // true when takeoff is complete
     static Vector3p auto_takeoff_complete_pos;  // target takeoff position as offset from ekf origin in cm

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -213,7 +213,7 @@ protected:
 
     // auto takeoff variables
     static float auto_takeoff_start_alt_cm;     // start altitude expressed as cm above ekf origin
-    static float auto_takeoff_complete_alt_cm;  // completion altitude expressed as cm above ekf origin
+    static float auto_takeoff_complete_alt_cm;  // completion altitude expressed in cm above ekf origin or above terrain (depending upon auto_takeoff_terrain_alt)
     static bool auto_takeoff_terrain_alt;       // true if altitudes are above terrain
     static bool auto_takeoff_complete;          // true when takeoff is complete
     static Vector3p auto_takeoff_complete_pos;  // target takeoff position as offset from ekf origin in cm

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -179,7 +179,7 @@ void Mode::auto_takeoff_run()
     }
 
     // handle takeoff completion
-    bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_takeoff_start_alt_cm) >= ((auto_takeoff_complete_alt_cm  - auto_takeoff_start_alt_cm) * 0.90);
+    bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_takeoff_start_alt_cm) >= ((auto_takeoff_complete_alt_cm + terr_offset - auto_takeoff_start_alt_cm) * 0.90);
     bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * 0.1;
     auto_takeoff_complete = reached_altitude && reached_climb_rate;
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -4,8 +4,8 @@ Mode::_TakeOff Mode::takeoff;
 
 bool Mode::auto_takeoff_no_nav_active = false;
 float Mode::auto_takeoff_no_nav_alt_cm = 0;
-float Mode::auto_take_off_start_alt_cm = 0;
-float Mode::auto_take_off_complete_alt_cm = 0;
+float Mode::auto_takeoff_start_alt_cm = 0;
+float Mode::auto_takeoff_complete_alt_cm = 0;
 bool Mode::auto_takeoff_terrain_alt = false;
 bool Mode::auto_takeoff_complete = false;
 Vector3p Mode::auto_takeoff_complete_pos;
@@ -159,7 +159,7 @@ void Mode::auto_takeoff_run()
     pos_control->update_xy_controller();
 
     // command the aircraft to the take off altitude
-    float pos_z = auto_take_off_complete_alt_cm + terr_offset;
+    float pos_z = auto_takeoff_complete_alt_cm + terr_offset;
     float vel_z = 0.0;
     copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0.0);
     
@@ -179,7 +179,7 @@ void Mode::auto_takeoff_run()
     }
 
     // handle takeoff completion
-    bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_take_off_start_alt_cm) >= ((auto_take_off_complete_alt_cm  - auto_take_off_start_alt_cm) * 0.90);
+    bool reached_altitude = (copter.pos_control->get_pos_target_z_cm() - auto_takeoff_start_alt_cm) >= ((auto_takeoff_complete_alt_cm  - auto_takeoff_start_alt_cm) * 0.90);
     bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * 0.1;
     auto_takeoff_complete = reached_altitude && reached_climb_rate;
 
@@ -192,13 +192,13 @@ void Mode::auto_takeoff_run()
 
 void Mode::auto_takeoff_start(float complete_alt_cm, bool terrain_alt)
 {
-    auto_take_off_start_alt_cm = inertial_nav.get_position_z_up_cm();
-    auto_take_off_complete_alt_cm = complete_alt_cm;
+    auto_takeoff_start_alt_cm = inertial_nav.get_position_z_up_cm();
+    auto_takeoff_complete_alt_cm = complete_alt_cm;
     auto_takeoff_terrain_alt = terrain_alt;
     auto_takeoff_complete = false;
     if ((g2.wp_navalt_min > 0) && (is_disarmed_or_landed() || !motors->get_interlock())) {
         // we are not flying, climb with no navigation to current alt-above-ekf-origin + wp_navalt_min
-        auto_takeoff_no_nav_alt_cm = auto_take_off_start_alt_cm + g2.wp_navalt_min * 100;
+        auto_takeoff_no_nav_alt_cm = auto_takeoff_start_alt_cm + g2.wp_navalt_min * 100;
         auto_takeoff_no_nav_active = true;
     } else {
         auto_takeoff_no_nav_active = false;


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/20277 and replaces PR https://github.com/ArduPilot/ardupilot/pull/20153.  Thank you very much to @hasi123 for finding this important bug and providing advice on the fix.

The bug was that the takeoff completion check was not using the terr_offset.  If the takeoff is using an alt-above-origin, terr_offset is zero so there is no change in behaviour.  If the takeoff is using alt-above-terrain then terr_offset is the terrain's height above the EKF origin or, put another way, to convert an alt-above-terrain to an alt-above-ekf-origin we must add "terr_offset".

This PR also renames some variables (e.g. "take_off" becomes "takeoff") to make them consistent. 

I have tested this in SITL by following the steps in issue https://github.com/ArduPilot/ardupilot/issues/20277 to confirm the problem occurs without this fix and is resolved with this fix.  For good measure I also did some other similar tests like setting the terrain altitude higher than home, etc.
![takeoff-terr-before-vs-after](https://user-images.githubusercontent.com/1498098/157801929-04952704-d169-45cc-8f3f-659f0ad70f78.png)

