### PR TITLE
GCS_Common: remrssi respect INVALID value

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -733,7 +733,7 @@ void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg, bool log_rad
 
     // record if the GCS has been receiving radio messages from
     // the aircraft
-    if (packet.remrssi != 0) {
+    if (packet.remrssi != 0 && packet.remrssi != 255) {
         last_radio_status.remrssi_ms = now;
     }
 


### PR DESCRIPTION
according to the mavlink standard a value of UINT8_MAX = 255 for remssi means invalid/unknown. So it should not be accepted.