### PR TITLE
AP_GPS: only use PPS time when there is atleast 2D Fix

### DIFF
--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -250,11 +250,12 @@ void AP_GPS_Backend::check_new_itow(uint32_t itow, uint32_t msg_length)
 
         // get the time the packet arrived on the UART
         uint64_t uart_us;
-        if (port && _last_pps_time_us == 0) {
-            uart_us = port->receive_time_constraint_us(msg_length);
-        } else if (_last_pps_time_us != 0) {
+        if (_last_pps_time_us != 0 && (state.status >= AP_GPS::GPS_OK_FIX_2D)) {
+            // pps is only reliable when we have some sort of GPS fix
             uart_us = _last_pps_time_us;
             _last_pps_time_us = 0;
+        } else if (port) {
+            uart_us = port->receive_time_constraint_us(msg_length);
         } else {
             uart_us = AP_HAL::micros64();
         }


### PR DESCRIPTION
PPS triggers can lag a lot at boot before at-least 2D fix has been reached, and hence falsely signalling unhealthy. So, we shouldn't rely on it before atleast 2D Fix has been achieved.