### PR TITLE
AP_Soaring: added SOAR_THML_MINRAD

### DIFF
--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -162,6 +162,13 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("THML_FLAP", 22, SoaringController, soar_thermal_flap, 0),
 
+    // @Param: THML_MINRAD
+    // @DisplayName: Minimum thermal radius
+    // @Description: This sets the minimum radius of the modelled thermal. If set to zero then no limit is applied
+    // @Range: 1 100
+    // @User: Advanced
+    AP_GROUPINFO("THML_MINRAD", 23, SoaringController, soar_thermal_min_radius, 40),
+    
     AP_GROUPEND
 };
 
@@ -322,9 +329,8 @@ void SoaringController::update_thermalling()
     Vector3f wind_drift = _ahrs.wind_estimate()*deltaT*_vario.get_filtered_climb()/_ekf.X[0];
 
     // update the filter
-    _ekf.update(_vario.reading, current_position.x, current_position.y, wind_drift.x, wind_drift.y);
+    _ekf.update(_vario.reading, current_position.x, current_position.y, wind_drift.x, wind_drift.y, MAX(0.1, soar_thermal_min_radius));
 
-    
     _thermalability = (_ekf.X[0]*expf(-powf(get_thermalling_radius()/_ekf.X[1], 2))) - _vario.get_exp_thermalling_sink();
 
     _prev_update_time = AP_HAL::micros64();

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -80,6 +80,7 @@ protected:
     AP_Float soar_thermal_airspeed;
     AP_Float soar_cruise_airspeed;
     AP_Float soar_thermal_flap;
+    AP_Float soar_thermal_min_radius;
 
 public:
     SoaringController(AP_TECS &tecs, const AP_Vehicle::FixedWing &parms);

--- a/libraries/AP_Soaring/ExtendedKalmanFilter.cpp
+++ b/libraries/AP_Soaring/ExtendedKalmanFilter.cpp
@@ -1,4 +1,5 @@
 #include "ExtendedKalmanFilter.h"
+#include "AP_Math/AP_Math.h"
 #include "AP_Math/matrixN.h"
 
 
@@ -29,7 +30,7 @@ void ExtendedKalmanFilter::reset(const VectorN<float,N> &x, const MatrixN<float,
 }
 
 
-void ExtendedKalmanFilter::update(float z, float Px, float Py, float driftX, float driftY)
+void ExtendedKalmanFilter::update(float z, float Px, float Py, float driftX, float driftY, float min_radius)
 {
     MatrixN<float,N> tempM;
     VectorN<float,N> H;
@@ -69,7 +70,7 @@ void ExtendedKalmanFilter::update(float z, float Px, float Py, float driftX, flo
     X += K * (z - z1);
 
     // Make sure X[1] stays positive.
-    X[1] = X[1]>40.0 ? X[1]: 40.0;
+    X[1] = MAX(min_radius, X[1]);
 
     // Correct the covariance too.
     // LINE 46

--- a/libraries/AP_Soaring/ExtendedKalmanFilter.h
+++ b/libraries/AP_Soaring/ExtendedKalmanFilter.h
@@ -20,7 +20,7 @@ public:
     MatrixN<float,N> Q;
     float R;
     void reset(const VectorN<float,N> &x, const MatrixN<float,N> &p, const MatrixN<float,N> q, float r);
-    void update(float z, float Px, float Py, float driftX, float driftY);
+    void update(float z, float Px, float Py, float driftX, float driftY, float min_radius);
 
 private:
     float measurementpredandjacobian(VectorN<float,N> &A, float Px, float Py);


### PR DESCRIPTION
allow for the mininimum radius to be set for the modelled thermal,
allowing for smaller thermals