### PR TITLE
AP_AHRS: Add case where both ekf2 and ekf3 are incorporated

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -221,6 +221,13 @@ void AP_AHRS::init()
         _ekf_type.set(2);
         EKF2.set_enable(true);
     }
+#elif HAL_NAVEKF3_AVAILABLE && HAL_NAVEKF2_AVAILABLE
+    if (_ekf_type.get() == 2 && EKF2.get_enable() == 0) {
+        EKF2.set_enable(true);
+    }
+    if (_ekf_type.get() == 3 && EKF3.get_enable() == 0) {
+        EKF3.set_enable(true);
+    }
 #endif
 
     last_active_ekf_type = (EKFType)_ekf_type.get();

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -254,6 +254,8 @@ public:
 
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set_enable(enable); }
+    // Get EKF2 enable/disable
+    int8_t get_enable() { return _enable.get(); }
 
     /*
      * Write position and quaternion data from an external navigation system

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -319,6 +319,8 @@ public:
 
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set_enable(enable); }
+    // Get EKF3 enable/disable
+    int8_t get_enable() { return _enable.get(); }
 
     /*
       check if switching lanes will reduce the normalised


### PR DESCRIPTION
EKF2 and EKF3 can coexist.
If the EKF designation in the AHRS is different from the valid flags of EKF2 and EKF3, the valid flags are changed.