### PR TITLE
Rover: balance bot stands in acro with no position estimate

### DIFF
--- a/Rover/mode_acro.cpp
+++ b/Rover/mode_acro.cpp
@@ -9,6 +9,12 @@ void ModeAcro::update()
         float desired_throttle;
         // convert pilot stick input into desired steering and throttle
         get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
+
+        // if vehicle is balance bot, calculate actual throttle required for balancing
+        if (rover.is_balancebot()) {
+            rover.balancebot_pitch_control(desired_throttle);
+        }
+
         // no valid speed, just use the provided throttle
         g2.motors.set_throttle(desired_throttle);
     } else {


### PR DESCRIPTION
This fixes a bug in Rover's Acro mode which causes balance bots fall over if they do not have a speed estimate.

Before and after tests have been performed on a real vehicle to confirm the problem exists in master (all the way back until at least 4.1) and also to confirm this patch fixes the problem.

Thanks very much to Webillo for reporting the problem [here](https://discuss.ardupilot.org/t/rover-4-1-3-rc1-released-for-beta-testing/79751/4) and sorry for taking so long to fix it!