### PR TITLE
AP_Arming: display a warning if arming checks disabled when arming

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1365,6 +1365,10 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         armed = false;
     }
 
+    if (armed && do_arming_checks && checks_to_perform == 0) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Warning: Arming Checks Disabled");
+    }
+
     return armed;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/831867/158555813-450d42fd-0da1-4213-88ea-76da02b28f1e.png)
