### PR TITLE
HAL_ChibiOS: prevent conflicting RC input

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -69,6 +69,7 @@ private:
     int16_t _rssi = -1;
     int16_t _rx_link_quality = -1;
     uint32_t _rcin_timestamp_last_signal;
+    uint32_t _rcin_last_iomcu_ms;
     bool _init;
     const char *last_protocol;
     bool pulse_input_enabled;


### PR DESCRIPTION
when we have RC from both IOMCU and from rcprotocol (eg. from
SERIALn_PROTOCOL=23) we need to only process one of them. This
prioritises IOMCU input