### PR TITLE
AP_UAVCAN: correct array indexing

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -564,9 +564,9 @@ void AP_UAVCAN::SRV_push_servos()
 {
     WITH_SEMAPHORE(SRV_sem);
 
-    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
+    for (uint8_t i = 0; i < UAVCAN_SRV_NUMBER; i++) {
         // Check if this channels has any function assigned
-        if (SRV_Channels::channel_function(i)) {
+        if (SRV_Channels::channel_function(i) > SRV_Channel::k_none) {
             _SRV_conf[i].pulse = SRV_Channels::srv_channel(i)->get_output_pwm();
             _SRV_conf[i].esc_pending = true;
             _SRV_conf[i].servo_pending = true;


### PR DESCRIPTION
Fix found by @pacolate12 when testing https://github.com/ArduPilot/ardupilot/pull/16301

`_SRV_conf` array is of size `UAVCAN_SRV_NUMBER` https://github.com/ArduPilot/ardupilot/blob/ebe2205ba76f10023e82ff2f8dc2eed861f4795b/libraries/AP_UAVCAN/AP_UAVCAN.h#L279

Also added `> SRV_Channel::k_none` so we also ignore the new `SRV_Channel::k_GPIO` function.