### PR TITLE
AP_GPS: UBlox: configure and log TIM-TM2

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -49,6 +49,9 @@
 #define UBLOX_MAX_RXM_RAW_SATS 22
 #define UBLOX_MAX_RXM_RAWX_SATS 32
 #define UBLOX_GNSS_SETTINGS 1
+#ifndef UBLOX_TIM_TM2_LOGGING
+    #define UBLOX_TIM_TM2_LOGGING (BOARD_FLASH_SIZE>1024)
+#endif
 
 #define UBLOX_MAX_GNSS_CONFIG_BLOCKS 7
 
@@ -65,6 +68,7 @@
 #define RATE_DOP 1
 #define RATE_HW 5
 #define RATE_HW2 5
+#define RATE_TIM_TM2 1
 
 #define CONFIG_RATE_NAV      (1<<0)
 #define CONFIG_RATE_POSLLH   (1<<1)
@@ -84,7 +88,8 @@
 #define CONFIG_RATE_TIMEGPS  (1<<15)
 #define CONFIG_TMODE_MODE    (1<<16)
 #define CONFIG_RTK_MOVBASE   (1<<17)
-#define CONFIG_LAST          (1<<18) // this must always be the last bit
+#define CONFIG_TIM_TM2       (1<<18)
+#define CONFIG_LAST          (1<<19) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
 
@@ -516,6 +521,19 @@ private:
         uint32_t loadMask;
     };
 
+    struct PACKED ubx_tim_tm2 {
+        uint8_t ch;
+        uint8_t flags;
+        uint16_t count;
+        uint16_t wnR;
+        uint16_t wnF;
+        uint32_t towMsR;
+        uint32_t towSubMsR;
+        uint32_t towMsF;
+        uint32_t towSubMsF;
+        uint32_t accEst;
+    };
+
     // Receive buffer
     union PACKED {
         DEFINE_BYTE_ARRAY_METHODS
@@ -548,6 +566,7 @@ private:
         ubx_rxm_rawx rxm_rawx;
 #endif
         ubx_ack_ack ack;
+        ubx_tim_tm2 tim_tm2;
     } _buffer;
 
     enum class RELPOSNED {
@@ -573,6 +592,7 @@ private:
         CLASS_CFG = 0x06,
         CLASS_MON = 0x0A,
         CLASS_RXM = 0x02,
+        CLASS_TIM = 0x0d,
         MSG_ACK_NACK = 0x00,
         MSG_ACK_ACK = 0x01,
         MSG_POSLLH = 0x2,
@@ -598,7 +618,8 @@ private:
         MSG_MON_VER = 0x04,
         MSG_NAV_SVINFO = 0x30,
         MSG_RXM_RAW = 0x10,
-        MSG_RXM_RAWX = 0x15
+        MSG_RXM_RAWX = 0x15,
+        MSG_TIM_TM2 = 0x03
     };
     enum ubx_gnss_identifier {
         GNSS_GPS     = 0x00,
@@ -655,6 +676,7 @@ private:
         STEP_RAWX,
         STEP_VERSION,
         STEP_RTK_MOVBASE, // setup moving baseline
+        STEP_TIM_TM2,
         STEP_LAST
     };
 
@@ -728,6 +750,7 @@ private:
     void unexpected_message(void);
     void log_mon_hw(void);
     void log_mon_hw2(void);
+    void log_tim_tm2(void);
     void log_rxm_raw(const struct ubx_rxm_raw &raw);
     void log_rxm_rawx(const struct ubx_rxm_rawx &raw);
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -101,6 +101,7 @@ const struct MultiplierStructure log_Multipliers[] = {
     { 'E', 1e-5 },
     { 'F', 1e-6 },
     { 'G', 1e-7 },
+    { 'I', 1e-9 },
 // <leave a gap here, just in case....>
     { '!', 3.6 }, // (ampere*second => milliampere*hour) and (km/h => m/s)
     { '/', 3600 }, // (ampere*second => ampere*hour)

--- a/libraries/AP_Logger/README.md
+++ b/libraries/AP_Logger/README.md
@@ -100,5 +100,6 @@ tl;dr a GCS shouldn't/mustn't infer any scaling from the unit name
 | 'E' | 1e-5 ||
 | 'F' | 1e-6 ||
 | 'G' | 1e-7 ||
+| 'I' | 1e-9 ||
 | '!' | 3.6 | (milliampere \* hour => ampere \* second) and (km/h => m/s)|
 | '/' | 3600 | (ampere \* hour => ampere \* second)|


### PR DESCRIPTION
This adds logging of TIM TM2 message useful for precise sync of signals to GPS time, via ext int pin on GPS. 

See: https://github.com/ArduPilot/ardupilot/issues/15428, https://github.com/ArduPilot/ardupilot/issues/10369, https://github.com/ArduPilot/ardupilot/issues/7892

Tested on m8p, I have verified the logged message is the same as that reported in u-center. 

![image](https://user-images.githubusercontent.com/33176108/159131892-7ff0e8c5-cbfc-4cf4-b2ce-d4ab94fe8917.png)

I have not checked if this message is supported by all UBlox variants, or what happens if it is not supported, I presume the GPS will not respond to the request for message rate in that case. So this new message will not be added to `_unconfigured_messages` and will not cause a arming failure. 