### PR TITLE
Copter/Global: Console output can be disabled

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1203,7 +1203,7 @@ const AP_Param::ConversionInfo conversion_table[] = {
 void Copter::load_parameters(void)
 {
     if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad var table\n");
+        DEV_PRINTF("Bad var table\n");
         AP_HAL::panic("Bad var table");
     }
 
@@ -1213,13 +1213,13 @@ void Copter::load_parameters(void)
         g.format_version != Parameters::k_format_version) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        DEV_PRINTF("Firmware change: erasing EEPROM...\n");
         StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version
         g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->printf("done.\n");
+        DEV_PRINTF("done.\n");
     }
 
     uint32_t before = micros();

--- a/libraries/AP_ADC/AP_ADC_ADS1115.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.cpp
@@ -192,7 +192,7 @@ float AP_ADC_ADS1115::_convert_register_data_to_mv(int16_t word) const
         break;
     default:
         pga = 0.0f;
-        hal.console->printf("Wrong gain");
+        DEV_PRINTF("Wrong gain");
         AP_HAL::panic("ADS1115: wrong gain selected");
         break;
     }

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -147,7 +147,7 @@ void AP_Avoidance::init(void)
 
         if (_obstacles == nullptr) {
             // dynamic RAM allocation of _obstacles[] failed, disable gracefully
-            hal.console->printf("Unable to initialize Avoidance obstacle list\n");
+            DEV_PRINTF("Unable to initialize Avoidance obstacle list\n");
             // disable ourselves to avoid repeated allocation attempts
             _enabled.set(0);
             return;

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1468,7 +1468,7 @@ void AP_BLHeli::read_telemetry_packet(void)
                 trpm = trpm * 200 / motor_poles;
             }
         }
-        hal.console->printf("ESC[%u] T=%u V=%f C=%f con=%f RPM=%u e=%.1f t=%u\n",
+        DEV_PRINTF("ESC[%u] T=%u V=%f C=%f con=%f RPM=%u e=%.1f t=%u\n",
                             last_telem_esc,
                             t.temperature_cdeg,
                             t.voltage,
@@ -1490,13 +1490,12 @@ void AP_BLHeli::log_bidir_telemetry(void)
         if (has_bidir_dshot(last_telem_esc)) {
             const uint8_t motor_idx = motor_map[last_telem_esc];
             uint16_t trpm = hal.rcout->get_erpm(motor_idx);
-            const float terr = hal.rcout->get_erpm_error_rate(motor_idx);
             if (trpm != 0xFFFF) {    // don't log invalid values as they are never used
                 trpm = trpm * 200 / motor_poles;
             }
 
             last_log_ms[last_telem_esc] = now;
-            hal.console->printf("ESC[%u] RPM=%u e=%.1f t=%u\n", last_telem_esc, trpm, terr, (unsigned)AP_HAL::millis());
+            DEV_PRINTF("ESC[%u] RPM=%u e=%.1f t=%u\n", last_telem_esc, trpm, hal.rcout->get_erpm_error_rate(motor_idx), (unsigned)AP_HAL::millis());
         }
     }
 

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -117,7 +117,7 @@ bool AP_Baro_LPS2XH::_imu_i2c_init(uint8_t imu_address)
 
     uint8_t whoami=0;
     _dev->read_registers(MPUREG_WHOAMI, &whoami, 1);
-    hal.console->printf("IMU: whoami 0x%02x old_address=%02x\n", whoami, old_address);
+    DEV_PRINTF("IMU: whoami 0x%02x old_address=%02x\n", whoami, old_address);
 
     _dev->write_register(MPUREG_FIFO_EN, 0x00);
     _dev->write_register(MPUREG_PWR_MGMT_1, BIT_PWR_MGMT_1_CLK_XGYRO);
@@ -194,7 +194,7 @@ bool AP_Baro_LPS2XH::_check_whoami(void)
     if (!_dev->read_registers(REG_ID, &whoami, 1)) {
 	   return false;
     }
-    hal.console->printf("LPS2XH whoami 0x%02x\n", whoami);
+    DEV_PRINTF("LPS2XH whoami 0x%02x\n", whoami);
 
     switch(whoami){
     case LPS22HB_WHOAMI:

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -316,7 +316,7 @@ void AP_BoardConfig::validate_board_type(void)
         config_error("Pixhawk2 requires FMUv3 firmware");        
 #endif
         state.board_type.set(PX4_BOARD_PIXHAWK2);
-        hal.console->printf("Forced PIXHAWK2\n");
+        DEV_PRINTF("Forced PIXHAWK2\n");
     }
 #endif
 
@@ -349,7 +349,7 @@ void AP_BoardConfig::board_autodetect(void)
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
     // only one choice
     state.board_type.set(PX4_BOARD_PX4V1);
-    hal.console->printf("Detected PX4v1\n");
+    DEV_PRINTF("Detected PX4v1\n");
 
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2) || defined(HAL_CHIBIOS_ARCH_FMUV3)
     if ((spi_check_register("mpu6000_ext", MPUREG_WHOAMI, MPU_WHOAMI_MPU60X0) ||
@@ -363,13 +363,13 @@ void AP_BoardConfig::board_autodetect(void)
          spi_check_register_inv2("icm20948_ext", INV2REG_WHOAMI, INV2_WHOAMI_ICM20948))) {
         // Pixhawk2 has LSM303D and MPUxxxx on external bus
         state.board_type.set(PX4_BOARD_PIXHAWK2);
-        hal.console->printf("Detected PIXHAWK2\n");
+        DEV_PRINTF("Detected PIXHAWK2\n");
     } else if ((spi_check_register("icm20608-am", MPUREG_WHOAMI, MPU_WHOAMI_ICM20608) ||
                 spi_check_register("icm20608-am", MPUREG_WHOAMI, MPU_WHOAMI_ICM20602)) &&
                spi_check_register("mpu9250", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) {
         // PHMINI has an ICM20608 and MPU9250 on sensor bus
         state.board_type.set(PX4_BOARD_PHMINI);
-        hal.console->printf("Detected PixhawkMini\n");
+        DEV_PRINTF("Detected PixhawkMini\n");
     } else if (spi_check_register("lsm9ds0_am", LSMREG_WHOAMI, LSM_WHOAMI_LSM303D) &&
                (spi_check_register("mpu6000", MPUREG_WHOAMI, MPU_WHOAMI_MPU60X0) ||
                 spi_check_register("icm20608", MPUREG_WHOAMI, MPU_WHOAMI_ICM20608) ||
@@ -378,52 +378,52 @@ void AP_BoardConfig::board_autodetect(void)
 
         // classic or upgraded Pixhawk1
         state.board_type.set(PX4_BOARD_PIXHAWK);
-        hal.console->printf("Detected Pixhawk\n");
+        DEV_PRINTF("Detected Pixhawk\n");
     } else {
         config_error("Unable to detect board type");
     }
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4) || defined(HAL_CHIBIOS_ARCH_FMUV4)
     // only one choice
     state.board_type.set_and_notify(PX4_BOARD_PIXRACER);
-    hal.console->printf("Detected Pixracer\n");
+    DEV_PRINTF("Detected Pixracer\n");
 #elif defined(HAL_CHIBIOS_ARCH_MINDPXV2)
     // only one choice
     state.board_type.set_and_notify(PX4_BOARD_MINDPXV2);
-    hal.console->printf("Detected MindPX-V2\n");
+    DEV_PRINTF("Detected MindPX-V2\n");
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4PRO) || defined(HAL_CHIBIOS_ARCH_FMUV4PRO)
     // only one choice
     state.board_type.set_and_notify(PX4_BOARD_PIXHAWK_PRO);
-    hal.console->printf("Detected Pixhawk Pro\n");	
+    DEV_PRINTF("Detected Pixhawk Pro\n");	
 #elif defined(CONFIG_ARCH_BOARD_AEROFC_V1)
     state.board_type.set_and_notify(PX4_BOARD_AEROFC);
-    hal.console->printf("Detected Aero FC\n");
+    DEV_PRINTF("Detected Aero FC\n");
 #elif defined(HAL_CHIBIOS_ARCH_FMUV5)
     state.board_type.set_and_notify(PX4_BOARD_FMUV5);
-    hal.console->printf("Detected FMUv5\n");
+    DEV_PRINTF("Detected FMUv5\n");
 #elif defined(HAL_CHIBIOS_ARCH_FMUV6)
     state.board_type.set_and_notify(PX4_BOARD_FMUV5);
-    hal.console->printf("Detected FMUv6\n");
+    DEV_PRINTF("Detected FMUv6\n");
 #elif defined(CONFIG_ARCH_BOARD_VRBRAIN_V51) || defined(HAL_CHIBIOS_ARCH_BRAINV51)
     state.board_type.set_and_notify(VRX_BOARD_BRAIN51);
-    hal.console->printf("Detected VR Brain 5.1\n");
+    DEV_PRINTF("Detected VR Brain 5.1\n");
 #elif defined(CONFIG_ARCH_BOARD_VRBRAIN_V52) || defined(HAL_CHIBIOS_ARCH_BRAINV52)
     state.board_type.set_and_notify(VRX_BOARD_BRAIN52);
-    hal.console->printf("Detected VR Brain 5.2\n");
+    DEV_PRINTF("Detected VR Brain 5.2\n");
 #elif defined(CONFIG_ARCH_BOARD_VRBRAIN_V52E)
     state.board_type.set_and_notify(VRX_BOARD_BRAIN52E);
-    hal.console->printf("Detected VR Brain 5.2E\n");
+    DEV_PRINTF("Detected VR Brain 5.2E\n");
 #elif defined(CONFIG_ARCH_BOARD_VRUBRAIN_V51) || defined(HAL_CHIBIOS_ARCH_UBRAINV51)
     state.board_type.set_and_notify(VRX_BOARD_UBRAIN51);
-    hal.console->printf("Detected VR Micro Brain 5.1\n");
+    DEV_PRINTF("Detected VR Micro Brain 5.1\n");
 #elif defined(CONFIG_ARCH_BOARD_VRUBRAIN_V52)
     state.board_type.set_and_notify(VRX_BOARD_UBRAIN52);
-    hal.console->printf("Detected VR Micro Brain 5.2\n");
+    DEV_PRINTF("Detected VR Micro Brain 5.2\n");
 #elif defined(CONFIG_ARCH_BOARD_VRCORE_V10) || defined(HAL_CHIBIOS_ARCH_COREV10)
     state.board_type.set_and_notify(VRX_BOARD_CORE10);
-    hal.console->printf("Detected VR Core 1.0\n");
+    DEV_PRINTF("Detected VR Core 1.0\n");
 #elif defined(CONFIG_ARCH_BOARD_VRBRAIN_V54) || defined(HAL_CHIBIOS_ARCH_BRAINV54)
     state.board_type.set_and_notify(VRX_BOARD_BRAIN54);
-    hal.console->printf("Detected VR Brain 5.4\n");
+    DEV_PRINTF("Detected VR Brain 5.4\n");
 #endif
 
 }

--- a/libraries/AP_CANManager/AP_CANTester.cpp
+++ b/libraries/AP_CANManager/AP_CANTester.cpp
@@ -328,10 +328,10 @@ bool CANTester::test_loopback(uint32_t loop_rate)
     }
 
     for (uint8_t i = 0; i < _num_ifaces; i++) {
-        hal.console->printf("Loopback Test Results %d->%d:\n", i, (i+1)%2);
-        hal.console->printf("num_tx: %lu, failed_tx: %lu\n",
+        DEV_PRINTF("Loopback Test Results %d->%d:\n", i, (i+1)%2);
+        DEV_PRINTF("num_tx: %lu, failed_tx: %lu\n",
                             (long unsigned int)_loopback_stats[i].num_tx, (long unsigned int)_loopback_stats[i].failed_tx);
-        hal.console->printf("num_rx: %lu, flushed_rx: %lu, bad_rx_data: %lu, bad_rx_seq: %lu\n",
+        DEV_PRINTF("num_rx: %lu, flushed_rx: %lu, bad_rx_data: %lu, bad_rx_seq: %lu\n",
                             (long unsigned int)_loopback_stats[i].num_rx, (long unsigned int)_loopback_stats[i].num_flushed_rx,
                             (long unsigned int)_loopback_stats[i].bad_rx_data, (long unsigned int)_loopback_stats[i].bad_rx_seq);
         if (_loopback_stats[i].num_rx < 0.9f * _loopback_stats[i].num_tx ||

--- a/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
+++ b/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
@@ -201,12 +201,12 @@ void AP_CANTester_KDECAN::loop(void)
 
 void AP_CANTester_KDECAN::print_stats(void)
 {
-    hal.console->printf("KDECANTester: TimeStamp: %u\n", (unsigned)AP_HAL::micros());
+    DEV_PRINTF("KDECANTester: TimeStamp: %u\n", (unsigned)AP_HAL::micros());
     for (uint16_t i=0; i<100; i++) {
         if (counters[i].frame_id == 0) {
             break;
         }
-        hal.console->printf("0x%08x: %u\n", (unsigned)counters[i].frame_id, (unsigned)counters[i].count);
+        DEV_PRINTF("0x%08x: %u\n", (unsigned)counters[i].frame_id, (unsigned)counters[i].count);
         counters[i].count = 0;
     }
 }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1461,7 +1461,7 @@ void Compass::_detect_backends(void)
 
     if (_backend_count == 0 ||
         _compass_count == 0) {
-        hal.console->printf("No Compass backends available\n");
+        DEV_PRINTF("No Compass backends available\n");
     }
 }
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -155,7 +155,7 @@ AP_Compass_Backend *AP_Compass_AK09916::probe_ICM20948(AP_HAL::OwnPtr<AP_HAL::I2
     if (dev->read_registers(REG_COMPANY_ID, (uint8_t *)&whoami, 2)) {
         // a device is replying on the AK09916 I2C address, don't
         // load the ICM20948
-        hal.console->printf("ICM20948: AK09916 bus conflict\n");
+        DEV_PRINTF("ICM20948: AK09916 bus conflict\n");
         goto fail;
     }
 
@@ -230,7 +230,7 @@ bool AP_Compass_AK09916::init()
     _bus->get_semaphore()->take_blocking();
 
     if (!_bus->configure()) {
-        hal.console->printf("AK09916: Could not configure the bus\n");
+        DEV_PRINTF("AK09916: Could not configure the bus\n");
         goto fail;
     }
 
@@ -239,7 +239,7 @@ bool AP_Compass_AK09916::init()
     }
 
     if (!_check_id()) {
-        hal.console->printf("AK09916: Wrong id\n");
+        DEV_PRINTF("AK09916: Wrong id\n");
         goto fail;
     }
 
@@ -247,12 +247,12 @@ bool AP_Compass_AK09916::init()
     _bus->setup_checked_registers(1);
 
     if (!_setup_mode()) {
-        hal.console->printf("AK09916: Could not setup mode\n");
+        DEV_PRINTF("AK09916: Could not setup mode\n");
         goto fail;
     }
 
     if (!_bus->start_measurements()) {
-        hal.console->printf("AK09916: Could not start measurements\n");
+        DEV_PRINTF("AK09916: Could not start measurements\n");
         goto fail;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -135,27 +135,27 @@ bool AP_Compass_AK8963::init()
     _bus->get_semaphore()->take_blocking();
 
     if (!_bus->configure()) {
-        hal.console->printf("AK8963: Could not configure the bus\n");
+        DEV_PRINTF("AK8963: Could not configure the bus\n");
         goto fail;
     }
 
     if (!_check_id()) {
-        hal.console->printf("AK8963: Wrong id\n");
+        DEV_PRINTF("AK8963: Wrong id\n");
         goto fail;
     }
 
     if (!_calibrate()) {
-        hal.console->printf("AK8963: Could not read calibration data\n");
+        DEV_PRINTF("AK8963: Could not read calibration data\n");
         goto fail;
     }
 
     if (!_setup_mode()) {
-        hal.console->printf("AK8963: Could not setup mode\n");
+        DEV_PRINTF("AK8963: Could not setup mode\n");
         goto fail;
     }
 
     if (!_bus->start_measurements()) {
-        hal.console->printf("AK8963: Could not start measurements\n");
+        DEV_PRINTF("AK8963: Could not start measurements\n");
         goto fail;
     }
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -118,7 +118,7 @@ bool AP_Compass_BMM150::_load_trim_values()
         }
     }
     if (-1 == tries) {
-        hal.console->printf("BMM150: Failed to load trim registers\n");
+        DEV_PRINTF("BMM150: Failed to load trim registers\n");
         return false;
     }
 
@@ -175,7 +175,7 @@ bool AP_Compass_BMM150::init()
             break;
         }
         if (boot_tries == 0) {
-            hal.console->printf("BMM150: Wrong chip ID 0x%02x should be 0x%02x\n", val, CHIP_ID_VAL);
+            DEV_PRINTF("BMM150: Wrong chip ID 0x%02x should be 0x%02x\n", val, CHIP_ID_VAL);
         }
     }
     if (-1 == boot_tries) {

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -152,7 +152,7 @@ bool AP_Compass_HMC5843::init()
     AP_HAL::Semaphore *bus_sem = _bus->get_semaphore();
 
     if (!bus_sem) {
-        hal.console->printf("HMC5843: Unable to get bus semaphore\n");
+        DEV_PRINTF("HMC5843: Unable to get bus semaphore\n");
         return false;
     }
     bus_sem->take_blocking();
@@ -161,7 +161,7 @@ bool AP_Compass_HMC5843::init()
     _bus->set_retries(10);
     
     if (!_bus->configure()) {
-        hal.console->printf("HMC5843: Could not configure the bus\n");
+        DEV_PRINTF("HMC5843: Could not configure the bus\n");
         goto errout;
     }
 
@@ -170,7 +170,7 @@ bool AP_Compass_HMC5843::init()
     }
 
     if (!_calibrate()) {
-        hal.console->printf("HMC5843: Could not calibrate sensor\n");
+        DEV_PRINTF("HMC5843: Could not calibrate sensor\n");
         goto errout;
     }
 
@@ -179,7 +179,7 @@ bool AP_Compass_HMC5843::init()
     }
 
     if (!_bus->start_measurements()) {
-        hal.console->printf("HMC5843: Could not start measurements on bus\n");
+        DEV_PRINTF("HMC5843: Could not start measurements on bus\n");
         goto errout;
     }
 
@@ -210,7 +210,7 @@ bool AP_Compass_HMC5843::init()
     _bus->register_periodic_callback(13333,
                                      FUNCTOR_BIND_MEMBER(&AP_Compass_HMC5843::_timer, void));
 
-    hal.console->printf("HMC5843 found on bus 0x%x\n", (unsigned)_bus->get_bus_id());
+    DEV_PRINTF("HMC5843 found on bus 0x%x\n", (unsigned)_bus->get_bus_id());
     
     return true;
 

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -222,7 +222,7 @@ bool AP_Compass_LSM303D::_read_sample()
     } rx;
 
     if (_register_read(ADDR_CTRL_REG7) != _reg7_expected) {
-        hal.console->printf("LSM303D _read_data_transaction_accel: _reg7_expected unexpected\n");
+        DEV_PRINTF("LSM303D _read_data_transaction_accel: _reg7_expected unexpected\n");
         return false;
     }
 
@@ -316,7 +316,7 @@ bool AP_Compass_LSM303D::_hardware_init()
         }
     }
     if (tries == 5) {
-        hal.console->printf("Failed to boot LSM303D 5 times\n");
+        DEV_PRINTF("Failed to boot LSM303D 5 times\n");
         goto fail_tries;
     }
 

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -84,23 +84,23 @@ bool AP_Compass_LSM9DS1::init()
     AP_HAL::Semaphore *bus_sem = _dev->get_semaphore();
 
     if (!bus_sem) {
-        hal.console->printf("LSM9DS1: Unable to get bus semaphore\n");
+        DEV_PRINTF("LSM9DS1: Unable to get bus semaphore\n");
         return false;
     }
     bus_sem->take_blocking();
 
     if (!_check_id()) {
-        hal.console->printf("LSM9DS1: Could not check id\n");
+        DEV_PRINTF("LSM9DS1: Could not check id\n");
         goto errout;
     }
 
     if (!_configure()) {
-        hal.console->printf("LSM9DS1: Could not check id\n");
+        DEV_PRINTF("LSM9DS1: Could not check id\n");
         goto errout;
     }
 
     if (!_set_scale()) {
-        hal.console->printf("LSM9DS1: Could not set scale\n");
+        DEV_PRINTF("LSM9DS1: Could not set scale\n");
         goto errout;
     }
 
@@ -127,15 +127,14 @@ errout:
 
 void AP_Compass_LSM9DS1::_dump_registers()
 {
-    hal.console->printf("LSMDS1 registers\n");
+    DEV_PRINTF("LSMDS1 registers\n");
     for (uint8_t reg = LSM9DS1M_OFFSET_X_REG_L_M; reg <= LSM9DS1M_INT_THS_H_M; reg++) {
-        uint8_t v = _register_read(reg);
-        hal.console->printf("%02x:%02x ", (unsigned)reg, (unsigned)v);
+        DEV_PRINTF("%02x:%02x ", (unsigned)reg, (unsigned)_register_read(reg));
         if ((reg - (LSM9DS1M_OFFSET_X_REG_L_M-1)) % 16 == 0) {
-            hal.console->printf("\n");
+            DEV_PRINTF("\n");
         }
     }
-    hal.console->printf("\n");
+    DEV_PRINTF("\n");
 }
 
 void AP_Compass_LSM9DS1::_update(void)
@@ -174,7 +173,7 @@ bool AP_Compass_LSM9DS1::_check_id(void)
 
     uint8_t value = _register_read(LSM9DS1M_WHO_AM_I);
     if (value != WHO_AM_I_MAG) {
-        hal.console->printf("LSM9DS1: unexpected WHOAMI 0x%x\n", (unsigned)value);
+        DEV_PRINTF("LSM9DS1: unexpected WHOAMI 0x%x\n", (unsigned)value);
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -149,7 +149,7 @@ bool AP_Compass_RM3100::init()
     }
     set_dev_id(compass_instance, dev->get_bus_id());
 
-    hal.console->printf("RM3100: Found at address 0x%x as compass %u\n", dev->get_bus_address(), compass_instance);
+    DEV_PRINTF("RM3100: Found at address 0x%x as compass %u\n", dev->get_bus_address(), compass_instance);
     
     set_rotation(compass_instance, rotation);
 

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -154,4 +154,11 @@ public:
 #if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
     AP_HAL::SIMState *simstate;
 #endif
+
+#ifndef HAL_CONSOLE_DISABLED
+# define DEV_PRINTF(fmt, args ...)  do { hal.console->printf(fmt, ## args); } while(0)
+#else
+# define DEV_PRINTF(fmt, args ...)
+#endif
+
 };

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -529,7 +529,7 @@ AP_HAL::AnalogSource* AnalogIn::channel(int16_t pin)
             return _channels[j];
         }
     }
-    hal.console->printf("Out of analog channels\n");
+    DEV_PRINTF("Out of analog channels\n");
     return nullptr;
 }
 

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -267,7 +267,7 @@ I2CDevice::I2CDevice(uint8_t busnum, uint8_t address, uint32_t bus_clock, bool u
             bus.i2ccfg.duty_cycle = STD_DUTY_CYCLE;
         }
 #endif
-        hal.console->printf("I2C%u clock %ukHz\n", busnum, unsigned(bus.busclock/1000));
+        DEV_PRINTF("I2C%u clock %ukHz\n", busnum, unsigned(bus.busclock/1000));
     }
 }
 
@@ -298,7 +298,7 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
                          uint8_t *recv, uint32_t recv_len)
 {
     if (!bus.semaphore.check_owner()) {
-        hal.console->printf("I2C: not owner of 0x%x for addr 0x%02x\n", (unsigned)get_bus_id(), _address);
+        DEV_PRINTF("I2C: not owner of 0x%x for addr 0x%02x\n", (unsigned)get_bus_id(), _address);
         return false;
     }
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -451,16 +451,16 @@ SPIDeviceManager::get_device(const char *name)
 void SPIDevice::test_clock_freq(void)
 {
     // delay for USB to come up
-    hal.console->printf("Waiting for USB\n");
+    DEV_PRINTF("Waiting for USB\n");
     for (uint8_t i=0; i<3; i++) {
         hal.scheduler->delay(1000);
-        hal.console->printf("Waiting %u\n", (unsigned)AP_HAL::millis());
+        DEV_PRINTF("Waiting %u\n", (unsigned)AP_HAL::millis());
     }
-    hal.console->printf("CLOCKS=\n");
+    DEV_PRINTF("CLOCKS=\n");
     for (uint8_t i=0; i<ARRAY_SIZE(bus_clocks); i++) {
-        hal.console->printf("%u:%u ", unsigned(i+1), unsigned(bus_clocks[i]));
+        DEV_PRINTF("%u:%u ", unsigned(i+1), unsigned(bus_clocks[i]));
     }
-    hal.console->printf("\n");
+    DEV_PRINTF("\n");
 
     // we will send 1024 bytes without any CS asserted and measure the
     // time it takes to do the transfer
@@ -485,7 +485,7 @@ void SPIDevice::test_clock_freq(void)
         chSysUnlock();
         if (msg == MSG_TIMEOUT) {
             spiAbort(spi_devices[i].driver);
-            hal.console->printf("SPI[%u] FAIL %p %p\n", spi_devices[i].busid, buf1, buf2);
+            DEV_PRINTF("SPI[%u] FAIL %p %p\n", spi_devices[i].busid, buf1, buf2);
             spiStop(spi_devices[i].driver);
             spiReleaseBus(spi_devices[i].driver);
             continue;
@@ -493,7 +493,7 @@ void SPIDevice::test_clock_freq(void)
         uint32_t t1 = AP_HAL::micros();
         spiStop(spi_devices[i].driver);
         spiReleaseBus(spi_devices[i].driver);
-        hal.console->printf("SPI[%u] clock=%u\n", unsigned(spi_devices[i].busid), unsigned(1000000ULL * len * 8ULL / uint64_t(t1 - t0)));
+        DEV_PRINTF("SPI[%u] clock=%u\n", unsigned(spi_devices[i].busid), unsigned(1000000ULL * len * 8ULL / uint64_t(t1 - t0)));
     }
     hal.util->free_type(buf1, len, AP_HAL::Util::MEM_DMA_SAFE);
     hal.util->free_type(buf2, len, AP_HAL::Util::MEM_DMA_SAFE);

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -226,7 +226,7 @@ void Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        DEV_PRINTF("Out of timer processes\n");
     }
     chBSemSignal(&_timer_semaphore);
 }
@@ -245,7 +245,7 @@ void Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        DEV_PRINTF("Out of IO processes\n");
     }
     chBSemSignal(&_io_semaphore);
 }

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1156,7 +1156,7 @@ void UARTDriver::write_pending_bytes(void)
         }
         if (AP_HAL::micros() - _first_write_started_us > 500*1000UL) {
             // it doesn't look like hw flow control is working
-            hal.console->printf("disabling flow control on serial %u\n", sdef.get_index());
+            DEV_PRINTF("disabling flow control on serial %u\n", sdef.get_index());
             set_flow_control(FLOW_CONTROL_DISABLE);
         }
     }

--- a/libraries/AP_HAL_ESP32/AnalogIn.cpp
+++ b/libraries/AP_HAL_ESP32/AnalogIn.cpp
@@ -179,7 +179,7 @@ bool AnalogSource::set_pin(uint8_t ardupin)
 
     int8_t pinconfig_offset = AnalogIn::find_pinconfig(ardupin);
     if (pinconfig_offset == -1 ) {
-        hal.console->printf("AnalogIn: sorry set_pin() can't determine ADC1 offset from ardupin : %d \n",ardupin);
+        DEV_PRINTF("AnalogIn: sorry set_pin() can't determine ADC1 offset from ardupin : %d \n",ardupin);
         return false;
     }
 
@@ -208,7 +208,7 @@ bool AnalogSource::set_pin(uint8_t ardupin)
         esp_adc_cal_characterize(ADC_UNIT_1, atten, ADC_WIDTH_BIT_12, DEFAULT_VREF, &adc_chars);
         printf("AnalogIn: Adding gpio on: %d\n", gpio);
 
-        hal.console->printf("AnalogIn: set_pin() FROM (ardupin:%d adc1_offset:%d gpio:%d) TO (ardupin:%d adc1_offset:%d gpio:%d)\n", \
+        DEV_PRINTF("AnalogIn: set_pin() FROM (ardupin:%d adc1_offset:%d gpio:%d) TO (ardupin:%d adc1_offset:%d gpio:%d)\n", \
                             _ardupin,_pin,_gpio,ardupin,newgpioAdcPin,gpio);
         _pin = newgpioAdcPin;
         _ardupin = ardupin;
@@ -336,7 +336,7 @@ AP_HAL::AnalogSource *AnalogIn::channel(int16_t ardupin)
     float scaler = -1;
 
     if ((ardupin != ANALOG_INPUT_NONE) && (pinconfig_offset == -1 )) {
-        hal.console->printf("AnalogIn: sorry channel() can't determine ADC1 offset from ardupin : %d \n",ardupin);
+        DEV_PRINTF("AnalogIn: sorry channel() can't determine ADC1 offset from ardupin : %d \n",ardupin);
         ardupin = ANALOG_INPUT_NONE; // default it to this not terrible value and allow to continue
     }
     // although ANALOG_INPUT_NONE=255 is not a valid pin, we let it through here as
@@ -351,18 +351,18 @@ AP_HAL::AnalogSource *AnalogIn::channel(int16_t ardupin)
             _channels[j] = new AnalogSource(ardupin,gpioAdcPin, scaler,0.0f,1);
 
             if (ardupin != ANALOG_INPUT_NONE) {
-                hal.console->printf("AnalogIn: channel:%d attached to ardupin:%d at adc1_offset:%d on gpio:%d\n",\
+                DEV_PRINTF("AnalogIn: channel:%d attached to ardupin:%d at adc1_offset:%d on gpio:%d\n",\
                                     j,ardupin, gpioAdcPin, _channels[j]->_gpio);
             }
 
             if (ardupin == ANALOG_INPUT_NONE) {
-                hal.console->printf("AnalogIn: channel:%d created but using delayed adc and gpio pin configuration\n",j );
+                DEV_PRINTF("AnalogIn: channel:%d created but using delayed adc and gpio pin configuration\n",j );
             }
 
             return _channels[j];
         }
     }
-    hal.console->printf("AnalogIn: out of channels\n");
+    DEV_PRINTF("AnalogIn: out of channels\n");
     return nullptr;
 }
 

--- a/libraries/AP_HAL_ESP32/Storage.cpp
+++ b/libraries/AP_HAL_ESP32/Storage.cpp
@@ -156,7 +156,7 @@ bool Storage::_flash_write_data(uint8_t sector, uint32_t offset, const uint8_t *
         if (now - _last_re_init_ms > 5000) {
             _last_re_init_ms = now;
             bool ok = _flash.re_initialise();
-            hal.console->printf("Storage: failed at %u:%u for %u - re-init %u\n",
+            DEV_PRINTF("Storage: failed at %u:%u for %u - re-init %u\n",
                                 (unsigned)sector, (unsigned)offset, (unsigned)length, (unsigned)ok);
 #ifdef STORAGEDEBUG
             printf("Storage: failed at %u:%u for %u - re-init %u\n",

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -73,7 +73,7 @@ void AP_Hott_Telem::init()
         if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Hott_Telem::loop, void),
                                           "Hott",
                                           1024, AP_HAL::Scheduler::PRIORITY_BOOST, 1)) {
-            hal.console->printf("Failed to create Hott thread\n");
+            DEV_PRINTF("Failed to create Hott thread\n");
         }
     }
 }

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -814,7 +814,7 @@ bool AP_IOMCU::check_crc(void)
 
     fw = AP_ROMFS::find_decompress(fw_name, fw_size);
     if (!fw) {
-        hal.console->printf("failed to find %s\n", fw_name);
+        DEV_PRINTF("failed to find %s\n", fw_name);
         return false;
     }
     uint32_t crc = crc32_small(0, fw, fw_size);
@@ -833,13 +833,13 @@ bool AP_IOMCU::check_crc(void)
         }
     }
     if (io_crc == crc) {
-        hal.console->printf("IOMCU: CRC ok\n");
+        DEV_PRINTF("IOMCU: CRC ok\n");
         crc_is_ok = true;
         AP_ROMFS::free(fw);
         fw = nullptr;
         return true;
     } else {
-        hal.console->printf("IOMCU: CRC mismatch expected: 0x%X got: 0x%X\n", (unsigned)crc, (unsigned)io_crc);
+        DEV_PRINTF("IOMCU: CRC mismatch expected: 0x%X got: 0x%X\n", (unsigned)crc, (unsigned)io_crc);
     }
 
     const uint16_t magic = REBOOT_BL_MAGIC;
@@ -1011,7 +1011,7 @@ void AP_IOMCU::check_iomcu_reset(void)
     if (last_iocmu_timestamp_ms == 0) {
         // initialisation
         last_iocmu_timestamp_ms = reg_status.timestamp_ms;
-        hal.console->printf("IOMCU startup\n");
+        DEV_PRINTF("IOMCU startup\n");
         return;
     }
     uint32_t dt_ms = reg_status.timestamp_ms - last_iocmu_timestamp_ms;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1166,7 +1166,7 @@ AP_InertialSensor::detect_backends(void)
         #if CONFIG_HAL_BOARD == HAL_BOARD_ESP32
         ADD_BACKEND(AP_InertialSensor_NONE::detect(*this, INS_NONE_SENSOR_A));
         #else
-        hal.console->printf("INS: unable to initialise driver\n");
+        DEV_PRINTF("INS: unable to initialise driver\n");
         GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "INS: unable to initialise driver");
         AP_BoardConfig::config_error("INS: unable to initialise driver");
         #endif
@@ -1446,7 +1446,7 @@ AP_InertialSensor::_init_gyro()
     AP_Notify::flags.initialising = true;
 
     // cold start
-    hal.console->printf("Init Gyro");
+    DEV_PRINTF("Init Gyro");
 
     /*
       we do the gyro calibration with no board rotation. This avoids
@@ -1497,7 +1497,7 @@ AP_InertialSensor::_init_gyro()
 
         memset(diff_norm, 0, sizeof(diff_norm));
 
-        hal.console->printf("*");
+        DEV_PRINTF("*");
 
         for (uint8_t k=0; k<num_gyros; k++) {
             gyro_sum[k].zero();
@@ -1550,10 +1550,10 @@ AP_InertialSensor::_init_gyro()
 
     // we've kept the user waiting long enough - use the best pair we
     // found so far
-    hal.console->printf("\n");
+    DEV_PRINTF("\n");
     for (uint8_t k=0; k<num_gyros; k++) {
         if (!converged[k]) {
-            hal.console->printf("gyro[%u] did not converge: diff=%f dps (expected < %f)\n",
+            DEV_PRINTF("gyro[%u] did not converge: diff=%f dps (expected < %f)\n",
                                 (unsigned)k,
                                 (double)ToDeg(best_diff[k]),
                                 (double)GYRO_INIT_MAX_DIFF_DPS);
@@ -2164,7 +2164,7 @@ void AP_InertialSensor::_acal_save_calibrations()
     if (fabsf(_trim_rad.x) > radians(HAL_INS_TRIM_LIMIT_DEG) ||
         fabsf(_trim_rad.y) > radians(HAL_INS_TRIM_LIMIT_DEG) ||
         fabsf(_trim_rad.z) > radians(HAL_INS_TRIM_LIMIT_DEG)) {
-        hal.console->printf("ERR: Trim over maximum of %.1f degrees!!", float(HAL_INS_TRIM_LIMIT_DEG));
+        DEV_PRINTF("ERR: Trim over maximum of %.1f degrees!!", float(HAL_INS_TRIM_LIMIT_DEG));
         _new_trim = false;  //we have either got faulty level during acal or highly misaligned accelerometers
     }
 
@@ -2302,7 +2302,7 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
 
         memset(diff_norm, 0, sizeof(diff_norm));
 
-        hal.console->printf("*");
+        DEV_PRINTF("*");
 
         for (uint8_t k=0; k<num_accels; k++) {
             accel_sum[k].zero();
@@ -2350,7 +2350,7 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
     _board_orientation = saved_orientation;
 
     if (result == MAV_RESULT_ACCEPTED) {
-        hal.console->printf("\nPASSED\n");
+        DEV_PRINTF("\nPASSED\n");
         for (uint8_t k=0; k<num_accels; k++) {
             // remove rotated gravity
             new_accel_offset[k] -= rotated_gravity;
@@ -2366,7 +2366,7 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
         // force trim to zero
         AP::ahrs().set_trim(Vector3f(0, 0, 0));
     } else {
-        hal.console->printf("\nFAILED\n");
+        DEV_PRINTF("\nFAILED\n");
         // restore old values
         for (uint8_t k=0; k<num_accels; k++) {
             _accel_offset[k] = saved_offsets[k];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
@@ -161,7 +161,7 @@ bool AP_InertialSensor_BMI055::accel_init()
         goto failed;
     }
 
-    hal.console->printf("BMI055: found accel\n");
+    DEV_PRINTF("BMI055: found accel\n");
 
     dev_accel->get_semaphore()->give();
     return true;
@@ -215,7 +215,7 @@ bool AP_InertialSensor_BMI055::gyro_init()
         goto failed;
     }
 
-    hal.console->printf("BMI055: found gyro\n");    
+    DEV_PRINTF("BMI055: found gyro\n");    
 
     dev_gyro->get_semaphore()->give();
     return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -184,7 +184,7 @@ bool AP_InertialSensor_BMI088::setup_accel_config(void)
         }
     }
     done_accel_config = true;
-    hal.console->printf("BMI088: accel config OK (%u tries)\n", (unsigned)accel_config_count);
+    DEV_PRINTF("BMI088: accel config OK (%u tries)\n", (unsigned)accel_config_count);
     return true;
 }
 
@@ -218,10 +218,10 @@ bool AP_InertialSensor_BMI088::accel_init()
     }
 
     if (!setup_accel_config()) {
-        hal.console->printf("BMI08x: delaying accel config\n");
+        DEV_PRINTF("BMI08x: delaying accel config\n");
     }
 
-    hal.console->printf("BMI08x: found accel\n");
+    DEV_PRINTF("BMI08x: found accel\n");
 
     return true;
 }
@@ -272,7 +272,7 @@ bool AP_InertialSensor_BMI088::gyro_init()
         return false;
     }
 
-    hal.console->printf("BMI088: found gyro\n");    
+    DEV_PRINTF("BMI088: found gyro\n");    
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -293,14 +293,14 @@ bool AP_InertialSensor_BMI160::_configure_int1_pin()
 
     r = _dev->write_register(BMI160_REG_INT_EN_1, BMI160_INT_FWM_EN);
     if (!r) {
-        hal.console->printf("BMI160: Unable to enable FIFO watermark interrupt engine\n");
+        DEV_PRINTF("BMI160: Unable to enable FIFO watermark interrupt engine\n");
         return false;
     }
     hal.scheduler->delay(1);
 
     r = _dev->write_register(BMI160_REG_INT_MAP_1, BMI160_INT_MAP_INT1_FWM);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure interrupt mapping\n");
+        DEV_PRINTF("BMI160: Unable to configure interrupt mapping\n");
         return false;
     }
     hal.scheduler->delay(1);
@@ -308,14 +308,14 @@ bool AP_InertialSensor_BMI160::_configure_int1_pin()
     r = _dev->write_register(BMI160_REG_INT_OUT_CTRL,
                              BMI160_INT1_OUTPUT_EN | BMI160_INT1_LVL);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure interrupt output\n");
+        DEV_PRINTF("BMI160: Unable to configure interrupt output\n");
         return false;
     }
     hal.scheduler->delay(1);
 
     _int1_pin = hal.gpio->channel(BMI160_INT1_GPIO);
     if (_int1_pin == nullptr) {
-        hal.console->printf("BMI160: Couldn't request data ready GPIO channel\n");
+        DEV_PRINTF("BMI160: Couldn't request data ready GPIO channel\n");
         return false;
     }
     _int1_pin->mode(HAL_GPIO_INPUT);
@@ -331,7 +331,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
     r = _dev->write_register(BMI160_REG_FIFO_CONFIG_0,
                              sizeof(struct RawData) / 4);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure FIFO watermark level\n");
+        DEV_PRINTF("BMI160: Unable to configure FIFO watermark level\n");
         return false;
     }
     hal.scheduler->delay(1);
@@ -339,7 +339,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
     r = _dev->write_register(BMI160_REG_FIFO_CONFIG_1,
                              BMI160_FIFO_ACC_EN | BMI160_FIFO_GYR_EN);
     if (!r) {
-        hal.console->printf("BMI160: Unable to enable FIFO\n");
+        DEV_PRINTF("BMI160: Unable to enable FIFO\n");
         return false;
     }
     hal.scheduler->delay(1);
@@ -348,7 +348,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
 
     r = _dev->write_register(BMI160_REG_CMD, BMI160_CMD_FIFO_FLUSH);
     if (!r) {
-        hal.console->printf("BMI160: Unable to flush FIFO\n");
+        DEV_PRINTF("BMI160: Unable to flush FIFO\n");
         return false;
     }
 
@@ -399,7 +399,7 @@ read_fifo_read_data:
 
     /* Read again just once */
     if (excess && num_samples) {
-        hal.console->printf("BMI160: dropping %u samples from fifo\n",
+        DEV_PRINTF("BMI160: dropping %u samples from fifo\n",
                             (uint8_t)(excess / sizeof(struct RawData)));
         _dev->write_register(BMI160_REG_CMD, BMI160_CMD_FIFO_FLUSH);
         excess = 0;
@@ -434,7 +434,7 @@ read_fifo_read_data:
 
 read_fifo_end:
     if (!r) {
-        hal.console->printf("BMI160: error on reading FIFO\n");
+        DEV_PRINTF("BMI160: error on reading FIFO\n");
     }
 }
 
@@ -510,7 +510,7 @@ bool AP_InertialSensor_BMI160::_init()
 
     ret = _hardware_init();
     if (!ret) {
-        hal.console->printf("BMI160: failed to init\n");
+        DEV_PRINTF("BMI160: failed to init\n");
     }
 
     return ret;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
@@ -533,7 +533,7 @@ bool AP_InertialSensor_BMI270::hardware_init()
 
         if ((status & 1) == 1) {
             ret = true;
-            hal.console->printf("BMI270 initialized after %d retries\n", i+1);
+            DEV_PRINTF("BMI270 initialized after %d retries\n", i+1);
             break;
         }
     }
@@ -551,7 +551,7 @@ bool AP_InertialSensor_BMI270::init()
 
     ret = hardware_init();
     if (!ret) {
-        hal.console->printf("BMI270: failed to init\n");
+        DEV_PRINTF("BMI270: failed to init\n");
     }
 
     return ret;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -1004,7 +1004,7 @@ bool AP_InertialSensor_Invensense::_hardware_init(void)
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     if (tries == 5) {
-        hal.console->printf("Failed to boot Invensense 5 times\n");
+        DEV_PRINTF("Failed to boot Invensense 5 times\n");
         return false;
     }
 
@@ -1055,7 +1055,7 @@ int AP_Invensense_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
                                                    uint8_t size)
 {
     if (_registered) {
-        hal.console->printf("Error: can't passthrough when slave is already configured\n");
+        DEV_PRINTF("Error: can't passthrough when slave is already configured\n");
         return -1;
     }
 
@@ -1081,7 +1081,7 @@ int AP_Invensense_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
 int AP_Invensense_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t val)
 {
     if (_registered) {
-        hal.console->printf("Error: can't passthrough when slave is already configured\n");
+        DEV_PRINTF("Error: can't passthrough when slave is already configured\n");
         return -1;
     }
 
@@ -1104,7 +1104,7 @@ int AP_Invensense_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t val)
 int AP_Invensense_AuxiliaryBusSlave::read(uint8_t *buf)
 {
     if (!_registered) {
-        hal.console->printf("Error: can't read before configuring slave\n");
+        DEV_PRINTF("Error: can't read before configuring slave\n");
         return -1;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -724,7 +724,7 @@ bool AP_InertialSensor_Invensensev2::_hardware_init(void)
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     if (tries == 5) {
-        hal.console->printf("Failed to boot Invensense 5 times\n");
+        DEV_PRINTF("Failed to boot Invensense 5 times\n");
         return false;
     }
 
@@ -771,7 +771,7 @@ int AP_Invensensev2_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *bu
                                                    uint8_t size)
 {
     if (_registered) {
-        hal.console->printf("Error: can't passthrough when slave is already configured\n");
+        DEV_PRINTF("Error: can't passthrough when slave is already configured\n");
         return -1;
     }
 
@@ -797,7 +797,7 @@ int AP_Invensensev2_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *bu
 int AP_Invensensev2_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t val)
 {
     if (_registered) {
-        hal.console->printf("Error: can't passthrough when slave is already configured\n");
+        DEV_PRINTF("Error: can't passthrough when slave is already configured\n");
         return -1;
     }
 
@@ -820,7 +820,7 @@ int AP_Invensensev2_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t va
 int AP_Invensensev2_AuxiliaryBusSlave::read(uint8_t *buf)
 {
     if (!_registered) {
-        hal.console->printf("Error: can't read before configuring slave\n");
+        DEV_PRINTF("Error: can't read before configuring slave\n");
         return -1;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -492,7 +492,7 @@ bool AP_InertialSensor_LSM9DS0::_hardware_init()
 #endif
     }
     if (tries == 5) {
-        hal.console->printf("Failed to boot LSM9DS0 5 times\n\n");
+        DEV_PRINTF("Failed to boot LSM9DS0 5 times\n\n");
         goto fail_tries;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
@@ -255,7 +255,7 @@ bool AP_InertialSensor_LSM9DS1::_hardware_init()
 
     whoami = _register_read(LSM9DS1XG_WHO_AM_I);
     if (whoami != WHO_AM_I) {
-        hal.console->printf("LSM9DS1: unexpected acc/gyro WHOAMI 0x%x\n", whoami);
+        DEV_PRINTF("LSM9DS1: unexpected acc/gyro WHOAMI 0x%x\n", whoami);
         goto fail_whoami;
     }
 
@@ -284,7 +284,7 @@ bool AP_InertialSensor_LSM9DS1::_hardware_init()
 #endif
     }
     if (tries == 5) {
-        hal.console->printf("Failed to boot LSM9DS1 5 times\n\n");
+        DEV_PRINTF("Failed to boot LSM9DS1 5 times\n\n");
         goto fail_tries;
     }
 
@@ -448,7 +448,7 @@ void AP_InertialSensor_LSM9DS1::_read_data_transaction_x(uint16_t samples)
         struct sensor_raw_data raw_data_temp = { };
 
         if (!_dev->transfer(&_reg, 1, (uint8_t *) &raw_data_temp, sizeof(raw_data_temp))) {
-            hal.console->printf("LSM9DS1: error reading accelerometer\n");
+            DEV_PRINTF("LSM9DS1: error reading accelerometer\n");
             return;
         }
 
@@ -485,7 +485,7 @@ void AP_InertialSensor_LSM9DS1::_read_data_transaction_g(uint16_t samples)
         struct sensor_raw_data raw_data_temp = { };
 
         if (!_dev->transfer(&_reg, 1, (uint8_t *) &raw_data_temp, sizeof(raw_data_temp))) {
-            hal.console->printf("LSM9DS1: error reading gyroscope\n");
+            DEV_PRINTF("LSM9DS1: error reading gyroscope\n");
             return;
         }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
@@ -261,7 +261,7 @@ void AP_InertialSensor_NONE::timer_update(void)
     static uint64_t last_msg_sent = 0;
     if (now > last_msg_sent + 2000000) { //2sec= 2000ms = 2000000us
         //gcs().send_text(MAV_SEVERITY_WARNING, "NO IMU FOUND");
-        hal.console->printf("INS: NO IMU FOUND\n");
+        DEV_PRINTF("INS: NO IMU FOUND\n");
         last_msg_sent = now;
     }
     if (now >= next_accel_sample) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_RST.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_RST.cpp
@@ -291,7 +291,7 @@ bool AP_InertialSensor_RST::_init_accel(void)
 
     _dev_accel->read_registers(ACCEL_WHO_AM_I, &whoami, sizeof(whoami));
     if (whoami != ACCEL_WHO_I_AM) {
-        hal.console->printf("RST: unexpected accel WHOAMI 0x%x\n", (unsigned)whoami);
+        DEV_PRINTF("RST: unexpected accel WHOAMI 0x%x\n", (unsigned)whoami);
         printf("RST: unexpected accel WHOAMI 0x%x\n", (unsigned)whoami);
         goto fail_whoami;
     }

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -45,16 +45,16 @@ void AP_Logger_Block::Init(void)
 
         // If we can't allocate the full size, try to reduce it until we can allocate it
         while (!writebuf.set_size(bufsize) && bufsize >= df_PageSize * df_PagePerBlock) {
-            hal.console->printf("AP_Logger_Block: Couldn't set buffer size to=%u\n", (unsigned)bufsize);
+            DEV_PRINTF("AP_Logger_Block: Couldn't set buffer size to=%u\n", (unsigned)bufsize);
             bufsize >>= 1;
         }
 
         if (!writebuf.get_size()) {
-            hal.console->printf("Out of memory for logging\n");
+            DEV_PRINTF("Out of memory for logging\n");
             return;
         }
 
-        hal.console->printf("AP_Logger_Block: buffer size=%u\n", (unsigned)bufsize);
+        DEV_PRINTF("AP_Logger_Block: buffer size=%u\n", (unsigned)bufsize);
         _initialised = true;
     }
 
@@ -408,15 +408,15 @@ void AP_Logger_Block::validate_log_structure()
             last_file = file;
         }
         if (file == next_file) {
-            hal.console->printf("Found complete log %d at %X-%X\n", int(file), unsigned(page), unsigned(find_last_page_of_log(file)));
+            DEV_PRINTF("Found complete log %d at %X-%X\n", int(file), unsigned(page), unsigned(find_last_page_of_log(file)));
         }
     }
 
     if (file != 0xFFFF && file != next_file && page <= df_NumPages && page > 0) {
-        hal.console->printf("Found corrupt log %d at 0x%04X, erasing", int(file), unsigned(page));
+        DEV_PRINTF("Found corrupt log %d at 0x%04X, erasing", int(file), unsigned(page));
         df_EraseFrom = page;
     } else if (next_file != 0xFFFF && page > 0 && next_file > 1) { // chip is empty
-        hal.console->printf("Found %d complete logs at 0x%04X-0x%04X", int(next_file - first_file), unsigned(page_start), unsigned(page - 1));
+        DEV_PRINTF("Found %d complete logs at 0x%04X-0x%04X", int(next_file - first_file), unsigned(page_start), unsigned(page - 1));
     }
 }
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -76,15 +76,15 @@ void AP_Logger_File::Init()
         bufsize *= 0.9;
     }
     if (bufsize >= _writebuf_chunk && bufsize != desired_bufsize) {
-        hal.console->printf("AP_Logger: reduced buffer %u/%u\n", (unsigned)bufsize, (unsigned)desired_bufsize);
+        DEV_PRINTF("AP_Logger: reduced buffer %u/%u\n", (unsigned)bufsize, (unsigned)desired_bufsize);
     }
 
     if (!_writebuf.get_size()) {
-        hal.console->printf("Out of memory for logging\n");
+        DEV_PRINTF("Out of memory for logging\n");
         return;
     }
 
-    hal.console->printf("AP_Logger_File: buffer size=%u\n", (unsigned)bufsize);
+    DEV_PRINTF("AP_Logger_File: buffer size=%u\n", (unsigned)bufsize);
 
     _initialised = true;
 
@@ -323,12 +323,12 @@ void AP_Logger_File::Prep_MinSpace()
             break;
         }
         if (file_exists(filename_to_remove)) {
-            hal.console->printf("Removing (%s) for minimum-space requirements (%.0fMB < %.0fMB)\n",
+            DEV_PRINTF("Removing (%s) for minimum-space requirements (%.0fMB < %.0fMB)\n",
                                 filename_to_remove, (double)avail*B_to_MB, (double)target_free*B_to_MB);
             EXPECT_DELAY_MS(2000);
             if (AP::FS().unlink(filename_to_remove) == -1) {
                 _cached_oldest_log = 0;
-                hal.console->printf("Failed to remove %s: %s\n", filename_to_remove, strerror(errno));
+                DEV_PRINTF("Failed to remove %s: %s\n", filename_to_remove, strerror(errno));
                 free(filename_to_remove);
                 if (errno == ENOENT) {
                     // corruption - should always have a continuous
@@ -627,7 +627,7 @@ int16_t AP_Logger_File::get_log_data(const uint16_t list_entry, const uint16_t p
             int saved_errno = errno;
             ::printf("Log read open fail for %s - %s\n",
                      fname, strerror(saved_errno));
-            hal.console->printf("Log read open fail for %s - %s\n",
+            DEV_PRINTF("Log read open fail for %s - %s\n",
                                 fname, strerror(saved_errno));
             free(fname);
             return -1;            
@@ -790,7 +790,7 @@ void AP_Logger_File::start_new_log(void)
     }
 
     if (disk_space_avail() < _free_space_min_avail && disk_space() > 0) {
-        hal.console->printf("Out of space for logging\n");
+        DEV_PRINTF("Out of space for logging\n");
         return;
     }
 
@@ -834,7 +834,7 @@ void AP_Logger_File::start_new_log(void)
         if (open_error_ms_was_zero) {
             ::printf("Log open fail for %s - %s\n",
                      _write_filename, strerror(saved_errno));
-            hal.console->printf("Log open fail for %s - %s\n",
+            DEV_PRINTF("Log open fail for %s - %s\n",
                                 _write_filename, strerror(saved_errno));
         }
         return;
@@ -934,7 +934,7 @@ void AP_Logger_File::io_timer(void)
         _free_space_last_check_time = tnow;
         last_io_operation = "disk_space_avail";
         if (disk_space_avail() < _free_space_min_avail && disk_space() > 0) {
-            hal.console->printf("Out of space for logging\n");
+            DEV_PRINTF("Out of space for logging\n");
             stop_logging();
             _open_error_ms = AP_HAL::millis(); // prevent logging starting again for 5s
             last_io_operation = "";

--- a/libraries/AP_Mount/SoloGimbalEKF.cpp
+++ b/libraries/AP_Mount/SoloGimbalEKF.cpp
@@ -107,7 +107,7 @@ void SoloGimbalEKF::RunEKF(float delta_time, const Vector3f &delta_angles, const
         for (uint8_t i=3; i <= 5; i++) Cov[i][i] = sq(Sigma_velNED);
         for (uint8_t i=6; i <= 8; i++) Cov[i][i] = sq(Sigma_dAngBias);
         FiltInit = true;
-        hal.console->printf("\nSoloGimbalEKF Alignment Started\n");
+        DEV_PRINTF("\nSoloGimbalEKF Alignment Started\n");
 
         // Don't run the filter in this timestep because we have already used the delta velocity data to set an initial orientation
         return;
@@ -142,7 +142,7 @@ void SoloGimbalEKF::RunEKF(float delta_time, const Vector3f &delta_angles, const
         //calculate the initial heading using magnetometer, estimated tilt and declination
         alignHeading();
         YawAligned = true;
-        hal.console->printf("\nSoloGimbalEKF Alignment Completed\n");
+        DEV_PRINTF("\nSoloGimbalEKF Alignment Completed\n");
     }
 
     // Fuse magnetometer data if  we have new measurements and an aligned heading

--- a/libraries/AP_Mount/SoloGimbal_Parameters.cpp
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.cpp
@@ -162,7 +162,7 @@ void SoloGimbal_Parameters::update()
     for(uint8_t i=0; i<MAVLINK_GIMBAL_NUM_TRACKED_PARAMS; i++) {
         if (!_params[i].seen && _params[i].fetch_attempts > _max_fetch_attempts) {
             _params[i].state = GMB_PARAMSTATE_NONEXISTANT;
-            hal.console->printf("Gimbal parameter %s timed out\n", get_param_name((gmb_param_t)i));
+            DEV_PRINTF("Gimbal parameter %s timed out\n", get_param_name((gmb_param_t)i));
         }
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -598,7 +598,7 @@ void NavEKF2_core::UpdateFilter(bool predict)
     static uint32_t timing_counter;
     total_us += dal.micros() - timing_start_us;
     if (timing_counter++ == 4000) {
-        hal.console->printf("ekf2 avg %.2f us\n", total_us / float(timing_counter));
+        DEV_PRINTF("ekf2 avg %.2f us\n", total_us / float(timing_counter));
         total_us = 0;
         timing_counter = 0;
     }

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -271,7 +271,7 @@ void AP_OSD::init()
         if (backend == nullptr) {
             break;
         }
-        hal.console->printf("Started MAX7456 OSD\n");
+        DEV_PRINTF("Started MAX7456 OSD\n");
 #endif
         break;
     }
@@ -282,7 +282,7 @@ void AP_OSD::init()
         if (backend == nullptr) {
             break;
         }
-        hal.console->printf("Started SITL OSD\n");
+        DEV_PRINTF("Started SITL OSD\n");
         break;
     }
 #endif
@@ -291,7 +291,7 @@ void AP_OSD::init()
         if (backend == nullptr) {
             break;
         }
-        hal.console->printf("Started MSP OSD\n");
+        DEV_PRINTF("Started MSP OSD\n");
         break;
     }
 #if HAL_WITH_MSP_DISPLAYPORT
@@ -300,7 +300,7 @@ void AP_OSD::init()
         if (backend == nullptr) {
             break;
         }
-        hal.console->printf("Started MSP DisplayPort OSD\n");
+        DEV_PRINTF("Started MSP DisplayPort OSD\n");
         break;
     }
 #endif

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1208,7 +1208,7 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
 
     if (ofs+type_size((enum ap_var_type)phdr.type)+2*sizeof(phdr) >= _storage.size()) {
         // we are out of room for saving variables
-        hal.console->printf("EEPROM full\n");
+        DEV_PRINTF("EEPROM full\n");
         return;
     }
 
@@ -1584,7 +1584,7 @@ void AP_Param::load_object_from_eeprom(const void *object_pointer, const struct 
     uint16_t key;
 
     if (!find_key_by_pointer(object_pointer, key)) {
-        hal.console->printf("ERROR: Unable to find param pointer\n");
+        DEV_PRINTF("ERROR: Unable to find param pointer\n");
         return;
     }
     
@@ -1869,7 +1869,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info, float sc
     AP_Param *ap2;
     ap2 = find(&info->new_name[0], &ptype);
     if (ap2 == nullptr) {
-        hal.console->printf("Unknown conversion '%s'\n", info->new_name);
+        DEV_PRINTF("Unknown conversion '%s'\n", info->new_name);
         return;
     }
 
@@ -1903,7 +1903,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info, float sc
         }
     } else {
         // can't do vector<->scalar conversion, or different vector types
-        hal.console->printf("Bad conversion type '%s'\n", info->new_name);
+        DEV_PRINTF("Bad conversion type '%s'\n", info->new_name);
     }
 }
 #pragma GCC diagnostic pop

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -46,7 +46,7 @@ bool AP_RAMTRON::init(void)
 {
     dev = hal.spi->get_device("ramtron");
     if (!dev) {
-        hal.console->printf("No RAMTRON device\n");
+        DEV_PRINTF("No RAMTRON device\n");
         return false;
     }
     WITH_SEMAPHORE(dev->get_semaphore());
@@ -88,7 +88,7 @@ bool AP_RAMTRON::init(void)
     }
 
     if (id == UINT8_MAX) {
-        hal.console->printf("Unknown RAMTRON device\n");
+        DEV_PRINTF("Unknown RAMTRON device\n");
         return false;
     }
 

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -1113,7 +1113,7 @@ void AP_Radio_cc2500::irq_handler_thd(void *arg)
         switch (evt) {
         case EVT_IRQ:
             if (radio_singleton->protocolState == STATE_FCCTEST) {
-                hal.console->printf("IRQ FCC\n");
+                DEV_PRINTF("IRQ FCC\n");
             }
             radio_singleton->irq_handler();
             break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
@@ -245,12 +245,12 @@ void AP_RangeFinder_Bebop::_loop(void)
         _capture();
 
         if (_apply_averaging_filter() < 0) {
-            hal.console->printf(
+            DEV_PRINTF(
                     "AR_RangeFinder_Bebop: could not apply averaging filter");
         }
 
         if (_search_local_maxima() < 0) {
-            hal.console->printf("Did not find any local maximum");
+            DEV_PRINTF("Did not find any local maximum");
         }
 
         max_index = _search_maximum_with_max_amplitude();
@@ -296,7 +296,7 @@ void AP_RangeFinder_Bebop::_configure_gpio(int value)
         _gpio->write(LINUX_GPIO_ULTRASOUND_VOLTAGE, 0);
         break;
     default:
-        hal.console->printf("bad gpio value (%d)", value);
+        DEV_PRINTF("bad gpio value (%d)", value);
         break;
     }
 }
@@ -310,10 +310,10 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
     /* configure the output buffer for a purge */
     /* perform a purge */
     if (_launch_purge() < 0) {
-        hal.console->printf("purge could not send data overspi");
+        DEV_PRINTF("purge could not send data overspi");
     }
     if (_capture() < 0) {
-        hal.console->printf("purge could not capture data");
+        DEV_PRINTF("purge could not capture data");
     }
 
     _tx_buf = _tx[_mode];
@@ -325,7 +325,7 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
         _configure_gpio(1);
         break;
     default:
-        hal.console->printf("WARNING, invalid value to configure gpio\n");
+        DEV_PRINTF("WARNING, invalid value to configure gpio\n");
         break;
     }
 }
@@ -355,13 +355,13 @@ int AP_RangeFinder_Bebop::_configure_capture()
     _adc.device = iio_context_find_device(_iio, adcname);
 
     if (!_adc.device) {
-        hal.console->printf("Unable to find %s", adcname);
+        DEV_PRINTF("Unable to find %s", adcname);
         goto error_destroy_context;
     }
     _adc.channel = iio_device_find_channel(_adc.device, adcchannel,
             false);
     if (!_adc.channel) {
-        hal.console->printf("Fail to init adc channel %s", adcchannel);
+        DEV_PRINTF("Fail to init adc channel %s", adcchannel);
         goto error_destroy_context;
     }
 
@@ -374,13 +374,13 @@ int AP_RangeFinder_Bebop::_configure_capture()
     /* Create input buffer */
     _adc.buffer_size = RNFD_BEBOP_P7_COUNT;
     if (iio_device_set_kernel_buffers_count(_adc.device, 1)) {
-        hal.console->printf("cannot set buffer count");
+        DEV_PRINTF("cannot set buffer count");
         goto error_destroy_context;
     }
     _adc.buffer = iio_device_create_buffer(_adc.device,
             _adc.buffer_size, false);
     if (!_adc.buffer) {
-        hal.console->printf("Fail to create buffer : %s", strerror(errno));
+        DEV_PRINTF("Fail to create buffer : %s", strerror(errno));
         goto error_destroy_context;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -107,13 +107,13 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
         goto fail;
     }
 
-    hal.console->printf(DRIVER ": found fw version %u.%u.%u\n",
+    DEV_PRINTF(DRIVER ": found fw version %u.%u.%u\n",
                         val[5], val[4], val[3]);
 
     for (i = 0; i < ARRAY_SIZE(cmds); i++) {
         ret = _dev->transfer(cmds[i], cmds[i][1], nullptr, 0);
         if (!ret) {
-            hal.console->printf(DRIVER ": Unable to set configuration register %u\n",
+            DEV_PRINTF(DRIVER ": Unable to set configuration register %u\n",
                                 cmds[i][2]);
             goto fail;
         }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -188,14 +188,14 @@ void AP_RangeFinder_LightWareI2C::sf20_get_version(const char* send_msg, const c
 bool AP_RangeFinder_LightWareI2C::init()
 {
     if (sf20_init()) {
-        hal.console->printf("Found SF20 native Lidar\n");
+        DEV_PRINTF("Found SF20 native Lidar\n");
         return true;
     }
     if (legacy_init()) {
-        hal.console->printf("Found SF20 legacy Lidar\n");
+        DEV_PRINTF("Found SF20 legacy Lidar\n");
         return true;
     }
-    hal.console->printf("SF20 not found\n");
+    DEV_PRINTF("SF20 not found\n");
     return false;
 }
 
@@ -242,7 +242,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_init()
     sf20_get_version("?P\r\n", "p:", version);
 
     if (version[0]) {
-        hal.console->printf("SF20 Lidar version %s\n", version);
+        DEV_PRINTF("SF20 Lidar version %s\n", version);
     }
 
     // Makes sure that "address tagging" is turned off.

--- a/libraries/AP_RobotisServo/AP_RobotisServo.cpp
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.cpp
@@ -344,7 +344,7 @@ void AP_RobotisServo::process_packet(const uint8_t *pkt, uint8_t length)
     if (!(id_mask & servo_mask)) {
         // mark the servo as present
         servo_mask |= id_mask;
-        hal.console->printf("Robotis: new servo %u\n", id);
+        DEV_PRINTF("Robotis: new servo %u\n", id);
     }
 }
 

--- a/libraries/AP_Scheduler/PerfInfo.cpp
+++ b/libraries/AP_Scheduler/PerfInfo.cpp
@@ -38,7 +38,7 @@ void AP::PerfInfo::allocate_task_info(uint8_t num_tasks)
 {
     _task_info = new TaskInfo[num_tasks];
     if (_task_info == nullptr) {
-        hal.console->printf("Unable to allocate scheduler TaskInfo\n");
+        DEV_PRINTF("Unable to allocate scheduler TaskInfo\n");
         _num_tasks = 0;
         return;
     }

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -93,7 +93,7 @@ void lua_scripts::set_and_print_new_error_message(MAV_SEVERITY severity, const c
     va_end(arg_list);
 
     // print to cosole and GCS
-    hal.console->printf("Lua: %s\n", error_msg_buf);
+    DEV_PRINTF("Lua: %s\n", error_msg_buf);
     print_error(severity);
 }
 

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -777,7 +777,7 @@ void AP_SerialManager::set_options(uint16_t i)
     struct UARTState &opt = state[i];
     // pass through to HAL
     if (!hal.serial(i)->set_options(opt.options)) {
-        hal.console->printf("Unable to setup options for Serial%u\n", i);
+        DEV_PRINTF("Unable to setup options for Serial%u\n", i);
     }
 }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -101,7 +101,7 @@ void AP_Vehicle::setup()
     // initialise serial port
     serial_manager.init_console();
 
-    hal.console->printf("\n\nInit %s"
+    DEV_PRINTF("\n\nInit %s"
                         "\n\nFree RAM: %u\n",
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());

--- a/libraries/GCS_MAVLink/GCS_Dummy.cpp
+++ b/libraries/GCS_MAVLink/GCS_Dummy.cpp
@@ -13,9 +13,9 @@ const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] {};
 void GCS_Dummy::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t dest_bitmask)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_Replay)
-    hal.console->printf("TOGCS: ");
+    DEV_PRINTF("TOGCS: ");
     hal.console->vprintf(fmt, arg_list);
-    hal.console->printf("\n");
+    DEV_PRINTF("\n");
 #else
     ::printf("TOGCS: ");
     ::vprintf(fmt, arg_list);

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -134,7 +134,7 @@ void GCS_MAVLINK::load_signing_key(void)
     }
     mavlink_status_t *status = mavlink_get_channel_status(chan);
     if (status == nullptr) {
-        hal.console->printf("Failed to load signing key - no status");
+        DEV_PRINTF("Failed to load signing key - no status");
         return;        
     }
     memcpy(signing.secret_key, key.secret_key, 32);


### PR DESCRIPTION
I have a USB connection between FC and GCS.
I debugged on the console when I was NUTTX.
I have not used the console since CHIBIOS.
I use HAL.UART for software debugging.
My drone does not use the messages output to the console.
I do not know how to use this message and consider it useless.
I can add a preprocessor for HAL_CONSOLE_DISABLED and choose not to output to the console.

If you do not use this message, you can free up about 4 Kbytes.