### PR TITLE
AP_Filesystem_posix: force Linux to relative paths too

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -35,8 +35,8 @@ extern const AP_HAL::HAL& hal;
  */
 static const char *map_filename(const char *fname)
 {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !APM_BUILD_TYPE(APM_BUILD_Replay)
-    // on SITL only allow paths under subdirectory. Users can still
+#if !APM_BUILD_TYPE(APM_BUILD_Replay)
+    // on SITL and Linux, only allow paths under subdirectory. Users can still
     // escape with .. if they want to
     if (strcmp(fname, "/") == 0) {
         return ".";


### PR DESCRIPTION
We should prevent this behavior in Linux, too.