### PR TITLE
AP_Math: add specialisation for sq(float)

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -207,6 +207,10 @@ ftype sq(const T val)
     ftype v = static_cast<ftype>(val);
     return v*v;
 }
+static inline constexpr float sq(const float val)
+{
+    return val*val;
+}
 
 /*
  * Variadic template for calculating the square norm of a vector of any

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -277,6 +277,12 @@ TEST(MathTest, Square)
     AP_Float t_sqfloat;
     t_sqfloat = sq(2);
     EXPECT_EQ(4.f, t_sqfloat);
+
+    EXPECT_FLOAT_EQ(sq(2.3), 5.289999999999999);  // uses template sq
+    EXPECT_FLOAT_EQ(sq(2.3f), 5.29); // uses sq(float v)
+    EXPECT_EQ(sq(4294967295), 18446744065119617025U);  // uses template sq
+    EXPECT_FLOAT_EQ(sq(4294967295.0), 1.8446744e+19);  // uses template sq
+    EXPECT_FLOAT_EQ(sq(pow(2,25)), pow(2,50));
 }
 
 TEST(MathTest, Norm)


### PR DESCRIPTION
avoids conversion to double

I added some printf debugging to work out which of the template or the function would actually be used.  Comments are against the new tests...

Saves ~1.1kB here on CubeOrange.
