### PR TITLE
AP_InertialSensor: Added BMI085 support

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -97,6 +97,7 @@ imu_types = {
     0x36 : "DEVTYPE_INS_ICM40605",
     0x37 : "DEVTYPE_INS_IIM42652",
     0x38 : "DEVTYPE_INS_BMI270",
+    0x39 : "DEVTYPE_INS_BMI085",
 }
 
 baro_types = {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.h
@@ -81,6 +81,7 @@ private:
     uint8_t gyro_instance;
     enum Rotation rotation;
     uint8_t temperature_counter;
+    enum DevTypes _accel_devtype;
 
     bool done_accel_config;
     uint32_t accel_config_count;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -121,6 +121,7 @@ public:
         DEVTYPE_INS_ICM40605 = 0x36,
         DEVTYPE_INS_IIM42652 = 0x37,
         DEVTYPE_BMI270       = 0x38,
+        DEVTYPE_INS_BMI085   = 0x39,
     };
 
 protected:


### PR DESCRIPTION
Boards with BMI085 sensors are able to use the BMI088 library which now labels them appropriately depending on the device's CHIPID.

Also REGA_FIFO_CONFIG0 needs a 1 in bit 1 as per the datasheet and #defines for temperature registers were fixed (swapped).