### PR TITLE
AP_HAL_ChibiOS: reversible DShot fix

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1414,7 +1414,7 @@ void RCOutput::dshot_send(pwm_group &group, uint32_t time_out_us)
             pwm = constrain_int16(pwm, 1000, 2000);
             uint16_t value = MIN(2 * (pwm - 1000), 1999);
 
-            if (chan_mask & (_reversible_mask>>chan_offset)) {
+            if ((chan_mask & _reversible_mask) != 0) {
                 // this is a DShot-3D output, map so that 1500 PWM is zero throttle reversed
                 if (value < 1000) {
                     value = 1999 - value;


### PR DESCRIPTION
This fixes the DShot output on Rovers (and perhaps Plane) when reversible DShot is used ([see wiki setup instructions here](https://ardupilot.org/rover/docs/common-blheli32-passthru.html#reversible-dshot-escs)).

This has been tested on a CubeOrange running Rover firmware with:

- BLHeli ESC connected to AUX2 (aka SERVO10)
- SERVO_BLH_3DMASK bitmask set for channel 10

Before this change the motor both spins in the wrong direction and when the throttle is just below 1500 (e.g. 1475) it spins at nearly full speed, when the throttle is near 1000 it spins at a low speed.  After this change the motor spins in the correct direction and at the correct speed as it did in 4.1.5.

This has also been tested on a pixracer which worked fine before the change and still works fine after the change.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/19346.

Thanks to @andyp1per for specifying the fix.