### PR TITLE
Correct channel offsets for dshot commands

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -200,7 +200,7 @@ public:
      * The mask uses servo channel numbering
      */
     void set_reversed_mask(uint16_t chanmask) override;
-    uint16_t get_reversed_mask() override { return _reversed_mask; }
+    uint16_t get_reversed_mask() override { return _reversed_mask << chan_offset; }
 
     /*
       mark escs as active for the purpose of sending dshot commands

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -98,7 +98,7 @@ void RCOutput::send_dshot_command(uint8_t command, uint8_t chan, uint32_t comman
 
     DshotCommandPacket pkt;
     pkt.command = command;
-    pkt.chan = chan + chan_offset;
+    pkt.chan = chan - chan_offset;
     if (command_timeout_ms == 0) {
         pkt.cycle = MAX(10, repeat_count);
     } else {
@@ -137,10 +137,10 @@ void RCOutput::update_channel_masks() {
     for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
         switch (_dshot_esc_type) {
             case DSHOT_ESC_BLHELI:
-                if (_reversible_mask & (1U<<i)) {
+                if ((_reversible_mask<<chan_offset) & (1U<<i)) {
                     send_dshot_command(DSHOT_3D_ON, i, 0, 10, true);
                 }
-                if (_reversed_mask & (1U<<i)) {
+                if ((_reversed_mask<<chan_offset) & (1U<<i)) {
                     send_dshot_command(DSHOT_REVERSE, i, 0, 10, true);
                 }
                 break;


### PR DESCRIPTION
Channel offsets are incorrect for dshot commands on flight controllers with IOMCU