### PR TITLE
web: changed from '3DR' to 'SiK'

### DIFF
--- a/Tools/autotest/web-firmware/index.html
+++ b/Tools/autotest/web-firmware/index.html
@@ -89,7 +89,7 @@ The software and hardware we provide is only for use in unmanned
 <a href="Tools/APMPlanner"><img src="images/ap_rc.png" width="80"
 		     alt="APM Planner 2.0">APM Planner 2.0</a> - APM Planner 2.0 tool<p>
 <a href="SiK"><img src="images/3DR_Radio.jpg" width="80"
-		     alt="Radio">SiK</a> - 3DR Radio Firmware<p>
+                     alt="Radio">SiK</a> - SiK Radio Firmware<p>
 <a href="Tools"><img src="images/tools.png" width="80"
 		     alt="Tools">Tools</a> - Build and development tools<p>
 <a href="devbuild"><img src="images/tools.png" width="80"


### PR DESCRIPTION
these radios have not been sold by 3DR for a long time

on the same page we still link to APM Planner 2.0. Is anyone still using APM Planner 2?