### PR TITLE
Plane: when shutting down motors force outputs to minimum

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3853,6 +3853,13 @@ float QuadPlane::get_land_airspeed(void)
 void QuadPlane::set_desired_spool_state(AP_Motors::DesiredSpoolState state)
 {
     if (motors->get_desired_spool_state() != state) {
+        if (state == AP_Motors::DesiredSpoolState::SHUT_DOWN) {
+            // also request zero throttle, so we avoid the slow ramp down
+            motors->set_roll(0);
+            motors->set_pitch(0);
+            motors->set_yaw(0);
+            motors->set_throttle(0);
+        }
         motors->set_desired_spool_state(state);
     }
 }


### PR DESCRIPTION
this fixes issue #20354 where a long spool time can lead to motors
running without control for an extended period of time.
with a 2s spool time and a switch to MANUAL we now get this:
![image](https://user-images.githubusercontent.com/831867/159586720-4d507e50-d468-42db-8674-69883e68bea7.png)
