### PR TITLE
Plane: fixed yaw on the ground when rudder disarming in AUTO

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -67,7 +67,8 @@ void Plane::fence_check()
             if (fence_act == AC_FENCE_ACTION_RTL_AND_LAND) {
                 if (control_mode == &mode_auto &&
                     mission.get_in_landing_sequence_flag() &&
-                    (g.rtl_autoland == 1 || g.rtl_autoland == 2)) {
+                    (g.rtl_autoland == RtlAutoland::RTL_THEN_DO_LAND_START ||
+                     g.rtl_autoland == RtlAutoland::RTL_IMMEDIATE_DO_LAND_START)) {
                     // already landing
                     return;
                 }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1174,8 +1174,10 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
 {
     bool manual_air_mode = plane.control_mode->is_vtol_man_throttle() && air_mode_active();
     if (!manual_air_mode &&
-        !is_positive(plane.get_throttle_input()) && !plane.control_mode->does_auto_throttle() &&
-        plane.arming.get_rudder_arming_type() != AP_Arming::RudderArming::IS_DISABLED && !(inertial_nav.get_velocity_z_up_cms() < -0.5 * get_pilot_velocity_z_max_dn())) {
+        !is_positive(plane.get_throttle_input()) &&
+        (!plane.control_mode->does_auto_throttle() || motors->limit.throttle_lower) &&
+        plane.arming.get_rudder_arming_type() != AP_Arming::RudderArming::IS_DISABLED &&
+        fabsf(inertial_nav.get_velocity_z_up_cms()) < 0.5 * get_pilot_velocity_z_max_dn()) {
         // the user may be trying to disarm
         return 0;
     }


### PR DESCRIPTION
when a quadplane touches down in an auto throttle mode the pilot may
use rudder to disarm. The check for rudder disarm was only active in
modes without auto-throttle. This expands it to all modes if the
throttle has hit the lower limit
the problem is easily reproducible in SITL if you use uneven ground (I used a grass hill in RF9) with a mission that just does a takeoff and immediate land
