### PR TITLE
Plane: handle AIRBRAKE RC option

### DIFF
--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -268,6 +268,7 @@ bool RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwit
 
     case AUX_FUNC::FLAP:
     case AUX_FUNC::FBWA_TAILDRAGGER:
+    case AUX_FUNC::AIRBRAKE:
         break; // input labels, nothing to do
 
 #if HAL_QUADPLANE_ENABLED


### PR DESCRIPTION
User reports that airbrake works, but complains "invalid channel option"
https://discuss.ardupilot.org/t/invalid-channel-option-210/83268

This should eliminate the error message, but it's strange that it hadn't been caught yet.
