### PR TITLE
AP_HAL_ChibiOS: check serial RC input in the background

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -181,7 +181,7 @@ void RCInput::_timer_tick(void)
         _rcin_last_iomcu_ms = 0;
     }
 
-    if (!have_iocmu_rc && rcprot.new_input()) {
+    if (rcprot.new_input() && !have_iocmu_rc) {
         WITH_SEMAPHORE(rcin_mutex);
         _rcin_timestamp_last_signal = AP_HAL::micros();
         _num_channels = rcprot.num_channels();


### PR DESCRIPTION
Further improve this fix #20322.
When transmitter1 (IOMCU) was turned off, an RC failsafe occured and then input from transmitter2 (rcprotocol) began arriving.

This PR fixes the RC failsafe issue.
The problem was caused by the time-consuming process of finding the five serial_configs in order.
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RCProtocol/AP_RCProtocol.cpp#L303-L312
This change allows for instantaneous switching, since the RC input is always updating in the background.

Before
![image](https://user-images.githubusercontent.com/16643069/160083227-2f30eacc-5986-424a-aaac-db065df53ece.png)
 I added the debug message like "check config x".

After
![image](https://user-images.githubusercontent.com/16643069/160083254-7985e00a-e6e1-41b3-97f1-596e3ae1ab07.png)
