### PR TITLE
RCInput: show source of RC input and rapidly switch between IOMCU and RCProt

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -181,7 +181,7 @@ void RCInput::_timer_tick(void)
         _rcin_last_iomcu_ms = 0;
     }
 
-    if (!have_iocmu_rc && rcprot.new_input()) {
+    if (rcprot.new_input() && !have_iocmu_rc) {
         WITH_SEMAPHORE(rcin_mutex);
         _rcin_timestamp_last_signal = AP_HAL::micros();
         _num_channels = rcprot.num_channels();

--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -72,6 +72,15 @@ private:
     uint32_t _rcin_last_iomcu_ms;
     bool _init;
     const char *last_protocol;
+
+    enum class RCSource {
+        NONE = 0,
+        IOMCU = 1,
+        RCPROT_PULSES = 2,
+        RCPROT_BYTES = 3,
+        APRADIO = 4,
+    } last_source;
+
     bool pulse_input_enabled;
 
 #if HAL_RCINPUT_WITH_AP_RADIO

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -142,6 +142,11 @@ public:
         bool invert_rx;
     };
 
+    // return true if we are decoding a byte stream, instead of pulses
+    bool using_uart(void) const {
+        return _detected_with_bytes;
+    }
+
 private:
     void check_added_uart(void);
 


### PR DESCRIPTION
This changes the display of the RC input decoding to say:
```
2022-03-27 14:47:13.937 RCInput: decoding FPORT(2)
2022-03-27 14:47:49.451 RCInput: decoding SBUS(1)
```
the (n) is the source, where 1 is IOMCU, 2 is pulses on FMU and 3 is uart on FMU

This also fixes the failover between IOMCU and FMU inputs to be fast enough it won't trigger a failsafe on copter

I flew several flights on this today on a plane, with a IOMCU primary (RFD900x SBUS) and FPort secondary on telem2, on a CubeOrange