### PR TITLE
Terrain: added reference height adjustment

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1369,6 +1369,17 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         gcs().send_text(MAV_SEVERITY_WARNING, "Warning: Arming Checks Disabled");
     }
 
+#if AP_TERRAIN_AVAILABLE
+    if (armed) {
+        // tell terrain we have just armed, so it can setup
+        // a reference location for terrain adjustment
+        auto *terrain = AP::terrain();
+        if (terrain != nullptr) {
+            terrain->set_reference_location();
+        }
+    }
+#endif
+
     return armed;
 }
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -906,7 +906,7 @@ void SITL_State::set_height_agl(void)
 
         AP_Terrain *_terrain = AP_Terrain::get_singleton();
         if (_terrain != nullptr &&
-            _terrain->height_amsl(location, terrain_height_amsl)) {
+            _terrain->height_amsl(location, terrain_height_amsl, false)) {
             _sitl->height_agl = _sitl->state.altitude - terrain_height_amsl;
             return;
         }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -451,6 +451,7 @@ struct PACKED log_TERRAIN {
     float current_height;
     uint16_t pending;
     uint16_t loaded;
+    float reference_offset;
 };
 
 struct PACKED log_CSRV {
@@ -1171,6 +1172,7 @@ struct PACKED log_VER {
 // @Field: CHeight: Vehicle height above terrain
 // @Field: Pending: Number of tile requests outstanding
 // @Field: Loaded: Number of tiles in memory
+// @Field: ROfs: terrain reference offset for arming altitude
 
 // @LoggerMessage: TSYN
 // @Description: Time synchronisation response information
@@ -1327,7 +1329,7 @@ LOG_STRUCTURE_FROM_AVOIDANCE \
     { LOG_SIMSTATE_MSG, sizeof(log_AHRS), \
       "SIM","QccCfLLffff","TimeUS,Roll,Pitch,Yaw,Alt,Lat,Lng,Q1,Q2,Q3,Q4", "sddhmDU????", "FBBB0GG????", true }, \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \
-      "TERR","QBLLHffHH","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded", "s-DU-mm--", "F-GG-00--", true }, \
+      "TERR","QBLLHffHHf","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded,ROfs", "s-DU-mm--m", "F-GG-00--0", true }, \
 LOG_STRUCTURE_FROM_ESC_TELEM \
     { LOG_CSRV_MSG, sizeof(log_CSRV), \
       "CSRV","QBfffB","TimeUS,Id,Pos,Force,Speed,Pow", "s#---%", "F-0000", true }, \

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1507,8 +1507,9 @@ function terrain:height_terrain_difference_home(extrapolate) end
 
 -- desc
 ---@param loc Location_ud
+---@param corrected boolean
 ---@return number|nil
-function terrain:height_amsl(loc) end
+function terrain:height_amsl(loc, corrected) end
 
 -- desc
 ---@return integer

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -176,7 +176,7 @@ singleton AP_Terrain alias terrain
 singleton AP_Terrain method enabled boolean
 singleton AP_Terrain enum TerrainStatusDisabled TerrainStatusUnhealthy TerrainStatusOK
 singleton AP_Terrain method status uint8_t
-singleton AP_Terrain method height_amsl boolean Location float'Null
+singleton AP_Terrain method height_amsl boolean Location float'Null boolean
 singleton AP_Terrain method height_terrain_difference_home boolean float'Null boolean
 singleton AP_Terrain method height_above_terrain boolean float'Null boolean
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -69,7 +69,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     AP_GROUPINFO("MARGIN",   3, AP_Terrain, margin, 0.05),
 
     // @Param: OFS_MAX
-    // @DisplayName: Maximum reference offset
+    // @DisplayName: Terrain reference offset maximum
     // @Description: The maximum adjustment of terrain altitude based on the assumption that the vehicle is on the ground when it is armed. When the vehicle is armed the location of the vehicle is recorded, and when terrain data is available for that location a height adjustment for terrain data is calculated that aligns the terrain height at that location with the altitude recorded at arming. This height adjustment is applied to all terrain data. This parameter clamps the amount of adjustment. A value of zero disables the use of terrain height adjustment.
     // @Units: m
     // @Range: 0 50
@@ -392,7 +392,8 @@ void AP_Terrain::log_terrain_data()
         terrain_height : terrain_height,
         current_height : current_height,
         pending        : pending,
-        loaded         : loaded
+        loaded         : loaded,
+        reference_offset : have_reference_offset?reference_offset:0,
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -67,6 +67,14 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Range: 0.05 50000
     // @User: Advanced
     AP_GROUPINFO("MARGIN",   3, AP_Terrain, margin, 0.05),
+
+    // @Param: OFS_MAX
+    // @DisplayName: Maximum reference offset
+    // @Description: The maximum adjustment of terrain altitude based on the assumption that the vehicle is on the ground when it is armed. When the vehicle is armed the location of the vehicle is recorded, and when terrain data is available for that location a height adjustment for terrain data is calculated that aligns the terrain height at that location with the altitude recorded at arming. This height adjustment is applied to all terrain data. This parameter clamps the amount of adjustment. A value of zero disables the use of terrain height adjustment.
+    // @Units: m
+    // @Range: 0 50
+    // @User: Advanced
+    AP_GROUPINFO("OFS_MAX",  4, AP_Terrain, offset_max, 15),
     
     AP_GROUPEND
 };
@@ -95,7 +103,7 @@ AP_Terrain::AP_Terrain() :
 
   This function costs about 20 microseconds on Pixhawk
  */
-bool AP_Terrain::height_amsl(const Location &loc, float &height)
+bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
 {
     if (!allocate()) {
         return false;
@@ -107,6 +115,9 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height)
     if (loc.lat == home_loc.lat &&
         loc.lng == home_loc.lng) {
         height = home_height;
+        if (corrected && have_reference_offset) {
+            height += reference_offset;
+        }
         return true;
     }
 
@@ -157,6 +168,10 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height)
         home_loc = loc;
     }
 
+    if (corrected && have_reference_offset) {
+        height += reference_offset;
+    }
+    
     return true;
 }
 
@@ -403,6 +418,78 @@ bool AP_Terrain::allocate(void)
     cache_size = TERRAIN_GRID_BLOCK_CACHE_SIZE;
     return true;
 }
+
+/*
+  setup a reference location for terrain adjustment. This should
+  be called when the vehicle is definately on the ground
+*/
+void AP_Terrain::set_reference_location(void)
+{
+    const auto &ahrs = AP::ahrs();
+
+    // check we have absolute position
+    nav_filter_status status;
+    if (!ahrs.get_filter_status(status) ||
+        !status.flags.vert_pos ||
+        !status.flags.horiz_pos_abs ||
+        !status.flags.attitude) {
+        return;
+    }
+
+    // check we have a small 3D velocity
+    Vector3f vel;
+    if (!ahrs.get_velocity_NED(vel) ||
+        vel.length() > 3) {
+        return;
+    }
+
+    have_reference_offset = false;
+    have_reference_loc = ahrs.get_location(reference_loc);
+
+    update_reference_offset();
+}
+
+/*
+  get the offset between terrain height and reference alt at the
+  reference location
+ */
+void AP_Terrain::update_reference_offset(void)
+{
+    // TERR_OFS_MAX of zero means no adjustment
+    if (!is_positive(offset_max)) {
+        have_reference_offset = false;
+        return;
+    }
+
+    // allow for change to TERRAIN_OFS_MAX while flying
+    if (have_reference_offset) {
+        reference_offset = constrain_float(reference_offset, -offset_max, offset_max);
+        return;
+    }
+
+    if (!have_reference_loc) {
+        // no reference available yet
+        return;
+    }
+
+    // calculate adjustment
+    float height;
+    if (!height_amsl(reference_loc, height)) {
+        return;
+    }
+    int32_t alt_cm;
+    if (!reference_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_cm)) {
+        return;
+    }
+    float adjustment = alt_cm*0.01 - height;
+    reference_offset = constrain_float(adjustment, -offset_max, offset_max);
+    if (fabsf(adjustment) > offset_max.get()+0.5) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Terrain: clamping offset %.0f to %.0f",
+                      adjustment, reference_offset);
+    }
+    have_reference_offset = true;
+}
+
 
 namespace AP {
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -122,7 +122,7 @@ public:
 
       return false if not available
      */
-    bool height_amsl(const Location &loc, float &height);
+    bool height_amsl(const Location &loc, float &height, bool corrected = true);
 
     /* 
        find difference between home terrain height and the terrain
@@ -188,6 +188,12 @@ public:
       returns true if initialisation failed because out-of-memory
      */
     bool init_failed() const { return memory_alloc_failed; }
+
+    /*
+      setup a reference location for terrain adjustment. This should
+      be called when the vehicle is definately on the ground
+     */
+    void set_reference_location(void);
 
 private:
     // allocate the terrain subsystem data
@@ -344,12 +350,18 @@ private:
      */
     void update_rally_data(void);
 
+    /*
+      calculate reference offset if needed
+     */
+    void update_reference_offset(void);
+
 
     // parameters
     AP_Int8  enable;
     AP_Float margin;
     AP_Int16 grid_spacing; // meters between grid points
     AP_Int16 options; // option bits
+    AP_Float offset_max;
 
     enum class Options {
         DisableDownload = (1U<<0),
@@ -395,6 +407,15 @@ private:
     // cache the home altitude, as it is needed so often
     float home_height;
     Location home_loc;
+
+    // reference position for terrain adjustment, set at arming
+    bool have_reference_loc;
+    Location reference_loc;
+
+    // calculated reference offset
+    bool have_reference_offset;
+    float reference_offset;
+
 
     // cache the last terrain height (AMSL) of the AHRS current
     // location. This is used for extrapolation when terrain data is

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -351,6 +351,8 @@ void AP_Terrain::io_timer(void)
         return;
     }
 
+    update_reference_offset();
+
     switch (disk_io_state) {
     case DiskIoIdle:
     case DiskIoDoneRead:

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -111,8 +111,8 @@ float Aircraft::ground_height_difference() const
     if (sitl &&
         terrain != nullptr &&
         sitl->terrain_enable &&
-        terrain->height_amsl(home, h1) &&
-        terrain->height_amsl(location, h2)) {
+        terrain->height_amsl(home, h1, false) &&
+        terrain->height_amsl(location, h2, false)) {
         h2 += local_ground_level;
         return h2 - h1;
     }

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -204,7 +204,7 @@ void ShipSim::send_report(void)
 #if AP_TERRAIN_AVAILABLE
     auto terrain = AP::terrain();
     float height;
-    if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height)) {
+    if (terrain != nullptr && terrain->enabled() && terrain->height_amsl(loc, height, false)) {
         alt_mm = height * 1000;
     }
 #endif


### PR DESCRIPTION
this restores the terrain adjustment functionality removed in #19946, but without the problematic approach of always using home (which can  be moved in flight) and with a TERRAIN_OFS_MAX parameter to limit the  amount of adjustment
If the adjustment exceeds TERRAIN_OFS_MAX then a warning is issued
![image](https://user-images.githubusercontent.com/831867/160302252-037894b9-2860-4c4e-97e0-e0b02095497a.png)
