### PR TITLE
AP_Param: fixed param class conversion code

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1951,6 +1951,10 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
         }
 
         AP_Param *ap2 = (AP_Param *)(group_info[i].offset + (uint8_t *)object_pointer);
+        if (ap2->configured_in_storage()) {
+            // user has already set a value, or previous conversion was done
+            continue;
+        }
         memcpy(ap2, ap, sizeof(old_value));
         // and save
         ap2->save();


### PR DESCRIPTION
param class conversion was unconditionally overwriting the parameter from the old parameter. This meant if the user has set a value in an old firmware they could not change it in a new firmware.

I hit this with ARSPD_TYPE. I had previously set this to 0 in a previous use of the board, and found that it kept resetting to 0 on
the new firmware when I tried to enable airspeed

To reproduce this bug:
 - checkout plane 4.1
 - set ARSPD_TYPE to 8 then set it back to 0
 - now start 4.2 with the same eeprom.bin
 - set ARSPD_TYPE to 8 and then reboot
 - fetch parameters and ARSPD_TYPE will be 0, reset by this bug