### PR TITLE
Copter: Add support for altitude offset input in AUTO mode

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -71,7 +71,8 @@ enum tuning_func {
     TUNING_RATE_MOT_YAW_HEADROOM =      55, // motors yaw headroom minimum
     TUNING_RATE_YAW_FILT =              56, // yaw rate input filter
     UNUSED =                            57, // was winch control
-    TUNING_SYSTEM_ID_MAGNITUDE =        58  // magnitude of the system ID signal
+    TUNING_SYSTEM_ID_MAGNITUDE =        58, // magnitude of the system ID signal
+    TUNING_WP_ALTITUDE =                59, // add altitude offset to waypoint in auto mode
 };
 
 // Yaw behaviours during missions - possible values for WP_YAW_BEHAVIOR parameter

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -104,6 +104,10 @@ void Copter::tuning()
         wp_nav->set_speed_xy(tuning_value);
         break;
 
+    case TUNING_WP_ALTITUDE:
+        pos_control->set_pos_tune_offset_z_cm(tuning_value);
+        break;
+
 #if MODE_ACRO_ENABLED == ENABLED || MODE_SPORT_ENABLED == ENABLED
     // Acro roll pitch rates
     case TUNING_ACRO_RP_RATE:

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -757,6 +757,7 @@ void AC_PosControl::init_z_controller()
     // initialise vertical offsets
     _pos_offset_target_z = 0.0;
     _pos_offset_z = 0.0;
+    _pos_tune_offset_z = 0.0;
     _vel_offset_z = 0.0;
     _accel_offset_z = 0.0;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -310,10 +310,13 @@ public:
     void set_pos_offset_target_z_cm(float pos_offset_target_z) { _pos_offset_target_z = pos_offset_target_z; }
 
     /// set_pos_offset_z_cm - set altitude offset in cm above the EKF origin
-    void set_pos_offset_z_cm(float pos_offset_z) { _pos_offset_z = pos_offset_z; }
+    void set_pos_offset_z_cm(float pos_offset_z) { _pos_offset_z = pos_offset_z + _pos_tune_offset_z; }
 
     /// get_pos_offset_z_cm - returns altitude offset in cm above the EKF origin
-    float get_pos_offset_z_cm() const { return _pos_offset_z; }
+    float get_pos_offset_z_cm() const { return _pos_offset_z + _pos_tune_offset_z; }
+
+    /// set_pos_tune_offset_z_cm - set altitude tune offset in cm above the EKF origin
+    void set_pos_tune_offset_z_cm(float pos_tune_offset_z) { _pos_tune_offset_z = pos_tune_offset_z; }
 
     /// get_vel_offset_z_cm - returns current vertical offset speed in cm/s
     float get_vel_offset_z_cms() const { return _vel_offset_z; }
@@ -462,6 +465,7 @@ protected:
 
     float       _pos_offset_target_z;   // vertical position offset target, frame NEU in cm relative to the EKF origin
     float       _pos_offset_z;          // vertical position offset, frame NEU in cm relative to the EKF origin
+    float       _pos_tune_offset_z;     // vertical position tune offset, frame NEU in cm relative to the EKF origin
     float       _vel_offset_z;          // vertical velocity offset in NEU cm/s calculated by pos_to_rate step
     float       _accel_offset_z;        // vertical acceleration offset in NEU cm/s/s
 


### PR DESCRIPTION
With this PR, if the TUNE parameter is set to 59, users can add offsets to the vehicle's altitude in centimeters within (TUNE_MIN, TUNE_MAX).