### PR TITLE
AP_HAL_SITL: init ArduSub pwm_output to 1500

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -698,6 +698,10 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
         if (_vehicle == Rover) {
             pwm_output[0] = pwm_output[1] = pwm_output[2] = pwm_output[3] = 1500;
         }
+        if (_vehicle == ArduSub) {
+            pwm_output[0] = pwm_output[1] = pwm_output[2] = pwm_output[3] =
+                    pwm_output[4] = pwm_output[5] = pwm_output[6] = pwm_output[7] = 1500;
+        }
     }
 
     // output at chosen framerate


### PR DESCRIPTION
Problem:

When using SIM_JSON with ArduSub the first ~500 packets sent to ArduPilotPlugin have pwm values [1000, ...]. This sends the sub flying for a few seconds.

It appears that `SITL_State::_simulator_servos` initializes pwm_output to [1000, ...] and these values are sent to ArduPilotPlugin by SIM_JSON before any ArduSub code is called.

Proposed solution:

Add code to `SITL_State::_simulator_servos` to initialize pwm_output to [1500, ...] if the vehicle is ArduSub. 

Tests:

* Tested with Ignition Gazebo, ardupilot_gazebo and a BlueROV2 model, see https://github.com/clydemcqueen/bluerov2_ignition/tree/clyde_relay
* `Tools/scripts/build_all.sh` builds everything cleanly