### PR TITLE
AP_Logger: increase stack of log_io thread by 256

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -27,7 +27,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 #ifndef HAL_LOGGING_STACK_SIZE
-#define HAL_LOGGING_STACK_SIZE 1324
+#define HAL_LOGGING_STACK_SIZE 1580
 #endif
 
 #ifndef HAL_LOGGING_MAV_BUFSIZE


### PR DESCRIPTION
This was seem on omnibusf4pro, it is a bit too close:

  log_io PRI= 59 sp=0x20015CC0 STACK=144/1656