### PR TITLE
AC_Fence: add check for enabling non existant fence

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -55,6 +55,10 @@ void Plane::fence_check()
          GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
      }
 
+    if( !orig_breaches && new_breaches && plane.is_flying()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+    }
+
     if (new_breaches || orig_breaches) {
         // if the user wants some kind of response and motors are armed
         const uint8_t fence_act = fence.get_action();


### PR DESCRIPTION
It's currently possible to Arm a vehicle with FENCE_AUTOENABLE = 1 but with no fence set up.
Once armed and flying - if an auto enable of a Geo Fence is triggered, the plane will send the message to the GCS that the fence is enabled, even if there is no fence to enable.
So either way, a pilot might think they have a geofence and it is enabled whereas there might be no fence.
This PR does two things.

adds a pre-arm check to prevent arming if FENCE_AUTOENABLE = 1 but there is no fence
if pre-arm checks are disabled, if a vehicle attempts to auto enable the geofence after takeoff, a warning message is sent to the GCS and the AC_Fence::enable() function is not called.