### PR TITLE
AC_Fence: add check for enabling non existant fence

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -55,6 +55,10 @@ void Plane::fence_check()
          GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
      }
 
+    if( !orig_breaches && new_breaches && plane.is_flying()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+    }
+
     if (new_breaches || orig_breaches) {
         // if the user wants some kind of response and motors are armed
         const uint8_t fence_act = fence.get_action();

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -168,8 +168,13 @@ void AC_Fence::auto_enable_fence_after_takeoff(void)
     switch(auto_enabled()) {
         case AC_Fence::AutoEnable::ALWAYS_ENABLED:
         case AC_Fence::AutoEnable::ENABLE_DISABLE_FLOOR_ONLY:
-            enable(true);
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence enabled (auto enabled)");
+            if(AC_Fence::present()) {
+                enable(true);
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Fence enabled (auto enabled)");
+            }
+            else {
+                gcs().send_text(MAV_SEVERITY_WARNING, "Enable fence failed (no fence found)");
+            }
             break;
         default:
             // fence does not auto-enable in other takeoff conditions
@@ -184,8 +189,13 @@ void AC_Fence::auto_disable_fence_for_landing(void)
 {
     switch (auto_enabled()) {
         case AC_Fence::AutoEnable::ALWAYS_ENABLED:
-            enable(false);
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence disabled (auto disable)");
+            if(AC_Fence::present()) {
+                enable(false);
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Fence disabled (auto disable)");
+            }
+            else {
+                gcs().send_text(MAV_SEVERITY_WARNING, "Disable fence failed (no fence found)");
+            }
             break;
         case AC_Fence::AutoEnable::ENABLE_DISABLE_FLOOR_ONLY:
             disable_floor();
@@ -281,7 +291,7 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
     fail_msg = nullptr;
 
     // if fences are enabled but none selected fail pre-arm check
-    if (enabled() && !present()) {
+    if ((enabled() || _auto_enabled) && !present()) {
         fail_msg = "Fences enabled, but none selected";
         return false;
     }


### PR DESCRIPTION
It's currently possible to Arm a vehicle with FENCE_AUTOENABLE = 1 but with no fence set up.
Once armed and flying - if an auto enable of a Geo Fence is triggered, the plane will send the message to the GCS that the fence is enabled, even if there is no fence to enable.
So either way, a pilot might think they have a geofence and it is enabled whereas there might be no fence.
This PR does two things.

adds a pre-arm check to prevent arming if FENCE_AUTOENABLE = 1 but there is no fence
if pre-arm checks are disabled, if a vehicle attempts to auto enable the geofence after takeoff, a warning message is sent to the GCS and the AC_Fence::enable() function is not called.