### PR TITLE
Plane: add check in Fence code to prevent enabling non existent fence

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -43,6 +43,10 @@ void Plane::fence_check()
         return;
     }
 
+    if( !orig_breaches && new_breaches && plane.is_flying()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+    }
+
     if (orig_breaches &&
         (control_mode->is_guided_mode()
         || control_mode == &mode_rtl || fence.get_action() == AC_FENCE_ACTION_REPORT_ONLY)) {
@@ -51,10 +55,6 @@ void Plane::fence_check()
         return;
     }
     
-     if(new_breaches && plane.is_flying()) {
-         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
-     }
-
     if (new_breaches || orig_breaches) {
         // if the user wants some kind of response and motors are armed
         const uint8_t fence_act = fence.get_action();

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1181,8 +1181,15 @@ class AutoTestPlane(AutoTest):
     def test_fence_static(self):
         ex = None
         try:
+            self.start_subtest("Plane Fence - Present")
             self.progress("Checking for bizarre healthy-when-not-present-or-enabled")
+            # If we try to enable before setting any type of fence the fence - it should fail
+            self.do_fence_enable(want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+            self.assert_fence_sys_status(False, False, True)
             self.set_parameter("FENCE_TYPE", 4) # Start by only setting polygon fences, otherwise fence will report present
+            self.assert_fence_sys_status(False, False, True)
+            # If we try to enable before populating the fence - it should fail
+            self.do_fence_enable(want_result=mavutil.mavlink.MAV_RESULT_FAILED)
             self.assert_fence_sys_status(False, False, True)
             self.load_fence("CMAC-fence.txt")
             m = self.mav.recv_match(type='FENCE_STATUS', blocking=True, timeout=2)
@@ -1211,8 +1218,12 @@ class AutoTestPlane(AutoTest):
             self.assert_fence_sys_status(False, False, True)
             self.progress("Trying to enable fence with no points")
             self.do_fence_enable(want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+            # enabling a fence with no points should fail
+            self.progress("Fence should not be enabled")
+            self.assert_fence_sys_status(False, False, True)
 
             # test a rather unfortunate behaviour:
+            self.start_subtest("Plane Fence - Killing a live fence")
             self.progress("Killing a live fence with fence-clear")
             self.load_fence("CMAC-fence.txt")
             self.set_parameter("FENCE_ACTION", 1) # AC_FENCE_ACTION_RTL_AND_LAND == 1. mavutil.mavlink.FENCE_ACTION_RTL == 4
@@ -1223,18 +1234,35 @@ class AutoTestPlane(AutoTest):
             if self.get_parameter("FENCE_TOTAL") != 0:
                 raise NotAchievedException("Expected zero points remaining")
             self.assert_fence_sys_status(False, False, True)
-            self.do_fence_disable()
 
-            # ensure that a fence is present if it is tin can, min alt or max alt
+            # ensure that a fence is present and enabled if it is tin can, min alt or max alt
+            self.start_subtest("Plane Fence - Non-Polygon Fence Types")
             self.progress("Test other fence types (tin-can, min alt, max alt")
+            # Maximum Altitude fence
             self.set_parameter("FENCE_TYPE", 1) # max alt
+            # Setting Fence to type 1 enables the fence - no enable message required
+            self.assert_fence_sys_status(True, True, True)
+            self.do_fence_disable()
             self.assert_fence_sys_status(True, False, True)
+            # Minimum Altitude Fence
             self.set_parameter("FENCE_TYPE", 8) # min alt
+            # Setting Fence to type 8 does NOT enable the fence - enable message IS required
             self.assert_fence_sys_status(True, False, True)
+            self.do_fence_enable()
+            self.assert_fence_sys_status(True, True, True)
+            self.do_fence_disable()
+            self.assert_fence_sys_status(True, False, True)
+            # Tin Can fence
             self.set_parameter("FENCE_TYPE", 2) # tin can
+            # Setting Fence to type 2 nos NOT the fence - enable message IS required
+            self.assert_fence_sys_status(True, False, True)
+            self.do_fence_enable()
+            self.assert_fence_sys_status(True, True, True)
+            self.do_fence_disable()
             self.assert_fence_sys_status(True, False, True)
 
             # Test cannot arm if outside of fence and fence is enabled
+            self.start_subtest("Plane Fence - Arming")
             self.progress("Test Arming while vehicle below FENCE_ALT_MIN")
             default_fence_alt_min = self.get_parameter("FENCE_ALT_MIN")
             self.set_parameter("FENCE_ALT_MIN", 50)
@@ -3621,7 +3649,7 @@ function'''
              self.test_rangefinder),
 
             ("FenceStatic",
-             "Test Basic Fence Functionality",
+             "Test Basic Plane Fence Functionality",
              self.test_fence_static),
 
             ("FenceRTL",

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7065,7 +7065,7 @@ Also, ignores heartbeats not from our target system'''
         remaining_to_send = set(range(0, len(items)))
         sent = set()
         while True:
-            if self.get_sim_time_cached() - tstart > (10 + len(items)/10):
+            if self.get_sim_time_cached() - tstart > (20 + len(items)/10):
                 raise NotAchievedException("timeout uploading %s" % str(mission_type))
             if len(remaining_to_send) == 0:
                 self.progress("All sent")
@@ -7120,7 +7120,7 @@ Also, ignores heartbeats not from our target system'''
                                        (mavutil.mavlink.enums["MAV_MISSION_RESULT"][m.type].name),)
         self.progress("Upload of all %u items succeeded" % len(items))
 
-    def download_using_mission_protocol(self, mission_type, verbose=False, timeout=10):
+    def download_using_mission_protocol(self, mission_type, verbose=False, timeout=20):
         '''mavlink2 required'''
         target_system = 1
         target_component = 1
@@ -7157,7 +7157,7 @@ Also, ignores heartbeats not from our target system'''
         tstart = self.get_sim_time_cached()
         remaining_to_receive = set(range(0, m.count))
         next_to_request = 0
-        timeout = (10 + m.count/10)
+        timeout = (timeout + 50 + m.count/10)
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
                 raise NotAchievedException("timeout downloading type=%s" %


### PR DESCRIPTION
It's currently possible to Arm a vehicle with FENCE_AUTOENABLE = 1 but with no fence set up.
Once armed and flying - if an auto enable of a Geo Fence is triggered, the plane will send the message to the GCS that the fence is enabled, even if there is no fence to enable.
So either way, a pilot might think they have a geofence and it is enabled whereas there might be no fence.
This PR does two things.

* adds a pre-arm check to prevent arming if FENCE_AUTOENABLE = 1 but there is no fence
* if pre-arm checks are disabled, if a vehicle attempts to auto enable the geofence after takeoff, a warning message is sent to the GCS and the AC_Fence::enable() function is not called.