### PR TITLE
HAL_ChibiOS: prevent long timeouts in DShot

### DIFF
--- a/libraries/AP_HAL_ChibiOS/EventSource.cpp
+++ b/libraries/AP_HAL_ChibiOS/EventSource.cpp
@@ -1,4 +1,5 @@
 #include "EventSource.h"
+#include <AP_Math/AP_Math.h>
 
 using namespace ChibiOS;
 
@@ -13,7 +14,7 @@ bool EventSource::wait(uint64_t duration, AP_HAL::EventHandle *evt_handle)
     if (duration == 0) {
         ret = chEvtWaitAnyTimeout(evt_mask, TIME_IMMEDIATE);
     } else {
-        ret = chEvtWaitAnyTimeout(evt_mask, chTimeUS2I(duration));
+        ret = chEvtWaitAnyTimeout(evt_mask, MAX(CH_CFG_ST_TIMEDELTA, chTimeUS2I(duration)));
     }
     ch_evt_src_.unregister(&evt_listener);
     return ret == MSG_OK;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -253,14 +253,23 @@ void RCOutput::dshot_collect_dma_locks(uint32_t time_out_us)
             // if we have time left wait for the event
             eventmask_t mask = 0;
             const uint32_t pulse_elapsed_us = now - group.last_dmar_send_us;
+            uint32_t wait_us = 0;
             if (now < time_out_us) {
-                mask = chEvtWaitOneTimeout(group.dshot_event_mask,
-                    chTimeUS2I(MAX(time_out_us - now, group.dshot_pulse_send_time_us - pulse_elapsed_us)));
+                wait_us = MAX(time_out_us - now, group.dshot_pulse_send_time_us - pulse_elapsed_us);
             } else if (pulse_elapsed_us < group.dshot_pulse_send_time_us) {
                 // better to let the burst write in progress complete rather than cancelling mid way through
-                mask = chEvtWaitOneTimeout(group.dshot_event_mask,
-                    chTimeUS2I(group.dshot_pulse_send_time_us - pulse_elapsed_us));
+                wait_us = group.dshot_pulse_send_time_us - pulse_elapsed_us;
             }
+
+            // waiting for a very short period of time can cause a
+            // timer wrap with ChibiOS timers. Use CH_CFG_ST_TIMEDELTA
+            // as minimum. Don't allow for a very long delay (over 1200us)
+            // to prevent bugs in handling timer wrap
+            const uint32_t max_delay_us = 1200;
+            const uint32_t min_delay_us = 10; // matches our CH_CFG_ST_TIMEDELTA
+            wait_us = constrain_uint32(wait_us, min_delay_us, max_delay_us);
+            mask = chEvtWaitOneTimeout(group.dshot_event_mask, chTimeUS2I(wait_us));
+
             // no time left cancel and restart
             if (!mask) {
                 dma_cancel(group);

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -313,9 +313,13 @@ T constrain_value(const T amt, const T low, const T high)
 }
 
 template int constrain_value<int>(const int amt, const int low, const int high);
+template unsigned int constrain_value<unsigned int>(const unsigned int amt, const unsigned int low, const unsigned int high);
 template long constrain_value<long>(const long amt, const long low, const long high);
+template unsigned long constrain_value<unsigned long>(const unsigned long amt, const unsigned long low, const unsigned long high);
 template long long constrain_value<long long>(const long long amt, const long long low, const long long high);
+template unsigned long long constrain_value<unsigned long long>(const unsigned long long amt, const unsigned long long low, const unsigned long long high);
 template short constrain_value<short>(const short amt, const short low, const short high);
+template unsigned short constrain_value<unsigned short>(const unsigned short amt, const unsigned short low, const unsigned short high);
 template float constrain_value<float>(const float amt, const float low, const float high);
 template double constrain_value<double>(const double amt, const double low, const double high);
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -179,12 +179,27 @@ inline int16_t constrain_int16(const int16_t amt, const int16_t low, const int16
     return constrain_value(amt, low, high);
 }
 
+inline uint16_t constrain_uint16(const uint16_t amt, const uint16_t low, const uint16_t high)
+{
+    return constrain_value(amt, low, high);
+}
+
 inline int32_t constrain_int32(const int32_t amt, const int32_t low, const int32_t high)
 {
     return constrain_value(amt, low, high);
 }
 
+inline uint32_t constrain_uint32(const uint32_t amt, const uint32_t low, const uint32_t high)
+{
+    return constrain_value(amt, low, high);
+}
+
 inline int64_t constrain_int64(const int64_t amt, const int64_t low, const int64_t high)
+{
+    return constrain_value(amt, low, high);
+}
+
+inline uint64_t constrain_uint64(const uint64_t amt, const uint64_t low, const uint64_t high)
 {
     return constrain_value(amt, low, high);
 }

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -383,6 +383,10 @@ TEST(MathTest, Constrain)
     EXPECT_EQ(19.9, constrain_value(19.8, 19.9, 20.1));
     EXPECT_EQ(19.9f, constrain_value(19.8f, 19.9f, 20.1f));
 
+    // test that constrain on 32 bit integer works correctly. Note the asymmetry
+    EXPECT_EQ(10,    constrain_int32( 0xFFFFFFFFU, 10U, 1200U));
+    EXPECT_EQ(1200U, constrain_uint32(0xFFFFFFFFU, 10U, 1200U));
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     EXPECT_EQ(1.0f, constrain_float(nanf("0x4152"), 1.0f, 1.0f));
     EXPECT_EQ(1.0f, constrain_value(nanf("0x4152"), 1.0f, 1.0f));


### PR DESCRIPTION
this prevents bad calculated timeouts in DShot. The timeout would
sometimes come out as 0xFFFFFFFF, which led to an assert and could
block the thread

This fix is meant to be minimilistic to allow it to be merged easily
into 4.2. A better fix would fix all the uint32_t wrap handling in
DShot