### PR TITLE
Fix application of EKF accel bias to earth-frame accel in AHRS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -606,7 +606,7 @@ void AP_AHRS::update_EKF3(void)
             // update _accel_ef_ekf
             for (uint8_t i=0; i<_ins.get_accel_count(); i++) {
                 Vector3f accel = _ins.get_accel(i);
-                if (i==_ins.get_primary_accel()) {
+                if (i == primary_imu) {
                     accel -= abias;
                 }
                 if (_ins.get_accel_health(i)) {


### PR DESCRIPTION
.... and add test for same.

The problem comes about because we ask the EKF for biases for the primary core - but we apply those corrections based on *the inertial sensor library's concept of the primary IMU*.  If you do not happen to have a core on that primary IMU then we end up applying the correction... elsehwere.  Roughly speaking that's having all of your `INS_USE` parameters true but having an `EK3_IMU_MASK` along the lines of `0x10`

This problem was discovered in-flight when Copter's landing detector failed to trigger - the EKF had learnt an accel z-bias of close to 1 for it sole core (using the second IMU), but that wasn't being applied to the INS's primary IMU (first IMU).

This can be replicated in SITL:
```
param set EK3_IMU_MASK 2
param set SIM_ACC2_BIAS_Z 0.7
param set LOG_DISARMED 1
reboot
```

wait 30 seconds, ctrl-c

`graph RATE.A` on the resulting logfile - it will indicate the vehicle is accelerating when it really isn't (note that it's in cm/s/s)

This is a minimal fix.  A better fix is probably to get the accel bias corrections from each core in turn, and apply that to the earth-frame-accels for the IMU that core is using.
