### PR TITLE
AP_InertialSensor: fixed BMI088 FIFO sync errors

### DIFF
--- a/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
+++ b/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
@@ -48,6 +48,10 @@ void GCS_MAVLINK::handle_device_op_read(const mavlink_message_t &msg)
         retcode = 2;
         goto fail;
     }
+    if (packet.count > sizeof(data)) {
+        retcode = 5;
+        goto fail;
+    }
     if (!dev->get_semaphore()->take(10)) {
         retcode = 3;
         goto fail;        


### PR DESCRIPTION
we have seen errors where the BMI088 gets out of sync, so that the 3 axes are rotated. The data is shifted by 4 bytes, so that X=Z, Y=X and Z=Y
    
this changes the BMI088 to "stop on full" mode, which is what Bosch use in their example drivers, and also catches FIFO overrun events and triggers a full FIFO reset. This should fix the problem with the FIFO sync
