### PR TITLE
Tools: scripts install_preqs_ubuntu python add dronecan

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -131,9 +131,9 @@ fi
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 if [ ${RELEASE_CODENAME} == 'xenial' ] || [ ${RELEASE_CODENAME} == 'disco' ] || [ ${RELEASE_CODENAME} == 'eoan' ]; then
     # use fixed version for package that drop python2 support
-    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 geocoder empy configparser==5.0.0 click==7.1.2 decorator==4.4.2"
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 geocoder empy configparser==5.0.0 click==7.1.2 decorator==4.4.2 dronecan"
 else
-    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder empy"
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder empy dronecan"
 fi
 
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:


### PR DESCRIPTION
Hi, 
I found a bug in docker image, it misses dronecan library.
When I try to run `../Tools/autotest/sim_vehicle.py` I got the following error when I try to build the project inside a docker container 

The code run without any errors after adding the `dronecan` library package to `Tools/environment_install/install-prereqs-ubuntu.sh` file and rebuild the docker image.

```
ardupilot@a61fdfa19f06:/ardupilot/ArduCopter$ ../Tools/autotest/sim_vehicle.py
SIM_VEHICLE: Start
SIM_VEHICLE: Killing tasks
SIM_VEHICLE: Starting up at SITL location
SIM_VEHICLE: WAF build
SIM_VEHICLE: Configure waf
SIM_VEHICLE: "/ardupilot/modules/waf/waf-light" "configure" "--board" "sitl"
Setting top to                           : /ardupilot
Setting out to                           : /ardupilot/build
Autoconfiguration                        : enabled
Setting board to                         : sitl
Using toolchain                          : native
Checking for 'g++' (C++ compiler)        : /usr/lib/ccache/g++
Checking for 'gcc' (C compiler)          : /usr/lib/ccache/gcc
Checking for c flags '-MMD'              : yes
Checking for cxx flags '-MMD'            : yes
CXX Compiler                             : g++ 9.4.0
Checking for need to link with librt     : not necessary
Checking for feenableexcept              : yes
Checking for HAVE_CMATH_ISFINITE         : yes
Checking for HAVE_CMATH_ISINF            : yes
Checking for HAVE_CMATH_ISNAN            : yes
Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE : yes
Checking for NEED_CMATH_ISINF_STD_NAMESPACE    : yes
Checking for NEED_CMATH_ISNAN_STD_NAMESPACE    : yes
Checking for header endian.h                   : yes
Checking for header byteswap.h                 : yes
Checking for HAVE_MEMRCHR                      : yes
Configured VSCode Intellisense:                : no
Checking for program 'python'                  : /usr/bin/python
Checking for python version >= 2.7.0           : 3.8.10
Checking for program 'python'                  : /usr/bin/python
Checking for python version >= 2.7.0           : 3.8.10
Source is git repository                       : yes
Update submodules                              : yes
Checking for program 'git'                     : /usr/bin/git
Checking for program 'size'                    : /usr/bin/size
Benchmarks                                     : disabled
Unit tests                                     : enabled
Scripting                                      : enabled
Scripting runtime checks                       : enabled
Debug build                                    : disabled
Coverage build                                 : disabled
SITL 32-bit build                              : disabled
Checking for program 'rsync'                   : not found
'configure' finished successfully (3.600s)
SIM_VEHICLE: Building
SIM_VEHICLE: "/ardupilot/modules/waf/waf-light" "build" "--target" "bin/arducopter"
Waf: Entering directory `/ardupilot/build/sitl'
Embedding file locations.txt:Tools/autotest/locations.txt
Embedding file models/Callisto.json:Tools/autotest/models/Callisto.json
[2/2] Running Submodule update: mavlink
Submodule path 'modules/mavlink/pymavlink': checked out 'd35da2692218f7a547bc60b99f6fab851bc9434c'

Submodule 'pymavlink' (https://github.com/ArduPilot/pymavlink.git) registered for path 'modules/mavlink/pymavlink'
Cloning into '/ardupilot/modules/mavlink/pymavlink'...

[3/7] Compiling libraries/AP_Scripting/generator/src/main.c
[4/7] Processing modules/mavlink/message_definitions/v1.0/all.xml
[5/7] Processing uavcangen: modules/DroneCAN/DSDL/ardupilot modules/DroneCAN/DSDL/com modules/DroneCAN/DSDL/cuav modules/DroneCAN/DSDL/dronecan modules/DroneCAN/DSDL/mppt modules/DroneCAN/DSDL/uavcan
[6/7] Creating build/sitl/ap_version.h
Validation skipped for /ardupilot/modules/mavlink/message_definitions/v1.0/all.xml.
Parsing /ardupilot/modules/mavlink/message_definitions/v1.0/all.xml
Validation skipped for /ardupilot/modules/mavlink/message_definitions/v1.0/ardupilotmega.xml.
Parsing /ardupilot/modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
Traceback (most recent call last):
  File "/ardupilot/modules/uavcan/libuavcan/dsdl_compiler/libuavcan_dsdlc", line 59, in <module>
    from libuavcan_dsdl_compiler import run as dsdlc_run
  File "/ardupilot/modules/uavcan/libuavcan/dsdl_compiler/libuavcan_dsdl_compiler/__init__.py", line 18, in <module>
    from dronecan import dsdl
ModuleNotFoundError: No module named 'dronecan'
```