### PR TITLE
AP_Filesystem: AP_Filesystem_ESP32 allow_absolute_paths in ::open()

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
@@ -26,7 +26,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-int AP_Filesystem_ESP32::open(const char *fname, int flags)
+int AP_Filesystem_ESP32::open(const char *fname, int flags, bool allow_absolute_paths)
 {
 #if FSDEBUG
     printf("DO open %s \n", fname);


### PR DESCRIPTION
This was broken by #20193 