### PR TITLE
Remove instance id from EK3 external interface 

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -569,7 +569,7 @@ void AP_AHRS::update_EKF3(void)
         if (active_EKF_type() == EKFType::THREE) {
             Vector3f eulers;
             EKF3.getRotationBodyToNED(_dcm_matrix);
-            EKF3.getEulerAngles(-1,eulers);
+            EKF3.getEulerAngles(eulers);
             roll  = eulers.x;
             pitch = eulers.y;
             yaw   = eulers.z;
@@ -615,7 +615,7 @@ void AP_AHRS::update_EKF3(void)
             }
             _accel_ef_ekf_blended = _accel_ef_ekf[_ins.get_primary_accel()];
             nav_filter_status filt_state;
-            EKF3.getFilterStatus(-1,filt_state);
+            EKF3.getFilterStatus(filt_state);
             update_notify_from_filter_status(filt_state);
         }
     }
@@ -828,7 +828,7 @@ Vector3f AP_AHRS::wind_estimate(void) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getWind(-1,wind);
+        EKF3.getWind(wind);
         break;
 #endif
 
@@ -918,7 +918,7 @@ bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        ret = EKF3.getWind(-1,wind_vel);
+        ret = EKF3.getWind(wind_vel);
         break;
 #endif
 
@@ -992,7 +992,7 @@ bool AP_AHRS::airspeed_vector_true(Vector3f &vec) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        return EKF3.getAirSpdVec(-1, vec);
+        return EKF3.getAirSpdVec(vec);
 #endif
 
 #if AP_AHRS_SIM_ENABLED
@@ -1071,7 +1071,7 @@ bool AP_AHRS::get_quaternion(Quaternion &quat) const
         if (!_ekf3_started) {
             return false;
         }
-        EKF3.getQuaternion(-1, quat);
+        EKF3.getQuaternion(quat);
         break;
 #endif
 #if AP_AHRS_SIM_ENABLED
@@ -1123,7 +1123,7 @@ bool AP_AHRS::get_secondary_attitude(Vector3f &eulers) const
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // EKF3 is secondary
-        EKF3.getEulerAngles(-1, eulers);
+        EKF3.getEulerAngles(eulers);
         return _ekf3_started;
 #endif
 
@@ -1184,7 +1184,7 @@ bool AP_AHRS::get_secondary_quaternion(Quaternion &quat) const
         if (!_ekf3_started) {
             return false;
         }
-        EKF3.getQuaternion(-1, quat);
+        EKF3.getQuaternion(quat);
         break;
 #endif
 
@@ -1269,7 +1269,7 @@ Vector2f AP_AHRS::groundspeed_vector(void)
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getVelNED(-1,vec);
+        EKF3.getVelNED(vec);
         return Vector2f(vec.x, vec.y);
 #endif
 
@@ -1382,7 +1382,7 @@ bool AP_AHRS::get_velocity_NED(Vector3f &vec) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getVelNED(-1,vec);
+        EKF3.getVelNED(vec);
         return true;
 #endif
 
@@ -1419,7 +1419,7 @@ bool AP_AHRS::get_mag_field_NED(Vector3f &vec) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getMagNED(-1,vec);
+        EKF3.getMagNED(vec);
         return true;
 #endif
 
@@ -1450,7 +1450,7 @@ bool AP_AHRS::get_mag_field_correction(Vector3f &vec) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getMagXYZ(-1,vec);
+        EKF3.getMagXYZ(vec);
         return true;
 #endif
 
@@ -1483,7 +1483,7 @@ bool AP_AHRS::get_vert_pos_rate(float &velocity) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        velocity = EKF3.getPosDownDerivative(-1);
+        velocity = EKF3.getPosDownDerivative();
         return true;
 #endif
 
@@ -1570,7 +1570,7 @@ bool AP_AHRS::get_relative_position_NED_origin(Vector3f &vec) const
     case EKFType::THREE: {
             Vector2f posNE;
             float posD;
-            if (EKF3.getPosNE(-1,posNE) && EKF3.getPosD(-1,posD)) {
+            if (EKF3.getPosNE(posNE) && EKF3.getPosD(posD)) {
                 // position is valid
                 vec.x = posNE.x;
                 vec.y = posNE.y;
@@ -1653,7 +1653,7 @@ bool AP_AHRS::get_relative_position_NE_origin(Vector2f &posNE) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
-        bool position_is_valid = EKF3.getPosNE(-1,posNE);
+        bool position_is_valid = EKF3.getPosNE(posNE);
         return position_is_valid;
     }
 #endif
@@ -1723,7 +1723,7 @@ bool AP_AHRS::get_relative_position_D_origin(float &posD) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
-        bool position_is_valid = EKF3.getPosD(-1,posD);
+        bool position_is_valid = EKF3.getPosD(posD);
         return position_is_valid;
     }
 #endif
@@ -1860,7 +1860,7 @@ AP_AHRS::EKFType AP_AHRS::active_EKF_type(void) const
         }
         if (always_use_EKF()) {
             uint16_t ekf3_faults;
-            EKF3.getFilterFaults(-1,ekf3_faults);
+            EKF3.getFilterFaults(ekf3_faults);
             if (ekf3_faults == 0) {
                 ret = EKFType::THREE;
             }
@@ -1903,7 +1903,7 @@ AP_AHRS::EKFType AP_AHRS::active_EKF_type(void) const
 #endif
 #if HAL_NAVEKF3_AVAILABLE
         if (ret == EKFType::THREE) {
-            EKF3.getFilterStatus(-1,filt_state);
+            EKF3.getFilterStatus(filt_state);
             should_use_gps = EKF3.configuredToUseGPSForPosXY();
         }
 #endif
@@ -2161,7 +2161,7 @@ bool AP_AHRS::get_filter_status(nav_filter_status &status) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        EKF3.getFilterStatus(-1,status);
+        EKF3.getFilterStatus(status);
         return true;
 #endif
 
@@ -2711,7 +2711,7 @@ bool AP_AHRS::get_origin(Location &ret) const
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        if (!EKF3.getOriginLLH(-1,ret)) {
+        if (!EKF3.getOriginLLH(ret)) {
             return false;
         }
         return true;
@@ -2817,7 +2817,7 @@ bool AP_AHRS::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // use EKF to get innovations
-        return EKF3.getInnovations(-1, velInnov, posInnov, magInnov, tasInnov, yawInnov);
+        return EKF3.getInnovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
 #endif
 
 #if AP_AHRS_SIM_ENABLED
@@ -2845,7 +2845,7 @@ bool AP_AHRS::is_vibration_affected() const
     switch (ekf_type()) {
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        return EKF3.isVibrationAffected(-1);
+        return EKF3.isVibrationAffected();
 #endif
     case EKFType::NONE:
 #if HAL_NAVEKF2_AVAILABLE
@@ -2885,7 +2885,7 @@ bool AP_AHRS::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3
     case EKFType::THREE: {
         // use EKF to get variance
         Vector2f offset;
-        return EKF3.getVariances(-1, velVar, posVar, hgtVar, magVar, tasVar, offset);
+        return EKF3.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
     }
 #endif
 
@@ -2926,7 +2926,7 @@ bool AP_AHRS::get_vel_innovations_and_variances_for_source(uint8_t source, Vecto
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // use EKF to get variance
-        return EKF3.getVelInnovationsAndVariancesForSource(-1, (AP_NavEKF_Source::SourceXY)source, innovations, variances);
+        return EKF3.getVelInnovationsAndVariancesForSource((AP_NavEKF_Source::SourceXY)source, innovations, variances);
 #endif
 
 #if AP_AHRS_SIM_ENABLED
@@ -2956,7 +2956,7 @@ uint8_t AP_AHRS::get_active_airspeed_index() const
 // we only have affinity for EKF3 as of now
 #if HAL_NAVEKF3_AVAILABLE
     if (active_EKF_type() == EKFType::THREE) {
-        uint8_t ret = EKF3.getActiveAirspeed(get_primary_core_index());
+        uint8_t ret = EKF3.getActiveAirspeed();
         if (ret != 255 && airspeed->healthy(ret)) {
             return ret;
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1154,55 +1154,49 @@ int8_t NavEKF3::getPrimaryCoreIMUIndex(void) const
 // Write the last calculated NE position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
-bool NavEKF3::getPosNE(int8_t instance, Vector2f &posNE) const
+bool NavEKF3::getPosNE(Vector2f &posNE) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (!core) {
         return false;
     }
-    return core[instance].getPosNE(posNE);
+    return core[primary].getPosNE(posNE);
 }
 
 // Write the last calculated D position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
-bool NavEKF3::getPosD(int8_t instance, float &posD) const
+bool NavEKF3::getPosD(float &posD) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (!core) {
         return false;
     }
-    return core[instance].getPosD(posD);
+    return core[primary].getPosD(posD);
 }
 
 // return NED velocity in m/s
-void NavEKF3::getVelNED(int8_t instance, Vector3f &vel) const
+void NavEKF3::getVelNED(Vector3f &vel) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getVelNED(vel);
+        core[primary].getVelNED(vel);
     }
 }
 
-// return estimate of true airspeed vector in body frame in m/s for the specified instance
-// An out of range instance (eg -1) returns data for the primary instance
+// return estimate of true airspeed vector in body frame in m/s
 // returns false if estimate is unavailable
-bool NavEKF3::getAirSpdVec(int8_t instance, Vector3f &vel) const
+bool NavEKF3::getAirSpdVec(Vector3f &vel) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        return core[instance].getAirSpdVec(vel);
+        return core[primary].getAirSpdVec(vel);
     }
     return false;
 }
 
 // Return the rate of change of vertical position in the down direction (dPosD/dt) in m/s
-float NavEKF3::getPosDownDerivative(int8_t instance) const
+float NavEKF3::getPosDownDerivative() const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     // return the value calculated from a complementary filter applied to the EKF height and vertical acceleration
     if (core) {
-        return core[instance].getPosDownDerivative();
+        return core[primary].getPosDownDerivative();
     }
     return 0.0f;
 }
@@ -1273,40 +1267,35 @@ void NavEKF3::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainSca
 
 // return the NED wind speed estimates in m/s (positive is air moving in the direction of the axis)
 // returns true if wind state estimation is active
-bool NavEKF3::getWind(int8_t instance, Vector3f &wind) const
+bool NavEKF3::getWind(Vector3f &wind) const
 {
-    bool ret = false;
-    if (instance < 0 || instance >= num_cores) instance = primary;
-    if (core) {
-        ret = core[instance].getWind(wind);
+    if (core == nullptr) {
+        return false;
     }
-    return ret;
+    return core[primary].getWind(wind);
 }
 
 // return earth magnetic field estimates in measurement units / 1000
-void NavEKF3::getMagNED(int8_t instance, Vector3f &magNED) const
+void NavEKF3::getMagNED(Vector3f &magNED) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getMagNED(magNED);
+        core[primary].getMagNED(magNED);
     }
 }
 
 // return body magnetic field estimates in measurement units / 1000
-void NavEKF3::getMagXYZ(int8_t instance, Vector3f &magXYZ) const
+void NavEKF3::getMagXYZ(Vector3f &magXYZ) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getMagXYZ(magXYZ);
+        core[primary].getMagXYZ(magXYZ);
     }
 }
 
-// return the airspeed sensor in use for the specified instance
-uint8_t NavEKF3::getActiveAirspeed(int8_t instance) const
+// return the airspeed sensor in use
+uint8_t NavEKF3::getActiveAirspeed() const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        return core[instance].getActiveAirspeed();
+        return core[primary].getActiveAirspeed();
     } else {
         return 255;
     }
@@ -1343,17 +1332,15 @@ bool NavEKF3::getLLH(struct Location &loc) const
     return core[primary].getLLH(loc);
 }
 
-// Return the latitude and longitude and height used to set the NED origin for the specified instance
-// An out of range instance (eg -1) returns data for the primary instance
+// Return the latitude and longitude and height used to set the NED origin
 // All NED positions calculated by the filter are relative to this location
 // Returns false if the origin has not been set
-bool NavEKF3::getOriginLLH(int8_t instance, struct Location &loc) const
+bool NavEKF3::getOriginLLH(struct Location &loc) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (!core) {
         return false;
     }
-    return core[instance].getOriginLLH(loc);
+    return core[primary].getOriginLLH(loc);
 }
 
 // set the latitude and longitude and height used to set the NED origin
@@ -1393,12 +1380,11 @@ bool NavEKF3::getHAGL(float &HAGL) const
     return core[primary].getHAGL(HAGL);
 }
 
-// return the Euler roll, pitch and yaw angle in radians for the specified instance
-void NavEKF3::getEulerAngles(int8_t instance, Vector3f &eulers) const
+// return the Euler roll, pitch and yaw angle in radians
+void NavEKF3::getEulerAngles(Vector3f &eulers) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getEulerAngles(eulers);
+        core[primary].getEulerAngles(eulers);
     }
 }
 
@@ -1422,45 +1408,39 @@ void NavEKF3::getQuaternionBodyToNED(int8_t instance, Quaternion &quat) const
 }
 
 // return the quaternions defining the rotation from NED to XYZ (autopilot) axes
-void NavEKF3::getQuaternion(int8_t instance, Quaternion &quat) const
+void NavEKF3::getQuaternion(Quaternion &quat) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getQuaternion(quat);
+        core[primary].getQuaternion(quat);
     }
 }
 
-// return the innovations for the specified instance
-bool NavEKF3::getInnovations(int8_t instance, Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const
+// return the innovations
+bool NavEKF3::getInnovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const
 {
     if (core == nullptr) {
         return false;
     }
-    if (instance < 0 || instance >= num_cores) instance = primary;
 
-    return core[instance].getInnovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
+    return core[primary].getInnovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
 }
 
 // return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
-bool NavEKF3::getVariances(int8_t instance, float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const
+bool NavEKF3::getVariances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const
 {
     if (core == nullptr) {
         return false;
     }
-    if (instance < 0 || instance >= num_cores) instance = primary;
 
-    return core[instance].getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
+    return core[primary].getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
 }
 
-// get a source's velocity innovations for the specified instance.  Set instance to -1 for the primary instance
+// get a source's velocity innovations
 // returns true on success and results are placed in innovations and variances arguments
-bool NavEKF3::getVelInnovationsAndVariancesForSource(int8_t instance, AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const
+bool NavEKF3::getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const
 {
-    if (instance < 0 || instance >= num_cores) {
-        instance = primary;
-    }
     if (core) {
-        return core[instance].getVelInnovationsAndVariancesForSource(source, innovations, variances);
+        return core[primary].getVelInnovationsAndVariancesForSource(source, innovations, variances);
     }
     return false;
 }
@@ -1754,11 +1734,10 @@ void NavEKF3::setTerrainHgtStable(bool val)
   6 = badly conditioned synthetic sideslip fusion
   7 = filter is not initialised
 */
-void NavEKF3::getFilterFaults(int8_t instance, uint16_t &faults) const
+void NavEKF3::getFilterFaults(uint16_t &faults) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getFilterFaults(faults);
+        core[primary].getFilterFaults(faults);
     } else {
         faults = 0;
     }
@@ -1767,11 +1746,10 @@ void NavEKF3::getFilterFaults(int8_t instance, uint16_t &faults) const
 /*
   return filter status flags
 */
-void NavEKF3::getFilterStatus(int8_t instance, nav_filter_status &status) const
+void NavEKF3::getFilterStatus(nav_filter_status &status) const
 {
-    if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getFilterStatus(status);
+        core[primary].getFilterStatus(status);
     } else {
         memset(&status, 0, sizeof(status));
     }
@@ -2019,14 +1997,11 @@ bool NavEKF3::yawAlignmentComplete(void) const
     return core[primary].have_aligned_yaw();
 }
 
-// returns true when the state estimates for the selected core are significantly degraded by vibration
-bool NavEKF3::isVibrationAffected(int8_t instance) const
+// returns true when the state estimates are significantly degraded by vibration
+bool NavEKF3::isVibrationAffected() const
 {
-    if (instance < 0 || instance >= num_cores) {
-        instance = primary;
-    }
     if (core) {
-        return core[instance].isVibrationAffected();
+        return core[primary].isVibrationAffected();
     }
     return false;
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -68,32 +68,27 @@ public:
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIMUIndex(void) const;
 
-    // Write the last calculated NE position relative to the reference point (m) for the specified instance.
-    // An out of range instance (eg -1) returns data for the primary instance
+    // Write the last calculated NE position relative to the reference point (m)
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
-    bool getPosNE(int8_t instance, Vector2f &posNE) const;
+    bool getPosNE(Vector2f &posNE) const;
 
-    // Write the last calculated D position relative to the reference point (m) for the specified instance.
-    // An out of range instance (eg -1) returns data for the primary instance
+    // Write the last calculated D position relative to the reference point (m)
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
-    bool getPosD(int8_t instance, float &posD) const;
+    bool getPosD(float &posD) const;
 
-    // return NED velocity in m/s for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    void getVelNED(int8_t instance, Vector3f &vel) const;
+    // return NED velocity in m/s
+    void getVelNED(Vector3f &vel) const;
 
-    // return estimate of true airspeed vector in body frame in m/s for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
+    // return estimate of true airspeed vector in body frame in m/s
     // returns false if estimate is unavailable
-    bool getAirSpdVec(int8_t instance, Vector3f &vel) const;
+    bool getAirSpdVec(Vector3f &vel) const;
 
-    // Return the rate of change of vertical position in the down direction (dPosD/dt) in m/s for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
+    // Return the rate of change of vertical position in the down direction (dPosD/dt) in m/s
     // This can be different to the z component of the EKF velocity state because it will fluctuate with height errors and corrections in the EKF
     // but will always be kinematically consistent with the z component of the EKF position state
-    float getPosDownDerivative(int8_t instance) const;
+    float getPosDownDerivative() const;
 
     // return body axis gyro bias estimates in rad/sec for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
@@ -117,22 +112,19 @@ public:
     // return the scale factor to be applied to navigation velocity gains to compensate for increase in velocity noise with height when using optical flow
     void getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const;
 
-    // return the NED wind speed estimates in m/s (positive is air moving in the direction of the axis)
-    // An out of range instance (eg -1) returns data for the the primary instance
-    // returns true if wind state estimation is active
-    bool getWind(int8_t instance, Vector3f &wind) const;
+    // return the NED wind speed estimates in m/s (positive is air
+    // moving in the direction of the axis) returns true if wind state
+    // estimation is active
+    bool getWind(Vector3f &wind) const;
 
-    // return earth magnetic field estimates in measurement units / 1000 for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    void getMagNED(int8_t instance, Vector3f &magNED) const;
+    // return earth magnetic field estimates in measurement units / 1000
+    void getMagNED(Vector3f &magNED) const;
 
-    // return body magnetic field estimates in measurement units / 1000 for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    void getMagXYZ(int8_t instance, Vector3f &magXYZ) const;
+    // return body magnetic field estimates in measurement units / 1000
+    void getMagXYZ(Vector3f &magXYZ) const;
 
-    // return the sensor in use for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    uint8_t getActiveAirspeed(int8_t instance) const;
+    // return the airspeed sensor in use
+    uint8_t getActiveAirspeed() const;
 
     // Return estimated magnetometer offsets
     // Return true if magnetometer offsets are valid
@@ -144,11 +136,10 @@ public:
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
     bool getLLH(struct Location &loc) const;
 
-    // Return the latitude and longitude and height used to set the NED origin for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
+    // Return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(int8_t instance, struct Location &loc) const;
+    bool getOriginLLH(struct Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -160,9 +151,8 @@ public:
     // return false if ground height is not being estimated.
     bool getHAGL(float &HAGL) const;
 
-    // return the Euler roll, pitch and yaw angle in radians for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    void getEulerAngles(int8_t instance, Vector3f &eulers) const;
+    // return the Euler roll, pitch and yaw angle in radians
+    void getEulerAngles(Vector3f &eulers) const;
 
     // return the transformation matrix from XYZ (body) to NED axes
     void getRotationBodyToNED(Matrix3f &mat) const;
@@ -171,19 +161,17 @@ public:
     void getQuaternionBodyToNED(int8_t instance, Quaternion &quat) const;
 
     // return the quaternions defining the rotation from NED to XYZ (autopilot) axes
-    void getQuaternion(int8_t instance, Quaternion &quat) const;
+    void getQuaternion(Quaternion &quat) const;
 
-    // return the innovations for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    bool getInnovations(int8_t index, Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const;
+    // return the innovations
+    bool getInnovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const;
 
-    // return the innovation consistency test ratios for the specified instance
-    // An out of range instance (eg -1) returns data for the primary instance
-    bool getVariances(int8_t instance, float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const;
+    // return the innovation consistency test ratios
+    bool getVariances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const;
 
-    // get a source's velocity innovations for the specified instance.  Set instance to -1 for the primary instance
+    // get a source's velocity innovations
     // returns true on success and results are placed in innovations and variances arguments
-    bool getVelInnovationsAndVariancesForSource(int8_t instance, AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const WARN_IF_UNUSED;
+    bool getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const WARN_IF_UNUSED;
 
     // should we use the compass? This is public so it can be used for
     // reporting via ahrs.use_compass()
@@ -271,8 +259,7 @@ public:
     void setTerrainHgtStable(bool val);
 
     /*
-    return the filter fault status as a bitmasked integer for the specified instance
-    An out of range instance (eg -1) returns data for the primary instance
+    return the filter fault status as a bitmasked integer
      0 = quaternions are NaN
      1 = velocities are NaN
      2 = badly conditioned X magnetometer fusion
@@ -282,13 +269,12 @@ public:
      6 = badly conditioned synthetic sideslip fusion
      7 = filter is not initialised
     */
-    void getFilterFaults(int8_t instance, uint16_t &faults) const;
+    void getFilterFaults(uint16_t &faults) const;
 
     /*
-    return filter status flags for the specified instance
-    An out of range instance (eg -1) returns data for the primary instance
+    return filter status flags
     */
-    void getFilterStatus(int8_t instance, nav_filter_status &status) const;
+    void getFilterStatus(nav_filter_status &status) const;
 
     // send an EKF_STATUS_REPORT message to GCS
     void send_status_report(mavlink_channel_t chan) const;
@@ -358,9 +344,9 @@ public:
     // returns true when the yaw angle has been aligned
     bool yawAlignmentComplete(void) const;
 
-    // returns true when the state estimates for the selected core are significantly degraded by vibration
-    // if instance < 0, the primary instance will be used
-    bool isVibrationAffected(int8_t instance) const;
+    // returns true when the state estimates are significantly
+    // degraded by vibration
+    bool isVibrationAffected() const;
 
     // get a yaw estimator instance
     const EKFGSF_yaw *get_yawEstimator(void) const;


### PR DESCRIPTION
Removes passing of instance id in interfaces where -1 was the only value
ever passed in

On MatekF405:
```
Binary Name      Text [B]         Data [B]     BSS (B)        Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  ---------------  -----------  -------------  ----------------------------  -------------------------
antennatracker   -380 (-0.0574%)  0 (0.0000%)  4 (+0.0031%)   -380 (-0.0573%)                                  320624
ardusub          -404 (-0.0498%)  0 (0.0000%)  4 (+0.0031%)   -404 (-0.0497%)                                  170824
ardurover        -380 (-0.0444%)  0 (0.0000%)  -4 (-0.0031%)  -380 (-0.0444%)                                  127584
arducopter       -420 (-0.0452%)  0 (0.0000%)  4 (+0.0031%)   -420 (-0.0451%)                                   51196
blimp            -404 (-0.0594%)  0 (0.0000%)  -4 (-0.0031%)  -404 (-0.0593%)                                  302280
arducopter-heli  -420 (-0.0446%)  0 (0.0000%)  -4 (-0.0031%)  -420 (-0.0445%)                                   40196
arduplane        -404 (-0.0418%)  0 (0.0000%)  4 (+0.0031%)   -404 (-0.0417%)                                   13808
```

We'd get another few hundred bytes with the equivalent modification on EK2.
