### PR TITLE
Copter: factor failsafe reporting

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -743,6 +743,7 @@ private:
     void set_mode_auto_do_land_start_or_RTL(ModeReason reason);
     bool should_disarm_on_failsafe();
     void do_failsafe_action(FailsafeAction action, ModeReason reason);
+    void announce_failsafe(const char *type, const char *action_undertaken=nullptr);
 
     // failsafe.cpp
     void failsafe_enable();

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -43,33 +43,33 @@ void Copter::failsafe_radio_on_event()
     // Conditions to deviate from FS_THR_ENABLE selection and send specific GCS warning
     if (should_disarm_on_failsafe()) {
         // should immediately disarm when we're on the ground
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Disarming");
+        announce_failsafe("Radio", "Disarming");
         arming.disarm(AP_Arming::Method::RADIOFAILSAFE);
         desired_action = FailsafeAction::NONE;
 
     } else if (flightmode->is_landing() && ((battery.has_failsafed() && battery.get_highest_failsafe_priority() <= FAILSAFE_LAND_PRIORITY))) {
         // Allow landing to continue when battery failsafe requires it (not a user option)
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio + Battery Failsafe - Continuing Landing");
+        announce_failsafe("Radio + Battery", "Continuing Landing");
         desired_action = FailsafeAction::LAND;
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING)) {
         // Allow landing to continue when FS_OPTIONS is set to continue landing
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Landing");
+        announce_failsafe("Radio", "Continuing Landing");
         desired_action = FailsafeAction::LAND;
 
     } else if (flightmode->mode_number() == Mode::Number::AUTO && failsafe_option(FailsafeOption::RC_CONTINUE_IF_AUTO)) {
         // Allow mission to continue when FS_OPTIONS is set to continue mission
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Auto Mode");       
+        announce_failsafe("Radio", "Continuing Auto");
         desired_action = FailsafeAction::NONE;
 
     } else if ((flightmode->in_guided_mode()) &&
       (failsafe_option(FailsafeOption::RC_CONTINUE_IF_GUIDED)) && (g.failsafe_gcs != FS_GCS_DISABLED)) {
         // Allow guided mode to continue when FS_OPTIONS is set to continue in guided mode.  Only if the GCS failsafe is enabled.
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Guided Mode");
+        announce_failsafe("Radio", "Continuing Guided Mode");
         desired_action = FailsafeAction::NONE;
 
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe");
+        announce_failsafe("Radio");
     }
 
     // Call the failsafe action handler
@@ -85,6 +85,15 @@ void Copter::failsafe_radio_off_event()
     gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe Cleared");
 }
 
+void Copter::announce_failsafe(const char *type, const char *action_undertaken)
+{
+    if (action_undertaken != nullptr) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe - %s", type, action_undertaken);
+    } else {
+        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe", type);
+    }
+}
+
 void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
 {
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_BATT, LogErrorCode::FAILSAFE_OCCURRED);
@@ -96,14 +105,14 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
         // should immediately disarm when we're on the ground
         arming.disarm(AP_Arming::Method::BATTERYFAILSAFE);
         desired_action = FailsafeAction::NONE;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe - Disarming");
+        announce_failsafe("Battery", "Disarming");
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING) && desired_action != FailsafeAction::NONE) {
         // Allow landing to continue when FS_OPTIONS is set to continue when landing
         desired_action = FailsafeAction::LAND;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe - Continuing Landing");
+        announce_failsafe("Battery", "Continuing Landing");
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe");
+        announce_failsafe("Battery");
     }
 
     // Battery FS options already use the Failsafe_Options enum. So use them directly.
@@ -183,35 +192,35 @@ void Copter::failsafe_gcs_on_event(void)
     // Conditions to deviate from FS_GCS_ENABLE parameter setting
     if (!motors->armed()) {
         desired_action = FailsafeAction::NONE;
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe");
+        announce_failsafe("GCS");
 
     } else if (should_disarm_on_failsafe()) {
         // should immediately disarm when we're on the ground
         arming.disarm(AP_Arming::Method::GCSFAILSAFE);
         desired_action = FailsafeAction::NONE;
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe - Disarming");
+        announce_failsafe("GCS", "Disarming");
 
     } else if (flightmode->is_landing() && ((battery.has_failsafed() && battery.get_highest_failsafe_priority() <= FAILSAFE_LAND_PRIORITY))) {
         // Allow landing to continue when battery failsafe requires it (not a user option)
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS + Battery Failsafe - Continuing Landing");
+        announce_failsafe("GCS + Battery", "Continuing Landing");
         desired_action = FailsafeAction::LAND;
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING)) {
         // Allow landing to continue when FS_OPTIONS is set to continue landing
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe - Continuing Landing");
+        announce_failsafe("GCS", "Continuing Landing");
         desired_action = FailsafeAction::LAND;
 
     } else if (flightmode->mode_number() == Mode::Number::AUTO && failsafe_option(FailsafeOption::GCS_CONTINUE_IF_AUTO)) {
         // Allow mission to continue when FS_OPTIONS is set to continue mission
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe - Continuing Auto Mode");
+        announce_failsafe("GCS", "Continuing Auto Mode");
         desired_action = FailsafeAction::NONE;
 
     } else if (failsafe_option(FailsafeOption::GCS_CONTINUE_IF_PILOT_CONTROL) && !flightmode->is_autopilot()) {
         // should continue when in a pilot controlled mode because FS_OPTIONS is set to continue in pilot controlled modes
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe - Continuing Pilot Control");
+        announce_failsafe("GCS", "Continuing Pilot Control");
         desired_action = FailsafeAction::NONE;
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe");
+        announce_failsafe("GCS");
     }
 
     // Call the failsafe action handler


### PR DESCRIPTION
Saves ~200 bytes on KakuteF4-Heli

Would be nice to pass a FailsafeAction into this rather than a string, but we don't have one for "disarm" at the very least, and that's what one of the strings read.
