### PR TITLE
hwdef: disable GPS drivers on low flash boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
@@ -161,5 +161,8 @@ define HAL_BATT_CURR_PIN 12
 define HAL_BATT_VOLT_SCALE 11
 define HAL_BATT_CURR_SCALE 25
 
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc
+
 # enable IMU fast sampling
 define HAL_DEFAULT_INS_FAST_SAMPLE 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
@@ -147,3 +147,6 @@ define HAL_LOGGING_DATAFLASH_ENABLED 1
 define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/hwdef.dat
@@ -153,3 +153,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 # To complementary channels work we define this
 #define STM32_PWM_USE_ADVANCED TRUE
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OmnibusNanoV6/hwdef.dat
@@ -150,3 +150,6 @@ define STM32_PWM_USE_ADVANCED TRUE
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 define HAL_MOUNT_ENABLED 0
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
@@ -131,3 +131,6 @@ define HAL_SPRAYER_ENABLED 0
 
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
@@ -180,3 +180,6 @@ define HAL_RUNCAM_ENABLED 0
 define HAL_SPEKTRUM_TELEM_ENABLED 0
 define HAL_SOARING_ENABLED 0
 define AP_OPTICALFLOW_ENABLED 0
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
@@ -13,3 +13,6 @@ define HAL_MINIMIZE_FEATURES 1
 
 # we don't have a flash page spare to write parameters to:
 undef STORAGE_FLASH_PAGE
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimal_GPS.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimal_GPS.inc
@@ -1,0 +1,5 @@
+# include file to reduce flash by including less GPS drivers
+
+define AP_GPS_BACKEND_DEFAULT_ENABLED 0
+define AP_GPS_UBLOX_ENABLED 1
+

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4v6/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4v6/hwdef.dat
@@ -149,3 +149,6 @@ define STM32_PWM_USE_ADVANCED TRUE
 define OSD_ENABLED 1
 #font for the osd
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
@@ -145,3 +145,6 @@ define HAL_LOGGING_DATAFLASH_ENABLED 1
 define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
+
+# minimal GPS drivers to reduce flash usage
+include ../include/minimal_GPS.inc


### PR DESCRIPTION
only leave uBlox enabled on boards that are running out of flash