### PR TITLE
Copter: properly set feedforward enabled before exiting SysID

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1471,6 +1471,7 @@ public:
 
     bool init(bool ignore_checks) override;
     void run() override;
+    void exit() override;
 
     bool requires_GPS() const override { return false; }
     bool has_manual_throttle() const override { return true; }

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -104,6 +104,13 @@ bool ModeSystemId::init(bool ignore_checks)
     return true;
 }
 
+// systemId_exit - clean up systemId controller before exiting
+void ModeSystemId::exit()
+{
+    // reset the feedfoward enabled parameter to the initialized state
+    attitude_control->bf_feedforward(att_bf_feedforward);
+}
+
 // systemId_run - runs the systemId controller
 // should be called at 100hz or more
 void ModeSystemId::run()
@@ -179,9 +186,9 @@ void ModeSystemId::run()
 
     switch (systemid_state) {
         case SystemIDModeState::SYSTEMID_STATE_STOPPED:
+            attitude_control->bf_feedforward(att_bf_feedforward);
             break;
         case SystemIDModeState::SYSTEMID_STATE_TESTING:
-            attitude_control->bf_feedforward(att_bf_feedforward);
 
             if (copter.ap.land_complete) {
                 systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;


### PR DESCRIPTION
the feedforward enabled variable was never reset before exiting.  Thus if a sweep was conducted with recovery roll (feedforward off) and subsequently conducted with just roll (feedforward on), then the feedforward enabled variable would never get set back to its original value after the recovery roll sweep.  

This PR adds an exit() method to reset the feedforward enabled variable.

No functional testing has been completed yet.
