### PR TITLE
Add specific compile options for Volz/RobotisServo

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -137,6 +137,10 @@ BUILD_OPTIONS = [
     Feature('GPS Drivers', 'NOVA', 'AP_GPS_NOVA_ENABLED', 'Enable NOVA GPS', 0, None),
     Feature('GPS Drivers', 'SBF', 'AP_GPS_SBF_ENABLED', 'Enable SBF GPS', 0, None),
     Feature('GPS Drivers', 'SIRF', 'AP_GPS_SIRF_ENABLED', 'Enable SiRF GPS', 0, None),
+
+    Feature('Actuators', 'Volz', 'AP_VOLZ_ENABLED', 'Enable Volz Protocol', 0, None),
+    Feature('Actuators', 'RobotisServo', 'AP_ROBOTISSERVO_ENABLED', 'Enable RobotisServo Protocol', 0, None),
+    Feature('Actuators', 'FETTecOneWire', 'AP_FETTEC_ONEWIRE_ENABLED', 'Enable FETTec OneWire ESCs', 0, None),
 ]
 
 BUILD_OPTIONS.sort(key=lambda x: x.category)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2774,6 +2774,10 @@ def add_apperiph_defaults(f):
 #define AP_AIRSPEED_AUTOCAL_ENABLE 0
 #endif
 
+#ifndef AP_VOLZ_ENABLED
+#define AP_VOLZ_ENABLED 0
+#endif
+
 ''')
 
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2778,6 +2778,10 @@ def add_apperiph_defaults(f):
 #define AP_VOLZ_ENABLED 0
 #endif
 
+#ifndef AP_ROBOTISSERVO_ENABLED
+#define AP_ROBOTISSERVO_ENABLED 0
+#endif
+
 ''')
 
 

--- a/libraries/AP_RobotisServo/AP_RobotisServo.cpp
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.cpp
@@ -34,14 +34,14 @@
 * limitations under the License.
 */
 
+#include "AP_RobotisServo.h"
+
+#if AP_ROBOTISSERVO_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <SRV_Channel/SRV_Channel.h>
-
-#include "AP_RobotisServo.h"
-
-#if NUM_SERVO_CHANNELS
 
 extern const AP_HAL::HAL& hal;
 
@@ -406,4 +406,5 @@ void AP_RobotisServo::update()
         send_command(i+1, REG_GOAL_POSITION, value, 4);
     }
 }
-#endif //NUM_SERVO_CHANNELS
+
+#endif  // AP_ROBOTISSERVO_ENABLED

--- a/libraries/AP_RobotisServo/AP_RobotisServo.h
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.h
@@ -18,6 +18,14 @@
 
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_ROBOTISSERVO_ENABLED
+#define AP_ROBOTISSERVO_ENABLED 1
+#endif
+
+#if AP_ROBOTISSERVO_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 
@@ -65,3 +73,5 @@ private:
     uint32_t last_send_us;
     uint32_t delay_time_us;
 };
+
+#endif  // AP_ROBOTISSERVO_ENABLED

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -4,13 +4,14 @@
  *  Created on: Oct 31, 2017
  *      Author: guy
  */
-#include <AP_HAL/AP_HAL.h>
-#include <SRV_Channel/SRV_Channel.h>
-
 #include "AP_Volz_Protocol.h"
-#if NUM_SERVO_CHANNELS
+
+#if AP_VOLZ_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
 
 #include <AP_SerialManager/AP_SerialManager.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -158,4 +159,5 @@ void AP_Volz_Protocol::update_volz_bitmask(uint32_t new_bitmask)
 
     volz_time_frame_micros = channels_micros;
 }
-#endif //NUM_SERVO_CHANNELS
+
+#endif  // AP_VOLZ_ENABLED

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
@@ -33,6 +33,14 @@
 
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_VOLZ_ENABLED
+#define AP_VOLZ_ENABLED 1
+#endif
+
+#if AP_VOLZ_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 
@@ -73,3 +81,5 @@ private:
     AP_Int32 bitmask;
     bool initialised;
 };
+
+#endif  // AP_VOLZ_PROTOCOL

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -575,11 +575,13 @@ private:
     static SRV_Channel *channels;
     static SRV_Channels *_singleton;
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_VOLZ_ENABLED
     // support for Volz protocol
     AP_Volz_Protocol volz;
     static AP_Volz_Protocol *volz_ptr;
+#endif
 
+#ifndef HAL_BUILD_AP_PERIPH
     // support for SBUS protocol
     AP_SBusOut sbus;
     static AP_SBusOut *sbus_ptr;

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -585,11 +585,13 @@ private:
     // support for SBUS protocol
     AP_SBusOut sbus;
     static AP_SBusOut *sbus_ptr;
+#endif // HAL_BUILD_AP_PERIPH
 
+#if AP_ROBOTISSERVO_ENABLED
     // support for Robotis servo protocol
     AP_RobotisServo robotis;
     static AP_RobotisServo *robotis_ptr;
-#endif // HAL_BUILD_AP_PERIPH
+#endif
 
 #if HAL_SUPPORT_RCOUT_SERIAL
     // support for BLHeli protocol

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -49,8 +49,11 @@ AP_Volz_Protocol *SRV_Channels::volz_ptr;
 
 #ifndef HAL_BUILD_AP_PERIPH
 AP_SBusOut *SRV_Channels::sbus_ptr;
+#endif
+
+#if AP_ROBOTISSERVO_ENABLED
 AP_RobotisServo *SRV_Channels::robotis_ptr;
-#endif // HAL_BUILD_AP_PERIPH
+#endif
 
 #if AP_FETTEC_ONEWIRE_ENABLED
 AP_FETtecOneWire *SRV_Channels::fetteconwire_ptr;
@@ -205,10 +208,13 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     AP_SUBGROUPINFO(blheli, "_BLH_",  21, SRV_Channels, AP_BLHeli),
 #endif
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_ROBOTISSERVO_ENABLED
     // @Group: _ROB_
     // @Path: ../AP_RobotisServo/AP_RobotisServo.cpp
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
+#endif
+
+#ifndef HAL_BUILD_AP_PERIPH
 
 #if AP_FETTEC_ONEWIRE_ENABLED
     // @Group: _FTW_
@@ -269,8 +275,12 @@ SRV_Channels::SRV_Channels(void)
 
 #ifndef HAL_BUILD_AP_PERIPH
     sbus_ptr = &sbus;
+#endif
+
+#if AP_ROBOTISSERVO_ENABLED
     robotis_ptr = &robotis;
-#endif // HAL_BUILD_AP_PERIPH
+#endif // AP_ROBOTISSERVO_ENABLED
+
 #if HAL_SUPPORT_RCOUT_SERIAL
     blheli_ptr = &blheli;
 #endif
@@ -398,11 +408,12 @@ void SRV_Channels::push()
 #ifndef HAL_BUILD_AP_PERIPH
     // give sbus library a chance to update
     sbus_ptr->update();
+#endif // HAL_BUILD_AP_PERIPH
 
+#if AP_ROBOTISSERVO_ENABLED
     // give robotis library a chance to update
     robotis_ptr->update();
-
-#endif // HAL_BUILD_AP_PERIPH
+#endif
 
 #if HAL_SUPPORT_RCOUT_SERIAL
     // give blheli telemetry a chance to update

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -43,8 +43,11 @@ extern const AP_HAL::HAL& hal;
 SRV_Channel *SRV_Channels::channels;
 SRV_Channels *SRV_Channels::_singleton;
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_VOLZ_ENABLED
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
+#endif
+
+#ifndef HAL_BUILD_AP_PERIPH
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
 #endif // HAL_BUILD_AP_PERIPH
@@ -184,11 +187,13 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Units: Hz
     AP_GROUPINFO("_RATE",  18, SRV_Channels, default_rate, 50),
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_VOLZ_ENABLED
     // @Group: _VOLZ_
     // @Path: ../AP_Volz_Protocol/AP_Volz_Protocol.cpp
     AP_SUBGROUPINFO(volz, "_VOLZ_",  19, SRV_Channels, AP_Volz_Protocol),
+#endif
 
+#ifndef HAL_BUILD_AP_PERIPH
     // @Group: _SBUS_
     // @Path: ../AP_SBusOut/AP_SBusOut.cpp
     AP_SUBGROUPINFO(sbus, "_SBUS_",  20, SRV_Channels, AP_SBusOut),
@@ -258,8 +263,11 @@ SRV_Channels::SRV_Channels(void)
     fetteconwire_ptr = &fetteconwire;
 #endif
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_VOLZ_ENABLED
     volz_ptr = &volz;
+#endif
+
+#ifndef HAL_BUILD_AP_PERIPH
     sbus_ptr = &sbus;
     robotis_ptr = &robotis;
 #endif // HAL_BUILD_AP_PERIPH
@@ -382,10 +390,12 @@ void SRV_Channels::push()
 {
     hal.rcout->push();
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_VOLZ_ENABLED
     // give volz library a chance to update
     volz_ptr->update();
+#endif
 
+#ifndef HAL_BUILD_AP_PERIPH
     // give sbus library a chance to update
     sbus_ptr->update();
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -214,15 +214,11 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     AP_SUBGROUPINFO(robotis, "_ROB_",  22, SRV_Channels, AP_RobotisServo),
 #endif
 
-#ifndef HAL_BUILD_AP_PERIPH
-
 #if AP_FETTEC_ONEWIRE_ENABLED
     // @Group: _FTW_
     // @Path: ../AP_FETtecOneWire/AP_FETtecOneWire.cpp
     AP_SUBGROUPINFO(fetteconwire, "_FTW_",  25, SRV_Channels, AP_FETtecOneWire),
 #endif
-
-#endif // HAL_BUILD_AP_PERIPH
 
     // @Param: _DSHOT_RATE
     // @DisplayName: Servo DShot output rate


### PR DESCRIPTION
... also add them to build_options so the custom build server can be used to compile them in/out.

Also fix a bug around compiling FETTecOneWire on AP_Periph.
