### PR TITLE
Stop including un-needed headers in other headers

### DIFF
--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -27,7 +27,6 @@
 #include <stdio.h>
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
 #include <AP_AHRS/AP_AHRS.h>         // ArduPilot Mega DCM Library

--- a/ArduPlane/qautotune.h
+++ b/ArduPlane/qautotune.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "quadplane.h"
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -59,7 +59,6 @@
 #include <AC_Fence/AC_Fence.h>           // Fence library
 #include <AP_Scheduler/AP_Scheduler.h>       // main loop scheduler
 #include <AP_Scheduler/PerfInfo.h>       // loop perf monitoring
-#include <AP_Notify/AP_Notify.h>          // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -2,6 +2,8 @@
 #include "AC_PosControl.h"
 #include <AP_Math/AP_Math.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Motors/AP_Motors.h>    // motors library
+#include <AP_Vehicle/AP_Vehicle.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -12,8 +12,6 @@
 #include <AC_PID/AC_PID_2D.h>       // PID library (2-axis)
 #include <AP_InertialNav/AP_InertialNav.h>  // Inertial Navigation library
 #include "AC_AttitudeControl.h"     // Attitude control library
-#include <AP_Motors/AP_Motors.h>    // motors library
-#include <AP_Vehicle/AP_Vehicle.h>  // common vehicle parameters
 
 
 // position controller default definitions
@@ -42,7 +40,7 @@ public:
 
     /// Constructor
     AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
-                  const AP_Motors& motors, AC_AttitudeControl& attitude_control, float dt);
+                  const class AP_Motors& motors, AC_AttitudeControl& attitude_control, float dt);
 
     /// get_dt - gets time delta in seconds for all position controllers
     float get_dt() const { return _dt; }
@@ -420,7 +418,7 @@ protected:
     // references to inertial nav and ahrs libraries
     AP_AHRS_View&           _ahrs;
     const AP_InertialNav&   _inav;
-    const AP_Motors&        _motors;
+    const class AP_Motors&        _motors;
     AC_AttitudeControl&     _attitude_control;
 
     // parameters

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -18,7 +18,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AC_AttitudeControl/AC_AttitudeControl.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -4,7 +4,6 @@
  Gain and phase determination algorithm
 */
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 
 #define AUTOTUNE_DWELL_CYCLES                6

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -8,9 +8,6 @@
 #include <Filter/Filter.h>
 #include <Filter/LowPassFilter.h>
 #include <AC_PID/AC_P.h>
-#include <AP_InertialNav/AP_InertialNav.h>
-#include <AP_AHRS/AP_AHRS.h>
-#include <AP_HAL/AP_HAL.h>
 
 
 class AC_Autorotation

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -3,7 +3,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_HAL/AP_HAL.h>
 
 /*
  * BendyRuler avoidance algorithm for avoiding the polygon and circular fence and dynamic objects detected by the proximity sensor
@@ -12,9 +11,7 @@ class AP_OABendyRuler {
 public:
     AP_OABendyRuler();
 
-    /* Do not allow copies */
-    AP_OABendyRuler(const AP_OABendyRuler &other) = delete;
-    AP_OABendyRuler &operator=(const AP_OABendyRuler&) = delete;
+    CLASS_NO_COPY(AP_OABendyRuler);  /* Do not allow copies */
 
     // send configuration info stored in front end parameters
     void set_config(float margin_max) { _margin_max = MAX(margin_max, 0.0f); }

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Param/AP_Param.h>
@@ -10,9 +10,7 @@ public:
 
     AP_OADatabase();
 
-    /* Do not allow copies */
-    AP_OADatabase(const AP_OADatabase &other) = delete;
-    AP_OADatabase &operator=(const AP_OADatabase&) = delete;
+    CLASS_NO_COPY(AP_OADatabase); /* Do not allow copies */
 
     // get singleton instance
     static AP_OADatabase *get_singleton() {

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -3,7 +3,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_OAVisGraph.h"
 
 /*
@@ -15,9 +14,7 @@ public:
 
     AP_OADijkstra(AP_Int16 &options);
 
-    /* Do not allow copies */
-    AP_OADijkstra(const AP_OADijkstra &other) = delete;
-    AP_OADijkstra &operator=(const AP_OADijkstra&) = delete;
+    CLASS_NO_COPY(AP_OADijkstra);  /* Do not allow copies */
 
     // set fence margin (in meters) used when creating "safe positions" within the polygon fence
     void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -3,7 +3,8 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Semaphores.h>
+
 #include "AP_OABendyRuler.h"
 #include "AP_OADijkstra.h"
 #include "AP_OADatabase.h"

--- a/libraries/AC_Avoidance/AP_OAVisGraph.h
+++ b/libraries/AC_Avoidance/AP_OAVisGraph.h
@@ -2,7 +2,6 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/AP_ExpandingArray.h>
-#include <AP_HAL/AP_HAL.h>
 
 /*
  * Visibility graph used by Dijkstra's algorithm for path planning around fence, stay-out zones and moving obstacles
@@ -11,9 +10,7 @@ class AP_OAVisGraph {
 public:
     AP_OAVisGraph();
 
-    /* Do not allow copies */
-    AP_OAVisGraph(const AP_OAVisGraph &other) = delete;
-    AP_OAVisGraph &operator=(const AP_OAVisGraph&) = delete;
+    CLASS_NO_COPY(AP_OAVisGraph);  /* Do not allow copies */
 
     // types of items held in graph
     enum OAType : uint8_t {

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -25,6 +25,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Math/AP_Math.h>
+#include <AC_PID/AC_PID.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/LogStructure.h>
-#include <AP_Param/AP_Param.h>
+
+#include <Filter/SlewLimiter.h>
 #include <AP_Vehicle/AP_Vehicle.h>
-#include <AC_PID/AC_PID.h>
 #include <Filter/ModeFilter.h>
 
 class AP_AutoTune
@@ -44,7 +43,7 @@ public:
 
 
     // constructor
-    AP_AutoTune(ATGains &_gains, ATType type, const AP_Vehicle::FixedWing &parms, AC_PID &rpid);
+    AP_AutoTune(ATGains &_gains, ATType type, const AP_Vehicle::FixedWing &parms, class AC_PID &rpid);
 
     // called when autotune mode is entered
     void start(void);
@@ -55,7 +54,7 @@ public:
 
     // update called whenever autotune mode is active. This is
     // called at the main loop rate
-    void update(AP_PIDInfo &pid_info, float scaler, float angle_err_deg);
+    void update(struct AP_PIDInfo &pid_info, float scaler, float angle_err_deg);
 
     // are we running?
     bool running;
@@ -63,7 +62,7 @@ public:
 private:
     // the current gains
     ATGains &current;
-    AC_PID &rpid;
+    class AC_PID &rpid;
 
     // what type of autotune is this
     ATType type;

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -21,7 +21,6 @@
   Tom Pittenger, November 2015
 */
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_ADSB_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -21,7 +21,8 @@
  *
  */
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 
 #ifndef HAL_NAVEKF2_AVAILABLE
 // only default to EK2 enabled on boards with over 1M flash

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -19,7 +19,8 @@
  */
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 #include "AP_Airspeed.h"
 
 class AP_Airspeed_Backend {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -26,6 +26,7 @@
 #include <AP_Rally/AP_Rally.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AC_Fence/AC_Fence.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Airspeed/AP_Airspeed.h>
@@ -42,6 +43,7 @@
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_OSD/AP_OSD.h>
+#include <RC_Channel/RC_Channel.h>
 #include <AP_Button/AP_Button.h>
 #include <AP_FETtecOneWire/AP_FETtecOneWire.h>
 #include <AP_RPM/AP_RPM.h>

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
-#include <RC_Channel/RC_Channel.h>
 
 class AP_Arming {
 public:
 
     AP_Arming();
 
-    /* Do not allow copies */
-    AP_Arming(const AP_Arming &other) = delete;
-    AP_Arming &operator=(const AP_Arming&) = delete;
+    CLASS_NO_COPY(AP_Arming);  /* Do not allow copies */
 
     static AP_Arming *get_singleton();
 
@@ -197,7 +195,7 @@ protected:
     virtual bool proximity_checks(bool report) const;
 
     bool servo_checks(bool report) const;
-    bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4]) const;
+    bool rc_checks_copter_sub(bool display_failure, const class RC_Channel *channels[4]) const;
 
     bool visodom_checks(bool report) const;
     bool disarm_switch_checks(bool report) const;
@@ -220,8 +218,8 @@ private:
 
     static AP_Arming *_singleton;
 
-    bool ins_accels_consistent(const AP_InertialSensor &ins);
-    bool ins_gyros_consistent(const AP_InertialSensor &ins);
+    bool ins_accels_consistent(const class AP_InertialSensor &ins);
+    bool ins_gyros_consistent(const class AP_InertialSensor &ins);
 
     // check if we should keep logging after disarming
     void check_forced_logging(const AP_Arming::Method method);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_BattMonitor.h"
 
 class AP_BattMonitor_Backend

--- a/libraries/AP_Beacon/AP_Beacon.h
+++ b/libraries/AP_Beacon/AP_Beacon.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>

--- a/libraries/AP_Common/ExpandingString.cpp
+++ b/libraries/AP_Common/ExpandingString.cpp
@@ -18,6 +18,8 @@
 
 #include "ExpandingString.h"
 
+#include <AP_HAL/AP_HAL.h>
+
 extern const AP_HAL::HAL& hal;
 
 #define EXPAND_INCREMENT 512

--- a/libraries/AP_Common/ExpandingString.h
+++ b/libraries/AP_Common/ExpandingString.h
@@ -18,7 +18,9 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+
+#include <stdint.h>
 
 class ExpandingString {
 public:

--- a/libraries/AP_Common/tests/test_expandingstring.cpp
+++ b/libraries/AP_Common/tests/test_expandingstring.cpp
@@ -1,5 +1,6 @@
 #include <AP_gtest.h>
 #include <AP_Common/ExpandingString.h>
+#include <AP_HAL/AP_HAL.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_Common/tests/test_expandingstring_failure.cpp
+++ b/libraries/AP_Common/tests/test_expandingstring_failure.cpp
@@ -1,6 +1,7 @@
 #include <AP_gtest.h>
 #include <stdlib.h>
 #include <AP_Common/ExpandingString.h>
+#include <AP_HAL/AP_HAL.h>
 
 /**
  * This file test realloc failure on ExpandingString

--- a/libraries/AP_EFI/AP_EFI_Backend.h
+++ b/libraries/AP_EFI/AP_EFI_Backend.h
@@ -16,7 +16,7 @@
 
 #include "AP_EFI.h"
 #include "AP_EFI_State.h"
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Semaphores.h>
 
 class AP_EFI; //forward declaration
 

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -26,6 +26,8 @@
 
 #define STAT_FIX_VALID 0x01
 
+#include <AP_HAL/AP_HAL.h>
+
 extern const AP_HAL::HAL& hal;
 
 #if ERB_DEBUGGING

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
 

--- a/libraries/AP_GPS/AP_GPS_ExternalAHRS.h
+++ b/libraries/AP_GPS/AP_GPS_ExternalAHRS.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "AP_GPS.h"
 #include "GPS_Backend.h"

--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -19,8 +19,7 @@
 //
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "AP_GPS.h"
 #include "GPS_Backend.h"

--- a/libraries/AP_HAL_Linux/RCInput_RCProtocol.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RCProtocol.cpp
@@ -23,6 +23,10 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <asm/termbits.h>
+#include <stdarg.h>
+
+#include <AP_RCProtocol/AP_RCProtocol.h>
+#include "RCInput.h"
 #include "RCInput_RCProtocol.h"
 #include <GCS_MAVLink/GCS.h>
 

--- a/libraries/AP_HAL_Linux/RCInput_RCProtocol.h
+++ b/libraries/AP_HAL_Linux/RCInput_RCProtocol.h
@@ -18,10 +18,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_RCProtocol/AP_RCProtocol.h>
-#include "RCInput.h"
-#include <stdarg.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO || \
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BLUE || \

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -34,7 +34,7 @@
 #include <AP_RTC/AP_RTC.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Mission/AP_Mission.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <stdio.h>
 
 #define PROT_BINARY   0x80

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.h
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 #ifndef HAL_HOTT_TELEM_ENABLED
 #define HAL_HOTT_TELEM_ENABLED !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -22,6 +22,7 @@
 #include <RC_Channel/RC_Channel.h>
 
 #include "AP_ICEngine.h"
+#include <AP_RPM/AP_RPM.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -18,13 +18,12 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_RPM/AP_RPM.h>
+#include <AP_Param/AP_Param.h>
 
 class AP_ICEngine {
 public:
     // constructor
-    AP_ICEngine(const AP_RPM &_rpm);
+    AP_ICEngine(const class AP_RPM &_rpm);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -56,7 +55,7 @@ public:
 private:
     static AP_ICEngine *_singleton;
 
-    const AP_RPM &rpm;
+    const class AP_RPM &rpm;
 
     enum ICE_State state;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -7,7 +7,7 @@
 #define AP_INERTIAL_SENSOR_ACCEL_VIBE_FILT_HZ           2.0f    // accel vibration filter hz
 #define AP_INERTIAL_SENSOR_ACCEL_PEAK_DETECT_TIMEOUT_MS 500     // peak-hold detector timeout
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 /**
    maximum number of INS instances available on this platform. If more

--- a/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
@@ -24,6 +24,7 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Common/ExpandingString.h>
+#include <AP_Notify/AP_Notify.h>
 
 // this scale factor ensures params are easy to work with in GUI parameter editors
 #define SCALE_FACTOR 1.0e6

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -5,13 +5,11 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_Logger_Backend.h"
 
 #if HAL_LOGGING_MAVLINK_ENABLED
 
-extern const AP_HAL::HAL& hal;
+#include <AP_HAL/Semaphores.h>
 
 #define DF_MAVLINK_DISABLE_INTERRUPTS 0
 

--- a/libraries/AP_MSP/AP_MSP.cpp
+++ b/libraries/AP_MSP/AP_MSP.cpp
@@ -21,6 +21,8 @@
 #include "AP_MSP_Telem_DJI.h"
 #include "AP_MSP_Telem_DisplayPort.h"
 
+#include <AP_Notify/AP_Notify.h>
+
 #include <ctype.h>
 #include <stdio.h>
 

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -22,6 +22,7 @@
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_Notify/AP_Notify.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_RCMapper/AP_RCMapper.h>

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -17,6 +17,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Stats/AP_Stats.h>
 #include <AP_RSSI/AP_RSSI.h>
+#include <AP_Notify/AP_Notify.h>
 
 #include "AP_MSP.h"
 #include "AP_MSP_Telem_DJI.h"

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 #include "vector2.h"
 #include "vector3.h"

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifdef M_PI
 # undef M_PI

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -12,11 +12,12 @@
  */
 #pragma once
 
+#include <AP_HAL/AP_HAL.h>
+
 #ifndef HAL_MISSION_ENABLED
 #define HAL_MISSION_ENABLED 1
 #endif
 
-#include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
@@ -3,7 +3,7 @@
 
 #include "AP_Mission_ChangeDetector.h"
 
-extern const AP_HAL::HAL& hal;
+#if HAL_MISSION_ENABLED
 
 // detect external changes to mission
 bool AP_Mission_ChangeDetector::check_for_mission_change()
@@ -59,3 +59,4 @@ bool AP_Mission_ChangeDetector::check_for_mission_change()
     return cmds_changed && !curr_cmd_idx_changed;
 }
 
+#endif  // AP_MISSION_ENABLED

--- a/libraries/AP_Module/AP_Module.h
+++ b/libraries/AP_Module/AP_Module.h
@@ -27,8 +27,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 #if AP_MODULE_SUPPORTED
 
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -18,6 +18,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Notify/AP_Notify.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
-#include <AP_Notify/AP_Notify.h>      // Notify library
-#include <SRV_Channel/SRV_Channel.h>
+#include <AP_Math/AP_Math.h>
 #include <Filter/Filter.h>         // filter library
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 // offsets for motors in motor_out and _motor_filtered arrays
 #define AP_MOTORS_MOT_1 0U

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -19,8 +19,7 @@
 ************************************************************/
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_MOUNT_ENABLED
 #define HAL_MOUNT_ENABLED !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -2,6 +2,8 @@
 #if HAL_MOUNT_ENABLED
 #include <AP_SerialManager/AP_SerialManager.h>
 
+#include <AP_AHRS/AP_AHRS.h>
+
 extern const AP_HAL::HAL& hal;
 
 void AP_Mount_Alexmos::init()

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -8,7 +8,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include "AP_Mount_Backend.h"
 
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -3,14 +3,14 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include "AP_Mount_Backend.h"
+
+#if HAL_MOUNT_ENABLED
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <RC_Channel/RC_Channel.h>
-#include "AP_Mount_Backend.h"
-#if HAL_MOUNT_ENABLED
+#include <AP_AHRS/AP_AHRS.h>
 
 #define AP_MOUNT_STORM32_RESEND_MS  1000    // resend angle targets to gimbal once per second
 #define AP_MOUNT_STORM32_SEARCH_MS  60000   // search for gimbal for 1 minute after startup

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -6,8 +6,7 @@
 ************************************************************/
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include "AP_Mount.h"
 #if HAL_SOLO_GIMBAL_ENABLED
 #include "SoloGimbalEKF.h"

--- a/libraries/AP_Notify/AP_BoardLED.h
+++ b/libraries/AP_Notify/AP_BoardLED.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "NotifyDevice.h"
 

--- a/libraries/AP_Notify/AP_BoardLED2.h
+++ b/libraries/AP_Notify/AP_BoardLED2.h
@@ -17,7 +17,7 @@
 
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "NotifyDevice.h"
 

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -17,8 +17,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 #include "NotifyDevice.h"
 
 class Buzzer: public NotifyDevice

--- a/libraries/AP_Notify/DiscoLED.h
+++ b/libraries/AP_Notify/DiscoLED.h
@@ -16,7 +16,7 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/Led_Sysfs.h>

--- a/libraries/AP_Notify/DiscreteRGBLed.cpp
+++ b/libraries/AP_Notify/DiscreteRGBLed.cpp
@@ -13,6 +13,8 @@
 
 #include "DiscreteRGBLed.h"
 
+#include <AP_HAL/HAL.h>
+
 extern const AP_HAL::HAL& hal;
 
 DiscreteRGBLed::DiscreteRGBLed(uint16_t red, uint16_t green, uint16_t blue, bool normal_polarity)

--- a/libraries/AP_Notify/ExternalLED.h
+++ b/libraries/AP_Notify/ExternalLED.h
@@ -15,10 +15,6 @@
 
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Param/AP_Param.h>
-
 #include "NotifyDevice.h"
 
 class ExternalLED: public NotifyDevice

--- a/libraries/AP_Notify/Led_Sysfs.h
+++ b/libraries/AP_Notify/Led_Sysfs.h
@@ -16,7 +16,7 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/Led_Sysfs.h>

--- a/libraries/AP_Notify/PixRacerLED.cpp
+++ b/libraries/AP_Notify/PixRacerLED.cpp
@@ -15,6 +15,8 @@
 
 #include "PixRacerLED.h"
 
+#include <AP_HAL/HAL.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 
 #ifndef HAL_GPIO_A_LED_PIN

--- a/libraries/AP_Notify/PixRacerLED.h
+++ b/libraries/AP_Notify/PixRacerLED.h
@@ -14,9 +14,6 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
-
 #include "RGBLed.h"
 
 class PixRacerLED: public RGBLed

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -19,7 +19,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include "NotifyDevice.h"
 
 class RGBLed: public NotifyDevice {

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -16,7 +16,7 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <SITL/SITL.h>
 
 #ifdef WITH_SITL_RGBLED

--- a/libraries/AP_OLC/AP_OLC.h
+++ b/libraries/AP_OLC/AP_OLC.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <stdint.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_PLUSCODE_ENABLE

--- a/libraries/AP_ONVIF/AP_ONVIF.h
+++ b/libraries/AP_ONVIF/AP_ONVIF.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if ENABLE_ONVIF
 #pragma GCC diagnostic push

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -31,7 +31,6 @@
  */
 
 #include <AP_MSP/msp.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AP_OpticalFlow_Calibrator.h"

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 
 #define AP_OPTICALFLOW_CAL_MAX_SAMPLES 50  // number of samples required before calibration begins

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -14,7 +14,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -17,9 +17,7 @@
 #include "AP_Proximity.h"
 
 #if HAL_PROXIMITY_ENABLED
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
-#include <AP_Common/Location.h>
 #include "AP_Proximity_Boundary_3D.h"
 
 #define PROXIMITY_GND_DETECT_THRESHOLD 1.0f // set ground detection threshold to be 1 meters

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -14,7 +14,6 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_OSD/AP_OSD.h>
 
@@ -28,9 +27,6 @@
 
 #if HAL_CRSF_TELEM_ENABLED
 
-#include <AP_Notify/AP_Notify.h>
-#include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_HAL/utility/RingBuffer.h>
 #include <AP_RCProtocol/AP_RCProtocol_CRSF.h>
 #include "AP_RCTelemetry.h"
 #include <AP_HAL/utility/sparse-endian.h>

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.h
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.h
@@ -14,10 +14,10 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Notify/AP_Notify.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define TELEM_PAYLOAD_STATUS_CAPACITY          5 // size of the message buffer queue (max number of messages waiting to be sent)
 

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
@@ -14,7 +14,7 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_SPEKTRUM_TELEM_ENABLED
 #define HAL_SPEKTRUM_TELEM_ENABLED !HAL_MINIMIZE_FEATURES
@@ -22,7 +22,6 @@
 
 #if HAL_SPEKTRUM_TELEM_ENABLED
 
-#include <AP_Notify/AP_Notify.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_RCTelemetry.h"

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -20,6 +20,11 @@
 #include "tinf.h"
 #include <AP_Math/crc.h>
 
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#include <string.h>
+
 #ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
 #include <ap_romfs_embedded.h>
 #else

--- a/libraries/AP_ROMFS/AP_ROMFS.h
+++ b/libraries/AP_ROMFS/AP_ROMFS.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <stdint.h>
 
 class AP_ROMFS {
 public:

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include "AP_RPM_Params.h"
@@ -32,9 +32,7 @@ class AP_RPM
 public:
     AP_RPM();
 
-    /* Do not allow copies */
-    AP_RPM(const AP_RPM &other) = delete;
-    AP_RPM &operator=(const AP_RPM&) = delete;
+    CLASS_NO_COPY(AP_RPM);  /* Do not allow copies */
 
     // RPM driver types
     enum RPM_Type {

--- a/libraries/AP_RPM/RPM_Backend.h
+++ b/libraries/AP_RPM/RPM_Backend.h
@@ -14,8 +14,6 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_RPM.h"
 
 class AP_RPM_Backend

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_RALLY_ENABLED
 #define HAL_RALLY_ENABLED 1

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_MSP/msp.h>

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 #include "AP_RangeFinder.h"
 
 class AP_RangeFinder_Backend

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -20,13 +20,15 @@
  */
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
 #ifndef HAL_SCHEDULER_ENABLED
 #define HAL_SCHEDULER_ENABLED 1
 #endif
 
 #include <AP_Param/AP_Param.h>
+#include <AP_HAL/Semaphores.h>
 #include <AP_HAL/Util.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include "PerfInfo.h"       // loop perf monitoring
 

--- a/libraries/AP_SerialLED/AP_SerialLED.h
+++ b/libraries/AP_SerialLED/AP_SerialLED.h
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <stdint.h>
 
 // limit number of LEDs, mostly to keep DMA memory consumption within
 // reasonable bounds

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Common/Location.h>
 #include <AP_Filesystem/AP_Filesystem_Available.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>

--- a/libraries/AP_Tuning/AP_Tuning.cpp
+++ b/libraries/AP_Tuning/AP_Tuning.cpp
@@ -1,7 +1,9 @@
 #include "AP_Tuning.h"
+
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 #include <RC_Channel/RC_Channel.h>
+#include <AP_Notify/AP_Notify.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -57,6 +57,7 @@
 #include <AP_ADSB/AP_ADSB.h>
 #include "AP_UAVCAN_DNA_Server.h"
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Notify/AP_Notify.h>
 
 #define LED_DELAY_US 50000
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/Semaphores.h>
 
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
 #include <uavcan/uavcan.hpp>

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -17,6 +17,8 @@
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <GCS_MAVLink/GCS.h>
 
+#include <AP_HAL/AP_HAL.h>
+
 extern const AP_HAL::HAL& hal;
 
 AP_VideoTX *AP_VideoTX::singleton;

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -14,9 +14,7 @@
 */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <RC_Channel/RC_Channel.h>
 
 #define VTX_MAX_CHANNELS 8
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -14,8 +14,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_VISUALODOM_ENABLED
 #define HAL_VISUALODOM_ENABLED (!HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024)

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_Backend.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Backend.cpp
@@ -14,7 +14,6 @@
  */
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_WheelEncoder.h"
 #include "WheelEncoder_Backend.h"
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_Backend.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Backend.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_WheelEncoder.h"
 
 class AP_WheelEncoder_Backend

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -24,8 +24,11 @@
 #include "AP_WindVane_NMEA.h"
 
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_SerialManager/AP_SerialManager.h>
+
+extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_WindVane::var_info[] = {
 

--- a/libraries/AP_WindVane/AP_WindVane_Analog.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Analog.cpp
@@ -22,6 +22,10 @@ extern const AP_HAL::HAL& hal;
 
 #define WINDVANE_CALIBRATION_VOLT_DIFF_MIN  1.0f    // calibration routine's min voltage difference required for success
 
+#include <AP_HAL/AP_HAL.h>
+
+extern const AP_HAL::HAL& hal;
+
 // constructor
 AP_WindVane_Analog::AP_WindVane_Analog(AP_WindVane &frontend) :
     AP_WindVane_Backend(frontend)

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
@@ -17,7 +17,10 @@
 // read wind speed from Modern Device rev p wind sensor
 // https://moderndevice.com/news/calibrating-rev-p-wind-sensor-new-regression/
 
+#include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
 
 // constructor
 AP_WindVane_ModernDevice::AP_WindVane_ModernDevice(AP_WindVane &frontend) :

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.h
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.h
@@ -16,10 +16,6 @@
 
 #include "AP_WindVane_Backend.h"
 
-#include <AP_HAL/AP_HAL.h>
-
-extern const AP_HAL::HAL& hal;
-
 class AP_WindVane_ModernDevice : public AP_WindVane_Backend
 {
 public:

--- a/libraries/Filter/Butter.h
+++ b/libraries/Filter/Butter.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-
 template <typename Coefficients>
 class Butter2
 {

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -11,6 +11,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
+#include <AP_Notify/AP_Notify.h>
 
 #include "MissionItemProtocol_Waypoints.h"
 #include "MissionItemProtocol_Rally.h"

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -2,7 +2,6 @@
 /// @brief	handle routing of MAVLink packets by ID
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include "GCS_MAVLink.h"
 

--- a/libraries/SITL/SIM_Gazebo.cpp
+++ b/libraries/SITL/SIM_Gazebo.cpp
@@ -23,10 +23,6 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include <AP_HAL/AP_HAL.h>
-
-extern const AP_HAL::HAL& hal;
-
 namespace SITL {
 
 Gazebo::Gazebo(const char *frame_str) :


### PR DESCRIPTION
Unnecessary includes lead to a rebuild cascade as everything depends on everything else.

This was focussing on the HAL includes, but lots of other things in here.
