### PR TITLE
Set GIT versions from environment

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -69,9 +69,9 @@ jobs:
 
           if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
              [ "${{matrix.config}}" = "f103-GPS" ]; then
-            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf AP_Periph
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" GIT_VERSION_INT="15" ./waf AP_Periph
           else
-            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" GIT_VERSION_INT="15" ./waf
           fi
           cp -r build/${{matrix.config}}/bin/* "$NO_VERSIONS_DIR"
 
@@ -114,9 +114,9 @@ jobs:
 
           if [ "${{matrix.config}}" = "Hitec-Airspeed" ] ||
              [ "${{matrix.config}}" = "f103-GPS" ]; then
-            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf AP_Periph
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" GIT_VERSION_INT="15" ./waf AP_Periph
           else
-            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" ./waf
+            CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" GIT_VERSION_INT="15" ./waf
           fi
           cp -r build/${{matrix.config}}/bin/* "$NO_VERSIONS_DIR"
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -380,7 +380,7 @@ def ap_version_append_str(ctx, k, v):
 
 @conf
 def ap_version_append_int(ctx, k, v):
-    ctx.env['AP_VERSION_ITEMS'] += [(k,v)]
+    ctx.env['AP_VERSION_ITEMS'] += [(k, '{}'.format(os.environ.get(k, v)))]
 
 @conf
 def write_version_header(ctx, tgt):

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -14,6 +14,7 @@ cxx_compiler=${CXX:-g++}
 export BUILDROOT=/tmp/ci.build
 rm -rf $BUILDROOT
 export GIT_VERSION="abcdef"
+export GIT_VERSION_INT="15"
 export CHIBIOS_GIT_VERSION="12345667"
 export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
 autotest_args=""


### PR DESCRIPTION
This should fix the github workflow where normal-vehicle builds aren't the same checksum even for absolutely-NFC PRs.

With command-line:
```
reset ; rm -rf build && ./waf configure --board=Durandal && CHIBIOS_GIT_VERSION="12345678" GIT_VERSION="abcdef" GIT_VERSION_INT=15 ./waf copter && cksum build/Durandal/bin/arducopter.bin
```

Before:

```
pbarker@bluebottle:~/rc/ardupilot(master)$ cat build/Durandal/ap_version.h
// auto-generated header, do not edit

#pragma once

#ifndef FORCE_VERSION_H_INCLUDE
#error ap_version.h should never be included directly. You probably want to include AP_Common/AP_FWVersion.h
#endif

#define GIT_VERSION "abcdef"
#define GIT_VERSION_INT 2847476283
#define CHIBIOS_GIT_VERSION "12345678"
```

Note `GIT_VERSION_INT` isn't taken from the env.

After:
```
pbarker@bluebottle:~/rc/ardupilot(pr/git-versions-from-env)$ cat build/Durandal/ap_version.h
// auto-generated header, do not edit

#pragma once

#ifndef FORCE_VERSION_H_INCLUDE
#error ap_version.h should never be included directly. You probably want to include AP_Common/AP_FWVersion.h
#endif

#define GIT_VERSION "abcdef"
#define GIT_VERSION_INT 15
#define CHIBIOS_GIT_VERSION "12345678"
pbarker@bluebottle:~/rc/ardupilot(pr/git-versions-from-env)$ 
```
