### PR TITLE
Plane: disable pitch based weathervaning for quadplanes

### DIFF
--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -104,7 +104,7 @@ AC_WeatherVane::AC_WeatherVane(void)
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, float pitch_cdeg, const bool is_takeoff, const bool is_landing)
+bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, const float pitch_cdeg, const bool is_takeoff, const bool is_landing)
 {
     Direction dir = (Direction)_direction.get();
     if ((dir == Direction::OFF) || !allowed || (pilot_yaw != 0) || !is_positive(_gain)) {
@@ -176,8 +176,8 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
             return false;
 
         case Direction::NOSE_IN:
-            if (pitch_enable && is_positive(pitch_cdeg)) {
-                output = fabsf(roll_cdeg) + pitch_cdeg;
+            if (pitch_enable && is_positive(pitch_cdeg - deadzone_cdeg)) {
+                output = fabsf(roll_cdeg) + (pitch_cdeg - deadzone_cdeg);
             } else {
                 output = MAX(fabsf(roll_cdeg) - deadzone_cdeg, 0.0);
             }
@@ -204,8 +204,8 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
             break;
 
         case Direction::TAIL_IN:
-            if (pitch_enable && is_negative(pitch_cdeg)) {
-                output = fabsf(roll_cdeg) - pitch_cdeg;
+            if (pitch_enable && is_negative(pitch_cdeg + deadzone_cdeg)) {
+                output = fabsf(roll_cdeg) - (pitch_cdeg + deadzone_cdeg);
             } else {
                 output = MAX(fabsf(roll_cdeg) - deadzone_cdeg, 0.0);
             }

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -10,7 +10,7 @@ class AC_WeatherVane {
         CLASS_NO_COPY(AC_WeatherVane);
 
         // Calculate and return the yaw output to weathervane the vehicle
-        bool get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, const float pitch_cdeg, const bool is_takeoff, const bool is_landing);
+        bool get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, float pitch_cdeg, const bool is_takeoff, const bool is_landing);
 
         // Function to reset all flags and set values. Invoked whenever the weather vaning process is interrupted
         void reset(void);
@@ -31,6 +31,10 @@ class AC_WeatherVane {
             TAIL_IN = 4, // backwards, for tailsitters, makes it easier to descend
         };
 
+        enum class Options {
+            PITCH_ENABLE = (1<<0),
+        };
+    
         // Paramaters
         AP_Int8 _direction;
         AP_Float _gain;
@@ -40,6 +44,7 @@ class AC_WeatherVane {
         AP_Float _max_vel_z;
         AP_Int8 _landing_direction;
         AP_Int8 _takeoff_direction;
+        AP_Int16 _options;
 
         float last_output;
         bool active_msg_sent;

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -10,7 +10,7 @@ class AC_WeatherVane {
         CLASS_NO_COPY(AC_WeatherVane);
 
         // Calculate and return the yaw output to weathervane the vehicle
-        bool get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, float pitch_cdeg, const bool is_takeoff, const bool is_landing);
+        bool get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, const float pitch_cdeg, const bool is_takeoff, const bool is_landing);
 
         // Function to reset all flags and set values. Invoked whenever the weather vaning process is interrupted
         void reset(void);


### PR DESCRIPTION
planes with a pitch asymmetry are very common, as used move payload slightly or have different front motors from rear motors (common in tilt quadplanes)

constantly yawing in no wind is annoying, so best to just disable pitch for weathervaning for nose-in and tail-in. 