### PR TITLE
Tools: ensure terminal uses current dir when using osascript in run_in_terminal_window.sh

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -31,7 +31,7 @@ if [ -n "$SITL_RITW_TERMINAL" ]; then
 elif [ "$TERM" = "screen" ] && [ -n "$TMUX" ]; then
   tmux new-window -dn "$name" "$*"
 elif [ -n "$DISPLAY" -a -n "$(which osascript)" ]; then
-  osascript -e 'tell application "Terminal" to do script "'"$* "'"'
+  osascript -e 'tell application "Terminal" to do script "'"cd $(pwd) && clear && $* "'"'
 elif [ -n "$DISPLAY" -a -n "$(which xterm)" ]; then
   if [ $SITL_RITW_MINIMIZE -eq 1 ]; then
       ICONIC=-iconic


### PR DESCRIPTION
This PR updates the script `run_in_terminal_window.sh` to ensure that when `osascript` is used to spawn a terminal it has the same working directory as the calling script.

Without this change SITL will not load the default params correctly when called from `sim_vehicle.py` as the params are supplied using a relative path.

System: macOS Big Sur 11.6.2

## Test

Run a rover SITL session:

```bash
$ sim_vehicle.py -N -v Rover -f rover --map --console
```

#### Before change

![before](https://user-images.githubusercontent.com/24916364/162772749-65114492-31ec-43dd-86d8-2c72f0ddcbc3.png)

### After change
 
![after](https://user-images.githubusercontent.com/24916364/162772761-f6b84fbb-cc86-4912-949b-6d40deac7175.png)
 