### PR TITLE
AP_Proximity: Allow multiple proximity backends

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -478,8 +478,8 @@ void AP_Logger::Write_Proximity(AP_Proximity &proximity)
         return;
     }
 
-    AP_Proximity::Proximity_Distance_Array dist_array{}; // raw distances stored here
-    AP_Proximity::Proximity_Distance_Array filt_dist_array{}; //filtered distances stored here
+    AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D dist_array{}; // raw distances stored here
+    AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D filt_dist_array{}; //filtered distances stored here
     for (uint8_t i = 0; i < proximity.get_num_layers(); i++) {
         const bool active = proximity.get_active_layer_distances(i, dist_array, filt_dist_array);
         if (!active) {

--- a/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_AirSimSITL.cpp
@@ -69,7 +69,7 @@ void AP_Proximity_AirSimSITL::update(void)
             // check distance from previous point to reduce amount of data sent to object database
             if (!prev_pos_valid || ((new_pos - prev_pos).length_squared() >= accuracy_sq)) {
                 // update OA database
-                database_push(yaw_angle_deg, safe_sqrt(distance_sq));
+                utility.database_push(yaw_angle_deg, safe_sqrt(distance_sq));
                 // store point
                 prev_pos_valid = true;
                 prev_pos = new_pos;
@@ -77,7 +77,7 @@ void AP_Proximity_AirSimSITL::update(void)
         }
     }
     // copy temp boundary to real boundary
-    temp_boundary.update_3D_boundary(boundary);
+    temp_boundary.update_3D_boundary(state.instance, boundary);
 }
 
 // get maximum and minimum distances (in meters) of primary sensor

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -28,9 +28,14 @@ extern const AP_HAL::HAL& hal;
   base class constructor. 
   This incorporates initialisation as well.
 */
-AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state) :
+AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend,
+                                           AP_Proximity::Proximity_State &_state,
+                                           AP_Proximity_Boundary_3D &_boundary,
+                                           AP_Proximity_Utils &_utility) :
         frontend(_frontend),
-        state(_state)
+        state(_state),
+        boundary(_boundary),
+        utility(_utility)
 {
 }
 
@@ -38,13 +43,13 @@ static_assert(PROXIMITY_MAX_DIRECTION <= 8,
               "get_horizontal_distances assumes 8-bits is enough for validity bitmask");
 
 // get distances in PROXIMITY_MAX_DIRECTION directions horizontally. used for sending distances to ground station
-bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const
+bool AP_Proximity_Backend::get_horizontal_distances(AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_dist_array) const
 {
-    AP_Proximity::Proximity_Distance_Array prx_filt_dist_array; // unused
+    AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D prx_filt_dist_array; // unused
     return boundary.get_layer_distances(PROXIMITY_MIDDLE_LAYER, distance_max(), prx_dist_array, prx_filt_dist_array);
 }
-// get distances in PROXIMITY_MAX_DIRECTION directions at a layer. used for logging
-bool AP_Proximity_Backend::get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const
+// // get distances in PROXIMITY_MAX_DIRECTION directions at a layer. used for logging
+bool AP_Proximity_Backend::get_active_layer_distances(uint8_t layer, AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_dist_array, AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_filt_dist_array) const
 {
     return boundary.get_layer_distances(layer, distance_max(), prx_dist_array, prx_filt_dist_array);
 }
@@ -53,21 +58,6 @@ bool AP_Proximity_Backend::get_active_layer_distances(uint8_t layer, AP_Proximit
 void AP_Proximity_Backend::set_status(AP_Proximity::Status status)
 {
     state.status = status;
-}
-
-// timeout faces that have not received data recently and update filter frequencies
-void AP_Proximity_Backend::boundary_3D_checks()
-{
-    // set the cutoff freq for low pass filter
-    boundary.set_filter_freq(frontend.get_filter_freq());
-
-    // check if any face has valid distance when it should not
-    const uint32_t now_ms = AP_HAL::millis();
-    // run this check every PROXIMITY_BOUNDARY_3D_TIMEOUT_MS
-    if ((now_ms - _last_timeout_check_ms) > PROXIMITY_BOUNDARY_3D_TIMEOUT_MS) {
-        _last_timeout_check_ms = now_ms;
-        boundary.check_face_timeout();
-    }
 }
 
 // correct an angle (in degrees) based on the orientation and yaw correction parameters
@@ -84,21 +74,6 @@ float AP_Proximity_Backend::correct_angle_for_orientation(float angle_degrees) c
 // angles should be in degrees and in the range of 0 to 360, distance should be in meteres
 bool AP_Proximity_Backend::ignore_reading(float pitch, float yaw, float distance_m, bool check_for_ign_area) const
 {
-    // check if distances are supposed to be in a particular range
-    if (!is_zero(frontend._max_m)) {
-        if (distance_m > frontend._max_m) {
-            // too far away
-            return true;
-        }
-    }
-
-    if (!is_zero(frontend._min_m)) {
-        if (distance_m < frontend._min_m) {
-            // too close
-            return true;
-        }
-    }
-
     if (check_for_ign_area) {
         // check angle vs each ignore area
         for (uint8_t i=0; i < PROXIMITY_MAX_IGNORE; i++) {
@@ -110,123 +85,7 @@ bool AP_Proximity_Backend::ignore_reading(float pitch, float yaw, float distance
         }
     }
 
-   // check if obstacle is near land
-   return check_obstacle_near_ground(pitch, yaw, distance_m);
-}
-
-// store rangefinder values
-void AP_Proximity_Backend::set_rangefinder_alt(bool use, bool healthy, float alt_cm)
-{
-    _last_downward_update_ms = AP_HAL::millis();
-    _rangefinder_use = use;
-    _rangefinder_healthy = healthy;
-    _rangefinder_alt = alt_cm * 0.01f;
-}
-
-// get alt from rangefinder in meters
-bool AP_Proximity_Backend::get_rangefinder_alt(float &alt_m) const
-{
-    if (!_rangefinder_use || !_rangefinder_healthy) {
-        // range finder is not healthy
-        return false;
-    }
-
-    const uint32_t dt = AP_HAL::millis() - _last_downward_update_ms;
-    if (dt > PROXIMITY_ALT_DETECT_TIMEOUT_MS) {
-        return false;
-    }
-
-    // readings are healthy
-    alt_m = _rangefinder_alt;
-    return true;
-}
-
-// Check if Obstacle defined by body-frame yaw and pitch is near ground
-bool AP_Proximity_Backend::check_obstacle_near_ground(float pitch, float yaw, float distance) const
-{
-    if (!frontend._ign_gnd_enable) {
-        return false;
-    }
-    if (!hal.util->get_soft_armed()) {
-        // don't run this feature while vehicle is disarmed, otherwise proximity data will not show up on GCS
-        return false;
-    }
-    if ((pitch > 90.0f) || (pitch < -90.0f)) {
-        // sanity check on pitch
-        return false;
-    }
-    // Assume object is yaw and pitch bearing and distance meters away from the vehicle
-    Vector3f object_3D;
-    object_3D.offset_bearing(wrap_180(yaw), (pitch * -1.0f), distance);
-    const Matrix3f body_to_ned = AP::ahrs().get_rotation_body_to_ned();
-    const Vector3f rotated_object_3D = body_to_ned * object_3D;
-
-    float alt = FLT_MAX;
-    if (!get_rangefinder_alt(alt)) {
-        return false;
-    }
-
-    if (rotated_object_3D.z > -0.5f) {
-        // obstacle is at the most 0.5 meters above vehicle
-        if ((alt - PROXIMITY_GND_DETECT_THRESHOLD) < rotated_object_3D.z) {
-            // obstacle is near or below ground
-            return true;
-        }
-    }
-    return false;
-}
-
-// returns true if database is ready to be pushed to and all cached data is ready
-bool AP_Proximity_Backend::database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned)
-{
-    AP_OADatabase *oaDb = AP::oadatabase();
-    if (oaDb == nullptr || !oaDb->healthy()) {
-        return false;
-    }
-
-    if (!AP::ahrs().get_relative_position_NED_origin(current_pos)) {
-        return false;
-    }
-
-    body_to_ned = AP::ahrs().get_rotation_body_to_ned();
-
-    return true;
-}
-
-// update Object Avoidance database with Earth-frame point
-void AP_Proximity_Backend::database_push(float angle, float distance)
-{
-    Vector3f current_pos;
-    Matrix3f body_to_ned;
-
-    if (database_prepare_for_push(current_pos, body_to_ned)) {
-        database_push(angle, distance, AP_HAL::millis(), current_pos, body_to_ned);
-    }
-}
-
-// update Object Avoidance database with Earth-frame point
-// pitch can be optionally provided if needed
-void AP_Proximity_Backend::database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned)
-{
-    AP_OADatabase *oaDb = AP::oadatabase();
-    if (oaDb == nullptr || !oaDb->healthy()) {
-        return;
-    }
-    if ((pitch > 90.0f) || (pitch < -90.0f)) {
-        // sanity check on pitch
-        return;
-    }
-    //Assume object is angle and pitch bearing and distance meters away from the vehicle 
-    Vector3f object_3D;
-    object_3D.offset_bearing(wrap_180(angle), (pitch * -1.0f), distance);
-    const Vector3f rotated_object_3D = body_to_ned * object_3D;
-
-    //Calculate the position vector from origin
-    Vector3f temp_pos = current_pos + rotated_object_3D;
-    //Convert the vector to a NEU frame from NED
-    temp_pos.z = temp_pos.z * -1.0f;
-
-    oaDb->queue_push(temp_pos, timestamp_ms, distance);
+    return utility.ignore_reading(pitch, yaw, distance_m, check_for_ign_area, frontend._max_m, frontend._min_m);
 }
 
 #endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -24,13 +24,13 @@
 
 #define PROXIMITY_GND_DETECT_THRESHOLD 1.0f // set ground detection threshold to be 1 meters
 #define PROXIMITY_ALT_DETECT_TIMEOUT_MS 500 // alt readings should arrive within this much time
-#define PROXIMITY_BOUNDARY_3D_TIMEOUT_MS 750 // we should check the 3D boundary faces after every this many ms
+
 
 class AP_Proximity_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-	AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+	AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_Proximity_Boundary_3D &_boundary, AP_Proximity_Utils &_utility);
 
     // we declare a virtual destructor so that Proximity drivers can
     // override with a custom destructor if need be
@@ -38,9 +38,6 @@ public:
 
     // update the state structure
     virtual void update() = 0;
-
-    // timeout faces that have not received data recently and update filter frequencies
-    void boundary_3D_checks();
 
     // get maximum and minimum distances (in meters) of sensor
     virtual float distance_max() const = 0;
@@ -52,35 +49,11 @@ public:
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(const mavlink_message_t &msg) {}
 
-    // get total number of obstacles, used in GPS based Simple Avoidance
-    uint8_t get_obstacle_count() { return boundary.get_obstacle_count(); }
-    
-    // get vector to obstacle based on obstacle_num passed, used in GPS based Simple Avoidance
-    bool get_obstacle(uint8_t obstacle_num, Vector3f& vec_to_obstacle) const { return boundary.get_obstacle(obstacle_num, vec_to_obstacle); }
-    
-    // returns shortest distance to "obstacle_num" obstacle, from a line segment formed between "seg_start" and "seg_end"
-    // used in GPS based Simple Avoidance
-    bool closest_point_from_segment_to_obstacle(const uint8_t obstacle_num, const Vector3f& seg_start, const Vector3f& seg_end, Vector3f& closest_point) const { return boundary.closest_point_from_segment_to_obstacle(obstacle_num , seg_start, seg_end, closest_point); }
-
-    // get distance and angle to closest object (used for pre-arm check)
-    //   returns true on success, false if no valid readings
-    bool get_closest_object(float& angle_deg, float &distance) const { return boundary.get_closest_object(angle_deg, distance); }
-
-    // get number of objects, angle and distance - used for non-GPS avoidance
-    uint8_t get_horizontal_object_count() const {return boundary.get_horizontal_object_count(); }
-    bool get_horizontal_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const { return boundary.get_horizontal_object_angle_and_distance(object_number, angle_deg, distance); }
-
     // get distances in 8 directions. used for sending distances to ground station
-    bool get_horizontal_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
+    bool get_horizontal_distances(AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_dist_array) const;
 
     // get raw and filtered distances in 8 directions per layer. used for logging
-    bool get_active_layer_distances(uint8_t layer, AP_Proximity::Proximity_Distance_Array &prx_dist_array, AP_Proximity::Proximity_Distance_Array &prx_filt_dist_array) const;
-
-    // get number of layers
-    uint8_t get_num_layers() const { return boundary.get_num_layers(); }
-
-    // store rangefinder values
-    void set_rangefinder_alt(bool use, bool healthy, float alt_cm);
+    bool get_active_layer_distances(uint8_t layer, AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_dist_array, AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D &prx_filt_dist_array) const;
 
 protected:
 
@@ -98,34 +71,14 @@ protected:
     bool ignore_reading(float pitch, float yaw, float distance_m, bool check_for_ign_area = true) const;
     bool ignore_reading(float yaw, float distance_m, bool check_for_ign_area = true) const { return ignore_reading(0.0f, yaw, distance_m, check_for_ign_area); }
 
-    // get alt from rangefinder in meters. This reading is corrected for vehicle tilt
-    bool get_rangefinder_alt(float &alt_m) const;
-
-    // Check if Obstacle defined by body-frame yaw and pitch is near ground
-    bool check_obstacle_near_ground(float pitch, float yaw, float distance) const;
-
-    // database helpers. All angles are in degrees
-    static bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
-    // Note: "angle" refers to yaw (in body frame) towards the obstacle
-    static void database_push(float angle, float distance);
-    static void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned) {
-        database_push(angle, 0.0f, distance, timestamp_ms, current_pos, body_to_ned);
-    };
-    static void database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
-
-    uint32_t _last_timeout_check_ms;  // time when boundary was checked for non-updated valid faces
-
-    // used for ground detection
-    uint32_t _last_downward_update_ms;
-    bool     _rangefinder_use;
-    bool     _rangefinder_healthy;
-    float    _rangefinder_alt;
-
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 
     // Methods to manipulate 3D boundary in this class
-    AP_Proximity_Boundary_3D boundary;
+    AP_Proximity_Boundary_3D &boundary;
+
+    // convenience functions in this class
+    AP_Proximity_Utils &utility;
 };
 
 #endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.cpp
@@ -24,22 +24,24 @@
    already know that we should setup the proximity sensor
 */
 AP_Proximity_Backend_Serial::AP_Proximity_Backend_Serial(AP_Proximity &_frontend,
-                                                         AP_Proximity::Proximity_State &_state) :
-    AP_Proximity_Backend(_frontend, _state)
+                                                         AP_Proximity::Proximity_State &_state,
+                                                         AP_Proximity_Boundary_3D &_boundary,
+                                                         AP_Proximity_Utils &_utility) :
+    AP_Proximity_Backend(_frontend, _state, _boundary, _utility)
 {
     const AP_SerialManager &serial_manager = AP::serialmanager();
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, _state.instance);
     if (_uart != nullptr) {
         // start uart with larger receive buffer
-        _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0), rxspace(), 0);
+        _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, _state.instance), rxspace(), _state.instance);
     }
 }
 
 // detect if a proximity sensor is connected by looking for a
 // configured serial port
-bool AP_Proximity_Backend_Serial::detect()
+bool AP_Proximity_Backend_Serial::detect(uint8_t instance)
 {
-    return AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
+    return AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_Lidar360, instance);
 }
 
 #endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend_Serial.h
@@ -8,9 +8,11 @@ class AP_Proximity_Backend_Serial : public AP_Proximity_Backend
 {
 public:
     AP_Proximity_Backend_Serial(AP_Proximity &_frontend,
-                                AP_Proximity::Proximity_State &_state);
+                                AP_Proximity::Proximity_State &_state,
+                                AP_Proximity_Boundary_3D &_boundary,
+                                AP_Proximity_Utils &_utility);
     // static detection function
-    static bool detect();
+    static bool detect(uint8_t instance);
 
 protected:
     virtual uint16_t rxspace() const { return 0; };

--- a/libraries/AP_Proximity/AP_Proximity_Cygbot_D1.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Cygbot_D1.cpp
@@ -118,7 +118,7 @@ bool AP_Proximity_Cygbot_D1::parse_byte(uint8_t data)
         // checksum is valid, parse payload
         _last_distance_received_ms = AP_HAL::millis();
         parse_payload();
-        _temp_boundary.update_3D_boundary(boundary);
+        _temp_boundary.update_3D_boundary(state.instance, boundary);
         reset();
         return true;
     }
@@ -152,7 +152,7 @@ void AP_Proximity_Cygbot_D1::parse_payload()
             // push face to temp boundary
             _temp_boundary.add_distance(face, sampled_angle, distance_m);
             // push to OA_DB
-            database_push(sampled_angle, distance_m);
+            utility.database_push(sampled_angle, distance_m);
         }
         // increment sampled angle
         sampled_angle += CYGBOT_2D_ANGLE_STEP;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -303,7 +303,7 @@ void AP_Proximity_LightWareSF40C::process_message()
         // prepare to push to object database
         Vector3f current_pos;
         Matrix3f body_to_ned;
-        const bool database_ready = database_prepare_for_push(current_pos, body_to_ned);
+        const bool database_ready = utility.database_prepare_for_push(current_pos, body_to_ned);
 
         // process each point
         const float angle_inc_deg = (1.0f / point_total) * 360.0f;
@@ -326,7 +326,7 @@ void AP_Proximity_LightWareSF40C::process_message()
             if (face != _face) {
                 // update boundary used for avoidance
                 if (_face_distance_valid) {
-                    boundary.set_face_attributes(_face, _face_yaw_deg, _face_distance);
+                    boundary.set_face_attributes(state.instance, _face, _face_yaw_deg, _face_distance);
                 } else {
                     // mark previous face invalid
                     boundary.reset_face(_face);
@@ -359,7 +359,7 @@ void AP_Proximity_LightWareSF40C::process_message()
             // send combined distance to object database
             if ((i+1 >= point_count) || (combined_count >= PROXIMITY_SF40C_COMBINE_READINGS)) {
                 if ((combined_dist_m < INT16_MAX) && database_ready) {
-                    database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_pos,body_to_ned);
+                    utility.database_push(combined_angle_deg, combined_dist_m, _last_distance_received_ms, current_pos,body_to_ned);
                 }
                 combined_count = 0;
                 combined_dist_m = INT16_MAX;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.cpp
@@ -144,7 +144,7 @@ void AP_Proximity_LightWareSF45B::process_message()
         const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
         if (face != _face) {
             if (_face_distance_valid) {
-                boundary.set_face_attributes(_face, _face_yaw_deg, _face_distance);
+                boundary.set_face_attributes(state.instance, _face, _face_yaw_deg, _face_distance);
             } else {
                 // mark previous face invalid
                 boundary.reset_face(_face);
@@ -160,7 +160,7 @@ void AP_Proximity_LightWareSF45B::process_message()
         const uint8_t minisector = convert_angle_to_minisector(angle_deg);
         if (minisector != _minisector) {
             if ((_minisector != UINT8_MAX) && _minisector_distance_valid) {
-                database_push(_minisector_angle, _minisector_distance);
+                utility.database_push(_minisector_angle, _minisector_distance);
             }
             // init mini sector
             _minisector = minisector;

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
@@ -11,8 +11,8 @@ class AP_Proximity_LightWareSF45B : public AP_Proximity_LightWareSerial
 public:
     // constructor
     AP_Proximity_LightWareSF45B(AP_Proximity &_frontend,
-                                AP_Proximity::Proximity_State &_state) :
-            AP_Proximity_LightWareSerial(_frontend, _state) {}
+                                AP_Proximity::Proximity_State &_state, AP_Proximity_Boundary_3D &_boundary, AP_Proximity_Utils &_utility)  :
+            AP_Proximity_LightWareSerial(_frontend, _state, _boundary, _utility) {}
 
     uint16_t rxspace() const override {
         return 1280;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -319,7 +319,7 @@ void AP_Proximity_RPLidarA2::parse_response_data()
                     if (face != _last_face) {
                         // distance is for a new face, the previous one can be updated now
                         if (_last_distance_valid) {
-                            boundary.set_face_attributes(_last_face, _last_angle_deg, _last_distance_m);
+                            boundary.set_face_attributes(state.instance, _last_face, _last_angle_deg, _last_distance_m);
                         } else {
                             // reset distance from last face
                             boundary.reset_face(face);
@@ -337,7 +337,7 @@ void AP_Proximity_RPLidarA2::parse_response_data()
                             _last_angle_deg = angle_deg;
                         }
                         // update OA database
-                        database_push(_last_angle_deg, _last_distance_m);
+                        utility.database_push(_last_angle_deg, _last_distance_m);
                     }
                 }
             } else {

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -51,9 +51,9 @@ void AP_Proximity_RangeFinder::update(void)
                 _distance_min = sensor->min_distance_cm() * 0.01f;
                 _distance_max = sensor->max_distance_cm() * 0.01f;
                 if ((distance <= _distance_max) && (distance >= _distance_min) && !ignore_reading(angle, distance, false)) {
-                    boundary.set_face_attributes(face, angle, distance);
+                    boundary.set_face_attributes(state.instance, face, angle, distance);
                     // update OA database
-                    database_push(angle, distance);
+                    utility.database_push(angle, distance);
                 } else {
                     boundary.reset_face(face);
                 }

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -33,8 +33,10 @@ extern const AP_HAL::HAL& hal;
    The constructor also initialises the proximity sensor. 
 */
 AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
-                                     AP_Proximity::Proximity_State &_state):
-    AP_Proximity_Backend(_frontend, _state),
+                                     AP_Proximity::Proximity_State &_state,
+                                     AP_Proximity_Boundary_3D &_boundary,
+                                     AP_Proximity_Utils &_utility):
+    AP_Proximity_Backend(_frontend, _state, _boundary, _utility),
     sitl(AP::sitl())
 {
     ap_var_type ptype;
@@ -62,9 +64,9 @@ void AP_Proximity_SITL::update(void)
             AP_Proximity_Boundary_3D::Face face = boundary.get_face(yaw_angle_deg);
             float fence_distance;
             if (get_distance_to_fence(yaw_angle_deg, fence_distance)) {
-                boundary.set_face_attributes(face, yaw_angle_deg, fence_distance);
+                boundary.set_face_attributes(state.instance, face, yaw_angle_deg, fence_distance);
                 // update OA database
-                database_push(yaw_angle_deg, fence_distance);
+                utility.database_push(yaw_angle_deg, fence_distance);
             } else {
                 boundary.reset_face(face);
             }

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -14,7 +14,7 @@ class AP_Proximity_SITL : public AP_Proximity_Backend
 
 public:
     // constructor
-    AP_Proximity_SITL(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+    AP_Proximity_SITL(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_Proximity_Boundary_3D &_boundary, AP_Proximity_Utils &_utility);
 
     // update state
     void update(void) override;

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -97,9 +97,9 @@ void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_
     // Get location on 3-D boundary based on angle to the object
     const AP_Proximity_Boundary_3D::Face face = boundary.get_face(angle_deg);
     if ((distance_cm != 0xffff) && !ignore_reading(angle_deg, distance_cm * 0.001f, false)) {
-        boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
+        boundary.set_face_attributes(state.instance, face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
-        database_push(angle_deg, ((float) distance_cm) / 1000);
+        utility.database_push(angle_deg, ((float) distance_cm) / 1000);
     } else {
         boundary.reset_face(face);
     }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -152,9 +152,9 @@ void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint
     //check for target too far, target too close and sensor not connected
     const bool valid = (distance_cm != 0xffff) && (distance_cm > 0x0001);
     if (valid && !ignore_reading(angle_deg, distance_cm * 0.001f, false)) {
-        boundary.set_face_attributes(face, angle_deg, ((float) distance_cm) / 1000);
+        boundary.set_face_attributes(state.instance, face, angle_deg, ((float) distance_cm) / 1000);
         // update OA database
-        database_push(angle_deg, ((float) distance_cm) / 1000);
+        utility.database_push(angle_deg, ((float) distance_cm) / 1000);
     } else {
         boundary.reset_face(face);
     }

--- a/libraries/AP_Proximity/AP_Proximity_Utils.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Utils.cpp
@@ -1,0 +1,168 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Proximity_Utils.h"
+
+#if HAL_PROXIMITY_ENABLED
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AC_Avoidance/AP_OADatabase.h>
+#include <AP_HAL/AP_HAL.h>
+
+extern const AP_HAL::HAL& hal;
+
+
+// check if a reading should be ignored because it falls into an ignore area (check_for_ign_area should be sent as false if this check is not needed)
+// pitch is the vertical body-frame angle (in degrees) to the obstacle (0=directly ahead, 90 is above the vehicle)
+// yaw is the horizontal body-frame angle (in degrees) to the obstacle (0=directly ahead of the vehicle, 90 is to the right of the vehicle)
+// Also checks if obstacle is near land or out of range
+// angles should be in degrees and in the range of 0 to 360, distance should be in meteres
+bool AP_Proximity_Utils::ignore_reading(float pitch, float yaw, float distance_m, bool check_for_ign_area, float max_range_m, float min_range_m) const
+{
+    // check if distances are supposed to be in a particular range
+    if (!is_zero(max_range_m)) {
+        if (distance_m > max_range_m) {
+            // too far away
+            return true;
+        }
+    }
+
+    if (!is_zero(min_range_m)) {
+        if (distance_m < min_range_m) {
+            // too close
+            return true;
+        }
+    }
+
+   // check if obstacle is near land
+   return check_obstacle_near_ground(pitch, yaw, distance_m);
+}
+
+// store rangefinder values
+void AP_Proximity_Utils::set_rangefinder_alt(bool use, bool healthy, float alt_cm)
+{
+    _last_downward_update_ms = AP_HAL::millis();
+    _rangefinder_use = use;
+    _rangefinder_healthy = healthy;
+    _rangefinder_alt = alt_cm * 0.01f;
+}
+
+// get alt from rangefinder in meters
+bool AP_Proximity_Utils::get_rangefinder_alt(float &alt_m) const
+{
+    if (!_rangefinder_use || !_rangefinder_healthy) {
+        // range finder is not healthy
+        return false;
+    }
+
+    const uint32_t dt = AP_HAL::millis() - _last_downward_update_ms;
+    if (dt > PROXIMITY_ALT_DETECT_TIMEOUT_MS) {
+        return false;
+    }
+
+    // readings are healthy
+    alt_m = _rangefinder_alt;
+    return true;
+}
+
+// Check if Obstacle defined by body-frame yaw and pitch is near ground
+bool AP_Proximity_Utils::check_obstacle_near_ground(float pitch, float yaw, float distance) const
+{
+    if (!hal.util->get_soft_armed()) {
+        // don't run this feature while vehicle is disarmed, otherwise proximity data will not show up on GCS
+        return false;
+    }
+    if ((pitch > 90.0f) || (pitch < -90.0f)) {
+        // sanity check on pitch
+        return false;
+    }
+    // Assume object is yaw and pitch bearing and distance meters away from the vehicle
+    Vector3f object_3D;
+    object_3D.offset_bearing(wrap_180(yaw), (pitch * -1.0f), distance);
+    const Matrix3f body_to_ned = AP::ahrs().get_rotation_body_to_ned();
+    const Vector3f rotated_object_3D = body_to_ned * object_3D;
+
+    float alt = FLT_MAX;
+    if (!get_rangefinder_alt(alt)) {
+        return false;
+    }
+
+    if (rotated_object_3D.z > -0.5f) {
+        // obstacle is at the most 0.5 meters above vehicle
+        if ((alt - PROXIMITY_GND_DETECT_THRESHOLD) < rotated_object_3D.z) {
+            // obstacle is near or below ground
+            return true;
+        }
+    }
+    return false;
+}
+
+// returns true if database is ready to be pushed to and all cached data is ready
+bool AP_Proximity_Utils::database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned)
+{
+    AP_OADatabase *oaDb = AP::oadatabase();
+    if (oaDb == nullptr || !oaDb->healthy()) {
+        return false;
+    }
+
+    if (!AP::ahrs().get_relative_position_NED_origin(current_pos)) {
+        return false;
+    }
+
+    body_to_ned = AP::ahrs().get_rotation_body_to_ned();
+
+    return true;
+}
+
+// update Object Avoidance database with Earth-frame point
+void AP_Proximity_Utils::database_push(float angle, float distance)
+{
+    Vector3f current_pos;
+    Matrix3f body_to_ned;
+
+    if (database_prepare_for_push(current_pos, body_to_ned)) {
+        database_push(angle, distance, AP_HAL::millis(), current_pos, body_to_ned);
+    }
+}
+
+// update Object Avoidance database with Earth-frame point
+// pitch can be optionally provided if needed
+void AP_Proximity_Utils::database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned)
+{
+    AP_OADatabase *oaDb = AP::oadatabase();
+    if (oaDb == nullptr || !oaDb->healthy()) {
+        return;
+    }
+    if ((pitch > 90.0f) || (pitch < -90.0f)) {
+        // sanity check on pitch
+        return;
+    }
+    //Assume object is angle and pitch bearing and distance meters away from the vehicle 
+    Vector3f object_3D;
+    object_3D.offset_bearing(wrap_180(angle), (pitch * -1.0f), distance);
+    const Vector3f rotated_object_3D = body_to_ned * object_3D;
+
+    //Calculate the position vector from origin
+    Vector3f temp_pos = current_pos + rotated_object_3D;
+    //Convert the vector to a NEU frame from NED
+    temp_pos.z = temp_pos.z * -1.0f;
+
+    oaDb->queue_push(temp_pos, timestamp_ms, distance);
+}
+
+#endif // HAL_PROXIMITY_ENABLED
+

--- a/libraries/AP_Proximity/AP_Proximity_Utils.h
+++ b/libraries/AP_Proximity/AP_Proximity_Utils.h
@@ -1,0 +1,71 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_PROXIMITY_ENABLED
+#define HAL_PROXIMITY_ENABLED (!HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024)
+#endif
+
+#if HAL_PROXIMITY_ENABLED
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+
+#define PROXIMITY_GND_DETECT_THRESHOLD 1.0f // set ground detection threshold to be 1 meters
+#define PROXIMITY_ALT_DETECT_TIMEOUT_MS 500 // alt readings should arrive within this much time
+
+class AP_Proximity_Utils
+{
+public:
+
+    // store rangefinder values
+    void set_rangefinder_alt(bool use, bool healthy, float alt_cm);
+
+    // check if a reading should be ignored because it falls into an ignore area (check_for_ign_area should be sent as false if this check is not needed)
+    // pitch is the vertical body-frame angle (in degrees) to the obstacle (0=directly ahead, 90 is above the vehicle)
+    // yaw is the horizontal body-frame angle (in degrees) to the obstacle (0=directly ahead of the vehicle, 90 is to the right of the vehicle)
+    // Also checks if obstacle is near land or out of range
+    // angles should be in degrees and in the range of 0 to 360, distance should be in meteres
+    bool ignore_reading(float pitch, float yaw, float distance_m, bool check_for_ign_area, float max_range_m, float min_range_m) const;
+
+    // get alt from rangefinder in meters. This reading is corrected for vehicle tilt
+    bool get_rangefinder_alt(float &alt_m) const;
+
+    // Check if Obstacle defined by body-frame yaw and pitch is near ground
+    bool check_obstacle_near_ground(float pitch, float yaw, float distance) const;
+
+    // database helpers. All angles are in degrees
+    static bool database_prepare_for_push(Vector3f &current_pos, Matrix3f &body_to_ned);
+    // Note: "angle" refers to yaw (in body frame) towards the obstacle
+    static void database_push(float angle, float distance);
+    static void database_push(float angle, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned) {
+        database_push(angle, 0.0f, distance, timestamp_ms, current_pos, body_to_ned);
+    };
+    static void database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
+
+protected:
+
+    // used for ground detection
+    uint32_t _last_downward_update_ms;
+    bool     _rangefinder_use;
+    bool     _rangefinder_healthy;
+    float    _rangefinder_alt;
+
+};
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -441,7 +441,7 @@ void GCS_MAVLINK::send_proximity()
 
     // send horizontal distances
     if (proximity->get_status() == AP_Proximity::Status::Good) {
-        AP_Proximity::Proximity_Distance_Array dist_array;
+        AP_Proximity_Boundary_3D::Proximity_Distance_Array_2D dist_array;
         if (proximity->get_horizontal_distances(dist_array)) {
             for (uint8_t i = 0; i < PROXIMITY_MAX_DIRECTION; i++) {
                 if (!HAVE_PAYLOAD_SPACE(chan, DISTANCE_SENSOR)) {


### PR DESCRIPTION
This is a big overhaul of the Proximity library to allow for multiple backends, i.e connect multiple lidars. With this PR I think it is much closer to its near relative, the AP_RangeFinder library.

The problem was that we had included a lot of methods in the Backend that did not belong there (example: 3D boundary code, OA DB functions, etc). As a result, I had to shift them into new, more appropriate classes so that they are not copied/duplicated when we connect multiple proximity sensors.

TO-DO:

- [ ] Figure out arming check behaviour

- [ ] Figure out how to log multiple sensors

- [ ] Test for breakages 
 