### PR TITLE
AP_HAL: remove BRD_PWM_COUNT reference

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat
@@ -165,9 +165,9 @@ PD12 USART3_RTS USART3
 PD10 FRAM_CS CS SPEED_VERYLOW
 
 # Now we start defining some PWM pins. We also map these pins to GPIO
-# values, so users can set BRD_PWM_COUNT to choose how many of the PWM
-# outputs on the primary MCU are setup as PWM and how many as
-# GPIOs. To match HAL_PX4 we number the GPIOs for the PWM outputs
+# values, so users can set SERVOx_FUNCTION=-1 to determine which
+# PWM outputs on the primary MCU are set up as GPIOs.
+# To match HAL_PX4 we number the GPIOs for the PWM outputs
 # starting at 50.
 PE14 TIM1_CH4 TIM1 PWM(1) GPIO(50)
 PE13 TIM1_CH3 TIM1 PWM(2) GPIO(51)


### PR DESCRIPTION
Quick PR to update comment text that contains a stale reference to BRD_PWM_COUNT.

https://discuss.ardupilot.org/t/brd-pwm-count-still-in-hwdef-dat/84160/2