### PR TITLE
SITL: JSON: add more keywords to define a vehicle

### DIFF
--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -127,6 +127,9 @@ private:
         // momentum drag coefficient
         float mdrag_coef = 0.2;
 
+        // if zero value will be estimated from mass
+        Vector3f moment_of_inertia;
+
     } default_model;
 
     struct Model model;

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -134,9 +134,7 @@ private:
     // exposed area times coefficient of drag
     float areaCd;
     float mass;
-    float velocity_max;
     float thrust_max;
-    float effective_prop_area;
     Battery *battery;
     float last_param_voltage;
 

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -21,6 +21,11 @@
 #include "SIM_Aircraft.h"
 #include "SIM_Motor.h"
 
+#define USE_PICOJSON (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#if USE_PICOJSON
+#include "picojson.h"
+#endif
+
 namespace SITL {
 
 /*
@@ -130,6 +135,10 @@ private:
         // if zero value will be estimated from mass
         Vector3f moment_of_inertia;
 
+        // if zero will no be used
+        Vector3f motor_pos[12];
+        Vector3f motor_thrust_vec[12];
+
     } default_model;
 
     struct Model model;
@@ -146,6 +155,8 @@ private:
 
     // load frame parameters from a json model file
     void load_frame_params(const char *model_json);
+    void parse_float(picojson::value val, const char* label, float &param);
+    void parse_vector3(picojson::value val, const char* label, Vector3f &param);
 
 };
 }

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -143,7 +143,7 @@ float Motor::get_current(void) const
 // setup PWM ranges for this motor
 void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                          float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
-                         float _velocity_max)
+                         float _velocity_max, Vector3f _position, Vector3f _thrust_vector)
 {
     mot_pwm_min = _pwm_min;
     mot_pwm_max = _pwm_max;
@@ -156,9 +156,17 @@ void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, 
     effective_prop_area = _effective_prop_area;
     max_outflow_velocity = _velocity_max;
 
-    position.x = cosf(radians(angle)) * _diagonal_size;
-    position.y =  sinf(radians(angle)) * _diagonal_size;
-    position.z = 0;
+    if (!_position.is_zero()) {
+        position = _position;
+    } else {
+        position.x = cosf(radians(angle)) * _diagonal_size;
+        position.y =  sinf(radians(angle)) * _diagonal_size;
+        position.z = 0;
+    }
+
+    if (!_thrust_vector.is_zero()) {
+        thrust_vector = _thrust_vector;
+    }
 }
 
 /*

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -104,7 +104,7 @@ public:
     // setup motor key parameters
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                       float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
-                      float _velocity_max);
+                      float _velocity_max, Vector3f _position, Vector3f _thrust_vector);
 
     // override slew limit
     void set_slew_max(float _slew_max) {

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -75,8 +75,6 @@ public:
                           Vector3f &body_thrust, // Z is down
                           const Vector3f &velocity_air_bf,
                           float air_density,
-                          float velocity_max,
-                          float effective_prop_area,
                           float voltage);
 
     uint16_t update_servo(uint16_t demand, uint64_t time_usec, float &last_value) const;
@@ -89,7 +87,8 @@ public:
 
     // setup motor key parameters
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
-                      float _vehicle_mass, float _diagonal_size, float _power_factor, float _voltage_max);
+                      float _vehicle_mass, float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
+                      float _velocity_max);
 
     // override slew limit
     void set_slew_max(float _slew_max) {
@@ -101,7 +100,7 @@ public:
     }
 
     // calculate thrust of motor
-    float calc_thrust(float command, float air_density, float effective_prop_area, float velocity_in, float velocity_max) const;
+    float calc_thrust(float command, float air_density, float velocity_in, float voltage_scale) const;
 
 private:
     float mot_pwm_min;
@@ -116,6 +115,8 @@ private:
     float power_factor;
     float voltage_max;
     Vector3f moment_of_inertia;
+    float effective_prop_area;
+    float max_outflow_velocity;
 
     float last_command;
     uint64_t last_calc_us;

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -49,7 +49,15 @@ public:
         angle(_angle), // angle in degrees from front
         yaw_factor(_yaw_factor), // positive is clockwise
         display_order(_display_order) // order for clockwise display
-    {}
+    {
+        position.x = cosf(radians(angle));
+        position.y =  sinf(radians(angle));
+        position.z = 0;
+
+        thrust_vector.x = 0;
+        thrust_vector.y = 0;
+        thrust_vector.z = -1;
+    }
 
     /*
       alternative constructor for tiltable motors
@@ -67,7 +75,15 @@ public:
         pitch_servo(_pitch_servo),
         pitch_min(_pitch_min),
         pitch_max(_pitch_max)
-    {}
+    {
+        position.x = cosf(radians(angle));
+        position.y =  sinf(radians(angle));
+        position.z = 0;
+
+        thrust_vector.x = 0;
+        thrust_vector.y = 0;
+        thrust_vector.z = -1;
+    }
 
     void calculate_forces(const struct sitl_input &input,
                           uint8_t motor_offset,
@@ -109,7 +125,6 @@ private:
     float mot_spin_max;
     float mot_expo;
     float slew_max;
-    float diagonal_size;
     float current;
     float power_factor;
     float voltage_max;
@@ -118,6 +133,9 @@ private:
 
     float last_command;
     uint64_t last_calc_us;
+
+    Vector3f position;
+    Vector3f thrust_vector;
 };
 
 }

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -87,7 +87,7 @@ public:
 
     // setup motor key parameters
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
-                      float _vehicle_mass, float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
+                      float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
                       float _velocity_max);
 
     // override slew limit
@@ -109,12 +109,10 @@ private:
     float mot_spin_max;
     float mot_expo;
     float slew_max;
-    float vehicle_mass;
     float diagonal_size;
     float current;
     float power_factor;
     float voltage_max;
-    Vector3f moment_of_inertia;
     float effective_prop_area;
     float max_outflow_velocity;
 


### PR DESCRIPTION
This reworks the motors/frame interface so constants are kept in motors and thrust/torque is returned. Then it adds the ability to define the vehicle inertia with `"moment_inertia" : [1,2,3],` and per motor position and thrust vector with `"motor1_position" : [1,2,3], "motor1_vector" : [1,2,3],` to `"motor12_position" : [1,2,3], "motor12_vector" : [1,2,3],`