### PR TITLE
AP_AHRS: View: return invalid rotation if pitch trim is set

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3207,14 +3207,6 @@ void AP_AHRS::set_alt_measurement_noise(float noise)
 #endif
 }
 
-/*
-  get the current view's rotation, or ROTATION_NONE
- */
-enum Rotation AP_AHRS::get_view_rotation(void) const
-{
-    return _view?_view->get_rotation():ROTATION_NONE;
-}
-
 // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
 const EKFGSF_yaw *AP_AHRS::get_yaw_estimator(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -609,8 +609,8 @@ public:
         _vehicle_class = vclass;
     }
 
-    // get the view's rotation, or ROTATION_NONE
-    enum Rotation get_view_rotation(void) const;
+    // get the view
+    AP_AHRS_View *get_view(void) const { return _view; };
 
     // get access to an EKFGSF_yaw estimator
     const EKFGSF_yaw *get_yaw_estimator(void) const;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -187,9 +187,13 @@ public:
 
 
     // get current rotation
+    // note that this may not be the rotation were actually using, see _pitch_trim_deg
     enum Rotation get_rotation(void) const {
         return rotation;
     }
+
+    // get pitch trim (deg)
+    float get_pitch_trim() const { return _pitch_trim_deg; }
 
 private:
     const enum Rotation rotation;


### PR DESCRIPTION
This is disables the new trim functionality added in https://github.com/ArduPilot/ardupilot/pull/18311 in the case that there is a pitch offset. 

Of course we could workout the correct trim including the pitch offset, but that would be significantly more effort. Pitch offset being set is relatively uncommon, this stops us getting the wrong answer in the case it is set. 

Extract from https://github.com/ArduPilot/ardupilot/pull/20074
