### PR TITLE
AP_Airspeed: Add enabled checks to public get funcs

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -737,6 +737,24 @@ bool AP_Airspeed::all_healthy(void) const
     return true;
 }
 
+// return true if airspeed is enabled
+bool AP_Airspeed::enabled(uint8_t i) const {
+    if (i < AIRSPEED_MAX_SENSORS) {
+        return param[i].type.get() != TYPE_NONE;
+    }
+    return false;
+}
+
+// return health status of sensor
+bool AP_Airspeed::healthy(uint8_t i) const {
+    bool ok = state[i].healthy && enabled(i);
+#ifndef HAL_BUILD_AP_PERIPH
+    // sanity check the offset parameter.  Zero is permitted if we are skipping calibration.
+    ok &= (fabsf(param[i].offset) > 0 || state[i].use_zero_offset || param[i].skip_cal);
+#endif
+    return ok;
+}
+
 #else  // build type is not appropriate; provide a dummy implementation:
 const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
 
@@ -744,6 +762,8 @@ void AP_Airspeed::update() {};
 bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) { return false; }
 void AP_Airspeed::calibrate(bool in_startup) {}
 bool AP_Airspeed::use(uint8_t i) const { return false; }
+bool AP_Airspeed::enabled(uint8_t i) const { return false; }
+bool AP_Airspeed::healthy(uint8_t i) const { return false; }
 
 #if HAL_MSP_AIRSPEED_ENABLED
 void AP_Airspeed::handle_msp(const MSP::msp_airspeed_data_message_t &pkt) {}

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -747,7 +747,7 @@ bool AP_Airspeed::enabled(uint8_t i) const {
 
 // return health status of sensor
 bool AP_Airspeed::healthy(uint8_t i) const {
-    bool ok = state[i].healthy && enabled(i);
+    bool ok = state[i].healthy && enabled(i) && sensor[i] != nullptr;
 #ifndef HAL_BUILD_AP_PERIPH
     // sanity check the offset parameter.  Zero is permitted if we are skipping calibration.
     ok &= (fabsf(param[i].offset) > 0 || state[i].use_zero_offset || param[i].skip_cal);

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -755,6 +755,40 @@ bool AP_Airspeed::healthy(uint8_t i) const {
     return ok;
 }
 
+// return the current airspeed in m/s
+float AP_Airspeed::get_airspeed(uint8_t i) const {
+    if (!enabled(i)) {
+        // we can't have negative airspeed so sending an obviously invalid value
+        return -1.0;
+    }
+    return state[i].airspeed;
+}
+
+// return the unfiltered airspeed in m/s
+float AP_Airspeed::get_raw_airspeed(uint8_t i) const {
+    if (!enabled(i)) {
+        // we can't have negative airspeed so sending an obviously invalid value
+        return -1.0;
+    }
+    return state[i].raw_airspeed;
+}
+
+// return the differential pressure in Pascal for the last airspeed reading
+float AP_Airspeed::get_differential_pressure(uint8_t i) const {
+    if (!enabled(i)) {
+        return 0.0;
+    }
+    return state[i].last_pressure;
+}
+
+// return the current corrected pressure
+float AP_Airspeed::get_corrected_pressure(uint8_t i) const {
+    if (!enabled(i)) {
+        return 0.0;
+    }
+    return state[i].corrected_pressure;
+}
+
 #else  // build type is not appropriate; provide a dummy implementation:
 const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
 
@@ -764,6 +798,8 @@ void AP_Airspeed::calibrate(bool in_startup) {}
 bool AP_Airspeed::use(uint8_t i) const { return false; }
 bool AP_Airspeed::enabled(uint8_t i) const { return false; }
 bool AP_Airspeed::healthy(uint8_t i) const { return false; }
+float AP_Airspeed::get_airspeed(uint8_t i) const { return 0.0; }
+float AP_Airspeed::get_differential_pressure(uint8_t i) const { return 0.0; }
 
 #if HAL_MSP_AIRSPEED_ENABLED
 void AP_Airspeed::handle_msp(const MSP::msp_airspeed_data_message_t &pkt) {}

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -73,15 +73,11 @@ public:
     void calibrate(bool in_startup);
 
     // return the current airspeed in m/s
-    float get_airspeed(uint8_t i) const {
-        return state[i].airspeed;
-    }
+    float get_airspeed(uint8_t i) const;
     float get_airspeed(void) const { return get_airspeed(primary); }
 
     // return the unfiltered airspeed in m/s
-    float get_raw_airspeed(uint8_t i) const {
-        return state[i].raw_airspeed;
-    }
+    float get_raw_airspeed(uint8_t i) const;
     float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }
 
     // return the current airspeed ratio (dimensionless)
@@ -114,9 +110,7 @@ public:
     bool enabled(void) const { return enabled(primary); }
 
     // return the differential pressure in Pascal for the last airspeed reading
-    float get_differential_pressure(uint8_t i) const {
-        return state[i].last_pressure;
-    }
+    float get_differential_pressure(uint8_t i) const;
     float get_differential_pressure(void) const { return get_differential_pressure(primary); }
 
     // update airspeed ratio calibration
@@ -173,9 +167,7 @@ public:
     static AP_Airspeed *get_singleton() { return _singleton; }
 
     // return the current corrected pressure, public for AP_Periph
-    float get_corrected_pressure(uint8_t i) const {
-        return state[i].corrected_pressure;
-    }
+    float get_corrected_pressure(uint8_t i) const;
     float get_corrected_pressure(void) const {
         return get_corrected_pressure(primary);
     }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -110,12 +110,7 @@ public:
     }
 
     // return true if airspeed is enabled
-    bool enabled(uint8_t i) const {
-        if (i < AIRSPEED_MAX_SENSORS) {
-            return param[i].type.get() != TYPE_NONE;
-        }
-        return false;
-    }
+    bool enabled(uint8_t i) const;
     bool enabled(void) const { return enabled(primary); }
 
     // return the differential pressure in Pascal for the last airspeed reading
@@ -128,14 +123,7 @@ public:
     void update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
 
     // return health status of sensor
-    bool healthy(uint8_t i) const {
-        bool ok = state[i].healthy && enabled(i);
-#ifndef HAL_BUILD_AP_PERIPH
-        // sanity check the offset parameter.  Zero is permitted if we are skipping calibration.
-        ok &= (fabsf(param[i].offset) > 0 || state[i].use_zero_offset || param[i].skip_cal);
-#endif
-        return ok;
-    }
+    bool healthy(uint8_t i) const;
     bool healthy(void) const { return healthy(primary); }
 
     // return true if all enabled sensors are healthy


### PR DESCRIPTION
This has been done as requested, and as a pre-requisite to #20499 to add airpseed bindings to scripting.

We now check that our airspeed is healthy for all public 'get' functions that are based on returning a measurement from the sensor.

The functions have gotten more complicated that a one-liner so have been moved out of the header file.

I have added an additional nullptr check to healthy().  If the backend does not get assigned to sensor we assign a nullptr.  But from what I can tell we have not been using that as a direct measure of sensor health.  