### PR TITLE
Copter: move rangefinder state to surface distance libbary

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -68,6 +68,7 @@
 #include <AC_Sprayer/AC_Sprayer.h>          // Crop sprayer library
 #include <AP_ADSB/AP_ADSB.h>                // ADS-B RF based collision avoidance module library
 #include <AP_Proximity/AP_Proximity.h>      // ArduPilot proximity sensor library
+#include <AC_SurfaceDistance/AC_SurfaceDistance.h>
 
 // Configuration
 #include "defines.h"
@@ -243,18 +244,8 @@ private:
     AP_Int8 *flight_modes;
     const uint8_t num_flight_modes = 6;
 
-    struct RangeFinderState {
-        bool enabled:1;
-        bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
-        int16_t alt_cm;     // tilt compensated altitude (in cm) from rangefinder
-        float inertial_alt_cm; // inertial alt at time of last rangefinder sample
-        uint32_t last_healthy_ms;
-        LowPassFilterFloat alt_cm_filt; // altitude filter
-        int16_t alt_cm_glitch_protected;    // last glitch protected altitude
-        int8_t glitch_count;    // non-zero number indicates rangefinder is glitching
-        uint32_t glitch_cleared_ms; // system time glitch cleared
-    } rangefinder_state, rangefinder_up_state;
-
+    AC_SurfaceDistance rangefinder_state {ROTATION_PITCH_270, inertial_nav};
+    AC_SurfaceDistance rangefinder_up_state {ROTATION_PITCH_90, inertial_nav};
     /*
       return rangefinder height interpolated using inertial altitude
      */

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -72,14 +72,6 @@
  # define RANGEFINDER_ENABLED ENABLED
 #endif
 
-#ifndef RANGEFINDER_HEALTH_MAX
- # define RANGEFINDER_HEALTH_MAX 3          // number of good reads that indicates a healthy rangefinder
-#endif
-
-#ifndef RANGEFINDER_TIMEOUT_MS
-# define RANGEFINDER_TIMEOUT_MS 1000        // rangefinder filter reset if no updates from sensor in 1 second
-#endif
-
 #ifndef RANGEFINDER_FILT_DEFAULT
  # define RANGEFINDER_FILT_DEFAULT 0.5f     // filter for rangefinder distance
 #endif
@@ -90,18 +82,6 @@
 
 #ifndef SURFACE_TRACKING_TIMEOUT_MS
  # define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
-#endif
-
-#ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF
- # define RANGEFINDER_TILT_CORRECTION ENABLED
-#endif
-
-#ifndef RANGEFINDER_GLITCH_ALT_CM
- # define RANGEFINDER_GLITCH_ALT_CM  200      // amount of rangefinder change to be considered a glitch
-#endif
-
-#ifndef RANGEFINDER_GLITCH_NUM_SAMPLES
- # define RANGEFINDER_GLITCH_NUM_SAMPLES  3   // number of rangefinder glitches in a row to take new reading
 #endif
 
 #ifndef MAV_SYSTEM_ID

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -30,90 +30,17 @@ void Copter::read_rangefinder(void)
 #if RANGEFINDER_ENABLED == ENABLED
     rangefinder.update();
 
-#if RANGEFINDER_TILT_CORRECTION == ENABLED
-    const float tilt_correction = MAX(0.707f, ahrs.get_rotation_body_to_ned().c.z);
-#else
-    const float tilt_correction = 1.0f;
-#endif
+    rangefinder_state.update();
+    rangefinder_up_state.update();
 
-    // iterate through downward and upward facing lidar
-    struct {
-        RangeFinderState &state;
-        enum Rotation orientation;
-    } rngfnd[2] = {{rangefinder_state, ROTATION_PITCH_270}, {rangefinder_up_state, ROTATION_PITCH_90}};
-
-    for (uint8_t i=0; i < ARRAY_SIZE(rngfnd); i++) {
-        // local variables to make accessing simpler
-        RangeFinderState &rf_state = rngfnd[i].state;
-        enum Rotation rf_orient = rngfnd[i].orientation;
-
-        // update health
-        rf_state.alt_healthy = ((rangefinder.status_orient(rf_orient) == RangeFinder::Status::Good) &&
-                                (rangefinder.range_valid_count_orient(rf_orient) >= RANGEFINDER_HEALTH_MAX));
-
-        // tilt corrected but unfiltered, not glitch protected alt
-        rf_state.alt_cm = tilt_correction * rangefinder.distance_cm_orient(rf_orient);
-
-        // remember inertial alt to allow us to interpolate rangefinder
-        rf_state.inertial_alt_cm = inertial_nav.get_position_z_up_cm();
-
-        // glitch handling.  rangefinder readings more than RANGEFINDER_GLITCH_ALT_CM from the last good reading
-        // are considered a glitch and glitch_count becomes non-zero
-        // glitches clear after RANGEFINDER_GLITCH_NUM_SAMPLES samples in a row.
-        // glitch_cleared_ms is set so surface tracking (or other consumers) can trigger a target reset
-        const int32_t glitch_cm = rf_state.alt_cm - rf_state.alt_cm_glitch_protected;
-        if (glitch_cm >= RANGEFINDER_GLITCH_ALT_CM) {
-            rf_state.glitch_count = MAX(rf_state.glitch_count+1, 1);
-        } else if (glitch_cm <= -RANGEFINDER_GLITCH_ALT_CM) {
-            rf_state.glitch_count = MIN(rf_state.glitch_count-1, -1);
-        } else {
-            rf_state.glitch_count = 0;
-            rf_state.alt_cm_glitch_protected = rf_state.alt_cm;
-        }
-        if (abs(rf_state.glitch_count) >= RANGEFINDER_GLITCH_NUM_SAMPLES) {
-            // clear glitch and record time so consumers (i.e. surface tracking) can reset their target altitudes
-            rf_state.glitch_count = 0;
-            rf_state.alt_cm_glitch_protected = rf_state.alt_cm;
-            rf_state.glitch_cleared_ms = AP_HAL::millis();
-        }
-
-        // filter rangefinder altitude
-        uint32_t now = AP_HAL::millis();
-        const bool timed_out = now - rf_state.last_healthy_ms > RANGEFINDER_TIMEOUT_MS;
-        if (rf_state.alt_healthy) {
-            if (timed_out) {
-                // reset filter if we haven't used it within the last second
-                rf_state.alt_cm_filt.reset(rf_state.alt_cm);
-            } else {
-                rf_state.alt_cm_filt.apply(rf_state.alt_cm, 0.05f);
-            }
-            rf_state.last_healthy_ms = now;
-        }
-
-        // send downward facing lidar altitude and health to the libraries that require it
-        if (rf_orient == ROTATION_PITCH_270) {
-            if (rangefinder_state.alt_healthy || timed_out) {
-                wp_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    wp_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 #if MODE_CIRCLE_ENABLED
-                circle_nav->set_rangefinder_alt(rangefinder_state.enabled && wp_nav->rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    circle_nav->set_rangefinder_alt(rangefinder_state.enabled && wp_nav->rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 #endif
 #if HAL_PROXIMITY_ENABLED
-                g2.proximity.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    g2.proximity.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 #endif
-            }
-        }
-    }
 
-#else
-    // downward facing rangefinder
-    rangefinder_state.enabled = false;
-    rangefinder_state.alt_healthy = false;
-    rangefinder_state.alt_cm = 0;
-
-    // upward facing rangefinder
-    rangefinder_up_state.enabled = false;
-    rangefinder_up_state.alt_healthy = false;
-    rangefinder_up_state.alt_cm = 0;
 #endif
 }
 

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -15,7 +15,7 @@ void Copter::SurfaceTracking::update_surface_offset()
 
         // calculate surfaces height above the EKF origin
         // e.g. if vehicle is 10m above the EKF origin and rangefinder reports alt of 3m.  curr_surface_alt_above_origin_cm is 7m (or 700cm)
-        RangeFinderState &rf_state = (surface == Surface::GROUND) ? copter.rangefinder_state : copter.rangefinder_up_state;
+        AC_SurfaceDistance &rf_state = (surface == Surface::GROUND) ? copter.rangefinder_state : copter.rangefinder_up_state;
         const float dir = (surface == Surface::GROUND) ? 1.0f : -1.0f;
         const float curr_surface_alt_above_origin_cm = copter.inertial_nav.get_position_z_up_cm() - dir * rf_state.alt_cm;
 

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -31,6 +31,7 @@ def build(bld):
             'AP_OSD',
             'AC_AutoTune',
             'AP_KDECAN',
+            'AC_SurfaceDistance'
         ],
     )
 

--- a/libraries/AC_SurfaceDistance/AC_SurfaceDistance.cpp
+++ b/libraries/AC_SurfaceDistance/AC_SurfaceDistance.cpp
@@ -1,0 +1,89 @@
+#include "AC_SurfaceDistance.h"
+
+#include <AP_RangeFinder/AP_RangeFinder.h>
+
+#if AP_RANGEFINDER_ENABLED
+
+#include <AP_AHRS/AP_AHRS.h>
+
+#ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF
+ # define RANGEFINDER_TILT_CORRECTION 1
+#endif
+
+#ifndef RANGEFINDER_GLITCH_NUM_SAMPLES
+ # define RANGEFINDER_GLITCH_NUM_SAMPLES  3   // number of rangefinder glitches in a row to take new reading
+#endif
+
+#ifndef RANGEFINDER_GLITCH_ALT_CM
+ # define RANGEFINDER_GLITCH_ALT_CM  200      // amount of rangefinder change to be considered a glitch
+#endif
+
+#ifndef RANGEFINDER_HEALTH_MAX
+ # define RANGEFINDER_HEALTH_MAX 3          // number of good reads that indicates a healthy rangefinder
+#endif
+
+#ifndef RANGEFINDER_TIMEOUT_MS
+ # define RANGEFINDER_TIMEOUT_MS 1000        // rangefinder filter reset if no updates from sensor in 1 second
+#endif
+
+void AC_SurfaceDistance::update()
+{
+    RangeFinder *rangefinder = RangeFinder::get_singleton();
+    if (rangefinder == nullptr) {
+        alt_healthy = false;
+        return;
+    }
+
+#if RANGEFINDER_TILT_CORRECTION == 1
+    const float tilt_correction = MAX(0.707f, AP::ahrs().get_rotation_body_to_ned().c.z);
+#else
+    const float tilt_correction = 1.0f;
+#endif
+
+    const uint32_t now = AP_HAL::millis();
+
+    // update health
+    alt_healthy = ((rangefinder->status_orient(rotation) == RangeFinder::Status::Good) &&
+                            (rangefinder->range_valid_count_orient(rotation) >= RANGEFINDER_HEALTH_MAX));
+
+    // tilt corrected but unfiltered, not glitch protected alt
+    alt_cm = tilt_correction * rangefinder->distance_cm_orient(rotation);
+
+    // remember inertial alt to allow us to interpolate rangefinder
+    inertial_alt_cm = inertial_nav.get_position_z_up_cm();
+
+    // glitch handling.  rangefinder readings more than RANGEFINDER_GLITCH_ALT_CM from the last good reading
+    // are considered a glitch and glitch_count becomes non-zero
+    // glitches clear after RANGEFINDER_GLITCH_NUM_SAMPLES samples in a row.
+    // glitch_cleared_ms is set so surface tracking (or other consumers) can trigger a target reset
+    const int32_t glitch_cm = alt_cm - alt_cm_glitch_protected;
+    if (glitch_cm >= RANGEFINDER_GLITCH_ALT_CM) {
+        glitch_count = MAX(glitch_count+1, 1);
+    } else if (glitch_cm <= -RANGEFINDER_GLITCH_ALT_CM) {
+        glitch_count = MIN(glitch_count-1, -1);
+    } else {
+        glitch_count = 0;
+        alt_cm_glitch_protected = alt_cm;
+    }
+    if (abs(glitch_count) >= RANGEFINDER_GLITCH_NUM_SAMPLES) {
+        // clear glitch and record time so consumers (i.e. surface tracking) can reset their target altitudes
+        glitch_count = 0;
+        alt_cm_glitch_protected = alt_cm;
+        glitch_cleared_ms = now;
+    }
+
+    // filter rangefinder altitude
+    const bool timed_out = now - last_healthy_ms > RANGEFINDER_TIMEOUT_MS;
+    if (alt_healthy) {
+        if (timed_out) {
+            // reset filter if we haven't used it within the last second
+            alt_cm_filt.reset(alt_cm);
+        } else {
+            alt_cm_filt.apply(alt_cm, 0.05f);
+        }
+        last_healthy_ms = now;
+    }
+
+}
+
+#endif // AP_RANGEFINDER_ENABLED

--- a/libraries/AC_SurfaceDistance/AC_SurfaceDistance.h
+++ b/libraries/AC_SurfaceDistance/AC_SurfaceDistance.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <AP_Math/AP_Math.h>
+#include <Filter/LowPassFilter.h>
+#include <AP_InertialNav/AP_InertialNav.h>
+
+class AC_SurfaceDistance {
+public:
+    AC_SurfaceDistance(Rotation rot, const AP_InertialNav& inav):rotation(rot),inertial_nav(inav) {};
+
+    void update();
+
+    bool enabled;
+    bool alt_healthy; // true if we can trust the altitude from the rangefinder
+    int16_t alt_cm; // tilt compensated altitude (in cm) from rangefinder
+    float inertial_alt_cm; // inertial alt at time of last rangefinder sample
+    uint32_t last_healthy_ms;
+    LowPassFilterFloat alt_cm_filt {0.5}; // altitude filter
+    int16_t alt_cm_glitch_protected;    // last glitch protected altitude
+    int8_t glitch_count;    // non-zero number indicates rangefinder is glitching
+    uint32_t glitch_cleared_ms; // system time glitch cleared
+
+    const AP_InertialNav& inertial_nav;
+    const Rotation rotation;
+};

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -117,7 +117,6 @@ bool AP_Proximity_Backend::ignore_reading(float pitch, float yaw, float distance
 // store rangefinder values
 void AP_Proximity_Backend::set_rangefinder_alt(bool use, bool healthy, float alt_cm)
 {
-    _last_downward_update_ms = AP_HAL::millis();
     _rangefinder_use = use;
     _rangefinder_healthy = healthy;
     _rangefinder_alt = alt_cm * 0.01f;
@@ -128,11 +127,6 @@ bool AP_Proximity_Backend::get_rangefinder_alt(float &alt_m) const
 {
     if (!_rangefinder_use || !_rangefinder_healthy) {
         // range finder is not healthy
-        return false;
-    }
-
-    const uint32_t dt = AP_HAL::millis() - _last_downward_update_ms;
-    if (dt > PROXIMITY_ALT_DETECT_TIMEOUT_MS) {
         return false;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -23,7 +23,6 @@
 #include "AP_Proximity_Boundary_3D.h"
 
 #define PROXIMITY_GND_DETECT_THRESHOLD 1.0f // set ground detection threshold to be 1 meters
-#define PROXIMITY_ALT_DETECT_TIMEOUT_MS 500 // alt readings should arrive within this much time
 #define PROXIMITY_BOUNDARY_3D_TIMEOUT_MS 750 // we should check the 3D boundary faces after every this many ms
 
 class AP_Proximity_Backend
@@ -116,7 +115,6 @@ protected:
     uint32_t _last_timeout_check_ms;  // time when boundary was checked for non-updated valid faces
 
     // used for ground detection
-    uint32_t _last_downward_update_ms;
     bool     _rangefinder_use;
     bool     _rangefinder_healthy;
     float    _rangefinder_alt;


### PR DESCRIPTION
This is a basic moving of surface distance tracking functionality to a library. This library can then be shared between vehicles in the future (I want to use it on plane). This is also the first step before some upgrades to use multiple rangefinders.