### PR TITLE
AP_Logger: must set default fd = -1

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -528,7 +528,7 @@ private:
         void reset();
         void remove_and_free(file_list *victim);
         struct file_list *head, *tail;
-        int fd;
+        int fd{-1};
         uint32_t offset;
         bool fast;
         uint8_t counter;


### PR DESCRIPTION
The default FD must be set to - 1, otherwise other file handles will be accidentally closed in the reset function。
This fix can be linked to the problem https://github.com/ArduPilot/ardupilot/issues/20519
