### PR TITLE
Plane: Allow reseting target airspeed to the parameter value

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -908,8 +908,12 @@ bool Plane::do_change_speed(const AP_Mission::Mission_Command& cmd)
     switch (cmd.content.speed.speed_type)
     {
     case 0:             // Airspeed
-        if ((cmd.content.speed.target_ms >= aparm.airspeed_min.get()) && (cmd.content.speed.target_ms <= aparm.airspeed_max.get()))  {
-           new_airspeed_cm = cmd.content.speed.target_ms * 100; //new airspeed target for AUTO or GUIDED modes
+        if (is_equal(cmd.content.speed.target_ms, -2.0f)) {
+            new_airspeed_cm = -1; // return to default airspeed
+            return true;
+        } else if ((cmd.content.speed.target_ms >= aparm.airspeed_min.get()) &&
+                   (cmd.content.speed.target_ms <= aparm.airspeed_max.get()))  {
+            new_airspeed_cm = cmd.content.speed.target_ms * 100; //new airspeed target for AUTO or GUIDED modes
             gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)cmd.content.speed.target_ms);
             return true;
         }


### PR DESCRIPTION
This allows us to send a MAVLink (or mission) command to resume the tuned airspeed of the aircraft, without having to know the speed in advance. This is useful for allowing a GCS to send any aircraft back to it's normal flight state, without having any dependency upon understanding it's parameters.

This should probably wait until I get the proposed flag change into MAVLink before coming in, unless we want to just push forward with it. I've opened this now though to prompt discussion of it.

As a note, I didn't change anything functional in the normal airspeed case, I simply fixed a tab/space whitespace issue, and split the if line into 2 lines for readability. I would *really* like to remove the send text of "Set airspeed" though :) We have NACK's for a reason!

This was tested using SITL in guided.