### PR TITLE
AP_BattMonitor: SMBus read_block fix append_zero bufflen

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -167,6 +167,7 @@ uint8_t AP_BattMonitor_SMBus_Generic::read_block(uint8_t reg, uint8_t* data, boo
     // optionally add zero to end
     if (append_zero) {
         data[bufflen] = '\0';
+        bufflen++;
     }
 
     // return success


### PR DESCRIPTION
Fixes an issue I found when testing #16167 .

We append another byte but don't increment the number of bytes returned. 

The `append == true` is currently only called here: https://github.com/ArduPilot/ardupilot/blob/4c9a851fc6bafc7ffba2a3eff5011015bb8629a5/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp#L203