### PR TITLE
Add and publish angular acceleration value

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -87,6 +87,12 @@ Vector3f AP_AHRS_View::get_gyro_latest(void) const {
     return rot_view * ahrs.get_gyro_latest();
 }
 
+Vector3f AP_AHRS_View::get_ang_accel_latest(void) const
+{
+    const uint8_t primary_gyro = ahrs.get_primary_gyro_index();
+    return AP::ins().get_ang_accel(primary_gyro);
+}
+
 // rotate a 2D vector from earth frame to body frame
 Vector2f AP_AHRS_View::earth_to_body2D(const Vector2f &ef) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -47,6 +47,8 @@ public:
     // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
     Vector3f get_gyro_latest(void) const;
 
+    Vector3f get_ang_accel_latest(void) const;
+
     // return a DCM rotation matrix representing our current attitude in this view
     const Matrix3f &get_rotation_body_to_ned(void) const {
         return rot_body_to_ned;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -641,6 +641,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     
 #endif // HAL_INS_TEMPERATURE_CAL_ENABLE
 
+    AP_GROUPINFO("ANG_ACC_FILT", 53, AP_InertialSensor, _ang_accel_filter_cuttoff, 30),
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully
@@ -1672,7 +1673,8 @@ void AP_InertialSensor::update(void)
 
     // Calculate angular acceleration using backward euler method
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-        _ang_accel[i] = (_gyro[i] - _gyro_prev[i])/get_delta_time();
+        _ang_accel_filter[i].set_cutoff_frequency(AP::scheduler().get_loop_rate_hz(), _ang_accel_filter_cuttoff);
+        _ang_accel[i] = _ang_accel_filter[i].apply((_gyro[i] - _gyro_prev[i])/AP::scheduler().get_loop_period_s());
         _gyro_prev[i] = _gyro[i];
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1670,6 +1670,12 @@ void AP_InertialSensor::update(void)
             }
         }
 
+    // Calculate angular acceleration using backward euler method
+    for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
+        _ang_accel[i] = (_gyro[i] - _gyro_prev[i])/get_delta_time();
+        _gyro_prev[i] = _gyro[i];
+    }
+
     _last_update_usec = AP_HAL::micros();
     
     _have_sample = false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -537,6 +537,8 @@ private:
     Vector3f _last_delta_angle[INS_MAX_INSTANCES];
     Vector3f _last_raw_gyro[INS_MAX_INSTANCES];
     Vector3f _ang_accel[INS_MAX_INSTANCES];
+    LowPassFilterVector3f _ang_accel_filter[INS_MAX_INSTANCES];
+    AP_Float _ang_accel_filter_cuttoff;
     Vector3f _gyro_prev[INS_MAX_INSTANCES];
 
     // bitmask indicating if a sensor is doing sensor-rate sampling:

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -129,6 +129,9 @@ public:
     const Vector3f     &get_gyro(uint8_t i) const { return _gyro[i]; }
     const Vector3f     &get_gyro(void) const { return get_gyro(_primary_gyro); }
 
+    // get angular acceleration in rad/sec/sec
+    const Vector3f &get_ang_accel(uint8_t i) const {return _ang_accel[i];};
+
     // set gyro offsets in radians/sec
     const Vector3f &get_gyro_offsets(uint8_t i) const { return _gyro_offset[i]; }
     const Vector3f &get_gyro_offsets(void) const { return get_gyro_offsets(_primary_gyro); }
@@ -533,6 +536,8 @@ private:
     Vector3f _delta_angle_acc[INS_MAX_INSTANCES];
     Vector3f _last_delta_angle[INS_MAX_INSTANCES];
     Vector3f _last_raw_gyro[INS_MAX_INSTANCES];
+    Vector3f _ang_accel[INS_MAX_INSTANCES];
+    Vector3f _gyro_prev[INS_MAX_INSTANCES];
 
     // bitmask indicating if a sensor is doing sensor-rate sampling:
     uint8_t _accel_sensor_rate_sampling_enabled;


### PR DESCRIPTION
This PR adds a filtered angular acceleration calculation. Although calculating angular acceleration is not the direct responsibility of AP_InertialSensor library, I didn't know which library to put.  This is one of the small PR to merge the [INDI Controller](https://github.com/ArduPilot/ardupilot/pull/20511).