### PR TITLE
Plane: remove support for alt wait

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -545,7 +545,7 @@ void Plane::update_alt()
     update_flight_stage();
 
 #if AP_SCRIPTING_ENABLED
-    if (nav_scripting_active()) {
+    if (nav_script_time_active()) {
         // don't call TECS while we are in a trick
         return;
     }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -402,7 +402,7 @@ void Plane::stabilize()
             control_mode == &mode_manual) {
         plane.control_mode->run();
 #if AP_SCRIPTING_ENABLED
-    } else if (nav_scripting_active()) {
+    } else if (nav_script_time_active()) {
         // scripting is in control of roll and pitch rates and throttle
         const float speed_scaler = get_speed_scaler();
         const float aileron = rollController.get_rate_out(nav_scripting.roll_rate_dps, speed_scaler);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -494,11 +494,6 @@ private:
         // have we checked for an auto-land?
         bool checked_for_autoland;
 
-        // Altitude threshold to complete a takeoff command in autonomous modes.  Centimeters
-        // are we in idle mode? used for balloon launch to stop servo
-        // movement until altitude is reached
-        bool idle_mode;
-
         // are we in VTOL mode in AUTO?
         bool vtol_mode;
 
@@ -523,6 +518,7 @@ private:
         float throttle_pct;
         uint32_t start_ms;
         uint32_t current_ms;
+        uint32_t read_ms;
         float rudder_offset_pct;
         bool run_yaw_rate_controller;
     } nav_scripting;
@@ -914,7 +910,6 @@ private:
     bool verify_continue_and_change_alt();
     bool verify_wait_delay();
     bool verify_within_distance();
-    bool verify_altitude_wait(const AP_Mission::Mission_Command &cmd);
     void do_loiter_at_location();
     bool verify_loiter_heading(bool init);
     void exit_mission_callback();
@@ -930,7 +925,6 @@ private:
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_loiter_turns(const AP_Mission::Mission_Command& cmd);
     void do_loiter_time(const AP_Mission::Mission_Command& cmd);
-    void do_altitude_wait(const AP_Mission::Mission_Command& cmd);
     void do_continue_and_change_alt(const AP_Mission::Mission_Command& cmd);
     void do_loiter_to_alt(const AP_Mission::Mission_Command& cmd);
     void do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
@@ -957,8 +951,8 @@ private:
 
 #if AP_SCRIPTING_ENABLED
     // nav scripting support
-    void do_nav_script_time(const AP_Mission::Mission_Command& cmd);
-    bool verify_nav_script_time(const AP_Mission::Mission_Command& cmd);
+    void do_nav_scripting(const AP_Mission::Mission_Command& cmd);
+    bool verify_nav_scripting(const AP_Mission::Mission_Command& cmd);
 #endif
 
     // commands.cpp
@@ -1093,7 +1087,6 @@ private:
     void avoidance_adsb_update(void);
 
     // servos.cpp
-    void set_servos_idle(void);
     void set_servos();
     void set_servos_controlled(void);
     void set_servos_old_elevons(void);
@@ -1153,8 +1146,9 @@ private:
 
 #if AP_SCRIPTING_ENABLED
     // support for NAV_SCRIPT_TIME mission command
-    bool nav_scripting_active(void);
+    bool nav_script_time_active(void);
     bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) override;
+    bool nav_script(uint16_t &id, mavlink_mission_item_int_t &cmd) override;
     void nav_script_time_done(uint16_t id) override;
 
     // command throttle percentage and roll, pitch, yaw target

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -127,7 +127,7 @@ void ModeAuto::navigate()
 bool ModeAuto::does_auto_navigation() const
 {
 #if AP_SCRIPTING_ENABLED
-   return (!plane.nav_scripting_active());
+   return (!plane.nav_script_time_active());
 #endif
    return true;
 }
@@ -135,7 +135,7 @@ bool ModeAuto::does_auto_navigation() const
 bool ModeAuto::does_auto_throttle() const
 {
 #if AP_SCRIPTING_ENABLED
-   return (!plane.nav_scripting_active());
+   return (!plane.nav_script_time_active());
 #endif
    return true;
 }

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -29,7 +29,7 @@ void ModeCruise::update()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting_active()) {
+    if (plane.nav_script_time_active()) {
         // while a trick is running unlock heading and zero altitude offset
         locked_heading = false;
         lock_timer_ms = 0;
@@ -53,7 +53,7 @@ void ModeCruise::update()
 void ModeCruise::navigate()
 {
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting_active()) {
+    if (plane.nav_script_time_active()) {
         // don't try to navigate while running trick
         return;
     }

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -29,7 +29,7 @@ void ModeLoiter::update()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting_active()) {
+    if (plane.nav_script_time_active()) {
         // while a trick is running we reset altitude
         plane.set_target_altitude_current();
         plane.next_WP_loc.set_alt_cm(plane.target_altitude.amsl_cm, Location::AltFrame::ABSOLUTE);
@@ -99,7 +99,7 @@ void ModeLoiter::navigate()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting_active()) {
+    if (plane.nav_script_time_active()) {
         // don't try to navigate while running trick
         return;
     }

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1998,6 +1998,11 @@ function vehicle:set_rudder_offset(rudder_pct, run_yaw_rate_control) end
 function vehicle:has_ekf_failsafed() end
 
 -- desc
+---@return integer|nil
+---@return mavlink_mission_item_int_t_ud|nil
+function vehicle:nav_script() end
+
+-- desc
 ---@return number|nil
 ---@return number|nil
 function vehicle:get_pan_tilt_norm() end
@@ -2876,6 +2881,10 @@ function ahrs:get_gyro() end
 -- desc
 ---@return Location_ud
 function ahrs:get_home() end
+
+-- desc
+---@return Location_ud|nil
+function ahrs:get_position() end
 
 -- desc
 ---@return Location_ud|nil

--- a/libraries/AP_Scripting/examples/Nav_Altitude_Wait.lua
+++ b/libraries/AP_Scripting/examples/Nav_Altitude_Wait.lua
@@ -1,0 +1,143 @@
+-- replicate functionality of plane MAV_CMD_NAV_ALTITUDE_WAIT
+
+local altitude, descent_rate, wiggle_time
+local filtered_sink_rate
+local last_wiggle_ms
+local idle_wiggle_stage
+local active_id
+
+local MAV_CMD_NAV_ALTITUDE_WAIT = 83
+local MAV_SEVERITY_INFO = 6
+local ABOVE_HOME = 1
+
+local aileron = 4
+local elevator = 19
+local rudder = 21
+local throttle = 70
+
+local function assert_param_get(name)
+  return assert(param:get(name), "Failed to get param: " .. name)
+end
+
+-- build a table of servo output chanel's to be overridden
+local servo_outputs = {}
+for i = 1, 16 do
+  local servo_prefix = string.format("SERVO%i_",i)
+  local function_num = assert_param_get(servo_prefix .. "FUNCTION")
+  if function_num == aileron or
+      function_num == elevator or
+      function_num == rudder or
+      function_num == throttle then
+
+    local min = assert_param_get(servo_prefix .. "MIN")
+    local max = assert_param_get(servo_prefix .. "MAX")
+    local trim = assert_param_get(servo_prefix .. "TRIM")
+
+    local servo_output = {}
+    servo_output['chan'] = i-1
+    servo_output['function'] = function_num
+    servo_output['min'] = min
+    servo_output['max'] = max
+    servo_output['trim'] = trim
+
+    table.insert(servo_outputs, servo_output)
+  end
+end
+
+gcs:send_text(MAV_SEVERITY_INFO, "Nav Altitude Wait loaded")
+
+local function update_servos()
+  local servo_value
+  -- move over full range for 4 seconds
+  if idle_wiggle_stage ~= 0 then
+      idle_wiggle_stage = idle_wiggle_stage + 5
+  end
+
+  if idle_wiggle_stage == 0 then
+      servo_value = 0
+  elseif idle_wiggle_stage < 50 then
+      servo_value = idle_wiggle_stage * (4500 / 50)
+  elseif idle_wiggle_stage < 100 then
+      servo_value = (100 - idle_wiggle_stage) * (4500 / 50)
+  elseif idle_wiggle_stage < 150 then
+      servo_value = (100 - idle_wiggle_stage) * (4500 / 50)
+  elseif idle_wiggle_stage < 200 then
+     servo_value = (idle_wiggle_stage-200) * (4500 / 50)
+  else
+      idle_wiggle_stage = 0
+      servo_value = 0
+  end
+  servo_value = servo_value / 4500
+
+  -- scan servo outputs and override where required
+  for i = 1, #servo_outputs do
+    local servo_output = servo_outputs[i]
+    local pwm_out = servo_output['trim']
+    if servo_output['function'] ~= throttle then
+      if servo_value > 0 then
+        pwm_out = pwm_out + (servo_output['max'] - servo_output['trim']) * servo_value
+      else
+        pwm_out = pwm_out + (servo_output['trim'] - servo_output['min']) * servo_value
+      end
+    end
+    SRV_Channels:set_output_pwm_chan_timeout(servo_output['chan'], pwm_out, 150)
+  end
+
+end
+
+function run_alt_wait()
+  local now = millis()
+
+  if (wiggle_time ~= 0) and (idle_wiggle_stage == 0) and ((now - last_wiggle_ms) > (wiggle_time*1000)) then
+    idle_wiggle_stage = 1
+    last_wiggle_ms = now
+  end
+
+  update_servos()
+
+  loc = ahrs:get_location()
+  vel = ahrs:get_velocity_NED()
+  if (not loc) or (not vel) then
+    -- wait to get location and velocity
+    filtered_sink_rate = 0
+    return run_alt_wait, 100
+  end
+  loc:change_alt_frame(ABOVE_HOME)
+
+  if loc:alt() > (altitude*100.0) then
+    gcs:send_text(MAV_SEVERITY_INFO, "Reached altitude")
+    vehicle:nav_script_time_done(active_id)
+    return update, 100
+  end
+
+  filtered_sink_rate = filtered_sink_rate * 0.8 + vel:z() * 0.2
+  if filtered_sink_rate > descent_rate then
+    gcs:send_text(MAV_SEVERITY_INFO, string.format("Reached descent rate %.1f m/s", filtered_sink_rate));
+    vehicle:nav_script_time_done(active_id)
+    return update, 100
+  end
+
+  return run_alt_wait, 100
+end
+
+function update()
+  -- wait to receive command
+  local cmd, id
+  id, cmd = vehicle:nav_script()
+  if cmd and (cmd:command() == MAV_CMD_NAV_ALTITUDE_WAIT) then
+    gcs:send_text(MAV_SEVERITY_INFO, "Nav Altitude Wait started")
+    altitude = cmd:param1()
+    descent_rate = cmd:param2()
+    wiggle_time = cmd:param3()
+    gcs:send_text(MAV_SEVERITY_INFO, string.format("alt %0.1fm, decent rate %0.1fm/s, wiggle %is", altitude, descent_rate, wiggle_time))
+    filtered_sink_rate = 0
+    idle_wiggle_stage = 0
+    last_wiggle_ms = 0
+    active_id = id
+    return run_alt_wait()
+  end
+
+  return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -304,6 +304,7 @@ singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
 singleton AP_Vehicle method is_landing boolean
 singleton AP_Vehicle method is_taking_off boolean
+singleton AP_Vehicle method nav_script boolean uint16_t'Null mavlink_mission_item_int_t'Null
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -189,6 +189,7 @@ public:
 
     // support for NAV_SCRIPT_TIME mission command
     virtual bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) { return false; }
+    virtual bool nav_script(uint16_t &id, mavlink_mission_item_int_t &cmd) { return false; }
     virtual void nav_script_time_done(uint16_t id) {}
 
     // allow for VTOL velocity matching of a target


### PR DESCRIPTION
This removes support for altitude wait mission command, used for high altitude balloon launches. Very rarely used functionality that can now be replicated with scripting. 