### PR TITLE
AP_Scripting: always free heap before returning

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -86,16 +86,11 @@ void Util::free_type(void *ptr, size_t size, AP_HAL::Util::Memory_Type mem_type)
 
 void *Util::allocate_heap_memory(size_t size)
 {
-    void *buf = malloc(size);
-    if (buf == nullptr) {
+    memory_heap_t *heap = (memory_heap_t *)malloc(size + sizeof(memory_heap_t));
+    if (heap == nullptr) {
         return nullptr;
     }
-
-    memory_heap_t *heap = (memory_heap_t *)malloc(sizeof(memory_heap_t));
-    if (heap != nullptr) {
-        chHeapObjectInit(heap, buf, size);
-    }
-
+    chHeapObjectInit(heap, heap + 1U, size);
     return heap;
 }
 

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -37,6 +37,10 @@ lua_scripts::lua_scripts(const AP_Int32 &vm_steps, const AP_Int32 &heap_size, co
     _heap = hal.util->allocate_heap_memory(heap_size);
 }
 
+lua_scripts::~lua_scripts() {
+    free(_heap);
+}
+
 void lua_scripts::hook(lua_State *L, lua_Debug *ar) {
     lua_scripts::overtime = true;
 
@@ -534,5 +538,20 @@ void lua_scripts::run(void) {
                 error_msg_buf = nullptr;
             }
         }
+    }
+
+    // make sure all scripts have been removed
+    while (scripts != nullptr) {
+        remove_script(lua_state, scripts);
+    }
+
+    if (lua_state != nullptr) {
+        lua_close(lua_state); // shutdown the old state
+        lua_state = nullptr;
+    }
+
+    if (error_msg_buf != nullptr) {
+        hal.util->heap_realloc(_heap, error_msg_buf, 0);
+        error_msg_buf = nullptr;
     }
 }

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -53,9 +53,9 @@ class lua_scripts
 public:
     lua_scripts(const AP_Int32 &vm_steps, const AP_Int32 &heap_size, const AP_Int8 &debug_options, struct AP_Scripting::terminal_s &_terminal);
 
-    /* Do not allow copies */
-    lua_scripts(const lua_scripts &other) = delete;
-    lua_scripts &operator=(const lua_scripts&) = delete;
+    ~lua_scripts();
+
+    CLASS_NO_COPY(lua_scripts);
 
     // return true if initialisation failed
     bool heap_allocated() const { return _heap != nullptr; }


### PR DESCRIPTION
All the other stuff that we allocate is allocated out of the heap, so freeing the heap should clear everything. 