### PR TITLE
AP_HAL_ChibiOS:  ICM4 series sensors as an alternative with IMU3.

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotH743/hwdef.dat
@@ -167,6 +167,7 @@ IMU Invensensev3 SPI:imu1      ROTATION_YAW_270
 IMU Invensense   SPI:imu2      ROTATION_ROLL_180
 IMU Invensensev3 SPI:imu2      ROTATION_YAW_270
 IMU Invensense   SPI:imu3      ROTATION_ROLL_180
+IMU Invensensev3 SPI:imu3      ROTATION_YAW_270
 
 
 # two Baro sensors


### PR DESCRIPTION
AP_HAL_ChibiOS:  ICM4 series sensors as an alternative with IMU3.