### PR TITLE
change struct Location to class Location

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -491,7 +491,7 @@ void GCS_MAVLINK_Tracker::handleMessage(const mavlink_message_t &msg)
 
         mavlink_msg_mission_item_decode(&msg, &packet);
 
-        struct Location tell_command;
+        class Location tell_command;
 
         switch (packet.frame)
         {

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -102,7 +102,7 @@ private:
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Tracker::handle_battery_failsafe, void, const char*, const int8_t),
                            nullptr};
-    struct Location current_loc;
+    class Location current_loc;
 
     Mode *mode_from_mode_num(enum Mode::Number num);
 
@@ -202,7 +202,7 @@ private:
 
     // system.cpp
     void init_ardupilot() override;
-    bool get_home_eeprom(struct Location &loc) const;
+    bool get_home_eeprom(class Location &loc) const;
     bool set_home_eeprom(const Location &temp) WARN_IF_UNUSED;
     bool set_home(const Location &temp) WARN_IF_UNUSED;
     void prepare_servos();

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -102,7 +102,7 @@ void Tracker::init_ardupilot()
 /*
   fetch HOME from EEPROM
 */
-bool Tracker::get_home_eeprom(struct Location &loc) const
+bool Tracker::get_home_eeprom(class Location &loc) const
 {
     // Find out proper location in memory by using the start_byte position + the index
     // --------------------------------------------------------------------------------

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1498,7 +1498,7 @@ void GCS_MAVLINK_Copter::send_wind() const
 int16_t GCS_MAVLINK_Copter::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
-    struct Location global_position_current;
+    class Location global_position_current;
     UNUSED_RESULT(ahrs.get_location(global_position_current));
 
     //return units are m

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1376,7 +1376,7 @@ uint64_t GCS_MAVLINK_Plane::capabilities() const
 int16_t GCS_MAVLINK_Plane::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
-    struct Location global_position_current;
+    class Location global_position_current;
     UNUSED_RESULT(ahrs.get_location(global_position_current));
 
 #if HAL_QUADPLANE_ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -710,13 +710,13 @@ private:
 
     // 3D Location vectors
     // Location structure defined in AP_Common
-    const struct Location &home = ahrs.get_home();
+    const class Location &home = ahrs.get_home();
 
     // The location of the previous waypoint.  Used for track following and altitude ramp calculations
     Location prev_WP_loc {};
 
     // The plane's current location
-    struct Location current_loc {};
+    class Location current_loc {};
 
     // The location of the current/active waypoint.  Used for altitude ramp, track following and loiter calculations.
     Location next_WP_loc {};
@@ -893,7 +893,7 @@ private:
     void load_parameters(void) override;
 
     // commands_logic.cpp
-    void set_next_WP(const struct Location &loc);
+    void set_next_WP(const class Location &loc);
     void do_RTL(int32_t alt);
     bool verify_takeoff();
     bool verify_loiter_unlim(const AP_Mission::Mission_Command &cmd);

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -7,7 +7,7 @@
 /*
  *  set_next_WP - sets the target location the vehicle should fly to
  */
-void Plane::set_next_WP(const struct Location &loc)
+void Plane::set_next_WP(const class Location &loc)
 {
     if (auto_state.next_wp_crosstrack) {
         // copy the current WP into the OldWP slot

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -797,7 +797,7 @@ int32_t GCS_MAVLINK_Sub::global_position_int_relative_alt() const {
 int16_t GCS_MAVLINK_Sub::high_latency_target_altitude() const
 {
     AP_AHRS &ahrs = AP::ahrs();
-    struct Location global_position_current;
+    class Location global_position_current;
     UNUSED_RESULT(ahrs.get_location(global_position_current));
 
     //return units are m

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -173,7 +173,7 @@ private:
     RC_Channels_Rover &rc() { return g2.rc_channels; }
 
     // The rover's current location
-    struct Location current_loc;
+    class Location current_loc;
 
     // Camera
 #if CAMERA == ENABLED

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -236,7 +236,7 @@ void AP_OAPathPlanner::avoidance_thread()
     bool origin_set = false;
     while (!origin_set) {
         hal.scheduler->delay(500);
-        struct Location ekf_origin {};
+        class Location ekf_origin {};
         {
             WITH_SEMAPHORE(AP::ahrs().get_semaphore());
             origin_set = AP::ahrs().get_origin(ekf_origin);    

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -195,7 +195,7 @@ bool AC_PolyFence_loader::load_point_from_eeprom(uint16_t i, Vector2l& point) co
 
 bool AC_PolyFence_loader::breached() const
 {
-    struct Location loc;
+    class Location loc;
     if (!AP::ahrs().get_location(loc)) {
         return false;
     }
@@ -637,7 +637,7 @@ bool AC_PolyFence_loader::load_from_eeprom()
         return _load_time_ms != 0;
     }
 
-    struct Location ekf_origin{};
+    class Location ekf_origin{};
     if (!AP::ahrs().get_origin(ekf_origin)) {
 //        Debug("fence load requires origin");
         return false;

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -744,7 +744,7 @@ void AP_AHRS::reset()
 }
 
 // dead-reckoning support
-bool AP_AHRS::get_location(struct Location &loc) const
+bool AP_AHRS::get_location(class Location &loc) const
 {
     switch (active_EKF_type()) {
     case EKFType::NONE:
@@ -1207,7 +1207,7 @@ bool AP_AHRS::get_secondary_quaternion(Quaternion &quat) const
 }
 
 // return secondary position solution if available
-bool AP_AHRS::get_secondary_position(struct Location &loc) const
+bool AP_AHRS::get_secondary_position(class Location &loc) const
 {
     EKFType secondary_ekf_type;
     if (!get_secondary_EKF_type(secondary_ekf_type)) {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -101,9 +101,9 @@ public:
     void            reset();
 
     // dead-reckoning support
-    bool get_location(struct Location &loc) const;
+    bool get_location(class Location &loc) const;
     // for scripting until aliases get sorted out:
-    bool get_position(struct Location &loc) const {
+    bool get_position(class Location &loc) const {
         return get_location(loc);
     }
 
@@ -186,7 +186,7 @@ public:
     bool get_secondary_quaternion(Quaternion &quat) const;
 
     // return secondary position solution if available
-    bool get_secondary_position(struct Location &loc) const;
+    bool get_secondary_position(class Location &loc) const;
 
     // EKF has a better ground speed vector estimate
     Vector2f groundspeed_vector();
@@ -452,7 +452,7 @@ public:
 
     // get the home location. This is const to prevent any changes to
     // home without telling AHRS about the change
-    const struct Location &get_home(void) const {
+    const class Location &get_home(void) const {
         return _home;
     }
 
@@ -732,7 +732,7 @@ private:
      */
     void load_watchdog_home();
     bool _checked_watchdog_home;
-    struct Location _home;
+    class Location _home;
     bool _home_is_set :1;
     bool _home_locked :1;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -113,7 +113,7 @@ public:
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
-    virtual bool get_location(struct Location &loc) const WARN_IF_UNUSED = 0;
+    virtual bool get_location(class Location &loc) const WARN_IF_UNUSED = 0;
 
     // get latest altitude estimate above ground level in meters and validity flag
     virtual bool get_hagl(float &height) const WARN_IF_UNUSED { return false; }
@@ -201,10 +201,10 @@ public:
     }
 
     //
-    virtual bool set_origin(const struct Location &loc) {
+    virtual bool set_origin(const class Location &loc) {
         return false;
     }
-    virtual bool get_origin(struct Location &ret) const = 0;
+    virtual bool get_origin(class Location &ret) const = 0;
 
     // return a position relative to origin in meters, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1046,7 +1046,7 @@ void AP_AHRS_DCM::estimate_wind(void)
 
 // return our current position estimate using
 // dead-reckoning or GPS
-bool AP_AHRS_DCM::get_location(struct Location &loc) const
+bool AP_AHRS_DCM::get_location(class Location &loc) const
 {
     loc.lat = _last_lat;
     loc.lng = _last_lng;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -62,7 +62,7 @@ public:
     }
 
     // dead-reckoning support
-    virtual bool get_location(struct Location &loc) const override;
+    virtual bool get_location(class Location &loc) const override;
 
     // status reporting
     float           get_error_rp() const {

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -9,7 +9,7 @@
 void AP_AHRS::Write_AHRS2() const
 {
     Vector3f euler;
-    struct Location loc;
+    class Location loc;
     Quaternion quat;
     if (!get_secondary_attitude(euler) || !get_secondary_position(loc) || !get_secondary_quaternion(quat)) {
         return;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -85,7 +85,7 @@ public:
       wrappers around ahrs functions which pass-thru directly. See
       AP_AHRS.h for description of each function
      */
-    bool get_location(struct Location &loc) const WARN_IF_UNUSED {
+    bool get_location(class Location &loc) const WARN_IF_UNUSED {
         return ahrs.get_location(loc);
     }
 

--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -291,12 +291,12 @@ bool AP_AIS::get_vessel_index(uint32_t mmsi, uint16_t &index, uint32_t lat, uint
         return false;
     }
 
-    struct Location current_loc;
+    class Location current_loc;
     if (!AP::ahrs().get_location(current_loc)) {
         return false;
     }
 
-    struct Location loc;
+    class Location loc;
     float dist;
     float max_dist = 0;
     for (uint16_t i = 0; i < list_size; i++) {

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -108,7 +108,7 @@ private:
     AP_Int16        _min_interval;      // Minimum time between shots required by camera
     AP_Int16        _max_roll;          // Maximum acceptable roll angle when trigging camera
     uint32_t        _last_photo_time;   // last time a photo was taken
-    struct Location _last_location;
+    class Location _last_location;
     uint16_t        _image_index;       // number of pictures taken since boot
 
     // pin number for accurate camera feedback messages

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -24,7 +24,7 @@ void Location::zero(void)
     memset(this, 0, sizeof(*this));
 }
 
-// Construct location using position (NEU) from ekf_origin for the given altitude frame
+// Conclass Location using position (NEU) from ekf_origin for the given altitude frame
 Location::Location(int32_t latitude, int32_t longitude, int32_t alt_in_cm, AltFrame frame)
 {
     zero();
@@ -237,7 +237,7 @@ bool Location::get_vector_from_origin_NEU(Vector3f &vec_neu) const
 }
 
 // return distance in meters between two locations
-ftype Location::get_distance(const struct Location &loc2) const
+ftype Location::get_distance(const class Location &loc2) const
 {
     ftype dlat = (ftype)(loc2.lat - lat);
     ftype dlng = ((ftype)diff_longitude(loc2.lng,lng)) * longitude_scale((lat+loc2.lat)/2);
@@ -245,7 +245,7 @@ ftype Location::get_distance(const struct Location &loc2) const
 }
 
 // return the altitude difference in meters taking into account alt frame.
-bool Location::get_alt_distance(const struct Location &loc2, ftype &distance) const
+bool Location::get_alt_distance(const class Location &loc2, ftype &distance) const
 {
     int32_t alt1, alt2;
     if (!get_alt_cm(AltFrame::ABSOLUTE, alt1) || !loc2.get_alt_cm(AltFrame::ABSOLUTE, alt2)) {
@@ -377,7 +377,7 @@ assert_storage_size<Location, 16> _assert_storage_size_Location;
 
 
 // return bearing in radians from location to loc2, return is 0 to 2*Pi
-ftype Location::get_bearing(const struct Location &loc2) const
+ftype Location::get_bearing(const class Location &loc2) const
 {
     const int32_t off_x = diff_longitude(loc2.lng,lng);
     const int32_t off_y = (loc2.lat - lat) / loc2.longitude_scale((lat+loc2.lat)/2);

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -57,10 +57,10 @@ public:
     bool get_vector_from_origin_NEU(Vector3f &vec_neu) const WARN_IF_UNUSED;
 
     // return distance in meters between two locations
-    ftype get_distance(const struct Location &loc2) const;
+    ftype get_distance(const class Location &loc2) const;
 
     // return the altitude difference in meters taking into account alt frame.
-    bool get_alt_distance(const struct Location &loc2, ftype &distance) const WARN_IF_UNUSED;
+    bool get_alt_distance(const class Location &loc2, ftype &distance) const WARN_IF_UNUSED;
 
     // return the distance in meters in North/East/Down plane as a N/E/D vector to loc2
     // NOT CONSIDERING ALT FRAME!
@@ -93,10 +93,10 @@ public:
     void zero(void);
 
     // return the bearing in radians, from 0 to 2*Pi
-    ftype get_bearing(const struct Location &loc2) const;
+    ftype get_bearing(const class Location &loc2) const;
 
     // return bearing in centi-degrees from location to loc2, return is 0 to 35999
-    int32_t get_bearing_to(const struct Location &loc2) const {
+    int32_t get_bearing_to(const class Location &loc2) const {
         return int32_t(get_bearing(loc2) * DEGX100 + 0.5);
     }
 
@@ -106,7 +106,7 @@ public:
     /*
      * convert invalid waypoint with useful data. return true if location changed
      */
-    bool sanitize(const struct Location &defaultLoc);
+    bool sanitize(const class Location &defaultLoc);
 
     // return true when lat and lng are within range
     bool check_latlng() const;

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -1068,7 +1068,7 @@ bool CompassCalibrator::fix_radius(void)
         _params.scale_factor = 0;
         return true;
     }
-    const struct Location &loc = AP::gps().location();
+    const class Location &loc = AP::gps().location();
     float intensity;
     float declination;
     float inclination;

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -185,7 +185,7 @@ public:
 
     // get the home location. This is const to prevent any changes to
     // home without telling AHRS about the change
-    const struct Location &get_home(void) const {
+    const class Location &get_home(void) const {
         return _home;
     }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2081,7 +2081,7 @@ bool AP_GPS::get_error_codes(uint8_t instance, uint32_t &error_codes) const
 void AP_GPS::Write_GPS(uint8_t i)
 {
     const uint64_t time_us = AP_HAL::micros64();
-    const struct Location &loc = location(i);
+    const class Location &loc = location(i);
 
     float yaw_deg=0, yaw_accuracy_deg=0;
     uint32_t yaw_time_ms;

--- a/libraries/AP_HAL/SIMState.cpp
+++ b/libraries/AP_HAL/SIMState.cpp
@@ -332,7 +332,7 @@ void SIMState::set_height_agl(void)
         // get height above terrain from AP_Terrain. This assumes
         // AP_Terrain is working
         float terrain_height_amsl;
-        struct Location location;
+        class Location location;
         location.lat = _sitl->state.latitude*1.0e7;
         location.lng = _sitl->state.longitude*1.0e7;
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -900,7 +900,7 @@ void SITL_State::set_height_agl(void)
         // get height above terrain from AP_Terrain. This assumes
         // AP_Terrain is working
         float terrain_height_amsl;
-        struct Location location;
+        class Location location;
         location.lat = _sitl->state.latitude*1.0e7;
         location.lng = _sitl->state.longitude*1.0e7;
 

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -193,10 +193,10 @@ void AP_L1_Control::_prevent_indecision(float &Nu)
 }
 
 // update L1 control for waypoint navigation
-void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min)
+void AP_L1_Control::update_waypoint(const class Location &prev_WP, const class Location &next_WP, float dist_min)
 {
 
-    struct Location _current_loc;
+    class Location _current_loc;
     float Nu;
     float xtrackVel;
     float ltrackVel;
@@ -332,9 +332,9 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
 }
 
 // update L1 control for loitering
-void AP_L1_Control::update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction)
+void AP_L1_Control::update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction)
 {
-    struct Location _current_loc;
+    class Location _current_loc;
 
     // scale loiter radius with square of EAS2TAS to allow us to stay
     // stable at high altitude

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -51,8 +51,8 @@ public:
     float turn_distance(float wp_radius) const override;
     float turn_distance(float wp_radius, float turn_angle) const override;
     float loiter_radius (const float loiter_radius) const override;
-    void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min = 0.0f) override;
-    void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction) override;
+    void update_waypoint(const class Location &prev_WP, const class Location &next_WP, float dist_min = 0.0f) override;
+    void update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction) override;
     void update_heading_hold(int32_t navigation_heading_cd) override;
     void update_level_flight(void) override;
     bool reached_loiter_target(void) override;

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -142,7 +142,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
       when landing we keep the L1 navigation waypoint 200m ahead. This
       prevents sudden turns if we overshoot the landing point
      */
-    struct Location land_WP_loc = next_WP_loc;
+    class Location land_WP_loc = next_WP_loc;
 
     int32_t land_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
     land_WP_loc.offset_bearing(land_bearing_cd * 0.01f, prev_WP_loc.get_distance(current_loc) + 200);

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -40,9 +40,9 @@ static const struct {
       Vector2f(-2.0f, 2.0f), true },
 };
 
-static struct Location location_from_point(Vector2f pt)
+static class Location location_from_point(Vector2f pt)
 {
-    struct Location loc = {};
+    class Location loc = {};
     loc.lat = pt.x * 1.0e7f;
     loc.lng = pt.y * 1.0e7f;
     return loc;
@@ -52,9 +52,9 @@ static void test_passed_waypoint(void)
 {
     hal.console->printf("waypoint tests starting\n");
     for (uint8_t i = 0; i < ARRAY_SIZE(test_points); i++) {
-        struct Location loc = location_from_point(test_points[i].location);
-        struct Location wp1 = location_from_point(test_points[i].wp1);
-        struct Location wp2 = location_from_point(test_points[i].wp2);
+        class Location loc = location_from_point(test_points[i].location);
+        class Location wp1 = location_from_point(test_points[i].wp1);
+        class Location wp2 = location_from_point(test_points[i].wp2);
         if (loc.past_interval_finish_line(wp1, wp2) != test_points[i].passed) {
             hal.console->printf("Failed waypoint test %u\n", (unsigned)i);
             return;
@@ -63,11 +63,11 @@ static void test_passed_waypoint(void)
     hal.console->printf("waypoint tests OK\n");
 }
 
-static void test_one_offset(const struct Location &loc,
+static void test_one_offset(const class Location &loc,
                             float ofs_north, float ofs_east,
                             float dist, float bearing)
 {
-    struct Location loc2;
+    class Location loc2;
     float dist2, bearing2;
 
     loc2 = loc;
@@ -102,7 +102,7 @@ static const struct {
 
 static void test_offset(void)
 {
-    struct Location loc {};
+    class Location loc {};
 
     loc.lat = -35 * 1.0e7f;
     loc.lng = 149 * 1.0e7f;
@@ -122,12 +122,12 @@ static void test_offset(void)
  */
 static void test_accuracy(void)
 {
-    struct Location loc {};
+    class Location loc {};
 
     loc.lat = 0.0e7f;
     loc.lng = -120.0e7f;
 
-    struct Location loc2 = loc;
+    class Location loc2 = loc;
     Vector2f v((loc.lat * 1.0e-7f), (loc.lng*  1.0e-7f));
     Vector2f v2;
 

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -17,7 +17,7 @@
  */
 
 /*
- *  this module deals with calculations involving struct Location
+ *  this module deals with calculations involving class Location
  */
 #include <stdlib.h>
 #include "AP_Math.h"

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2025,7 +2025,7 @@ uint16_t AP_Mission::num_commands_max(void) const
 // be found.
 uint16_t AP_Mission::get_landing_sequence_start()
 {
-    struct Location current_loc;
+    class Location current_loc;
 
     if (!AP::ahrs().get_location(current_loc)) {
         return 0;
@@ -2083,7 +2083,7 @@ bool AP_Mission::jump_to_landing_sequence(void)
 // jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
 bool AP_Mission::jump_to_abort_landing_sequence(void)
 {
-    struct Location current_loc;
+    class Location current_loc;
 
     uint16_t abort_index = 0;
     if (AP::ahrs().get_location(current_loc)) {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -717,7 +717,7 @@ private:
     uint16_t                _prev_nav_cmd_id;       // id of the previous "navigation" command. (WAYPOINT, LOITER_TO_ALT, ect etc)
     uint16_t                _prev_nav_cmd_index;    // index of the previous "navigation" command.  Rarely used which is why we don't store the whole command
     uint16_t                _prev_nav_cmd_wp_index; // index of the previous "navigation" command that contains a waypoint.  Rarely used which is why we don't store the whole command
-    struct Location         _exit_position;  // the position in the mission that the mission was exited
+    class Location         _exit_position;  // the position in the mission that the mission was exited
 
     // jump related variables
     struct jump_tracking_struct {

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -673,7 +673,7 @@ void AP_Mount::set_target_sysid(uint8_t instance, uint8_t sysid)
 }
 
 // set_roi_target - sets target location that mount should attempt to point towards
-void AP_Mount::set_roi_target(uint8_t instance, const struct Location &target_loc)
+void AP_Mount::set_roi_target(uint8_t instance, const class Location &target_loc)
 {
     // call instance's set_roi_cmd
     if (check_instance(instance)) {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -121,8 +121,8 @@ public:
     void set_angle_targets(uint8_t instance, float roll, float tilt, float pan);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const struct Location &target_loc) { set_roi_target(_primary,target_loc); }
-    void set_roi_target(uint8_t instance, const struct Location &target_loc);
+    void set_roi_target(const class Location &target_loc) { set_roi_target(_primary,target_loc); }
+    void set_roi_target(uint8_t instance, const class Location &target_loc);
 
     // point at system ID sysid
     void set_target_sysid(uint8_t instance, const uint8_t sysid);
@@ -183,7 +183,7 @@ protected:
         AP_Float        _pitch_stb_lead;    // pitch lead control gain
 
         MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
-        struct Location _roi_target;        // roi target location
+        class Location _roi_target;        // roi target location
         bool _roi_target_set;
 
         uint8_t _target_sysid;           // sysid to track

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -17,7 +17,7 @@ void AP_Mount_Backend::set_angle_targets(float roll, float tilt, float pan)
 }
 
 // set_roi_target - sets target location that mount should attempt to point towards
-void AP_Mount_Backend::set_roi_target(const struct Location &target_loc)
+void AP_Mount_Backend::set_roi_target(const class Location &target_loc)
 {
     // set the target gps location
     _state._roi_target = target_loc;
@@ -195,7 +195,7 @@ bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad
 }
 
 // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (and radians) to point at the given target
-bool AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
+bool AP_Mount_Backend::calc_angle_to_location(const class Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
 {
     Location current_loc;
     if (!AP::ahrs().get_location(current_loc)) {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -56,7 +56,7 @@ public:
     void set_angle_targets(float roll, float tilt, float pan);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const struct Location &target_loc);
+    void set_roi_target(const class Location &target_loc);
 
     // set_sys_target - sets system that mount should attempt to point towards
     void set_target_sysid(uint8_t sysid);
@@ -95,7 +95,7 @@ protected:
 
     // calc_angle_to_location - calculates the earth-frame roll, tilt
     // and pan angles (and radians) to point at the given target
-    bool calc_angle_to_location(const struct Location &target,
+    bool calc_angle_to_location(const class Location &target,
                                 Vector3f& angles_to_target_rad,
                                 bool calc_tilt,
                                 bool calc_pan,

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1070,7 +1070,7 @@ bool NavEKF2::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 // If a calculated location isn't available, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-bool NavEKF2::getLLH(struct Location &loc) const
+bool NavEKF2::getLLH(class Location &loc) const
 {
     if (!core) {
         return false;
@@ -1082,7 +1082,7 @@ bool NavEKF2::getLLH(struct Location &loc) const
 // An out of range instance (eg -1) returns data for the primary instance
 // All NED positions calculated by the filter are relative to this location
 // Returns false if the origin has not been set
-bool NavEKF2::getOriginLLH(struct Location &loc) const
+bool NavEKF2::getOriginLLH(class Location &loc) const
 {
     if (!core) {
         return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -131,13 +131,13 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(struct Location &loc) const;
+    bool getLLH(class Location &loc) const;
 
     // Return the latitude and longitude and height used to set the NED origin for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(struct Location &loc) const;
+    bool getOriginLLH(class Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -397,7 +397,7 @@ private:
     const float maxYawEstVelInnov = 2.0f;          // Maximum acceptable length of the velocity innovation returned by the EKF-GSF yaw estimator (m/s)
 
     // origin set by one of the cores
-    struct Location common_EKF_origin;
+    class Location common_EKF_origin;
     bool common_origin_valid;
 
     // time at start of current filter update

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -593,7 +593,7 @@ void NavEKF2_core::readGpsData()
             }
 
             // Read the GPS location in WGS-84 lat,long,height coordinates
-            const struct Location &gpsloc = gps.location();
+            const class Location &gpsloc = gps.location();
 
             // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
             if (gpsGoodToAlign && !validOrigin) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -217,7 +217,7 @@ bool NavEKF2_core::getPosNE(Vector2f &posNE) const
         if(validOrigin) {
             if ((dal.gps().status(dal.gps().primary_sensor()) >= AP_DAL_GPS::GPS_OK_FIX_2D)) {
                 // If the origin has been set and we have GPS, then return the GPS position relative to the origin
-                const struct Location &gpsloc = dal.gps().location();
+                const class Location &gpsloc = dal.gps().location();
                 const Vector2F tempPosNE = EKF_origin.get_distance_NE_ftype(gpsloc);
                 posNE.x = tempPosNE.x;
                 posNE.y = tempPosNE.y;
@@ -277,7 +277,7 @@ bool NavEKF2_core::getHAGL(float &HAGL) const
 // If a calculated location isn't available, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-bool NavEKF2_core::getLLH(struct Location &loc) const
+bool NavEKF2_core::getLLH(class Location &loc) const
 {
     const auto &gps = dal.gps();
     Location origin;
@@ -299,7 +299,7 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
             // in this mode we cannot use the EKF states to estimate position so will return the best available data
             if ((gps.status() >= AP_DAL_GPS::GPS_OK_FIX_2D)) {
                 // we have a GPS position fix to return
-                const struct Location &gpsloc = gps.location();
+                const class Location &gpsloc = gps.location();
                 loc.lat = gpsloc.lat;
                 loc.lng = gpsloc.lng;
                 return true;
@@ -344,7 +344,7 @@ void NavEKF2_core::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGa
 
 
 // return the LLH location of the filters NED origin
-bool NavEKF2_core::getOriginLLH(struct Location &loc) const
+bool NavEKF2_core::getOriginLLH(class Location &loc) const
 {
     if (validOrigin) {
         loc = EKF_origin;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -54,7 +54,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
 
     // Check for significant change in GPS position if disarmed which indicates bad GPS
     // This check can only be used when the vehicle is stationary
-    const struct Location &gpsloc = gps.location(); // Current location
+    const class Location &gpsloc = gps.location(); // Current location
     const ftype posFiltTimeConst = 10.0f; // time constant used to decay position drift
     // calculate time lapsed since last update and limit to prevent numerical errors
     ftype deltaTime = constrain_ftype(float(imuDataDelayed.time_ms - lastPreAlignGpsCheckTime_ms)*0.001f,0.01f,posFiltTimeConst);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -158,12 +158,12 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(struct Location &loc) const;
+    bool getLLH(class Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(struct Location &loc) const;
+    bool getOriginLLH(class Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -853,7 +853,7 @@ private:
     bool needMagBodyVarReset;       // we need to reset mag body variances at next CovariancePrediction
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
-    struct Location EKF_origin;     // LLH origin of the NED axis system
+    class Location EKF_origin;     // LLH origin of the NED axis system
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
     ftype gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
@@ -940,7 +940,7 @@ private:
     } vertCompFiltState;
 
     // variables used by the pre-initialisation GPS checks
-    struct Location gpsloc_prev;    // LLH location of previous GPS measurement
+    class Location gpsloc_prev;    // LLH location of previous GPS measurement
     uint32_t lastPreAlignGpsCheckTime_ms;   // last time in msec the GPS quality was checked during pre alignment checks
     ftype gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     ftype gpsVertVelFilt;           // amount of filterred vertical GPS velocity detected durng pre-flight GPS checks

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1324,7 +1324,7 @@ bool NavEKF3::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 // If a calculated location isn't available, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-bool NavEKF3::getLLH(struct Location &loc) const
+bool NavEKF3::getLLH(class Location &loc) const
 {
     if (!core) {
         return false;
@@ -1335,7 +1335,7 @@ bool NavEKF3::getLLH(struct Location &loc) const
 // Return the latitude and longitude and height used to set the NED origin
 // All NED positions calculated by the filter are relative to this location
 // Returns false if the origin has not been set
-bool NavEKF3::getOriginLLH(struct Location &loc) const
+bool NavEKF3::getOriginLLH(class Location &loc) const
 {
     if (!core) {
         return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -134,12 +134,12 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(struct Location &loc) const;
+    bool getLLH(class Location &loc) const;
 
     // Return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(struct Location &loc) const;
+    bool getOriginLLH(class Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -505,7 +505,7 @@ private:
     uint64_t coreLastTimePrimary_us[MAX_EKF_CORES]; // last time we were using this core as primary
 
     // origin set by one of the cores
-    struct Location common_EKF_origin;
+    class Location common_EKF_origin;
     bool common_origin_valid;
     
     // update the yaw reset data to capture changes due to a lane switch

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -643,7 +643,7 @@ void NavEKF3_core::readGpsData()
     calcGpsGoodForFlight();
 
     // Read the GPS location in WGS-84 lat,long,height coordinates
-    const struct Location &gpsloc = gps.location(selected_gps);
+    const class Location &gpsloc = gps.location(selected_gps);
 
     // Set the EKF origin and magnetic field declination if not previously set and GPS checks have passed
     if (gpsGoodToAlign && !validOrigin) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -216,7 +216,7 @@ bool NavEKF3_core::getPosNE(Vector2f &posNE) const
             auto &gps = dal.gps();
             if ((gps.status(selected_gps) >= AP_DAL_GPS::GPS_OK_FIX_2D)) {
                 // If the origin has been set and we have GPS, then return the GPS position relative to the origin
-                const struct Location &gpsloc = gps.location(selected_gps);
+                const class Location &gpsloc = gps.location(selected_gps);
                 posNE = public_origin.get_distance_NE_ftype(gpsloc).tofloat();
                 return false;
             } else if (rngBcnAlignmentStarted) {
@@ -271,7 +271,7 @@ bool NavEKF3_core::getHAGL(float &HAGL) const
 // If a calculated location isn't available, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-bool NavEKF3_core::getLLH(struct Location &loc) const
+bool NavEKF3_core::getLLH(class Location &loc) const
 {
     Location origin;
     if (getOriginLLH(origin)) {
@@ -317,7 +317,7 @@ bool NavEKF3_core::getLLH(struct Location &loc) const
     }
 }
 
-bool NavEKF3_core::getGPSLLH(struct Location &loc) const
+bool NavEKF3_core::getGPSLLH(class Location &loc) const
 {
     const auto &gps = dal.gps();
     if ((gps.status(selected_gps) >= AP_DAL_GPS::GPS_OK_FIX_3D)) {
@@ -350,7 +350,7 @@ void NavEKF3_core::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGa
 
 
 // return the LLH location of the filters NED origin
-bool NavEKF3_core::getOriginLLH(struct Location &loc) const
+bool NavEKF3_core::getOriginLLH(class Location &loc) const
 {
     if (validOrigin) {
         loc = public_origin;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -50,7 +50,7 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     // This check can only be used when the vehicle is stationary
     const auto &gps = dal.gps();
 
-    const struct Location &gpsloc = gps.location(preferred_gps); // Current location
+    const class Location &gpsloc = gps.location(preferred_gps); // Current location
     const ftype posFiltTimeConst = 10.0; // time constant used to decay position drift
     // calculate time lapsed since last update and limit to prevent numerical errors
     ftype deltaTime = constrain_ftype(ftype(imuDataDelayed.time_ms - lastPreAlignGpsCheckTime_ms)*0.001f,0.01f,posFiltTimeConst);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -197,12 +197,12 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(struct Location &loc) const;
+    bool getLLH(class Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(struct Location &loc) const;
+    bool getOriginLLH(class Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -973,7 +973,7 @@ private:
     void SelectDragFusion();
     void SampleDragData(const imu_elements &imu);
 
-    bool getGPSLLH(struct Location &loc) const;
+    bool getGPSLLH(class Location &loc) const;
 
     // Variables
     bool statesInitialised;         // boolean true when filter states have been initialised
@@ -1061,8 +1061,8 @@ private:
     bool needEarthBodyVarReset;     // we need to reset mag earth variances at next CovariancePrediction
     bool inhibitDelAngBiasStates;   // true when IMU delta angle bias states are inactive
     bool gpsIsInUse;                // bool true when GPS data is being used to correct states estimates
-    struct Location EKF_origin;     // LLH origin of the NED axis system, internal only
-    struct Location &public_origin; // LLH origin of the NED axis system, public functions
+    class Location EKF_origin;     // LLH origin of the NED axis system, internal only
+    class Location &public_origin; // LLH origin of the NED axis system, public functions
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
     ftype gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
@@ -1154,7 +1154,7 @@ private:
     } vertCompFiltState;
 
     // variables used by the pre-initialisation GPS checks
-    struct Location gpsloc_prev;    // LLH location of previous GPS measurement
+    class Location gpsloc_prev;    // LLH location of previous GPS measurement
     uint32_t lastPreAlignGpsCheckTime_ms;   // last time in msec the GPS quality was checked during pre alignment checks
     ftype gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     ftype gpsVertVelFilt;           // amount of filtered vertical GPS velocity detected during pre-flight GPS checks

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -67,7 +67,7 @@ public:
     // main flight code will call an output function (such as
     // nav_roll_cd()) after this function to ask for the new required
     // navigation attitude/steering.
-    virtual void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min = 0.0f) = 0;
+    virtual void update_waypoint(const class Location &prev_WP, const class Location &next_WP, float dist_min = 0.0f) = 0;
 
     // update the internal state of the navigation controller for when
     // the vehicle has been commanded to circle about a point.  This
@@ -76,7 +76,7 @@ public:
     // main flight code will call an output function (such as
     // nav_roll_cd()) after this function to ask for the new required
     // navigation attitude/steering.
-    virtual void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction) = 0;
+    virtual void update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction) = 0;
 
     // update the internal state of the navigation controller, given a
     // fixed heading. This is the step function for navigation control

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -171,7 +171,7 @@ Location AP_Rally::calc_best_rally_or_home_location(const Location &current_loc,
 {
     RallyLocation ral_loc = {};
     Location return_loc = {};
-    const struct Location &home_loc = AP::ahrs().get_home();
+    const class Location &home_loc = AP::ahrs().get_home();
     
     // no valid rally point, return home position
     return_loc = home_loc;

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -199,7 +199,7 @@ void AR_WPNav::set_nudge_speed_max(float nudge_speed_max)
 
 // set desired location and (optionally) next_destination
 // next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav::set_desired_location(const struct Location& destination, Location next_destination)
+bool AR_WPNav::set_desired_location(const class Location& destination, Location next_destination)
 {
     // re-initialise if inactive, previous destination has been interrupted or different controller was used
     if (!is_active() || !_reached_destination || (_nav_control_type != NavControllerType::NAV_SCURVE)) {

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -137,7 +137,7 @@ void AR_WPNav_OA::update(float dt)
 
 // set desired location and (optionally) next_destination
 // next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav_OA::set_desired_location(const struct Location& destination, Location next_destination)
+bool AR_WPNav_OA::set_desired_location(const class Location& destination, Location next_destination)
 {
     const bool ret = AR_WPNav::set_desired_location(destination, next_destination);
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -943,7 +943,7 @@ private:
     
     // we cache the current location and send it even if the AHRS has
     // no idea where we are:
-    struct Location global_position_current_loc;
+    class Location global_position_current_loc;
 
     uint8_t last_tx_seq;
     uint16_t send_packet_count;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -496,7 +496,7 @@ void GCS_MAVLINK::send_ahrs2()
 {
     const AP_AHRS &ahrs = AP::ahrs();
     Vector3f euler;
-    struct Location loc {};
+    class Location loc {};
     // we want one or both of these, use | to avoid short-circuiting:
     if (ahrs.get_secondary_attitude(euler) |
         ahrs.get_secondary_position(loc)) {


### PR DESCRIPTION
Remove a warning

```
../../libraries/AP_Common/Location.h:96:29: warning: struct 'Location' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    ftype get_bearing(const struct Location &loc2) const;
                            ^
../../libraries/AP_Common/Location.h:7:7: note: previous use is here
class Location
      ^
../../libraries/AP_Common/Location.h:99:34: warning: struct 'Location' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    int32_t get_bearing_to(const struct Location &loc2) const {
                                 ^
../../libraries/AP_Common/Location.h:7:7: note: previous use is here
class Location
      ^
```