### PR TITLE
AP_Param: fix aliasing issue due to deferencing

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2095,7 +2095,7 @@ bool AP_Param::parse_param_line(char *line, char **vname, float &value, bool &re
     if (value_s == nullptr) {
         return false;
     }
-    value = strtof(value_s, NULL);
+    value = strtof(value_s, nullptr);
     *vname = pname;
 
     const char *flags_s = strtok_r(nullptr, ", =\t\r\n", &saveptr);

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2855,7 +2855,7 @@ bool AP_Param::add_table(uint8_t _key, const char *prefix, uint8_t num_params)
     invalidate_count();
 
     // save the CRC
-    AP_Int32 *crc_param = const_cast<AP_Int32 *>((AP_Int32 *)info.ptr);
+    AP_Int32 *crc_param = const_cast<AP_Int32 *>((const AP_Int32 *)info.ptr);
     crc_param->set(crc);
     crc_param->save(true);
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2763,7 +2763,7 @@ bool AP_Param::add_table(uint8_t _key, const char *prefix, uint8_t num_params)
     // find existing key (allows for script reload)
     uint8_t i;
     for (i=0; i<AP_PARAM_MAX_DYNAMIC; i++) {
-        auto &info = _var_info_dynamic[i];
+        auto const &info = _var_info_dynamic[i];
         if (info.type != AP_PARAM_NONE && info.key == key) {
             if (_dynamic_table_sizes[i] != 0 &&
                 num_params > _dynamic_table_sizes[i]) {
@@ -2782,7 +2782,7 @@ bool AP_Param::add_table(uint8_t _key, const char *prefix, uint8_t num_params)
     if (i == AP_PARAM_MAX_DYNAMIC) {
         // find an unused slot
         for (i=0; i<AP_PARAM_MAX_DYNAMIC; i++) {
-            auto &info = _var_info_dynamic[i];
+            auto const &info = _var_info_dynamic[i];
             if (info.type == AP_PARAM_NONE ) {
                 break;
             }
@@ -2899,7 +2899,7 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     // find the info
     uint8_t i;
     for (i=0; i<AP_PARAM_MAX_DYNAMIC; i++) {
-        auto &info = _var_info_dynamic[i];
+        auto const &info = _var_info_dynamic[i];
         if (info.key == key) {
             break;
         }

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2919,8 +2919,8 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     }
 
     // check CRC
-    auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
-    const int32_t crc = *(const int32_t *)(&hinfo.def_value);
+    auto &hinfo = (info.group_info)[0];
+    const auto crc = *(const int32_t*)(&hinfo.def_value);
 
     int32_t current_crc;
     if (load_int32(key, 0, current_crc) && current_crc != crc) {


### PR DESCRIPTION
Fix aliasing issue due to deferencing issue : checked on gdb that the result is the same on SITL ( just need to load a script like the motor failure one's)
improve some system (const, nullptr)