### PR TITLE
AP_CustomRotations: fix param referencing

### DIFF
--- a/libraries/AP_CustomRotations/AP_CustomRotations.cpp
+++ b/libraries/AP_CustomRotations/AP_CustomRotations.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_CustomRotations::var_info[] = {
     AP_GROUPEND
 };
 
-AP_CustomRotation::AP_CustomRotation(AP_CustomRotation_params _params):
+AP_CustomRotation::AP_CustomRotation(AP_CustomRotation_params &_params):
     params(_params)
 {
     init();

--- a/libraries/AP_CustomRotations/AP_CustomRotations.h
+++ b/libraries/AP_CustomRotations/AP_CustomRotations.h
@@ -32,7 +32,7 @@ public:
 
 class AP_CustomRotation {
 public:
-    AP_CustomRotation(AP_CustomRotation_params _params);
+    AP_CustomRotation(AP_CustomRotation_params &_params);
 
     void init();
 


### PR DESCRIPTION
This issue caused param conversion to not work, its the only case where we ever change the params. Manually setting the params from GCS still worked fine. 