### PR TITLE
actions: skip periph check on gcc6

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -44,6 +44,8 @@ jobs:
             config: revo-mini
           - gcc: 6
             config: MatekF405-Wing
+          - gcc: 6
+            config: periph-build
         include:
           - config: stm32h7
             toolchain: chibios-py2


### PR DESCRIPTION
Should stop the oversize check failing continually. 