### PR TITLE
AP_Button, AP_Relay, AP_RPM: improve PreArm warning of GPIO vs SERVOn_FUNCTION conflicts

### DIFF
--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -388,7 +388,12 @@ bool AP_Button::arming_checks(size_t buflen, char *buffer) const
     }
     for (uint8_t i=0; i<AP_BUTTON_NUM_PINS; i++) {
         if (pin[i] != -1 && !hal.gpio->valid_pin(pin[i])) {
-            hal.util->snprintf(buffer, buflen, "BTN_PIN%u %d invalid", unsigned(i + 1), int(pin[i].get()));
+            uint8_t servo_ch;
+            if (hal.gpio->pin_to_servo_channel(pin[i], servo_ch)) {
+                hal.util->snprintf(buffer, buflen, "BTN_PIN%u=%d, set SERVO%u_FUNCTION=-1", unsigned(i + 1), int(pin[i].get()), unsigned(servo_ch+1));
+            } else {
+                hal.util->snprintf(buffer, buflen, "BTN_PIN%u=%d invalid", unsigned(i + 1), int(pin[i].get()));
+            }
             return false;
         }
     }

--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -55,6 +55,10 @@ public:
     virtual void    toggle(uint8_t pin) = 0;
     virtual bool    valid_pin(uint8_t pin) const { return true; }
 
+    // return servo channel associated with GPIO pin.  Returns true on success and fills in servo_ch argument
+    // servo_ch uses zero-based indexing
+    virtual bool    pin_to_servo_channel(uint8_t pin, uint8_t& servo_ch) const { return false; }
+
     // allow for save and restore of pin settings
     virtual bool    get_mode(uint8_t pin, uint32_t &mode) { return false; }
     virtual void    set_mode(uint8_t pin, uint32_t mode) {}

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -90,7 +90,7 @@ void GPIO::init()
         chan_offset = 8;
     }
 #endif
-    // auto-disable pins being used for PWM output based on BRD_PWM_COUNT parameter
+    // auto-disable pins being used for PWM output
     for (uint8_t i=0; i<ARRAY_SIZE(_gpio_tab); i++) {
         struct gpio_entry *g = &_gpio_tab[i];
         if (g->pwm_num != 0) {

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -82,6 +82,10 @@ public:
     // check if a pin number is valid
     bool valid_pin(uint8_t pin) const override;
 
+    // return servo channel associated with GPIO pin.  Returns true on success and fills in servo_ch argument
+    // servo_ch uses zero-based indexing
+    bool pin_to_servo_channel(uint8_t pin, uint8_t& servo_ch) const override;
+
     /*
       resolve an ioline to take account of alternative configurations
      */

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -1064,10 +1064,16 @@ void AP_IOMCU::check_iomcu_reset(void)
     last_rc_protocols = 0;
 }
 
-// Check if pin number is valid for GPIO
+// Check if pin number is valid and configured for GPIO
 bool AP_IOMCU::valid_GPIO_pin(uint8_t pin) const
 {
-    return convert_pin_number(pin);
+    // sanity check pin number
+    if (!convert_pin_number(pin)) {
+        return false;
+    }
+
+    // check pin is enabled as GPIO
+    return ((GPIO.channel_mask & (1U << pin)) != 0);
 }
 
 // convert external pin numbers 101 to 108 to internal 0 to 7

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -1073,13 +1073,10 @@ bool AP_IOMCU::valid_GPIO_pin(uint8_t pin) const
 // convert external pin numbers 101 to 108 to internal 0 to 7
 bool AP_IOMCU::convert_pin_number(uint8_t& pin) const
 {
-    if (pin < 101) {
+    if (pin < 101 || pin > 108) {
         return false;
     }
     pin -= 101;
-    if (pin > 7) {
-        return false;
-    }
     return true;
 }
 

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -107,7 +107,7 @@ public:
     bool setup_mixing(RCMapper *rcmap, int8_t override_chan,
                       float mixing_gain, uint16_t manual_rc_mask);
 
-    // Check if pin number is valid for GPIO
+    // Check if pin number is valid and configured for GPIO
     bool valid_GPIO_pin(uint8_t pin) const;
 
     // convert external pin numbers 101 to 108 to internal 0 to 7

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -248,11 +248,16 @@ bool AP_RPM::arming_checks(size_t buflen, char *buffer) const
         case RPM_TYPE_PWM:
         case RPM_TYPE_PIN:
             if (_params[i].pin == -1) {
-                hal.util->snprintf(buffer, buflen, "RPM[%u] no pin set", i + 1);
+                hal.util->snprintf(buffer, buflen, "RPM%u_PIN not set", unsigned(i + 1));
                 return false;
             }
             if (!hal.gpio->valid_pin(_params[i].pin)) {
-                hal.util->snprintf(buffer, buflen, "RPM[%u] pin %d invalid", unsigned(i + 1), int(_params[i].pin.get()));
+                uint8_t servo_ch;
+                if (hal.gpio->pin_to_servo_channel(_params[i].pin, servo_ch)) {
+                    hal.util->snprintf(buffer, buflen, "RPM%u_PIN=%d, set SERVO%u_FUNCTION=-1", unsigned(i + 1), int(_params[i].pin.get()), unsigned(servo_ch+1));
+                } else {
+                    hal.util->snprintf(buffer, buflen, "RPM%u_PIN=%d invalid", unsigned(i + 1), int(_params[i].pin.get()));
+                }
                 return false;
             }
             break;

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -156,8 +156,18 @@ void AP_Relay::toggle(uint8_t instance)
 bool AP_Relay::arming_checks(size_t buflen, char *buffer) const
 {
     for (uint8_t i=0; i<AP_RELAY_NUM_RELAYS; i++) {
-        if (_pin[i] != -1 && !hal.gpio->valid_pin(_pin[i])) {
-            hal.util->snprintf(buffer, buflen, "Relay[%u] pin %d invalid", i + 1, int(_pin[i].get()));
+        int8_t pin = _pin[i].get();
+        if (pin != -1 && !hal.gpio->valid_pin(pin)) {
+            char param_name_buf[11] = "RELAY_PIN";
+            if (i > 0) {
+                hal.util->snprintf(param_name_buf, ARRAY_SIZE(param_name_buf), "RELAY_PIN%u", unsigned(i+1));
+            }
+            uint8_t servo_ch;
+            if (hal.gpio->pin_to_servo_channel(pin, servo_ch)) {
+                hal.util->snprintf(buffer, buflen, "%s=%d, set SERVO%u_FUNCTION=-1", param_name_buf, int(pin), unsigned(servo_ch+1));
+            } else {
+                hal.util->snprintf(buffer, buflen, "%s=%d invalid", param_name_buf, int(pin));
+            }
             return false;
         }
     }


### PR DESCRIPTION
This PR attempts to resolve 4.2 user struggles when setting up buttons, relays and RPM sensors where the GPIO pin selected conflicts with a servo output channel.

- a new AP_HAL::GPIO::pin_to_servo_channel() method has been added that returns the servo channel that could use the GPIO pin.
- the AP_Button, AP_Relay and AP_RPM pre-arm checks have been enhanced so that if the GPIO pin is invalid and the above method says the pin could be used for PWM output then we assume the reason the pin is invalid is because of the conflict with the servo output and display a warning as shown in the screen shots below.

This has been tested on a CubeOrange and some testing evidence is below

![cubeorange-testing](https://user-images.githubusercontent.com/1498098/163929782-82ef7ef7-f6ac-4436-a88b-55e9231133a0.png)


Here are some links to user struggles:

- [Rover discussion](https://discuss.ardupilot.org/t/rover-4-2-0-beta3-released-for-beta-testing/83623/17)
- [Copter discussion](https://discuss.ardupilot.org/t/brd-pwm-count-mentioned-in-wiki-but-not-in-parameters-or-in-parameter-list-doc/84155)

BTW, we could simplify the pre-arm code a bit if AP_Param could return us the name of the parameter directly instead of the library having to reconstruct it.

Note that as part of testing I discovered this other issue where the RPM library will spam the GCS https://github.com/ArduPilot/ardupilot/issues/20575