### PR TITLE
SRV_Channel: function of zero is valid

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -183,7 +183,7 @@ public:
 
     // check if a function is valid for indexing into functions
     static bool valid_function(Aux_servo_function_t fn) {
-        return fn > k_none && fn < k_nr_aux_servo_functions;
+        return fn >= k_none && fn < k_nr_aux_servo_functions;
     }
     bool valid_function(void) const {
         return valid_function(function);


### PR DESCRIPTION
This PR allows DO_SET_SERVO commands to work again but I'm not yet confident that this won't cause issues to re-appear in Rover's bi-directional DShot support which [this PR fixed](https://github.com/ArduPilot/ardupilot/pull/20374).

The issue can be reproduced by doing this:

- attach a servo (or servo tester) to a Pixhawk/Cube's AUX OUT 1 (aka Servo9)
- set SERVO9_FUNCTION = 0 (Disabled)
- use MP's Data screen's "Servo/Relay" tab's Low, Mid, High and Toggle buttons to change the PWM output and confirm the servo moves

This has been lightly tested on a CubeOrange.
![image](https://user-images.githubusercontent.com/1498098/163937840-42b5d415-541c-43bd-8eba-0fbe0629fabb.png)

