### PR TITLE
Added MMC5xx3 compass to main compass probe

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1094,6 +1094,23 @@ void Compass::_probe_external_i2c_compasses(void)
     }
 #endif
 
+#if !defined(HAL_DISABLE_I2C_MAGS_BY_DEFAULT) || defined(HAL_USE_I2C_MAG_MMC5XX3)
+    //external i2c bus
+    FOREACH_I2C_EXTERNAL(i) {
+        ADD_BACKEND(DRIVER_MMC5XX3, AP_Compass_MMC5XX3::probe(GET_I2C_DEVICE(i, HAL_COMPASS_MMC5xx3_I2C_ADDR),
+                    true, ROTATION_NONE));
+    }
+
+    // internal i2c bus
+    if (all_external) {
+        // only probe MMC5XX on internal if we are treating internals as externals
+        FOREACH_I2C_INTERNAL(i) {
+            ADD_BACKEND(DRIVER_MMC5XX3, AP_Compass_MMC5XX3::probe(GET_I2C_DEVICE(i, HAL_COMPASS_MMC5xx3_I2C_ADDR),
+                        all_external, ROTATION_NONE));
+        }
+    }
+#endif
+
 #ifndef HAL_BUILD_AP_PERIPH
     // AK09916 on ICM20948
     FOREACH_I2C_EXTERNAL(i) {


### PR DESCRIPTION
Not sure why the MMC5xx3 driver was added but not initialized anywhere. This PR adds the MMC5xx3 compass to the main compass i2c probe section. Confirmed working with eval board.