### PR TITLE
SITL: add example to evaluate battery model

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -325,7 +325,7 @@ void Scheduler::reboot(bool hold_in_bootloader)
     exit(1);
 }
 
-#if APM_BUILD_TYPE(APM_BUILD_Replay)
+#if APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
 void Scheduler::stop_clock(uint64_t time_usec)
 {
     if (time_usec < _stopped_clock_usec) {

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#if AP_SIM_ENABLED
+
 #include <AP_Math/AP_Math.h>
 
 #include "SITL.h"
@@ -343,3 +345,5 @@ private:
 };
 
 } // namespace SITL
+
+#endif // AP_SIM_ENABLED

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -471,6 +471,7 @@ void Frame::parse_vector3(picojson::value val, const char* label, Vector3f &para
 /*
   initialise the frame
  */
+#if AP_SIM_ENABLED
 void Frame::init(const char *frame_str, Battery *_battery)
 {
     model = default_model;
@@ -671,3 +672,4 @@ void Frame::current_and_voltage(float &voltage, float &current)
         current += motors[i].get_current();
     }
 }
+#endif // AP_SIM_ENABLED

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -21,7 +21,10 @@
 #include "SIM_Aircraft.h"
 #include "SIM_Motor.h"
 
+#ifndef USE_PICOJSON
 #define USE_PICOJSON (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif
+
 #if USE_PICOJSON
 #include "picojson.h"
 #endif
@@ -142,8 +145,15 @@ private:
 
     } default_model;
 
+protected:
+#if USE_PICOJSON
+    // load frame parameters from a json model file
+    void load_frame_params(const char *model_json);
+#endif
+
     struct Model model;
 
+private:
     // exposed area times coefficient of drag
     float areaCd;
     float mass;
@@ -156,9 +166,8 @@ private:
     // get air density in kg/m^3
     float get_air_density(float alt_amsl) const;
 
+    // json parsing helpers
 #if USE_PICOJSON
-    // load frame parameters from a json model file
-    void load_frame_params(const char *model_json);
     void parse_float(picojson::value val, const char* label, float &param);
     void parse_vector3(picojson::value val, const char* label, Vector3f &param);
 #endif

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -44,7 +44,7 @@ public:
           num_motors(_num_motors),
           motors(_motors) {}
 
-
+#if AP_SIM_ENABLED
     // find a frame by name
     static Frame *find_frame(const char *name);
     
@@ -56,7 +56,8 @@ public:
                           const struct sitl_input &input,
                           Vector3f &rot_accel, Vector3f &body_accel, float* rpm,
                           bool use_drag=true);
-    
+#endif // AP_SIM_ENABLED
+
     float terminal_velocity;
     float terminal_rotation_rate;
     uint8_t motor_offset;
@@ -147,8 +148,10 @@ private:
     float areaCd;
     float mass;
     float thrust_max;
-    Battery *battery;
     float last_param_voltage;
+#if AP_SIM_ENABLED
+    Battery *battery;
+#endif
 
     // get air density in kg/m^3
     float get_air_density(float alt_amsl) const;

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "SIM_Aircraft.h"
+#include <AP_Math/AP_Math.h>
 
 namespace SITL {
 

--- a/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
+++ b/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
@@ -1,0 +1,87 @@
+#include <AP_HAL/AP_HAL.h>
+
+#include <SITL/SIM_Battery.h>
+#include <SITL/SIM_Frame.h>
+
+#include <stdio.h>
+
+/* run with:
+    ./waf configure --board linux
+    ./waf build --targets examples/EvaluateBatteryModel
+    ./build/linux/examples/EvaluateBatteryModel Tools/autotest/models/Callisto.json 50
+*/
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+// helper to give access to protected functions
+class Frame_helper : public SITL::Frame {
+public:
+    using SITL::Frame::Frame;
+
+    void public_load_frame_params(const char *model_json) {
+        load_frame_params(model_json);
+    }
+
+    float get_capacity() { return model.battCapacityAh; }
+    float get_max_volt() { return model.maxVoltage; }
+    float get_resistance() { return model.refBatRes; }
+
+};
+
+Frame_helper frame {nullptr, 0, nullptr};
+SITL::Battery battery;
+
+void setup(void)
+{
+    uint8_t argc;
+    char * const *argv;
+
+    hal.util->commandline_arguments(argc, argv);
+
+    if (argc <= 2) {
+        ::printf("pass .json model definition path and current draw\n");
+        exit(0);
+    }
+
+    // parse JSON vehicle definition
+    frame.public_load_frame_params(argv[1]);
+
+    // parse current draw
+    const float current = strtof(argv[2], NULL);
+
+    const float amp_hour_capacity = frame.get_capacity();
+    const float resistance = frame.get_resistance();
+    const float max_voltage = frame.get_max_volt();
+    const float min_voltage = max_voltage * 0.7;
+
+    ::printf("Simulating %0.2fv, %0.2f ah battery with resistance of %f\n", max_voltage, amp_hour_capacity, resistance);
+    ::printf("Voltage from %0.2f to %0.2f with constant current draw of %0.2f\n", max_voltage, min_voltage, current);
+
+    // setup battery model
+    battery.setup(amp_hour_capacity, resistance, max_voltage);
+    battery.init_voltage(max_voltage);
+
+    uint64_t time = 0;
+    hal.scheduler->stop_clock(time);
+    const double time_step = 0.05;
+
+    ::printf("time, voltage\n");
+    while (battery.get_voltage() >= min_voltage) {
+        battery.set_current(current);
+
+        ::printf("%0.2f, %0.2f\n", time * 1.0e-6, battery.get_voltage());
+
+        time += time_step*1e6;
+        hal.scheduler->stop_clock(time);
+    }
+}
+
+void loop(void)
+{
+    exit(0);
+}
+
+AP_HAL_MAIN();

--- a/libraries/SITL/examples/EvaluateBatteryModel/wscript
+++ b/libraries/SITL/examples/EvaluateBatteryModel/wscript
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+
+    if bld.env.BOARD != 'linux':
+        return
+
+    source = bld.path.ant_glob('*.cpp')
+    source.append('../../../../libraries/SITL/SIM_Battery.cpp')
+    source.append('../../../../libraries/SITL/SIM_Frame.cpp')
+
+    bld.env.DEFINES.append("USE_PICOJSON=1")
+
+    bld.ap_program(
+        use='ap',
+        program_groups=['examples'],
+        source=source,
+    )
+

--- a/libraries/SITL/tests/wscript
+++ b/libraries/SITL/tests/wscript
@@ -2,6 +2,10 @@
 # encoding: utf-8
 
 def build(bld):
+
+    if bld.env.BOARD != 'sitl':
+        return
+
     bld.ap_find_tests(
         use='ap',
     )

--- a/wscript
+++ b/wscript
@@ -683,7 +683,6 @@ def _build_recursion(bld):
     common_dirs_excl = [
         'modules',
         'libraries/AP_HAL_*',
-        'libraries/SITL',
     ]
 
     hal_dirs_patterns = [


### PR DESCRIPTION
This allows one to test the SITL battery model with a constant current draw. This can then be used to tune the parameters to better fit a real test.

run with:
```
./waf configure --board linux
./waf build --targets examples/EvaluateBatteryModel
./build/linux/examples/EvaluateBatteryModel Tools/autotest/models/Callisto.json 50
```
That will load the battery setup from `Callisto.json` and apply a constant current draw of 50 amps giving:
```
Loading model Tools/autotest/models/Callisto.json
Loaded model params from Tools/autotest/models/Callisto.json
Simulating 50.40v, 44.00 ah battery with resistance of 0.024000
Voltage from 50.40 to 35.28 with constant current draw of 50.00
time, voltage
0.00, 49.20
0.05, 49.20
0.10, 49.20
0.15, 49.20
0.20, 49.20
0.25, 49.20
0.30, 49.20
....
```
One could then plot the results:
![image](https://user-images.githubusercontent.com/33176108/164759612-dd9fab40-f69c-46c9-bc14-d2eac1dcf81d.png)

Next step is to allow one to configure the battery SoC model from the json input. 

https://github.com/ArduPilot/ardupilot/blob/291d70940937171543699d0df5341fb9f2f3d6f3/libraries/SITL/SIM_Battery.cpp#L23-L69

