### PR TITLE
Sub: tweak output function in AP_Motors6DOF

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -715,6 +715,8 @@ void Sub::load_parameters()
     AP_Param::set_default_by_name("RC8_OPTION", 213);   // MOUNT1_PITCH
     // We should ignore this parameter since ROVs are neutral buoyancy
     AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
+    AP_Param::set_default_by_name("MOT_PWM_MIN", 1100);
+    AP_Param::set_default_by_name("MOT_PWM_MAX", 1900);
 
 // PARAMETER_CONVERSION - Added: JAN-2022
 #if AP_AIRSPEED_ENABLED

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -232,7 +232,9 @@ void AP_Motors6DOF::output_min()
 
 int16_t AP_Motors6DOF::calc_thrust_to_pwm(float thrust_in) const
 {
-    return constrain_int16(1500 + thrust_in * 400, get_pwm_output_min(), get_pwm_output_max());
+    int16_t range_up = get_pwm_output_max() - 1500;
+    int16_t range_down = 1500 - get_pwm_output_min();
+    return 1500 + thrust_in * (thrust_in > 0 ? range_up : range_down);
 }
 
 void AP_Motors6DOF::output_to_motors()


### PR DESCRIPTION
This removes the hardcoded `400` and now consumes MOT_MIN/MAX for calculating the range.
fix #16576 