### PR TITLE
SITL: a few more physics changes

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -611,8 +611,6 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     rot_accel.y = torque.y / model.moment_of_inertia.y;
     rot_accel.z = torque.z / model.moment_of_inertia.z;
 
-    body_accel = thrust/aircraft.gross_mass();
-
     if (terminal_rotation_rate > 0) {
         // rotational air resistance
         rot_accel.x -= gyro.x * radians(400.0) / terminal_rotation_rate;
@@ -625,13 +623,13 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         Vector3f drag_bf;
         drag_bf.x = areaCd * 0.5f * air_density * sq(vel_air_bf.x) +
                     model.mdrag_coef * fabsf(vel_air_bf.x) * sqrtf(fabsf(thrust.z) * air_density * model.disc_area);
-        if (is_positive(vel_air_bf.x)) {
+        if (is_negative(vel_air_bf.x)) {
             drag_bf.x = -drag_bf.x;
         }
 
         drag_bf.y = areaCd * 0.5f * air_density * sq(vel_air_bf.y) +
                     model.mdrag_coef * fabsf(vel_air_bf.y) * sqrtf(fabsf(thrust.z) * air_density * model.disc_area);
-        if (is_positive(vel_air_bf.y)) {
+        if (is_negative(vel_air_bf.y)) {
             drag_bf.y = -drag_bf.y;
         }
 
@@ -641,13 +639,14 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         // the Motor class with one based on DC motor, mometum disc and blade elemnt theory.
         drag_bf.z = areaCd * 0.5f * air_density * sq(vel_air_bf.z) +
                     model.mdrag_coef * fabsf(vel_air_bf.z) * sqrtf(fabsf(thrust.z) * air_density * model.disc_area);
-        if (is_positive(vel_air_bf.z)) {
+        if (is_negative(vel_air_bf.z)) {
             drag_bf.z = -drag_bf.z;
         }
 
-        body_accel += drag_bf / mass;
+        thrust -= drag_bf;
     }
 
+    body_accel = thrust/aircraft.gross_mass();
 }
 
 

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -515,7 +515,6 @@ void Frame::init(const char *frame_str, Battery *_battery)
     float hover_velocity_out = 2 * hover_power / hover_thrust;
     float effective_disc_area = hover_thrust / (0.5 * ref_air_density * sq(hover_velocity_out));
     float velocity_max = hover_velocity_out / sqrtf(model.hoverThrOut);
-    thrust_max = 0.5 * ref_air_density * effective_disc_area * sq(velocity_max);
     float effective_prop_area = effective_disc_area / num_motors;
 
     // power_factor is ratio of power consumed per newton of thrust
@@ -649,16 +648,6 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         body_accel += drag_bf / mass;
     }
 
-    // add some noise
-    const float gyro_noise = radians(0.1);
-    const float accel_noise = 0.3;
-    const float noise_scale = thrust.length() / thrust_max;
-    rot_accel += Vector3f(aircraft.rand_normal(0, 1),
-                          aircraft.rand_normal(0, 1),
-                          aircraft.rand_normal(0, 1)) * gyro_noise * noise_scale;
-    body_accel += Vector3f(aircraft.rand_normal(0, 1),
-                           aircraft.rand_normal(0, 1),
-                           aircraft.rand_normal(0, 1)) * accel_noise * noise_scale;
 }
 
 

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -590,13 +590,14 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     Vector3f torque;
 
     const float air_density = get_air_density(aircraft.get_location().alt*0.01);
+    const Vector3f gyro = aircraft.get_gyro();
 
     Vector3f vel_air_bf = aircraft.get_dcm().transposed() * aircraft.get_velocity_air_ef();
 
     float current = 0;
     for (uint8_t i=0; i<num_motors; i++) {
         Vector3f mtorque, mthrust;
-        motors[i].calculate_forces(input, motor_offset, mtorque, mthrust, vel_air_bf, air_density, battery->get_voltage());
+        motors[i].calculate_forces(input, motor_offset, mtorque, mthrust, vel_air_bf, gyro, air_density, battery->get_voltage());
         current += motors[i].get_current();
         torque += mtorque;
         thrust += mthrust;
@@ -615,7 +616,6 @@ void Frame::calculate_forces(const Aircraft &aircraft,
 
     if (terminal_rotation_rate > 0) {
         // rotational air resistance
-        const Vector3f &gyro = aircraft.get_gyro();
         rot_accel.x -= gyro.x * radians(400.0) / terminal_rotation_rate;
         rot_accel.y -= gyro.y * radians(400.0) / terminal_rotation_rate;
         rot_accel.z -= gyro.z * radians(400.0) / terminal_rotation_rate;

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -158,7 +158,6 @@ private:
     // exposed area times coefficient of drag
     float areaCd;
     float mass;
-    float thrust_max;
     float last_param_voltage;
 #if AP_SIM_ENABLED
     Battery *battery;

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -142,6 +142,7 @@ private:
         // if zero will no be used
         Vector3f motor_pos[12];
         Vector3f motor_thrust_vec[12];
+        float yaw_factor[12] = {0};
 
     } default_model;
 

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -143,7 +143,7 @@ float Motor::get_current(void) const
 // setup PWM ranges for this motor
 void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                          float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
-                         float _velocity_max, Vector3f _position, Vector3f _thrust_vector)
+                         float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor)
 {
     mot_pwm_min = _pwm_min;
     mot_pwm_max = _pwm_max;
@@ -166,6 +166,9 @@ void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, 
 
     if (!_thrust_vector.is_zero()) {
         thrust_vector = _thrust_vector;
+    }
+    if (!is_zero(_yaw_factor)) {
+        yaw_factor = _yaw_factor;
     }
 }
 

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -88,9 +88,10 @@ public:
 
     void calculate_forces(const struct sitl_input &input,
                           uint8_t motor_offset,
-                          Vector3f &rot_accel, // rad/sec
-                          Vector3f &body_thrust, // Z is down
+                          Vector3f &torque, // Newton meters
+                          Vector3f &thrust, // Z is down, Newtons
                           const Vector3f &velocity_air_bf,
+                          const Vector3f &gyro, // rad/sec
                           float air_density,
                           float voltage);
 

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -93,7 +93,8 @@ public:
                           const Vector3f &velocity_air_bf,
                           const Vector3f &gyro, // rad/sec
                           float air_density,
-                          float voltage);
+                          float voltage,
+                          bool use_drag);
 
     uint16_t update_servo(uint16_t demand, uint64_t time_usec, float &last_value) const;
 
@@ -106,7 +107,8 @@ public:
     // setup motor key parameters
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                       float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
-                      float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor);
+                      float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor,
+                      float _true_prop_area, float _momentum_drag_coefficient);
 
     // override slew limit
     void set_slew_max(float _slew_max) {
@@ -132,6 +134,8 @@ private:
     float voltage_max;
     float effective_prop_area;
     float max_outflow_velocity;
+    float true_prop_area;
+    float momentum_drag_coefficient;
 
     float last_command;
     uint64_t last_calc_us;

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -105,7 +105,7 @@ public:
     // setup motor key parameters
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                       float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
-                      float _velocity_max, Vector3f _position, Vector3f _thrust_vector);
+                      float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor);
 
     // override slew limit
     void set_slew_max(float _slew_max) {


### PR DESCRIPTION
Firstly this adds the ability to set motor rotation direction in the JSON configuration file, I forgot about it when adding position and thrust vector. 

It accounts for vehicle rotation when calculating the airflow the motor sees,  IE when yawing the motor has a larger radial velocity than then when still. 

It stops adding random noise at the physics level, noise is already added at the sensor level, adding it pre integration to the raw vehicle accels just makes our physics model worse for no reason. (This will affect the filter tests)

It takes drag from thrust not acceleration, this makes it more correct if there is a payload mass as thrust was normalized by gross mass and drag by empty mass. 

It moves momentum drag calculation down to the motor level. This means it can take account of the vehicle rotation thanks point 2. This also means that we get per motor rather than average. It also applies it in 3D no longer assuming motor can only produce thrust in the Z axis. (There is still the odd hack for the Z axis and its big comment).

