### PR TITLE
AP_Rangefinder: VL53L1X Preserve new address

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
@@ -84,6 +84,11 @@ bool AP_RangeFinder_VL53L1X::check_id(void)
 }
 
 bool AP_RangeFinder_VL53L1X::reset(void) {
+    if (dev->get_bus_id()!=0x29) {
+        // if sensor is on a different port than the default do not  reset sensor otherwise we will lose the addess.
+        // we assume it is already confirgured.
+        return true;
+    }
     if (!write_register(SOFT_RESET, 0x00)) {
         return false;
     }


### PR DESCRIPTION
When calling reset() for sensor VL53L1X the sensor resets its i2c address to its default address 0x29.

When connecting multiple VL53L1X sensors to Ardupilot and configure RNGFNDx with proper addresses ArduPilot detects them then calls reset which reset the addresses to 0x29 and they become not accessible anymore.

I added and if condition to bypass reset when the sensor address is not the default address.


