### PR TITLE
EKF3: added EK3_MAG_LRN_LIM

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -719,6 +719,14 @@ const AP_Param::GroupInfo NavEKF3::var_info2[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("PRIMARY", 8, NavEKF3, _primary_core, EK3_PRIMARY_DEFAULT),
+
+    // @Param: MAG_LRN_LIM
+    // @DisplayName: Magnetometer offset learning limit
+    // @Description: This limits the size of the learned magnetometer offsets. A value of zero means no limit. Limiting the learned offsets can be helpful when the compass calibration is known to be good and the vehicle is operating in an environment that can lead to significant incorrect learned offsets due to temporary local fields
+    // @User: Advanced
+    // @Range: 0 500
+    // @Units: mGauss
+    AP_GROUPINFO("MAG_LRN_LIM", 9, NavEKF3, _mag_learn_limit, 0),
     
     AP_GROUPEND
 };

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -411,6 +411,7 @@ private:
     AP_Int8  _flowUse;              // Controls if the optical flow data is fused into the main navigation estimator and/or the terrain estimator.
     AP_Float _hrt_filt_freq;        // frequency of output observer height rate complementary filter in Hz
     AP_Int16 _mag_ef_limit;         // limit on difference between WMM tables and learned earth field.
+    AP_Int16 _mag_learn_limit;      // limit on learned magnetometer body offsets
     AP_Int8 _gsfRunMask;            // mask controlling which EKF3 instances run a separate EKF-GSF yaw estimator
     AP_Int8 _gsfUseMask;            // mask controlling which EKF3 instances will use EKF-GSF yaw estimator data to assit with yaw resets
     AP_Int8 _gsfResetMaxCount;      // maximum number of times the EKF3 is allowed to reset it's yaw to the EKF-GSF estimate

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1982,6 +1982,17 @@ void NavEKF3_core::MagTableConstrain(void)
                                                    table_earth_field_ga.z+limit_ga);
 }
 
+// constrain states using limit on mag offsets
+void NavEKF3_core::MagOffsetConstrain(void)
+{
+    if (frontend->_mag_learn_limit > 0) {
+        const float limit_ga = frontend->_mag_learn_limit * 0.001;
+        stateStruct.body_magfield.x = constrain_float(stateStruct.body_magfield.x, -limit_ga, limit_ga);
+        stateStruct.body_magfield.y = constrain_float(stateStruct.body_magfield.y, -limit_ga, limit_ga);
+        stateStruct.body_magfield.z = constrain_float(stateStruct.body_magfield.z, -limit_ga, limit_ga);
+    }
+}
+
 // constrain states to prevent ill-conditioning
 void NavEKF3_core::ConstrainStates()
 {
@@ -2005,6 +2016,9 @@ void NavEKF3_core::ConstrainStates()
         // use table constrain
         MagTableConstrain();
     }
+
+    MagOffsetConstrain();
+
     // body magnetic field limit
     for (uint8_t i=19; i<=21; i++) statesArray[i] = constrain_ftype(statesArray[i],-0.5f,0.5f);
     // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -661,6 +661,9 @@ private:
     // constrain earth field using WMM tables
     void MagTableConstrain(void);
 
+    // constrain mag offsets
+    void MagOffsetConstrain(void);
+    
     // fuse selected position, velocity and height measurements
     void FuseVelPosNED();
 


### PR DESCRIPTION
This sets a limit on EKF3 magnetometer offset learning. It is useful
when you know you have good compass offsets, and the environment you
are flying in leads to poor EKF learned offsets which are not handled
well by the usual auto reset on takeoff