### PR TITLE
AP_Scripting: allow deprecation warnings

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -132,8 +132,12 @@ private:
 
     // must be static for use in atpanic
     static void print_error(MAV_SEVERITY severity);
-    static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
     static char *error_msg_buf;
     static uint8_t print_error_count;
     static uint32_t last_print_ms;
+
+public:
+    // must be static for use in atpanic, public to allow bindings to issue none fatal warnings
+    static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
+
 };


### PR DESCRIPTION
This adds a new `deprecate` keyword to the binding generator eg:

```
singleton AP_AHRS method get_home deprecate this method will be removed in 4.3
```
On the first call of the method each boot a scripting warning will be issued, this uses the exiting error path repeating 10 times.

![image](https://user-images.githubusercontent.com/33176108/165359830-0ff3bbe3-89c1-4214-8b8c-84a5e009ce5d.png)

It is also added to the docs:
```
-- desc
---@deprecated this method will be removed in 4.3
---@return Location_ud
function ahrs:get_home() end
```

Resulting in a nice warning in VS code:

![image](https://user-images.githubusercontent.com/33176108/165360421-4b5d1a1f-f3be-4e51-aa0f-3b6de55364e3.png)

![image](https://user-images.githubusercontent.com/33176108/165360481-85a63b6f-53b3-4d5c-a767-dedbabbaf278.png)

This new function is not used anywhere yet, but it give us a path to use in the future.
