### PR TITLE
hwdef: uncompress bootloader for HolybroG4_GPS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/HolybroG4_GPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HolybroG4_GPS/hwdef.dat
@@ -150,5 +150,12 @@ define HAL_PERIPH_ENABLE_BARO
 define HAL_PERIPH_ENABLE_NOTIFY
 define HAL_PERIPH_ENABLE_RC_OUT
 
+# single baro
+define BARO_MAX_INSTANCES 1
+
 # GPS on 2nd port
 define HAL_PERIPH_GPS_PORT_DEFAULT 1
+
+# keep ROMFS uncompressed as we don't have enough RAM
+# to uncompress the bootloader at runtime
+env ROMFS_UNCOMPRESSED True


### PR DESCRIPTION
not enough ram to uncompress at runtime
also limit to single baro