### PR TITLE
fix vehicle specific parameters

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -99,10 +99,10 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO_FRAME("RET_ALT",   9,  AC_Fence,   _ret_altitude,       0.0f, AP_PARAM_FRAME_PLANE),
 
-    // @Param: AUTOENABLE
+    // @Param{Plane}: AUTOENABLE
     // @DisplayName: Fence Auto-Enable
     // @Description: Auto-enable of fence
-    // @Values{Plane}: 0:AutoEnableOff,1:AutoEnableOnTakeoff,2:AutoEnableDisableFloorOnLanding,3:AutoEnableOnlyWhenArmed
+    // @Values: 0:AutoEnableOff,1:AutoEnableOnTakeoff,2:AutoEnableDisableFloorOnLanding,3:AutoEnableOnlyWhenArmed
     // @Range: 0 3
     // @Increment: 1
     // @User: Standard

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -128,7 +128,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
-    // @Param: OPTIONS
+    // @Param{Copter}: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
     // @Values: 0:None,1:Disable prearm display

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_EXT_BUS", 7, AP_Baro, _ext_bus, HAL_BARO_EXTERNAL_BUS_DEFAULT),
 
-    // @Param: _SPEC_GRAV
+    // @Param{Sub}: _SPEC_GRAV
     // @DisplayName: Specific Gravity (For water depth measurement)
     // @Description: This sets the specific gravity of the fluid when flying an underwater ROV.
     // @Values: 1.0:Freshwater,1.024:Saltwater

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
     // @Units: deg
     // @Range: 0 89
     // @User: Advanced
-    AP_GROUPINFO_FRAME("LIM_BANK",   3, AP_L1_Control, _loiter_bank_limit, 0.0f, AP_PARAM_FRAME_PLANE),
+    AP_GROUPINFO("LIM_BANK",   3, AP_L1_Control, _loiter_bank_limit, 0.0f),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -147,7 +147,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: YAW_SV_ANGLE
     // @DisplayName: Yaw Servo Max Lean Angle
-    // @Description: Yaw servo's maximum lean angle
+    // @Description: Yaw servo's maximum lean angle (Tricopter only)
     // @Range: 5 80
     // @Units: deg
     // @Increment: 1

--- a/libraries/AP_RCMapper/AP_RCMapper.cpp
+++ b/libraries/AP_RCMapper/AP_RCMapper.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("YAW",         3, RCMapper, _ch_yaw, 4),
 
-    // @Param{Rover,Sub}: FORWARD
+    // @Param{Sub}: FORWARD
     // @DisplayName: Forward channel
     // @Description: Forward channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Forward is normally on channel 5, but you can move it to any channel with this parameter. Reboot is required for changes to take effect.
     // @Range: 1 8
@@ -47,7 +47,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO_FRAME("FORWARD",    4, RCMapper, _ch_forward, 6, AP_PARAM_FRAME_SUB),
 
-    // @Param{Rover,Sub}: LATERAL
+    // @Param{Sub}: LATERAL
     // @DisplayName: Lateral channel
     // @Description: Lateral channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Lateral is normally on channel 6, but you can move it to any channel with this parameter. Reboot is required for changes to take effect.
     // @Range: 1 8


### PR DESCRIPTION
I changed these parameter's metadata.

FENCE_AUTOENABLE - Move {Plane} mark from Value to Param
ARMING_OPTIONS - set {Copter}
BARO_SPEC_GRAV - set {Sub}
RCMAP_FORWARD - remove {Rover}
RCMAP_LATERAL - remove {Rover}
MOT_YAW_SV_ANGLE/Q_M_YAW_SV_ANGLE - add Tricopter only to the description
NAVL1_LIM_BANK - remove AP_PARAM_FRAME_PLANE flag
  Copter/Rover/Sub don't have this param because NAVL1 is loaded by Plane only. Other parameters of NAVL1 params don't have AP_PARAM_FRAME_PLANE flag
