### PR TITLE
Rover: wscript: remove AP_L1_Control

### DIFF
--- a/Rover/wscript
+++ b/Rover/wscript
@@ -9,7 +9,6 @@ def build(bld):
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'APM_Control',
             'AP_Arming',
-            'AP_L1_Control',
             'AP_Mount',
             'AP_Navigation',
             'AR_WPNav',


### PR DESCRIPTION
Very minor build speedup now rover no longer uses L1 thanks to https://github.com/ArduPilot/ardupilot/pull/19220