### PR TITLE
Copter: vibration compensation turns off in manual modes

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -262,7 +262,7 @@ void Copter::check_vibration()
 
     const bool is_vibration_affected = ahrs.is_vibration_affected();
     const bool bad_vibe_detected = (innovation_checks_valid && innov_velD_posD_positive && (vel_variance > 1.0f)) || is_vibration_affected;
-    const bool do_bad_vibe_actions = (g2.fs_vibe_enabled == 1) && bad_vibe_detected && motors->armed();
+    const bool do_bad_vibe_actions = (g2.fs_vibe_enabled == 1) && bad_vibe_detected && motors->armed() && !flightmode->has_manual_throttle();
 
     if (!vibration_check.high_vibes) {
         // initialise timers
@@ -271,7 +271,7 @@ void Copter::check_vibration()
         }
         // check if failure has persisted for at least 1 second
         if (now - vibration_check.start_ms > 1000) {
-            // switch ekf to use resistant gains
+            // switch position controller to use resistant gains
             vibration_check.clear_ms = 0;
             vibration_check.high_vibes = true;
             pos_control->set_vibe_comp(true);
@@ -285,7 +285,7 @@ void Copter::check_vibration()
         }
         // turn off vibration compensation after 15 seconds
         if (now - vibration_check.clear_ms > 15000) {
-            // restore ekf gains, reset timers and update user
+            // restore position controller gains, reset timers and update user
             vibration_check.start_ms = 0;
             vibration_check.high_vibes = false;
             pos_control->set_vibe_comp(false);


### PR DESCRIPTION
This is a minimal change so the vibration compensation will not be triggered while the vehicle is in manual modes (Stabilize, Acro).  This attempts to resolve issue https://github.com/ArduPilot/ardupilot/issues/20627

This change does not immediately turn off the vibration compensation when the vehicle enters a manual mode though.  Instead it just starts the timer that leads to it turning off 15sec later.  I'm happy to do it either way, this was just easier and perhaps sufficient.

This has been lightly tested in SITL to confirm that:

1. the vibration compensation still engages in autonomous modes
2. the vibration compensation will not engage in stabilize mode
3. if vibration compensation is on and vehicle is changed to a manual mode, the vibration compensation will turn off within 15sec

There are also two drive-by fixes to comments.