### PR TITLE
AP_Baro: move error logging of sensor health into AP_Baro

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -744,7 +744,6 @@ Copter::Copter(void)
     flightmode(&mode_stabilize)
 {
     // init sensor error logging flags
-    sensor_health.baro = true;
     sensor_health.compass = true;
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -399,7 +399,6 @@ private:
 
     // sensor health for logging
     struct {
-        uint8_t baro        : 1;    // true if baro is healthy
         uint8_t compass     : 1;    // true if compass is healthy
     } sensor_health;
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -220,18 +220,11 @@ void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, float t
     logger.WriteBlock(&pkt_tune, sizeof(pkt_tune));
 }
 
-// logs when baro or compass becomes unhealthy
+// logs when compass becomes unhealthy
 void Copter::Log_Sensor_Health()
 {
     if (!should_log(MASK_LOG_ANY)) {
         return;
-    }
-
-    // check baro
-    if (sensor_health.baro != barometer.healthy()) {
-        sensor_health.baro = barometer.healthy();
-        AP::logger().Write_Error(LogErrorSubsystem::BARO,
-                                 (sensor_health.baro ? LogErrorCode::ERROR_RESOLVED : LogErrorCode::UNHEALTHY));
     }
 
     // check compass

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -168,17 +168,11 @@ void Sub::Log_Write_Data(LogDataID id, float value)
     }
 }
 
-// logs when baro or compass becomes unhealthy
+// logs when compass becomes unhealthy
 void Sub::Log_Sensor_Health()
 {
     if (!should_log(MASK_LOG_ANY)) {
         return;
-    }
-
-    // check baro
-    if (sensor_health.baro != barometer.healthy()) {
-        sensor_health.baro = barometer.healthy();
-        AP::logger().Write_Error(LogErrorSubsystem::BARO, (sensor_health.baro ? LogErrorCode::ERROR_RESOLVED : LogErrorCode::UNHEALTHY));
     }
 
     // check compass

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -40,7 +40,6 @@ Sub::Sub()
           param_loader(var_info)
 {
     // init sensor error logging flags
-    sensor_health.baro = true;
     sensor_health.compass = true;
 
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -233,7 +233,6 @@ private:
 
     // sensor health for logging
     struct {
-        uint8_t baro        : 1;    // true if any single baro is healthy
         uint8_t depth       : 1;    // true if depth sensor is healthy
         uint8_t compass     : 1;    // true if compass is healthy
     } sensor_health;

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -278,7 +278,6 @@ Blimp::Blimp(void)
       flightmode(&mode_manual)
 {
     // init sensor error logging flags
-    sensor_health.baro = true;
     sensor_health.compass = true;
 }
 

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -189,7 +189,6 @@ private:
 
     // sensor health for logging
     struct {
-        uint8_t baro        : 1;    // true if baro is healthy
         uint8_t compass     : 1;    // true if compass is healthy
     } sensor_health;
 

--- a/Blimp/Log.cpp
+++ b/Blimp/Log.cpp
@@ -232,18 +232,11 @@ tuning_max     : tune_max
     logger.WriteBlock(&pkt_tune, sizeof(pkt_tune));
 }
 
-// logs when baro or compass becomes unhealthy
+// logs when compass becomes unhealthy
 void Blimp::Log_Sensor_Health()
 {
     if (!should_log(MASK_LOG_ANY)) {
         return;
-    }
-
-    // check baro
-    if (sensor_health.baro != barometer.healthy()) {
-        sensor_health.baro = barometer.healthy();
-        AP::logger().Write_Error(LogErrorSubsystem::BARO,
-                                 (sensor_health.baro ? LogErrorCode::ERROR_RESOLVED : LogErrorCode::UNHEALTHY));
     }
 
     // check compass

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -851,6 +851,10 @@ void AP_Baro::update(void)
         _alt_offset_active = _alt_offset;
     }
 
+#if HAL_LOGGING_ENABLED
+    bool old_primary_healthy = sensors[_primary].healthy;
+#endif
+
     for (uint8_t i=0; i<_num_drivers; i++) {
         drivers[i]->backend_update(i);
     }
@@ -904,6 +908,16 @@ void AP_Baro::update(void)
 #if HAL_LOGGING_ENABLED
     if (should_log()) {
         Write_Baro();
+    }
+
+#define MASK_LOG_ANY                    0xFFFF
+
+    // log sensor healthy state change:
+    if (sensors[_primary].healthy != old_primary_healthy) {
+        if (AP::logger().should_log(MASK_LOG_ANY)) {
+            const LogErrorCode code = sensors[_primary].healthy ? LogErrorCode::ERROR_RESOLVED : LogErrorCode::UNHEALTHY;
+            AP::logger().Write_Error(LogErrorSubsystem::BARO, code);
+        }
     }
 #endif
 }


### PR DESCRIPTION
For some reason we think it a good idea to do this logging in Copter's fast loop.  Stop that, and only log it when it could actually have changed.

... this will obviously mean that Plane (and Rover?!) will start to log this.
