### PR TITLE
Copter: FS_OPTIONS for RC failsafe to continue in guided always applies

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -75,7 +75,7 @@ void Copter::set_failsafe_gcs(bool b)
     failsafe.gcs = b;
 
     // update AP_Notify
-        AP_Notify::flags.failsafe_gcs = b;
+    AP_Notify::flags.failsafe_gcs = b;
 }
 
 // ---------------------------------------------

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -62,9 +62,8 @@ void Copter::failsafe_radio_on_event()
         announce_failsafe("Radio", "Continuing Auto");
         desired_action = FailsafeAction::NONE;
 
-    } else if ((flightmode->in_guided_mode()) &&
-      (failsafe_option(FailsafeOption::RC_CONTINUE_IF_GUIDED)) && (g.failsafe_gcs != FS_GCS_DISABLED)) {
-        // Allow guided mode to continue when FS_OPTIONS is set to continue in guided mode.  Only if the GCS failsafe is enabled.
+    } else if ((flightmode->in_guided_mode()) && failsafe_option(FailsafeOption::RC_CONTINUE_IF_GUIDED)) {
+        // Allow guided mode to continue when FS_OPTIONS is set to continue in guided mode
         announce_failsafe("Radio", "Continuing Guided Mode");
         desired_action = FailsafeAction::NONE;
 

--- a/ArduCopter/leds.cpp
+++ b/ArduCopter/leds.cpp
@@ -1,1 +1,0 @@
-#include "Copter.h"


### PR DESCRIPTION
Copter's RC failsafe feature includes an FS_OPTIONS bit, "2:Continue if in Guided on RC failsafe" ([see param description here](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/Parameters.cpp#L981)) but this is conditional upon the GCS failsafe also being enabled ([see code here](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/events.cpp#L66)).  If the GCS failsafe is **not** enabled, we essentially ignore this bit and trigger the RC failsafe anyway.

I think the idea behind this extra condition was to avoid users setting this bit but forgetting to enable the GCS failsafe (which defaults to off).  Without the GCS failsafe enabled users could switch their vehicles into Guided mode, set a "Fly to here" point really far away and be unable to get their vehicles back.

I guess what I don't like about this extra condition is that we are second guessing what the operator wants.  We essentially don't allow them to fly in Guided mode without the GCS failsafe unless they also disable the RC failsafe which could be counter productive.

As a counter measure to this slight increase in danger, maybe we should enable the GCS failsafe by default?  The GCS failsafe will never trigger unless a GCS has been connected since startup.  The GCS failsafe will also not trigger while the vehicle is in manual modes (FS_OPTIONS defaults to "16").

This has been lightly tested in SITL by doing this:

- param set FS_OPTION = 20 ("Continue if in Guided on RC failsafe" | "Continue if in pilot controlled modes on GCS failsafe")
- param show FS_GCS_ENABLE (0 by default)
- GUIDED
- arm throttle
- takeoff 20
- Fly-To-Here xxx,yyy
- param set SIM_RC_FAIL 1

With master the vehicle RTLs home.  With this PR it keeps flying.
![image](https://user-images.githubusercontent.com/1498098/165510832-af6a60c0-1d09-4813-a1de-65d609870a9b.png)

This PR also includes a couple of drive-by format fixes.





