### PR TITLE
Allow high ANGLE_P gains in autotune

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -51,7 +51,7 @@
 #define AUTOTUNE_RLPF_MAX                  5.0f     // maximum Rate Yaw filter value
 #define AUTOTUNE_RP_MIN                   0.01f     // minimum Rate P value
 #define AUTOTUNE_RP_MAX                    2.0f     // maximum Rate P value
-#define AUTOTUNE_SP_MAX                   20.0f     // maximum Stab P value
+#define AUTOTUNE_SP_MAX                   40.0f     // maximum Stab P value
 #define AUTOTUNE_SP_MIN                    0.5f     // maximum Stab P value
 #define AUTOTUNE_RP_ACCEL_MIN            4000.0f     // Minimum acceleration for Roll and Pitch
 #define AUTOTUNE_Y_ACCEL_MIN             1000.0f     // Minimum acceleration for Yaw


### PR DESCRIPTION
Modern, powerful copters are capable of increasingly more powerful maneuvers. Currently we artificially limit the calculated ANGLE_P gains to 18 when many copters are capable of much more than this. Higher gains allow the copter to react more quickly to different kinds of disturbance 