### PR TITLE
AP_NavEKF3: Notify message in case of all compass anomalies

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -272,6 +272,7 @@ void NavEKF3_core::tryChangeCompass(void)
             return;
         }
     }
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 All compasses could not be switched");
 }
 
 // check for new magnetometer data and update store measurements if available


### PR DESCRIPTION
No message when all compasses are abnormal.
When there is no message, normal and abnormal cannot be distinguished.
I notify a message when all compass anomalies are detected.
When a compass error occurs, fluctuation occurs in the attitude control of the aircraft.
I indicate that the cause of this fluctuation is a compass anomaly.