### PR TITLE
CAN Nodes health prearm check

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -51,7 +51,11 @@ extern const AP_HAL::HAL &hal;
 extern AP_Periph_FW periph;
 
 #ifndef HAL_CAN_POOL_SIZE
-#define HAL_CAN_POOL_SIZE 4000
+#if HAL_CANFD_SUPPORTED
+    #define HAL_CAN_POOL_SIZE 16000
+#else
+    #define HAL_CAN_POOL_SIZE 4000
+#endif
 #endif
 
 #ifndef HAL_PERIPH_LOOP_DELAY_US
@@ -1301,7 +1305,7 @@ static void process1HzTasks(uint64_t timestamp_usec)
          */
         for (auto &ins : instances) {
             if (pool_peak_percent(ins) > 70) {
-                printf("WARNING: ENLARGE MEMORY POOL on Iface %d\n", ins.index);
+                printf("WARNING: ENLARGE MEMORY POOL on Iface %d Peak Usage: %u%%\n", ins.index, pool_peak_percent(ins));
             }
         }
     }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2459,6 +2459,26 @@ class AutoTestCopter(AutoTest):
                 self.wait_statustext(case[4], check_context=True)
                 self.context_stop_collecting('STATUSTEXT')
         self.progress("############################### All GPS Order Cases Tests Passed")
+        self.progress("############################### Test Healthy Prearm check")
+        self.set_parameter("ARMING_CHECK", 1)
+        self.stop_sup_program(instance=0)
+        self.start_sup_program(instance=0, args="-M")
+        self.delay_sim_time(2)
+        self.context_collect('STATUSTEXT')
+        self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                     1,  # ARM
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     timeout=10,
+                     want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+        self.wait_statustext("Node {} unhealthy".format(gps1_nodeid), check_context=True)
+        self.stop_sup_program(instance=0)
+        self.start_sup_program(instance=0)
+        self.context_stop_collecting('STATUSTEXT')
         self.context_pop()
         self.fly_auto_test()
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1069,7 +1069,8 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CANManager::Driver_Type_UAVCAN:
                 {
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
-                    if (!AP::uavcan_dna_server().prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
+                    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
+                    if (ap_uavcan != nullptr && !ap_uavcan->prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
                         check_failed(ARMING_CHECK_SYSTEM, report, "UAVCAN: %s", fail_msg);
                         return false;
                     }

--- a/libraries/AP_Common/Bitmask.h
+++ b/libraries/AP_Common/Bitmask.h
@@ -37,6 +37,18 @@ public:
         return *this;
     }
 
+    bool operator==(const Bitmask&other) {
+        if (other.numbits != numbits) {
+            return false;
+        } else {
+            return memcmp(bits, other.bits, sizeof(bits[0])*numwords) == 0;
+        }
+    }
+
+    bool operator!=(const Bitmask&other) {
+        return !(*this == other);
+    }
+
     Bitmask(const Bitmask &other) = delete;
 
     // set given bitnumber

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -193,6 +193,13 @@ uint8_t HAL_SITL::get_instance() const
     return _sitl_state->get_instance();
 }
 
+#if defined(HAL_BUILD_AP_PERIPH)
+bool HAL_SITL::run_in_maintenance_mode() const
+{
+    return _sitl_state->run_in_maintenance_mode();
+}
+#endif
+
 void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
 {
     assert(callbacks);

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -37,6 +37,10 @@ public:
 
     uint8_t get_instance() const;
 
+#if defined(HAL_BUILD_AP_PERIPH)
+    bool run_in_maintenance_mode() const;
+#endif
+
 private:
     HALSITL::SITL_State *_sitl_state;
 

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -29,12 +29,13 @@ void SITL_State::init(int argc, char * const argv[]) {
     const struct GetOptLong::option options[] = {
         {"help",            false,  0, 'h'},
         {"instance",        true,   0, 'I'},
+        {"maintenance",     false,  0, 'M'},
     };
 
     setvbuf(stdout, (char *)0, _IONBF, 0);
     setvbuf(stderr, (char *)0, _IONBF, 0);
 
-    GetOptLong gopt(argc, argv, "hI:",
+    GetOptLong gopt(argc, argv, "hI:M",
                     options);
 
     while((opt = gopt.getoption()) != -1) {
@@ -42,10 +43,15 @@ void SITL_State::init(int argc, char * const argv[]) {
             case 'I':
                 _instance = atoi(gopt.optarg);
                 break;
+            case 'M':
+                printf("Running in Maintenance Mode\n");
+                _maintenance = true;
+                break;
             default:
                 printf("Options:\n"
                     "\t--help|-h                display this help information\n"
-                    "\t--instance|-I N          set instance of SITL Periph\n");
+                    "\t--instance|-I N          set instance of SITL Periph\n"
+                    "\t--maintenance|-M         run in maintenance mode\n");
                 exit(1);
         }
     }

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.h
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.h
@@ -61,6 +61,8 @@ public:
 
     uint8_t get_instance() const { return _instance; }
 
+    bool run_in_maintenance_mode() const { return _maintenance; }
+
     SITL::SerialDevice *create_serial_sim(const char *name, const char *arg) {
         return nullptr;
     }
@@ -74,6 +76,7 @@ private:
     const char *defaults_path = HAL_PARAM_DEFAULTS_PATH;
 
     uint8_t _instance;
+    bool _maintenance;
 };
 
 #endif

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -122,7 +122,7 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
     // @Param: OPTION
     // @DisplayName: UAVCAN options
     // @Description: Option flags
-    // @Bitmask: 0:ClearDNADatabase,1:IgnoreDNANodeConflicts,2:EnableCanfd
+    // @Bitmask: 0:ClearDNADatabase,1:IgnoreDNANodeConflicts,2:EnableCanfd,3:IgnoreDNANodeUnhealthy
     // @User: Advanced
     AP_GROUPINFO("OPTION", 5, AP_UAVCAN, _options, 0),
     

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -322,8 +322,14 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
         return;
     }
 
+    _dna_server = new AP_UAVCAN_DNA_Server(this, StorageAccess(StorageManager::StorageCANDNA));
+    if (_dna_server == nullptr) {
+        debug_uavcan(AP_CANManager::LOG_ERROR, "UAVCAN: couldn't allocate DNA server\n\r");
+        return;
+    }
+
     //Start Servers
-    if (!AP::uavcan_dna_server().init(this)) {
+    if (!_dna_server->init()) {
         debug_uavcan(AP_CANManager::LOG_ERROR, "UAVCAN: Failed to start DNA Server\n\r");
         return;
     }
@@ -483,7 +489,7 @@ void AP_UAVCAN::loop(void)
         notify_state_send();
         send_parameter_request();
         send_parameter_save_request();
-        AP::uavcan_dna_server().verify_nodes(this);
+        _dna_server->verify_nodes();
     }
 }
 
@@ -1196,6 +1202,13 @@ bool AP_UAVCAN::check_and_reset_option(Options option)
         _options.set_and_save(int16_t(_options.get() & ~uint16_t(option)));
     }
     return ret;
+}
+
+// handle prearm check
+bool AP_UAVCAN::prearm_check(char* fail_msg, uint8_t fail_msg_len) const
+{
+    // forward this to DNA_Server
+    return _dna_server->prearm_check(fail_msg, fail_msg_len);
 }
 
 #endif // HAL_NUM_CAN_IFACES

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -202,6 +202,7 @@ public:
         DNA_CLEAR_DATABASE        = (1U<<0),
         DNA_IGNORE_DUPLICATE_NODE = (1U<<1),
         CANFD_ENABLED             = (1U<<2),
+        DNA_IGNORE_UNHEALTHY_NODE = (1U<<3),
     };
 
     // check if a option is set

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -23,7 +23,7 @@
 #include <uavcan/uavcan.hpp>
 #include "AP_UAVCAN_IfaceMgr.h"
 #include "AP_UAVCAN_Clock.h"
-#include <AP_CANManager/AP_CANDriver.h>
+#include <AP_CANManager/AP_CANManager.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -21,7 +21,6 @@
 #if HAL_ENABLE_LIBUAVCAN_DRIVERS
 
 #include <uavcan/uavcan.hpp>
-#include "AP_UAVCAN_DNA_Server.h"
 #include "AP_UAVCAN_IfaceMgr.h"
 #include "AP_UAVCAN_Clock.h"
 #include <AP_CANManager/AP_CANDriver.h>
@@ -54,6 +53,7 @@ class DebugCb;
 class ParamGetSetCb;
 class ParamExecuteOpcodeCb;
 class AP_PoolAllocator;
+class AP_UAVCAN_DNA_Server;
 
 #if defined(__GNUC__) && (__GNUC__ > 8)
 #define DISABLE_W_CAST_FUNCTION_TYPE_PUSH \
@@ -98,6 +98,7 @@ class AP_PoolAllocator;
     }
 
 class AP_UAVCAN : public AP_CANDriver, public AP_ESC_Telem_Backend {
+    friend class AP_UAVCAN_DNA_Server;
 public:
     AP_UAVCAN();
     ~AP_UAVCAN();
@@ -106,6 +107,7 @@ public:
 
     // Return uavcan from @driver_index or nullptr if it's not ready or doesn't exist
     static AP_UAVCAN *get_uavcan(uint8_t driver_index);
+    bool prearm_check(char* fail_msg, uint8_t fail_msg_len) const;
 
     void init(uint8_t driver_index, bool enable_filters) override;
     bool add_interface(AP_HAL::CANIface* can_iface) override;
@@ -267,6 +269,8 @@ private:
     AP_Int16 _pool_size;
 
     AP_PoolAllocator *_allocator;
+    AP_UAVCAN_DNA_Server *_dna_server;
+
     uavcan::Node<0> *_node;
 
     uint8_t _driver_index;

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -12,6 +12,7 @@
 class AllocationCb;
 class NodeStatusCb;
 class NodeInfoCb;
+class GetNodeInfoCb;
 class AP_UAVCAN;
 
 class AP_UAVCAN_DNA_Server
@@ -51,8 +52,6 @@ class AP_UAVCAN_DNA_Server
     //Allocation params
     uint8_t rcvd_unique_id[16];
     uint8_t rcvd_unique_id_offset;
-    uint8_t current_driver_index;
-    uint32_t last_activity_ms;
     uint32_t last_alloc_msg_ms;
 
     //Methods to handle and report Node IDs seen on the bus
@@ -88,18 +87,25 @@ class AP_UAVCAN_DNA_Server
     //Look in the storage and check if there's a valid Server Record there
     bool isValidNodeDataAvailable(uint8_t node_id);
 
-    HAL_Semaphore sem;
+    static void trampoline_handleNodeInfo(AP_UAVCAN* ap_uavcan, uint8_t node_id, const GetNodeInfoCb& resp);
+    static void trampoline_handleAllocation(AP_UAVCAN* ap_uavcan, uint8_t node_id, const AllocationCb &cb);
+    static void trampoline_handleNodeStatus(AP_UAVCAN* ap_uavcan, uint8_t node_id, const NodeStatusCb &cb);
+
+
+    HAL_Semaphore storage_sem;
     AP_UAVCAN *_ap_uavcan;
+    uint8_t driver_index;
 
 public:
-    AP_UAVCAN_DNA_Server(StorageAccess _storage) : storage(_storage) {}
+    AP_UAVCAN_DNA_Server(AP_UAVCAN *ap_uavcan, StorageAccess _storage);
+
 
     // Do not allow copies
     AP_UAVCAN_DNA_Server(const AP_UAVCAN_DNA_Server &other) = delete;
     AP_UAVCAN_DNA_Server &operator=(const AP_UAVCAN_DNA_Server&) = delete;
 
     //Initialises publisher and Server Record for specified uavcan driver
-    bool init(AP_UAVCAN *ap_uavcan);
+    bool init();
 
     //Reset the Server Record
     void reset();
@@ -118,16 +124,12 @@ public:
     bool prearm_check(char* fail_msg, uint8_t fail_msg_len) const;
 
     //Callbacks
-    void handleAllocation(uint8_t driver_index, uint8_t node_id, const AllocationCb &cb);
+    void handleAllocation(uint8_t node_id, const AllocationCb &cb);
     void handleNodeStatus(uint8_t node_id, const NodeStatusCb &cb);
     void handleNodeInfo(uint8_t node_id, uint8_t unique_id[], char name[], uint8_t major, uint8_t minor, uint32_t vcs_commit);
 
     //Run through the list of seen node ids for verification
-    void verify_nodes(AP_UAVCAN *ap_uavcan);
+    void verify_nodes();
 };
 
-namespace AP
-{
-AP_UAVCAN_DNA_Server& uavcan_dna_server();
-}
 #endif

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -25,6 +25,7 @@ class AP_UAVCAN_DNA_Server
     };
 
     enum ServerState {
+        NODE_STATUS_UNHEALTHY = -5,
         STORAGE_FAILURE = -3,
         DUPLICATE_NODES = -2,
         FAILED_TO_ADD_NODE = -1,
@@ -40,6 +41,7 @@ class AP_UAVCAN_DNA_Server
     Bitmask<128> verified_mask;
     Bitmask<128> node_seen_mask;
     Bitmask<128> logged;
+    Bitmask<128> node_healthy_mask;
 
     uint8_t last_logging_count;
 


### PR DESCRIPTION
Serves two purposes:
* as a stepping stone to do node capabilities, as we need to ensure no node is in bootloader stage while calculating capabilites.
* will make it possible to remove the 5s wait for nodes to appear at boot.