### PR TITLE
AP_NavEKF3: Notify the reason for switching IMUs

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -968,7 +968,7 @@ void NavEKF3::UpdateFilter(void)
             coreLastTimePrimary_us[primary] = imuSampleTime_us;
             primary = newPrimaryIndex;
             lastLaneSwitch_ms = AP::dal().millis();
-            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 lane switch %u", primary);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 lane switch %u, eScore=%.2f>1.0", primary, primaryErrorScore);
         }       
     }
 


### PR DESCRIPTION
Notify the reason for switching IMUs.
The reason for switching IMUs has an error scope value.
I need to know this value so I can make an initial determination of whether it is trivial or serious.