### PR TITLE
Scripting: use generator to load manual bindings

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -453,6 +453,8 @@ include AP_InertialSensor/AP_InertialSensor.h
 singleton AP_InertialSensor rename ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
 
+singleton CAN manual get_device lua_get_CAN_device
+singleton CAN depends HAL_MAX_CAN_PROTOCOL_DRIVERS
 
 include AP_Scripting/AP_Scripting_CANSensor.h depends HAL_MAX_CAN_PROTOCOL_DRIVERS
 include AP_HAL/AP_HAL.h
@@ -510,3 +512,14 @@ singleton AP_Follow method get_target_heading_deg boolean float'Null
 include AC_AttitudeControl/AC_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AC_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AC_AttitudeControl method get_rpy_srate void float'Ref float'Ref float'Ref
+
+
+
+singleton AP_Logger rename logger
+singleton AP_Logger manual write AP_Logger_Write
+
+singleton i2c manual get_device lua_get_i2c_device
+
+global manual millis lua_millis
+global manual micros lua_micros
+global manual mission_receive lua_mission_receive

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1496,10 +1496,12 @@ void emit_userdata_fields() {
   struct userdata * node = parsed_userdata;
   while(node) {
     struct userdata_field *field = node->fields;
-    start_dependency(source, node->dependency);
-    while(field) {
-      emit_userdata_field(node, field);
-      field = field->next;
+    if (field) {
+      start_dependency(source, node->dependency);
+      while(field) {
+        emit_userdata_field(node, field);
+        field = field->next;
+      }
     }
     end_dependency(source, node->dependency);
     node = node->next;
@@ -1594,12 +1596,14 @@ void emit_singleton_fields() {
   struct userdata * node = parsed_singletons;
   while(node) {
     struct userdata_field *field = node->fields;
-    start_dependency(source, node->dependency);
-    while(field) {
-      emit_singleton_field(node, field);
-      field = field->next;
+    if (field) {
+      start_dependency(source, node->dependency);
+      while(field) {
+        emit_singleton_field(node, field);
+        field = field->next;
+      }
+      end_dependency(source, node->dependency);
     }
-    end_dependency(source, node->dependency);
     node = node->next;
   }
 }

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1,5 +1,4 @@
 #include <AP_Common/AP_Common.h>
-#include <SRV_Channel/SRV_Channel.h>
 #include <AP_HAL/HAL.h>
 #include <AP_Logger/AP_Logger.h>
 
@@ -29,7 +28,7 @@ int check_arguments(lua_State *L, int expected_arguments, const char *fn_name) {
 }
 
 // millis
-static int lua_millis(lua_State *L) {
+int lua_millis(lua_State *L) {
     check_arguments(L, 0, "millis");
 
     new_uint32_t(L);
@@ -39,7 +38,7 @@ static int lua_millis(lua_State *L) {
 }
 
 // micros
-static int lua_micros(lua_State *L) {
+int lua_micros(lua_State *L) {
     check_arguments(L, 0, "micros");
 
     new_uint32_t(L);
@@ -48,7 +47,7 @@ static int lua_micros(lua_State *L) {
     return 1;
 }
 
-static int lua_mission_receive(lua_State *L) {
+int lua_mission_receive(lua_State *L) {
     check_arguments(L, 0, "mission_receive");
 
     ObjectBuffer<struct AP_Scripting::scripting_mission_cmd> *input = AP::scripting()->mission_data;
@@ -76,15 +75,7 @@ static int lua_mission_receive(lua_State *L) {
     return 5;
 }
 
-static const luaL_Reg global_functions[] =
-{
-    {"millis", lua_millis},
-    {"micros", lua_micros},
-    {"mission_receive", lua_mission_receive},
-    {NULL, NULL}
-};
-
-static int AP_Logger_Write(lua_State *L) {
+int AP_Logger_Write(lua_State *L) {
     AP_Logger * AP_logger = AP_Logger::get_singleton();
     if (AP_logger == nullptr) {
         return luaL_argerror(L, 1, "logger not supported on this firmware");
@@ -283,12 +274,7 @@ static int AP_Logger_Write(lua_State *L) {
     return 0;
 }
 
-const luaL_Reg AP_Logger_functions[] = {
-    {"write", AP_Logger_Write},
-    {NULL, NULL}
-};
-
-static int lua_get_i2c_device(lua_State *L) {
+int lua_get_i2c_device(lua_State *L) {
 
     const int args = lua_gettop(L);
     if (args < 2) {
@@ -342,13 +328,8 @@ static int lua_get_i2c_device(lua_State *L) {
     return 1;
 }
 
-const luaL_Reg i2c_functions[] = {
-    {"get_device", lua_get_i2c_device},
-    {NULL, NULL}
-};
-
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
-static int lua_get_CAN_device(lua_State *L) {
+int lua_get_CAN_device(lua_State *L) {
 
     check_arguments(L, 1, "CAN:get_device");
 
@@ -368,28 +349,4 @@ static int lua_get_CAN_device(lua_State *L) {
 
     return 1;
 }
-
-const luaL_Reg CAN_functions[] = {
-    {"get_device", lua_get_CAN_device},
-    {NULL, NULL}
-};
 #endif // HAL_MAX_CAN_PROTOCOL_DRIVERS
-
-void load_lua_bindings(lua_State *L) {
-    lua_pushstring(L, "logger");
-    luaL_newlib(L, AP_Logger_functions);
-    lua_settable(L, -3);
-
-    lua_pushstring(L, "i2c");
-    luaL_newlib(L, i2c_functions);
-    lua_settable(L, -3);
-
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    lua_pushstring(L, "CAN");
-    luaL_newlib(L, CAN_functions);
-    lua_settable(L, -3);
-#endif
-
-    luaL_setfuncs(L, global_functions, 0);
-}
-

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -2,5 +2,10 @@
 
 #include "lua/src/lua.hpp"
 
-// load all known lua bindings into the state
-void load_lua_bindings(lua_State *state);
+int lua_millis(lua_State *L);
+int lua_micros(lua_State *L);
+int lua_mission_receive(lua_State *L);
+int AP_Logger_Write(lua_State *L);
+int lua_get_i2c_device(lua_State *L);
+int lua_get_CAN_device(lua_State *L);
+

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -163,7 +163,6 @@ void lua_scripts::create_sandbox(lua_State *L) {
     lua_pushstring(L, "utf8");
     luaopen_utf8(L);
     lua_settable(L, -3);
-    load_lua_bindings(L);
     load_generated_sandbox(L);
 
 }

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -19,9 +19,10 @@
 #include <setjmp.h>
 
 #include <AP_Filesystem/posix_compat.h>
-#include "lua_bindings.h"
 #include <AP_Scripting/AP_Scripting.h>
 #include <GCS_MAVLink/GCS.h>
+
+#include "lua/src/lua.hpp"
 
 #ifndef REPL_DIRECTORY
   #if HAL_OS_FATFS_IO


### PR DESCRIPTION
This moves loading of manual bindings to the generated code. This means that it uses the same method to move from memory to flash. This saves 373 bytes of memory (simple loop in SITL). It also allows us to mix and match auto generated and manual bindings for a singleton.

Should be no change in behavior for those using the bindings. 

Also saves 80 bytes of flash. 

replaces https://github.com/ArduPilot/ardupilot/pull/15246