### PR TITLE
AP_Filesystem: Support symlinks 

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -34,6 +34,7 @@
 #endif
 #define DT_REG 0
 #define DT_DIR 1
+#define DT_LNK 10
 
 struct dirent {
    char    d_name[MAX_NAME_LEN]; /* filename */

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -567,7 +567,7 @@ void GCS_MAVLINK::ftp_worker(void) {
 
 // calculates how much string length is needed to fit this in a list response
 int GCS_MAVLINK::gen_dir_entry(char *dest, size_t space, const char *path, const struct dirent * entry) {
-    const bool is_file = entry->d_type == DT_REG;
+    const bool is_file = entry->d_type == DT_REG || entry->d_type == DT_LNK;
 
     if (space < 3) {
         return -1;


### PR DESCRIPTION
This allows for symlinks to be used for files in FTP and lua scripting

The motivation for this is SITL testing, where I commonly symlink a lua script in a test directory back to the AP_Scripting/examples/ directory. This change allows scripts linked in that manner to work
