### PR TITLE
Tools: treat brltty like modemmanager

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -271,9 +271,12 @@ if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 too
     DO_AP_STM_ENV=1
 fi
 
-heading "Removing modemmanager package that could conflict with firmware uploading"
+heading "Removing modemmanager and brltty package that could conflict with firmware uploading"
 if package_is_installed "modemmanager"; then
     $APT_GET remove modemmanager
+fi
+if package_is_installed "brltty"; then
+    $APT_GET remove brltty
 fi
 echo "Done!"
 

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -1012,9 +1012,15 @@ def ports_to_try(args):
 def modemmanager_check():
     if os.path.exists("/usr/sbin/ModemManager"):
         print("""
-==========================================================================================================
-WARNING: You should uninstall ModemManager as it conflicts with any non-modem serial device (like Pixhawk)
-==========================================================================================================
+===========================================================================================
+WARNING: You should uninstall ModemManager as it conflicts with any non-modem serial device
+===========================================================================================
+""")
+    if os.path.exists("/usr/bin/brltty"):
+        print("""
+=====================================================================================
+WARNING: You should uninstall brltty as it conflicts with any non-modem serial device
+=====================================================================================
 """)
 
 


### PR DESCRIPTION
on Ubuntu 22.04 brltty prevents use of serial radios