### PR TITLE
Allow RichenPower generators to arm in maintenance period

### DIFF
--- a/libraries/AP_Generator/AP_Generator.cpp
+++ b/libraries/AP_Generator/AP_Generator.cpp
@@ -33,6 +33,13 @@ const AP_Param::GroupInfo AP_Generator::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_Generator, _type, 0, AP_PARAM_FLAG_ENABLE),
 
+    // @Param: OPTIONS
+    // @DisplayName: Generator Options
+    // @Description: Bitmask of options for generators
+    // @Bitmask: 0:Supress Maintenance-Required Warnings
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 2, AP_Generator, _options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Generator/AP_Generator.h
+++ b/libraries/AP_Generator/AP_Generator.h
@@ -66,6 +66,15 @@ public:
     // Parameter block
     static const struct AP_Param::GroupInfo var_info[];
 
+    // bits which can be set in _options to modify generator behaviour:
+    enum class Option {
+        INHIBIT_MAINTENANCE_WARNINGS = 0,
+    };
+
+    bool option_set(Option opt) const {
+        return (_options & 1U<<uint32_t(opt)) != 0;
+    }
+
 private:
 
     // Pointer to chosen driver
@@ -73,6 +82,7 @@ private:
 
     // Parameters
     AP_Int8 _type; // Select which generator to use
+    AP_Int32 _options; // Select which generator to use
 
     enum class Type {
         GEN_DISABLED = 0,

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -201,12 +201,14 @@ void AP_Generator_RichenPower::check_maintenance_required()
         return;
     }
 
-    const uint32_t now = AP_HAL::millis();
+    if (!AP::generator()->option_set(AP_Generator::Option::INHIBIT_MAINTENANCE_WARNINGS)) {
+        const uint32_t now = AP_HAL::millis();
 
-    if (last_reading.errors & (1U<<uint16_t(Errors::MaintenanceRequired))) {
-        if (now - last_maintenance_warning_ms > 60000) {
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Generator: requires maintenance");
-            last_maintenance_warning_ms = now;
+        if (last_reading.errors & (1U<<uint16_t(Errors::MaintenanceRequired))) {
+            if (now - last_maintenance_warning_ms > 60000) {
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Generator: requires maintenance");
+                last_maintenance_warning_ms = now;
+            }
         }
     }
 }

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -194,6 +194,23 @@ constexpr float AP_Generator_RichenPower::heat_required_for_run()
 }
 
 
+void AP_Generator_RichenPower::check_maintenance_required()
+{
+    // don't bother the user while flying:
+    if (hal.util->get_soft_armed()) {
+        return;
+    }
+
+    const uint32_t now = AP_HAL::millis();
+
+    if (last_reading.errors & (1U<<uint16_t(Errors::MaintenanceRequired))) {
+        if (now - last_maintenance_warning_ms > 60000) {
+            gcs().send_text(MAV_SEVERITY_NOTICE, "Generator: requires maintenance");
+            last_maintenance_warning_ms = now;
+        }
+    }
+}
+
 /*
   update the state of the sensor
 */
@@ -205,6 +222,7 @@ void AP_Generator_RichenPower::update(void)
 
     if (last_reading_ms != 0) {
         update_runstate();
+        check_maintenance_required();
     }
 
     (void)get_reading();
@@ -335,17 +353,22 @@ bool AP_Generator_RichenPower::pre_arm_check(char *failmsg, uint8_t failmsg_len)
         hal.util->snprintf(failmsg, failmsg_len, "no messages in %ums", unsigned(now - last_reading_ms));
         return false;
     }
-    if (last_reading.seconds_until_maintenance == 0) {
-        hal.util->snprintf(failmsg, failmsg_len, "requires maintenance");
-    }
     if (SRV_Channels::get_channel_for(SRV_Channel::k_generator_control) == nullptr) {
         hal.util->snprintf(failmsg, failmsg_len, "need a servo output channel");
         return false;
     }
 
-    if (last_reading.errors) {
+    uint16_t errors = last_reading.errors;
+
+    // requiring maintenance isn't something that should stop
+    // people flying - they have work to do.  But we definitely
+    // complain about it - a lot.
+    errors &= ~(1U << uint16_t(Errors::MaintenanceRequired));
+
+    if (errors) {
+
         for (uint16_t i=0; i<16; i++) {
-            if (last_reading.errors & (1U << (uint16_t)i)) {
+            if (errors & (1U << i)) {
                 if (i < (uint16_t)Errors::LAST) {
                     hal.util->snprintf(failmsg, failmsg_len, "error: %s", error_strings[i]);
                 } else {

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -204,5 +204,11 @@ private:
         }
         return AP_HAL::millis() - idle_state_start_ms;
     }
+
+    // check if the generator requires maintenance and send a message if it does:
+    void check_maintenance_required();
+    // if we are emitting warnings about the generator requiring
+    // maintenamce, this is the last time we sent the warning:
+    uint32_t last_maintenance_warning_ms;
 };
 #endif

--- a/libraries/SITL/SIM_RichenPower.cpp
+++ b/libraries/SITL/SIM_RichenPower.cpp
@@ -198,11 +198,15 @@ void RichenPower::update_send()
     u.packet.runtime_seconds = runtime_seconds_remainder;
 
     const int32_t seconds_until_maintenance = (original_seconds_until_maintenance - _runtime_ms/1000.0f);
+    uint16_t errors = htobe16(u.packet.errors);
     if (seconds_until_maintenance <= 0) {
         u.packet.seconds_until_maintenance = htobe32(0);
+        errors |= (1U<<(uint8_t(Errors::MaintenanceRequired)));
     } else {
         u.packet.seconds_until_maintenance = htobe32(seconds_until_maintenance);
+        errors &= ~(1U<<(uint8_t(Errors::MaintenanceRequired)));
     }
+    u.packet.errors = htobe16(errors);
 
     switch (_state) {
     case State::IDLE:

--- a/libraries/SITL/SIM_RichenPower.h
+++ b/libraries/SITL/SIM_RichenPower.h
@@ -96,6 +96,10 @@ private:
 
     uint32_t last_rpm_update_ms;
 
+    enum class Errors {
+        MaintenanceRequired = 0,
+    };
+
     // packet to send:
     struct PACKED RichenPacket {
         uint8_t magic1;


### PR DESCRIPTION
This bit should always have been masked out when determining whether prearms should pass or not.
