### PR TITLE
AP_Scripting: load uint32_t via generator

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -524,3 +524,24 @@ singleton i2c manual get_device lua_get_i2c_device
 global manual millis lua_millis
 global manual micros lua_micros
 global manual mission_receive lua_mission_receive
+
+userdata uint32_t creation lua_new_uint32_t
+userdata uint32_t manual_operator __add uint32_t___add
+userdata uint32_t manual_operator __sub uint32_t___sub
+userdata uint32_t manual_operator __mul uint32_t___mul
+userdata uint32_t manual_operator __div uint32_t___div
+userdata uint32_t manual_operator __mod uint32_t___mod
+userdata uint32_t manual_operator __idiv uint32_t___idiv
+userdata uint32_t manual_operator __band uint32_t___band
+userdata uint32_t manual_operator __bor uint32_t___bor
+userdata uint32_t manual_operator __bxor uint32_t___bxor
+userdata uint32_t manual_operator __shl uint32_t___shl
+userdata uint32_t manual_operator __shr uint32_t___shr
+userdata uint32_t manual_operator __eq uint32_t___eq
+userdata uint32_t manual_operator __lt uint32_t___lt
+userdata uint32_t manual_operator __le uint32_t___le
+userdata uint32_t manual_operator __bnot uint32_t___bnot
+userdata uint32_t manual_operator __tostring uint32_t___tostring
+userdata uint32_t manual toint uint32_t_toint
+userdata uint32_t manual tofloat uint32_t_tofloat
+

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -30,6 +30,7 @@ char keyword_deprecate[]           = "deprecate";
 char keyword_manual[]              = "manual";
 char keyword_global[]              = "global";
 char keyword_creation[]            = "creation";
+char keyword_manual_operator[]     = "manual_operator";
 
 // attributes (should include the leading ' )
 char keyword_attr_enum[]    = "'enum";
@@ -136,6 +137,7 @@ enum operator_type {
   OP_SUB  = (1U << 1),
   OP_MUL  = (1U << 2),
   OP_DIV  = (1U << 3),
+  OP_MANUAL = (1U << 4),
   OP_LAST
 };
 
@@ -352,12 +354,18 @@ struct method {
   uint32_t flags; // filled out with TYPE_FLAGS
 };
 
+enum alias_type {
+  ALIAS_TYPE_NONE,
+  ALIAS_TYPE_MANUAL,
+  ALIAS_TYPE_MANUAL_OPERATOR,
+};
+
 struct method_alias {
   struct method_alias *next;
   char *name;
   char *alias;
   int line;
-  int is_manual;
+  enum alias_type type;
 };
 
 struct userdata_field {
@@ -827,7 +835,7 @@ void handle_method(struct userdata *node) {
   }
 }
 
-void handle_manual(struct userdata *node) {
+void handle_manual(struct userdata *node, enum alias_type type) {
   char *name = next_token();
   if (name == NULL) {
     error(ERROR_SINGLETON, "Expected a lua name for manual %s method",node->name);
@@ -840,7 +848,7 @@ void handle_manual(struct userdata *node) {
   string_copy(&(alias->name), cpp_function_name);
   string_copy(&(alias->alias), name);
   alias->line = state.line_num;
-  alias->is_manual = 1;
+  alias->type = type;
   alias->next = node->method_aliases;
   node->method_aliases = alias;
 }
@@ -941,6 +949,9 @@ void handle_userdata(void) {
       }
       string_copy(&(node->dependency), depends);
 
+  } else if (strcmp(type, keyword_manual) == 0) {
+    handle_manual(node, ALIAS_TYPE_MANUAL);
+
   } else if (strcmp(type, keyword_creation) == 0) {
       if (node->creation != NULL) {
         error(ERROR_SINGLETON, "Userdata only support a single creation function");
@@ -950,6 +961,11 @@ void handle_userdata(void) {
         error(ERROR_USERDATA, "Expected a creation string for %s",node->name);
       }
       string_copy(&(node->creation), creation);
+
+  } else if (strcmp(type, keyword_manual_operator) == 0) {
+    handle_manual(node, ALIAS_TYPE_MANUAL_OPERATOR);
+    node->operations |= OP_MANUAL;
+
   } else {
     error(ERROR_USERDATA, "Unknown or unsupported type for userdata: %s", type);
   }
@@ -1025,7 +1041,7 @@ void handle_singleton(void) {
   } else if (strcmp(type, keyword_reference) == 0) {
     node->flags |= UD_FLAG_REFERENCE;
   } else if (strcmp(type, keyword_manual) == 0) {
-    handle_manual(node);
+    handle_manual(node, ALIAS_TYPE_MANUAL);
   } else {
     error(ERROR_SINGLETON, "Singletons only support renames, methods, semaphore, depends, literal or manual keywords (got %s)", type);
   }
@@ -1127,7 +1143,7 @@ void handle_global(void) {
   }
 
   if (strcmp(type, keyword_manual) == 0) {
-    handle_manual(parsed_globals);
+    handle_manual(parsed_globals, ALIAS_TYPE_MANUAL);
   } else {
     error(ERROR_GLOBALS, "globals only support manual keyword (got %s)", type);
   }
@@ -1141,7 +1157,7 @@ void handle_global(void) {
 void sanity_check_userdata(void) {
   struct userdata * node = parsed_userdata;
   while(node) {
-    if ((node->fields == NULL) && (node->methods == NULL)) {
+    if ((node->fields == NULL) && (node->methods == NULL) && (node->method_aliases == NULL)) {
       error(ERROR_USERDATA, "Userdata %s has no fields or methods", node->name);
     }
     node = node->next;
@@ -2019,6 +2035,7 @@ const char * get_name_for_operation(enum operator_type op) {
     case OP_DIV:
       return "__div";
       break;
+    case OP_MANUAL:
     case OP_LAST:
       return NULL;
   }
@@ -2050,6 +2067,7 @@ void emit_operators(struct userdata *data) {
       case OP_DIV:
         op_sym = '/';
         break;
+      case OP_MANUAL:
       case OP_LAST:
         return;
     }
@@ -2119,9 +2137,9 @@ void emit_index(struct userdata *head) {
 
     struct method_alias *alias = node->method_aliases;
     while(alias) {
-      if (alias->is_manual) {
+      if (alias->type == ALIAS_TYPE_MANUAL) {
         fprintf(source, "    {\"%s\", %s},\n", alias->alias, alias->name);
-      } else {
+      } else if (alias->type == ALIAS_TYPE_NONE) {
         fprintf(source, "    {\"%s\", %s_%s},\n", alias->alias, node->sanatized_name, alias->name);
       }
       alias = alias->next;
@@ -2137,6 +2155,13 @@ void emit_index(struct userdata *head) {
           continue;
         }
         fprintf(source, "    {\"%s\", %s_%s},\n", op_name, node->sanatized_name, op_name);
+      }
+      struct method_alias *alias = node->method_aliases;
+      while(alias) {
+        if (alias->type == ALIAS_TYPE_MANUAL_OPERATOR) {
+          fprintf(source, "    {\"%s\", %s},\n", alias->alias, alias->name);
+        }
+        alias = alias->next;
       }
       fprintf(source, "    {NULL, NULL},\n");
       fprintf(source, "};\n\n");
@@ -2285,7 +2310,7 @@ void emit_sandbox(void) {
   if (parsed_globals) {
     struct method_alias *manual_aliases = parsed_globals->method_aliases;
     while (manual_aliases) {
-      if (manual_aliases->is_manual == 0) {
+      if (manual_aliases->type != ALIAS_TYPE_MANUAL) {
         error(ERROR_GLOBALS, "Globals only support manual methods");
       }
       fprintf(source, "    {\"%s\", %s},\n", manual_aliases->alias, manual_aliases->name);
@@ -2521,7 +2546,7 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
     struct method_alias *alias = node->method_aliases;
     while(alias) {
       // dont do manual bindings
-      if (alias->is_manual == 0) {
+      if (alias->type == ALIAS_TYPE_NONE) {
         // find the method this is a alias of
         struct method * method = node->methods;
         while (method != NULL && strcmp(method->name, alias->name)) {

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2278,8 +2278,6 @@ void emit_loaders(void) {
   fprintf(source, "    }\n");
 
   fprintf(source, "\n");
-  fprintf(source, "    load_boxed_numerics(L);\n");
-
   fprintf(source, "}\n\n");
 }
 
@@ -2335,9 +2333,6 @@ void emit_sandbox(void) {
   fprintf(source, "    }\n");
 
   fprintf(source, "\n");
-  fprintf(source, "    load_boxed_numerics_sandbox(L);\n");
-
-  // load the userdata complex functions
   fprintf(source, "}\n");
 }
 

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2076,40 +2076,6 @@ void emit_methods(struct userdata *node) {
   }
 }
 
-void emit_userdata_metatables(void) {
-  struct userdata * node = parsed_userdata;
-  while(node) {
-    start_dependency(source, node->dependency);
-    fprintf(source, "const luaL_Reg %s_meta[] = {\n", node->sanatized_name);
-
-    struct userdata_field *field = node->fields;
-    while(field) {
-      fprintf(source, "    {\"%s\", %s_%s},\n", field->rename ? field->rename : field->name, node->sanatized_name, field->name);
-      field = field->next;
-    }
-
-    struct method *method = node->methods;
-    while(method) {
-      fprintf(source, "    {\"%s\", %s_%s},\n", method->rename ? method->rename :  method->name, node->sanatized_name, method->sanatized_name);
-      method = method->next;
-    }
-
-    for (uint32_t i = 1; i < OP_LAST; i = i << 1) {
-      const char * op_name = get_name_for_operation((node->operations) & i);
-      if (op_name == NULL) {
-        continue;
-      }
-      fprintf(source, "    {\"%s\", %s_%s},\n", op_name, node->sanatized_name, op_name);
-    }
-
-    fprintf(source, "    {NULL, NULL}\n");
-    fprintf(source, "};\n");
-    end_dependency(source, node->dependency);
-    fprintf(source, "\n");
-    node = node->next;
-  }
-}
-
 void emit_enum(struct userdata * data) {
     fprintf(source, "struct userdata_enum %s_enums[] = {\n", data->sanatized_name);
     struct userdata_enum *ud_enum = data->enums;

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include "lua_boxed_numerics.h"
+#include <AP_Scripting/lua_generated_bindings.h>
 
 
 extern const AP_HAL::HAL& hal;
@@ -34,18 +35,7 @@ uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     return luaL_argerror(L, arg, "Unable to coerce to uint32_t");
 }
 
-// creates a new userdata for a uint32_t
-int new_uint32_t(lua_State *L) {
-    luaL_checkstack(L, 2, "Out of stack");
-
-    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = 0;
-    luaL_getmetatable(L, "uint32_t");
-    lua_setmetatable(L, -2);
-    return 1;
-}
-
 // the exposed constructor to lua calls to create a uint32_t
-int lua_new_uint32_t(lua_State *L);
 int lua_new_uint32_t(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 1) {
@@ -58,13 +48,8 @@ int lua_new_uint32_t(lua_State *L) {
     return 1;
 }
 
-uint32_t * check_uint32_t(lua_State *L, int arg) {
-    void *data = luaL_checkudata(L, arg, "uint32_t");
-    return static_cast<uint32_t *>(data);
-}
-
 #define UINT32_T_BOX_OP(name, sym) \
-    static int uint32_t___##name(lua_State *L) { \
+    int uint32_t___##name(lua_State *L) { \
         const int args = lua_gettop(L); \
         if (args > 2) { \
             return luaL_argerror(L, args, "too many arguments"); \
@@ -93,7 +78,7 @@ UINT32_T_BOX_OP(shl, <<)
 UINT32_T_BOX_OP(shr, >>)
 
 #define UINT32_T_BOX_OP_BOOL(name, sym) \
-    static int uint32_t___##name(lua_State *L) { \
+    int uint32_t___##name(lua_State *L) { \
         const int args = lua_gettop(L); \
         luaL_checkstack(L, 1, "Out of stack"); \
         if (args > 2) { \
@@ -114,7 +99,7 @@ UINT32_T_BOX_OP_BOOL(lt, <)
 UINT32_T_BOX_OP_BOOL(le, <=)
 
 #define UINT32_T_BOX_OP_UNARY(name, sym) \
-    static int uint32_t___##name(lua_State *L) { \
+    int uint32_t___##name(lua_State *L) { \
         const int args = lua_gettop(L); \
         luaL_checkstack(L, 1, "Out of stack"); \
         if (args != 1) { \
@@ -131,7 +116,7 @@ UINT32_T_BOX_OP_BOOL(le, <=)
 // DO NOT SUPPORT UNARY NEGATION
 UINT32_T_BOX_OP_UNARY(bnot, ~)
 
-static int uint32_t_toint(lua_State *L) {
+int uint32_t_toint(lua_State *L) {
     const int args = lua_gettop(L);
     if (args != 1) {
         return luaL_argerror(L, args, "Expected 1 argument");
@@ -144,7 +129,7 @@ static int uint32_t_toint(lua_State *L) {
     return 1;
 }
 
-static int uint32_t_tofloat(lua_State *L) {
+int uint32_t_tofloat(lua_State *L) {
     const int args = lua_gettop(L);
     if (args != 1) {
         return luaL_argerror(L, args, "Expected 1 argument");
@@ -157,7 +142,7 @@ static int uint32_t_tofloat(lua_State *L) {
     return 1;
 }
 
-static int uint32_t___tostring(lua_State *L) {
+int uint32_t___tostring(lua_State *L) {
     const int args = lua_gettop(L);
     if (args != 1) {
         return luaL_argerror(L, args, "Expected 1 argument");
@@ -171,44 +156,4 @@ static int uint32_t___tostring(lua_State *L) {
     lua_pushstring(L, buf);
 
     return 1;
-}
-
-const luaL_Reg uint32_t_meta[] = {
-    {"__add", uint32_t___add},
-    {"__sub", uint32_t___sub},
-    {"__mul", uint32_t___mul},
-    {"__div", uint32_t___div},
-    {"__mod", uint32_t___mod},
-    {"__idiv", uint32_t___idiv},
-    {"__band", uint32_t___band},
-    {"__bor", uint32_t___bor},
-    {"__bxor", uint32_t___bxor},
-    {"__shl", uint32_t___shl},
-    {"__shr", uint32_t___shr},
-    {"__shr", uint32_t___shr},
-    {"__eq", uint32_t___eq},
-    {"__lt", uint32_t___lt},
-    {"__le", uint32_t___le},
-    {"__bnot", uint32_t___bnot},
-    {"__tostring", uint32_t___tostring},
-    {"toint", uint32_t_toint},
-    {"tofloat", uint32_t_tofloat},
-    {NULL, NULL}
-};
-
-void load_boxed_numerics(lua_State *L) {
-    luaL_checkstack(L, 5, "Out of stack");
-    luaL_newmetatable(L, "uint32_t");
-    luaL_setfuncs(L, uint32_t_meta, 0);
-    lua_pushstring(L, "__index");
-    lua_pushvalue(L, -2);
-    lua_settable(L, -3);
-    lua_pop(L, 1);
-}
-
-void load_boxed_numerics_sandbox(lua_State *L) {
-    // if there are ever more drivers then move to a table based solution
-    lua_pushstring(L, "uint32_t");
-    lua_pushcfunction(L, lua_new_uint32_t);
-    lua_settable(L, -3);
 }

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -2,9 +2,24 @@
 
 #include "lua/src/lua.hpp"
 
-int new_uint32_t(lua_State *L);
-uint32_t *check_uint32_t(lua_State *L, int arg);
 uint32_t coerce_to_uint32_t(lua_State *L, int arg);
+int lua_new_uint32_t(lua_State *L);
 
-void load_boxed_numerics(lua_State *L);
-void load_boxed_numerics_sandbox(lua_State *L);
+int uint32_t___add(lua_State *L);
+int uint32_t___sub(lua_State *L);
+int uint32_t___mul(lua_State *L);
+int uint32_t___div(lua_State *L);
+int uint32_t___mod(lua_State *L);
+int uint32_t___idiv(lua_State *L);
+int uint32_t___band(lua_State *L);
+int uint32_t___bor(lua_State *L);
+int uint32_t___bxor(lua_State *L);
+int uint32_t___shl(lua_State *L);
+int uint32_t___shr(lua_State *L);
+int uint32_t___eq(lua_State *L);
+int uint32_t___lt(lua_State *L);
+int uint32_t___le(lua_State *L);
+int uint32_t___bnot(lua_State *L);
+int uint32_t___tostring(lua_State *L);
+int uint32_t_toint(lua_State *L);
+int uint32_t_tofloat(lua_State *L);


### PR DESCRIPTION
Final bit of binding shuffling, now all bindings are defined in the generator. This saves 22 bytes of memory (simple_loop.lua) and 548 bytes of flash. We don't save much memory as operators still get loaded in memory, only the `toint` and `tofloat` functions are moved to flash.

We could potentially move some of the uint32_t to generated bindings with a little more effort, but there is little further benefit.

This also adds support for manual bindings as creation functions for userdata and manual operators. 