### PR TITLE
SITL: fixed build warnings

### DIFF
--- a/libraries/AP_Filesystem/posix_compat.h
+++ b/libraries/AP_Filesystem/posix_compat.h
@@ -50,7 +50,7 @@ long apfs_ftell(APFS_FILE *stream);
 APFS_FILE *apfs_freopen(const char *pathname, const char *mode, APFS_FILE *stream);
 int apfs_remove(const char *pathname);
 int apfs_rename(const char *oldpath, const char *newpath);
-char *tmpnam(char *s);
+char *tmpnam(char s[L_tmpnam]);
 
 #undef stdin
 #undef stdout

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -52,7 +52,7 @@ void WEAK panic(const char *errormsg, ...)
 }
 
 // partly flogged from: https://github.com/tridge/junkcode/blob/master/segv_handler/segv_handler.c
-void run_command_on_ownpid(const char *commandname)
+static void run_command_on_ownpid(const char *commandname)
 {
     // find dumpstack command:
     const char *command_filepath = commandname; // if we can't find it trust in PATH


### PR DESCRIPTION
this fixes all warnings for building with g++ 11.2.0 on ubuntu 22.04
