### PR TITLE
Copter/Rover: Enhance the Mission Change detector

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -40,7 +40,7 @@
 #include <AP_InertialSensor/AP_InertialSensor.h>                // ArduPilot Mega Inertial Sensor (accel & gyro) Library
 #include <AP_AHRS/AP_AHRS.h>                                    // AHRS (Attitude Heading Reference System) interface library for ArduPilot
 #include <AP_Mission/AP_Mission.h>                              // Mission command library
-#include <AP_Mission/AP_Mission_ChangeDetector.h>               // Mission command change detection library
+#include <AP_Mission/AP_Mission_ChangeDetector_Copter.h>        // Mission command change detection library
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi.h>        // Attitude control library
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h>   // 6DoF Attitude control library
 #include <AC_AttitudeControl/AC_AttitudeControl_Heli.h>         // Attitude control library for traditional helicopter

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -467,7 +467,7 @@ public:
         FUNCTOR_BIND_MEMBER(&ModeAuto::exit_mission, void)};
 
     // Mission change detector
-    AP_Mission_ChangeDetector mis_change_detector;
+    AP_Mission_ChangeDetector_Copter mis_change_detector;
 
 protected:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -491,8 +491,6 @@ private:
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     void exit_mission();
 
-    bool check_for_mission_change();    // detect external changes to mission
-
     void takeoff_run();
     void wp_run();
     void land_run();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -516,6 +516,7 @@ private:
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);
     bool set_next_wp(const AP_Mission::Mission_Command& current_cmd, const Location &default_loc);
+    bool mission_changed_add_next_wp();
     void do_land(const AP_Mission::Mission_Command& cmd);
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_circle(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -45,7 +45,7 @@ bool ModeAuto::init(bool ignore_checks)
         waiting_to_start = true;
 
         // initialise mission change check (ignore results)
-        IGNORE_RETURN(mis_change_detector.check_for_mission_change());
+        IGNORE_RETURN(mis_change_detector.check_for_mission_change(false));
 
         // clear guided limits
         copter.mode_guided.limit_clear();
@@ -91,11 +91,11 @@ void ModeAuto::run()
             waiting_to_start = false;
 
             // initialise mission change check (ignore results)
-            IGNORE_RETURN(mis_change_detector.check_for_mission_change());
+            IGNORE_RETURN(mis_change_detector.check_for_mission_change(false));
         }
     } else {
         // check for mission changes
-        if (mis_change_detector.check_for_mission_change()) {
+        if (mis_change_detector.check_for_mission_change(wp_nav->using_next_waypoint()) != AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE) {
             // if mission is running restart the current command if it is a waypoint or spline command
             if ((mission.state() == AP_Mission::MISSION_RUNNING) && (_mode == SubMode::WP)) {
                 if (mission.restart_current_nav_cmd()) {

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -55,11 +55,13 @@ void ModeAuto::update()
             waiting_to_start = false;
 
             // initialise mission change check
-            IGNORE_RETURN(mis_change_detector.check_for_mission_change());
+            uint8_t first_changed_cmd_idx;
+            IGNORE_RETURN(mis_change_detector.check_for_mission_change(first_changed_cmd_idx));
         }
     } else {
         // check for mission changes
-        if (mis_change_detector.check_for_mission_change()) {
+        uint8_t first_changed_cmd_idx;
+        if (mis_change_detector.check_for_mission_change(first_changed_cmd_idx)) {
             // if mission is running restart the current command if it is a waypoint command
             if ((mission.state() == AP_Mission::MISSION_RUNNING) && (_submode == AutoSubMode::Auto_WP)) {
                 if (mission.restart_current_nav_cmd()) {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -156,6 +156,9 @@ public:
     // returns true if update_wpnav has been run very recently
     bool is_active() const;
 
+    /// using_next_waypoint - true when in a turn using S-Curves
+    virtual bool using_next_waypoint() const { return _scurve_next_leg.started(); }
+
     ///
     /// spline methods
     ///

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -491,7 +491,7 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
     // check for change of leg on fast waypoint
     const float time_to_destination = get_time_remaining();
     if (fast_waypoint 
-        && is_zero(next_leg.get_time_elapsed()) 
+        && !next_leg.started()
         && (get_time_elapsed() >= time_turn_out() - next_leg.time_turn_in()) 
         && (position_sq >= 0.25 * track.length_squared())) {
 
@@ -505,7 +505,7 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
              (Vector2f{turn_accel.x, turn_accel.y}.length() < accel_corner)) {
             next_leg.move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
         }
-    } else if (!is_zero(next_leg.get_time_elapsed())) {
+    } else if (next_leg.started()) {
         next_leg.move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
         if (next_leg.get_time_elapsed() >= get_time_remaining()) {
             s_finished = true;

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -94,6 +94,9 @@ public:
     // time has reached the end of the sequence
     bool finished() const WARN_IF_UNUSED;
 
+    // time has started the sequence
+    bool started() const WARN_IF_UNUSED { return is_positive(get_time_elapsed()); }
+
 private:
 
     // increment time and return the position, velocity and acceleration vectors relative to the origin

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
@@ -43,7 +43,7 @@ bool AP_Mission_ChangeDetector::check_for_mission_change(uint8_t& first_changed_
             mis_change_detect.cmd[num_cmds-1] = cmd[num_cmds-1];
             if (!cmds_changed) {
                 cmds_changed = true;
-                first_changed_cmd_idx = cmd_idx;
+                first_changed_cmd_idx = num_cmds-1;
             }
         }
         cmd_idx = cmd[num_cmds-1].index+1;

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector.h
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector.h
@@ -23,14 +23,15 @@ class AP_Mission_ChangeDetector
 
 public:
 
-    // check for changes to mission. returns true if mission has been changed since last check
-    bool check_for_mission_change() WARN_IF_UNUSED;
+    // check for changes to mission
+    // returns true if mission has been changed since last check and set first_changed_cmd_idx (e.g. 0=current command changed, 1=next command, etc)
+    bool check_for_mission_change(uint8_t& first_changed_cmd_idx) WARN_IF_UNUSED;
 
-private:
+protected:
 
     // number of upcoming commands to monitor for changes
     static const uint8_t mis_change_detect_cmd_max = 3;
-    struct {
+    struct MissionCommandList {
         uint32_t last_change_time_ms;       // local copy of last time mission was changed
         uint16_t curr_cmd_index;            // local copy of AP_Mission's current command index
         uint8_t cmd_count;                  // number of commands in the cmd array

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector_Copter.cpp
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector_Copter.cpp
@@ -1,0 +1,168 @@
+/// @file    AP_Mission_ChangeDetector_Copter.cpp
+/// @brief   Detects changes in the next few nav commands in the mission
+
+#include "AP_Mission_ChangeDetector_Copter.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define MIS_CHANGE_DETECT_DEBUG 1
+#if MIS_CHANGE_DETECT_DEBUG
+#include <GCS_MAVLink/GCS.h>
+#define debug(fmt, args...) gcs().send_text(MAV_SEVERITY_CRITICAL, fmt, ##args)
+#else
+#define debug(fmt, args...)
+#endif
+
+// check for changes to mission. returns required response to change (if any)
+// using_next_command should be set to try if waypoint controller is already using the next navigation command
+AP_Mission_ChangeDetector_Copter::ChangeResponseType AP_Mission_ChangeDetector_Copter::check_for_mission_change(bool using_next_command)
+{
+    // take backup of command list
+    MissionCommandList cmd_list_bak = mis_change_detect;
+
+    uint8_t first_changed_cmd_idx = 0;
+    if (!AP_Mission_ChangeDetector::check_for_mission_change(first_changed_cmd_idx)) {
+        // the mission has not changed
+        return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+    }
+
+    // if the current command has change a reset is always required
+    // ToDo: check this handles mission erased
+    if (first_changed_cmd_idx == 0) {
+        debug("check_for_mission_change: 1st comment changed, Reset");
+        return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+    }
+
+    // 1st exists and 2nd or 3rd command has been added, changed or deleted
+
+    const bool cmd0_is_wp = (mis_change_detect.cmd[0].id == MAV_CMD_NAV_WAYPOINT);
+    const bool cmd0_is_loiter = (mis_change_detect.cmd[0].id == MAV_CMD_NAV_LOITER_UNLIM ||
+                                 mis_change_detect.cmd[0].id == MAV_CMD_NAV_LOITER_TIME);
+    const bool cmd0_is_spline = (mis_change_detect.cmd[0].id == MAV_CMD_NAV_SPLINE_WAYPOINT);
+    const bool cmd0_is_other = (!cmd0_is_wp && !cmd0_is_loiter && !cmd0_is_spline);
+
+    // if 1st segment is not a wp, loiter or spline then return NONE
+    if (cmd0_is_other) {
+        debug("check_for_mission_change: 1st is neither wp nor spline, None");
+        return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+    }
+
+    const bool cmd0_has_pause = (mis_change_detect.cmd[0].p1 > 0);
+
+    // if 1st segment wp/spline has pause or is loiter then return NONE
+    if (((cmd0_is_wp || cmd0_is_spline) && cmd0_has_pause) || cmd0_is_loiter) {
+        debug("check_for_mission_change: 1st has pause, None");
+        return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+    }
+
+    const bool cmd1_exists = mis_change_detect.cmd_count >= 2;
+    const bool cmd1_has_pause = (mis_change_detect.cmd[1].p1 > 0);
+    const bool cmd1_is_wp = (mis_change_detect.cmd[1].id == MAV_CMD_NAV_WAYPOINT ||
+                             mis_change_detect.cmd[1].id == MAV_CMD_NAV_LOITER_UNLIM ||
+                             mis_change_detect.cmd[1].id == MAV_CMD_NAV_LOITER_TIME);
+    const bool cmd1_is_spline = (mis_change_detect.cmd[1].id == MAV_CMD_NAV_SPLINE_WAYPOINT);
+    const bool cmd1_is_other = (!cmd1_is_wp && !cmd1_is_spline);
+    const bool cmd1_existed = cmd_list_bak.cmd_count >= 2;
+    const bool cmd1_was_wp = (cmd_list_bak.cmd[1].id == MAV_CMD_NAV_WAYPOINT ||
+                             cmd_list_bak.cmd[1].id == MAV_CMD_NAV_LOITER_UNLIM ||
+                             cmd_list_bak.cmd[1].id == MAV_CMD_NAV_LOITER_TIME);
+    const bool cmd1_was_spline = (cmd_list_bak.cmd[1].id == MAV_CMD_NAV_SPLINE_WAYPOINT);
+    const bool cmd1_was_other = (!cmd1_was_wp && !cmd1_was_spline);
+
+    // if 2nd segment forces a pause then return NONE
+    if ((!cmd1_existed || cmd1_was_other) && (!cmd1_exists || cmd1_is_other)) {
+        debug("check_for_mission_change: 1st is forced pause, None");
+        return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+    }
+
+    // check for 1st is wp (without a pause), if add of 2nd wp then ADD_NEXT_WAYPOINT
+    const bool cmd1_added = (cmd_list_bak.cmd_count == 1) && (mis_change_detect.cmd_count > 1);
+
+    if (cmd0_is_wp && cmd1_added) {
+        if (cmd1_is_wp) {
+            // 2nd is wp
+            debug("check_for_mission_change: 1st is wp, no pause, 2nd added, AddNextWP");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::ADD_NEXT_WAYPOINT;
+        } else if (cmd1_is_spline) {
+            // 2nd is spline
+            // Currently we don't support set_destination_speed_max after leg has been started
+            // Therefore we can't add a spline without reseting
+            debug("check_for_mission_change: 1st is wp, no pause, 2nd added but is spline, Reset");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+        } else {
+            // 2nd is nether wp or spline
+            // should be handled by pause above so we should not reach here
+            debug("check_for_mission_change: 1st is wp, no pause, 2nd added but not wp or spline, None");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+        }
+    }
+
+    // trajectory may be dependent on multiple waypoints, handle changed waypoints
+    if (cmd0_is_wp) {
+        // 1st is wp
+        if (!cmd1_exists) {
+            // 2nd deleted, Reset
+            // This could be extended to check cmd_list_bak for the deleted waypoint and return REMOVE_NEXT_WAYPOINT
+            debug("check_for_mission_change: 1st is wp, deleted 2nd wp, Reset");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+        } else if (cmd1_is_wp && cmd1_was_wp) {
+            // 2nd was and is wp
+            if (first_changed_cmd_idx == 1) {
+                // if 2nd has changed
+                if (using_next_command) {
+                    debug("check_for_mission_change: 1st is wp, 2nd wp changed, Reset");
+                    return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+                } else {
+                    debug("check_for_mission_change: 1st is wp, not using changed 2nd wp, None");
+                    return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+                }
+            } else {
+                // 2nd has not changed
+                debug("check_for_mission_change: 1st is wp, 2nd wp same, None");
+                return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+            }
+        } else if (cmd1_is_spline && cmd1_has_pause && (first_changed_cmd_idx == 2)) {
+                // 2nd spline with pause has not changed
+                // we do not check 3rd forces pause and change in forces pause
+                debug("check_for_mission_change: 1st is wp, 2nd spline with pause not changed, None");
+                return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+        } else {
+            // not all combinations will result in a changed state but to keep this simple we will call a reset
+            debug("check_for_mission_change: 1st is wp, catch change, Reset");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+        }
+    } else {
+        // 1st is spline (cmd0_is_loiter and cmd0_is_other have already been handled above)
+        if (!cmd1_exists) {
+            // 2nd deleted, Reset
+            // This could be extended to check cmd_list_bak for the deleted waypoint and return REMOVE_NEXT_WAYPOINT
+            debug("check_for_mission_change: 1st is spline, deleted 2nd wp, Reset");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+        } else if (cmd1_is_wp) {
+            // 2nd is wp
+            if (first_changed_cmd_idx == 1) {
+                // 2nd has changed
+                debug("check_for_mission_change: 1st is spline, 2nd wp changed, Reset");
+                return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+            } else {
+                // 2nd not changed, 3rd must have changed
+                debug("check_for_mission_change: 1st is spline, 2nd wp same, None");
+                return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+            }
+        } else if (cmd1_is_spline && cmd1_has_pause && (first_changed_cmd_idx == 2)) {
+            // 2nd spline with pause has not changed
+            // we do not check 3rd forces pause and change in forces pause
+            debug("check_for_mission_change: 1st is spline, 2nd spline with pause not changed, None");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::NONE;
+        } else {
+            // not all combinations will result in a changed state but to keep this simple we will call a reset
+            debug("check_for_mission_change: 1st is spline, catch change, Reset");
+            return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+        }
+    }
+
+    // we should not reach here unless we have missed something so reset to be safe
+    debug("check_for_mission_change: got to end, Reset");
+    return AP_Mission_ChangeDetector_Copter::ChangeResponseType::RESET_REQUIRED;
+}
+

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector_Copter.h
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector_Copter.h
@@ -1,0 +1,38 @@
+/// @file    AP_Mission_ChangeDetector_Copter.h
+/// @brief   Detects changes in the next few nav commands in the mission
+
+/*
+ *   The AP_Mission_ChangeDetector library:
+ *   - records the index of the active nav command
+ *   - maintains a copy of the next few navigation commands
+ *   - checks for changes in either the active command or the next few nav commands
+ *
+ *   Detecting changes in the next few nav commands is critical for SCurves and splines
+ *   which plan the path through the corners
+ */
+#pragma once
+
+#include "AP_Mission_ChangeDetector.h"
+
+#if HAL_MISSION_ENABLED
+
+/// @class    AP_Mission_ChangeDetector
+/// @brief    Mission command change detector
+class AP_Mission_ChangeDetector_Copter: private AP_Mission_ChangeDetector
+{
+
+public:
+
+    enum ChangeResponseType {
+        NONE = 0,           // no response to change is required
+        ADD_NEXT_WAYPOINT,  // add next waypoint when convenient
+        RESET_REQUIRED      // reload / reset of active commands is required
+    };
+
+    // check for changes to mission. returns required response to change (if any)
+    // using_next_command should be set to try if waypoint controller is already using the next navigation command
+    ChangeResponseType check_for_mission_change(bool using_next_command) WARN_IF_UNUSED;
+
+};
+
+#endif // HAL_MISSION_ENABLED


### PR DESCRIPTION
This PR enhances the Mission Change Detector to check if the change requires a change in the navigation controller based on the current waypoints dependency on future waypoints.

To do this the code considers:

- normal waypoint does not need to be changed if it is a pause or followed by a command that has also not changed,
- spline waypoints require the following two waypoints to not change if a pause is not used,
- loiter commands behave as a waypoint with a pause
- other commands behave as a pause

AP_Mission_ChangeDetector_Copter returns three states:

- NONE (no change required)
- ADD_NEXT_WAYPOINT (no change required but waypoints are now available to be added)
- RESET_REQUIRED (auto mode should re-initialise as the change in auto will alter the current state)