### PR TITLE
Remove duplicate parachute event logging

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -856,11 +856,9 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         switch ((uint16_t)packet.param1) {
         case PARACHUTE_DISABLE:
             copter.parachute.enabled(false);
-            AP::logger().Write_Event(LogEvent::PARACHUTE_DISABLED);
             return MAV_RESULT_ACCEPTED;
         case PARACHUTE_ENABLE:
             copter.parachute.enabled(true);
-            AP::logger().Write_Event(LogEvent::PARACHUTE_ENABLED);
             return MAV_RESULT_ACCEPTED;
         case PARACHUTE_RELEASE:
             // treat as a manual release which performs some additional check of altitude

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -326,11 +326,9 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
             switch (ch_flag) {
                 case AuxSwitchPos::LOW:
                     copter.parachute.enabled(false);
-                    AP::logger().Write_Event(LogEvent::PARACHUTE_DISABLED);
                     break;
                 case AuxSwitchPos::MIDDLE:
                     copter.parachute.enabled(true);
-                    AP::logger().Write_Event(LogEvent::PARACHUTE_ENABLED);
                     break;
                 case AuxSwitchPos::HIGH:
                     copter.parachute.enabled(true);


### PR DESCRIPTION
These events are logged by the Parachute library itself; no need for Copter to log them.

RC tested in SITL by assigning parachute function to a channel.  

mavlink tested by using MAVProxy's "long" to issue the relevant command

RC before:
```
pbarker@bluebottle:~/rc/ardupilot(master)$ mavlogdump.py logs/00000006.BIN  --t EV
2022-05-06 11:17:27.67: EV {TimeUS : 240863616, Id : 50}
2022-05-06 11:17:27.67: EV {TimeUS : 240863616, Id : 50}
2022-05-06 11:17:31.37: EV {TimeUS : 244563802, Id : 49}
2022-05-06 11:17:31.37: EV {TimeUS : 244563802, Id : 49}
pbarker@bluebottle:~/rc/ardupilot(master)$ 
```

RC after:
```
pbarker@bluebottle:~/rc/ardupilot(pr/remove-duplicate-logging)$ mavlogdump.py logs/00000007.BIN  --t EV
2022-05-06 11:18:52.17: EV {TimeUS : 11363786, Id : 50}
2022-05-06 11:18:56.37: EV {TimeUS : 15563772, Id : 49}
pbarker@bluebottle:~/rc/ardupilot(pr/remove-duplicate-logging)$ 
```

GCS before:
```
2022-05-06 11:20:39.59: EV {TimeUS : 43780814, Id : 49}
2022-05-06 11:20:39.59: EV {TimeUS : 43780814, Id : 49}
2022-05-06 11:20:41.28: EV {TimeUS : 45470971, Id : 50}
2022-05-06 11:20:41.28: EV {TimeUS : 45470971, Id : 50}
```

GCS after:
```
2022-05-06 11:22:22.97: EV {TimeUS : 40163928, Id : 49}
2022-05-06 11:22:27.17: EV {TimeUS : 44363914, Id : 50}
```
