### PR TITLE
AP_Logger: make LogStructure non-packed to fix compilation of SITL on Apple M1

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -136,7 +136,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_AIS/LogStructure.h>
 
 // structure used to define logging format
-struct PACKED LogStructure {
+struct LogStructure {
     uint8_t msg_type;
     uint8_t msg_len;
     const char *name;

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -136,12 +136,13 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_AIS/LogStructure.h>
 
 // structure used to define logging format
-// It is packed to save flash space; however, this causes problems when building
-// the SITL on an Apple M1 CPU so we do not pack it when compiling SITL
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-struct LogStructure {
-#else
+// It is packed on ChibiOS to save flash space; however, this causes problems
+// when building the SITL on an Apple M1 CPU (and is also slower) so we do not
+// pack it by default
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 struct PACKED LogStructure {
+#else
+struct LogStructure {
 #endif
     uint8_t msg_type;
     uint8_t msg_len;

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -136,7 +136,13 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_AIS/LogStructure.h>
 
 // structure used to define logging format
+// It is packed to save flash space; however, this causes problems when building
+// the SITL on an Apple M1 CPU so we do not pack it when compiling SITL
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 struct LogStructure {
+#else
+struct PACKED LogStructure {
+#endif
     uint8_t msg_type;
     uint8_t msg_len;
     const char *name;


### PR DESCRIPTION
As of ArduCopter 4.2.0-rc2, the compilation of the SITL simulator fails on Apple M1 with `clang` (version 13.1.6); the compiler emits the following error messages during the linking phase:

```
ld: warning: pointer not aligned at address 0x100363D61 (__ZN6Copter13log_structureE + 7129 from ArduCopter/Log.cpp.44.o)
ld: warning: pointer not aligned at address 0x100363D59 (__ZN6Copter13log_structureE + 7121 from ArduCopter/Log.cpp.44.o)
ld: warning: pointer not aligned at address 0x100363D51 (__ZN6Copter13log_structureE + 7113 from ArduCopter/Log.cpp.44.o)
ld: warning: pointer not aligned at address 0x100363D49 (__ZN6Copter13log_structureE + 7105 from ArduCopter/Log.cpp.44.o)
[... lots of similar messages ...]
ld: warning: pointer not aligned at address 0x10036219A (__ZN6Copter13log_structureE + 18 from ArduCopter/Log.cpp.44.o)
ld: warning: pointer not aligned at address 0x100362192 (__ZN6Copter13log_structureE + 10 from ArduCopter/Log.cpp.44.o)
ld: warning: pointer not aligned at address 0x10036218A (__ZN6Copter13log_structureE + 2 from ArduCopter/Log.cpp.44.o)
ld: unaligned pointer(s) for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Removing `PACKED` from `struct LogStructure` fixes the problem. A short discussion with @andyp1per on Discord seems to indicate that this particular structure does not need to be packed as it does not represent the exact byte-level layout of a concrete log record that we may write to the SD card or a disk.

Note that you need a Mac with an Apple M1 CPU to reproduce the problem. Compiling the SITL for an Intel CPU does not exhibit this behaviour; even on an Apple M1, cross-compiling for Intel works correctly. The problem appears only when targeting an Apple M1 CPU during SITL compilation.