### PR TITLE
AP_Airspeed: Remove Negative Pressure Check that sets Unhealthy Flag

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -613,13 +613,6 @@ void AP_Airspeed::read(uint8_t i)
         state[i].airspeed       = sqrtf(fabsf(state[i].filtered_pressure) * param[i].ratio);
         break;
     }
-
-    if (state[i].last_pressure < -32) {
-        // we're reading more than about -8m/s. The user probably has
-        // the ports the wrong way around
-        state[i].healthy = false;
-    }
-
 }
 
 // read all airspeed sensors


### PR DESCRIPTION
This has annoyed a Partner for a bit and occurs both on the ground and during transitions to VTOL land.

This shows up on the ground stations as an "Unhealthy Airspeed Sensor" 

Example graph below from a flight on a transition to land:  
![image](https://user-images.githubusercontent.com/69225461/167508576-2b5739c8-c457-48a9-be02-529c0e3224c1.png)

This check isn't that valuable in  my mind.  If someone has correctly set the tube order, the sensor is unhealthy even if the data may be valid and reasonable.