### PR TITLE
AP_NavEKF: require three GSF models to be healthy to provide estimates

### DIFF
--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -167,7 +167,7 @@ void EKFGSF_yaw::fuseVelData(const Vector2F &vel, const ftype velAcc)
             if (!state_update_failed) {
                 // Calculate weighting for each model assuming a normal error distribution
                 const ftype min_weight = 1e-5f;
-                uint8_t n_clips = 0;
+                n_clips = 0;
                 for (uint8_t mdl_idx = 0; mdl_idx < N_MODELS_EKFGSF; mdl_idx++) {
                     newWeight[mdl_idx] = gaussianDensity(mdl_idx) * GSF.weights[mdl_idx];
                     if (newWeight[mdl_idx] < min_weight) {
@@ -628,6 +628,11 @@ Matrix3F EKFGSF_yaw::updateRotMat(const Matrix3F &R, const Vector3F &g) const
 bool EKFGSF_yaw::getYawData(ftype &yaw, ftype &yawVariance) const
 {
     if (!vel_fuse_running) {
+        return false;
+    }
+    // at least three models must be in good health for a result to be
+    // valid:
+    if (N_MODELS_EKFGSF - n_clips < 3) {
         return false;
     }
     yaw = GSF.yaw;

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -136,4 +136,9 @@ private:
     // Returns the probability for a selected model assuming a Gaussian error distribution
     // Used by the Guassian Sum Filter to calculate the weightings when combining the outputs from the bank of EKF's
     ftype gaussianDensity(const uint8_t mdl_idx) const;
+
+    // number of models whose weights underflowed due to excessive
+    // innovation variances:
+    uint8_t n_clips;
+
 };


### PR DESCRIPTION
The GSF can get into a state where it is implicitly trusting a single
model, and rotating between each model in turn.  In this state the
yaw innovation is very low as the weighting on the other models is
essentially zero.

This change ensures that we have several models generally healthy before
providing data to any caller.

This is a crude fix.  Modifying the acceptance gate based on the number of non-zero-weighted models is something else I considered.

In the following flight the model chosen was 180-degrees away from the true yaw:

![image](https://user-images.githubusercontent.com/7077857/167520454-51c35f0b-ded1-4067-b6a0-21c0c6cc41c5.png)

![image](https://user-images.githubusercontent.com/7077857/167520950-1e899c0f-9a87-405e-ac03-a8b39bf8081a.png)

Log available by request

GPS velocity errors probably an error.
