### PR TITLE
Allow storing of large loiter radii for loiter_turns

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1371,7 +1371,12 @@ void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
     const Location circle_center = loc_from_cmd(cmd, copter.current_loc);
 
     // calculate radius
-    uint8_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    uint16_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    if (cmd.id == MAV_CMD_NAV_LOITER_TURNS &&
+        cmd.type_specific_bits & (1U << 0)) {
+        // special storage handling allows for larger radii
+        circle_radius_m *= 10;
+    }
 
     // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
     circle_movetoedge_start(circle_center, circle_radius_m);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -713,6 +713,10 @@ bool Plane::verify_loiter_turns(const AP_Mission::Mission_Command &cmd)
 {
     bool result = false;
     uint16_t radius = HIGHBYTE(cmd.p1);
+    if (cmd.type_specific_bits & (1U<<0)) {
+        // special storage handling allows for larger radii
+        radius *= 10;
+    }
     update_loiter(radius);
 
     // LOITER_TURNS makes no sense as VTOL

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -353,7 +353,10 @@ void Sub::do_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // calculate radius
-    uint8_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    uint16_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    if (cmd.type_specific_bits & (1U << 0)) {
+        circle_radius_m *= 10;
+    }
 
     // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
     auto_circle_movetoedge_start(circle_center, circle_radius_m);

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7235,6 +7235,10 @@ Also, ignores heartbeats not from our target system'''
         m = self.mav.messages.get("POSITION_TARGET_GLOBAL_INT", None)
         return mavutil.location(m.lat_int*1e-7, m.lon_int*1e-7, m.alt)
 
+    def current_waypoint(self):
+        m = self.assert_receive_message('MISSION_CURRENT')
+        return m.seq
+
     def distance_to_nav_target(self, use_cached_nav_controller_output=False):
         '''returns distance to waypoint navigation target in metres'''
         m = self.mav.messages.get("NAV_CONTROLLER_OUTPUT", None)

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -639,6 +639,7 @@ struct PACKED Packed_Location_Option_Flags {
     uint8_t terrain_alt  : 1;           // this altitude is above terrain
     uint8_t origin_alt   : 1;           // this altitude is above ekf origin
     uint8_t loiter_xtrack : 1;          // 0 to crosstrack from center of waypoint, 1 to crosstrack from tangent exit location
+    uint8_t type_specific_bit_0 : 1;    // each mission item type can use this for storing 1 bit of extra data
 };
 
 struct PACKED PackedLocation {
@@ -724,6 +725,10 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
         cmd.content.location.alt = packed_content.location.alt;
         cmd.content.location.lat = packed_content.location.lat;
         cmd.content.location.lng = packed_content.location.lng;
+
+        if (packed_content.location.flags.type_specific_bit_0) {
+            cmd.type_specific_bits = 1U << 0;
+        }
     } else {
         // all other options in Content are assumed to be packed:
         static_assert(sizeof(cmd.content) >= 12,
@@ -785,6 +790,7 @@ bool AP_Mission::write_cmd_to_storage(uint16_t index, const Mission_Command& cmd
         packed.location.flags.terrain_alt = cmd.content.location.terrain_alt;
         packed.location.flags.origin_alt = cmd.content.location.origin_alt;
         packed.location.flags.loiter_xtrack = cmd.content.location.loiter_xtrack;
+        packed.location.flags.type_specific_bit_0 = cmd.type_specific_bits & (1U<<0);
         packed.location.alt = cmd.content.location.alt;
         packed.location.lat = cmd.content.location.lat;
         packed.location.lng = cmd.content.location.lng;
@@ -920,9 +926,20 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_NAV_LOITER_TURNS: {                    // MAV ID: 18
-        uint16_t num_turns = MIN(255,packet.param1);              // param 1 is number of times to circle is held in low p1
-        uint16_t radius_m = MIN(255,fabsf(packet.param3));        // param 3 is radius in meters is held in high p1
-        cmd.p1 = (radius_m<<8) | (num_turns & 0x00FF);   // store radius in high byte of p1, num turns in low byte of p1
+        // number of turns is stored in the lowest bits.  radii below
+        // 255m are stored in the top 8 bits as an 8-bit integer.
+        // Radii above 255m are stored divided by 10 and a bit set in
+        // storage so that on retrieval they are multiplied by 10
+        cmd.p1 = MIN(255, packet.param1); // store number of times to circle in low p1
+        uint8_t radius_m;
+        const float abs_radius = fabsf(packet.param3);
+        if (abs_radius <= 255) {
+            radius_m = abs_radius;
+        } else {
+            radius_m = MIN(255, abs_radius * 0.1);
+            cmd.type_specific_bits = 1U << 0;
+        }
+        cmd.p1 |= (radius_m<<8);   // store radius in high byte of p1
         cmd.content.location.loiter_ccw = (packet.param3 < 0);
         cmd.content.location.loiter_xtrack = (packet.param4 > 0); // 0 to xtrack from center of waypoint, 1 to xtrack from tangent exit location
     }
@@ -1387,6 +1404,9 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param3 = HIGHBYTE(cmd.p1);               // radius is held in high byte of p1
         if (cmd.content.location.loiter_ccw) {
             packet.param3 = -packet.param3;
+        }
+        if (cmd.type_specific_bits & (1U<<0)) {
+            packet.param3 *= 10;
         }
         packet.param4 = cmd.content.location.loiter_xtrack; // 0 to xtrack from center of waypoint, 1 to xtrack from tangent exit location
         break;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -314,6 +314,10 @@ public:
         uint16_t p1;                // general purpose parameter 1
         Content content;
 
+        // for items which store in location, we offer a few more bits
+        // of storage:
+        uint8_t type_specific_bits;  // bitmask of set/unset bits
+
         // return a human-readable interpretation of the ID stored in this command
         const char *type() const;
 


### PR DESCRIPTION
This is a mostly-user-transparent change.

Packed mission commands can store the radius/10 - this reduces fidelity but does allow storing of radii up to 2550m.

From a user perspective they will now be able to send up mission items which are >255 - but these will be rounded down to the nearest 10m.

There's a new test for Plane which passes - this is the map output:
![image](https://user-images.githubusercontent.com/7077857/167767958-70490ea7-7c35-432e-8475-0056d0e21936.png)

I've tested Copter in SITL:

```
0	0	0	16	0.000000	0.000000	0.000000	0.000000	-35.363262	149.165237	584.070007	1
1	0	3	22	0.000000	0.000000	0.000000	0.000000	-35.363105	149.167922	50.000000	1
2	0	3	16	0.000000	0.000000	0.000000	0.000000	-35.363060	149.164301	50.000000	1
3	0	3	18	2.000000	0.000000	50.000000	0.000000	-35.360870	149.162883	50.000000	1
4	0	3	18	2.000000	0.000000	1000.000000	0.000000	-35.360870	149.167633	50.000000	1
5	0	0	20	0.000000	0.000000	0.000000	0.000000	0.000000	0.000000	0.000000	1
```

![image](https://user-images.githubusercontent.com/7077857/167767521-be8250dc-173b-490f-8194-4900765ffb2e.png)
