### PR TITLE
Fixed use of configured() vs configured_in_storage()

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1493,10 +1493,10 @@ void Copter::convert_lgr_parameters(void)
         // this shouldn't happen
         return;
     }
-    if (servo_min->configured_in_storage() ||
-        servo_max->configured_in_storage() ||
-        servo_trim->configured_in_storage() ||
-        servo_reversed->configured_in_storage()) {
+    if (servo_min->configured() ||
+        servo_max->configured() ||
+        servo_trim->configured() ||
+        servo_reversed->configured()) {
         // has been previously saved, don't upgrade
         return;
     }
@@ -1587,7 +1587,7 @@ void Copter::convert_tradheli_parameters(void) const
                 // make sure the pointer is valid
                 if (ap2 != nullptr) {
                     // see if we can load it from EEPROM
-                    if (!ap2->configured_in_storage()) {
+                    if (!ap2->configured()) {
                         // the new parameter is not in storage so set generic swash
                         AP_Param::set_and_save_by_name("H_SW_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3);            
                     }
@@ -1645,7 +1645,7 @@ void Copter::convert_tradheli_parameters(void) const
             // make sure the pointer is valid
             if (ap2 != nullptr) {
                 // see if we can load it from EEPROM
-                if (!ap2->configured_in_storage()) {
+                if (!ap2->configured()) {
                     // the new parameter is not in storage so set generic swash
                     AP_Param::set_and_save_by_name("H_SW_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3);            
                 }
@@ -1662,7 +1662,7 @@ void Copter::convert_tradheli_parameters(void) const
             // make sure the pointer is valid
             if (ap2 != nullptr) {
                 // see if we can load it from EEPROM
-                if (!ap2->configured_in_storage()) {
+                if (!ap2->configured()) {
                     // the new parameter is not in storage so set generic swash
                     AP_Param::set_and_save_by_name("H_SW2_TYPE", SwashPlateType::SWASHPLATE_TYPE_H3);            
                 }
@@ -1735,7 +1735,7 @@ void Copter::convert_fs_options_params(void) const
     enum ap_var_type ptype;
     AP_Int32 *fs_opt = (AP_Int32 *)AP_Param::find("FS_OPTIONS", &ptype);
 
-    if (fs_opt == nullptr || fs_opt->configured_in_storage() || ptype != AP_PARAM_INT32) {
+    if (fs_opt == nullptr || fs_opt->configured() || ptype != AP_PARAM_INT32) {
         return;
     }
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -51,7 +51,7 @@ void Copter::init_rc_out()
     motors->set_update_rate(g.rc_speed);
 
 #if FRAME_CONFIG != HELI_FRAME
-    if (channel_throttle->configured_in_storage()) {
+    if (channel_throttle->configured()) {
         // throttle inputs setup, use those to set motor PWM min and max if not already configured
         motors->convert_pwm_min_max_param(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
     } else {

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -356,7 +356,7 @@ void AP_PitchController::reset_I()
 void AP_PitchController::convert_pid()
 {
     AP_Float &ff = rate_pid.ff();
-    if (ff.configured_in_storage()) {
+    if (ff.configured()) {
         return;
     }
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -258,7 +258,7 @@ void AP_RollController::reset_I()
 void AP_RollController::convert_pid()
 {
     AP_Float &ff = rate_pid.ff();
-    if (ff.configured_in_storage()) {
+    if (ff.configured()) {
         return;
     }
     float old_ff=0, old_p=1.0, old_i=0.3, old_d=0.08;

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -587,7 +587,7 @@ void Util::apply_persistent_params(void) const
                             errors++;
                             break;
                         }
-                        if (!ap->configured_in_storage()) {
+                        if (!ap->configured()) {
                             ap->save();
                         }
                     }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -794,7 +794,7 @@ void AP_MotorsMulticopter::save_params_on_disarm()
 // convert to PWM min and max in the motor lib
 void AP_MotorsMulticopter::convert_pwm_min_max_param(int16_t radio_min, int16_t radio_max)
 {
-    if (_pwm_min.configured_in_storage() || _pwm_max.configured_in_storage()) {
+    if (_pwm_min.configured() || _pwm_max.configured()) {
         return;
     }
     _pwm_min.set_and_save(radio_min);

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -286,20 +286,20 @@ bool AP_NavEKF_Source::usingGPS() const
 }
 
 // true if some parameters have been configured (used during parameter conversion)
-bool AP_NavEKF_Source::configured_in_storage()
+bool AP_NavEKF_Source::configured()
 {
-    if (config_in_storage) {
+    if (_configured) {
         return true;
     }
 
     // first source parameter is used to determine if configured or not
-    config_in_storage = _source_set[0].posxy.configured_in_storage();
+    _configured = _source_set[0].posxy.configured();
 
-    return config_in_storage;
+    return _configured;
 }
 
-// mark parameters as configured in storage (used to ensure parameter conversion is only done once)
-void AP_NavEKF_Source::mark_configured_in_storage()
+// mark parameters as configured (used to ensure parameter conversion is only done once)
+void AP_NavEKF_Source::mark_configured()
 {
     // save first parameter's current value to mark as configured
     return _source_set[0].posxy.save(true);

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -85,10 +85,10 @@ public:
     bool usingGPS() const;
 
     // true if source parameters have been configured (used for parameter conversion)
-    bool configured_in_storage();
+    bool configured();
 
-    // mark parameters as configured in storage (used to ensure parameter conversion is only done once)
-    void mark_configured_in_storage();
+    // mark parameters as configured (used to ensure parameter conversion is only done once)
+    void mark_configured();
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked
@@ -119,5 +119,5 @@ private:
     AP_Int16 _options;      // source options bitmask
 
     uint8_t active_source_set; // index of active source set
-    bool config_in_storage; // true once configured in storage has returned true
+    bool _configured; // true once configured has returned true
 };

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1606,7 +1606,7 @@ void NavEKF3::writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms,
 void NavEKF3::convert_parameters()
 {
     // exit immediately if param conversion has been done before
-    if (sources.configured_in_storage()) {
+    if (sources.configured()) {
         return;
     }
 
@@ -1643,12 +1643,12 @@ void NavEKF3::convert_parameters()
         case 3:
         default:
             // EK3_GPS_TYPE == 3 (No GPS) we don't know what to do, could be optical flow, beacon or external nav
-            sources.mark_configured_in_storage();
+            sources.mark_configured();
             break;
         }
     } else {
         // mark configured in storage so conversion is only run once
-        sources.mark_configured_in_storage();
+        sources.mark_configured();
     }
 
     // use EK3_ALT_SOURCE to set EK3_SRC1_POSZ

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -488,12 +488,6 @@ public:
     // check var table for consistency
     static bool             check_var_info(void);
 
-    // return true if the parameter is configured in the defaults file
-    bool configured_in_defaults_file(bool &read_only) const;
-
-    // return true if the parameter is configured in EEPROM/FRAM
-    bool configured_in_storage(void) const;
-
     // return true if the parameter is configured
     bool configured(void) const;
 
@@ -703,6 +697,12 @@ private:
      */
     static bool count_embedded_param_defaults(uint16_t &count);
     static void load_embedded_param_defaults(bool last_pass);
+
+    // return true if the parameter is configured in the defaults file
+    bool configured_in_defaults_file(bool &read_only) const;
+
+    // return true if the parameter is configured in EEPROM/FRAM
+    bool configured_in_storage(void) const;
 
     // send a parameter to all GCS instances
     void send_parameter(const char *name, enum ap_var_type param_header_type, uint8_t idx) const;

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -104,8 +104,8 @@ PARAMETER_CONVERSION - Added: Aug-2021
 */
 void AP_RPM::convert_params(void)
 {
-    if (_params[0].type.configured_in_storage()) {
-        // _params[0].type will always be configured in storage after conversion is done the first time
+    if (_params[0].type.configured()) {
+        // _params[0].type will always be configured after conversion is done the first time
         return;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -175,8 +175,9 @@ RangeFinder::RangeFinder()
 }
 
 void RangeFinder::convert_params(void) {
-    if (params[0].type.configured_in_storage()) {
-        // _params[0]._type will always be configured in storage after conversion is done the first time
+    if (params[0].type.configured()) {
+        // _params[0]._type will always be configured after conversion is done the first time
+        // or the user has set a type in a defaults.parm file or via apj tool
         return;
     }
 

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -217,7 +217,7 @@ void AP_VideoTX::set_power_level(uint8_t level) {
 // set the current channel
 void AP_VideoTX::set_enabled(bool enabled) {
     _current_enabled = enabled;
-    if (!_enabled.configured_in_storage()) {
+    if (!_enabled.configured()) {
         _enabled.set_and_save(enabled);
     }
 }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -88,8 +88,8 @@ public:
     // set and save trim if changed
     void       set_and_save_radio_trim(int16_t val) { radio_trim.set_and_save_ifchanged(val);}
 
-    // check if any of the trim/min/max param are configured in storage, this would indicate that the user has done a calibration at somepoint
-    bool       configured_in_storage() { return radio_min.configured_in_storage() || radio_max.configured_in_storage() || radio_trim.configured_in_storage(); }
+    // check if any of the trim/min/max param are configured, this would indicate that the user has done a calibration at somepoint
+    bool       configured() { return radio_min.configured() || radio_max.configured() || radio_trim.configured(); }
 
     ControlType get_type(void) const { return type_in; }
 


### PR DESCRIPTION
Many of our parameter conversion functions were using configured_in_storage() when they should have been using configured(). The difference is that configured() returns true when the parameter is either configured in storage or is configured in a defaults file (which can come from apjtool or from a defaults.parm in the hwdef directory)
This matters as otherwise it is impossible to configure these parameters in a defaults file.
@lthall hit this recently with a vehicle where he wanted to configure MOT_PWM_MIN and MOT_PWM_MAX. Setting these values in a defaults.parm for a vehicle specific build did not work as convert_pwm_min_max_param() in Copter::init_rc_out() would override them, as they were not configured_in_storage()
