### PR TITLE
Copter: fix bug for heli takeoff in guided mode

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -544,6 +544,8 @@ void Mode::make_safe_ground_handling(bool force_throttle_unlimited)
         break;
     }
 
+    pos_control->relax_velocity_controller_xy();
+    pos_control->update_xy_controller();
     pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
     pos_control->update_z_controller();
     // we may need to move this out

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -900,7 +900,6 @@ void ModeAuto::wp_run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        wp_nav->wp_and_spline_init();
         return;
     }
 
@@ -997,7 +996,6 @@ void ModeAuto::loiter_run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        wp_nav->wp_and_spline_init();
         return;
     }
 
@@ -1023,7 +1021,7 @@ void ModeAuto::loiter_to_alt_run()
 {
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (is_disarmed_or_landed() || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
+        make_safe_ground_handling();
         return;
     }
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -37,7 +37,6 @@ void ModeBrake::run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        pos_control->relax_velocity_controller_xy();
         pos_control->relax_z_controller(0.0f);
         return;
     }


### PR DESCRIPTION
This fixes the bug identified [here](https://discuss.ardupilot.org/t/heli-frame-prearm-internal-error-0x100000-l-602-flow-of-ctr/85172).  The issue was an internal error that occurred when attempting a guided mode takeoff for heli.  The user determined that the position controller was not being initialized.  It was further discovered that this was also occurring when attempting auto takeoff when the aircraft was armed in auto mode and interlock was enable to initiate takeoff.

This has been tested in SITL and verified that it fixes both issues.