### PR TITLE
AP_HAL_Chibios: add 12Mhz Clock Option stm32F405

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
@@ -178,6 +178,11 @@
 #define STM32_PLLN_VALUE                    336
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    7
+#elif STM32_HSECLK == 12000000U
+#define STM32_PLLM_VALUE                    12
+#define STM32_PLLN_VALUE                    336
+#define STM32_PLLP_VALUE                    2
+#define STM32_PLLQ_VALUE                    7
 #elif STM32_HSECLK == 16000000U
 #define STM32_PLLM_VALUE                    16
 #define STM32_PLLN_VALUE                    336


### PR DESCRIPTION
There was no option for 12Mhz for STM32F405. 