### PR TITLE
AP_OSD: correct compilation without OSD_ENABLED

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -267,7 +267,9 @@ void AP_OSD::init()
         if (!spi_dev) {
             break;
         }
+#if HAL_WITH_OSD_BITMAP
         backend = AP_OSD_MAX7456::probe(*this, std::move(spi_dev));
+#endif
         if (backend == nullptr) {
             break;
         }


### PR DESCRIPTION
The max7456 header file is guarded by his macro

Compilation fails as the class isn't defined...
