### PR TITLE
Plane: refuse arming if we are in a landing sequence

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -102,6 +102,11 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
        }
     }
 
+    if (plane.mission.get_in_landing_sequence_flag()) {
+        check_failed(display_failure,"In landing sequence");
+        ret = false;
+    }
+    
     return ret;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1793,8 +1793,17 @@ void QuadPlane::update_throttle_suppression(void)
         return;
     }
 
-    // if the users throttle is above zero then allow motors to run
-    if (!is_zero(plane.get_throttle_input())) {
+    /* if the users throttle is above zero then allow motors to run
+
+       if the user has unset the "check throttle zero when arming"
+       then the RC controller has a sprung throttle and we should not
+       consider non-zero throttle to mean that pilot is commanding
+       takeoff unless in a manual thottle mode
+    */
+    if (!is_zero(plane.get_throttle_input()) &&
+        (rc().arming_check_throttle() ||
+         plane.control_mode->is_vtol_man_throttle() ||
+         plane.channel_throttle->norm_input_dz() > 0)) {
         return;
     }
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -614,6 +614,7 @@ class AutoTestPlane(AutoTest):
         self.wait_servo_channel_value(2, deepstall_elevator_pwm)
 
         self.disarm_wait(timeout=120)
+        self.set_current_waypoint(0, check_afterwards=False)
 
         self.progress("Flying home")
         self.takeoff(100)
@@ -784,6 +785,7 @@ class AutoTestPlane(AutoTest):
         #        tend to miss the final waypoint by a fair bit, and
         #        this is probably too noisy anyway?
         self.wait_disarmed(timeout=timeout)
+        self.set_current_waypoint(0, check_afterwards=False)
 
     def fly_flaps(self):
         """Test flaps functionality."""

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -590,6 +590,7 @@ class AutoTestPlane(AutoTest):
         self.disarm_wait(timeout=120)
 
         self.progress("Flying home")
+        self.set_current_waypoint(0, check_afterwards=False)
         self.takeoff(10)
         self.set_parameter("LAND_TYPE", 0)
         self.fly_home_land_and_disarm()
@@ -617,6 +618,7 @@ class AutoTestPlane(AutoTest):
         self.set_current_waypoint(0, check_afterwards=False)
 
         self.progress("Flying home")
+        self.set_current_waypoint(0, check_afterwards=False)
         self.takeoff(100)
         self.set_parameter("LAND_TYPE", 0)
         self.fly_home_land_and_disarm(timeout=240)
@@ -785,7 +787,6 @@ class AutoTestPlane(AutoTest):
         #        tend to miss the final waypoint by a fair bit, and
         #        this is probably too noisy anyway?
         self.wait_disarmed(timeout=timeout)
-        self.set_current_waypoint(0, check_afterwards=False)
 
     def fly_flaps(self):
         """Test flaps functionality."""
@@ -1810,6 +1811,8 @@ class AutoTestPlane(AutoTest):
             )
 
         self.fly_home_land_and_disarm()
+        self.set_current_waypoint(0, check_afterwards=False)
+
         self.change_mode("MANUAL")
         self.set_rc(3, 1000)
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3876,7 +3876,13 @@ class AutoTest(ABC):
             wp.z)
         return wp_int
 
-    def load_mission_from_filepath(self, filepath, filename, target_system=1, target_component=1, strict=True):
+    def load_mission_from_filepath(self,
+                                   filepath,
+                                   filename,
+                                   target_system=1,
+                                   target_component=1,
+                                   strict=True,
+                                   reset_current_wp=True):
         self.progress("Loading mission (%s)" % filename)
         path = os.path.join(testdir, filepath, filename)
         wploader = mavwp.MAVWPLoader(
@@ -3886,6 +3892,11 @@ class AutoTest(ABC):
         wploader.load(path)
         wpoints_int = [self.wp_to_mission_item_int(x) for x in wploader.wpoints]
         self.check_mission_upload_download(wpoints_int, strict=strict)
+        if reset_current_wp:
+            # ArduPilot doesn't reset the current waypoint by default
+            # we may be in auto mode and running waypoints, so we
+            # can't check the current waypoint after resetting it.
+            self.set_current_waypoint(0, check_afterwards=False)
         return len(wpoints_int)
 
     def load_mission_using_mavproxy(self, mavproxy, filename):
@@ -6790,6 +6801,8 @@ Also, ignores heartbeats not from our target system'''
         try:
             self.check_rc_defaults()
             self.change_mode(self.default_mode())
+            # ArduPilot can still move the current waypoint from 0,
+            # even if we are not in AUTO mode, so cehck_afterwards=False:
             self.set_current_waypoint(0, check_afterwards=False)
             self.drain_mav()
             self.drain_all_pexpects()
@@ -6908,6 +6921,7 @@ Also, ignores heartbeats not from our target system'''
 
         if not self.is_tracker(): # FIXME - more to the point, fix Tracker's mission handling
             self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_ALL)
+            self.set_current_waypoint(0, check_afterwards=False)
 
         tee.close()
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -6790,6 +6790,7 @@ Also, ignores heartbeats not from our target system'''
         try:
             self.check_rc_defaults()
             self.change_mode(self.default_mode())
+            self.set_current_waypoint(0, check_afterwards=False)
             self.drain_mav()
             self.drain_all_pexpects()
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -446,6 +446,7 @@ class AutoTestQuadPlane(AutoTest):
 
     def takeoff(self, height, mode):
         """climb to specified height and set throttle to 1500"""
+        self.set_current_waypoint(0, check_afterwards=False)
         self.change_mode(mode)
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -470,6 +471,7 @@ class AutoTestQuadPlane(AutoTest):
         self.change_mode("AUTO")
         self.set_current_waypoint(7)
         self.wait_disarmed(timeout=timeout)
+        self.set_current_waypoint(0, check_afterwards=False)
 
     def wait_level_flight(self, accuracy=5, timeout=30):
         """Wait for level flight."""


### PR DESCRIPTION
this helps when the aircraft has gone into a landing sequence due to a
failsafe before it is armed. Arming while in the landing sequence is
very unlikely to be what the user wants

This PR now also treats RC_OPTIONS with the "don't check throttle on arming" option as an indicator that
we should not unsuppress throttle in VTOL based on pilot throttle unless throttle is above deadzone+trim in auto throttle modes