### PR TITLE
Copter: Determine the result of processing the get_location method

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -8,9 +8,12 @@ void Copter::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_location(loc);
+    if (ahrs.get_location(loc) == false) {
+        return;
+    }
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
+
 
     // exit immediately if we do not have an altitude estimate
     if (!inertial_nav.get_filter_status().flags.vert_pos) {


### PR DESCRIPTION
The get_location method may return FALSE if no value is set for the argument.
I would change it to If the argument has a value, subsequent processing is performed.