### PR TITLE
RC_Channel: notify RC switch

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -572,6 +572,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::RUNCAM_CONTROL,"RunCamControl"},
     { AUX_FUNC::RUNCAM_OSD_CONTROL,"RunCamOSDControl"},
     { AUX_FUNC::VISODOM_ALIGN,"VisOdomAlign"},
+    { AUX_FUNC::AIRMODE, "AirMode"},
     { AUX_FUNC::EKF_POS_SOURCE,"EKFPosSource"},
     { AUX_FUNC::CAM_MODE_TOGGLE,"CamModeToggle"},
     { AUX_FUNC::GENERATOR,"Generator"},


### PR DESCRIPTION
~~You can still disarm with airmode active, I guess for the most part the advice would be to disable rudder arming with the param. When enabling airmode with a switch you have both.~~ I have added a message for the airmode switch so its easier to check. 

~~Of course this does mean that users may no longer be able to disarm....~~

At least I think the second commit is usefull. 