### PR TITLE
CI:  solve git rev-parse issue

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -1,8 +1,8 @@
 name: test environment setup
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 6'  # every saturday at midnight
+  workflow_dispatch:
 
 
 concurrency:
@@ -104,6 +104,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source ~/.bashrc
+          git config --global --add safe.directory /__w/ardupilot/ardupilot
           ./waf configure
           ./waf rover
 
@@ -115,5 +116,6 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source ~/.bashrc
+          git config --global --add safe.directory /__w/ardupilot/ardupilot
           ./waf configure --board CubeOrange
           ./waf plane

--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -23,7 +23,7 @@ while getopts "yq" opt; do
 done
 
 BASE_PKGS="base-devel ccache git gsfonts tk wget gcc"
-SITL_PKGS="python-pip python-setuptools python-wheel wxpython opencv python-numpy python-scipy"
+SITL_PKGS="python-pip python-setuptools python-wheel python-wxpython opencv python-numpy python-scipy"
 PX4_PKGS="lib32-glibc zip zlib ncurses"
 
 PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect argparse matplotlib pyparsing geocoder pyserial empy"


### PR DESCRIPTION
Fix dev env weekly workflow. The issue https://github.com/ArduPilot/ardupilot/runs/6431277712?check_suite_focus=true is that git isn't call with the same user that the own that own the directory and thus the git rev-parse return nothing and make waf failed to configure the build. Adding the directory to the git safe directory solve the issue.

Also fix arch wxpython install