### PR TITLE
Tradheli AutoTune: improve angle P tuning

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -153,6 +153,8 @@ const char *AC_AutoTune::type_string() const
         return "Angle P Down";
     case MAX_GAINS:
         return "Find Max Gains";
+    case TUNE_CHECK:
+        return "Check Tune Frequency Response";
     case TUNE_COMPLETE:
         return "Tune Complete";
     }
@@ -437,6 +439,9 @@ void AC_AutoTune::control_attitude()
         case MAX_GAINS:
             updating_max_gains_all(axis);
             break;
+        case TUNE_CHECK:
+            counter = AUTOTUNE_SUCCESS_COUNT;
+            FALLTHROUGH;
         case TUNE_COMPLETE:
             break;
         }

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -201,7 +201,8 @@ protected:
         SP_UP = 4,                // angle P is being tuned up
         SP_DOWN = 5,              // angle P is being tuned down
         MAX_GAINS = 6,            // max allowable stable gains are determined
-        TUNE_COMPLETE = 7         // Reached end of tuning
+        TUNE_CHECK = 7,           // frequency sweep with tuned gains
+        TUNE_COMPLETE = 8         // Reached end of tuning
     };
     TuneType tune_seq[6];         // holds sequence of tune_types to be performed
     uint8_t tune_seq_curr;        // current tune sequence step

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -502,8 +502,8 @@ void AC_AutoTune_Heli::load_test_gains()
     float rate_p, rate_i, rate_d;
     switch (axis) {
     case ROLL:
-        if (tune_type == SP_UP) {
-            rate_i = orig_roll_ri;
+        if (tune_type == SP_UP || tune_type == TUNE_CHECK) {
+            rate_i = tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL;
         } else {
             // freeze integrator to hold trim by making i term small during rate controller tuning
             rate_i = 0.01f * orig_roll_ri;
@@ -518,8 +518,8 @@ void AC_AutoTune_Heli::load_test_gains()
         load_gain_set(ROLL, rate_p, rate_i, rate_d, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, 0.0f);
         break;
     case PITCH:
-        if (tune_type == SP_UP) {
-            rate_i = orig_pitch_ri;
+        if (tune_type == SP_UP || tune_type == TUNE_CHECK) {
+            rate_i = tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL;
         } else {
             // freeze integrator to hold trim by making i term small during rate controller tuning
             rate_i = 0.01f * orig_pitch_ri;
@@ -534,8 +534,13 @@ void AC_AutoTune_Heli::load_test_gains()
         load_gain_set(PITCH, rate_p, rate_i, rate_d, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, 0.0f);
         break;
     case YAW:
-        // freeze integrator to hold trim by making i term small during rate controller tuning
-        load_gain_set(YAW, tune_yaw_rp, tune_yaw_rp*0.01f, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, 0.0f);
+        if (tune_type == SP_UP || tune_type == TUNE_CHECK) {
+            rate_i = tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL;
+        } else {
+            // freeze integrator to hold trim by making i term small during rate controller tuning
+            rate_i = 0.01f * orig_yaw_ri;
+        }
+        load_gain_set(YAW, tune_yaw_rp, rate_i, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, 0.0f);
         break;
     }
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -147,6 +147,7 @@ private:
     enum DwellType {
         RATE    = 0,
         ANGLE   = 1,
+        DRB     = 2,
     };
 
     // Feedforward test used to determine Rate FF gain

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -726,6 +726,7 @@ void AC_AutoTune_Multi::set_gains_post_tune(AxisType test_axis)
         break;
     case RFF_UP:
     case MAX_GAINS:
+    case TUNE_CHECK:
         // this should never happen
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         break;
@@ -1175,6 +1176,7 @@ void AC_AutoTune_Multi::twitch_test_run(AxisType test_axis, const float dir_sign
         break;
     case RFF_UP:
     case MAX_GAINS:
+    case TUNE_CHECK:
         // this should never happen
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         break;


### PR DESCRIPTION
This PR improves the tradheli autotune angle P tuning by looking at the disturbance rejection peak.  Also incorporates a tune check option that allow the user to do a frequency sweep with the tuned values.