### PR TITLE
AP_NavEKF3: replace AP_HAL::millis() with dal.millis()

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -612,7 +612,7 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
 
             // calculate innovation for Y observation
             flowInnov[1] = losPred[1] - ofDataDelayed.flowRadXYcomp.y;
-            flowInnovTime_ms = AP_HAL::millis();
+            flowInnovTime_ms = dal.millis();
 
             // calculate Kalman gains for the Y-axis observation
             Kfusion[0] = -t78*(t12+P[0][5]*t2*t8-P[0][6]*t2*t10+P[0][1]*t2*t16-P[0][2]*t2*t19+P[0][3]*t2*t22+P[0][4]*t2*t27);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -459,7 +459,7 @@ bool NavEKF3_core::getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::Sour
     switch (source) {
     case AP_NavEKF_Source::SourceXY::GPS:
         // check for timeouts
-        if (AP_HAL::millis() - gpsVelInnovTime_ms > 500) {
+        if (dal.millis() - gpsVelInnovTime_ms > 500) {
             return false;
         }
         innovations = gpsVelInnov.tofloat();
@@ -468,7 +468,7 @@ bool NavEKF3_core::getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::Sour
 #if EK3_FEATURE_EXTERNAL_NAV
     case AP_NavEKF_Source::SourceXY::EXTNAV:
         // check for timeouts
-        if (AP_HAL::millis() - extNavVelInnovTime_ms > 500) {
+        if (dal.millis() - extNavVelInnovTime_ms > 500) {
             return false;
         }
         innovations = extNavVelInnov.tofloat();
@@ -477,7 +477,7 @@ bool NavEKF3_core::getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::Sour
 #endif // EK3_FEATURE_EXTERNAL_NAV
     case AP_NavEKF_Source::SourceXY::OPTFLOW:
         // check for timeouts
-        if (AP_HAL::millis() - flowInnovTime_ms > 500) {
+        if (dal.millis() - flowInnovTime_ms > 500) {
             return false;
         }
         innovations.x = flowInnov[0];

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -442,7 +442,7 @@ void NavEKF3_core::SelectVelPosFusion()
         CalculateVelInnovationsAndVariances(extNavVelDelayed.vel, extNavVelDelayed.err, frontend->extNavVelVarAccScale, extNavVelInnov, extNavVelVarInnov);
 
         // record time innovations were calculated (for timeout checks)
-        extNavVelInnovTime_ms = AP_HAL::millis();
+        extNavVelInnovTime_ms = dal.millis();
     }
 #endif // EK3_FEATURE_EXTERNAL_NAV
 
@@ -457,7 +457,7 @@ void NavEKF3_core::SelectVelPosFusion()
         // calculate innovations and variances for reporting purposes only
         CalculateVelInnovationsAndVariances(gpsDataDelayed.vel, frontend->_gpsHorizVelNoise, frontend->gpsNEVelVarAccScale, gpsVelInnov, gpsVelVarInnov);
         // record time innovations were calculated (for timeout checks)
-        gpsVelInnovTime_ms = AP_HAL::millis();
+        gpsVelInnovTime_ms = dal.millis();
     }
 
     // detect position source changes.  Trigger position reset if position source is valid


### PR DESCRIPTION
These are functionally the same except when using Replay.  I'm pretty sure that I was the one who added the code in question and the code in question is only used for timeout checking when reporting innovations to Lua (used by the EKF source switching scripts).

This has been lightly tested by re-running Replay on some real flght logs.  I was hoping this would resolve some discrepancies I was seeing with the Replay EKF output vs the original output but it didn't actually fix the issue.  Still, I did successfully run Replay with these changes and I think this is a correct change.

The explanation for [how to produce Replay logs is here on the wiki](https://ardupilot.org/dev/docs/testing-with-replay.html).

