### PR TITLE
AP_InertialSensor: extend ENABLE_MASK param desc IMUs 4 to 7

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -545,7 +545,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @DisplayName: IMU enable mask
     // @Description: Bitmask of IMUs to enable. It can be used to prevent startup of specific detected IMUs
     // @User: Advanced
-    // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU
+    // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU,3:FourthIMU,4:FifthIMU,5:SixthIMU,6:SeventhIMU
     AP_GROUPINFO("ENABLE_MASK",  40, AP_InertialSensor, _enable_mask, 0x7F),
 
     // @Group: HNTCH_


### PR DESCRIPTION
This improves the INS_ENABLE_MASK parameter description so that users can more easily enable/disable IMUs beyond the first 3.

This was discovered during 4.2.0 testing in [this discussion](https://discuss.ardupilot.org/t/rover-4-2-0-rc3-released-for-beta-testing/85121).