### PR TITLE
Plane: cope with QGC retrying AUTO mode

### DIFF
--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -10,6 +10,7 @@ bool ModeAuto::_enter()
         quadplane.guided_wait_takeoff_on_mode_enter) {
         if (!plane.mission.starts_with_takeoff_cmd()) {
             gcs().send_text(MAV_SEVERITY_ERROR,"Takeoff waypoint required");
+            quadplane.guided_wait_takeoff = true;
             return false;
         }
     }


### PR DESCRIPTION
QGC tries several times to enter AUTO even when it is refused. We need
to keep refusing otherwise we end up going into AUTO without a takeoff on the 2nd or 3rd try from QGC
