### PR TITLE
Copter/Sub: Clarify that the target_yaw_rate variable is set

### DIFF
--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -22,7 +22,6 @@ bool ModeStabilize_Heli::init(bool ignore_checks)
 void ModeStabilize_Heli::run()
 {
     float target_roll, target_pitch;
-    float target_yaw_rate;
     float pilot_throttle_scaled;
 
     // apply SIMPLE mode transform to pilot inputs
@@ -32,7 +31,7 @@ void ModeStabilize_Heli::run()
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->norm_input_dz());
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->norm_input_dz());
 
     // get pilot's desired throttle
     pilot_throttle_scaled = copter.input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());

--- a/ArduSub/control_stabilize.cpp
+++ b/ArduSub/control_stabilize.cpp
@@ -16,7 +16,6 @@ void Sub::stabilize_run()
 {
     uint32_t tnow = AP_HAL::millis();
     float target_roll, target_pitch;
-    float target_yaw_rate;
 
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
@@ -34,7 +33,7 @@ void Sub::stabilize_run()
     get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // call attitude controller
     // update attitude controller targets

--- a/ArduSub/control_surface.cpp
+++ b/ArduSub/control_surface.cpp
@@ -21,7 +21,6 @@ bool Sub::surface_init()
 void Sub::surface_run()
 {
     float target_roll, target_pitch;
-    float target_yaw_rate;
 
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
@@ -43,7 +42,7 @@ void Sub::surface_run()
     get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // call attitude controller
     attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);


### PR DESCRIPTION
Related #20801
Clarify that the target_yaw_rate variable is already in place.