### PR TITLE
Adjust dshot bitwidth and ticks to support more ESC variants

### DIFF
--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -2,6 +2,10 @@
 
 extern const AP_HAL::HAL &hal;
 
+uint32_t AP_HAL::RCOutput::DSHOT_BIT_WIDTH_TICKS = DSHOT_BIT_WIDTH_TICKS_DEFAULT;
+uint32_t AP_HAL::RCOutput::DSHOT_BIT_0_TICKS = DSHOT_BIT_0_TICKS_DEFAULT;
+uint32_t AP_HAL::RCOutput::DSHOT_BIT_1_TICKS = DSHOT_BIT_1_TICKS_DEFAULT;
+
 // helper function for implementation of get_output_mode_banner
 const char* AP_HAL::RCOutput::get_output_mode_string(enum output_mode out_mode) const
 {

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -209,7 +209,8 @@ public:
     static bool is_dshot_protocol(const enum output_mode mode);
 
 
-    // https://github.com/bitdump/BLHeli/blob/master/BLHeli_32%20ARM/BLHeli_32%20Firmware%20specs/Digital_Cmd_Spec.txt
+    // BLHeli32: https://github.com/bitdump/BLHeli/blob/master/BLHeli_32%20ARM/BLHeli_32%20Firmware%20specs/Digital_Cmd_Spec.txt
+    // BLHeli_S: https://github.com/bitdump/BLHeli/blob/master/BLHeli_S%20SiLabs/Dshotprog%20spec%20BLHeli_S.txt
     enum BLHeliDshotCommand : uint8_t {
       DSHOT_RESET = 0,
       DSHOT_BEEP1 = 1,
@@ -225,6 +226,7 @@ public:
       DSHOT_SAVE = 12,
       DSHOT_NORMAL = 20,
       DSHOT_REVERSE = 21,
+      // The following options are only available on BLHeli32
       DSHOT_LED0_ON = 22,
       DSHOT_LED1_ON = 23,
       DSHOT_LED2_ON = 24,
@@ -239,7 +241,8 @@ public:
 
     enum DshotEscType {
       DSHOT_ESC_NONE = 0,
-      DSHOT_ESC_BLHELI = 1
+      DSHOT_ESC_BLHELI = 1,
+      DSHOT_ESC_BLHELI_S = 2
     };
 
     virtual void    set_output_mode(uint16_t mask, enum output_mode mode) {}
@@ -327,9 +330,25 @@ public:
     /*
      * bit width values for different protocols
      */
-    static constexpr uint32_t DSHOT_BIT_WIDTH_TICKS = 8;
-    static constexpr uint32_t DSHOT_BIT_0_TICKS = 3;
-    static constexpr uint32_t DSHOT_BIT_1_TICKS = 6;
+    /*
+     * It seems ESCs are quite sensitive to the DSHOT duty cycle.
+     * Options are (ticks, percentage):
+     * 20/7/14, 35/70
+     * 11/4/8, 36/72
+     * 8/3/6, 37/75
+     */
+    // bitwidths: 8/3/6 == 37%/75%
+    static constexpr uint32_t DSHOT_BIT_WIDTH_TICKS_DEFAULT = 8;
+    static constexpr uint32_t DSHOT_BIT_0_TICKS_DEFAULT = 3;
+    static constexpr uint32_t DSHOT_BIT_1_TICKS_DEFAULT = 6;
+    // bitwidths: 11/4/8 == 36%/72%
+    static constexpr uint32_t DSHOT_BIT_WIDTH_TICKS_S = 11;
+    static constexpr uint32_t DSHOT_BIT_0_TICKS_S = 4;
+    static constexpr uint32_t DSHOT_BIT_1_TICKS_S = 8;
+
+    static uint32_t DSHOT_BIT_WIDTH_TICKS;
+    static uint32_t DSHOT_BIT_0_TICKS;
+    static uint32_t DSHOT_BIT_1_TICKS;
 
     // See WS2812B spec for expected pulse widths
     static constexpr uint32_t NEOP_BIT_WIDTH_TICKS = 20;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -473,6 +473,28 @@ void RCOutput::set_dshot_rate(uint8_t dshot_rate, uint16_t loop_rate_hz)
     _dshot_period_us = 1000000UL / drate;
 }
 
+#ifndef DISABLE_DSHOT
+/*
+ Set/get the dshot esc_type
+ */
+void RCOutput::set_dshot_esc_type(DshotEscType dshot_esc_type)
+{
+    _dshot_esc_type = dshot_esc_type;
+    switch (_dshot_esc_type) {
+        case DSHOT_ESC_BLHELI_S:
+            DSHOT_BIT_WIDTH_TICKS = DSHOT_BIT_WIDTH_TICKS_S;
+            DSHOT_BIT_0_TICKS = DSHOT_BIT_0_TICKS_S;
+            DSHOT_BIT_1_TICKS = DSHOT_BIT_1_TICKS_S;
+            break;
+        default:
+            DSHOT_BIT_WIDTH_TICKS = DSHOT_BIT_WIDTH_TICKS_DEFAULT;
+            DSHOT_BIT_0_TICKS = DSHOT_BIT_0_TICKS_DEFAULT;
+            DSHOT_BIT_1_TICKS = DSHOT_BIT_1_TICKS_DEFAULT;
+            break;
+    }
+}
+#endif
+
 /*
   find pwm_group and index in group given a channel number
  */

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -171,7 +171,7 @@ public:
     /*
       Set/get the dshot esc_type
      */
-    void set_dshot_esc_type(DshotEscType dshot_esc_type) override { _dshot_esc_type = dshot_esc_type; }
+    void set_dshot_esc_type(DshotEscType dshot_esc_type) override;
 
     DshotEscType get_dshot_esc_type() const override { return _dshot_esc_type; }
 #endif

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -146,6 +146,7 @@ void RCOutput::update_channel_masks() {
     for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
         switch (_dshot_esc_type) {
             case DSHOT_ESC_BLHELI:
+            case DSHOT_ESC_BLHELI_S:
                 if (_reversible_mask & (1U<<i)) {
                     send_dshot_command(DSHOT_3D_ON, i + chan_offset, 0, 10, true);
                 }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -125,6 +125,7 @@ void AP_Motors::rc_set_freq(uint32_t motor_mask, uint16_t freq_hz)
 
     const uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
     hal.rcout->set_freq(mask, freq_hz);
+    hal.rcout->set_dshot_esc_type(SRV_Channels::get_dshot_esc_type());
 
     switch (pwm_type(_pwm_type.get())) {
     case PWM_TYPE_ONESHOT:

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -504,6 +504,8 @@ void AP_MotorsUGV::setup_pwm_type()
 {
     _motor_mask = 0;
 
+    hal.rcout->set_dshot_esc_type(SRV_Channels::get_dshot_esc_type());
+
     // work out mask of channels assigned to motors
     _motor_mask |= SRV_Channels::get_output_channel_mask(SRV_Channel::k_throttle);
     _motor_mask |= SRV_Channels::get_output_channel_mask(SRV_Channel::k_throttleLeft);

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -230,7 +230,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Param: _DSHOT_ESC
     // @DisplayName: Servo DShot ESC type
     // @Description: This sets the DShot ESC type for all outputs. The ESC type affects the range of DShot commands available. None means that no dshot commands will be executed.
-    // @Values: 0:None,1:BLHeli32/BLHeli_S/Kiss
+    // @Values: 0:None,1:BLHeli32/Kiss,2:BLHeli_S
     // @User: Advanced
     AP_GROUPINFO("_DSHOT_ESC",  24, SRV_Channels, dshot_esc_type, 0),
 


### PR DESCRIPTION
This is configurable change to the bitwidths that appears to work better for some ESCs, particularly BLHeli_S. To get the new behaviour set ```SERVO_DSHOT_ESC=2```

https://discuss.ardupilot.org/t/copter-4-2-0-rc4-available-for-beta-testing/85556/38
https://discuss.ardupilot.org/t/copter-4-2-0-rc4-available-for-beta-testing/85556/29

Confirmed with users on the forum