### PR TITLE
Copter: 4.2.0 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.2.0-rc4 14-May-2022
+Copter 4.2.0 23-May-2022 / 4.2.0-rc4 14-May-2022
 Changes from 4.2.0-rc3
 1) FlyingMoon F407 and F427 autopilots supported
 2) Vibration failsafe disabled in manual modes

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.0-rc4"
+#define THISFIRMWARE "ArduCopter V4.2.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,0,FIRMWARE_VERSION_TYPE_RC+4
+#define FIRMWARE_VERSION 4,2,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,6 +1,6 @@
 Rover Release Notes:
 ------------------------------------------------------------------
-Rover 4.2.0-rc4 14-May-2022
+Rover 4.2.0 23-May-2022 / 4.2.0-rc4 14-May-2022
 Changes from 4.2.0-rc3
 1) FlyingMoon F407 and F427 autopilots supported
 2) Bug fixes

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.2.0-rc4"
+#define THISFIRMWARE "ArduRover V4.2.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,0,FIRMWARE_VERSION_TYPE_RC+4
+#define FIRMWARE_VERSION 4,2,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the official release of 4.2.0 for Copter.  This is exactly the same as the previous release candidate, "rc4".