### PR TITLE
Allow SITL rangefinder to work on sim-on-hardware

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -565,7 +565,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         break;
 
     case Type::SIM:
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if AP_SIM_RANGEFINDER_ENABLED
         _add_backend(new AP_RangeFinder_SITL(state[instance], params[instance], instance), instance);
 #endif
         break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
@@ -12,11 +12,12 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <AP_HAL/AP_HAL.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include "AP_RangeFinder_SITL.h"
+
+#if AP_SIM_RANGEFINDER_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -49,4 +50,5 @@ void AP_RangeFinder_SITL::update(void)
     update_status();
 }
 
-#endif
+#endif  // AP_SIM_RANGEFINDER_ENABLED
+

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
@@ -14,9 +14,15 @@
  */
 #pragma once
 
-#include "AP_RangeFinder_Backend.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#ifndef AP_SIM_RANGEFINDER_ENABLED
+#define AP_SIM_RANGEFINDER_ENABLED (AP_SIM_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
+#endif
+
+#if AP_SIM_RANGEFINDER_ENABLED
+
+#include "AP_RangeFinder_Backend.h"
 
 #include <SITL/SITL.h>
 
@@ -41,4 +47,4 @@ private:
 
 };
 
-#endif
+#endif  // AP_SIM_RANGEFINDER_ENABLED

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -950,6 +950,13 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
         external_payload_mass += sprayer->payload_mass();
     }
 
+    {
+        const float range = rangefinder_range();
+        for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+            rangefinder_m[i] = range;
+        }
+    }
+
     // update i2c
     if (i2c) {
         i2c->update(*this);


### PR DESCRIPTION
... and, incidentally, SITL when using in-built simulations.

This is rangefinder type=100

It's not a "perfect sensor", but probably should be?

Tested in SIM-on-HW.
