### PR TITLE
Rover: fix compiler warning, uninitialized variables in GCS msg

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -149,8 +149,8 @@ int16_t GCS_MAVLINK_Rover::vfr_hud_throttle() const
 
 void GCS_MAVLINK_Rover::send_rangefinder() const
 {
-    float distance;
-    float voltage;
+    float distance = 0;
+    float voltage = 0;
     bool got_one = false;
 
     // report smaller distance of all rangefinders


### PR DESCRIPTION
Rover: fix compiler warning, uninitialized variables in GCS msg