### PR TITLE
Tools: uploader.py: exit with error on failure

### DIFF
--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -1171,8 +1171,8 @@ def main():
                         up.upload(fw, force=args.force, boot_delay=args.boot_delay)
 
                 except RuntimeError as ex:
-                    # print the error
-                    print("\nERROR: %s" % ex.args)
+                    # print the error and exit as a failure
+                    sys.exit("\nERROR: %s" % ex.args)
 
                 except IOError:
                     up.close()


### PR DESCRIPTION
- Script was already exiting at this point anyway, this just sets a non-zero program return code in the case of a failure
- Means programatic callers can detect if flashing fails, without needing to monitor (and parse) stdout

Issue was raised [here](https://github.com/bluerobotics/BlueOS-docker/issues/840#issuecomment-1135213693).