### PR TITLE
AP_Motors: quadratic programming optimal mixer (fixed size matrixes)

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -380,8 +380,8 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_DECA:
         case AP_Motors::MOTOR_FRAME_SCRIPTING_MATRIX:
         default:
-            motors = new AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
-            motors_var_info = AP_MotorsMatrix::var_info;
+            motors = new AP_MotorsMatrix_Optimal(copter.scheduler.get_loop_rate_hz()); // AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsMatrix_Optimal::var_info;
             break;
         case AP_Motors::MOTOR_FRAME_TRI:
             motors = new AP_MotorsTri(copter.scheduler.get_loop_rate_hz());

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -149,6 +149,18 @@ MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_div(const MatrixRC<T,R,C>& b) const
     return r;
 }
 
+// elementwise inversion, to faster to inverse and multiply than several per_element_div calls
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_inv() const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = 1.0 / v[i][j];
+        }
+    }
+    return r;
+}
+
 // elementwise multiplication, matrix by vector
 template <typename T, uint8_t R, uint8_t C>
 MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult_vector_columns(const MatrixRC<T,1,C>& b) const {
@@ -232,8 +244,9 @@ MatrixRC<T,R,R> cholesky(const MatrixRC<T,R,R>& b) {
     MatrixRC<T,R,R> x = b;
     for (uint8_t i = 0; i < R; i++) {
         x.v[i][i] = sqrt(x.v[i][i]);
+        T ii_inv = 1.0 / x.v[i][i];
         for (uint8_t j = i+1; j < R; j++) {
-            x.v[j][i] /= x.v[i][i];
+            x.v[j][i] *= ii_inv;
         }
         for (uint8_t k = i+1; k < R; k++) {
             for (uint8_t j = k; j < R; j++) {

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -1,0 +1,295 @@
+/*
+ * R x C rectangular matrix operations
+ */
+
+//#pragma GCC optimize("O2")
+
+#include "matrixRC.h"
+#include "AP_Math.h"
+
+extern const AP_HAL::HAL& hal;
+
+// get and set with ()
+template <typename T, uint8_t R, uint8_t C>
+T& MatrixRC<T,R,C>::operator () (uint8_t i, uint8_t j) {
+    return v[i][j];
+}
+
+// const getter
+template <typename T, uint8_t R, uint8_t C>
+const T& MatrixRC<T,R,C>::operator () (uint8_t i, uint8_t j) const {
+    return v[i][j];
+}
+
+// set all values
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> &MatrixRC<T,R,C>::operator =(const T num) {
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            v[i][j] = num;
+        }
+    }
+    return *this;
+}
+
+// scale by constant
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> &MatrixRC<T,R,C>::operator *=(const T num) {
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            v[i][j] *= num;
+        }
+    }
+    return *this;
+}
+
+// multiply by constant
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator *(const T num) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] * num;
+        }
+    }
+    return r;
+}
+
+// add constant
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator +(const T num) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] + num;
+        }
+    }
+    return r;
+}
+
+// subtract constant
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator -(const T num) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] - num;
+        }
+    }
+    return r;
+}
+
+// elementwise matrix addition
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> &MatrixRC<T,R,C>::operator +=(const MatrixRC<T,R,C>& b) {
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            v[i][j] += b.v[i][j];
+        }
+    }
+    return *this;
+}
+
+// elementwise matrix subtraction
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> &MatrixRC<T,R,C>::operator -=(const MatrixRC<T,R,C>& b) {
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            v[i][j] -= b.v[i][j];
+        }
+    }
+    return *this;
+}
+
+// elementwise matrix addition
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator +(const MatrixRC<T,R,C>& b) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] + b.v[i][j];
+        }
+    }
+    return r;
+}
+
+// elementwise matrix subtraction
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::operator -(const MatrixRC<T,R,C>& b) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] - b.v[i][j];
+        }
+    }
+    return r;
+}
+
+// elementwise multiplication
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult(const MatrixRC<T,R,C>& b) const{
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] * b.v[i][j];
+        }
+    }
+    return r;
+}
+
+// elementwise division
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_div(const MatrixRC<T,R,C>& b) const{
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] / b.v[i][j];
+        }
+    }
+    return r;
+}
+
+// elementwise multiplication, matrix by vector
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult_vector_columns(const MatrixRC<T,1,C>& b) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] * b.v[0][j];
+        }
+    }
+    return r;
+}
+template MatrixRC<double,4,12> MatrixRC<double,4,12>::per_element_mult_vector_columns(const MatrixRC<double,1,12>& b) const;
+
+// elementwise division, matrix by vector
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult_vector_rows(const MatrixRC<T,R,1>& b) const {
+    MatrixRC<T,R,C> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[i][j] = v[i][j] * b.v[i][0];
+        }
+    }
+    return r;
+}
+template MatrixRC<double,25,12> MatrixRC<double,25,12>::per_element_mult_vector_rows(const MatrixRC<double,25,1>& b) const;
+
+// dot product
+template <typename T, uint8_t R, uint8_t C>
+T MatrixRC<T,R,C>::dot(const MatrixRC<T,R,C>& b) const {
+    T r = 0;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r +=  v[i][j] * b.v[i][j];
+        }
+    }
+    return r;
+}
+
+// transpose
+template <typename T, uint8_t R, uint8_t C>
+MatrixRC<T,C,R> MatrixRC<T,R,C>::transposed() const {
+    MatrixRC<T,C,R> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < C; j++) {
+            r.v[j][i] = v[i][j];
+        }
+    }
+    return r;
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+// print matrix to console for debugging
+template <typename T, uint8_t R, uint8_t C>
+void MatrixRC<T,R,C>::print(const char* name) const {
+    hal.console->printf("Matrix: %s [%u,%u]\n", name, R, C);
+    for (uint8_t i = 0; i < R; i++) {
+        hal.console->printf("\t");
+        for (uint8_t j = 0; j < C; j++) {
+            hal.console->printf("%+0.4f", v[i][j]);
+            if (j < (C - 1)) {
+                hal.console->printf(", ");
+            }
+        }
+        hal.console->printf("\n");
+    }
+}
+#endif
+
+template class MatrixRC<double, 1, 4>;
+template class MatrixRC<double, 4, 1>;
+template class MatrixRC<double, 12, 1>;
+template class MatrixRC<double, 12, 4>;
+template class MatrixRC<double, 12, 12>;
+template class MatrixRC<double, 25, 1>;
+
+// perform Cholesky decomposition in place
+// Note that this method does not zero the upper triangle
+// No need with forward_sub and backward_sub implementation
+template <typename T, uint8_t R>
+MatrixRC<T,R,R> cholesky(const MatrixRC<T,R,R>& b) {
+    MatrixRC<T,R,R> x = b;
+    for (uint8_t i = 0; i < R; i++) {
+        x.v[i][i] = sqrt(x.v[i][i]);
+        for (uint8_t j = i+1; j < R; j++) {
+            x.v[j][i] /= x.v[i][i];
+        }
+        for (uint8_t k = i+1; k < R; k++) {
+            for (uint8_t j = k; j < R; j++) {
+                x.v[j][k] -= x.v[j][i]*x.v[k][i];
+            }
+        }
+    }
+    return x;
+}
+template MatrixRC<double,12,12> cholesky<double,12>(const MatrixRC<double,12,12>& b);
+
+// forward substitution
+// equivelent to: x = a \ b if a is lower triangular
+template <typename T, uint8_t R>
+MatrixRC<T,R,1> forward_sub(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& b) {
+    MatrixRC<T,R,1> x;
+    for (uint8_t i = 0; i < R; i++) {
+        x.v[i][0] = b.v[i][0];
+        for (uint8_t j = 0; j < i; j++) {
+            x.v[i][0] -= a.v[i][j] * x.v[j][0];
+        }
+        x.v[i][0] /= a.v[i][i];
+    }
+    return x;
+}
+template MatrixRC<double,12,1> forward_sub<double,12>(const MatrixRC<double,12,12>& a, const MatrixRC<double,12,1>& b);
+
+// backwards substitution, transposing a
+// equivelent to: x = a' \ b if a is lower triangular
+template <typename T, uint8_t R>
+MatrixRC<T,R,1> backward_sub_t(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& b) {
+    MatrixRC<T,R,1> x;
+    for (int8_t i = R-1; i >= 0; i--) {
+        x.v[i][0] = b.v[i][0];
+        for (int8_t j = R-1; j > i; j--) {
+            x.v[i][0] -= a.v[j][i]*x.v[j][0];
+        }
+        x.v[i][0] /= a.v[i][i];
+    }
+    return x;
+}
+template MatrixRC<double,12,1> backward_sub_t<double,12>(const MatrixRC<double,12,12>& a, const MatrixRC<double,12,1>& b);
+
+// matrix multiplication
+template <typename T, uint8_t R, uint8_t C, uint8_t J>
+MatrixRC<T,R,J> matrix_multiply(const MatrixRC<T,R,C>&a, const MatrixRC<T,C,J>& b) {
+    MatrixRC<T,R,J> r;
+    for (uint8_t i = 0; i < R; i++) {
+        for (uint8_t j = 0; j < J; j++) {
+            for (uint8_t k = 0; k < C; k++) {
+                r.v[i][j] += a.v[i][k] * b.v[k][j];
+            }
+        }
+    }
+    return r;
+}
+template MatrixRC<double,12,12> matrix_multiply<double,12,4,12>(const MatrixRC<double,12,4>&a, const MatrixRC<double,4,12>& b);
+template MatrixRC<double,12,1> matrix_multiply<double,12,4,1>(const MatrixRC<double,12,4>&a, const MatrixRC<double,4,1>& b);
+template MatrixRC<double,12,1> matrix_multiply<double,12,12,1>(const MatrixRC<double,12,12>&a, const MatrixRC<double,12,1>& b);

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -9,18 +9,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-// get and set with ()
-template <typename T, uint8_t R, uint8_t C>
-T& MatrixRC<T,R,C>::operator () (uint8_t i, uint8_t j) {
-    return v[i][j];
-}
-
-// const getter
-template <typename T, uint8_t R, uint8_t C>
-const T& MatrixRC<T,R,C>::operator () (uint8_t i, uint8_t j) const {
-    return v[i][j];
-}
-
 // set all values
 template <typename T, uint8_t R, uint8_t C>
 MatrixRC<T,R,C> &MatrixRC<T,R,C>::operator =(const T num) {

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -172,7 +172,7 @@ MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult_vector_columns(const MatrixRC<
     }
     return r;
 }
-template MatrixRC<double,4,12> MatrixRC<double,4,12>::per_element_mult_vector_columns(const MatrixRC<double,1,12>& b) const;
+template MatrixRC<float,4,12> MatrixRC<float,4,12>::per_element_mult_vector_columns(const MatrixRC<float,1,12>& b) const;
 
 // elementwise division, matrix by vector
 template <typename T, uint8_t R, uint8_t C>
@@ -185,7 +185,7 @@ MatrixRC<T,R,C> MatrixRC<T,R,C>::per_element_mult_vector_rows(const MatrixRC<T,R
     }
     return r;
 }
-template MatrixRC<double,25,12> MatrixRC<double,25,12>::per_element_mult_vector_rows(const MatrixRC<double,25,1>& b) const;
+template MatrixRC<float,25,12> MatrixRC<float,25,12>::per_element_mult_vector_rows(const MatrixRC<float,25,1>& b) const;
 
 // dot product
 template <typename T, uint8_t R, uint8_t C>
@@ -229,12 +229,12 @@ void MatrixRC<T,R,C>::print(const char* name) const {
 }
 #endif
 
-template class MatrixRC<double, 1, 4>;
-template class MatrixRC<double, 4, 1>;
-template class MatrixRC<double, 12, 1>;
-template class MatrixRC<double, 12, 4>;
-template class MatrixRC<double, 12, 12>;
-template class MatrixRC<double, 25, 1>;
+template class MatrixRC<float, 1, 4>;
+template class MatrixRC<float, 4, 1>;
+template class MatrixRC<float, 12, 1>;
+template class MatrixRC<float, 12, 4>;
+template class MatrixRC<float, 12, 12>;
+template class MatrixRC<float, 25, 1>;
 
 // perform Cholesky decomposition in place
 // Note that this method does not zero the upper triangle
@@ -256,7 +256,7 @@ MatrixRC<T,R,R> cholesky(const MatrixRC<T,R,R>& b) {
     }
     return x;
 }
-template MatrixRC<double,12,12> cholesky<double,12>(const MatrixRC<double,12,12>& b);
+template MatrixRC<float,12,12> cholesky<float,12>(const MatrixRC<float,12,12>& b);
 
 // forward substitution
 // equivelent to: x = a \ b if a is lower triangular
@@ -272,7 +272,7 @@ MatrixRC<T,R,1> forward_sub(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& b) 
     }
     return x;
 }
-template MatrixRC<double,12,1> forward_sub<double,12>(const MatrixRC<double,12,12>& a, const MatrixRC<double,12,1>& b);
+template MatrixRC<float,12,1> forward_sub<float,12>(const MatrixRC<float,12,12>& a, const MatrixRC<float,12,1>& b);
 
 // backwards substitution, transposing a
 // equivelent to: x = a' \ b if a is lower triangular
@@ -288,7 +288,7 @@ MatrixRC<T,R,1> backward_sub_t(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& 
     }
     return x;
 }
-template MatrixRC<double,12,1> backward_sub_t<double,12>(const MatrixRC<double,12,12>& a, const MatrixRC<double,12,1>& b);
+template MatrixRC<float,12,1> backward_sub_t<float,12>(const MatrixRC<float,12,12>& a, const MatrixRC<float,12,1>& b);
 
 // matrix multiplication
 template <typename T, uint8_t R, uint8_t C, uint8_t J>
@@ -303,6 +303,6 @@ MatrixRC<T,R,J> matrix_multiply(const MatrixRC<T,R,C>&a, const MatrixRC<T,C,J>& 
     }
     return r;
 }
-template MatrixRC<double,12,12> matrix_multiply<double,12,4,12>(const MatrixRC<double,12,4>&a, const MatrixRC<double,4,12>& b);
-template MatrixRC<double,12,1> matrix_multiply<double,12,4,1>(const MatrixRC<double,12,4>&a, const MatrixRC<double,4,1>& b);
-template MatrixRC<double,12,1> matrix_multiply<double,12,12,1>(const MatrixRC<double,12,12>&a, const MatrixRC<double,12,1>& b);
+template MatrixRC<float,12,12> matrix_multiply<float,12,4,12>(const MatrixRC<float,12,4>&a, const MatrixRC<float,4,12>& b);
+template MatrixRC<float,12,1> matrix_multiply<float,12,4,1>(const MatrixRC<float,12,4>&a, const MatrixRC<float,4,1>& b);
+template MatrixRC<float,12,1> matrix_multiply<float,12,12,1>(const MatrixRC<float,12,12>&a, const MatrixRC<float,12,1>& b);

--- a/libraries/AP_Math/matrixRC.cpp
+++ b/libraries/AP_Math/matrixRC.cpp
@@ -243,7 +243,7 @@ template <typename T, uint8_t R>
 MatrixRC<T,R,R> cholesky(const MatrixRC<T,R,R>& b) {
     MatrixRC<T,R,R> x = b;
     for (uint8_t i = 0; i < R; i++) {
-        x.v[i][i] = sqrt(x.v[i][i]);
+        x.v[i][i] = sqrtf(x.v[i][i]);
         T ii_inv = 1.0 / x.v[i][i];
         for (uint8_t j = i+1; j < R; j++) {
             x.v[j][i] *= ii_inv;

--- a/libraries/AP_Math/matrixRC.h
+++ b/libraries/AP_Math/matrixRC.h
@@ -1,0 +1,62 @@
+/*
+ *  R x C rectangular matrix operations
+ */
+
+#pragma once
+
+#include "math.h"
+#include <stdint.h>
+#include <AP_HAL/AP_HAL.h>
+
+template <typename T, uint8_t R, uint8_t C>
+class MatrixRC {
+public:
+    // constructor to zeros
+    MatrixRC<T,R,C>() {
+        memset(v, 0, sizeof(v));
+    }
+
+    T& operator () (uint8_t i, uint8_t j);
+    const T&operator() (uint8_t i, uint8_t j) const;
+
+    MatrixRC<T,R,C> &operator =(const T num);
+    MatrixRC<T,R,C> &operator *=(const T num);
+
+    MatrixRC<T,R,C> operator *(const T num) const;
+    MatrixRC<T,R,C> operator +(const T num) const;
+    MatrixRC<T,R,C> operator -(const T num) const;
+
+    MatrixRC<T,R,C> &operator +=(const MatrixRC<T,R,C>& b);
+    MatrixRC<T,R,C> &operator -=(const MatrixRC<T,R,C>& b);
+
+    MatrixRC<T,R,C> operator +(const MatrixRC<T,R,C>& b) const;
+    MatrixRC<T,R,C> operator -(const MatrixRC<T,R,C>& b) const;
+
+    MatrixRC<T,R,C> per_element_mult(const MatrixRC<T,R,C>& b) const;
+    MatrixRC<T,R,C> per_element_div(const MatrixRC<T,R,C>& b) const;
+
+    MatrixRC<T,R,C> per_element_mult_vector_columns(const MatrixRC<T,1,C>& b) const;
+    MatrixRC<T,R,C> per_element_mult_vector_rows(const MatrixRC<T,R,1>& b) const;
+
+    T dot(const MatrixRC<T,R,C>& b) const;
+
+    MatrixRC<T,C,R> transposed() const;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    void print(const char* name) const;
+#endif
+
+    T v[R][C];
+};
+
+template <typename T, uint8_t R>
+MatrixRC<T,R,R> cholesky(const MatrixRC<T,R,R>& b);
+
+template <typename T, uint8_t R>
+MatrixRC<T,R,1> forward_sub(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& b);
+
+template <typename T, uint8_t R>
+MatrixRC<T,R,1> backward_sub_t(const MatrixRC<T,R,R>& a, const MatrixRC<T,R,1>& b);
+
+template <typename T, uint8_t R, uint8_t C, uint8_t J>
+MatrixRC<T,R,J> matrix_multiply(const MatrixRC<T,R,C> &a, const MatrixRC<T,C,J> &b);

--- a/libraries/AP_Math/matrixRC.h
+++ b/libraries/AP_Math/matrixRC.h
@@ -34,6 +34,7 @@ public:
 
     MatrixRC<T,R,C> per_element_mult(const MatrixRC<T,R,C>& b) const;
     MatrixRC<T,R,C> per_element_div(const MatrixRC<T,R,C>& b) const;
+    MatrixRC<T,R,C> per_element_inv() const;
 
     MatrixRC<T,R,C> per_element_mult_vector_columns(const MatrixRC<T,1,C>& b) const;
     MatrixRC<T,R,C> per_element_mult_vector_rows(const MatrixRC<T,R,1>& b) const;

--- a/libraries/AP_Math/matrixRC.h
+++ b/libraries/AP_Math/matrixRC.h
@@ -16,9 +16,6 @@ public:
         memset(v, 0, sizeof(v));
     }
 
-    T& operator () (uint8_t i, uint8_t j);
-    const T&operator() (uint8_t i, uint8_t j) const;
-
     MatrixRC<T,R,C> &operator =(const T num);
     MatrixRC<T,R,C> &operator *=(const T num);
 

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -13,3 +13,4 @@
 #include "AP_Motors6DOF.h"
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
 #include "AP_MotorsMatrix_Scripting_Dynamic.h"
+#include "AP_MotorsMatrix_Optimal.h"

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -16,6 +16,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_MotorsMatrix.h"
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -1289,6 +1290,29 @@ void AP_MotorsMatrix::disable_yaw_torque(void)
         _yaw_factor[i] = 0;
     }
 }
+
+#if APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+// examples can pull values direct
+float AP_MotorsMatrix::get_thrust_rpyt_out(uint8_t i)
+{
+    if (i < AP_MOTORS_MAX_NUM_MOTORS) {
+        return _thrust_rpyt_out[i];
+    }
+    return 0.0;
+}
+
+bool AP_MotorsMatrix::get_factors(uint8_t i, float &roll, float &pitch, float &yaw, float &throttle)
+{
+    if ((i < AP_MOTORS_MAX_NUM_MOTORS) && motor_enabled[i]) {
+        roll = _roll_factor[i];
+        pitch = _pitch_factor[i];
+        yaw = _yaw_factor[i];
+        throttle = _throttle_factor[i];
+        return true;
+    }
+    return false;
+}
+#endif
 
 // singleton instance
 AP_MotorsMatrix *AP_MotorsMatrix::_singleton;

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -101,6 +101,10 @@ public:
     };
     void add_motors_raw(const struct MotorDefRaw *motors, uint8_t num_motors);
 
+    // pull values direct, (examples only)
+    float get_thrust_rpyt_out(uint8_t i);
+    bool get_factors(uint8_t i, float &roll, float &pitch, float &yaw, float &throttle);
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
@@ -20,6 +20,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_InternalError/AP_InternalError.h>
 
+#pragma GCC diagnostic error "-Wframe-larger-than=4500"
+
 extern const AP_HAL::HAL& hal;
 
 void AP_MotorsMatrix_Optimal::init(motor_frame_class frame_class, motor_frame_type frame_type)

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
@@ -326,12 +326,17 @@ void AP_MotorsMatrix_Optimal::interior_point_solve(const MatrixRC<double,max_num
         z -= dz*alpha*eta;
         s -= ds*alpha*eta;
 
-        // Update rhs and mu
-        rL = matrix_multiply(H,x) + f - A_mult(z);
-        rs = s - At_mult(x) + b;
+        // Update rhs and mu, checking for convergence
         mu = z.dot(s);
-
-        if ((mu < tol_nA) || (rL.dot(rL) < tol_sq) || (rs.dot(rs) < tol_sq)) {
+        if (mu < tol_nA) {
+            break;
+        }
+        rs = s - At_mult(x) + b;
+        if (rs.dot(rs) < tol_sq) {
+            break;
+        }
+        rL = matrix_multiply(H,x) + f - A_mult(z);
+        if (rL.dot(rL) < tol_sq) {
             break;
         }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.cpp
@@ -1,0 +1,351 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_MotorsMatrix_Optimal.h"
+
+#if HAL_HAVE_HARDWARE_DOUBLE
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_InternalError/AP_InternalError.h>
+
+extern const AP_HAL::HAL& hal;
+
+void AP_MotorsMatrix_Optimal::init(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    AP_MotorsMatrix::init(frame_class, frame_type);
+    if (!initialised_ok()) {
+        // underlying class must init correctly
+        return;
+    }
+
+    if (frame_class == MOTOR_FRAME_SCRIPTING_MATRIX) {
+        // Scripting frame class not supported
+        // Scripting is setup to use the AP_MotorsMatrix singleton, which wont exist if were here.
+        // So there is no way for scripting to setup the motors, once we fix that it should work well...
+        set_initialised_ok(false);
+        return;
+    }
+
+    // conversion factors so the new mix comes out close to the old
+    // should reduce the need to re-tune, I have not calculated them all yet...
+    // there may be some way to derive from the motor matrix, but I can't work it out
+    // these are still not a perfect conversion, I'm not sure why....
+    // may also need a yaw conversion for the A V and tail frames... but there quads so this mixer won't help much in anycase
+    float roll_conversion; 
+    float pitch_conversion;
+    switch (frame_class) {
+        case MOTOR_FRAME_QUAD: {
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_PLUS:
+                    roll_conversion = 0.5;
+                    pitch_conversion = 0.5;
+                    break;
+                case MOTOR_FRAME_TYPE_X:
+                    roll_conversion = 1.0;
+                    pitch_conversion = 1.0;
+                    break;
+                default:
+                    return;
+            }
+            break;
+        }
+        case MOTOR_FRAME_HEXA: {
+            switch (frame_type) {
+                 case MOTOR_FRAME_TYPE_X:
+                    roll_conversion = 0.75;
+                    pitch_conversion = 1.0;
+                    break;
+                default:
+                    return;
+            }
+            break;
+        }
+        case MOTOR_FRAME_OCTA: {
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_X:
+                    roll_conversion = 1.1715728;
+                    pitch_conversion = 1.1715728;
+                    break;
+                default:
+                    return;
+            }
+            break;
+        }
+        case MOTOR_FRAME_OCTAQUAD: {
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_X:
+                    roll_conversion = 2.0;
+                    pitch_conversion = 2.0;
+                    break;
+                default:
+                    return;
+            }
+            break;
+        }
+        case MOTOR_FRAME_DODECAHEXA: {
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_X:
+                    roll_conversion = 1.5;
+                    pitch_conversion = 2.0;
+                    break;
+                default:
+                    return;
+            }
+            break;
+        }
+        default:
+            return;
+    }
+
+    // convert motor factors to matrix format
+    uint8_t num_motors = 0;
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        if (motor_enabled[i]) {
+            motor_factors(i, 0) = _roll_factor[i] / roll_conversion;
+            motor_factors(i, 1) = _pitch_factor[i] / pitch_conversion;
+            motor_factors(i, 2) = _yaw_factor[i];
+            motor_factors(i, 3) = _throttle_factor[i];
+            num_motors++;
+        }
+    }
+
+    // Weighting vector defines the relative weighting of roll, pitch, yaw and throttle
+    // may want to change this on the fly in the future, but in that case we can no longer pre-compute the hessian
+    MatrixRC<double,1,4> w;
+    w(0, 0) = 15.0; // roll
+    w(0, 1) = 15.0; // pitch
+    w(0, 2) = 15.0; // yaw
+    w(0, 3) = 1.0;  // throttle
+
+    // setup hessian matrix
+    H = matrix_multiply(motor_factors.per_element_mult_vector_columns(w), motor_factors.transposed());
+    for (uint8_t i = num_motors; i < max_num_motors; i++) {
+        H(i,i) = 1.0; // populate remaining diagonals to ensure positive definite matrix
+    }
+
+    // setup constraints
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        A.average_throttle(i, 0) = -motor_factors(i, 3) / num_motors;
+        if (motor_enabled[i]) {
+            A.max_throttle(i, 0) = -1.0;
+            A.min_throttle(i, 0) =  1.0;
+        }
+    }
+
+    // re-scale by weights to save runtime calculation
+    w(0, 3) *= num_motors;
+    w *= -1;
+    motor_factors = motor_factors.per_element_mult_vector_columns(w);
+
+}
+
+
+// output - sends commands to the motors, 
+void AP_MotorsMatrix_Optimal::output_armed_stabilizing()
+{
+    if (!initialised_ok()) {
+        AP_MotorsMatrix::output_armed_stabilizing();
+        return;
+    }
+
+    // apply voltage and air pressure compensation
+    const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
+    const float roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
+    const float pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
+    const float yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
+    float throttle_thrust = get_throttle() * compensation_gain;
+    float throttle_avg_max = _throttle_avg_max * compensation_gain;
+
+    // If thrust boost is active then do not limit maximum thrust
+    const float throttle_thrust_max = _thrust_boost_ratio + (1.0 - _thrust_boost_ratio) * _throttle_thrust_max * compensation_gain;
+
+    // sanity check throttle is above zero and below current limited throttle
+    if (throttle_thrust <= 0.0) {
+        throttle_thrust = 0.0;
+        limit.throttle_lower = true;
+    }
+    if (throttle_thrust >= throttle_thrust_max) {
+        throttle_thrust = throttle_thrust_max;
+        limit.throttle_upper = true;
+    }
+
+    // ensure that throttle_avg_max is between the input throttle and the maximum throttle
+    throttle_avg_max = constrain_float(throttle_avg_max, throttle_thrust, throttle_thrust_max);
+
+    // set roll, pitch, yaw and throttle input value
+    MatrixRC<double,4,1> input;
+    input(0, 0) = roll_thrust;
+    input(1, 0) = pitch_thrust;
+    input(2, 0) = yaw_thrust;
+    input(3, 0) = throttle_thrust;
+
+    // input matrix
+    MatrixRC<double,max_num_motors,1> f = matrix_multiply(motor_factors, input);
+
+    // constraints, average throttle, 1 and 0
+    MatrixRC<double,num_constraints,1> b;
+    b(0, 0) = -throttle_avg_max;
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        if (motor_enabled[i]) {
+            b(1+i, 0) = -1.0; // could set this to 0 if a failed motor is detected
+        }
+    }
+
+    // the clever bit
+    MatrixRC<double,max_num_motors,1> out = interior_point_solve(f, b);
+
+    // copy to motor outputs
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] = out(i,0);
+        }
+    }
+
+    // note that this does not do anything with the limit flags, we could set a threshold on desired vs achieved output.
+    // hopefully limit flags will be triggered much less often in anycase...
+}
+
+// sparse A matrix handling
+// x = A * B
+MatrixRC<double,AP_MotorsMatrix_Optimal::max_num_motors,1> AP_MotorsMatrix_Optimal::A_mult(const MatrixRC<double,num_constraints,1>& B) const
+{
+    MatrixRC<double,max_num_motors,1> x;
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        x(i,0) = A.average_throttle(i,0)*B(0,0) + A.max_throttle(i,0)*B(1+i,0) + A.min_throttle(i,0)*B(1+max_num_motors+i,0);
+    }
+    return x;
+}
+
+// x = A' * B
+MatrixRC<double,AP_MotorsMatrix_Optimal::num_constraints,1> AP_MotorsMatrix_Optimal::At_mult(const MatrixRC<double,max_num_motors,1>& B) const
+{
+    MatrixRC<double,num_constraints,1> x;
+    x(0,0) = A.average_throttle.dot(B);
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        x(1+i,0) = A.max_throttle(i,0)*B(i,0);
+        x(1+max_num_motors+i,0) = A.min_throttle(i,0)*B(i,0);
+    }
+    return x;
+}
+
+// x = A*diag(B)*A'
+MatrixRC<double,AP_MotorsMatrix_Optimal::max_num_motors,AP_MotorsMatrix_Optimal::max_num_motors> AP_MotorsMatrix_Optimal::A_mult_b_mult_At(const MatrixRC<double,num_constraints,1>& B) const
+{
+    MatrixRC<double,max_num_motors,max_num_motors> x;
+    for (uint8_t i = 0; i < max_num_motors; i++) {
+        for (uint8_t j = 0; j < max_num_motors; j++) {
+            x(i,j) = A.average_throttle(i,0) * A.average_throttle(j,0) * B(0,0);
+            if (i == j) {
+                x(i,j) += A.max_throttle(i,0)*A.max_throttle(j,0)*B(j+1,0) + A.min_throttle(i,0)*A.min_throttle(j,0)*B(j+max_num_motors+1,0);
+            }
+        }
+    }
+    return x;
+}
+
+// interior point method quadratic programming solver
+// Inspired by: https://github.com/jarredbarber/eigen-QP
+// solves min( 0.5*x'Hx + f'x )
+// with constraints A'x >= b
+MatrixRC<double,AP_MotorsMatrix_Optimal::max_num_motors,1> AP_MotorsMatrix_Optimal::interior_point_solve(const MatrixRC<double,max_num_motors,1> &f, const MatrixRC<double,num_constraints,1> &b) const
+{
+    const double eta = 0.95;
+
+    // init matrix size
+    MatrixRC<double,max_num_motors,1> x;
+    MatrixRC<double,num_constraints,1> z;
+    MatrixRC<double,num_constraints,1> s;
+    MatrixRC<double,num_constraints,1> z_rs;
+    MatrixRC<double,max_num_motors,1> rL;
+    MatrixRC<double,num_constraints,1> rs;
+    MatrixRC<double,num_constraints,1> rsz;
+    MatrixRC<double,max_num_motors,max_num_motors> H_bar;
+    MatrixRC<double,max_num_motors,1> f_bar;
+    MatrixRC<double,max_num_motors,1> dx;
+    MatrixRC<double,num_constraints,1> dz;
+    MatrixRC<double,num_constraints,1> ds;
+
+    // setup starting points
+    // x is init to 0
+    z = 1.0;
+    s = 1.0;
+
+    // compute residuals
+    rL = f - A_mult(z);
+    rs = s + b;
+    rsz = 1.0;
+    double mu = num_constraints;
+
+    constexpr double tol = 1e-6;
+    constexpr double tol_sq = tol * tol;
+    constexpr double tol_nA = tol * num_constraints;
+    // limit to 15 iterations
+    for (uint8_t k = 0; k < 15; k++) {
+
+        // Pre-decompose to speed up solve
+        H_bar = cholesky(H + A_mult_b_mult_At(z.per_element_div(s)));
+        z_rs = z.per_element_mult(rs);
+
+        double alpha;
+        for (uint8_t i = 0; i < 2; i++) {
+            // centring on fist iteration, correction on second
+
+            // Solve system
+            f_bar = rL + A_mult((rsz - z_rs).per_element_div(s));
+            dx = backward_sub_t(H_bar, forward_sub(H_bar,f_bar));
+            ds = At_mult(dx) + rs;
+            dz = (rsz - z.per_element_mult(ds)).per_element_div(s);
+
+            // Compute alpha
+            alpha = 1.0;
+            for (uint8_t j = 0; j < num_constraints; j++) {
+                if (dz(j,0) > 0) {
+                    alpha = MIN(alpha, z(j,0)/dz(j,0));
+                }
+                if (ds(j,0) > 0) {
+                    alpha = MIN(alpha, s(j,0)/ds(j,0));
+                }
+            }
+
+            if (i == 1) {
+                break;
+            }
+
+            // affine duality gap
+            double mu_a = (z-dz*alpha).dot(s-(ds*alpha));
+
+            // apply centring parameter
+            rsz += ds.per_element_mult(dz) - ((mu_a*mu_a*mu_a)/(mu*mu*num_constraints));
+
+        }
+        // Update x, z, s
+        x -= dx*alpha*eta;
+        z -= dz*alpha*eta;
+        s -= ds*alpha*eta;
+
+        // Update rhs and mu
+        rL = matrix_multiply(H,x) + f - A_mult(z);
+        rs = s - At_mult(x) + b;
+        rsz = s.per_element_mult(z);
+        mu = z.dot(s);
+
+        if ((mu < tol_nA) || (rL.dot(rL) < tol_sq) || (rs.dot(rs) < tol_sq)) {
+            break;
+        }
+    }
+    return x;
+}
+
+#endif // HAL_HAVE_HARDWARE_DOUBLE

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
@@ -40,7 +40,7 @@ private:
     // sparse constraints matrix handling
     MatrixRC<float,max_num_motors,1> A_mult(const MatrixRC<float,num_constraints,1>& B) const;
     MatrixRC<float,num_constraints,1> At_mult(const MatrixRC<float,max_num_motors,1>& B) const;
-    MatrixRC<float,max_num_motors,max_num_motors> A_mult_b_mult_At(const MatrixRC<float,num_constraints,1>& B) const;
+    MatrixRC<float,max_num_motors,max_num_motors> H_plus_A_mult_b_mult_At(const MatrixRC<float,num_constraints,1>& B) const;
 
     // solver
     void interior_point_solve(const MatrixRC<float,max_num_motors,1> &f, const MatrixRC<float,num_constraints,1> &b);

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
@@ -46,7 +46,21 @@ private:
     MatrixRC<double,max_num_motors,max_num_motors> A_mult_b_mult_At(const MatrixRC<double,num_constraints,1>& B) const;
 
     // solver
-    MatrixRC<double,max_num_motors,1> interior_point_solve(const MatrixRC<double,max_num_motors,1> &f, const MatrixRC<double,num_constraints,1> &b) const;
+    void interior_point_solve(const MatrixRC<double,max_num_motors,1> &f, const MatrixRC<double,num_constraints,1> &b);
+
+    // interior_point_solve function local variables, global to avoid frame size error
+    MatrixRC<double,max_num_motors,1> x;
+    MatrixRC<double,num_constraints,1> z;
+    MatrixRC<double,num_constraints,1> s;
+    MatrixRC<double,num_constraints,1> z_rs;
+    MatrixRC<double,max_num_motors,1> rL;
+    MatrixRC<double,num_constraints,1> rs;
+    MatrixRC<double,num_constraints,1> rsz;
+    MatrixRC<double,max_num_motors,max_num_motors> H_bar;
+    MatrixRC<double,max_num_motors,1> f_bar;
+    MatrixRC<double,max_num_motors,1> dx;
+    MatrixRC<double,num_constraints,1> dz;
+    MatrixRC<double,num_constraints,1> ds;
 
 };
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
@@ -52,6 +52,7 @@ private:
     MatrixRC<double,max_num_motors,1> x;
     MatrixRC<double,num_constraints,1> z;
     MatrixRC<double,num_constraints,1> s;
+    MatrixRC<double,num_constraints,1> s_inv;
     MatrixRC<double,num_constraints,1> z_rs;
     MatrixRC<double,max_num_motors,1> rL;
     MatrixRC<double,num_constraints,1> rs;

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL_Boards.h>
-#if HAL_HAVE_HARDWARE_DOUBLE
-
 #include "AP_MotorsMatrix.h"
 #include <AP_Math/matrixRC.h>
 
@@ -21,10 +18,10 @@ private:
     static constexpr uint8_t num_constraints = (max_num_motors*2) + 1;
 
     // motor output factors
-    MatrixRC<double,max_num_motors,4> motor_factors;
+    MatrixRC<float,max_num_motors,4> motor_factors;
 
     // Hessian matrix
-    MatrixRC<double,max_num_motors,max_num_motors> H;
+    MatrixRC<float,max_num_motors,max_num_motors> H;
 
     // sparse representation of constraints matrix
     // full size matrix would be [max_num_motors, num_constraints]
@@ -35,35 +32,33 @@ private:
     // 1 0 0 1 0 0 0 1 0
     // 1 0 0 0 1 0 0 0 1
     struct sparse_A {
-        MatrixRC<double,max_num_motors,1> average_throttle;
-        MatrixRC<double,max_num_motors,1> max_throttle;
-        MatrixRC<double,max_num_motors,1> min_throttle;
+        MatrixRC<float,max_num_motors,1> average_throttle;
+        MatrixRC<float,max_num_motors,1> max_throttle;
+        MatrixRC<float,max_num_motors,1> min_throttle;
     } A;
 
     // sparse constraints matrix handling
-    MatrixRC<double,max_num_motors,1> A_mult(const MatrixRC<double,num_constraints,1>& B) const;
-    MatrixRC<double,num_constraints,1> At_mult(const MatrixRC<double,max_num_motors,1>& B) const;
-    MatrixRC<double,max_num_motors,max_num_motors> A_mult_b_mult_At(const MatrixRC<double,num_constraints,1>& B) const;
+    MatrixRC<float,max_num_motors,1> A_mult(const MatrixRC<float,num_constraints,1>& B) const;
+    MatrixRC<float,num_constraints,1> At_mult(const MatrixRC<float,max_num_motors,1>& B) const;
+    MatrixRC<float,max_num_motors,max_num_motors> A_mult_b_mult_At(const MatrixRC<float,num_constraints,1>& B) const;
 
     // solver
-    void interior_point_solve(const MatrixRC<double,max_num_motors,1> &f, const MatrixRC<double,num_constraints,1> &b);
+    void interior_point_solve(const MatrixRC<float,max_num_motors,1> &f, const MatrixRC<float,num_constraints,1> &b);
 
     // interior_point_solve function local variables, global to avoid frame size error
-    MatrixRC<double,max_num_motors,1> x;
-    MatrixRC<double,num_constraints,1> z;
-    MatrixRC<double,num_constraints,1> s;
-    MatrixRC<double,num_constraints,1> s_inv;
-    MatrixRC<double,num_constraints,1> z_rs;
-    MatrixRC<double,max_num_motors,1> rL;
-    MatrixRC<double,num_constraints,1> rs;
-    MatrixRC<double,num_constraints,1> rsz;
-    MatrixRC<double,max_num_motors,max_num_motors> H_bar;
-    MatrixRC<double,max_num_motors,1> f_bar;
-    MatrixRC<double,max_num_motors,1> dx;
-    MatrixRC<double,num_constraints,1> dz;
-    MatrixRC<double,num_constraints,1> ds;
+    MatrixRC<float,max_num_motors,1> x;
+    MatrixRC<float,num_constraints,1> z;
+    MatrixRC<float,num_constraints,1> s;
+    MatrixRC<float,num_constraints,1> s_inv;
+    MatrixRC<float,num_constraints,1> z_rs;
+    MatrixRC<float,max_num_motors,1> rL;
+    MatrixRC<float,num_constraints,1> rs;
+    MatrixRC<float,num_constraints,1> rsz;
+    MatrixRC<float,max_num_motors,max_num_motors> H_bar;
+    MatrixRC<float,max_num_motors,1> f_bar;
+    MatrixRC<float,max_num_motors,1> dx;
+    MatrixRC<float,num_constraints,1> dz;
+    MatrixRC<float,num_constraints,1> ds;
 
 };
-
-#endif // HAL_HAVE_HARDWARE_DOUBLE
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_Optimal.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+#if HAL_HAVE_HARDWARE_DOUBLE
+
+#include "AP_MotorsMatrix.h"
+#include <AP_Math/matrixRC.h>
+
+class AP_MotorsMatrix_Optimal : public AP_MotorsMatrix {
+public:
+
+    using AP_MotorsMatrix::AP_MotorsMatrix;
+
+    void init(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+    void output_armed_stabilizing() override;
+
+private:
+
+    static constexpr uint8_t max_num_motors = AP_MOTORS_MAX_NUM_MOTORS;
+    static constexpr uint8_t num_constraints = (max_num_motors*2) + 1;
+
+    // motor output factors
+    MatrixRC<double,max_num_motors,4> motor_factors;
+
+    // Hessian matrix
+    MatrixRC<double,max_num_motors,max_num_motors> H;
+
+    // sparse representation of constraints matrix
+    // full size matrix would be [max_num_motors, num_constraints]
+    // [average_throttle', diag(max_throttle), diag(min_throttle)]
+    // eg for four motors:
+    // 1 1 0 0 0 1 0 0 0
+    // 1 0 1 0 0 0 1 0 0
+    // 1 0 0 1 0 0 0 1 0
+    // 1 0 0 0 1 0 0 0 1
+    struct sparse_A {
+        MatrixRC<double,max_num_motors,1> average_throttle;
+        MatrixRC<double,max_num_motors,1> max_throttle;
+        MatrixRC<double,max_num_motors,1> min_throttle;
+    } A;
+
+    // sparse constraints matrix handling
+    MatrixRC<double,max_num_motors,1> A_mult(const MatrixRC<double,num_constraints,1>& B) const;
+    MatrixRC<double,num_constraints,1> At_mult(const MatrixRC<double,max_num_motors,1>& B) const;
+    MatrixRC<double,max_num_motors,max_num_motors> A_mult_b_mult_At(const MatrixRC<double,num_constraints,1>& B) const;
+
+    // solver
+    MatrixRC<double,max_num_motors,1> interior_point_solve(const MatrixRC<double,max_num_motors,1> &f, const MatrixRC<double,num_constraints,1> &b) const;
+
+};
+
+#endif // HAL_HAVE_HARDWARE_DOUBLE
+

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -76,7 +76,9 @@ void setup()
         if (strcmp(argv[1],"t") == 0) {
             motor_order_test();
         } else if (strcmp(argv[1],"s") == 0) {
+            uint32_t start = AP_HAL::millis();
             stability_test();
+            hal.console->printf("Took %i ms\n",AP_HAL::millis() - start);
         } else {
             ::printf("Expected single argument, 't' or 's'\n");
         }

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -3,6 +3,12 @@
  *  Code by Randy Mackay. DIYDrones.com
  */
 
+/* on Linux run with
+    ./waf configure --board linux
+    ./waf --targets examples/AP_Motors_test
+    ./build/linux/examples/AP_Motors_test
+*/
+
 // Libraries
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -11,6 +17,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <stdio.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -22,32 +29,72 @@ void stability_test();
 void update_motors();
 
 #define HELI_TEST       0   // set to 1 to test helicopters
-#define NUM_OUTPUTS     4   // set to 6 for hexacopter, 8 for octacopter and heli
+#define NUM_OUTPUTS     8   // set to 6 for hexacopter, 8 for octacopter and heli
 
 SRV_Channels srvs;
 
 // uncomment the row below depending upon what frame you are using
+// setting very slow loop rate removes the need to wait for filters, see update_motors()
 //AP_MotorsTri  motors(400);
-AP_MotorsMatrix   motors(400);
+//AP_MotorsMatrix   motors(1);
 //AP_MotorsHeli_Single motors(rc7, rsc, h1, h2, h3, h4, 400);
 //AP_MotorsSingle motors(400);
 //AP_MotorsCoax motors(400);
+AP_MotorsMatrix_Optimal motors(1);
 
 AP_BattMonitor _battmonitor{0, nullptr, nullptr};
 
 // setup
 void setup()
 {
-    hal.console->printf("AP_Motors library test ver 1.0\n");
+    hal.console->printf("AP_Motors library test ver 1.1\n");
 
     // motor initialisation
     motors.set_update_rate(490);
+#if NUM_OUTPUTS == 8
+    motors.init(AP_Motors::MOTOR_FRAME_OCTA, AP_Motors::MOTOR_FRAME_TYPE_X);
+#elif NUM_OUTPUTS == 6
+    motors.init(AP_Motors::MOTOR_FRAME_HEXA, AP_Motors::MOTOR_FRAME_TYPE_X);
+#else
     motors.init(AP_Motors::MOTOR_FRAME_QUAD, AP_Motors::MOTOR_FRAME_TYPE_X);
+#endif
 #if HELI_TEST == 0
     motors.update_throttle_range();
     motors.set_throttle_avg_max(0.5f);
 #endif
     motors.output_min();
+
+    // allow command line args for single run
+    uint8_t argc;
+    char * const *argv;
+    hal.util->commandline_arguments(argc, argv);
+    if (argc > 1) {
+        if (argc > 2) {
+            ::printf("Expected single argument, 't' or 's'\n");
+            exit(0);
+        }
+        if (strcmp(argv[1],"t") == 0) {
+            motor_order_test();
+        } else if (strcmp(argv[1],"s") == 0) {
+            stability_test();
+        } else {
+            ::printf("Expected single argument, 't' or 's'\n");
+        }
+        hal.scheduler->delay(1000);
+        exit(0);
+    }
+
+#if HELI_TEST == 0
+    ::printf("\nMotor Factors:\n");
+    ::printf("motor num, roll, pitch, yaw, throttle\n");
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        float roll, pitch, yaw, throttle;
+        if (motors.get_factors(i, roll, pitch, yaw, throttle)) {
+            ::printf("%i, %0.4f, %0.4f, %0.4f, %0.4f\n",i,roll,pitch,yaw,throttle);
+        }
+    }
+    ::printf("\n");
+#endif
 
     hal.scheduler->delay(1000);
 }
@@ -71,9 +118,11 @@ void loop()
     // test motors
     if (value == 't' || value == 'T') {
         motor_order_test();
+        hal.console->printf("finished test.\n");
     }
     if (value == 's' || value == 'S') {
         stability_test();
+        hal.console->printf("finished test.\n");
     }
 }
 
@@ -90,20 +139,18 @@ void motor_order_test()
         hal.scheduler->delay(2000);
     }
     motors.armed(false);
-    hal.console->printf("finished test.\n");
 
 }
 
 // stability_test
 void stability_test()
 {
-    int16_t roll_in, pitch_in, yaw_in, avg_out;
-    float throttle_in;
+    float roll_in, pitch_in, yaw_in, throttle_in;
 
-    int16_t throttle_tests[] = {0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000};
-    uint8_t throttle_tests_num = sizeof(throttle_tests) / sizeof(int16_t);
-    int16_t rpy_tests[] = {0, 1000, 2000, 3000, 4500, -1000, -2000, -3000, -4500};
-    uint8_t rpy_tests_num = sizeof(rpy_tests) / sizeof(int16_t);
+    float throttle_tests[] = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    uint8_t throttle_tests_num = ARRAY_SIZE(throttle_tests);
+    float rpy_tests[] = {-1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    uint8_t rpy_tests_num = ARRAY_SIZE(rpy_tests);
 
     // arm motors
     motors.armed(true);
@@ -111,11 +158,11 @@ void stability_test()
     SRV_Channels::enable_aux_servos();
 
 #if NUM_OUTPUTS <= 4
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,AvgOut,LimRP,LimY,LimThD,LimThU\n");                       // quad
+    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot1_norm,Mot2_norm,Mot3_norm,Mot4_norm,LimR,LimP,LimY,LimThD,LimThU\n");                       // quad
 #elif NUM_OUTPUTS <= 6
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,AvgOut,LimRP,LimY,LimThD,LimThU\n");             // hexa
+    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,Mot1_norm,Mot2_norm,Mot3_norm,Mot4_norm,Mot5_norm,Mot6_norm,LimR,LimP,LimY,LimThD,LimThU\n");             // hexa
 #else
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,Mot7,Mot8,AvgOut,LimRP,LimY,LimThD,LimThU\n");   // octa
+    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,Mot7,Mot8,Mot1_norm,Mot2_norm,Mot3_norm,Mot4_norm,Mot5_norm,Mot6_norm,Mot7_norm,Mot8_norm,LimR,LimP,LimY,LimThD,LimThU\n");   // octa
 #endif
 
     // run stability test
@@ -126,26 +173,25 @@ void stability_test()
                     roll_in = rpy_tests[r];
                     pitch_in = rpy_tests[p];
                     yaw_in = rpy_tests[y];
-                    throttle_in = throttle_tests[t]/1000.0f;
-                    motors.set_roll(roll_in/4500.0f);
-                    motors.set_pitch(pitch_in/4500.0f);
-                    motors.set_yaw(yaw_in/4500.0f);
+                    throttle_in = throttle_tests[t];
+                    motors.set_roll(roll_in);
+                    motors.set_pitch(pitch_in);
+                    motors.set_yaw(yaw_in);
                     motors.set_throttle(throttle_in);
                     motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
                     update_motors();
-                    avg_out = ((hal.rcout->read(0) + hal.rcout->read(1) + hal.rcout->read(2) + hal.rcout->read(3))/4);
                     // display input and output
 #if NUM_OUTPUTS <= 4
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",                // quad
+                    hal.console->printf("%0.2f,%0.2f,%0.2f,%0.2f,%d,%d,%d,%d,%0.4f,%0.4f,%0.4f,%0.4f,%d,%d,%d,%d,%d\n",                // quad
 #elif NUM_OUTPUTS <= 6
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",          // hexa
+                    hal.console->printf("%0.2f,%0.2f,%0.2f,%0.2f,%d,%d,%d,%d,%d,%d,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%d,%d,%d,%d,%d\n",          // hexa
 #else
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",    // octa
+                    hal.console->printf("%0.2f,%0.2f,%0.2f,%0.2f,%d,%d,%d,%d,%d,%d,%d,%d,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%d,%d,%d,%d,%d\n",    // octa
 #endif
-                            (int)roll_in,
-                            (int)pitch_in,
-                            (int)yaw_in,
-                            (double)throttle_in,
+                            roll_in,
+                            pitch_in,
+                            yaw_in,
+                            throttle_in,
                             (int)hal.rcout->read(0),
                             (int)hal.rcout->read(1),
                             (int)hal.rcout->read(2),
@@ -158,7 +204,18 @@ void stability_test()
                             (int)hal.rcout->read(6),
                             (int)hal.rcout->read(7),
 #endif
-                            (int)avg_out,
+                            motors.get_thrust_rpyt_out(0),
+                            motors.get_thrust_rpyt_out(1),
+                            motors.get_thrust_rpyt_out(2),
+                            motors.get_thrust_rpyt_out(3),
+#if NUM_OUTPUTS >= 6
+                            motors.get_thrust_rpyt_out(4),
+                            motors.get_thrust_rpyt_out(5),
+#endif
+#if NUM_OUTPUTS >= 8
+                            motors.get_thrust_rpyt_out(6),
+                            motors.get_thrust_rpyt_out(7),
+#endif
                             (int)motors.limit.roll,
                             (int)motors.limit.pitch,
                             (int)motors.limit.yaw,
@@ -176,13 +233,12 @@ void stability_test()
     motors.set_throttle(0);
     motors.armed(false);
 
-    hal.console->printf("finished test.\n");
 }
 
 void update_motors()
 {
-    // call update motors 1000 times to get any ramp limiting complete
-    for (uint16_t i=0; i<1000; i++) {
+    // call update motors 10 times and long loop rate to get any ramp limiting complete
+    for (uint16_t i=0; i<10; i++) {
         motors.output();
     }
 }

--- a/libraries/AP_Motors/examples/AP_Motors_test/Mixer_Compare.m
+++ b/libraries/AP_Motors/examples/AP_Motors_test/Mixer_Compare.m
@@ -1,0 +1,298 @@
+clc
+clear
+close all
+
+% generate input files with: ./build/linux/examples/AP_Motors_test s >> output.csv
+
+AP_MOTORS_MATRIX_YAW_FACTOR_CW =  -1;
+AP_MOTORS_MATRIX_YAW_FACTOR_CCW = 1;
+
+% Set matching frame type and class
+%{
+frame_definition = [ % quad plus
+      90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  2;
+     -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  4;
+       0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   1;
+     180, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3;];
+%}
+%{
+frame_definition = [ % quad x
+       45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1;
+     -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  3;
+      -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   4;
+      135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   2;];
+%}
+%{
+frame_definition = [ % hex x
+      90, AP_MOTORS_MATRIX_YAW_FACTOR_CW    2;
+     -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  5;
+     -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   6;
+     150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  3;
+      30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1;
+    -150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   4];
+%}
+%%{
+frame_definition = [ % octo X
+      22.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,   1;
+    -157.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,   5;
+      67.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  2;
+     157.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  4;
+     -22.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  8;
+    -112.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  6;
+     -67.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,   7;
+     112.5,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3];
+%}
+%{
+frame_definition = [ % octo quad x
+     45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1;
+    -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   7;
+   -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  5;
+    135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3;
+    -45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  8;
+     45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   2;
+    135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  4;
+   -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   6];
+%}
+%{
+frame_definition = [ % octo quad x
+     30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   1;
+     30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,    2;
+     90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,    3;
+     90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   4;
+    150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   5;
+    150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,    6;
+   -150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,    7;
+   -150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   8;
+    -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,   9;
+    -90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   10;
+    -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   11;
+    -30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  12];
+%}
+
+num_motors = size(frame_definition,1);
+
+% roll, pitch, yaw, throttle
+motor_factors = [cosd(frame_definition(:,1) + 90), cosd(frame_definition(:,1)), frame_definition(:,2), ones(num_motors,1)];
+motor_factors = (motor_factors ./ max(abs(motor_factors))) .* [0.5, 0.5, 0.5, 1];
+
+files = dir('*.csv');
+if isempty(files)
+    error('no .csv files found')
+end
+
+for i = numel(files):-1:1
+    results(i).raw = readmatrix(files(i).name);
+    if size(results(i).raw,2) ~= (num_motors*2) + 9
+        error('%s - found wrong number of motors', files(i).name)
+    end
+    results(i).name = extractBefore(files(i).name,'.');
+
+    results(i).roll_in = unique(results(i).raw(:,1));
+    results(i).pitch_in = unique(results(i).raw(:,2));
+    results(i).yaw_in = unique(results(i).raw(:,3));
+    results(i).throttle_in = unique(results(i).raw(:,4));
+
+    results(i).norm_out = nan(numel(results(i).roll_in),numel(results(i).pitch_in),numel(results(i).yaw_in),numel(results(i).throttle_in),num_motors);
+    results(i).achieved_output = nan(numel(results(i).roll_in),numel(results(i).pitch_in),numel(results(i).yaw_in),numel(results(i).throttle_in),4);
+    results(i).error = nan(numel(results(i).roll_in),numel(results(i).pitch_in),numel(results(i).yaw_in),numel(results(i).throttle_in),4);
+    for j = 1:size(results(i).raw,1)
+        roll_index = find(results(i).roll_in == results(i).raw(j,1));
+        pitch_index = find(results(i).pitch_in == results(i).raw(j,2));
+        yaw_index = find(results(i).yaw_in == results(i).raw(j,3));
+        throttle_index = find(results(i).throttle_in == results(i).raw(j,4));
+        if numel(roll_index) ~= 1 || numel(pitch_index) ~= 1 || numel(yaw_index) ~= 1 || numel(throttle_index) ~= 1
+            error('%s - indeing issue', files(i).name)
+        end
+        results(i).norm_out(roll_index,pitch_index,yaw_index,throttle_index,:) = results(i).raw(j,num_motors+4+(1:num_motors));
+        results(i).achieved_output(roll_index,pitch_index,yaw_index,throttle_index,:) = squeeze(results(i).norm_out(roll_index,pitch_index,yaw_index,throttle_index,:))' / motor_factors';
+        results(i).error(roll_index,pitch_index,yaw_index,throttle_index,:) = abs(squeeze(results(i).achieved_output(roll_index,pitch_index,yaw_index,throttle_index,:)) - results(i).raw(j,1:4)');
+    end
+end
+
+if  any(abs(diff([results(:).roll_in],[],2)) > 10^-6,'all') ||...
+    any(abs(diff([results(:).pitch_in],[],2)) > 10^-6,'all') ||...
+    any(abs(diff([results(:).yaw_in],[],2)) > 10^-6,'all') ||...
+    any(abs(diff([results(:).throttle_in],[],2)) > 10^-6,'all')
+    error('inputs do not match')
+end
+
+[roll_in,pitch_in] = meshgrid(results(1).roll_in,results(1).pitch_in);
+
+yaw_in = results(1).yaw_in;
+throttle_in = results(1).throttle_in;
+
+yaw_index =  ceil(numel(yaw_in)/2);
+throttle_index = ceil(numel(throttle_in)/2);
+
+[yaw_in_m, throttle_in_m] = meshgrid(yaw_in, throttle_in);
+
+
+
+%% Setup plots
+figure
+if num_motors <= 10
+    tiledlayout(2, num_motors / 2)
+else
+    tiledlayout(4, num_motors / 4)
+end
+for i = num_motors:-1:1
+    axis1(i) = nexttile(i);
+    hold all
+    title(sprintf('motor %i',i))
+    xlabel('roll in')
+    ylabel('pitch in')
+    zlim([-0.01,1.01])
+    view(3);
+end
+
+figure
+tiledlayout(2, 2)
+titles = {'roll','pitch','yaw','throttle'};
+for i = 4:-1:1
+    axis2(i) = nexttile(i);
+    hold all
+
+    if i == 1
+        surf(axis2(i),roll_in,pitch_in,roll_in,'EdgeColor','none','FaceColor','k','FaceAlpha',0.25);
+    elseif i == 2
+        surf(axis2(i),roll_in,pitch_in,pitch_in,'EdgeColor','none','FaceColor','k','FaceAlpha',0.25);
+    elseif i == 3
+        yaw_ideal = surf(axis2(i),roll_in,pitch_in,yaw_in(yaw_index)*ones(size(roll_in)),'EdgeColor','none','FaceColor','k','FaceAlpha',0.25);
+    elseif i ==4
+        throttle_ideal = surf(axis2(i),roll_in,pitch_in,throttle_in(throttle_index)*ones(size(roll_in)),'EdgeColor','none', 'FaceColor','k','FaceAlpha',0.25);
+        throttle_max = surf(axis2(i),roll_in,pitch_in,get_throttle_avg_max(throttle_in(throttle_index))*ones(size(roll_in)),'EdgeColor','none', 'FaceColor','c','FaceAlpha',0.25);
+        if get_throttle_avg_max(throttle_in(throttle_index)) == throttle_in(throttle_index)
+            set(throttle_max,'Visible','off');
+        else
+            set(throttle_max,'Visible','on');
+        end
+    end
+    title(titles(i))
+    xlabel('roll in')
+    ylabel('pitch in')
+
+    if i < 4
+        zlim([-1.01,1.01])
+    else
+        zlim([-0.01,1.01])
+    end
+
+    view(3);
+end
+
+
+
+figure
+hold all
+title('error')
+xlabel('roll in')
+ylabel('pitch in')
+zlim([0,inf])
+view(3);
+axis3 = gca;
+
+
+figure
+tiledlayout(2, 2)
+for i = 4:-1:1
+    axis4(i) = nexttile(i);
+    hold all
+    title([titles{i},' error'])
+    xlabel('roll in')
+    ylabel('pitch in')
+    zlim([0,inf])
+    view(3);
+end
+    
+hlink1 = linkprop([axis1,axis2,axis3,axis4],{'CameraPosition'});
+
+
+%% Plot outputs
+colour = 'rbgy';
+for i = 1:numel(results)
+    for j = 1:num_motors
+        results(i).motor_plots(j) = surf(axis1(j),roll_in,pitch_in,results(i).norm_out(:,:,yaw_index,throttle_index,j)','FaceColor',colour(i),'EdgeColor','k','FaceAlpha',0.5);
+    end
+    for j = 1:4
+        results(i).output_plots(j) = surf(axis2(j),roll_in,pitch_in,results(i).achieved_output(:,:,yaw_index,throttle_index,j)','FaceColor',colour(i),'EdgeColor','k','FaceAlpha',0.5);
+    end
+    results(i).error_plot = surf(axis3,roll_in,pitch_in,sum(squeeze(results(i).error(:,:,yaw_index,throttle_index,:)),3)','FaceColor',colour(i),'EdgeColor','k','FaceAlpha',0.5);
+    for j = 1:4
+        results(i).error_plots(j) = surf(axis4(j),roll_in,pitch_in,results(i).error(:,:,yaw_index,throttle_index,j)','FaceColor',colour(i),'EdgeColor','k','FaceAlpha',0.5);
+    end
+end
+legend(axis3,{results(:).name},'location','eastoutside','Interpreter','none')
+
+%% Plot throtte and yaw input plot
+
+figure
+hold all
+
+c = zeros(numel(yaw_in_m),3);
+c(sub2ind(size(yaw_in_m),throttle_index,yaw_index), :) = [1,0,0];
+
+
+input_plot = scatter(yaw_in_m(:),throttle_in_m(:),[],c,'filled');
+
+xlabel('Yaw input')
+ylabel('Throttle input')
+
+xlim([min(yaw_in_m(:)), max(yaw_in_m(:))]*1.1)
+ylim([-0.05, 1.05])
+
+while(true)
+    [x, y] = ginput(1);
+
+    [~, yaw_index] = min(abs(yaw_in-x));
+    [~, throttle_index] = min(abs(throttle_in-y));
+
+    c = zeros(numel(yaw_in_m),3);
+    c(sub2ind(size(yaw_in_m),throttle_index,yaw_index), :) = [1,0,0];
+
+    set(input_plot,'CData',c);
+
+
+    for i = 1:numel(results)
+
+        for j = 1:num_motors
+            if isvalid(results(i).motor_plots(j))
+                set(results(i).motor_plots(j),'ZData',results(i).norm_out(:,:,yaw_index,throttle_index,j)');
+            end
+        end
+        for j = 1:4
+            if isvalid(results(i).output_plots(j))
+                set(results(i).output_plots(j),'ZData',results(i).achieved_output(:,:,yaw_index,throttle_index,j)');
+            end
+        end
+        if isvalid(results(i).error_plot)
+            set(results(i).error_plot,'ZData',sum(squeeze(results(i).error(:,:,yaw_index,throttle_index,:)),3)');
+        end
+        for j = 1:4
+            if isvalid(results(i).error_plots(j))
+                set(results(i).error_plots(j),'ZData',results(i).error(:,:,yaw_index,throttle_index,j)');
+            end
+        end
+
+    end
+
+
+     if isvalid(yaw_ideal)
+         set(yaw_ideal,'ZData',yaw_in(yaw_index)*ones(size(roll_in)));
+     end
+     if isvalid(throttle_ideal) && isvalid(throttle_max)
+         set(throttle_ideal,'ZData',throttle_in(throttle_index)*ones(size(roll_in)));
+         
+         throttle_avg_max = get_throttle_avg_max(throttle_in(throttle_index));
+         set(throttle_max,'ZData',throttle_avg_max*ones(size(roll_in)));
+         if throttle_avg_max == throttle_in(throttle_index)
+             set(throttle_max,'Visible','off');
+         else
+             set(throttle_max,'Visible','on');
+         end
+     end
+end
+
+%% AP max throttle limit
+function throttle_avg_max = get_throttle_avg_max(throttle_in)
+    throttle_avg_max = max(throttle_in, 0.5);
+end


### PR DESCRIPTION
The key difference between this and the new mixer is how the constraints are applied. The current mixer constrains all motors by the maximum or minimum output. This new approach constrains each motor individually.

This is a demo and explanation, that turned out longer than I planned:
https://youtu.be/oaU7gt31oZk

The new approach should be better with high numbers of motors and for motor failure. It also allows new possibility such as imposing slew limiting at a mixer level. It also makes it much easier to trade priorities between roll, pitch, yaw and throttle.

See https://github.com/ArduPilot/ardupilot/pull/20775

This version uses fixed matrix sizes setup for the max of 12 motors, this has the advantage of not having to allocate dynamically. However it does mean that the were solving more than we need to if there are less than 12 motors. Spent lots of time optimising the maths, this now uses a sparse constraints matrix. 

Not yet tested on real hardware, should be much faster than v1, hopefully it will run. Still to be tested are different optimisation levels and inlining functions. 