### PR TITLE
AP_AccelCal: limit COMMAND_ACKs accepted for vehicle pose confirmation

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -362,15 +362,13 @@ bool AP_AccelCal::client_active(uint8_t client_num)
 }
 
 #if HAL_GCS_ENABLED
-void AP_AccelCal::handleMessage(const mavlink_message_t &msg)
+void AP_AccelCal::handle_command_ack(const mavlink_command_ack_t &packet)
 {
     if (!_waiting_for_mavlink_ack) {
         return;
     }
     _waiting_for_mavlink_ack = false;
-    if (msg.msgid == MAVLINK_MSG_ID_COMMAND_ACK) {
-        _start_collect_sample = true;
-    }
+    _start_collect_sample = true;
 }
 
 bool AP_AccelCal::gcs_vehicle_position(float position)

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -43,7 +43,7 @@ public:
     static void register_client(AP_AccelCal_Client* client);
 
 #if HAL_GCS_ENABLED
-    void handleMessage(const mavlink_message_t &msg);
+    void handle_command_ack(const mavlink_command_ack_t &packet);
 #endif
 
     // true if we are in a calibration process

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3356,9 +3356,12 @@ void GCS_MAVLINK::handle_vision_speed_estimate(const mavlink_message_t &msg)
 void GCS_MAVLINK::handle_command_ack(const mavlink_message_t &msg)
 {
 #if HAL_INS_ACCELCAL_ENABLED
+    mavlink_command_ack_t packet;
+    mavlink_msg_command_ack_decode(&msg, &packet);
+
     AP_AccelCal *accelcal = AP::ins().get_acal();
     if (accelcal != nullptr) {
-        accelcal->handleMessage(msg);
+        accelcal->handle_command_ack(packet);
     }
 #endif
 }


### PR DESCRIPTION
    On a multi-mavlink-node network COMMAND_ACKs can come from pretty much anywhere.  I struck a case where the autopilot was commanding a generator while also doing an accelcal - and the acks for the generator commands were causing the accel calibration to skip ahead before the user had a chance to pose the vehicle.
    
    This reduces the likelihood of accepting a bad COMMAND_ACK by only accepting a limited range of values in the return packet.

Tested  on a CubeOrange using MissionPlanner, QGC and MAVProxy.

Both QGC and MAVProxy really should move to the new ack-with-pose system, eliminating _gcs_snoop.

I did consider filtering acks based on source system, but the plumbing is a little awkward for that.  We'd have to pass the `mavlink_msg_t` down and may end up decoding the same thing twice.  That still might be worthwhile, but since the code should be killed with fire anyway I'm not inclined to chase it.

This work was sponsored by Harris Aerial.