### PR TITLE
improve performance when boat loiter downstream

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -216,6 +216,7 @@ protected:
     float _distance_to_destination; // distance from vehicle to final destination in meters
     bool _reached_destination;  // true once the vehicle has reached the destination
     float _desired_yaw_cd;      // desired yaw in centi-degrees.  used in Auto, Guided and Loiter
+    float _loiter_yaw_cd;
 };
 
 

--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -21,6 +21,14 @@ bool ModeLoiter::_enter()
 
 void ModeLoiter::update()
 {
+    // boat loiter downstream , use a oppsite direction of known water flow
+    if (g2.loit_type == 1 && !isnan(_loiter_yaw_cd) && 
+        fabs(wrap_180_cd(_loiter_yaw_cd - ahrs.yaw_sensor)) > 9000.0f) {
+        // run steering and throttle controllers
+        calc_steering_to_heading(_loiter_yaw_cd, 0.0f);
+        calc_throttle(0.0f, true);
+    }
+
     // get distance (in meters) to destination
     _distance_to_destination = rover.current_loc.get_distance(_destination);
 
@@ -44,12 +52,12 @@ void ModeLoiter::update()
         _desired_yaw_cd = rover.current_loc.get_bearing_to(_destination);
         float yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
         // if destination is behind vehicle, reverse towards it
-        if ((fabsf(yaw_error_cd) > 9000 && g2.loit_type == 0) || g2.loit_type == 2) {
+        if ((fabsf(yaw_error_cd) > 9000 && g2.loit_type == 0) || g2.loit_type == 2 || (fabsf(yaw_error_cd) > 9000 && g2.loit_type == 1)) {
             _desired_yaw_cd = wrap_180_cd(_desired_yaw_cd + 18000);
             yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
             _desired_speed = -_desired_speed;
         }
-
+        
         // reduce desired speed if yaw_error is large
         // 45deg of error reduces speed to 75%, 90deg of error reduces speed to 50%
         float yaw_error_ratio = 1.0f - constrain_float(fabsf(yaw_error_cd / 9000.0f), 0.0f, 1.0f) * 0.5f;
@@ -71,6 +79,18 @@ void ModeLoiter::update()
     // run steering and throttle controllers
     calc_steering_to_heading(_desired_yaw_cd, turn_rate);
     calc_throttle(_desired_speed, true);
+
+    // update loiter heading
+    float speed;
+    if (g2.loit_type == 1 && attitude_control.get_forward_speed(speed)) {
+        const bool loiter_success = fabs(speed) < 0.25f && 
+                                    fabs(wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor)) < 1000.0f && 
+                                    _distance_to_destination < 1.25f * loiter_radius;
+        if (loiter_success) {
+            _loiter_yaw_cd = ahrs.yaw_sensor;
+        }
+    }
+    
 }
 
 // get desired location


### PR DESCRIPTION
Improve boat loiter by using the last loiter direction, especially, this change will improve performance when boat loiter downstream