### PR TITLE
AC_AttitudeControl: reduce alt hold min lean angle to 5deg on plane

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -6,9 +6,11 @@ extern const AP_HAL::HAL& hal;
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
  // default gains for Plane
  # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.2f    // Soft
+ #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_MIN     5.0     // Min lean angle so that vehicle can maintain limited control
 #else
  // default gains for Copter and Sub
  # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.15f   // Medium
+ #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_MIN     10.0   // Min lean angle so that vehicle can maintain limited control
 #endif
 
 AC_AttitudeControl *AC_AttitudeControl::_singleton;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -35,7 +35,6 @@
 
 #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_TC_DEFAULT      1.0f    // Time constant used to limit lean angle so that vehicle does not lose altitude
 #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_THROTTLE_MAX    0.8f    // Max throttle used to limit lean angle so that vehicle does not lose altitude
-#define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_MIN             10.0f   // Min lean angle so that vehicle can maintain limited control
 
 #define AC_ATTITUDE_CONTROL_MIN_DEFAULT                 0.1f    // minimum throttle mix default
 #define AC_ATTITUDE_CONTROL_MAN_DEFAULT                 0.1f    // manual throttle mix default


### PR DESCRIPTION
It is possible to set a `Q_WP_SPEED` high enough that a quadplane can no longer maintain altitude. For example:

![image](https://user-images.githubusercontent.com/33176108/170281637-4247b9d3-9ce1-4122-a2a3-0730c38b7640.png)

The Q throttle is at 100% but the vehicle is still descending, The desired pitch is limited to 10 deg by `get_althold_lean_angle_max_cd`. Reducing that minimum limit to 5deg is sufficient to allow the vehicle to maintain altitude. In this case ending up with a pitch angle of 7deg.

![image](https://user-images.githubusercontent.com/33176108/170282493-bc30a941-bcaf-4222-bff5-740e8cea383c.png)

Quadplanes are much worse than copter for this due to the extra surface area of the wings, particularly when flying into wind.

The disadvantage is that some may see the maximum speed of there vehicle reduce as `get_althold_lean_angle_max_cd` is a conservative limit, however those vehicle would have been very close to not being able to maintain altitude.

Copter is unchanged.
 