### PR TITLE
Copter: Auto mode gets attitude control

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -720,6 +720,7 @@ private:
     bool ekf_over_threshold();
     void failsafe_ekf_event();
     void failsafe_ekf_off_event(void);
+    void failsafe_ekf_recheck();
     void check_ekf_reset();
     void check_vibration();
 

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -61,7 +61,7 @@ void Copter::ekf_check()
 
     // increment or decrement counters and take action
     if (!checks_passed) {
-        // if compass is not yet flagged as bad
+        // if variances are not yet flagged as bad
         if (!ekf_check_state.bad_variance) {
             // increase counter
             ekf_check_state.fail_count++;
@@ -94,7 +94,7 @@ void Copter::ekf_check()
         if (ekf_check_state.fail_count > 0) {
             ekf_check_state.fail_count--;
 
-            // if compass is flagged as bad and the counter reaches zero then clear flag
+            // if variances are flagged as bad and the counter reaches zero then clear flag
             if (ekf_check_state.bad_variance && ekf_check_state.fail_count == 0) {
                 ekf_check_state.bad_variance = false;
                 AP::logger().Write_Error(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_VARIANCE_CLEARED);

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -152,11 +152,6 @@ bool Copter::ekf_over_threshold()
 // failsafe_ekf_event - perform ekf failsafe
 void Copter::failsafe_ekf_event()
 {
-    // return immediately if ekf failsafe already triggered
-    if (failsafe.ekf) {
-        return;
-    }
-
     // EKF failsafe event has occurred
     failsafe.ekf = true;
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_OCCURRED);
@@ -211,6 +206,19 @@ void Copter::failsafe_ekf_off_event(void)
         gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe Cleared");
     }
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_RESOLVED);
+}
+
+// re-check if the flight mode requires GPS but EKF failsafe is active
+// this should be called by flight modes that are changing their submode from one that does NOT require a position estimate to one that does
+void Copter::failsafe_ekf_recheck()
+{
+    // return immediately if not in ekf failsafe
+    if (!failsafe.ekf) {
+        return;
+    }
+
+    // trigger EKF failsafe action
+    failsafe_ekf_event();
 }
 
 // check for ekf yaw reset and adjust target heading, also log position reset

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -404,7 +404,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override;
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const override { return mode() == SubMode::NAVGUIDED || mode() == SubMode::NAV_SCRIPT_TIME; }
+    bool in_guided_mode() const override { return _mode == SubMode::NAVGUIDED || _mode == SubMode::NAV_SCRIPT_TIME; }
 
     // Auto modes
     enum class SubMode : uint8_t {
@@ -422,8 +422,6 @@ public:
         NAV_ATTITUDE_TIME,
     };
 
-    // Auto
-    SubMode mode() const { return _mode; }
 
     // pause continue in auto mode
     bool pause() override;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -400,7 +400,7 @@ public:
     void exit() override;
     void run() override;
 
-    bool requires_GPS() const override { return true; }
+    bool requires_GPS() const override;
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override;
     bool is_autopilot() const override { return true; }
@@ -422,6 +422,8 @@ public:
         NAV_ATTITUDE_TIME,
     };
 
+    // set submode.  returns true on success, false on failure
+    void set_submode(SubMode new_submode);
 
     // pause continue in auto mode
     bool pause() override;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -419,6 +419,7 @@ public:
         LOITER_TO_ALT,
         NAV_PAYLOAD_PLACE,
         NAV_SCRIPT_TIME,
+        NAV_ATTITUDE_TIME,
     };
 
     // Auto
@@ -500,6 +501,7 @@ private:
     void nav_guided_run();
     void loiter_run();
     void loiter_to_alt_run();
+    void nav_attitude_time_run();
 
     Location loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const;
 
@@ -546,6 +548,7 @@ private:
 #if AP_SCRIPTING_ENABLED
     void do_nav_script_time(const AP_Mission::Mission_Command& cmd);
 #endif
+    void do_nav_attitude_time(const AP_Mission::Mission_Command& cmd);
 
     bool verify_takeoff();
     bool verify_land();
@@ -567,6 +570,7 @@ private:
 #if AP_SCRIPTING_ENABLED
     bool verify_nav_script_time();
 #endif
+    bool verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd);
 
     // Loiter control
     uint16_t loiter_time_max;                // How long we should stay in Loiter Mode for mission scripting (time in seconds)
@@ -622,6 +626,15 @@ private:
         float arg2;         // 2nd argument provided by mission command
     } nav_scripting;
 #endif
+
+    // nav attitude time command variables
+    struct {
+        int16_t roll_deg;   // target roll angle in degrees.  provided by mission command
+        int8_t pitch_deg;   // target pitch angle in degrees.  provided by mission command
+        int16_t yaw_deg;    // target yaw angle in degrees.  provided by mission command
+        float climb_rate;   // climb rate in m/s. provided by mission command
+        uint32_t start_ms;  // system time that nav attitude time command was recieved (used for timeout)
+    } nav_attitude_time;
 };
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -695,7 +695,7 @@ void ModeAuto::exit_mission()
 bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 {
     // only process guided waypoint if we are in guided mode
-    if (copter.flightmode->mode_number() != Mode::Number::GUIDED && !(copter.flightmode->mode_number() == Mode::Number::AUTO && mode() == SubMode::NAVGUIDED)) {
+    if (copter.flightmode->mode_number() != Mode::Number::GUIDED && !(copter.flightmode->mode_number() == Mode::Number::AUTO && _mode == SubMode::NAVGUIDED)) {
         return false;
     }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -292,7 +292,7 @@ void ModeAuto::rtl_start()
     }
 }
 
-// auto_takeoff_start - initialises waypoint controller to implement take-off
+// initialise waypoint controller to implement take-off
 void ModeAuto::takeoff_start(const Location& dest_loc)
 {
     if (!copter.current_loc.initialised()) {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -229,7 +229,16 @@ public:
         float arg1;
         float arg2;
     };
-    
+
+    // Scripting NAV command (with verify)
+    struct PACKED nav_attitude_time_Command {
+        uint16_t time_sec;
+        int16_t roll_deg;
+        int8_t pitch_deg;
+        int16_t yaw_deg;
+        float climb_rate;
+    };
+
     union Content {
         // jump structure
         Jump_Command jump;
@@ -302,7 +311,10 @@ public:
 
         // nav scripting
         nav_script_time_Command nav_script_time;
-        
+
+        // nav attitude time
+        nav_attitude_time_Command nav_attitude_time;
+
         // location
         Location location{};      // Waypoint location
     };


### PR DESCRIPTION
This PR adds support for a new NAV_ATTITUDE_TIME mission command that maintains a specified roll, pitch and yaw target for a specified time.  While auto is in this attitude control submode it is impervious to EKF failsafes.

This is the corresponding mavlink PR https://github.com/ArduPilot/mavlink/pull/272

This has been tested in SITL consisting of a circuit of WAYPOINT commands and a few NAV_ATTITUDE_TIME commands which caused the vehicle to fly East for 60 seconds and then fly West for 60 seconds before resuming the circuit near home.  During this test the GPS was disabled using the RCx_OPTION = 65 and all worked as expected:

- Disabling the GPS had no effect while the vehicle was executing the NAV_ATTITUDE_TIME command
- If the GPS recovered before the next WAYPOINT command the vehicle continued the circuit
- If the GPS remained disabled when the next WAYPOINT command started the EKF failsafe triggered a LAND

Below are some screenshots of the SITL testing

![image](https://user-images.githubusercontent.com/1498098/170420294-96ebdad0-be2e-4547-a463-8792a1f93827.png)
![image](https://user-images.githubusercontent.com/1498098/170420333-30b550bd-4c02-469e-bf89-3598a060429d.png)
![image](https://user-images.githubusercontent.com/1498098/170420380-f2d9233b-9788-4856-9784-665fe580cb75.png)

How to Use
------------

- Create an Auto mission with the regular Takeoff, RTL, etc
- If using MP, add an UNKNOWN command and set the "command ID" to 42703
    - 1st column is time in seconds
    - 2nd column = roll (in degrees, positive is roll right, negative is roll left)
    - 3rd column = pitch (in degrees, negative is pitch forward, positive is pitch back)
    - 4th column is yaw (in degrees, 0=North, 90=East, 180=South, 270=West, all inbetween values also OK)
    - 5th column is climb rate (in m/s, positive is up, negative is down) <-- best to leave as zero
- arm the vehicle and switch to Auto
- optionally try disabling the GPS while the vehicle is executing the new command by setting RCx_OPTION = 65 and pull the appropriate switch high
![image](https://user-images.githubusercontent.com/1498098/170484745-70e0a39f-c5e6-4631-9f96-418d393194a7.png)

