### PR TITLE
Replay: fixed replaying with EK3 source set changes

### DIFF
--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -71,6 +71,8 @@ void LR_MsgHandler_REV2::process_message(uint8_t *msgbytes)
     case AP_DAL::Event::checkLaneSwitch:
         ekf2.checkLaneSwitch();
         break;
+    case AP_DAL::Event::setSourceSet0 ... AP_DAL::Event::setSourceSet2:
+        break;
     }
     if (replay_force_ekf3) {
         LR_MsgHandler_REV3 h{f, ekf2, ekf3};
@@ -127,6 +129,9 @@ void LR_MsgHandler_REV3::process_message(uint8_t *msgbytes)
         break;
     case AP_DAL::Event::checkLaneSwitch:
         ekf3.checkLaneSwitch();
+        break;
+    case AP_DAL::Event::setSourceSet0 ... AP_DAL::Event::setSourceSet2:
+        ekf3.setPosVelYawSourceSet(uint8_t(msg.event)-uint8_t(AP_DAL::Event::setSourceSet0));
         break;
     }
 

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -47,6 +47,9 @@ public:
         unsetTerrainHgtStable     = 10,
         requestYawReset           = 11,
         checkLaneSwitch           = 12,
+        setSourceSet0             = 13,
+        setSourceSet1             = 14,
+        setSourceSet2             = 15,
     };
 
     // must remain the same as AP_AHRS_VehicleClass numbers-wise

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1083,6 +1083,9 @@ void NavEKF3::resetCoreErrors(void)
 // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
 void NavEKF3::setPosVelYawSourceSet(uint8_t source_set_idx)
 {
+    if (source_set_idx < AP_NAKEKF_SOURCE_SET_MAX) {
+        AP::dal().log_event3(AP_DAL::Event(uint8_t(AP_DAL::Event::setSourceSet0)+source_set_idx));
+    }
     sources.setPosVelYawSourceSet(source_set_idx);
 }
 


### PR DESCRIPTION
This records EK3 source set changes so replay correctly changes the source to match the flight
tested with a replay log from CubeOrang