### PR TITLE
EKF: fixed ring buffer implementation

### DIFF
--- a/libraries/AP_NavEKF/EKF_Buffer.h
+++ b/libraries/AP_NavEKF/EKF_Buffer.h
@@ -28,7 +28,7 @@ public:
      * Zeros old data so it cannot not be used again
      * Returns false if no data can be found that is less than 100msec old
     */
-    bool recall(void *element, uint32_t sample_time);
+    bool recall(void *element, const uint32_t sample_time_ms);
 
     /*
      * Writes data and timestamp to a Ring buffer and advances indices that
@@ -42,9 +42,17 @@ public:
 private:
     const uint8_t elsize;
     void *buffer;
-    uint8_t _size, _head, _tail, _new_data;
 
-    uint32_t &time_ms(uint8_t idx);
+    // size of allocated buffer in elsize units
+    uint8_t size;
+
+    // index of the oldest element in the buffer
+    uint8_t oldest;
+
+    // total number of elements in the buffer
+    uint8_t count;
+
+    uint32_t time_ms(uint8_t idx) const;
     void *get_offset(uint8_t idx) const;
 };
 
@@ -63,15 +71,15 @@ public:
         ekf_ring_buffer(sizeof(element_type))
         {}
 
-    bool init(uint8_t size) {
-        return ekf_ring_buffer::init(size);
+    bool init(uint8_t _size) {
+        return ekf_ring_buffer::init(_size);
     }
 
     bool recall(element_type &element,uint32_t sample_time) {
         return ekf_ring_buffer::recall(&element, sample_time);
     }
 
-    void push(element_type element) {
+    void push(const element_type &element) {
         return ekf_ring_buffer::push(&element);
     }
 

--- a/libraries/AP_NavEKF/tests/test_ring_buffer.cpp
+++ b/libraries/AP_NavEKF/tests/test_ring_buffer.cpp
@@ -1,0 +1,124 @@
+#include <AP_gtest.h>
+
+/*
+  tests for AP_NavEKF/EKF_Buffer.cpp
+ */
+
+#include <AP_NavEKF/EKF_Buffer.h>
+#include <stdlib.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+TEST(EKF_Buffer, EKF_Buffer)
+{
+    struct test_data : EKF_obs_element_t {
+        uint32_t data;
+    };
+    EKF_obs_buffer_t<test_data> buf;
+    buf.init(8);
+    struct test_data d, d2;
+    uint32_t now = 100;
+    d.data = 17;
+    d.time_ms = now++;
+    buf.push(d);
+
+    EXPECT_TRUE(buf.recall(d2, now));
+    EXPECT_EQ(d2.data, d.data);
+    EXPECT_EQ(d2.time_ms, uint32_t(100));
+
+    d.time_ms = 101;
+    buf.push(d);
+    d.time_ms = 102;
+    buf.push(d);
+
+    // recall first element
+    EXPECT_TRUE(buf.recall(d2, 101));
+    EXPECT_EQ(d2.data, d.data);
+    EXPECT_EQ(d2.time_ms, uint32_t(101));
+
+    EXPECT_TRUE(buf.recall(d2, 102));
+    EXPECT_EQ(d2.data, d.data);
+    EXPECT_EQ(d2.time_ms, uint32_t(102));
+
+    EXPECT_FALSE(buf.recall(d2, 103));
+
+    d.time_ms = 101;
+    buf.push(d);
+    d.time_ms = 102;
+    buf.push(d);
+
+    // recall 2nd element, note that first element is discarded
+    EXPECT_TRUE(buf.recall(d2, 103));
+    EXPECT_EQ(d2.data, d.data);
+    EXPECT_EQ(d2.time_ms, uint32_t(102));
+
+    EXPECT_FALSE(buf.recall(d2, 103));
+    EXPECT_FALSE(buf.recall(d2, 103));
+
+    // test overflow of buffer
+    for (uint8_t i=0; i<16; i++) {
+        d.time_ms = 100+i;
+        d.data = 1000+i;
+        buf.push(d);
+    }
+    for (uint8_t i=0; i<16; i++) {
+        if (i < 8) {
+            EXPECT_TRUE(buf.recall(d2, 108+i));
+        } else {
+            EXPECT_FALSE(buf.recall(d2, 1100));
+        }
+    }
+
+    // test with an element that is too old
+    d.time_ms = 101;
+    d.data = 200;
+    buf.push(d);
+    d.time_ms = 1002;
+    d.data = 2000;
+    buf.push(d);
+
+    // recall element, first one is too old so will be discarded
+    EXPECT_TRUE(buf.recall(d2, 1003));
+    EXPECT_EQ(d2.data, 2000U);
+    EXPECT_EQ(d2.time_ms, uint32_t(1002));
+
+    EXPECT_FALSE(buf.recall(d2, 103));
+
+
+    // test 32 bit time wrap
+    d.time_ms = 0xFFFFFFF0U;
+    d.data = 200;
+    buf.push(d);
+    d.time_ms = 0xFFFFFFFAU;
+    d.data = 2000;
+    buf.push(d);
+    d.time_ms = 0xFFFFFFFBU;
+    d.data = 2001;
+    buf.push(d);
+
+    // recall element, first one is too old so will be discarded
+    EXPECT_TRUE(buf.recall(d2, 10));
+    EXPECT_EQ(d2.data, 2001U);
+    EXPECT_EQ(d2.time_ms, uint32_t(0xFFFFFFFBU));
+
+    EXPECT_FALSE(buf.recall(d2, 103));
+
+    // test 32 bit time wrap with a too old element
+    d.time_ms = 0xFFFFFFFFU - 1000U;
+    d.data = 200;
+    buf.push(d);
+    d.time_ms = 0xFFFFFFFBU;
+    d.data = 2001;
+    buf.push(d);
+
+    // recall element, first one is too old so will be discarded
+    EXPECT_TRUE(buf.recall(d2, 10));
+    EXPECT_EQ(d2.data, 2001U);
+    EXPECT_EQ(d2.time_ms, uint32_t(0xFFFFFFFBU));
+
+    EXPECT_FALSE(buf.recall(d2, 103));
+}
+
+AP_GTEST_MAIN()
+
+#endif // HAL_SITL or HAL_LINUX

--- a/libraries/AP_NavEKF/tests/wscript
+++ b/libraries/AP_NavEKF/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )


### PR DESCRIPTION
This fixes a bug in the EKF ring buffer implementation. It was noticed while putting in external nav elements very slowly (every few seconds). The ring buffer would not return the first element pushed, even though it matched.
The head/tail logic was just too complex. This reimplements it in a much simpler fashion, and adds a test suite
only tested in SITL so far
this has been testing flown several times on a complex vehicle with CubeOrange
