### PR TITLE
Plane: adjust down default quadplane gains

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -478,6 +478,10 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "Q_WP_SPEED",       500 },
     { "Q_WP_ACCEL",       100 },
     { "Q_P_JERK_XY",      2   },
+    // lower rotational accel limits
+    { "Q_A_ACCEL_R_MAX", 40000 },
+    { "Q_A_ACCEL_P_MAX", 40000 },
+    { "Q_A_ACCEL_Y_MAX", 10000 },
 };
 
 /*

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -20,10 +20,10 @@ extern const AP_HAL::HAL& hal;
  # define POSCONTROL_ACC_Z_IMAX                 800     // vertical acceleration controller IMAX gain default
  # define POSCONTROL_ACC_Z_FILT_HZ              10.0f   // vertical acceleration controller input filter default
  # define POSCONTROL_ACC_Z_DT                   0.02f   // vertical acceleration controller dt default
- # define POSCONTROL_POS_XY_P                   1.0f    // horizontal position controller P gain default
- # define POSCONTROL_VEL_XY_P                   1.4f    // horizontal velocity controller P gain default
- # define POSCONTROL_VEL_XY_I                   0.7f    // horizontal velocity controller I gain default
- # define POSCONTROL_VEL_XY_D                   0.35f   // horizontal velocity controller D gain default
+ # define POSCONTROL_POS_XY_P                   0.5f    // horizontal position controller P gain default
+ # define POSCONTROL_VEL_XY_P                   0.7f    // horizontal velocity controller P gain default
+ # define POSCONTROL_VEL_XY_I                   0.35f    // horizontal velocity controller I gain default
+ # define POSCONTROL_VEL_XY_D                   0.17f   // horizontal velocity controller D gain default
  # define POSCONTROL_VEL_XY_IMAX                1000.0f // horizontal velocity controller IMAX gain default
  # define POSCONTROL_VEL_XY_FILT_HZ             5.0f    // horizontal velocity controller input filter
  # define POSCONTROL_VEL_XY_FILT_D_HZ           5.0f    // horizontal velocity controller input filter for D


### PR DESCRIPTION
make it better for a typical quadplane, the defaults were more suitable on smaller aircraft