### PR TITLE
AP_ESC_Telem:Fix SITL Crash on M1 Mac caused by floating point to uin…

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -341,7 +341,7 @@ void AP_ESC_Telem::update_telem_data(const uint8_t esc_index, const AP_ESC_Telem
 
 // record an update to the RPM together with timestamp, this allows the notch values to be slewed
 // this should be called by backends when new telemetry values are available
-void AP_ESC_Telem::update_rpm(const uint8_t esc_index, const uint16_t new_rpm, const float error_rate)
+void AP_ESC_Telem::update_rpm(const uint8_t esc_index, const int32_t new_rpm, const float error_rate)
 {
     if (esc_index >= ESC_TELEM_MAX_ESCS) {
         return;
@@ -353,7 +353,9 @@ void AP_ESC_Telem::update_rpm(const uint8_t esc_index, const uint16_t new_rpm, c
     volatile AP_ESC_Telem_Backend::RpmData& rpmdata = _rpm_data[esc_index];
 
     rpmdata.prev_rpm = rpmdata.rpm;
-    rpmdata.rpm = new_rpm;
+    // RPM is passed in as an int, but stored as a float. Likely this means consumers (e.g. mavlink and logs)
+    // think they are getting precision when they are not.
+    rpmdata.rpm = (float)new_rpm;
     if (now > rpmdata.last_update_us) { // cope with wrapping
         rpmdata.update_rate_hz = 1.0e6f / (now - rpmdata.last_update_us);
     }

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -84,7 +84,7 @@ public:
 
 private:
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
-    void update_rpm(const uint8_t esc_index, const uint16_t new_rpm, const float error_rate);
+    void update_rpm(const uint8_t esc_index, const int32_t new_rpm, const float error_rate);
     // callback to update the data in the frontend, should be called by the driver when new data is available
     void update_telem_data(const uint8_t esc_index, const AP_ESC_Telem_Backend::TelemetryData& new_data, const uint16_t data_mask);
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
@@ -31,7 +31,7 @@ AP_ESC_Telem_Backend::AP_ESC_Telem_Backend() {
 }
 
 // callback to update the rpm in the frontend, should be called by the driver when new data is available
-void AP_ESC_Telem_Backend::update_rpm(const uint8_t esc_index, const uint16_t new_rpm, const float error_rate) {
+void AP_ESC_Telem_Backend::update_rpm(const uint8_t esc_index, const int32_t new_rpm, const float error_rate) {
     _frontend->update_rpm(esc_index, new_rpm, error_rate);
 }
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -51,7 +51,7 @@ public:
 
 protected:
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
-    void update_rpm(const uint8_t esc_index, const uint16_t new_rpm, const float error_rate = 0.0f);
+    void update_rpm(const uint8_t esc_index, const int32_t new_rpm, const float error_rate = 0.0f);
 
     // callback to update the data in the frontend, should be called by the driver when new data is available
     void update_telem_data(const uint8_t esc_index, const TelemetryData& new_data, const uint16_t data_present_mask);


### PR DESCRIPTION
Discussed in detail on the forum here: https://discuss.ardupilot.org/t/bad-instruction-running-sitl/86112/2

In essence float values were being passed as unsigned 16 bit ints which is likely causing "undefined behaviour" on other architectures, but on the M1 Mac It crashes with a BAD_INSTRUCTION exception. This is probably a floating point error, one of my tests saw this consistently failing when -1 was passed as the RPM. Of course this is not a valid value for an unsigned int. Other architectures may be more forgiving, but this could be causing unexpected values to end up in the AP_ESC_Telem_Backend state[]. This is likely also a problem if an RPM of > 65535 is passed.

In general, it seems that front end code is calculating RPM as integers and then its being stored on the backend as floats and probably surfaces in mavlink and logs as floats values, but will almost never contain fractional rpm or rpm > 65535.

Therefore, my proposal is not fix the 'big' problem which would affect a lot of code, and simply to make sure that when update_rpm() is called, it will work reliably pass the supplied values down to the backend. There seems to be no good reason for passing uint16_t values as they are almost always going to be passed as integers under the covers anyway, there is no space saving and no performance benefit to the current approach.