### PR TITLE
AP_WheelEncoder: fix WheelEncoder_Quadrature timestamp.

### DIFF
--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
@@ -138,5 +138,5 @@ void AP_WheelEncoder_Quadrature::irq_handler(uint8_t pin,
     update_phase_and_error_count();
 
     // record update time
-    irq_state.last_reading_ms = timestamp;
+    irq_state.last_reading_ms = timestamp * 1e-3f;
 }


### PR DESCRIPTION
Convert timestamp to ms from us.
https://github.com/ArduPilot/ardupilot/issues/20880