### PR TITLE
AP_UAVCAN: added dynamically allocated pool size param

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -30,7 +30,6 @@
 #include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 #include <uavcan/protocol/param/GetSet.hpp>
 #include <uavcan/protocol/param/ExecuteOpcode.hpp>
-#include <uavcan/helpers/heap_based_pool_allocator.hpp>
 #include <SRV_Channel/SRV_Channel.h>
 
 
@@ -54,6 +53,7 @@ class ESCStatusCb;
 class DebugCb;
 class ParamGetSetCb;
 class ParamExecuteOpcodeCb;
+class AP_PoolAllocator;
 
 #if defined(__GNUC__) && (__GNUC__ > 8)
 #define DISABLE_W_CAST_FUNCTION_TYPE_PUSH \
@@ -264,7 +264,9 @@ private:
     AP_Int16 _servo_rate_hz;
     AP_Int16 _options;
     AP_Int16 _notify_state_hz;
+    AP_Int16 _pool_size;
 
+    AP_PoolAllocator *_allocator;
     uavcan::Node<0> *_node;
 
     uint8_t _driver_index;

--- a/libraries/AP_UAVCAN/AP_UAVCAN_pool.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_pool.cpp
@@ -1,0 +1,79 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+/*
+  based on dynamic_memory.hpp which is:
+  Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+ */
+
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_ENABLE_LIBUAVCAN_DRIVERS
+
+#include "AP_UAVCAN.h"
+#include "AP_UAVCAN_pool.h"
+
+AP_PoolAllocator::AP_PoolAllocator(uint16_t _pool_size) :
+    num_blocks(_pool_size / UAVCAN_NODE_POOL_BLOCK_SIZE)
+{
+}
+
+bool AP_PoolAllocator::init(void)
+{
+    WITH_SEMAPHORE(sem);
+    pool_nodes = (Node *)calloc(num_blocks, UAVCAN_NODE_POOL_BLOCK_SIZE);
+    if (pool_nodes == nullptr) {
+        return false;
+    }
+    for (uint16_t i=0; i<(num_blocks-1); i++) {
+        pool_nodes[i].next = &pool_nodes[i+1];
+    }
+    free_list = &pool_nodes[0];
+    return true;
+}
+
+void* AP_PoolAllocator::allocate(std::size_t size)
+{
+    WITH_SEMAPHORE(sem);
+    if (free_list == nullptr || size > UAVCAN_NODE_POOL_BLOCK_SIZE) {
+        return nullptr;
+    }
+    Node *ret = free_list;
+    free_list = free_list->next;
+
+    used++;
+    if (used > max_used) {
+        max_used = used;
+    }
+
+    return ret;
+}
+
+void AP_PoolAllocator::deallocate(const void* ptr)
+{
+    if (ptr == nullptr) {
+        return;
+    }
+    WITH_SEMAPHORE(sem);
+
+    Node *p = reinterpret_cast<Node*>(const_cast<void*>(ptr));
+    p->next = free_list;
+    free_list = p;
+
+    used--;
+}
+
+#endif // HAL_ENABLE_LIBUAVCAN_DRIVERS
+

--- a/libraries/AP_UAVCAN/AP_UAVCAN_pool.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_pool.cpp
@@ -51,6 +51,11 @@ void* AP_PoolAllocator::allocate(std::size_t size)
         return nullptr;
     }
     Node *ret = free_list;
+    const uint32_t blk = ret - pool_nodes;
+    if (blk >= num_blocks) {
+        INTERNAL_ERROR(AP_InternalError::error_t::mem_guard);
+        return nullptr;
+    }
     free_list = free_list->next;
 
     used++;
@@ -69,6 +74,11 @@ void AP_PoolAllocator::deallocate(const void* ptr)
     WITH_SEMAPHORE(sem);
 
     Node *p = reinterpret_cast<Node*>(const_cast<void*>(ptr));
+    const uint32_t blk = p - pool_nodes;
+    if (blk >= num_blocks) {
+        INTERNAL_ERROR(AP_InternalError::error_t::mem_guard);
+        return;
+    }
     p->next = free_list;
     free_list = p;
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN_pool.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_pool.h
@@ -1,0 +1,60 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+/*
+  based on dynamic_memory.hpp which is:
+  Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+ */
+
+#pragma once
+
+#include "AP_UAVCAN.h"
+
+#ifndef UAVCAN_NODE_POOL_BLOCK_SIZE
+#if HAL_CANFD_SUPPORTED
+#define UAVCAN_NODE_POOL_BLOCK_SIZE 128
+#else
+#define UAVCAN_NODE_POOL_BLOCK_SIZE 64
+#endif
+#endif
+
+class AP_PoolAllocator : public uavcan::IPoolAllocator
+{
+public:
+    AP_PoolAllocator(uint16_t _pool_size);
+
+    bool init(void);
+    void *allocate(std::size_t size) override;
+    void deallocate(const void* ptr) override;
+
+    uint16_t getBlockCapacity() const override {
+        return num_blocks;
+    }
+
+private:
+    const uint16_t num_blocks;
+
+    union Node {
+        uint8_t data[UAVCAN_NODE_POOL_BLOCK_SIZE];
+        Node* next;
+    };
+
+    Node *free_list;
+    Node *pool_nodes;
+    HAL_Semaphore sem;
+
+    uint16_t used;
+    uint16_t max_used;
+};


### PR DESCRIPTION
allow for smaller pool size to save memory. On F427 boards this can be needed to have both CAN and other memory intensive subsystems such as scripting or terrain
Note that this also adds a semaphore for alloc/de-alloc in DroneCAN. This paves the way for multi-threaded operation