### PR TITLE
AP_Scripting: modify QUIKTUNE for audio monitoring in TX

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.md
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.md
@@ -130,12 +130,11 @@ The script will also adjust filter settings using the following rules:
  - if no SMAX is set for a rate controller than the SMAX will be set to 50Hz
 
 Once the tuning is finished you will see a "Tuning: done" message. You
-can save the tune by moving the switch to the high position. You
-should do this to save before you land and disarm.
+can save the tune by moving the switch to the high position (Tune Save). You
+should do this to save before you land and disarm. If you save before the tune is completed the tune will pause, and any parameters completed will be saved and the current value of the one being actively tuned will remain active. You can resume tuning by returning the switch again to the middle position, or if moved to the low position, the parameter currently being tuned will be reverted but any previously saved parameters will remain.
 
-If you move the switch to the low position at any time in the tune
-then all parameters will be reverted to their original
-values. Parameters will also be reverted if you disarm.
+If you move the switch to the low position at any time in the tune before using the Tune Save switch position, then all parameters will be reverted to their original
+values. Parameters will also be reverted if you disarm before saving.
 
 If the pilot gives roll, pitch or yaw input while tuning then the tune
 is paused until 4 seconds after the pilot input stops.


### PR DESCRIPTION
Allows monitoring by audio on TX when GCS messages are not visible in sun...also to control the amount of GSC messages during the tune....normal enable of QUIK_TUNE (=1) gives sparse but continuous messaging during tune visible in MP HUD but not overwhelming in audio feedback on OpenTX...QUIK_TUNE=2 gives verbose messaging with gain steps,etc. (intermediate steps not visible on MP HUD, but still gives each axis completion notifications on the HUD)

of course all GCS messages are visible in MP message tab whether or not they display in the MP HUD (no info messages ever display in the HUD in MP)

also fixes the problem that current script floods QGC with emergency message popups throughout the tune...
![tuning_verbose](https://user-images.githubusercontent.com/6076534/172000369-eca0ee9e-477c-4d67-82b6-7ddc2dba9f59.jpg)
![tuning_normal](https://user-images.githubusercontent.com/6076534/172000370-c9e87c53-1fef-40d8-9fae-9f8cbaefed4a.jpg)
