### PR TITLE
AC_Fence: Minimum altitude decision available or not for FENCE_TYPE only

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -535,7 +535,7 @@ uint8_t AC_Fence::check()
     }
 
     // minimum altitude fence check
-    if (_floor_enabled && check_fence_alt_min()) {
+    if (check_fence_alt_min()) {
         ret |= AC_FENCE_TYPE_ALT_MIN;
     }
 


### PR DESCRIPTION
Japan has few plains.
Multicopters sometimes fly at altitudes lower than their takeoff point.
In this case, it may fly over trees.
Therefore, setting a minimum altitude can avoid collisions with trees.
The Japanese radio does not have the general-purpose GCS function.

AFTER
![Screenshot from 2022-06-05 15-05-13](https://user-images.githubusercontent.com/646194/172037687-aeb33bcd-bd22-4f3a-a3ab-9808394d2043.png)
