### PR TITLE
AP_Logger: save crash_dump.bin to sdcard on boot

### DIFF
--- a/libraries/AP_BoardConfig/IMU_heater.cpp
+++ b/libraries/AP_BoardConfig/IMU_heater.cpp
@@ -81,6 +81,7 @@ void AP_BoardConfig::set_imu_temp(float current)
         heater.output = constrain_float(heater.output, 0, 100);
     }
 
+#if HAL_LOGGING_ENABLED
     if (now - heater.last_log_ms >= 1000) {
 // @LoggerMessage: HEAT
 // @Description: IMU Heater data
@@ -98,6 +99,8 @@ void AP_BoardConfig::set_imu_temp(float current)
                            heater.output);
         heater.last_log_ms = now;
     }
+#endif // HAL_LOGGING_ENABLED
+
 #if 0
     gcs().send_text(MAV_SEVERITY_INFO, "Heater: Out=%.1f Temp=%.1f",
                     double(heater.output),

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -30,7 +30,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define SBP_DEBUGGING 1
-#define SBP_HW_LOGGING 1
+#define SBP_HW_LOGGING HAL_LOGGING_ENABLED
 
 #define SBP_TIMEOUT_HEATBEAT  4000
 #define SBP_TIMEOUT_PVT       500
@@ -228,7 +228,9 @@ AP_GPS_SBP::_sbp_process_message() {
             break;
     }
 
+#if SBP_HW_LOGGING
     logging_log_raw_sbp(parser_state.msg_type, parser_state.sender_id, parser_state.msg_len, parser_state.msg_buff);
+#endif
 }
 
 bool
@@ -292,7 +294,9 @@ AP_GPS_SBP::_attempt_state_update()
         last_full_update_cpu_ms = now;
         state.rtk_iar_num_hypotheses = last_iar_num_hypotheses;
 
+#if SBP_HW_LOGGING
         logging_log_full_update();
+#endif
         ret = true;
 
     } else if (now - last_full_update_cpu_ms > SBP_TIMEOUT_PVT) {

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -208,17 +208,21 @@ AP_GPS_SBP2::_sbp_process_message() {
         case SBP_EXT_EVENT_MSGTYPE:
             memcpy(&last_event, parser_state.msg_buff, sizeof(struct sbp_ext_event_t));
             check_new_itow(last_event.tow, parser_state.msg_len);
+#if HAL_LOGGING_ENABLED
             logging_ext_event();
+#endif
             break;
 
         default:
             break;
     }
 
+#if HAL_LOGGING_ENABLED
     // send all messages we receive to log, even if it's an unsupported message,
     // so we can do additional post-processing from logs.
     // The log mask will be used to adjust or suppress logging
     logging_log_raw_sbp(parser_state.msg_type, parser_state.sender_id, parser_state.msg_len, parser_state.msg_buff);
+#endif
 }
 
 int32_t 
@@ -440,6 +444,7 @@ AP_GPS_SBP2::_detect(struct SBP2_detect_state &state, uint8_t data)
     return false;
 }
 
+#if HAL_LOGGING_ENABLED
 void
 AP_GPS_SBP2::logging_log_full_update()
 {
@@ -525,4 +530,5 @@ AP_GPS_SBP2::logging_ext_event() {
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 };
+#endif // HAL_LOGGING_ENABLED
 #endif //AP_GPS_SBP2_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -418,6 +418,7 @@ void AP_InertialSensor_Backend::_notify_new_delta_angle(uint8_t instance, const 
 
 void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &gyro)
 {
+#if HAL_LOGGING_ENABLED
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger == nullptr) {
         // should not have been called
@@ -430,6 +431,7 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
             _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
         }
     }
+#endif
 }
 
 /*
@@ -631,6 +633,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_sensor_rate_sample(uint8_t inst
 
 void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel)
 {
+#if HAL_LOGGING_ENABLED
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger == nullptr) {
         // should not have been called
@@ -643,6 +646,7 @@ void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t s
             _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);
         }
     }
+#endif
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
@@ -771,10 +775,12 @@ bool AP_InertialSensor_Backend::should_log_imu_raw() const
 // log an unexpected change in a register for an IMU
 void AP_InertialSensor_Backend::log_register_change(uint32_t bus_id, const AP_HAL::Device::checkreg &reg)
 {
+#if HAL_LOGGING_ENABLED
     AP::logger().Write("IREG", "TimeUS,DevID,Bank,Reg,Val", "QIBBB",
                        AP_HAL::micros64(),
                        bus_id,
                        reg.bank,
                        reg.regnum,
                        reg.value);
+#endif
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -759,7 +759,9 @@ check_registers:
               events to help with log analysis, but don't shout at the
               GCS to prevent possible flood
             */
+#if HAL_LOGGING_ENABLED
             AP::logger().Write_MessageF("ICM20602 yofs fix: %x %x", y_ofs, _saved_y_ofs_high);
+#endif
             _register_write(MPUREG_ACC_OFF_Y_H, _saved_y_ofs_high);
         }
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_tempcal.cpp
@@ -304,7 +304,7 @@ void AP_InertialSensor::TCal::Learn::add_sample(const Vector3f &sample, float te
     }
 
     const float tdiff = T - TEMP_REFERENCE;
-
+#if HAL_LOGGING_ENABLED
     AP::logger().Write("TCLR", "TimeUS,I,SType,Temp,X,Y,Z,NSamp",
                        "s#------",
                        "F000000-",
@@ -315,6 +315,7 @@ void AP_InertialSensor::TCal::Learn::add_sample(const Vector3f &sample, float te
                        T,
                        st.sum.x, st.sum.y, st.sum.z,
                        st.sum_count);
+#endif
     
     
     st.pfit.update(tdiff, st.sum);

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -265,6 +265,7 @@ bool AP_InertialSensor::BatchSampler::should_log(uint8_t _instance, IMU_SENSOR_T
 
 void AP_InertialSensor::BatchSampler::sample(uint8_t _instance, AP_InertialSensor::IMU_SENSOR_TYPE _type, uint64_t sample_us, const Vector3f &_sample)
 {
+#if HAL_LOGGING_ENABLED
     if (!should_log(_instance, _type)) {
         return;
     }
@@ -277,5 +278,6 @@ void AP_InertialSensor::BatchSampler::sample(uint8_t _instance, AP_InertialSenso
     data_z[data_write_offset] = multiplier*_sample.z;
 
     data_write_offset++; // may unblock the reading process
+#endif
 }
 #endif //#if HAL_INS_ENABLED

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1293,6 +1293,36 @@ int16_t AP_Logger::Write_calc_msg_len(const char *fmt) const
     return len;
 }
 
+/*
+  see if we need to save a crash dump. Returns true if either no crash
+  dump available or we have saved it to sdcard. This is called
+  continuously until success to account for late mount of the microSD
+ */
+bool AP_Logger::check_crash_dump_save(void)
+{
+    int fd = AP::FS().open("@SYS/crash_dump.bin", O_RDONLY);
+    if (fd == -1) {
+        // we don't have a crash dump file. The @SYS filesystem
+        // returns -1 for open on empty files
+        return true;
+    }
+    int fd2 = AP::FS().open("APM/crash_dump.bin", O_WRONLY|O_CREAT|O_TRUNC);
+    if (fd2 == -1) {
+        // sdcard not available yet, try again later
+        AP::FS().close(fd);
+        return false;
+    }
+    uint8_t buf[128];
+    int32_t n;
+    while ((n = AP::FS().read(fd, buf, sizeof(buf))) > 0) {
+        AP::FS().write(fd2, buf, n);
+    }
+    AP::FS().close(fd2);
+    AP::FS().close(fd);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Saved crash_dump.bin");
+    return true;
+}
+
 // thread for processing IO - in general IO involves a long blocking DMA write to an SPI device
 // and the thread will sleep while this completes preventing other tasks from running, it therefore
 // is necessary to run the IO in it's own thread
@@ -1300,6 +1330,8 @@ void AP_Logger::io_thread(void)
 {
     uint32_t last_run_us = AP_HAL::micros();
     uint32_t last_stack_us = last_run_us;
+    uint32_t last_crash_check_us = last_run_us;
+    bool done_crash_dump_save = false;
 
     while (true) {
         uint32_t now = AP_HAL::micros();
@@ -1317,6 +1349,13 @@ void AP_Logger::io_thread(void)
         if (now - last_stack_us > 100000U) {
             last_stack_us = now;
             hal.util->log_stack_info();
+        }
+
+        // check for saving a crash dump file every 5s
+        if (!done_crash_dump_save &&
+            now - last_crash_check_us > 5000000U) {
+            last_crash_check_us = now;
+            done_crash_dump_save = check_crash_dump_save();
         }
 #if HAL_LOGGER_FILE_CONTENTS_ENABLED
         file_content_update();

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1,5 +1,7 @@
 #include "AP_Logger.h"
 
+#if HAL_LOGGING_ENABLED
+
 #include "AP_Logger_Backend.h"
 
 #include "AP_Logger_File.h"
@@ -1631,3 +1633,5 @@ AP_Logger &logger()
 }
 
 };
+
+#endif // HAL_LOGGING_ENABLED

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -525,6 +525,7 @@ private:
 
     void start_io_thread(void);
     void io_thread();
+    bool check_crash_dump_save(void);
 
 #if HAL_LOGGER_FILE_CONTENTS_ENABLED
     // support for logging file content


### PR DESCRIPTION
on each boot write crash_dump.bin to the microSD if it is available
this makes it easier for users to send in their crash dumps, and less
likely they will overwrite it with a fw update