### PR TITLE
AP_Math: calc_lowpass_alpha_dt: remove unused constrain

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -404,7 +404,7 @@ float calc_lowpass_alpha_dt(float dt, float cutoff_freq)
         return 1.0;
     }
     float rc = 1.0f/(M_2PI*cutoff_freq);
-    return constrain_float(dt/(dt+rc), 0.0f, 1.0f);
+    return dt/(dt+rc);
 }
 
 #ifndef AP_MATH_FILL_NANF_USE_MEMCPY


### PR DESCRIPTION
A little bit of a drive by, the constrain will never trigger.

`dt/(dt+rc)` is already constrained to 0 -> 1.

dt = 0 or rc = inf

0/(0+rc) = 0

rc = 0 or dt = inf

dt/(dt + 0) = 1

