### PR TITLE
GCS_MAVLink: learn routes even on private channels

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -97,13 +97,14 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
         return true;
     }
 
+    // learn new routes including private channels
+    // so that find_mav_type works for all channels
+    learn_route(in_channel, msg);
+
     // don't ever forward data from a private channel
     if ((GCS_MAVLINK::is_private(in_channel))) {
         return true;
     }
-
-    // learn new routes
-    learn_route(in_channel, msg);
 
     if (msg.msgid == MAVLINK_MSG_ID_RADIO ||
         msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {


### PR DESCRIPTION
This PR changes the GCS_MAVLink check_and_forward() method so that it learns routes to systems/components even if they are on "private channels".  By "private channels" we means those serial ports where the user has set the SERIALx_OPTIONS "Don't forward mavlink to/from" bit (e.g. 1024).  This bit is normally set when the user wants to stop high-speed/low-level communication between the autopilot and the gimbal or companion computer from being forwarded to the autopilot<->GCS link and unnecessarily consuming bandwidth.

It is important that we "learn" routes to systems/components on private links so that the AP_Mount library can use mav_find_component to find the gimbal.  This method is also used by Rover's auto mode to send the latest navigation target to an offboard companion computer (normally running ROS) as part of support for off-board navigation.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/20886

This has been tested on a real vehicle with a Gremsy gimbal (which uses MAVLink) and confirmed it allows the gimbal to be attached to a private channel.

This change means the "routes" array has "private" items in it that it previously did not.  This array is only directly accessed by these methods of the MAVLink_routing class (see GCS_MAVLink/MAVLink_routine.cpp):

- check_and_forward()
- send_to_components()
- find_by_mavtype()
- learn_route() <-- private
- handle_heartbeat() <-- private

Thanks to @peterbarker for finding this solution.