### PR TITLE
AP_Mount: custom Gremsy driver

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -725,6 +725,13 @@ bool Copter::get_wp_crosstrack_error_m(float &xtrack_error) const
     return true;
 }
 
+// get the target body-frame angular velocities in rad/s (Z-axis component used by some gimbals)
+bool Copter::get_rate_bf_targets(Vector3f& rate_bf_targets) const
+{
+    rate_bf_targets = attitude_control->rate_bf_targets();
+    return true;
+}
+
 /*
   constructor for main Copter class
  */

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -676,6 +676,7 @@ private:
     bool get_wp_distance_m(float &distance) const override;
     bool get_wp_bearing_deg(float &bearing) const override;
     bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
+    bool get_rate_bf_targets(Vector3f& rate_bf_targets) const override;
 
     // Attitude.cpp
     void update_throttle_hover();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -673,6 +673,9 @@ private:
     void update_super_simple_bearing(bool force_update);
     void read_AHRS(void);
     void update_altitude();
+    bool get_wp_distance_m(float &distance) const override;
+    bool get_wp_bearing_deg(float &bearing) const override;
+    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
 
     // Attitude.cpp
     void update_throttle_hover();
@@ -913,11 +916,6 @@ private:
     void userhook_auxSwitch1(const RC_Channel::AuxSwitchPos ch_flag);
     void userhook_auxSwitch2(const RC_Channel::AuxSwitchPos ch_flag);
     void userhook_auxSwitch3(const RC_Channel::AuxSwitchPos ch_flag);
-
-    // vehicle specific waypoint info helpers
-    bool get_wp_distance_m(float &distance) const override;
-    bool get_wp_bearing_deg(float &bearing) const override;
-    bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
 
 #if MODE_ACRO_ENABLED == ENABLED
 #if FRAME_CONFIG == HELI_FRAME

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -239,6 +239,16 @@ public:
         float climb_rate;
     };
 
+    // MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW support
+    struct PACKED gimbal_manager_pitchyaw_Command {
+        int8_t pitch_angle_deg;
+        int16_t yaw_angle_deg;
+        int8_t pitch_rate_degs;
+        int8_t yaw_rate_degs;
+        uint8_t flags;
+        uint8_t gimbal_id;
+    };
+
     union Content {
         // jump structure
         Jump_Command jump;
@@ -314,6 +324,9 @@ public:
 
         // nav attitude time
         nav_attitude_time_Command nav_attitude_time;
+
+        // MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW
+        gimbal_manager_pitchyaw_Command gimbal_manager_pitchyaw;
 
         // location
         Location location{};      // Waypoint location
@@ -760,7 +773,7 @@ private:
 
     bool start_command_do_sprayer(const AP_Mission::Mission_Command& cmd);
     bool start_command_do_scripting(const AP_Mission::Mission_Command& cmd);
-
+    bool start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Mission_Command& cmd);
 };
 
 namespace AP

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -8,6 +8,7 @@
 #include <AC_Sprayer/AC_Sprayer.h>
 #include <AP_Scripting/AP_Scripting.h>
 #include <RC_Channel/RC_Channel.h>
+#include <AP_Mount/AP_Mount.h>
 
 bool AP_Mission::start_command_do_aux_function(const AP_Mission::Mission_Command& cmd)
 {
@@ -203,4 +204,41 @@ bool AP_Mission::start_command_do_scripting(const AP_Mission::Mission_Command& c
 #else
     return false;
 #endif // AP_SCRIPTING_ENABLED
+}
+
+bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Mission_Command& cmd)
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount *mount = AP::mount();
+    if (mount == nullptr) {
+        return false;
+    }
+    // check flags for change to RETRACT
+    if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
+        mount->set_mode(MAV_MOUNT_MODE_RETRACT);
+        return true;
+    }
+    // check flags for change to NEUTRAL
+    if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_NEUTRAL) > 0) {
+        mount->set_mode(MAV_MOUNT_MODE_NEUTRAL);
+        return true;
+    }
+
+    // To-Do: handle earth-frame vs body-frame angles
+    //bool earth_frame = cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_ROLL_LOCK |
+    //                   cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_PITCH_LOCK |
+    //                   cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_YAW_LOCK;
+    // To-Do: handle pitch and yaw rates
+    // To-Do: handle gimbal device id
+
+    if (!isnan(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) && !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg)) {
+        mount->set_angle_targets(0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg);
+        return true;
+    }
+
+    // if we got this far then message is not handled
+    return false;
+#else
+    return false;
+#endif // HAL_MOUNT_ENABLED
 }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -558,6 +558,19 @@ void AP_Mount::set_mode(uint8_t instance, enum MAV_MOUNT_MODE mode)
     _backends[instance]->set_mode(mode);
 }
 
+// set yaw_lock.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
+// If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
+void AP_Mount::set_yaw_lock(uint8_t instance, bool yaw_lock)
+{
+    // sanity check instance
+    if (!check_instance(instance)) {
+        return;
+    }
+
+    // return immediately if no change
+    state[instance]._yaw_lock = yaw_lock;
+}
+
 // set_angle_targets - sets angle targets in degrees
 void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float pan)
 {

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -766,6 +766,9 @@ void AP_Mount::handle_message(mavlink_channel_t chan, const mavlink_message_t &m
     case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
         handle_global_position_int(msg);
         break;
+    case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
+        handle_gimbal_device_attitude_status(msg);
+        break;
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Unhandled mount case");
@@ -784,6 +787,16 @@ void AP_Mount::handle_param_value(const mavlink_message_t &msg)
     }
 }
 
+
+// handle GIMBAL_DEVICE_ATTITUDE_STATUS message
+void AP_Mount::handle_gimbal_device_attitude_status(const mavlink_message_t &msg)
+{
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->handle_gimbal_device_attitude_status(msg);
+        }
+    }
+}
 
 // singleton instance
 AP_Mount *AP_Mount::_singleton;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -468,10 +468,12 @@ void AP_Mount::init()
             _backends[instance] = new AP_Mount_SToRM32_serial(*this, state[instance], instance);
             _num_instances++;
 
+#if HAL_MOUNT_GREMSY_ENABLED
         // check for Gremsy mounts
         } else if (mount_type == Mount_Type_Gremsy) {
             _backends[instance] = new AP_Mount_Gremsy(*this, state[instance], instance);
             _num_instances++;
+#endif // HAL_MOUNT_GREMSY_ENABLED
         }
 
         // init new instance

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -207,6 +207,7 @@ private:
     MAV_RESULT handle_command_do_mount_control(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet);
     void handle_global_position_int(const mavlink_message_t &msg);
+    void handle_gimbal_device_attitude_status(const mavlink_message_t &msg);
 };
 
 namespace AP {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -46,6 +46,7 @@ class AP_Mount_SoloGimbal;
 class AP_Mount_Alexmos;
 class AP_Mount_SToRM32;
 class AP_Mount_SToRM32_serial;
+class AP_Mount_Gremsy;
 
 /*
   This is a workaround to allow the MAVLink backend access to the
@@ -61,6 +62,7 @@ class AP_Mount
     friend class AP_Mount_Alexmos;
     friend class AP_Mount_SToRM32;
     friend class AP_Mount_SToRM32_serial;
+    friend class AP_Mount_Gremsy;
 
 public:
     AP_Mount();
@@ -81,7 +83,8 @@ public:
         Mount_Type_SoloGimbal = 2,      /// Solo's gimbal
         Mount_Type_Alexmos = 3,         /// Alexmos mount
         Mount_Type_SToRM32 = 4,         /// SToRM32 mount using MAVLink protocol
-        Mount_Type_SToRM32_serial = 5   /// SToRM32 mount using custom serial protocol
+        Mount_Type_SToRM32_serial = 5,  /// SToRM32 mount using custom serial protocol
+        Mount_Type_Gremsy = 6           /// Gremsy gimbal using MAVLink v2 Gimbal protocol
     };
 
     // init - detect and initialise all mounts
@@ -207,6 +210,7 @@ private:
     MAV_RESULT handle_command_do_mount_control(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet);
     void handle_global_position_int(const mavlink_message_t &msg);
+    void handle_gimbal_device_information(const mavlink_message_t &msg);
     void handle_gimbal_device_attitude_status(const mavlink_message_t &msg);
 };
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -115,6 +115,11 @@ public:
     void set_mode_to_default() { set_mode_to_default(_primary); }
     void set_mode_to_default(uint8_t instance);
 
+    // set yaw_lock.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
+    // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
+    void set_yaw_lock(bool yaw_lock) { set_yaw_lock(_primary, yaw_lock); }
+    void set_yaw_lock(uint8_t instance, bool yaw_lock);
+
     // set_angle_targets - sets angle targets in degrees
     void set_angle_targets(float roll, float tilt, float pan) { set_angle_targets(_primary, roll, tilt, pan); }
     void set_angle_targets(uint8_t instance, float roll, float tilt, float pan);
@@ -179,6 +184,7 @@ protected:
         AP_Float        _pitch_stb_lead;    // pitch lead control gain
 
         MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
+        bool            _yaw_lock;          // If true the gimbal's yaw target is maintained in earth-frame, if false (aka "follow") it is maintained in body-frame
         struct Location _roi_target;        // roi target location
         bool _roi_target_set;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -205,6 +205,7 @@ private:
 
     MAV_RESULT handle_command_do_mount_configure(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_mount_control(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet);
     void handle_global_position_int(const mavlink_message_t &msg);
 };
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -4,6 +4,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+#define AP_MOUNT_UPDATE_DT 0.02     // update rate in seconds.  update() should be called at this rate
+
 // set_angle_targets - sets angle targets in degrees
 void AP_Mount_Backend::set_angle_targets(float roll, float tilt, float pan)
 {
@@ -114,13 +116,17 @@ bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavli
     return true;
 }
 
-void AP_Mount_Backend::rate_input_rad(float &out, const RC_Channel *chan, float min, float max) const
+// update rate and angle targets from RC input
+// current angle target (in radians) should be provided in angle_rad target
+// rate and angle targets are returned in rate_rads and angle_rad arguments
+void AP_Mount_Backend::update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_rad, float angle_max_rad) const
 {
     if ((chan == nullptr) || (chan->get_radio_in() == 0)) {
+        rate_rads = 0;
         return;
     }
-    out += chan->norm_input_dz() * 0.0001f * _frontend._joystick_speed;
-    out = constrain_float(out, radians(min*0.01f), radians(max*0.01f));
+    rate_rads = chan->norm_input_dz() * 0.005f * _frontend._joystick_speed;
+    angle_rad = constrain_float(angle_rad + (rate_rads * AP_MOUNT_UPDATE_DT), radians(angle_min_rad*0.01f), radians(angle_max_rad*0.01f));
 }
 
 // update_targets_from_rc - updates angle targets using input from receiver
@@ -131,20 +137,12 @@ void AP_Mount_Backend::update_targets_from_rc()
     const RC_Channel *pan_ch = rc().channel(_state._pan_rc_in - 1);
 
     // if joystick_speed is defined then pilot input defines a rate of change of the angle
-    if (_frontend._joystick_speed) {
+    if (_frontend._joystick_speed > 0) {
         // allow pilot position input to come directly from an RC_Channel
-        rate_input_rad(_angle_ef_target_rad.x,
-                       roll_ch,
-                       _state._roll_angle_min,
-                       _state._roll_angle_max);
-        rate_input_rad(_angle_ef_target_rad.y,
-                       tilt_ch,
-                       _state._tilt_angle_min,
-                       _state._tilt_angle_max);
-        rate_input_rad(_angle_ef_target_rad.z,
-                       pan_ch,
-                       _state._pan_angle_min,
-                       _state._pan_angle_max);
+        update_rate_and_angle_from_rc(roll_ch, _rate_target_rads.x, _angle_ef_target_rad.x, _state._roll_angle_min, _state._roll_angle_max);
+        update_rate_and_angle_from_rc(tilt_ch, _rate_target_rads.y, _angle_ef_target_rad.y, _state._tilt_angle_min, _state._tilt_angle_max);
+        update_rate_and_angle_from_rc(pan_ch, _rate_target_rads.z, _angle_ef_target_rad.z, _state._pan_angle_min, _state._pan_angle_max);
+        _rate_target_rads_valid = true;
     } else {
         // allow pilot rate input to come directly from an RC_Channel
         if ((roll_ch != nullptr) && (roll_ch->get_radio_in() != 0)) {
@@ -156,6 +154,8 @@ void AP_Mount_Backend::update_targets_from_rc()
         if ((pan_ch != nullptr) && (pan_ch->get_radio_in() != 0)) {
             _angle_ef_target_rad.z = angle_input_rad(pan_ch, _state._pan_angle_min, _state._pan_angle_max);
         }
+        // not using rate input
+        _rate_target_rads_valid = false;
     }
 }
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -118,10 +118,15 @@ protected:
     AP_Mount::mount_state &_state;    // references to the parameters and state for this backend
     uint8_t     _instance;  // this instance's number
     Vector3f    _angle_ef_target_rad;   // desired earth-frame roll, tilt and vehicle-relative pan angles in radians
+    Vector3f    _rate_target_rads;      // desired roll, pitch, yaw rate in radians/sec
+    bool        _rate_target_rads_valid;// true if _rate_target_rads should can be used (e.g. RC input is using rate control)
 
 private:
 
-    void rate_input_rad(float &out, const RC_Channel *ch, float min, float max) const;
+    // update rate and angle targets from RC input
+    // current angle target (in radians) should be provided in angle_rad target
+    // rate and angle targets are returned in rate_rads and angle_rad arguments
+    void update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_rad, float angle_max_rad) const;
 };
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -79,6 +79,9 @@ public:
     // handle a GLOBAL_POSITION_INT message
     bool handle_global_position_int(uint8_t msg_sysid, const mavlink_global_position_int_t &packet);
 
+    // handle GIMBAL_DEVICE_INFORMATION message
+    virtual void handle_gimbal_device_information(const mavlink_message_t &msg) {}
+
     // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
     virtual void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) {}
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -79,6 +79,9 @@ public:
     // handle a GLOBAL_POSITION_INT message
     bool handle_global_position_int(uint8_t msg_sysid, const mavlink_global_position_int_t &packet);
 
+    // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
+    virtual void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) {}
+
 protected:
 
     // update_targets_from_rc - updates angle targets (i.e. _angle_ef_target_rad) using input from receiver

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -34,9 +34,6 @@ public:
         _instance(instance)
     {}
 
-    // Virtual destructor
-    virtual ~AP_Mount_Backend(void) {}
-
     // init - performs any required initialisation for this instance
     virtual void init() = 0;
 

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -1,0 +1,311 @@
+#include "AP_Mount_Gremsy.h"
+#if HAL_MOUNT_ENABLED
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define AP_MOUNT_GREMSY_RESEND_MS  1000     // resend angle targets to gimbal at least once per second
+#define AP_MOUNT_GREMSY_SEARCH_MS  60000    // search for gimbal for 1 minute after startup
+#define AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US    10000  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 100hz
+
+AP_Mount_Gremsy::AP_Mount_Gremsy(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance) :
+    AP_Mount_Backend(frontend, state, instance)
+{}
+
+// update mount position
+void AP_Mount_Gremsy::update()
+{
+    // exit immediately if not initialised
+    if (!_initialised) {
+        find_gimbal();
+        return;
+    }
+
+    // update based on mount mode
+    switch (get_mode()) {
+
+        // move mount to a "retracted" position.  We disable motors
+        case MAV_MOUNT_MODE_RETRACT:
+            // handled below
+            enable_motors(false);
+            break;
+
+        // move mount to a neutral position, typically pointing forward
+        case MAV_MOUNT_MODE_NEUTRAL: {
+            const Vector3f &target = _state._neutral_angles.get();
+            _angle_ef_target_rad.x = ToRad(target.x);
+            _angle_ef_target_rad.y = ToRad(target.y);
+            _angle_ef_target_rad.z = ToRad(target.z);
+            send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, false);
+            }
+            break;
+
+        // point to the angles given by a mavlink message
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+            // angle targets should have been set by a MOUNT_CONTROL message from GCS
+            send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, true);
+            break;
+
+        // RC radio manual angle control, but with stabilization from the AHRS
+        case MAV_MOUNT_MODE_RC_TARGETING:
+            // update targets using pilot's rc inputs
+            update_targets_from_rc();
+            if (_rate_target_rads_valid) {
+                send_gimbal_device_set_rate(_rate_target_rads.x, _rate_target_rads.y, _rate_target_rads.z, _state._yaw_lock);
+            } else {
+                send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, _state._yaw_lock);
+            }
+            break;
+
+        // point mount to a GPS point given by the mission planner
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, false)) {
+                send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, true);
+            }
+            break;
+
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            // constantly update the home location:
+            if (!AP::ahrs().home_is_set()) {
+                break;
+            }
+            _state._roi_target = AP::ahrs().get_home();
+            _state._roi_target_set = true;
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, false)) {
+                send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, true);
+            }
+            break;
+
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, false)) {
+                send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, true);
+            }
+            break;
+
+        default:
+            // unknown mode so do nothing
+            break;
+    }
+}
+
+// send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_Gremsy::send_mount_status(mavlink_channel_t chan)
+{
+    // check we have space for the message
+    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_ATTITUDE_STATUS)) {
+        return;
+    }
+
+    // check we have received an updated message
+    if (_gimbal_device_attitude_status.time_boot_ms == _sent_gimbal_device_attitude_status_ms) {
+        return;
+    }
+    _sent_gimbal_device_attitude_status_ms = _gimbal_device_attitude_status.time_boot_ms;
+
+    // forward on message to GCS
+    mavlink_msg_gimbal_device_attitude_status_send(chan,
+                                                   0,    // target system
+                                                   0,    // target component
+                                                   AP_HAL::millis(),    // autopilot system time
+                                                   _gimbal_device_attitude_status.flags,
+                                                   _gimbal_device_attitude_status.q,
+                                                   _gimbal_device_attitude_status.angular_velocity_x,
+                                                   _gimbal_device_attitude_status.angular_velocity_y,
+                                                   _gimbal_device_attitude_status.angular_velocity_z,
+                                                   _gimbal_device_attitude_status.failure_flags);
+}
+
+// search for gimbal in GCS_MAVLink routing table
+void AP_Mount_Gremsy::find_gimbal()
+{
+    // do not look for gimbal for first 10 seconds so user may see banner
+    if (AP_HAL::millis() < 10000) {
+        return;
+    }
+
+    // return if search time has has passed
+    if (AP_HAL::millis() > AP_MOUNT_GREMSY_SEARCH_MS) {
+        return;
+    }
+
+    // search for a mavlink enabled gimbal
+    if (!_found_gimbal) {
+        mavlink_channel_t chan;
+        uint8_t sysid, compid;
+        if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, sysid, compid, chan)) {
+            if (((_instance == 0) && (compid == MAV_COMP_ID_GIMBAL)) ||
+                ((_instance == 1) && (compid == MAV_COMP_ID_GIMBAL2))) {
+                _found_gimbal = true;
+                _sysid = sysid;
+                _compid = compid;
+                _chan = chan;
+            }
+        } else {
+            // have not yet found a gimbal so return
+            return;
+        }
+    }
+
+    // request GIMBAL_DEVICE_INFORMATION
+    if (!_got_device_info) {
+        uint32_t now_ms = AP_HAL::millis();
+        if (now_ms - _last_devinfo_req_ms > 1000) {
+            _last_devinfo_req_ms = now_ms;
+            request_gimbal_device_information();
+        }
+        return;
+    }
+
+    // start sending autopilot attitude to gimbal
+    if (start_sending_attitude_to_gimbal()) {
+        _initialised = true;
+    }
+}
+
+// handle GIMBAL_DEVICE_INFORMATION message
+void AP_Mount_Gremsy::handle_gimbal_device_information(const mavlink_message_t &msg)
+{
+    // exit immediately if this is not our message
+    if (msg.sysid != _sysid || msg.compid != _compid) {
+        return;
+    }
+
+    mavlink_gimbal_device_information_t info;
+    mavlink_msg_gimbal_device_information_decode(&msg, &info);
+
+    // set parameter defaults from gimbal information
+    _state._roll_angle_min.set_default(degrees(info.roll_min) * 100);
+    _state._roll_angle_max.set_default(degrees(info.roll_max) * 100);
+    _state._tilt_angle_min.set_default(degrees(info.pitch_min) * 100);
+    _state._tilt_angle_max.set_default(degrees(info.pitch_max) * 100);
+    _state._pan_angle_min.set_default(degrees(info.yaw_min) * 100);
+    _state._pan_angle_max.set_default(degrees(info.yaw_max) * 100);
+
+    const uint8_t fw_ver_major = info.firmware_version & 0x000000FF;
+    const uint8_t fw_ver_minor = (info.firmware_version & 0x0000FF00) >> 8;
+    const uint8_t fw_ver_revision = (info.firmware_version & 0x00FF0000) >> 16;
+    const uint8_t fw_ver_build = (info.firmware_version & 0xFF000000) >> 24;
+
+    // display gimbal info to user
+    gcs().send_text(MAV_SEVERITY_INFO, "Mount: %s %s fw:%u.%u.%u.%u",
+            info.vendor_name,
+            info.model_name,
+            (unsigned)fw_ver_major,
+            (unsigned)fw_ver_minor,
+            (unsigned)fw_ver_revision,
+            (unsigned)fw_ver_build);
+
+    _got_device_info = true;
+}
+
+// handle GIMBAL_DEVICE_ATTITUDE_STATUS message
+void AP_Mount_Gremsy::handle_gimbal_device_attitude_status(const mavlink_message_t &msg)
+{
+    // exit immediately if this is not our message
+    if (msg.sysid != _sysid || msg.compid != _compid) {
+        return;
+    }
+
+    // take copy of message so it can be forwarded onto GCS later
+    mavlink_msg_gimbal_device_attitude_status_decode(&msg, &_gimbal_device_attitude_status);
+}
+
+// request GIMBAL_DEVICE_INFORMATION message
+void AP_Mount_Gremsy::request_gimbal_device_information() const
+{
+    // check we have space for the message
+    if (!HAVE_PAYLOAD_SPACE(_chan, COMMAND_LONG)) {
+        return;
+    }
+
+    mavlink_msg_command_long_send(
+        _chan,
+        _sysid,
+        _compid,
+        MAV_CMD_REQUEST_MESSAGE,
+        0, MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, 0, 0, 0, 0, 0, 0);
+}
+
+// start sending ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE to gimbal
+bool AP_Mount_Gremsy::start_sending_attitude_to_gimbal()
+{
+    // send AUTOPILOT_STATE_FOR_GIMBAL_DEVICE
+    const MAV_RESULT res = gcs().set_message_interval(_chan, MAVLINK_MSG_ID_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE, AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US);
+
+    // return true on success
+    return (res == MAV_RESULT_ACCEPTED);
+}
+
+// send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
+// earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
+void AP_Mount_Gremsy::send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const
+{
+    // check we have space for the message
+    if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
+        return;
+    }
+
+    // prepare flags
+    const uint16_t flags = earth_frame ? (GIMBAL_DEVICE_FLAGS_ROLL_LOCK | GIMBAL_DEVICE_FLAGS_PITCH_LOCK | GIMBAL_DEVICE_FLAGS_YAW_LOCK) : 0;
+    const float quat_array[4] = {NAN, NAN, NAN, NAN};
+
+    // send command_long command containing a do_mount_control command
+    mavlink_msg_gimbal_device_set_attitude_send(_chan,
+                                                _sysid,     // target system
+                                                _compid,    // target component
+                                                flags,      // gimbal device flags
+                                                quat_array, // attitude as a quaternion
+                                                roll_rads, pitch_rads, yaw_rads);   // angular velocities
+}
+
+// send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
+// earth_frame should be true if yaw_rad target is in earth frame angle, false if body_frame
+void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const
+{
+    // exit immediately if not initialised
+    if (!_initialised) {
+        return;
+    }
+
+    // check we have space for the message
+    if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
+        return;
+    }
+
+    // prepare flags
+    const uint16_t flags = earth_frame ? (GIMBAL_DEVICE_FLAGS_ROLL_LOCK | GIMBAL_DEVICE_FLAGS_PITCH_LOCK | GIMBAL_DEVICE_FLAGS_YAW_LOCK) : 0;
+
+    // convert euler angles to quaternion
+    Quaternion q;
+    q.from_euler(roll_rad, pitch_rad, yaw_rad);
+    const float quat_array[4] = {q.q1, q.q2, q.q3, q.q4};
+
+    // send command_long command containing a do_mount_control command
+    mavlink_msg_gimbal_device_set_attitude_send(_chan,
+                                                _sysid,     // target system
+                                                _compid,    // target component
+                                                flags,      // gimbal device flags
+                                                quat_array, // attitude as a quaternion
+                                                NAN, NAN, NAN);   // angular velocities
+}
+
+// turn motors on/off
+void AP_Mount_Gremsy::enable_motors(bool on) const
+{
+    // check we have space for the message
+    if (!HAVE_PAYLOAD_SPACE(_chan, COMMAND_LONG)) {
+        return;
+    }
+
+    // send COMPMAND_LONG with MAV_CMD_USER_1 command with Param7 populated to turn on/off motor
+    mavlink_msg_command_long_send(_chan,
+                                  _sysid,
+                                  _compid,
+                                  MAV_CMD_USER_1,
+                                  0,                // confirmation of zero means this is the first time this message has been sent
+                                  0, 0, 0, 0, 0, 0, // param1 to param6 unused
+                                  on ? 0x01 : 0x00);// 0=OFF, 1=ON
+}
+
+#endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -1,7 +1,6 @@
 #include "AP_Mount_Gremsy.h"
-#if HAL_MOUNT_ENABLED
-#include <AP_HAL/AP_HAL.h>
-#include <GCS_MAVLink/GCS.h>
+
+#if HAL_MOUNT_GREMSY_ENABLED
 
 extern const AP_HAL::HAL& hal;
 
@@ -308,4 +307,4 @@ void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitc
                                                 NAN, NAN, NAN);   // angular velocities
 }
 
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_GREMSY_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -1,0 +1,79 @@
+/*
+  SToRM32 mount using serial protocol backend class
+ */
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+#include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include "AP_Mount_Backend.h"
+
+#if HAL_MOUNT_ENABLED
+
+
+class AP_Mount_Gremsy : public AP_Mount_Backend
+{
+
+public:
+    // Constructor
+    AP_Mount_Gremsy(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
+
+    // init
+    void init() override {}
+
+    // update mount position
+    void update() override;
+
+    // has_pan_control
+    bool has_pan_control() const override { return true; }
+
+    // set_mode
+    void set_mode(enum MAV_MOUNT_MODE mode) override { _state._mode = mode; }
+
+    // send_mount_status
+    void send_mount_status(mavlink_channel_t chan) override;
+
+    // handle GIMBAL_DEVICE_INFORMATION message
+    void handle_gimbal_device_information(const mavlink_message_t &msg) override;
+
+    // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
+    void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) override;
+
+private:
+
+    // search for gimbal in GCS_MAVLink routing table
+    void find_gimbal();
+
+    // request GIMBAL_DEVICE_INFORMATION from gimbal (holds vendor and model name, max lean angles)
+    void request_gimbal_device_information() const;
+
+    // start sending ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE to gimbal
+    // returns true on success, false on failure to start sending
+    bool start_sending_attitude_to_gimbal();
+
+    // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
+    // earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
+    void send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const;
+
+    // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
+    // earth_frame should be true if yaw_rad target is an earth frame angle, false if body_frame
+    void send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const;
+
+    // turn motors on/off
+    void enable_motors(bool on) const;
+
+    // internal variables
+    bool _found_gimbal;             // true once a MAVLink enabled gimbal has been found
+    bool _got_device_info;          // true once gimbal has provided device info
+    bool _initialised;              // true once the gimbal has provided a GIMBAL_DEVICE_INFORMATION
+    uint32_t _last_devinfo_req_ms;  // system time that GIMBAL_DEVICE_INFORMATION was last requested (used to throttle requests)
+    mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
+    uint8_t _sysid;                 // sysid of gimbal
+    uint8_t _compid;                // component id of gimbal
+    mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status
+    uint32_t _sent_gimbal_device_attitude_status_ms;    // time_boot_ms field of gimbal_device_status message last forwarded to the GCS (used to prevent sending duplicates)
+};
+#endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -54,6 +54,9 @@ private:
     // returns true on success, false on failure to start sending
     bool start_sending_attitude_to_gimbal();
 
+    // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)
+    void send_gimbal_device_retract() const;
+
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
     // earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
     void send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const;
@@ -61,9 +64,6 @@ private:
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
     // earth_frame should be true if yaw_rad target is an earth frame angle, false if body_frame
     void send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const;
-
-    // turn motors on/off
-    void enable_motors(bool on) const;
 
     // internal variables
     bool _found_gimbal;             // true once a MAVLink enabled gimbal has been found

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -1,18 +1,21 @@
 /*
-  SToRM32 mount using serial protocol backend class
+  Gremsy mount backend class
  */
 #pragma once
 
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_GREMSY_ENABLED
+#define HAL_MOUNT_GREMSY_ENABLED (HAL_MOUNT_ENABLED && !HAL_MINIMIZE_FEATURES && BOARD_FLASH_SIZE > 1024)
+#endif
+
+#if HAL_MOUNT_GREMSY_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
-
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include "AP_Mount_Backend.h"
-
-#if HAL_MOUNT_ENABLED
-
 
 class AP_Mount_Gremsy : public AP_Mount_Backend
 {
@@ -76,4 +79,4 @@ private:
     mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status
     uint32_t _sent_gimbal_device_attitude_status_ms;    // time_boot_ms field of gimbal_device_status message last forwarded to the GCS (used to prevent sending duplicates)
 };
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_GREMSY_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -5,6 +5,9 @@
 
 extern const AP_HAL::HAL& hal;
 
+#define AP_MOUNT_STORM32_RESEND_MS  1000    // resend angle targets to gimbal once per second
+#define AP_MOUNT_STORM32_SEARCH_MS  60000   // search for gimbal for 1 minute after startup
+
 AP_Mount_SToRM32::AP_Mount_SToRM32(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance) :
     AP_Mount_Backend(frontend, state, instance),
     _chan(MAVLINK_COMM_0)

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -12,9 +12,6 @@
 #include <RC_Channel/RC_Channel.h>
 #include <AP_AHRS/AP_AHRS.h>
 
-#define AP_MOUNT_STORM32_RESEND_MS  1000    // resend angle targets to gimbal once per second
-#define AP_MOUNT_STORM32_SEARCH_MS  60000   // search for gimbal for 1 minute after startup
-
 class AP_Mount_SToRM32 : public AP_Mount_Backend
 {
 
@@ -49,7 +46,7 @@ private:
     bool _initialised;              // true once the driver has been initialised
     uint8_t _sysid;                 // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
-    mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal.  Currently hard-coded to Telem2
+    mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
 };
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -292,6 +292,11 @@ public:
     virtual void get_osd_roll_pitch_rad(float &roll, float &pitch) const;
 #endif
 
+    /*
+     get the target body-frame angular velocities in rad/s (Z-axis component used by some gimbals)
+     */
+    virtual bool get_rate_bf_targets(Vector3f& rate_bf_targets) const { return false; }
+
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -318,6 +318,7 @@ public:
     void send_high_latency2() const;
 #endif // HAL_HIGH_LATENCY2_ENABLED
     void send_uavionix_adsb_out_status() const;
+    void send_autopilot_state_for_gimbal_device() const;
 
     // lock a channel, preventing use by MAVLink
     void lock(bool _lock) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3629,6 +3629,8 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
         break;
 
     case MAVLINK_MSG_ID_GIMBAL_REPORT:
+    case MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION:
+    case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
         handle_mount_message(msg);
         break;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1450,6 +1450,7 @@ void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
         return;
     }
     if (msg.msgid == MAVLINK_MSG_ID_GLOBAL_POSITION_INT) {
+        // allow mounts to see the location of other vehicles
         handle_mount_message(msg);
     }
     if (!accept_packet(status, msg)) {

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -81,5 +81,6 @@ enum ap_message : uint8_t {
     MSG_MCU_STATUS,
     MSG_UAVIONIX_ADSB_OUT_STATUS,
     MSG_ATTITUDE_TARGET,
+    MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -522,6 +522,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::FFT_NOTCH_TUNE:
 #if HAL_MOUNT_ENABLED
     case AUX_FUNC::RETRACT_MOUNT:
+    case AUX_FUNC::MOUNT_LOCK:
 #endif
         run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
         break;
@@ -582,6 +583,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::WEATHER_VANE_ENABLE, "Weathervane"},
     { AUX_FUNC::TURBINE_START, "Turbine Start"},
     { AUX_FUNC::FFT_NOTCH_TUNE, "FFT Notch Tuning"},
+    { AUX_FUNC::MOUNT_LOCK, "MountLock"},
 };
 
 /* lookup the announcement for switch change */
@@ -1212,6 +1214,17 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
                 mount->set_mode_to_default();
                 break;
         }
+#endif
+        break;
+    }
+
+    case AUX_FUNC::MOUNT_LOCK: {
+#if HAL_MOUNT_ENABLED
+        AP_Mount *mount = AP::mount();
+        if (mount == nullptr) {
+            break;
+        }
+        mount->set_yaw_lock(ch_flag == AuxSwitchPos::HIGH);
 #endif
         break;
     }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -226,6 +226,7 @@ public:
         WEATHER_VANE_ENABLE = 160, // enable/disable weathervaning
         TURBINE_START =      161, // initialize turbine start sequence
         FFT_NOTCH_TUNE =     162, // FFT notch tuning function
+        MOUNT_LOCK =         163, // Mount yaw lock vs follow
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input


### PR DESCRIPTION
This improves our support of the [Gremsy gimbals](https://ardupilot.org/copter/docs/common-gremsy-pixyu-gimbal.html#common-gremsy-pixyu-gimbal) in the following ways:

- Adds an auxiliary switch option MOUNT_LOCK (163) to allow a pilot to specify whether the gimbal should maintain a body-frame heading or an earth-frame heading while under pilot control (e.g. mode is RC_TARGETING).  This is only implemented for the new Gremsy driver at this stage but will be extended to other drivers in a follow-up PR
- Gremsy specific driver (separate from the SToRM32 mavlink driver) which implements these additional features:
    - GIMBAL_DEVICE_INFORMATION message is consumed to display the gimbal hardware and firmware information at startup.   This message is also used to default AP_Mount's angular limits (e.g.  MNT_ANGMIN_ROLL, etc) to ease setup
    - AUTO_PILOT_STATE_FOR_GIMBAL_DEVICE is sent at 100hz to the gimbal to allow it to know its "earth-frame" yaw
    - GIMBAL_DEVICE_ATTITUDE_STATUS messages from the gimbal are consumed and re-sent (at a lower rate) to the GCS in place of the regular MOUNT_STATUS message that other gimbals send.  I plan to migrate other gimbal drivers to use this message in a follow-up PR
    - GIMBAL_DEVICE_SET_ATTITUDE is used to send the angular or rate targets to the gimbal.  These can be either earth-frame or body-frame depending upon the mode and auxiliary switch position.  For example:
        - RC_TARGETING will send **rate** targets if MNT_JSTICK_SPD > 0.  These will be either earth-frame or body-frame rates depending upon the MOUNT_LOCK aux switch position
        - DO_MOUNT_CONTROL mission commands are sent as earth-frame angles
        - DO_SET_ROI commands result in earth-frame angles
        - DO_GIMBAL_MANAGER_PITCHYAW commands result in earth-frame angles but in the future Param5 will be used to allow the user to specify the framed (this change was left-out to reduce the scope of this PR)
        - if mode is NEUTRAL mode body-frame angles are sent
    - If mode is RETRACTED the gimbal motors are turned off and the gimbal relaxes making it easier to adjust the camera (turn it on, attach an hdmi cable, etc)

- Basic DO_GIMBAL_MANAGER_PITCHYAW support added for both missions and if sent by GCS.  I say "basic" because there are these known issues:
    - [Mission Planner](https://github.com/ArduPilot/MissionPlanner/issues/2871) and MAVProxy are dividing/multiplying Param5 by 10e7 for all messages regardless of whether the field holds a lattitude or not which limits the usefulness of this message.
    - Support for the user to set the frame (held in Param5) is missing because this would affect all gimbals and would greatly expand the scope of this PR.  I'll fix this in a follow-up PR.

This PR is built upon these other PRs

- https://github.com/ArduPilot/mavlink/pull/274
- https://github.com/ArduPilot/ardupilot/pull/20914
- https://github.com/ArduPilot/ardupilot/pull/20899

This driver has been tested on real vehicle using a Gremsy Pixy-U gimbal.  The SToRM32 mavlink driver has also been tested (but using the Gremsy gimbal) to confirm it is unaffected by these changes.  Other gimbals have not been re-tested but should be fine.

[I've started testing with beta testers here](https://discuss.ardupilot.org/t/ardupilot-4-3-gremsy-gimbal-improvements-testers-wanted/86479)

Thanks to @bugobliterator for his initial work on this driver.


Size comparison shows there is some extra consumption for all boards probably because of the new mission command and mavlink message handling.

Durandal
```
Binary Name      Text [B]         Data [B]     BSS (B)        Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  ---------------  -----------  -------------  ----------------------------  -------------------------
arducopter-heli  2868 (+0.1621%)  0 (0.0000%)  -4 (-0.0015%)  2868 (+0.1618%)                                  190592
ardurover        2876 (+0.1811%)  0 (0.0000%)  4 (+0.0015%)   2876 (+0.1809%)                                  373112
arduplane        2812 (+0.1613%)  0 (0.0000%)  4 (+0.0015%)   2812 (+0.1610%)                                  216688
blimp            936 (+0.0725%)   0 (0.0000%)  0 (0.0000%)    936 (+0.0724%)                                   672644
arducopter       2868 (+0.1628%)  0 (0.0000%)  -4 (-0.0015%)  2868 (+0.1625%)                                  198624
antennatracker   928 (+0.0688%)   0 (0.0000%)  0 (0.0000%)    928 (+0.0687%)                                   613672
ardusub          2800 (+0.1807%)  0 (0.0000%)  0 (0.0000%)    2800 (+0.1805%)                                  411748
```

MatekF405
```
Binary Name      Text [B]         Data [B]     BSS (B)        Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  ---------------  -----------  -------------  ----------------------------  -------------------------
arducopter-heli  1040 (+0.1102%)  0 (0.0000%)  0 (0.0000%)    1040 (+0.1099%)                                   35936
ardurover        1004 (+0.1171%)  0 (0.0000%)  -4 (-0.0031%)  1004 (+0.1170%)                                  123656
arduplane        980 (+0.1008%)   0 (0.0000%)  -4 (-0.0031%)  980 (+0.1006%)                                     8136
blimp            980 (+0.1436%)   0 (0.0000%)  -4 (-0.0031%)  980 (+0.1434%)                                   298820
arducopter       1040 (+0.1114%)  0 (0.0000%)  0 (0.0000%)    1040 (+0.1112%)                                   46416
antennatracker   972 (+0.1463%)   0 (0.0000%)  4 (+0.0031%)   972 (+0.1461%)                                   316904
ardusub          968 (+0.1189%)   0 (0.0000%)  0 (0.0000%)    968 (+0.1188%)                                   167116
```

Pixhawk1-1M
```
Binary Name      Text [B]        Data [B]     BSS (B)        Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  --------------  -----------  -------------  ----------------------------  -------------------------
arducopter-heli  644 (+0.0637%)  0 (0.0000%)  -4 (-0.0020%)  644 (+0.0636%)                                    19140
ardurover        584 (+0.0636%)  0 (0.0000%)  0 (0.0000%)    584 (+0.0635%)                                   112140
arduplane        588 (+0.0572%)  0 (0.0000%)  -4 (-0.0020%)  588 (+0.0572%)                                     3444
blimp            584 (+0.0816%)  0 (0.0000%)  0 (0.0000%)    584 (+0.0815%)                                   314996
arducopter       644 (+0.0645%)  0 (0.0000%)  4 (+0.0020%)   644 (+0.0644%)                                    31716
antennatracker   584 (+0.0769%)  0 (0.0000%)  0 (0.0000%)    584 (+0.0768%)                                   271640
ardusub          584 (+0.0635%)  0 (0.0000%)  0 (0.0000%)    584 (+0.0634%)                                   110616
```