### PR TITLE
AP_DAL: fix rangefinder get_backend range check

### DIFF
--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -115,15 +115,11 @@ bool AP_DAL_RangeFinder::has_orientation(enum Rotation orientation) const
 
 AP_DAL_RangeFinder_Backend *AP_DAL_RangeFinder::get_backend(uint8_t id) const
 {
-   if (id >= RANGEFINDER_MAX_INSTANCES) {
-       INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-       return nullptr;
-   }
-   if (id >= _RRNH.num_sensors) {
+    if (id >= _RRNH.num_sensors) {
         return nullptr;
     }
 
-   return _backend[id];
+    return _backend[id];
 }
 
 void AP_DAL_RangeFinder::handle_message(const log_RRNH &msg)


### PR DESCRIPTION
This change allow to set RANGEFINDER_MAX_INSTANCES to 1.

If I set RANGEFINDER_MAX_INSTANCES=1, I got this error before.

```
#5  0x000055596030d8b6 in AP_HAL::panic (errormsg=0x555960451075 "AP_InternalError::error_t::%s") at ../../libraries/AP_HAL_SITL/system.cpp:43
        ap = {{gp_offset = 16, fp_offset = 48, overflow_arg_area = 0x7ffeed8ca4b0, reg_save_area = 0x7ffeed8ca3f0}}
#6  0x00005559601e5776 in AP_InternalError::error (this=0x55596056b098 <instance>, e=AP_InternalError::error_t::flow_of_control, line=119) at ../../libraries/AP_InternalError/AP_InternalError.cpp:22
        buffer = "flow_of_ctrl", '\000' <repeats 37 times>, "\245"
#7  0x00005559603b9b02 in AP_DAL_RangeFinder::get_backend (this=0x555960d56f50, id=1 '\001') at ../../libraries/AP_DAL/AP_DAL_RangeFinder.cpp:119
No locals.
#8  0x00005559601a0f16 in NavEKF3_core::readRangeFinder (this=0x555960d5b9a0) at ../../libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp:38
        sensor = 0x555960d56fb0
        sampleFresh = {{false, true, false}, {false, false, false}}
        sensorIndex = <optimized out>
        midIndex = <optimized out>
        maxIndex = <optimized out>
        minIndex = 56 '8'
        _rng = 0x555960d56f50
#9  0x00005559601aec59 in NavEKF3_core::selectHeightForFusion (this=0x555960d5b9a0) at ../../libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp:1056
        _rng = 0x0
        rangeFinderDataIsFresh = false
        extNavDataIsFresh = <optimized out>
        lostRngHgt = <optimized out>
        lostGpsHgt = <optimized out>
        lostRngBcnHgt = <optimized out>
        fallback_to_baro = <optimized out>
        lostExtNavHgt = <optimized out>
#10 0x00005559601ad3a7 in NavEKF3_core::SelectVelPosFusion (this=0x555960d5b9a0) at ../../libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp:521
        posxy_source = AP_NavEKF_Source::SourceXY::NONE
#11 0x00005559601b7a12 in NavEKF3_core::UpdateFilter (this=0x555960d5b9a0, predict=56) at ../../libraries/AP_NavEKF3/AP_NavEKF3_core.cpp:678
No locals.
#12 0x0000555960191e49 in NavEKF3::UpdateFilter (this=0x55596055de00 <copter+9216>) at ../../libraries/AP_NavEKF3/AP_NavEKF3.cpp:903
        allow_state_prediction = <optimized out>
        i = 1 '\001'
        armed = true
        user_primary = <optimized out>
#13 0x000055596011a621 in AP_AHRS::update_EKF3 (this=0x55596055dc68 <copter+8808>) at ../../libraries/AP_AHRS/AP_AHRS.cpp:568
No locals.
#14 0x0000555960119c97 in AP_AHRS::update (this=0x55596055dc68 <copter+8808>, skip_ins_update=true) at ../../libraries/AP_AHRS/AP_AHRS.cpp:353
        _getsem18 = {_mtx = @0x55596055e018}
        active = 2141192192
#15 0x00005559600de549 in Copter::read_AHRS (this=0x55596055ba00 <copter>) at ../../ArduCopter/Copter.cpp:689
No locals.
```

reference #15944