### PR TITLE
Rover: 4.2.1 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.2.1-rc1 28-May-2022
+Copter 4.2.1 07-Jun-2022 / 4.2.1-rc1 28-May-2022
 Changes from 4.2.0
 1) CAN ESCs bus bandwidth efficiency improvements (see CAN_Dx_UC_ESC_OF parameter)
 2) DShot timing improvements to support for ESC variants

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.1-rc1"
+#define THISFIRMWARE "ArduCopter V4.2.1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,1,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,2,1,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,6 +1,6 @@
 Rover Release Notes:
 ------------------------------------------------------------------
-Rover 4.2.1-rc1 28-May-2022
+Rover 4.2.1 07-Jun-2022 / 4.2.1-rc1 28-May-2022
 Changes from 4.2.0
 1) CAN ESCs bus bandwidth efficiency improvements (see CAN_Dx_UC_ESC_OF parameter)
 2) DShot timing improvements to support for ESC variants

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.2.1-rc1"
+#define THISFIRMWARE "ArduRover V4.2.1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,1,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,2,1,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Rover-4.2.1 release which is identical to the [Copter-4.2.1](https://github.com/ArduPilot/ardupilot/pull/20919) release and has been available for beta testing for 10 days.

Not a lot of reports back but also no complaints so considering this is just like the Plane-4.2.1 release it should be fine.