### PR TITLE
Tools: cope with change in cygwin build

### DIFF
--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -24,6 +24,14 @@ mkdir artifacts
 
 i686-pc-cygwin-g++ -print-sysroot
 
+# copy both with exe and without to cope with differences
+# between windows versions in CI
+cp -v build/sitl/bin/arduplane artifacts/ArduPlane.elf.exe
+cp -v build/sitl/bin/arducopter artifacts/ArduCopter.elf.exe
+cp -v build/sitl/bin/arducopter-heli artifacts/ArduHeli.elf.exe
+cp -v build/sitl/bin/ardurover artifacts/ArduRover.elf.exe
+cp -v build/sitl/bin/ardusub artifacts/ArduSub.elf.exe
+
 cp -v build/sitl/bin/arduplane artifacts/ArduPlane.elf
 cp -v build/sitl/bin/arducopter artifacts/ArduCopter.elf
 cp -v build/sitl/bin/arducopter-heli artifacts/ArduHeli.elf
@@ -33,3 +41,4 @@ cp -v build/sitl/bin/ardusub artifacts/ArduSub.elf
 cp -v /usr/i686-pc-cygwin/sys-root/usr/bin/*.dll artifacts/
 
 git log -1 > artifacts/git.txt
+ls -l artifacts/


### PR DESCRIPTION
copy both with and without exe extension. This fixes the CI failures 