### PR TITLE
Copter/Plane/Rover:  Initialize a string array

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -258,7 +258,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 #endif
 
         // ensure controllers are OK with us arming:
-        char failure_msg[50];
+        char failure_msg[50] = {};
         if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
@@ -344,7 +344,7 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
 bool AP_Arming_Copter::oa_checks(bool display_failure)
 {
 #if AC_OAPATHPLANNER_ENABLED == ENABLED
-    char failure_msg[50];
+    char failure_msg[50] = {};
     if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
         return true;
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -158,7 +158,7 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
     }
 
     // ensure controllers are OK with us arming:
-    char failure_msg[50];
+    char failure_msg[50] = {};
     if (!plane.quadplane.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
         check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
         ret = false;

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -157,7 +157,7 @@ bool AP_Arming_Rover::disarm(const AP_Arming::Method method, bool do_disarm_chec
 // check object avoidance has initialised correctly
 bool AP_Arming_Rover::oa_check(bool report)
 {
-    char failure_msg[50];
+    char failure_msg[50] = {};
     if (rover.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
         return true;
     }
@@ -205,7 +205,7 @@ bool AP_Arming_Rover::motor_checks(bool report)
     bool ret = rover.g2.motors.pre_arm_check(report);
 
 #if HAL_TORQEEDO_ENABLED
-    char failure_msg[50];
+    char failure_msg[50] = {};
     AP_Torqeedo *torqeedo = AP_Torqeedo::get_singleton();
     if (torqeedo != nullptr) {
         if (!torqeedo->pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {


### PR DESCRIPTION
Initialize the message array of the AUTO variable.
Other methods initialize.
I want to match other methods.
I think AUTO variables are good, initialize and then use.