### PR TITLE
SIM_Precland: add option to set orientation of precland device in sitl

### DIFF
--- a/libraries/SITL/SIM_Precland.h
+++ b/libraries/SITL/SIM_Precland.h
@@ -50,6 +50,7 @@ public:
     AP_Int32 _rate;
     AP_Float _alt_limit;
     AP_Float _dist_limit;
+    AP_Int8 _orient;
     bool _over_precland_base;
 
     enum PreclandType {


### PR DESCRIPTION
This adds an option to set orientation of simulated precland device in sitl. This will help us test the coming autodocking feature for rover. The new code works for any possible orientation of precland device, though currently we only provide option to set orientation to PITCH_90 (i.e., up), NONE (i.e., front) or YAW_180 (i.e. back). 
I have tested it on sitl for copter and it works great. The detailed logic behind this approach can be found under **Setting orientation of the sensor in SIM_Precland** section of [this](https://discuss.ardupilot.org/t/gsoc-2022-rover-autodocking/86104) blog post.