### PR TITLE
AP_Vehicle: allow the throttle based notch to track below reference

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -446,12 +446,22 @@ public:
         // Update the harmonic notch frequencies
         void update_freq_hz(float scaled_freq);
         void update_frequencies_hz(uint8_t num_freqs, const float scaled_freq[]);
-        
+
+        // enable/disable the notch
+        void set_inactive(bool _inactive) {
+            inactive = _inactive;
+        }
+
+        bool is_inactive(void) const {
+            return inactive;
+        }
+
     private:
         // support for updating harmonic filter at runtime
         float last_center_freq_hz[INS_MAX_INSTANCES];
         float last_bandwidth_hz[INS_MAX_INSTANCES];
         float last_attenuation_dB[INS_MAX_INSTANCES];
+        bool inactive;
     } harmonic_notches[HAL_INS_NUM_HARMONIC_NOTCH_FILTERS];
 
 private:

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -250,9 +250,6 @@ public:
 
 #endif // AP_SCRIPTING_ENABLED
 
-    // update the harmonic notch
-    void update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch);
-
     // zeroing the RC outputs can prevent unwanted motor movement:
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
 
@@ -415,6 +412,12 @@ private:
     // if there's been a watchdog reset, notify the world via a
     // statustext:
     void send_watchdog_reset_statustext();
+
+    // update the harmonic notch for throttle based notch
+    void update_throttle_notch(AP_InertialSensor::HarmonicNotch &notch);
+
+    // update the harmonic notch
+    void update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch);
 
     // run notch update at either loop rate or 200Hz
     void update_dynamic_notch_at_specified_rate();

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -90,6 +90,13 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("OPTS", 8, HarmonicNotchFilterParams, _options, 0),
 
+    // @Param: FM_RAT
+    // @DisplayName: Throttle notch min freqency ratio
+    // @Description: The minimum ratio below the configured frequency to take throttle based notch filters when flying at a throttle level below the reference throttle. Note that lower frequency notch filters will have more phase lag. If you want throttle based notch filtering to be effective at a throttle up to 30% below the configured notch frequency then set this parameter to 0.7. The default of 1.0 means the notch will not go below the frequency in the FREQ parameter.
+    // @Range: 0.1 1.0
+    // @User: Advanced
+    AP_GROUPINFO("FM_RAT", 9, HarmonicNotchFilterParams, _freq_min_ratio, 1.0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -311,3 +311,5 @@ void HarmonicNotchFilterParams::save_params()
   instantiate template classes
  */
 template class HarmonicNotchFilter<Vector3f>;
+template class HarmonicNotchFilter<float>;
+

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -106,6 +106,11 @@ public:
     HarmonicNotchDynamicMode tracking_mode(void) const { return HarmonicNotchDynamicMode(_tracking_mode.get()); }
     static const struct AP_Param::GroupInfo var_info[];
 
+    // return minimum frequency ratio for throttle notch
+    float freq_min_ratio(void) const {
+        return _freq_min_ratio;
+    }
+
     // save parameters
     void save_params();
 
@@ -118,6 +123,9 @@ private:
     AP_Int8 _tracking_mode;
     // notch options
     AP_Int16 _options;
+
+    // minimum frequency ratio for throttle based notches
+    AP_Float _freq_min_ratio;
 };
 
 typedef HarmonicNotchFilter<Vector3f> HarmonicNotchFilterVector3f;

--- a/libraries/Filter/tests/plot_harmonics.gnu
+++ b/libraries/Filter/tests/plot_harmonics.gnu
@@ -1,0 +1,11 @@
+#!/usr/bin/gnuplot -persist
+set y2tics 0,10
+set ytics nomirror
+set style data linespoints
+set key autotitle
+set datafile separator ","
+set key autotitle columnhead
+set xlabel "Freq(Hz)"
+set ylabel "Attenuation"
+#set ylabel2 "PhaseLag(deg)"
+plot "harmonicnotch_test.csv" using 1:2 axis x1y1, "harmonicnotch_test.csv" using 1:3 axis x1y2

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -2,6 +2,7 @@
 
 #include <Filter/Filter.h>
 #include <Filter/NotchFilter.h>
+#include <Filter/HarmonicNotchFilter.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -30,7 +31,7 @@ TEST(NotchFilterTest, SineTest)
     const float test_freq = 47;
     const float attenuation_dB = 43;
     const float rate_hz = 2000;
-    double dt = 1.0 / rate_hz;
+    const double dt = 1.0 / rate_hz;
     const uint32_t period_samples = rate_hz / test_freq;
     const uint32_t periods = 1000;
     const float test_amplitude = 0.7;
@@ -63,6 +64,92 @@ TEST(NotchFilterTest, SineTest)
     ::printf("ratio1=%f expected_ratio=%f\n", ratio1, expected_ratio);
     const float err_pct = 100 * fabsf(ratio1 - expected_ratio) / ratio1;
     EXPECT_LE(err_pct, 1);
+}
+
+/*
+  test attentuation versus frequency
+  This is a way to get a graph of the attenuation and phase lag for a complex filter setup
+ */
+TEST(NotchFilterTest, HarmonicNotchTest)
+{
+    const uint8_t num_test_freq = 150;
+    const uint8_t harmonics = 15;
+    const uint8_t num_harmonics = __builtin_popcount(harmonics);
+    const float base_freq = 46;
+    const float bandwidth = base_freq/2;
+    const float attenuation_dB = 60;
+    // number of identical filters chained together, simulating
+    // usage of per-motor notch filtering
+    const uint8_t chained_filters = 8;
+    const uint16_t rate_hz = 2000;
+    const uint32_t samples = 50000;
+    const float test_amplitude = 0.7;
+    const double dt = 1.0 / rate_hz;
+
+    bool double_notch = false;
+    HarmonicNotchFilter<float> filters[num_test_freq][chained_filters] {};
+    struct {
+        double in;
+        double out;
+        double last_in;
+        double last_out;
+        uint32_t last_crossing;
+        uint32_t total_lag_samples;
+        uint32_t lag_count;
+        float get_lag_degrees(const float freq) const {
+            const float lag_avg = total_lag_samples/float(lag_count);
+            return (360.0 * lag_avg * freq) / rate_hz;
+        }
+    } integrals[num_test_freq] {};
+
+    for (uint8_t i=0; i<num_test_freq; i++) {
+        for (uint8_t c=0; c<chained_filters; c++) {
+            auto &f = filters[i][c];
+            f.allocate_filters(num_harmonics, harmonics, double_notch);
+            f.init(rate_hz, base_freq, bandwidth, attenuation_dB);
+        }
+    }
+
+    for (uint32_t s=0; s<samples; s++) {
+        const double t = s * dt;
+
+        for (uint8_t i=0; i<num_test_freq; i++) {
+            const float freq = i+1;
+            const double sample = sin(freq * t * 2 * M_PI) * test_amplitude;
+            float v = sample;
+            for (uint8_t c=0; c<chained_filters; c++) {
+                auto &f = filters[i][c];
+                v = f.apply(v);
+            }
+            if (s >= s/10) {
+                integrals[i].in += fabsf(sample) * dt;
+                integrals[i].out += fabsf(v) * dt;
+            }
+            if (sample >= 0 && integrals[i].last_in < 0) {
+                integrals[i].last_crossing = s;
+            }
+            if (v >= 0 && integrals[i].last_out < 0 && integrals[i].last_crossing != 0) {
+                integrals[i].total_lag_samples += s - integrals[i].last_crossing;
+                integrals[i].lag_count++;
+            }
+            integrals[i].last_in = sample;
+            integrals[i].last_out = v;
+        }
+    }
+    const char *csv_file = "harmonicnotch_test.csv";
+    FILE *f = fopen(csv_file, "w");
+    fprintf(f, "Freq(Hz),Ratio,Lag(deg)\n");
+    for (uint8_t i=0; i<num_test_freq; i++) {
+        const float freq = i+1;
+        const float lag_degrees = integrals[i].get_lag_degrees(freq);
+        fprintf(f, "%.1f,%f,%f\n", freq, integrals[i].out/integrals[i].in, lag_degrees);
+    }
+    fclose(f);
+    printf("Wrote %s\n", csv_file);
+    ::printf("Lag at 1Hz %.2f degrees\n", integrals[0].get_lag_degrees(1));
+    ::printf("Lag at 2Hz %.2f degrees\n", integrals[1].get_lag_degrees(2));
+    ::printf("Lag at 5Hz %.2f degrees\n", integrals[4].get_lag_degrees(5));
+    ::printf("Lag at 10Hz %.2f degrees\n", integrals[9].get_lag_degrees(10));
 }
 
 AP_GTEST_MAIN()


### PR DESCRIPTION
this allows a throttle based notch to track down to INS_HNTCH_FM_RAT ratio of the reference frequency, allowing for lighter loads, rapid descent and tracking through quadplane transitions. Right now we rely on either the user doing the notch setup at "lightest load" or following the advanced instructions which involves changing the reference and freq in a way to allow for lower values. The "lightest load" doesn't really work as real vehicles vary too much (atmospheric conditions matter) plus it doesn't work for quadplanes at all as any wind can change the throttle below hover. The advanced instructions are not followed by many users, they are just too complex.

This also disables the notch completely when AP_Motors is in SHUT_DOWN state, calling reset() on it. That will lower CPU load on quadplanes in forward flight
This PR is based on top of #20107 

tool to play with filters: https://firmware.ardupilot.org/Tools/FilterTool/