### PR TITLE
Fix errors in MSP display port on ChibiOS platforms. This fixes HDZERO issues in bug 20955

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -348,11 +348,14 @@ void AP_MSP_Telem_Backend::process_incoming_data()
     if (numc > 0) {
         // Process incoming bytes
         while (numc-- > 0) {
-            const uint8_t c = _msp_port.uart->read();
-            msp_parse_received_data(&_msp_port, c);
+			//Read result is signed need to check
+            const int16_t c = _msp_port.uart->read(); 
+			if(c>=0){
+					msp_parse_received_data(&_msp_port,(uint8_t)c);
 
-            if (_msp_port.c_state == MSP_COMMAND_RECEIVED) {
+             if (_msp_port.c_state == MSP_COMMAND_RECEIVED) {
                 msp_process_received_command();
+			 }
             }
         }
     }

--- a/libraries/AP_MSP/msp.cpp
+++ b/libraries/AP_MSP/msp.cpp
@@ -177,7 +177,7 @@ bool MSP::msp_parse_received_data(msp_port_t *msp, uint8_t c)
         break;
 
     case MSP_HEADER_M:      // Waiting for '<'
-        if (c == '<') {
+        if ((c == '<')|| (c=='>')) {
             msp->offset = 0;
             msp->checksum1 = 0;
             msp->checksum2 = 0;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -45,8 +45,7 @@ bool AP_OSD_MSP_DisplayPort::init(void)
         gcs().send_text(MAV_SEVERITY_WARNING,"MSP DisplayPort uart not available");
         return false;
     }
-    // re-init port here for use in this thread
-    _displayport->init_uart();
+	_bInitedUart=false;
     return true;
 }
 
@@ -77,6 +76,13 @@ uint8_t AP_OSD_MSP_DisplayPort::format_string_for_osd(char* buff, uint8_t size, 
 
 void AP_OSD_MSP_DisplayPort::flush(void)
 {
+    if(!_bInitedUart)
+	{
+		_bInitedUart=true;
+		_displayport->init_uart();
+	}
+
+
     // grab the screen and force a redraw
     _displayport->msp_displayport_grab();
     _displayport->msp_displayport_draw_screen();

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -204,7 +204,7 @@ private:
         SYM_RNGFD,
         SYM_LQ,
     };
-
+	bool _bInitedUart;
     bool _blink_on;
 };
 #endif


### PR DESCRIPTION
Fixed multiple issues preventing MSP packets from being correctly processed. from HDZERO VTX, likely also effected other VTXes. See detailed description in bug 20955
