### PR TITLE
fix: baro same driver multi-definition issues:20887

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -531,6 +531,21 @@ bool AP_Baro::_add_backend(AP_Baro_Backend *backend)
 }
 
 /*
+  wrapper around hal.i2c_mgr->get_device() that prevents duplicate devices being opened
+ */
+bool AP_Baro::_have_i2c_driver(uint8_t bus, uint8_t address) const
+{
+    for (int i=0; i<_num_drivers; ++i) {
+        if (AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_I2C, bus, address, 0) ==
+            AP_HAL::Device::change_bus_id(uint32_t(sensors[i].bus_id.get()), 0)) {
+            // device already has been defined.
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
   macro to add a backend with check for too many sensors
  We don't try to start more than the maximum allowed
  */
@@ -587,7 +602,7 @@ void AP_Baro::init(void)
 #endif
 
 // macro for use by HAL_INS_PROBE_LIST
-#define GET_I2C_DEVICE(bus, address) hal.i2c_mgr->get_device(bus, address)
+#define GET_I2C_DEVICE(bus, address) _have_i2c_driver(bus, address)?nullptr:hal.i2c_mgr->get_device(bus, address)
 
 #if AP_SIM_BARO_ENABLED
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL && AP_BARO_MS56XX_ENABLED

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -292,6 +292,8 @@ private:
     // when did we last notify the GCS of new pressure reference?
     uint32_t                            _last_notify_ms;
 
+    // see if we already have probed a i2c driver by bus number and address
+    bool _have_i2c_driver(uint8_t bus_num, uint8_t address) const;
     bool _add_backend(AP_Baro_Backend *backend);
     void _probe_i2c_barometers(void);
     AP_Int8                            _filter_range;  // valid value range from mean value

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -59,6 +59,9 @@ AP_Baro_Backend * AP_Baro_BMP085::probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::De
 
 bool AP_Baro_BMP085::_init()
 {
+    if (!_dev) {
+        return false;
+    }
     union {
         uint8_t buff[22];
         uint16_t wb[11];


### PR DESCRIPTION
This is a proposed fix for this issue [https://github.com/ArduPilot/ardupilot/issues/20887](https://github.com/ArduPilot/ardupilot/issues/20887)

The fix checks that there is no baro driver already allocated on the same type/bus/address, and if found then it does not create it.