### PR TITLE
Copter: avoid ascend beyond fence's max alt in circle mode

### DIFF
--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -90,6 +90,9 @@ void ModeCircle::run()
     // get pilot desired climb rate (or zero if in radio failsafe)
     float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
 
+    // get avoidance adjusted climb rate
+    target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();


### PR DESCRIPTION
Fixes #20939. The climb rate must be such that the vehicle does not breach the fence. 
I gave it a test on sitl and it worked well.
@rmackay9 Would be great if you could have a look once, please.