### PR TITLE
autotest: fix race condition in plane fly_mission

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -531,13 +531,16 @@ class AutoTestPlane(AutoTest):
         self.progress("Flying mission %s" % filename)
         num_wp = self.load_mission(filename, strict=strict)-1
         self.set_current_waypoint(0, check_afterwards=False)
+        self.context_push()
+        self.context_collect('STATUSTEXT')
         self.change_mode('AUTO')
         self.wait_waypoint(1, num_wp, max_dist=60, timeout=mission_timeout)
         self.wait_groundspeed(0, 0.5, timeout=mission_timeout)
         if quadplane:
-            self.wait_statustext("Throttle disarmed", timeout=200)
+            self.wait_statustext("Throttle disarmed", timeout=200, check_context=True)
         else:
-            self.wait_statustext("Auto disarmed", timeout=60)
+            self.wait_statustext("Auto disarmed", timeout=60, check_context=True)
+        self.context_pop()
         self.progress("Mission OK")
 
     def fly_do_reposition(self):


### PR DESCRIPTION
We can lose the final message when we get_sim_time and wait_heartbeats and similar

Fixes:
```
2022-06-13T04:49:02.8347740Z AT-0224.0: Exception caught: Failed to receive text: auto disarmed
2022-06-13T04:49:02.8348042Z Traceback (most recent call last):
2022-06-13T04:49:02.8348401Z   File "/__w/ardupilot/ardupilot/Tools/autotest/common.py", line 6810, in run_one_test_attempt
2022-06-13T04:49:02.8348700Z     test_function()
2022-06-13T04:49:02.8349027Z   File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 1689, in test_main_flight
2022-06-13T04:49:02.8349367Z     self.run_subtest("Mission test",
2022-06-13T04:49:02.8349714Z   File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 1564, in run_subtest
2022-06-13T04:49:02.8350003Z     func()
2022-06-13T04:49:02.8350301Z   File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 1690, in <lambda>
2022-06-13T04:49:02.8350824Z     lambda: self.fly_mission("ap1.txt", strict=False))
2022-06-13T04:49:02.8351190Z   File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 540, in fly_mission
2022-06-13T04:49:02.8351550Z     self.wait_statustext("Auto disarmed", timeout=60)
2022-06-13T04:49:02.8351912Z   File "/__w/ardupilot/ardupilot/Tools/autotest/common.py", line 6604, in wait_statustext
2022-06-13T04:49:02.8352300Z     raise AutoTestTimeoutException("Failed to receive text: %s" %
2022-06-13T04:49:02.8352689Z common.AutoTestTimeoutException: Failed to receive text: auto disarmed
```
