### PR TITLE
AP_Mount: allow individual mounts to be disabled and add to custom build server

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -85,7 +85,12 @@ BUILD_OPTIONS = [
     Feature('Mode', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
 
     Feature('Gimbal', 'MOUNT', 'HAL_MOUNT_ENABLED', 'Enable Mount', 0, None),
+    Feature('Gimbal', 'ALEXMOS', 'HAL_MOUNT_ALEXMOS_ENABLED', 'Enable Alexmos Gimbal', 0, None),
+    Feature('Gimbal', 'GREMSY', 'HAL_MOUNT_GREMSY_ENABLED', 'Enable Gremsy Gimbal', 0, None),
+    Feature('Gimbal', 'SERVO', 'HAL_MOUNT_SERVO_ENABLED', 'Enable Servo Gimbal', 0, None),
     Feature('Gimbal', 'SOLOGIMBAL', 'HAL_SOLO_GIMBAL_ENABLED', 'Enable Solo Gimbal', 0, None),
+    Feature('Gimbal', 'STORM32_MAVLINK', 'HAL_MOUNT_STORM32MAVLINK_ENABLED', 'Enable SToRM32 MAVLink Gimbal', 0, None),
+    Feature('Gimbal', 'STORM32_SERIAL', 'HAL_MOUNT_STORM32SERIAL_ENABLED', 'Enable SToRM32 Serial Gimbal', 0, None),
 
     Feature('VTOL Frame', 'QUAD', 'AP_MOTORS_FRAME_QUAD_ENABLED', 'QUADS(BI,TRI also)', 1, None),
     Feature('VTOL Frame', 'HEXA', 'AP_MOTORS_FRAME_HEXA_ENABLED', 'HEXA', 0, None),

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -12,6 +12,7 @@
 #include "AP_Mount_SToRM32_serial.h"
 #include "AP_Mount_Gremsy.h"
 #include <AP_Math/location.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 const AP_Param::GroupInfo AP_Mount::var_info[] = {
 
@@ -449,7 +450,7 @@ void AP_Mount::init()
 #endif
 
 #if HAL_SOLO_GIMBAL_ENABLED
-        // check for MAVLink mounts
+        // check for Solo mounts
         } else if (mount_type == Mount_Type_SoloGimbal) {
             _backends[instance] = new AP_Mount_SoloGimbal(*this, state[instance], instance);
             _num_instances++;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -453,10 +453,12 @@ void AP_Mount::init()
             _num_instances++;
 #endif // HAL_SOLO_GIMBAL_ENABLED
 
+#if HAL_MOUNT_ALEXMOS_ENABLED
         // check for Alexmos mounts
         } else if (mount_type == Mount_Type_Alexmos) {
             _backends[instance] = new AP_Mount_Alexmos(*this, state[instance], instance);
             _num_instances++;
+#endif
 
         // check for SToRM32 mounts using MAVLink protocol
         } else if (mount_type == Mount_Type_SToRM32) {

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -469,10 +469,12 @@ void AP_Mount::init()
             _num_instances++;
 #endif
 
+#if HAL_MOUNT_STORM32SERIAL_ENABLED
         // check for SToRM32 mounts using serial protocol
         } else if (mount_type == Mount_Type_SToRM32_serial) {
             _backends[instance] = new AP_Mount_SToRM32_serial(*this, state[instance], instance);
             _num_instances++;
+#endif
 
 #if HAL_MOUNT_GREMSY_ENABLED
         // check for Gremsy mounts

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -443,8 +443,10 @@ void AP_Mount::init()
 
         // check for servo mounts
         if (mount_type == Mount_Type_Servo) {
+#if HAL_MOUNT_SERVO_ENABLED
             _backends[instance] = new AP_Mount_Servo(*this, state[instance], instance);
             _num_instances++;
+#endif
 
 #if HAL_SOLO_GIMBAL_ENABLED
         // check for MAVLink mounts

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -462,10 +462,12 @@ void AP_Mount::init()
             _num_instances++;
 #endif
 
+#if HAL_MOUNT_STORM32MAVLINK_ENABLED
         // check for SToRM32 mounts using MAVLink protocol
         } else if (mount_type == Mount_Type_SToRM32) {
             _backends[instance] = new AP_Mount_SToRM32(*this, state[instance], instance);
             _num_instances++;
+#endif
 
         // check for SToRM32 mounts using serial protocol
         } else if (mount_type == Mount_Type_SToRM32_serial) {

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,7 +1,7 @@
 #include "AP_Mount_Alexmos.h"
-#if HAL_MOUNT_ENABLED
-#include <AP_SerialManager/AP_SerialManager.h>
 
+#if HAL_MOUNT_ALEXMOS_ENABLED
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_AHRS/AP_AHRS.h>
 
 extern const AP_HAL::HAL& hal;
@@ -307,4 +307,4 @@ void AP_Mount_Alexmos::read_incoming()
         }
     }
 }
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_ALEXMOS_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -3,13 +3,16 @@
 */
 #pragma once
 
-#include "AP_Mount.h"
-#if HAL_MOUNT_ENABLED
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_ALEXMOS_ENABLED
+#define HAL_MOUNT_ALEXMOS_ENABLED HAL_MOUNT_ENABLED
+#endif
+
+#if HAL_MOUNT_ALEXMOS_ENABLED
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include "AP_Mount_Backend.h"
-
 
 //definition of the commands id for the Alexmos Serial Protocol
 #define CMD_READ_PARAMS 'R'
@@ -299,4 +302,4 @@ private:
     // confirmed that last command was ok
     bool _last_command_confirmed : 1;
 };
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_ALEXMOS_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -19,9 +19,9 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
 #include "AP_Mount.h"
 #if HAL_MOUNT_ENABLED
+#include <AP_Common/AP_Common.h>
 #include <RC_Channel/RC_Channel.h>
 
 class AP_Mount_Backend

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -1,5 +1,6 @@
 #include "AP_Mount_SToRM32.h"
-#if HAL_MOUNT_ENABLED
+
+#if HAL_MOUNT_STORM32MAVLINK_ENABLED
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 
@@ -172,4 +173,4 @@ void AP_Mount_SToRM32::send_do_mount_control(float pitch_deg, float roll_deg, fl
     // store time of send
     _last_send = AP_HAL::millis();
 }
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_STORM32MAVLINK_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -5,7 +5,11 @@
 
 #include "AP_Mount_Backend.h"
 
-#if HAL_MOUNT_ENABLED
+#ifndef HAL_MOUNT_STORM32MAVLINK_ENABLED
+#define HAL_MOUNT_STORM32MAVLINK_ENABLED HAL_MOUNT_ENABLED
+#endif
+
+#if HAL_MOUNT_STORM32MAVLINK_ENABLED
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
@@ -49,4 +53,4 @@ private:
     mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
 };
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_STORM32MAVLINK_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -1,5 +1,6 @@
 #include "AP_Mount_SToRM32_serial.h"
-#if HAL_MOUNT_ENABLED
+
+#if HAL_MOUNT_STORM32SERIAL_ENABLED
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
@@ -296,4 +297,4 @@ void AP_Mount_SToRM32_serial::parse_reply() {
             break;
     }
 }
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_STORM32SERIAL_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -3,14 +3,19 @@
  */
 #pragma once
 
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_STORM32SERIAL_ENABLED
+#define HAL_MOUNT_STORM32SERIAL_ENABLED HAL_MOUNT_ENABLED
+#endif
+
+#if HAL_MOUNT_STORM32SERIAL_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
-
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include "AP_Mount_Backend.h"
-#if HAL_MOUNT_ENABLED
 
 #define AP_MOUNT_STORM32_SERIAL_RESEND_MS   1000    // resend angle targets to gimbal once per second
 
@@ -148,4 +153,4 @@ private:
     // keep the last _current_angle values
     Vector3l _current_angle;
 };
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_STORM32SERIAL_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -1,5 +1,5 @@
 #include "AP_Mount_Servo.h"
-#if HAL_MOUNT_ENABLED
+#if HAL_MOUNT_SERVO_ENABLED
 
 extern const AP_HAL::HAL& hal;
 
@@ -221,4 +221,4 @@ void AP_Mount_Servo::move_servo(uint8_t function_idx, int16_t angle, int16_t ang
 	int16_t servo_out = closest_limit(angle, angle_min, angle_max);
 	SRV_Channels::move_servo((SRV_Channel::Aux_servo_function_t)function_idx, servo_out, angle_min, angle_max);
 }
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_SERVO_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -3,13 +3,19 @@
  */
 #pragma once
 
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_SERVO_ENABLED
+#define HAL_MOUNT_SERVO_ENABLED HAL_MOUNT_ENABLED
+#endif
+
+#if HAL_MOUNT_SERVO_ENABLED
+
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <SRV_Channel/SRV_Channel.h>
-#include "AP_Mount_Backend.h"
-#if HAL_MOUNT_ENABLED
 
 class AP_Mount_Servo : public AP_Mount_Backend
 {
@@ -71,4 +77,4 @@ private:
 
     uint32_t _last_check_servo_map_ms;  // system time of latest call to check_servo_map function
 };
-#endif // HAL_MOUNT_ENABLED
+#endif // HAL_MOUNT_SERVO_ENABLED


### PR DESCRIPTION
This allows individual mounts (aka gimbals) to be defined out to save flash.  The build options have been added to the custom build server to help users create a build with the drivers they need.

This has been lightly tested in SITL to confirm that individual mount drivers can be enabled/disabled including testing that all drivers can be disabled leaving just the empty mount library.

Durandal size difference is below

```
Binary Name      Text [B]     Data [B]     BSS (B)      Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  -----------  -----------  -----------  ----------------------------  -------------------------
arducopter-heli  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      181960
ardurover        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      364032
arduplane        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      208056
blimp            0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      663756
arducopter       0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      189992
antennatracker   0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      604592
ardusub          0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      402860
```

MatekF405
```
Binary Name      Text [B]     Data [B]     BSS (B)      Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  -----------  -----------  -----------  ----------------------------  -------------------------
arducopter-heli  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                       35936
ardurover        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      123656
arduplane        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                        8136
blimp            0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      298820
arducopter       0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                       46416
antennatracker   0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      316904
ardusub          0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      167116
```

Pixhawk1-1M
```
Binary Name      Text [B]     Data [B]     BSS (B)      Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  -----------  -----------  -----------  ----------------------------  -------------------------
arducopter-heli  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                       19140
ardurover        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      112140
arduplane        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                        3444
blimp            0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      314996
arducopter       0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                       31716
antennatracker   0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      271640
ardusub          0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      110616
```