### PR TITLE
GPS: added GPS_DRV_OPTIONS bit for ellipsoid height on uBlox

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -309,7 +309,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _DRV_OPTIONS
     // @DisplayName: driver options
     // @Description: Additional backend specific options
-    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline
+    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL for uBlox driver
     // @User: Advanced
     AP_GROUPINFO("_DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 #endif

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -560,7 +560,7 @@ void AP_GPS::send_blob_start(uint8_t instance, const char *_blob, uint16_t size)
  */
 void AP_GPS::send_blob_start(uint8_t instance)
 {
-    if (_type[instance] == GPS_TYPE_UBLOX && (_driver_options & AP_GPS_Backend::DriverOptions::UBX_Use115200)) {
+    if (_type[instance] == GPS_TYPE_UBLOX && option_set(DriverOptions::UBX_Use115200)) {
         static const char blob[] = UBLOX_SET_BINARY_115200;
         send_blob_start(instance, blob, sizeof(blob));
         return;
@@ -569,7 +569,7 @@ void AP_GPS::send_blob_start(uint8_t instance)
 #if GPS_MOVING_BASELINE
     if ((_type[instance] == GPS_TYPE_UBLOX_RTK_BASE ||
          _type[instance] == GPS_TYPE_UBLOX_RTK_ROVER) &&
-        ((_driver_options.get() & AP_GPS_Backend::DriverOptions::UBX_MBUseUart2) == 0)) {
+        !option_set(DriverOptions::UBX_MBUseUart2)) {
         // we use 460800 when doing moving baseline as we need
         // more bandwidth. We don't do this if using UART2, as
         // in that case the RTCMv3 data doesn't go over the
@@ -738,13 +738,13 @@ void AP_GPS::detect_instance(uint8_t instance)
         if ((_type[instance] == GPS_TYPE_AUTO ||
              _type[instance] == GPS_TYPE_UBLOX) &&
             ((!_auto_config && _baudrates[dstate->current_baud] >= 38400) ||
-             (_baudrates[dstate->current_baud] >= 115200 && (_driver_options & AP_GPS_Backend::DriverOptions::UBX_Use115200)) ||
+             (_baudrates[dstate->current_baud] >= 115200 && option_set(DriverOptions::UBX_Use115200)) ||
              _baudrates[dstate->current_baud] == 230400) &&
             AP_GPS_UBLOX::_detect(dstate->ublox_detect_state, data)) {
             new_gps = new AP_GPS_UBLOX(*this, state[instance], _port[instance], GPS_ROLE_NORMAL);
         }
 
-        const uint32_t ublox_mb_required_baud = (_driver_options.get() & AP_GPS_Backend::DriverOptions::UBX_MBUseUart2)?230400:460800;
+        const uint32_t ublox_mb_required_baud = option_set(DriverOptions::UBX_MBUseUart2)?230400:460800;
         if ((_type[instance] == GPS_TYPE_UBLOX_RTK_BASE ||
              _type[instance] == GPS_TYPE_UBLOX_RTK_ROVER) &&
             _baudrates[dstate->current_baud] == ublox_mb_required_baud &&

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -588,6 +588,18 @@ protected:
 
     uint32_t _log_gps_bit = -1;
 
+    enum DriverOptions : int16_t {
+        UBX_MBUseUart2    = (1U << 0U),
+        SBF_UseBaseForYaw = (1U << 1U),
+        UBX_Use115200     = (1U << 2U),
+        UAVCAN_MBUseDedicatedBus  = (1 << 3U),
+    };
+
+    // check if an option is set
+    bool option_set(const DriverOptions option) const {
+        return (uint8_t(_driver_options.get()) & uint8_t(option)) != 0;
+    }
+
 private:
     static AP_GPS *_singleton;
     HAL_Semaphore rsem;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -593,6 +593,7 @@ protected:
         SBF_UseBaseForYaw = (1U << 1U),
         UBX_Use115200     = (1U << 2U),
         UAVCAN_MBUseDedicatedBus  = (1 << 3U),
+        HeightEllipsoid   = (1U << 4),
     };
 
     // check if an option is set

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -68,7 +68,7 @@ AP_GPS_SBF::AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
 
     // if we ever parse RTK observations it will always be of type NED, so set it once
     state.rtk_baseline_coords_type = RTK_BASELINE_COORDINATE_SYSTEM_NED;
-    if (driver_options() & DriverOptions::SBF_UseBaseForYaw) {
+    if (option_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
         state.gps_yaw_configured = true;
     }
 }
@@ -533,7 +533,7 @@ AP_GPS_SBF::process_message(void)
 
 #if GPS_MOVING_BASELINE
             // copy the baseline data as a yaw source
-            if (driver_options() & DriverOptions::SBF_UseBaseForYaw) {
+            if (option_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
                 calculate_moving_base_yaw(temp.info.Azimuth * 0.01f + 180.0f,
                                           Vector3f(temp.info.DeltaNorth, temp.info.DeltaEast, temp.info.DeltaUp).length(),
                                           -temp.info.DeltaUp);

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -955,14 +955,14 @@ bool AP_GPS_UAVCAN::handle_param_get_set_response_int(AP_UAVCAN* ap_uavcan, uint
     }
 
     if (strcmp(name, "GPS_MB_ONLY_PORT") == 0 && cfg_step == STEP_SET_MB_CAN_TX) {
-        if ((gps._driver_options & UAVCAN_MBUseDedicatedBus) && !value) {
+        if (option_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && !value) {
             // set up so that another CAN port is used for the Moving Baseline Data
             // setting this value will allow another CAN port to be used as dedicated
             // line for the Moving Baseline Data
             value = 1;
             requires_save_and_reboot = true;
             return true;
-        } else if (!(gps._driver_options & UAVCAN_MBUseDedicatedBus) && value) {
+        } else if (!option_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && value) {
             // set up so that all CAN ports are used for the Moving Baseline Data
             value = 0;
             requires_save_and_reboot = true;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1284,7 +1284,11 @@ AP_GPS_UBLOX::_parse_gps(void)
         _last_pos_time        = _buffer.posllh.itow;
         state.location.lng    = _buffer.posllh.longitude;
         state.location.lat    = _buffer.posllh.latitude;
-        state.location.alt    = _buffer.posllh.altitude_msl / 10;
+        if (option_set(AP_GPS::HeightEllipsoid)) {
+            state.location.alt    = _buffer.posllh.altitude_ellipsoid / 10;
+        } else {
+            state.location.alt    = _buffer.posllh.altitude_msl / 10;
+        }
         state.status          = next_fix;
         _new_position = true;
         state.horizontal_accuracy = _buffer.posllh.horizontal_accuracy*1.0e-3f;
@@ -1437,8 +1441,12 @@ AP_GPS_UBLOX::_parse_gps(void)
         _last_pos_time        = _buffer.pvt.itow;
         state.location.lng    = _buffer.pvt.lon;
         state.location.lat    = _buffer.pvt.lat;
-        state.location.alt    = _buffer.pvt.h_msl / 10;
-        switch (_buffer.pvt.fix_type) 
+        if (option_set(AP_GPS::HeightEllipsoid)) {
+            state.location.alt    = _buffer.pvt.h_ellipsoid / 10;
+        } else {
+            state.location.alt    = _buffer.pvt.h_msl / 10;
+        }
+        switch (_buffer.pvt.fix_type)
         {
             case 0:
                 state.status = AP_GPS::NO_FIX;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -346,7 +346,7 @@ private:
         uint8_t flags2; 
         uint8_t num_sv; 
         int32_t lon, lat; 
-        int32_t height, h_msl; 
+        int32_t h_ellipsoid, h_msl;
         uint32_t h_acc, v_acc; 
         int32_t velN, velE, velD, gspeed; 
         int32_t head_mot; 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -757,7 +757,7 @@ private:
 #if GPS_MOVING_BASELINE
     // see if we should use uart2 for moving baseline config
     bool mb_use_uart2(void) const {
-        return (driver_options() & DriverOptions::UBX_MBUseUart2)?true:false;
+        return option_set(AP_GPS::DriverOptions::UBX_MBUseUart2)?true:false;
     }
 #endif
 

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -98,12 +98,10 @@ public:
         return (_pseudo_itow_delta_ms == 0)?(_last_itow_ms):((_pseudo_itow/1000ULL) + _pseudo_itow_delta_ms);
     }
 
-    enum DriverOptions : int16_t {
-        UBX_MBUseUart2    = (1U << 0U),
-        SBF_UseBaseForYaw = (1U << 1U),
-        UBX_Use115200     = (1U << 2U),
-        UAVCAN_MBUseDedicatedBus  = (1 << 3U),
-    };
+    // check if an option is set
+    bool option_set(const AP_GPS::DriverOptions option) const {
+        return gps.option_set(option);
+    }
 
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
@@ -140,13 +138,6 @@ protected:
     void set_uart_timestamp(uint16_t nbytes);
 
     void check_new_itow(uint32_t itow, uint32_t msg_length);
-
-    /*
-      access to driver option bits
-     */
-    DriverOptions driver_options(void) const {
-        return DriverOptions(gps._driver_options.get());
-    }
 
 #if GPS_MOVING_BASELINE
     bool calculate_moving_base_yaw(const float reported_heading_deg, const float reported_distance, const float reported_D);


### PR DESCRIPTION
This adds an option for using ellipsoid height instead of AMSL for the uBlox driver. Some users may prefer ellipsoid height for their mission planning. Setting GPS_DRV_OPTIONS=16 gives ellipsoid height
The option only applies to uBlox for now, but could be extended to other drivers if we do testing
Justification from Magnus here: https://docs.google.com/document/d/1moTEHNc2UvtNVAVSorW6DUtdWkANMklEBRj9AvUiQ00/edit?usp=sharing