### PR TITLE
Copter: land & payload place obey altitude frame when lat/lon specified

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -255,10 +255,8 @@ private:
         uint32_t glitch_cleared_ms; // system time glitch cleared
     } rangefinder_state, rangefinder_up_state;
 
-    /*
-      return rangefinder height interpolated using inertial altitude
-     */
-    bool get_rangefinder_height_interpolated_cm(int32_t& ret);
+    // return rangefinder height interpolated using inertial altitude
+    bool get_rangefinder_height_interpolated_cm(int32_t& ret) const;
 
     class SurfaceTracking {
     public:

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -513,7 +513,7 @@ private:
 
     SubMode _mode = SubMode::TAKEOFF;   // controls which auto controller is run
 
-    Location terrain_adjusted_location(const AP_Mission::Mission_Command& cmd) const;
+    bool shift_alt_to_current_alt(Location& target_loc) const;
 
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1228,25 +1228,33 @@ void ModeAuto::payload_place_run_descend()
     land_run_vertical_control();
 }
 
-// terrain_adjusted_location: returns a Location with lat/lon from cmd
-// and altitude from our current altitude adjusted for location
-Location ModeAuto::terrain_adjusted_location(const AP_Mission::Mission_Command& cmd) const
+// sets the target_loc's alt to the vehicle's current alt but does not change target_loc's frame
+// in the case of terrain altitudes either the terrain database or the rangefinder may be used
+// returns true on success, false on failure
+bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
 {
-    // convert to location class
-    Location target_loc(cmd.content.location);
-
-    // decide if we will use terrain following
-    int32_t curr_terr_alt_cm, target_terr_alt_cm;
-    if (copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, curr_terr_alt_cm) &&
-        target_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, target_terr_alt_cm)) {
-        curr_terr_alt_cm = MAX(curr_terr_alt_cm,200);
-        // if using terrain, set target altitude to current altitude above terrain
-        target_loc.set_alt_cm(curr_terr_alt_cm, Location::AltFrame::ABOVE_TERRAIN);
-    } else {
-        // set target altitude to current altitude above home
-        target_loc.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
+    // if terrain alt using rangefinder is being used then set alt to current rangefinder altitude
+    if ((target_loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) &&
+        (wp_nav->get_terrain_source() == AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER)) {
+        int32_t curr_rngfnd_alt_cm;
+        if (copter.get_rangefinder_height_interpolated_cm(curr_rngfnd_alt_cm)) {
+            // wp_nav is using rangefinder so use current rangefinder alt
+            target_loc.set_alt_cm(MAX(curr_rngfnd_alt_cm, 200), Location::AltFrame::ABOVE_TERRAIN);
+            return true;
+        }
+        return false;
     }
-    return target_loc;
+
+    // take copy of current location and change frame to match target
+    Location currloc = copter.current_loc;
+    if (!currloc.change_alt_frame(target_loc.get_alt_frame())) {
+        // this could fail due missing terrain database alt
+        return false;
+    }
+
+    // set target_loc's alt
+    target_loc.set_alt_cm(currloc.alt, currloc.get_alt_frame());
+    return true;
 }
 
 /********************************************************************************/
@@ -1398,7 +1406,15 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
         // set state to fly to location
         state = State::FlyToLocation;
 
-        const Location target_loc = terrain_adjusted_location(cmd);
+        // convert cmd to location class
+        Location target_loc(cmd.content.location);
+        if (!shift_alt_to_current_alt(target_loc)) {
+            // this can only fail due to missing terrain database alt or rangefinder alt
+            // use current alt-above-home and report error
+            target_loc.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
+            AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Land: no terrain data, using alt-above-home");
+        }
 
         wp_start(target_loc);
     } else {
@@ -1748,7 +1764,15 @@ void ModeAuto::do_payload_place(const AP_Mission::Mission_Command& cmd)
         // set state to fly to location
         nav_payload_place.state = PayloadPlaceStateType_FlyToLocation;
 
-        const Location target_loc = terrain_adjusted_location(cmd);
+        // convert cmd to location class
+        Location target_loc(cmd.content.location);
+        if (!shift_alt_to_current_alt(target_loc)) {
+            // this can only fail due to missing terrain database alt or rangefinder alt
+            // use current alt-above-home and report error
+            target_loc.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
+            AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PayloadPlace: no terrain data, using alt-above-home");
+        }
 
         wp_start(target_loc);
     } else {

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -135,7 +135,7 @@ bool Copter::rangefinder_up_ok() const
   difference between the inertial height at that time and the current
   inertial height to give us interpolation of height from rangefinder
  */
-bool Copter::get_rangefinder_height_interpolated_cm(int32_t& ret)
+bool Copter::get_rangefinder_height_interpolated_cm(int32_t& ret) const
 {
     if (!rangefinder_alt_ok()) {
         return false;


### PR DESCRIPTION
This PR fixes a "bug" in how Copter flies to the specified lat/lon during Auto mode Land or Payload Place commands.  In master it always attempts to fly to the lat/lon using terrain following (at the current alt above terrain).  With this fix it properly obeys the altitude frame specified in the command.  I write "bug" (in quotes) because the behaviour is not particularly terrible and it was likely done on purpose before Mission Planner allowed the altitude frame to be set for each command.

The issue can be reproduced in SITL by creating a mission like below where the LAND command's frame is set to "Rel".
![land-map-and-mission](https://user-images.githubusercontent.com/1498098/173735520-0b0461da-f483-48dd-a364-ead2a8c2cc52.png)

We can see in the "Before" that despite the "Rel" alt frame, the vehicle flies at an alt-above-terrain.  In the "After" we see it correctly flies at the current altitude.
![land-frame-fix-before-vs-after-relative](https://user-images.githubusercontent.com/1498098/173735704-3d869595-fdc4-4abe-8144-ad303f01121d.png)

Other tests were performed as well to ensure that when the cmd's frame was AGL/Terrain or AMSL/Abs it flew at the correct altitude.  The failure case was also tested by reducing the rangefinder's range to be very short and disabling the terrain database by setting TERRAIN_ENABLE = 0.
![land-frame-fix-failure-example](https://user-images.githubusercontent.com/1498098/173735835-fbbf6e9a-daf4-4636-9209-0ee09b9895e1.png)

I also tested both Land and PayLoadPlace commands (although the PayloadPlace testing was less extensive).

This resolves the top 4.2 issue listed on the [4.2.0 issues list](https://github.com/ArduPilot/ardupilot/issues/20192) stemming from [this discussion](https://discuss.ardupilot.org/t/quad-rises-to-40m-before-landing/86311).