### PR TITLE
Plane: Takeoff throttle at AUTO inconsistency

### DIFF
--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -83,7 +83,7 @@ void ModeAuto::update()
         (nav_cmd_id == MAV_CMD_NAV_LAND && plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND)) {
         plane.takeoff_calc_roll();
         plane.takeoff_calc_pitch();
-        plane.calc_throttle();
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100.0);
     } else if (nav_cmd_id == MAV_CMD_NAV_LAND) {
         plane.calc_nav_roll();
         plane.calc_nav_pitch();


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/blob/e9942f9a17ab87a7e67821f25c997330d9286f61/ArduPlane/mode_auto.cpp#L86
https://github.com/ArduPilot/ardupilot/blob/e9942f9a17ab87a7e67821f25c997330d9286f61/ArduPlane/mode_takeoff.cpp#L123

In AUTO mode takeoff throttle is working with TECS and is not set to 100%.

I also have a strong feeling that `class ModeTakeoff` and it's logic is not used in AUTO.