### PR TITLE
AP_RCMapper: Increase parameter metadata range to match NUM_RC_CHANNELS

### DIFF
--- a/libraries/AP_RCMapper/AP_RCMapper.cpp
+++ b/libraries/AP_RCMapper/AP_RCMapper.cpp
@@ -5,7 +5,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param: ROLL
     // @DisplayName: Roll channel
     // @Description: Roll channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Roll is normally on channel 1, but you can move it to any channel with this parameter.  Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
@@ -14,7 +14,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param: PITCH
     // @DisplayName: Pitch channel
     // @Description: Pitch channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Pitch is normally on channel 2, but you can move it to any channel with this parameter.  Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
@@ -23,7 +23,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param: THROTTLE
     // @DisplayName: Throttle channel
     // @Description: Throttle channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Throttle is normally on channel 3, but you can move it to any channel with this parameter. Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param: YAW
     // @DisplayName: Yaw channel
     // @Description: Yaw channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Yaw (also known as rudder) is normally on channel 4, but you can move it to any channel with this parameter.  Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param{Sub}: FORWARD
     // @DisplayName: Forward channel
     // @Description: Forward channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Forward is normally on channel 5, but you can move it to any channel with this parameter. Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] = {
     // @Param{Sub}: LATERAL
     // @DisplayName: Lateral channel
     // @Description: Lateral channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Lateral is normally on channel 6, but you can move it to any channel with this parameter. Reboot is required for changes to take effect.
-    // @Range: 1 8
+    // @Range: 1 16
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True


### PR DESCRIPTION
Increases the range in the RCMAP parameter metadata to 16 to match the number of input channels supported. Non-functional change, but might warrant a small bit of discussion.