### PR TITLE
AP_OSD: fixed serial port initialization for MSP DisplayPort protocol

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -320,6 +320,9 @@ void AP_OSD::init()
 #if OSD_ENABLED
 void AP_OSD::osd_thread()
 {
+    // initialize thread specific code once
+    backend->osd_thread_run_once();
+
     while (true) {
         hal.scheduler->delay(100);
         update_osd();

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -56,6 +56,9 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     virtual void init_symbol_set(uint8_t *symbols, const uint8_t size);
 
+    // called by the OSD thread once
+    virtual void osd_thread_run_once() { return; }
+
     AP_OSD * get_osd()
     {
         return &_osd;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -50,6 +50,14 @@ bool AP_OSD_MSP_DisplayPort::init(void)
     return true;
 }
 
+// called by the OSD thread once
+void AP_OSD_MSP_DisplayPort::osd_thread_run_once()
+{
+    if (_displayport != nullptr) {
+        _displayport->init_uart();
+    }
+}
+
 void AP_OSD_MSP_DisplayPort::clear(void)
 {
     // clear remote MSP screen

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -24,6 +24,10 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     void init_symbol_set(uint8_t *lookup_table, const uint8_t size) override;
 
+    // called by the OSD thread once
+    // used to initialize the uart in the correct thread
+    void osd_thread_run_once() override;
+
 
 protected:
     uint8_t format_string_for_osd(char* dst, uint8_t size, bool decimal_packed, const char *fmt, va_list ap) override;


### PR DESCRIPTION
Thanks to @pbreed for catching this issue https://github.com/ArduPilot/ardupilot/issues/20955

Uart read access requires initialization in the OSD thread which was missing.
Without this fix the OSD thread could write but not read, so the MSP DisplayPort OSD was working but ArduPilot was not responding to telemetry data polls, as a side effect the VTX "sticks" menu was not working.