### PR TITLE
AC_AutoTune: fix tradheli bug with load gain set

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -521,7 +521,7 @@ void AC_AutoTune_Heli::load_test_gains()
 // load gains
 void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i, float rate_d, float rate_ff, float angle_p, float max_accel, float rate_fltt, float rate_flte, float smax)
 {
-    switch (axis) {
+    switch (s_axis) {
     case ROLL:
         attitude_control->get_rate_roll_pid().kP(rate_p);
         attitude_control->get_rate_roll_pid().kI(rate_i);


### PR DESCRIPTION
This PR fixes a bug where the wrong gains are loaded for an axis in multi axis tuning.