### PR TITLE
Copter: No arm operation ng notification in GUIDED mode

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -572,7 +572,11 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     // always check if the current mode allows arming
     if (!copter.flightmode->allows_arming(method)) {
-        check_failed(true, "Mode not armable");
+        if (!(copter.flightmode->mode_number() == Mode::Number::GUIDED || copter.flightmode->mode_number() == Mode::Number::GUIDED_NOGPS)) {
+            check_failed(true, "Mode not armable");
+        } else {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mode not armable");
+        }
         return false;
     }
 
@@ -684,7 +688,9 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     }
 
     if (!AP_Arming::arm(method, do_arming_checks)) {
-        AP_Notify::events.arming_failed = true;
+        if (!(copter.flightmode->mode_number() == Mode::Number::GUIDED || copter.flightmode->mode_number() == Mode::Number::GUIDED_NOGPS)) {
+            AP_Notify::events.arming_failed = true;
+        }
         in_arm_motors = false;
         return false;
     }


### PR DESCRIPTION
GUIDED mode is indicated from CC and GCS.
ARM operation in GUIDED mode only indicates throttle lowest and rudder highest.
It is the CC and GCS that determine this value to be an ARM operation.
I have chosen not to notify ARM operation determination in GUIDED mode.

AFTER
![Screenshot from 2022-06-18 12-50-50](https://user-images.githubusercontent.com/646194/174422009-2f670084-fcba-47c0-a09d-db5f3e61e155.png)

GCS
![Screenshot from 2022-06-18 12-50-38](https://user-images.githubusercontent.com/646194/174422016-f8a46554-7af5-4cdb-a4b0-0a1306f167b3.png)