### PR TITLE
Plane: Quadplane: always reset to QPOS_NONE on mode entry

### DIFF
--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -14,9 +14,6 @@ bool ModeQRTL::_enter()
     submode = SubMode::RTL;
     plane.prev_WP_loc = plane.current_loc;
 
-    // clear QPOS state
-    quadplane.poscontrol.set_state(QuadPlane::QPOS_NONE);
-
     const int32_t RTL_alt_abs_cm = plane.home.alt + quadplane.qrtl_alt*100UL;
     if (quadplane.motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED) {
         // VTOL motors are active, either in VTOL flight or assisted flight

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4137,6 +4137,7 @@ void QuadPlane::mode_enter(void)
     poscontrol.xy_correction.zero();
     poscontrol.velocity_match.zero();
     poscontrol.last_velocity_match_ms = 0;
+    poscontrol.set_state(QuadPlane::QPOS_NONE);
 
     // clear guided takeoff wait on any mode change, but remember the
     // state for special behaviour


### PR DESCRIPTION
Had to add a special QPOS reset to QRTL enter to stop funny business. This moves that reset to every mode enter, so should prevent future funny business. We will get a internal error if we try and use pos control in state none.