### PR TITLE
Allow connection of INA2xx battery mon after boot

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -740,6 +740,19 @@ uint32_t AP_BattMonitor::get_mavlink_fault_bitmask(const uint8_t instance) const
     return drivers[instance]->get_mavlink_fault_bitmask();
 }
 
+/*
+  check that all configured battery monitors are healthy
+ */
+bool AP_BattMonitor::healthy() const
+{
+    for (uint8_t i=0; i< _num_instances; i++) {
+        if (get_type(i) != Type::NONE && !healthy(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 namespace AP {
 
 AP_BattMonitor &battery()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -156,7 +156,9 @@ public:
 
     // healthy - returns true if monitor is functioning
     bool healthy(uint8_t instance) const;
-    bool healthy() const { return healthy(AP_BATT_PRIMARY_INSTANCE); }
+
+    // return true if all configured battery monitors are healthy
+    bool healthy() const;
 
     /// voltage - returns battery voltage in volts
     float voltage(uint8_t instance) const;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -176,7 +176,8 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
                                 is_positive(_params._low_voltage) &&
                                 (_params._low_voltage < _params._critical_voltage);
 
-    bool result =      update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
+    bool result = update_check(buflen, buffer, !_state.healthy, "unhealthy");
+    result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
     result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
     result = result && update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
     result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
@@ -184,7 +185,6 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
     result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical > low");
     result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical > low");
-    result = result && update_check(buflen, buffer, !_state.healthy, "unhealthy");
 
     return result;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -184,6 +184,7 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
     result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical > low");
     result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical > low");
+    result = result && update_check(buflen, buffer, !_state.healthy, "unhealthy");
 
     return result;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
@@ -26,20 +26,25 @@ public:
     bool reset_remaining(float percentage) override { return false; }
     bool get_cycle_count(uint16_t &cycles) const override { return false; }
 
-    virtual void init(void) override;
-    virtual void read() override;
+    void init(void) override;
+    void read() override;
 
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
 
+    void configure(void);
     bool read_word(const uint8_t reg, int16_t& data) const;
     bool write_word(const uint8_t reg, const uint16_t data) const;
     void timer(void);
 
     AP_Int8 i2c_bus;
     AP_Int8 i2c_address;
+    bool configured;
+    bool callback_registered;
+    uint32_t failed_reads;
+    uint32_t last_configure_ms;
 
     struct {
         uint16_t count;


### PR DESCRIPTION
and report arming failure if battery monitor backend is unhealthy. This is important for i2c devices, especially if they can be disconnected at boot
This also fixes healthy() to check all configured backends, which means we get an arming failure if any of the configured backends are unhealthy. 