### PR TITLE
Clean up LeddarOne rangefinder driver a little

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -133,14 +133,13 @@ bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCh
   */
 LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detections)
 {
-    uint8_t index;
     uint8_t index_offset = LEDDARONE_DETECTION_DATA_INDEX_OFFSET;
 
     // read serial
     uint32_t nbytes = uart->available();
 
     if (nbytes != 0)  {
-        for (index=read_len; index<nbytes+read_len; index++) {
+        for (uint8_t index=read_len; index<nbytes+read_len; index++) {
             if (index >= LEDDARONE_READ_BUFFER_SIZE) {
                 return LEDDARONE_STATE_ERR_BAD_RESPONSE;
             }
@@ -173,7 +172,7 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
     }
 
     sum_distance = 0;
-    for (index=0; index<number_detections; index++) {
+    for (uint8_t index=0; index<number_detections; index++) {
         // construct data word from two bytes and convert mm to cm
         sum_distance += (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -172,12 +172,10 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
         return LEDDARONE_STATE_ERR_NUMBER_DETECTIONS;
     }
 
-    memset(detections, 0, sizeof(detections));
     sum_distance = 0;
     for (index=0; index<number_detections; index++) {
         // construct data word from two bytes and convert mm to cm
-        detections[index] =  (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
-        sum_distance += detections[index];
+        sum_distance += (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
 
         // add index offset (4) to read next detection data
         index_offset += LEDDARONE_DETECTION_DATA_OFFSET;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -72,7 +72,7 @@ bool AP_RangeFinder_LeddarOne::get_reading(float &reading_m)
         leddarone_status = parse_response(number_detections);
 
         if (leddarone_status == LEDDARONE_STATE_OK) {
-            reading_m = (sum_distance * 0.01f) / number_detections;
+            reading_m = (sum_distance_mm * 0.001f) / number_detections;
 
             // reset mod_bus status to read new buffer
             modbus_status = LEDDARONE_MODBUS_STATE_INIT;
@@ -171,10 +171,10 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
         return LEDDARONE_STATE_ERR_NUMBER_DETECTIONS;
     }
 
-    sum_distance = 0;
+    sum_distance_mm = 0;
     for (uint8_t index=0; index<number_detections; index++) {
-        // construct data word from two bytes and convert mm to cm
-        sum_distance += (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
+        // construct data word from two bytes
+        sum_distance_mm += read_buffer[index_offset]<<8 | read_buffer[index_offset+1];
 
         // add index offset (4) to read next detection data
         index_offset += LEDDARONE_DETECTION_DATA_OFFSET;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -69,7 +69,7 @@ private:
     uint32_t last_sending_request_ms;
     uint32_t last_available_ms;
 
-    uint32_t sum_distance;
+    uint32_t sum_distance_mm;
 
     LeddarOne_ModbusStatus modbus_status = LEDDARONE_MODBUS_STATE_INIT;
     uint8_t read_buffer[LEDDARONE_READ_BUFFER_SIZE];

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -69,7 +69,6 @@ private:
     uint32_t last_sending_request_ms;
     uint32_t last_available_ms;
 
-    uint16_t detections[LEDDARONE_DETECTIONS_MAX];
     uint32_t sum_distance;
 
     LeddarOne_ModbusStatus modbus_status = LEDDARONE_MODBUS_STATE_INIT;


### PR DESCRIPTION
I can only test this in SITL.

Our autotests already test this driver's results match our other rangefinder results.  The graphs for distance before/after these changes are the same.

![image](https://user-images.githubusercontent.com/7077857/174925394-993e618a-9223-49d0-838e-ab4bf877a14d.png)
