### PR TITLE
AP_Mount: add earth-frame/body-frame angle and rate support to all backends

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1730,7 +1730,7 @@ void ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
         auto_yaw.set_yaw_angle_rate(cmd.content.mount_control.yaw,0.0f);
     }
     // pass the target angles to the camera mount
-    copter.camera_mount.set_angle_targets(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw);
+    copter.camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
 #endif
 }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -180,9 +180,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_DO_MOUNT_CONTROL:          // 205
         // point the camera to a specified angle
-        camera_mount.set_angle_targets(cmd.content.mount_control.roll, 
-                                       cmd.content.mount_control.pitch, 
-                                       cmd.content.mount_control.yaw);
+        camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
         break;
 #endif
 

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -685,6 +685,6 @@ void Sub::do_roi(const AP_Mission::Mission_Command& cmd)
 void Sub::do_mount_control(const AP_Mission::Mission_Command& cmd)
 {
 #if HAL_MOUNT_ENABLED
-    camera_mount.set_angle_targets(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw);
+    camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
 #endif
 }

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -183,7 +183,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
 
     case JSButton::button_function_t::k_mount_center:
 #if HAL_MOUNT_ENABLED
-        camera_mount.set_angle_targets(0, 0, 0);
+        camera_mount.set_angle_target(0, 0, 0, false);
         // for some reason the call to set_angle_targets changes the mode to mavlink targeting!
         camera_mount.set_mode(MAV_MOUNT_MODE_RC_TARGETING);
 #endif

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -98,7 +98,7 @@ void Sub::init_ardupilot()
     // initialise camera mount
     camera_mount.init();
     // This step ncessary so the servo is properly initialized
-    camera_mount.set_angle_targets(0, 0, 0);
+    camera_mount.set_angle_target(0, 0, 0, false);
     // for some reason the call to set_angle_targets changes the mode to mavlink targeting!
     camera_mount.set_mode(MAV_MOUNT_MODE_RC_TARGETING);
 #endif

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -326,6 +326,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_SPRAYER:
     case MAV_CMD_DO_AUX_FUNCTION:
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
+    case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         return true;
     default:
         return _cmd_verify_fn(cmd);

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -224,15 +224,19 @@ bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Miss
         return true;
     }
 
-    // To-Do: handle earth-frame vs body-frame angles
-    //bool earth_frame = cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_ROLL_LOCK |
-    //                   cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_PITCH_LOCK |
-    //                   cmd.content.gimbal_manager_pitchyaw.flags.GIMBAL_MANAGER_FLAGS_YAW_LOCK;
-    // To-Do: handle pitch and yaw rates
     // To-Do: handle gimbal device id
 
-    if (!isnan(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) && !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg)) {
-        mount->set_angle_targets(0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg);
+    // handle angle target
+    const bool pitch_angle_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) && (fabsf(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) <= 90);
+    const bool yaw_angle_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg) && (fabsf(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg) <= 360);
+    if (pitch_angle_valid && yaw_angle_valid) {
+        mount->set_angle_target(0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        return true;
+    }
+
+    // handle rate target
+    if (!isnan(cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs) && !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs)) {
+        mount->set_rate_target(0, cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs, cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return true;
     }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -648,7 +648,7 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
     }
 
     // check flags for change to RETRACT
-    uint8_t flags = (uint8_t)packet.param5;
+    uint32_t flags = (uint32_t)packet.param5;
     if ((flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
         _backends[_primary]->set_mode(MAV_MOUNT_MODE_RETRACT);
         return MAV_RESULT_ACCEPTED;
@@ -666,7 +666,7 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
     const float pitch_angle_deg = packet.param1;
     const float yaw_angle_deg = packet.param2;
     if (!isnan(pitch_angle_deg) && !isnan(yaw_angle_deg)) {
-        set_angle_target(0, pitch_angle_deg, yaw_angle_deg, (uint32_t)packet.param5 & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        set_angle_target(0, pitch_angle_deg, yaw_angle_deg, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return MAV_RESULT_ACCEPTED;
     }
 
@@ -675,7 +675,7 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
     const float pitch_rate_degs = packet.param3;
     const float yaw_rate_degs = packet.param4;
     if (!isnan(pitch_rate_degs) && !isnan(yaw_rate_degs)) {
-        set_rate_target(0, pitch_rate_degs, yaw_rate_degs, (uint32_t)packet.param5 & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        set_rate_target(0, pitch_rate_degs, yaw_rate_degs, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return MAV_RESULT_ACCEPTED;
     }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -609,9 +609,9 @@ MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_lon
         return MAV_RESULT_FAILED;
     }
     _backends[_primary]->set_mode((MAV_MOUNT_MODE)packet.param1);
-    state[0]._stab_roll = packet.param2;
-    state[0]._stab_tilt = packet.param3;
-    state[0]._stab_pan = packet.param4;
+    state[_primary]._stab_roll = packet.param2;
+    state[_primary]._stab_tilt = packet.param3;
+    state[_primary]._stab_pan = packet.param4;
 
     return MAV_RESULT_ACCEPTED;
 }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -772,7 +772,7 @@ void AP_Mount::set_target_sysid(uint8_t instance, uint8_t sysid)
 }
 
 // set_roi_target - sets target location that mount should attempt to point towards
-void AP_Mount::set_roi_target(uint8_t instance, const struct Location &target_loc)
+void AP_Mount::set_roi_target(uint8_t instance, const Location &target_loc)
 {
     // call instance's set_roi_cmd
     if (check_instance(instance)) {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -128,12 +128,12 @@ public:
     void set_angle_targets(uint8_t instance, float roll, float tilt, float pan);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const struct Location &target_loc) { set_roi_target(_primary,target_loc); }
-    void set_roi_target(uint8_t instance, const struct Location &target_loc);
+    void set_roi_target(const Location &target_loc) { set_roi_target(_primary,target_loc); }
+    void set_roi_target(uint8_t instance, const Location &target_loc);
 
     // point at system ID sysid
-    void set_target_sysid(uint8_t instance, const uint8_t sysid);
-    void set_target_sysid(const uint8_t sysid) { set_target_sysid(_primary, sysid); }
+    void set_target_sysid(uint8_t sysid) { set_target_sysid(_primary, sysid); }
+    void set_target_sysid(uint8_t instance, uint8_t sysid);
 
     // mavlink message handling:
     MAV_RESULT handle_command_long(const mavlink_command_long_t &packet);

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -123,9 +123,15 @@ public:
     void set_yaw_lock(bool yaw_lock) { set_yaw_lock(_primary, yaw_lock); }
     void set_yaw_lock(uint8_t instance, bool yaw_lock);
 
-    // set_angle_targets - sets angle targets in degrees
-    void set_angle_targets(float roll, float tilt, float pan) { set_angle_targets(_primary, roll, tilt, pan); }
-    void set_angle_targets(uint8_t instance, float roll, float tilt, float pan);
+    // set angle target in degrees
+    // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
+    void set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame) { set_angle_target(_primary, roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame); }
+    void set_angle_target(uint8_t instance, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame);
+
+    // sets rate target in deg/s
+    // yaw_lock should be true if the yaw rate is earth-frame, false if body-frame (e.g. rotates with body of vehicle)
+    void set_rate_target(float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock) { set_rate_target(_primary, roll_degs, pitch_degs, yaw_degs, yaw_lock); }
+    void set_rate_target(uint8_t instance, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock);
 
     // set_roi_target - sets target location that mount should attempt to point towards
     void set_roi_target(const Location &target_loc) { set_roi_target(_primary,target_loc); }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -190,15 +190,6 @@ protected:
         AP_Float        _roll_stb_lead;     // roll lead control gain
         AP_Float        _pitch_stb_lead;    // pitch lead control gain
 
-        MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
-        bool            _yaw_lock;          // If true the gimbal's yaw target is maintained in earth-frame, if false (aka "follow") it is maintained in body-frame
-        struct Location _roi_target;        // roi target location
-        bool _roi_target_set;
-
-        uint8_t _target_sysid;           // sysid to track
-        Location _target_sysid_location; // sysid target location
-        bool _target_sysid_location_set;
-
     } state[AP_MOUNT_MAX_INSTANCES];
 
 private:

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -15,6 +15,7 @@ void AP_Mount_Alexmos::init()
         _initialised = true;
         get_boardinfo();
         read_params(0); //we request parameters for profile 0 and therfore get global and profile parameters
+        set_mode((enum MAV_MOUNT_MODE)_state._default_mode.get());
     }
 }
 
@@ -64,8 +65,8 @@ void AP_Mount_Alexmos::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false, true)) {
                 control_axis(_angle_ef_target_rad, false);
             }
@@ -89,13 +90,6 @@ bool AP_Mount_Alexmos::has_pan_control() const
     return _gimbal_3axis;
 }
 
-// set_mode - sets mount's mode
-void AP_Mount_Alexmos::set_mode(enum MAV_MOUNT_MODE mode)
-{
-    // record the mode change and return success
-    _state._mode = mode;
-}
-
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_Alexmos::send_mount_status(mavlink_channel_t chan)
 {
@@ -104,7 +98,7 @@ void AP_Mount_Alexmos::send_mount_status(mavlink_channel_t chan)
     }
 
     get_angles();
-    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y*100, _current_angle.x*100, _current_angle.z*100, _state._mode);
+    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y*100, _current_angle.x*100, _current_angle.z*100, _mode);
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -29,59 +29,71 @@ void AP_Mount_Alexmos::update()
     read_incoming(); // read the incoming messages from the gimbal
 
     // update based on mount mode
-    switch(get_mode()) {
+    switch (get_mode()) {
         // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism
-        case MAV_MOUNT_MODE_RETRACT:
-            control_axis(_state._retract_angles.get(), true);
+        case MAV_MOUNT_MODE_RETRACT: {
+            const Vector3f &target = _state._retract_angles.get();
+            _angle_rad.roll = radians(target.x);
+            _angle_rad.pitch = radians(target.y);
+            _angle_rad.yaw = radians(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL:
-            control_axis(_state._neutral_angles.get(), true);
+        case MAV_MOUNT_MODE_NEUTRAL: {
+            const Vector3f &target = _state._neutral_angles.get();
+            _angle_rad.roll = radians(target.x);
+            _angle_rad.pitch = radians(target.y);
+            _angle_rad.yaw = radians(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
-            control_axis(_angle_ef_target_rad, false);
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                _angle_rad = mavt_target.angle_rad;
+                break;
+            case MountTargetType::RATE:
+                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
+                break;
+            }
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            // update targets using pilot's rc inputs
-            update_targets_from_rc();
-            control_axis(_angle_ef_target_rad, false);
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's RC inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                update_angle_target_from_rate(rc_target, _angle_rad);
+            } else if (get_rc_angle_target(rc_target)) {
+                _angle_rad = rc_target;
+            }
             break;
+        }
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false, true)) {
-                control_axis(_angle_ef_target_rad, false);
-            }
+            IGNORE_RETURN(get_angle_target_to_roi(_angle_rad));
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            // constantly update the home location:
-            if (!AP::ahrs().home_is_set()) {
-                break;
-            }
-            _roi_target = AP::ahrs().get_home();
-            _roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false, true)) {
-                control_axis(_angle_ef_target_rad, false);
-            }
+            IGNORE_RETURN(get_angle_target_to_home(_angle_rad));
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, false, true)) {
-                control_axis(_angle_ef_target_rad, false);
-            }
+            IGNORE_RETURN(get_angle_target_to_sysid(_angle_rad));
             break;
 
         default:
             // we do not know this mode so do nothing
             break;
     }
+
+    // send latest targets to gimbal
+    control_axis(_angle_rad);
 }
 
 // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
@@ -137,23 +149,18 @@ void AP_Mount_Alexmos::get_boardinfo()
 }
 
 /*
-  control_axis : send new angles to the gimbal at a fixed speed of 30 deg/s
+  control_axis : send new angle target to the gimbal at a fixed speed of 30 deg/s
 */
-void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degrees)
+void AP_Mount_Alexmos::control_axis(const MountTarget& angle_target_rad)
 {
-    // convert to degrees if necessary
-    Vector3f target_deg = angle;
-    if (!target_in_degrees) {
-        target_deg *= RAD_TO_DEG;
-    }
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode = AP_MOUNT_ALEXMOS_MODE_ANGLE;
     outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
-    outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
+    outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(degrees(angle_target_rad.roll));
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
-    outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
+    outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(degrees(angle_target_rad.pitch));
     outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
-    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
+    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(degrees(get_bf_yaw_angle(angle_target_rad)));
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -54,7 +54,7 @@ void AP_Mount_Alexmos::update()
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false, true)) {
                 control_axis(_angle_ef_target_rad, false);
             }
             break;
@@ -66,15 +66,13 @@ void AP_Mount_Alexmos::update()
             }
             _state._roi_target = AP::ahrs().get_home();
             _state._roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, false, true)) {
                 control_axis(_angle_ef_target_rad, false);
             }
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad,
-                                           true,
-                                           false)) {
+            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, false, true)) {
                 control_axis(_angle_ef_target_rad, false);
             }
             break;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -78,7 +78,7 @@ public:
     // update mount position - should be called periodically
     void update() override;
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
     bool has_pan_control() const override;
 
     // set_mode - sets mount's mode

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -81,9 +81,6 @@ public:
     // has_pan_control - returns true if this mount can control its pan (required for multicopters)
     bool has_pan_control() const override;
 
-    // set_mode - sets mount's mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override;
-
     // send_mount_status - called to allow mounts to send their status to GCS via MAVLink
     void send_mount_status(mavlink_channel_t chan) override;
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -95,8 +95,8 @@ private:
     // get_boardinfo - get board version and firmware version
     void get_boardinfo();
 
-    // control_axis - send new angles to the gimbal at a fixed speed of 30 deg/s
-    void control_axis(const Vector3f& angle , bool targets_in_degrees);
+    // send new angles to the gimbal at a fixed speed of 30 deg/s
+    void control_axis(const MountTarget& angle_target_rad);
 
     // read_params - read current profile profile_id and global parameters from the gimbal settings
     void read_params(uint8_t profile_id);
@@ -104,7 +104,7 @@ private:
     // write_params - write new parameters to the gimbal settings
     void write_params();
 
-    bool get_realtimedata( Vector3f& angle);
+    bool get_realtimedata(Vector3f& angle);
 
     // Alexmos Serial Protocol reading part implementation
     // send_command - send a command to the Alemox Serial API
@@ -115,6 +115,8 @@ private:
 
     // read_incoming - detect and read the header of the incoming message from the gimbal
     void read_incoming();
+
+    MountTarget _angle_rad;         // latest angle target
 
     // structure for the Serial Protocol
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -119,14 +119,15 @@ bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavli
 // update rate and angle targets from RC input
 // current angle target (in radians) should be provided in angle_rad target
 // rate and angle targets are returned in rate_rads and angle_rad arguments
-void AP_Mount_Backend::update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_rad, float angle_max_rad) const
+// angle min and max are in centi-degrees
+void AP_Mount_Backend::update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_cd, float angle_max_cd) const
 {
     if ((chan == nullptr) || (chan->get_radio_in() == 0)) {
         rate_rads = 0;
         return;
     }
     rate_rads = chan->norm_input_dz() * radians(_frontend._rc_rate_max);
-    angle_rad = constrain_float(angle_rad + (rate_rads * AP_MOUNT_UPDATE_DT), radians(angle_min_rad*0.01f), radians(angle_max_rad*0.01f));
+    angle_rad = constrain_float(angle_rad + (rate_rads * AP_MOUNT_UPDATE_DT), radians(angle_min_cd*0.01f), radians(angle_max_cd*0.01f));
 }
 
 // update_targets_from_rc - updates angle targets using input from receiver

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -6,13 +6,31 @@ extern const AP_HAL::HAL& hal;
 
 #define AP_MOUNT_UPDATE_DT 0.02     // update rate in seconds.  update() should be called at this rate
 
-// set_angle_targets - sets angle targets in degrees
-void AP_Mount_Backend::set_angle_targets(float roll, float tilt, float pan)
+// set angle target in degrees
+// yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
+void AP_Mount_Backend::set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame)
 {
     // set angle targets
-    _angle_ef_target_rad.x = radians(roll);
-    _angle_ef_target_rad.y = radians(tilt);
-    _angle_ef_target_rad.z = radians(pan);
+    mavt_target.target_type = MountTargetType::ANGLE;
+    mavt_target.angle_rad.roll = radians(roll_deg);
+    mavt_target.angle_rad.pitch = radians(pitch_deg);
+    mavt_target.angle_rad.yaw = radians(yaw_deg);
+    mavt_target.angle_rad.yaw_is_ef = yaw_is_earth_frame;
+
+    // set the mode to mavlink targeting
+    set_mode(MAV_MOUNT_MODE_MAVLINK_TARGETING);
+}
+
+// sets rate target in deg/s
+// yaw_lock should be true if the yaw rate is earth-frame, false if body-frame (e.g. rotates with body of vehicle)
+void AP_Mount_Backend::set_rate_target(float roll_degs, float pitch_degs, float yaw_degs, bool yaw_is_earth_frame)
+{
+    // set rate targets
+    mavt_target.target_type = MountTargetType::RATE;
+    mavt_target.rate_rads.roll = radians(roll_degs);
+    mavt_target.rate_rads.pitch = radians(pitch_degs);
+    mavt_target.rate_rads.yaw = radians(yaw_degs);
+    mavt_target.rate_rads.yaw_is_ef = yaw_is_earth_frame;
 
     // set the mode to mavlink targeting
     set_mode(MAV_MOUNT_MODE_MAVLINK_TARGETING);
@@ -66,7 +84,7 @@ void AP_Mount_Backend::control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_
 
         // set earth frame target angles from mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            set_angle_targets(roll_or_lon*0.01f, pitch_or_lat*0.01f, yaw_or_alt*0.01f);
+            set_angle_target(roll_or_lon*0.01f, pitch_or_lat*0.01f, yaw_or_alt*0.01f, false);
             break;
 
         // Load neutral position and start RC Roll,Pitch,Yaw control with stabilization
@@ -116,86 +134,100 @@ bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavli
     return true;
 }
 
-// update rate and angle targets from RC input
-// current angle target (in radians) should be provided in angle_rad target
-// rate and angle targets are returned in rate_rads and angle_rad arguments
-// angle min and max are in centi-degrees
-void AP_Mount_Backend::update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_cd, float angle_max_cd) const
-{
-    if ((chan == nullptr) || (chan->get_radio_in() == 0)) {
-        rate_rads = 0;
-        return;
-    }
-    rate_rads = chan->norm_input_dz() * radians(_frontend._rc_rate_max);
-    angle_rad = constrain_float(angle_rad + (rate_rads * AP_MOUNT_UPDATE_DT), radians(angle_min_cd*0.01f), radians(angle_max_cd*0.01f));
-}
-
-// update_targets_from_rc - updates angle targets using input from receiver
-void AP_Mount_Backend::update_targets_from_rc()
+// get pilot input (in the range -1 to +1) received through RC
+void AP_Mount_Backend::get_rc_input(float& roll_in, float& pitch_in, float& yaw_in) const
 {
     const RC_Channel *roll_ch = rc().channel(_state._roll_rc_in - 1);
-    const RC_Channel *tilt_ch = rc().channel(_state._tilt_rc_in - 1);
-    const RC_Channel *pan_ch = rc().channel(_state._pan_rc_in - 1);
+    const RC_Channel *pitch_ch = rc().channel(_state._tilt_rc_in - 1);
+    const RC_Channel *yaw_ch = rc().channel(_state._pan_rc_in - 1);
 
-    // if joystick_speed is defined then pilot input defines a rate of change of the angle
+    roll_in = 0;
+    if ((roll_ch != nullptr) && (roll_ch->get_radio_in() > 0)) {
+        roll_in = roll_ch->norm_input_dz();
+    }
+
+    pitch_in = 0;
+    if ((pitch_ch != nullptr) && (pitch_ch->get_radio_in() > 0)) {
+        pitch_in = pitch_ch->norm_input_dz();
+    }
+
+    yaw_in = 0;
+    if ((yaw_ch != nullptr) && (yaw_ch->get_radio_in() > 0)) {
+        yaw_in = yaw_ch->norm_input_dz();
+    }
+}
+
+// get rate targets (in rad/s) from pilot RC
+// returns true on success (RC is providing rate targets), false on failure (RC is providing angle targets)
+bool AP_Mount_Backend::get_rc_rate_target(MountTarget& rate_rads) const
+{
+    // exit immediately if RC is not providing rate targets
+    if (_frontend._rc_rate_max <= 0) {
+        return false;
+    }
+
+    // get RC input from pilot
+    float roll_in, pitch_in, yaw_in;
+    get_rc_input(roll_in, pitch_in, yaw_in);
+
+    // calculate rates
+    const float rc_rate_max_rads = radians(_frontend._rc_rate_max.get());
+    rate_rads.roll = roll_in * rc_rate_max_rads;
+    rate_rads.pitch = pitch_in * rc_rate_max_rads;
+    rate_rads.yaw = yaw_in * rc_rate_max_rads;
+
+    // yaw frame
+    rate_rads.yaw_is_ef = _yaw_lock;
+
+    return true;
+}
+
+// get angle targets (in radians) from pilot RC
+// returns true on success (RC is providing angle targets), false on failure (RC is providing rate targets)
+bool AP_Mount_Backend::get_rc_angle_target(MountTarget& angle_rad) const
+{
+    // exit immediately if RC is not providing angle targets
     if (_frontend._rc_rate_max > 0) {
-        // allow pilot position input to come directly from an RC_Channel
-        update_rate_and_angle_from_rc(roll_ch, _rate_target_rads.x, _angle_ef_target_rad.x, _state._roll_angle_min, _state._roll_angle_max);
-        update_rate_and_angle_from_rc(tilt_ch, _rate_target_rads.y, _angle_ef_target_rad.y, _state._tilt_angle_min, _state._tilt_angle_max);
-        update_rate_and_angle_from_rc(pan_ch, _rate_target_rads.z, _angle_ef_target_rad.z, _state._pan_angle_min, _state._pan_angle_max);
-        _rate_target_rads_valid = true;
+        return false;
+    }
+
+    // get RC input from pilot
+    float roll_in, pitch_in, yaw_in;
+    get_rc_input(roll_in, pitch_in, yaw_in);
+
+    // roll angle
+    angle_rad.roll = radians(((roll_in + 1.0f) * 0.5f * (_state._roll_angle_max - _state._roll_angle_min) + _state._roll_angle_min)*0.01f);
+
+    // pitch angle
+    angle_rad.pitch = radians(((pitch_in + 1.0f) * 0.5f * (_state._tilt_angle_max - _state._tilt_angle_min) + _state._tilt_angle_min)*0.01f);
+
+    // yaw angle
+    angle_rad.yaw_is_ef = _yaw_lock;
+    if (angle_rad.yaw_is_ef) {
+        // if yaw is earth-frame pilot yaw input control angle from -180 to +180 deg
+        angle_rad.yaw = yaw_in * M_PI;
     } else {
-        // allow pilot rate input to come directly from an RC_Channel
-        if ((roll_ch != nullptr) && (roll_ch->get_radio_in() != 0)) {
-            _angle_ef_target_rad.x = angle_input_rad(roll_ch, _state._roll_angle_min, _state._roll_angle_max);
-        }
-        if ((tilt_ch != nullptr) && (tilt_ch->get_radio_in() != 0)) {
-            _angle_ef_target_rad.y = angle_input_rad(tilt_ch, _state._tilt_angle_min, _state._tilt_angle_max);
-        }
-        if ((pan_ch != nullptr) && (pan_ch->get_radio_in() != 0)) {
-            _angle_ef_target_rad.z = angle_input_rad(pan_ch, _state._pan_angle_min, _state._pan_angle_max);
-        }
-        // not using rate input
-        _rate_target_rads_valid = false;
+        // yaw target in body frame so apply body frame limits
+        angle_rad.yaw = radians(((yaw_in + 1.0f) * 0.5f * (_state._pan_angle_max - _state._pan_angle_min) + _state._pan_angle_min)*0.01f);
     }
+
+    return true;
 }
 
-// returns the angle (radians) that the RC_Channel input is receiving
-float AP_Mount_Backend::angle_input_rad(const RC_Channel* rc, int16_t angle_min, int16_t angle_max)
+// get angle targets (in radians) to a Location
+// returns true on success, false on failure
+bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountTarget& angle_rad) const
 {
-    return radians(((rc->norm_input_ignore_trim() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min)*0.01f);
-}
-
-bool AP_Mount_Backend::calc_angle_to_roi_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
-{
-    if (!_roi_target_set) {
-        return false;
-    }
-    return calc_angle_to_location(_roi_target, angles_to_target_rad, calc_tilt, calc_pan, relative_pan);
-}
-
-bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
-{
-    if (!_target_sysid_location_set) {
-        return false;
-    }
-    if (!_target_sysid) {
-        return false;
-    }
-    return calc_angle_to_location(_target_sysid_location, angles_to_target_rad, calc_tilt, calc_pan, relative_pan);
-}
-
-// calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (in radians) to point at the given target
-bool AP_Mount_Backend::calc_angle_to_location(const Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
-{
+    // exit immediately if vehicle's location is unavailable
     Location current_loc;
     if (!AP::ahrs().get_location(current_loc)) {
         return false;
     }
-    const float GPS_vector_x = Location::diff_longitude(target.lng,current_loc.lng)*cosf(ToRad((current_loc.lat+target.lat)*0.00000005f))*0.01113195f;
-    const float GPS_vector_y = (target.lat-current_loc.lat)*0.01113195f;
+
+    const float GPS_vector_x = Location::diff_longitude(loc.lng, current_loc.lng)*cosf(ToRad((current_loc.lat + loc.lat) * 0.00000005f)) * 0.01113195f;
+    const float GPS_vector_y = (loc.lat - current_loc.lat) * 0.01113195f;
     int32_t target_alt_cm = 0;
-    if (!target.get_alt_cm(Location::AltFrame::ABOVE_HOME, target_alt_cm)) {
+    if (!loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, target_alt_cm)) {
         return false;
     }
     int32_t current_alt_cm = 0;
@@ -205,23 +237,102 @@ bool AP_Mount_Backend::calc_angle_to_location(const Location &target, Vector3f& 
     float GPS_vector_z = target_alt_cm - current_alt_cm;
     float target_distance = 100.0f*norm(GPS_vector_x, GPS_vector_y);      // Careful , centimeters here locally. Baro/alt is in cm, lat/lon is in meters.
 
-    // initialise all angles to zero
-    angles_to_target_rad.zero();
+    // calculate roll, pitch, yaw angles
+    angle_rad.roll = 0;
+    angle_rad.pitch = atan2f(GPS_vector_z, target_distance);
+    angle_rad.yaw = atan2f(GPS_vector_x, GPS_vector_y);
+    angle_rad.yaw_is_ef = true;
 
-    // tilt calcs
-    if (calc_tilt) {
-        angles_to_target_rad.y = atan2f(GPS_vector_z, target_distance);
-    }
-
-    // pan calcs
-    if (calc_pan) {
-        // calc absolute heading and then convert to vehicle relative yaw
-        angles_to_target_rad.z = atan2f(GPS_vector_x, GPS_vector_y);
-        if (relative_pan) {
-            angles_to_target_rad.z = wrap_PI(angles_to_target_rad.z - AP::ahrs().yaw);
-        }
-    }
     return true;
+}
+
+// get angle targets (in radians) to ROI location
+// returns true on success, false on failure
+bool AP_Mount_Backend::get_angle_target_to_roi(MountTarget& angle_rad) const
+{
+    if (!_roi_target_set) {
+        return false;
+    }
+    return get_angle_target_to_location(_roi_target, angle_rad);
+}
+
+// return body-frame yaw angle from a mount target
+float AP_Mount_Backend::get_bf_yaw_angle(const MountTarget& angle_rad) const
+{
+    if (angle_rad.yaw_is_ef) {
+        // convert to body-frame
+        return wrap_PI(angle_rad.yaw - AP::ahrs().yaw);
+    }
+
+    // target is already body-frame
+    return angle_rad.yaw;
+}
+
+// return earth-frame yaw angle from a mount target
+float AP_Mount_Backend::get_ef_yaw_angle(const MountTarget& angle_rad) const
+{
+    if (angle_rad.yaw_is_ef) {
+        // target is already earth-frame
+        return angle_rad.yaw;
+    }
+
+    // convert to earth-frame
+    return wrap_PI(angle_rad.yaw + AP::ahrs().yaw);
+}
+
+// update angle targets using a given rate target
+// the resulting angle_rad yaw frame will match the rate_rad yaw frame
+// assumes a 50hz update rate
+void AP_Mount_Backend::update_angle_target_from_rate(const MountTarget& rate_rad, MountTarget& angle_rad) const
+{
+    // update roll and pitch angles and apply limits
+    angle_rad.roll = constrain_float(angle_rad.roll + rate_rad.roll * AP_MOUNT_UPDATE_DT, radians(_state._roll_angle_min * 0.01), radians(_state._roll_angle_max * 0.01));
+    angle_rad.pitch = constrain_float(angle_rad.pitch + rate_rad.pitch * AP_MOUNT_UPDATE_DT, radians(_state._tilt_angle_min * 0.01), radians(_state._tilt_angle_max * 0.01));
+
+    // ensure angle yaw frames matches rate yaw frame
+    if (angle_rad.yaw_is_ef != rate_rad.yaw_is_ef) {
+        if (rate_rad.yaw_is_ef) {
+            angle_rad.yaw = get_ef_yaw_angle(angle_rad);
+        } else {
+            angle_rad.yaw = get_bf_yaw_angle(angle_rad);
+        }
+        angle_rad.yaw_is_ef = rate_rad.yaw_is_ef;
+    }
+
+    // update yaw angle target
+    angle_rad.yaw = angle_rad.yaw + rate_rad.yaw * AP_MOUNT_UPDATE_DT;
+    if (angle_rad.yaw_is_ef) {
+        // if earth-frame yaw wraps between += 180 degrees
+        angle_rad.yaw = wrap_PI(angle_rad.yaw);
+    } else {
+        // if body-frame constrain yaw to body-frame limits
+        angle_rad.yaw = constrain_float(angle_rad.yaw, radians(_state._pan_angle_min * 0.01), radians(_state._pan_angle_max * 0.01));
+    }
+}
+
+// get angle targets (in radians) to home location
+// returns true on success, false on failure
+bool AP_Mount_Backend::get_angle_target_to_home(MountTarget& angle_rad) const
+{
+    // exit immediately if home is not set
+    if (!AP::ahrs().home_is_set()) {
+        return false;
+    }
+    return get_angle_target_to_location(AP::ahrs().get_home(), angle_rad);
+}
+
+// get angle targets (in radians) to a vehicle with sysid of  _target_sysid
+// returns true on success, false on failure
+bool AP_Mount_Backend::get_angle_target_to_sysid(MountTarget& angle_rad) const
+{
+    // exit immediately if sysid is not set or no location available
+    if (!_target_sysid_location_set) {
+        return false;
+    }
+    if (!_target_sysid) {
+        return false;
+    }
+    return get_angle_target_to_location(_target_sysid_location, angle_rad);
 }
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -166,10 +166,7 @@ float AP_Mount_Backend::angle_input_rad(const RC_Channel* rc, int16_t angle_min,
     return radians(((rc->norm_input_ignore_trim() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min)*0.01f);
 }
 
-bool AP_Mount_Backend::calc_angle_to_roi_target(Vector3f& angles_to_target_rad,
-                                                bool calc_tilt,
-                                                bool calc_pan,
-                                                bool relative_pan) const
+bool AP_Mount_Backend::calc_angle_to_roi_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
 {
     if (!_state._roi_target_set) {
         return false;
@@ -177,10 +174,7 @@ bool AP_Mount_Backend::calc_angle_to_roi_target(Vector3f& angles_to_target_rad,
     return calc_angle_to_location(_state._roi_target, angles_to_target_rad, calc_tilt, calc_pan, relative_pan);
 }
 
-bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad,
-                                                  bool calc_tilt,
-                                                  bool calc_pan,
-                                                  bool relative_pan) const
+bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
 {
     if (!_state._target_sysid_location_set) {
         return false;
@@ -188,11 +182,7 @@ bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad
     if (!_state._target_sysid) {
         return false;
     }
-    return calc_angle_to_location(_state._target_sysid_location,
-                                  angles_to_target_rad,
-                                  calc_tilt,
-                                  calc_pan,
-                                  relative_pan);
+    return calc_angle_to_location(_state._target_sysid_location, angles_to_target_rad, calc_tilt, calc_pan, relative_pan);
 }
 
 // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (in radians) to point at the given target

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -19,7 +19,7 @@ void AP_Mount_Backend::set_angle_targets(float roll, float tilt, float pan)
 }
 
 // set_roi_target - sets target location that mount should attempt to point towards
-void AP_Mount_Backend::set_roi_target(const struct Location &target_loc)
+void AP_Mount_Backend::set_roi_target(const Location &target_loc)
 {
     // set the target gps location
     _state._roi_target = target_loc;
@@ -186,7 +186,7 @@ bool AP_Mount_Backend::calc_angle_to_sysid_target(Vector3f& angles_to_target_rad
 }
 
 // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (in radians) to point at the given target
-bool AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
+bool AP_Mount_Backend::calc_angle_to_location(const Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const
 {
     Location current_loc;
     if (!AP::ahrs().get_location(current_loc)) {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -135,7 +135,8 @@ private:
     // update rate and angle targets from RC input
     // current angle target (in radians) should be provided in angle_rad target
     // rate and angle targets are returned in rate_rads and angle_rad arguments
-    void update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_rad, float angle_max_rad) const;
+    // angle min and max are in centi-degrees
+    void update_rate_and_angle_from_rc(const RC_Channel *chan, float &rate_rads, float &angle_rad, float angle_min_cd, float angle_max_cd) const;
 };
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -56,7 +56,7 @@ public:
     void set_angle_targets(float roll, float tilt, float pan);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const struct Location &target_loc);
+    void set_roi_target(const Location &target_loc);
 
     // set_sys_target - sets system that mount should attempt to point towards
     void set_target_sysid(uint8_t sysid);
@@ -98,7 +98,7 @@ protected:
 
     // calc_angle_to_location - calculates the earth-frame roll, tilt
     // and pan angles (in radians) to point at the given target
-    bool calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const WARN_IF_UNUSED;
+    bool calc_angle_to_location(const Location &target, Vector3f& angles_to_target_rad, bool yaw_is_earth_frame) const WARN_IF_UNUSED;
 
     // calc_angle_to_roi_target - calculates the earth-frame roll, tilt
     // and pan angles (in radians) to point at the ROI-target (as set

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -49,8 +49,15 @@ public:
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
     virtual bool has_pan_control() const = 0;
 
-    // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode) = 0;
+    // get mount's mode
+    enum MAV_MOUNT_MODE get_mode() const { return _mode; }
+
+    // set mount's mode
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) { _mode = mode; }
+
+    // set yaw_lock.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
+    // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
+    void set_yaw_lock(bool yaw_lock) { _yaw_lock = yaw_lock; }
 
     // set_angle_targets - sets angle targets in degrees
     void set_angle_targets(float roll, float tilt, float pan);
@@ -110,15 +117,23 @@ protected:
     // by various mavlink messages)
     bool calc_angle_to_sysid_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const WARN_IF_UNUSED;
 
-    // get the mount mode from frontend
-    MAV_MOUNT_MODE get_mode(void) const { return _frontend.get_mode(_instance); }
 
     AP_Mount    &_frontend; // reference to the front end which holds parameters
     AP_Mount::mount_state &_state;    // references to the parameters and state for this backend
     uint8_t     _instance;  // this instance's number
+
+    MAV_MOUNT_MODE  _mode;          // current mode (see MAV_MOUNT_MODE enum)
+    bool _yaw_lock;                 // True if the gimbal's yaw target is maintained in earth-frame, if false (aka "follow") it is maintained in body-frame
+
     Vector3f    _angle_ef_target_rad;   // desired earth-frame roll, tilt and vehicle-relative pan angles in radians
     Vector3f    _rate_target_rads;      // desired roll, pitch, yaw rate in radians/sec
     bool        _rate_target_rads_valid;// true if _rate_target_rads should can be used (e.g. RC input is using rate control)
+    Location _roi_target;           // roi target location
+    bool _roi_target_set;           // true if the roi target has been set
+
+    uint8_t _target_sysid;          // sysid to track
+    Location _target_sysid_location;// sysid target location
+    bool _target_sysid_location_set;// true if _target_sysid has been set
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -98,27 +98,17 @@ protected:
 
     // calc_angle_to_location - calculates the earth-frame roll, tilt
     // and pan angles (in radians) to point at the given target
-    bool calc_angle_to_location(const struct Location &target,
-                                Vector3f& angles_to_target_rad,
-                                bool calc_tilt,
-                                bool calc_pan,
-                                bool relative_pan = true) const WARN_IF_UNUSED;
+    bool calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const WARN_IF_UNUSED;
 
     // calc_angle_to_roi_target - calculates the earth-frame roll, tilt
     // and pan angles (in radians) to point at the ROI-target (as set
     // by various mavlink messages)
-    bool calc_angle_to_roi_target(Vector3f& angles_to_target_rad,
-                                  bool calc_tilt,
-                                  bool calc_pan,
-                                  bool relative_pan = true) const WARN_IF_UNUSED;
+    bool calc_angle_to_roi_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const WARN_IF_UNUSED;
 
     // calc_angle_to_sysid_target - calculates the earth-frame roll, tilt
     // and pan angles (in radians) to point at the sysid-target (as set
     // by various mavlink messages)
-    bool calc_angle_to_sysid_target(Vector3f& angles_to_target_rad,
-                                    bool calc_tilt,
-                                    bool calc_pan,
-                                    bool relative_pan = true) const WARN_IF_UNUSED;
+    bool calc_angle_to_sysid_target(Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan) const WARN_IF_UNUSED;
 
     // get the mount mode from frontend
     MAV_MOUNT_MODE get_mode(void) const { return _frontend.get_mode(_instance); }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -66,8 +66,8 @@ void AP_Mount_Gremsy::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, false)) {
                 send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, true);
             }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -32,11 +32,8 @@ void AP_Mount_Gremsy::update()
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
-            const Vector3f &target = _state._neutral_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            send_gimbal_device_set_attitude(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z, false);
+            const Vector3f &angle_bf_target = _state._neutral_angles.get();
+            send_gimbal_device_set_attitude(ToRad(angle_bf_target.x), ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
             }
             break;
 

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -36,9 +36,6 @@ public:
     // has_pan_control
     bool has_pan_control() const override { return true; }
 
-    // set_mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override { _state._mode = mode; }
-
     // send_mount_status
     void send_mount_status(mavlink_channel_t chan) override;
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -73,8 +73,8 @@ void AP_Mount_SToRM32::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
@@ -113,14 +113,14 @@ void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
     }
 
     // record the mode change
-    _state._mode = mode;
+    _mode = mode;
 }
 
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_SToRM32::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.  To-Do: retrieve actual gimbal attitude and send these instead
-    mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100, _state._mode);
+    mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100, _mode);
 }
 
 // search for gimbal in GCS_MAVLink routing table

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -63,7 +63,7 @@ void AP_Mount_SToRM32::update()
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;
@@ -75,13 +75,13 @@ void AP_Mount_SToRM32::update()
             }
             _state._roi_target = AP::ahrs().get_home();
             _state._roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true)) {
+            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -29,59 +29,66 @@ void AP_Mount_SToRM32::update()
     // update based on mount mode
     switch(get_mode()) {
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
-        case MAV_MOUNT_MODE_RETRACT:
-            {
+        case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &target = _state._retract_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            }
+            _angle_rad.roll = radians(target.x);
+            _angle_rad.pitch = radians(target.y);
+            _angle_rad.yaw = radians(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL:
-            {
+        case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &target = _state._neutral_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            }
+            _angle_rad.roll = radians(target.x);
+            _angle_rad.pitch = radians(target.y);
+            _angle_rad.yaw = radians(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                _angle_rad = mavt_target.angle_rad;
+                break;
+            case MountTargetType::RATE:
+                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
+                break;
+            }
             resend_now = true;
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            // update targets using pilot's rc inputs
-            update_targets_from_rc();
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's RC inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                update_angle_target_from_rate(rc_target, _angle_rad);
+            } else if (get_rc_angle_target(rc_target)) {
+                _angle_rad = rc_target;
+            }
             resend_now = true;
             break;
+        }
 
-        // point mount to a GPS point given by the mission planner
+        // point mount to a GPS location
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_roi(_angle_rad)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            // constantly update the home location:
-            if (!AP::ahrs().home_is_set()) {
-                break;
-            }
-            _roi_target = AP::ahrs().get_home();
-            _roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_home(_angle_rad)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_sysid(_angle_rad)) {
                 resend_now = true;
             }
             break;
@@ -93,7 +100,7 @@ void AP_Mount_SToRM32::update()
 
     // resend target angles at least once per second
     if (resend_now || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
-        send_do_mount_control(ToDeg(_angle_ef_target_rad.y), ToDeg(_angle_ef_target_rad.x), ToDeg(_angle_ef_target_rad.z), MAV_MOUNT_MODE_MAVLINK_TARGETING);
+        send_do_mount_control(_angle_rad);
     }
 }
 
@@ -120,7 +127,7 @@ void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
 void AP_Mount_SToRM32::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.  To-Do: retrieve actual gimbal attitude and send these instead
-    mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100, _mode);
+    mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_rad.pitch)*100, degrees(_angle_rad.roll)*100, degrees(get_bf_yaw_angle(_angle_rad))*100, _mode);
 }
 
 // search for gimbal in GCS_MAVLink routing table
@@ -142,7 +149,7 @@ void AP_Mount_SToRM32::find_gimbal()
 }
 
 // send_do_mount_control - send a COMMAND_LONG containing a do_mount_control message
-void AP_Mount_SToRM32::send_do_mount_control(float pitch_deg, float roll_deg, float yaw_deg, enum MAV_MOUNT_MODE mount_mode)
+void AP_Mount_SToRM32::send_do_mount_control(const MountTarget& angle_target_rad)
 {
     // exit immediately if not initialised
     if (!_initialised) {
@@ -154,21 +161,18 @@ void AP_Mount_SToRM32::send_do_mount_control(float pitch_deg, float roll_deg, fl
         return;
     }
 
-    // reverse pitch and yaw control
-    pitch_deg = -pitch_deg;
-    yaw_deg = -yaw_deg;
-
     // send command_long command containing a do_mount_control command
+    // Note: pitch and yaw are reversed
     mavlink_msg_command_long_send(_chan,
                                   _sysid,
                                   _compid,
                                   MAV_CMD_DO_MOUNT_CONTROL,
                                   0,        // confirmation of zero means this is the first time this message has been sent
-                                  pitch_deg,
-                                  roll_deg,
-                                  yaw_deg,
+                                  -degrees(angle_target_rad.pitch),
+                                  degrees(angle_target_rad.roll),
+                                  -degrees(get_bf_yaw_angle(angle_target_rad)),
                                   0, 0, 0,  // param4 ~ param6 unused
-                                  mount_mode);
+                                  MAV_MOUNT_MODE_MAVLINK_TARGETING);
 
     // store time of send
     _last_send = AP_HAL::millis();

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -43,8 +43,8 @@ private:
     // search for gimbal in GCS_MAVLink routing table
     void find_gimbal();
 
-    // send_do_mount_control - send a COMMAND_LONG containing a do_mount_control message
-    void send_do_mount_control(float pitch_deg, float roll_deg, float yaw_deg, enum MAV_MOUNT_MODE mount_mode);
+    // send_do_mount_control with latest angle targets
+    void send_do_mount_control(const MountTarget& angle_target_rad);
 
     // internal variables
     bool _initialised;              // true once the driver has been initialised
@@ -52,5 +52,6 @@ private:
     uint8_t _compid;                // component id of gimbal
     mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
+    MountTarget _angle_rad;         // latest angle target
 };
 #endif // HAL_MOUNT_STORM32MAVLINK_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -42,59 +42,66 @@ void AP_Mount_SToRM32_serial::update()
     // update based on mount mode
     switch(get_mode()) {
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
-        case MAV_MOUNT_MODE_RETRACT:
-            {
+        case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &target = _state._retract_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            }
+            _angle_rad.roll = ToRad(target.x);
+            _angle_rad.pitch = ToRad(target.y);
+            _angle_rad.yaw = ToRad(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL:
-            {
+        case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &target = _state._neutral_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            }
+            _angle_rad.roll = ToRad(target.x);
+            _angle_rad.pitch = ToRad(target.y);
+            _angle_rad.yaw = ToRad(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                _angle_rad = mavt_target.angle_rad;
+                break;
+            case MountTargetType::RATE:
+                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
+                break;
+            }
             resend_now = true;
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            // update targets using pilot's rc inputs
-            update_targets_from_rc();
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's RC inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                update_angle_target_from_rate(rc_target, _angle_rad);
+            } else if (get_rc_angle_target(rc_target)) {
+                _angle_rad = rc_target;
+            }
             resend_now = true;
             break;
+        }
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_roi(_angle_rad)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            // constantly update the home location:
-            if (!AP::ahrs().home_is_set()) {
-                break;
-            }
-            _roi_target = AP::ahrs().get_home();
-            _roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_home(_angle_rad)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true)) {
+            if (get_angle_target_to_sysid(_angle_rad)) {
                 resend_now = true;
             }
             break;
@@ -112,7 +119,7 @@ void AP_Mount_SToRM32_serial::update()
     }
     if (can_send(resend_now)) {
         if (resend_now) {
-            send_target_angles(ToDeg(_angle_ef_target_rad.y), ToDeg(_angle_ef_target_rad.x), ToDeg(_angle_ef_target_rad.z));
+            send_target_angles(_angle_rad);
             get_angles();
             _reply_type = ReplyType_ACK;
             _reply_counter = 0;
@@ -162,7 +169,7 @@ bool AP_Mount_SToRM32_serial::can_send(bool with_control) {
 
 
 // send_target_angles
-void AP_Mount_SToRM32_serial::send_target_angles(float pitch_deg, float roll_deg, float yaw_deg)
+void AP_Mount_SToRM32_serial::send_target_angles(const MountTarget& angle_target_rad)
 {
 
     static cmd_set_angles_struct cmd_set_angles_data = {
@@ -186,14 +193,10 @@ void AP_Mount_SToRM32_serial::send_target_angles(float pitch_deg, float roll_deg
         return;
     }
 
-    // reverse pitch and yaw control
-    pitch_deg = -pitch_deg;
-    yaw_deg = -yaw_deg;
-
-    // send CMD_SETANGLE
-    cmd_set_angles_data.pitch = pitch_deg;
-    cmd_set_angles_data.roll = roll_deg;
-    cmd_set_angles_data.yaw = yaw_deg;
+    // send CMD_SETANGLE (Note: reversed pitch and yaw)
+    cmd_set_angles_data.pitch = -degrees(angle_target_rad.pitch);
+    cmd_set_angles_data.roll = degrees(angle_target_rad.roll);
+    cmd_set_angles_data.yaw = -degrees(get_bf_yaw_angle(angle_target_rad));
 
     uint8_t* buf = (uint8_t*)&cmd_set_angles_data;
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -86,8 +86,8 @@ void AP_Mount_SToRM32_serial::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
@@ -142,14 +142,14 @@ void AP_Mount_SToRM32_serial::set_mode(enum MAV_MOUNT_MODE mode)
     }
 
     // record the mode change
-    _state._mode = mode;
+    _mode = mode;
 }
 
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_SToRM32_serial::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.
-    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y, _current_angle.x, _current_angle.z, _state._mode);
+    mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y, _current_angle.x, _current_angle.z, _mode);
 }
 
 bool AP_Mount_SToRM32_serial::can_send(bool with_control) {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -76,7 +76,7 @@ void AP_Mount_SToRM32_serial::update()
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;
@@ -88,15 +88,13 @@ void AP_Mount_SToRM32_serial::update()
             }
             _state._roi_target = AP::ahrs().get_home();
             _state._roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true)) {
+            if (calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad,
-                                           true,
-                                           true)) {
+            if (calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true)) {
                 resend_now = true;
             }
             break;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -44,7 +44,7 @@ public:
 private:
 
     // send_target_angles
-    void send_target_angles(float pitch_deg, float roll_deg, float yaw_deg);
+    void send_target_angles(const MountTarget& angle_target_rad);
 
     // send read data request
     void get_angles();
@@ -137,6 +137,7 @@ private:
     AP_HAL::UARTDriver *_port;
 
     bool _initialised;              // true once the driver has been initialised
+    MountTarget _angle_rad;         // latest angle target
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
 
     uint8_t _reply_length;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -81,8 +81,8 @@ void AP_Mount_Servo::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             if (calc_angle_to_roi_target(_angle_ef_target_rad, _flags.tilt_control, _flags.pan_control, true)) {
                 stabilize();
             }
@@ -115,13 +115,6 @@ void AP_Mount_Servo::update()
     move_servo(_pan_idx,  _angle_bf_output_deg.z*10, _state._pan_angle_min*0.1f, _state._pan_angle_max*0.1f);
 }
 
-// set_mode - sets mount's mode
-void AP_Mount_Servo::set_mode(enum MAV_MOUNT_MODE mode)
-{
-    // record the mode change and return success
-    _state._mode = mode;
-}
-
 // private methods
 
 // check_servo_map - detects which axis we control using the functions assigned to the servos in the RC_Channel_aux
@@ -136,7 +129,7 @@ void AP_Mount_Servo::check_servo_map()
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_Servo::send_mount_status(mavlink_channel_t chan)
 {
-    mavlink_msg_mount_status_send(chan, 0, 0, _angle_bf_output_deg.y*100, _angle_bf_output_deg.x*100, _angle_bf_output_deg.z*100, _state._mode);
+    mavlink_msg_mount_status_send(chan, 0, 0, _angle_bf_output_deg.y*100, _angle_bf_output_deg.x*100, _angle_bf_output_deg.z*100, _mode);
 }
 
 // stabilize - stabilizes the mount relative to the Earth's frame

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -18,84 +18,86 @@ void AP_Mount_Servo::init()
         _pan_idx  = SRV_Channel::k_mount2_pan;
         _open_idx = SRV_Channel::k_mount2_open;
     }
-
-    // check which servos have been assigned
-    check_servo_map();
 }
 
 // update mount position - should be called periodically
 void AP_Mount_Servo::update()
 {
-    static bool mount_open = 0;     // 0 is closed
-
-    // check servo map every three seconds to allow users to modify parameters
-    uint32_t now = AP_HAL::millis();
-    if (now - _last_check_servo_map_ms > 3000) {
-        check_servo_map();
-        _last_check_servo_map_ms = now;
-    }
-
-    switch(get_mode()) {
+    switch (get_mode()) {
         // move mount to a "retracted position" or to a position where a fourth servo can retract the entire mount into the fuselage
-        case MAV_MOUNT_MODE_RETRACT:
-        {
+        case MAV_MOUNT_MODE_RETRACT: {
             _angle_bf_output_deg = _state._retract_angles.get();
+
+            // initialise _angle_rad to smooth transition if user changes to RC_TARGETTING
+            _angle_rad.roll = radians(_angle_bf_output_deg.x);
+            _angle_rad.pitch = radians(_angle_bf_output_deg.y);
+            _angle_rad.yaw = radians(_angle_bf_output_deg.z);
+            _angle_rad.yaw_is_ef = false;
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL:
-        {
+        case MAV_MOUNT_MODE_NEUTRAL: {
             _angle_bf_output_deg = _state._neutral_angles.get();
+
+            // initialise _angle_rad to smooth transition if user changes to RC_TARGETTING
+            _angle_rad.roll = radians(_angle_bf_output_deg.x);
+            _angle_rad.pitch = radians(_angle_bf_output_deg.y);
+            _angle_rad.yaw = radians(_angle_bf_output_deg.z);
+            _angle_rad.yaw_is_ef = false;
             break;
         }
 
         // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-        {
-            // earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
-            stabilize();
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                _angle_rad = mavt_target.angle_rad;
+                break;
+            case MountTargetType::RATE:
+                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
+                break;
+            }
+            // update _angle_bf_output_deg based on angle target
+            update_angle_outputs(_angle_rad);
             break;
         }
 
         // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-        {
-            // update targets using pilot's rc inputs
-            update_targets_from_rc();
-            stabilize();
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's RC inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                update_angle_target_from_rate(rc_target, _angle_rad);
+            } else if (get_rc_angle_target(rc_target)) {
+                _angle_rad = rc_target;
+            }
+            // update _angle_bf_output_deg based on angle target
+            update_angle_outputs(_angle_rad);
             break;
         }
 
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-        {
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, _flags.tilt_control, _flags.pan_control, true)) {
-                stabilize();
+        // point mount to a GPS location
+        case MAV_MOUNT_MODE_GPS_POINT: {
+            if (get_angle_target_to_roi(_angle_rad)) {
+                update_angle_outputs(_angle_rad);
             }
             break;
         }
 
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            // constantly update the home location:
-            if (!AP::ahrs().home_is_set()) {
-                break;
-            }
-            _roi_target = AP::ahrs().get_home();
-            _roi_target_set = true;
-            if (calc_angle_to_roi_target(_angle_ef_target_rad, _flags.tilt_control, _flags.pan_control, true)) {
-                stabilize();
+        case MAV_MOUNT_MODE_HOME_LOCATION: {
+            if (get_angle_target_to_home(_angle_rad)) {
+                update_angle_outputs(_angle_rad);
             }
             break;
+        }
 
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (calc_angle_to_sysid_target(_angle_ef_target_rad,
-                                           _flags.tilt_control,
-                                           _flags.pan_control,
-                                           true)) {
-                stabilize();
+        case MAV_MOUNT_MODE_SYSID_TARGET: {
+            if (get_angle_target_to_sysid(_angle_rad)) {
+                update_angle_outputs(_angle_rad);
             }
             break;
+        }
 
         default:
             //do nothing
@@ -103,11 +105,8 @@ void AP_Mount_Servo::update()
     }
 
     // move mount to a "retracted position" into the fuselage with a fourth servo
-    bool mount_open_new = (get_mode() == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
-    if (mount_open != mount_open_new) {
-        mount_open = mount_open_new;
-        move_servo(_open_idx, mount_open_new, 0, 1);
-    }
+    const bool mount_open = (get_mode() == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
+    move_servo(_open_idx, mount_open, 0, 1);
 
     // write the results to the servos
     move_servo(_roll_idx, _angle_bf_output_deg.x*10, _state._roll_angle_min*0.1f, _state._roll_angle_max*0.1f);
@@ -115,16 +114,13 @@ void AP_Mount_Servo::update()
     move_servo(_pan_idx,  _angle_bf_output_deg.z*10, _state._pan_angle_min*0.1f, _state._pan_angle_max*0.1f);
 }
 
-// private methods
-
-// check_servo_map - detects which axis we control using the functions assigned to the servos in the RC_Channel_aux
-//  should be called periodically (i.e. 1hz or less)
-void AP_Mount_Servo::check_servo_map()
+// returns true if this mount can control its pan (required for multicopters)
+bool AP_Mount_Servo::has_pan_control() const
 {
-    _flags.roll_control = SRV_Channels::function_assigned(_roll_idx);
-    _flags.tilt_control = SRV_Channels::function_assigned(_tilt_idx);
-    _flags.pan_control = SRV_Channels::function_assigned(_pan_idx);
+    return SRV_Channels::function_assigned(_pan_idx);
 }
+
+// private methods
 
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_Servo::send_mount_status(mavlink_channel_t chan)
@@ -132,31 +128,30 @@ void AP_Mount_Servo::send_mount_status(mavlink_channel_t chan)
     mavlink_msg_mount_status_send(chan, 0, 0, _angle_bf_output_deg.y*100, _angle_bf_output_deg.x*100, _angle_bf_output_deg.z*100, _mode);
 }
 
-// stabilize - stabilizes the mount relative to the Earth's frame
-//  input: _angle_ef_target_rad (earth frame targets in radians)
-//  output: _angle_bf_output_deg (body frame angles in degrees)
-void AP_Mount_Servo::stabilize()
+// update body-frame angle outputs from earth-frame angle targets
+void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
 {
-    AP_AHRS &ahrs = AP::ahrs();
-    // only do the full 3D frame transform if we are doing pan control
+    const AP_AHRS &ahrs = AP::ahrs();
+
+    // only do the full 3D frame transform if we are stabilising yaw
     if (_state._stab_pan) {
-        Matrix3f m;                         ///< holds 3 x 3 matrix, var is used as temp in calcs
-        Matrix3f cam;                       ///< Rotation matrix earth to camera. Desired camera from input.
-        Matrix3f gimbal_target;             ///< Rotation matrix from plane to camera. Then Euler angles to the servos.
+        Matrix3f m;                         // 3 x 3 rotation matrix used as temporary variable in calculations
+        Matrix3f ef_to_cam;                 // rotation matrix from earth-frame to camera. Desired camera from input.
+        Matrix3f gimbal_target_bf;          // rotation matrix from vehicle to camera then Euler angles to the servos
+        Vector3f gimbal_angle_bf_rad;       // gimbal angle targets in body-frame euler angles
         m = ahrs.get_rotation_body_to_ned();
         m.transpose();
-        cam.from_euler(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z);
-        gimbal_target = m * cam;
-        gimbal_target.to_euler(&_angle_bf_output_deg.x, &_angle_bf_output_deg.y, &_angle_bf_output_deg.z);
-        _angle_bf_output_deg.x  = _state._stab_roll ? degrees(_angle_bf_output_deg.x) : degrees(_angle_ef_target_rad.x);
-        _angle_bf_output_deg.y  = _state._stab_tilt ? degrees(_angle_bf_output_deg.y) : degrees(_angle_ef_target_rad.y);
-        _angle_bf_output_deg.z = degrees(_angle_bf_output_deg.z);
+        ef_to_cam.from_euler(angle_rad.roll, angle_rad.pitch, get_ef_yaw_angle(angle_rad));
+        gimbal_target_bf = m * ef_to_cam;
+        gimbal_target_bf.to_euler(&gimbal_angle_bf_rad.x, &gimbal_angle_bf_rad.y, &gimbal_angle_bf_rad.z);
+        _angle_bf_output_deg.x = _state._stab_roll ? degrees(gimbal_angle_bf_rad.x) : degrees(angle_rad.roll);
+        _angle_bf_output_deg.y = _state._stab_tilt ? degrees(gimbal_angle_bf_rad.y) : degrees(angle_rad.pitch);
+        _angle_bf_output_deg.z = degrees(gimbal_angle_bf_rad.z);
     } else {
-        // otherwise base mount roll and tilt on the ahrs
-        // roll/tilt attitude, plus any requested angle
-        _angle_bf_output_deg.x = degrees(_angle_ef_target_rad.x);
-        _angle_bf_output_deg.y = degrees(_angle_ef_target_rad.y);
-        _angle_bf_output_deg.z = degrees(_angle_ef_target_rad.z);
+        // otherwise base roll and pitch on the ahrs roll and pitch angle plus any requested angle
+        _angle_bf_output_deg.x = degrees(angle_rad.roll);
+        _angle_bf_output_deg.y = degrees(angle_rad.pitch);
+        _angle_bf_output_deg.z = degrees(get_bf_yaw_angle(angle_rad));
         if (_state._stab_roll) {
             _angle_bf_output_deg.x -= degrees(ahrs.roll);
         }

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -39,9 +39,6 @@ public:
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
     bool has_pan_control() const override { return _flags.pan_control; }
 
-    // set_mode - sets mount's mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override;
-
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     void send_mount_status(mavlink_channel_t chan) override;
 

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -36,32 +36,21 @@ public:
     // update mount position - should be called periodically
     void update() override;
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    bool has_pan_control() const override { return _flags.pan_control; }
+    // returns true if this mount can control its pan (required for multicopters)
+    bool has_pan_control() const override;
 
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     void send_mount_status(mavlink_channel_t chan) override;
 
 private:
 
-    // flags structure
-    struct {
-        bool roll_control   :1; // true if mount has roll control
-        bool tilt_control   :1; // true if mount has tilt control
-        bool pan_control    :1; // true if mount has pan control
-    } _flags;
+    // update body-frame angle outputs from earth-frame targets
+    void update_angle_outputs(const MountTarget& angle_rad);
 
-    // check_servo_map - detects which axis we control (i.e. _flags) using the functions assigned to the servos in the SRV_Channel
-    //  should be called periodically (i.e. 1hz or less)
-    void    check_servo_map();
-
-    // stabilize - stabilizes the mount relative to the Earth's frame
-    void stabilize();
-
-    // closest_limit - returns closest angle to 'angle' taking into account limits.  all angles are in degrees * 10
+    // returns closest angle to 'angle' taking into account limits.  all angles are in body-frame and degrees * 10
     int16_t closest_limit(int16_t angle, int16_t angle_min, int16_t angle_max);
 
-    /// move_servo - moves servo with the given id to the specified angle.  all angles are in degrees * 10
+    ///  moves servo with the given function id to the specified angle.  all angles are in body-frame and degrees * 10
     void move_servo(uint8_t rc, int16_t angle, int16_t angle_min, int16_t angle_max);
 
     // SRV_Channel - different id numbers are used depending upon the instance number
@@ -70,8 +59,7 @@ private:
     SRV_Channel::Aux_servo_function_t    _pan_idx;   // SRV_Channel mount pan  function index
     SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
 
+    MountTarget _angle_rad;         // angle target
     Vector3f _angle_bf_output_deg;  // final body frame output angle in degrees
-
-    uint32_t _last_check_servo_map_ms;  // system time of latest call to check_servo_map function
 };
 #endif // HAL_MOUNT_SERVO_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -40,65 +40,67 @@ void AP_Mount_SoloGimbal::update()
         // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism
         case MAV_MOUNT_MODE_RETRACT:
             _gimbal.set_lockedToBody(true);
+            // initialise _angle_rad to smooth transition if user changes to RC_TARGETTINg
+            _angle_rad = {0, 0, 0, false};
             break;
 
         // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL:
-            {
+        case MAV_MOUNT_MODE_NEUTRAL: {
             _gimbal.set_lockedToBody(false);
             const Vector3f &target = _state._neutral_angles.get();
-            _angle_ef_target_rad.x = ToRad(target.x);
-            _angle_ef_target_rad.y = ToRad(target.y);
-            _angle_ef_target_rad.z = ToRad(target.z);
-            }
+            _angle_rad.roll = radians(target.x);
+            _angle_rad.pitch = radians(target.y);
+            _angle_rad.yaw = radians(target.z);
+            _angle_rad.yaw_is_ef = false;
             break;
+        }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             _gimbal.set_lockedToBody(false);
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                _angle_rad = mavt_target.angle_rad;
+                break;
+            case MountTargetType::RATE:
+                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
+                break;
+            }
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
+        case MAV_MOUNT_MODE_RC_TARGETING: {
             _gimbal.set_lockedToBody(false);
-            // update targets using pilot's rc inputs
-            update_targets_from_rc();
+            // update targets using pilot's RC inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                update_angle_target_from_rate(rc_target, _angle_rad);
+            } else if (get_rc_angle_target(rc_target)) {
+                _angle_rad = rc_target;
+            }
             break;
+        }
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
             _gimbal.set_lockedToBody(false);
-            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
+            IGNORE_RETURN(get_angle_target_to_roi(_angle_rad));
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
             _gimbal.set_lockedToBody(false);
-            // constantly update the home location:
-            if (!AP::ahrs().home_is_set()) {
-                break;
-            }
-            _roi_target = AP::ahrs().get_home();
-            _roi_target_set = true;
-            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
+            IGNORE_RETURN(get_angle_target_to_home(_angle_rad));
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
             _gimbal.set_lockedToBody(false);
-            UNUSED_RESULT(calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true));
+            IGNORE_RETURN(get_angle_target_to_sysid(_angle_rad));
             break;
 
         default:
             // we do not know this mode so do nothing
             break;
     }
-}
-
-// has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-bool AP_Mount_SoloGimbal::has_pan_control() const
-{
-    // we do not have yaw control
-    return false;
 }
 
 // set_mode - sets mount's mode
@@ -117,9 +119,9 @@ void AP_Mount_SoloGimbal::set_mode(enum MAV_MOUNT_MODE mode)
 void AP_Mount_SoloGimbal::send_mount_status(mavlink_channel_t chan)
 {
     if (_gimbal.aligned()) {
-        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100, _mode);
+        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_rad.roll)*100, degrees(_angle_rad.pitch)*100, degrees(get_bf_yaw_angle(_angle_rad))*100, _mode);
     }
-    
+
     // block heartbeat from transmitting to the GCS
     GCS_MAVLINK::disable_channel_routing(chan);
 }
@@ -129,7 +131,7 @@ void AP_Mount_SoloGimbal::send_mount_status(mavlink_channel_t chan)
  */
 void AP_Mount_SoloGimbal::handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t &msg)
 {
-    _gimbal.update_target(_angle_ef_target_rad);
+    _gimbal.update_target(Vector3f{_angle_rad.roll, _angle_rad.pitch, get_bf_yaw_angle(_angle_rad)});
     _gimbal.receive_feedback(chan,msg);
 
     AP_Logger *logger = AP_Logger::get_singleton();

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -78,8 +78,8 @@ void AP_Mount_SoloGimbal::update()
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
-            _state._roi_target = AP::ahrs().get_home();
-            _state._roi_target_set = true;
+            _roi_target = AP::ahrs().get_home();
+            _roi_target_set = true;
             UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
             break;
 
@@ -110,14 +110,14 @@ void AP_Mount_SoloGimbal::set_mode(enum MAV_MOUNT_MODE mode)
     }
 
     // record the mode change
-    _state._mode = mode;
+    _mode = mode;
 }
 
 // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
 void AP_Mount_SoloGimbal::send_mount_status(mavlink_channel_t chan)
 {
     if (_gimbal.aligned()) {
-        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100, _state._mode);
+        mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100, _mode);
     }
     
     // block heartbeat from transmitting to the GCS

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -73,17 +73,18 @@ void AP_Mount_SoloGimbal::update()
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
+            _gimbal.set_lockedToBody(false);
             // constantly update the home location:
             if (!AP::ahrs().home_is_set()) {
                 break;
             }
             _state._roi_target = AP::ahrs().get_home();
             _state._roi_target_set = true;
-            _gimbal.set_lockedToBody(false);
             UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
+            _gimbal.set_lockedToBody(false);
             UNUSED_RESULT(calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true));
             break;
 

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -69,7 +69,7 @@ void AP_Mount_SoloGimbal::update()
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
             _gimbal.set_lockedToBody(false);
-            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true));
+            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
             break;
 
         case MAV_MOUNT_MODE_HOME_LOCATION:
@@ -80,11 +80,11 @@ void AP_Mount_SoloGimbal::update()
             _state._roi_target = AP::ahrs().get_home();
             _state._roi_target_set = true;
             _gimbal.set_lockedToBody(false);
-            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true));
+            UNUSED_RESULT(calc_angle_to_roi_target(_angle_ef_target_rad, true, true, true));
             break;
 
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            UNUSED_RESULT(calc_angle_to_sysid_target(_angle_ef_target_rad, true, true));
+            UNUSED_RESULT(calc_angle_to_sysid_target(_angle_ef_target_rad, true, true, true));
             break;
 
         default:

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -30,7 +30,7 @@ public:
     void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    bool has_pan_control() const override;
+    bool has_pan_control() const override { return false; }
 
     // set_mode - sets mount's mode
     void set_mode(enum MAV_MOUNT_MODE mode) override;
@@ -53,7 +53,7 @@ private:
     void Log_Write_Gimbal(SoloGimbal &gimbal);
 
     bool _params_saved;
-
+    MountTarget _angle_rad;         // angle target
     SoloGimbal _gimbal;
 };
 


### PR DESCRIPTION
This expands upon the Gremsy PR https://github.com/ArduPilot/ardupilot/pull/20988 by adding earth-frame and body-frame angle and rate support to all backends.

This resolves the following items from issue https://github.com/ArduPilot/ardupilot/issues/20985:

- DO_GIMBAL_MANAGER_PITCHYAW mission and immediate command should support
  - both earth-frame vs body-frame angles
  - earth-frame and body-frame rates
- bring other gimbal drivers up to the same level as the Gremsy driver including
  - body-frame and earth-frame control during missions
  - pilot control of lock vs follow (during angle or rate control)

This has been tested on Gremsy and Servo gimbals and appears to work correctly.  I plan to work with beta testers and other developers to test the other gimbal drivers (Alexmos, Solo, SToRM32-mavlink, SToRM32-serial)

If reviewers would prefer, I'm happy to squash some of the commits together because I started off fixing some obvious errors and then moved onto a more serious restructure of the backends.

