### PR TITLE
AP_Control: change autotune I determination for Roll axis

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -415,7 +415,11 @@ void AP_AutoTune::update(AP_PIDInfo &pinfo, float scaler, float angle_err_deg)
     rpid.ff().set(FF);
     rpid.kP().set(P);
     rpid.kD().set(D);
-    rpid.kI().set(MAX(P*AUTOTUNE_I_RATIO, (FF / TRIM_TCONST)));
+    if (type == AUTOTUNE_ROLL) {  // for roll set I = smaller of FF or P
+        rpid.kI().set(MIN(P, (FF / TRIM_TCONST)));
+    } else {                      // for pitch/yaw naturally damped axes) set I usually = FF to get 1 sec I closure
+        rpid.kI().set(MAX(P*AUTOTUNE_I_RATIO, (FF / TRIM_TCONST)));
+    }
 
     // setup filters to be suitable for time constant and gyro filter
     rpid.filt_T_hz().set(10.0/(current.tau * 2 * M_PI));


### PR DESCRIPTION
@tridge as discussed.....autotuning all my planes showed that for flying wings, often the P value will be small (1/10 to 1/4 of FF) compared to the resulting FF, leading to I being set too high and slow oscillations in roll occuring....since is probably due to the roll axis not having any inherent damping like the pitch and yaw axes do in a plane....and flying wings typically have larger FF terms compared to normal aileron equipped planes...lowering I to equal P or 2xP reduces the wobble to levels not excessive in FPV  views...

anyway, here is the PR so you and Leonard can discuss...