### PR TITLE
Plane: added ICE_OPTIONS bit for throttle while disarmed

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -886,6 +886,8 @@ void Plane::set_servos(void)
     // slew rate limit throttle
     throttle_slew_limit(SRV_Channel::k_throttle);
 
+    const float base_throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+
     if (!arming.is_armed()) {
         //Some ESCs get noisy (beep error msgs) if PWM == 0.
         //This little segment aims to avoid this.
@@ -912,7 +914,7 @@ void Plane::set_servos(void)
     }
 
     float override_pct = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
-    if (g2.ice_control.throttle_override(override_pct)) {
+    if (g2.ice_control.throttle_override(override_pct, base_throttle)) {
         // the ICE controller wants to override the throttle for starting, idle, or redline
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, override_pct);
 #if HAL_QUADPLANE_ENABLED

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -31,7 +31,7 @@ public:
     void update(void);
 
     // check for throttle override
-    bool throttle_override(float &percent);
+    bool throttle_override(float &percent, const float base_throttle);
 
     enum ICE_State {
         ICE_OFF=0,
@@ -126,6 +126,7 @@ private:
     enum class Options : uint16_t {
         DISABLE_IGNITION_RC_FAILSAFE=(1U<<0),
         DISABLE_REDLINE_GOVERNOR = (1U << 1),
+        THROTTLE_WHILE_DISARMED = (1U << 2),
     };
     AP_Int16 options;
 


### PR DESCRIPTION
This allows for starting and warming up an ICE engine while disarmed

note: needs testing with THR_MIN behaviour