### PR TITLE
GCS_Mavlink: added MSG_POSITION_TARGET_LOCAL_NED field

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -497,6 +497,7 @@ static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_NAV_CONTROLLER_OUTPUT,
     MSG_FENCE_STATUS,
     MSG_POSITION_TARGET_GLOBAL_INT,
+    MSG_POSITION_TARGET_LOCAL_NED,
 };
 static const ap_message STREAM_POSITION_msgs[] = {
     MSG_LOCATION,


### PR DESCRIPTION
Why is MSG_POSITION_TARGET_LOCAL_NED not set in any message stream?
added MSG_POSITION_TARGET_LOCAL_NED field for the loopback reception