### PR TITLE
Tools: Update flake8 check and add PrintVersion.py to flake8 check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore =
+extend-ignore =
     # H301: one import per line
     H301,
     # H306: imports not in alphabetical order (time, os)
@@ -14,5 +14,10 @@ ignore =
     E203,
     # E221 multiple spaces before operator
     E221
+
+extend-exclude =
+    build,
+    modules,
+    .git
 
 max-line-length = 127

--- a/Tools/PrintVersion.py
+++ b/Tools/PrintVersion.py
@@ -2,6 +2,9 @@
 
 """
 Extract version information for the various vehicle types, print it
+
+AP_FLAKE8_CLEAN
+
 """
 
 import os
@@ -39,8 +42,8 @@ else:
 
 file = open(includefilepath)
 
-firmware_version_regex = re.compile(".*define +FIRMWARE_VERSION.*")
-firmware_version_extract_regex = re.compile(".*define +FIRMWARE_VERSION[	 ]+(?P<major>\d+)[ ]*,[ 	]*(?P<minor>\d+)[ ]*,[	 ]*(?P<point>\d+)[ ]*,[	 ]*(?P<type>[A-Z_]+)[	 ]*")
+firmware_version_regex = re.compile(r".*define +FIRMWARE_VERSION.*")
+firmware_version_extract_regex = re.compile(r".*define +FIRMWARE_VERSION[	 ]+(?P<major>\d+)[ ]*,[ 	]*(?P<minor>\d+)[ ]*,[	 ]*(?P<point>\d+)[ ]*,[	 ]*(?P<type>[A-Z_]+)[	 ]*")  # noqa: E501
 
 for line in file:
     if not firmware_version_regex.match(line):


### PR DESCRIPTION
This speeds up the flake8 check A LOT. It's much faster to load the checkers once and then let flake8 multiprocess its way through all of the input files. Since I changed the subprocess.call to subprocess.run, this only works on Python >=3.5.

Added a few directories to the overall exclude so it only looks at files that are the responsibility of ArduPilot. Running `flake8 .` from ardupilot will still bring up ~35k errors. One file at a time. If your are curious, here are the errors broken down by rough subdirectory. You can see a list of the files with errors with `flake8 . --quiet`. The /libraries number is primarily from the Chibios hwdef scripts.

```
# error count as of 2022-06-24 (4bb3b08a4a)
Tools/ardupilotwaf,  # 585 errors
Tools/autotest,  # 131
Tools/LogAnalyzer,  # 859
Tools/mavproxy_modules,  # 75
Tools/Replay,  # 58
Tools/scripts,  # 230
Tools/debug,  # 10
Tools/FilterTestTool,  # 9
Tools/Vicon,  # 16
libraries  # 48,643
```

Also a sample of the new output:
```
~/ardupilot$ ./Tools/scripts/run_flake8.py 
****** Checking (Tools/PrintVersion.py)
****** Checking (Tools/autotest/antennatracker.py)
****** Checking (Tools/autotest/arducopter.py)
****** Checking (Tools/autotest/arduplane.py)
****** Checking (Tools/autotest/ardusub.py)
****** Checking (Tools/autotest/autotest.py)
****** Checking (Tools/autotest/balancebot.py)
****** Checking (Tools/autotest/bisect-helper.py)
****** Checking (Tools/autotest/build-with-disabled-features.py)
****** Checking (Tools/autotest/check_autotest_speedup.py)
****** Checking (Tools/autotest/common.py)
****** Checking (Tools/autotest/examples.py)
****** Checking (Tools/autotest/helicopter.py)
****** Checking (Tools/autotest/quadplane.py)
****** Checking (Tools/autotest/rover.py)
****** Checking (Tools/autotest/sailboat.py)
****** Checking (Tools/autotest/sim_vehicle.py)
****** Checking (Tools/autotest/test_build_options.py)
****** Checking (Tools/autotest/param_metadata/param_parse.py)
****** Checking (Tools/gittools/pre-commit.py)
****** Checking (Tools/scripts/board_list.py)
****** Checking (Tools/scripts/build_binaries.py)
****** Checking (Tools/scripts/build_examples.py)
****** Checking (Tools/scripts/build_iofirmware.py)
****** Checking (Tools/scripts/build_options.py)
****** Checking (Tools/scripts/decode_ICSR.py)
****** Checking (Tools/scripts/decode_watchdog.py)
****** Checking (Tools/scripts/du32_change.py)
****** Checking (Tools/scripts/make_apj.py)
****** Checking (Tools/scripts/powr_change.py)
****** Checking (Tools/scripts/pretty_diff_size.py)
****** Checking (Tools/scripts/run_coverage.py)
****** Checking (Tools/scripts/run_flake8.py)
****** Checking (Tools/scripts/size_compare_branches.py)
****** Checking (Tools/scripts/solution_status_change.py)
****** Checking (Tools/scripts/uploader.py)
****** Checking (Tools/scripts/build_sizes/build_sizes.py)
****** Checking (Tools/scripts/build_tests/test_ccache.py)
****** Flake8 check failed: (Tools/PrintVersion.py:46:128: E501 line too long (233 > 127 characters)
firmware_version_extract_regex = re.compile(r".*define +FIRMWARE_VERSION[        ]+(?P<major>\d+)[ ]*,[         ]*(?P<minor>\d+)[ ]*,[   ]*(?P<point>\d+)[ ]*,[  ]*(?P<type>[A-Z_]+)[    ]*")  # noqa: E503 (change back 501. 503 is just for testing CI)
                                                                                                                                             ^
)
```