### PR TITLE
Run MatekH743 at 480Mhz

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH743/hwdef.dat
@@ -10,6 +10,8 @@ APJ_BOARD_ID 1013
 # crystal frequency, setup to use external oscillator
 OSCILLATOR_HZ 8000000
 
+MCU_CLOCKRATE_MHZ 480
+
 FLASH_SIZE_KB 2048
 env OPTIMIZE -Os
 


### PR DESCRIPTION
The board uses rev V exclusively and so can be run at the default clock of 480Mhz