### PR TITLE
Fix constructors declaration template parameters

### DIFF
--- a/libraries/AP_Common/AP_ExpandingArray.h
+++ b/libraries/AP_Common/AP_ExpandingArray.h
@@ -83,12 +83,12 @@ class AP_ExpandingArray : public AP_ExpandingArrayGeneric
 {
 public:
 
-    AP_ExpandingArray<T>(uint16_t elements_per_chunk) :
+    AP_ExpandingArray(uint16_t elements_per_chunk) :
         AP_ExpandingArrayGeneric(sizeof(T), elements_per_chunk)
     {}
 
     /* Do not allow copies */
-    AP_ExpandingArray<T>(const AP_ExpandingArray<T> &other) = delete;
+    AP_ExpandingArray(const AP_ExpandingArray<T> &other) = delete;
     AP_ExpandingArray<T> &operator=(const AP_ExpandingArray<T>&) = delete;
 
     // allow use as an array for assigning to elements. no bounds checking is performed

--- a/libraries/AP_Math/matrixN.h
+++ b/libraries/AP_Math/matrixN.h
@@ -19,12 +19,12 @@ class MatrixN {
 
 public:
     // constructor from zeros
-    MatrixN<T,N>(void) {
+    MatrixN(void) {
         memset(v, 0, sizeof(v));        
     }
 
     // constructor from 4 diagonals
-    MatrixN<T,N>(const float d[N]) {
+    MatrixN(const float d[N]) {
         memset(v, 0, sizeof(v));
         for (uint8_t i = 0; i < N; i++) {
             v[i][i] = d[i];

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -32,20 +32,20 @@ public:
 
     // constructor creates a quaternion equivalent
     // to roll=0, pitch=0, yaw=0
-    QuaternionT<T>()
+    QuaternionT()
     {
         q1 = 1;
         q2 = q3 = q4 = 0;
     }
 
     // setting constructor
-    QuaternionT<T>(const T _q1, const T _q2, const T _q3, const T _q4) :
+    QuaternionT(const T _q1, const T _q2, const T _q3, const T _q4) :
         q1(_q1), q2(_q2), q3(_q3), q4(_q4)
     {
     }
 
     // setting constructor
-    QuaternionT<T>(const T _q[4]) :
+    QuaternionT(const T _q[4]) :
         q1(_q[0]), q2(_q[1]), q3(_q[2]), q4(_q[3])
     {
     }


### PR DESCRIPTION
The error is reported by GCC 11.2.0 on a C++23 build. Class template parameters are not needed, expected on constructor declarations or definitions.