### PR TITLE
Copter: 4.2.2 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.2.2-rc1 21-Jun-2022
+Copter 4.2.2 28-Jun-2022 / 4.2.2-rc1 21-Jun-2022
 Changes from 4.2.1
 1) MambaH743v4 and MambaF405 MK4 autopilot support
 2) Second full harmonic notches available (see INS_HNTC2_ parameters)

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.2-rc1"
+#define THISFIRMWARE "ArduCopter V4.2.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,2,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,2,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,6 +1,6 @@
 Rover Release Notes:
 ------------------------------------------------------------------
-Rover 4.2.2-rc1 21-Jun-2022
+Rover 4.2.2 28-Jun-2022 / 4.2.2-rc1 21-Jun-2022
 Changes from 4.2.1
 1) MambaH743v4 and MambaF405 MK4 autopilot support
 2) Second full harmonic notches available (see INS_HNTC2_ parameters)

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.2.2-rc1"
+#define THISFIRMWARE "ArduRover V4.2.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,2,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,2,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.2.2 release which has undergone a week of beta testing ([see discussion here](https://discuss.ardupilot.org/t/copter-4-2-2-rc1-available-for-beta-testing/87183)).