### PR TITLE
EKF: fix should not use range finder beyond its range

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -1013,7 +1013,7 @@ void NavEKF2_core::selectHeightForFusion()
     }
 
     // Use Baro alt as a fallback if we lose range finder, GPS, external nav or Beacon
-    bool lostRngHgt = ((activeHgtSource == HGT_SOURCE_RNG) && (!rangeFinderDataIsFresh));
+    bool lostRngHgt = _rng && ((activeHgtSource == HGT_SOURCE_RNG) && (!rangeFinderDataIsFresh || ((terrainState - stateStruct.position.z)> 1e-2 * (ftype)_rng->max_distance_cm_orient(ROTATION_PITCH_270))));
     bool lostGpsHgt = ((activeHgtSource == HGT_SOURCE_GPS) && ((imuSampleTime_ms - lastTimeGpsReceived_ms) > 2000));
     bool lostExtNavHgt = ((activeHgtSource == HGT_SOURCE_EXTNAV) && ((imuSampleTime_ms - extNavMeasTime_ms) > 2000));
     bool lostRngBcnHgt = ((activeHgtSource == HGT_SOURCE_BCN) && ((imuSampleTime_ms - rngBcnDataDelayed.time_ms) > 2000));

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1134,7 +1134,7 @@ void NavEKF3_core::selectHeightForFusion()
     }
 
     // Use Baro alt as a fallback if we lose range finder, GPS, external nav or Beacon
-    bool lostRngHgt = ((activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER) && !rangeFinderDataIsFresh);
+    bool lostRngHgt = _rng && ((activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER) && (!rangeFinderDataIsFresh ||  ((terrainState - stateStruct.position.z)> 1e-2 * (ftype)_rng->max_distance_cm_orient(ROTATION_PITCH_270))));
     bool lostGpsHgt = ((activeHgtSource == AP_NavEKF_Source::SourceZ::GPS) && ((imuSampleTime_ms - lastTimeGpsReceived_ms) > 2000));
     bool lostRngBcnHgt = ((activeHgtSource == AP_NavEKF_Source::SourceZ::BEACON) && ((imuSampleTime_ms - rngBcnDataDelayed.time_ms) > 2000));
     bool fallback_to_baro = lostRngHgt || lostGpsHgt || lostRngBcnHgt;


### PR DESCRIPTION
if RangeFinder is used as primary POSZ i.e.
`param set EK3_SRC1_POSZ 2`
**lostRngHgt** does not consider max height limit in the following [line](https://github.com/ArduPilot/ardupilot/blob/67aa9ecdd4b6140fa97b19ecc14a4d551ed9bf75/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp#L1137) 
`bool lostRngHgt = ((activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER) && !rangeFinderDataIsFresh);
`    

Same happens in EKF2.

run the SITL and execute the following lines

```
param set SIM_SONAR_SCALE 10
param set RNGFND1_TYPE 1
param set RNGFND1_SCALING 10
param set RNGFND1_PIN 0
param set RNGFND1_MAX_CM 5000
param set RNGFND1_MIN_CM 0

param set EK3_SRC1_POSZ 2
param set EK3_SRC2_POSZ 1
param set EK3_SRC3_POSZ 3
```

the restart and run 

```
mode guided
arm uncheck all 
arm throttle
takeoff 60
```

the errors starts to occur.

This PR is my proposed solution.

