### PR TITLE
AP_Scripting: add mount bindings and example script

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -697,6 +697,42 @@ function RC_Channel_ud:norm_input_dz() end
 
 
 -- desc
+---@class mount
+mount = {}
+
+-- desc
+---@param instance integer
+---@param target_loc Location_ud
+function mount:set_roi_target(instance, target_loc) end
+
+-- desc
+---@param instance integer
+---@param roll_degs number
+---@param pitch_degs number
+---@param yaw_degs number
+---@param yaw_is_earth_frame boolean
+function mount:set_rate_target(instance, roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame) end
+
+-- desc
+---@param instance integer
+---@param roll_deg number
+---@param pitch_deg number
+---@param yaw_deg number
+---@param yaw_is_earth_frame boolean
+function mount:set_angle_target(instance, roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame) end
+
+-- desc
+---@param instance integer
+---@param mode integer
+function mount:set_mode(instance, mode) end
+
+-- desc
+---@param instance integer
+---@return integer
+function mount:get_mode(instance) end
+
+
+-- desc
 ---@class motors
 motors = {}
 

--- a/libraries/AP_Scripting/examples/mount-test.lua
+++ b/libraries/AP_Scripting/examples/mount-test.lua
@@ -1,0 +1,130 @@
+-- moves 3-axis gimbal (aka "mount") using earth-frame and body-frame rates and angles
+--
+-- stage 0: move gimbal to neutral position
+-- stage 1: yaw CW at 10deg/s in body-frame
+-- stage 2: yaw CCW at 10 deg/s in body-frame
+-- stage 3: pitch at 10 deg/s in body-frame
+-- stage 4: pitch at -10 deg/s in body-frame
+-- stage 5: roll at 10 deg/s in body-frame
+-- stage 6: roll at -10 deg/s in body-frame
+-- stage 7: point North
+-- stage 8: point South and center
+-- stage 9: point North and Down
+-- stage 10: move angle to neutral position
+
+local stage = 0
+local stage_time_ms = 5000
+local stage_start_time_ms = 0
+local last_stage = 10
+
+-- the main update function that performs a simplified version of RTL
+function update()
+
+  -- get current system time
+  local now_ms = millis()
+
+  -- start
+  if stage_start_time_ms == 0 then
+    stage_start_time_ms = now_ms
+  end
+
+  -- check if time to move to next stage
+  local update_user = false
+  if (now_ms - stage_start_time_ms > stage_time_ms) and (stage < last_stage) then
+    stage = stage + 1
+    stage_start_time_ms = now_ms
+    update_user = true
+  end
+
+  if stage == 0 or stage >= last_stage then
+    -- move angle to neutral position
+    mount:set_angle_target(0, 0, 0, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " move to neutral position")
+    end
+  end
+
+  if stage == 1 then
+    -- yaw CW at 10deg/s in body-frame
+    mount:set_rate_target(0, 0, 0, 10, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " yaw at 10deg/s")
+    end
+  end
+
+  if stage == 2 then
+    -- yaw CCW at 10 deg/s in body-frame
+    mount:set_rate_target(0, 0, 0, -10, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " yaw at -10deg/s")
+    end
+  end
+
+  if stage == 3 then
+    -- pitch at 10 deg/s in body-frame
+    mount:set_rate_target(0, 0, 10, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " pitch at 10deg/s")
+    end
+  end
+
+  if stage == 4 then
+    -- pitch at -10 deg/s in body-frame
+    mount:set_rate_target(0, 0, -10, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " pitch at -10deg/s")
+    end
+  end
+
+  if stage == 5 then
+    -- roll at 10 deg/s in body-frame
+    mount:set_rate_target(0, 10, 0, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " roll at 10deg/s")
+    end
+  end
+
+  if stage == 6 then
+    -- roll at -10 deg/s in body-frame
+    mount:set_rate_target(0, -10, 0, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " roll at -10deg/s")
+    end
+  end
+
+  if stage == 7 then
+    -- point North
+    mount:set_angle_target(0, 0, 0, 0, true)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " point North")
+    end
+  end
+
+  if stage == 8 then
+    -- point South and center
+    mount:set_angle_target(0, 0, 0, 180, true)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " point South")
+    end
+  end
+
+  if stage == 9 then
+    -- point North and Down
+    mount:set_angle_target(0, 0, -90, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " point Down")
+    end
+  end
+
+  if stage > last_stage then
+    -- move angle to neutral position
+    mount:set_angle_target(0, 0, 0, 0, false)
+    if update_user then
+      gcs:send_text(6, "stage:" .. tostring(stage) .. " done!")
+    end
+  end
+
+  return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -514,7 +514,13 @@ include AC_AttitudeControl/AC_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD
 singleton AC_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AC_AttitudeControl method get_rpy_srate void float'Ref float'Ref float'Ref
 
-
+include AP_Mount/AP_Mount.h
+singleton AP_Mount rename mount
+singleton AP_Mount method get_mode MAV_MOUNT_MODE'enum uint8_t 0 UINT8_MAX
+singleton AP_Mount method set_mode void uint8_t 0 UINT8_MAX MAV_MOUNT_MODE'enum MAV_MOUNT_MODE_RETRACT MAV_MOUNT_MODE_HOME_LOCATION
+singleton AP_Mount method set_angle_target void uint8_t 0 UINT8_MAX float'skip_check float'skip_check float'skip_check boolean
+singleton AP_Mount method set_rate_target void uint8_t 0 UINT8_MAX float'skip_check float'skip_check float'skip_check boolean
+singleton AP_Mount method set_roi_target void uint8_t 0 UINT8_MAX Location
 
 singleton AP_Logger rename logger
 singleton AP_Logger manual write AP_Logger_Write


### PR DESCRIPTION
This adds Lua bindings to control a gimbal (aka mount).  Every method's first argument is the gimbal number which should normally be left at zero.

- get_mode
- set_mode
- set_angle_target: accepts roll, pitch and yaw degrees along with a final boolean to indicate earth-frame (false = body-frame)
- set_angle_target: accepts roll, pitch and yaw rates in deg/s along with a final boolean to indicate earth-frame (false = body-frame)
- set_roi_target accepts a Location

All methods have been tested in RealFlight and on a real vehicle