### PR TITLE
Add RockBlock SBD satellite modem support

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -23,6 +23,7 @@
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_HAL/I2CDevice.h>
 #include "AP_Scripting_CANSensor.h"
+#include "AP_Scripting_MAVLink.h"
 
 #ifndef SCRIPTING_MAX_NUM_I2C_DEVICE
   #define SCRIPTING_MAX_NUM_I2C_DEVICE 4
@@ -74,6 +75,10 @@ public:
     // Scripting CAN sensor
     ScriptingCANSensor *_CAN_dev;
     ScriptingCANSensor *_CAN_dev2;
+#endif
+
+#if HAL_HIGH_LATENCY2_ENABLED
+    ScriptingMAVLink *_MAVlink_dev;
 #endif
 
     // mission item buffer

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
@@ -1,0 +1,181 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting MAVLink class, to generate MAVLink packets and decode incoming
+  MAvLink data. It is designed for High Latency MAVLink connections, in most cases
+  users should use a regular MAVLink serial port.
+ */
+#include "AP_Scripting_MAVLink.h"
+
+#if HAL_HIGH_LATENCY2_ENABLED
+ScriptingMAVLink::ScriptingMAVLink(bool use_mavlink1)
+{
+    // Instantiate a ScriptingMAVLink and set the MAVLink version
+    // true to use MAVLink1, false to use MAVLink2
+
+    useMAVLink1 = use_mavlink1;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (_singleton != nullptr) {
+        AP_HAL::panic("ScriptingMAVLink must be singleton");
+    }
+#endif
+    _singleton = this;
+};
+
+bool ScriptingMAVLink::is_high_latency_enabled()
+{
+    // Return true if high latency mode is enabled
+    GCS_MAVLINK *link = gcs().chan(0);
+    return link->high_latency_link_enabled;
+}
+
+void ScriptingMAVLink::set_high_latency_enabled(bool hl_enabled)
+{
+    //enable or disable high latency mode
+    GCS_MAVLINK *link = gcs().chan(0);
+    mavlink_command_long_t pkt;
+    pkt.param1 = hl_enabled;
+
+    link->handle_control_high_latency(pkt);
+}
+
+uint16_t ScriptingMAVLink::create_high_latency2(uint8_t* msgbuf)
+{
+    // Create a High_Latency2 MAvLink packet and save into msgbuf
+    // returns the length of the msgbuf
+
+    AP_AHRS &ahrs = AP::ahrs();
+    GCS_MAVLINK *link = gcs().chan(0);
+
+    Location global_position_current;
+    UNUSED_RESULT(ahrs.get_location(global_position_current));
+#if !defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_BATTERY)
+    const int8_t battery_remaining = link->battery_remaining_pct(AP_BATT_PRIMARY_INSTANCE);
+#endif
+
+    AP_Mission *mission = AP::mission();
+    uint16_t current_waypoint = 0;
+    if (mission != nullptr) {
+        current_waypoint = mission->get_current_nav_index();
+    }
+
+    uint32_t present;
+    uint32_t enabled;
+    uint32_t health;
+    gcs().get_sensor_status_flags(present, enabled, health);
+    // Remap HL_FAILURE_FLAG from system status flags
+    static const struct PACKED status_map_t {
+        MAV_SYS_STATUS_SENSOR sensor;
+        HL_FAILURE_FLAG failure_flag;
+    } status_map[] {
+        { MAV_SYS_STATUS_SENSOR_GPS, HL_FAILURE_FLAG_GPS },
+        { MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE, HL_FAILURE_FLAG_DIFFERENTIAL_PRESSURE },
+        { MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE, HL_FAILURE_FLAG_ABSOLUTE_PRESSURE },
+        { MAV_SYS_STATUS_SENSOR_3D_ACCEL, HL_FAILURE_FLAG_3D_ACCEL },
+        { MAV_SYS_STATUS_SENSOR_3D_GYRO, HL_FAILURE_FLAG_3D_GYRO },
+        { MAV_SYS_STATUS_SENSOR_3D_MAG, HL_FAILURE_FLAG_3D_MAG },
+        { MAV_SYS_STATUS_TERRAIN, HL_FAILURE_FLAG_TERRAIN },
+        { MAV_SYS_STATUS_SENSOR_BATTERY, HL_FAILURE_FLAG_BATTERY },
+        { MAV_SYS_STATUS_SENSOR_RC_RECEIVER, HL_FAILURE_FLAG_RC_RECEIVER },
+        { MAV_SYS_STATUS_GEOFENCE, HL_FAILURE_FLAG_GEOFENCE },
+        { MAV_SYS_STATUS_AHRS, HL_FAILURE_FLAG_ESTIMATOR },
+    };
+
+    uint16_t failure_flags = 0;
+    for (auto &map_entry : status_map) {
+        if ((health & map_entry.sensor) == 0) {
+            failure_flags |= map_entry.failure_flag;
+        }
+    }
+
+    mavlink_message_t msg;
+    mavlink_high_latency2_t hl2_message {};
+    
+    hl2_message.timestamp = AP_HAL::millis();
+    hl2_message.latitude = global_position_current.lat;
+    hl2_message.longitude = global_position_current.lng;
+    hl2_message.custom_mode = gcs().custom_mode();
+    hl2_message.altitude = global_position_current.alt * 0.01f;
+    hl2_message.target_altitude = link->high_latency_target_altitude();
+    hl2_message.target_distance = link->high_latency_tgt_dist();
+    hl2_message.wp_num = current_waypoint;
+    hl2_message.failure_flags = failure_flags;
+    hl2_message.type = gcs().frame_type();
+    hl2_message.autopilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
+    hl2_message.heading = (((uint16_t)ahrs.yaw_sensor / 100) % 360) / 2;
+    hl2_message.target_heading = link->high_latency_tgt_heading();
+    hl2_message.throttle = abs(link->vfr_hud_throttle());
+    hl2_message.airspeed = MIN(link->vfr_hud_airspeed() * 5, UINT8_MAX);
+    hl2_message.airspeed_sp = link->high_latency_tgt_airspeed();
+    hl2_message.groundspeed = MIN(ahrs.groundspeed() * 5, UINT8_MAX);
+    hl2_message.windspeed = link->high_latency_wind_speed();
+    hl2_message.wind_heading = link->high_latency_wind_direction();
+    hl2_message.eph = 0;
+    hl2_message.epv = 0;
+    hl2_message.temperature_air = link->high_latency_air_temperature();
+    hl2_message.climb_rate = 0;
+#if !defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_BATTERY)
+        hl2_message.battery = battery_remaining; // [%] Battery level (-1 if field not provided).
+#else
+        hl2_message.battery = -1;
+#endif
+    hl2_message.custom0 = link->base_mode();
+    hl2_message.custom1 = 0;
+    hl2_message.custom2 = 0;
+
+    uint16_t len;
+    
+    // borrow chan0 to encode the packet
+    mavlink_status_t *chan0_status = mavlink_get_channel_status(MAVLINK_COMM_0);
+    uint8_t saved_seq = chan0_status->current_tx_seq;
+    uint8_t saved_flags = chan0_status->flags;
+    if (useMAVLink1) {
+        chan0_status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+    }
+    else {
+        chan0_status->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+    }
+    chan0_status->current_tx_seq = mavlink.seq;
+    len = mavlink_msg_high_latency2_encode(mavlink_system.sysid,
+                                            mavlink_system.compid,
+                                            &msg, &hl2_message);
+
+    mavlink.seq = chan0_status->current_tx_seq;
+    chan0_status->current_tx_seq = saved_seq;
+    chan0_status->flags = saved_flags;
+    
+    len = mavlink_msg_to_send_buffer(msgbuf, &msg);
+
+    return len;
+
+}
+
+void ScriptingMAVLink::handle_rx_byte(uint8_t rx_byte) {
+    // Handle an incoming byte and parse. If a valid packet (command_long
+    // or command_int) is detected, send on to GCS_MAVLINK for execution
+    mavlink_message_t msg;
+    mavlink_status_t status;
+    if (mavlink_frame_char_buffer(&mavlink.rxmsg, &mavlink.status,
+                                    rx_byte,
+                                    &msg, &status) == MAVLINK_FRAMING_OK) {
+        GCS_MAVLINK &link = *gcs().chan(0);
+        // only allow commands to be passed on
+        if(msg.msgid == MAVLINK_MSG_ID_COMMAND_LONG || msg.msgid == MAVLINK_MSG_ID_COMMAND_INT) {
+            link.packetReceived(status, msg);
+        }
+    }
+}
+#endif

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.h
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.h
@@ -1,0 +1,57 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting MAVLink class, for easy scripting MAVLink packet support
+ */
+ 
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+#if !defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_BATTERY)
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#endif
+
+#if HAL_HIGH_LATENCY2_ENABLED
+class ScriptingMAVLink {
+public:
+    ScriptingMAVLink(bool use_mavlink1);
+
+    uint16_t create_high_latency2(uint8_t* msgbuf);
+
+    bool is_high_latency_enabled();
+
+    void set_high_latency_enabled(bool hl_enabled);
+
+    void handle_rx_byte(uint8_t rx_byte);
+
+    // singleton support
+    ScriptingMAVLink *get_singleton() {
+        return _singleton;
+    }
+private:
+    bool useMAVLink1 = false;
+    ScriptingMAVLink* _singleton = nullptr;
+
+    // hold relevant MAVLink data for encoding/decoding messages
+    struct {
+        mavlink_message_t rxmsg;
+        mavlink_status_t status;
+        uint8_t seq;
+    } mavlink {};
+
+};
+#endif

--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -1,0 +1,274 @@
+-- Lua script to send a recieve very basic MAVLink telemetry over a
+-- Rockblock SBD satellite modem
+-- Requires https://github.com/stephendade/rockblock2mav at the GCS end
+
+-- Setup:
+-- This script requires 1 serial port:
+-- A "Script" to connect the modem
+
+-- Usage:
+-- Use the MAVLink High Latency Control ("link hl on|off" in MAVProxy) to control
+-- whether to send or not (or use "force_hl_enable")
+-- Use the "debug_text" variable to view debugging statustexts at the GCS
+-- Use the "force_hl_enable" variable to force-enable high latency mode, instead of enabling from GCS
+
+-- Caveats:
+-- This will *only* send HIGH_LATENCY2 packets via the SBD modem. No heartbeats,
+-- no command acknowledgements, no statustexts, no parameters, etc
+-- A single HIGH_LATENCY2 packet will be send every 20 sec
+-- MAVLink 1 will be used, as it's slightly more efficient (50 vs 52 bytes for a HL2 message)
+-- Any incoming packets on the first mailbox check will be ignored (as these may be from a long time in the past)
+-- Only 1 command can be sent at a time from the GCS. Any subsequent commands will overwrite the previous command
+
+-- Written by Stephen Dade (stephen_dade@hotmail.com)
+
+local port = serial:find_serial(0)
+
+port:begin(19200)
+port:set_flow_control(0)
+
+-- true to use MAVLink1, false to use MAVLink2
+MAVLink:begin(true)
+
+local AT_query = "AT+CGMM\r"
+local AT_mailbox_check = "AT+SBDIXA\r"
+local AT_load_tx_buffer = "AT+SBDWB="
+local AT_read_rx_buffer = "AT+SBDRB\r"
+local AT_clear_tx_buffer = "AT+SBDD0\r"
+local AT_clear_rx_buffer = "AT+SBDD1\r"
+local modem_detected = false
+local str_recieved = ""
+local modem_history = {}
+local modem_to_send = {}
+
+local debug_text = false
+local force_hl_enable = true
+local is_transmitting = false
+local first_sucessful_mailbox_check = false
+
+local time_last_tx = millis():tofloat() * 0.001
+local last_modem_status_check = 0
+
+-- Parse any incoming text from the modem
+function check_cmd_return()
+    -- modem detection (response to AT_query)
+    if #modem_history == 3 and modem_history[1] == 'AT+CGMM' and
+        modem_history[3] == 'OK' then
+        gcs:send_text(3, "SATCOM modem detected - " ..
+                          nicestring(modem_history[2]))
+        modem_history = nil
+        modem_history = {}
+        modem_detected = true
+        table.insert(modem_to_send, AT_clear_rx_buffer)
+        table.insert(modem_to_send, AT_clear_tx_buffer)
+
+        -- enable high latency mode, if desired
+        if force_hl_enable then MAVLink:set_high_latency_enabled(true) end
+    end
+
+    if modem_detected then
+        -- TX Buffer clear (response to AT_query)
+        if #modem_history >= 3 and modem_history[#modem_history - 2] ==
+            'AT+SBDD0' and modem_history[#modem_history] == 'OK' then
+            if debug_text then
+                gcs:send_text(3, "SATCOM cleared modem TX buffer")
+            end
+            modem_history = nil
+            modem_history = {}
+        end
+
+        -- RX buffer clear (response to AT_query)
+        if #modem_history >= 3 and modem_history[#modem_history - 2] ==
+            'AT+SBDD1' and modem_history[#modem_history] == 'OK' then
+            if debug_text then
+                gcs:send_text(3, "SATCOM cleared modem RX buffer")
+            end
+            modem_history = nil
+            modem_history = {}
+        end
+
+        -- Tx buffer loaded (response to AT command)
+        if #modem_history >= 4 and
+            string.find(modem_history[#modem_history - 3], AT_load_tx_buffer, 1,
+                        true) and modem_history[#modem_history] == 'OK' then
+            if debug_text then
+                gcs:send_text(3, "SATCOM loaded packet into tx buffer, " ..
+                                  tostring(modem_history[#modem_history - 3]))
+            end
+            if modem_history[#modem_history - 1] ~= '0' then
+                gcs:send_text(3, "SATCOM Error loading packet into buffer")
+            end
+            modem_history = nil
+            modem_history = {}
+        end
+
+        -- Got received data (response to AT command)
+        if modem_history[#modem_history - 2] == 'AT+SBDRB' and
+            modem_history[#modem_history] == 'OK' then
+            -- Message format is { 2 byte msg length} + {message} + {2 byte checksum}
+            local totallen = #(modem_history[#modem_history - 1])
+            local len = string.unpack(">i2", modem_history[#modem_history - 1])
+            local msg = string.sub(modem_history[#modem_history - 1], 3,
+                                   totallen - 2)
+            local checksumrx = string.sub(modem_history[#modem_history - 1],
+                                          totallen - 1, totallen)
+            local highByte, lowByte = checksum(msg)
+
+            -- check that received message is OK, then send to MAVLink processor
+            if len ~= #msg then
+                gcs:send_text(3,
+                              "SATCOM: Bad RX message length " .. tostring(len) ..
+                                  " vs actual " .. tostring(#msg))
+            elseif checksumrx ~= (tostring(highByte) .. tostring(lowByte)) then
+                gcs:send_text(3,
+                              "SATCOM: Bad RX CRC " .. checksumrx .. " vs " ..
+                                  tostring(highByte) .. tostring(lowByte))
+            else
+                if debug_text then
+                    gcs:send_text(3, "totmsg=" ..
+                                      nicestring(
+                                          modem_history[#modem_history - 1]))
+                end
+                for idx = 1, #msg do
+                    MAVLink:receive(msg:byte(idx))
+                end
+
+            end
+
+            modem_history = nil
+            modem_history = {}
+        end
+
+        -- Mailbox check  (response to AT command) (can be a fail or success)
+        if modem_history[#modem_history - 2] == 'AT+SBDIXA' and
+            modem_history[#modem_history] == 'OK' then
+
+            -- Parse response (comma and : delimited, trimming whitespace)
+            local statusReponse = {}
+            for w in modem_history[#modem_history - 1]:gmatch("[^,:]+") do
+                table.insert(statusReponse, w)
+            end
+
+            if #statusReponse == 7 then
+                if tonumber(statusReponse[2]) < 5 then
+                    gcs:send_text(3, "SATCOM Packet Transmitted successfully")
+                    -- check for rx packet
+                    if tonumber(statusReponse[4]) == 1 and
+                        first_sucessful_mailbox_check then
+                        gcs:send_text(3, "SATCOM Packet received")
+                        -- read messages, if not first mailbox check
+                        table.insert(modem_to_send, AT_read_rx_buffer)
+                    elseif debug_text then
+                        gcs:send_text(3, "SATCOM: No message to receive")
+                    end
+                    first_sucessful_mailbox_check = true
+                elseif tonumber(statusReponse[2]) == 32 then
+                    gcs:send_text(3, "SATCOM Error: No network service")
+                else
+                    gcs:send_text(3, "SATCOM Error: Unable to send")
+                end
+            end
+            modem_history = nil
+            modem_history = {}
+            is_transmitting = false
+        end
+    end
+end
+
+function checksum(bytes)
+    -- Checksum calculation for SBDWB
+    -- The checksum is the least significant 2-bytes of the summation of the entire SBD message
+    local SUM = 0
+
+    for idx = 1, #bytes do SUM = SUM + bytes:byte(idx) end
+
+    local SUM_H = (SUM & 0xFF << 8) >> 8
+    local SUM_L = SUM & 0xFF
+
+    if debug_text then
+        gcs:send_text(3, "Modem CRC: " .. string.char(SUM_H) .. " " ..
+                          string.char(SUM_L))
+    end
+
+    return string.char(SUM_H), string.char(SUM_L)
+end
+
+function nicestring(instr)
+    -- make any strings printable to GCS (constrain to ASCII range)
+    local retstr = ""
+    for i = 1, #instr do
+        local c = string.byte(instr:sub(i, i))
+        if c < 0x20 or c > 0x7E then c = 0x5F end
+        retstr = retstr .. string.char(c)
+    end
+
+    return tostring(retstr)
+end
+
+function HLSatcom()
+    -- read in any bytes and form into received commands
+    local n_bytes = port:available()
+    while n_bytes > 0 do
+        read = port:read()
+        read = string.char(read)
+        if read == '\r' or read == '\n' then
+            if #str_recieved > 0 then
+                table.insert(modem_history, str_recieved)
+                if debug_text then
+                    gcs:send_text(3, "Modem response: " ..
+                                      nicestring(modem_history[#modem_history]))
+                end
+                check_cmd_return()
+            end
+            str_recieved = ""
+        else
+            str_recieved = str_recieved .. read
+        end
+        n_bytes = n_bytes - 1
+    end
+
+    -- write out commands from send list. one cmd per loop
+    if #modem_to_send > 0 then
+        for idx = 1, #modem_to_send[1] do
+            port:write(modem_to_send[1]:byte(idx))
+        end
+        if debug_text then
+            gcs:send_text(3, "Sent to modem: " .. nicestring(modem_to_send[1]))
+        end
+        table.remove(modem_to_send, 1)
+    end
+
+    --- send detect command to modem every 10 sec if not detected
+    if not modem_detected and (millis():tofloat() * 0.001) -
+        last_modem_status_check > 10 then
+        table.insert(modem_to_send, AT_query)
+        last_modem_status_check = millis():tofloat() * 0.001
+    end
+
+    -- send HL2 packet every 30 sec, if not aleady in a mailbox check
+    if modem_detected and MAVLink:is_high_latency_enabled() and
+        (millis():tofloat() * 0.001) - time_last_tx > 30 and not is_transmitting then
+
+        local pkt = MAVLink:create_high_latency_packet()
+
+        local highByte, lowByte = checksum(pkt)
+
+        if #pkt > 50 then
+            gcs:send_text(3, "SATCOM Tx packet > 50 bytes: " .. tostring(#pkt))
+        end
+
+        -- Send as binary data, plus checksum
+        table.insert(modem_to_send, AT_load_tx_buffer .. tostring(#pkt) .. '\r')
+        table.insert(modem_to_send, pkt)
+        table.insert(modem_to_send, highByte .. lowByte .. "\r")
+
+        time_last_tx = millis():tofloat() * 0.001
+        table.insert(modem_to_send, AT_mailbox_check)
+        is_transmitting = true
+
+    end
+
+    return HLSatcom, 100
+end
+
+return HLSatcom, 100

--- a/libraries/AP_Scripting/applets/RockBlock.md
+++ b/libraries/AP_Scripting/applets/RockBlock.md
@@ -1,0 +1,24 @@
+# RockBlock Lua Script
+
+Lua script to send a recieve very basic MAVLink telemetry over a
+Rockblock SBD satellite modem
+Requires https://github.com/stephendade/rockblock2mav at the GCS end
+
+Note that this uses MAVLink1 messaging, due to it's smaller message size compared
+to MAVLink2.
+
+Setup:
+This script requires 1 serial port:
+- A "Script" port to connect the modem to
+
+Usage:
+- Use the MAVLink High Latency Control ("link hl on|off" in MAVProxy) to control whether to send or not
+  (or set the "force_hl_enable" variable to true)
+- Use the "debug_text" variable to view debugging statustexts at the GCS
+
+Caveats:
+- This will *only* send HIGH_LATENCY2 packets via the SBD modem. No heartbeats, no command acknowledgements, no statustexts, no parameters, etc
+- A single HIGH_LATENCY2 packet will be sent every 20 sec, in addition to recieving 
+   a single MAVLink packet from the GCS. This is known as a mailbox check.
+- Any incoming packets on the first mailbox check will be ignored (as these may be from a long time in the past)
+- Only 1 command can be sent per mailbox check from the GCS. Any additional commands will overwrite the previous command

--- a/libraries/AP_Scripting/examples/MAVLinkHL-loopback.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL-loopback.lua
@@ -1,0 +1,60 @@
+-- Lua script to simulate a HL connection over a UART
+
+-- Setup:
+-- This script requires 1 serial port:
+-- A "Script" serial port to connect directly to the GCS
+
+-- Usage:
+-- Use the MAVLink High Latency Control ("link hl on|off" in MAVProxy) to control
+-- whether to send or not
+
+-- Caveats:
+-- This will send HIGH_LATENCY2 packets in place of HEARTBEAT packets
+-- A single HIGH_LATENCY2 packet will be send every 5 sec
+-- MAVLink 1 will be used, as it's slightly more efficient (50 vs 52 bytes for a HL2 message)
+-- Only MAVLink commands (COMMAND_LONG, COMMAND_INT) from the GCS will *not* be ignored
+
+-- Written by Stephen Dade (stephen_dade@hotmail.com)
+
+local port = serial:find_serial(0)
+
+if not port or baud == 0 then
+    gcs:send_text(0, "No Scripting Serial Port")
+    return
+end
+
+port:begin(19200)
+port:set_flow_control(0)
+
+-- true to use MAVLink1, false to use MAVLink2
+MAVLink:begin(true)
+
+local time_last_tx = millis():tofloat() * 0.001
+
+-- enable high latency mode from here, instead of having to enable from GCS
+MAVLink:set_high_latency_enabled(true)
+
+function HLSatcom ()
+  -- read in any bytes from GCS and and send to MAVLink processor
+  while port:available() > 0 do
+    local byte = port:read()
+    MAVLink:receive(byte)
+  end
+  
+  -- send HL2 packet every 5 sec
+  if MAVLink:is_high_latency_enabled() and (millis():tofloat() * 0.001) - time_last_tx > 5 then
+    
+    local pkt = MAVLink:create_high_latency_packet()
+    for idx = 1, #pkt do
+      port:write(pkt:byte(idx))
+    end
+    gcs:send_text(3, "HL2 packet sent, size: " .. tostring(#pkt))
+    
+    time_last_tx = millis():tofloat() * 0.001
+
+  end
+  
+  return HLSatcom, 100
+end
+
+return HLSatcom, 100

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -555,3 +555,11 @@ userdata uint32_t manual_operator __tostring uint32_t___tostring
 userdata uint32_t manual toint uint32_t_toint
 userdata uint32_t manual tofloat uint32_t_tofloat
 
+include AP_Scripting/AP_Scripting_MAVLink.h
+singleton ScriptingMAVLink depends HAL_HIGH_LATENCY2_ENABLED
+singleton ScriptingMAVLink rename MAVLink
+singleton ScriptingMAVLink manual begin lua_mavlink_get_MAVLink
+singleton ScriptingMAVLink manual create_high_latency_packet lua_mavlink_create_high_latency_packet
+singleton ScriptingMAVLink manual is_high_latency_enabled lua_mavlink_is_high_latency_enabled
+singleton ScriptingMAVLink manual set_high_latency_enabled lua_mavlink_set_high_latency_enabled
+singleton ScriptingMAVLink manual receive lua_mavlink_receive

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -9,3 +9,11 @@ int AP_Logger_Write(lua_State *L);
 int lua_get_i2c_device(lua_State *L);
 int lua_get_CAN_device(lua_State *L);
 int lua_get_CAN_device2(lua_State *L);
+
+#if HAL_HIGH_LATENCY2_ENABLED
+int lua_mavlink_get_MAVLink(lua_State *L);
+int lua_mavlink_create_high_latency_packet(lua_State *L);
+int lua_mavlink_receive(lua_State *L);
+int lua_mavlink_is_high_latency_enabled(lua_State *L);
+int lua_mavlink_set_high_latency_enabled(lua_State *L);
+#endif

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -125,7 +125,7 @@ void GCS::enable_high_latency_connections(bool enabled)
 {
     for (uint8_t i=0; i<num_gcs(); i++) {
         GCS_MAVLINK &c = *chan(i);
-        c.high_latency_link_enabled = enabled && c.is_high_latency_link;
+        c.high_latency_link_enabled = enabled;
     } 
     gcs().send_text(MAV_SEVERITY_NOTICE, "High Latency %s", enabled ? "enabled" : "disabled");
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -133,6 +133,7 @@ class GCS_MAVLINK
 {
 public:
     friend class GCS;
+    friend class ScriptingMAVLink;
 
     GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters, AP_HAL::UARTDriver &uart);
     virtual ~GCS_MAVLINK() {}


### PR DESCRIPTION
This PR adds support for sending & receiving very basic MAVLink telemetry via a RockBlock SBD satellite modem.

It will allow for literal worldwide telemetry coverage for any vehicle fitted with the aforementioned modem.

The modem bandwidth is very low (~50 bytes per 20sec or so), so I've deliberately limited what can be sent and when (1 HIGH_LATENCY2 packet every 20 sec). I did have to trim the message down (remove MAVLink header and compatibility flag, with are restored at the gateway) a little to keep within 50 bytes.

Requires https://github.com/stephendade/rockblock2mav at the GCS end to send and receive packets.

This PR is WIP, as it requires a bit more testing.