### PR TITLE
autotest: set Rover speedup to 30

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -71,7 +71,7 @@ class AutoTestRover(AutoTest):
         return "rover"
 
     def default_speedup(self):
-        return 100
+        return 30
 
     def is_rover(self):
         return True


### PR DESCRIPTION
This is closer to what's achieved on modern CPUs.

Running at 100 can lead to very rapid RC inputs which can cause issues.