### PR TITLE
autotest: add timeout in drain_mav

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4065,7 +4065,7 @@ class AutoTest(ABC):
         return self.check_mission_items_same(check_atts, want, got, skip_first_item=True, strict=strict)
 
     def check_mission_item_upload_download(self, items, itype, mission_type, strict=True):
-        self.progress("check %s _upload/download: upload %u items" %
+        self.progress("check %s upload/download: upload %u items" %
                       (itype, len(items),))
         self.upload_using_mission_protocol(mission_type, items)
         self.progress("check %s upload/download: download items" % itype)


### PR DESCRIPTION
At large speedups we can create more telemetry than we can consume.  Detect that and raise an exception, assuming we should be able to drain anything within 2 minutes

Interim solution until we work out something better.

It might be that we can just do timesync roundtrips rather than drain_mav - and have the timesync roundtrip timeout in wallclock time?

