### PR TITLE
autotest: use slightly faster recv_msg call in drain_mav

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2731,7 +2731,7 @@ class AutoTest(ABC):
         tstart = time.time()
         timeout = 120
         failed_to_drain = False
-        while mav.recv_match(blocking=False) is not None:
+        while mav.recv_msg() is not None:
             count += 1
             if time.time() - tstart > timeout:
                 # ArduPilot can produce messages faster than we can


### PR DESCRIPTION
At large speedups we can create more telemetry than we can consume.  Detect that and raise an exception, assuming we should be able to drain anything within 2 minutes