### PR TITLE
AP_Scripting: Generator: fix docs generator aliasing

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2552,13 +2552,11 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
         }
 
         emit_docs_method(name, alias->alias, method);
-
-        alias = alias->next;
       }
-
-      fprintf(docs, "\n");
-      free(name);
+      alias = alias->next;
     }
+    fprintf(docs, "\n");
+    free(name);
     node = node->next;
   }
 }


### PR DESCRIPTION
Fix for the broken docs generation. No change to flight code. Discovered by @rmackay9 in https://github.com/ArduPilot/ardupilot/pull/21067