### PR TITLE
AP_Bootloader: add ID for target SkystarsH7HD

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -174,6 +174,7 @@ AP_HW_GreenSight_UltraBlue           1071
 AP_HW_GreenSight_microBlue           1072
 AP_HW_MAMBAH743_V4                   1073
 AP_HW_REAPERF745_V2                  1074
+AP_HW_SKYSTARSH7HD                   1075
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
add ID for target SkystarsH7HD for up coming board
AP_HW_SKYSTARSH7HD                   1075