### PR TITLE
autotest: build Heli in parallel to Copter

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -121,7 +121,6 @@ jobs:
            retention-days: 7
 
   build-gcc-heli:
-    needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
       image: ardupilot/ardupilot-dev-base:latest


### PR DESCRIPTION
CI always seems to have the heli tests stuck out at the end.  This should fix that at tthe cost of a few extra seconds of compilation