### PR TITLE
Scripting: support 2nd CAN scripting protocol

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1070,6 +1070,7 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CANManager::Driver_Type_USD1:
                 case AP_CANManager::Driver_Type_None:
                 case AP_CANManager::Driver_Type_Scripting:
+                case AP_CANManager::Driver_Type_Scripting2:
                 case AP_CANManager::Driver_Type_Benewake:
                     break;
             }

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Param: PROTOCOL
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
-    // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake
+    // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake,12:Scripting2
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_UAVCAN),

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -64,6 +64,7 @@ public:
         // 9 was Driver_Type_MPPT_PacketDigital
         Driver_Type_Scripting = 10,
         Driver_Type_Benewake = 11,
+        Driver_Type_Scripting2 = 12,
     };
 
     void init(void);

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -73,6 +73,7 @@ public:
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
     // Scripting CAN sensor
     ScriptingCANSensor *_CAN_dev;
+    ScriptingCANSensor *_CAN_dev2;
 #endif
 
     // mission item buffer

--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.h
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.h
@@ -25,8 +25,9 @@ class ScriptingCANBuffer;
 class ScriptingCANSensor : public CANSensor {
 public:
 
-    ScriptingCANSensor():CANSensor("Script") {
-        register_driver(AP_CANManager::Driver_Type::Driver_Type_Scripting);
+    ScriptingCANSensor(AP_CANManager::Driver_Type dtype)
+        : CANSensor("Script") {
+        register_driver(dtype);
     }
 
     // handler for outgoing frames, using uint32

--- a/libraries/AP_Scripting/examples/CAN_read.lua
+++ b/libraries/AP_Scripting/examples/CAN_read.lua
@@ -1,19 +1,36 @@
 -- This script is an example of reading from the CAN bus
 
--- Load CAN driver, using the scripting protocol and with a buffer size of 5
-local driver = CAN.get_device(5)
+-- Load CAN driver1. The first will attach to a protocol of 10, the 2nd to a protocol of 12
+-- this allows the script to distinguish packets on two CAN interfaces
+local driver1 = CAN.get_device(5)
+local driver2 = CAN.get_device2(5)
+
+if not driver1 and not driver2 then
+   gcs:send_text(0,"No scripting CAN interfaces found")
+   return
+end
+
+function show_frame(dnum, frame)
+    gcs:send_text(0,string.format("CAN[%u] msg from " .. tostring(frame:id()) .. ": %i, %i, %i, %i, %i, %i, %i, %i", dnum, frame:data(0), frame:data(1), frame:data(2), frame:data(3), frame:data(4), frame:data(5), frame:data(6), frame:data(7)))
+end
 
 function update()
 
-  -- Read a message from the buffer
-  frame = driver:read_frame()
+   -- see if we got any frames
+   if driver1 then
+      frame = driver1:read_frame()
+      if frame then
+         show_frame(1, frame)
+      end
+   end
+   if driver2 then
+      frame = driver2:read_frame()
+      if frame then
+         show_frame(2, frame)
+      end
+   end
 
-  if frame then
-    -- note that we have to be careful to keep the ID as a uint32_t userdata to retain precision
-    gcs:send_text(0,string.format("CAN msg from " .. tostring(frame:id()) .. ": %i, %i, %i, %i, %i, %i, %i, %i", frame:data(0), frame:data(1), frame:data(2), frame:data(3), frame:data(4), frame:data(5), frame:data(6), frame:data(7)))
-  end
-
-  return update, 100
+  return update, 10
 
 end
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -455,6 +455,7 @@ singleton AP_InertialSensor rename ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
 
 singleton CAN manual get_device lua_get_CAN_device
+singleton CAN manual get_device2 lua_get_CAN_device2
 singleton CAN depends HAL_MAX_CAN_PROTOCOL_DRIVERS
 
 include AP_Scripting/AP_Scripting_CANSensor.h depends HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -338,7 +338,7 @@ int lua_get_CAN_device(lua_State *L) {
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev == nullptr) {
-        AP::scripting()->_CAN_dev = new ScriptingCANSensor();
+        AP::scripting()->_CAN_dev = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting);
         if (AP::scripting()->_CAN_dev == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }
@@ -346,6 +346,27 @@ int lua_get_CAN_device(lua_State *L) {
 
     new_ScriptingCANBuffer(L);
     *check_ScriptingCANBuffer(L, -1) = AP::scripting()->_CAN_dev->add_buffer(buffer_len);
+
+    return 1;
+}
+
+int lua_get_CAN_device2(lua_State *L) {
+
+    check_arguments(L, 1, "CAN:get_device2");
+
+    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1);
+    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1, "argument out of range");
+    const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
+
+    if (AP::scripting()->_CAN_dev2 == nullptr) {
+        AP::scripting()->_CAN_dev2 = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting2);
+        if (AP::scripting()->_CAN_dev2 == nullptr) {
+            return luaL_argerror(L, 1, "CAN device nullptr");
+        }
+    }
+
+    new_ScriptingCANBuffer(L);
+    *check_ScriptingCANBuffer(L, -1) = AP::scripting()->_CAN_dev2->add_buffer(buffer_len);
 
     return 1;
 }

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -8,4 +8,4 @@ int lua_mission_receive(lua_State *L);
 int AP_Logger_Write(lua_State *L);
 int lua_get_i2c_device(lua_State *L);
 int lua_get_CAN_device(lua_State *L);
-
+int lua_get_CAN_device2(lua_State *L);


### PR DESCRIPTION
This allows a script to attach to two CAN buses and differentiate between them as two separate drivers
This is for an aircraft with two CAN ECUs, one for each of two EFI engines, with a lua script controlling the two engines separately
