### PR TITLE
Plane: Quadplane QPOS1 never acclerate away from home

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2459,6 +2459,7 @@ void QuadPlane::vtol_position_controller(void)
         const float distance = diff_wp.length();
         const Vector2f rel_groundspeed_vector = landing_closing_velocity();
         const float rel_groundspeed_sq = rel_groundspeed_vector.length_squared();
+        const float closing_groundspeed = rel_groundspeed_vector * diff_wp.normalized();
 
         // calculate speed we should be at to reach the position2
         // target speed at the position2 distance threshold, assuming
@@ -2494,11 +2495,11 @@ void QuadPlane::vtol_position_controller(void)
 
         Vector2f target_speed_xy_cms;
         Vector2f target_accel_cms;
-        const float target_accel = accel_needed(distance, rel_groundspeed_sq);
+        const float target_accel = accel_needed(distance, closing_groundspeed*closing_groundspeed);
         if (distance > 0.1) {
             Vector2f diff_wp_norm = diff_wp.normalized();
             target_speed_xy_cms = diff_wp_norm * target_speed * 100;
-            target_accel_cms = diff_wp_norm * (-target_accel*100);
+            target_accel_cms = diff_wp_norm * (target_accel*100) * (is_positive(closing_groundspeed) ? -1.0 : 1.0);
         }
         const float target_speed_ms = target_speed_xy_cms.length() * 0.01;
 


### PR DESCRIPTION
Currently the QPOS1 controller always accelerates away from home. This is to decelerate the vehicle based on the assumption that you will always be moving towards home and want to slow down. However if your not this causes issues, such as https://github.com/ArduPilot/ardupilot/pull/21064

Take off in Qloiter, switch to loiter and then QRTL.
![image](https://user-images.githubusercontent.com/33176108/177014511-a1fbea89-9593-4729-b73d-805c0e50503f.png)

The vehicle is pushed away from home by this "deceleration". 

This PR stops it doing that resulting in:

![image](https://user-images.githubusercontent.com/33176108/177014532-5bfbb39f-3e6c-4440-93e9-80fa485e7482.png)

Once in the QPOS1 state it takes a more or less tangential path. This is better but still not really ideal. 

I think the underlying problem is that were inputting velocity and acceleration. To calculate those velocity's and accelerations we have a limited position controller. 

I think we should just be using the full position controller. However, we may need to add some functionality to allow overspeeds. 

Just a draft because its not a great solution but does highlight the issue. 
