### PR TITLE
autotest: add diagnostics for Plane Terrain test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2572,6 +2572,18 @@ function'''
         '''test AP_Terrain'''
         self.reboot_sitl()  # we know the terrain height at CMAC
 
+        # install a message hook to show ArduPilot's terrain requests
+        # as they flow through.  MAVProxy should answer these with
+        # TERRAIN_DATA responses
+        def mh(mav, m):
+            t = m.get_type()
+            want_t = frozenset(['TERRAIN_REQUEST', 'TERRAIN_DATA'])
+            if t not in want_t:
+                return
+            self.progress("%s seen:" % t)
+            self.progress(self.dump_message_verbose(m))
+        self.install_message_hook_context(mh)
+
         mavproxy = self.start_mavproxy()
 
         self.wait_ready_to_arm()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1611,14 +1611,15 @@ class AutoTest(ABC):
     def autotest_connection_string_to_ardupilot(self):
         return "tcp:127.0.0.1:5760"
 
-    def mavproxy_options(self):
+    def mavproxy_options(self, streamrate=None):
         """Returns options to be passed to MAVProxy."""
         ret = [
             '--sitl=127.0.0.1:5502',
-            '--streamrate=%u' % self.sitl_streamrate(),
             '--target-system=%u' % self.sysid_thismav(),
             '--target-component=1',
         ]
+        if streamrate is not None:
+            ret.append('--streamrate=%u' % streamrate)
         if self.viewerip:
             ret.append("--out=%s:14550" % self.viewerip)
         if self.use_map:


### PR DESCRIPTION
CI is having issues with MAVProxy not supplying data for the test; add diagnostics to make sure it's just MAVProxy not getting to the request because of all the other data it's putting up with
