### PR TITLE
Plane: add yaw input shaping command model

### DIFF
--- a/ArduPlane/mode_qacro.cpp
+++ b/ArduPlane/mode_qacro.cpp
@@ -8,6 +8,10 @@ bool ModeQAcro::_enter()
     quadplane.throttle_wait = false;
     quadplane.transition->force_transition_complete();
     attitude_control->relax_attitude_controllers();
+
+    // disable yaw rate time contant to mantain old behaviour
+    quadplane.disable_yaw_rate_time_constant();
+
     return true;
 }
 

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -77,6 +77,9 @@ void ModeQLoiter::run()
         pos_control->set_externally_limited_xy();
     }
 
+    // Pilot input, use yaw rate time constant
+    quadplane.set_pilot_yaw_rate_time_constant();
+
     // call attitude controller with conservative smoothing gain of 4.0f
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -82,6 +82,7 @@ void ModeQRTL::run()
                 pos_control->set_externally_limited_xy();
             }
             // weathervane with no pilot input
+            quadplane.disable_yaw_rate_time_constant();
             attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                           plane.nav_pitch_cd,
                                                                           quadplane.get_weathervane_yaw_rate_cds());

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -11,6 +11,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <AC_PID/AC_PID.h>
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi.h> // Attitude control library
+#include <AC_AttitudeControl/AC_CommandModel.h>
 #include <AP_InertialNav/AP_InertialNav.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AC_AttitudeControl/AC_WeatherVane.h>
@@ -196,6 +197,13 @@ private:
     // air mode state: OFF, ON, ASSISTED_FLIGHT_ONLY
     AirMode air_mode;
 
+    // Command model parameter class
+    // Default max rate, default expo, default time constant
+    AC_CommandModel command_model_pilot{100.0, 0.25, 0.25};
+    // helper functions to set and disable time constant from command model
+    void set_pilot_yaw_rate_time_constant();
+    void disable_yaw_rate_time_constant();
+
     // return true if airmode should be active
     bool air_mode_active() const;
 
@@ -318,9 +326,6 @@ private:
     AP_Int16 assist_alt;
     uint32_t alt_error_start_ms;
     bool in_alt_assist;
-
-    // maximum yaw rate in degrees/second
-    AP_Float yaw_rate_max;
 
     // landing speed in cm/s
     AP_Int16 land_speed_cms;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -796,6 +796,7 @@ void Tailsitter_Transition::update()
         // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
         plane.nav_pitch_cd = constrain_float(fw_transition_initial_pitch - (quadplane.tailsitter.transition_rate_fw * dt) * 0.1f * (plane.fly_inverted()?-1.0f:1.0f), -8500, 8500);
         plane.nav_roll_cd = 0;
+        quadplane.disable_yaw_rate_time_constant();
         quadplane.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,
                                                                       0);


### PR DESCRIPTION
Follow up from https://github.com/ArduPilot/ardupilot/pull/20307

This adds yaw input expo and time constant to plane. It also moves the existing max rate param. A little expo and time constant make the vehicle much nicer to fly, a big improvement. 

@bnsgeyer @rmackay9 To get `PILOT_Y_RATE_TC` to fit on quadplane with the `Q_` prefix I had to shorten it to: `PILOT_Y_RAT_TC`. This allows the params to remain the same across plane and copter. I could try and find a letter in the prefix on plane only and leave copter as it is. But I think there is a lot of value in keeping params consistent and the `RATE` -> `RAT` is one we use elsewhere. Open to other suggestions of course.