### PR TITLE
AP_Param: always use set method, remove `=`

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -386,7 +386,7 @@ void GCS_MAVLINK_Tracker::mavlink_check_target(const mavlink_message_t &msg)
 
     // set our sysid to the target, this ensures we lock onto a single vehicle
     if (tracker.g.sysid_target == 0) {
-        tracker.g.sysid_target = msg.sysid;
+        tracker.g.sysid_target.set(msg.sysid);
     }
 
     // send data stream request to target on all channels

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -58,7 +58,7 @@ float Copter::get_pilot_desired_climb_rate(float throttle_control)
     throttle_control = constrain_float(throttle_control,0.0f,1000.0f);
 
     // ensure a reasonable deadzone
-    g.throttle_deadzone = constrain_int16(g.throttle_deadzone, 0, 400);
+    g.throttle_deadzone.set(constrain_int16(g.throttle_deadzone, 0, 400));
 
     float desired_rate = 0.0f;
     const float mid_stick = get_throttle_mid();

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -268,15 +268,15 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
 #if MODE_ACRO_ENABLED == ENABLED
             switch(ch_flag) {
                 case AuxSwitchPos::LOW:
-                    copter.g.acro_trainer = (uint8_t)ModeAcro::Trainer::OFF;
+                    copter.g.acro_trainer.set((uint8_t)ModeAcro::Trainer::OFF);
                     AP::logger().Write_Event(LogEvent::ACRO_TRAINER_OFF);
                     break;
                 case AuxSwitchPos::MIDDLE:
-                    copter.g.acro_trainer = (uint8_t)ModeAcro::Trainer::LEVELING;
+                    copter.g.acro_trainer.set((uint8_t)ModeAcro::Trainer::LEVELING);
                     AP::logger().Write_Event(LogEvent::ACRO_TRAINER_LEVELING);
                     break;
                 case AuxSwitchPos::HIGH:
-                    copter.g.acro_trainer = (uint8_t)ModeAcro::Trainer::LIMITED;
+                    copter.g.acro_trainer.set((uint8_t)ModeAcro::Trainer::LIMITED);
                     AP::logger().Write_Event(LogEvent::ACRO_TRAINER_LIMITED);
                     break;
             }

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -102,7 +102,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     }
 
     // disable throttle failsafe
-    g.failsafe_throttle = FS_THR_DISABLED;
+    g.failsafe_throttle.set(FS_THR_DISABLED);
 
     // disable motor compensation
     compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1505,7 +1505,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool logs_attitude() const override { return true; }
 
-    void set_magnitude(float input) { waveform_magnitude = input; }
+    void set_magnitude(float input) { waveform_magnitude.set(input); }
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -29,9 +29,9 @@ bool ModeTurtle::init(bool ignore_checks)
     change_motor_direction(true);
 
     // disable throttle and gps failsafe
-    g.failsafe_throttle = FS_THR_DISABLED;
-    g.failsafe_gcs = FS_GCS_DISABLED;
-    g.fs_ekf_action = 0;
+    g.failsafe_throttle.set(FS_THR_DISABLED);
+    g.failsafe_gcs.set(FS_GCS_DISABLED);
+    g.fs_ekf_action.set(0);
 
     // arm
     motors->armed(true);

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -159,9 +159,9 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             }
 
             // disable throttle and gps failsafe
-            g.failsafe_throttle = FS_THR_DISABLED;
-            g.failsafe_gcs = FS_GCS_DISABLED;
-            g.fs_ekf_action = 0;
+            g.failsafe_throttle.set(FS_THR_DISABLED);
+            g.failsafe_gcs.set(FS_GCS_DISABLED);
+            g.fs_ekf_action.set(0);
 
             // turn on notify leds
             AP_Notify::flags.esc_calibration = true;

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -5,7 +5,7 @@
 void Sub::get_pilot_desired_lean_angles(float roll_in, float pitch_in, float &roll_out, float &pitch_out, float angle_max)
 {
     // sanity check angle max parameter
-    aparm.angle_max = constrain_int16(aparm.angle_max,1000,8000);
+    aparm.angle_max.set(constrain_int16(aparm.angle_max,1000,8000));
 
     // limit max lean angle
     angle_max = constrain_float(angle_max, 1000, aparm.angle_max);
@@ -103,7 +103,7 @@ float Sub::get_pilot_desired_climb_rate(float throttle_control)
     throttle_control = constrain_float(throttle_control,0.0f,1000.0f);
 
     // ensure a reasonable deadzone
-    g.throttle_deadzone = constrain_int16(g.throttle_deadzone, 0, 400);
+    g.throttle_deadzone.set(constrain_int16(g.throttle_deadzone, 0, 400));
 
     // check throttle is above, below or in the deadband
     if (throttle_control < deadband_bottom) {

--- a/ArduSub/control_acro.cpp
+++ b/ArduSub/control_acro.cpp
@@ -76,7 +76,7 @@ void Sub::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int16
 
         // range check expo
         if (g.acro_expo > 1.0f) {
-            g.acro_expo = 1.0f;
+            g.acro_expo.set(1.0f);
         }
 
         // roll expo

--- a/Rover/motor_test.cpp
+++ b/Rover/motor_test.cpp
@@ -130,9 +130,9 @@ MAV_RESULT Rover::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, AP_Motor
             }
 
             // disable failsafes
-            g.fs_gcs_enabled = 0;
-            g.fs_throttle_enabled = 0;
-            g.fs_crash_check = 0;
+            g.fs_gcs_enabled.set(0);
+            g.fs_throttle_enabled.set(0);
+            g.fs_crash_check.set(0);
 
             // turn on notify leds
             AP_Notify::flags.esc_calibration = true;

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -31,7 +31,7 @@ class ReplayVehicle : public AP_Vehicle {
 public:
     friend class Replay;
 
-    ReplayVehicle() { unused = -1; }
+    ReplayVehicle() { unused.set(-1); }
     // HAL::Callbacks implementation.
     void load_parameters(void) override;
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -1025,9 +1025,9 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
             _accel_yaw_max.load();
         }
     } else {
-        _accel_roll_max = 0.0f;
-        _accel_pitch_max = 0.0f;
-        _accel_yaw_max = 0.0f;
+        _accel_roll_max.set(0.0f);
+        _accel_pitch_max.set(0.0f);
+        _accel_yaw_max.set(0.0f);
     }
 }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -87,7 +87,7 @@ public:
     float get_accel_roll_max_radss() const { return radians(_accel_roll_max * 0.01f); }
 
     // Sets the roll acceleration limit in centidegrees/s/s
-    void set_accel_roll_max_cdss(float accel_roll_max) { _accel_roll_max = accel_roll_max; }
+    void set_accel_roll_max_cdss(float accel_roll_max) { _accel_roll_max.set(accel_roll_max); }
 
     // Sets and saves the roll acceleration limit in centidegrees/s/s
     void save_accel_roll_max_cdss(float accel_roll_max) { _accel_roll_max.set_and_save(accel_roll_max); }
@@ -97,7 +97,7 @@ public:
     float get_accel_pitch_max_radss() const { return radians(_accel_pitch_max * 0.01f); }
 
     // Sets the pitch acceleration limit in centidegrees/s/s
-    void set_accel_pitch_max_cdss(float accel_pitch_max) { _accel_pitch_max = accel_pitch_max; }
+    void set_accel_pitch_max_cdss(float accel_pitch_max) { _accel_pitch_max.set(accel_pitch_max); }
 
     // Sets and saves the pitch acceleration limit in centidegrees/s/s
     void save_accel_pitch_max_cdss(float accel_pitch_max) { _accel_pitch_max.set_and_save(accel_pitch_max); }
@@ -107,7 +107,7 @@ public:
     float get_accel_yaw_max_radss() const { return radians(_accel_yaw_max * 0.01f); }
 
     // Sets the yaw acceleration limit in centidegrees/s/s
-    void set_accel_yaw_max_cdss(float accel_yaw_max) { _accel_yaw_max = accel_yaw_max; }
+    void set_accel_yaw_max_cdss(float accel_yaw_max) { _accel_yaw_max.set(accel_yaw_max); }
 
     // Sets and saves the yaw acceleration limit in centidegrees/s/s
     void save_accel_yaw_max_cdss(float accel_yaw_max) { _accel_yaw_max.set_and_save(accel_yaw_max); }
@@ -128,7 +128,7 @@ public:
     float get_input_tc() const { return _input_tc; }
 
     // set the rate control input smoothing time constant
-    void set_input_tc(float input_tc) { _input_tc = constrain_float(input_tc, 0.0f, 1.0f); }
+    void set_input_tc(float input_tc) { _input_tc.set(constrain_float(input_tc, 0.0f, 1.0f)); }
 
     // Ensure attitude controller have zero errors to relax rate controller output
     void relax_attitude_controllers();
@@ -269,7 +269,7 @@ public:
     Vector3f rate_bf_targets() const { return _ang_vel_body + _sysid_ang_vel_body; }
 
     // Enable or disable body-frame feed forward
-    void bf_feedforward(bool enable_or_disable) { _rate_bf_ff_enabled = enable_or_disable; }
+    void bf_feedforward(bool enable_or_disable) { _rate_bf_ff_enabled.set(enable_or_disable); }
 
     // Enable or disable body-frame feed forward and save
     void bf_feedforward_save(bool enable_or_disable) { _rate_bf_ff_enabled.set_and_save(enable_or_disable); }

--- a/libraries/AC_AttitudeControl/AC_CommandModel.h
+++ b/libraries/AC_AttitudeControl/AC_CommandModel.h
@@ -19,7 +19,7 @@ public:
     float get_expo() const { return expo; }
 
     // Set the max rate
-    void set_rate(float input) { rate = input; }
+    void set_rate(float input) { rate.set(input); }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -133,7 +133,7 @@ void AC_AutoTune_Multi::backup_gains_and_initialise()
 {
     AC_AutoTune::backup_gains_and_initialise();
 
-    aggressiveness = constrain_float(aggressiveness, 0.05f, 0.2f);
+    aggressiveness.set(constrain_float(aggressiveness, 0.05f, 0.2f));
 
     orig_bf_feedforward = attitude_control->get_bf_feedforward();
 

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -143,7 +143,7 @@ void AC_Autorotation::init_hs_controller()
     _healthy_rpm_counter = 0;
 
     // Protect against divide by zero
-    _param_head_speed_set_point = MAX(_param_head_speed_set_point,500);
+    _param_head_speed_set_point.set(MAX(_param_head_speed_set_point,500));
 }
 
 
@@ -213,7 +213,7 @@ float AC_Autorotation::get_rpm(bool update_counter)
     if (rpm != nullptr) {
         //Check requested rpm instance to ensure either 0 or 1.  Always defaults to 0.
         if ((_param_rpm_instance > 1) || (_param_rpm_instance < 0)) {
-            _param_rpm_instance = 0;
+            _param_rpm_instance.set(0);
         }
 
         //Get RPM value

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -93,7 +93,7 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
     const float distance_to_dest = current_loc.get_distance(destination);
 
     // make sure user has set a meaningful value for _lookahead
-    _lookahead = MAX(_lookahead,1.0f);
+    _lookahead.set(MAX(_lookahead,1.0f));
 
     // lookahead distance is adjusted dynamically based on avoidance results
     _current_lookahead = constrain_float(_current_lookahead, _lookahead * 0.5f, _lookahead);

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -141,7 +141,7 @@ void AC_Fence::enable(bool value)
     } else if (!_enabled && value) {
         AP::logger().Write_Event(LogEvent::FENCE_ENABLE);
     }
-    _enabled = value;
+    _enabled.set(value);
     if (!value) {
         clear_breach(AC_FENCE_TYPE_ALT_MIN | AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON);
         disable_floor();

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -296,7 +296,7 @@ bool AC_PolyFence_loader::format()
 bool AC_PolyFence_loader::convert_to_new_storage()
 {
     // sanity check total
-    _total = constrain_int16(_total, 0, max_items());
+    _total.set(constrain_int16(_total, 0, max_items()));
     // FIXME: ensure the fence was closed and don't load it if it was not
     if (_total < 5) {
         // fence was invalid.  Just format it and move on

--- a/libraries/AC_InputManager/AC_InputManager_Heli.cpp
+++ b/libraries/AC_InputManager/AC_InputManager_Heli.cpp
@@ -91,7 +91,7 @@ float AC_InputManager_Heli::get_pilot_desired_collective(int16_t control_in)
     // calculate expo-scaled acro collective
     // range check expo
     if (_acro_col_expo > 1.0f) {
-        _acro_col_expo = 1.0f;
+        _acro_col_expo.set(1.0f);
     }
 
     if (_acro_col_expo <= 0.0f) {

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -54,7 +54,7 @@ public:
     //@{
 
     /// Overload the function call operator to permit relatively easy initialisation
-    void operator() (const float p) { _kp = p; }
+    void operator() (const float p) { _kp.set(p); }
 
     // accessors
     AP_Float    &kP() { return _kp; }

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -282,7 +282,7 @@ void AC_PID::load_gains()
     _kd.load();
     _kff.load();
     _kimax.load();
-    _kimax = fabsf(_kimax);
+    _kimax.set(fabsf(_kimax));
     _filt_T_hz.load();
     _filt_E_hz.load();
     _filt_D_hz.load();
@@ -304,14 +304,14 @@ void AC_PID::save_gains()
 /// Overload the function call operator to permit easy initialisation
 void AC_PID::operator()(float p_val, float i_val, float d_val, float ff_val, float imax_val, float input_filt_T_hz, float input_filt_E_hz, float input_filt_D_hz, float dt)
 {
-    _kp = p_val;
-    _ki = i_val;
-    _kd = d_val;
-    _kff = ff_val;
-    _kimax = fabsf(imax_val);
-    _filt_T_hz = input_filt_T_hz;
-    _filt_E_hz = input_filt_E_hz;
-    _filt_D_hz = input_filt_D_hz;
+    _kp.set(p_val);
+    _ki.set(i_val);
+    _kd.set(d_val);
+    _kff.set(ff_val);
+    _kimax.set(fabsf(imax_val));
+    _filt_T_hz.set(input_filt_T_hz);
+    _filt_E_hz.set(input_filt_E_hz);
+    _filt_D_hz.set(input_filt_D_hz);
     _dt = dt;
 }
 

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -60,7 +60,7 @@ void AC_PI_2D::filt_hz(float hz)
     _filt_hz.set(fabsf(hz));
 
     // sanity check _filt_hz
-    _filt_hz = MAX(_filt_hz, AC_PI_2D_FILT_HZ_MIN);
+    _filt_hz.set(MAX(_filt_hz, AC_PI_2D_FILT_HZ_MIN));
 
     // calculate the input filter alpha
     calc_filt_alpha();
@@ -135,7 +135,7 @@ void AC_PI_2D::load_gains()
     _kp.load();
     _ki.load();
     _imax.load();
-    _imax = fabsf(_imax);
+    _imax.set(fabsf(_imax));
     _filt_hz.load();
 
     // calculate the input filter alpha
@@ -154,10 +154,10 @@ void AC_PI_2D::save_gains()
 /// Overload the function call operator to permit easy initialisation
 void AC_PI_2D::operator() (float p, float i, float imaxval, float input_filt_hz, float dt)
 {
-    _kp = p;
-    _ki = i;
-    _imax = fabsf(imaxval);
-    _filt_hz = input_filt_hz;
+    _kp.set(p);
+    _ki.set(i);
+    _imax.set(fabsf(imaxval));
+    _filt_hz.set(input_filt_hz);
     _dt = dt;
     // calculate the input filter alpha
     calc_filt_alpha();

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -203,7 +203,7 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
 
     // create inertial history buffer
     // constrain lag parameter to be within bounds
-    _lag = constrain_float(_lag, 0.02f, 0.25f);
+    _lag.set(constrain_float(_lag, 0.02f, 0.25f));
 
     // calculate inertial buffer size from lag and minimum of main loop rate and update_rate_hz argument
     const uint16_t inertial_buffer_size = MAX((uint16_t)roundf(_lag * MIN(update_rate_hz, AP::scheduler().get_loop_rate_hz())), 1);

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -135,7 +135,7 @@ void AC_Circle::set_center(const Location& center)
 void AC_Circle::set_rate(float deg_per_sec)
 {
     if (!is_equal(deg_per_sec, _rate.get())) {
-        _rate = deg_per_sec;
+        _rate.set(deg_per_sec);
     }
 }
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -195,8 +195,8 @@ void AC_Loiter::update(bool avoidance_on)
 // sanity check parameters
 void AC_Loiter::sanity_check_params()
 {
-    _speed_cms = MAX(_speed_cms, LOITER_SPEED_MIN);
-    _accel_cmss = MIN(_accel_cmss, GRAVITY_MSS * 100.0f * tanf(ToRad(_attitude_control.lean_angle_max_cd() * 0.01f)));
+    _speed_cms.set(MAX(_speed_cms, LOITER_SPEED_MIN));
+    _accel_cmss.set(MIN(_accel_cmss, GRAVITY_MSS * 100.0f * tanf(ToRad(_attitude_control.lean_angle_max_cd() * 0.01f))));
 }
 
 /// calc_desired_velocity - updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -235,7 +235,7 @@ int32_t AP_SteerController::get_steering_out_lat_accel(float desired_accel)
 int32_t AP_SteerController::get_steering_out_angle_error(int32_t angle_err)
 {
     if (_tau < 0.1f) {
-        _tau = 0.1f;
+        _tau.set(0.1f);
     }
 	
 	// Calculate the desired steering rate (deg/sec) from the angle error

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -354,7 +354,7 @@ void AP_YawController::autotune_start(void)
 {
     if (autotune == nullptr && rate_control_enabled()) {
         // the autotuner needs a time constant. Use an assumed tconst of 0.5
-        gains.tau = 0.5;
+        gains.tau.set(0.5);
         gains.rmax_pos.set(90);
 
         autotune = new AP_AutoTune(gains, AP_AutoTune::AUTOTUNE_YAW, aparm, rate_pid);

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -190,7 +190,7 @@ void AP_ADSB::init(void)
 {
     if (in_state.vehicle_list == nullptr) {
         // sanity check param
-        in_state.list_size_param = constrain_int16(in_state.list_size_param, 1, INT16_MAX);
+        in_state.list_size_param.set(constrain_int16(in_state.list_size_param, 1, INT16_MAX));
 
         in_state.vehicle_list = new adsb_vehicle_t[in_state.list_size_param];
 
@@ -350,7 +350,7 @@ void AP_ADSB::update(void)
         // param changed, check that it's a valid octal
         if (!is_valid_callsign(out_state.cfg.squawk_octal_param)) {
             // invalid, reset it to default
-            out_state.cfg.squawk_octal_param = ADSB_SQUAWK_OCTAL_DEFAULT;
+            out_state.cfg.squawk_octal_param.set(ADSB_SQUAWK_OCTAL_DEFAULT);
         }
         out_state.cfg.squawk_octal = (uint16_t)out_state.cfg.squawk_octal_param;
     }
@@ -616,16 +616,16 @@ void AP_ADSB::handle_out_cfg(const mavlink_uavionix_adsb_out_cfg_t &packet)
     out_state.cfg.was_set_externally = true;
 
     out_state.cfg.ICAO_id = packet.ICAO;
-    out_state.cfg.ICAO_id_param = out_state.cfg.ICAO_id_param_prev = packet.ICAO & 0x00FFFFFFFF;
+    out_state.cfg.ICAO_id_param.set(out_state.cfg.ICAO_id_param_prev = packet.ICAO & 0x00FFFFFFFF);
 
     // May contain a non-null value at the end so accept it as-is with memcpy instead of strcpy
     memcpy(out_state.cfg.callsign, packet.callsign, sizeof(out_state.cfg.callsign));
 
-    out_state.cfg.emitterType = packet.emitterType;
-    out_state.cfg.lengthWidth = packet.aircraftSize;
-    out_state.cfg.gpsOffsetLat = packet.gpsOffsetLat;
-    out_state.cfg.gpsOffsetLon = packet.gpsOffsetLon;
-    out_state.cfg.rfSelect = packet.rfSelect;
+    out_state.cfg.emitterType.set(packet.emitterType);
+    out_state.cfg.lengthWidth.set(packet.aircraftSize);
+    out_state.cfg.gpsOffsetLat.set(packet.gpsOffsetLat);
+    out_state.cfg.gpsOffsetLon.set(packet.gpsOffsetLon);
+    out_state.cfg.rfSelect.set(packet.rfSelect);
     out_state.cfg.stall_speed_cm = packet.stallSpeed;
 
     // guard against string with non-null end char

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -150,7 +150,7 @@ public:
     bool get_vehicle_by_ICAO(const uint32_t icao, adsb_vehicle_t &vehicle) const;
 
     uint32_t get_special_ICAO_target() const { return (uint32_t)_special_ICAO_target; };
-    void set_special_ICAO_target(const uint32_t new_icao_target) { _special_ICAO_target = (int32_t)new_icao_target; };
+    void set_special_ICAO_target(const uint32_t new_icao_target) { _special_ICAO_target.set((int32_t)new_icao_target); };
     bool is_special_vehicle(uint32_t icao) const { return _special_ICAO_target != 0 && (_special_ICAO_target == (int32_t)icao); }
 
     // confirm a value is a valid callsign

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -587,7 +587,7 @@ AP_AHRS_DCM::drift_correction_yaw(void)
 
     // sanity check _kp_yaw
     if (_kp_yaw < AP_AHRS_YAW_P_MIN) {
-        _kp_yaw = AP_AHRS_YAW_P_MIN;
+        _kp_yaw.set(AP_AHRS_YAW_P_MIN);
     }
 
     // update the proportional control to drag the
@@ -927,7 +927,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
 
     // sanity check _kp value
     if (_kp < AP_AHRS_RP_P_MIN) {
-        _kp = AP_AHRS_RP_P_MIN;
+        _kp.set(AP_AHRS_RP_P_MIN);
     }
 
     // we now want to calculate _omega_P and _omega_I. The

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -95,8 +95,8 @@ public:
     void update();
 
     // enable or disable avoidance
-    void enable() { _enabled = true; };
-    void disable() { _enabled = false; };
+    void enable() { _enabled.set(true); };
+    void disable() { _enabled.set(false); };
 
     // current overall threat level
     MAV_COLLISION_THREAT_LEVEL current_threat_level() const;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -885,7 +885,7 @@ void AP_Baro::update(void)
             // update altitude calculation
             float ground_pressure = sensors[i].ground_pressure;
             if (!is_positive(ground_pressure) || isnan(ground_pressure) || isinf(ground_pressure)) {
-                sensors[i].ground_pressure = sensors[i].pressure;
+                sensors[i].ground_pressure.set(sensors[i].pressure);
             }
             float altitude = sensors[i].altitude;
             float corrected_pressure = sensors[i].pressure + sensors[i].p_correction;

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -173,7 +173,7 @@ public:
     uint8_t num_instances(void) const { return _num_sensors; }
 
     // set baro drift amount
-    void set_baro_drift_altitude(float alt) { _alt_offset = alt; }
+    void set_baro_drift_altitude(float alt) { _alt_offset.set(alt); }
 
     // get baro drift amount
     float get_baro_drift_offset(void) const { return _alt_offset_active; }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -39,8 +39,8 @@ AP_BattMonitor_SMBus::AP_BattMonitor_SMBus(AP_BattMonitor &mon,
     _state.var_info = var_info;
 
     _bus.set_default(i2c_bus);
-    _params._serial_number = AP_BATT_SERIAL_NUMBER_DEFAULT;
-    _params._pack_capacity = 0;
+    _params._serial_number.set(AP_BATT_SERIAL_NUMBER_DEFAULT);
+    _params._pack_capacity.set(0);
 }
 
 void AP_BattMonitor_SMBus::init(void)

--- a/libraries/AP_Beacon/AP_Beacon_Backend.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Backend.cpp
@@ -90,7 +90,7 @@ Vector3f AP_Beacon_Backend::correct_for_orient_yaw(const Vector3f &vector)
 
     // check for change in parameter value and update constants
     if (orient_yaw_deg != _frontend.orient_yaw) {
-        _frontend.orient_yaw = wrap_180(_frontend.orient_yaw.get());
+        _frontend.orient_yaw.set(wrap_180(_frontend.orient_yaw.get()));
 
         // calculate rotation constants
         orient_yaw_deg = _frontend.orient_yaw;

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -75,7 +75,7 @@ void AP_BoardConfig::board_setup_drivers(void)
 {
     if (state.board_type == PX4_BOARD_OLDDRIVERS) {
         printf("Old drivers no longer supported\n");
-        state.board_type = PX4_BOARD_AUTO;
+        state.board_type.set(PX4_BOARD_AUTO);
     }
 
     // run board auto-detection

--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -123,7 +123,7 @@ AP_RunCam::AP_RunCam()
         AP_HAL::panic("AP_RunCam must be singleton");
     }
     _singleton = this;
-    _cam_type = constrain_int16(_cam_type, 0, RUNCAM_MAX_DEVICE_TYPES);
+    _cam_type.set(constrain_int16(_cam_type, 0, RUNCAM_MAX_DEVICE_TYPES));
     _video_recording = VideoOption(_cam_control_option & uint8_t(ControlOption::VIDEO_RECORDING_AT_BOOT));
 }
 
@@ -950,7 +950,7 @@ void AP_RunCam::parse_device_info(const Request& request)
     uint8_t featureLowBits = request._recv_buf[2];
     uint8_t featureHighBits = request._recv_buf[3];
     if (!has_feature(Feature::FEATURES_OVERRIDE)) {
-        _features = (featureHighBits << 8) | featureLowBits;
+        _features.set((featureHighBits << 8) | featureLowBits);
     }
     if (_features > 0) {
         _state = State::INITIALIZED;

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1905,7 +1905,7 @@ bool Compass::configured(uint8_t i)
     // if dev_id loaded from eeprom is different from detected dev id or dev_id loaded from eeprom is different from cached dev_id, compass is unconfigured
     if (_state[id].dev_id != _state[id].detected_dev_id || _state[id].dev_id != dev_id_cache_value) {
         // restore cached value
-        _state[id].dev_id = dev_id_cache_value;
+        _state[id].dev_id.set(dev_id_cache_value);
         // return failure
         return false;
     }
@@ -1957,7 +1957,7 @@ bool Compass::configured(char *failure_msg, uint8_t failure_msg_len)
 void Compass::motor_compensation_type(const uint8_t comp_type)
 {
     if (_motor_comp_type <= AP_COMPASS_MOT_COMP_CURRENT && _motor_comp_type != (int8_t)comp_type) {
-        _motor_comp_type = (int8_t)comp_type;
+        _motor_comp_type.set((int8_t)comp_type);
         _thr = 0; // set current  throttle to zero
         for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             set_motor_compensation(i, Vector3f(0,0,0)); // clear out invalid compensation vectors

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -147,7 +147,7 @@ AP_Follow::AP_Follow() :
 void AP_Follow::clear_offsets_if_required()
 {
     if (_offsets_were_zero) {
-        _offset = Vector3f();
+        _offset.set(Vector3f());
     }
     _offsets_were_zero = false;
 }
@@ -440,11 +440,11 @@ void AP_Follow::init_offsets_if_required(const Vector3f &dist_vec_ned)
     float target_heading_deg;
     if ((_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) && get_target_heading_deg(target_heading_deg)) {
         // rotate offsets from north facing to vehicle's perspective
-        _offset = rotate_vector(-dist_vec_ned, -target_heading_deg);
+        _offset.set(rotate_vector(-dist_vec_ned, -target_heading_deg));
         gcs().send_text(MAV_SEVERITY_INFO, "Relative follow offset loaded");
     } else {
         // initialise offset in NED frame
-        _offset = -dist_vec_ned;
+        _offset.set(-dist_vec_ned);
         // ensure offset_type used matches frame of offsets saved
         _offset_type.set(AP_FOLLOW_OFFSET_TYPE_NED);
         gcs().send_text(MAV_SEVERITY_INFO, "N-E-D follow offset loaded");

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -446,7 +446,7 @@ void AP_Follow::init_offsets_if_required(const Vector3f &dist_vec_ned)
         // initialise offset in NED frame
         _offset = -dist_vec_ned;
         // ensure offset_type used matches frame of offsets saved
-        _offset_type = AP_FOLLOW_OFFSET_TYPE_NED;
+        _offset_type.set(AP_FOLLOW_OFFSET_TYPE_NED);
         gcs().send_text(MAV_SEVERITY_INFO, "N-E-D follow offset loaded");
     }
 }

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -48,7 +48,7 @@ public:
     bool enabled() const { return _enabled; }
 
     // set which target to follow
-    void set_target_sysid(uint8_t sysid) { _sysid = sysid; }
+    void set_target_sysid(uint8_t sysid) { _sysid.set(sysid); }
 
     // restore offsets to zero if necessary, should be called when vehicle exits follow mode
     void clear_offsets_if_required();

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -460,7 +460,7 @@ void AP_GPS::init(const AP_SerialManager& serial_manager)
     // sanity check update rate
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         if (_rate_ms[i] <= 0 || _rate_ms[i] > GPS_MAX_RATE_MS) {
-            _rate_ms[i] = GPS_MAX_RATE_MS;
+            _rate_ms[i].set(GPS_MAX_RATE_MS);
         }
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1566,12 +1566,12 @@ AP_InertialSensor::_init_gyro()
                                 (unsigned)k,
                                 (double)ToDeg(best_diff[k]),
                                 (double)GYRO_INIT_MAX_DIFF_DPS);
-            _gyro_offset[k] = best_avg[k];
+            _gyro_offset[k].set(best_avg[k]);
             // flag calibration as failed for this gyro
             _gyro_cal_ok[k] = false;
         } else {
             _gyro_cal_ok[k] = true;
-            _gyro_offset[k] = new_gyro_offset[k];
+            _gyro_offset[k].set(new_gyro_offset[k]);
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
             caltemp_gyro[k].set(0.5 * (get_temperature(k) + start_temperature[k]));
 #endif
@@ -2378,8 +2378,8 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
         DEV_PRINTF("\nFAILED\n");
         // restore old values
         for (uint8_t k=0; k<num_accels; k++) {
-            _accel_offset[k] = saved_offsets[k];
-            _accel_scale[k] = saved_scaling[k];
+            _accel_offset[k].set(saved_offsets[k]);
+            _accel_scale[k].set(saved_scaling[k]);
         }
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1573,7 +1573,7 @@ AP_InertialSensor::_init_gyro()
             _gyro_cal_ok[k] = true;
             _gyro_offset[k] = new_gyro_offset[k];
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
-            caltemp_gyro[k] = 0.5 * (get_temperature(k) + start_temperature[k]);
+            caltemp_gyro[k].set(0.5 * (get_temperature(k) + start_temperature[k]));
 #endif
         }
     }

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -56,7 +56,7 @@ void AP_InertialSensor::BatchSampler::init()
         return;
     }
 
-    _required_count -= _required_count % 32; // round down to nearest multiple of 32
+    _required_count.set(_required_count - (_required_count % 32)); // round down to nearest multiple of 32
 
     const uint32_t total_allocation = 3*_required_count*sizeof(uint16_t);
     GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "INS: alloc %u bytes for ISB (free=%u)", (unsigned int)total_allocation, (unsigned int)hal.util->available_memory());

--- a/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
@@ -247,7 +247,7 @@ void AP_LoggerTest_AllTypes::setup(void)
 {
     hal.console->printf("Logger All Types 1.0\n");
 
-    log_bitmask = (uint32_t)-1;
+    log_bitmask.set((uint32_t)-1);
     logger.Init(log_structure, ARRAY_SIZE(log_structure));
     logger.set_vehicle_armed(true);
     logger.Write_Message("AP_Logger Test");

--- a/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
@@ -52,7 +52,7 @@ void AP_LoggerTest::setup(void)
 {
     hal.console->printf("Logger Log Test 1.0\n");
 
-    log_bitmask = (uint32_t)-1;
+    log_bitmask.set((uint32_t)-1);
     logger.Init(log_structure, ARRAY_SIZE(log_structure));
     logger.set_vehicle_armed(true);
     logger.Write_Message("AP_Logger Test");

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -100,9 +100,9 @@ TEST(MathTest, IsZero)
     EXPECT_TRUE(is_zero(FLT_MIN));
     EXPECT_TRUE(is_zero(-FLT_MIN));
     AP_Float t_float;
-    t_float = 0.1f;
+    t_float.set(0.1f);
     EXPECT_FALSE(is_zero(t_float));
-    t_float = 0.0f;
+    t_float.set(0.0f);
     EXPECT_TRUE(is_zero(t_float));
 }
 
@@ -113,9 +113,9 @@ TEST(MathTest, IsPositive)
     EXPECT_FALSE(is_positive(0.0f));
     EXPECT_FALSE(is_positive(-1.0f));
     AP_Float t_float;
-    t_float = 0.1f;
+    t_float.set(0.1f);
     EXPECT_TRUE(is_positive(t_float));
-    t_float = -0.1f;
+    t_float.set(-0.1f);
     EXPECT_FALSE(is_positive(t_float));
 }
 
@@ -126,9 +126,9 @@ TEST(MathTest, IsNegative)
     EXPECT_FALSE(is_negative(0.0f));
     EXPECT_FALSE(is_negative(1.0f));
     AP_Float t_float;
-    t_float = 0.1f;
+    t_float.set(0.1f);
     EXPECT_FALSE(is_negative(t_float));
-    t_float = -0.1f;
+    t_float.set(-0.1f);
     EXPECT_TRUE(is_negative(t_float));
 }
 
@@ -217,18 +217,18 @@ TEST(MathTest, MAX)
     EXPECT_EQ(2.0f, MAX(testushort, 2.0f));
     EXPECT_EQ(2.0f, MAX(testi32, 2.0f));
     AP_Float t_float;
-    t_float = 0.1f;
+    t_float.set(0.1f);
     EXPECT_EQ(2.0f, MAX(t_float, 2.0f));
     EXPECT_EQ(2.0f, MAX(2.0f, t_float));
     AP_Int8 t_int8;
-    t_int8 = 1;
+    t_int8.set(1);
     EXPECT_EQ(2, MAX(t_int8, 2));
     EXPECT_EQ(2, MAX(2, t_int8));
     AP_Int16 t_int16;
-    t_int16 = 1;
+    t_int16.set(1);
     EXPECT_EQ(2, MAX(t_int16, 2));
     AP_Int32 t_int32;
-    t_int32 = 1;
+    t_int32.set(1);
     EXPECT_EQ(2, MAX(t_int32, 2));
     EXPECT_EQ(2.0f, MAX(1.0f, 2.0f));
     EXPECT_EQ(2.0f, MAX(1.0f, 2));
@@ -275,7 +275,7 @@ TEST(MathTest, Square)
     EXPECT_EQ(1.f, sq_1);
     EXPECT_EQ(4.f, sq_2);
     AP_Float t_sqfloat;
-    t_sqfloat = sq(2);
+    t_sqfloat.set(sq(2));
     EXPECT_EQ(4.f, t_sqfloat);
 
     EXPECT_FLOAT_EQ(sq(2.3), 5.289999999999999);  // uses template sq
@@ -294,9 +294,9 @@ TEST(MathTest, Norm)
     float norm_5 = norm(3,4);
     float norm_6 = norm(4,3,12);
     AP_Float t_float1, t_float2, t_float3;
-    t_float1 = 4.0f;
-    t_float2 = 3.0f;
-    t_float3 = 12.f;
+    t_float1.set(4.0f);
+    t_float2.set(3.0f);
+    t_float3.set(12.f);
     float norm_7 = norm(t_float1, t_float2, t_float3);
 
     EXPECT_FLOAT_EQ(norm_1, 4.3174066f);

--- a/libraries/AP_Math/tests/test_math_double.cpp
+++ b/libraries/AP_Math/tests/test_math_double.cpp
@@ -23,7 +23,7 @@ TEST(MathTest, IsZeroDouble)
 TEST(MathTest, MAXDouble)
 {
     AP_Float t_float;
-    t_float = 0.1f;
+    t_float.set(0.1f);
     EXPECT_EQ(2.0, MAX(t_float, 2.0));
 }
 TEST(MathTest, IsEqualDouble)

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -167,7 +167,7 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
     _servo_test_cycle_counter = _servo_test;
 
     // ensure inputs are not passed through to servos on start-up
-    _servo_mode = SERVO_CONTROL_MODE_AUTOMATED;
+    _servo_mode.set(SERVO_CONTROL_MODE_AUTOMATED);
 
     // initialise radio passthrough for collective to middle
     _throttle_radio_passthrough = 0.5f;
@@ -536,7 +536,7 @@ void AP_MotorsHeli::update_throttle_filter()
 // reset_flight_controls - resets all controls and scalars to flight status
 void AP_MotorsHeli::reset_flight_controls()
 {
-    _servo_mode = SERVO_CONTROL_MODE_AUTOMATED;
+    _servo_mode.set(SERVO_CONTROL_MODE_AUTOMATED);
     init_outputs();
     calculate_scalars();
 }
@@ -564,7 +564,7 @@ void AP_MotorsHeli::update_throttle_hover(float dt)
         }
 
         // we have chosen to constrain the hover collective to be within the range reachable by the third order expo polynomial.
-        _collective_hover = constrain_float(_collective_hover + (dt / (dt + AP_MOTORS_HELI_COLLECTIVE_HOVER_TC)) * (curr_collective - _collective_hover), AP_MOTORS_HELI_COLLECTIVE_HOVER_MIN, AP_MOTORS_HELI_COLLECTIVE_HOVER_MAX);
+        _collective_hover.set(constrain_float(_collective_hover + (dt / (dt + AP_MOTORS_HELI_COLLECTIVE_HOVER_TC)) * (curr_collective - _collective_hover), AP_MOTORS_HELI_COLLECTIVE_HOVER_MIN, AP_MOTORS_HELI_COLLECTIVE_HOVER_MAX));
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -353,20 +353,20 @@ void AP_MotorsHeli_Dual::calculate_scalars()
 {
     // range check collective min, max and mid
     if( _collective_min >= _collective_max ) {
-        _collective_min = AP_MOTORS_HELI_COLLECTIVE_MIN;
-        _collective_max = AP_MOTORS_HELI_COLLECTIVE_MAX;
+        _collective_min.set(AP_MOTORS_HELI_COLLECTIVE_MIN);
+        _collective_max.set(AP_MOTORS_HELI_COLLECTIVE_MAX);
     }
 
 
     // range check collective min, max and mid for rear swashplate
     if( _collective2_min >= _collective2_max ) {
-        _collective2_min = AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN;
-        _collective2_max = AP_MOTORS_HELI_DUAL_COLLECTIVE2_MAX;
+        _collective2_min.set(AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN);
+        _collective2_max.set(AP_MOTORS_HELI_DUAL_COLLECTIVE2_MAX);
     }
 
-    _collective_zero_thrust_deg = constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg);
+    _collective_zero_thrust_deg.set(constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg));
 
-    _collective_land_min_deg = constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg);
+    _collective_land_min_deg.set(constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg));
 
     if (!is_equal((float)_collective_max_deg, (float)_collective_min_deg)) {
         // calculate collective zero thrust point as a number from 0 to 1

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -132,13 +132,13 @@ void AP_MotorsHeli_Quad::calculate_scalars()
 {
     // range check collective min, max and mid
     if( _collective_min >= _collective_max ) {
-        _collective_min = AP_MOTORS_HELI_COLLECTIVE_MIN;
-        _collective_max = AP_MOTORS_HELI_COLLECTIVE_MAX;
+        _collective_min.set(AP_MOTORS_HELI_COLLECTIVE_MIN);
+        _collective_max.set(AP_MOTORS_HELI_COLLECTIVE_MAX);
     }
 
-    _collective_zero_thrust_deg = constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg);
+    _collective_zero_thrust_deg.set(constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg));
 
-    _collective_land_min_deg = constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg);
+    _collective_land_min_deg.set(constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg));
 
     if (!is_equal((float)_collective_max_deg, (float)_collective_min_deg)) {
         // calculate collective zero thrust point as a number from 0 to 1

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -72,7 +72,7 @@ public:
     uint8_t     get_control_mode() const { return _control_mode; }
 
     // set_critical_speed
-    void        set_critical_speed(float critical_speed) { _critical_speed = critical_speed; }
+    void        set_critical_speed(float critical_speed) { _critical_speed.set(critical_speed); }
 
     // get_desired_speed
     float       get_desired_speed() const { return _desired_speed; }
@@ -88,13 +88,13 @@ public:
     float       get_governor_output() const { return _governor_output; }
     void        governor_reset();
     float       get_control_output() const { return _control_output; }
-    void        set_idle_output(float idle_output) { _idle_output = idle_output; }
+    void        set_idle_output(float idle_output) { _idle_output.set(idle_output); }
     void        autothrottle_run();
     void        set_throttle_curve();
 
     // functions for ramp and runup timers, runup_complete flag
-    void        set_ramp_time(int8_t ramp_time) { _ramp_time = ramp_time; }
-    void        set_runup_time(int8_t runup_time) { _runup_time = runup_time; }
+    void        set_ramp_time(int8_t ramp_time) { _ramp_time.set(ramp_time); }
+    void        set_runup_time(int8_t runup_time) { _runup_time.set(runup_time); }
     bool        is_runup_complete() const { return _runup_complete; }
 
     // is_spooldown_complete

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -310,13 +310,13 @@ void AP_MotorsHeli_Single::calculate_scalars()
 {
     // range check collective min, max and zero
     if( _collective_min >= _collective_max ) {
-        _collective_min = AP_MOTORS_HELI_COLLECTIVE_MIN;
-        _collective_max = AP_MOTORS_HELI_COLLECTIVE_MAX;
+        _collective_min.set(AP_MOTORS_HELI_COLLECTIVE_MIN);
+        _collective_max.set(AP_MOTORS_HELI_COLLECTIVE_MAX);
     }
 
-    _collective_zero_thrust_deg = constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg);
+    _collective_zero_thrust_deg.set(constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg));
 
-    _collective_land_min_deg = constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg);
+    _collective_land_min_deg.set(constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg));
 
     if (!is_equal((float)_collective_max_deg, (float)_collective_min_deg)) {
         // calculate collective zero thrust point as a number from 0 to 1
@@ -467,7 +467,7 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
         // also not required if we are using external gyro
         if ((_main_rotor.get_control_output() > _main_rotor.get_idle_output()) && _tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
             // sanity check collective_yaw_effect
-            _collective_yaw_effect = constrain_float(_collective_yaw_effect, -AP_MOTORS_HELI_SINGLE_COLYAW_RANGE, AP_MOTORS_HELI_SINGLE_COLYAW_RANGE);
+            _collective_yaw_effect.set(constrain_float(_collective_yaw_effect, -AP_MOTORS_HELI_SINGLE_COLYAW_RANGE, AP_MOTORS_HELI_SINGLE_COLYAW_RANGE));
             // the 4.5 scaling factor is to bring the values in line with previous releases
             yaw_offset = _collective_yaw_effect * fabsf(collective_out - _collective_zero_thrust_pct) / 4.5f;
         }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -82,7 +82,7 @@ public:
     uint32_t get_motor_mask() override;
 
     // ext_gyro_gain - set external gyro gain in range 0 ~ 1000
-    void ext_gyro_gain(float gain)  override { if (gain >= 0 && gain <= 1000) { _ext_gyro_gain_std = gain; }}
+    void ext_gyro_gain(float gain)  override { if (gain >= 0 && gain <= 1000) { _ext_gyro_gain_std.set(gain); }}
 
     // has_flybar - returns true if we have a mechical flybar
     bool has_flybar() const  override { return _flybar_mode; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -94,9 +94,9 @@ void AP_MotorsHeli_Swash::configure()
     _collective_direction = static_cast<CollectiveDirection>(_swash_coll_dir.get());
     _make_servo_linear = _linear_swash_servo;
     if (_swash_type == SWASHPLATE_TYPE_H3) {
-        enable = 1;
+        enable.set(1);
     } else {
-        enable = 0;
+        enable.set(0);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -383,7 +383,7 @@ void AP_MotorsMulticopter::update_lift_max_from_batt_voltage()
         return;
     }
 
-    _batt_voltage_min = MAX(_batt_voltage_min, _batt_voltage_max * 0.6f);
+    _batt_voltage_min.set(MAX(_batt_voltage_min, _batt_voltage_max * 0.6f));
 
     // contrain resting voltage estimate (resting voltage is actual voltage with sag removed based on current draw and resistance)
     _batt_voltage_resting_estimate = constrain_float(_batt_voltage_resting_estimate, _batt_voltage_min, _batt_voltage_max);
@@ -529,7 +529,7 @@ void AP_MotorsMulticopter::update_throttle_hover(float dt)
 {
     if (_throttle_hover_learn != HOVER_LEARN_DISABLED) {
         // we have chosen to constrain the hover throttle to be within the range reachable by the third order expo polynomial.
-        _throttle_hover = constrain_float(_throttle_hover + (dt / (dt + AP_MOTORS_THST_HOVER_TC)) * (get_throttle() - _throttle_hover), AP_MOTORS_THST_HOVER_MIN, AP_MOTORS_THST_HOVER_MAX);
+        _throttle_hover.set(constrain_float(_throttle_hover + (dt / (dt + AP_MOTORS_THST_HOVER_TC)) * (get_throttle() - _throttle_hover), AP_MOTORS_THST_HOVER_MIN, AP_MOTORS_THST_HOVER_MAX));
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -42,7 +42,7 @@ public:
     void                output_min() override;
 
     // set_yaw_headroom - set yaw headroom (yaw is given at least this amount of pwm)
-    void                set_yaw_headroom(int16_t pwm) { _yaw_headroom = pwm; }
+    void                set_yaw_headroom(int16_t pwm) { _yaw_headroom.set(pwm); }
 
     // update_throttle_range - update throttle endpoints
     void                update_throttle_range();

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -159,7 +159,7 @@ void AP_MotorsTri::output_armed_stabilizing()
     SRV_Channels::set_angle(SRV_Channels::get_motor_function(AP_MOTORS_CH_TRI_YAW), _yaw_servo_angle_max_deg*100);
 
     // sanity check YAW_SV_ANGLE parameter value to avoid divide by zero
-    _yaw_servo_angle_max_deg = constrain_float(_yaw_servo_angle_max_deg, AP_MOTORS_TRI_SERVO_RANGE_DEG_MIN, AP_MOTORS_TRI_SERVO_RANGE_DEG_MAX);
+    _yaw_servo_angle_max_deg.set(constrain_float(_yaw_servo_angle_max_deg, AP_MOTORS_TRI_SERVO_RANGE_DEG_MIN, AP_MOTORS_TRI_SERVO_RANGE_DEG_MAX));
 
     // apply voltage and air pressure compensation
     const float compensation_gain = get_compensation_gain();

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -621,9 +621,9 @@ MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_lon
         return MAV_RESULT_FAILED;
     }
     _backends[_primary]->set_mode((MAV_MOUNT_MODE)packet.param1);
-    state[_primary]._stab_roll = packet.param2;
-    state[_primary]._stab_tilt = packet.param3;
-    state[_primary]._stab_pan = packet.param4;
+    state[_primary]._stab_roll.set(packet.param2);
+    state[_primary]._stab_tilt.set(packet.param3);
+    state[_primary]._stab_pan.set(packet.param4);
 
     return MAV_RESULT_ACCEPTED;
 }

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -60,9 +60,9 @@ void AP_Mount_Backend::set_target_sysid(uint8_t sysid)
 void AP_Mount_Backend::handle_mount_configure(const mavlink_mount_configure_t &packet)
 {
     set_mode((MAV_MOUNT_MODE)packet.mount_mode);
-    _state._stab_roll = packet.stab_roll;
-    _state._stab_tilt = packet.stab_pitch;
-    _state._stab_pan = packet.stab_yaw;
+    _state._stab_roll.set(packet.stab_roll);
+    _state._stab_tilt.set(packet.stab_pitch);
+    _state._stab_pan.set(packet.stab_yaw);
 }
 
 // process MOUNT_CONTROL messages received from GCS. deprecated.

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -240,7 +240,7 @@ AP_OSD::AP_OSD()
     AP_Param::setup_object_defaults(this, var_info);
 #if OSD_ENABLED
     // default first screen enabled
-    screen[0].enabled = 1;
+    screen[0].enabled.set(1);
     previous_pwm_screen = -1;
 #endif
 #ifdef WITH_SITL_OSD

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -375,11 +375,11 @@ void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
 
     if (param != nullptr) {
         // update the stored index
-        setting._param_group = setting._current_token.group_element;
-        setting._param_key = AP_Param::get_persistent_key(setting._current_token.key);
-        setting._param_idx = setting._current_token.idx;
+        setting._param_group.set(setting._current_token.group_element);
+        setting._param_key.set(AP_Param::get_persistent_key(setting._current_token.key));
+        setting._param_idx.set(setting._current_token.idx);
         setting._param = param;
-        setting._type = OSD_PARAM_NONE;
+        setting._type.set(OSD_PARAM_NONE);
         // force update() to refresh the token
         setting._current_token.key = 0;
         setting._current_token.idx = 0;

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -239,34 +239,34 @@ extern const AP_HAL::HAL& hal;
 AP_OSD_ParamSetting::AP_OSD_ParamSetting(uint8_t param_number, bool _enabled, uint8_t x, uint8_t y,  int16_t key, int8_t idx, int32_t group, int8_t type, float min, float max, float incr)
     : AP_OSD_Setting(_enabled, x, y), _param_number(param_number)
 {
-    _param_group = group;
-    _param_idx = idx;
-    _param_key = key;
-    _param_min = min;
-    _param_max = max;
-    _param_incr = incr;
-    _type = type;
+    _param_group.set(group);
+    _param_idx.set(idx);
+    _param_key.set(key);
+    _param_min.set(min);
+    _param_max.set(max);
+    _param_incr.set(incr);
+    _type.set(type);
 }
 
 // default constructor that just sets some sensible defaults that exist on all platforms
 AP_OSD_ParamSetting::AP_OSD_ParamSetting(uint8_t param_number)
     : AP_OSD_Setting(false, 2, param_number + 1), _param_number(param_number)
 {
-    _param_min = 0.0f;
-    _param_max = 1.0f;
-    _param_incr = 0.001f;
-    _type = OSD_PARAM_NONE;
+    _param_min.set(0.0f);
+    _param_max.set(1.0f);
+    _param_incr.set(0.001f);
+    _type.set(OSD_PARAM_NONE);
 }
 
 // construct a setting from a compact static initializer structure
 AP_OSD_ParamSetting::AP_OSD_ParamSetting(const Initializer& initializer)
     : AP_OSD_ParamSetting(initializer.index)
 {
-    _param_group = initializer.token.group_element;
-    _param_idx = initializer.token.idx;
-    _param_key = initializer.token.key;
-    _type = initializer.type;
-    enabled = true;
+    _param_group.set(initializer.token.group_element);
+    _param_idx.set(initializer.token.idx);
+    _param_key.set(initializer.token.key);
+    _type.set(initializer.type);
+    enabled.set(true);
 }
 
 // update the contained parameter
@@ -287,7 +287,7 @@ void AP_OSD_ParamSetting::update()
     }
 
     if (_param == nullptr) {
-        enabled = false;
+        enabled.set(false);
     } else {
         guess_ranges();
     }
@@ -406,13 +406,13 @@ void AP_OSD_ParamSetting::guess_ranges(bool force)
         }
 
         if (force || !_param_min.configured()) {
-            _param_min = min;
+            _param_min.set(min);
         }
         if (force || !_param_max.configured()) {
-            _param_max = max;
+            _param_max.set(max);
         }
         if (force || !_param_incr.configured()) {
-            _param_incr = incr;
+            _param_incr.set(incr);
         }
     }
 }
@@ -438,9 +438,9 @@ bool AP_OSD_ParamSetting::set_from_metadata()
 {
     // check for statically configured setting metadata
     if (_type > 0 && _type < OSD_PARAM_NUM_TYPES && _param_metadata[_type - 1].values_max > 0) {
-        _param_incr = _param_metadata[_type - 1].increment;
-        _param_min = _param_metadata[_type - 1].min_value;
-        _param_max = _param_metadata[_type - 1].max_value;
+        _param_incr.set(_param_metadata[_type - 1].increment);
+        _param_min.set(_param_metadata[_type - 1].min_value);
+        _param_max.set(_param_metadata[_type - 1].max_value);
         return true;
     }
     return false;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1290,7 +1290,7 @@ void AP_OSD_Screen::draw_avgcellvolt(uint8_t x, uint8_t y)
     uint8_t p = (100 - pct) / 16.6;
     float v = battery.voltage();
     // calculate cell count - WARNING this can be inaccurate if the LIPO/LIION  battery is far from fully charged when attached and is used in this panel
-    osd->max_battery_voltage = MAX(osd->max_battery_voltage,v);
+    osd->max_battery_voltage.set(MAX(osd->max_battery_voltage,v));
     if (osd->cell_count > 0) {
         v = v / osd->cell_count;
         backend->write(x,y, v < osd->warn_avgcellvolt, "%c%1.2f%c", SYMBOL(SYM_BATT_FULL) + p, v, SYMBOL(SYM_VOLT));

--- a/libraries/AP_OSD/AP_OSD_Setting.cpp
+++ b/libraries/AP_OSD/AP_OSD_Setting.cpp
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_OSD_Setting::var_info[] = {
 // constructor
 AP_OSD_Setting::AP_OSD_Setting(bool _enabled, uint8_t x, uint8_t y)
 {
-    enabled = _enabled;
-    xpos = x;
-    ypos = y;
+    enabled.set(_enabled);
+    xpos.set(x);
+    ypos.set(y);
 }

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
@@ -114,7 +114,7 @@ void AP_OpticalFlow_SITL::update(void)
         // cope with updates to the delay control
         if (_sitl->flow_delay > 0 &&
             (uint8_t)(_sitl->flow_delay) > ARRAY_SIZE(optflow_data)) {
-            _sitl->flow_delay = ARRAY_SIZE(optflow_data);
+            _sitl->flow_delay.set(ARRAY_SIZE(optflow_data));
         }
         optflow_delay = _sitl->flow_delay;
         for (uint8_t i=0; i<optflow_delay; i++) {

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -87,7 +87,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
 /// enabled - enable or disable parachute release
 void AP_Parachute::enabled(bool on_off)
 {
-    _enabled = on_off;
+    _enabled.set(on_off);
 
     // clear release_time
     _release_time = 0;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -893,35 +893,6 @@ public:
         return _value;
     }
 
-    /// Copy assignment from T is equivalent to ::set.
-    ///
-    AP_ParamT<T,PT>& operator= (const T &v) {
-        _value = v;
-        return *this;
-    }
-
-    /// bit ops on parameters
-    ///
-    AP_ParamT<T,PT>& operator |=(const T &v) {
-        _value |= v;
-        return *this;
-    }
-
-    AP_ParamT<T,PT>& operator &=(const T &v) {
-        _value &= v;
-        return *this;
-    }
-
-    AP_ParamT<T,PT>& operator +=(const T &v) {
-        _value += v;
-        return *this;
-    }
-
-    AP_ParamT<T,PT>& operator -=(const T &v) {
-        _value -= v;
-        return *this;
-    }
-
     /// AP_ParamT types can implement AP_Param::cast_to_float
     ///
     float cast_to_float(void) const {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -973,13 +973,6 @@ public:
         return _value;
     }
 
-    /// Copy assignment from T is equivalent to ::set.
-    ///
-    AP_ParamV<T,PT>& operator=(const T &v) {
-        _value = v;
-        return *this;
-    }
-
 protected:
     T        _value;
 };

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -175,12 +175,12 @@ void AP_PiccoloCAN::loop()
         }
 
         // Calculate the output rate for ESC commands
-        _esc_hz = constrain_int16(_esc_hz, PICCOLO_MSG_RATE_HZ_MIN, PICCOLO_MSG_RATE_HZ_MAX);
+        _esc_hz.set(constrain_int16(_esc_hz, PICCOLO_MSG_RATE_HZ_MIN, PICCOLO_MSG_RATE_HZ_MAX));
 
         uint16_t escCmdRateMs = 1000 / _esc_hz;
 
         // Calculate the output rate for servo commands
-        _srv_hz = constrain_int16(_srv_hz, PICCOLO_MSG_RATE_HZ_MIN, PICCOLO_MSG_RATE_HZ_MAX);
+        _srv_hz.set(constrain_int16(_srv_hz, PICCOLO_MSG_RATE_HZ_MIN, PICCOLO_MSG_RATE_HZ_MAX));
 
         uint16_t servoCmdRateMs = 1000 / _srv_hz;
 

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -450,7 +450,7 @@ void AP_Scheduler::task_info(ExpandingString &str)
 
     // dynamically enable statistics collection
     if (!(_options & uint8_t(Options::RECORD_TASK_INFO))) {
-        _options |= uint8_t(Options::RECORD_TASK_INFO);
+        _options.set(_options | uint8_t(Options::RECORD_TASK_INFO));
         return;
     }
 

--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -99,7 +99,7 @@ void AP_SmartRTL::init()
     }
 
     // constrain the path length, in case the user decided to make the path unreasonably long.
-    _points_max = constrain_int16(_points_max, 0, SMARTRTL_POINTS_MAX);
+    _points_max.set(constrain_int16(_points_max, 0, SMARTRTL_POINTS_MAX));
 
     // check if user has disabled SmartRTL
     if (_points_max == 0 || !is_positive(_accuracy)) {

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -102,7 +102,7 @@ public:
     void update(void);
 
     bool enabled() const { return enable; }
-    void set_enabled(bool _enable) { enable = _enable; }
+    void set_enabled(bool _enable) { enable.set(_enable); }
 
     // return status enum for health reporting
     enum TerrainStatus status(void) const { return system_status; }

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -235,10 +235,10 @@ void AP_VideoTX::update(void)
     // manipulate pitmode if pitmode-on-disarm or power-on-arm is set
     if (has_option(VideoOptions::VTX_PITMODE_ON_DISARM) || has_option(VideoOptions::VTX_PITMODE_UNTIL_ARM)) {
         if (hal.util->get_soft_armed() && has_option(VideoOptions::VTX_PITMODE)) {
-            _options &= ~uint8_t(VideoOptions::VTX_PITMODE);
+            _options.set(_options & ~uint8_t(VideoOptions::VTX_PITMODE));
         } else if (!hal.util->get_soft_armed() && !has_option(VideoOptions::VTX_PITMODE)
             && has_option(VideoOptions::VTX_PITMODE_ON_DISARM)) {
-            _options |= uint8_t(VideoOptions::VTX_PITMODE);
+            _options.set(_options | uint8_t(VideoOptions::VTX_PITMODE));
         }
     }
 }

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -383,7 +383,7 @@ void AP_WindVane::record_home_heading()
 bool AP_WindVane::start_direction_calibration()
 {
     if (enabled() && (_calibration == 0)) {
-        _calibration = 1;
+        _calibration.set(1);
         return true;
     }
     return false;
@@ -393,7 +393,7 @@ bool AP_WindVane::start_direction_calibration()
 bool AP_WindVane::start_speed_calibration()
 {
     if (enabled() && (_calibration == 0)) {
-        _calibration = 2;
+        _calibration.set(2);
         return true;
     }
     return false;

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -494,9 +494,9 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
 // sanity check parameters
 void AP_MotorsUGV::sanity_check_parameters()
 {
-    _throttle_min = constrain_int16(_throttle_min, 0, 20);
-    _throttle_max = constrain_int16(_throttle_max, 30, 100);
-    _vector_angle_max = constrain_float(_vector_angle_max, 0.0f, 90.0f);
+    _throttle_min.set(constrain_int16(_throttle_min, 0, 20));
+    _throttle_max.set(constrain_int16(_throttle_max, 30, 100));
+    _vector_angle_max.set(constrain_float(_vector_angle_max, 0.0f, 90.0f));
 }
 
 // setup pwm output type

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -100,7 +100,7 @@ public:
     void set_default_harmonics(uint8_t hmncs) { _harmonics.set_default(hmncs); }
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
-    void set_reference(float ref) { _reference = ref; }
+    void set_reference(float ref) { _reference.set(ref); }
     // notch options
     bool hasOption(Options option) const { return _options & uint16_t(option); }
     // notch dynamic tracking mode

--- a/libraries/PID/PID.h
+++ b/libraries/PID/PID.h
@@ -63,7 +63,7 @@ public:
                              const float    i,
                              const float    d,
                              const int16_t  imaxval) {
-        _kp = p; _ki = i; _kd = d; _imax = imaxval;
+        _kp.set(p); _ki.set(i); _kd.set(d); _imax.set(imaxval);
     }
 
     float        kP() const {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -447,7 +447,7 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
 
     // in the first call here, if a speedup option is specified, overwrite it
     if (is_equal(last_speedup, -1.0f) && !is_equal(get_speedup(), 1.0f)) {
-        sitl->speedup = get_speedup();
+        sitl->speedup.set(get_speedup());
     }
     
     if (!is_equal(last_speedup, float(sitl->speedup)) && sitl->speedup > 0) {
@@ -1031,7 +1031,7 @@ void Aircraft::add_shove_forces(Vector3f &rot_accel, Vector3f &body_accel)
         body_accel.z += sitl->shove.z;
     } else {
         sitl->shove.start_ms = 0;
-        sitl->shove.t = 0;
+        sitl->shove.t.set(0);
     }
 }
 
@@ -1120,7 +1120,7 @@ void Aircraft::add_twist_forces(Vector3f &rot_accel)
         rot_accel.z += sitl->twist.z;
     } else {
         sitl->twist.start_ms = 0;
-        sitl->twist.t = 0;
+        sitl->twist.t.set(0);
     }
 }
 

--- a/libraries/SITL/SIM_Precland.cpp
+++ b/libraries/SITL/SIM_Precland.cpp
@@ -194,8 +194,8 @@ void SIM_Precland::update(const Location &loc, const Vector3d &position)
 
 void SIM_Precland::set_default_location(float lat, float lon, int16_t yaw) {
     if (is_zero(_origin_lat) && is_zero(_origin_lon)) {
-        _origin_lat = lat;
-        _origin_lon = lon;
-        _orient_yaw = yaw;
+        _origin_lat.set(lat);
+        _origin_lon.set(lon);
+        _orient_yaw.set(yaw);
     }
 }

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -387,10 +387,10 @@ public:
         return (AP_HAL::Util::safety_state)_safety_switch_state.get();
     }
     void force_safety_off() {
-        _safety_switch_state = (uint8_t)AP_HAL::Util::SAFETY_ARMED;
+        _safety_switch_state.set((uint8_t)AP_HAL::Util::SAFETY_ARMED);
     }
     bool force_safety_on() {
-        _safety_switch_state = (uint8_t)AP_HAL::Util::SAFETY_DISARMED;
+        _safety_switch_state.set((uint8_t)AP_HAL::Util::SAFETY_DISARMED);
         return true;
     }
 


### PR DESCRIPTION
This removes the inline `=` methods for params replacing with `set()`. Mainly because I was trying to track down where we should be setting the default along with the value. 

I do think this is a improvement, makes it clear if a value is a param. Should be no change in bahavour.

Note that this omits the ones converted to `set_and_default` in https://github.com/ArduPilot/ardupilot/pull/20972 so won't build yet.

