### PR TITLE
Plane: fixed issue with fwd throttle and ICE cut

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -915,6 +915,9 @@ void Plane::set_servos(void)
     if (g2.ice_control.throttle_override(override_pct)) {
         // the ICE controller wants to override the throttle for starting, idle, or redline
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, override_pct);
+#if HAL_QUADPLANE_ENABLED
+        quadplane.vel_forward.integrator = 0;
+#endif
     }
 
     // run output mixer and send values to the hal for output

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -129,6 +129,10 @@ private:
     };
     AP_Int16 options;
 
+    bool option_set(Options option) const {
+        return (options & uint16_t(option)) != 0;
+    }
+
     // start_chan debounce
     uint16_t start_chan_last_value = 1500;
     uint32_t start_chan_last_ms;


### PR DESCRIPTION
this fixes an issue with EFI engines that use low throttle demand to stop the engine, instead of using an ignition channel. This option needs to be set on these aircraft to prevent the idle governor or the fwd throttle integrator in quadplanes from keeping the engine on when the pilot asks for it to be off.
I'm marking this as a bug as for aircraft like this it can be a very serious issue, causing a crash 
