### PR TITLE
Plane: don't failsafe when in RTL_AUTOLAND landing sequence

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -12,6 +12,9 @@ bool Plane::failsafe_in_landing_sequence() const
         return true;
     }
 #endif
+    if (mission.get_in_landing_sequence_flag()) {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
when in AUTO and already in the landing sequence then don't trigger a
failsafe