### PR TITLE
SITL: Make Yaw control scale with aircraft size

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8286,15 +8286,15 @@ class AutoTestCopter(AutoTest):
 
         # move vehicle on x direction
         location = self.offset_location_ne(location=self.mav.location(), metres_north=0, metres_east=-300)
-        self.mav.mav.set_position_target_local_ned_send(
+        self.mav.mav.set_position_target_global_int_send(
             0, # system time in milliseconds
             1, # target system
             1, # target component
-            mavutil.mavlink.MAV_FRAME_BODY_NED, # coordinate frame MAV_FRAME_BODY_NED
+            mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT, # coordinate frame MAV_FRAME_BODY_NED
             MAV_POS_TARGET_TYPE_MASK.POS_ONLY, # type mask (pos only)
-            300, # position x
-            0, # position y
-            0, # position z
+            int(location.lat*1e7), # position x
+            int(location.lng*1e7), # position y
+            30, # position z
             0, # velocity x
             0, # velocity y
             0, # velocity z

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -32,8 +32,6 @@ void Motor::calculate_forces(const struct sitl_input &input,
                              float voltage,
                              bool use_drag)
 {
-    // fudge factors
-    const float yaw_scale = radians(40);
 
     const float pwm = input.servos[motor_offset+servo];
     float command = pwm_to_command(pwm);
@@ -57,9 +55,6 @@ void Motor::calculate_forces(const struct sitl_input &input,
     last_calc_us = now_us;
     last_command = command;
 
-    // the yaw torque of the motor
-    Vector3f rotor_torque = thrust_vector * yaw_factor * command * yaw_scale * voltage_scale * -1.0;
-
     // velocity of motor through air
     Vector3f motor_vel = velocity_air_bf;
 
@@ -71,6 +66,10 @@ void Motor::calculate_forces(const struct sitl_input &input,
 
     // get thrust for untilted motor
     float motor_thrust = calc_thrust(command, air_density, velocity_in, voltage_scale);
+
+    // the yaw torque of the motor
+    const float yaw_scale = 0.05 * diagonal_size * motor_thrust;
+    Vector3f rotor_torque = thrust_vector * yaw_factor * command * yaw_scale * -1.0;
 
     // thrust in bodyframe NED
     thrust = thrust_vector * motor_thrust;
@@ -181,6 +180,7 @@ void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, 
     max_outflow_velocity = _velocity_max;
     true_prop_area = _true_prop_area;
     momentum_drag_coefficient = _momentum_drag_coefficient;
+    diagonal_size = _diagonal_size;
 
     if (!_position.is_zero()) {
         position = _position;

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -136,6 +136,7 @@ private:
     float max_outflow_velocity;
     float true_prop_area;
     float momentum_drag_coefficient;
+    float diagonal_size;
 
     float last_command;
     uint64_t last_calc_us;


### PR DESCRIPTION
I have approximated the yaw torque by a simple thrust vector. This is an improvement but should be replaced by a combination of propeller drag and momentum.