### PR TITLE
Copter: Payload Place fix take-off

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -507,7 +507,7 @@ private:
 
     void payload_place_run();
     bool payload_place_run_should_run();
-    void payload_place_run_loiter();
+    void payload_place_run_hover();
     void payload_place_run_descend();
     void payload_place_run_release();
 


### PR DESCRIPTION
This change uses the existing take-off code rather than WPNav to mirror our changes to take-off. It also fixes a bug where we stopped updating the position controller targets during the release.