### PR TITLE
Scripting: allow setting of ESC RPM from a lua script

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -406,11 +406,12 @@ void AP_ESC_Telem::update_rpm(const uint8_t esc_index, const uint16_t new_rpm, c
 
     const uint32_t now = AP_HAL::micros();
     volatile AP_ESC_Telem_Backend::RpmData& rpmdata = _rpm_data[esc_index];
+    const auto last_update_us = rpmdata.last_update_us;
 
     rpmdata.prev_rpm = rpmdata.rpm;
     rpmdata.rpm = new_rpm;
-    if (now > rpmdata.last_update_us) { // cope with wrapping
-        rpmdata.update_rate_hz = 1.0e6f / (now - rpmdata.last_update_us);
+    if (now > last_update_us) { // cope with wrapping
+        rpmdata.update_rate_hz = 1.0e6f / (now - last_update_us);
     }
     rpmdata.last_update_us = now;
     rpmdata.error_rate = error_rate;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -91,9 +91,11 @@ public:
     // udpate at 10Hz to log telemetry
     void update();
 
-private:
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
+    // can also be called from scripting
     void update_rpm(const uint8_t esc_index, const uint16_t new_rpm, const float error_rate);
+    
+private:
     // callback to update the data in the frontend, should be called by the driver when new data is available
     void update_telem_data(const uint8_t esc_index, const AP_ESC_Telem_Backend::TelemetryData& new_data, const uint16_t data_mask);
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1113,6 +1113,12 @@ function esc_telem:get_temperature(instance) end
 ---@return number|nil
 function esc_telem:get_rpm(instance) end
 
+-- update RPM for an ESC
+---@param param1 integer -- ESC number
+---@param param2 integer -- RPM
+---@param param3 number -- error rate
+function esc_telem:update_rpm(esc_index, rpm, error_rate) end
+
 
 -- desc
 ---@class optical_flow

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -309,6 +309,7 @@ singleton AP_ESC_Telem method get_current boolean uint8_t 0 NUM_SERVO_CHANNELS f
 singleton AP_ESC_Telem method get_voltage boolean uint8_t 0 NUM_SERVO_CHANNELS float'Null
 singleton AP_ESC_Telem method get_consumption_mah boolean uint8_t 0 NUM_SERVO_CHANNELS float'Null
 singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null
+singleton AP_ESC_Telem method update_rpm void uint8_t 0 NUM_SERVO_CHANNELS uint16_t'skip_check float'skip_check
 
 include AP_Param/AP_Param.h
 singleton AP_Param rename param


### PR DESCRIPTION
This gives a powerful way of setting up notches for LUA scripts, and reporting engine RPMs. I added this for CAN EFI engines, but it could be used for any ESC telem protocol
