### PR TITLE
AP_Common: AP_FWVersion doesn't need mavlink headers

### DIFF
--- a/Tools/AP_Periph/version.h
+++ b/Tools/AP_Periph/version.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
 #define THISFIRMWARE "AP_Periph V1.4dev"
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <stdint.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 class PACKED AP_FWVersion {
 


### PR DESCRIPTION
This is PACKED so using the stdint types is sensible.
