### PR TITLE
Plane: do not re-trigger fence if mode changed for expected reason

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1201,6 +1201,9 @@ private:
     float pitch_in_expo(bool use_dz) const;
     float rudder_in_expo(bool use_dz) const;
 
+    // mode reason for entering previous mode
+    ModeReason previous_mode_reason = ModeReason::UNKNOWN;
+
 public:
     void failsafe_check(void);
 #if AP_SCRIPTING_ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1048,7 +1048,6 @@ private:
     bool set_mode(Mode& new_mode, const ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
     bool set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason);
-    ModeReason _last_reason;
     void check_long_failsafe();
     void check_short_failsafe();
     void startup_INS_ground(void);

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -200,11 +200,11 @@ void Plane::failsafe_short_off_event(ModeReason reason)
     // We're back in radio contact
     gcs().send_text(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
     failsafe.state = FAILSAFE_NONE;
-    //restore entry mode if desired but check that our current mode is still due to failsafe
-    if ( _last_reason == ModeReason::RADIO_FAILSAFE) { 
+    // restore entry mode if desired but check that our current mode is still due to failsafe
+    if (control_mode_reason == ModeReason::RADIO_FAILSAFE) { 
        set_mode_by_number(failsafe.saved_mode_number, ModeReason::RADIO_FAILSAFE_RECOVERY);
        gcs().send_text(MAV_SEVERITY_INFO,"Flight mode %s restored",control_mode->name());
-     }
+    }
 }
 
 void Plane::failsafe_long_off_event(ModeReason reason)

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -43,9 +43,13 @@ void Plane::fence_check()
         return;
     }
 
-    if (orig_breaches &&
-        (control_mode->is_guided_mode()
-        || control_mode == &mode_rtl || fence.get_action() == AC_FENCE_ACTION_REPORT_ONLY)) {
+    const bool current_mode_breach = plane.control_mode_reason == ModeReason::FENCE_BREACHED;
+    const bool previous_mode_breach = plane.previous_mode_reason ==  ModeReason::FENCE_BREACHED;
+    const bool previous_mode_complete = (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_VTOL_LAND_RTL) ||
+                                        (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_FIXEDWING_AUTOLAND) ||
+                                        (plane.control_mode_reason == ModeReason::QRTL_INSTEAD_OF_RTL) ||
+                                        (plane.control_mode_reason == ModeReason::QLAND_INSTEAD_OF_RTL);
+    if (orig_breaches && (current_mode_breach || (previous_mode_breach && previous_mode_complete))) {
         // we have already triggered, don't trigger again until the
         // user disables/re-enables using the fence channel switch
         return;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -257,7 +257,8 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
     // TODO: move these to be after enter() once start_command_callback() no longer checks control_mode
     previous_mode = control_mode;
     control_mode = &new_mode;
-    const ModeReason previous_mode_reason = control_mode_reason;
+    const ModeReason  old_previous_mode_reason = previous_mode_reason;
+    previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
 
     // attempt to enter new mode
@@ -269,6 +270,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
         previous_mode = &old_previous_mode;
         control_mode = &old_mode;
         control_mode_reason = previous_mode_reason;
+        previous_mode_reason = old_previous_mode_reason;
 
         // make sad noise
         if (reason != ModeReason::INITIALISED) {
@@ -284,9 +286,6 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 
     // exit previous mode
     old_mode.exit();
-
-    // record reasons
-    control_mode_reason = reason;
 
     // log and notify mode change
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -204,14 +204,11 @@ void Plane::startup_ground(void)
 
 bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 {
-    // update last reason
-    const ModeReason last_reason = _last_reason;
-    _last_reason = reason;
 
     if (control_mode == &new_mode) {
         // don't switch modes if we are already in the correct mode.
         // only make happy noise if using a difent method to switch, this stops beeping for repeated change mode requests from GCS
-        if ((reason != last_reason) && (reason != ModeReason::INITIALISED)) {
+        if ((reason != control_mode_reason) && (reason != ModeReason::INITIALISED)) {
             AP_Notify::events.user_mode_change = 1;
         }
         return true;


### PR DESCRIPTION
Current master will re trigger fence if your using some `Q_RTL_MODE` options or `RTL_AUTOLAND`. In these cases we do not stay in the mode the fence breach put us in, so the fence re-triggers. Current code is also immune from re-trigger in guided even if you manually changed to it after the breach.

Example re-triggering using fence action RTL and `Q_RTL_MODE` QRTL always. It just keeps triggering until the vehicle gets inside the fence again.
![image](https://user-images.githubusercontent.com/33176108/178076776-764ce6ec-ca53-4020-a820-bd0f19ab452f.png)

Same test with this branch results in only the first mode switch.

![image](https://user-images.githubusercontent.com/33176108/178076982-fd68d6df-d8c2-49a8-8d7e-3b039877bd7d.png)

Also discovered we had both AP vehicle's `control_mode_reason` and a local plane `_last_reason` this removes the local plane copy and uses `control_mode_reason` in its place.

