### PR TITLE
AP_OSD: Enable OSD and LED displays on macOS

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -254,6 +254,9 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if STATS_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Stats,             &copter.g2.stats,            update,           1, 100, 171),
 #endif
+#ifdef WITH_SITL_OSD
+    SCHED_TASK_CLASS(AP_OSD,                &copter.osd,                update,          50, 300, 180),
+#endif
 };
 
 void Copter::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -133,6 +133,9 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if LANDING_GEAR_ENABLED == ENABLED
     SCHED_TASK(landing_gear_update, 5, 50, 159),
 #endif
+#ifdef WITH_SITL_OSD
+    SCHED_TASK_CLASS(AP_OSD,     &plane.osd,        update, 50, 300, 180),
+#endif
 };
 
 void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -130,6 +130,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #if ADVANCED_FAILSAFE == ENABLED
     SCHED_TASK(afs_fs_check,           10,    200, 129),
 #endif
+#ifdef WITH_SITL_OSD
+    SCHED_TASK_CLASS(AP_OSD,              &rover.osd,              update,         50,  300,  180),
+#endif
 };
 
 

--- a/libraries/AP_Common/AP_FEHideExcept.cpp
+++ b/libraries/AP_Common/AP_FEHideExcept.cpp
@@ -1,0 +1,40 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ *  AP_FEHideExcept.cpp - hide floating point exceptions
+ *
+ *  Links
+ *
+ *  https://stackoverflow.com/questions/37819235/how-do-you-enable-floating-point-exceptions-for-clang-in-os-x
+ *  http://www-personal.umich.edu/~williams/archive/computation/fe-handling-example.c
+ *  https://android.googlesource.com/platform/bionic/+/a147a1d/libm/arm64/fenv.c
+ *
+ */
+
+#include "AP_FEHideExcept.h"
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+FEHideExcept::FEHideExcept()
+{
+    feholdexcept(&envp);
+}
+
+FEHideExcept::~FEHideExcept()
+{
+    feclearexcept(FE_ALL_EXCEPT);
+    feupdateenv(&envp);
+}
+
+#endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_Common/AP_FEHideExcept.h
+++ b/libraries/AP_Common/AP_FEHideExcept.h
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+///
+/// @file   AP_FEHideExcept.h
+/// @brief  Hide floating point exceptions
+///
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <fenv.h>
+
+/// \brief Class to temporarily hide floating point exceptions
+class FEHideExcept
+{
+public:
+    FEHideExcept();
+    ~FEHideExcept();
+
+    // no-copy
+    FEHideExcept(const FEHideExcept &) = delete;
+    FEHideExcept(const FEHideExcept &&) = delete;
+    FEHideExcept& operator=(const FEHideExcept &) = delete;
+    FEHideExcept& operator=(const FEHideExcept &&) = delete;
+
+private:
+    fenv_t envp;
+};
+
+#endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_Common/examples/AP_FEHideExcept/AP_FEHideExcept.cpp
+++ b/libraries/AP_Common/examples/AP_FEHideExcept/AP_FEHideExcept.cpp
@@ -1,0 +1,146 @@
+//
+// Examples for AP_FEHideExcept
+//
+
+#include <AP_Common/AP_FEHideExcept.h>
+#include <AP_HAL/AP_HAL.h>
+
+#include <fenv.h>
+
+#include <chrono>
+#include <thread>
+
+void print_supported_fpu_env();
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+void print_supported_fpu_env()
+{
+    // IEEE 754 exception macros
+    hal.console->printf("IEEE 754 exception macros\n");
+#ifdef FE_ALL_EXCEPT
+    hal.console->printf("Have FE_ALL_EXCEPT         yes\n");
+#else
+    hal.console->printf("Have FE_ALL_EXCEPT         no\n");
+#endif
+
+#ifdef FE_INEXACT
+    hal.console->printf("Have FE_INEXACT            yes\n");
+#else
+    hal.console->printf("Have FE_INEXACT            no\n");
+#endif
+
+#ifdef FE_DIVBYZERO
+    hal.console->printf("Have FE_DIVBYZERO          yes\n");
+#else
+    hal.console->printf("Have FE_DIVBYZERO          no\n");
+#endif
+
+#ifdef FE_UNDERFLOW
+    hal.console->printf("Have FE_UNDERFLOW          yes\n");
+#else
+    hal.console->printf("Have FE_UNDERFLOW          no\n");
+#endif
+
+#ifdef FE_OVERFLOW
+    hal.console->printf("Have FE_OVERFLOW           yes\n");
+#else
+    hal.console->printf("Have FE_OVERFLOW           no\n");
+#endif
+
+#ifdef FE_INVALID
+    hal.console->printf("Have FE_INVALID            yes\n");
+#else
+    hal.console->printf("Have FE_INVALID            no\n");
+#endif
+
+#ifdef FE_DOWNWARD
+    hal.console->printf("Have FE_DOWNWARD           yes\n");
+#else
+    hal.console->printf("Have FE_DOWNWARD           no\n");
+#endif
+
+#ifdef FE_TONEAREST
+    hal.console->printf("Have FE_TONEAREST          yes\n");
+#else
+    hal.console->printf("Have FE_TONEAREST          no\n");
+#endif
+
+#ifdef FE_TONEAREST
+    hal.console->printf("Have FE_TOWARDZERO         yes\n");
+#else
+    hal.console->printf("Have FE_TOWARDZERO         no\n");
+#endif
+
+#ifdef FE_UPWARD
+    hal.console->printf("Have FE_UPWARD             yes\n");
+#else
+    hal.console->printf("Have FE_UPWARD             no\n");
+#endif
+
+    // Intel specific exception macros
+    hal.console->printf("\nIntel exception macros\n");
+#ifdef FE_DENORMALOPERAND
+    hal.console->printf("Have FE_DENORMALOPERAND    yes\n");
+#else
+    hal.console->printf("Have FE_DENORMALOPERAND    no\n");
+#endif
+
+    // ARM specific exception macros
+    hal.console->printf("\nARM exception macros\n");
+#ifdef FE_FLUSHTOZERO
+    hal.console->printf("Have FE_FLUSHTOZERO        yes\n");
+#else
+    hal.console->printf("Have FE_FLUSHTOZERO        no\n");
+#endif
+}
+
+void setup(void)
+{
+    hal.console->printf("AP_FEHideExcept Tests\n\n");
+
+    print_supported_fpu_env();
+
+    hal.console->printf("\n");
+}
+
+double zero = 0.0; 
+
+void loop(void)
+{
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // hide floating point exceptions
+    {
+        FEHideExcept hide_except;
+
+        hal.console->printf("1.0/0.0 = %f\n", 1.0 / zero);
+
+        if(fetestexcept(FE_DIVBYZERO)) {
+            hal.console->printf("division by zero reported\n");
+        } else {
+            hal.console->printf("division by zero not reported\n");
+        }
+    }
+
+    // floating point exceptions cleared and unhidden
+    {
+        // uncommenting the line below will cause an abort
+        // hal.console->printf("1.0/0.0 = %f\n", 1.0 / zero);
+
+        if(fetestexcept(FE_DIVBYZERO)) {
+            hal.console->printf("division by zero reported\n");
+        } else {
+            hal.console->printf("division by zero not reported\n");
+        }
+    }
+#endif  // CONFIG_HAL_BOARD
+
+    // hal.scheduler->delay(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}
+
+
+AP_HAL_MAIN();

--- a/libraries/AP_Common/examples/AP_FEHideExcept/wscript
+++ b/libraries/AP_Common/examples/AP_FEHideExcept/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )

--- a/libraries/AP_Notify/Display_SITL.h
+++ b/libraries/AP_Notify/Display_SITL.h
@@ -40,9 +40,12 @@ private:
 
     uint8_t _displaybuffer[COLUMNS * ROWS];
     bool _need_hw_update;
+    bool _is_closing {false};
 
     static void *update_thread_start(void *obj);
     void update_thread(void);
+    void poll_events();
+
     sf::RenderWindow *w;
     pthread_t thread;
     HAL_Semaphore mutex;

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -34,16 +34,25 @@ class SITL_SFML_LED: public RGBLed
 public:
     SITL_SFML_LED();
     bool init(void) override;
+    void update() override;
 
 protected:
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:
 
+    sf::RenderWindow *w_rgb {nullptr};
+    bool rgb_is_closing {false};
+
+    sf::RenderWindow *w_serial {nullptr};
+    bool serial_is_closing {false};
+
     pthread_t thread;
     void update_thread(void);
     void update_serial_LEDs(void);
     static void *update_thread_start(void *obj);
+
+    void poll_events(sf::RenderWindow *w, bool &is_closing);
 
     static constexpr uint8_t height = 50;
     static constexpr uint8_t width = height;

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -317,6 +317,24 @@ void AP_OSD::init()
 #endif
 }
 
+void AP_OSD::update()
+{
+#if OSD_ENABLED
+    if (backend != nullptr) {
+        switch (osd_types(osd_type.get())) {
+        default:
+            break;
+#ifdef WITH_SITL_OSD
+        case OSD_SITL: {
+            backend->update();
+            break;
+        }
+#endif
+        }
+    }
+#endif
+}
+
 #if OSD_ENABLED
 void AP_OSD::osd_thread()
 {

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -449,6 +449,9 @@ public:
     // init - perform required initialisation
     void init();
 
+    // update - allow updates that must occur on the main loop
+    void update();
+
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -40,6 +40,9 @@ public:
     //initilize framebuffer and underlying hardware
     virtual bool init() = 0;
 
+    // updates for display and events that must be called from main loop
+    virtual void update() {}
+
     //update screen
     virtual void flush() = 0;
 

--- a/libraries/AP_OSD/AP_OSD_SITL.h
+++ b/libraries/AP_OSD/AP_OSD_SITL.h
@@ -37,6 +37,9 @@ public:
     //initilize display port and underlying hardware
     bool init() override;
 
+    // updates for display and events that must be called from main loop
+    void update() override;
+
     //flush framebuffer to screen
     void flush() override;
 
@@ -48,6 +51,7 @@ private:
     AP_OSD_SITL(AP_OSD &osd);
 
     sf::RenderWindow *w;
+    bool is_closing {false};
 
     sf::Texture font[256];
     uint8_t last_font;
@@ -67,6 +71,7 @@ private:
     void update_thread();
     static void *update_thread_start(void *obj);
     void load_font();
+    void poll_events();
 
     pthread_t thread;
     HAL_Semaphore mutex;

--- a/libraries/AP_OSD/examples/sfml_display/CMakeLists.txt
+++ b/libraries/AP_OSD/examples/sfml_display/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+project(sfml_display)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(SFML 2.5 COMPONENTS graphics audio REQUIRED)
+
+add_executable(sfml_display
+    main.cpp
+)
+
+target_link_libraries(sfml_display
+  sfml-window
+)
+
+# uncomment to match the compiler flags used in ./waf
+# target_compile_options(sfml_display
+#   PUBLIC
+#   -std=gnu++14
+#   # -std=gnu++11
+#   -fdata-sections
+#   -ffunction-sections
+#   -fno-exceptions
+#   -fsigned-char
+#   -Wall
+#   -Wextra
+#   -Wpointer-arith
+#   -Wno-unused-parameter
+#   -Wno-missing-field-initializers
+#   -Wno-reorder
+#   -Wno-redundant-decls
+#   -Wno-unknown-pragmas
+#   -Wno-expansion-to-defined
+#   -Werror=cast-align
+#   -Werror=attributes
+#   -Werror=format-security
+#   -Werror=format-extra-args
+#   -Werror=enum-compare
+#   -Werror=format
+#   -Werror=array-bounds
+#   -Werror=uninitialized
+#   -Werror=init-self
+#   -Werror=narrowing
+#   -Werror=return-type
+#   -Werror=switch
+#   -Werror=sign-compare
+#   -Werror=type-limits
+#   -Werror=undef
+#   -Werror=unused-result
+#   -Werror=shadow
+#   -Werror=unused-value
+#   -Werror=unused-variable
+#   -Werror=delete-non-virtual-dtor
+#   -Wfatal-errors
+#   -Wno-trigraphs
+#   -Werror=parentheses
+#   -Wuninitialized
+#   -Warray-bounds
+#   -fcolor-diagnostics
+#   -Werror=address-of-packed-member
+#   -Werror=inconsistent-missing-override
+#   -Werror=overloaded-virtual
+#   -Werror=bitfield-enum-conversion
+#   -Werror=bool-conversion
+#   -Werror=constant-conversion
+#   -Werror=enum-conversion
+#   -Werror=int-conversion
+#   -Werror=literal-conversion
+#   -Werror=non-literal-null-conversion
+#   -Werror=null-conversion
+#   -Werror=objc-literal-conversion
+#   -Werror=string-conversion
+#   -Wno-gnu-designator
+#   -Wno-mismatched-tags
+#   -Wno-gnu-variable-sized-type-not-at-end
+#   -Werror=implicit-fallthrough
+#   -Werror=float-equal
+#   -g
+#   -O0
+#   # -MMD
+#   -fno-slp-vectorize
+# )
+
+# get_target_property(TARGET_CXX_FLAGS sfml_display COMPILE_OPTIONS)
+
+# message("COMPILE_OPTIONS: ${TARGET_CXX_FLAGS}")

--- a/libraries/AP_OSD/examples/sfml_display/main.cpp
+++ b/libraries/AP_OSD/examples/sfml_display/main.cpp
@@ -1,0 +1,137 @@
+#include <SFML/Graphics.hpp>
+#include <SFML/Window.hpp>
+
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <memory>
+#include <string>
+
+class Display
+{
+public:
+    Display(const std::string& title)
+      : title(title)
+    {
+    }
+
+    ~Display()
+    {
+        stop_render_thread();
+    }
+
+    /// \note call on main thread
+    void init() {
+        window = std::make_unique<sf::Window>();
+        window->create(sf::VideoMode(400, 400), title);
+
+        start_render_thread();
+    }
+
+    /// \note call on main thread
+    void update() {
+      poll_events();
+    }
+
+    /// \note call on any thread
+    bool is_open() {
+      std::lock_guard<std::mutex> lock(window_mutex);
+
+      return window->isOpen();
+    }
+
+private:
+
+    /// \note call on main thread
+    void start_render_thread() {
+        render_thread = std::thread(&Display::render, this);
+    }
+
+    /// \note run on main thread
+    void stop_render_thread() {
+
+        // shutdown window
+        {
+            std::lock_guard<std::mutex> lock(window_mutex);
+            window->setVisible(false);
+            is_closing = true;
+        }
+
+        poll_events();
+
+        // joint thread
+        render_thread.join();
+
+        std::cout << "stopped render thread: " << title << "\n";
+    }
+
+    /// \note call on render thread
+    void render() {
+        while (true) {
+            {
+                std::lock_guard<std::mutex> lock(window_mutex);
+                if (window->isOpen()) {
+                    std::cout << "rendering: " << title << "\n";
+                }
+                else {
+                    std::cout << "stopped rendering: " << title << "\n";
+                    break;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    }
+
+    /// \note call on main thread
+    void poll_events() {
+        std::lock_guard<std::mutex> lock(window_mutex);
+
+        if (window->isOpen()) {
+            if (is_closing) {
+                window->close();
+            }
+            sf::Event event;
+            while (window->pollEvent(event))
+            {
+                if (event.type == sf::Event::Closed) {
+                    window->setVisible(false);
+                    is_closing = true;
+                }
+            }
+        }
+    }
+
+    std::string title;
+    std::unique_ptr<sf::Window> window;
+    bool is_closing {false};
+    std::mutex window_mutex;
+    std::thread render_thread;
+};
+
+int main()
+{
+    {
+        Display display1("Display 1");
+        Display display2("Display 2");
+
+        display1.init();
+        display2.init();
+
+        // main loop
+        while (display1.is_open() || display2.is_open())
+        {
+            display1.update();
+            display2.update();
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+
+    // exit
+    std::cout << "Displays closed\n";
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+    std::cout << "Exiting\n";
+    return 0;
+  }

--- a/libraries/AP_OSD/examples/sfml_display/sfml_display.cpp
+++ b/libraries/AP_OSD/examples/sfml_display/sfml_display.cpp
@@ -1,0 +1,51 @@
+/**
+ * Usage
+ * 
+ * Configure
+ * ./waf configure --board=sitl --osd --osd-fonts --sitl-osd --enable-sfml --debug
+ * 
+ * Build
+ * ./waf build --target examples/sfml_display
+ * 
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Notify/AP_Notify.h>
+#include <AP_OSD/AP_OSD.h>
+
+#include <chrono>
+#include <thread>
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+static AP_Notify notify;
+static AP_OSD osd;
+
+void setup()
+{
+    hal.console->begin(115200);
+    hal.console->printf("SFML Display\n\n");
+
+    /// \note require notify for the singleton and semaphore,
+    ///       but don't initialise as we don't have I2C devices.
+    // notify.init();
+
+    osd.init();
+
+   return;
+}
+
+void loop()
+{
+    // update display
+    osd.update();
+
+    /// \note hal.scheduler tries to update a FDM, even for a simple case?
+    // hal.scheduler->delay(20);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}
+
+AP_HAL_MAIN();

--- a/libraries/AP_OSD/examples/sfml_display/wscript
+++ b/libraries/AP_OSD/examples/sfml_display/wscript
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+
+    # bld.ap_example(
+    #     use='ap',
+    # )
+
+    bld.ap_program(
+        use='ap',
+        program_groups=['examples'],
+        source = [
+          'sfml_display.cpp'
+        ]
+    )


### PR DESCRIPTION
This PR enables the OSD and other displays (on-board, LED and serial LED) on macOS (both Intel and M1 machines).

MacOS requires that window creation and event updates are on the main thread. In the SITL classes that use SFML `RenderWindow` initialisation and event polling are moved to the main thread, rendering operations remain on the worker thread.

On macOS capturing floating point exceptions during window creation and event polling will cause a crash. A small class `FEHideExcept` is introduced that suspends reporting floating point exceptions in the scope where the SMFL calls that raise floating point exceptions are made.

Finally an additional step is introduced in the window closing code to ensure that the window exits cleanly - there seems to be an issue on macOS where SFML does not release the resources for the last display cleanly causing the window to remain visible and unresponsive.

## Testing

Run a rover example enabling various displays:

```bash
sim_vehicle.py -v Rover -f rover --map --console --osd --rgbled --debug
```

Update these parameters

```bash
SCR_ENABLE       1           # Lua Scripts
SCR_HEAP_SIZE    204800
NTF_DISPLAY_TYPE 10          # SITL
NTF_LED_LEN      49
NTF_LED_TYPES    455         # Build in LED|Internal ToshibaLED|External ToshibaLED|NCP5623 External|NCP5623 Internal|NeoPixel
SERVO8_FUNCTION  94          # Script 1
SERVO9_FUNCTION  132         # ProfiLED Clock
```

The example runs the script `libraries/AP_Scripting/examples/LED_matrix_image.lua` with a couple of changes to use the simulated NeoPixel device and increase the LED brightness.

```diff
diff --git a/libraries/AP_Scripting/examples/LED_matrix_image.lua b/libraries/AP_Scripting/examples/LED_matrix_image.lua
index db07ae16a7..d629b97df6 100644
--- a/libraries/AP_Scripting/examples/LED_matrix_image.lua
+++ b/libraries/AP_Scripting/examples/LED_matrix_image.lua
@@ -486,8 +486,8 @@ chan = chan + 1
 gcs:send_text(6, "LEDs: chan=" .. tostring(chan))
 
 -- initialisation code
---serialLED:set_num_neopixel(chan,  matrix_x * matrix_y)
-serialLED:set_num_profiled(chan,  matrix_x * matrix_y)
+serialLED:set_num_neopixel(chan,  matrix_x * matrix_y)
+-- serialLED:set_num_profiled(chan,  matrix_x * matrix_y)
 
 local offset = 8;
 
@@ -518,9 +518,9 @@ end
 
 function update_LEDs()
 
-  serialLED:set_RGB(chan, -1, 0, 0, 0)
+  serialLED:set_RGB(chan, 0, 0, 0, 0)
 
-  display_image(image,offset,0.05) 
+  display_image(image, offset, 1.0)
 
   serialLED:send(chan)
```

#### macOS (intel and M1)

![ap_display_macos_2](https://user-images.githubusercontent.com/24916364/179509017-f38dea76-aeaa-484d-ad62-615ac5c6d785.gif)

<!--
![ap_osd_sitl_macos](https://user-images.githubusercontent.com/24916364/178102976-5e19243b-409d-40e2-99b1-8ca3171e9cbe.png)
-->

On the mac M1 you need to install `sfml` and configure with the following flags:

```bash
$ brew install sfml
$ CXXFLAGS=-I/opt/homebrew/include LDFLAGS=-L/opt/homebrew/lib ./waf configure --board sitl --enable-sfml --sitl-osd
```

#### Ubuntu 20.04

OSD and LED displays work as before.

![osd-sitl-ubtuntu_2](https://user-images.githubusercontent.com/24916364/179747241-c869c891-f03e-40cd-bf7a-5bbd7e910b0a.png)

<!--
![osd-sitl-ubuntu](https://user-images.githubusercontent.com/24916364/178102985-b278fda4-0e4c-46ae-a8a3-77e5a8cc875f.png)
-->

