### PR TITLE
Heading hold in takeoff mission

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -534,7 +534,8 @@ bool Plane::verify_takeoff()
             auto_state.takeoff_speed_time_ms = millis();
         }
         if (auto_state.takeoff_speed_time_ms != 0 &&
-            millis() - auto_state.takeoff_speed_time_ms >= 2000) {
+            millis() - auto_state.takeoff_speed_time_ms >= 2000
+            && g.level_roll_limit != 0) {
             // once we reach sufficient speed for good GPS course
             // estimation we save our current GPS ground course
             // corrected for summed yaw to set the take off


### PR DESCRIPTION
Plane, while in takeoff mission even with g.level_takeoff=0 still trying to hold course. This happens after plane reaches 15m limit https://github.com/ArduPilot/ardupilot/blob/0ec06511aefe9ad35cc13d25568f5b073d2f9855/ArduPlane/takeoff.cpp#L136-L148

On poorly tuned aircrafts this can cause roll oscillations
e.g https://discuss.ardupilot.org/t/roll-oscillations-during-automatic-takeoff/84691