### PR TITLE
Remove mavlink-specific methods from AP_SerialManager

### DIFF
--- a/libraries/AP_AIS/AP_AIS.h
+++ b/libraries/AP_AIS/AP_AIS.h
@@ -32,6 +32,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Common/AP_ExpandingArray.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define AIVDM_BUFFER_SIZE 10
 #define AIVDM_PAYLOAD_SIZE 65

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -23,6 +23,7 @@
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <SITL/SIM_GPS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 /**
    maximum number of GPS instances available on this platform. If more

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -26,6 +26,7 @@
 #include <AP_OLC/AP_OLC.h>
 #include <AP_MSP/msp.h>
 #include <AP_Baro/AP_Baro.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef OSD_ENABLED
 #define OSD_ENABLED !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Param/AP_Param.h>
 
 #ifdef HAL_UART_NUM_SERIAL_PORTS
@@ -201,13 +200,6 @@ public:
     // find_portnum - find port number (SERIALn index) for a protocol and instance, -1 for not found
     int8_t find_portnum(enum SerialProtocol protocol, uint8_t instance) const;
 
-    // should_forward_mavlink_telemetry - returns true if this port should forward telemetry
-    bool should_forward_mavlink_telemetry(enum SerialProtocol protocol, uint8_t instance) const;
-
-    // get_mavlink_protocol - provides the specific MAVLink protocol for a
-    // given channel, or SerialProtocol_None if not found
-    SerialProtocol get_mavlink_protocol(mavlink_channel_t mav_chan) const;
-
     // set_blocking_writes_all - sets block_writes on or off for all serial channels
     void set_blocking_writes_all(bool blocking);
 
@@ -229,26 +221,45 @@ public:
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
+    class UARTState {
+        friend class AP_SerialManager;
+    public:
+        bool option_enabled(uint16_t option) const {
+            return (options & option) == option;
+        }
+        // returns a baudrate such as 9600.  May map from a special
+        // parameter value like "57" to "57600":
+        uint32_t baudrate() const {
+            return AP_SerialManager::map_baudrate(baud);
+        }
+        AP_SerialManager::SerialProtocol get_protocol() const {
+            return AP_SerialManager::SerialProtocol(protocol.get());
+        }
+    private:
+        AP_Int32 baud;
+        AP_Int16 options;
+        AP_Int8 protocol;
+    };
+
+    // search through managed serial connections looking for the
+    // instance-nth UART which is running protocol protocol.
+    // protocol_match is used to determine equivalence of one protocol
+    // to another, e.g. MAVLink2 is considered MAVLink1 for finding
+    // mavlink1 protocol instances.
+    const UARTState *find_protocol_instance(enum SerialProtocol protocol,
+                                            uint8_t instance) const;
+
 private:
     static AP_SerialManager *_singleton;
 
     // array of uart info. See comment above about
     // SERIALMANAGER_MAX_PORTS
-    struct UARTState {
-        AP_Int32 baud;
-        AP_Int16 options;
-        AP_Int8 protocol;
-    } state[SERIALMANAGER_MAX_PORTS];
+    UARTState state[SERIALMANAGER_MAX_PORTS];
 
     // pass-through serial support
     AP_Int8 passthru_port1;
     AP_Int8 passthru_port2;
     AP_Int8 passthru_timeout;
-
-    // search through managed serial connections looking for the
-    // instance-nth UART which is running protocol protocol
-    const UARTState *find_protocol_instance(enum SerialProtocol protocol,
-                                      uint8_t instance) const;
 
     // protocol_match - returns true if the protocols match
     bool protocol_match(enum SerialProtocol protocol1, enum SerialProtocol protocol2) const;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -636,6 +636,8 @@ protected:
 
 private:
 
+    const AP_SerialManager::UARTState *uartstate;
+
     // last time we got a non-zero RSSI from RADIO_STATUS
     static struct LastRadioStatus {
         uint32_t remrssi_ms;


### PR DESCRIPTION
This capitalises on years-old cleanups to create the `find_protocol_instance` method.

This should make mavlink a little more efficient, especially when we increase the number of mavlink channels available.  In master every packet received makes at least one call to `get_mavlink_protocol`, which iterates through all backends.

Based on https://github.com/ArduPilot/ardupilot/pull/21165 which does a little bit of prep work.
