### PR TITLE
Docker env: add non interactive support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,36 +2,48 @@ FROM ubuntu:20.04
 WORKDIR /ardupilot
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN useradd -U -m ardupilot && \
-    usermod -G users ardupilot
+ARG USER_NAME=ardupilot
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN groupadd ${USER_NAME} --gid ${USER_GID}\
+    && useradd -l -m ${USER_NAME} -u ${USER_UID} -g ${USER_GID} -s /bin/bash
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     lsb-release \
     sudo \
-    bash-completion \
-    software-properties-common
+    tzdata \
+    bash-completion
 
 COPY Tools/environment_install/install-prereqs-ubuntu.sh /ardupilot/Tools/environment_install/
 COPY Tools/completion /ardupilot/Tools/completion/
 
 # Create non root user for pip
-ENV USER=ardupilot
+ENV USER=${USER_NAME}
 
-RUN echo "ardupilot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ardupilot
-RUN chmod 0440 /etc/sudoers.d/ardupilot
+RUN echo "ardupilot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME}
+RUN chmod 0440 /etc/sudoers.d/${USER_NAME}
 
-RUN chown -R ardupilot:ardupilot /ardupilot
+RUN chown -R ${USER_NAME}:${USER_NAME} /${USER_NAME}
 
-USER ardupilot
+USER ${USER_NAME}
 
 ENV SKIP_AP_EXT_ENV=1 SKIP_AP_GRAPHIC_ENV=1 SKIP_AP_COV_ENV=1 SKIP_AP_GIT_CHECK=1
 RUN Tools/environment_install/install-prereqs-ubuntu.sh -y
 
 # add waf alias to ardupilot waf to .bashrc
-RUN echo "alias waf=\"/ardupilot/waf\"" >> ~/.bashrc
+RUN echo "alias waf=\"/${USER_NAME}/waf\"" >> ~/ardupilot_entrypoint.sh
 
 # Check that local/bin are in PATH for pip --user installed package
-RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/.bashrc
+RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/ardupilot_entrypoint.sh
+
+# Create entrypoint as docker cannot do shell substitution correctly
+RUN export ARDUPILOT_ENTRYPOINT="/home/${USER_NAME}/ardupilot_entrypoint.sh" \
+    && echo "#!/bin/bash" > $ARDUPILOT_ENTRYPOINT \
+    && echo "set -e" >> $ARDUPILOT_ENTRYPOINT \
+    && echo "source /home/${USER_NAME}/.ardupilot_env" >> $ARDUPILOT_ENTRYPOINT \
+    && echo 'exec "$@"' >> $ARDUPILOT_ENTRYPOINT \
+    && chmod +x $ARDUPILOT_ENTRYPOINT \
+    && sudo mv $ARDUPILOT_ENTRYPOINT /ardupilot_entrypoint.sh
 
 # Set the buildlogs directory into /tmp as other directory aren't accessible
 ENV BUILDLOGS=/tmp/buildlogs
@@ -41,3 +53,5 @@ RUN sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV CCACHE_MAXSIZE=1G
+ENTRYPOINT ["/ardupilot_entrypoint.sh"]
+CMD ["bash"]

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -316,7 +316,8 @@ echo "Done!"
 SHELL_LOGIN=".profile"
 if $IS_DOCKER; then
     echo "Inside docker, we add the tools path into .bashrc directly"
-    SHELL_LOGIN=".bashrc"
+    SHELL_LOGIN=".ardupilot_env"
+    echo "# ArduPilot env file. Need to be loaded by your Shell." > ~/$SHELL_LOGIN
 fi
 
 heading "Adding ArduPilot Tools to environment"
@@ -377,4 +378,10 @@ if [[ $SKIP_AP_GIT_CHECK -ne 1 ]]; then
     echo "Done!"
   fi
 fi
+
+if $IS_DOCKER; then
+    echo "Finalizing ArduPilot env for Docker"
+    echo "source ~/.ardupilot_env">> ~/.bashrc
+fi
+
 echo "---------- $0 end ----------"


### PR DESCRIPTION
This allow the docker container to do direct build. 
Instead of using `docker run -it -v `pwd`:/ardupilot ardupilot:latest` to enter the container and do stuff, we can now also do : 
`docker run -v `pwd`:/ardupilot ardupilot:latest ./waf configure ` to send commands.

Some optional arg were also add to allow to set the user and group from cmdline.

close https://github.com/ArduPilot/ardupilot/pull/20409
close https://github.com/ArduPilot/ardupilot/pull/20857
close https://github.com/ArduPilot/ardupilot/issues/16722
close https://github.com/ArduPilot/ardupilot/issues/20850