### PR TITLE
AP_Arming: Use aggregate last-passed values for AP_InertialSensor consistency checks

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -3,7 +3,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_Arming {
 public:
@@ -142,8 +142,8 @@ protected:
 
     // internal members
     bool                    armed;
-    uint32_t                last_accel_pass_ms[INS_MAX_INSTANCES];
-    uint32_t                last_gyro_pass_ms[INS_MAX_INSTANCES];
+    uint32_t                last_accel_pass_ms;
+    uint32_t                last_gyro_pass_ms;
 
     virtual bool barometer_checks(bool report);
 

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -26,9 +26,9 @@
 #include <AP_HAL/Util.h>
 #include <limits.h>
 #include <ctype.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_Arming/AP_Arming.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -629,7 +629,7 @@ void AP_OSD_ParamScreen::save_parameters()
 
 // handle OSD configuration messages
 #if HAL_GCS_ENABLED
-void AP_OSD_ParamScreen::handle_write_msg(const mavlink_osd_param_config_t& packet, const GCS_MAVLINK& link)
+void AP_OSD_ParamScreen::handle_write_msg(const mavlink_osd_param_config_t& packet, const class GCS_MAVLINK& link)
 {
     // request out of range - return an error
     if (packet.osd_index < 1 || packet.osd_index > AP_OSD_ParamScreen::NUM_PARAMS) {
@@ -642,7 +642,7 @@ void AP_OSD_ParamScreen::handle_write_msg(const mavlink_osd_param_config_t& pack
 }
 
 // handle OSD show configuration messages
-void AP_OSD_ParamScreen::handle_read_msg(const mavlink_osd_param_show_config_t& packet, const GCS_MAVLINK& link)
+void AP_OSD_ParamScreen::handle_read_msg(const mavlink_osd_param_show_config_t& packet, const class GCS_MAVLINK& link)
 {
     // request out of range - return an error
     if (packet.osd_index < 1 || packet.osd_index > AP_OSD_ParamScreen::NUM_PARAMS) {


### PR DESCRIPTION
All used sensors must be consistent with the primary sensor for 10 seconds, so we don't need to record times individually

Removes the use of the inertial sensor library's sensor count in the header file.

Also fixes AP_OSD_Param as it relied on transitive includes from `AP_InertialSensor.h` which it was getting from`AP_Arming.h`

Flashed this onto a CubeOrange and it didn't fuss.
