### PR TITLE
AP_Periph: The patch number should also be clearly indicated

### DIFF
--- a/Tools/AP_Periph/version.h
+++ b/Tools/AP_Periph/version.h
@@ -2,7 +2,7 @@
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define THISFIRMWARE "AP_Periph V1.4dev"
+#define THISFIRMWARE "AP_Periph V1.4.0dev"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 1,4,0,FIRMWARE_VERSION_TYPE_DEV


### PR DESCRIPTION
ArduCopter, for example, will also clearly indicate the patch number.
It will be easier to understand the changes if the patch number is also clearly indicated.