### PR TITLE
Copter: Clarify the exclusion determination in the ENUM definition

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -49,7 +49,7 @@ void ModeRTL::restart_without_terrain()
 ModeRTL::RTLAltType ModeRTL::get_alt_type() const
 {
     // sanity check parameter
-    if (g.rtl_alt_type < 0 || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
+    if (g.rtl_alt_type < (int)RTLAltType::RTL_ALTTYPE_RELATIVE || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
         return RTLAltType::RTL_ALTTYPE_RELATIVE;
     }
     return (RTLAltType)g.rtl_alt_type.get();


### PR DESCRIPTION
This determination is made outside the range of the altitude definition.
Therefore, it is better to compare it to the definition that is the minimum of ENUM.