### PR TITLE
autotest: pause/unpause SITL while draining mav

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6668,7 +6668,6 @@ class AutoTestCopter(AutoTest):
             raise ex
 
     def wait_generator_speed_and_state(self, rpm_min, rpm_max, want_state, timeout=240):
-        self.drain_mav()
         tstart = self.get_sim_time()
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
@@ -6812,7 +6811,6 @@ class AutoTestCopter(AutoTest):
         self.progress("Reset mission")
         self.set_rc(7, 2000)
         self.delay_sim_time(1)
-        self.drain_mav()
         self.wait_current_waypoint(0, timeout=10)
         self.set_rc(7, 1000)
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -802,7 +802,6 @@ class AutoTestPlane(AutoTest):
         # waypoint:
         self.wait_distance_to_waypoint(8, 100, 10000000)
         self.set_current_waypoint(8)
-        self.drain_mav()
         # TODO: reflect on file to find this magic waypoint number?
         #        self.wait_waypoint(7, num_wp-1, timeout=500) # we
         #        tend to miss the final waypoint by a fair bit, and

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -14,6 +14,7 @@ import math
 import os
 import re
 import shutil
+import signal
 import sys
 import time
 import traceback
@@ -2556,6 +2557,16 @@ class AutoTest(ABC):
         self.apply_default_parameters()
         self.progress("Reset SITL commandline to default")
 
+    def pause_SITL(self):
+        '''temporarily stop the SITL process from running.  Note that
+        simulation time will not move forward!'''
+        # self.progress("Pausing SITL")
+        self.sitl.kill(signal.SIGSTOP)
+
+    def unpause_SITL(self):
+        # self.progress("Unpausing SITL")
+        self.sitl.kill(signal.SIGCONT)
+
     def stop_SITL(self):
         self.progress("Stopping SITL")
         self.expect_list_remove(self.sitl)
@@ -2735,6 +2746,7 @@ class AutoTest(ABC):
         tstart = time.time()
         timeout = 120
         failed_to_drain = False
+        self.pause_SITL()
         while mav.recv_msg() is not None:
             count += 1
             if time.time() - tstart > timeout:
@@ -2743,6 +2755,7 @@ class AutoTest(ABC):
                 # just die if that seems to be the case:
                 failed_to_drain = True
                 quiet = False
+        self.unpause_SITL()
         if quiet:
             self.in_drain_mav = False
             return

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11059,12 +11059,12 @@ switch value'''
                 last_len_received_statustexts = len(received_statustexts)
                 self.progress("received statustexts: %s" % str([x.text for x in received_statustexts]))
                 self.progress("received frsky texts: %s" % str(received_frsky_texts))
-                for (want_sev, text) in received_frsky_texts:
+                for (want_sev, received_text) in received_frsky_texts:
                     for m in received_statustexts:
-                        if m.text == text:
+                        if m.text == received_text:
                             if want_sev != m.severity:
                                 raise NotAchievedException("Incorrect severity; want=%u got=%u" % (want_sev, severity))
-                            self.progress("Got statustext (%s)" % text)
+                            self.progress("Got statustext (%s)" % received_text)
                             break
         self.context_stop_collecting('STATUSTEXT')
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5554,7 +5554,6 @@ class AutoTest(ABC):
     #################################################
     def delay_sim_time(self, seconds_to_wait, reason=None):
         """Wait some second in SITL time."""
-        self.drain_mav()
         tstart = self.get_sim_time()
         tnow = tstart
         r = "Delaying %f seconds"
@@ -6663,7 +6662,6 @@ Also, ignores heartbeats not from our target system'''
 
     def wait_ekf_flags(self, required_value, error_bits, timeout=30):
         self.progress("Waiting for EKF value %u" % required_value)
-        self.drain_mav()
         last_print_time = 0
         tstart = self.get_sim_time()
         while timeout is None or self.get_sim_time_cached() < tstart + timeout:
@@ -7334,7 +7332,6 @@ Also, ignores heartbeats not from our target system'''
         '''mavlink2 required'''
         target_system = 1
         target_component = 1
-        self.drain_mav()
         self.progress("Sending mission_request_list")
         tstart = self.get_sim_time()
         self.mav.mav.mission_request_list_send(target_system,
@@ -7613,7 +7610,6 @@ Also, ignores heartbeats not from our target system'''
 
     def zero_mag_offset_parameters(self, compass_count=3):
         self.progress("Zeroing Mag OFS parameters")
-        self.drain_mav()
         self.get_sim_time()
         self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
                      2, # param1 (compass0)
@@ -7658,7 +7654,6 @@ Also, ignores heartbeats not from our target system'''
 
     def forty_two_mag_dia_odi_parameters(self, compass_count=3):
         self.progress("Forty twoing Mag DIA and ODI parameters")
-        self.drain_mav()
         self.get_sim_time()
         params = [
             [("SIM_MAG_DIA_X", "COMPASS_DIA_X", 42.0),
@@ -7719,7 +7714,6 @@ Also, ignores heartbeats not from our target system'''
         def reset_pos_and_start_magcal(mavproxy, tmask):
             mavproxy.send("sitl_stop\n")
             mavproxy.send("sitl_attitude 0 0 0\n")
-            self.drain_mav()
             self.get_sim_time()
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
                          tmask, # p1: mag_mask
@@ -7776,7 +7770,6 @@ Also, ignores heartbeats not from our target system'''
             if self.is_copter():
                 # set frame class to pass arming check on copter
                 self.set_parameter("FRAME_CLASS", 1)
-            self.drain_mav()
             self.progress("Setting SITL Magnetometer model value")
             self.set_parameter("COMPASS_AUTO_ROT", 0)
             # MAG_ORIENT = 4
@@ -9030,7 +9023,6 @@ Also, ignores heartbeats not from our target system'''
     def poll_message(self, message_id, timeout=10):
         if type(message_id) == str:
             message_id = eval("mavutil.mavlink.MAVLINK_MSG_ID_%s" % message_id)
-        self.drain_mav()
         tstart = self.get_sim_time() # required for timeout in run_cmd_get_ack to work
         self.send_poll_message(message_id)
         self.run_cmd_get_ack(

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11015,10 +11015,11 @@ switch value'''
 
         received_frsky_texts = []
         last_len_received_statustexts = 0
+        timeout = 7 * self.speedup # it can take a *long* time to get these messages down!
         while True:
             self.drain_mav()
             now = self.get_sim_time_cached()
-            if now - tstart > 60: # it can take a *long* time to get these messages down!
+            if now - tstart > timeout:
                 raise NotAchievedException("Did not get statustext in time")
             frsky.update()
             data = frsky.get_data(0x5000) # no timestamping on this data, so we can't catch legitimate repeats.

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2747,7 +2747,17 @@ class AutoTest(ABC):
         timeout = 120
         failed_to_drain = False
         self.pause_SITL()
-        while mav.recv_msg() is not None:
+        # sometimes we recv() when the process is likely to go away..
+        old_autoreconnect = mav.autoreconnect
+        mav.autoreconnect = False
+        while True:
+            try:
+                receive_result = mav.recv_msg()
+            except Exception:
+                mav.autoreconnect = True
+                raise
+            if receive_result is None:
+                break
             count += 1
             if time.time() - tstart > timeout:
                 # ArduPilot can produce messages faster than we can
@@ -2755,6 +2765,7 @@ class AutoTest(ABC):
                 # just die if that seems to be the case:
                 failed_to_drain = True
                 quiet = False
+        mav.autoreconnect = old_autoreconnect
         self.unpause_SITL()
         if quiet:
             self.in_drain_mav = False


### PR DESCRIPTION
If Python can't keep up with the message volume coming from the autopilot we never manage to drain all messages from the vehicle.

So try pausing/unpausing the simulation so we can drain the link...

AT-1968.6: AP: PreArm: Radio failsafe on
AT-1969.9: AP: PreArm: Radio failsafe on
AT-1971.2: AP: PreArm: Radio failsafe on
AT-1972.4: AP: PreArm: Radio failsafe on
AT-1973.7: AP: PreArm: Radio failsafe on
AT-1974.9: AP: PreArm: Radio failsafe on
AT-1975.3: Drained 2000283 messages from mav (7218.974791/s)
AT-1975.3: Exception caught: Traceback (most recent call last):
  File "/mnt/volume_nyc3_01/autotest/APM/APM/Tools/autotest/common.py", line 699
8, in run_one_test_attempt
    self.context_pop()
  File "/mnt/volume_nyc3_01/autotest/APM/APM/Tools/autotest/common.py", line 499
3, in context_pop
    self.set_parameters(dead_parameters_dict, add_to_context=False)