### PR TITLE
Update pid_info with integrator reset for logging purposes 

### DIFF
--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -272,6 +272,7 @@ float AC_PID::get_ff()
 void AC_PID::reset_I()
 {
     _integrator = 0.0;
+    _pid_info.I = 0.0;
 }
 
 void AC_PID::load_gains()

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -166,6 +166,13 @@ Vector2f AC_PID_2D::get_ff()
     return _target * _kff;
 }
 
+void AC_PID_2D::reset_I()
+{
+    _integrator.zero(); 
+    _pid_info_x.I = 0.0;
+    _pid_info_y.I = 0.0;
+}
+
 // save_gains - save gains to eeprom
 void AC_PID_2D::save_gains()
 {

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -41,7 +41,7 @@ public:
     const Vector2f& get_error() const { return _error; }
 
     // reset the integrator
-    void reset_I() { _integrator.zero(); };
+    void reset_I();
 
     // reset_filter - input and D term filter will be reset to the next value provided to set_input()
     void reset_filter() { _reset_filter = true; }

--- a/libraries/AC_PID/AC_PID_Basic.cpp
+++ b/libraries/AC_PID/AC_PID_Basic.cpp
@@ -139,6 +139,12 @@ void AC_PID_Basic::update_i(bool limit_neg, bool limit_pos)
     }
 }
 
+void AC_PID_Basic::reset_I()
+{
+    _integrator = 0.0; 
+    _pid_info.I = 0.0;
+}
+
 // save_gains - save gains to eeprom
 void AC_PID_Basic::save_gains()
 {
@@ -176,4 +182,5 @@ void AC_PID_Basic::set_integrator(float error, float i)
 void AC_PID_Basic::set_integrator(float i)
 {
     _integrator = constrain_float(i, -_kimax, _kimax);
+    _pid_info.I = _integrator;
 }

--- a/libraries/AC_PID/AC_PID_Basic.h
+++ b/libraries/AC_PID/AC_PID_Basic.h
@@ -37,7 +37,7 @@ public:
     float get_error() const WARN_IF_UNUSED { return _error; }
 
     // reset the integrator
-    void reset_I() { _integrator = 0.0f; }
+    void reset_I();
 
     // input and D term filter will be reset to the next value provided to set_input()
     void reset_filter() { _reset_filter = true; }

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -343,7 +343,8 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
 
 void AP_YawController::reset_I()
 {
-    _integrator = 0;
+    _integrator = 0.0;
+    _pid_info.I = 0.0;
 }
 
 /*


### PR DESCRIPTION
This is a non-functional change, that update `_pid_info.I` when the integrator reset is called. The is added to allow better log inspection when the quadplane multi PID is not working or when the custom controller is active. 