### PR TITLE
Copter: takeoff check that motors are spinning at TKOFF_RPM_MIN

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -192,6 +192,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(ekf_check,             10,     75,  84),
     SCHED_TASK(check_vibration,       10,     50,  87),
     SCHED_TASK(gpsglitch_check,       10,     50,  90),
+    SCHED_TASK(takeoff_check,         50,     50,  91),
 #if LANDING_GEAR_ENABLED == ENABLED
     SCHED_TASK(landinggear_update,    10,     75,  93),
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -319,6 +319,9 @@ private:
         uint32_t clear_ms;  // system time high vibrations stopped
     } vibration_check;
 
+    // takeoff check
+    uint32_t takeoff_check_warning_ms;  // system time user was last warned of takeoff check failure
+
     // GCS selection
     GCS_Copter _gcs; // avoid using this; use gcs()
     GCS_Copter &gcs() { return _gcs; }
@@ -881,6 +884,9 @@ private:
     bool rangefinder_up_ok() const;
     void update_optical_flow(void);
     void compass_cal_update(void);
+
+    // takeoff_check.cpp
+    void takeoff_check();
 
     // RC_Channel.cpp
     void save_trim();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1143,6 +1143,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_SUBGROUPINFO(command_model_pilot, "PILOT_Y_", 56, ParametersG2, AC_CommandModel),
 
+    // @Param: TKOFF_RPM_MIN
+    // @DisplayName: Takeoff Check RPM minimum
+    // @Description: Takeoff is not permitted until motors report at least this RPM.  Set to zero to disable check
+    // @Range: 0 10000
+    // @User: Standard
+    AP_GROUPINFO("TKOFF_RPM_MIN", 57, ParametersG2, takeoff_rpm_min, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -666,6 +666,7 @@ public:
     AP_Int8                 surftrak_mode;
     AP_Int8                 failsafe_dr_enable;
     AP_Int16                failsafe_dr_timeout;
+    AP_Int16                takeoff_rpm_min;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -24,17 +24,21 @@ void ModeAcro::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     }
 
+    bool limit_throttle_out = false;
+
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
         attitude_control->reset_target_and_rate(true);
         attitude_control->reset_rate_controller_I_terms();
+        limit_throttle_out = true;
         break;
 
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
         attitude_control->reset_target_and_rate();
         attitude_control->reset_rate_controller_I_terms_smoothly();
+        limit_throttle_out = true;
         break;
 
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
@@ -58,7 +62,7 @@ void ModeAcro::run()
     }
 
     // output pilot's throttle without angle boost
-    attitude_control->set_throttle_out(get_pilot_desired_throttle(),
+    attitude_control->set_throttle_out(limit_throttle_out ? 0 : get_pilot_desired_throttle(),
                                        false,
                                        copter.g.throttle_filt);
 }

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -28,17 +28,21 @@ void ModeStabilize::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     }
 
+    bool limit_throttle_out = false;
+
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
         // Motors Stopped
         attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
+        limit_throttle_out = true;
         break;
 
     case AP_Motors::SpoolState::GROUND_IDLE:
         // Landed
         attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms_smoothly();
+        limit_throttle_out = true;
         break;
 
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
@@ -58,7 +62,7 @@ void ModeStabilize::run()
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
 
     // output pilot's throttle
-    attitude_control->set_throttle_out(get_pilot_desired_throttle(),
+    attitude_control->set_throttle_out(limit_throttle_out ? 0 : get_pilot_desired_throttle(),
                                        true,
                                        g.throttle_filt);
 }

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -1,0 +1,56 @@
+#include "Copter.h"
+
+//
+// pre-takeoff checks
+//
+
+// detects if the vehicle should be allowed to takeoff or not and sets the motors.blocked flag
+void Copter::takeoff_check()
+{
+#if HAL_WITH_ESC_TELEM
+    // If takeoff check is disabled or vehicle is armed and flying then clear block and return
+    if ((g2.takeoff_rpm_min <= 0) || (motors->armed() && !ap.land_complete)) {
+        motors->set_spoolup_block(false);
+        return;
+    }
+
+    // block takeoff when disarmed but do not display warnings
+    if (!motors->armed()) {
+        motors->set_spoolup_block(true);
+        takeoff_check_warning_ms = 0;
+        return;
+    }
+
+    // if motors have become unblocked return immediately
+    // this ensures the motors can only be blocked immediate after arming
+    if (!motors->get_spoolup_block()) {
+        return;
+    }
+
+    // check ESCs are sending RPM at expected level
+    uint32_t motor_mask = motors->get_motor_mask();
+    const bool telem_active = AP::esc_telem().is_telemetry_active(motor_mask);
+    const bool rpm_adequate = AP::esc_telem().are_motors_running(motor_mask, g2.takeoff_rpm_min);
+
+    // if RPM is at the expected level clear block
+    if (telem_active && rpm_adequate) {
+        motors->set_spoolup_block(false);
+        return;
+    }
+
+    // warn user telem inactive or rpm is inadequate every 5 seconds
+    uint32_t now_ms = AP_HAL::millis();
+    if (takeoff_check_warning_ms == 0) {
+        takeoff_check_warning_ms = now_ms;
+    }
+    if (now_ms - takeoff_check_warning_ms > 5000) {
+        takeoff_check_warning_ms = now_ms;
+        const char* prefix_str = "Takeoff blocked:";
+        if (!telem_active) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s waiting for ESC RPM", prefix_str);
+        } else if (!rpm_adequate) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s ESC RPM too low", prefix_str);
+        }
+    }
+#endif
+}

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -24,6 +24,8 @@
 
 //#define ESC_TELEM_DEBUG
 
+#define ESC_RPM_CHECK_TIMEOUT_US 100000UL   // timeout for motor running validity
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -111,6 +113,40 @@ uint32_t AP_ESC_Telem::get_active_esc_mask() const {
 uint8_t AP_ESC_Telem::get_num_active_escs() const {
     uint32_t active = get_active_esc_mask();
     return __builtin_popcount(active);
+}
+
+// return the whether all the motors in servo_channel_mask are running
+bool AP_ESC_Telem::are_motors_running(uint32_t servo_channel_mask, float min_rpm) const
+{
+    const uint32_t now = AP_HAL::micros();
+
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        if (BIT_IS_SET(servo_channel_mask, i)) {
+            const volatile AP_ESC_Telem_Backend::RpmData& rpmdata = _rpm_data[i];
+            // we choose a relatively strict measure of health so that failsafe actions can rely on the results
+            if (now < rpmdata.last_update_us || now - rpmdata.last_update_us > ESC_RPM_CHECK_TIMEOUT_US) {
+                return false;
+            }
+            if (rpmdata.rpm < min_rpm) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// is telemetry active for the provided channel mask
+bool AP_ESC_Telem::is_telemetry_active(uint32_t servo_channel_mask) const
+{
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        if (BIT_IS_SET(servo_channel_mask, i)) {
+            // no data received
+            if (get_last_telem_data_ms(i) == 0 && _rpm_data[i].last_update_us == 0) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 // get an individual ESC's slewed rpm if available, returns true on success

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -42,6 +42,9 @@ public:
     // return the average motor RPM
     float get_average_motor_rpm() const { return get_average_motor_rpm(0xFFFFFFFF); }
 
+    // determine whether all the motors in servo_channel_mask are running
+    bool are_motors_running(uint32_t servo_channel_mask, float min_rpm) const;
+
     // get an individual ESC's temperature in centi-degrees if available, returns true on success
     bool get_temperature(uint8_t esc_index, int16_t& temp) const;
 
@@ -90,6 +93,12 @@ public:
 
     // udpate at 10Hz to log telemetry
     void update();
+
+    // is ESC telemetry working
+    bool is_active() const { return _have_data; }
+
+    // is rpm telemetry configured for the provided channel mask
+    bool is_telemetry_active(uint32_t servo_channel_mask) const;
 
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
     // can also be called from scripting

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
@@ -36,13 +36,34 @@ void AP_ESC_Telem_SITL::update()
         return;
     }
 
+#if HAL_WITH_ESC_TELEM
+    for (uint8_t i = 0; i < sitl->state.num_motors; i++) {
+        // some fake values so that is_telemetry_active() returns true
+        TelemetryData t {
+            .temperature_cdeg = 32,
+            .voltage = 16.8f,
+            .current = 0.8f,
+            .consumption_mah = 1.0f,
+        };
+
+        update_telem_data(i, t,
+            AP_ESC_Telem_Backend::TelemetryType::CURRENT
+                | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
+                | AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION
+                | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
+    }
+
     if (is_zero(sitl->throttle)) {
+        if (hal.util->get_soft_armed()) {
+            for (uint8_t i = 0; i < sitl->state.num_motors; i++) {
+                update_rpm(i, sitl->esc_rpm_armed);
+            }
+        }
         return;
     }
 
-#if HAL_WITH_ESC_TELEM
     for (uint8_t i = 0; i < sitl->state.num_motors; i++) {
-        update_rpm(i, sitl->state.rpm[sitl->state.vtol_motor_start+i]);
+        update_rpm(i, MAX(sitl->state.rpm[sitl->state.vtol_motor_start+i], sitl->esc_rpm_armed));
     }
 #endif
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -77,6 +77,11 @@ void AP_Motors::armed(bool arm)
 
 void AP_Motors::set_desired_spool_state(DesiredSpoolState spool)
 {
+    // check if spoolup has been blocked
+    if (_spoolup_block && (spool == DesiredSpoolState::THROTTLE_UNLIMITED)) {
+        return;
+    }
+
     if (_armed || (spool == DesiredSpoolState::SHUT_DOWN)) {
         _spool_desired = spool;
     }

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -122,6 +122,10 @@ public:
     // get motor interlock status.  true means motors run, false motors don't run
     bool                get_interlock() const { return _interlock; }
 
+    // get/set spoolup block
+    bool                get_spoolup_block() const { return _spoolup_block; }
+    void                set_spoolup_block(bool set) { _spoolup_block = set; }
+
     // set_roll, set_pitch, set_yaw, set_throttle
     void                set_roll(float roll_in) { _roll_in = roll_in; };        // range -1 ~ +1
     void                set_roll_ff(float roll_in) { _roll_in_ff = roll_in; };    // range -1 ~ +1
@@ -360,6 +364,7 @@ private:
     bool _armed;             // 0 if disarmed, 1 if armed
     bool _interlock;         // 1 if the motor interlock is enabled (i.e. motors run), 0 if disabled (motors don't run)
     bool _initialised_ok;    // 1 if initialisation was successful
+    bool _spoolup_block;     // true if spoolup is blocked
 
     static AP_Motors *_singleton;
 };

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -285,6 +285,8 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 
     AP_GROUPINFO("ESC_TELEM", 40, SIM, esc_telem, 1),
 
+    AP_GROUPINFO("ESC_ARM_RPM", 41, SIM,  esc_rpm_armed, 1000.0f),
+
     AP_SUBGROUPINFO(airspeed[0], "ARSPD_", 50, SIM, SIM::AirspeedParm),
 #if AIRSPEED_MAX_SENSORS > 1
     AP_SUBGROUPINFO(airspeed[1], "ARSPD2_", 51, SIM, SIM::AirspeedParm),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -438,6 +438,8 @@ public:
 
     // ESC telemetry
     AP_Int8 esc_telem;
+    // RPM when motors are armed
+    AP_Float esc_rpm_armed;
 
     struct {
         // LED state, for serial LED emulation


### PR DESCRIPTION
This is an alternative implementation of PR https://github.com/ArduPilot/ardupilot/pull/20856

This adds a Copter takeoff check that all motors are spinning at at least TKOFF_RPM_MIN.  If the motors aren't spinning at this RPM then the vehicle is unable to takeoff and a message like, "Takeoff blocked: ESC RPM too low" appears until the motors do spin-up.

- AP_ESC_Telem gets new is_telemetry_active() and are_motors_running() methods
- AP_Motors gets new get/set_spoolup_block() methods to allow an external caller to stop the motors from spooling up to THROTTLE_UNLIMITED.  This is done by ignoring calls to get_desired_spool_state(THROTTLE_UNLIMITED) if the block is true.  This should be safe because it essentially only blocks the motors from spooling up if they haven't spooled up already.  Even if the block is set while the vehicle is armed and flying, it won't immediately cause the motors to spool down.
- Copter::takeoff_check is added to set the motors block if the vehicle is armed and landed AND ESC telemetry is inactive or the RPM is below TKOFF_RPM_MIN
- Stabilize and Acro are modified to send zero throttle to the attitude control until the spool state has created unlimited

This feature cannot be used if MOT_SPIN_ARMED = 0 (maybe we should add a pre-arm check for this)

Once proven to be safe this feature could potentially be extended to cover other checks we wish to run post-arming but pre-takeoff (who knows what those might be though).

To-Do:

- [ ] Test all modes for both multicopter and helicopter to confirm it really does keep the vehicle on the ground.
- [x] Test on a real vehicle

This has been lightly tested in SITL including the following test:

- start sim_vehicle as a copter or helicopter
- stabilize (or whichever mode you would like to test)
- param set DISARM_DELAY 0 (to give you enough time to play around without the vehicle automatically disarming)
- param set TKOFF_RPM_MIN 1100
- arm throttle
- rc 3 2000 <-- the vehicle should fail to takeoff and an error message should be displayed because TKOFF_RPM_MIN > SIM_ESC_ARM_RPM
- param set TKOFF_RPM_MIN 1000 <-- the vehicle should takeoff


