### PR TITLE
Plane: tailsitter: dont check if flying its always true in vtol transtion

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -294,7 +294,7 @@ void Tailsitter::output(void)
     // handle forward flight modes and transition to VTOL modes
     if (!active() || in_vtol_transition()) {
         // get FW controller throttle demand and mask of motors enabled during forward flight
-        if (hal.util->get_soft_armed() && in_vtol_transition() && !quadplane.throttle_wait && quadplane.is_flying()) {
+        if (hal.util->get_soft_armed() && in_vtol_transition() && !quadplane.throttle_wait) {
             /*
               during transitions to vtol mode set the throttle to hover thrust, center the rudder
             */


### PR DESCRIPTION
Taken from https://github.com/ArduPilot/ardupilot/pull/20068

`quadplane.is_flying()` is always true if `in_vtol_transition()`:

https://github.com/ArduPilot/ardupilot/blob/b59a2143ae42e77b6da02ab30ad452733a1e5b1f/ArduPlane/quadplane.cpp#L1107-L1123

In that case it can only return false if quadplane is not enabled, but we already check that on line 283 of `Tailsitter::output` 