### PR TITLE
autotest: increase timeout allowed for mavlite parameter test

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11152,7 +11152,6 @@ switch value'''
     def read_message_via_mavlite(self, frsky, sport_to_mavlite):
         '''read bytes from frsky mavlite stream, trying to form up a mavlite
         message'''
-        self.drain_mav(quiet=True)
         tstart = self.get_sim_time()
         while True:
             self.drain_mav(quiet=True)
@@ -11170,11 +11169,10 @@ switch value'''
                 return message
 
     def read_parameter_via_mavlite(self, frsky, sport_to_mavlite, name):
-        self.drain_mav(quiet=True)
         tstart = self.get_sim_time()
         while True:
             tnow = self.get_sim_time_cached()
-            if tnow - tstart > 30:
+            if tnow - tstart > 30 * self.speedup / 10.0:
                 raise NotAchievedException("Did not get parameter via mavlite")
             message = self.read_message_via_mavlite(frsky, sport_to_mavlite)
             if message.msgid != mavutil.mavlink.MAVLINK_MSG_ID_PARAM_VALUE:


### PR DESCRIPTION
the FRSky thread isn't any faster, but ArduPlane's speedup was increased.  So allow more simulated time to get the data