### PR TITLE
TECS.cpp: Remove redundant throttle demand saturation

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -664,17 +664,6 @@ void AP_TECS::_update_throttle_with_airspeed(void)
         }
         _throttle_dem = (_STE_error + STEdot_error * throttle_damp) * K_STE2Thr + ff_throttle;
 
-        // Constrain throttle demand and record clipping
-        if (_throttle_dem > _THRmaxf) {
-            _thr_clip_status = ThrClipStatus::MAX;
-            _throttle_dem = _THRmaxf;
-        } else if (_throttle_dem < _THRminf) {
-            _thr_clip_status = ThrClipStatus::MIN;
-            _throttle_dem = _THRminf;
-        } else {
-            _thr_clip_status = ThrClipStatus::NONE;
-        }
-
         float THRminf_clipped_to_zero = constrain_float(_THRminf, 0, _THRmaxf);
 
         // Calculate integrator state upper and lower limits
@@ -720,13 +709,15 @@ void AP_TECS::_update_throttle_with_airspeed(void)
         _throttle_dem = _throttle_dem + _integTHR_state;
     }
 
-    // Constrain throttle demand and record clip status
+    // Constrain throttle demand and record clipping
     if (_throttle_dem > _THRmaxf) {
         _thr_clip_status = ThrClipStatus::MAX;
         _throttle_dem = _THRmaxf;
     } else if (_throttle_dem < _THRminf) {
         _thr_clip_status = ThrClipStatus::MIN;
         _throttle_dem = _THRminf;
+    } else {
+        _thr_clip_status = ThrClipStatus::NONE;
     }
 }
 


### PR DESCRIPTION
# Reason
There is a redundant saturation occurring prior to the integrator being added to throttle demand.

# Issue
The issue this causes is subtle, but it causes the approach to 100% throttle during a max climb to be slower than what would be intuitive.  Throttle should come up to 100% at the slew rate and time constant for a climb that well above the airplane.  Instead, this takes more of a an upside down hockey stick approach to 100% throttle.

# Solution
Remove the throttle demand saturation occurring before the integrator is added and ensure that only one saturation block is happening at the very end of the determination of throttle demand.  The last saturation block didn't have complete handling of the clipping state enum, so I fixed that for completeness as well.