### PR TITLE
AP_AHRS: body_to_earth is unused and bugged

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -535,7 +535,7 @@ public:
 
     // convert a vector from body to earth frame
     Vector3f body_to_earth(const Vector3f &v) const {
-        return v * get_rotation_body_to_ned();
+        return get_rotation_body_to_ned() * v;
     }
 
     // convert a vector from earth to body frame


### PR DESCRIPTION
body_to_earth function is unused and not rotating correctly. Would
expect the earth_to_body function to be the inverse but that is not the
case, with the earth_to_body function correctly rotating the frame.

A feature I'm still working on required rotating from body to earth and I've found that the rotation wasn't working as expected. I tested the output of the body_to_earth function with the earth_to_body function and found that the result wasn't my initial vector.

What I would have expected:
![expectation](https://user-images.githubusercontent.com/39617257/179937142-e99adad5-4b0e-4397-8dde-bd8939f7d4db.PNG)
With intermediate being the output of body_to_earth, and result being the intermediate vector rotated with earth_to_body

What is implemented:
![implementation](https://user-images.githubusercontent.com/39617257/179937129-1aa1dcb2-6203-4130-8602-bd383d612987.PNG)
With intermediate being the output of body_to_earth, and result being the intermediate vector rotated with earth_to_body

body_to_earth is unused through the ArduPilot source and should have no issues with being removed. If there is a reason to keep the function modifying it to be consistent with earth_to_body would prevent future errors and require minimal effort.

After removing body_to_earth the build_all.sh script ran with no failed builds.

