### PR TITLE
AP_Notify: Add new LedLayout for Lua LED matrix image example

### DIFF
--- a/libraries/AP_Notify/SITL_SFML_LED.cpp
+++ b/libraries/AP_Notify/SITL_SFML_LED.cpp
@@ -40,6 +40,7 @@ bool SITL_SFML_LED::layout_size(SITL::LedLayout layout, uint16_t &xsize, uint16_
 {
     switch (layout) {
     case SITL::LedLayout::ROWS:
+        // (max LED strip size) x (max number of channels)
         xsize = MAX_LEDS;
         ysize = 16;
         break;
@@ -48,6 +49,12 @@ bool SITL_SFML_LED::layout_size(SITL::LedLayout layout, uint16_t &xsize, uint16_
         xsize = 5 + 3 + 5;
         ysize = 5 + 3 + 5;
         break;
+
+    case SITL::LedLayout::LUA_LED_MATRIX_IMAGE:
+        xsize = 7;
+        ysize = 7;
+        break;
+
     default:
         return false;
     }
@@ -105,6 +112,71 @@ bool SITL_SFML_LED::layout_pos(SITL::LedLayout layout, uint8_t chan, uint8_t led
             return false;
         }
         break;
+    case SITL::LedLayout::LUA_LED_MATRIX_IMAGE:
+        /*
+          The Lua scripting example LED_matrix_image.lua has
+          a 7x7 grid of LEDs arranged in diagonal strips on PWM8
+        */
+        if (chan != 7) {
+            return false;
+        }
+
+        static uint16_t index[49][2] = {
+          {0, 6}, //0
+          {1, 6}, //1
+          {0, 5}, //2
+          {0, 4}, //3
+          {1, 5}, //4 
+          {2, 6}, //5
+          {3, 6}, //6
+          {2, 5}, //7
+          {1, 4}, //8
+          {0, 3}, //9
+          {0, 2}, //10
+          {1, 3}, //11
+          {2, 4}, //12
+          {3, 5}, //13
+          {4, 6}, //14
+          {5, 6}, //15
+          {4, 5}, //16
+          {3, 4}, //17
+          {2, 3}, //18
+          {1, 2}, //19
+          {0, 1}, //20
+          {0, 0}, //21
+          {1, 1}, //22
+          {2, 2}, //23
+          {3, 3}, //24
+          {4, 4}, //25
+          {5, 5}, //26
+          {6, 6}, //27
+          {6, 5}, //28
+          {5, 4}, //29
+          {4, 3}, //30
+          {3, 2}, //31
+          {2, 1}, //32
+          {1, 0}, //33
+          {2, 0}, //34
+          {3, 1}, //35
+          {4, 2}, //36
+          {5, 3}, //37
+          {6, 4}, //38
+          {6, 3}, //39
+          {5, 2}, //40
+          {4, 1}, //41
+          {3, 0}, //42
+          {4, 0}, //43
+          {5, 1}, //44
+          {6, 2}, //45
+          {6, 1}, //46
+          {5, 0}, //47
+          {6, 0}  //48
+        };
+
+        xpos = index[led][0];
+        ypos = index[led][1];
+        break;
+
     default:
         return false;
     }

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -45,10 +45,10 @@ private:
     void update_serial_LEDs(void);
     static void *update_thread_start(void *obj);
 
-    static constexpr uint8_t height = 50;
+    static constexpr uint8_t height = 100;
     static constexpr uint8_t width = height;
 
-    static constexpr uint8_t serialLED_size = 16;
+    static constexpr uint8_t serialLED_size = 32;
 
     enum class brightness {
         LED_LOW    = 0x33,

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -33,6 +33,7 @@ namespace SITL {
 enum class LedLayout {
     ROWS=0,
     LUMINOUSBEE=1,
+    LUA_LED_MATRIX_IMAGE=2,
 };
     
 struct vector3f_array {


### PR DESCRIPTION
This PR adds a new custom layout to the SITL_SFML_LED backend to display the matrix of LEDs in the Lua scripting example `LED_matrix_image.lua`. It also increases the default size of the RBG LED and Serial LEDs to make them easier to see. 

### Testing

Run a SITL session with the `--rgbled` flag. For the scripting example set the params:

```bash
SCR_ENABLE       1           # Lua Scripts
SCR_HEAP_SIZE    204800
NTF_DISPLAY_TYPE 10          # SITL
NTF_LED_LEN      49
NTF_LED_TYPES    455         # Build in LED|Internal ToshibaLED|External ToshibaLED|NCP5623 External|NCP5623 Internal|NeoPixel
SERVO8_FUNCTION  94          # Script 1
SERVO9_FUNCTION  132         # ProfiLED Clock
SIM_LED_LAYOUT   2
```

The new layout mirrors the custom grid (LED strips arranged in diagonals) in the Lua example.

 ![led-matrix-layout](https://user-images.githubusercontent.com/24916364/179995673-e8cd16ae-2a10-47a8-b086-76e04939db7e.gif)

