### PR TITLE
add skip-string-normalization to black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ skip = ["./modules/", "./build/"]
 
 [tool.black]
 line-length = 120
+skip-string-normalization = true
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
This allows usage of black without creating unnecessary changes to files (mostly changing single quotes to double quotes, but it also stops a few other changes).