### PR TITLE
Enable OSD parameter menus on KakuteH7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
@@ -151,7 +151,6 @@ define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 
 # setup for OSD
 define OSD_ENABLED 1
-define OSD_PARAM_ENABLED 0
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 


### PR DESCRIPTION
This looks like a copy and paste error coming from the KakuteF7. This should be enabled by default on this board.