### PR TITLE
autotest: add --extra_hwdef option to test_build_options.py

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -23,7 +23,9 @@ class TestBuildOptions(object):
                  do_step_disable_defaults=True,
                  do_step_disable_in_turn=True,
                  build_targets=None,
-                 board="DevEBoxH7v2"):
+                 board="DevEBoxH7v2",
+                 extra_hwdef=None):
+        self.extra_hwdef = extra_hwdef
         self.sizes_nothing_disabled = None
         self.match_glob = match_glob
         self.do_step_disable_all = do_step_disable_all
@@ -94,6 +96,10 @@ class TestBuildOptions(object):
     def test_compile_with_defines(self, defines):
         extra_hwdef_filepath = "/tmp/extra.hwdef"
         self.write_defines_to_file(defines, extra_hwdef_filepath)
+        if self.extra_hwdef is not None:
+            content = open(self.extra_hwdef, "r").read()
+            with open(extra_hwdef_filepath, "a") as f:
+                f.write(content)
         util.waf_configure(
             self.board(),
             extra_hwdef=extra_hwdef_filepath,
@@ -204,6 +210,10 @@ if __name__ == '__main__':
                       choices=TestBuildOptions.all_targets(),
                       action='append',
                       help='vehicle targets to build')
+    parser.add_option("--extra-hwdef",
+                      type='string',
+                      default=None,
+                      help="file containing extra hwdef information")
     parser.add_option("--board",
                       type='string',
                       default="DevEBoxH7v2",
@@ -219,5 +229,6 @@ if __name__ == '__main__':
         do_step_disable_in_turn=not opts.no_disable_in_turn,
         build_targets=opts.build_targets,
         board=opts.board,
+        extra_hwdef=opts.extra_hwdef,
     )
     tbo.run()


### PR DESCRIPTION
This is useful for enabling or disabling more hwdef features when you're testing the build options - specifically for those options not present in the `build_options.py`  script.
