### PR TITLE
autotest: allow dataflash time to write before downloading log

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8518,6 +8518,7 @@ Also, ignores heartbeats not from our target system'''
             self.set_parameter("LOG_DISARMED", 1)
             self.delay_sim_time(3)
             self.set_parameter("LOG_DISARMED", 0)
+            self.delay_sim_time(3)
             mavproxy.send("log download 1 logs/dataflash-log-erase.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
             # read the downloaded log - it must parse without error


### PR DESCRIPTION
pretty sure we need to let IO do its thing here

```
2022-07-21T22:31:11.7748076Z AT-1155.2: LOG_DISARMED want=0.000000 autopilot=0.0 (attempt=3/10)
2022-07-21T22:31:11.7748541Z AT-1155.2: LOG_DISARMED is now 0.000000
2022-07-21T22:31:11.7748954Z log download 1 logs/dataflash-log-erase.BIN
2022-07-21T22:31:11.7749378Z log download 1 logs/dataflash-log-erase.BIN
2022-07-21T22:31:11.7749836Z STABILIZE> Downloading log 1 as logs/dataflash-log-erase.BIN
2022-07-21T22:31:11.7750406Z Finished downloading logs/dataflash-log-erase.BIN (7996 bytes 0 seconds, 831.0 kbyte/sec 0 retries)
2022-07-21T22:31:11.7751029Z AT-1155.2: Exception caught: Error parsing log file logs/dataflash-log-erase.BIN, 1 header errors
2022-07-21T22:31:11.7751454Z Traceback (most recent call last):
2022-07-21T22:31:11.7751812Z   File "/__w/ardupilot/ardupilot/Tools/autotest/common.py", line 8524, in test_dataflash_erase
2022-07-21T22:31:11.7752325Z     self.validate_log_file("logs/dataflash-log-erase.BIN")
2022-07-21T22:31:11.7752769Z   File "/__w/ardupilot/ardupilot/Tools/autotest/common.py", line 8504, in validate_log_file
```
