### PR TITLE
AP_Vehicle: correct description of G_Dt

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -316,8 +316,7 @@ protected:
     // main loop scheduler
     AP_Scheduler scheduler;
 
-    // IMU variables
-    // Integration time; time last loop took to run
+    // simple copy of get_loop_period_s
     float G_Dt;
 
     // sensor drivers


### PR DESCRIPTION
I'm quite sure this is not the correct fix for this problem - I'm creating this PR for discussion.

`G_Dt` should probable rightly be set from `get_last_loop_time_s` rather than `get_loop_period_s`.  The former is the measured time for the last loop.  The latter is memoised at vehicle startup based on the configured loop rate (`SCHED_LOOP_RATE`).

https://github.com/ArduPilot/ardupilot/pull/13399 made us consistent across vehicles, but did move us from using the last loop period on Copter to using the configured loop period instead.  It was the only vehicle which was using the last loop period.

I think the correct fix here is probably to eliminate `G_Dt` altogether, and have each place where it was being used changed to either use the desired loop rate (when initialising slew rates, for example), or to use actual last loop period (when updating filters, perhaps?).  grep finds 74 matches for `G_Dt`, but some of the matches look identical-in-shape to others meaning it won't be 74 decisions to make.
