### PR TITLE
GCS_MAVLink: ensure payload space for ACK before sending

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2974,6 +2974,19 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
         return MAV_RESULT_UNSUPPORTED;
     }
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    {  // autotest relies in receiving the ACK for the reboot.  Ensure
+       // there is space for it:
+        const uint32_t tstart_ms = AP_HAL::millis();
+        while (AP_HAL::millis() - tstart_ms < 1000) {
+            if (HAVE_PAYLOAD_SPACE(chan, COMMAND_ACK)) {
+                break;
+            }
+            hal.scheduler->delay(10);
+        }
+    }
+#endif
+
     // send ack before we reboot
     mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED,
                                  0, 0, 0, 0);


### PR DESCRIPTION
Attempting to fix instance of the ACK not arriving on SITL reboot.  We already have a lot of code around trying to get this out, but there's been at least once instance it hasn't.


Failing test here: https://pipelines.actions.githubusercontent.com/serviceHosts/931110f1-affa-41d4-ade0-47b5803520e6/_apis/pipelines/1/runs/45333/signedlogcontent/28?urlExpires=2022-07-22T03%3A55%3A53.5254003Z&urlSigningMethod=HMACV1&urlSignature=SQR%2FkPw%2Fvh9uf03aZAW%2FYKmaA6obM%2B2yDwqvS7BYnhw%3D