### PR TITLE
Remove references to config.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,6 @@ Thumbs.db
 autotest.lck
 build
 cmake_install.cmake
-config.mk
 cscope.in.out
 cscope.out
 cscope.po.out
@@ -102,7 +101,6 @@ test.ArduCopter/*
 GPATH
 GRTAGS
 GTAGS
-config.mk
 *.apj
 .gdbinit
 /.vscode

--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -1,8 +1,5 @@
 // User specific config file.  Any items listed in config.h can be overridden here.
 
-// If you used to define your CONFIG_APM_HARDWARE setting here, it is no longer
-// valid! You should switch to using a HAL_BOARD flag in your local config.mk.
-
 // uncomment the lines below to disable features (flash sizes listed are for APM2 boards and will underestimate savings on Pixhawk and other boards)
 //#define LOGGING_ENABLED       DISABLED            // disable logging to save 11K of flash space
 //#define MOUNT                 DISABLED            // disable the camera gimbal to save 8K of flash space

--- a/Tools/scripts/build_all.sh
+++ b/Tools/scripts/build_all.sh
@@ -3,8 +3,6 @@
 # This helps when doing large merges
 # Andrew Tridgell, November 2011
 
-. config.mk
-
 set -e
 set -x
 

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -84,7 +84,6 @@ git reset --hard origin/master
 git pull || report_pull_failure
 git clean -f -f -x -d -d
 git tag autotest-$(date '+%Y-%m-%d-%H%M%S') -m "test tag `date`"
-cp ../config.mk .
 popd
 
 rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -641,18 +641,6 @@ is bob we will attempt to checkout bob-AVR'''
                                  (str(self.tags)))
             self.dirty = True
 
-    def pollute_env_from_file(self, filepath):
-        with open(filepath) as f:
-            for line in f:
-                try:
-                    (name, value) = str.split(line, "=")
-                except ValueError as e:
-                    self.progress("%s: split failed: %s" % (filepath, str(e)))
-                    continue
-                value = value.rstrip()
-                self.progress("%s: %s=%s" % (filepath, name, value))
-                os.environ[name] = value
-
     def remove_tmpdir(self):
         if os.path.exists(self.tmpdir):
             self.progress("Removing (%s)" % (self.tmpdir,))
@@ -704,10 +692,6 @@ is bob we will attempt to checkout bob-AVR'''
         self.binaries = os.path.join(self.buildlogs_dirpath(), "binaries")
         self.basedir = os.getcwd()
         self.error_strings = []
-
-        if os.path.exists("config.mk"):
-            # FIXME: narrow exception
-            self.pollute_env_from_file("config.mk")
 
         if not self.dirty:
             self.run_git_update_submodules()


### PR DESCRIPTION
dates from APM-build days.  The build server files references APM1 which is long gone.  Users running build_binaries can pollute their own environments, not need for this.