### PR TITLE
Build parameters / log messages honours BUILDLOGS from env

### DIFF
--- a/Tools/scripts/build_log_message_documentation.sh
+++ b/Tools/scripts/build_log_message_documentation.sh
@@ -3,7 +3,10 @@
 set -e
 set -x
 
-DIR="../buildlogs/LogMessages"
+if [ "x$BUILDLOGS" = "x" ]; then
+    BUILDLOGS="../buildlogs"
+fi
+DIR="$BUILDLOGS/LogMessages"
 
 # work from either APM directory or above
 [ -d ArduPlane ] || cd APM

--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -3,7 +3,10 @@
 set -e
 set -x
 
-PARAMS_DIR="../buildlogs/Parameters"
+if [ "x$BUILDLOGS" = "x" ]; then
+    BUILDLOGS="../buildlogs"
+fi
+PARAMS_DIR="$BUILDLOGS/Parameters"
 
 # work from either APM directory or above
 [ -d ArduPlane ] || cd APM


### PR DESCRIPTION
Allows a target directory to be specified in the environment when building parameters and log message documentation

This environment variable is also honoured by autotest.
