### PR TITLE
Math: create row_times_mat()

### DIFF
--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -84,7 +84,7 @@ float Airspeed_Calibration::update(float airspeed, const Vector3f &vg, int16_t m
     state += KG*(TAS_mea - TAS_pred); // [3 x 1] + [3 x 1] * [1 x 1]
 
     // Update the covariance matrix
-    Vector3f HP2 = H_TAS * P;
+    Vector3f HP2 = H_TAS.row_times_mat(P);
     P -= KG.mul_rowcol(HP2);
 
     // force symmetry on the covariance matrix - necessary due to rounding

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -437,7 +437,7 @@ T Vector3<T>::angle(const Vector3<T> &v2) const
 
 // multiplication of transpose by a vector
 template <typename T>
-Vector3<T> Vector3<T>::operator *(const Matrix3<T> &m) const
+Vector3<T> Vector3<T>::row_times_mat(const Matrix3<T> &m) const
 {
     return Vector3<T>(*this * m.colx(),
                       *this * m.coly(),

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -158,7 +158,7 @@ public:
     }
     
     // multiply a row vector by a matrix, to give a row vector
-    Vector3<T> operator *(const Matrix3<T> &m) const;
+    Vector3<T> row_times_mat(const Matrix3<T> &m) const;
 
     // multiply a column vector by a row vector, returning a 3x3 matrix
     Matrix3<T> mul_rowcol(const Vector3<T> &v) const;

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -494,7 +494,7 @@ void FlightAxis::update(const struct sitl_input &input)
     Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
 
     if (last_imu_rotation != ROTATION_NONE) {
-        airspeed3d = airspeed3d * sitl->ahrs_rotation_inv;
+        airspeed3d = sitl->ahrs_rotation_inv * airspeed3d;
     }
     airspeed_pitot = MAX(airspeed3d.x,0);
 


### PR DESCRIPTION
After the bug fixed in #21237 I wondered if the same bug was in other places. It was also in SITL (in a rarely used location), so this renames the operator to row_times_mat() to make the bug less likely
