### PR TITLE
Tools: Filter tool updates

### DIFF
--- a/Tools/autotest/web-firmware/Tools/FilterTool/app.py
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/app.py
@@ -1,0 +1,16 @@
+import os
+from flask import Flask
+from flask import render_template
+
+# A flask app to allow hosting filter tool locally
+
+this_path = os.path.dirname(os.path.realpath(__file__))
+
+app = Flask(__name__, template_folder=this_path, static_folder=this_path)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+if __name__ == "__main__":
+    app.run()

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -5,6 +5,8 @@
 <title>ArduPilot Filter Analysis</title>
 <script type="text/javascript" src="filters.js"></script>
 <script type="text/javascript" src="FileSaver.js"></script>
+<script type="text/javascript" src={{url_for('static', filename='filters.js')}}></script>
+<script type="text/javascript" src={{url_for('static', filename='FileSaver.js')}}></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 </head>
 <a href="https://ardupilot.org"><img src="logo.png"></a>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -52,7 +52,7 @@ ArduPilot 4.2 filter setup.
 <fieldset>
   <legend>PID Settings</legend>
         <p>
-                <label for="FLTD">D Filter</label>
+                <label for="FLTD">Roll D Filter</label>
                 <input id="FLTD" name="FLTD" type="number" step="0.1" value="10.0"/>
 	</p>
 </fieldset>


### PR DESCRIPTION
This is a number of updates to the filter tool

- More accurate phase calculation using interpolation
- RMS for amplitude calculation
- Amplitude calculation for a exact number of cycles
- Changed phase wrapping, it can now go positive, but this seems to line up with example phase plots online.
- Removed scatter points
- Corrected linear amplitude scale (it was inverted with attention of 1 at the top)
- removed grid lines for phase lag
- round tooltip to 2 decimal places
- Added flask python launcher for local testing
- Increased frequency resolution
- Decreased number of samples
- labeled D filter as roll axis. (I'm still not sure about including it in this tool at all, its also applied at the wrong sample rate (gyro rate vs PID rate))

Comparisons, current on left this PR on right.

Gyro filter only:
![image](https://user-images.githubusercontent.com/33176108/180655366-4a0bf858-5637-4dbc-ab5b-c8686a513ed6.png)

Gyro + notch:
![image](https://user-images.githubusercontent.com/33176108/180655417-14beb8de-4122-4a79-95fc-54dcb89d8b87.png)

Notch only:
![image](https://user-images.githubusercontent.com/33176108/180655455-7ef5d591-b347-4380-85ff-e57e44bf944c.png)

Gyro + notch + D:
![image](https://user-images.githubusercontent.com/33176108/180655494-6be77a01-1e1a-46d7-97cf-ad3e453248f8.png)

As above with log scale:
![image](https://user-images.githubusercontent.com/33176108/180655512-662d69bf-5d1a-4052-8e31-fd484fb6fb48.png)

Lots of stuff:
![image](https://user-images.githubusercontent.com/33176108/180656276-82859ebd-7daa-43e5-a152-830858f434ea.png)

Here we see the new method go a little wobbly on high frequency attenuation, this is due to the reduced number of samples, we could put the number of samples back to original. But it would run slower due to the increased frequency resolution. We need the better frequency resolution so we don't get any expected phase changes of more than 180 deg between one point and the next, they mess up the unwrapping code. Currently this is ten times fewer samples and twice as many frequency steps, so its five times faster. We could mess with that to get more resolution for the same run time.

Old tooltip:
![image](https://user-images.githubusercontent.com/33176108/180655860-b1c3a514-0014-4d81-bc87-50a436eeb9db.png)

New tooltip:
![image](https://user-images.githubusercontent.com/33176108/180656464-98324c49-1f82-4dcc-b53a-9bf7cabff0b7.png)


