### PR TITLE
AP_SerialManager: correct bug in find_baudrate() function

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -630,7 +630,7 @@ uint32_t AP_SerialManager::find_baudrate(enum SerialProtocol protocol, uint8_t i
     if (_state == nullptr) {
         return 0;
     }
-    return state->baudrate();
+    return _state->baudrate();
 }
 
 // find_portnum - find port number (SERIALn index) for a protocol and instance, -1 for not found


### PR DESCRIPTION
This bug is related to issues：https://github.com/ArduPilot/ardupilot/issues/21271