### PR TITLE
Add prearm check that we are using configured AHRS type

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1836,6 +1836,17 @@ class AutoTest(ABC):
                      0,
                      0)
 
+    def run_cmd_run_prearms(self):
+        self.run_cmd(mavutil.mavlink.MAV_CMD_RUN_PREARM_CHECKS,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0)
+
     def run_cmd_enable_high_latency(self, new_state):
         p1 = 0
         if new_state:
@@ -6590,6 +6601,9 @@ class AutoTest(ABC):
                 raise NotAchievedException("Sensor did not achieve state")
             if self.sensor_has_state(sensor, present=present, enabled=enabled, healthy=healthy, verbose=verbose):
                 break
+
+    def wait_not_ready_to_arm(self):
+        self.wait_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK, True, True, False)
 
     def wait_prearm_sys_status_healthy(self, timeout=60):
         self.do_timesync_roundtrip()

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2084,6 +2084,16 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         ret = false;
     }
 
+    if (!attitudes_consistent(failure_msg, failure_msg_len)) {
+        return false;
+    }
+
+    // ensure we're using the configured backend:
+    if (ekf_type() != active_EKF_type()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "AHRS: not using configured AHRS type");
+        return false;
+    }
+
     switch (ekf_type()) {
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -277,9 +277,6 @@ public:
     // true if offsets are valid
     bool getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const;
 
-    // check all cores providing consistent attitudes for prearm checks
-    bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const;
-
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng);
@@ -674,6 +671,9 @@ private:
     bool always_use_EKF() const {
         return _ekf_flags & FLAG_ALWAYS_USE_EKF;
     }
+
+    // check all cores providing consistent attitudes for prearm checks
+    bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const;
 
     /*
      * Attitude-related private methods and attributes:

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -432,13 +432,6 @@ bool AP_Arming::ins_checks(bool report)
             check_failed(ARMING_CHECK_INS, report, "temperature cal running");
             return false;
         }
-        
-        // check AHRS attitudes are consistent
-        char failure_msg[50] = {};
-        if (!AP::ahrs().attitudes_consistent(failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_INS, report, "%s", failure_msg);
-            return false;
-        }
     }
 
 #if HAL_GYROFFT_ENABLED


### PR DESCRIPTION
```
arm throttle
QLOITER> Got COMMAND_ACK: COMPONENT_ARM_DISARM: FAILED
AP: PreArm: AHRS: not using configured AHRS type
AP: EKF2 IMU0 is using GPS
AP: EKF2 IMU1 is using GPS
AP: AHRS: EKF2 active

QLOITER> 
QLOITER> arm throttle
QLOITER> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
AP: Throttle armed
ARMED
```
