### PR TITLE
Add support for redundant CAN bus in AP Periph

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1240,6 +1240,7 @@ static void processRx(void)
 #if DEBUG_PKTS
             const int16_t res = 
 #endif
+            rx_frame.iface_id = ins.index;
             canardHandleRxFrame(&ins.canard, &rx_frame, timestamp);
 #if DEBUG_PKTS
             if (res < 0 &&


### PR DESCRIPTION
requires https://github.com/dronecan/libcanard/pull/10

Tested on Here3+