### PR TITLE
autotest: allow a test to override speedup

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1434,11 +1434,12 @@ class LocationInt(object):
 
 class Test(object):
     '''a test definition - information about a test'''
-    def __init__(self, name, description, function, attempts=1):
+    def __init__(self, name, description, function, attempts=1, speedup=None):
         self.name = name
         self.description = description
         self.function = function
         self.attempts = attempts
+        self.speedup = speedup
 
 
 class AutoTest(ABC):
@@ -7048,6 +7049,8 @@ Also, ignores heartbeats not from our target system'''
 
         start_time = time.time()
 
+        orig_speedup = None
+
         ex = None
         try:
             self.check_rc_defaults()
@@ -7057,6 +7060,10 @@ Also, ignores heartbeats not from our target system'''
             self.set_current_waypoint(0, check_afterwards=False)
             self.drain_mav()
             self.drain_all_pexpects()
+            if test.speedup is not None:
+                self.progress("Overriding speedup to %u" % test.speedup)
+                orig_speedup = self.get_parameter("SIM_SPEEDUP")
+                self.set_parameter("SIM_SPEEDUP", test.speedup)
 
             test_function()
         except Exception as e:
@@ -7069,6 +7076,9 @@ Also, ignores heartbeats not from our target system'''
                     self.mav.message_hooks.remove(h)
         self.test_timings[desc] = time.time() - start_time
         reset_needed = self.contexts[-1].sitl_commandline_customised
+
+        if orig_speedup is not None:
+            self.set_parameter("SIM_SPEEDUP", orig_speedup)
 
         passed = True
         if ex is not None:


### PR DESCRIPTION
EDIT: removed the bit which sets it for a test which was failing, just retains the infrastructure now

Just a test to see if slowing the test down helps.

It doesn't.
