### PR TITLE
AP_Param: allow Vector3f defaults

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -374,7 +374,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass soft-iron diagonal Z component
     // @Description: DIA_Z in the compass soft-iron calibration matrix: [[DIA_X, ODI_X, ODI_Y], [ODI_X, DIA_Y, ODI_Z], [ODI_Y, ODI_Z, DIA_Z]]
     // @User: Advanced
-    AP_GROUPINFO("DIA",    24, Compass, _state._priv_instance[0].diagonals, 0),
+    AP_GROUPINFO("DIA",    24, Compass, _state._priv_instance[0].diagonals, 1.0),
 
     // @Param: ODI_X
     // @DisplayName: Compass soft-iron off-diagonal X component
@@ -412,7 +412,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 soft-iron diagonal Z component
     // @Description: DIA_Z in the compass2 soft-iron calibration matrix: [[DIA_X, ODI_X, ODI_Y], [ODI_X, DIA_Y, ODI_Z], [ODI_Y, ODI_Z, DIA_Z]]
     // @User: Advanced
-    AP_GROUPINFO("DIA2",    26, Compass, _state._priv_instance[1].diagonals, 0),
+    AP_GROUPINFO("DIA2",    26, Compass, _state._priv_instance[1].diagonals, 1.0),
 
     // @Param: ODI2_X
     // @DisplayName: Compass2 soft-iron off-diagonal X component
@@ -450,7 +450,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 soft-iron diagonal Z component
     // @Description: DIA_Z in the compass3 soft-iron calibration matrix: [[DIA_X, ODI_X, ODI_Y], [ODI_X, DIA_Y, ODI_Z], [ODI_Y, ODI_Z, DIA_Z]]
     // @User: Advanced
-    AP_GROUPINFO("DIA3",    28, Compass, _state._priv_instance[2].diagonals, 0),
+    AP_GROUPINFO("DIA3",    28, Compass, _state._priv_instance[2].diagonals, 1.0),
 
     // @Param: ODI3_X
     // @DisplayName: Compass3 soft-iron off-diagonal X component

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -48,10 +48,6 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
 {
     Compass::mag_state &state = _compass._state[Compass::StateIndex(i)];
 
-    if (state.diagonals.get().is_zero()) {
-        state.diagonals.set(Vector3f(1.0f,1.0f,1.0f));
-    }
-
     const Vector3f &offsets = state.offset.get();
     const Vector3f &diagonals = state.diagonals.get();
     const Vector3f &offdiagonals = state.offdiagonals.get();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -200,7 +200,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Range: 0.8 1.2
     // @User: Advanced
     // @Calibration: 1
-    AP_GROUPINFO("ACCSCAL",     12, AP_InertialSensor, _accel_scale[0],  0),
+    AP_GROUPINFO("ACCSCAL",     12, AP_InertialSensor, _accel_scale[0],  1.0),
 
     // @Param: ACCOFFS_X
     // @DisplayName: Accelerometer offsets of X axis
@@ -249,7 +249,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Calibration: 1
 
 #if INS_MAX_INSTANCES > 1
-    AP_GROUPINFO("ACC2SCAL",    14, AP_InertialSensor, _accel_scale[1],   0),
+    AP_GROUPINFO("ACC2SCAL",    14, AP_InertialSensor, _accel_scale[1],   1.0),
 #endif
 
     // @Param: ACC2OFFS_X
@@ -302,7 +302,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Calibration: 1
 
 #if INS_MAX_INSTANCES > 2
-    AP_GROUPINFO("ACC3SCAL",    16, AP_InertialSensor, _accel_scale[2],   0),
+    AP_GROUPINFO("ACC3SCAL",    16, AP_InertialSensor, _accel_scale[2],   1.0),
 #endif
 
     // @Param: ACC3OFFS_X
@@ -859,14 +859,6 @@ AP_InertialSensor::init(uint16_t loop_rate)
 
     if (_gyro_count == 0 && _accel_count == 0) {
         _start_backends();
-    }
-
-    // initialise accel scale if need be. This is needed as we can't
-    // give non-zero default values for vectors in AP_Param
-    for (uint8_t i=0; i<get_accel_count(); i++) {
-        if (_accel_scale[i].get().is_zero()) {
-            _accel_scale[i].set(Vector3f(1,1,1));
-        }
     }
 
     // calibrate gyros unless gyro calibration has been disabled

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1461,6 +1461,11 @@ void AP_Param::setup_object_defaults(const void *object_pointer, const struct Gr
             void *ptr = (void *)(base + group_info[i].offset);
             set_value((enum ap_var_type)type, ptr,
                       get_default_value((const AP_Param *)ptr, &group_info[i].def_value));
+        } else if (type == AP_PARAM_VECTOR3F) {
+            // Single default for all components
+            void *ptr = (void *)(base + group_info[i].offset);
+            const float default_val = get_default_value((const AP_Param *)ptr, &group_info[i].def_value);
+            ((AP_Vector3f *)ptr)->set(Vector3f{default_val, default_val, default_val});
         }
     }
 }

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -96,10 +96,6 @@ class SIM {
 public:
 
     SIM() {
-        // set a default compass offset
-        for (uint8_t i = 0; i < HAL_COMPASS_MAX_SENSORS; i++) {
-            mag_ofs[i].set(Vector3f(5, 13, -18));
-        }
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
         AP_Param::setup_object_defaults(this, var_info3);
@@ -116,6 +112,10 @@ public:
         }
         for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
             AP_Param::setup_object_defaults(&airspeed[i], airspeed[i].var_info);
+        }
+        // set compass offset
+        for (uint8_t i = 0; i < HAL_COMPASS_MAX_SENSORS; i++) {
+            mag_ofs[i].set(Vector3f(5, 13, -18));
         }
         if (_singleton != nullptr) {
             AP_HAL::panic("Too many SITL instances");


### PR DESCRIPTION
Came up while discussing https://github.com/ArduPilot/ardupilot/pull/21245. This allows default values to be set so they do not show up as none default when doing a diff using the new defaults param support over FTP. 

This does also remove the code that was setting the vectors to 1. Because this was done after param load if someone had saved a zeros in there params we would now use it where previously we would change it to all ones.

The param diff with and without this patch after a wipe shows only `INS_ACC3SCAL_` ... `X`,`Y` and `Z`. This is because the removed param set in `AP_InertialSensor` did a loop to `get_accel_count()` which on SITL is 2. So the 3rd set of params remained at zero, with this patch there all one.