### PR TITLE
AP_LandingGear: SITL: only set defualts is SITL pin is set avoiding enable via param conversion

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6987,7 +6987,13 @@ class AutoTestCopter(AutoTest):
     def fly_rangefinder_mavlink_distance_sensor(self):
         self.start_subtest("Test mavlink rangefinder using DISTANCE_SENSOR messages")
         self.context_push()
-        self.set_parameter('RTL_ALT_TYPE', 0)
+        self.set_parameters({
+            "RTL_ALT_TYPE": 0,
+            "LGR_ENABLE": 1,
+            "LGR_DEPLOY_ALT": 1,
+            "LGR_RETRACT_ALT": 10, # metres
+            "SERVO10_FUNCTION": 29
+        })
         ex = None
         try:
             self.set_parameter("SERIAL5_PROTOCOL", 1)
@@ -7040,11 +7046,6 @@ class AutoTestCopter(AutoTest):
                     255  # covariance
                 )
             self.arm_vehicle()
-            self.set_parameters({
-                "SERVO10_FUNCTION": 29,
-                "LGR_DEPLOY_ALT": 1,
-                "LGR_RETRACT_ALT": 10,  # metres
-            })
             self.delay_sim_time(1)  # servo function maps only periodically updated
 #            self.send_debug_trap()
 

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -6,6 +6,10 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <SITL/SITL.h>
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
@@ -47,14 +51,14 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO("WOW_PIN", 5, AP_LandingGear, _pin_weight_on_wheels, DEFAULT_PIN_WOW),
+    AP_GROUPINFO("WOW_PIN", 5, AP_LandingGear, _pin_weight_on_wheels, -1),
 
     // @Param: WOW_POL
     // @DisplayName: Weight on wheels feedback pin polarity
     // @Description: Polarity for feedback pin. If this is 1 then the pin should be high when there is weight on wheels. If set to 0 then then weight on wheels level is low.
     // @Values: 0:Low,1:High
     // @User: Standard
-    AP_GROUPINFO("WOW_POL", 6, AP_LandingGear, _pin_weight_on_wheels_polarity, DEFAULT_PIN_WOW_POL),
+    AP_GROUPINFO("WOW_POL", 6, AP_LandingGear, _pin_weight_on_wheels_polarity, 0),
 
     // @Param: DEPLOY_ALT
     // @DisplayName: Landing gear deployment altitude
@@ -91,6 +95,13 @@ AP_LandingGear *AP_LandingGear::_singleton;
 /// initialise state of landing gear
 void AP_LandingGear::init()
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (AP::sitl()->wow_pin > 0) {
+        _pin_weight_on_wheels.set_and_default(AP::sitl()->wow_pin);
+        _pin_weight_on_wheels_polarity.set_and_default(1);
+    }
+#endif
+
     if (!_enable.configured() && (SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control) || 
             (_pin_deployed > 0) || (_pin_weight_on_wheels > 0))) {
         // if not configured set enable param if output servo or sense pins are defined

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -5,14 +5,6 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#define DEFAULT_PIN_WOW 8
-#define DEFAULT_PIN_WOW_POL 1
-#else
-#define DEFAULT_PIN_WOW -1
-#define DEFAULT_PIN_WOW_POL 0
-#endif
-
 /// @class  AP_LandingGear
 /// @brief  Class managing the control of landing gear
 class AP_LandingGear {


### PR DESCRIPTION
Another little fixup from https://github.com/ArduPilot/ardupilot/pull/21245. The wow pin was defaulting to a value in SITL, so we were hitting the param conversion here:

https://github.com/ArduPilot/ardupilot/blob/b7a3038996873c712cd93633de2060a20b974d44/libraries/AP_LandingGear/AP_LandingGear.cpp#L94-L98

That resulted in landing gear always being enabled. This changes to only setup the defaults if the SITL wow pin parameter is set. 

Due to that I also had to enable gear in the autotest.