### PR TITLE
SITL: SIM_Buzzer: hide params if not WITH_SITL_TONEALARM

### DIFF
--- a/libraries/SITL/SIM_Buzzer.cpp
+++ b/libraries/SITL/SIM_Buzzer.cpp
@@ -40,6 +40,8 @@ namespace BuzzerSynth {
 
 using namespace SITL;
 
+#ifdef WITH_SITL_TONEALARM
+
 // table of user settable parameters
 const AP_Param::GroupInfo Buzzer::var_info[] = {
 
@@ -59,8 +61,6 @@ const AP_Param::GroupInfo Buzzer::var_info[] = {
 
     AP_GROUPEND
 };
-
-#ifdef WITH_SITL_TONEALARM
 
 static sf::SoundBuffer xsoundBuffer;
 static sf::Sound xdemoSound;
@@ -125,6 +125,8 @@ void Buzzer::update(const struct sitl_input &input)
 #else
 
 using namespace SITL;
+
+const AP_Param::GroupInfo Buzzer::var_info[] = { AP_GROUPEND };
 
 Buzzer::Buzzer() { };
 


### PR DESCRIPTION
Last fix from https://github.com/ArduPilot/ardupilot/pull/21245

We always had the param table but only set the defaults in the constructor if `WITH_SITL_TONEALARM` so the params were showing up as changed. This removes the param table in that case, they don't do anything in that case.