### PR TITLE
Tools: FilterTool: add support for query strings

### DIFF
--- a/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
@@ -398,7 +398,9 @@ function calculate_filter() {
     var filters = get_filters(sample_rate);
 
     var use_dB = document.getElementById("ScaleLog").checked;
+    setCookie("Scale", use_dB ? "Log" : "Linear");
     var use_RPM = document.getElementById("freq_Scale_RPM").checked;
+    setCookie("feq_unit", use_RPM ? "RPM" : "Hz");
     var attenuation = []
     var phase_lag = []
     var min_phase_lag = 0.0;
@@ -461,6 +463,7 @@ function calculate_filter() {
     }
 
     var freq_log = document.getElementById("freq_ScaleLog").checked;
+    setCookie("feq_scale", freq_log ? "Log" : "Linear");
     if ((freq_log_scale != null) && (freq_log_scale != freq_log)) {
         // Scale changed, no easy way to update, delete chart and re-draw
         chart.clear();
@@ -586,7 +589,9 @@ function calculate_pid(axis_id) {
                         get_form(axis_prefix + "FLTD")));
 
     var use_dB = document.getElementById("PID_ScaleLog").checked;
+    setCookie("PID_Scale", use_dB ? "Log" : "Linear");
     var use_RPM =  document.getElementById("PID_freq_Scale_RPM").checked;
+    setCookie("PID_feq_unit", use_RPM ? "RPM" : "Hz");
     var attenuation = []
     var phase_lag = []
     var min_phase_lag = 0.0;
@@ -612,6 +617,7 @@ function calculate_pid(axis_id) {
         fast_sample_rate = get_form("GyroSampleRate");
         fast_filters = get_filters(fast_sample_rate);
     }
+    setCookie("filtering", fast_filters == null ? "Pre" : "Post");
 
 
     for (freq=freq_step; freq<=freq_max; freq+=freq_step) {
@@ -659,6 +665,7 @@ function calculate_pid(axis_id) {
     max_phase_lag = Math.min(get_form("PID_MaxPhaseLag"), max_phase_lag);
 
     var freq_log = document.getElementById("PID_freq_ScaleLog").checked;
+    setCookie("PID_feq_scale", use_dB ? "Log" : "Linear");
     if ((PID_freq_log_scale != null) && (PID_freq_log_scale != freq_log)) {
         // Scale changed, no easy way to update, delete chart and re-draw
         PID_chart.clear();
@@ -783,6 +790,13 @@ function load_cookies() {
         var inputs = document.forms[sections[i]].getElementsByTagName("input");
         for (const v in inputs) {
             var name = inputs[v].name;
+            if (inputs[v].type == "radio") {
+                // only checked buttons are included
+                if (inputs[v].value == getCookie(name)) {
+                    inputs[v].checked = true;
+                }
+                continue;
+            }
             inputs[v].value = parseFloat(getCookie(name,inputs[v].value));
         }
     }

--- a/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
@@ -760,6 +760,68 @@ function calculate_pid(axis_id) {
     }
 }
 
+function load() {
+    var url_string = (window.location.href).toLowerCase();
+    if (url_string.indexOf('?') == -1) {
+        // no query params, load from cookies
+        load_cookies();
+        return;
+    }
+
+    // populate from query's
+    var params = new URL(url_string).searchParams;
+    var sections = ["params", "PID_params"];
+    for (var j = 0; j<sections.length; j++) {
+        var items = document.forms[sections[j]].getElementsByTagName("input");
+        for (var i=-0;i<items.length;i++) {
+            var name = items[i].name.toLowerCase();
+            if (params.has(name)) {
+                if (items[i].type == "radio") {
+                    // only checked buttons are included
+                    if (items[i].value.toLowerCase() == params.get(name)) {
+                        items[i].checked = true;
+                    }
+                    continue;
+                }
+                var value = parseFloat(params.get(name));
+                if (!isNaN(value)) {
+                    items[i].value = value;
+                }
+            }
+        }
+    }
+}
+
+// build url and query string for current view and copy to clipboard
+function get_link() {
+
+    if (!(navigator && navigator.clipboard && navigator.clipboard.writeText)) {
+        // copy not available
+        return
+    }
+
+    // get base url
+    var url =  new URL((window.location.href).split('?')[0]);
+
+    // Add all query strings
+    var sections = ["params", "PID_params"];
+    for (var j = 0; j<sections.length; j++) {
+        var items = document.forms[sections[j]].getElementsByTagName("input");
+        for (var i=-0;i<items.length;i++) {
+            if (items[i].type == "radio" && !items[i].checked) {
+                // Only add checked radio buttons
+                continue;
+            }
+            url.searchParams.append(items[i].name, items[i].value);
+        }
+    }
+
+    // copy to clipboard
+    navigator.clipboard.writeText(url.toString());
+
+}
+
+
 function setCookie(c_name, value) {
     var exdate = new Date();
     var exdays = 365;

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -15,13 +15,14 @@
 
 The following form will display the attenuation and phase lag for an
 ArduPilot 4.2 filter setup.
-<body onload="load_cookies(); fill_docs(); update_all_hidden(); calculate_filter(); calculate_pid(); ">
+<body onload="load(); fill_docs(); update_all_hidden(); calculate_filter(); calculate_pid();">
   <canvas id="Attenuation" style="width:100%;max-width:1200px"></canvas>
 <p>
   <input type="button" id="calculate" value="Calculate">
   <input type="button" id="SaveParams" value="Save Parameters" onclick="save_parameters();">
   <button class="styleClass" onclick="document.getElementById('param_file').click()">Load Parameters</button>
   <input type='file' id="param_file" style="display:none" onchange="load_parameters(this.files[0]);">
+  <input type="button" id="GetLink" value="Get Link" onclick="get_link();">
 
   <form id="params" action="">
 <fieldset style="max-width:1200px">


### PR DESCRIPTION
This adds support for query strings for each config element and adds a button to generate a URL with all the strings generated to get the same result. This includes the graph settings, not just the the parameter settings that you can get from a param file.

eg: `https://firmware.ardupilot.org/Tools/FilterTool/?Scale=Log&MaxFreq=1234&MaxPhaseLag=360&GYRO_SAMPLE_RATE=2000&INS_GYRO_FILTER=20&FLTD=10&Throttle=0.3&NUM_MOTORS=1&ESC_RPM=2500&RPM1=2500&RPM2=2500&INS_HNTCH_ENABLE=0&INS_HNTCH_MODE=0&INS_HNTCH_FREQ=0&INS_HNTCH_BW=0&INS_HNTCH_ATT=0&INS_HNTCH_REF=0&INS_HNTCH_FM_RAT=1&INS_HNTCH_HMNCS=1&INS_HNTCH_OPTS=0&INS_HNTC2_ENABLE=0&INS_HNTC2_MODE=0&INS_HNTC2_FREQ=0&INS_HNTC2_BW=0&INS_HNTC2_ATT=0&INS_HNTC2_REF=0&INS_HNTC2_FM_RAT=1&INS_HNTC2_HMNCS=1&INS_HNTC2_OPTS=0`

New "Get Link" button copy's the url to clipboard.

![image](https://user-images.githubusercontent.com/33176108/181606661-46e46201-b9e6-4849-9c06-a61bd25a995b.png)

The string is quite long, and will get longer as we add more stuff. Being in plain text does mean that it would be quite easy for a  GCS to generate a link to show the current filter setup for example. If the string is not a complete params will be left at default rather than loaded from cookies. 

No query string will load from cookies as now, but now the scale option is also remembered.
