### PR TITLE
autotest: integrate features.json generation to build_binaries.py

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -126,6 +126,7 @@ def build_binaries():
             "build_binaries.py",
             "build_sizes/build_sizes.py",
             "generate_manifest.py",
+            "extract_features.py",
             "gen_stable.py",
     ]:
         orig = util.reltopdir('Tools/scripts/%s' % thing)

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -25,6 +25,7 @@ import traceback
 import generate_manifest
 import gen_stable
 import build_binaries_history
+import extract_features
 
 import board_list
 from board_list import AP_PERIPH_BOARDS
@@ -489,6 +490,10 @@ is bob we will attempt to checkout bob-AVR'''
                         files_to_copy.append((filepath, os.path.basename(filepath)))
                 if not os.path.exists(bare_path):
                     raise Exception("No elf file?!")
+
+                ef = extract_features.ExtractFeatures(bare_path)
+                features_text = ef.extract()
+
                 # only rename the elf if we have have other files to
                 # copy.  So linux gets "arducopter" and stm32 gets
                 # "arducopter.elf"
@@ -510,6 +515,7 @@ is bob we will attempt to checkout bob-AVR'''
                             if not os.path.exists(ddir):
                                 self.mkpath(ddir)
                             self.addfwversion(ddir, vehicle)
+                            self.write_string_to_filepath(features_text, os.path.join(ddir, "features.txt"))
                             self.progress("Copying %s to %s" % (path, ddir,))
                             shutil.copy(path, os.path.join(ddir, target_filename))
                         # the most recent build of every tag is kept around:
@@ -519,6 +525,7 @@ is bob we will attempt to checkout bob-AVR'''
                         # must addfwversion even if path already
                         # exists as we re-use the "beta" directories
                         self.addfwversion(tdir, vehicle)
+                        self.write_string_to_filepath(features_text, os.path.join(ddir, "features.txt"))
                         shutil.copy(path, os.path.join(tdir, target_filename))
                     except Exception as e:
                         self.print_exception_caught(e)
@@ -623,6 +630,7 @@ is bob we will attempt to checkout bob-AVR'''
         generator.run()
 
         generator.write_manifest_json(os.path.join(self.binaries, "manifest.json"))
+        generator.write_features_json(os.path.join(self.binaries, "features.json"))
         self.progress("Manifest generation successful")
 
         self.progress("Generating stable releases")


### PR DESCRIPTION
There are two logical changes in here.  The first changes build_binaries.py to create features.txt in every build directory - next to git_version.txt and the binaries themselves:
```
├── binaries
│   ├── AntennaTracker
│   │   └── dirty
│   │       ├── CubeOrange
│   │       │   ├── antennatracker.apj
│   │       │   ├── features.txt
│   │       │   ├── firmware-version.txt
│   │       │   └── git-version.txt
│   │       └── MatekF405-Wing
│   │           ├── antennatracker.apj
│   │           ├── features.txt
│   │           ├── firmware-version.txt
│   │           └── git-version.txt
```

Format is simple enough:
```
pbarker@recursion:~/rc/ardupilot((HEAD detached at github/pr/build-binaries-collect-features))$ cat /mnt/storage/buildlogs/binaries/AntennaTracker/dirty/CubeOrange/features.txt 
AIRSPEED
AP_EFI
pbarker@recursion:~/rc/ardupilot((HEAD detached at github/pr/build-binaries-collect-features))$ 
```

The second logical change is to `generate_manifest.py`.  It now generates two json objects - one of the versions manifest and one for the features manifest.  build_binaries.py puts the features manifest into `features.json` next to `manifest.json`.
