### PR TITLE
Tools: FilterTool: add support for PIDs and other updates.

### DIFF
--- a/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
@@ -983,4 +983,19 @@ function update_hidden_mode()
     }
 }
 
+function check_nyquist()
+{
+    var checks = [["GyroSampleRate", "MaxFreq", "MaxFreq_warning"],
+                  ["SCHED_LOOP_RATE", "PID_MaxFreq", "PID_MaxFreq_warning"]];
+
+    for (var i = 0; i < checks.length; i++) {
+        var freq_limit = get_form(checks[i][0]) * 0.5;
+        var sample_rate = document.getElementById(checks[i][1]);
+        if (parseFloat(sample_rate.value) > freq_limit) {
+            sample_rate.value = freq_limit;
+            document.getElementById(checks[i][2]).innerHTML = "Nyquist limit of half sample rate";
+        } else {
+            document.getElementById(checks[i][2]).innerHTML = "";
+        }
+    }
 }

--- a/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/filters.js
@@ -581,7 +581,9 @@ function fill_docs()
         if (!doc) {
             continue;
         }
-        inputs[v].onchange = fill_docs;
+        if (inputs[v].onchange == null) {
+            inputs[v].onchange = fill_docs;
+        }
         var value = parseFloat(inputs[v].value);
         if (name.endsWith("_ENABLE")) {
             if (value >= 1) {
@@ -659,5 +661,41 @@ function fill_docs()
             doc.innerHTML = bits.join(", ");
         }
 
+    }
+}
+
+// update all hidden params, to be called at init
+function update_all_hidden()
+{
+    var enable_params = ["INS_HNTCH_ENABLE", "INS_HNTC2_ENABLE"];
+    for (var i=-0;i<enable_params.length;i++) {
+        update_hidden(enable_params[i])
+    }
+}
+
+// update hidden inputs based on param value
+function update_hidden(enable_param)
+{
+    var enabled = parseFloat(document.getElementById(enable_param).value) > 0;
+    var prefix = enable_param.split("_ENABLE")[0];
+
+    // find all elements with same prefix
+    var inputs = document.forms["params"].getElementsByTagName("*");
+    for (var i=-0;i<inputs.length;i++) {
+        var key = inputs[i].id;
+        if (key.length == 0) {
+            // no id, but bound to a valid one
+            if (inputs[i].htmlFor == null) {
+                continue;
+            }
+            key = inputs[i].htmlFor
+        }
+        if (key.startsWith(enable_param)) {
+            // found original param, don't change
+            continue;
+        }
+        if (key.startsWith(prefix)) {
+            inputs[i].hidden = !enabled;
+        }
     }
 }

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -23,7 +23,7 @@ ArduPilot 4.2 filter setup.
   <input type='file' id="param_file" style="display:none" onchange="load_parameters(this.files[0]);">
 
   <form id="params" action="">
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>Graph Settings</legend>
         <p>
                 <input type="radio" id="ScaleLog" name="Scale" value="Log">
@@ -40,7 +40,7 @@ ArduPilot 4.2 filter setup.
                 <input id="MaxPhaseLag" name="MaxPhaseLag" type="number" step="1" value="360"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>INS Settings</legend>
         <p>
                 <label for="GyroSampleRate">Gyro Sample Rate</label>
@@ -51,21 +51,21 @@ ArduPilot 4.2 filter setup.
                 <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>PID Settings</legend>
         <p>
                 <label for="FLTD">Roll D Filter</label>
                 <input id="FLTD" name="FLTD" type="number" step="0.1" value="10.0"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>Throttle Based</legend>
         <p>
                 <label for="Throttle">Throttle</label>
                 <input id="Throttle" name="Throttle" type="number" step="0.01" value="0.3"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>ESC Telemetry</legend>
         <p>
                 <label for="NUM_MOTORS">Number of Motors</label>
@@ -76,7 +76,7 @@ ArduPilot 4.2 filter setup.
                 <input id="ESC_RPM" name="ESC_RPM" type="number" step="1" value="2500"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>RPM/EFI Based</legend>
         <p>
                 <label for="RPM1">RPM1</label>
@@ -87,7 +87,7 @@ ArduPilot 4.2 filter setup.
                 <input id="RPM2" name="RPM2" type="number" step="1" value="2500"/>
 	</p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>First Notch Filter</legend>
         <p>
                 <label for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
@@ -130,7 +130,7 @@ ArduPilot 4.2 filter setup.
                 <label id="INS_HNTCH_OPTS.doc"></label>
         </p>
 </fieldset>
-<fieldset>
+<fieldset style="max-width:1200px">
   <legend>Second Notch Filter</legend>
         <p>
                 <label for="INS_HNTC2_ENABLE">INS_HNTC2_ENABLE</label>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -14,7 +14,7 @@
 
 The following form will display the attenuation and phase lag for an
 ArduPilot 4.2 filter setup.
-<body onload="load_cookies(); calculate_filter(); fill_docs();">
+<body onload="load_cookies(); calculate_filter(); fill_docs(); update_all_hidden();">
   <canvas id="Attenuation" style="width:100%;max-width:1200px"></canvas>
 <p>
   <input type="button" id="calculate" value="Calculate">
@@ -91,7 +91,7 @@ ArduPilot 4.2 filter setup.
   <legend>First Notch Filter</legend>
         <p>
                 <label for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
-                <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0"/>
+                <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0" onchange="update_hidden(this.id); fill_docs();"/>
                 <label id="INS_HNTCH_ENABLE.doc"></label>
         </p>
         <p>
@@ -134,7 +134,7 @@ ArduPilot 4.2 filter setup.
   <legend>Second Notch Filter</legend>
         <p>
                 <label for="INS_HNTC2_ENABLE">INS_HNTC2_ENABLE</label>
-                <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0"/>
+                <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0" onchange="update_hidden(this.id); fill_docs();"/>
                 <label id="INS_HNTC2_ENABLE.doc"></label>
         </p>
         <p>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -25,12 +25,40 @@ ArduPilot 4.2 filter setup.
   <form id="params" action="">
 <fieldset style="max-width:1200px">
   <legend>Graph Settings</legend>
-        <p>
-                <input type="radio" id="ScaleLog" name="Scale" value="Log">
-                <label for="LogScale">Log Scale</label><br>
-                <input type="radio" id="ScaleLinear" name="Scale" value="Linear" checked>
-                <label for="LinearScale">Linear Scale</label><br>
-        </p>
+        <table>
+                <tr>
+                        <td>
+                                <fieldset style="width:150px">
+                                        <legend>Magnitude scale</legend>
+                                        <input type="radio" id="ScaleLog" name="Scale" value="Log" checked>
+                                        <label for="LogScale">dB</label><br>
+                                        <input type="radio" id="ScaleLinear" name="Scale" value="Linear">
+                                        <label for="LinearScale">Linear</label><br>
+                                </fieldset>
+                        </td>
+                        <td>
+                                <fieldset style="width:150px">
+                                        <legend>Frequency scale</legend>
+                                        <table>
+                                                <tr>
+                                                        <td>
+                                                                <input type="radio" id="freq_ScaleLog" name="feq_scale" value="Log" checked>
+                                                                <label for="LogScale">Log</label><br>
+                                                                <input type="radio" id="freq_ScaleLinear" name="feq_scale" value="Linear">
+                                                                <label for="LinearScale">Linear</label><br>
+                                                        </td>
+                                                        <td>
+                                                                <input type="radio" id="freq_Scale_Hz" name="feq_unit" value="Hz" checked>
+                                                                <label for="Scale_unit_Hz">Hz</label><br>
+                                                                <input type="radio" id="freq_Scale_RPM" name="feq_unit" value="RPM">
+                                                                <label for="Scale_unit_RPM">RPM</label><br>
+                                                        </td>
+                                                </tr>
+                                        </table>
+                                </fieldset>
+                        </td>
+                </tr>
+        </table>
         <p>
                 <label for="MaxFreq">Maximum Displayed Frequency</label>
                 <input id="MaxFreq" name="MaxFreq" type="number" step="1" value="150"/>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -14,7 +14,7 @@
 
 The following form will display the attenuation and phase lag for an
 ArduPilot 4.2 filter setup.
-<body onload="load_cookies(); calculate_filter(); fill_docs(); update_all_hidden();">
+<body onload="load_cookies(); fill_docs(); update_all_hidden(); calculate_filter(); calculate_pid(); ">
   <canvas id="Attenuation" style="width:100%;max-width:1200px"></canvas>
 <p>
   <input type="button" id="calculate" value="Calculate">
@@ -52,42 +52,6 @@ ArduPilot 4.2 filter setup.
 	</p>
 </fieldset>
 <fieldset style="max-width:1200px">
-  <legend>PID Settings</legend>
-        <p>
-                <label for="FLTD">Roll D Filter</label>
-                <input id="FLTD" name="FLTD" type="number" step="0.1" value="10.0"/>
-	</p>
-</fieldset>
-<fieldset style="max-width:1200px">
-  <legend>Throttle Based</legend>
-        <p>
-                <label for="Throttle">Throttle</label>
-                <input id="Throttle" name="Throttle" type="number" step="0.01" value="0.3"/>
-	</p>
-</fieldset>
-<fieldset style="max-width:1200px">
-  <legend>ESC Telemetry</legend>
-        <p>
-                <label for="NUM_MOTORS">Number of Motors</label>
-                <input id="NUM_MOTORS" name="NUM_MOTORS" type="number" step="1" value="1"/>
-	</p>
-        <p>
-                <label for="ESC_RPM">ESC RPM</label>
-                <input id="ESC_RPM" name="ESC_RPM" type="number" step="1" value="2500"/>
-	</p>
-</fieldset>
-<fieldset style="max-width:1200px">
-  <legend>RPM/EFI Based</legend>
-        <p>
-                <label for="RPM1">RPM1</label>
-                <input id="RPM1" name="RPM1" type="number" step="1" value="2500"/>
-	</p>
-        <p>
-                <label for="RPM2">RPM2</label>
-                <input id="RPM2" name="RPM2" type="number" step="1" value="2500"/>
-	</p>
-</fieldset>
-<fieldset style="max-width:1200px">
   <legend>First Notch Filter</legend>
         <p>
                 <label for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
@@ -96,7 +60,7 @@ ArduPilot 4.2 filter setup.
         </p>
         <p>
                 <label for="INS_HNTCH_MODE">INS_HNTCH_MODE</label>
-                <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0"/>
+                <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0" onchange="update_hidden_mode(); fill_docs();"/>
                 <label id="INS_HNTCH_MODE.doc"></label>
         </p>
         <p>
@@ -139,7 +103,7 @@ ArduPilot 4.2 filter setup.
         </p>
         <p>
                 <label for="INS_HNTC2_MODE">INS_HNTC2_MODE</label>
-                <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0"/>
+                <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0" onchange="update_hidden_mode(); fill_docs();"/>
                 <label id="INS_HNTC2_MODE.doc"></label>
         </p>
         <p>
@@ -173,7 +137,179 @@ ArduPilot 4.2 filter setup.
                 <label id="INS_HNTC2_OPTS.doc"></label>
         </p>
 </fieldset>
-<hr>
+<fieldset style="max-width:1200px" id="Throttle_input">
+        <legend>Throttle Based</legend>
+              <p>
+                      <label for="Throttle">Throttle</label>
+                      <input id="Throttle" name="Throttle" type="number" step="0.01" value="0.3"/>
+              </p>
+</fieldset>
+<fieldset style="max-width:1200px" id="ESC_input">
+        <legend>ESC Telemetry</legend>
+              <p>
+                      <label for="NUM_MOTORS">Number of Motors</label>
+                      <input id="NUM_MOTORS" name="NUM_MOTORS" type="number" step="1" value="1"/>
+              </p>
+              <p>
+                      <label for="ESC_RPM">ESC RPM</label>
+                      <input id="ESC_RPM" name="ESC_RPM" type="number" step="1" value="2500"/>
+              </p>
+</fieldset>
+<fieldset style="max-width:1200px" id="RPM_input">
+        <legend>RPM/EFI Based</legend>
+              <p>
+                      <label for="RPM1">RPM1</label>
+                      <input id="RPM1" name="RPM1" type="number" step="1" value="2500"/>
+              </p>
+              <p>
+                      <label for="RPM2">RPM2</label>
+                      <input id="RPM2" name="RPM2" type="number" step="1" value="2500"/>
+              </p>
+</fieldset>
+</form>
+
+<h2>PIDs</h2>
+<h3><label id="PID_title">Title</label></h3>
+<canvas id="PID_Attenuation" style="width:100%;max-width:1200px"></canvas>
+<p>
+<input type="button" id="CalculateRoll" value="Caculate Roll" onclick="calculate_pid(this.id);">
+<input type="button" id="CalculatePitch" value="Caculate Pitch" onclick="calculate_pid(this.id);">
+<input type="button" id="CalculateYaw" value="Caculate Yaw" onclick="calculate_pid(this.id);">
+</p>
+<form id="PID_params" action="">
+        <fieldset style="max-width:1200px">
+          <legend>Graph Settings</legend>
+                <p>
+                        <table>
+                                <tr>
+                                        <td>
+                                                <fieldset style="width:150px">
+                                                        <legend>Gain scale</legend>
+                                                        <input type="radio" id="PID_ScaleLog" name="PID_Scale" value="Log" checked>
+                                                        <label for="LogScale">dB</label><br>
+                                                        <input type="radio" id="PID_ScaleLinear" name="PID_Scale" value="Linear">
+                                                        <label for="LinearScale">Linear</label><br>
+                                                </fieldset>
+                                        </td>
+                                        <td>
+                                                <fieldset style="width:150px">
+                                                        <legend>Frequency scale</legend>
+                                                        <table>
+                                                                <tr>
+                                                                        <td>
+                                                                                <input type="radio" id="PID_freq_ScaleLog" name="PID_feq_scale" value="Log" checked>
+                                                                                <label for="LogScale">Log</label><br>
+                                                                                <input type="radio" id="PID_freq_ScaleLinear" name="PID_feq_scale" value="Linear">
+                                                                                <label for="LinearScale">Linear</label><br>
+                                                                        </td>
+                                                                        <td>
+                                                                                <input type="radio" id="PID_freq_Scale_Hz" name="PID_feq_unit" value="Hz" checked>
+                                                                                <label for="Scale_unit_Hz">Hz</label><br>
+                                                                                <input type="radio" id="PID_freq_Scale_RPM" name="PID_feq_unit" value="RPM">
+                                                                                <label for="Scale_unit_RPM">RPM</label><br>
+                                                                        </td>
+                                                                </tr>
+                                                        </table>
+                                                </fieldset>
+                                        </td>
+                                        <td>
+                                                <fieldset style="width:150px">
+                                                        <legend>Filtering</legend>
+                                                        <input type="radio" id="PID_filtering_Pre" name="filtering" value="Pre" checked>
+                                                        <label for="LogScale">Pre</label><br>
+                                                        <input type="radio" id="PID_filtering_Post" name="filtering" value="Post">
+                                                        <label for="LinearScale">Post</label><br>
+                                                </fieldset>
+                                        </td>
+                                </tr>
+                        </table> 
+                </p>
+                <p>
+                        <label for="PID_MaxFreq">Maximum Displayed Frequency</label>
+                        <input id="PID_MaxFreq" name="PID_MaxFreq" type="number" step="1" value="150" onchange="check_nyquist();"/>
+                        <label id="PID_MaxFreq_warning"></label>
+                </p>
+                <p>
+                        <label for="PID_MaxPhaseLag">Maximum Displayed Phase Lag</label>
+                        <input id="PID_MaxPhaseLag" name="PID_MaxPhaseLag" type="number" step="1" value="360"/>
+                </p>
+        </fieldset>
+        <fieldset style="max-width:1200px">
+        <legend>Loop Rate</legend>
+               <p>
+                        <label for="SCHED_LOOP_RATE">SCHED_LOOP_RATE</label>
+                        <input id="SCHED_LOOP_RATE" name="SCHED_LOOP_RATE" type="number" step="1" value="400"/>
+                </p>
+        </fieldset>
+        <fieldset style="max-width:1200px">
+        <legend>Roll</legend>
+                <p>
+                        <label for="ATC_RAT_RLL_P">ATC_RAT_RLL_P</label>
+                        <input id="ATC_RAT_RLL_P" name="ATC_RAT_RLL_P" type="number" step="0.01" value="0.135"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_RLL_I">ATC_RAT_RLL_I</label>
+                        <input id="ATC_RAT_RLL_I" name="ATC_RAT_RLL_I" type="number" step="0.01" value="0.135"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_RLL_D">ATC_RAT_RLL_D</label>
+                        <input id="ATC_RAT_RLL_D" name="ATC_RAT_RLL_D" type="number" step="0.0001" value="0.0036"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_RLL_FLTE">ATC_RAT_RLL_FLTE</label>
+                        <input id="ATC_RAT_RLL_FLTE" name="ATC_RAT_RLL_FLTE" type="number" step="0.01" value="0"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_RLL_FLTD">ATC_RAT_RLL_FLTD</label>
+                        <input id="ATC_RAT_RLL_FLTD" name="ATC_RAT_RLL_FLTD" type="number" step="0.01" value="20"/>
+                </p>
+        </fieldset>
+        <fieldset style="max-width:1200px">
+        <legend>Pitch</legend>
+                <p>
+                        <label for="ATC_RAT_PIT_P">ATC_RAT_PIT_P</label>
+                        <input id="ATC_RAT_PIT_P" name="ATC_RAT_PIT_P" type="number" step="0.01" value="0.135"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_PIT_I">ATC_RAT_PIT_I</label>
+                        <input id="ATC_RAT_PIT_I" name="ATC_RAT_PIT_I" type="number" step="0.01" value="0.135"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_PIT_D">ATC_RAT_PIT_D</label>
+                        <input id="ATC_RAT_PIT_D" name="ATC_RAT_PIT_D" type="number" step="0.0001" value="0.0036"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_PIT_FLTE">ATC_RAT_PIT_FLTE</label>
+                        <input id="ATC_RAT_PIT_FLTE" name="ATC_RAT_PIT_FLTE" type="number" step="0.01" value="0"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_PIT_FLTD">ATC_RAT_PIT_FLTD</label>
+                        <input id="ATC_RAT_PIT_FLTD" name="ATC_RAT_PIT_FLTD" type="number" step="0.01" value="20"/>
+                </p>
+        </fieldset>
+        <fieldset style="max-width:1200px">
+        <legend>Yaw</legend>
+                <p>
+                        <label for="ATC_RAT_YAW_P">ATC_RAT_YAW_P</label>
+                        <input id="ATC_RAT_YAW_P" name="ATC_RAT_YAW_P" type="number" step="0.01" value="0.09"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_YAW_I">ATC_RAT_YAW_I</label>
+                        <input id="ATC_RAT_YAW_I" name="ATC_RAT_YAW_I" type="number" step="0.01" value="0.009"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_YAW_D">ATC_RAT_YAW_D</label>
+                        <input id="ATC_RAT_YAW_D" name="ATC_RAT_YAW_D" type="number" step="0.0001" value="0"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_YAW_FLTE">ATC_RAT_YAW_FLTE</label>
+                        <input id="ATC_RAT_YAW_FLTE" name="ATC_RAT_YAW_FLTE" type="number" step="0.01" value="2.5"/>
+                </p>
+                <p>
+                        <label for="ATC_RAT_YAW_FLTD">ATC_RAT_YAW_FLTD</label>
+                        <input id="ATC_RAT_YAW_FLTD" name="ATC_RAT_YAW_FLTD" type="number" step="0.01" value="0"/>
+                </p>
+        </fieldset>
 </form>
 
 <script>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -8,6 +8,7 @@
 <script type="text/javascript" src={{url_for('static', filename='filters.js')}}></script>
 <script type="text/javascript" src={{url_for('static', filename='FileSaver.js')}}></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
+<script src="https://www.lactame.com/lib/ml/6.0.0/ml.min.js"></script>
 </head>
 <a href="https://ardupilot.org"><img src="logo.png"></a>
 <h1>ArduPilot Filter Analysis</h1>

--- a/Tools/autotest/web-firmware/Tools/FilterTool/index.html
+++ b/Tools/autotest/web-firmware/Tools/FilterTool/index.html
@@ -61,7 +61,8 @@ ArduPilot 4.2 filter setup.
         </table>
         <p>
                 <label for="MaxFreq">Maximum Displayed Frequency</label>
-                <input id="MaxFreq" name="MaxFreq" type="number" step="1" value="150"/>
+                <input id="MaxFreq" name="MaxFreq" type="number" step="1" value="150" onchange="check_nyquist();"/>
+                <label id="MaxFreq_warning"></label>
 	</p>
         <p>
                 <label for="MaxPhaseLag">Maximum Displayed Phase Lag</label>


### PR DESCRIPTION
Lots more updates:

Interface reworked slightly:
![image](https://user-images.githubusercontent.com/33176108/182037478-6825cf92-2480-429d-8ccf-421879deada4.png)

Params and options hidden if not used, eg:
![image](https://user-images.githubusercontent.com/33176108/182037506-00a3fef6-b310-4db0-8c81-767910cee0e2.png)

![image](https://user-images.githubusercontent.com/33176108/182037517-ea50fb2b-e300-434b-9051-f6a12ac6ce68.png)

Support for log scale on X axis:
![image](https://user-images.githubusercontent.com/33176108/182037547-11f4ea9e-5649-4c3e-a585-e3eb7c4138dc.png)

X axis in RPM instead of Hz.
![image](https://user-images.githubusercontent.com/33176108/182037582-92c808bf-7395-4d84-ae6c-c69a810fba8e.png)

Warning about Nyquist limit if display frequency is set more than half sample rate.

![image](https://user-images.githubusercontent.com/33176108/182037605-91ec3647-3ec8-4194-8f3f-ddd2e34980fe.png)

Improved calculation of gain and phase overcomes previous 1/4 sample rate limitation. New method also allows 10 times reduction in samples for calculation speedup. Current on left new on right
![image](https://user-images.githubusercontent.com/33176108/182037728-ccb895ff-74bd-4795-8646-f760201bffc0.png)

PID evaluation with and without gyro filters:

![image](https://user-images.githubusercontent.com/33176108/182037840-9fd8e1dc-4a98-4f9b-a610-903a7f4b243e.png)

![image](https://user-images.githubusercontent.com/33176108/182037894-9a48cc7c-234a-4da7-a756-dd8ed85bf2b2.png)


New param values load from logs, both quadplane and copter, and work with cookies as before.