### PR TITLE
PrecLand: support LANDING_TARGET ext field

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -1,4 +1,5 @@
 #include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
 #include "AC_PrecLand_Companion.h"
 
 // perform any required initialisation of backend
@@ -46,9 +47,28 @@ void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, u
 {
     _distance_to_target = packet.distance;
 
-    // compute unit vector towards target
-    _los_meas_body = Vector3f(-tanf(packet.angle_y), tanf(packet.angle_x), 1.0f);
-    _los_meas_body /= _los_meas_body.length();
+    if (packet.position_valid == 1) {
+        if (packet.frame == MAV_FRAME_BODY_FRD) {
+            if (_distance_to_target > 0) {
+                _los_meas_body = Vector3f(packet.x, packet.y, packet.z);
+                _los_meas_body /= _distance_to_target;
+            } else {
+                // distance to target must be positive
+                return;
+            }
+        } else {
+            //we do not support this frame
+            if (!_wrong_frame_msg_sent) {
+                _wrong_frame_msg_sent = true;
+                gcs().send_text(MAV_SEVERITY_INFO,"Plnd: Frame not supported ");
+            }
+            return;
+        }
+    } else {
+        // compute unit vector towards target
+        _los_meas_body = Vector3f(-tanf(packet.angle_y), tanf(packet.angle_x), 1.0f);
+        _los_meas_body /= _los_meas_body.length();
+    }
 
     _los_meas_time_ms = timestamp_ms;
     _have_los_meas = true;

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -44,4 +44,5 @@ private:
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    bool                _wrong_frame_msg_sent;
 };


### PR DESCRIPTION
This PR add support for LANDING_TARGET mavlink2 position extension field.  For companion computer using fiducial markers, it makes FC integration easier.  I will do more tests once weather condition is ok.

[2022-08-01 15-49-41.zip](https://github.com/ArduPilot/ardupilot/files/9238663/2022-08-01.15-49-41.zip)
 