### PR TITLE
Copter: RC_Channel: reserve IDs used by the Skybrush fork

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1137,6 +1137,9 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_SUBGROUPINFO(command_model_pilot, "PILOT_Y_", 56, ParametersG2, AC_CommandModel),
 
+    // ID 62 is reserved for the SHOW_... parameters from the Skybrush fork at
+    // https://github.com/skybrush-io/ardupilot
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -39,6 +39,9 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+
+        // Mode number 127 reserved for the "drone show mode" in the Skybrush
+        // fork at https://github.com/skybrush-io/ardupilot
     };
 
     // constructor

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -240,6 +240,9 @@ public:
         AIRBRAKE =           210, // manual airbrake control
         WALKING_HEIGHT =     211, // walking robot height input
 
+        // inputs 248-249 are reserved for the Skybrush fork at
+        // https://github.com/skybrush-io/ardupilot
+
         // inputs for the use of onboard lua scripting
         SCRIPTING_1 =        300,
         SCRIPTING_2 =        301,


### PR DESCRIPTION
As discussed with @tridge earlier on Discord, this PR officially reserves some of the IDs already used by the Skybrush fork to make it easier to maintain the fork in the future. In particular:

* mode number 127 in Copter is assigned to the "drone show mode"
* param group 62 in Copter is assigned to Skybrush-specific parameters, all starting with `SHOW_`
* RC aux functions 248 and 249 are reserved for "show start" and "coordinated return-to-launch"

I would also be okay with giving up on RC aux functions 248 and 249 and just assigning them to the "user aux" functions that are already there in the codebase. Not many people use this functionaity yet because they need an RC transmitter that can be bound to multiple receivers (drones) at the same time, and we only managed to do it with FrSky receivers so far.