### PR TITLE
SITL: fix var naming for precland device center

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -989,7 +989,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     if (precland && precland->is_enabled()) {
         precland->update(get_location(), get_position_relhome());
         if (precland->_over_precland_base) {
-            local_ground_level += precland->_origin_height;
+            local_ground_level += precland->_device_height;
         }
     }
 

--- a/libraries/SITL/SIM_Precland.h
+++ b/libraries/SITL/SIM_Precland.h
@@ -42,9 +42,9 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     AP_Int8 _enable;
-    AP_Float _origin_lat;
-    AP_Float _origin_lon;
-    AP_Float _origin_height;
+    AP_Float _device_lat;
+    AP_Float _device_lon;
+    AP_Float _device_height;
     AP_Int16 _orient_yaw;
     AP_Int8 _type;
     AP_Int32 _rate;


### PR DESCRIPTION
The position of simulated precland device was being called "origin" at many places in the code which can be confused with EKF origin. We should not reference anything as _origin_ unless its really necessary. This renaming is done to avoid any ambiguity in code.
**This must be merged after #21133**