### PR TITLE
AP_Arming: use prearm-display-timeout in milliseconds instead of counter

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -163,14 +163,16 @@ AP_Arming::AP_Arming()
 // performs pre-arm checks. expects to be called at 1hz.
 void AP_Arming::update(void)
 {
+    const uint32_t now_ms = AP_HAL::millis();
     // perform pre-arm checks & display failures every 30 seconds
-    static uint8_t pre_arm_display_counter = PREARM_DISPLAY_PERIOD/2;
-    pre_arm_display_counter++;
     bool display_fail = false;
-    if ((_arming_options & uint32_t(AP_Arming::ArmingOptions::DISABLE_PREARM_DISPLAY)) == 0 &&
-        pre_arm_display_counter >= PREARM_DISPLAY_PERIOD) {
+    if (now_ms - last_prearm_display_ms > PREARM_DISPLAY_PERIOD*1000) {
         display_fail = true;
-        pre_arm_display_counter = 0;
+        last_prearm_display_ms = now_ms;
+    }
+    // OTOH, the user may never want to display them:
+    if (option_enabled(Option::DISABLE_PREARM_DISPLAY)) {
+        display_fail = false;
     }
 
     pre_arm_checks(display_fail);

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -126,9 +126,12 @@ public:
     Method last_disarm_method() const { return _last_disarm_method; }
 
     // enum for ARMING_OPTIONS parameter
-    enum class ArmingOptions : int32_t {
+    enum class Option : int32_t {
         DISABLE_PREARM_DISPLAY   = (1U << 0),
     };
+    bool option_enabled(Option option) const {
+        return (_arming_options & uint32_t(option)) != 0;
+    }
 
 protected:
 
@@ -256,6 +259,8 @@ private:
     // method that was last used for disarm; invalid unless the
     // vehicle has been disarmed at least once.
     Method _last_disarm_method = Method::UNKNOWN;
+
+    uint32_t last_prearm_display_ms;  // last time we send statustexts for prearm failures
 };
 
 namespace AP {


### PR DESCRIPTION
Remopves dependence on call rate to the update method.
