### PR TITLE
Copter: move motors check to be must-run prearm

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -288,10 +288,6 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
         return false;
     }
 #endif
-    // further checks enabled with parameters
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
-        return true;
-    }
 
     return true;
 }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -42,13 +42,17 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         return false;
     }
 
+    // always check motors
+    if (!motor_checks(display_failure)) {
+        return false;
+    }
+
     // if pre arm checks are disabled run only the mandatory checks
     if (checks_to_perform == 0) {
         return mandatory_checks(display_failure);
     }
 
     return parameter_checks(display_failure)
-        & motor_checks(display_failure)
         & oa_checks(display_failure)
         & gcs_failsafe_check(display_failure)
         & winch_checks(display_failure)
@@ -573,11 +577,6 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     // always check if the current mode allows arming
     if (!copter.flightmode->allows_arming(method)) {
         check_failed(true, "Mode not armable");
-        return false;
-    }
-
-    // always check motors
-    if (!motor_checks(true)) {
         return false;
     }
 


### PR DESCRIPTION
After this change, even if ARMING_CHECKS is 0 the user will be warned they need to set FRAME_CLASS and FRAME_TYPE, rather than just when they try to arm the vehicle.