### PR TITLE
Copter: make rc-in-failsafe checks a prearm check rather than an at-arm check

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -63,6 +63,34 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         & AP_Arming::pre_arm_checks(display_failure);
 }
 
+bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
+{
+    // throttle failsafe.  In this case the parameter also gates the
+    // no-pulses RC failure case - the radio-in value can be zero due
+    // to not having received any RC pulses at all.  Note that if we
+    // have ever seen RC and then we *lose* RC then these checks are
+    // likely to pass if the user is relying on no-pulses to detect RC
+    // failure.  However, arming is precluded in that case by being in
+    // RC failsafe.
+    if (copter.g.failsafe_throttle == FS_THR_DISABLED) {
+        return true;
+    }
+
+#if FRAME_CONFIG == HELI_FRAME
+    const char *rc_item = "Collective";
+#else
+    const char *rc_item = "Throttle";
+#endif
+
+    // check throttle is not too low - must be above failsafe throttle
+    if (copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {
+        check_failed(ARMING_CHECK_RC, true, "%s below failsafe", rc_item);
+        return false;
+    }
+
+    return true;
+}
+
 bool AP_Arming_Copter::barometer_checks(bool display_failure)
 {
     if (!AP_Arming::barometer_checks(display_failure)) {
@@ -597,17 +625,15 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     // check throttle
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
+        if (!rc_throttle_failsafe_checks(true)) {
+            return false;
+        }
+
          #if FRAME_CONFIG == HELI_FRAME
         const char *rc_item = "Collective";
         #else
         const char *rc_item = "Throttle";
         #endif
-        // check throttle is not too low - must be above failsafe throttle
-        if (copter.g.failsafe_throttle != FS_THR_DISABLED && copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {
-            check_failed(ARMING_CHECK_RC, true, "%s below failsafe", rc_item);
-            return false;
-        }
-
         // check throttle is not too high - skips checks if arming from GCS in Guided
         if (!(method == AP_Arming::Method::MAVLINK && (copter.flightmode->mode_number() == Mode::Number::GUIDED || copter.flightmode->mode_number() == Mode::Number::GUIDED_NOGPS))) {
             // above top of deadband is too always high

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -56,6 +56,7 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         & oa_checks(display_failure)
         & gcs_failsafe_check(display_failure)
         & winch_checks(display_failure)
+        & rc_throttle_failsafe_checks(display_failure)
         & alt_checks(display_failure)
 #if AP_AIRSPEED_ENABLED
         & AP_Arming::airspeed_checks(display_failure)
@@ -65,6 +66,12 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
 
 bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
 {
+    if ((checks_to_perform != ARMING_CHECK_ALL) &&
+        (checks_to_perform & ARMING_CHECK_RC) == 0) {
+        // this check has been disabled
+        return true;
+    }
+
     // throttle failsafe.  In this case the parameter also gates the
     // no-pulses RC failure case - the radio-in value can be zero due
     // to not having received any RC pulses at all.  Note that if we
@@ -625,10 +632,6 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     // check throttle
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
-        if (!rc_throttle_failsafe_checks(true)) {
-            return false;
-        }
-
          #if FRAME_CONFIG == HELI_FRAME
         const char *rc_item = "Collective";
         #else

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -48,6 +48,7 @@ protected:
     bool gcs_failsafe_check(bool display_failure);
     bool winch_checks(bool display_failure) const;
     bool alt_checks(bool display_failure);
+    bool rc_throttle_failsafe_checks(bool display_failure) const;
 
     void set_pre_arm_check(bool b);
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8739,6 +8739,18 @@ class AutoTestCopter(AutoTest):
         self.wait_disarmed()
         self.assert_at_home()
 
+    def NoRCOnBootPreArmFailure(self):
+        self.context_push()
+        for rc_failure_mode in 1, 2:
+            self.set_parameters({
+                "SIM_RC_FAIL": rc_failure_mode,
+            })
+            self.reboot_sitl()
+            self.assert_prearm_failure("Throttle below failsafe",
+                                       other_prearm_failures_fatal=False)
+        self.context_pop()
+        self.reboot_sitl()
+
     def tests1a(self):
         '''return list of all tests'''
         ret = super(AutoTestCopter, self).tests()  # about 5 mins and ~20 initial tests from autotest/common.py
@@ -8802,6 +8814,10 @@ class AutoTestCopter(AutoTest):
             ("AutoTune",
              "Fly AUTOTUNE mode",
              self.fly_autotune),  # 73s
+
+            ("NoRCOnBootPreArmFailure",
+             "Ensure we can't arm with no RC on boot if THR_FS_VALUE set",
+             self.NoRCOnBootPreArmFailure),
         ])
         return ret
 


### PR DESCRIPTION
This was requested by a partner; their manual encourages their users to look at the pretty flashing lights to determine when the vehicle is ready to arm.  If the RC transmitter wasn't on, the vehicle would still flash the lights indicating ready-to-arm.

This PR moves the checks to be prearm rather than arm so the lights are closer to indicating whether arming will be successful.
