### PR TITLE
Plane: Quadplane: allow servo auto trim for motors only tailsitter asist

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4275,4 +4275,28 @@ void QuadPlane::disable_yaw_rate_time_constant()
     attitude_control->set_yaw_rate_tc(0.0);
 }
 
+// Check if servo auto trim is allowed, only if countrol surfaces are fully in use
+bool QuadPlane::allow_servo_auto_trim()
+{
+    if (!available()) {
+        // Quadplane disabled, auto trim always allowed
+        return true;
+    }
+    if (in_vtol_mode()) {
+        // VTOL motors active in VTOL modes
+        return false;
+    }
+    if (!in_assisted_flight()) {
+        // In forward flight and VTOL motors not active
+        return true;
+    }
+    if (tailsitter.enabled() && ((options & QuadPlane::OPTION_TAILSIT_Q_ASSIST_MOTORS_ONLY) != 0)) {
+        // Tailsitter in forward flight, motors providing active stabalisation with motors only option
+        // Control surfaces are running as normal with I term active, motor I term is zeroed
+        return true;
+    }
+    // In forward flight with active VTOL motors
+    return false;
+}
+
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -168,6 +168,9 @@ public:
     // called when we change mode (for any mode, not just Q modes)
     void mode_enter(void);
 
+    // Check if servo auto trim is allowed
+    bool allow_servo_auto_trim();
+
 private:
     AP_AHRS &ahrs;
     AP_Vehicle::MultiCopter aparm;

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -1037,7 +1037,7 @@ void Plane::servos_auto_trim(void)
         return;
     }
 #if HAL_QUADPLANE_ENABLED
-    if (quadplane.in_assisted_flight() || quadplane.in_vtol_mode()) {
+    if (!quadplane.allow_servo_auto_trim()) {
         // can't auto-trim with quadplane motors running
         return;
     }


### PR DESCRIPTION
Allows auto trim to work on a tailsitter when in using motors only assist. In this case the motors are stabilising but not using I term. The plane I term is used on the control surfaces so using auto trim is valid. Has been flight tested. 