### PR TITLE
AP_AHRS: modify AHRS type check for compass-less setups

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2091,8 +2091,8 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         return false;
     }
 
-    // ensure we're using the configured backend:
-    if (ekf_type() != active_EKF_type()) {
+    // ensure we're using the configured backend, but bypass in compass-less cases:
+    if (ekf_type() != active_EKF_type() && AP::compass().use_for_yaw()) {
         hal.util->snprintf(failure_msg, failure_msg_len, "AHRS: not using configured AHRS type");
         return false;
     }


### PR DESCRIPTION
Allows compass-less setups to arm even if on DCM when EKF is setup....this is a common occurrence on compass-less, toggling between DCM and EKF on the ground (due to velocity noise from GPS?) after EKF has been initialized and origin set....if there is a  compass yaw source, then this exception does not occur and EKF should be stable on the ground while disarmed, so the check is valid...

verified that the autotest involved still passes....

bench tested...arming still fails if EKF origin is not set....but does not give pre-arm when it fallsback to DCM afterwards
