### PR TITLE
Throttle-Gain Boost aka "Anti-Gravity" support

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -150,8 +150,17 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("INPUT_TC", 20, AC_AttitudeControl, _input_tc, AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT),
 
+    // @Param: THR_G_BOOST
+    // @DisplayName: Throttle-gain boost
+    // @Description: Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("THR_G_BOOST", 21, AC_AttitudeControl, _throttle_gain_boost, 0.0f),
+
     AP_GROUPEND
 };
+
+constexpr Vector3f AC_AttitudeControl::VECTORF_111;
 
 // get the slew yaw rate limit in deg/s
 float AC_AttitudeControl::get_slew_yaw_max_degs() const
@@ -1006,6 +1015,13 @@ bool AC_AttitudeControl::ang_vel_to_euler_rate(const Vector3f& euler_rad, const 
 Vector3f AC_AttitudeControl::update_ang_vel_target_from_att_error(const Vector3f &attitude_error_rot_vec_rad)
 {
     Vector3f rate_target_ang_vel;
+
+    // Boost Angle P one very rapid throttle changes
+    if (_motors.get_throttle_slew_rate() > AC_ATTITUDE_CONTROL_THR_G_BOOST_THRESH) {
+        float angle_p_boost = constrain_float((_throttle_gain_boost + 1.0f) * (_throttle_gain_boost + 1.0f), 1.0, 4.0);
+        set_angle_P_scale_mult(Vector3f(angle_p_boost, angle_p_boost, 1.0f));
+    }
+
     // Compute the roll angular velocity demand from the roll angle error
     const float angleP_roll = _p_angle_roll.kP() * _angle_P_scale.x;
     if (_use_sqrt_controller && !is_zero(get_accel_roll_max_radss())) {
@@ -1032,7 +1048,7 @@ Vector3f AC_AttitudeControl::update_ang_vel_target_from_att_error(const Vector3f
 
     // reset angle P scaling, saving used value for logging
     _angle_P_scale_used = _angle_P_scale;
-    _angle_P_scale = Vector3f{1,1,1};
+    _angle_P_scale = VECTORF_111;
 
     return rate_target_ang_vel;
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -44,6 +44,7 @@
 #define AC_ATTITUDE_CONTROL_MAX                         5.0f    // maximum throttle mix default
 
 #define AC_ATTITUDE_CONTROL_THR_MIX_DEFAULT             0.5f  // ratio controlling the max throttle output during competing requests of low throttle from the pilot (or autopilot) and higher throttle for attitude control.  Higher favours Attitude over pilot input
+#define AC_ATTITUDE_CONTROL_THR_G_BOOST_THRESH          1.0f  // default angle-p/pd throttle boost threshold
 
 class AC_AttitudeControl {
 public:
@@ -396,8 +397,19 @@ public:
     // get the value of the angle P scale that was used in the last loop, for logging
     const Vector3f &get_angle_P_scale_logging(void) const { return _angle_P_scale_used; }
     
+    // setup a one loop PD scale multiplier, multiplying by any
+    // previously applied scale from this loop. This allows for more
+    // than one type of scale factor to be applied for different
+    // purposes
+    void set_PD_scale_mult(const Vector3f &pd_scale) { _pd_scale *= pd_scale; }
+
+    // get the value of the PD scale that was used in the last loop, for logging
+    const Vector3f &get_PD_scale_logging(void) const { return _pd_scale_used; }
+
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
+
+    static constexpr Vector3f VECTORF_111{1.0f,1.0f,1.0f};
 
 protected:
 
@@ -444,6 +456,9 @@ protected:
 
     // rate controller input smoothing time constant
     AP_Float            _input_tc;
+
+    // angle_p/pd boost multiplier
+    AP_Float            _throttle_gain_boost;
 
     // Intersampling period in seconds
     float               _dt;
@@ -520,6 +535,12 @@ protected:
 
     // angle scale used for last loop, used for logging
     Vector3f            _angle_P_scale_used;
+
+    // PD scaling vector for roll, pitch, yaw
+    Vector3f            _pd_scale{1,1,1};
+
+    // PD scale used for last loop, used for logging
+    Vector3f            _pd_scale_used;
 
     // References to external libraries
     const AP_AHRS_View&  _ahrs;

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -123,7 +123,7 @@ void AC_PID::slew_limit(float smax)
 //  target and error are filtered
 //  the derivative is then calculated and filtered
 //  the integral is then updated based on the setting of the limit flag
-float AC_PID::update_all(float target, float measurement, float dt, bool limit)
+float AC_PID::update_all(float target, float measurement, float dt, bool limit, float boost)
 {
     // don't process inf or NaN
     if (!isfinite(target) || !isfinite(measurement)) {
@@ -160,6 +160,10 @@ float AC_PID::update_all(float target, float measurement, float dt, bool limit)
 
     P_out *= _pid_info.Dmod;
     D_out *= _pid_info.Dmod;
+
+    // boost output if required
+    P_out *= boost;
+    D_out *= boost;
 
     _pid_info.target = _target;
     _pid_info.actual = measurement;

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -31,7 +31,7 @@ public:
     //  target and error are filtered
     //  the derivative is then calculated and filtered
     //  the integral is then updated based on the setting of the limit flag
-    float update_all(float target, float measurement, float dt, bool limit = false);
+    float update_all(float target, float measurement, float dt, bool limit = false, float boost = 1.0f);
 
     //  update_error - set error input to PID controller and calculate outputs
     //  target is set to zero and error is set and filtered

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -160,21 +160,26 @@ void AP_AHRS_View::Write_Rate(const AP_Motors &motors, const AC_AttitudeControl 
         yaw_out         : motors.get_yaw()+motors.get_yaw_ff(),
         control_accel   : (float)accel_target.z,
         accel           : (float)(-(get_accel_ef().z + GRAVITY_MSS) * 100.0f),
-        accel_out       : motors.get_throttle()
+        accel_out       : motors.get_throttle(),
+        throttle_slew   : motors.get_throttle_slew_rate()
     };
     AP::logger().WriteBlock(&pkt_rate, sizeof(pkt_rate));
 
     /*
-      log P gain scale if not == 1.0
+      log P/PD gain scale if not == 1.0
      */
     const Vector3f &scale = attitude_control.get_angle_P_scale_logging();
-    if (!is_equal(scale.x,1.0f) || !is_equal(scale.y,1.0f) || !is_equal(scale.z,1.0f)) {
+    const Vector3f &pd_scale = attitude_control.get_PD_scale_logging();
+    if (scale != AC_AttitudeControl::VECTORF_111 || pd_scale != AC_AttitudeControl::VECTORF_111) {
         const struct log_ATSC pkt_ATSC {
             LOG_PACKET_HEADER_INIT(LOG_ATSC_MSG),
             time_us  : timeus,
             scaleP_x : scale.x,
             scaleP_y : scale.y,
             scaleP_z : scale.z,
+            scalePD_x : pd_scale.x,
+            scalePD_y : pd_scale.y,
+            scalePD_z : pd_scale.z,
         };
         AP::logger().WriteBlock(&pkt_ATSC, sizeof(pkt_ATSC));
     }

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -123,6 +123,7 @@ struct PACKED log_POS {
 // @Field: ADes: desired vehicle vertical acceleration
 // @Field: A: achieved vehicle vertical acceleration
 // @Field: AOut: percentage of vertical thrust output current being used
+// @Field: AOutSlew: vertical thrust output slew rate
 struct PACKED log_Rate {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -138,6 +139,7 @@ struct PACKED log_Rate {
     float   control_accel;
     float   accel;
     float   accel_out;
+    float   throttle_slew;
 };
 
 // @LoggerMessage: VSTB
@@ -175,12 +177,18 @@ struct PACKED log_Video_Stabilisation {
 // @Field: AngPScX: Angle P scale X
 // @Field: AngPScY: Angle P scale Y
 // @Field: AngPScZ: Angle P scale Z
+// @Field: PDScX: PD scale X
+// @Field: PDScY: PD scale Y
+// @Field: PDScZ: PD scale Z
 struct PACKED log_ATSC {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     float scaleP_x;
     float scaleP_y;
     float scaleP_z;
+    float scalePD_x;
+    float scalePD_y;
+    float scalePD_z;
 };
 
 
@@ -196,9 +204,9 @@ struct PACKED log_ATSC {
     { LOG_POS_MSG, sizeof(log_POS), \
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \
-        "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" , true }, \
+        "RATE", "Qfffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut,AOutSlew", "skk-kk-kk-oo--", "F?????????BB--" , true }, \
     { LOG_ATSC_MSG, sizeof(log_ATSC), \
-        "ATSC", "Qfff",  "TimeUS,AngPScX,AngPScY,AngPScZ", "s---", "F000" , true }, \
+        "ATSC", "Qffffff",  "TimeUS,AngPScX,AngPScY,AngPScZ,PDScX,PDScY,PDScZ", "s------", "F000000" , true }, \
     { LOG_VIDEO_STABILISATION_MSG, sizeof(log_Video_Stabilisation), \
         "VSTB", "Qffffffffff",  "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,Q1,Q2,Q3,Q4", "sEEEooo????", "F000000????" },
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -314,7 +314,7 @@ void AP_MotorsMulticopter::update_throttle_filter()
 
     // calculate slope normalized from per-micro
     const float rate = fabsf(_throttle_slew.slope() * 1e6);
-    _throttle_slew_rate = _throttle_slew_filter.apply(rate, 1.0f / _loop_rate);
+    _throttle_slew_rate = _throttle_slew_filter.apply(rate, _dt);
 }
 
 // return current_limit as a number from 0 ~ 1 in the range throttle_min to throttle_max

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -19,6 +19,8 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Notify/AP_Notify.h>
 
+#define AP_MOTORS_SLEW_FILTER_CUTOFF 50.0f
+
 extern const AP_HAL::HAL& hal;
 
 // singleton instance
@@ -28,6 +30,8 @@ AP_Motors *AP_Motors::_singleton;
 AP_Motors::AP_Motors(uint16_t speed_hz) :
     _speed_hz(speed_hz),
     _throttle_filter(),
+    _throttle_slew(),
+    _throttle_slew_filter(),
     _spool_desired(DesiredSpoolState::SHUT_DOWN),
     _spool_state(SpoolState::SHUT_DOWN),
     _air_density_ratio(1.0f)
@@ -37,6 +41,12 @@ AP_Motors::AP_Motors(uint16_t speed_hz) :
     // setup throttle filtering
     _throttle_filter.set_cutoff_frequency(0.0f);
     _throttle_filter.reset(0.0f);
+
+    _throttle_slew_filter.set_cutoff_frequency(AP_MOTORS_SLEW_FILTER_CUTOFF);
+    _throttle_slew_filter.reset(0.0f);
+
+    // setup throttle slew detector
+    _throttle_slew.reset();
 
     // init limit flags
     limit.roll = true;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -3,6 +3,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <Filter/Filter.h>         // filter library
+#include <Filter/DerivativeFilter.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 // offsets for motors in motor_out and _motor_filtered arrays
@@ -137,6 +138,7 @@ public:
     void                set_throttle(float throttle_in) { _throttle_in = throttle_in; };   // range 0 ~ 1
     void                set_throttle_avg_max(float throttle_avg_max) { _throttle_avg_max = constrain_float(throttle_avg_max, 0.0f, 1.0f); };   // range 0 ~ 1
     void                set_throttle_filter_cutoff(float filt_hz) { _throttle_filter.set_cutoff_frequency(filt_hz); }
+    void                set_slew_filter_cutoff(float filt_hz) { _throttle_slew_filter.set_cutoff_frequency(filt_hz); }
     void                set_forward(float forward_in) { _forward_in = forward_in; }; // range -1 ~ +1
     void                set_lateral(float lateral_in) { _lateral_in = lateral_in; };     // range -1 ~ +1
 
@@ -153,6 +155,7 @@ public:
     float               get_throttle_out() const { return _throttle_out; }
     float               get_throttle() const { return constrain_float(_throttle_filter.get(), 0.0f, 1.0f); }
     float               get_throttle_bidirectional() const { return constrain_float(2 * (_throttle_filter.get() - 0.5f), -1.0f, 1.0f); }
+    float               get_throttle_slew_rate() const { return _throttle_slew_rate; }
     float               get_forward() const { return _forward_in; }
     float               get_lateral() const { return _lateral_in; }
     virtual float       get_throttle_hover() const = 0;
@@ -306,10 +309,13 @@ protected:
     float               _yaw_in_ff;                 // desired yaw feed forward control from attitude controller, -1 ~ +1
     float               _throttle_in;               // last throttle input from set_throttle caller
     float               _throttle_out;              // throttle after mixing is complete
+    float               _throttle_slew_rate;        // throttle slew rate from input
     float               _forward_in;                // last forward input from set_forward caller
     float               _lateral_in;                // last lateral input from set_lateral caller
     float               _throttle_avg_max;          // last throttle input from set_throttle_avg_max
-    LowPassFilterFloat  _throttle_filter;           // throttle input filter
+    LowPassFilterFloat  _throttle_filter;           // pilot throttle input filter
+    DerivativeFilterFloat_Size7  _throttle_slew;    // throttle output slew detector
+    LowPassFilterFloat  _throttle_slew_filter;      // filter for the output of the throttle slew
     DesiredSpoolState   _spool_desired;             // desired spool state
     SpoolState          _spool_state;               // current spool mode
 


### PR DESCRIPTION
This supersedes https://github.com/ArduPilot/ardupilot/pull/20738 by only providing the necessary features - namely boosting of PD on roll and pitch when the throttle slews above a limit. This dramatically reducing "nodding" - uncommanded pitch and roll variations caused by the copter accelerating into the airstream.