### PR TITLE
SITL: add param in SIM_Precland to enable return dist to target

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -19,6 +19,7 @@ void AC_PrecLand_SITL::update()
         const Vector3d position = _sitl->precland_sim.get_target_position();
         const Matrix3d body_to_ned = AP::ahrs().get_rotation_body_to_ned().todouble();
         _los_meas_body =  body_to_ned.mul_transpose(-position).tofloat();
+        _distance_to_target = _sitl->precland_sim.option_enabled(SITL::SIM_Precland::Option::ENABLE_TARGET_DISTANCE) ? _los_meas_body.length() : 0.0f;
         _los_meas_body /= _los_meas_body.length();
         _have_los_meas = true;
         _los_meas_time_ms = _sitl->precland_sim.last_update_ms();
@@ -32,7 +33,6 @@ void AC_PrecLand_SITL::update()
 bool AC_PrecLand_SITL::have_los_meas() {
     return AP_HAL::millis() - _los_meas_time_ms < 1000;
 }
-
 
 // provides a unit vector towards the target in body frame
 //  returns same as have_los_meas()

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -32,11 +32,15 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
 
+    // returns distance to target in meters (0 means distance is not known)
+    float distance_to_target() override { return _distance_to_target; }
+
 private:
     SITL::SIM           *_sitl;                 // sitl instance pointer
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
+    float               _distance_to_target;    // distance to target in meters
 };
 
 #endif

--- a/libraries/SITL/SIM_Precland.cpp
+++ b/libraries/SITL/SIM_Precland.cpp
@@ -105,6 +105,13 @@ const AP_Param::GroupInfo SIM_Precland::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 9, SIM_Precland, _orient, ROTATION_PITCH_90),
 
+    // @Param: OPTIONS
+    // @DisplayName: SIM_Precland extra options
+    // @Description: SIM_Precland extra options
+    // @Bitmask: 0: Enable target distance
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS",  10, SIM_Precland, _options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SIM_Precland.h
+++ b/libraries/SITL/SIM_Precland.h
@@ -41,6 +41,11 @@ public:
     void set_default_location(float lat, float lon, int16_t yaw);
     static const struct AP_Param::GroupInfo var_info[];
 
+    // enum for SIM_PLD_OPTIONS parameter
+    enum class Option : uint8_t {
+        ENABLE_TARGET_DISTANCE   = (1U << 0),
+    };
+
     AP_Int8 _enable;
     AP_Float _device_lat;
     AP_Float _device_lon;
@@ -51,6 +56,7 @@ public:
     AP_Float _alt_limit;
     AP_Float _dist_limit;
     AP_Int8 _orient;
+    AP_Enum<Option> _options;
     bool _over_precland_base;
 
     enum PreclandType {
@@ -58,6 +64,10 @@ public:
         PRECLAND_TYPE_CONE = 1,
         PRECLAND_TYPE_SPHERE = 2,
     };
+
+    bool option_enabled(Option option) const {
+        return (_options & uint8_t(option)) != 0;
+    }
 private:
     uint32_t _last_update_ms;
     bool _healthy;


### PR DESCRIPTION
The need for this change came while testing the new DOCK mode (which uses AC_PrecLand) on Rover. On copter, we construct the vector towards the target using position vector from SIM_Precland and distance towards the target from a simulated rangefinder. On rover, getting distance to the target using a rangefinder is not possible (since the sensor is mounted in front of a rover), so we need SIM_Precland to simulate a device that also gives distance towards the target.
To avoid any change in copter's behavior, `AC_PrecLand_SITL` returns distance towards the target only if `SIM_PLD_OPTIONS` param is set to 1 otherwise the copter would still have to construct the target vector the same way we were doing earlier (using a simulated rangefinder for distance).