### PR TITLE
AHRS and EKF3: getting Active source set

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3148,6 +3148,16 @@ void AP_AHRS::set_posvelyaw_source_set(uint8_t source_set_idx)
 #endif
 }
 
+//returns active source set used, 0=primary, 1=secondary, 2=tertiary
+uint8_t AP_AHRS::get_posvelyaw_source_set() const
+{
+#if HAL_NAVEKF3_AVAILABLE
+    return EKF3.get_active_source_set();
+#else
+    return 0;
+#endif   
+}
+
 void AP_AHRS::Log_Write()
 {
 #if HAL_NAVEKF2_AVAILABLE

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -360,6 +360,9 @@ public:
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
     void set_posvelyaw_source_set(uint8_t source_set_idx);
 
+    //returns index of active source set used, 0=primary, 1=secondary, 2=tertiary
+    uint8_t get_posvelyaw_source_set() const;
+
     void Log_Write();
 
     // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -524,6 +524,12 @@ bool AP_NavEKF_Source::wheel_encoder_enabled(void) const
     return false;
 }
 
+// returns active source set
+uint8_t AP_NavEKF_Source::get_active_source_set() const
+{
+    return active_source_set;
+}
+
 // return true if GPS yaw is enabled on any source
 bool AP_NavEKF_Source::gps_yaw_enabled(void) const
 {

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -103,6 +103,9 @@ public:
     // return true if wheel encoder is enabled on any source
     bool wheel_encoder_enabled(void) const;
 
+    // returns active source set 
+    uint8_t get_active_source_set() const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1239,6 +1239,12 @@ void NavEKF3::getAccelBias(int8_t instance, Vector3f &accelBias) const
     }
 }
 
+// returns active source set used by EKF3
+uint8_t NavEKF3::get_active_source_set() const
+{
+    return sources.get_active_source_set();
+}
+
 // reset body axis gyro bias estimates
 void NavEKF3::resetGyroBias(void)
 {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -98,6 +98,9 @@ public:
     // An out of range instance (eg -1) returns data for the primary instance
     void getAccelBias(int8_t instance, Vector3f &accelBias) const;
 
+    //returns index of the active source set used
+    uint8_t get_active_source_set() const;
+
     // reset body axis gyro bias estimates
     void resetGyroBias(void);
 

--- a/libraries/AP_Scripting/examples/active_source_set.lua
+++ b/libraries/AP_Scripting/examples/active_source_set.lua
@@ -1,0 +1,12 @@
+
+--returns active source set used by EKF3
+-- can be used for infering the current source set in use without RC for autonomous source switching
+
+function update() -- this is the loop which periodically runs
+
+  gcs:send_text(0, string.format("current source  set in use :%d", ahrs:get_posvelyaw_source_set()))
+
+  return update, 1000 -- 1000ms reschedules the loop (1Hz)
+end
+
+return update() -- run immediately before starting to reschedule

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -54,6 +54,7 @@ singleton AP_AHRS method set_home boolean Location
 singleton AP_AHRS method get_origin boolean Location'Null
 singleton AP_AHRS method set_origin boolean Location
 singleton AP_AHRS method initialised boolean
+singleton AP_AHRS method get_posvelyaw_source_set uint8_t
 
 include AP_Arming/AP_Arming.h
 


### PR DESCRIPTION
Hi, I noticed we have no bindings in Lua to find the active source set without an RC as demonstrated in other examples in Lua scripts. It will help in reducing the code used to infer the current source set from RC in the existing examples, this will be really helpful in autonomous source switching from GPS to SLAM to other sources autonomously based on some logic and in absence of RC 