### PR TITLE
Notch esc index bug

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -82,7 +82,10 @@ uint8_t AP_ESC_Telem::get_motor_frequencies_hz(uint8_t nfreqs, float* freqs) con
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS && i < nfreqs; i++) {
         float rpm;
         if (get_rpm(i, rpm)) {
-            freqs[valid_escs++] = rpm * (1.0f / 60.0f);
+            freqs[i] = rpm * (1.0f / 60.0f);
+            valid_escs++;
+        } else {
+            freqs[i] = 0.0f;
         }
     }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -490,12 +490,14 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
             if (notch.params.hasOption(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
                 const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(notch.num_dynamic_notches, notches);
-
-                for (uint8_t i = 0; i < num_notches; i++) {
-                    notches[i] =  MAX(ref_freq, notches[i]);
+                // ESC telemetry will return 0 for missing data, but only after 1s
+                for (uint8_t i = 0; i < notch.num_dynamic_notches; i++) {
+                    if (!is_zero(notches[i])) {
+                        notches[i] =  MAX(ref_freq, notches[i]);
+                    }
                 }
                 if (num_notches > 0) {
-                    notch.update_frequencies_hz(num_notches, notches);
+                    notch.update_frequencies_hz(notch.num_dynamic_notches, notches);
                 } else {    // throttle fallback
                     update_throttle_notch(notch);
                 }


### PR DESCRIPTION
If we lost ESC telemetry then we would return notch frequency updates that were not synchronized with the actual notches meaning that the wrong notches would get updated and resetting the frequency of the others