### PR TITLE
Plane: only trigger fence action for new breaches, don't allow mode change in breach unless fence option set. 

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -979,6 +979,7 @@ private:
     // fence.cpp
     void fence_check();
     bool fence_stickmixing() const;
+    bool in_fence_recovery() const;
 #endif
 
     // ArduPlane.cpp

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -49,17 +49,15 @@ void Plane::fence_check()
                                         (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_FIXEDWING_AUTOLAND) ||
                                         (plane.control_mode_reason == ModeReason::QRTL_INSTEAD_OF_RTL) ||
                                         (plane.control_mode_reason == ModeReason::QLAND_INSTEAD_OF_RTL);
-    if (orig_breaches && (current_mode_breach || (previous_mode_breach && previous_mode_complete))) {
+    if (current_mode_breach || (previous_mode_breach && previous_mode_complete)) {
         // we have already triggered, don't trigger again until the
         // user disables/re-enables using the fence channel switch
         return;
     }
-    
-     if(new_breaches && plane.is_flying()) {
-         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
-     }
 
-    if (new_breaches || orig_breaches) {
+    if (new_breaches) {
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+
         // if the user wants some kind of response and motors are armed
         const uint8_t fence_act = fence.get_action();
         switch (fence_act) {

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -43,13 +43,7 @@ void Plane::fence_check()
         return;
     }
 
-    const bool current_mode_breach = plane.control_mode_reason == ModeReason::FENCE_BREACHED;
-    const bool previous_mode_breach = plane.previous_mode_reason ==  ModeReason::FENCE_BREACHED;
-    const bool previous_mode_complete = (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_VTOL_LAND_RTL) ||
-                                        (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_FIXEDWING_AUTOLAND) ||
-                                        (plane.control_mode_reason == ModeReason::QRTL_INSTEAD_OF_RTL) ||
-                                        (plane.control_mode_reason == ModeReason::QLAND_INSTEAD_OF_RTL);
-    if (current_mode_breach || (previous_mode_breach && previous_mode_complete)) {
+    if (in_fence_recovery()) {
         // we have already triggered, don't trigger again until the
         // user disables/re-enables using the fence channel switch
         return;
@@ -131,13 +125,25 @@ bool Plane::fence_stickmixing(void) const
 {
     if (fence.enabled() &&
         fence.get_breaches() &&
-        control_mode->is_guided_mode())
+        in_fence_recovery())
     {
         // don't mix in user input
         return false;
     }
     // normal mixing rules
     return true;
+}
+
+bool Plane::in_fence_recovery() const
+{
+    const bool current_mode_breach = plane.control_mode_reason == ModeReason::FENCE_BREACHED;
+    const bool previous_mode_breach = plane.previous_mode_reason ==  ModeReason::FENCE_BREACHED;
+    const bool previous_mode_complete = (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_VTOL_LAND_RTL) ||
+                                        (plane.control_mode_reason == ModeReason::RTL_COMPLETE_SWITCHING_TO_FIXEDWING_AUTOLAND) ||
+                                        (plane.control_mode_reason == ModeReason::QRTL_INSTEAD_OF_RTL) ||
+                                        (plane.control_mode_reason == ModeReason::QLAND_INSTEAD_OF_RTL);
+
+    return current_mode_breach || (previous_mode_breach && previous_mode_complete);
 }
 
 #endif

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -101,6 +101,13 @@ bool Mode::enter()
 
         // update RC failsafe, as mode change may have necessitated changing the failsafe throttle
         plane.control_failsafe();
+
+#if AP_FENCE_ENABLED
+        // pilot requested flight mode change during a fence breach indicates pilot is attempting to manually recover
+        // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)
+        // but it should be harmless to disable the fence temporarily in these situations as well
+        plane.fence.manual_recovery_start();
+#endif
     }
 
     return enter_result;

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1525,6 +1525,9 @@ class AutoTestPlane(AutoTest):
         self.wait_circling_point_with_radius(rally_loc, return_radius)
         self.set_parameter("FENCE_ALT_MIN", 0) # Clear fence breach
 
+        # 10 second fence min retrigger time
+        self.delay_sim_time(15)
+
         # Fly up before re-triggering fence breach. Fly to fence return point
         self.change_altitude(self.homeloc.alt+30)
         self.set_parameters({

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -134,6 +134,13 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO_FRAME("AUTOENABLE", 10, AC_Fence, _auto_enabled, static_cast<uint8_t>(AutoEnable::ALWAYS_DISABLED), AP_PARAM_FRAME_PLANE),
 
+    // @Param{Plane}: OPTIONS
+    // @DisplayName: Fence options
+    // @Description: 0:Disable mode change following fence action until fence breach is cleared
+    // @Bitmask: 0:Disable mode change following fence action until fence breach is cleared
+    // @User: Standard
+    AP_GROUPINFO_FRAME("OPTIONS", 11, AC_Fence, _options, static_cast<uint16_t>(OPTIONS::DISABLE_MODE_CHANGE), AP_PARAM_FRAME_PLANE),
+
     AP_GROUPEND
 };
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -24,6 +24,22 @@ extern const AP_HAL::HAL& hal;
 #define AC_FENCE_TYPE_DEFAULT AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON
 #endif
 
+// default boundaries
+#define AC_FENCE_ALT_MAX_DEFAULT                    100.0f  // default max altitude is 100m
+#define AC_FENCE_ALT_MIN_DEFAULT                    -10.0f  // default maximum depth in meters
+#define AC_FENCE_CIRCLE_RADIUS_DEFAULT              300.0f  // default circular fence radius is 300m
+#define AC_FENCE_ALT_MAX_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further up
+#define AC_FENCE_ALT_MIN_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further down
+#define AC_FENCE_MARGIN_DEFAULT                     2.0f    // default distance in meters that autopilot's should maintain from the fence to avoid a breach
+#define AC_FENCE_MANUAL_RECOVERY_TIME_MIN           10000   // pilot has 10seconds to recover during which time the autopilot will not attempt to re-take control
+
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+#define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE     100.0   // after fence is broken we recreate the fence 50m further out
+#else
+#define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE      20.0   // after fence is broken we recreate the fence 20m further out
+#endif
+
+
 const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: ENABLE
     // @DisplayName: Fence enable/disable

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -146,6 +146,13 @@ public:
     AC_PolyFence_loader &polyfence();
     const AC_PolyFence_loader &polyfence() const;
 
+    enum class OPTIONS {
+        DISABLE_MODE_CHANGE = 1 << 0,
+    };
+    bool option_enabled(OPTIONS opt) const {
+        return (_options.get() & int16_t(opt)) != 0;
+    }
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -186,6 +193,7 @@ private:
     AP_Int8         _total;                 // number of polygon points saved in eeprom
     AP_Int8         _ret_rally;             // return to fence return point or rally point/home
     AP_Int16        _ret_altitude;          // return to this altitude
+    AP_Int16        _options;               // options bitmask, see OPTIONS enum
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -26,18 +26,8 @@
 #define AC_FENCE_ACTION_GUIDED                      6       // guided mode, with target waypoint as fence return point
 #define AC_FENCE_ACTION_GUIDED_THROTTLE_PASS        7       // guided mode, but pilot retains manual throttle control
 
-// default boundaries
-#define AC_FENCE_ALT_MAX_DEFAULT                    100.0f  // default max altitude is 100m
-#define AC_FENCE_ALT_MIN_DEFAULT                    -10.0f  // default maximum depth in meters
-#define AC_FENCE_CIRCLE_RADIUS_DEFAULT              300.0f  // default circular fence radius is 300m
-#define AC_FENCE_ALT_MAX_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further up
-#define AC_FENCE_ALT_MIN_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further down
-#define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE      20.0f   // after fence is broken we recreate the fence 20m further out
-#define AC_FENCE_MARGIN_DEFAULT                     2.0f    // default distance in meters that autopilot's should maintain from the fence to avoid a breach
-
 // give up distance
 #define AC_FENCE_GIVE_UP_DISTANCE                   100.0f  // distance outside the fence at which we should give up and just land.  Note: this is not used by library directly but is intended to be used by the main code
-#define AC_FENCE_MANUAL_RECOVERY_TIME_MIN           10000   // pilot has 10seconds to recover during which time the autopilot will not attempt to re-take control
 
 class AC_Fence
 {


### PR DESCRIPTION
This brings plane in line with copter to only trigger on new breaches. Currently it is impossible to change mode following a fence breach as the breach action will continually re-trigger effectively removing all control from the pilot/GCS (unless you go and turn off fence). 

This also increases the circle fence backup distance for plane from 20m to 50m. This means that circle fence will re-trigger every additional 50m from home.

This also sets the manual recovery flag on plane mode change, this means that the fence will never re-trigger in less than 10 seconds after as mode change.
