### PR TITLE
Add back in bdshot targets for KakuteF7 and CubeYellow

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -126,9 +126,7 @@ class BoardList(object):
             'iomcu_f103_8MHz',
 
             # bdshot
-            "CubeYellow-bdshot",
             "fmuv3-bdshot",
-            "KakuteF7-bdshot",
             "OMNIBUSF7V2-bdshot",
             "Pixhawk1-1M-bdshot",
 


### PR DESCRIPTION
I don't know why these are on the black list. I don't think they should be