### PR TITLE
GPS Drivers: Add Ellipsoid height to all drivers for DroneID Compliance

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1859,7 +1859,16 @@ void AP_Periph_FW::can_gps_update(void)
         }
         pkt.longitude_deg_1e8 = uint64_t(loc.lng) * 10ULL;
         pkt.latitude_deg_1e8 = uint64_t(loc.lat) * 10ULL;
-        pkt.height_ellipsoid_mm = loc.alt * 10;
+
+        // If we dont have WGS84 altitude set the WGS84 altitude to INT32_MAX
+        // a user could attach a module that doesn't output WGS84 in a periph
+        // for DroneID compliance we must know it is being received
+        if (gps.have_height_above_WGS84()) {
+            pkt.height_ellipsoid_mm = gps.height_above_WGS84() * 1000;
+        } else {
+            pkt.height_ellipsoid_mm = INT32_MAX;
+        }
+
         pkt.height_msl_mm = loc.alt * 10;
         for (uint8_t i=0; i<3; i++) {
             // the canard dsdl compiler doesn't understand float16

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -122,6 +122,7 @@ public:
         int32_t  longitude;
         int32_t  latitude;
         int32_t  msl_altitude;       // cm
+        float    wgs84_altitude;     // WGS84 ellipsoidal altitude (meters)
         float  ned_vel_north;
         float  ned_vel_east;
         float  ned_vel_down;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.h
@@ -107,6 +107,7 @@ private:
         int32_t lon;
         int32_t lat;
         int32_t msl_altitude;
+        float wgs84_altitude;           // WGS84 ellipsoidal altitude (cm)
         float ned_velocity_north;
         float ned_velocity_east;
         float ned_velocity_down;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -178,6 +178,8 @@ public:
         uint32_t time_week_ms;              ///< GPS time (milliseconds from start of GPS week)
         uint16_t time_week;                 ///< GPS week number
         Location location;                  ///< last fix location
+        float height_above_WGS84;           ///< height above the WGS84 ellipsoid (meters)
+        bool have_height_above_WGS84;       ///< true if has height above the WGS84 ellipsoid
         float ground_speed;                 ///< ground speed in m/sec
         float ground_course;                ///< ground course in degrees
         float gps_yaw;                      ///< GPS derived yaw information, if available (degrees)
@@ -201,6 +203,8 @@ public:
         uint64_t last_corrected_gps_time_us;///< the system time we got the last corrected GPS timestamp, microseconds
         bool corrected_timestamp_updated;  ///< true if the corrected timestamp has been updated
         uint32_t lagged_sample_count;       ///< number of samples with 50ms more lag than expected
+        uint32_t time_accuracy;             ///< time accuracy (nano seconds)
+        uint32_t have_time_accuracy;        ///< does GPS give time accuracy? Set to true only once available.
 
         // all the following fields must only all be filled by RTK capable backend drivers
         uint32_t rtk_time_week_ms;         ///< GPS Time of Week of last baseline in milliseconds
@@ -297,6 +301,16 @@ public:
         return location(primary_instance);
     }
 
+    // Height (meters) above the WGS84 ellipsoid
+    float height_above_WGS84(uint8_t instance) const {
+        return state[instance].height_above_WGS84;
+    }
+
+    // Height (meters) above the WGS84 ellipsoid
+    float height_above_WGS84() const {
+        return height_above_WGS84(primary_instance);
+    }
+
     // report speed accuracy
     bool speed_accuracy(uint8_t instance, float &sacc) const;
     bool speed_accuracy(float &sacc) const {
@@ -311,6 +325,14 @@ public:
     bool vertical_accuracy(uint8_t instance, float &vacc) const;
     bool vertical_accuracy(float &vacc) const {
         return vertical_accuracy(primary_instance, vacc);
+    }
+
+    // Time accuracy in seconds
+    bool time_accuracy(uint8_t instance, float &t_acc) const;
+
+    // Time accuracy in seconds
+    bool time_accuracy(float &t_acc) const {
+        return time_accuracy(primary_instance, t_acc);
     }
 
     // 3D velocity in NED format
@@ -437,6 +459,16 @@ public:
         return have_gps_yaw(primary_instance);
     }
 
+    // return true if the GPS currently has the height above the WGS84 ellipsoid available
+    bool have_height_above_WGS84(uint8_t instance) const {
+        return state[instance].have_height_above_WGS84;
+    }
+
+    // return true if the primary GPS currently has the height above the WGS84 ellipsoid available
+    bool have_height_above_WGS84(void) const {
+        return have_height_above_WGS84(primary_instance);
+    }
+
     // return true if the GPS is configured to provide yaw. This will
     // be true if we expect the GPS to provide yaw, even if it
     // currently is not able to provide yaw
@@ -554,6 +586,9 @@ public:
     bool get_RTCMV3(const uint8_t *&bytes, uint16_t &len);
     void clear_RTCMV3();
 #endif // GPS_MOVING_BASELINE
+
+    // Get the GPS class' reported location altitude frame (cm): geoid (AKA AMSL) or WGS84 ellipsoid
+    const int32_t& get_location_altitude_frame(const int32_t &geoid_alt, const int32_t &ellipsoid_alt) const;
 
 protected:
 

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -147,7 +147,11 @@ AP_GPS_ERB::_parse_gps(void)
         _last_pos_time        = _buffer.pos.time;
         state.location.lng    = (int32_t)(_buffer.pos.longitude * (double)1e7);
         state.location.lat    = (int32_t)(_buffer.pos.latitude * (double)1e7);
-        state.location.alt    = (int32_t)(_buffer.pos.altitude_msl * 100);
+        state.location.alt    = gps.get_location_altitude_frame(int32_t(_buffer.pos.altitude_msl * 100.0), int32_t(_buffer.pos.altitude_ellipsoid * 100.0));
+
+        state.height_above_WGS84 = float(_buffer.pos.altitude_ellipsoid);
+        state.have_height_above_WGS84 = true;
+
         state.status          = next_fix;
         _new_position = true;
         state.horizontal_accuracy = _buffer.pos.horizontal_accuracy * 1.0e-3f;

--- a/libraries/AP_GPS/AP_GPS_ExternalAHRS.cpp
+++ b/libraries/AP_GPS/AP_GPS_ExternalAHRS.cpp
@@ -51,7 +51,10 @@ void AP_GPS_ExternalAHRS::handle_external(const AP_ExternalAHRS::gps_data_messag
     Location loc = {};
     loc.lat = pkt.latitude;
     loc.lng = pkt.longitude;
-    loc.alt = pkt.msl_altitude;
+    loc.alt = gps.get_location_altitude_frame(pkt.msl_altitude, pkt.wgs84_altitude);
+
+    state.height_above_WGS84 = float(pkt.wgs84_altitude) * 0.01;
+    state.have_height_above_WGS84 = true;
 
     state.location = loc;
     state.hdop = pkt.hdop;

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -296,11 +296,14 @@ AP_GPS_GSOF::process_message(void)
                 }
                 valid++;
             }
-            else if (output_type == 2) // position
+            else if (output_type == 2) // GSOF message: LLH position, https://receiverhelp.trimble.com/oem-gnss/#GSOFmessages_LLH.html
             {
                 state.location.lat = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a)) * (double)1e7);
                 state.location.lng = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a + 8)) * (double)1e7);
-                state.location.alt = (int32_t)(SwapDouble(gsof_msg.data, a + 16) * 100);
+                state.location.alt = (int32_t)(SwapDouble(gsof_msg.data, a + 16) * 100);    // Altitude field is in meters referenced from the WGS84 ellipsoid
+
+                state.height_above_WGS84 = float(state.location.alt) * 0.01;
+                state.have_height_above_WGS84 = true;
 
                 state.last_gps_time_ms = AP_HAL::millis();
 

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -62,9 +62,11 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t &msg)
             loc.lat = packet.lat;
             loc.lng = packet.lon;
             if (have_alt) {
-                loc.alt = packet.alt * 100; // convert to centimeters
+                loc.alt = packet.alt * 100; // ASML, convert to centimeters
             }
             state.location = loc;
+
+            state.have_height_above_WGS84 = false;
 
             if (have_hdop) {
                 state.hdop = packet.hdop * 100; // convert to centimeters

--- a/libraries/AP_GPS/AP_GPS_MSP.cpp
+++ b/libraries/AP_GPS/AP_GPS_MSP.cpp
@@ -49,6 +49,8 @@ void AP_GPS_MSP::handle_msp(const MSP::msp_gps_data_message_t &pkt)
     loc.lng = pkt.longitude;
     loc.alt = pkt.msl_altitude;
 
+    state.have_height_above_WGS84 = false;
+
     state.location = loc;
     state.hdop = pkt.hdop;
     state.vdop = GPS_UNKNOWN_DOP;

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -135,7 +135,8 @@ private:
     int32_t _new_date;                                                  ///< date parsed from a term
     int32_t _new_latitude;                                      ///< latitude parsed from a term
     int32_t _new_longitude;                                     ///< longitude parsed from a term
-    int32_t _new_altitude;                                      ///< altitude parsed from a term
+    int32_t _new_altitude;                                      ///< altitude, AMSL Reference Geoid, parsed from a term
+    int32_t _new_undulation;                                    ///< height of the geoid above the ellipsoid, in cm
     int32_t _new_speed;                                                 ///< speed parsed from a term
     int32_t _new_course;                                        ///< course parsed from a term
     float   _new_gps_yaw;                                        ///< yaw parsed from a term

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -204,7 +204,10 @@ AP_GPS_NOVA::process_message(void)
 
         state.location.lat = (int32_t) (bestposu.lat * (double)1e7);
         state.location.lng = (int32_t) (bestposu.lng * (double)1e7);
-        state.location.alt = (int32_t) (bestposu.hgt * 100);
+
+        state.height_above_WGS84 = float(bestposu.hgt) - bestposu.undulation;   // see page 327, Section 2.4.170 Undulation
+        state.have_height_above_WGS84 = true;
+        state.location.alt = gps.get_location_altitude_frame(int32_t(bestposu.hgt * 100), int32_t(state.height_above_WGS84 * 100));
 
         state.num_sats = bestposu.svsused;
 

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -15,7 +15,8 @@
 
 //  Novatel/Tersus/ComNav GPS driver for ArduPilot.
 //  Code by Michael Oborne
-//  Derived from http://www.novatel.com/assets/Documents/Manuals/om-20000129.pdf
+//  Derived from https://hexagondownloads.blob.core.windows.net/public/Novatel/assets/Documents/Manuals/om-20000129/om-20000129.pdf
+//  NovAtel OEM6® Family Firmware Reference Manual
 
 #pragma once
 
@@ -110,7 +111,7 @@ private:
         double lat;            ///< latitude (deg)
         double lng;            ///< longitude (deg)
         double hgt;            ///< height above mean sea level (m)
-        float undulation;      ///< relationship between the geoid and the ellipsoid (m)
+        float undulation;      ///< relationship between the geoid and the ellipsoid (m), the default setting uses the EGM96 Geoid model
         uint32_t datumid;      ///< datum id number
         float latsdev;         ///< latitude standard deviation (m)
         float lngsdev;         ///< longitude standard deviation (m)

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -120,8 +120,8 @@ private:
          uint8_t Error;
          double Latitude;
          double Longitude;
-         double Height;
-         float Undulation;
+         double Height;         // Ellipsoidal height with respect to datum given by the DATUM field
+         float Undulation;      // Geoid undulation (meters) with respect to the WGS84 ellipsoid
          float Vn;
          float Ve;
          float Vu;

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -282,6 +282,14 @@ AP_GPS_SBP::_attempt_state_update()
         state.location.alt      = (int32_t) (pos_llh->height * 100);
         state.num_sats          = pos_llh->n_sats;
 
+        // This driver has no capability to return both WGS84 ellipsoid height and geoid height AMSL
+        if (pos_llh->flags | (1<<3)) {
+            state.have_height_above_WGS84 = false;
+        } else {
+            state.height_above_WGS84      = float(pos_llh->height);
+            state.have_height_above_WGS84 = true;
+        }
+
         if (pos_llh->flags == 0) {
             state.status = AP_GPS::GPS_OK_FIX_3D;
         } else if (pos_llh->flags == 2) {

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -200,6 +200,11 @@ AP_GPS_SBP2::_sbp_process_message() {
             check_new_itow(last_pos_llh.tow, parser_state.msg_len);
             break;
 
+        case SBP_POS_LLH_ACC_MSGTYPE:
+            memcpy(&last_pos_llh_acc, parser_state.msg_buff, sizeof(struct sbp_pos_llh_acc));
+            check_new_itow(last_pos_llh_acc.tow, parser_state.msg_len);
+            break;
+
         case SBP_DOPS_MSGTYPE:
             memcpy(&last_dops, parser_state.msg_buff, sizeof(struct sbp_dops_t));
             check_new_itow(last_dops.tow, parser_state.msg_len);
@@ -333,7 +338,11 @@ AP_GPS_SBP2::_attempt_state_update()
         //
         state.location.lat      = (int32_t) (last_pos_llh.lat * (double)1e7);
         state.location.lng      = (int32_t) (last_pos_llh.lon * (double)1e7);
-        state.location.alt      = (int32_t) (last_pos_llh.height * 100);
+        state.location.alt      = gps.get_location_altitude_frame(int32_t(last_pos_llh_acc.height_msl * 100.0), int32_t(last_pos_llh.height_ellipsoid * 100.0));
+
+        state.height_above_WGS84 = (float) last_pos_llh.height_ellipsoid;
+        state.have_height_above_WGS84 = true;
+
         state.num_sats          = last_pos_llh.n_sats;
 
         switch (last_pos_llh.flags.fix_mode) {

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -18,6 +18,7 @@
 //	Code by Niels Joubert
 //
 //  Swift Binary Protocol format: http://docs.swift-nav.com/
+//  Swift Navigation Binary Protocol Specification v4.1.4.pdf
 //
 #pragma once
 
@@ -77,6 +78,7 @@ private:
     static const uint16_t SBP_BASELINE_NED_MSGTYPE   = 0x020C;
     static const uint16_t SBP_VEL_ECEF_MSGTYPE       = 0x020D;
     static const uint16_t SBP_VEL_NED_MSGTYPE        = 0x020E;
+    static const uint16_t SBP_POS_LLH_ACC_MSGTYPE    = 0x0218;
     static const uint16_t SBP_TRACKING_STATE_MSGTYPE = 0x0013;
     static const uint16_t SBP_IAR_STATE_MSGTYPE      = 0x0019;
     static const uint16_t SBP_EXT_EVENT_MSGTYPE      = 0x0101;
@@ -122,13 +124,13 @@ private:
 
     // Geodetic position solution.
     struct PACKED sbp_pos_llh_t {
-        uint32_t tow;         //< GPS Time of Week (unit: ms)
-        double lat;           //< Latitude (unit: degrees)
-        double lon;           //< Longitude (unit: degrees)
-        double height;        //< Height (unit: meters)
-        uint16_t h_accuracy;  //< Horizontal position accuracy estimate (unit: mm)
-        uint16_t v_accuracy;  //< Vertical position accuracy estimate (unit: mm)
-        uint8_t n_sats;       //< Number of satellites used in solution
+        uint32_t tow;               //< GPS Time of Week (unit: ms)
+        double lat;                 //< Latitude (unit: degrees)
+        double lon;                 //< Longitude (unit: degrees)
+        double height_ellipsoid;    //< Height above WGS84 Ellipsoid (unit: meters)
+        uint16_t h_accuracy;        //< Horizontal position accuracy estimate (unit: mm)
+        uint16_t v_accuracy;        //< Vertical position accuracy estimate (unit: mm)
+        uint8_t n_sats;             //< Number of satellites used in solution
         struct PACKED flags {
             uint8_t fix_mode:3;  //< Fix mode (0: invalid, 1: SPP, 2: DGNSS, 3: Float RTX, 4: Fixed RTX, 5: Dead Reckoning, 6: SBAS Position
             uint8_t ins_mode:2;  //< Inertial navigation mode (0: none, 1: INS used)
@@ -151,6 +153,30 @@ private:
             uint8_t res:3;       //< Reserved
         } flags;
     }; // 22 bytes
+
+
+    // Geodetic position solution.
+    struct PACKED sbp_pos_llh_acc {
+        uint32_t tow;                   //< GPS Time of Week (unit: ms)
+        double lat;                     //< Latitude (unit: degrees)
+        double lon;                     //< Longitude (unit: degrees)
+        double height_ellipsoid;        //< Height above WGS84 Ellipsoid (unit: meters)
+        double height_msl;              //< Height above the geoid, mean sea-level (unit: meters)
+        float h_accuracy;               //< Horizontal position accuracy estimate (unit: meters)
+        float v_accuracy;               //< Vertical position accuracy estimate (unit: meters)
+        float ct_accuracy;              // Cross track error (unit: meters)
+        float at_accuracy;              // Along-track error (unit: meters)
+        float h_ellipse_semi_major;     // Semi major axis of the estimated horizontal error ellipse (units: meters)
+        float h_ellipse_semi_minor;     // Semi minor axis of the estimated horizontal error ellipse (units: meters)
+        float h_ellipse_orientation;    // (units: degrees) Orientation of the semi major axis of the estimated horizontal error ellipse with respect to North
+        uint8_t confidence_and_geoid;   // The lower bits describe the configured confidence level for the estimated position error. The middle bits describe the geoid model used to calculate the orthometric height.
+        uint8_t n_sats;                 //< Number of satellites used in solution
+        struct PACKED flags {
+            uint8_t fix_mode:3;         //< Fix mode (0: invalid, 1: SPP, 2: DGNSS, 3: Float RTX, 4: Fixed RTX, 5: Dead Reckoning, 6: SBAS Position
+            uint8_t ins_mode:2;         //< Inertial navigation mode (0: none, 1: INS used)
+            uint8_t res:3;              //< Reserved
+        } flags;
+    }; // 67 bytes
 
     // Messages reporting accurately-timestamped external events, e.g. camera shutter time.
     struct PACKED sbp_ext_event_t {
@@ -179,6 +205,7 @@ private:
     struct sbp_gps_time_t  last_gps_time;
     struct sbp_dops_t      last_dops;
     struct sbp_pos_llh_t   last_pos_llh;
+    struct sbp_pos_llh_acc last_pos_llh_acc;
     struct sbp_vel_ned_t   last_vel_ned;
     struct sbp_ext_event_t last_event;
 

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -179,7 +179,10 @@ AP_GPS_SIRF::_parse_gps(void)
         }
         state.location.lat      = swap_int32(_buffer.nav.latitude);
         state.location.lng      = swap_int32(_buffer.nav.longitude);
-        state.location.alt      = swap_int32(_buffer.nav.altitude_msl);
+        state.location.alt      = gps.get_location_altitude_frame(swap_int32(_buffer.nav.altitude_msl), swap_int32(_buffer.nav.altitude_ellipsoid)) * 0.1;
+        state.height_above_WGS84      = swap_int32(_buffer.nav.altitude_ellipsoid) * 0.1;
+        state.have_height_above_WGS84 = true;
+
         state.ground_speed      = swap_int32(_buffer.nav.ground_speed)*0.01f;
         state.ground_course     = wrap_360(swap_int16(_buffer.nav.ground_course)*0.01f);
         state.num_sats          = _buffer.nav.satellites;

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -411,8 +411,17 @@ void AP_GPS_UAVCAN::handle_fix_msg(const FixCb &cb)
         Location loc = { };
         loc.lat = cb.msg->latitude_deg_1e8 / 10;
         loc.lng = cb.msg->longitude_deg_1e8 / 10;
-        loc.alt = cb.msg->height_msl_mm / 10;
+        loc.alt = gps.get_location_altitude_frame(cb.msg->height_msl_mm, cb.msg->height_ellipsoid_mm) / 10;
         interim_state.location = loc;
+
+        // INT32_MAX is used to signal if the CAN GPS is unable to provide WGS84 altitude
+        if (cb.msg->height_ellipsoid_mm == INT32_MAX)
+        {
+            interim_state.have_height_above_WGS84 = false;
+        } else {
+            interim_state.have_height_above_WGS84 = true;
+        }
+        interim_state.height_above_WGS84 = cb.msg->height_ellipsoid_mm  * 0.001;
 
         if (!uavcan::isNaN(cb.msg->ned_velocity[0])) {
             Vector3f vel(cb.msg->ned_velocity[0], cb.msg->ned_velocity[1], cb.msg->ned_velocity[2]);
@@ -535,8 +544,17 @@ void AP_GPS_UAVCAN::handle_fix2_msg(const Fix2Cb &cb)
         Location loc = { };
         loc.lat = cb.msg->latitude_deg_1e8 / 10;
         loc.lng = cb.msg->longitude_deg_1e8 / 10;
-        loc.alt = cb.msg->height_msl_mm / 10;
+        loc.alt = gps.get_location_altitude_frame(cb.msg->height_msl_mm, cb.msg->height_ellipsoid_mm) / 10;
         interim_state.location = loc;
+
+        // INT32_MAX is used to signal if the CAN GPS is unable to provide WGS84 altitude
+        if (cb.msg->height_ellipsoid_mm == INT32_MAX)
+        {
+            interim_state.have_height_above_WGS84 = false;
+        } else {
+            interim_state.have_height_above_WGS84 = true;
+        }
+        interim_state.height_above_WGS84 = cb.msg->height_ellipsoid_mm  * 0.001;
 
         if (!uavcan::isNaN(cb.msg->ned_velocity[0])) {
             Vector3f vel(cb.msg->ned_velocity[0], cb.msg->ned_velocity[1], cb.msg->ned_velocity[2]);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1287,11 +1287,10 @@ AP_GPS_UBLOX::_parse_gps(void)
         _last_pos_time        = _buffer.posllh.itow;
         state.location.lng    = _buffer.posllh.longitude;
         state.location.lat    = _buffer.posllh.latitude;
-        if (option_set(AP_GPS::HeightEllipsoid)) {
-            state.location.alt    = _buffer.posllh.altitude_ellipsoid / 10;
-        } else {
-            state.location.alt    = _buffer.posllh.altitude_msl / 10;
-        }
+        state.location.alt    = gps.get_location_altitude_frame(_buffer.posllh.altitude_msl, _buffer.posllh.altitude_ellipsoid) / 10;
+        state.height_above_WGS84 = _buffer.posllh.altitude_ellipsoid * 0.001;
+        state.have_height_above_WGS84 = true;
+
         state.status          = next_fix;
         _new_position = true;
         state.horizontal_accuracy = _buffer.posllh.horizontal_accuracy*1.0e-3f;
@@ -1444,11 +1443,10 @@ AP_GPS_UBLOX::_parse_gps(void)
         _last_pos_time        = _buffer.pvt.itow;
         state.location.lng    = _buffer.pvt.lon;
         state.location.lat    = _buffer.pvt.lat;
-        if (option_set(AP_GPS::HeightEllipsoid)) {
-            state.location.alt    = _buffer.pvt.h_ellipsoid / 10;
-        } else {
-            state.location.alt    = _buffer.pvt.h_msl / 10;
-        }
+        state.location.alt    = gps.get_location_altitude_frame(_buffer.pvt.h_msl, _buffer.pvt.h_ellipsoid) / 10;
+        state.height_above_WGS84 = _buffer.posllh.altitude_ellipsoid * 0.001;
+        state.have_height_above_WGS84 = true;
+
         switch (_buffer.pvt.fix_type)
         {
             case 0:
@@ -1510,6 +1508,8 @@ AP_GPS_UBLOX::_parse_gps(void)
         
         // time
         state.time_week_ms    = _buffer.pvt.itow;
+        state.time_accuracy   = _buffer.pvt.t_acc;  // Time accuracy in nano-seconds
+        state.have_time_accuracy = true;
 #if UBLOX_FAKE_3DLOCK
         state.location.lng = 1491652300L;
         state.location.lat = -353632610L;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -299,8 +299,8 @@ private:
         uint32_t itow;                                  // GPS msToW
         int32_t longitude;
         int32_t latitude;
-        int32_t altitude_ellipsoid;
-        int32_t altitude_msl;
+        int32_t altitude_ellipsoid;                     // altitude AMSL using the WGS84 ellipsoid (in mm)
+        int32_t altitude_msl;                           // altitude AMSL using the EGM96 geoid (in mm)
         uint32_t horizontal_accuracy;
         uint32_t vertical_accuracy;
     };

--- a/libraries/AP_GPS/LogStructure.h
+++ b/libraries/AP_GPS/LogStructure.h
@@ -5,6 +5,7 @@
 
 #define LOG_IDS_FROM_GPS                        \
     LOG_GPS_MSG,                                \
+    LOG_GPS2_MSG,                               \
     LOG_GPA_MSG,                                \
     LOG_GPS_RAW_MSG,                            \
     LOG_GPS_RAWH_MSG,                           \
@@ -50,6 +51,18 @@ struct PACKED log_GPS {
     uint8_t  used;
 };
 
+// @LoggerMessage: GPS2
+// @Description: Auxillary GNSS information
+// @Field: TimeUS: Time since system startup
+// @Field: I: GPS instance number
+// @Field: AltE: altitude above the WGS84 ellipsoid
+struct PACKED log_GPS2 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  instance;
+    float    alt_above_ellipsoid;
+};
+
 // @LoggerMessage: GPA
 // @Description: GPS accuracy information
 // @Field: I: GPS instance number
@@ -62,6 +75,7 @@ struct PACKED log_GPS {
 // @Field: VV: true if vertical velocity is available
 // @Field: SMS: time since system startup this sample was taken
 // @Field: Delta: system time delta between the last two reported positions
+// @Field: TAcc: Time accuracy
 struct PACKED log_GPA {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -74,6 +88,7 @@ struct PACKED log_GPA {
     uint8_t  have_vv;
     uint32_t sample_ms;
     uint16_t delta_ms;
+    float t_acc;
 };
 
 /*
@@ -199,8 +214,10 @@ struct PACKED log_GPS_RAWS {
 #define LOG_STRUCTURE_FROM_GPS \
     { LOG_GPS_MSG, sizeof(log_GPS), \
       "GPS",  "QBBIHBcLLeffffB", "TimeUS,I,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,Yaw,U", "s#---SmDUmnhnh-", "F----0BGGB000--" , true }, \
+    { LOG_GPS2_MSG, sizeof(log_GPS2), \
+      "GPS2",  "QBf", "TimeUS,I,AltE", "s#m", "F-0", true }, \
     { LOG_GPA_MSG,  sizeof(log_GPA), \
-      "GPA",  "QBCCCCfBIH", "TimeUS,I,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta", "s#mmmnd-ss", "F-BBBB0-CC" , true }, \
+      "GPA",  "QBCCCCfBIHf", "TimeUS,I,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta,TAcc", "s#mmmnd-sss", "F-BBBB0-CC0" , true }, \
     { LOG_GPS_UBX1_MSG, sizeof(log_Ubx1), \
       "UBX1", "QBHBBHI",  "TimeUS,Instance,noisePerMS,jamInd,aPower,agcCnt,config", "s#-----", "F------"  , true }, \
     { LOG_GPS_UBX2_MSG, sizeof(log_Ubx2), \


### PR DESCRIPTION
**WIP ---- NEEDS TESTING (UNTESTED JUST COMPILES)**

This updates all GPS drivers to be compliant with DroneID requirements to output WGS84 altitudes.

Below is a summary for each driver.
Some were using WGS84 altitudes as if they were AMSL EGM96 altitudes. (Why does that matter? Because terrain following uses SRTM which is AMSL EGM96 referenced. And the differences average 30m to 80-100m)

**Drivers being defaulted to WGS84 reference for position & without AMSL**
For these drivers I've set the driver_options default to the current behavior....  But that behavior could cause issues with large differences between the terrain database and the altitude being used for positioning. 

GPS_TYPE_SBF : Septetrino
GPS_TYPE_GSOF: Trimble GSOF Protocol
ExternalAHRS_VectorNAV

**Drivers being defaulted to WGS84 reference for position**
GPS_SBP2: Swift Serial 2

**Drivers without WGS84 Availability:**
GPS_TYPE_MSP
GPS_TYPE_MAV

**Drivers** with Either WGS84 available or AMSL not both:
AP_GPS_SBP: Swift Serial 1 

**Still to do:**
Run through every `Location.Alt` to become Location.set_alt_cm()

Find a better way to log the ellipsoid height...... but the GPS message is at 64 chars long...  

**Test output from each GPS.....**
Swift SBP2: needed to add a new message to get AMSL info. need to ensure that is output by default
Test when attached to periphs

**!!!!! Important Periph Compliance Note !!!!**

Old Periph firmwares are sending incorrect height above ellipsoid data. It may be prudent to add a pre-arm check for periph firmware version eventually? If that is possible?