### PR TITLE
AP_OABendyRuler: correct margin consider vehicle speed

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -114,6 +114,9 @@ bool AP_OABendyRuler::update(const Location& current_loc, const Location& destin
         ground_course_deg = degrees(ground_speed_vec.angle());
     }
 
+    // consider self driving speed, planning frequency is 1Hz default
+    _margin_max += ground_speed_vec.length() * 1.0f;
+
     bool ret;
     switch (get_type()) {
         case OABendyType::OA_BENDY_VERTICAL:


### PR DESCRIPTION
The obstacle avoidance margin needs to consider the current speed of the vehicle. Since the planning period is 1Hz, when the vehicle speed is high, the obstacle avoidance output must be predicted in advance.
A better way is to predict the planning starting point rather than the current position, hoping to get better opinions!
Thank you very much!