### PR TITLE
Tools: remove MAV_POWER_STATUS_ from bit descriptions

### DIFF
--- a/Tools/scripts/powr_change.py
+++ b/Tools/scripts/powr_change.py
@@ -28,7 +28,9 @@ class POWRChange(object):
         if 1 << bit_number not in mavutil.mavlink.enums["MAV_POWER_STATUS"]:
             return "UNKNOWN_BIT[%u]" % bit_number
 
-        return mavutil.mavlink.enums["MAV_POWER_STATUS"][1 << bit_number].name
+        name = mavutil.mavlink.enums["MAV_POWER_STATUS"][1 << bit_number].name
+        # return name with common prefix removed:
+        return name[len("MAV_POWER_STATUS_"):]
 
     def run(self):
 


### PR DESCRIPTION
looks much neater afterwards:
```
pbarker@fx:~/rc/ardupilot(master)$ ./Tools/scripts/powr_change.py ~/rc/flight-data/splat/logs/2022-07-31/00000071.BIN
1660011491: Creating connection
2022-07-31 11:45:15.49:  +MAV_POWER_STATUS_BRICK_VALID ACCFLAGS+MAV_POWER_STATUS_BRICK_VALID
2022-07-31 11:46:11.86:  +MAV_POWER_STATUS_USB_CONNECTED ACCFLAGS+MAV_POWER_STATUS_USB_CONNECTED
```

```
pbarker@fx:~/rc/ardupilot(master)$ ./Tools/scripts/powr_change.py ~/rc/flight-data/splat/logs/2022-07-31/00000071.BIN
1660011747: Creating connection
2022-07-31 11:45:15.49:  +BRICK_VALID ACCFLAGS+BRICK_VALID
2022-07-31 11:46:11.86:  +USB_CONNECTED ACCFLAGS+USB_CONNECTED
pbarker@fx:~/rc/ardupilot(master)$ git checkout -b pr/powr-flags-remove-prefix
```
