### PR TITLE
rename contains_terrain_relative->contains_terrain_alt_items

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1026,7 +1026,7 @@ bool AP_Arming::terrain_database_required() const
         // no mission support?
         return false;
     }
-    if (mission->contains_terrain_relative()) {
+    if (mission->contains_terrain_alt_items()) {
         return true;
     }
     return false;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2468,16 +2468,16 @@ bool AP_Mission::contains_item(MAV_CMD command) const
 /*
   return true if the mission has a terrain relative item.  ~2200us for 530 items on H7
  */
-bool AP_Mission::contains_terrain_relative(void)
+bool AP_Mission::contains_terrain_alt_items(void)
 {
     if (_last_contains_relative_calculated_ms != _last_change_time_ms) {
-        _contains_terrain_relative = calculate_contains_terrain_relative();
+        _contains_terrain_alt_items = calculate_contains_terrain_alt_items();
         _last_contains_relative_calculated_ms = _last_change_time_ms;
     }
-    return _contains_terrain_relative;
+    return _contains_terrain_alt_items;
 }
 
-bool AP_Mission::calculate_contains_terrain_relative(void) const
+bool AP_Mission::calculate_contains_terrain_alt_items(void) const
 {
     for (int i = 1; i < num_commands(); i++) {
         Mission_Command tmp;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -620,7 +620,7 @@ public:
     bool contains_item(MAV_CMD command) const;
 
     // returns true if the mission has a terrain relative mission item
-    bool contains_terrain_relative(void);
+    bool contains_terrain_alt_items(void);
 
     // reset the mission history to prevent recalling previous mission histories when restarting missions.
     void reset_wp_history(void);
@@ -765,9 +765,9 @@ private:
     uint32_t _last_change_time_ms;
 
     // memoisation of contains-relative:
-    bool _contains_terrain_relative;  // true if the mission has terrain-relative items
-    uint32_t _last_contains_relative_calculated_ms;  // will be equal to _last_change_time_ms if _contains_terrain_relative is up-to-date
-    bool calculate_contains_terrain_relative(void) const;
+    bool _contains_terrain_alt_items;  // true if the mission has terrain-relative items
+    uint32_t _last_contains_relative_calculated_ms;  // will be equal to _last_change_time_ms if _contains_terrain_alt_items is up-to-date
+    bool calculate_contains_terrain_alt_items(void) const;
 
     // multi-thread support. This is static so it can be used from
     // const functions


### PR DESCRIPTION
From request:
can we rename "constains_terrain_relative" to "contains_terrain_alt"? No big deal of course but "terrain_alt" is what we use in Copter so it's more likely to show up in searches.