### PR TITLE
AP_Math: add dignostic message for SCurve internal error

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -16,6 +16,10 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_InternalError/AP_InternalError.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#if APM_BUILD_COPTER_OR_HELI
+#include <AP_Logger/AP_Logger.h>
+#endif
 #include "SCurve.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -862,6 +866,48 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
         ::printf("SCurve::calculate_path invalid outputs\n");
 #endif
         INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+
+#if APM_BUILD_COPTER_OR_HELI
+        // @LoggerMessage: SCVE
+        // @Description: Debug message for SCurve internal error
+        // @Field: TimeUS: Time since system startup
+        // @Field: Sm: duration of the raised cosine jerk profile
+        // @Field: Jm: maximum value of the raised cosine jerk profile
+        // @Field: V0: initial velocity magnitude
+        // @Field: Am: maximum constant acceleration
+        // @Field: Vm: maximum constant velocity
+        // @Field: L: Length of the path
+        // @Field: Jm_out: maximum value of the raised cosine jerk profile
+        // @Field: tj_out: segment duration
+        // @Field: t2_out: segment duration
+        // @Field: t4_out: segment duration
+        // @Field: t6_out: segment duration
+
+        static bool logged_scve;  // only log once
+        if (!logged_scve) {
+            logged_scve = true;
+            AP::logger().Write(
+                "SCVE",
+                "TimeUS,Sm,Jm,V0,Am,Vm,L,Jm_out,tj_out,t2_out,t4_out,t6_out",
+                "s-----------",
+                "F-----------",
+                "Qfffffffffff",
+                AP_HAL::micros64(),
+                (double)Sm,
+                (double)Jm,
+                (double)V0,
+                (double)Am,
+                (double)Vm,
+                (double)L,
+                (double)Jm_out,
+                (double)tj_out,
+                (double)t2_out,
+                (double)t4_out,
+                (double)t6_out
+                );
+        }
+#endif  // APM_BUILD_COPTER_OR_HELI
+
         Jm_out = 0.0f;
         t2_out = 0.0f;
         t4_out = 0.0f;


### PR DESCRIPTION
We had a report from a partner of an internal error in SCurve navigation.  It is possible this is the second report - we assumed a previous report was lacking a patch which tridge did which fixed the problem.  e don't have enough information to continue diagnosing the problem ATM - this adds more logging to try to fix that problem.

Tested on CubeOrange-SimOnHW using the following patch:
```
@@ -852,6 +853,11 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
     tj_out = tj;
     Jm_out = Jm;
 
+    static bool done = false;
+    if (!done && AP_HAL::millis() > 10000) {
+        Jm_out = 1/0.0;
+    }
```

That gave me the following log message:
```
pbarker@fx:~/rc$ mavlogdump.py --t SCVE  log5.bin 
1970-01-01 10:00:14.63: SCVE {TimeUS : 14636173, Sm : 523.5987548828125, Jm : inf, V0 : 0.0, Am : 249.9158935546875, Vm : 699.5543212890625, L : 6994.1494140625, Jm : inf, tj : 0.30000001192092896, t2 : 2.1991589069366455, t4 : 0.0, t6 : 2.1991589069366455}
pbarker@fx:~/rc$ 
```
