### PR TITLE
build_binaries.py: print not-found-on-boardlist message

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -225,7 +225,10 @@ is bob we will attempt to checkout bob-AVR'''
                     line = line.replace("'", "")
                     line = line.replace(" ", "")
                     boards = line.split(",")
-                    return board not in boards
+                    ret = board not in boards
+                    if ret:
+                        self.progress("Skipping board (%s) - not in board list" % board)
+                    return ret
         except IOError as e:
             if e.errno != 2:
                 raise


### PR DESCRIPTION
Makes it clearer in the output that we're skipping a board because it isn't in the configure list.  Currently it just does the submodule updaet then goes onto the next build, without telling you why it's not doing anything more