### PR TITLE
do_set_mission_current: if no mission fail with MAV_RESULT_FAILED

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4231,7 +4231,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
 {
     AP_Mission *mission = AP::mission();
     if (mission == nullptr) {
-        return MAV_RESULT_UNSUPPORTED;
+        return MAV_RESULT_FAILED;
     }
 
     const uint32_t seq = (uint32_t)packet.param1;


### PR DESCRIPTION
Calling `MAV_CMD_DO_SET_MISSION_CURRENT` when there is no mission should fail with [MAV_RESULT_FAILED](https://mavlink.io/en/messages/common.html#MAV_RESULT_FAILED) not [MAV_RESULT_UNSUPPORTED](https://mavlink.io/en/messages/common.html#MAV_RESULT_UNSUPPORTED)

Unsupported indicates that the command is not understood. In this case the command is understood and valid, but there is an "unexpected environmental problem" that requires user intervention.

FYI @peterbarker 