### PR TITLE
Backport: Rover: fix stick mixing in auto mode

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -459,7 +459,7 @@ void Mode::calc_steering_from_turn_rate(float turn_rate)
                                                                       g2.motors.limit.steer_left,
                                                                       g2.motors.limit.steer_right,
                                                                       rover.G_Dt);
-    g2.motors.set_steering(steering_out * 4500.0f);
+    set_steering(steering_out * 4500.0f);
 }
 
 /*


### PR DESCRIPTION
Backport to fix stick mixing in Auto. PR for master change is #21402. Tested in SITL.