### PR TITLE
Arming: add check for WPs outside fence

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: MIS_ITEMS
     // @DisplayName: Required mission items
     // @Description: Bitmask of mission items that are required to be planned in order to arm the aircraft
-    // @Bitmask: 0:Land,1:VTOL Land,2:DO_LAND_START,3:Takeoff,4:VTOL Takeoff,5:Rallypoint
+    // @Bitmask: 0:Land,1:VTOL Land,2:DO_LAND_START,3:Takeoff,4:VTOL Takeoff,5:Rallypoint,6:All WPs within fence
     // @User: Advanced
     AP_GROUPINFO("MIS_ITEMS",    7,     AP_Arming, _required_mission_items, 0),
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -828,6 +828,26 @@ bool AP_Arming::mission_checks(bool report)
                 return false;
             }
           }
+
+        if (_required_mission_items & MIS_ITEM_CHECK_WP_IN_FENCE) {
+            AP_Mission::Mission_Command cmd;
+            AC_Fence *fence = AP::fence();
+            if (fence == nullptr) {
+                check_failed(ARMING_CHECK_MISSION, report, "No fence library present");
+                #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+                    AP_HAL::panic("Mission checks requested, but no fence was allocated");
+                #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+                return false;
+            }
+            uint16_t cmd_index = 0;
+            while (mission->get_next_nav_cmd(cmd_index, cmd)) {
+                if (!fence->check_destination_within_fence(cmd.content.location)) {
+                    check_failed(ARMING_CHECK_MISSION, report, "There are mission items outside the fence");
+                    return false;
+                }
+                cmd_index = cmd.index + 1;
+            }
+        }
     }
 
     return true;

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -247,6 +247,7 @@ private:
         MIS_ITEM_CHECK_TAKEOFF       = (1 << 3),
         MIS_ITEM_CHECK_VTOL_TAKEOFF  = (1 << 4),
         MIS_ITEM_CHECK_RALLY         = (1 << 5),
+        MIS_ITEM_CHECK_WP_IN_FENCE   = (1 << 6),
         MIS_ITEM_CHECK_MAX
     };
 


### PR DESCRIPTION
May close #14534. There is some discussion there if this should be checked when trying to activate AUTO instead/additionally; this PR only implements the PreArm check.