### PR TITLE
Copter: 4.2.3-rc2 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.2.3-rc2 13-Aug-2022
+Changes from 4.2.3-rc1
+1) BlueRobotics Navigator autopilot filesystem fix
+------------------------------------------------------------------
 Copter 4.2.3-rc1 12-Aug-2022
 Changes from 4.2.2
 1) OpenDroneId support (aka RemoteID)

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.3-rc1"
+#define THISFIRMWARE "ArduCopter V4.2.3-rc2"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_RC

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,9 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.2.3-rc2 13-Aug-2022
+Changes from 4.2.3-rc1
+1) BlueRobotics Navigator autopilot filesystem fix
+------------------------------------------------------------------
 Rover 4.2.3-rc1 12-Aug-2022
 Changes from 4.2.2
 1) OpenDroneId support (aka RemoteID)

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.2.3-rc1"
+#define THISFIRMWARE "ArduRover V4.2.3-rc2"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_RC

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -106,10 +106,10 @@ const AP_Filesystem::Backend &AP_Filesystem::backend_by_fd(int &fd) const
     return backends[idx];
 }
 
-int AP_Filesystem::open(const char *fname, int flags)
+int AP_Filesystem::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     const Backend &backend = backend_by_path(fname);
-    int fd = backend.fs.open(fname, flags);
+    int fd = backend.fs.open(fname, flags, allow_absolute_paths);
     if (fd < 0) {
         return -1;
     }

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -80,7 +80,7 @@ public:
     AP_Filesystem() {}
 
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags);
+    int open(const char *fname, int flags, bool allow_absolute_paths = false);
     int close(int fd);
     int32_t read(int fd, void *buf, uint32_t count);
     int32_t write(int fd, const void *buf, uint32_t count);

--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
@@ -21,7 +21,7 @@ class AP_Filesystem_ESP32 : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -279,7 +279,7 @@ static bool remount_file_system(void)
     return true;
 }
 
-int AP_Filesystem_FATFS::open(const char *pathname, int flags)
+int AP_Filesystem_FATFS::open(const char *pathname, int flags, bool allow_absolute_path)
 {
     int fileno;
     int fatfs_modes;

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -20,7 +20,7 @@ class AP_Filesystem_FATFS : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -30,7 +30,7 @@ extern int errno;
 
 #define IDLE_TIMEOUT_MS 30000
 
-int AP_Filesystem_Mission::open(const char *fname, int flags)
+int AP_Filesystem_Mission::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     enum MAV_MISSION_TYPE mtype;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -23,7 +23,7 @@ class AP_Filesystem_Mission : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -26,7 +26,7 @@
 extern const AP_HAL::HAL& hal;
 extern int errno;
 
-int AP_Filesystem_Param::open(const char *fname, int flags)
+int AP_Filesystem_Param::open(const char *fname, int flags, bool allow_absolute_path)
 {
     if (!check_file_name(fname)) {
         errno = ENOENT;

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.h
@@ -24,7 +24,7 @@ class AP_Filesystem_Param : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -23,7 +23,7 @@
 
 #if defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
 
-int AP_Filesystem_ROMFS::open(const char *fname, int flags)
+int AP_Filesystem_ROMFS::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     if ((flags & O_ACCMODE) != O_RDONLY) {
         errno = EROFS;

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -21,7 +21,7 @@ class AP_Filesystem_ROMFS : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -60,7 +60,7 @@ int8_t AP_Filesystem_Sys::file_in_sysfs(const char *fname) {
     return -1;
 }
 
-int AP_Filesystem_Sys::open(const char *fname, int flags)
+int AP_Filesystem_Sys::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     if ((flags & O_ACCMODE) != O_RDONLY) {
         errno = EROFS;

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.h
@@ -23,7 +23,7 @@ class AP_Filesystem_Sys : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t lseek(int fd, int32_t offset, int whence) override;

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -43,7 +43,7 @@ class AP_Filesystem_Backend {
 
 public:
     // functions that closely match the equivalent posix calls
-    virtual int open(const char *fname, int flags) {
+    virtual int open(const char *fname, int flags, bool allow_absolute_paths = false) {
         return -1;
     }
     virtual int close(int fd) { return -1; }

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -49,10 +49,12 @@ static const char *map_filename(const char *fname)
     return fname;
 }
 
-int AP_Filesystem_Posix::open(const char *fname, int flags)
+int AP_Filesystem_Posix::open(const char *fname, int flags, bool allow_absolute_paths)
 {
     FS_CHECK_ALLOWED(-1);
-    fname = map_filename(fname);
+    if (! allow_absolute_paths) {
+        fname = map_filename(fname);
+    }
     // we automatically add O_CLOEXEC as we always want it for ArduPilot FS usage
     return ::open(fname, flags | O_CLOEXEC, 0644);
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_posix.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.h
@@ -29,7 +29,7 @@ class AP_Filesystem_Posix : public AP_Filesystem_Backend
 {
 public:
     // functions that closely match the equivalent posix calls
-    int open(const char *fname, int flags) override;
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
     int32_t read(int fd, void *buf, uint32_t count) override;
     int32_t write(int fd, const void *buf, uint32_t count) override;


### PR DESCRIPTION
These are the changes for the 4.2.3-rc2 beta release.  This is hot on the heels of 4.2.3-rc1 which just went out yesterday but I forgot the important fix for the BlueRobotics Navigator autopilot that we discussed on the dev call.

https://github.com/ArduPilot/ardupilot/pull/20193

