### PR TITLE
Rover: return true straight away in prearm checks if armed

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -71,6 +71,11 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
 bool AP_Arming_Rover::pre_arm_checks(bool report)
 {
+    if (armed) {
+        // if we are already armed then skip the checks
+        return true;
+    }
+
     //are arming checks disabled?
     if (checks_to_perform == 0) {
         return true;


### PR DESCRIPTION
mirrors equivalent clause in Plane


Noted this didn't look right in an autotest:
```
AT-0287.1: Distance to Location (40.0716, -105.2294) =61.59 (want 0.000000 +- 1.500000)
AT-0287.1: Distance to Location (40.0716, -105.2294) =59.14 (want 0.000000 +- 1.500000)
AT-0287.2: Distance to Location (40.0716, -105.2294) =56.07 (want 0.000000 +- 1.500000)
AT-0287.2: Distance to Location (40.0716, -105.2294) =51.04 (want 0.000000 +- 1.500000)
AT-0287.3: Distance to Location (40.0716, -105.2294) =45.99 (want 0.000000 +- 1.500000)
AT-0287.3: Distance to Location (40.0716, -105.2294) =39.96 (want 0.000000 +- 1.500000)
AT-0287.4: AP: PreArm: Mode not armable
AT-0287.4: Distance to Location (40.0716, -105.2294) =34.31 (want 0.000000 +- 1.500000)
AT-0287.5: Distance to Location (40.0716, -105.2294) =28.73 (want 0.000000 +- 1.500000)
AT-0287.5: Distance to Location (40.0716, -105.2294) =23.24 (want 0.000000 +- 1.500000)
AT-0287.6: Distance to Location (40.0716, -105.2294) =18.90 (want 0.000000 +- 1.500000)
AT-0287.6: Distance to Location (40.0716, -105.2294) =14.30 (want 0.000000 +- 1.500000)
```
