### PR TITLE
build_ci.sh: change back to original directory after running profile

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -3,7 +3,11 @@
 # This helps when doing large merges
 # Andrew Tridgell, November 2011
 
+XOLDPWD=$PWD  # profile changes directory :-(
+
 . ~/.profile
+
+cd $XOLDPWD
 
 set -ex
 


### PR DESCRIPTION
.profile changes directory on Vagrant VMs.