### PR TITLE
Fixed use of BRD_IO_ENABLE=0

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -890,7 +890,7 @@ bool AP_Arming::servo_checks(bool report) const
     }
 
 #if HAL_WITH_IO_MCU
-    if (!iomcu.healthy()) {
+    if (!iomcu.healthy() && AP_BoardConfig::io_enabled()) {
         check_failed(report, "IOMCU is unhealthy");
         check_passed = false;
     }

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2034,11 +2034,9 @@ bool RCOutput::force_safety_on(void)
     if (AP_BoardConfig::io_enabled()) {
         return iomcu.force_safety_on();
     }
-    return false;
-#else
+#endif
     safety_state = AP_HAL::Util::SAFETY_DISARMED;
     return true;
-#endif
 }
 
 /*
@@ -2049,10 +2047,10 @@ void RCOutput::force_safety_off(void)
 #if HAL_WITH_IO_MCU
     if (AP_BoardConfig::io_enabled()) {
         iomcu.force_safety_off();
+        return;
     }
-#else
-    safety_state = AP_HAL::Util::SAFETY_ARMED;
 #endif
+    safety_state = AP_HAL::Util::SAFETY_ARMED;
 }
 
 /*


### PR DESCRIPTION
fixed IOMCU disable for arming and safety switch
