### PR TITLE
AP_HAL_ChibiOS: remove unused HAL_RCIN_PULSE_PPM_ONLY define

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/iomcu/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/iomcu/hwdef.dat
@@ -95,10 +95,6 @@ define RCIN_ICU_TIMER ICUD1
 define RCIN_ICU_CHANNEL ICU_CHANNEL_1
 define STM32_RCIN_DMA_STREAM STM32_DMA_STREAM_ID(1, 2)
 
-# only use pulse input for PPM, other protocols
-# are on serial
-define HAL_RCIN_PULSE_PPM_ONLY
-
 #DMA Channel Not relevant for F1 series
 define STM32_RCIN_DMA_CHANNEL 0
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/iomcu_f103_8MHz/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/iomcu_f103_8MHz/hwdef.dat
@@ -95,10 +95,6 @@ define RCIN_ICU_TIMER ICUD1
 define RCIN_ICU_CHANNEL ICU_CHANNEL_1
 define STM32_RCIN_DMA_STREAM STM32_DMA_STREAM_ID(1, 2)
 
-# only use pulse input for PPM, other protocols
-# are on serial
-define HAL_RCIN_PULSE_PPM_ONLY
-
 #DMA Channel Not relevant for F1 series
 define STM32_RCIN_DMA_CHANNEL 0
 


### PR DESCRIPTION
After this patch, which only affects hwdef files:

```
pbarker@fx:~/rc/ardupilot(pr/remove-unused-define)$ git grep 'HAL_RCIN_PULSE'
pbarker@fx:~/rc/ardupilot(pr/remove-unused-define)$ 
```
