### PR TITLE
Rename OpticalFlow -> AP_OpticalFlow

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -144,7 +144,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(throttle_loop,         50,     75,  6),
     SCHED_TASK_CLASS(AP_GPS,               &copter.gps,                 update,          50, 200,   9),
 #if AP_OPTICALFLOW_ENABLED
-    SCHED_TASK_CLASS(OpticalFlow,          &copter.optflow,             update,         200, 160,  12),
+    SCHED_TASK_CLASS(AP_OpticalFlow,          &copter.optflow,             update,         200, 160,  12),
 #endif
     SCHED_TASK(update_batt_compass,   10,    120, 15),
     SCHED_TASK_CLASS(RC_Channels, (RC_Channels*)&copter.g2.rc_channels, read_aux_all,    10,  50,  18),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -310,7 +310,7 @@ private:
 
     // Optical flow sensor
 #if AP_OPTICALFLOW_ENABLED
-    OpticalFlow optflow;
+    AP_OpticalFlow optflow;
 #endif
 
     // system time in milliseconds of last recorded yaw reset from ekf

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -115,7 +115,7 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
 #endif
 
 #if AP_OPTICALFLOW_ENABLED
-    const OpticalFlow *optflow = AP::opticalflow();
+    const AP_OpticalFlow *optflow = AP::opticalflow();
     if (optflow && optflow->enabled()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -674,7 +674,7 @@ const AP_Param::Info Copter::var_info[] = {
 #if AP_OPTICALFLOW_ENABLED
     // @Group: FLOW
     // @Path: ../libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
-    GOBJECT(optflow,   "FLOW", OpticalFlow),
+    GOBJECT(optflow,   "FLOW", AP_OpticalFlow),
 #endif
 
 #if PRECISION_LANDING == ENABLED

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -83,7 +83,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_ICEngine,      &plane.g2.ice_control, update,     10, 100,  81),
 #endif
 #if AP_OPTICALFLOW_ENABLED
-    SCHED_TASK_CLASS(OpticalFlow, &plane.optflow, update,    50,    50,  87),
+    SCHED_TASK_CLASS(AP_OpticalFlow, &plane.optflow, update,    50,    50,  87),
 #endif
     SCHED_TASK(one_second_loop,         1,    400,  90),
     SCHED_TASK(three_hz_loop,           3,     75,  93),

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -99,7 +99,7 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
     }
 
 #if AP_OPTICALFLOW_ENABLED
-    const OpticalFlow *optflow = AP::opticalflow();
+    const AP_OpticalFlow *optflow = AP::opticalflow();
     if (optflow && optflow->enabled()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -939,7 +939,7 @@ const AP_Param::Info Plane::var_info[] = {
 #if AP_OPTICALFLOW_ENABLED
     // @Group: FLOW
     // @Path: ../libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
-    GOBJECT(optflow,   "FLOW", OpticalFlow),
+    GOBJECT(optflow,   "FLOW", AP_OpticalFlow),
 #endif
 
     // @Group: MIS_

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -240,7 +240,7 @@ private:
 
 #if AP_OPTICALFLOW_ENABLED
     // Optical flow sensor
-    OpticalFlow optflow;
+    AP_OpticalFlow optflow;
 #endif
 
     // Rally Ponints

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -72,7 +72,7 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(fifty_hz_loop,         50,     75,   3),
     SCHED_TASK_CLASS(AP_GPS, &sub.gps, update, 50, 200,   6),
 #if AP_OPTICALFLOW_ENABLED
-    SCHED_TASK_CLASS(OpticalFlow,          &sub.optflow,             update,         200, 160,   9),
+    SCHED_TASK_CLASS(AP_OpticalFlow,          &sub.optflow,             update,         200, 160,   9),
 #endif
     SCHED_TASK(update_batt_compass,   10,    120,  12),
     SCHED_TASK(read_rangefinder,      20,    100,  15),

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -57,7 +57,7 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
     }
 
 #if AP_OPTICALFLOW_ENABLED
-    const OpticalFlow *optflow = AP::opticalflow();
+    const AP_OpticalFlow *optflow = AP::opticalflow();
     if (optflow && optflow->enabled()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW;

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -596,7 +596,7 @@ const AP_Param::Info Sub::var_info[] = {
 #if AP_OPTICALFLOW_ENABLED
     // @Group: FLOW
     // @Path: ../libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
-    GOBJECT(optflow,   "FLOW", OpticalFlow),
+    GOBJECT(optflow,   "FLOW", AP_OpticalFlow),
 #endif
 
 #if RPM_ENABLED == ENABLED

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -163,7 +163,7 @@ private:
 
     // Optical flow sensor
 #if AP_OPTICALFLOW_ENABLED
-    OpticalFlow optflow;
+    AP_OpticalFlow optflow;
 #endif
 
     // system time in milliseconds of last recorded yaw reset from ekf

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -124,7 +124,7 @@ private:
     AP_Arming_Rover arming;
 
 #if AP_OPTICALFLOW_ENABLED
-    OpticalFlow optflow;
+    AP_OpticalFlow optflow;
 #endif
 
 #if OSD_ENABLED || OSD_PARAM_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -25,7 +25,6 @@
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 
-class OpticalFlow;
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
 #define AP_AHRS_YAW_P_MIN  0.05f        // minimum value for AHRS_YAW_P parameter

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -527,7 +527,7 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_sensor_command(uint16_t cmd_m
 void AP_MSP_Telem_Backend::msp_handle_opflow(const MSP::msp_opflow_data_message_t &pkt)
 {
 #if HAL_MSP_OPTICALFLOW_ENABLED
-    OpticalFlow *optflow = AP::opticalflow();
+    AP_OpticalFlow *optflow = AP::opticalflow();
     if (optflow == nullptr) {
         return;
     }

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -37,23 +37,21 @@
 
 class OpticalFlow_backend;
 
-class OpticalFlow
+class AP_OpticalFlow
 {
     friend class OpticalFlow_backend;
 
 public:
-    OpticalFlow();
+    AP_OpticalFlow();
 
-    /* Do not allow copies */
-    OpticalFlow(const OpticalFlow &other) = delete;
-    OpticalFlow &operator=(const OpticalFlow&) = delete;
+    CLASS_NO_COPY(AP_OpticalFlow);
 
     // get singleton instance
-    static OpticalFlow *get_singleton() {
+    static AP_OpticalFlow *get_singleton() {
         return _singleton;
     }
 
-    enum class OpticalFlowType {
+    enum class Type {
         NONE = 0,
         PX4FLOW = 1,
         PIXART = 2,
@@ -70,7 +68,7 @@ public:
     void init(uint32_t log_bit);
 
     // enabled - returns true if optical flow is enabled
-    bool enabled() const { return _type != (int8_t)OpticalFlowType::NONE; }
+    bool enabled() const { return _type != Type::NONE; }
 
     // healthy - return true if the sensor is healthy
     bool healthy() const { return backend != nullptr && _flags.healthy; }
@@ -118,7 +116,7 @@ public:
 
 private:
 
-    static OpticalFlow *_singleton;
+    static AP_OpticalFlow *_singleton;
 
     OpticalFlow_backend *backend;
 
@@ -127,7 +125,7 @@ private:
     } _flags;
 
     // parameters
-    AP_Int8  _type;                 // user configurable sensor type
+    AP_Enum<Type>  _type;           // user configurable sensor type
     AP_Int16 _flowScalerX;          // X axis flow scale factor correction - parts per thousand
     AP_Int16 _flowScalerY;          // Y axis flow scale factor correction - parts per thousand
     AP_Int16 _yawAngle_cd;          // yaw angle of sensor X axis with respect to vehicle X axis - centi degrees
@@ -151,7 +149,7 @@ private:
 };
 
 namespace AP {
-    OpticalFlow *opticalflow();
+    AP_OpticalFlow *opticalflow();
 }
 
 #include "AP_OpticalFlow_Backend.h"

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
@@ -19,7 +19,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-OpticalFlow_backend::OpticalFlow_backend(OpticalFlow &_frontend) :
+OpticalFlow_backend::OpticalFlow_backend(AP_OpticalFlow &_frontend) :
     frontend(_frontend)
 {
 }
@@ -29,7 +29,7 @@ OpticalFlow_backend::~OpticalFlow_backend(void)
 }
 
 // update the frontend
-void OpticalFlow_backend::_update_frontend(const struct OpticalFlow::OpticalFlow_state &state)
+void OpticalFlow_backend::_update_frontend(const struct AP_OpticalFlow::OpticalFlow_state &state)
 {
     frontend.update_state(state);
 }

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
@@ -15,20 +15,22 @@
 #pragma once
 
 /*
-  OpticalFlow backend class for ArduPilot
+  AP_OpticalFlow backend class for ArduPilot
  */
 
 #include "AP_OpticalFlow.h"
 
 class OpticalFlow_backend
 {
-    friend class OpticalFlow;
+    friend class AP_OpticalFlow;
 
 public:
     // constructor
-    OpticalFlow_backend(OpticalFlow &_frontend);
+    OpticalFlow_backend(AP_OpticalFlow &_frontend);
     virtual ~OpticalFlow_backend(void);
-    
+
+    CLASS_NO_COPY(OpticalFlow_backend);
+
     // init - initialise sensor
     virtual void init() = 0;
 
@@ -45,10 +47,10 @@ public:
 
 protected:
     // access to frontend
-    OpticalFlow &frontend;
+    AP_OpticalFlow &frontend;
 
     // update the frontend
-    void _update_frontend(const struct OpticalFlow::OpticalFlow_state &state);
+    void _update_frontend(const struct AP_OpticalFlow::OpticalFlow_state &state);
 
     // get the flow scaling parameters
     Vector2f _flowScaler(void) const { return Vector2f(frontend._flowScalerX, frontend._flowScalerY); }

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -51,14 +51,14 @@
 extern const AP_HAL::HAL& hal;
 
 // constructor
-AP_OpticalFlow_CXOF::AP_OpticalFlow_CXOF(OpticalFlow &_frontend, AP_HAL::UARTDriver *_uart) :
+AP_OpticalFlow_CXOF::AP_OpticalFlow_CXOF(AP_OpticalFlow &_frontend, AP_HAL::UARTDriver *_uart) :
     OpticalFlow_backend(_frontend),
     uart(_uart)
 {
 }
 
 // detect the device
-AP_OpticalFlow_CXOF *AP_OpticalFlow_CXOF::detect(OpticalFlow &_frontend)
+AP_OpticalFlow_CXOF *AP_OpticalFlow_CXOF::detect(AP_OpticalFlow &_frontend)
 {
     AP_SerialManager *serial_manager = AP::serialmanager().get_singleton();
     if (serial_manager == nullptr) {
@@ -159,7 +159,7 @@ void AP_OpticalFlow_CXOF::update(void)
         return;
     }
 
-    struct OpticalFlow::OpticalFlow_state state {};
+    struct AP_OpticalFlow::OpticalFlow_state state {};
 
     // average surface quality scaled to be between 0 and 255
     state.surface_quality = (constrain_int16(qual_sum / count, 64, 78) - 64) * 255 / 14;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
@@ -14,7 +14,7 @@ class AP_OpticalFlow_CXOF : public OpticalFlow_backend
 {
 public:
     /// constructor
-    AP_OpticalFlow_CXOF(OpticalFlow &_frontend, AP_HAL::UARTDriver *uart);
+    AP_OpticalFlow_CXOF(AP_OpticalFlow &_frontend, AP_HAL::UARTDriver *uart);
 
     // initialise the sensor
     void init() override;
@@ -23,7 +23,7 @@ public:
     void update(void) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_CXOF *detect(OpticalFlow &_frontend);
+    static AP_OpticalFlow_CXOF *detect(AP_OpticalFlow &_frontend);
 
 private:
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
@@ -20,7 +20,7 @@ AP_UAVCAN* AP_OpticalFlow_HereFlow::_ap_uavcan = nullptr;
 /*
   constructor - registers instance at top Flow driver
  */
-AP_OpticalFlow_HereFlow::AP_OpticalFlow_HereFlow(OpticalFlow &flow) :
+AP_OpticalFlow_HereFlow::AP_OpticalFlow_HereFlow(AP_OpticalFlow &flow) :
     OpticalFlow_backend(flow)
 {
     if (_driver) {
@@ -83,7 +83,7 @@ void AP_OpticalFlow_HereFlow::_push_state(void)
     if (!new_data) {
         return;
     }
-    struct OpticalFlow::OpticalFlow_state state;
+    struct AP_OpticalFlow::OpticalFlow_state state;
     const Vector2f flowScaler = _flowScaler();
     //setup scaling based on parameters
     float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.h
@@ -14,7 +14,7 @@ class MeasurementCb;
 
 class AP_OpticalFlow_HereFlow : public OpticalFlow_backend {
 public:
-    AP_OpticalFlow_HereFlow(OpticalFlow &flow);
+    AP_OpticalFlow_HereFlow(AP_OpticalFlow &flow);
 
     void init() override {}
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
@@ -23,7 +23,7 @@
 #define OPTFLOW_MAV_TIMEOUT_SEC 0.5f
 
 // detect the device
-AP_OpticalFlow_MAV *AP_OpticalFlow_MAV::detect(OpticalFlow &_frontend)
+AP_OpticalFlow_MAV *AP_OpticalFlow_MAV::detect(AP_OpticalFlow &_frontend)
 {
     // we assume mavlink messages will be sent into this driver
     AP_OpticalFlow_MAV *sensor = new AP_OpticalFlow_MAV(_frontend);
@@ -47,7 +47,7 @@ void AP_OpticalFlow_MAV::update(void)
         return;
     }
 
-    struct OpticalFlow::OpticalFlow_state state {};
+    struct AP_OpticalFlow::OpticalFlow_state state {};
 
     state.surface_quality = quality_sum / count;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.h
@@ -26,7 +26,7 @@ public:
     void handle_msg(const mavlink_message_t &msg) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_MAV *detect(OpticalFlow &_frontend);
+    static AP_OpticalFlow_MAV *detect(AP_OpticalFlow &_frontend);
 
 private:
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.cpp
@@ -26,7 +26,7 @@ extern const AP_HAL::HAL& hal;
 using namespace MSP;
 
 // detect the device
-AP_OpticalFlow_MSP *AP_OpticalFlow_MSP::detect(OpticalFlow &_frontend)
+AP_OpticalFlow_MSP *AP_OpticalFlow_MSP::detect(AP_OpticalFlow &_frontend)
 {
     // we assume msp messages will be sent into this driver
     return new AP_OpticalFlow_MSP(_frontend);
@@ -49,7 +49,7 @@ void AP_OpticalFlow_MSP::update(void)
         return;
     }
 
-    struct OpticalFlow::OpticalFlow_state state {};
+    struct AP_OpticalFlow::OpticalFlow_state state {};
 
     state.surface_quality = quality_sum / count;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.h
@@ -21,7 +21,7 @@ public:
     void handle_msp(const MSP::msp_opflow_data_message_t &pkt) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_MSP *detect(OpticalFlow &_frontend);
+    static AP_OpticalFlow_MSP *detect(AP_OpticalFlow &_frontend);
 
 private:
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.cpp
@@ -30,10 +30,6 @@
 #define OPTICALFLOW_ONBOARD_ID 1
 extern const AP_HAL::HAL& hal;
 
-AP_OpticalFlow_Onboard::AP_OpticalFlow_Onboard(OpticalFlow &_frontend) :
-    OpticalFlow_backend(_frontend)
-{}
-
 void AP_OpticalFlow_Onboard::init(void)
 {
     /* register callback to get gyro data */
@@ -54,7 +50,7 @@ void AP_OpticalFlow_Onboard::update()
         return;
     }
 
-    struct OpticalFlow::OpticalFlow_state state;
+    struct AP_OpticalFlow::OpticalFlow_state state;
     state.surface_quality = data_frame.quality;
     if (data_frame.delta_time > 0) {
         const Vector2f flowScaler = _flowScaler();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.h
@@ -32,7 +32,9 @@
 class AP_OpticalFlow_Onboard : public OpticalFlow_backend
 {
 public:
-    AP_OpticalFlow_Onboard(OpticalFlow &_frontend);
+
+    using OpticalFlow_backend::OpticalFlow_backend;
+
     void init(void) override;
     void update(void) override;
 private:

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -34,15 +34,9 @@ extern const AP_HAL::HAL& hal;
 #define PX4FLOW_BASE_I2C_ADDR   0x42
 #define PX4FLOW_INIT_RETRIES    10      // attempt to initialise the sensor up to 10 times at startup
 
-// constructor
-AP_OpticalFlow_PX4Flow::AP_OpticalFlow_PX4Flow(OpticalFlow &_frontend) :
-    OpticalFlow_backend(_frontend)
-{
-}
-
 
 // detect the device
-AP_OpticalFlow_PX4Flow *AP_OpticalFlow_PX4Flow::detect(OpticalFlow &_frontend)
+AP_OpticalFlow_PX4Flow *AP_OpticalFlow_PX4Flow::detect(AP_OpticalFlow &_frontend)
 {
     AP_OpticalFlow_PX4Flow *sensor = new AP_OpticalFlow_PX4Flow(_frontend);
     if (!sensor) {
@@ -119,7 +113,7 @@ void AP_OpticalFlow_PX4Flow::timer(void)
     if (!dev->read_registers(REG_INTEGRAL_FRAME, (uint8_t *)&frame, sizeof(frame))) {
         return;
     }
-    struct OpticalFlow::OpticalFlow_state state {};
+    struct AP_OpticalFlow::OpticalFlow_state state {};
 
     if (frame.integration_timespan > 0) {
         const Vector2f flowScaler = _flowScaler();

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.h
@@ -14,7 +14,9 @@ class AP_OpticalFlow_PX4Flow : public OpticalFlow_backend
 {
 public:
     /// constructor
-    AP_OpticalFlow_PX4Flow(OpticalFlow &_frontend);
+    using OpticalFlow_backend::OpticalFlow_backend;
+
+    CLASS_NO_COPY(AP_OpticalFlow_PX4Flow);
 
     // init - initialise the sensor
     void init() override {}
@@ -23,7 +25,7 @@ public:
     void update(void) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_PX4Flow *detect(OpticalFlow &_frontend);
+    static AP_OpticalFlow_PX4Flow *detect(AP_OpticalFlow &_frontend);
 
 private:
     AP_HAL::OwnPtr<AP_HAL::Device> dev;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -83,14 +83,14 @@ extern const AP_HAL::HAL& hal;
 #define PIXART_SROM_CRC_RESULT 0xBEEF
 
 // constructor
-AP_OpticalFlow_Pixart::AP_OpticalFlow_Pixart(const char *devname, OpticalFlow &_frontend) :
+AP_OpticalFlow_Pixart::AP_OpticalFlow_Pixart(const char *devname, AP_OpticalFlow &_frontend) :
     OpticalFlow_backend(_frontend)
 {
     _dev = std::move(hal.spi->get_device(devname));
 }
 
 // detect the device
-AP_OpticalFlow_Pixart *AP_OpticalFlow_Pixart::detect(const char *devname, OpticalFlow &_frontend)
+AP_OpticalFlow_Pixart *AP_OpticalFlow_Pixart::detect(const char *devname, AP_OpticalFlow &_frontend)
 {
     AP_OpticalFlow_Pixart *sensor = new AP_OpticalFlow_Pixart(devname, _frontend);
     if (!sensor) {
@@ -329,7 +329,7 @@ void AP_OpticalFlow_Pixart::update(void)
     }
     last_update_ms = now;
 
-    struct OpticalFlow::OpticalFlow_state state;
+    struct AP_OpticalFlow::OpticalFlow_state state;
     state.surface_quality = burst.squal;
 
     if (integral.sum_us > 0) {

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
@@ -14,7 +14,7 @@ class AP_OpticalFlow_Pixart : public OpticalFlow_backend
 {
 public:
     /// constructor
-    AP_OpticalFlow_Pixart(const char *devname, OpticalFlow &_frontend);
+    AP_OpticalFlow_Pixart(const char *devname, AP_OpticalFlow &_frontend);
 
     // init - initialise the sensor
     void init() override {}
@@ -23,7 +23,7 @@ public:
     void update(void) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_Pixart *detect(const char *devname, OpticalFlow &_frontend);
+    static AP_OpticalFlow_Pixart *detect(const char *devname, AP_OpticalFlow &_frontend);
 
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _dev;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
@@ -25,7 +25,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-AP_OpticalFlow_SITL::AP_OpticalFlow_SITL(OpticalFlow &_frontend) :
+AP_OpticalFlow_SITL::AP_OpticalFlow_SITL(AP_OpticalFlow &_frontend) :
     OpticalFlow_backend(_frontend),
     _sitl(AP::sitl())
 {
@@ -52,7 +52,7 @@ void AP_OpticalFlow_SITL::update(void)
                   radians(_sitl->state.pitchRate), 
                   radians(_sitl->state.yawRate));
 
-    OpticalFlow::OpticalFlow_state state;
+    AP_OpticalFlow::OpticalFlow_state state;
 
     // NED velocity vector in m/s
     Vector3f velocity(_sitl->state.speedN,

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.h
@@ -8,7 +8,7 @@ class AP_OpticalFlow_SITL : public OpticalFlow_backend
 {
 public:
     /// constructor
-    AP_OpticalFlow_SITL(OpticalFlow &_frontend);
+    AP_OpticalFlow_SITL(AP_OpticalFlow &_frontend);
 
     // init - initialise the sensor
     void init() override;
@@ -22,6 +22,6 @@ private:
 
     uint8_t next_optflow_index;
     uint8_t optflow_delay;
-    OpticalFlow::OpticalFlow_state optflow_data[20];
+    AP_OpticalFlow::OpticalFlow_state optflow_data[20];
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.cpp
@@ -53,14 +53,14 @@
 extern const AP_HAL::HAL& hal;
 
 // constructor
-AP_OpticalFlow_UPFLOW::AP_OpticalFlow_UPFLOW(OpticalFlow &_frontend, AP_HAL::UARTDriver *_uart) :
+AP_OpticalFlow_UPFLOW::AP_OpticalFlow_UPFLOW(AP_OpticalFlow &_frontend, AP_HAL::UARTDriver *_uart) :
     OpticalFlow_backend(_frontend),
     uart(_uart)
 {
 }
 
 // detect the device
-AP_OpticalFlow_UPFLOW *AP_OpticalFlow_UPFLOW::detect(OpticalFlow &_frontend)
+AP_OpticalFlow_UPFLOW *AP_OpticalFlow_UPFLOW::detect(AP_OpticalFlow &_frontend)
 {
     AP_SerialManager *serial_manager = AP::serialmanager().get_singleton();
     if (serial_manager == nullptr) {
@@ -156,7 +156,7 @@ void AP_OpticalFlow_UPFLOW::update(void)
         return;
     }
 
-    struct OpticalFlow::OpticalFlow_state state {};
+    struct AP_OpticalFlow::OpticalFlow_state state {};
 
     state.surface_quality = updata.quality;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_UPFLOW.h
@@ -14,7 +14,7 @@ class AP_OpticalFlow_UPFLOW : public OpticalFlow_backend
 {
 public:
     /// constructor
-    AP_OpticalFlow_UPFLOW(OpticalFlow &_frontend, AP_HAL::UARTDriver *uart);
+    AP_OpticalFlow_UPFLOW(AP_OpticalFlow &_frontend, AP_HAL::UARTDriver *uart);
 
     // initialise the sensor
     void init() override;
@@ -23,7 +23,7 @@ public:
     void update(void) override;
 
     // detect if the sensor is available
-    static AP_OpticalFlow_UPFLOW *detect(OpticalFlow &_frontend);
+    static AP_OpticalFlow_UPFLOW *detect(AP_OpticalFlow &_frontend);
 
 private:
     struct PACKED UpixelsOpticalFlow {

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -32,7 +32,7 @@ public:
 
 static DummyVehicle vehicle;
 #if AP_OPTICALFLOW_ENABLED
-static OpticalFlow optflow;
+static AP_OpticalFlow optflow;
 #endif
 
 void setup()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -293,11 +293,11 @@ singleton AP_Baro method get_temperature float
 singleton AP_Baro method get_external_temperature float
 
 include AP_OpticalFlow/AP_OpticalFlow.h
-singleton OpticalFlow depends AP_OPTICALFLOW_ENABLED
-singleton OpticalFlow rename optical_flow
-singleton OpticalFlow method enabled boolean
-singleton OpticalFlow method healthy boolean
-singleton OpticalFlow method quality uint8_t
+singleton AP_OpticalFlow depends AP_OPTICALFLOW_ENABLED
+singleton AP_OpticalFlow rename optical_flow
+singleton AP_OpticalFlow method enabled boolean
+singleton AP_OpticalFlow method healthy boolean
+singleton AP_OpticalFlow method quality uint8_t
 
 include AP_ESC_Telem/AP_ESC_Telem.h
 singleton AP_ESC_Telem depends HAL_WITH_ESC_TELEM == 1

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2414,7 +2414,7 @@ MAV_RESULT GCS_MAVLINK::_set_mode_common(const MAV_MODE _base_mode, const uint32
  */
 void GCS_MAVLINK::send_opticalflow()
 {
-    const OpticalFlow *optflow = AP::opticalflow();
+    const AP_OpticalFlow *optflow = AP::opticalflow();
 
     // exit immediately if no optical flow sensor or not healthy
     if (optflow == nullptr ||
@@ -3510,7 +3510,7 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
 #if AP_OPTICALFLOW_ENABLED
 void GCS_MAVLINK::handle_optical_flow(const mavlink_message_t &msg)
 {
-    OpticalFlow *optflow = AP::opticalflow();
+    AP_OpticalFlow *optflow = AP::opticalflow();
     if (optflow == nullptr) {
         return;
     }

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1158,7 +1158,7 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
 
     case AUX_FUNC::OPTFLOW_CAL: {
 #if AP_OPTICALFLOW_ENABLED
-        OpticalFlow *optflow = AP::opticalflow();
+        AP_OpticalFlow *optflow = AP::opticalflow();
         if (optflow == nullptr) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "OptFlow Cal: failed sensor not enabled");
             break;


### PR DESCRIPTION
Brings us in-line with other classes in ArduPilot.

Removes ambiguity with AP_HAL::OpticalFlow which can cause compilation errors as we start to make code more portable across targets