### PR TITLE
Make HAL_FLASH_PROTECTION boolean define

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -77,7 +77,7 @@ int main(void)
     AFIO->MAPR = mapr | AFIO_MAPR_CAN_REMAP_REMAP2 | AFIO_MAPR_SPI3_REMAP;
 #endif
 
-#ifdef HAL_FLASH_PROTECTION
+#if HAL_FLASH_PROTECTION
     stm32_flash_unprotect_flash();
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -249,7 +249,7 @@ static void main_loop()
     utilInstance.apply_persistent_params();
 #endif
 
-#ifdef HAL_FLASH_PROTECTION
+#if HAL_FLASH_PROTECTION
     if (AP_BoardConfig::unlock_flash()) {
         stm32_flash_unprotect_flash();
     } else {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
@@ -284,7 +284,7 @@ void stm32_flash_lock(void)
 #endif
 }
 
-#if defined(STM32H7) && defined(HAL_FLASH_PROTECTION)
+#if defined(STM32H7) && HAL_FLASH_PROTECTION
 static void stm32_flash_wait_opt_idle(void)
 {
     __DSB();
@@ -863,7 +863,7 @@ void stm32_flash_protect_flash(bool bootloader, bool protect)
 {
     (void)bootloader;
     (void)protect;
-#if defined(STM32H7) && !defined(HAL_BOOTLOADER_BUILD) && defined(HAL_FLASH_PROTECTION)
+#if defined(STM32H7) && HAL_FLASH_PROTECTION
     uint32_t prg1 = FLASH->WPSN_CUR1;
     uint32_t prg2 = FLASH->WPSN_CUR2;
 #ifndef STORAGE_FLASH_PAGE
@@ -925,7 +925,7 @@ void stm32_flash_protect_flash(bool bootloader, bool protect)
  */
 void stm32_flash_unprotect_flash()
 {
-#if defined(STM32H7) && defined(HAL_FLASH_PROTECTION)
+#if defined(STM32H7) && HAL_FLASH_PROTECTION
     stm32_flash_opt_clear_errors();
     stm32_flash_clear_errors();
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1146,6 +1146,21 @@ def write_mcu_config(f):
     if not args.bootloader:
         f.write('''#define STM32_DMA_REQUIRED TRUE\n\n''')
 
+    if args.bootloader:
+        # do not enable flash protection in bootloader, even if hwdef
+        # requests it:
+        f.write('''
+#undef HAL_FLASH_PROTECTION
+#define HAL_FLASH_PROTECTION 0
+''')
+    else:
+        # flash protection is off by default:
+        f.write('''
+#ifndef HAL_FLASH_PROTECTION
+#define HAL_FLASH_PROTECTION 0
+#endif
+''')
+
 def write_ldscript(fname):
     '''write ldscript.ld for this board'''
     flash_size = get_config('FLASH_USE_MAX_KB', type=int, default=0)


### PR DESCRIPTION
... stop using ifdef on it

Tested that the protection is enabled on SPRacingH7 and not enabled on Pixhawk6x using a # error in the relevant block.

Built and installed a Pixhawk6x bootloader using this branch, then used that bootloader to flash that Pixahawk6x.

I don't have an SPRacingH7 to test on it.
