### PR TITLE
Crashdump enable cleanups

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -135,9 +135,11 @@ int AP_Filesystem_Sys::open(const char *fname, int flags, bool allow_absolute_pa
     if (strcmp(fname, "persistent.parm") == 0) {
         hal.util->load_persistent_params(*r.str);
     }
+#if AP_CRASHDUMP_ENABLED
     if (strcmp(fname, "crash_dump.bin") == 0) {
         r.str->set_buffer((char*)hal.util->last_crash_dump_ptr(), hal.util->last_crash_dump_size(), hal.util->last_crash_dump_size());
-    } else
+    }
+#endif
     if (strcmp(fname, "storage.bin") == 0) {
         // we don't want to store the contents of storage.bin
         // we read directly from the storage driver
@@ -270,8 +272,10 @@ int AP_Filesystem_Sys::stat(const char *pathname, struct stat *stbuf)
     // read every file for a directory listing
     if (strcmp(pathname_noslash, "storage.bin") == 0) {
         stbuf->st_size = HAL_STORAGE_SIZE;
+#if AP_CRASHDUMP_ENABLED
     } else if (strcmp(pathname_noslash, "crash_dump.bin") == 0) {
         stbuf->st_size = hal.util->last_crash_dump_size();
+#endif
     } else {
         stbuf->st_size = 100000;
     }

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -277,6 +277,10 @@
 #define HAL_WITH_MCU_MONITORING 0
 #endif
 
+#ifndef AP_CRASHDUMP_ENABLED
+#define AP_CRASHDUMP_ENABLED 0
+#endif
+
 #ifndef HAL_HNF_MAX_FILTERS
 // On an F7 The difference in CPU load between 1 notch and 24 notches is about 2%
 // The difference in CPU load between 1Khz backend and 2Khz backend is about 10%

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -196,8 +196,11 @@ public:
     // log info on stack usage
     virtual void log_stack_info(void) {}
 
+#if AP_CRASHDUMP_ENABLED
     virtual size_t last_crash_dump_size() const { return 0; }
     virtual void* last_crash_dump_ptr() const { return nullptr; }
+#endif
+
 protected:
     // we start soft_armed false, so that actuators don't send any
     // values until the vehicle code has fully started

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -722,10 +722,9 @@ void Util::log_stack_info(void)
 #endif
 }
 
-#if !defined(HAL_BOOTLOADER_BUILD)
+#if AP_CRASHDUMP_ENABLED
 size_t Util::last_crash_dump_size() const
 {
-#if HAL_CRASHDUMP_ENABLE
     // get dump size
     uint32_t size = stm32_crash_dump_size();
     char* dump_start = (char*)stm32_crash_dump_addr();
@@ -738,22 +737,16 @@ size_t Util::last_crash_dump_size() const
         size = stm32_crash_dump_max_size();
     }
     return size;
-#endif
-    return 0;
 }
 
 void* Util::last_crash_dump_ptr() const
 {
-#if HAL_CRASHDUMP_ENABLE
     if (last_crash_dump_size() == 0) {
         return nullptr;
     }
     return (void*)stm32_crash_dump_addr();
-#else
-    return nullptr;
-#endif
 }
-#endif // HAL_BOOTLOADER_BUILD
+#endif // AP_CRASHDUMP_ENABLED
 
 // set armed state
 void Util::set_soft_armed(const bool b)

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -146,7 +146,7 @@ private:
     // log info on stack usage
     void log_stack_info(void) override;
 
-#if !defined(HAL_BOOTLOADER_BUILD)
+#if AP_CRASHDUMP_ENABLED
     // get last crash dump
     size_t last_crash_dump_size() const override;
     void* last_crash_dump_ptr() const override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -972,10 +972,10 @@ def write_mcu_config(f):
 
     if flash_size >= 2048 and not args.bootloader:
         # lets pick a flash sector for Crash log
-        f.write('#define HAL_CRASHDUMP_ENABLE 1\n')
+        f.write('#define AP_CRASHDUMP_ENABLED 1\n')
         env_vars['ENABLE_CRASHDUMP'] = 1
     else:
-        f.write('#define HAL_CRASHDUMP_ENABLE 0\n')
+        f.write('#define AP_CRASHDUMP_ENABLED 0\n')
         env_vars['ENABLE_CRASHDUMP'] = 0
 
     if args.bootloader:

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -23,7 +23,7 @@
 #include "hwdef/common/watchdog.h"
 #include "hwdef/common/stm32_util.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
-#if HAL_CRASHDUMP_ENABLE
+#if AP_CRASHDUMP_ENABLED
 #include <CrashCatcher.h>
 #endif
 #include <ch.h>
@@ -52,7 +52,7 @@ extern "C"
 {
 #define bkpt() __asm volatile("BKPT #0\n")
 
-#if !HAL_CRASHDUMP_ENABLE
+#if !AP_CRASHDUMP_ENABLED
 // do legacy hardfault handling
 void HardFault_Handler(void);
 void HardFault_Handler(void) {


### PR DESCRIPTION
 - renamed from `HAL_CRASHDUMP_ENABLE` to AP_CRASHDUMP_ENABLED` 
 - set don't-build-in-bootloader in hwdef.h rather than in code
 - remove functions entirely rather than leaving empty functions

Saves a few bytes on smaller boards (e.g. MatekF405-Wing`:
![image](https://user-images.githubusercontent.com/7077857/184603054-f1a80d9c-4dba-4385-8767-a8680f65cc46.png)

And Hitec-Airspeeed:
![image](https://user-images.githubusercontent.com/7077857/184603182-9651d3c7-c6e0-4040-9e96-1de68d3d1945.png)

Tested that crashdump still works on Pixhawk6x (it does)
