### PR TITLE
Filtering: fixed non-contiguous ESC telemetry motor sets

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -808,8 +808,12 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
         // do a little quadplane dance
         float hover_throttle = 0.0f;
         uint8_t running_motors = 0;
-        for (uint8_t i=0; i < sitl_model->get_num_motors() - 1; i++) {
-            float motor_throttle = constrain_float((input.servos[sitl_model->get_motors_offset() + i] - 1000) / 1000.0f, 0.0f, 1.0f);
+        uint32_t mask = _sitl->state.motor_mask;
+        uint8_t bit;
+        while ((bit = __builtin_ffs(mask)) != 0) {
+            uint8_t motor = bit-1;
+            mask &= ~(1U<<motor);
+            float motor_throttle = constrain_float((input.servos[motor] - 1000) / 1000.0f, 0.0f, 1.0f);
             // update motor_on flag
             if (!is_zero(motor_throttle)) {
                 hover_throttle += motor_throttle;
@@ -831,8 +835,12 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
     } else {
         // run checks on each motor
         uint8_t running_motors = 0;
-        for (uint8_t i=0; i < sitl_model->get_num_motors(); i++) {
-            float motor_throttle = constrain_float((input.servos[i] - 1000) / 1000.0f, 0.0f, 1.0f);
+        uint32_t mask = _sitl->state.motor_mask;
+        uint8_t bit;
+        while ((bit = __builtin_ffs(mask)) != 0) {
+            const uint8_t motor = bit-1;
+            mask &= ~(1U<<motor);
+            float motor_throttle = constrain_float((input.servos[motor] - 1000) / 1000.0f, 0.0f, 1.0f);
             // update motor_on flag
             if (!is_zero(motor_throttle)) {
                 throttle += motor_throttle;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
@@ -47,8 +47,8 @@ private:
     uint64_t next_accel_sample;
     float gyro_time;
     float accel_time;
-    float gyro_motor_phase[12];
-    float accel_motor_phase[12];
+    float gyro_motor_phase[32];
+    float accel_motor_phase[32];
 
     static uint8_t bus_id;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -43,8 +43,8 @@ private:
     uint64_t next_accel_sample;
     float gyro_time;
     float accel_time;
-    float gyro_motor_phase[12];
-    float accel_motor_phase[12];
+    float gyro_motor_phase[32];
+    float accel_motor_phase[32];
     uint32_t temp_start_ms;
 
     static uint8_t bus_id;

--- a/libraries/AP_RPM/RPM_SITL.cpp
+++ b/libraries/AP_RPM/RPM_SITL.cpp
@@ -34,10 +34,17 @@ void AP_RPM_SITL::update(void)
     if (sitl == nullptr) {
         return;
     }
-    if (instance == 0) {
-        state.rate_rpm = sitl->state.rpm[0];
-    } else {
-        state.rate_rpm = sitl->state.rpm[1];
+    const uint32_t motor_mask = sitl->state.motor_mask;
+    uint8_t count = 0;
+    // find the motor with the corresponding index
+    for (uint8_t i=0; i<32; i++) {
+        if (motor_mask & (1U<<i)) {
+            if (count == instance) {
+                state.rate_rpm = sitl->state.rpm[i];
+                break;
+            }
+            count++;
+        }
     }
     state.rate_rpm *= ap_rpm._params[state.instance].scaling;
     state.signal_quality = 0.5f;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -517,8 +517,8 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
             // set the harmonic notch filter frequency scaled on measured frequency
             if (notch.params.hasOption(HarmonicNotchFilterParams::Options::DynamicHarmonic)) {
                 float notches[INS_MAX_NOTCHES];
-                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(notch.num_dynamic_notches, notches);
                 // ESC telemetry will return 0 for missing data, but only after 1s
+                const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
                 for (uint8_t i = 0; i < num_notches; i++) {
                     if (!is_zero(notches[i])) {
                         notches[i] =  MAX(ref_freq, notches[i]);

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -31,6 +31,8 @@ public:
     ~HarmonicNotchFilter();
     // allocate a bank of notch filters for this harmonic notch filter
     void allocate_filters(uint8_t num_notches, uint8_t harmonics, uint8_t composite_notches);
+    // expand filter bank with new filters
+    void expand_filter_count(uint8_t num_notches);
     // initialize the underlying filters using the provided filter parameters
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
     // update the underlying filters' center frequencies using center_freq_hz as the fundamental
@@ -64,6 +66,9 @@ private:
     // number of enabled filters
     uint8_t _num_enabled_filters;
     bool _initialised;
+
+    // have we failed to expand filters?
+    bool _alloc_has_failed;
 };
 
 // Harmonic notch update mode

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -390,9 +390,8 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     fdm.velocity_air_bf = velocity_air_bf;
     fdm.battery_voltage = battery_voltage;
     fdm.battery_current = battery_current;
-    fdm.num_motors = num_motors;
-    fdm.vtol_motor_start = vtol_motor_start;
-    memcpy(fdm.rpm, rpm, num_motors * sizeof(float));
+    fdm.motor_mask = motor_mask;
+    memcpy(fdm.rpm, rpm, sizeof(fdm.rpm));
     fdm.rcin_chan_count = rcin_chan_count;
     fdm.range = rangefinder_range();
     memcpy(fdm.rcin, rcin, rcin_chan_count * sizeof(float));

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -390,7 +390,7 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     fdm.velocity_air_bf = velocity_air_bf;
     fdm.battery_voltage = battery_voltage;
     fdm.battery_current = battery_current;
-    fdm.motor_mask = motor_mask;
+    fdm.motor_mask = motor_mask | sitl->vibe_motor_mask;
     memcpy(fdm.rpm, rpm, sizeof(fdm.rpm));
     fdm.rcin_chan_count = rcin_chan_count;
     fdm.range = rangefinder_range();

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -91,16 +91,6 @@ public:
     // get frame rate of model in Hz
     float get_rate_hz(void) const { return rate_hz; }
 
-    // get number of motors for model
-    uint16_t get_num_motors() const {
-        return num_motors;
-    }
-
-    // get motor offset for model
-    virtual uint16_t get_motors_offset() const {
-        return 0;
-    }
-
     const Vector3f &get_gyro(void) const {
         return gyro;
     }
@@ -189,9 +179,8 @@ protected:
     // battery model
     Battery battery;
 
-    uint8_t num_motors = 1;
-    uint8_t vtol_motor_start;
-    float rpm[12];
+    uint32_t motor_mask;
+    float rpm[32];
     uint8_t rcin_chan_count;
     float rcin[12];
 

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -109,7 +109,6 @@ FlightAxis::FlightAxis(const char *frame_str) :
     Aircraft(frame_str)
 {
     use_time_sync = false;
-    num_motors = 2;
     rate_hz = 250 / target_speedup;
     heli_demix = strstr(frame_str, "helidemix") != nullptr;
     rev4_servos = strstr(frame_str, "rev4") != nullptr;

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -589,7 +589,7 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         thrust += mthrust;
         // simulate motor rpm
         if (!is_zero(AP::sitl()->vibe_motor)) {
-            rpm[i] = motors[i].get_command() * AP::sitl()->vibe_motor * 60.0f;
+            rpm[motor_offset+i] = motors[i].get_command() * AP::sitl()->vibe_motor * 60.0f;
         }
     }
 

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -64,7 +64,6 @@ JSBSim::JSBSim(const char *frame_str) :
     }
     control_port = 5505 + instance*10;
     fdm_port = 5504 + instance*10;
-    num_motors = 2;
 
     printf("JSBSim backend started: control_port=%u fdm_port=%u\n",
            control_port, fdm_port);

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -36,7 +36,6 @@ MultiCopter::MultiCopter(const char *frame_str) :
 
     mass = frame->get_mass();
     frame_height = 0.1;
-    num_motors = frame->num_motors;
     ground_behavior = GROUND_BEHAVIOR_NO_MOVEMENT;
     lock_step_scheduled = true;
 }
@@ -44,6 +43,7 @@ MultiCopter::MultiCopter(const char *frame_str) :
 // calculate rotational and linear accelerations
 void MultiCopter::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
+    motor_mask |= ((1U<<frame->num_motors)-1U) << frame->motor_offset;
     frame->calculate_forces(*this, input, rot_accel, body_accel, rpm);
 
     add_shove_forces(rot_accel, body_accel);

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -34,11 +34,6 @@ public:
     /* update model by one time step */
     void update(const struct sitl_input &input) override;
 
-    // get motor offset for model
-    virtual uint16_t get_motors_offset() const override {
-        return frame->motor_offset;
-    }
-
     /* static object creator */
     static Aircraft *create(const char *frame_str) {
         return new MultiCopter(frame_str);

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -36,7 +36,6 @@ Plane::Plane(const char *frame_str) :
     */
     thrust_scale = (mass * GRAVITY_MSS) / hover_throttle;
     frame_height = 0.1f;
-    num_motors = 1;
 
     ground_behavior = GROUND_BEHAVIOR_FWD_ONLY;
     lock_step_scheduled = true;
@@ -354,7 +353,8 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     }
     
     // simulate engine RPM
-    rpm[0] = thrust * 7000;
+    motor_mask |= (1U<<2);
+    rpm[2] = thrust * 7000;
     
     // scale thrust to newtons
     thrust *= thrust_scale;

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -80,8 +80,6 @@ QuadPlane::QuadPlane(const char *frame_str) :
         printf("Failed to find frame '%s'\n", frame_type);
         exit(1);
     }
-    num_motors = 1 + frame->num_motors;
-    vtol_motor_start = 1;
 
     if (strstr(frame_str, "cl84")) {
         // setup retract servos at front
@@ -120,7 +118,8 @@ void QuadPlane::update(const struct sitl_input &input)
     Vector3f quad_rot_accel;
     Vector3f quad_accel_body;
 
-    frame->calculate_forces(*this, input, quad_rot_accel, quad_accel_body, &rpm[1], false);
+    motor_mask |= ((1U<<frame->num_motors)-1U) << frame->motor_offset;
+    frame->calculate_forces(*this, input, quad_rot_accel, quad_accel_body, rpm, false);
 
     // rotate frames for copter tailsitters
     if (copter_tailsitter) {

--- a/libraries/SITL/SIM_QuadPlane.h
+++ b/libraries/SITL/SIM_QuadPlane.h
@@ -39,12 +39,6 @@ public:
         return new QuadPlane(frame_str);
     }
 
-    // get motor offset for model
-    virtual uint16_t get_motors_offset() const override {
-        return frame->motor_offset;
-    }
-
-
 private:
     Frame *frame;
 };

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -47,7 +47,6 @@ XPlane::XPlane(const char *frame_str) :
     }
 
     heli_frame = (strstr(frame_str, "-heli") != nullptr);
-    num_motors = 2;
 
     socket_in.bind("0.0.0.0", bind_port);
     printf("Waiting for XPlane data on UDP port %u and sending to port %u\n",

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -174,6 +174,9 @@ const AP_Param::GroupInfo SIM::var_info2[] = {
     // motor harmonics
     AP_GROUPINFO("VIB_MOT_HMNC", 60, SIM,  vibe_motor_harmonics, 1),
 
+    // motor mask, allowing external simulators to mark motors
+    AP_GROUPINFO("VIB_MOT_MASK", 5, SIM,  vibe_motor_mask, 0),
+    
     // max motor vibration frequency
     AP_GROUPINFO("VIB_MOT_MAX", 61, SIM,  vibe_motor, 0.0f),
     // minimum throttle for simulated ins noise

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -63,8 +63,8 @@ struct sitl_fdm {
     double battery_current; // Amps
     double battery_remaining; // Ah, if non-zero capacity
     uint8_t num_motors;
-    uint8_t vtol_motor_start;
-    float rpm[12];         // RPM of all motors
+    uint32_t motor_mask;
+    float rpm[32];         // RPM of all motors
     uint8_t rcin_chan_count;
     float  rcin[12];         // RC input 0..1
     double range;           // rangefinder value

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -336,6 +336,9 @@ public:
     // what harmonics to generate
     AP_Int16 vibe_motor_harmonics;
 
+    // what servos are motors
+    AP_Int32 vibe_motor_mask;
+    
     // minimum throttle for addition of ins noise
     AP_Float ins_noise_throttle_min;
 


### PR DESCRIPTION
This fixes a bug in handling non-contiguous motor sets introduced by this PR:
https://github.com/ArduPilot/ardupilot/pull/21370
In quadplanes it is common for the ESCs to be on motors 5-8 or 9-12, plus a fwd motor on output 3 (SERVO3)
The above PR broke this by assuming that all motors were contiguous starting at index 0
This PR also makes it possible to test this setup in SITL, by converting SITL to using a 32 bit mask of which outputs are motors instead of a starting index and count. That matches the way real aircraft are setup.
It also fixes the assumption that all ESCs are in AP_Motors. In quadplanes some of the motors can be not managed by AP_Motors. I changes the harmonic notch filter to allow expansion of the number of filters which allows for ESCs to be outside of AP_Motors, or even generated by lua scripts
