### PR TITLE
AP_Scripting: unint32: remove integer range check

### DIFF
--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -20,7 +20,7 @@ uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
 
         int success;
         const lua_Integer v = lua_tointegerx(L, arg, &success);
-        if (success && v >= 0) {
+        if (success) {
             return static_cast<uint32_t>(v);
         }
     }


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/21391, this removes the range check on converting ints to uints. On master:
```
Float failed at 16777217, got 16777218 from 16777217.1
Hexadecimal error at 2147483648 with 0x80000000
Integer failed at 2147483649, got 2147483648 from 2147483649
Uint32 test complete
```
This branch:
```
Float failed at 16777217, got 16777218 from 16777217.1
Integer failed at 2147483649, got 2147483648 from 2147483649
Uint32 test complete
```
The key difference is that Hex never fails. So there is no benefit to the suggested two argument high word low word approach as that requires hex which works fine in full form. 

As the test shows we still change to float above int32 max and loose precision. Float to uint32 is rubbish anyway failing very quickly.

The testing does not test negative decimal numbers, which are also now accepted as a byproduct. EG: `uint32_t(-1) == uint32(0xFFFFFFFF) == 4294967295`

Test script:
```
local count = uint32_t(0)
local inc = uint32_t(1)
local stop = uint32_t(0)

local test_val
local function test_uint(num_string)
  test_val = uint32_t(num_string)
end

local int_test = {}
int_test.valid = true
int_test.name = "Integer"
int_test.func = tostring

local function tostring_float()
  return tostring(count) .. ".1"
end

local float_test = {}
float_test.valid = true
float_test.name = "Float"
float_test.func = tostring_float

local word_mask = uint32_t(0xFFFF)
local function to_hex_string(num)
  return string.format("0x%04x%04x", (num >> 16):toint(), (num & word_mask):toint())
end

local hex_test = {}
hex_test.valid = true
hex_test.name = "Hexadecimal"
hex_test.func = to_hex_string

local tests = {int_test, float_test, hex_test}

local one = uint32_t(1)
function update()

  for i = 1,1000000 do
    local tests_running = false
    for j = 1,#tests do
      local test = tests[j]
      if test.valid then
        local num_string = test.func(count)
        if not pcall(test_uint,num_string) then
          gcs:send_text(0, string.format("%s error at %s with %s", test.name, tostring(count), num_string))
          test.valid = false
        elseif not (test_val == count) then
          gcs:send_text(0, string.format("%s failed at %s, got %s from %s",test.name, tostring(count), tostring(test_val), num_string))
          test.valid = false
        end
      end
      tests_running = tests_running or test.valid
    end

    count = count + inc
    if count == stop or not tests_running then
      gcs:send_text(0, string.format("Uint32 test complete"))
      return
    end
  end

  gcs:send_text(0, string.format("Uint32 test : %0.2f%%", (count:tofloat()/(stop-one):tofloat())*100))

  return update, 0
end

return update()
```

Test script takes ages to run highlighting @tridge's comments on speed.  

 @WickedShell also pointed out that even with double support we would need `uint32_t` still for things like wrapping of timestamps.