### PR TITLE
autotest: stop vehicle running into terrain in MAV_CMD_NAV_LOITER_TURNS

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3707,7 +3707,7 @@ function'''
 
     def MAV_CMD_NAV_LOITER_TURNS(self, target_system=1, target_component=1):
         '''test MAV_CMD_NAV_LOITER_TURNS mission item'''
-        alt = 20
+        alt = 100
         seq = 0
         items = []
         tests = [


### PR DESCRIPTION
From autotest:
```
AT-0483.6: wait-circling: got-r=1001.55 want-r=1005.000000 avg-r=1003.883971 on want-a=180.0 got-a=18.00
AT-0483.6: wait-circling: got-r=1001.78 want-r=1005.000000 avg-r=1003.778672 on want-a=180.0 got-a=18.00
AT-0483.7: wait-circling: got-r=1002.18 want-r=1005.000000 avg-r=1003.698627 on want-a=180.0 got-a=18.00
AT-0483.7: AP: SIM Hit ground at 2.031358 m/s
AT-0483.7: wait-circling: got-r=1002.52 want-r=1005.000000 avg-r=1003.639742 on want-a=180.0 got-a=19.00
AT-0483.7: wait-circling: got-r=1003.19 want-r=1005.000000 avg-r=1003.617272 on want-a=180.0 got-a=19.00
AT-0483.8: wait-circling: got-r=1003.70 want-r=1005.000000 avg-r=1003.621449 on want-a=180.0 got-a=19.00
AT-0483.8: AP: SIM Hit ground at 1.520168 m/s
```

.... 20m wasn't even a good guess.
