### PR TITLE
AP_Module: correct ModuleTest example for lack of GCS object

### DIFF
--- a/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
+++ b/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
@@ -8,6 +8,12 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
+
+const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
+    AP_GROUPEND
+};
+GCS_Dummy _gcs;
 
 void setup();
 void loop();


### PR DESCRIPTION
segfault when some library tries to gcs_send_text
