### PR TITLE
Tools: SITL copter param file for wind speed estimation

### DIFF
--- a/Tools/autotest/default_params/copter-wind-estimates.parm
+++ b/Tools/autotest/default_params/copter-wind-estimates.parm
@@ -1,0 +1,5 @@
+# copter with wind speed estimates enabled
+EK3_DRAG_BCOEF_X 9.5
+EK3_DRAG_BCOEF_Y 9.5
+EK3_DRAG_MCOEF 0.082
+SIM_WIND_SPD 3


### PR DESCRIPTION
This parameter file makes it easier for users to get copter's wind speed estimation working in SITL.

Note that the EK3_DRAG_BCOEF_X/Y parameter values are really low (e.g. 9.5) compared to what the autotest uses (e.g. 361) but I've found that these lower values work better.

In any case, I don't think that this discrepancy should hold up this PR going in.  Perhaps we want to change the autotest to use this param file instead but that's a separate issue I think.