### PR TITLE
Fix examples

### DIFF
--- a/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
+++ b/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
@@ -1,4 +1,20 @@
 #include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+void setup() { }
+
+void loop()
+{
+    // the library simply panics if a JEDEC device can't be found.  We
+    // can't really recover from that.
+    hal.console->printf("No JEDEC on linux\n");
+    hal.scheduler->delay(1000);
+}
+
+#else
+
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_SerialManager/AP_SerialManager.h>
@@ -184,4 +200,7 @@ void loop()
     hal.scheduler->delay(1000);
 }
 
+#endif
+
 AP_HAL_MAIN();
+

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -68,7 +68,7 @@ AP_RCProtocol::~AP_RCProtocol()
 
 bool AP_RCProtocol::should_search(uint32_t now_ms) const
 {
-#ifndef IOMCU_FW
+#if !defined(IOMCU_FW) && !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
     if (_detected_protocol != AP_RCProtocol::NONE && !rc().multiple_receiver_support()) {
         return false;
     }

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -4,6 +4,12 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_RangeFinder/AP_RangeFinder_Backend.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
+
+const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
+    AP_GROUPEND
+};
+GCS_Dummy _gcs;
 
 void setup();
 void loop();

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -8,6 +8,12 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
+
+const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
+    AP_GROUPEND
+};
+GCS_Dummy _gcs;
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 


### PR DESCRIPTION
 - the JEDEC test just panics if it can't find a device - so that doesn't work well when just running it under linux
 - two examples suddenly need a GCS object due to HAL:_GCS_ENABLED being true but the singleton not being avaialble
 - the RC protocol test sprouted a dependency on the `RC_Channels` singleton when we added multi-receiver support

Tested using `./waf configure --board=linux && ./waf examples && ./Tools/autotest/autotest.py examples`
