### PR TITLE
Fix sailboat tests and run them in CI

### DIFF
--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         config: [
             sitltest-rover,
+            sitltest-sailboat,
             sitltest-balancebot
         ]
 

--- a/Tools/autotest/sailboat.py
+++ b/Tools/autotest/sailboat.py
@@ -11,6 +11,9 @@ import os
 
 from rover import AutoTestRover
 
+from common import AutoTestTimeoutException
+from common import PreconditionFailedException
+
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 
@@ -28,6 +31,48 @@ class AutoTestSailboat(AutoTestRover):
         if self.frame is None:
             self.frame = 'sailboat'
         super(AutoTestSailboat, self).init()
+
+    def drive_rtl_mission(self, timeout=120):
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        self.load_mission("rtl.txt")
+        self.change_mode("AUTO")
+
+        tstart = self.get_sim_time()
+        while True:
+            now = self.get_sim_time_cached()
+            if now - tstart > timeout:
+                raise AutoTestTimeoutException("Didn't see wp 3")
+            m = self.mav.recv_match(type='MISSION_CURRENT',
+                                    blocking=True,
+                                    timeout=1)
+            self.progress("MISSION_CURRENT: %s" % str(m))
+            if m.seq == 3:
+                break
+
+        self.drain_mav()
+
+        m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT', timeout=1)
+
+        wp_dist_min = 5
+        if m.wp_dist < wp_dist_min:
+            raise PreconditionFailedException(
+                "Did not start at least %f metres from destination (is=%f)" %
+                (wp_dist_min, m.wp_dist))
+
+        self.progress("NAV_CONTROLLER_OUTPUT.wp_dist looks good (%u >= %u)" %
+                      (m.wp_dist, wp_dist_min,))
+
+        # wait for mission to complete
+        self.wait_statustext("Mission Complete", timeout=70)
+
+        # sailboat loiters around RTL point indefinitely:
+        self.wait_groundspeed(0.5, 3, timeout=20, minimum_duration=10)
+
+        self.disarm_vehicle()
+
+        self.progress("RTL Mission OK")
 
     def tests(self):
         '''return list of all tests'''

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -152,6 +152,10 @@ for t in $CI_BUILD_TARGET; do
         run_autotest "Rover" "build.Rover" "test.Rover"
         continue
     fi
+    if [ "$t" == "sitltest-sailboat" ]; then
+        run_autotest "Rover" "build.Rover" "test.Sailboat"
+        continue
+    fi
     if [ "$t" == "sitltest-tracker" ]; then
         run_autotest "Tracker" "build.Tracker" "test.Tracker"
         continue


### PR DESCRIPTION
Sailboats don't stop after this - they loiter.

stop them breaking again by running them in CI
