### PR TITLE
Copter: auto takeoff may trigger terrain failsafe

### DIFF
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -112,7 +112,8 @@ void Mode::auto_takeoff_run()
     // get terrain offset
     float terr_offset = 0.0f;
     if (auto_takeoff_terrain_alt && !wp_nav->get_terrain_offset(terr_offset)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "auto takeoff: failed to get terrain offset");
+        // trigger terrain failsafe
+        copter.failsafe_terrain_on_event();
         return;
     }
 


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/21488 which can lead to a "climb away" in Auto during the Takeoff command with Frame = Terrain.

Below is a screenshot of a SITL test confirming that with the setup mentioned in [the issue](https://github.com/ArduPilot/ardupilot/issues/21488 ), the terrain failsafe is correctly triggered and the vehicle RTLs home.
![takeoff-terr-fs-test-ok](https://user-images.githubusercontent.com/1498098/185574631-5ed40843-53a3-4920-9c7f-b3cbed31aa95.png)

Additional testing we should do includes:

- [x] Confirm the behaviour when the terrain failsafe triggers while the vehicle is landed (it should just disarm) -- auto_takeoff_start silently falls back to alt-above-current-alt
- [x] Test the payload place command that may also run takeoff_run() -- payload place never uses takeoff with terrain following
- [x] Test in Guided mode which may also run auto_takeoff_run() although it doesn't seem to have the same bug -- GUIDED mode has a special check to catch exactly this problem ([see code here](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_guided.cpp#L120)) although it is still possible to trigger the problem by reducing RNGFND1_MAX_CM after takeoff (e.g. purposely fail the rangefinder).  The fix in this PR resolves this very rare failure in Guided mode as well.
