### PR TITLE
Rover: include fix in mode.h

### DIFF
--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <stdarg.h>
+#include <stdint.h>
 
 // Libraries
 #include <AP_Common/AP_Common.h>
@@ -37,18 +38,21 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AR_Motors/AP_MotorsUGV.h>
+#include <AP_Mission/AP_Mission.h>
+#include <AP_Mission/AP_Mission_ChangeDetector.h>
+#include <AR_WPNav/AR_WPNav_OA.h>
+
+// Configuration
+#include "defines.h"
+#include "config.h"
 
 #if AP_SCRIPTING_ENABLED
 #include <AP_Scripting/AP_Scripting.h>
 #endif
 
 // Local modules
-#include "mode.h"
 #include "AP_Arming.h"
 #include "sailboat.h"
-// Configuration
-#include "config.h"
-#include "defines.h"
 #if ADVANCED_FAILSAFE == ENABLED
 #include "afs_rover.h"
 #endif
@@ -57,6 +61,8 @@
 #include "GCS_Rover.h"
 #include "AP_Rally.h"
 #include "RC_Channel.h"                  // RC Channel Library
+
+#include "mode.h"
 
 class Rover : public AP_Vehicle {
 public:

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 Mode::Mode() :

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -1,14 +1,6 @@
 #pragma once
 
-#include <stdint.h>
-
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_Math/AP_Math.h>
-#include <AP_Mission/AP_Mission.h>
-#include <AP_Mission/AP_Mission_ChangeDetector.h>
-#include <AR_WPNav/AR_WPNav_OA.h>
-
-#include "defines.h"
+#include "Rover.h"
 
 // pre-define ModeRTL so Auto can appear higher in this file
 class ModeRTL;

--- a/Rover/mode_acro.cpp
+++ b/Rover/mode_acro.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 void ModeAcro::update()

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 #define AUTO_GUIDED_SEND_TARGET_MS 1000

--- a/Rover/mode_follow.cpp
+++ b/Rover/mode_follow.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 // initialize follow mode

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 bool ModeGuided::_enter()

--- a/Rover/mode_hold.cpp
+++ b/Rover/mode_hold.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 void ModeHold::update()

--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 bool ModeLoiter::_enter()

--- a/Rover/mode_manual.cpp
+++ b/Rover/mode_manual.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 void ModeManual::_exit()

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 bool ModeRTL::_enter()

--- a/Rover/mode_simple.cpp
+++ b/Rover/mode_simple.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 void ModeSimple::init_heading()

--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 bool ModeSmartRTL::_enter()

--- a/Rover/mode_steering.cpp
+++ b/Rover/mode_steering.cpp
@@ -1,4 +1,3 @@
-#include "mode.h"
 #include "Rover.h"
 
 void ModeSteering::update()


### PR DESCRIPTION
This is how includes are done in copter. This needs to be done to include "config.h" in "mode.h". I was getting a weird segmentation fault if we include config.h there directly. Hence, @peterbarker came with a workaround.
Thanks @peterbarker for your help on this one.