### PR TITLE
Copter: fix userhook_init() call

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -138,7 +138,7 @@ void Copter::init_ardupilot()
 #endif
 
 #ifdef USERHOOK_INIT
-    USERHOOK_INIT
+    userhook_init();
 #endif
 
     // read Baro pressure at ground


### PR DESCRIPTION
This PR adds a call to ```userhook_init()``` in system.cpp instead of USERHOOK_INIT that should be defined if using userhook functions