### PR TITLE
AR_Motors: remove arming check to allow ackerman and skid-steering

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -454,16 +454,6 @@ bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
 //  returns true if checks pass, false if they fail.  report should be true to send text messages to GCS
 bool AP_MotorsUGV::pre_arm_check(bool report) const
 {
-    // check if both regular and skid steering functions have been defined
-    if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) &&
-        SRV_Channels::function_assigned(SRV_Channel::k_throttleRight) &&
-        SRV_Channels::function_assigned(SRV_Channel::k_throttle) &&
-        SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: regular AND skid steering configured");
-        }
-        return false;
-    }
     // check if only one of skid-steering output has been configured
     if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) != SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
         if (report) {


### PR DESCRIPTION
This removes the Rover arming check that prevented users from using both skid-steering and ackermann steering at the same time.  At some point (probably when we improved the vectored thrust suport) we restructured when the speed scaling was applied and resolved this problem.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/19395

This has been tested in SITL to confirm that the servo outputs and resulting turn rates do not change on both skid-steering and ackermann steering vehicles when the other type is enabled.

![ackerman-sitl-test](https://user-images.githubusercontent.com/1498098/185842445-a4dfd7c1-494a-4246-9913-234fc8aee381.png)
![skid-steering-sitl-test](https://user-images.githubusercontent.com/1498098/185842460-d8dd212f-b754-4d15-86f9-ef330bc00fba.png)
![skid-steering-turn-rate](https://user-images.githubusercontent.com/1498098/185842470-6b24a690-4161-4174-a389-b8edf8e906ac.png)

This is how the above tests were performed

Initial parameter setup:

1. param set ARMING_CHECK 0 (to allow arming with skid-steering and ackermann enabled)
2. param set MANUAL_OPTIONS 1 (to scale steering even in Manual mode)

Testing ackermann steering rovers are not affected by having skid-steering also enabled:

1. start SITL with ackermann steering rover
2. rc 3 1700 <-- want speed over 1m/s
3. rc 1 1600 <-- steering right
4. rc 3 1500 <-- reduce speed
5. rc 1 1500 <-- re-center steering
6. repeat with skid-steering enabled
    - set SERVO5_FUNCTION = 73 (throttle left)
    - set SERVO6_FUNCTION = 74 (throttle right)
7. confirm similar RCOU.servo1 (steering) and STER.TurnRate in the two logs

Test skid-steering rovers are not affected by having ackermann also enabled:

1. start SITL with skid-steering rover
2. rc 3 1700 <-- want speed over 1m/s
3. rc 1 1600
4. repeat with ackermann steering enabled
    - set SERVO5_FUNCTION = 26 (ground steering)
    - set SERVO6_FUNCTION = 70 (throttle)
5. confirm similar RCOU.servo1 RCOU.servo3 and STER.TurnRate in the two logs