### PR TITLE
sitl-on-hw.sh: add option for simply appending a parameter file to defaults

### DIFF
--- a/libraries/SITL/examples/on-hardware/sitl-on-hw.sh
+++ b/libraries/SITL/examples/on-hardware/sitl-on-hw.sh
@@ -7,7 +7,8 @@ BOARD=NucleoH743
 BOARD=MatekH743
 #BOARD=F35Lightning
 
-THISDIR=$(dirname $0)
+THISDIR=$(realpath $(dirname $0))
+ROOTDIR=$(realpath "$THISDIR/../../../..")
 
 VEHICLE="copter"
 DEFAULTS_PATH=""
@@ -46,6 +47,8 @@ if [ -z "${DEFAULTS_PATH}" ]; then
         EXTRA_HWDEF="$THISDIR/extra-hwdef-sitl-on-hw.dat"
     fi
 fi
+
+pushd $ROOTDIR
 
 ./waf configure \
       --board=$BOARD \

--- a/libraries/SITL/examples/on-hardware/sitl-on-hw.sh
+++ b/libraries/SITL/examples/on-hardware/sitl-on-hw.sh
@@ -15,11 +15,11 @@ DEFAULTS_PATH=""
 EXTRA_HWDEF=""
 
 usage() {
-    echo "Usage: $0 [-v <plane|copter>] [-d DEFAULT_FILEPATH] [-b BOARDNAME]" >&2;
+    echo "Usage: $0 [-v <plane|copter>] [-d DEFAULT_FILEPATH] [-b BOARDNAME] [-m APPEND_DEFAULTS_PATH" >&2;
     exit 1;
 }
 
-while getopts ":v:d:b:" o; do
+while getopts ":v:d:b:m:" o; do
     case "${o}" in
         v)
             VEHICLE=${OPTARG}
@@ -27,6 +27,9 @@ while getopts ":v:d:b:" o; do
             ;;
         d)
             DEFAULTS_PATH=${OPTARG}
+            ;;
+        m)
+            MORE_DEFAULTS_PATH=${OPTARG}
             ;;
         b)
             BOARD=${OPTARG}
@@ -46,6 +49,13 @@ if [ -z "${DEFAULTS_PATH}" ]; then
         DEFAULTS_PATH="$THISDIR/default.param"
         EXTRA_HWDEF="$THISDIR/extra-hwdef-sitl-on-hw.dat"
     fi
+fi
+
+if [ ! -z "${MORE_DEFAULTS_PATH}" ]; then
+    NEW_DEFAULTS_PATH="/tmp/some-defaults.param"
+    cp "$DEFAULTS_PATH" "$NEW_DEFAULTS_PATH"
+    cat "$MORE_DEFAULTS_PATH" >> "$NEW_DEFAULTS_PATH"
+    DEFAULTS_PATH="$NEW_DEFAULTS_PATH"
 fi
 
 pushd $ROOTDIR


### PR DESCRIPTION
This allows you to have a separate set of default values on top of the base set which gets sitl-on-hw generally working.

This also adds patches which allows you to run sitl-on-hw.sh from any branch, e.g.:

An example might be:
```
#!/bin/bash

../../libraries/SITL/examples/on-hardware/sitl-on-hw.sh \
    -b CubeOrange-SimOnHardWare \
    -v plane \
    -m $PWD/params.parm
```
