### PR TITLE
AP_Mount: fix SITL crash when user sets mode to GPS_POINT with all zero lat,lon,alt

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -252,6 +252,11 @@ bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountTa
         return false;
     }
 
+    // exit immediate if location is invalid
+    if (!loc.initialised()) {
+        return false;
+    }
+
     const float GPS_vector_x = Location::diff_longitude(loc.lng, current_loc.lng)*cosf(ToRad((current_loc.lat + loc.lat) * 0.00000005f)) * 0.01113195f;
     const float GPS_vector_y = (loc.lat - current_loc.lat) * 0.01113195f;
     int32_t target_alt_cm = 0;


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/21526 by adding an additional check into the get_angle_target_to_location method to first ensure the provided Location is valid.

This has been tested in SITL to confirm the panic no longer occurs and that GPS_POINT and HOME_LOCATION modes still work.

Below shows the panic no longer occurs
![change-to-gps-point-no-panic](https://user-images.githubusercontent.com/1498098/186302412-369d00fd-77fc-4d53-987a-7b915588d096.png)

Below shows that HOME_LOCATION still works
![pointing-at-home-still-works](https://user-images.githubusercontent.com/1498098/186302454-731b8c8b-9425-4252-bf10-a421f32725e5.png)

Below shows that GPS_POINT still works
![roi-still-works](https://user-images.githubusercontent.com/1498098/186302474-007d7ac0-52fd-411f-90f2-7b051aa3706e.png)

