### PR TITLE
Create and use GCS_MAVLink/GCS_config.h

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -22,6 +22,7 @@
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for fence points and paths to destination will grow in increments of 20 elements
 #define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -13,6 +13,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -1,6 +1,7 @@
 #include "AC_PrecLand_StateMachine.h"
 #include <AC_PrecLand/AC_PrecLand.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
 
 static const float MAX_POS_ERROR_M = 0.75f;  // Maximum possition error for retry locations
 static const uint32_t FAILSAFE_INIT_TIMEOUT_MS = 7000;   // Timeout in ms before failsafe measures are started. During this period vehicle is completely stopped to give user the time to take over

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -12,12 +12,13 @@
 */
 
 #include "AP_AccelCal.h"
-#include <stdarg.h>
-#include <GCS_MAVLink/GCS.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_HAL/AP_HAL.h>
 
 #if HAL_INS_ACCELCAL_ENABLED
+
+#include <stdarg.h>
+#include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
+
 #define AP_ACCELCAL_POSITION_REQUEST_INTERVAL_MS 1000
 
 #define _printf(fmt, args ...) do {                                     \

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <GCS_MAVLink/GCS.h>
-#include "AccelCalibrator.h"
-#include "AP_Vehicle/AP_Vehicle_Type.h"
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <GCS_MAVLink/GCS_config.h>
 
 #ifndef HAL_INS_ACCELCAL_ENABLED
 #if HAL_GCS_ENABLED
@@ -11,6 +10,10 @@
 #define HAL_INS_ACCELCAL_ENABLED 0
 #endif
 #endif
+
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include "AccelCalibrator.h"
+#include "AP_Vehicle/AP_Vehicle_Type.h"
 
 #define AP_ACCELCAL_MAX_NUM_CLIENTS 4
 class GCS_MAVLINK;
@@ -50,7 +53,7 @@ public:
     bool running(void) const;
 
 private:
-    GCS_MAVLINK *_gcs;
+    class GCS_MAVLINK *_gcs;
     bool _use_gcs_snoop;
     bool _waiting_for_mavlink_ack = false;
     uint32_t _last_position_request_ms;

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -3,6 +3,7 @@
 #if AP_CAMERA_ENABLED
 
 #include <AP_Logger/AP_Logger.h>
+#include <AP_GPS/AP_GPS.h>
 
 // Write a Camera packet
 void AP_Camera::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)

--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -23,6 +23,7 @@
 #include "AP_EFI_DroneCAN.h"
 #include "AP_EFI_Currawong_ECU.h"
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
 #include <AP_CANManager/AP_CANManager.h>

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -1,6 +1,7 @@
 #include "AP_Mount_Backend.h"
 #if HAL_MOUNT_ENABLED
 #include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -2,6 +2,8 @@
 
 #if HAL_MOUNT_GREMSY_ENABLED
 
+#include <GCS_MAVLink/GCS.h>
+
 extern const AP_HAL::HAL& hal;
 
 #define AP_MOUNT_GREMSY_RESEND_MS  1000     // resend angle targets to gimbal at least once per second

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -23,6 +23,7 @@
 #include "AP_WindVane_SITL.h"
 #include "AP_WindVane_NMEA.h"
 
+#include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
@@ -274,11 +275,11 @@ void AP_WindVane::update()
         } else if (_calibration == 2 && have_speed) {
             _speed_driver->calibrate();
         } else if (_calibration != 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "WindVane: driver not found");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: driver not found");
             _calibration.set_and_save(0);
         }
     } else if (_calibration != 0) {
-        gcs().send_text(MAV_SEVERITY_INFO, "WindVane: disarm for cal");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: disarm for cal");
         _calibration.set_and_save(0);
     }
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -3,11 +3,7 @@
 // protocols.
 #pragma once
 
-#include <AP_HAL/AP_HAL_Boards.h>
-
-#ifndef HAL_GCS_ENABLED
-#define HAL_GCS_ENABLED 1
-#endif
+#include "GCS_config.h"
 
 #if HAL_GCS_ENABLED
 

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_GCS_ENABLED
+#define HAL_GCS_ENABLED 1
+#endif


### PR DESCRIPTION
A lot of places really only care that GCS is present or not.  This is a pattern we're generally adopting which helps avoid include loops.
