### PR TITLE
AP_Mount: correct handling of mav-cmd-do-mount-control

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -635,10 +635,7 @@ MAV_RESULT AP_Mount::handle_command_do_mount_control(const mavlink_command_long_
         return MAV_RESULT_FAILED;
     }
 
-    // send message to backend
-    _backends[_primary]->control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
-
-    return MAV_RESULT_ACCEPTED;
+    return _backends[_primary]->handle_command_do_mount_control(packet);
 }
 
 MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet)

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -162,6 +162,9 @@ protected:
     // helper function to provide GIMBAL_DEVICE_FLAGS for use in GIMBAL_DEVICE_ATTITUDE_STATUS message
     uint16_t get_gimbal_device_flags() const;
 
+    // sent warning to GCS
+    void send_warning_to_GCS(const char* warning_str);
+
     AP_Mount    &_frontend; // reference to the front end which holds parameters
     AP_Mount::mount_state &_state;    // references to the parameters and state for this backend
     uint8_t     _instance;  // this instance's number
@@ -182,6 +185,8 @@ protected:
     uint8_t _target_sysid;          // sysid to track
     Location _target_sysid_location;// sysid target location
     bool _target_sysid_location_set;// true if _target_sysid has been set
+
+    uint32_t _last_warning_ms;      // system time of last warning sent to GCS
 };
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -73,8 +73,8 @@ public:
     // set_sys_target - sets system that mount should attempt to point towards
     void set_target_sysid(uint8_t sysid);
 
-    // control - control the mount
-    virtual void control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, MAV_MOUNT_MODE mount_mode);
+    // handle do_mount_control command.  Returns MAV_RESULT_ACCEPTED on success
+    MAV_RESULT handle_command_do_mount_control(const mavlink_command_long_t &packet);
     
     // process MOUNT_CONFIGURE messages received from GCS. deprecated.
     void handle_mount_configure(const mavlink_mount_configure_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3720,7 +3720,13 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
 
 #if HAL_MOUNT_ENABLED
     case MAVLINK_MSG_ID_MOUNT_CONFIGURE: // deprecated. Use MAV_CMD_DO_MOUNT_CONFIGURE
+        send_received_message_deprecation_warning("MOUNT_CONFIGURE");
+        handle_mount_message(msg);
+        break;
     case MAVLINK_MSG_ID_MOUNT_CONTROL: // deprecated. Use MAV_CMD_DO_MOUNT_CONTROL
+        send_received_message_deprecation_warning("MOUNT_CONTROL");
+        handle_mount_message(msg);
+        break;
     case MAVLINK_MSG_ID_GIMBAL_REPORT:
     case MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION:
     case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:


### PR DESCRIPTION
This PR resolves https://github.com/ArduPilot/ardupilot/issues/21528 by doing the following:

- MOUNT_CONTROL and MAV_CMD_DO_MOUNT_CONTROL are separated into different methods to remove confusion over which fields should be used and their scaling
- This corrects the MAV_CMD_DO_MOUNT_CONTROL scaling for roll, pitch and yaw angles.  These were interpreted as centi-degrees when they should have been interpreted as degrees
- This also corrects how MAV_CMD_DO_MOUNT_CONTROL can be used for setting a location target
    - latitude moved from param1 to param5 (scaling unchanged)
    - longitude moved from param2 to param6 (scaling unchanged)
    - altitude moved from param1 to param4 (scaling changed from cm to m)
- "deprecated" warnings are sent for both MOUNT_CONTROL and MOUNT_CONFIGURE

This has been thoroughly tested in SITL.  I performed before-vs-after comparisons of both MOUNT_CONTROL and MAV_CMD_DO_MOUNT_CONTROL in every mode (retracted, neutral, mavlink targeting, rc targeting, gps-point, sysid-target, home-location) and only the expected changes (see above) were found.

MAV_CMD_DO_MOUNT_CONTROL mavlink-targeting mode angle scaling before vs after
![mav-cmd-do-mount-control-mavlink-targeting-before-bad](https://user-images.githubusercontent.com/1498098/186335455-1fe14b8d-f551-458f-a4d7-bbe8ed3a5d41.png)
![mav-cmd-do-mount-mavlink-targeting-after-good](https://user-images.githubusercontent.com/1498098/186335421-e1bd7c80-36ad-4e6c-982d-c0b05da998c1.png)

MAV_CMD_DO_MOUNT_CONTROL gps-location testing before vs after
![mav-cmd-do-mount-control-gps-location-before](https://user-images.githubusercontent.com/1498098/186336062-eb6ab1c8-3e50-4893-aff9-5bdab7630c54.png)
![mav-cmd-do-mount-gps-location-after](https://user-images.githubusercontent.com/1498098/186335925-7b9bb161-4d27-4380-b20d-f44f618e7c0b.png)
![map-of-gps-point-testing](https://user-images.githubusercontent.com/1498098/186336196-bc45db01-9f48-40ff-b910-7400eb394cbd.png)

Mission Planner only uses the MAV_CMD_DO_MOUNT_CONTROL message to change the mount's mode.  All other fields are always sent as zero.  MP's "Point Camera Here" is implemented using MAV_CMD_DO_SET_ROI.

I've also tested that the deprecated warnings for MOUNT_CONTROL and MOUNT_CONFIGURE appear
![deprecated-messages-appear](https://user-images.githubusercontent.com/1498098/186345138-e9165b58-abb2-434d-b117-85e93a406b47.png)

To help GCS developers I've posted in this [GCS discussion thread](https://discuss.ardupilot.org/t/ap-4-3-changes-to-gimbal-control-and-reporting-messages/89742/2), emailed the ardupilot-gcs email group and I will also add a new page to AP wiki's [MAVLink interface section](https://ardupilot.org/dev/docs/mavlink-commands.html) to explain how developers can control a gimbal using MAVLink.