### PR TITLE
Copter: Disable throw mode

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -304,7 +304,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Throw - fly vehicle after throwing it in the air
 #ifndef MODE_THROW_ENABLED
-# define MODE_THROW_ENABLED ENABLED
+# define MODE_THROW_ENABLED DISABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -588,6 +588,7 @@
 # define AUTO_DISARMING_DELAY  10
 #endif
 
+#ifndef MODE_THROW_ENABLED
 //////////////////////////////////////////////////////////////////////////////
 // Throw mode configuration
 //
@@ -596,6 +597,7 @@
 #endif
 #ifndef THROW_VERTICAL_SPEED
 # define THROW_VERTICAL_SPEED   50.0f   // motors start when vehicle reaches this total 3D speed in cm/s
+#endif
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are no videos of the mode of throwing vehicles, except for ArduPilot members.
There are almost no scenes that use the vehicle throw mode.
I would disable this flight mode.

There is no video uploaded of a micro drone with ArduPilot hovering in throw mode.