### PR TITLE
Create and use AP_FILESYSTEM_x_ENABLED defines

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -15,6 +15,9 @@
 
 #include "AP_Filesystem.h"
 
+#include "AP_Filesystem_config.h"
+#include <AP_HAL/HAL.h>
+
 static AP_Filesystem fs;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
@@ -37,19 +40,22 @@ static AP_Filesystem_ESP32 fs_local;
 static AP_Filesystem_Posix fs_local;
 #endif
 
-#ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
+#if AP_FILESYSTEM_ROMFS_ENABLED
 #include "AP_Filesystem_ROMFS.h"
 static AP_Filesystem_ROMFS fs_romfs;
 #endif
 
+#if AP_FILESYSTEM_PARAM_ENABLED
 #include "AP_Filesystem_Param.h"
 static AP_Filesystem_Param fs_param;
+#endif
 
+#if AP_FILESYSTEM_SYS_ENABLED
 #include "AP_Filesystem_Sys.h"
 static AP_Filesystem_Sys fs_sys;
+#endif
 
-#include <AP_Mission/AP_Mission.h>
-#if AP_MISSION_ENABLED
+#if AP_FILESYSTEM_MISSION_ENABLED
 #include "AP_Filesystem_Mission.h"
 static AP_Filesystem_Mission fs_mission;
 #endif
@@ -59,13 +65,17 @@ static AP_Filesystem_Mission fs_mission;
  */
 const AP_Filesystem::Backend AP_Filesystem::backends[] = {
     { nullptr, fs_local },
-#ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_H
+#if AP_FILESYSTEM_ROMFS_ENABLED
     { "@ROMFS/", fs_romfs },
 #endif
+#if AP_FILESYSTEM_PARAM_ENABLED
     { "@PARAM/", fs_param },
+#endif
+#if AP_FILESYSTEM_SYS_ENABLED
     { "@SYS/", fs_sys },
     { "@SYS", fs_sys },
-#if AP_MISSION_ENABLED
+#endif
+#if AP_FILESYSTEM_MISSION_ENABLED
     { "@MISSION/", fs_mission },
 #endif
 };

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 
-#include "AP_Filesystem_Available.h"
+#include "AP_Filesystem_config.h"
 
 #ifndef MAX_NAME_LEN
 #define MAX_NAME_LEN 255

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -15,6 +15,11 @@
 /*
   ArduPilot filesystem interface for mission/fence/rally
  */
+
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_MISSION_ENABLED
+
 #include "AP_Filesystem.h"
 #include "AP_Filesystem_Mission.h"
 #include <AP_Mission/AP_Mission.h>
@@ -22,8 +27,6 @@
 #include <AP_Rally/AP_Rally.h>
 #include <GCS_MAVLink/MissionItemProtocol_Rally.h>
 #include <GCS_MAVLink/MissionItemProtocol_Fence.h>
-
-#if AP_MISSION_ENABLED
 
 extern const AP_HAL::HAL& hal;
 extern int errno;
@@ -406,4 +409,4 @@ bool AP_Filesystem_Mission::finish_upload(const rfile &r)
     return true;
 }
 
-#endif
+#endif  // AP_FILESYSTEM_MISSION_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_MISSION_ENABLED
+
 #include "AP_Filesystem_backend.h"
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Common/ExpandingString.h>
@@ -72,3 +76,5 @@ private:
     // see if a block of memory is all zero
     bool all_zero(const uint8_t *b, uint8_t size) const;
 };
+
+#endif  // AP_FILESYSTEM_MISSION_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -15,6 +15,11 @@
 /*
   ArduPilot filesystem interface for parameters
  */
+
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_PARAM_ENABLED
+
 #include "AP_Filesystem.h"
 #include "AP_Filesystem_Param.h"
 #include <AP_Param/AP_Param.h>
@@ -646,3 +651,5 @@ bool AP_Filesystem_Param::finish_upload(const rfile &r)
     }
     return true;
 }
+
+#endif  // AP_FILESYSTEM_PARAM_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.h
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_PARAM_ENABLED
+
 #include "AP_Filesystem_backend.h"
 #include <AP_Common/ExpandingString.h>
 
@@ -82,3 +86,5 @@ private:
     bool finish_upload(const rfile &r);
     bool param_upload_parse(const rfile &r, bool &need_retry);
 };
+
+#endif  // AP_FILESYSTEM_PARAM_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -15,13 +15,16 @@
 /*
   ArduPilot filesystem interface for ROMFS
  */
+
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_ROMFS_ENABLED
+
 #include "AP_Filesystem.h"
 #include "AP_Filesystem_ROMFS.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_ROMFS/AP_ROMFS.h>
-
-#if defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
 
 int AP_Filesystem_ROMFS::open(const char *fname, int flags, bool allow_absolute_paths)
 {
@@ -236,4 +239,4 @@ void AP_Filesystem_ROMFS::unload_file(FileData *fd)
     AP_ROMFS::free(fd->data);
 }
 
-#endif // HAL_HAVE_AP_ROMFS_EMBEDDED_H
+#endif // AP_FILESYSTEM_ROMFS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_ROMFS_ENABLED
+
 #include "AP_Filesystem_backend.h"
 
 class AP_Filesystem_ROMFS : public AP_Filesystem_Backend
@@ -68,3 +72,5 @@ private:
         struct dirent de;
     } dir[max_open_dir];
 };
+
+#endif  // AP_FILESYSTEM_ROMFS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -19,6 +19,9 @@
  */
 #include "AP_Filesystem.h"
 #include "AP_Filesystem_Sys.h"
+
+#if AP_FILESYSTEM_SYS_ENABLED
+
 #include <AP_Math/AP_Math.h>
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Scheduler/AP_Scheduler.h>
@@ -281,3 +284,5 @@ int AP_Filesystem_Sys::stat(const char *pathname, struct stat *stbuf)
     }
     return 0;
 }
+
+#endif  // AP_FILESYSTEM_SYS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.h
@@ -17,6 +17,10 @@
 
 #include "AP_Filesystem_backend.h"
 
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_SYS_ENABLED
+
 class ExpandingString;
 
 class AP_Filesystem_Sys : public AP_Filesystem_Backend
@@ -48,3 +52,5 @@ private:
         ExpandingString *str;
     } file[max_open_file];
 };
+
+#endif  // AP_FILESYSTEM_SYS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 
-#include "AP_Filesystem_Available.h"
+#include "AP_Filesystem_config.h"
 
 #include <AP_InternalError/AP_InternalError.h>
 

--- a/libraries/AP_Filesystem/AP_Filesystem_config.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#include <AP_Mission/AP_Mission_config.h>
+
+#ifndef AP_FILESYSTEM_PARAM_ENABLED
+#define AP_FILESYSTEM_PARAM_ENABLED 1
+#endif
+
+#ifndef AP_FILESYSTEM_MISSION_ENABLED
+#define AP_FILESYSTEM_MISSION_ENABLED AP_MISSION_ENABLED
+#endif
+
+#ifndef AP_FILESYSTEM_SYS_ENABLED
+#define AP_FILESYSTEM_SYS_ENABLED 1
+#endif
+
+#ifndef AP_FILESYSTEM_ROMFS_ENABLED
+#define AP_FILESYSTEM_ROMFS_ENABLED defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
+#endif

--- a/libraries/AP_Filesystem/AP_Filesystem_config.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_config.h
@@ -4,6 +4,12 @@
 
 #include <AP_Mission/AP_Mission_config.h>
 
+#if HAL_OS_POSIX_IO || HAL_OS_FATFS_IO
+#define HAVE_FILESYSTEM_SUPPORT 1
+#else
+#define HAVE_FILESYSTEM_SUPPORT 0
+#endif
+
 #ifndef AP_FILESYSTEM_PARAM_ENABLED
 #define AP_FILESYSTEM_PARAM_ENABLED 1
 #endif

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -171,8 +171,10 @@ bool sdcard_retry(void)
 #ifdef USE_POSIX
     if (!sdcard_running) {
         if (sdcard_init()) {
+#if HAVE_FILESYSTEM_SUPPORT
             // create APM directory
             AP::FS().mkdir("/APM");
+#endif
         }
     }
     return sdcard_running;

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -3,7 +3,7 @@
 /* ************************************************************ */
 #pragma once
 
-#include <AP_Filesystem/AP_Filesystem_Available.h>
+#include <AP_Filesystem/AP_Filesystem_config.h>
 
 #ifndef HAL_LOGGING_ENABLED
 #define HAL_LOGGING_ENABLED 1

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -17,7 +17,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Common/Location.h>
-#include <AP_Filesystem/AP_Filesystem_Available.h>
+#include <AP_Filesystem/AP_Filesystem_config.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef AP_TERRAIN_AVAILABLE

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -21,7 +21,7 @@
 #include <AP_Common/Bitmask.h>
 #include <AP_LTM_Telem/AP_LTM_Telem.h>
 #include <AP_Devo_Telem/AP_Devo_Telem.h>
-#include <AP_Filesystem/AP_Filesystem_Available.h>
+#include <AP_Filesystem/AP_Filesystem_config.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_OpenDroneID/AP_OpenDroneID.h>


### PR DESCRIPTION
This should allow us to move `HAVE_FILESYSTEM_SUPPORT` to be renamed and defined in AP_Filesystem_config.h as `AP_FILESYSTEM_ENABLED`
