### PR TITLE
Change required to make the Solo Gimbal mavlink communication work

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -102,9 +102,9 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     learn_route(in_channel, msg);
 
     // don't ever forward data from a private channel
-    if ((GCS_MAVLINK::is_private(in_channel))) {
-        return true;
-    }
+    //if ((GCS_MAVLINK::is_private(in_channel))) {
+    //    return true;
+    //}
 
     if (msg.msgid == MAVLINK_MSG_ID_RADIO ||
         msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {


### PR DESCRIPTION
This is the only change to Arducopter 4.2.3 needed to re-enable the Solo Gimbal mavlink communication (see issue https://github.com/ArduPilot/ardupilot/issues/20923#top)
Works fine on my Solo @davidbuzz @rmackay9 
I hope it doesnt conflict with other Arducopter targets and can be incorporated into AC 4.2.x