### PR TITLE
Tools: make hirsute and impish support EOL for env install and vagrant.

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -83,9 +83,7 @@ elif [ ${RELEASE_CODENAME} == 'jammy' ]; then
     PYTHON_V="python3"
     PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
-         [ ${RELEASE_CODENAME} == 'hirsute' ] ||
-         [ ${RELEASE_CODENAME} == 'bullseye' ] ||
-         [ ${RELEASE_CODENAME} == 'impish' ]; then
+         [ ${RELEASE_CODENAME} == 'bullseye' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
     PYTHON_V="python3"
@@ -226,10 +224,8 @@ then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
-         [ ${RELEASE_CODENAME} == 'hirsute' ] ||
          [ ${RELEASE_CODENAME} == 'bullseye' ] ||
-         [ ${RELEASE_CODENAME} == 'jammy' ] ||
-         [ ${RELEASE_CODENAME} == 'impish' ]; then
+         [ ${RELEASE_CODENAME} == 'jammy' ]; then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 else
@@ -241,7 +237,6 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   if [ ${RELEASE_CODENAME} == 'bullseye' ]; then
     SITL_PKGS+=" libjpeg62-turbo-dev"
   elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
-           [ ${RELEASE_CODENAME} == 'hirsute' ] ||
            [ ${RELEASE_CODENAME} == 'focal' ] ||
            [ ${RELEASE_CODENAME} == 'ulyssa'  ]; then
     SITL_PKGS+=" libjpeg8-dev"
@@ -257,11 +252,9 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   fi
   if [ ${RELEASE_CODENAME} == 'bullseye' ] ||
          [ ${RELEASE_CODENAME} == 'groovy' ] ||
-         [ ${RELEASE_CODENAME} == 'hirsute' ] ||
          [ ${RELEASE_CODENAME} == 'focal' ] ||
          [ ${RELEASE_CODENAME} == 'ulyssa' ] ||
-         [ ${RELEASE_CODENAME} == 'jammy' ] ||
-         [ ${RELEASE_CODENAME} == 'impish' ]; then
+         [ ${RELEASE_CODENAME} == 'jammy' ]; then
     SITL_PKGS+=" python3-wxgtk4.0"
     SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   fi

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -188,44 +188,44 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     focal.vm.boot_timeout = 1500
   end
 
-  # 20.10
-  config.vm.define "groovy", autostart: false do |groovy|
-    groovy.vm.box = "ubuntu/groovy64"
-    groovy.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    groovy.vm.provider "virtualbox" do |vb|
-      vb.name = "ArduPilot (groovy)"
-    end
-    groovy.vm.boot_timeout = 1200
-  end
+  # 20.10  EOL July 2021
+#   config.vm.define "groovy", autostart: false do |groovy|
+#     groovy.vm.box = "ubuntu/groovy64"
+#     groovy.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+#     groovy.vm.provider "virtualbox" do |vb|
+#       vb.name = "ArduPilot (groovy)"
+#     end
+#     groovy.vm.boot_timeout = 1200
+#   end
 
-  # 21.04
-  config.vm.define "hirsute", autostart: false do |hirsute|
-    hirsute.vm.box = "ubuntu/hirsute64"
-    hirsute.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    hirsute.vm.provider "virtualbox" do |vb|
-      vb.name = "ArduPilot (hirsute)"
-    end
-    hirsute.vm.boot_timeout = 1200
-  end
-  config.vm.define "hirsute-desktop", autostart: false do |hirsute|
-    hirsute.vm.box = "ubuntu/hirsute64"
-    hirsute.vm.provision :shell, path: "Tools/vagrant/initvagrant-desktop.sh"
-    hirsute.vm.provider "virtualbox" do |vb|
-      vb.name = "ArduPilot (hirsute-desktop)"
-      vb.gui = true
-    end
-    hirsute.vm.boot_timeout = 1200
-  end
+  # 21.04 EOL January 2022 apt repo down
+#   config.vm.define "hirsute", autostart: false do |hirsute|
+#     hirsute.vm.box = "ubuntu/hirsute64"
+#     hirsute.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+#     hirsute.vm.provider "virtualbox" do |vb|
+#       vb.name = "ArduPilot (hirsute)"
+#     end
+#     hirsute.vm.boot_timeout = 1200
+#   end
+#   config.vm.define "hirsute-desktop", autostart: false do |hirsute|
+#     hirsute.vm.box = "ubuntu/hirsute64"
+#     hirsute.vm.provision :shell, path: "Tools/vagrant/initvagrant-desktop.sh"
+#     hirsute.vm.provider "virtualbox" do |vb|
+#       vb.name = "ArduPilot (hirsute-desktop)"
+#       vb.gui = true
+#     end
+#     hirsute.vm.boot_timeout = 1200
+#   end
 
-  # 21.10
-  config.vm.define "impish", autostart: false do |impish|
-    impish.vm.box = "ubuntu/impish64"
-    impish.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
-    impish.vm.provider "virtualbox" do |vb|
-      vb.name = "ArduPilot (impish)"
-    end
-    impish.vm.boot_timeout = 1200
-  end
+  # 21.10 EOL July 2022
+#   config.vm.define "impish", autostart: false do |impish|
+#     impish.vm.box = "ubuntu/impish64"
+#     impish.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"
+#     impish.vm.provider "virtualbox" do |vb|
+#       vb.name = "ArduPilot (impish)"
+#     end
+#     impish.vm.boot_timeout = 1200
+#   end
 
   # 22.04 LTS EOL Apr 2032
   config.vm.define "jammy", autostart: false do |jammy|


### PR DESCRIPTION
As per our test suite Hirsute doesn't work anymore as apt repo were moved to archive. 
I don't want to spend time to support this so it is better to EOL this distro.
Same for impish.
Nothing make want to stick on those non LTS version. 

Vagrant support was also updated