### PR TITLE
autotest: Address various mavlink connection issues in autotest

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4861,7 +4861,7 @@ class AutoTestCopter(AutoTest):
             roi_alt = 0
             self.progress("Using MAV_CMD_DO_SET_ROI_SYSID")
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_SYSID,
-                         250,
+                         self.mav.source_system,
                          0,
                          0,
                          0,

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7574,7 +7574,7 @@ Also, ignores heartbeats not from our target system'''
                 raise NotAchievedException("Received MISSION_ACK while waiting for MISSION_COUNT")
             if m.get_type() != 'MISSION_COUNT':
                 continue
-            if m.target_component != 250: # FIXME: constant?!
+            if m.target_component != self.mav.source_system:
                 continue
             if m.mission_type != mission_type:
                 raise NotAchievedException("Mission count response of incorrect type")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2517,11 +2517,13 @@ class AutoTest(ABC):
                                    set_streamrate_callback=None):
         '''customisations could be "--uartF=sim:nmea" '''
         self.contexts[-1].sitl_commandline_customised = True
+        self.mav.close()
         self.stop_SITL()
         self.start_SITL(model=model,
                         defaults_filepath=defaults_filepath,
                         customisations=customisations,
                         wipe=wipe)
+        self.mav.do_connect()
         tstart = time.time()
         while True:
             if time.time() - tstart > 30:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2759,7 +2759,7 @@ class AutoTest(ABC):
             try:
                 this = mav.recv(1000000)
             except Exception:
-                mav.autoreconnect = True
+                mav.autoreconnect = old_autoreconnect
                 raise
             if len(this) == 0:
                 break


### PR DESCRIPTION
May fix 

```
2022-08-25T02:47:06.8601346Z Waiting for connection ....
2022-08-25T02:47:06.8601623Z Connection reset or closed by peer on TCP socket
2022-08-25T02:47:06.8601907Z Connection reset or closed by peer on TCP socket
2022-08-25T02:47:06.8602163Z Attempting reconnect
2022-08-25T02:47:06.8602507Z AT-0352.2: Exception caught: Failed to set streamrate
2022-08-25T02:47:06.8602799Z Traceback (most recent call last):
```
in AccelCal test
