### PR TITLE
AP_Mount: allow users to disable yaw on 3-axis gimbals

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -99,7 +99,7 @@ void AP_Mount_Alexmos::update()
 // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
 bool AP_Mount_Alexmos::has_pan_control() const
 {
-    return _gimbal_3axis;
+    return _gimbal_3axis && yaw_range_valid();
 }
 
 // get attitude as a quaternion.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -46,7 +46,7 @@ public:
     // return true if healthy
     virtual bool healthy() const { return true; }
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    // returns true if this mount can control its pan (required for multicopters)
     virtual bool has_pan_control() const = 0;
 
     // get mount's mode
@@ -114,6 +114,10 @@ protected:
         float yaw;
         bool yaw_is_ef;
     };
+
+    // returns true if user has configured a valid yaw angle range
+    // allows user to disable yaw even on 3-axis gimbal
+    bool yaw_range_valid() const { return (_state._pan_angle_min < _state._pan_angle_max); }
 
     // returns true if mavlink heartbeat should be suppressed for this gimbal (only used by Solo gimbal)
     virtual bool suppress_heartbeat() const { return false; }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -34,7 +34,7 @@ public:
     bool healthy() const override;
 
     // has_pan_control
-    bool has_pan_control() const override { return true; }
+    bool has_pan_control() const override { return yaw_range_valid(); }
 
     // handle GIMBAL_DEVICE_INFORMATION message
     void handle_gimbal_device_information(const mavlink_message_t &msg) override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -104,13 +104,6 @@ void AP_Mount_SToRM32::update()
     }
 }
 
-// has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-bool AP_Mount_SToRM32::has_pan_control() const
-{
-    // we do not have yaw control
-    return false;
-}
-
 // set_mode - sets mount's mode
 void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -30,7 +30,7 @@ public:
     void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    bool has_pan_control() const override;
+    bool has_pan_control() const override { return yaw_range_valid(); }
 
     // set_mode - sets mount's mode
     void set_mode(enum MAV_MOUNT_MODE mode) override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -133,13 +133,6 @@ void AP_Mount_SToRM32_serial::update()
     }
 }
 
-// has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-bool AP_Mount_SToRM32_serial::has_pan_control() const
-{
-    // we do not have yaw control
-    return false;
-}
-
 // set_mode - sets mount's mode
 void AP_Mount_SToRM32_serial::set_mode(enum MAV_MOUNT_MODE mode)
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -33,7 +33,7 @@ public:
     void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    bool has_pan_control() const override;
+    bool has_pan_control() const override { return yaw_range_valid(); };
 
     // set_mode - sets mount's mode
     void set_mode(enum MAV_MOUNT_MODE mode) override;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -117,7 +117,7 @@ void AP_Mount_Servo::update()
 // returns true if this mount can control its pan (required for multicopters)
 bool AP_Mount_Servo::has_pan_control() const
 {
-    return SRV_Channels::function_assigned(_pan_idx);
+    return SRV_Channels::function_assigned(_pan_idx) && yaw_range_valid();
 }
 
 // get attitude as a quaternion.  returns true on success


### PR DESCRIPTION
This PR improves multicopter handling of the DO_SET_ROI in two ways:

1. Users can essentially disable a 3-axis gimbal's yaw by setting MNT_ANGMIN_PAN and MTN_ANGMAX_PAN to zero (or any other invalid setting).  Multicopters and helicopters will then point their nose at the DO_SET_ROI location (see https://github.com/ArduPilot/ardupilot/issues/6542)
2. Fixes the SToRM32 serial and SToRM32 MAVLink gimbal drivers' has_pan_control() method to correctly return "true" (the gimbal hardware and drivers do support 3-axis gimbals).  If users don't like this for some reason, they can get back to the old behaviour by setting the MTN_ANGMIN/MAX_PAN parameters mentioned above.

**Background**: when any vehicle with a mount executes a DO_SET_ROI command (either as part of a mission or as an "immediate" command), the Location is passed into the gimbal mount library which attempts to point the gimbal at this Location.  If the gimbal is only a 2-axis gimbal (e.g. roll and pitch) then the pitch will change but of course the gimbal has no yaw so, on its own, the gimbal can't point directly at the Location.  To improve this situation, when multicopters and helicopters execute a DO_SET_ROI, if the Mount library's has_pan_control() method returns false (e.g. the gimbal is a 2-axis roll & pitch gimbal) then the vehicle is also pointed at the ROI Location.



This has been tested in SITL to confirm the multicopter does correctly point the vehicle and gimbal as expected.

Below is a BEFORE screen shot in SITL of a vehicle with a 3-axis SToRM32 mavlink gimbal but the vehicle is incorrectly pointing the vehicle's nose at the ROI location
![mission-planner-map-before](https://user-images.githubusercontent.com/1498098/186826696-d15924ea-314b-455a-a925-a619a1d73296.png)

Below is an AFTER screen shot of the same vehicle but with the fix (2) from above.  The vehicle now does not point the nose at the vehicle, but the gimbal is pointing towards the ROI Location.
![mission-planner-map-after](https://user-images.githubusercontent.com/1498098/186826966-b8434ac6-f13b-4b39-84c7-32ba87394dae.png)

Finally below is another AFTER screenshot showing how the same vehicle can get back to the old behaviour (e.g. vehicle points at the ROI target) if the mount's pan min/max params are set to zero.
![mission-planner-map-after-2d](https://user-images.githubusercontent.com/1498098/186827162-a2ce7419-99bb-4e6b-bdd4-d9ce9edd7ece.png)

Note that there is still another bug in our gimbal drivers which means that the output to the gimbals is not respecting the angle limits input by the user (see https://github.com/ArduPilot/ardupilot/issues/21547).

