### PR TITLE
Copter: Arming: check EKF height variance

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -498,7 +498,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
         }
     }
 
-    // check EKF's compass, position and velocity variances are below failsafe threshold
+    // check EKF's compass, position, height and velocity variances are below failsafe threshold
     if (copter.g.fs_ekf_thresh > 0.0f) {
         float vel_variance, pos_variance, hgt_variance, tas_variance;
         Vector3f mag_variance;
@@ -513,6 +513,10 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
         }
         if (vel_variance >= copter.g.fs_ekf_thresh) {
             check_failed(display_failure, "EKF velocity variance");
+            return false;
+        }
+        if (hgt_variance >= copter.g.fs_ekf_thresh) {
+            check_failed(display_failure, "EKF height variance");
             return false;
         }
     }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -404,7 +404,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: FS_EKF_THRESH
     // @DisplayName: EKF failsafe variance threshold
-    // @Description: Allows setting the maximum acceptable compass and velocity variance
+    // @Description: Allows setting the maximum acceptable compass, velocity, position and height variances. Used in arming check and EKF failsafe.
     // @Values: 0.6:Strict, 0.8:Default, 1.0:Relaxed
     // @User: Advanced
     GSCALAR(fs_ekf_thresh, "FS_EKF_THRESH",    FS_EKF_THRESHOLD_DEFAULT),


### PR DESCRIPTION
This adds height variance to the EKF pre-arm. Height is also not induced in the EKF failsafe check, we could change that but we also have vibration compensation to deal with that case. 