### PR TITLE
Copter: Add a "RC not found" message

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -90,6 +90,11 @@ bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
     const char *rc_item = "Throttle";
 #endif
 
+    if (!rc().has_had_rc_receiver()) {
+        check_failed(ARMING_CHECK_RC, display_failure, "RC not found");
+        return false;
+    }
+
     // check throttle is not too low - must be above failsafe throttle
     if (copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {
         check_failed(ARMING_CHECK_RC, true, "%s below failsafe", rc_item);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8690,8 +8690,12 @@ class AutoTestCopter(AutoTest):
                 "SIM_RC_FAIL": rc_failure_mode,
             })
             self.reboot_sitl()
-            self.assert_prearm_failure("Throttle below failsafe",
-                                       other_prearm_failures_fatal=False)
+            if rc_failure_mode == 1:
+                self.assert_prearm_failure("RC not found",
+                                           other_prearm_failures_fatal=False)
+            elif rc_failure_mode == 2:
+                self.assert_prearm_failure("Throttle below failsafe",
+                                           other_prearm_failures_fatal=False)
         self.context_pop()
         self.reboot_sitl()
 


### PR DESCRIPTION
I have tested the radio receiver not connecting to FC.
The "Throttle below failsafe" message is incorrect.
I added the message "Radio signal not received".

AFTER
![Screenshot from 2022-08-27 16-57-59](https://user-images.githubusercontent.com/646194/187021484-cd050f58-b15c-46dd-a6c9-fa8aa734b71d.png)

BEFORE
![Screenshot from 2022-08-27 16-30-05](https://user-images.githubusercontent.com/646194/187021500-0a7e32c8-8364-47aa-bf5a-b9953b924da0.png)