### PR TITLE
Scripting: add arming check

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -148,7 +148,7 @@ void AP_Scripting::init(void) {
     const char *dir_name = SCRIPTING_DIRECTORY;
     if (AP::FS().mkdir(dir_name)) {
         if (errno != EEXIST) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Lua: failed to create (%s)", dir_name);
+            gcs().send_text(MAV_SEVERITY_INFO, "Scripting: failed to create (%s)", dir_name);
         }
     }
 
@@ -191,7 +191,7 @@ bool AP_Scripting::repl_start(void) {
     if ((AP::FS().stat(REPL_DIRECTORY, &st) == -1) &&
         (AP::FS().unlink(REPL_DIRECTORY)  == -1) &&
         (errno != EEXIST)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Unable to delete old REPL %s", strerror(errno));
+        gcs().send_text(MAV_SEVERITY_INFO, "Scripting: Unable to delete old REPL %s", strerror(errno));
     }
 
     // create a new folder
@@ -203,7 +203,7 @@ bool AP_Scripting::repl_start(void) {
     // make the output pointer
     terminal.output_fd = AP::FS().open(REPL_OUT, O_WRONLY|O_CREAT|O_TRUNC);
     if (terminal.output_fd == -1) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Unable to make new REPL");
+        gcs().send_text(MAV_SEVERITY_INFO, "Scripting: %s", "Unable to make new REPL");
         return false;
     }
 
@@ -225,14 +225,14 @@ void AP_Scripting::thread(void) {
 
         lua_scripts *lua = new lua_scripts(_script_vm_exec_count, _script_heap_size, _debug_options, terminal);
         if (lua == nullptr || !lua->heap_allocated()) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Unable to allocate scripting memory");
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting: %s", "Unable to allocate memory");
             _init_failed = true;
         } else {
             // run won't return while scripting is still active
             lua->run();
 
             // only reachable if the lua backend has died for any reason
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting has stopped");
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting: %s", "stopped");
         }
         delete lua;
 
@@ -247,11 +247,11 @@ void AP_Scripting::thread(void) {
             }
             // must be enabled to get this far
             if (cleared || _restart) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting restarted");
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting: %s", "restarted");
                 break;
             }
             if ((_debug_options.get() & uint8_t(lua_scripts::DebugLevel::NO_SCRIPTS_TO_RUN)) != 0) {
-                gcs().send_text(MAV_SEVERITY_DEBUG, "Lua: scripting stopped");
+                gcs().send_text(MAV_SEVERITY_DEBUG, "Scripting: %s", "stopped");
             }
         }
     }
@@ -267,7 +267,7 @@ void AP_Scripting::handle_mission_command(const AP_Mission::Mission_Command& cmd
         // load buffer
         mission_data = new ObjectBuffer<struct AP_Scripting::scripting_mission_cmd>(mission_cmd_queue_size);
         if (mission_data == nullptr) {
-            gcs().send_text(MAV_SEVERITY_INFO, "scripting: unable to receive mission command");
+            gcs().send_text(MAV_SEVERITY_INFO, "Scripting: %s", "unable to receive mission command");
             return;
         }
     }

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -297,11 +297,14 @@ bool AP_Scripting::arming_checks(size_t buflen, char *buffer) const
         return false;
     }
 
+    lua_scripts::get_last_error_semaphore()->take_blocking();
     const char *error_buf = lua_scripts::get_last_error_message();
     if (error_buf != nullptr) {
         hal.util->snprintf(buffer, buflen, "Scripting: %s", error_buf);
+        lua_scripts::get_last_error_semaphore()->give();
         return false;
     }
+    lua_scripts::get_last_error_semaphore()->give();
 
     return true;
 }

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -78,7 +78,7 @@ const AP_Param::GroupInfo AP_Scripting::var_info[] = {
     // @Param: DEBUG_OPTS
     // @DisplayName: Scripting Debug Level
     // @Description: Debugging options
-    // @Bitmask: 0:No Scripts to run message if all scripts have stopped, 1:Runtime messages for memory usage and execution time, 2:Suppress logging scripts to dataflash, 3:log runtime memory usage and execution time
+    // @Bitmask: 0:No Scripts to run message if all scripts have stopped, 1:Runtime messages for memory usage and execution time, 2:Suppress logging scripts to dataflash, 3:log runtime memory usage and execution time, 4:Disable pre-arm check
     // @User: Advanced
     AP_GROUPINFO("DEBUG_OPTS", 4, AP_Scripting, _debug_options, 0),
 
@@ -283,7 +283,7 @@ void AP_Scripting::handle_mission_command(const AP_Mission::Mission_Command& cmd
 
 bool AP_Scripting::arming_checks(size_t buflen, char *buffer) const
 {
-    if (!enabled()) {
+    if (!enabled() || ((_debug_options.get() & uint8_t(lua_scripts::DebugLevel::DISABLE_PRE_ARM)) != 0)) {
         return true;
     }
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -38,7 +38,6 @@ public:
     AP_Scripting &operator=(const AP_Scripting&) = delete;
 
     void init(void);
-    bool init_failed(void) const { return _init_failed; }
 
     bool enabled(void) const { return _enable != 0; };
     bool should_run(void) const { return enabled() && !_stop; }
@@ -50,6 +49,8 @@ public:
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
     void handle_mission_command(const class AP_Mission::Mission_Command& cmd);
+
+    bool arming_checks(size_t buflen, char *buffer) const;
 
    // User parameters for inputs into scripts 
    AP_Float _user[6];
@@ -102,6 +103,7 @@ private:
     AP_Int8 _debug_options;
     AP_Int16 _dir_disable;
 
+    bool _thread_failed; // thread allocation failed
     bool _init_failed;  // true if memory allocation failed
     bool _restart; // true if scripts should be restarted
     bool _stop; // true if scripts should be stopped

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -531,12 +531,9 @@ void lua_scripts::run(void) {
         // re-print the latest error message every 10 seconds 10 times
         const uint8_t error_prints = 10;
         if ((print_error_count < error_prints) && (AP_HAL::millis() - last_print_ms > 10000)) {
+            // note that we do not clear the buffer after we have finished printing, this allows it to be used for a pre-arm check
             print_error(MAV_SEVERITY_DEBUG);
             print_error_count++;
-            if ((print_error_count >= error_prints) && (error_msg_buf != nullptr)) {
-                hal.util->heap_realloc(_heap, error_msg_buf, 0);
-                error_msg_buf = nullptr;
-            }
         }
     }
 

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -21,6 +21,7 @@
 #include <AP_Filesystem/posix_compat.h>
 #include <AP_Scripting/AP_Scripting.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_HAL/Semaphores.h>
 
 #include "lua/src/lua.hpp"
 
@@ -135,6 +136,7 @@ private:
     // must be static for use in atpanic
     static void print_error(MAV_SEVERITY severity);
     static char *error_msg_buf;
+    static HAL_Semaphore error_msg_buf_sem;
     static uint8_t print_error_count;
     static uint32_t last_print_ms;
 
@@ -142,7 +144,10 @@ public:
     // must be static for use in atpanic, public to allow bindings to issue none fatal warnings
     static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
 
-    // return last error message, nullptr if none
+    // return last error message, nullptr if none, must use semaphore as this is updated in the scripting thread
     static const char* get_last_error_message() { return error_msg_buf; }
+
+    // get semaphore for above error buffer
+    static AP_HAL::Semaphore* get_last_error_semaphore() { return &error_msg_buf_sem; }
 
 };

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -70,6 +70,7 @@ public:
         RUNTIME_MSG = 1U << 1,
         SUPPRESS_SCRIPT_LOG = 1U << 2,
         LOG_RUNTIME = 1U << 3,
+        DISABLE_PRE_ARM = 1U << 4,
     };
 
 private:

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -141,4 +141,7 @@ public:
     // must be static for use in atpanic, public to allow bindings to issue none fatal warnings
     static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
 
+    // return last error message, nullptr if none
+    static const char* get_last_error_message() { return error_msg_buf; }
+
 };


### PR DESCRIPTION
This moves the existing arming check into AP Scripting and now checks for all types script fail.

![image](https://user-images.githubusercontent.com/33176108/187091395-297f1ee7-7486-46f2-8ba1-cf1855187224.png)

Due to the reduced buffer length we don't get such a long message as the existing error prints, but the point is really to prevent arming rather than give the exact error. 

I have also added a debug option bit to disable the scripting pre arm checks. This might be useful during script development I guess. 

Also did a little messing with the scripting message strings to save some flash.