### PR TITLE
Copter: 4.2.3 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.2.3 30-Aug-2022
+Changes from 4.2.3-rc3
+1) OpenDroneId bug fix to consume open-drone-id-system-update message
+------------------------------------------------------------------
 Copter 4.2.3-rc3 20-Aug-2022
 Changes from 4.2.3-rc2
 1) OpenDroneId improvements including reporting if operator location is lost

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.3-rc3"
+#define THISFIRMWARE "ArduCopter V4.2.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_RC+3
+#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,36 @@
+Release 4.2.3 21st August 2022
+------------------------------
+
+This is a minor stable release with a few new features and bug
+fixes. The changes from 4.2.0 are:
+
+- OpenDroneID improvements
+- added --enable-opendroneid configure option
+- added --enable-check-firmware configure option
+- enable OSD menus on KakuteH7
+- added prearm checks for rangefinder pin conflicts
+- added diagnostics for scurve internal error
+- allow absolute paths for linux boards in param defaults
+- fixed AIRBRAKE rc option warning
+- fixed notch filtering ordering issue on loss of RPM source
+- fixed Lutan EFI update serial flood
+- fixed --upload to work on WSL2
+- allow INA2xx battery to init after startup
+- fixed healthy check on battery monitors to check all enabled monitors
+- added Pixhawk6C and Pixhawk6X support
+- fixed alighment of QRTL start in fixed wing circle landing approach
+- added Foxeer Reaper F745 support
+- added MFE PixSurveyA1 support
+- fixed combination of waypoint passby with acceptance distance
+- cut throttle on ICE stop when armed
+- added ICE option for starting when disarmed
+- zero VFWD integrator on ICE override in quadplanes
+- don't failsafe when in fixed wing landing sequence with RTL_AUTOLAND
+- improved handling of overshoot in VTOL landing
+- improved choice of target airspeed in VTOL landing approach
+- improved ICM42xxx filter settings
+- allow for faster sample rates on ICM42xxx
+
 Release 4.2.3beta3 19th August 2022
 -----------------------------------
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.2.3beta3"
+#define THISFIRMWARE "ArduPlane V4.2.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_BETA+2
+#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+2
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,9 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.2.3 30-Aug-2022
+Changes from 4.2.3-rc3
+1) OpenDroneId bug fix to consume open-drone-id-system-update message
+------------------------------------------------------------------
 Rover 4.2.3-rc3 20-Aug-2022
 Changes from 4.2.3-rc2
 1) OpenDroneId improvements including reporting if operator location is lost

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.2.3-rc3"
+#define THISFIRMWARE "ArduRover V4.2.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_RC+3
+#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
 #define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3732,6 +3732,7 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_OPEN_DRONE_ID_SELF_ID:
     case MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID:
     case MAVLINK_MSG_ID_OPEN_DRONE_ID_SYSTEM:
+    case MAVLINK_MSG_ID_OPEN_DRONE_ID_SYSTEM_UPDATE:
         AP::opendroneid().handle_msg(chan, msg);
         break;
 #endif


### PR DESCRIPTION
This is the Copter-4.2.3 official release.  This is exactly the same as the last beta (4.2.3-rc3) with one additional bug fix:

- GCS_MAVLink: pass OPEN_DRONE_ID_SYSTEM_UPDATE msg to library

The list of changes can be seen in the "4.2.3" column of the [Copter-4.2 project](https://github.com/ArduPilot/ardupilot/projects/21)

This is the same as the Plane-4.2.3 release