### PR TITLE
Copter: fix auto mode is_taking_off

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -523,7 +523,7 @@ bool ModeAuto::is_landing() const
 
 bool ModeAuto::is_taking_off() const
 {
-    return ((_mode == SubMode::TAKEOFF) && !wp_nav->reached_wp_destination());
+    return ((_mode == SubMode::TAKEOFF) && !auto_takeoff_complete);
 }
 
 // auto_payload_place_start - initialises controller to implement a placing


### PR DESCRIPTION
This includes a small bug fix to Auto mode's is_taking_off() method extracted from this larger PR https://github.com/ArduPilot/ardupilot/pull/21158.

The is_taking_off() method is used for two purposes:

- reporting in the HIGH_LATENCY and EXTENDED_SYS_STATE mavlink message
- EKF2, EKF3 use this when deciding when barometer or rangefinder is used when EK3_RNG_USE_HGT > 0 (search in AP_NavEKF2/3 for "terrainHgtStable").  This bug probably means that range finder was never used by the EKF for height estimation while taking off in Auto.


Extracting this bug fix simplifies the other PR and also allows backporting this bug fix to 4.2.  This bug was probably new to 4.2 (e.g. not in 4.1).

Below are screen shots of the before vs after SITL test showing the flag is now being set correctly.
![takeoff-flag-fix-before](https://user-images.githubusercontent.com/1498098/187135455-fc76da36-3efb-4eba-b671-79ab2a79f3fa.png)

![takeoff-flag-fix-after](https://user-images.githubusercontent.com/1498098/187133150-1cd9223f-16d5-47da-a609-849d8a30dc58.png)

