### PR TITLE
AP_BattMonitor: fix Rotoye Temperature Monitoring

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.cpp
@@ -3,20 +3,25 @@
 #include <AP_HAL/AP_HAL.h>
 
 // Specific to Rotoye Batmon
-#define BATTMONITOR_SMBUS_TEMP_EXT 0x07
+#define BATTMONITOR_SMBUS_TEMP_EXT 0x48
 
 // return the maximum of the internal and external temperature sensors
 void AP_BattMonitor_SMBus_Rotoye::read_temp(void) {
-    
-    uint16_t t_int, t_ext;
-    
-    /*  Both internal and external values will always be sent by Batmon. 
+    uint16_t t_int = 0;
+    uint16_t t_ext = 0;
+
+    /*  Both internal and external values will always be sent by Batmon.
         If no external thermistor is used, a zero-value is sent. */
-    if (read_word(BATTMONITOR_SMBUS_TEMP, t_int) && 
-        read_word(BATTMONITOR_SMBUS_TEMP_EXT, t_ext)) {
-        uint16_t t;
-        _state.temperature_time = AP_HAL::millis();
-        t = ((t_ext > t_int) ? t_ext : t_int);
-        _state.temperature = KELVIN_TO_C(0.1f * (float)t);
+    const bool have_temp_internal = read_word(BATTMONITOR_SMBUS_TEMP, t_int);
+    const bool have_temp_external = read_word(BATTMONITOR_SMBUS_TEMP_EXT, t_ext);
+
+    if (!have_temp_internal && !have_temp_external) {
+        _has_temperature = (AP_HAL::millis() - _state.temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
+        return;
     }
+
+    _has_temperature = true;
+
+    _state.temperature_time = AP_HAL::millis();
+    _state.temperature = KELVIN_TO_C(0.1f * float(MAX(t_int, t_ext)));
 }


### PR DESCRIPTION
The Rotoye battery monitor was not reporting temperature due to `_has_temperature` not being set. Also the external thermistor was set to the wrong register. The wrong register was confirmed using a hardware debugger. With this register the temperatures read then match the values seen on the OLED display.

@amilcarlucas  have you had issues with the temperature reporting? 

@echoGee is this the correct register for the external thermistor for your older models as well?