### PR TITLE
GCS_MAVLink: Check for mission space before sending items

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -75,6 +75,12 @@ void gcs_out_of_space_to_send(mavlink_channel_t chan);
 // scope.
 #define CHECK_PAYLOAD_SIZE2(id) if (!HAVE_PAYLOAD_SPACE(chan, id)) return false
 
+// CHECK_PAYLOAD_SIZE2_VOID - macro which inserts code which will
+// immediately return from the current (void) function if there is no
+// room to fit the mavlink message with id id on the mavlink output
+// channel "chan".
+#define CHECK_PAYLOAD_SIZE2_VOID(chan, id) if (!HAVE_PAYLOAD_SPACE(chan, id)) return
+
 // convenience macros for defining which ap_message ids are in which streams:
 #define MAV_STREAM_ENTRY(stream_name)           \
     {                                           \
@@ -170,6 +176,7 @@ public:
     void send_mission_ack(const mavlink_message_t &msg,
                           MAV_MISSION_TYPE mission_type,
                           MAV_MISSION_RESULT result) const {
+        CHECK_PAYLOAD_SIZE2_VOID(chan, MISSION_ACK);
         mavlink_msg_mission_ack_send(chan,
                                      msg.sysid,
                                      msg.compid,

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -65,11 +65,14 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(const GCS_MAVLINK &_l
     if (packet.seq != 0 && // always allow HOME to be read
         packet.seq >= mission.num_commands()) {
         // try to educate the GCS on the actual size of the mission:
-        mavlink_msg_mission_count_send(_link.get_chan(),
-                                       msg.sysid,
-                                       msg.compid,
-                                       mission.num_commands(),
-                                       MAV_MISSION_TYPE_MISSION);
+        const mavlink_channel_t chan = _link.get_chan();
+        if (HAVE_PAYLOAD_SPACE(chan, MISSION_COUNT)) {
+            mavlink_msg_mission_count_send(chan,
+                                           msg.sysid,
+                                           msg.compid,
+                                           mission.num_commands(),
+                                           MAV_MISSION_TYPE_MISSION);
+        }
         return MAV_MISSION_ERROR;
     }
 


### PR DESCRIPTION
Corrects a lack of space check on mission items. This leads to corrupted partial items being sent over the link, it's particularly noticeable if a UART is being kept extremely busy.