### PR TITLE
AP_OSD: skip drawing if not required by the backend (refactoring)

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -335,8 +335,8 @@ void AP_OSD::update_osd()
         update_current_screen();
 
         get_screen(current_screen).set_backend(backend);
-        // skip drawing for MSP OSD backends to save some resources
-        if (osd_types(osd_type.get()) != OSD_MSP) {
+        // skip drawing if not required by the backend
+        if (backend->is_draw_required()) {
             get_screen(current_screen).draw();
         }
     }

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -56,6 +56,9 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     virtual void init_symbol_set(uint8_t *symbols, const uint8_t size);
 
+    // does this backend require the screen to be drawn by the OSD thread
+    virtual bool is_draw_required() const {return true;};
+
     AP_OSD * get_osd()
     {
         return &_osd;

--- a/libraries/AP_OSD/AP_OSD_MSP.h
+++ b/libraries/AP_OSD/AP_OSD_MSP.h
@@ -19,6 +19,9 @@ public:
     //clear framebuffer
     void clear() override {};
 
+    // MSP OSD does not require the screen to be drawn by the OSD thread
+    bool is_draw_required() const override {return false;};
+
 private:
     void setup_defaults(void);
 };


### PR DESCRIPTION
refactored to backend virtual methods