### PR TITLE
AP_OSD: lowered MSP Displayport OSD refresh rate from 10Hz to 5Hz

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -320,8 +320,10 @@ void AP_OSD::init()
 #if OSD_ENABLED
 void AP_OSD::osd_thread()
 {
+    const uint8_t scheduler_delay_ms = backend->get_scheduler_delay_ms();
+
     while (true) {
-        hal.scheduler->delay(100);
+        hal.scheduler->delay(scheduler_delay_ms);
         update_osd();
     }
 }

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -56,6 +56,9 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     virtual void init_symbol_set(uint8_t *symbols, const uint8_t size);
 
+    // Default OSD thread scheduler delay is 10Hz
+    virtual uint8_t get_scheduler_delay_ms() const {return 100u;};
+
     AP_OSD * get_osd()
     {
         return &_osd;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -24,6 +24,8 @@ public:
     // copy the backend specific symbol set to the OSD lookup table
     void init_symbol_set(uint8_t *lookup_table, const uint8_t size) override;
 
+    // DisplayPort OSD thread scheduler delay is 5Hz
+    uint8_t get_scheduler_delay_ms() const override {return 200u;};
 
 protected:
     uint8_t format_string_for_osd(char* dst, uint8_t size, bool decimal_packed, const char *fmt, va_list ap) override;


### PR DESCRIPTION
At 115k baud the serial port can't always keep up with a 10Hz refresh rate, especially if the screen has many OSD panels.
Missed DisplayPort "DRAW" commands can lead the OSD to buffer overruns, such an example is the DJI [msp-osd engine]( https://github.com/bri3d/msp-osd), lowering the refresh rate to 5Hz fixes the issue while keeping good enough fps.
HDZero VTXs seem less affected by the issue.