### PR TITLE
SITL: fix simulated RC failure while receiving RC overrides

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -441,6 +441,11 @@ bool SITL_State::_read_rc_sitl_input()
 
     const ssize_t size = _sitl_rc_in.recv(&pwm_pkt, sizeof(pwm_pkt), 0);
 
+    // if we are simulating no pulses RC failure, do not update pwm_input
+    if (_sitl->rc_fail == SITL::SIM::SITL_RCFail_NoPulses) {
+        return size != -1; // we must continue to drain _sitl_rc
+    }
+
     if (_sitl->rc_fail == SITL::SIM::SITL_RCFail_Throttle950) {
         // discard anything we just read from the "receiver" and set
         // values to bind values:


### PR DESCRIPTION
This fixes the behavior of SIM_RC_FAIL = 1 (no pulses) when RC override messages are being received.

Currently, in SITL, if the user sets SIM_RC_FAIL = 1 while sending RC overrides, conventional RC messages are still received by the vehicle for channels not being overridden.  In this [screen recording](https://www.youtube.com/watch?v=Rrjh9ruWUpY), the vehicle is sent RC overrides for channel 4 to induce yaw motion.  SIM_RC_FAIL is then set to 1.  Conventional RC messages are then sent for channels 1 and 2, to which the vehicle responds.  Expected behavior is for the vehicle to not receive these conventional RC messages, as there is a simulated RC failure.

This [screen recording](https://www.youtube.com/watch?v=Oj37U4ZvjbM) shows the behavior after applying this patch.  After setting SIM_RC_FAIL to 1, the vehicle no longer receives the conventional RC commands while still responding to the RC overrides.

This does not affect behavior with SIM_RC_FAIL = 2, which already appears to be correct.