### PR TITLE
Plane: quadplane: improve mav_type reporting for GCS

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4039,21 +4039,32 @@ bool QuadPlane::using_wp_nav(void) const
  */
 MAV_TYPE QuadPlane::get_mav_type(void) const
 {
-    if (mav_type.get() != 0) {
-        return MAV_TYPE(mav_type.get());
-    }
     if (!available()) {
+        // Not enabled, must be a normal plane
         return MAV_TYPE_FIXED_WING;
     }
+    if (mav_type.get() != 0) {
+        // Override parameter set by user
+        return MAV_TYPE(mav_type.get());
+    }
     if (tiltrotor.enabled()) {
+        // Tiltrotor specific type
         return MAV_TYPE_VTOL_TILTROTOR;
     }
-    switch (motors->get_frame_mav_type()) {
-    case MAV_TYPE_QUADROTOR:
-        return MAV_TYPE_VTOL_QUADROTOR;
-    default:
-        break;
+    if (tailsitter.enabled()) {
+        // Tailsitter specific types
+        switch (motors->get_frame_mav_type()) {
+        case MAV_TYPE_VTOL_DUOROTOR:
+            return MAV_TYPE_VTOL_DUOROTOR;
+
+        case MAV_TYPE_QUADROTOR:
+            return MAV_TYPE_VTOL_QUADROTOR;
+
+        default:
+            break;
+        }
     }
+    // Default to normal plane
     return MAV_TYPE_FIXED_WING;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4039,10 +4039,22 @@ bool QuadPlane::using_wp_nav(void) const
  */
 MAV_TYPE QuadPlane::get_mav_type(void) const
 {
-    if (mav_type.get() == 0) {
+    if (mav_type.get() != 0) {
+        return MAV_TYPE(mav_type.get());
+    }
+    if (!available()) {
         return MAV_TYPE_FIXED_WING;
     }
-    return MAV_TYPE(mav_type.get());
+    if (tiltrotor.enabled()) {
+        return MAV_TYPE_VTOL_TILTROTOR;
+    }
+    switch (motors->get_frame_mav_type()) {
+    case MAV_TYPE_QUADROTOR:
+        return MAV_TYPE_VTOL_QUADROTOR;
+    default:
+        break;
+    }
+    return MAV_TYPE_FIXED_WING;
 }
 
 /*


### PR DESCRIPTION
I am using QGC. When connected to QuadPlane, it is recognized as Fixed-Wing. This happens setting Q_MAV_TYPE to the default 0. You can work around this by setting it to something other than 0.
I know this issue has been discussed in https://github.com/ArduPilot/ardupilot/issues/7137 but it doesn't seem to be fixed. 0 is auto so I would expect it to report correctly. I don't know if my suggestion is good, but I'll make a PR. Please give me your comments and advice.