### PR TITLE
Log IOMCU status-page receive errors

### DIFF
--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -362,14 +362,16 @@ void AP_IOMCU::write_log()
 // @LoggerMessage: IOMC
 // @Description: IOMCU diagnostic information
 // @Field: TimeUS: Time since system startup
+// @Field: RSErr: Status Read error count (zeroed on successful read)
 // @Field: Mem: Free memory
 // @Field: TS: IOMCU uptime
 // @Field: NPkt: Number of packets received by IOMCU
 // @Field: Nerr: Protocol failures on MCU side
 // @Field: Nerr2: Reported number of failures on IOMCU side
 // @Field: NDel: Number of delayed packets received by MCU
-            AP::logger().WriteStreaming("IOMC", "TimeUS,Mem,TS,NPkt,Nerr,Nerr2,NDel", "QHIIIII",
+            AP::logger().WriteStreaming("IOMC", "TimeUS,RSErr,Mem,TS,NPkt,Nerr,Nerr2,NDel", "QHHIIIII",
                                AP_HAL::micros64(),
+                               read_status_errors,
                                reg_status.freemem,
                                reg_status.timestamp_ms,
                                reg_status.total_pkts,

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -242,6 +242,7 @@ void AP_IOMCU::thread_main(void)
             // read status at 20Hz
             read_status();
             last_status_read_ms = AP_HAL::millis();
+            write_log();
         }
 
         if (now - last_servo_read_ms > 50) {
@@ -350,8 +351,6 @@ void AP_IOMCU::read_status()
             force_safety_off();
         }
     }
-
-    write_log();
 }
 
 void AP_IOMCU::write_log()

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -351,6 +351,11 @@ void AP_IOMCU::read_status()
         }
     }
 
+    write_log();
+}
+
+void AP_IOMCU::write_log()
+{
     uint32_t now = AP_HAL::millis();
     if (now - last_log_ms >= 1000U) {
         last_log_ms = now;

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -269,6 +269,8 @@ private:
     void handle_repeated_failures();
     void check_iomcu_reset();
 
+    void write_log();  // handle onboard logging
+
     static AP_IOMCU *singleton;
 
     enum {


### PR DESCRIPTION
Tested with this patch to the IOMCU firmware:
```
--- a/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
+++ b/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
@@ -437,6 +437,12 @@ bool AP_IOMCU_FW::handle_code_read()
         COPY_PAGE(rc_input);
         break;
     case PAGE_STATUS:
+
+    if (AP_HAL::millis() > 10000 &&
+        AP_HAL::millis() < 20000) {
+        return false;
+    }
+
         COPY_PAGE(reg_status);
         break;
     case PAGE_SERVOS:
```

yielded this data:
![image](https://user-images.githubusercontent.com/7077857/187820037-7d9035b5-e1f5-4db1-b82e-41324eb805bb.png)
