### PR TITLE
PosController: Slow relax behaviour bug

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -118,8 +118,8 @@ void AC_Loiter::init_target()
     _pos_control.set_correction_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
     _pos_control.set_pos_error_max_xy_cm(LOITER_POS_CORRECTION_MAX);
 
-    // initialise position controller
-    _pos_control.init_xy_controller();
+    // initialise position controller and move target accelerations smoothly towards zero
+    _pos_control.relax_velocity_controller_xy();
 
     // initialise predicted acceleration and angles from the position controller
     _predicted_accel.x = _pos_control.get_accel_target_cmss().x;


### PR DESCRIPTION
This PR fixes two problems:
1. The position controller relax_velocity_controller_xy function results in a much slower decay of the target acceleration than expected because it uses the attitude controller target attitude as the reference state. The additional input shaping means that the target attitude does not follow the commanded attitude exactly meaning that each commanded angular step towards zero is much smaller than expected.
2. Loiter was not using relax_velocity_controller_xy and instead was using init_xy_controller. This meant that if loiter landed and shut down with a non-zero attitude, this attitude would persist until the following take-off. 
Master:
![image](https://user-images.githubusercontent.com/100896/187848810-2f344c17-db32-4783-b5df-a8307ff115c4.png)
Attitude target does not return to zero.

After PR:
![image](https://user-images.githubusercontent.com/100896/187847820-ed0e726d-8ffc-4c05-a775-d52c9fc28043.png)

The change to the position controller ensures the aircraft relaxes as expected after shutdown:
Without the change:
![image](https://user-images.githubusercontent.com/100896/187908265-f360f458-0f50-4ec3-b84f-1f77edf35413.png)


With the change:
![image](https://user-images.githubusercontent.com/100896/187908320-1320589e-9b81-4722-a03c-7a4af6495c04.png)

