### PR TITLE
Scripting: added set_rpm_scale ESC telem API

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -171,6 +171,13 @@ bool AP_ESC_Telem::get_rpm(uint8_t esc_index, float& rpm) const
         && (now - rpmdata.last_update_us < ESC_RPM_DATA_TIMEOUT_US)) {
         const float slew = MIN(1.0f, (now - rpmdata.last_update_us) * rpmdata.update_rate_hz * (1.0f / 1e6f));
         rpm = (rpmdata.prev_rpm + (rpmdata.rpm - rpmdata.prev_rpm) * slew);
+
+#if AP_SCRIPTING_ENABLED
+        if ((1U<<esc_index) & rpm_scale_mask) {
+            rpm *= rpm_scale_factor[esc_index];
+        }
+#endif
+
         return true;
     }
     return false;
@@ -506,6 +513,19 @@ void AP_ESC_Telem::update()
         }
     }
 }
+
+#if AP_SCRIPTING_ENABLED
+/*
+  set RPM scale factor from script
+*/
+void AP_ESC_Telem::set_rpm_scale(const uint8_t esc_index, const float scale_factor)
+{
+    if (esc_index < ESC_TELEM_MAX_ESCS) {
+        rpm_scale_factor[esc_index] = scale_factor;
+        rpm_scale_mask |= (1U<<esc_index);
+    }
+}
+#endif
 
 AP_ESC_Telem *AP_ESC_Telem::_singleton = nullptr;
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -100,6 +100,14 @@ public:
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
     // can also be called from scripting
     void update_rpm(const uint8_t esc_index, const float new_rpm, const float error_rate);
+
+#if AP_SCRIPTING_ENABLED
+    /*
+      set RPM scale factor from script
+     */
+    void set_rpm_scale(const uint8_t esc_index, const float scale_factor);
+#endif
+
 private:
 
     // callback to update the data in the frontend, should be called by the driver when new data is available
@@ -114,6 +122,12 @@ private:
     uint32_t _last_rpm_log_us[ESC_TELEM_MAX_ESCS];
     uint8_t next_idx;
 
+#if AP_SCRIPTING_ENABLED
+    // allow for scaling of RPMs via lua scripts
+    float rpm_scale_factor[ESC_TELEM_MAX_ESCS];
+    uint32_t rpm_scale_mask;
+#endif
+    
     bool _have_data;
 
     AP_Int8 mavlink_offset;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1119,6 +1119,10 @@ function esc_telem:get_rpm(instance) end
 ---@param param3 number -- error rate
 function esc_telem:update_rpm(esc_index, rpm, error_rate) end
 
+-- set scale factor for RPM on a motor
+---@param param1 motor index (0 is first motor)
+---@param param2 scale factor
+function esc_telem:set_rpm_scale(esc_index, scale_factor) end
 
 -- desc
 ---@class optical_flow

--- a/libraries/AP_Scripting/examples/esc_rpm_scale.lua
+++ b/libraries/AP_Scripting/examples/esc_rpm_scale.lua
@@ -1,0 +1,11 @@
+--[[
+set scale factor for RPM on some ESCs to allow for different pole count on some ESCs
+--]]
+
+-- set ESC 4 (index 3) to 2.0 times reported RPM
+esc_telem:set_rpm_scale(3, 2.0)
+
+-- set ESC 6 (index 5) to 2.0 times reported RPM
+esc_telem:set_rpm_scale(5, 2.0)
+
+gcs:send_text(0,"Setup motor poles")

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -311,6 +311,7 @@ singleton AP_ESC_Telem method get_voltage boolean uint8_t 0 NUM_SERVO_CHANNELS f
 singleton AP_ESC_Telem method get_consumption_mah boolean uint8_t 0 NUM_SERVO_CHANNELS float'Null
 singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null
 singleton AP_ESC_Telem method update_rpm void uint8_t 0 NUM_SERVO_CHANNELS uint16_t'skip_check float'skip_check
+singleton AP_ESC_Telem method set_rpm_scale void uint8_t 0 NUM_SERVO_CHANNELS float'skip_check
 
 include AP_Param/AP_Param.h
 singleton AP_Param rename param


### PR DESCRIPTION
This allows for vehicles with different numbers of poles per motor by running a lua script which adds a scale factor for ESC RPMs
