### PR TITLE
Copter: PosHold: remove unnecessary loiter_nav->update

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -106,7 +106,6 @@ void ModePosHold::run()
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update(false);
 
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;
@@ -131,7 +130,6 @@ void ModePosHold::run()
         // init and update loiter although pilot is controlling lean angles
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update(false);
 
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;
@@ -141,7 +139,6 @@ void ModePosHold::run()
     case AltHold_Landed_Ground_Idle:
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-        loiter_nav->update(false);
         attitude_control->reset_yaw_target_and_rate();
         init_wind_comp_estimate();
         FALLTHROUGH;


### PR DESCRIPTION
This is a small and unimportant update to PosHold where I have removed the unnecessary calls to loiter_nav->update.

It doesn't fix any problems, just simplifies the code and makes it consistent with Loiter.