### PR TITLE
AP_Mount: add second instance of mount

### DIFF
--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -213,30 +213,35 @@ bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Miss
     if (mount == nullptr) {
         return false;
     }
+
+    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is 2nd gimbal, etc
+    uint8_t gimbal_instance = mount->get_primary();
+    if (cmd.content.gimbal_manager_pitchyaw.gimbal_id > 0) {
+        gimbal_instance = cmd.content.gimbal_manager_pitchyaw.gimbal_id - 1;
+    }
+
     // check flags for change to RETRACT
     if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
-        mount->set_mode(MAV_MOUNT_MODE_RETRACT);
+        mount->set_mode(gimbal_instance, MAV_MOUNT_MODE_RETRACT);
         return true;
     }
     // check flags for change to NEUTRAL
     if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_NEUTRAL) > 0) {
-        mount->set_mode(MAV_MOUNT_MODE_NEUTRAL);
+        mount->set_mode(gimbal_instance, MAV_MOUNT_MODE_NEUTRAL);
         return true;
     }
-
-    // To-Do: handle gimbal device id
 
     // handle angle target
     const bool pitch_angle_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) && (fabsf(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) <= 90);
     const bool yaw_angle_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg) && (fabsf(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg) <= 360);
     if (pitch_angle_valid && yaw_angle_valid) {
-        mount->set_angle_target(0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        mount->set_angle_target(gimbal_instance, 0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return true;
     }
 
     // handle rate target
     if (!isnan(cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs) && !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs)) {
-        mount->set_rate_target(0, cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs, cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        mount->set_rate_target(gimbal_instance, 0, cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs, cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return true;
     }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -278,14 +278,21 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
         return MAV_RESULT_ACCEPTED;
     }
 
-    // To-Do: handle gimbal device id
+    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is 2nd gimbal, etc
+    if ((packet.param7 < 0) || (packet.param7 > AP_MOUNT_MAX_INSTANCES)) {
+        return MAV_RESULT_FAILED;
+    }
+    const uint8_t gimbal_instance = (packet.param7 < 1) ? get_primary() : (uint8_t)packet.param7 - 1;
+    if (!check_instance(gimbal_instance)) {
+        return MAV_RESULT_FAILED;
+    }
 
     // param1 : pitch_angle (in degrees)
     // param2 : yaw angle (in degrees)
     const float pitch_angle_deg = packet.param1;
     const float yaw_angle_deg = packet.param2;
     if (!isnan(pitch_angle_deg) && !isnan(yaw_angle_deg)) {
-        set_angle_target(0, pitch_angle_deg, yaw_angle_deg, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        set_angle_target(gimbal_instance, 0, pitch_angle_deg, yaw_angle_deg, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return MAV_RESULT_ACCEPTED;
     }
 
@@ -294,7 +301,7 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
     const float pitch_rate_degs = packet.param3;
     const float yaw_rate_degs = packet.param4;
     if (!isnan(pitch_rate_degs) && !isnan(yaw_rate_degs)) {
-        set_rate_target(0, pitch_rate_degs, yaw_rate_degs, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        set_rate_target(gimbal_instance, 0, pitch_rate_degs, yaw_rate_degs, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return MAV_RESULT_ACCEPTED;
     }
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -98,6 +98,9 @@ public:
     // used for gimbals that need to read INS data at full rate
     void update_fast();
 
+    // return primary instance
+    uint8_t get_primary() const { return _primary; }
+
     // get_mount_type - returns the type of mount
     AP_Mount::MountType get_mount_type() const { return get_mount_type(_primary); }
     AP_Mount::MountType get_mount_type(uint8_t instance) const;

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -38,7 +38,7 @@
 #include "AP_Mount_Params.h"
 
 // maximum number of mounts
-#define AP_MOUNT_MAX_INSTANCES          1
+#define AP_MOUNT_MAX_INSTANCES          2
 
 // declare backend classes
 class AP_Mount_Backend;


### PR DESCRIPTION
This PR adds support for a 2nd gimbal, and while at first this looks like a big change, in fact, it is only the last 3 commits that are new.  The rest are from this existing PR https://github.com/ArduPilot/ardupilot/pull/21602

Changes included in this PR are:

1. MNT2_xx parameters appear in the parameter list for all vehicles that include AP_Mount
2. DO_GIMBAL_MANAGER_PITCHYAW handling is enhanced to consume the gimbal_id (aka "instance") and pass it to the mount library which already supports multiple gimbals.  This change affects both mission commands and "immediate" commands sent from the ground station.

This is how it behaves:

1. Older commands including MOUNT_CONTROL, MOUNT_CONFIG, SET_ROI have no way to specify the "gimbal id" (aka "instance") so they always affect the "primary" gimbal which is the 1st gimbal.  So for example, if using Mission Planner, clicking on the map and selecting, "Point Camera Here" only affects the first gimbal.  Similarly pushing the "Set Mount" button only affects the first gimbal.
![image](https://user-images.githubusercontent.com/1498098/188072391-f728d633-d138-4da3-b03f-761c998bf826.png)
2. The MNTx_DEFLT_MODE parameter exists for each instance so if the user always wants the gimbal to point home (for example) this PR is sufficient for them.
3. The DO_GIMBAL_MANAGER_PITCHYAW can be used to point any gimbal instance in a particular direction (in either body-frame or earth-frame).  This command also supports switching to Retracted or Neutral mode through the use of the Flags field
4. RCx_OPTION values exist for the 1st or 2nd gimbal so RC control of either gimbal works

Known limitations:

1. RC control only works for up to 2 gimbals (we would need to add more RCx_OPTION enums to expand this)
2. Multiple Servo and Gremsy gimbals work
3. Two SToRM32 MAVlink gimbals won't work because they "find" using GCS_MAVLINK::find_by_mavtype() which would always find the first instance meaning both drivers would try to control the same gimbal.  We could perhaps resolve this by enhancing the find_by_mavtype() to accept and instance.
4. SToRM32 serial and Alexmos serial gimbals have similar problems to above because they use Serial_Manager::find_serial() to find the serial port for the gimbal.  We could easily resolve this by passing in the instance but then users would struggle to use a mix of gimbal types (e.g. a Servo gimbal and a SToRM32 serial gimbal).  I can easily add the instance in though if others think this would be useful.
5. We don't have a "Mount2 Lock" RC option so the pilot can't switch between earth-frame and body-frame for the 2nd gimbal.  We should add this.

This has been lightly tested in SITL with the following successful results:

- Pilot RC input worked for two gimbals
- "Legacy" commands only affected the first gimbal
- DO_GIMBAL_MANAGER_PITCHYAW could control each gimbal correctly

![image](https://user-images.githubusercontent.com/1498098/188074678-a167aa22-8f2f-4c09-b257-1ce47345513c.png)

Questions:

- [ ] should we search-and-replace "Mount" to "Gimbal" in the code?  How about MNTx_ params renamed to GIMx_?