### PR TITLE
Tools: extract_features.py: add more feature defines/symbols

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -94,6 +94,7 @@ BUILD_OPTIONS = [
     Feature('Mode', 'MODE_TURTLE', 'MODE_TURTLE_ENABLED', 'Enable Mode Turtle', 0, None),
     Feature('Mode', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
     Feature('Mode', 'MODE_FLOWHOLD', 'MODE_FLOWHOLD_ENABLED', 'Enable Mode Flowhold', 0, "OPTICALFLOW"),
+    Feature('Mode', 'MODE_FLIP', 'MODE_FLIP_ENABLED', 'Enable Mode Flip', 0, None),
 
     Feature('Gimbal', 'MOUNT', 'HAL_MOUNT_ENABLED', 'Enable Mount', 0, None),
     Feature('Gimbal', 'ALEXMOS', 'HAL_MOUNT_ALEXMOS_ENABLED', 'Enable Alexmos Gimbal', 0, "MOUNT"),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -55,10 +55,16 @@ class ExtractFeatures(object):
 
             ('AP_RANGEFINDER_ENABLED', 'RangeFinder::RangeFinder',),
             ('AP_RANGEFINDER_{type}_ENABLED', r'AP_RangeFinder_(?P<type>.*)::update\b',),
+            ('AP_RANGEFINDER_{type}_ENABLED', r'AP_RangeFinder_(?P<type>.*)::get_reading\b',),
+            ('AP_RANGEFINDER_{type}_ENABLED', r'AP_RangeFinder_(?P<type>.*)::model_dist_max_cm\b',),
+            ('AP_RANGEFINDER_LIGHTWARE_SERIAL_ENABLED', r'AP_RangeFinder_LightWareSerial::get_reading\b',),
+            ('AP_RANGEFINDER_LWI2C_ENABLED', r'AP_RangeFinder_LightWareI2C::update\b',),
+            ('AP_RANGEFINDER_MAXBOTIX_SERIAL_ENABLED', r'AP_RangeFinder_MaxsonarSerialLV::get_reading\b',),
+            ('AP_RANGEFINDER_TRI2C_ENABLED', r'AP_RangeFinder_TeraRangerI2C::update\b',),
 
             ('AP_GPS_{type}_ENABLED', r'AP_GPS_(?P<type>.*)::read\b',),
 
-            ('AP_OPTICALFLOW_ENABLED', 'OpticalFlow::OpticalFlow',),
+            ('AP_OPTICALFLOW_ENABLED', 'AP_OpticalFlow::AP_OpticalFlow',),
             ('AP_OPTICALFLOW_{type}_ENABLED', r'AP_OpticalFlow_(?P<type>.*)::update\b',),
 
             ('AP_BARO_{type}_ENABLED', r'AP_Baro_(?P<type>.*)::update\b',),
@@ -85,7 +91,8 @@ class ExtractFeatures(object):
             ('AP_LTM_TELEM_ENABLED', 'AP_LTM_Telem::init',),
             ('HAL_HIGH_LATENCY2_ENABLED', 'GCS_MAVLINK::handle_control_high_latency',),
 
-            ('MODE_{type}_ENABLED', r'Mode(?P<type>.*)::init',),
+            ('MODE_{type}_ENABLED', r'Mode(?P<type>.+)::init',),
+            ('MODE_GUIDED_NOGPS_ENABLED', r'ModeGuidedNoGPS::init',),
 
             ('HAL_RUNCAM_ENABLED', 'AP_RunCam::AP_RunCam',),
 
@@ -130,6 +137,8 @@ class ExtractFeatures(object):
             ('HAL_NMEA_OUTPUT_ENABLED', r'AP_NMEA_Output::update\b',),
             ('HAL_BARO_WIND_COMP_ENABLED', r'AP_Baro::wind_pressure_correction\b',),
 
+            ('HAL_PICCOLO_CAN_ENABLE', r'AP_PiccoloCAN::update',),
+            ('EK3_FEATURE_EXTERNAL_NAV', r'NavEKF3::writeExtNavVelData'),
         ]
 
     def progress(self, string):

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -233,6 +233,7 @@ class ExtractFeatures(object):
 
         symbols = self.extract_symbols_from_elf(filename)
 
+        remaining_build_options_defines = build_options_defines
         for (feature_define, symbol) in self.features:
             some_dict = symbols.dict_for_symbol(symbol)
             # look for symbols without arguments
@@ -253,6 +254,9 @@ class ExtractFeatures(object):
                 if some_define not in build_options_defines:
                     continue
                 print(some_define)
+                remaining_build_options_defines.discard(some_define)
+        for remaining in sorted(remaining_build_options_defines):
+            print("!" + remaining)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
New sample output:
```
pbarker@fx:~/rc/ardupilot(pr/extract-features-improvements)$ ./Tools/scripts/extract_features.py build/CubeOrange/bin/arduplane
/usr/lib/python3.10/subprocess.py:956: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
AP_AIRSPEED_ENABLED
AP_AIRSPEED_MSP_ENABLED
AP_AIRSPEED_DLVR_ENABLED
AP_AIRSPEED_SDP3X_ENABLED
AP_AIRSPEED_ANALOG_ENABLED
AP_AIRSPEED_MS4525_ENABLED
AP_AIRSPEED_MS5525_ENABLED
AP_AIRSPEED_UAVCAN_ENABLED
AP_AIRSPEED_ASP5033_ENABLED
HAL_ADSB_ENABLED
HAL_ADSB_SAGETECH_ENABLED
HAL_ADSB_SAGETECH_MXS_ENABLED
HAL_ADSB_UAVIONIX_MAVLINK_ENABLED
HAL_ADSB_UCP_ENABLED
AP_AIS_ENABLED
HAL_EFI_ENABLED
HAL_NAVEKF3_AVAILABLE
HAL_NAVEKF2_AVAILABLE
HAL_EXTERNAL_AHRS_ENABLED
HAL_INS_TEMPERATURE_CAL_ENABLE
HAL_VISUALODOM_ENABLED
AP_RANGEFINDER_ENABLED
AP_RANGEFINDER_PWM_ENABLED
AP_RANGEFINDER_WASP_ENABLED
AP_RANGEFINDER_ANALOG_ENABLED
AP_RANGEFINDER_BLPING_ENABLED
AP_RANGEFINDER_UAVCAN_ENABLED
AP_RANGEFINDER_HC_SR04_ENABLED
AP_RANGEFINDER_MAVLINK_ENABLED
AP_RANGEFINDER_VL53L0X_ENABLED
AP_RANGEFINDER_VL53L1X_ENABLED
AP_RANGEFINDER_USD1_CAN_ENABLED
AP_RANGEFINDER_BENEWAKE_CAN_ENABLED
AP_RANGEFINDER_MAXSONARI2CXL_ENABLED
AP_RANGEFINDER_PULSEDLIGHTLRF_ENABLED
AP_RANGEFINDER_BENEWAKE_TFMINIPLUS_ENABLED
AP_RANGEFINDER_NMEA_ENABLED
AP_RANGEFINDER_LANBAO_ENABLED
AP_RANGEFINDER_GYUS42V2_ENABLED
AP_RANGEFINDER_LEDDARONE_ENABLED
AP_RANGEFINDER_LEDDARVU8_ENABLED
AP_RANGEFINDER_USD1_SERIAL_ENABLED
AP_RANGEFINDER_TERARANGER_SERIAL_ENABLED
AP_RANGEFINDER_BENEWAKE_TF02_ENABLED
AP_RANGEFINDER_BENEWAKE_TF03_ENABLED
AP_RANGEFINDER_BENEWAKE_TFMINI_ENABLED
AP_RANGEFINDER_LIGHTWARE_SERIAL_ENABLED
AP_RANGEFINDER_LWI2C_ENABLED
AP_RANGEFINDER_MAXBOTIX_SERIAL_ENABLED
AP_RANGEFINDER_TRI2C_ENABLED
AP_GPS_ERB_ENABLED
AP_GPS_MAV_ENABLED
AP_GPS_SBF_ENABLED
AP_GPS_SBP_ENABLED
AP_GPS_GSOF_ENABLED
AP_GPS_NMEA_ENABLED
AP_GPS_NOVA_ENABLED
AP_GPS_SBP2_ENABLED
AP_GPS_SIRF_ENABLED
AP_GPS_UBLOX_ENABLED
AP_OPTICALFLOW_ENABLED
AP_OPTICALFLOW_MAV_ENABLED
AP_OPTICALFLOW_CXOF_ENABLED
AP_OPTICALFLOW_PIXART_ENABLED
AP_OPTICALFLOW_UPFLOW_ENABLED
AP_OPTICALFLOW_PX4FLOW_ENABLED
AP_OPTICALFLOW_HEREFLOW_ENABLED
AP_BARO_MSP_ENABLED
AP_BARO_SPL06_ENABLED
AP_BARO_BMP085_ENABLED
AP_BARO_BMP280_ENABLED
AP_BARO_BMP388_ENABLED
AP_BARO_DPS280_ENABLED
AP_BARO_FBM320_ENABLED
AP_BARO_LPS2XH_ENABLED
AP_BARO_MS56XX_ENABLED
AP_BARO_UAVCAN_ENABLED
AP_BARO_EXTERNALAHRS_ENABLED
AP_MOTORS_FRAME_Y6_ENABLED
AP_MOTORS_FRAME_HEXA_ENABLED
AP_MOTORS_FRAME_OCTA_ENABLED
AP_MOTORS_FRAME_QUAD_ENABLED
AP_MOTORS_FRAME_OCTAQUAD_ENABLED
AP_MOTORS_FRAME_DECA_ENABLED
AP_MOTORS_FRAME_DODECAHEXA_ENABLED
HAL_MSP_ENABLED
HAL_MSP_OPTICALFLOW_ENABLED
HAL_MSP_RANGEFINDER_ENABLED
HAL_MSP_GPS_ENABLED
HAL_MSP_COMPASS_ENABLED
HAL_WITH_MSP_DISPLAYPORT
AP_BATTMON_SMBUS_ENABLE
AP_BATTMON_FUELFLOW_ENABLE
AP_BATTMON_FUELLEVEL_PWM_ENABLE
AP_BATTMON_FUELLEVEL_ANALOG_ENABLE
HAL_BATTMON_INA2XX_ENABLED
HAL_MOUNT_ENABLED
HAL_MOUNT_SERVO_ENABLED
HAL_MOUNT_GREMSY_ENABLED
HAL_MOUNT_ALEXMOS_ENABLED
HAL_SOLO_GIMBAL_ENABLED
HAL_MOUNT_STORM32SERIAL_ENABLED
HAL_MOUNT_STORM32MAVLINK_ENABLED
HAL_CRSF_TELEM_ENABLED
HAL_HOTT_TELEM_ENABLED
HAL_SPEKTRUM_TELEM_ENABLED
HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED
AP_LTM_TELEM_ENABLED
HAL_HIGH_LATENCY2_ENABLED
HAL_RUNCAM_ENABLED
HAL_PARACHUTE_ENABLED
AP_FENCE_ENABLED
AP_ICENGINE_ENABLED
HAL_EFI_NWPWU_ENABLED
HAL_GENERATOR_ENABLED
OSD_ENABLED
HAL_PLUSCODE_ENABLE
OSD_PARAM_ENABLED
HAL_OSD_SIDEBAR_ENABLE
HAL_SMARTAUDIO_ENABLED
AP_TRAMP_ENABLED
HAL_QUADPLANE_ENABLED
HAL_SOARING_ENABLED
HAL_LANDING_DEEPSTALL_ENABLED
GRIPPER_ENABLED
LANDING_GEAR_ENABLED
AP_VOLZ_ENABLED
AP_ROBOTISSERVO_ENABLED
AP_FETTEC_ONEWIRE_ENABLED
RPM_ENABLED
GPS_MOVING_BASELINE
HAL_WITH_DSP
HAL_DISPLAY_ENABLED
HAL_NMEA_OUTPUT_ENABLED
HAL_BARO_WIND_COMP_ENABLED
HAL_PICCOLO_CAN_ENABLE
EK3_FEATURE_EXTERNAL_NAV
!AC_AVOID_ENABLED
!AC_OAPATHPLANNER_ENABLED
!AP_AIRSPEED_NMEA_ENABLED
!AP_BARO_DUMMY_ENABLED
!AP_BARO_ICM20789_ENABLED
!AP_BARO_ICP101XX_ENABLED
!AP_BARO_ICP201XX_ENABLED
!AP_BARO_KELLERLD_ENABLED
!AP_OPTICALFLOW_ONBOARD_ENABLED
!AP_RANGEFINDER_BBB_PRU_ENABLED
!AP_RANGEFINDER_BEBOP_ENABLED
!AP_RANGEFINDER_SIM_ENABLED
!BEACON_ENABLED
!HAL_MSP_SENSORS_ENABLED
!HAL_PROXIMITY_ENABLED
!HAL_SPRAYER_ENABLED
!HAL_TORQEEDO_ENABLED
!MODE_FLIP_ENABLED
!MODE_FLOWHOLD_ENABLED
!MODE_FOLLOW_ENABLED
!MODE_GUIDED_NOGPS_ENABLED
!MODE_SPORT_ENABLED
!MODE_SYSTEMID_ENABLED
!MODE_TURTLE_ENABLED
!MODE_ZIGZAG_ENABLED
!WINCH_ENABLED
pbarker@fx:~/rc/ardupilot(pr/extract-features-improvements)$ 
```
