### PR TITLE
AP_Scripting: allow : access to manual bindings 

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -320,7 +320,7 @@ function update_slew_gain()
       local ax_stage = string.sub(slew_parm, -1)
       adjust_gain(slew_parm, P:get()+slew_delta)
       slew_steps = slew_steps - 1
-      logger.write('QUIK','SRate,Gain,Param', 'ffn', get_slew_rate(axis), P:get(), axis .. ax_stage)
+      logger:write('QUIK','SRate,Gain,Param', 'ffn', get_slew_rate(axis), P:get(), axis .. ax_stage)
       if slew_steps == 0 then
          gcs:send_text(MAV_SEVERITY_INFO, string.format("%s %.4f", slew_parm, P:get()))
          slew_parm = nil
@@ -459,7 +459,7 @@ function update()
          adjust_gain(P_name, new_P)
       end
       setup_slew_gain(pname, new_gain)
-      logger.write('QUIK','SRate,Gain,Param', 'ffn', srate, P:get(), axis .. stage)
+      logger:write('QUIK','SRate,Gain,Param', 'ffn', srate, P:get(), axis .. stage)
       gcs:send_text(6, string.format("Tuning: %s done", pname))
       advance_stage(axis)
       last_stage_change = get_time()
@@ -469,7 +469,7 @@ function update()
          new_gain = 0.001
       end
       adjust_gain(pname, new_gain)
-      logger.write('QUIK','SRate,Gain,Param', 'ffn', srate, P:get(), axis .. stage)
+      logger:write('QUIK','SRate,Gain,Param', 'ffn', srate, P:get(), axis .. stage)
       if get_time() - last_gain_report > 3 then
          last_gain_report = get_time()
          gcs:send_text(MAV_SEVERITY_INFO, string.format("%s %.4f sr:%.2f", pname, new_gain, srate))

--- a/libraries/AP_Scripting/examples/Aerobatics/Missions/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Missions/plane_aerobatics.lua
@@ -164,7 +164,7 @@ local function PI_controller(kP,kI,iMax)
    -- log the controller internals
    function self.log(name, add_total)
       -- allow for an external addition to total
-      logger.write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
+      logger:write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
    end
    -- return the instance
    return self

--- a/libraries/AP_Scripting/examples/Aerobatics/Via_Switch/10_loops-and-immelman.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Via_Switch/10_loops-and-immelman.lua
@@ -139,7 +139,7 @@ local function PI_controller(kP,kI,iMax)
    -- log the controller internals
    function self.log(name, add_total)
       -- allow for an external addition to total
-      logger.write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
+      logger:write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
    end
    -- return the instance
    return self

--- a/libraries/AP_Scripting/examples/Aerobatics/Via_Switch/5_knifedges.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Via_Switch/5_knifedges.lua
@@ -104,7 +104,7 @@ local function PI_controller(kP,kI,iMax)
    -- log the controller internals
    function self.log(name, add_total)
       -- allow for an external addition to total
-      logger.write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
+      logger:write(name,'Targ,Curr,P,I,Total,Add','ffffff',_target,_current,_P,_I,_total,add_total)
    end
    -- return the instance
    return self

--- a/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
+++ b/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
@@ -2,7 +2,7 @@
 -- https://os.mbed.com/users/benkatz/code/HKC_MiniCheetah/docs/tip/CAN__com_8cpp_source.html
 
 -- Load CAN driver with a buffer size of 20
-local driver = CAN.get_device(20)
+local driver = CAN:get_device(20)
 
 local target_ID = uint32_t(1)
 

--- a/libraries/AP_Scripting/examples/CAN_read.lua
+++ b/libraries/AP_Scripting/examples/CAN_read.lua
@@ -2,8 +2,8 @@
 
 -- Load CAN driver1. The first will attach to a protocol of 10, the 2nd to a protocol of 12
 -- this allows the script to distinguish packets on two CAN interfaces
-local driver1 = CAN.get_device(5)
-local driver2 = CAN.get_device2(5)
+local driver1 = CAN:get_device(5)
+local driver2 = CAN:get_device2(5)
 
 if not driver1 and not driver2 then
    gcs:send_text(0,"No scripting CAN interfaces found")

--- a/libraries/AP_Scripting/examples/CAN_write.lua
+++ b/libraries/AP_Scripting/examples/CAN_write.lua
@@ -1,7 +1,7 @@
 -- This script is an example of writing to CAN bus
 
 -- Load CAN driver, using the scripting protocol and with a buffer size of 5
-local driver = CAN.get_device(5)
+local driver = CAN:get_device(5)
 
 -- transfer ID of the message were sending
 local Transfer_ID = 0

--- a/libraries/AP_Scripting/examples/OOP_example.lua
+++ b/libraries/AP_Scripting/examples/OOP_example.lua
@@ -57,7 +57,7 @@ local function PIFF(kFF,kP,kI,iMax)
 
    -- log the controller internals
    function self.log(name)
-      logger.write(name,'Targ,Curr,FF,P,I,Total','ffffff',table.unpack(_log_data))
+      logger:write(name,'Targ,Curr,FF,P,I,Total','ffffff',table.unpack(_log_data))
    end
 
    -- return the instance
@@ -110,7 +110,7 @@ function PIFF2.update(self, target, current)
 end
 
 function PIFF2.log(self, name)
-   logger.write(name,'Targ,Curr,FF,P,I,Total','ffffff',table.unpack(self.log_data))
+   logger:write(name,'Targ,Curr,FF,P,I,Total','ffffff',table.unpack(self.log_data))
 end
 
 --[[

--- a/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
+++ b/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
@@ -28,7 +28,7 @@ file:write('Lattitude (°), Longitude (°), Absolute Altitude (m), PM 1.0, PM 2.
 file:close()
 
 -- load the i2c driver, bus 0
-local sensor = i2c.get_device(0,0x33)
+local sensor = i2c:get_device(0,0x33)
 sensor:set_retries(10)
 
 -- register names
@@ -173,7 +173,7 @@ function update() -- this is the loop which periodically runs
   file:close()
 
   -- save to data flash
-  logger.write('PART','PM1,PM2.5,PM10,Cnt0.5,Cnt1,Cnt2.5,Cnt5,Cnt7.5,Cnt10','fffffffff',PM1_0,PM2_5,PM10,PC0_5,PC1_0,PC2_5,PC5_0,PC7_5,PC10)
+  logger:write('PART','PM1,PM2.5,PM10,Cnt0.5,Cnt1,Cnt2.5,Cnt5,Cnt7.5,Cnt10','fffffffff',PM1_0,PM2_5,PM10,PC0_5,PC1_0,PC2_5,PC5_0,PC7_5,PC10)
 
   -- send to GCS
   gcs:send_named_float('PM 1.0',PM1_0)

--- a/libraries/AP_Scripting/examples/UART_log.lua
+++ b/libraries/AP_Scripting/examples/UART_log.lua
@@ -100,7 +100,7 @@ function update()
             -- format characters specify the type of variable to be logged, see AP_Logger/README.md
             -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, N, and Z
             -- Note that Lua automatically adds a timestamp in micro seconds
-            logger.write('SCR','Sensor1, Sensor2, Sensor3','fff',table.unpack(log_data))
+            logger:write('SCR','Sensor1, Sensor2, Sensor3','fff',table.unpack(log_data))
 
             -- reset for the next message
             log_data = {}

--- a/libraries/AP_Scripting/examples/i2c_scan.lua
+++ b/libraries/AP_Scripting/examples/i2c_scan.lua
@@ -2,7 +2,7 @@
 local address = 0
 local found = 0
 
-local i2c_bus = i2c.get_device(0,0)
+local i2c_bus = i2c:get_device(0,0)
 i2c_bus:set_retries(10)
 
 function update() -- this is the loop which periodically runs

--- a/libraries/AP_Scripting/examples/logging.lua
+++ b/libraries/AP_Scripting/examples/logging.lua
@@ -30,10 +30,10 @@ local function write_to_dataflash()
   -- https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Logger
   -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, and N
   -- lua automatically adds a timestamp in micro seconds
-  logger.write('SCR1','roll(deg),pitch(deg),yaw(deg)','fff',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
+  logger:write('SCR1','roll(deg),pitch(deg),yaw(deg)','fff',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
 
   -- it is also possible to give units and multipliers
-  logger.write('SCR2','roll,pitch,yaw','fff','ddd','---',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
+  logger:write('SCR2','roll,pitch,yaw','fff','ddd','---',interesting_data[roll],interesting_data[pitch],interesting_data[yaw])
 
 end
 

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -244,7 +244,7 @@ function track_return_time()
       end
     end
 
-    logger.write('SFSC','total_return_time,remaining_return_time','If','ss','--',total_time,return_time)
+    logger:write('SFSC','total_return_time,remaining_return_time','If','ss','--',total_time,return_time)
   end
   return track_return_time, 100
 end
@@ -332,7 +332,7 @@ function update()
     return_q = 0.5 * density * return_airspeed^2 -- we could estimate the change in density also, but will be negligible
   end
 
-  logger.write('SFSA','return_time,return_airspeed,Q,return_Q','ffff','snPP','----',return_time,return_airspeed,q,return_q)
+  logger:write('SFSA','return_time,return_airspeed,Q,return_Q','ffff','snPP','----',return_time,return_airspeed,q,return_q)
 
   for i = 1, #batt_info do
     local instance, norm_filtered_amps, rated_capacity_mah = table.unpack(batt_info[i])
@@ -354,7 +354,7 @@ function update()
       local remaining_time = remaining_capacity / return_amps
 
       local buffer_time = remaining_time - ((return_time * time_SF) + margin)
-      logger.write('SFSB','Instance,current,rem_cap,rem_time,buffer','Bffff','#Aiss','--C--',i-1,return_amps,remaining_capacity,remaining_time,buffer_time)
+      logger:write('SFSB','Instance,current,rem_cap,rem_time,buffer','Bffff','#Aiss','--C--',i-1,return_amps,remaining_capacity,remaining_time,buffer_time)
       if  (return_time < 0) or buffer_time < 0 then
         if return_time < 0 then
           gcs:send_text(0, "Failsafe: ground speed low can not get home")

--- a/libraries/AP_Scripting/examples/plane_ship_landing.lua
+++ b/libraries/AP_Scripting/examples/plane_ship_landing.lua
@@ -253,7 +253,7 @@ function check_approach_tangent()
       local holdoff_dist = get_holdoff_distance()
       local error1 = math.abs(wrap_180(target_bearing_deg - ground_bearing_deg))
       local error2 = math.abs(wrap_180(ground_bearing_deg - (target_heading + SHIP_LAND_ANGLE:get())))
-      logger.write('SLND','TBrg,GBrg,Dist,HDist,Err1,Err2','ffffff',target_bearing_deg, ground_bearing_deg, distance, holdoff_dist, error1, error2)
+      logger:write('SLND','TBrg,GBrg,Dist,HDist,Err1,Err2','ffffff',target_bearing_deg, ground_bearing_deg, distance, holdoff_dist, error1, error2)
       if (error1 < margin and
           distance < 2.5*holdoff_dist and
           distance > 0.7*holdoff_dist and

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -66,15 +66,18 @@ int AP_Logger_Write(lua_State *L) {
         return luaL_argerror(L, 1, "logger not supported on this firmware");
     }
 
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "logger") != NULL) ? 1 : 0;
+
     // check we have at least 4 arguments passed in
-    const int args = lua_gettop(L);
+    const int args = lua_gettop(L) - arg_offset;
     if (args < 4) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    const char * name = luaL_checkstring(L, 1);
-    const char * labels = luaL_checkstring(L, 2);
-    const char * fmt = luaL_checkstring(L, 3);
+    const char * name = luaL_checkstring(L, 1 + arg_offset);
+    const char * labels = luaL_checkstring(L, 2 + arg_offset);
+    const char * fmt = luaL_checkstring(L, 3 + arg_offset);
 
     // cheack the name, labels and format are not too long
     if (strlen(name) >= LS_NAME_SIZE) {
@@ -132,8 +135,8 @@ int AP_Logger_Write(lua_State *L) {
     } else {
         // read in units and multiplers strings
         field_start += 2;
-        const char * units = luaL_checkstring(L, 4);
-        const char * multipliers = luaL_checkstring(L, 5);
+        const char * units = luaL_checkstring(L, 4 + arg_offset);
+        const char * multipliers = luaL_checkstring(L, 5 + arg_offset);
 
         if (length != strlen(units)) {
             return luaL_error(L, "units must be same length as format");
@@ -180,6 +183,7 @@ int AP_Logger_Write(lua_State *L) {
     for (uint8_t i=field_start; i<=args; i++) {
         uint8_t charlen = 0;
         uint8_t index = have_units ? i-5 : i-3;
+        uint8_t arg_index = i + arg_offset;
         switch(fmt_cat[index]) {
             // logger varable types not available to scripting
             // 'b': int8_t
@@ -194,15 +198,15 @@ int AP_Logger_Write(lua_State *L) {
             case 'i':
             case 'L':
             case 'e': {
-                const lua_Integer tmp1 = luaL_checkinteger(L, i);
-                luaL_argcheck(L, ((tmp1 >= INT32_MIN) && (tmp1 <= INT32_MAX)), i, "argument out of range");
+                const lua_Integer tmp1 = luaL_checkinteger(L, arg_index);
+                luaL_argcheck(L, ((tmp1 >= INT32_MIN) && (tmp1 <= INT32_MAX)), arg_index, "argument out of range");
                 int32_t tmp = tmp1;
                 luaL_addlstring(&buffer, (char *)&tmp, sizeof(int32_t));
                 break;
             }
             case 'f': {
-                float tmp = luaL_checknumber(L, i);
-                luaL_argcheck(L, ((tmp >= -INFINITY) && (tmp <= INFINITY)), i, "argument out of range");
+                float tmp = luaL_checknumber(L, arg_index);
+                luaL_argcheck(L, ((tmp >= -INFINITY) && (tmp <= INFINITY)), arg_index, "argument out of range");
                 luaL_addlstring(&buffer, (char *)&tmp, sizeof(float));
                 break;
             }
@@ -212,15 +216,15 @@ int AP_Logger_Write(lua_State *L) {
             }
             case 'M':
             case 'B': {
-                const lua_Integer tmp1 = luaL_checkinteger(L, i);
-                luaL_argcheck(L, ((tmp1 >= 0) && (tmp1 <= UINT8_MAX)), i, "argument out of range");
+                const lua_Integer tmp1 = luaL_checkinteger(L, arg_index);
+                luaL_argcheck(L, ((tmp1 >= 0) && (tmp1 <= UINT8_MAX)), arg_index, "argument out of range");
                 uint8_t tmp = static_cast<uint8_t>(tmp1);
                 luaL_addlstring(&buffer, (char *)&tmp, sizeof(uint8_t));
                 break;
             }
             case 'I':
             case 'E': {
-                const uint32_t tmp = coerce_to_uint32_t(L, i);
+                const uint32_t tmp = coerce_to_uint32_t(L, arg_index);
                 luaL_addlstring(&buffer, (char *)&tmp, sizeof(uint32_t));
                 break;
             }
@@ -233,14 +237,14 @@ int AP_Logger_Write(lua_State *L) {
                 break;
             }
             default: {
-                return luaL_error(L, "%c unsupported format",fmt_cat[i-3]);
+                return luaL_error(L, "%c unsupported format",fmt_cat[arg_index-3]);
             }
         }
         if (charlen != 0) {
-            const char *tmp = luaL_checkstring(L, i);
+            const char *tmp = luaL_checkstring(L, arg_index);
             const size_t slen = strlen(tmp);
             if (slen > charlen) {
-                return luaL_error(L, "arg %i too long for %c format",i,fmt_cat[i-3]);
+                return luaL_error(L, "arg %i too long for %c format",arg_index,fmt_cat[arg_index-3]);
             }
             char tstr[charlen];
             memcpy(tstr, tmp, slen);
@@ -261,7 +265,10 @@ int AP_Logger_Write(lua_State *L) {
 
 int lua_get_i2c_device(lua_State *L) {
 
-    const int args = lua_gettop(L);
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "i2c") != NULL) ? 1 : 0;
+
+    const int args = lua_gettop(L) - arg_offset;
     if (args < 2) {
         return luaL_argerror(L, args, "require i2c bus and address");
     }
@@ -269,12 +276,12 @@ int lua_get_i2c_device(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    const lua_Integer bus_in = luaL_checkinteger(L, 1);
-    luaL_argcheck(L, ((bus_in >= 0) && (bus_in <= 4)), 1, "bus out of range");
+    const lua_Integer bus_in = luaL_checkinteger(L, 1 + arg_offset);
+    luaL_argcheck(L, ((bus_in >= 0) && (bus_in <= 4)), 1 + arg_offset, "bus out of range");
     const uint8_t bus = static_cast<uint8_t>(bus_in);
 
-    const lua_Integer address_in = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((address_in >= 0) && (address_in <= 128)), 2, "address out of range");
+    const lua_Integer address_in = luaL_checkinteger(L, 2 + arg_offset);
+    luaL_argcheck(L, ((address_in >= 0) && (address_in <= 128)), 2 + arg_offset, "address out of range");
     const uint8_t address = static_cast<uint8_t>(address_in);
 
     // optional arguments, use the same defaults as the hal get_device function
@@ -282,10 +289,10 @@ int lua_get_i2c_device(lua_State *L) {
     bool use_smbus = false;
 
     if (args > 2) {
-        bus_clock = coerce_to_uint32_t(L, 3);
+        bus_clock = coerce_to_uint32_t(L, 3 + arg_offset);
 
         if (args > 3) {
-            use_smbus = static_cast<bool>(lua_toboolean(L, 4));
+            use_smbus = static_cast<bool>(lua_toboolean(L, 4 + arg_offset));
         }
     }
 
@@ -316,10 +323,13 @@ int lua_get_i2c_device(lua_State *L) {
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
 int lua_get_CAN_device(lua_State *L) {
 
-    binding_argcheck(L, 1);
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "CAN") != NULL) ? 1 : 0;
 
-    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1);
-    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1, "argument out of range");
+    binding_argcheck(L, 1 + arg_offset);
+
+    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1 + arg_offset);
+    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1 + arg_offset, "argument out of range");
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev == nullptr) {
@@ -337,10 +347,13 @@ int lua_get_CAN_device(lua_State *L) {
 
 int lua_get_CAN_device2(lua_State *L) {
 
-    binding_argcheck(L, 1);
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "CAN") != NULL) ? 1 : 0;
 
-    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1);
-    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1, "argument out of range");
+    binding_argcheck(L, 1 + arg_offset);
+
+    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1 + arg_offset);
+    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1 + arg_offset, "argument out of range");
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev2 == nullptr) {


### PR DESCRIPTION
This updates our manual bindings to allow both types of access. EG `logger.write(...` and `logger:write(...`. This oddity of the manual bindings is annoying and confusing. 

This also updates all the examples to use the `:` in line with all the other AP bindings. This does mean that all the master examples will not work on stable, but that is true whenever we add new stuff. 

Old scripts using `.` will still work on master, tested both methods for i2c and CAN on CubeOrange and logging in SITL.
