### PR TITLE
Plane: correct extened range airspeed scailing limits

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -12,14 +12,14 @@ float Plane::calc_speed_scaler(void)
         if (aspeed > auto_state.highest_airspeed && hal.util->get_soft_armed()) {
             auto_state.highest_airspeed = aspeed;
         }
+        // ensure we have scaling over the full configured airspeed
+        const float scale_min = MIN(0.5, g.scaling_speed / (2.0 * aparm.airspeed_max));
+        const float scale_max = MAX(2.0, g.scaling_speed / (0.7 * aparm.airspeed_min));
         if (aspeed > 0.0001f) {
             speed_scaler = g.scaling_speed / aspeed;
         } else {
-            speed_scaler = 2.0;
+            speed_scaler = scale_max;
         }
-        // ensure we have scaling over the full configured airspeed
-        float scale_min = MIN(0.5, (0.5 * aparm.airspeed_min) / g.scaling_speed);
-        float scale_max = MAX(2.0, (1.5 * aparm.airspeed_max) / g.scaling_speed);
         speed_scaler = constrain_float(speed_scaler, scale_min, scale_max);
 
 #if HAL_QUADPLANE_ENABLED


### PR DESCRIPTION
This fixes a error from https://github.com/ArduPilot/ardupilot/pull/9680

The current code uses airspeed min for scaling min and airspeed max for scaling max. This is backwards. Currently changing max air speed makes no difference to the lower scaling limit used at high airspeed, instead it changes the upper limit used at low airseed.

In order to not change the limits too much I have changed the scale factors from 0.5 and 1.5 to 0.7 and 2.0. This matches up the two limits fairly well with default param, but might not for others. 

![image](https://user-images.githubusercontent.com/33176108/188282071-f62a1f5f-2a98-4d8d-8864-766218e2030e.png)

I wonder if we should just hard code the upper limit to 2 at low airspeed. That is the one that will likely cause issues. Due to the gradient of the line at low airspeed small changes will make a big scaling difference. 
