### PR TITLE
Copter: fix do-mount-control yaw scaling

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -737,9 +737,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t
         // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
         if ((copter.camera_mount.get_mount_type() != copter.camera_mount.MountType::Mount_Type_None) &&
             !copter.camera_mount.has_pan_control()) {
-            copter.flightmode->auto_yaw.set_yaw_angle_rate(
-                (float)packet.param3 * 0.01f,
-                0.0f);
+            copter.flightmode->auto_yaw.set_yaw_angle_rate((float)packet.param3, 0.0f);
         }
         break;
     default:


### PR DESCRIPTION
This fixes a scaling issue in Copter's consumption of the MAV_CMD_DO_MOUNT_CONTROL message.  The command's yaw was being interpreted as if it was centi-degrees but the [mavlink spec](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1166) says degrees.  This only affects Copters with a 2-axis gimbal

This is related to PR https://github.com/ArduPilot/ardupilot/pull/21530 (which solved a similar problem in the AP_Mount driver but didn't resolve this Copter vehicle level issue).

This resolves issue https://github.com/ArduPilot/ardupilot/issues/15699

I've tested this in SITL and confirmed that before, the vehicle was always pointed quite close to zero (e.g. a request for 90 degrees would point the vehicle at 0.9 deg) and that after it points in the correct direction.
![mav-cmd-do-mount-control-copter-yaw-fix](https://user-images.githubusercontent.com/1498098/188358446-8f897c54-d89a-427b-840f-34103cba2a9b.png)

As a side note, the handling of DO_MOUNT_CONTROL is odd in that the angles are treated as earth-frame angles with a 2-axis gimbal but body-frame angles when using a 3-axis gimbal.  This odd difference is another good reason why we should encourage use of the new gimbalv2 messages like DO_GIMBAL_MANAGER_PITCHYAW.
