### PR TITLE
Send local ned home location to GCS

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8946,6 +8946,7 @@ class AutoTestCopter(AutoTest):
              self.TakeoffAlt,
              self.SplineLastWaypoint,
              self.Gripper,
+             self.TestLocalHomePosition,
              self.TestGripperMission,
              self.VisionPosition,
              self.ATTITUDE_FAST,

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9553,6 +9553,34 @@ Also, ignores heartbeats not from our target system'''
         self.context_pop()
         self.reboot_sitl()
 
+    def TestLocalHomePosition(self):
+        """Test local home position is sent in HOME_POSITION message"""
+        self.context_push()
+        self.wait_ready_to_arm()
+
+        # set home to a new location
+        self.mav.mav.command_long_send(1,
+                                       1,
+                                       mavutil.mavlink.MAV_CMD_DO_SET_HOME,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       -35.357466,
+                                       149.142589,
+                                       630)
+
+        # check home after home set
+        m = self.assert_receive_message("HOME_POSITION", timeout=5)
+        if abs(m.x) < 10 or abs(m.y) < 10 or abs(m.z) < 10:
+            raise NotAchievedException("Failed to get local home position: (got=%u, %u, %u)", m.x, m.y, m.z)
+        else:
+            self.progress(f"Received local home position successfully: (got={m.x}, {m.y}, {m.z})")
+
+        self.context_pop()
+        self.reboot_sitl()
+
     def install_terrain_handlers_context(self):
         '''install a message handler into the current context which will
         listen for an fulfill terrain requests from ArduPilot.  Will

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2578,13 +2578,21 @@ void GCS_MAVLINK::send_home_position() const
 
     const Location &home = AP::ahrs().get_home();
 
+    // get home position from origin
+    Vector3f home_pos_neu_cm;
+    if (!home.get_vector_from_origin_NEU(home_pos_neu_cm)) {
+        return;
+    }
+
     const float q[4] = {1.0f, 0.0f, 0.0f, 0.0f};
     mavlink_msg_home_position_send(
         chan,
         home.lat,
         home.lng,
         home.alt * 10,
-        0.0f, 0.0f, 0.0f,
+        home_pos_neu_cm.x * 0.01f, // position of home on x-axis in meters
+        home_pos_neu_cm.y * 0.01f, // position of home on y-axis in meters
+        home_pos_neu_cm.z * -0.01f, // position of home on z-axis in meters in NED frame
         q,
         0.0f, 0.0f, 0.0f,
         AP_HAL::micros64());


### PR DESCRIPTION
This is a PR about sending local neu home location in [HOME_POSITION](https://mavlink.io/en/messages/common.html#HOME_POSITION) MAVLink message.
Can be tested using: `./Tools/autotest/autotest.py build.Copter test.Copter.TestLocalHomePosition`
This helps to calculate the distance between the vehicle and home rather than the origin (calculating the euclidian distance between [HOME_POSITION](https://mavlink.io/en/messages/common.html#HOME_POSITION) and [LOCAL_POSITION_NED](https://mavlink.io/en/messages/common.html#LOCAL_POSITION_NED)).