### PR TITLE
GCS_MAVLink: Rate limit blocking accel calibrations

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2717,6 +2717,7 @@ function'''
             "INS_GYR_CAL": 1,
         })
         self.reboot_sitl()
+        self.delay_sim_time(5)
         self.progress("Running accelcal")
         self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
                      0, 0, 0, 0, 4, 0, 0,

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -10866,6 +10866,7 @@ switch value'''
     def ahrstrim(self):
         self.start_subtest("Attitude Correctness")
         self.ahrstrim_attitude_correctness()
+        self.delay_sim_time(5)
         self.start_subtest("Preflight Calibration")
         self.ahrstrim_preflight_cal()
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -652,6 +652,8 @@ private:
 
     void log_mavlink_stats();
 
+    uint32_t last_accel_cal_ms; // used to rate limit accel cals for bad links
+
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);
 
     // send a (textual) message to the GCS that a received message has


### PR DESCRIPTION
This allows us to drop any queued commands that may have arrived while we were calibrating. Rather then entering a second and unexpected calibration.

EDIT: Testing was done against mission planner with a cube orange over usb and using the level accel cal button (the param5==2 path). I don't have a GCS here that lets me test the simple_accel_cal path. If I sent commands within 5 seconds of it finishing it was rejected, if I waited they worked again.

EDIT2: `accelcalsimple` in mavproxy looks like it works as intended.