### PR TITLE
AP_Arming: Expose ARMING_OPTIONS to all vehicles

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -136,12 +136,12 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
-    // @Param{Copter}: OPTIONS
+    // @Param: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
     // @Values: 0:None,1:Disable prearm display
     // @User: Advanced
-    AP_GROUPINFO_FRAME("OPTIONS", 9,   AP_Arming, _arming_options, 0, AP_PARAM_FRAME_COPTER),
+    AP_GROUPINFO("OPTIONS", 9,   AP_Arming, _arming_options, 0),
 
     AP_GROUPEND
 };


### PR DESCRIPTION
Expose the option to all vehicles, I don't see a reason why it doesn't apply to all of them, and on plane I don't want these broadcast at me continuously.

Tested against plane.