### PR TITLE
Plane: Fixed divide by zero error when changing to GUIDED

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2501,7 +2501,11 @@ void QuadPlane::vtol_position_controller(void)
         const float distance = diff_wp.length();
         const Vector2f rel_groundspeed_vector = landing_closing_velocity();
         const float rel_groundspeed_sq = rel_groundspeed_vector.length_squared();
-        const float closing_groundspeed = rel_groundspeed_vector * diff_wp.normalized();
+        float closing_groundspeed = 0;
+
+        if (distance > 0.1) {
+            closing_groundspeed = rel_groundspeed_vector * diff_wp.normalized();
+        }
 
         // calculate speed we should be at to reach the position2
         // target speed at the position2 distance threshold, assuming


### PR DESCRIPTION
Fixed a bug where when Q_GUIDED_MODE was set to 1 and you attempted to change to GUIDED a divide by zero exception occurred. This issue would occur because the next and current waypoints were set to be the same and attempting to get the vector norm between the two waypoints would be a divide by zero.

Changed so that the distance between waypoints is checked before computing the norm of the vector