### PR TITLE
GCS_MAVLink/AP_Mount: find_by_mavtype supports instance -- WIP

### DIFF
--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -391,7 +391,7 @@ void ModeAuto::send_guided_position_target()
         uint8_t sysid;
         uint8_t compid;
         mavlink_channel_t chan;
-        if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_ONBOARD_CONTROLLER, sysid, compid, chan)) {
+        if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_ONBOARD_CONTROLLER, sysid, compid, chan, 0)) {
             gcs().chan(chan-MAVLINK_COMM_0)->send_set_position_target_global_int(sysid, compid, guided_target.loc);
         }
     }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -152,7 +152,8 @@ void AP_Mount_Gremsy::find_gimbal()
     if (!_found_gimbal) {
         mavlink_channel_t chan;
         uint8_t sysid, compid;
-        if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, sysid, compid, chan)) {
+        uint8_t found_instance = 0;
+        while (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, sysid, compid, chan, found_instance) && (found_instance < 10)) {
             if (((_instance == 0) && (compid == MAV_COMP_ID_GIMBAL)) ||
                 ((_instance == 1) && (compid == MAV_COMP_ID_GIMBAL2))) {
                 _found_gimbal = true;
@@ -160,8 +161,10 @@ void AP_Mount_Gremsy::find_gimbal()
                 _compid = compid;
                 _chan = chan;
             }
-        } else {
-            // have not yet found a gimbal so return
+            found_instance++;
+        }
+        if (!_found_gimbal) {
+            // still have not yet found a gimbal so return
             return;
         }
     }

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -136,7 +136,7 @@ void AP_Mount_SToRM32::find_gimbal()
         return;
     }
 
-    if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, _sysid, _compid, _chan)) {
+    if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, _sysid, _compid, _chan, 0)) {
         _initialised = true;
     }
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -372,9 +372,10 @@ public:
     
     /*
       search for a component in the routing table with given mav_type and retrieve it's sysid, compid and channel
+      instance should be zero if searching for the first instance, 1 for the second, etc
       returns if a matching component is found
      */
-    static bool find_by_mavtype(uint8_t mav_type, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel) { return routing.find_by_mavtype(mav_type, sysid, compid, channel); }
+    static bool find_by_mavtype(uint8_t mav_type, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel, uint8_t instance) { return routing.find_by_mavtype(mav_type, sysid, compid, channel, instance); }
 
     // update signing timestamp on GPS lock
     static void update_signing_timestamp(uint64_t timestamp_usec);

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -244,17 +244,23 @@ void MAVLink_routing::send_to_components(const char *pkt, const mavlink_msg_entr
 
 /*
   search for the first vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
+  instance should be zero if searching for the first instance, 1 for the second, etc
   returns true if a match is found
  */
-bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel)
+bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel, uint8_t instance)
 {
+    uint8_t found_instance = 0;
+
     // check learned routes
     for (uint8_t i=0; i<num_routes; i++) {
         if (routes[i].mavtype == mavtype) {
-            sysid = routes[i].sysid;
-            compid = routes[i].compid;
-            channel = routes[i].channel;
-            return true;
+            if (found_instance == instance) {
+                sysid = routes[i].sysid;
+                compid = routes[i].compid;
+                channel = routes[i].channel;
+                return true;
+            }
+            found_instance++;
         }
     }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -38,10 +38,11 @@ public:
     void send_to_components(uint32_t msgid, const char *pkt, uint8_t pkt_len);
 
     /*
-      search for the first vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
+      search for the vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
+      instance should be zero if searching for the first instance, 1 for the second, etc
       returns true if a match is found
      */
-    bool find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel);
+    bool find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel, uint8_t instance);
 
 private:
     // a simple linear routing table. We don't expect to have a lot of


### PR DESCRIPTION
This is a follow-up to PR https://github.com/ArduPilot/ardupilot/pull/21614 which added support for multiple gimbals

The previous PR worked fine for two Servo gimbals and where a mix of Servo and MAVLink gimbals were used but it still did not work with two MAVLink gimbals.  The underlying issue is that [GCS_MAVLink::find_by_mavtype()](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/MAVLink_routing.cpp#L249) always returns the first gimbal found in the routing table.

Changes included in this PR:

- GCS_MAVLink::find_by_mavtype() gets an "instance" argument allowing the caller to iteratively retrieve all matching devices.  Note we cannot assume that the instance of a particular mavlink device will be consistent across boots or ordered in some way (e.g. lowest component or system id first, etc).
- Gremsy gimbal driver is enhanced to iterate through all gimbal devices and latches onto the one with a component-id that matches the driver's instance.  This means MNT1* will connect to the Gremsy gimbal with component-id = MAV_COMP_ID_GIMBAL**1**, MNT2* will connect to MAV_COMP_ID_GIMBAL**2**.  Note that the Gremsy gimbal setup application allows the user to change this component id (see below)
![gremsy-settings-compid](https://user-images.githubusercontent.com/1498098/188790684-3982fbe8-ff60-41bf-9bad-aaf6d12edd69.png)
- Other callers of GCS_MAVLink::find_by_mavtype() provide zero so their behaviour remains unchanged.  This includes the SToRM32 mavlink gimbal driver.

This change does not allow users complete flexibility in terms of multiple gimbals:

- If MNT1=Servo and MNT2=Gremsy, the users would need to set the Gremsy's component id to GIMBAL_COMPID**2**
- Multiple SToRM32 mavlink gimbals still don't work.  The [SToRM32 setup app](https://ardupilot.org/copter/docs/common-storm32-gimbal.html#setup-if-using-mavlink-protocol) does allow users to change the system and component id of the gimbal so with more discussion with @olliw42 I think we could find a way
- Multiple Alexmos or SToRM32 **serial** drivers also don't work because they similarly uses AP_SerialManager::find_serial() but always ask for the first instance.
 
Perhaps a better solution would be to add an AP_Mount::get_instance_by_type(uint8_t instance, MountType mnt_type) that would essentially tell the caller which gimbal instance they are of their own type.  E.g. you are the 2nd Gremsy gimbal.  You are the 1st Servo gimbal.
