### PR TITLE
install-ROS-ubuntu: updated script to download ap_navigation

### DIFF
--- a/Tools/environment_install/install-ROS-ubuntu.sh
+++ b/Tools/environment_install/install-ROS-ubuntu.sh
@@ -232,7 +232,7 @@ if maybe_prompt_user "Add ardupilot-ws to your home folder [N/y]?" ; then
         pushd $ROS_WS_ROOT
         catkin init
         pushd src
-        git clone https://github.com/snktshrma/ardupilot_ros.git
+        git clone https://github.com/ArduPilot/ardupilot_ros.git
         wget https://github.com/ArduPilot/companion/raw/master/Common/ROS/ap_navigation.zip
         unzip ap_navigation.zip
         popd

--- a/Tools/environment_install/install-ROS-ubuntu.sh
+++ b/Tools/environment_install/install-ROS-ubuntu.sh
@@ -233,6 +233,8 @@ if maybe_prompt_user "Add ardupilot-ws to your home folder [N/y]?" ; then
         catkin init
         pushd src
         git clone https://github.com/snktshrma/ardupilot_ros.git
+        wget https://github.com/ArduPilot/companion/raw/master/Common/ROS/ap_navigation.zip
+        unzip ap_navigation.zip
         popd
         sudo apt update
         rosdep install --from-paths src --ignore-src --rosdistro=${ROS_DISTRO} -y


### PR DESCRIPTION
Install ap_navigation package alongside ardupilot_ros package for non-gps navigation