### PR TITLE
AP_Mission: Share the method RETURN

### DIFF
--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -245,9 +245,7 @@ bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Miss
         return true;
     }
 
+#endif // HAL_MOUNT_ENABLED
     // if we got this far then message is not handled
     return false;
-#else
-    return false;
-#endif // HAL_MOUNT_ENABLED
 }


### PR DESCRIPTION
The final RETURN of this method is the same regardless of whether MOUNT is enabled or disabled.
Therefore, it can be shared.