### PR TITLE
GCS_MAVLink/AP_Mount: find_by_mavtype supports instance (attempt2)

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -150,16 +150,12 @@ void AP_Mount_Gremsy::find_gimbal()
 
     // search for a mavlink enabled gimbal
     if (!_found_gimbal) {
-        mavlink_channel_t chan;
-        uint8_t sysid, compid;
-        if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, sysid, compid, chan)) {
-            if (((_instance == 0) && (compid == MAV_COMP_ID_GIMBAL)) ||
-                ((_instance == 1) && (compid == MAV_COMP_ID_GIMBAL2))) {
-                _found_gimbal = true;
-                _sysid = sysid;
-                _compid = compid;
-                _chan = chan;
-            }
+        // we expect that instance 0 has compid = MAV_COMP_ID_GIMBAL, instance 1 has compid = MAV_COMP_ID_GIMBAL2, etc
+        uint8_t compid = (_instance == 0) ? MAV_COMP_ID_GIMBAL : MAV_COMP_ID_GIMBAL2 + (_instance - 1);
+        if (GCS_MAVLINK::find_by_mavtype_and_compid(MAV_TYPE_GIMBAL, compid, _sysid, _chan)) {
+            _compid = compid;
+            _found_gimbal = true;
+            return;
         } else {
             // have not yet found a gimbal so return
             return;

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -136,7 +136,10 @@ void AP_Mount_SToRM32::find_gimbal()
         return;
     }
 
-    if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, _sysid, _compid, _chan)) {
+    // we expect that instance 0 has compid = MAV_COMP_ID_GIMBAL, instance 1 has compid = MAV_COMP_ID_GIMBAL2, etc
+    uint8_t compid = (_instance == 0) ? MAV_COMP_ID_GIMBAL : MAV_COMP_ID_GIMBAL2 + (_instance - 1);
+    if (GCS_MAVLINK::find_by_mavtype_and_compid(MAV_TYPE_GIMBAL, compid, _sysid, _chan)) {
+        _compid = compid;
         _initialised = true;
     }
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -383,6 +383,12 @@ public:
      */
     static bool find_by_mavtype(uint8_t mav_type, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel) { return routing.find_by_mavtype(mav_type, sysid, compid, channel); }
 
+    /*
+      search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
+      returns true if a match is found
+     */
+    static bool find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) { return routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel); }
+
     // update signing timestamp on GPS lock
     static void update_signing_timestamp(uint64_t timestamp_usec);
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -263,6 +263,22 @@ bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &
 }
 
 /*
+  search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
+  returns true if a match is found
+ */
+bool MAVLink_routing::find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) const
+{
+    for (uint8_t i=0; i<num_routes; i++) {
+        if ((routes[i].mavtype == mavtype) && (routes[i].compid == compid)) {
+            sysid = routes[i].sysid;
+            channel = routes[i].channel;
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
   see if the message is for a new route and learn it
 */
 void MAVLink_routing::learn_route(mavlink_channel_t in_channel, const mavlink_message_t &msg)

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -43,6 +43,12 @@ public:
      */
     bool find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel);
 
+    /*
+      search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
+      returns true if a match is found
+     */
+    bool find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) const;
+
 private:
     // a simple linear routing table. We don't expect to have a lot of
     // routes, so a scalable structure isn't worthwhile yet.


### PR DESCRIPTION
This is an alternative implementation of https://github.com/ArduPilot/ardupilot/pull/21658.  The changes are:

- GCS_MAVLink::find_by_mavtype_and_compid is added and used to more directly find the Gremsy (and SToRM32 mavlink) gimbals.  The advantage is that this skips the need for the two drivers to iterate through all the matching devices to find the one with the correct component id.  For this reason I prefer this solution to the original PR.
- SToRM32 mavlink driver requires the gimbal component id to be MAV_COMP_ID_GIMBAL, MAV_COMP_ID_GIMBAL2, etc.

Some SToRM32 users will need to re-configure their gimbals to use them with AP but this change is consistent with @olliw42's popular BetaPilot fork of AP.

This has been lightly tested on a Gremsy gimbal to confirm two gimbals could be controlled.