### PR TITLE
autotest: throw exception when GIMBAL_DEVICE_ATTITUDE_STATUS not rece…

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4633,9 +4633,7 @@ class AutoTestCopter(AutoTest):
     def get_mount_roll_pitch_yaw_deg(self):
         '''return mount (aka gimbal) roll, pitch and yaw angles in degrees'''
         # wait for gimbal attitude message
-        m = self.mav.recv_match(type='GIMBAL_DEVICE_ATTITUDE_STATUS',
-                                blocking=True,
-                                timeout=5)
+        m = self.assert_receive_message('GIMBAL_DEVICE_ATTITUDE_STATUS', timeout=5)
 
         # convert quaternion to euler angles and return
         q = quaternion.Quaternion(m.q)
@@ -4667,9 +4665,7 @@ class AutoTestCopter(AutoTest):
             self.reboot_sitl() # to handle MNT_TYPE changing
 
             # make sure we're getting gimbal device attitude status
-            self.mav.recv_match(type='GIMBAL_DEVICE_ATTITUDE_STATUS',
-                                blocking=True,
-                                timeout=5)
+            self.assert_receive_message('GIMBAL_DEVICE_ATTITUDE_STATUS', timeout=5)
 
             # change mount to neutral mode (point forward, not stabilising)
             self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_NEUTRAL)


### PR DESCRIPTION
…ived

```
AT-2222.0: Exception caught: 'NoneType' object has no attribute 'q'    
Traceback (most recent call last):    
  File "/home/wickedshell/code/ardupilot/Tools/autotest/common.py", line 7174, in run_one_test_attempt    
    test_function()    
  File "/home/wickedshell/code/ardupilot/Tools/autotest/arducopter.py", line 4957, in test_mount    
    raise ex    
  File "/home/wickedshell/code/ardupilot/Tools/autotest/arducopter.py", line 4641, in test_mount    
    mount_roll_deg, mount_pitch_deg, mount_yaw_deg = self.get_mount_roll_pitch_yaw_deg()    
  File "/home/wickedshell/code/ardupilot/Tools/autotest/arducopter.py", line 4604, in get_mount_roll_pitch_yaw_deg    
    q = quaternion.Quaternion(m.q)    
AttributeError: 'NoneType' object has no attribute 'q' 
```
