### PR TITLE
autotest: fail if no steps supplied and not autotest server

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -1225,6 +1225,10 @@ if __name__ == "__main__":
         newargs.append(arg)
     args = newargs
 
+    if len(args) == 0 and not opts.autotest_server:
+        print("Steps must be supplied; try --list and/or --list-subtests or --help")
+        sys.exit(1)
+
     if len(args) > 0:
         # allow a wildcard list of steps
         matched = []
@@ -1243,12 +1247,6 @@ if __name__ == "__main__":
                 sys.exit(1)
             matched.extend(matches)
         steps = matched
-    elif opts.autotest_server:
-        # we will be changing this script to give a help message if
-        # --autotest-server isn't given, instead of assuming we want
-        # to do everything that happens on autotest.ardupilot.org,
-        # which includes some significant state-changing actions.
-        print("AutoTest-Server Mode")
 
     # skip steps according to --skip option:
     steps_to_run = [s for s in steps if should_run_step(s)]


### PR DESCRIPTION
I've confirmed the autotest server is adding the relevant command-line option.

This makes the autotest tool less dangerous; running without arguments causes all sorts of fun stuff to happen as we do the build binaries step.
