### PR TITLE
Tools: remove vestiges of travis autotest hooks

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8536,16 +8536,6 @@ class AutoTestCopter(AutoTest):
         self.change_mode('AUTO')
         self.wait_disarmed()
 
-    # a wrapper around all the 1A,1B,1C..etc tests for travis
-    def tests1(self):
-        ret = ([])
-        ret.extend(self.tests1a())
-        ret.extend(self.tests1b())
-        ret.extend(self.tests1c())
-        ret.extend(self.tests1d())
-        ret.extend(self.tests1e())
-        return ret
-
     def ATTITUDE_FAST(self):
         '''ensure that when ATTITDE_FAST is set we get many messages'''
         self.context_push()
@@ -9177,13 +9167,6 @@ class AutoTestCopter(AutoTest):
         ])
         return ret
 
-    # a wrapper around all the 2A,2B,2C..etc tests for travis
-    def tests2(self):
-        ret = ([])
-        ret.extend(self.tests2a())
-        ret.extend(self.tests2b())
-        return ret
-
     def tests2a(self):
         '''return list of all tests'''
         ret = ([
@@ -9383,8 +9366,13 @@ class AutoTestCopter(AutoTest):
 
     def tests(self):
         ret = []
-        ret.extend(self.tests1())
-        ret.extend(self.tests2())
+        ret.extend(self.tests1a())
+        ret.extend(self.tests1b())
+        ret.extend(self.tests1c())
+        ret.extend(self.tests1d())
+        ret.extend(self.tests1e())
+        ret.extend(self.tests2a())
+        ret.extend(self.tests2b())
         return ret
 
     def disabled_tests(self):
@@ -9395,11 +9383,6 @@ class AutoTestCopter(AutoTest):
             "GroundEffectCompensation_takeOffExpected": "Flapping",
             "GroundEffectCompensation_touchDownExpected": "Flapping",
         }
-
-
-class AutoTestCopterTests1(AutoTestCopter):
-    def tests(self):
-        return self.tests1()
 
 
 class AutoTestCopterTests1a(AutoTestCopter):
@@ -9425,11 +9408,6 @@ class AutoTestCopterTests1d(AutoTestCopter):
 class AutoTestCopterTests1e(AutoTestCopter):
     def tests(self):
         return self.tests1e()
-
-
-class AutoTestCopterTests2(AutoTestCopter):
-    def tests(self):
-        return self.tests2()
 
 
 class AutoTestCopterTests2a(AutoTestCopter):

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -308,14 +308,12 @@ def should_run_step(step):
 
 __bin_names = {
     "Copter": "arducopter",
-    "CopterTests1": "arducopter",
     "CopterTests1a": "arducopter",
     "CopterTests1b": "arducopter",
     "CopterTests1c": "arducopter",
     "CopterTests1d": "arducopter",
     "CopterTests1e": "arducopter",
 
-    "CopterTests2": "arducopter",
     "CopterTests2a": "arducopter",
     "CopterTests2b": "arducopter",
 
@@ -384,13 +382,11 @@ def find_specific_test_to_run(step):
 
 tester_class_map = {
     "test.Copter": arducopter.AutoTestCopter,
-    "test.CopterTests1": arducopter.AutoTestCopterTests1,               # travis-ci
     "test.CopterTests1a": arducopter.AutoTestCopterTests1a, # 8m43s
     "test.CopterTests1b": arducopter.AutoTestCopterTests1b, # 8m5s
     "test.CopterTests1c": arducopter.AutoTestCopterTests1c, # 5m17s
     "test.CopterTests1d": arducopter.AutoTestCopterTests1d, # 8m20s
     "test.CopterTests1e": arducopter.AutoTestCopterTests1e, # 8m32s
-    "test.CopterTests2": arducopter.AutoTestCopterTests2,               # travis-ci
     "test.CopterTests2a": arducopter.AutoTestCopterTests2a, # 8m23s
     "test.CopterTests2b": arducopter.AutoTestCopterTests2b, # 8m18s
     "test.Plane": arduplane.AutoTestPlane,
@@ -1117,14 +1113,12 @@ if __name__ == "__main__":
     ]
 
     moresteps = [
-        'test.CopterTests1',
         'test.CopterTests1a',
         'test.CopterTests1b',
         'test.CopterTests1c',
         'test.CopterTests1d',
         'test.CopterTests1e',
 
-        'test.CopterTests2',
         'test.CopterTests2a',
         'test.CopterTests2b',
 
@@ -1155,14 +1149,12 @@ if __name__ == "__main__":
         "defaults.ArduSub": "defaults.Sub",
         "defaults.APMrover2": "defaults.Rover",
         "defaults.AntennaTracker": "defaults.Tracker",
-        "fly.ArduCopterTests1": "test.CopterTests1",
         "fly.ArduCopterTests1a": "test.CopterTests1a",
         "fly.ArduCopterTests1b": "test.CopterTests1b",
         "fly.ArduCopterTests1c": "test.CopterTests1c",
         "fly.ArduCopterTests1d": "test.CopterTests1d",
         "fly.ArduCopterTests1e": "test.CopterTests1e",
 
-        "fly.ArduCopterTests2": "test.CopterTests2",
         "fly.ArduCopterTests2a": "test.CopterTests2a",
         "fly.ArduCopterTests2b": "test.CopterTests2b",
 

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -92,11 +92,6 @@ for t in $CI_BUILD_TARGET; do
         run_autotest "Heli" "build.Helicopter" "test.Helicopter"
         continue
     fi
-    # travis-ci
-    if [ "$t" == "sitltest-copter-tests1" ]; then
-        run_autotest "Copter" "build.Copter" "test.CopterTests1"
-        continue
-    fi
     #github actions ci
     if [ "$t" == "sitltest-copter-tests1a" ]; then
         run_autotest "Copter" "build.Copter" "test.CopterTests1a"
@@ -118,13 +113,6 @@ for t in $CI_BUILD_TARGET; do
         run_autotest "Copter" "build.Copter" "test.CopterTests1e"
         continue
     fi
-
-    # travis-ci
-    if [ "$t" == "sitltest-copter-tests2" ]; then
-        run_autotest "Copter" "build.Copter" "test.CopterTests2"
-        continue
-    fi
-    #github actions ci
     if [ "$t" == "sitltest-copter-tests2a" ]; then
         run_autotest "Copter" "build.Copter" "test.CopterTests2a"
         continue


### PR DESCRIPTION
travis had a split into two tests, test1 and test2 - which we no longer need