### PR TITLE
Rover: fix overshoot beyond stopping dist in dock mode

### DIFF
--- a/Rover/mode_dock.cpp
+++ b/Rover/mode_dock.cpp
@@ -227,6 +227,9 @@ float ModeDock::apply_slowdown(float desired_speed)
     
     desired_speed = MAX(dock_speed_slowdown_lmt, fabsf(desired_speed) * (1 - error_ratio * slowdown_weight));
 
+    // restrict speed to avoid going beyond stopping distance
+    desired_speed = MIN(desired_speed, safe_sqrt(2 * fabsf(_distance_to_destination - stopping_dist) * g2.pos_control.get_accel_max()));
+
     // we worked on absolute value of speed before
     // make it negative again if reversed
     if (g2.pos_control.get_reversed()) {


### PR DESCRIPTION
This restricts the vehicle speed in DOCK mode such that it stops _before_ the stopping distance instead of overshooting beyond it.
I have tested this on SITL and my real rover. It worked perfect in both the cases.