### PR TITLE
AP_Proximity: Add support for CAN MR72

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1147,6 +1147,7 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CANManager::Driver_Type_Scripting:
                 case AP_CANManager::Driver_Type_Scripting2:
                 case AP_CANManager::Driver_Type_Benewake:
+                case AP_CANManager::Driver_Type_MR72:
                     break;
             }
         }

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -65,6 +65,7 @@ public:
         Driver_Type_Scripting = 10,
         Driver_Type_Benewake = 11,
         Driver_Type_Scripting2 = 12,
+        Driver_Type_MR72 = 13,
     };
 
     void init(void);

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -56,6 +56,7 @@ public:
         AirSimSITL = 12,
 #endif
         CYGBOT_D1 = 13,
+        MR72 = 14,
     };
 
     enum class Status {
@@ -145,7 +146,11 @@ public:
     struct Proximity_State {
         uint8_t instance;   // the instance number of this proximity sensor
         Status status;      // sensor status
+
+        const struct AP_Param::GroupInfo *var_info; // stores extra parameter information for the sensor (if it exists)
     };
+
+    static const struct AP_Param::GroupInfo *backend_var_info[PROXIMITY_MAX_INSTANCES];
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -67,6 +67,8 @@ protected:
     };
     static void database_push(float angle, float pitch, float distance, uint32_t timestamp_ms, const Vector3f &current_pos, const Matrix3f &body_to_ned);
 
+    HAL_Semaphore _sem;
+
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
     AP_Proximity_Params &params;            // parameters for this backend

--- a/libraries/AP_Proximity/AP_Proximity_MR72_CAN.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MR72_CAN.cpp
@@ -1,0 +1,131 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include "AP_Proximity_MR72_CAN.h"
+#include <AP_HAL/utility/sparse-endian.h>
+
+#if (HAL_PROXIMITY_ENABLED && AP_PROXIMITY_MR72_ENABLED)
+
+const AP_Param::GroupInfo AP_Proximity_MR72_CAN::var_info[] = {
+
+    // @Param: RECV_ID
+    // @DisplayName: CAN receive ID
+    // @Description: The receive ID of the CAN frames.
+    // @Range: 0 8
+    // @User: Advanced
+    AP_GROUPINFO("RECV_ID", 1, AP_Proximity_MR72_CAN, receive_id, 0),
+
+    AP_GROUPEND
+};
+
+MR72_MultiCAN *AP_Proximity_MR72_CAN::multican;
+
+AP_Proximity_MR72_CAN::AP_Proximity_MR72_CAN(AP_Proximity &_frontend,
+                                     AP_Proximity::Proximity_State &_state,
+                                     AP_Proximity_Params& _params):
+    AP_Proximity_Backend(_frontend, _state, _params)
+{
+    if (multican == nullptr) {
+        multican = new MR72_MultiCAN();
+        if (multican == nullptr) {
+            AP_BoardConfig::allocation_error("MR72_CAN");
+        }
+    }
+
+    {
+        // add to linked list of drivers
+        WITH_SEMAPHORE(multican->sem);
+        auto *prev = multican->drivers;
+        next = prev;
+        multican->drivers = this;
+    }
+
+    AP_Param::setup_object_defaults(this, var_info);
+    state.var_info = var_info;
+}
+
+
+
+// update state
+void AP_Proximity_MR72_CAN::update(void)
+{
+    WITH_SEMAPHORE(_sem);
+    const uint32_t now = AP_HAL::millis();
+    if (now - last_update_ms > 500) {
+        // no new data.
+        set_status(AP_Proximity::Status::NoData);
+    } else {
+        set_status(AP_Proximity::Status::Good);
+    }
+}
+
+// handler for incoming frames. These come in at 100Hz
+bool AP_Proximity_MR72_CAN::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(_sem);
+
+    // check if message is coming from the right sensor ID
+    const uint16_t id = frame.id;
+
+    if ((id & 0xF0) != (receive_id * 0x10)) {
+        return false;
+    }
+
+    switch (id & 0xF) {
+    case 0xA:
+        // number of objects
+        _object_count = frame.data[0];
+        _current_object_index = 0;
+        _temp_boundary.update_3D_boundary(state.instance, frontend.boundary);
+        _temp_boundary.reset();
+        last_update_ms = AP_HAL::millis();
+        break;
+    case 0xB:
+        // obstacle data
+        parse_distance_message(frame);
+        break;
+    default:
+        break;
+    }
+
+    return true;
+
+}
+
+bool AP_Proximity_MR72_CAN::parse_distance_message(AP_HAL::CANFrame &frame)
+{
+    if (_current_object_index >= _object_count) {
+        // should never happen
+        return false;
+    }
+    _current_object_index++;
+
+    Vector2f obstacle_fr;
+    obstacle_fr.x = ((frame.data[2]&0x07)*256+frame.data[3])*0.2-204.6;
+    obstacle_fr.y = (frame.data[1]*32+(frame.data[2] >> 3))*0.2-500;
+    float yaw = wrap_360(degrees(atan2f(-obstacle_fr.x, obstacle_fr.y)));
+    yaw = correct_angle_for_orientation(yaw);
+
+    const float objects_dist = obstacle_fr.length();
+
+    if (ignore_reading(yaw, objects_dist)) {
+        // obstacle is probably near ground or out of range
+        return false;
+    }
+
+    const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(yaw);
+    _temp_boundary.add_distance(face, yaw, objects_dist);
+    return true;
+}
+
+// handle frames from CANSensor, passing to the drivers
+void MR72_MultiCAN::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(sem);
+    for (auto *d = drivers; d; d=d->next) {
+        if (d->handle_frame(frame)) {
+            break;
+        }
+    }
+}
+
+#endif // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Proximity/AP_Proximity_MR72_CAN.h
+++ b/libraries/AP_Proximity/AP_Proximity_MR72_CAN.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "AP_Proximity.h"
+
+
+#ifndef AP_PROXIMITY_MR72_ENABLED
+#define AP_PROXIMITY_MR72_ENABLED (HAL_PROXIMITY_ENABLED && HAL_MAX_CAN_PROTOCOL_DRIVERS)
+#endif
+
+#if (HAL_PROXIMITY_ENABLED && AP_PROXIMITY_MR72_ENABLED)
+
+#include "AP_Proximity_Backend.h"
+#include <AP_HAL/AP_HAL.h>
+#include <AP_CANManager/AP_CANSensor.h>
+
+#define MR72_MAX_RANGE_M             50.0f   // max range of the sensor in meters
+#define MR72_MIN_RANGE_M             0.2f   // min range of the sensor in meters
+
+class MR72_MultiCAN;
+
+class AP_Proximity_MR72_CAN : public AP_Proximity_Backend {
+public:
+    friend class MR72_MultiCAN;
+
+    AP_Proximity_MR72_CAN(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_Proximity_Params& _params);
+
+    void update() override;
+
+    // handler for incoming frames. Return true if consumed
+    bool handle_frame(AP_HAL::CANFrame &frame);
+
+    bool parse_distance_message(AP_HAL::CANFrame &frame);
+
+      // get maximum and minimum distances (in meters) of sensor
+    float distance_max() const override { return MR72_MAX_RANGE_M; }
+    float distance_min() const override { return MR72_MIN_RANGE_M; }
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    AP_Proximity_Temp_Boundary _temp_boundary;
+
+private:
+    uint32_t _object_count;
+    uint32_t _current_object_index;
+
+    AP_Int32 receive_id;
+
+    uint32_t last_update_ms;
+
+    static MR72_MultiCAN *multican;
+    AP_Proximity_MR72_CAN *next;
+};
+
+// a class to allow for multiple MR_72 backends with one
+// CANSensor driver
+class MR72_MultiCAN : public CANSensor {
+public:
+    MR72_MultiCAN() : CANSensor("MR72") {
+        register_driver(AP_CANManager::Driver_Type_MR72);
+    }
+
+    // handler for incoming frames
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+
+    HAL_Semaphore sem;
+    AP_Proximity_MR72_CAN *drivers;
+
+};
+
+#endif // HAL_PROXIMITY_ENABLED
+


### PR DESCRIPTION
This adds CAN support for a 77GHz radar to the proximity lib: http://en.nanoradar.cn/Article/detail/id/488.html
This is the first radar and CAN sensor support in the Proximity library!

More testing to come soon. 

This work was sponsored by Sky Drones: https://skydrones.com.br/en/