### PR TITLE
Plane: add proportional term to VFWD control for VTOLs.

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -373,7 +373,9 @@ private:
 
     struct {
         AP_Float gain;
+		AP_Float p;
         float integrator;
+		float proportional;
         uint32_t last_ms;
         float last_pct;
     } vel_forward;


### PR DESCRIPTION
Proportional term added to original integrative term implementation of VFWD control in quadplanes. Aim to tighter control of velocity during VTOL modes (especially tilt-rotor&Tilt-wing)