### PR TITLE
autotest: remove disabled LogUpload test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8976,7 +8976,6 @@ class AutoTestCopter(AutoTest):
              self.PAUSE_CONTINUE_GUIDED,
              self.RichenPower,
              self.IE24,
-             self.LogUpload,
              self.MAVLandedStateTakeoff,
         ])
         return ret
@@ -9039,7 +9038,6 @@ class AutoTestCopter(AutoTest):
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,
-            self.LogUpload,
         ])
         return ret
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3998,7 +3998,6 @@ class AutoTestPlane(AutoTest):
             self.MSP_DJI,
             self.SpeedToFly,
             self.GlideSlopeThresh,
-            self.LogUpload,
             self.HIGH_LATENCY2,
             self.MidAirDisarmDisallowed,
         ])

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -413,7 +413,6 @@ class AutoTestSub(AutoTest):
             self.MotorThrustHoverParameterIgnore,
             self.SET_POSITION_TARGET_GLOBAL_INT,
             self.TestLogDownloadMAVProxy,
-            self.LogUpload,
         ])
 
         return ret

--- a/Tools/autotest/balancebot.py
+++ b/Tools/autotest/balancebot.py
@@ -115,7 +115,6 @@ inherit Rover's tests!'''
             self.GetBanner,
             self.DO_SET_MODE,
             self.ServoRelayEvents,
-            self.LogUpload,
         ])
         return ret
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3651,24 +3651,6 @@ class AutoTest(ABC):
         self.mavproxy_unload_module(mavproxy, 'log')
         self.stop_mavproxy(mavproxy)
 
-    def LogUpload(self):
-        '''upload logs to ArduPilot firmware server'''
-        self.progress("Log upload disabled as CI artifacts are good")
-        return
-        if len(self.fail_list) > 0 and os.getenv("AUTOTEST_UPLOAD"):
-            # optionally upload logs to server so we can see travis failure logs
-            import datetime
-            import glob
-            import subprocess
-            logdir = self.buildlogs_dirpath()
-            datedir = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M")
-            flist = glob.glob("logs/*.BIN")
-            for e in ['BIN', 'bin', 'tlog']:
-                flist += glob.glob(os.path.join(logdir, '*.%s' % e))
-            self.progress("Uploading %u logs to https://firmware.ardupilot.org/CI-Logs/%s" % (len(flist), datedir))
-            cmd = ['rsync', '-avz'] + flist + ['cilogs@autotest.ardupilot.org::CI-Logs/%s/' % datedir]
-            subprocess.call(cmd)
-
     def show_gps_and_sim_positions(self, on_off):
         """Allow to display gps and actual position on map."""
         if on_off is True:

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -438,7 +438,6 @@ class AutoTestHelicopter(AutoTestCopter):
             self.SplineWaypoint,
             self.AutoRotation,
             self.FlyEachFrame,
-            self.LogUpload,
             self.AirspeedDrivers,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -946,6 +946,5 @@ class AutoTestQuadPlane(AutoTest):
             self.MidAirDisarmDisallowed,
             self.BootInAUTO,
             self.Ship,
-            self.LogUpload,
         ])
         return ret

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6125,7 +6125,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.EndMissionBehavior,
             self.FlashStorage,
             self.FRAMStorage,
-            self.LogUpload,
             self.DepthFinder,
             self.ChangeModeByNumber,
             self.EStopAtBoot,


### PR DESCRIPTION
This has been unused for a long time, and is getting in the way of reforms.  Its position as a test rather than as a part of a framework was always going to cause oddities, particularly after we split the Copter tests into several chunks.