### PR TITLE
autotest: create and use a Result object to ship failure data around

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -421,8 +421,7 @@ class AutoTestCopter(AutoTest):
             os.path.join(testdir, "ch7_mission.txt"))
         self.stop_mavproxy(mavproxy)
         if not num_wp:
-            self.fail_list.append("save_mission_to_file")
-            self.progress("save_mission_to_file failed")
+            raise NotAchievedException("save_mission_to_file failed")
 
         self.progress("test: Fly a mission from 1 to %u" % num_wp)
         self.change_mode('AUTO')

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -785,8 +785,7 @@ def run_tests(steps):
             print("  %s:" % key)
             for testinstance in failed_testinstances[key]:
                 for failure in testinstance.fail_list:
-                    (desc, exception, debug_filename) = failure
-                    print("    %s (%s) (see %s)" % (desc, exception, debug_filename))
+                    print("  " + str(failure))
 
         print("FAILED %u tests: %s" % (len(failed), failed))
 


### PR DESCRIPTION
This attempts to simplify the way results are handled.

We need to preserve the creation of `self.fail_list` as the autotest.py script uses it when printing an overall test result summary.
