### PR TITLE
HAL_ChibiOS: increase short board names to 23 chars

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -120,7 +120,7 @@ public:
       Buf should be filled with a printable string and must be null
       terminated
      */
-    virtual bool get_system_id(char buf[40]) { return false; }
+    virtual bool get_system_id(char buf[50]) { return false; }
     virtual bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) { return false; }
 
     /**

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -372,22 +372,24 @@ Util::FlashBootloader Util::flash_bootloader()
 /*
   display system identifer - board type and serial number
  */
-bool Util::get_system_id(char buf[40])
+bool Util::get_system_id(char buf[50])
 {
     uint8_t serialid[12];
-    char board_name[14];
+    char board_name[24];
 
     memcpy(serialid, (const void *)UDID_START, 12);
-    strncpy(board_name, CHIBIOS_SHORT_BOARD_NAME, 13);
-    board_name[13] = 0;
+    // avoid board names greater than 23 chars (sizeof includes null char, so allow 24 bytes total)
+    static_assert(sizeof(CHIBIOS_SHORT_BOARD_NAME) <= 24, "CHIBIOS_SHORT_BOARD_NAME must be 23 characters or less");
+    strncpy(board_name, CHIBIOS_SHORT_BOARD_NAME, 23);
+    board_name[23] = 0;
 
     // this format is chosen to match the format used by HAL_PX4
-    snprintf(buf, 40, "%s %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X",
+    snprintf(buf, 50, "%s %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X",
              board_name,
              (unsigned)serialid[3], (unsigned)serialid[2], (unsigned)serialid[1], (unsigned)serialid[0],
              (unsigned)serialid[7], (unsigned)serialid[6], (unsigned)serialid[5], (unsigned)serialid[4],
              (unsigned)serialid[11], (unsigned)serialid[10], (unsigned)serialid[9],(unsigned)serialid[8]);
-    buf[39] = 0;
+    buf[49] = 0;
     return true;
 }
 

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -59,7 +59,7 @@ public:
     enum safety_state safety_switch_state(void) override;
 
     // get system ID as a string
-    bool get_system_id(char buf[40]) override;
+    bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
     bool toneAlarm_init(uint8_t types) override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-SimOnHardWare/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-SimOnHardWare/hwdef.dat
@@ -3,4 +3,7 @@
 include ../CubeOrange/hwdef.dat
 include ../include/SimOnHW.inc
 
+# short board name override (23 chars)
+define CHIBIOS_SHORT_BOARD_NAME "CubeOrangeSimOnHardWare"
+
 AUTOBUILD_TARGETS Copter

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -6,6 +6,9 @@ MCU STM32F4xx STM32F412Rx
 # board ID for firmware load
 APJ_BOARD_ID 9
 
+# short board name override (13 chars) to match original max length; can't change because name is used for transmitter bind CRC
+define CHIBIOS_SHORT_BOARD_NAME "skyviper-f412"
+
 # crystal frequency
 OSCILLATOR_HZ 24000000
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -6,6 +6,9 @@ MCU STM32F4xx STM32F412Rx
 # board ID for firmware load
 APJ_BOARD_ID 9
 
+# short board name override (13 chars) to match original max length; can't change because name is used for transmitter bind CRC
+define CHIBIOS_SHORT_BOARD_NAME "skyviper-jour"
+
 # crystal frequency
 OSCILLATOR_HZ 24000000
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -27,6 +27,9 @@ undef SDIO
 undef HAL_BOARD_LOG_DIRECTORY
 undef HAL_BOARD_TERRAIN_DIRECTORY
 
+# short board name override (13 chars) to match original max length; can't change because name is used for transmitter bind CRC
+define CHIBIOS_SHORT_BOARD_NAME "skyviper-v245"
+
 SERIAL_ORDER OTG1 USART2 EMPTY UART4
 
 # enable AP_Radio support

--- a/libraries/AP_HAL_ESP32/Util.cpp
+++ b/libraries/AP_HAL_ESP32/Util.cpp
@@ -214,7 +214,7 @@ Util::FlashBootloader Util::flash_bootloader()
  */
 
 
-bool Util::get_system_id(char buf[40])
+bool Util::get_system_id(char buf[50])
 {
     //uint8_t serialid[12];
     char board_name[14] = "esp32-buzz   ";

--- a/libraries/AP_HAL_ESP32/Util.h
+++ b/libraries/AP_HAL_ESP32/Util.h
@@ -51,7 +51,7 @@ public:
     enum safety_state safety_switch_state(void) override;
 
     // get system ID as a string
-    bool get_system_id(char buf[40]) override;
+    bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
 #ifdef HAL_PWM_ALARM

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -150,7 +150,7 @@ bool Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
   as get_system_id_unformatted will already be ascii, we use the same
   ID here
  */
-bool Util::get_system_id(char buf[40])
+bool Util::get_system_id(char buf[50])
 {
     uint8_t len = 40;
     return get_system_id_unformatted((uint8_t *)buf, len);

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -69,7 +69,7 @@ public:
 
     uint32_t available_memory(void) override;
 
-    bool get_system_id(char buf[40]) override;
+    bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
 #ifdef ENABLE_HEAP

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -72,7 +72,7 @@ bool HALSITL::Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
   as get_system_id_unformatted will already be ascii, we use the same
   ID here
  */
-bool HALSITL::Util::get_system_id(char buf[40])
+bool HALSITL::Util::get_system_id(char buf[50])
 {
     uint8_t len = 40;
     return get_system_id_unformatted((uint8_t *)buf, len);

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -42,7 +42,7 @@ public:
     void set_hw_rtc(uint64_t time_utc_usec) override { /* fail silently */ }
 
 
-    bool get_system_id(char buf[40]) override;
+    bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
     void dump_stack_trace();
 

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -279,7 +279,7 @@ void LoggerMessageWriter_WriteSysInfo::process() {
         FALLTHROUGH;
     }
     case Stage::SYSTEM_ID:
-        char sysid[40];
+        char sysid[50];
         if (hal.util->get_system_id(sysid)) {
             if (! _logger_backend->Write_Message(sysid)) {
                 return; // call me again

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -365,7 +365,7 @@ void AP_Radio_cc2500::radio_init(void)
     hal.gpio->attach_interrupt(HAL_GPIO_RADIO_IRQ, trigger_irq_radio_event, AP_HAL::GPIO::INTERRUPT_RISING);
 
     // fill in rxid for use in double bind prevention
-    char sysid[40] {};
+    char sysid[50] {};
     hal.util->get_system_id(sysid);
     uint16_t sysid_crc = calc_crc((const uint8_t *)sysid, strnlen(sysid, sizeof(sysid)));
     if (sysid_crc == 0) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3982,7 +3982,7 @@ void GCS_MAVLINK::send_banner()
     }
 
     // send system ID if we can
-    char sysid[40];
+    char sysid[50];
     if (hal.util->get_system_id(sysid)) {
         send_text(MAV_SEVERITY_INFO, "%s", sysid);
     }


### PR DESCRIPTION
EDIT: This started as a quick fix to improve the readability of QioTek board names in GCS banner messages, but Pete suggested a broader fix to allow for longer board names overall.

Discussion:
https://discuss.ardupilot.org/t/zealoth743-board-name-truncated-in-gcs-messages/86770