### PR TITLE
CAN: support sending actuators as PWM

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -219,7 +219,8 @@ public:
     void rcout_init();
     void rcout_init_1Hz();
     void rcout_esc(int16_t *rc, uint8_t num_channels);
-    void rcout_srv(const uint8_t actuator_id, const float command_value);
+    void rcout_srv_unitless(const uint8_t actuator_id, const float command_value);
+    void rcout_srv_PWM(const uint8_t actuator_id, const float command_value);
     void rcout_update();
     void rcout_handle_safety_state(uint8_t safety_state);
 #endif

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -796,11 +796,14 @@ static void handle_act_command(CanardInstance* ins, CanardRxTransfer* transfer)
     }
 
     for (uint8_t i=0; i < data_count; i++) {
-        if (data[i].command_type != UAVCAN_EQUIPMENT_ACTUATOR_COMMAND_COMMAND_TYPE_UNITLESS) {
-            // this is the only type we support
-            continue;
+        switch (data[i].command_type) {
+        case UAVCAN_EQUIPMENT_ACTUATOR_COMMAND_COMMAND_TYPE_UNITLESS:
+            periph.rcout_srv_unitless(data[i].actuator_id, data[i].command_value);
+            break;
+        case UAVCAN_EQUIPMENT_ACTUATOR_COMMAND_COMMAND_TYPE_PWM:
+            periph.rcout_srv_PWM(data[i].actuator_id, data[i].command_value);
+            break;
         }
-        periph.rcout_srv(data[i].actuator_id, data[i].command_value);
     }
 }
 #endif // HAL_PERIPH_ENABLE_RC_OUT

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -99,11 +99,21 @@ void AP_Periph_FW::rcout_esc(int16_t *rc, uint8_t num_channels)
     rcout_has_new_data_to_update = true;
 }
 
-void AP_Periph_FW::rcout_srv(uint8_t actuator_id, const float command_value)
+void AP_Periph_FW::rcout_srv_unitless(uint8_t actuator_id, const float command_value)
 {
 #if HAL_PWM_COUNT > 0
     const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
     SRV_Channels::set_output_norm(function, command_value);
+
+    rcout_has_new_data_to_update = true;
+#endif
+}
+
+void AP_Periph_FW::rcout_srv_PWM(uint8_t actuator_id, const float command_value)
+{
+#if HAL_PWM_COUNT > 0
+    const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
+    SRV_Channels::set_output_pwm(function, uint16_t(command_value+0.5));
 
     rcout_has_new_data_to_update = true;
 #endif

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -528,11 +528,13 @@ void AP_UAVCAN::SRV_send_actuator(void)
             if (_SRV_conf[starting_servo].servo_pending && ((((uint32_t) 1) << starting_servo) & _servo_bm)) {
                 cmd.actuator_id = starting_servo + 1;
 
-                // TODO: other types
-                cmd.command_type = uavcan::equipment::actuator::Command::COMMAND_TYPE_UNITLESS;
-
-                // TODO: failsafe, safety
-                cmd.command_value = constrain_float(((float) _SRV_conf[starting_servo].pulse - 1000.0) / 500.0 - 1.0, -1.0, 1.0);
+                if (option_is_set(Options::USE_ACTUATOR_PWM)) {
+                    cmd.command_type = uavcan::equipment::actuator::Command::COMMAND_TYPE_PWM;
+                    cmd.command_value = _SRV_conf[starting_servo].pulse;
+                } else {
+                    cmd.command_type = uavcan::equipment::actuator::Command::COMMAND_TYPE_UNITLESS;
+                    cmd.command_value = constrain_float(((float) _SRV_conf[starting_servo].pulse - 1000.0) / 500.0 - 1.0, -1.0, 1.0);
+                }
 
                 msg.commands.push_back(cmd);
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -203,6 +203,7 @@ public:
         DNA_IGNORE_DUPLICATE_NODE = (1U<<1),
         CANFD_ENABLED             = (1U<<2),
         DNA_IGNORE_UNHEALTHY_NODE = (1U<<3),
+        USE_ACTUATOR_PWM          = (1U<<4),
     };
 
     // check if a option is set


### PR DESCRIPTION
This makes debugging CAN servo setups easier
![image](https://user-images.githubusercontent.com/831867/189773435-c2c5642f-3367-4e6d-b690-cbe10c073a44.png)
