### PR TITLE
Harmonic notch slew limit

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1615,6 +1615,7 @@ void AP_InertialSensor::HarmonicNotch::update_params(uint8_t instance, bool conv
     const float center_freq = calculated_notch_freq_hz[0];
     if (!is_equal(last_bandwidth_hz[instance], params.bandwidth_hz()) ||
         !is_equal(last_attenuation_dB[instance], params.attenuation_dB()) ||
+        (params.tracking_mode() == HarmonicNotchDynamicMode::Fixed && !is_equal(last_center_freq_hz[instance], center_freq)) ||
         converging) {
         filter[instance].init(gyro_rate,
                               center_freq,
@@ -1623,7 +1624,7 @@ void AP_InertialSensor::HarmonicNotch::update_params(uint8_t instance, bool conv
         last_center_freq_hz[instance] = center_freq;
         last_bandwidth_hz[instance] = params.bandwidth_hz();
         last_attenuation_dB[instance] = params.attenuation_dB();
-    } else if (!is_equal(last_center_freq_hz[instance], center_freq)) {
+    } else if (params.tracking_mode() != HarmonicNotchDynamicMode::Fixed) {
         if (num_calculated_notch_frequencies > 1) {
             filter[instance].update(num_calculated_notch_frequencies, calculated_notch_freq_hz);
         } else {

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -20,6 +20,10 @@
 
 #include "NotchFilter.h"
 
+const static float NOTCH_MAX_SLEW       = 0.05f;
+const static float NOTCH_MAX_SLEW_LOWER = 1.0f - NOTCH_MAX_SLEW;
+const static float NOTCH_MAX_SLEW_UPPER = 1.0f / NOTCH_MAX_SLEW_LOWER;
+
 /*
    calculate the attenuation and quality factors of the filter
  */
@@ -43,6 +47,7 @@ void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float band
     // check center frequency is in the allowable range
     if ((center_freq_hz > 0.5 * bandwidth_hz) && (center_freq_hz < 0.5 * sample_freq_hz)) {
         float A, Q;
+        _center_freq_hz = center_freq_hz;
         calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
         init_with_A_and_Q(sample_freq_hz, center_freq_hz, A, Q);
     } else {
@@ -53,8 +58,16 @@ void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float band
 template <class T>
 void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q)
 {
-    if ((center_freq_hz > 0.0) && (center_freq_hz < 0.5 * sample_freq_hz) && (Q > 0.0)) {
-        float omega = 2.0 * M_PI * center_freq_hz / sample_freq_hz;
+    float new_center_freq = center_freq_hz;
+
+    // constrain the new center frequency by a percentage of the old frequency
+    if (initialised && !need_reset && !is_zero(_center_freq_hz)) {
+        new_center_freq = constrain_float(new_center_freq, _center_freq_hz * NOTCH_MAX_SLEW_LOWER,
+                                          _center_freq_hz * NOTCH_MAX_SLEW_UPPER);
+    }
+
+    if ((new_center_freq > 0.0) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)) {
+        float omega = 2.0 * M_PI * new_center_freq / sample_freq_hz;
         float alpha = sinf(omega) / (2 * Q);
         b0 =  1.0 + alpha*sq(A);
         b1 = -2.0 * cosf(omega);
@@ -62,8 +75,10 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
         a0_inv =  1.0/(1.0 + alpha);
         a1 = b1;
         a2 =  1.0 - alpha;
+        _center_freq_hz = new_center_freq;
         initialised = true;
     } else {
+        // leave center_freq_hz at last value
         initialised = false;
     }
 }

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -42,6 +42,7 @@ private:
 
     bool initialised, need_reset;
     float b0, b1, b2, a1, a2, a0_inv;
+    float _center_freq_hz;
     T ntchsig, ntchsig1, ntchsig2, signal2, signal1;
 };
 


### PR DESCRIPTION
This PR constraints the maximum change allowed per-tick to the harmonic notch center frequency as a percentage of the old frequency. Experiments show that rapid changes to the center frequency can result in filter instability and cascading failures.

This works well and solves the problem on my 5" Beater with KakuteH7v2. Lower values prevent filter instability entirely at some cost to accuracy. Higher values allow more accurate tracking but can result in filter instability in extreme conditions, however this PR also prevents runaway instability.

Flying at 5% (0.05) gave less control in propwash due to the filter tracking less well. Flying at 10% (0.1) made it possible to provoke the issue but in a very subdued form. 7.5% (0.075) turned out to be a good compromise.