### PR TITLE
SITL: fixed tailsitter airspeed in RF9

### DIFF
--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -494,7 +494,7 @@ void FlightAxis::update(const struct sitl_input &input)
     Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
 
     if (last_imu_rotation != ROTATION_NONE) {
-        airspeed3d = sitl->ahrs_rotation_inv * airspeed3d;
+        airspeed3d = sitl->ahrs_rotation * airspeed3d;
     }
     airspeed_pitot = MAX(airspeed3d.x,0);
 


### PR DESCRIPTION
the rotation was backwards since https://github.com/ArduPilot/ardupilot/pull/21268
the previous code relied on a double error to get correct airspeed for tailsitters
