### PR TITLE
AP_Motors: move PWM range check from copter and plane

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -252,12 +252,6 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Invalid MultiCopter FRAME_CLASS");
             return false;
         }
-
-        // checks MOT_PWM_MIN/MAX for acceptable values
-        if (!copter.motors->check_mot_pwm_params()) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check MOT_PWM_MIN/MAX");
-            return false;
-        }
         #endif // HELI_FRAME
 
         // checks when using range finder for RTL

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -185,10 +185,6 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
         check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
         ret = false;
     }
-    if (!plane.quadplane.motors->check_mot_pwm_params()) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check Q_M_PWM_MIN/MAX");
-        ret = false;
-    }
 
     if (plane.quadplane.option_is_set(QuadPlane::OPTION::ONLY_ARM_IN_QMODE_OR_AUTO)) {
         if (!plane.control_mode->is_vtol_mode() && (plane.control_mode != &plane.mode_auto) && (plane.control_mode != &plane.mode_guided)) {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7449,14 +7449,29 @@ class AutoTestCopter(AutoTest):
             "MOT_PWM_MAX": 50,
         })
         self.drain_mav()
-        self.assert_prearm_failure("Check MOT_PWM_MIN/MAX")
+        self.assert_prearm_failure("Motors: Check MOT_PWM_MIN and MOT_PWM_MAX")
         self.progress("invalid; min must be less than max (equal case):")
         self.set_parameters({
             "MOT_PWM_MIN": 100,
             "MOT_PWM_MAX": 100,
         })
         self.drain_mav()
-        self.assert_prearm_failure("Check MOT_PWM_MIN/MAX")
+        self.assert_prearm_failure("Motors: Check MOT_PWM_MIN and MOT_PWM_MAX")
+        self.progress("Spin min more than 0.3")
+        self.set_parameters({
+            "MOT_PWM_MIN": 1000,
+            "MOT_PWM_MAX": 2000,
+            "MOT_SPIN_MIN": 0.5,
+        })
+        self.drain_mav()
+        self.assert_prearm_failure("PreArm: Motors: MOT_SPIN_MIN too high 0.50 > 0.3")
+        self.progress("Spin arm more than spin min")
+        self.set_parameters({
+            "MOT_SPIN_MIN": 0.1,
+            "MOT_SPIN_ARM": 0.2,
+        })
+        self.drain_mav()
+        self.assert_prearm_failure("PreArm: Motors: MOT_SPIN_ARM > MOT_SPIN_MIN")
 
     def SensorErrorFlags(self):
         '''Test we get ERR messages when sensors have issues'''

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -19,6 +19,13 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger.h>
 
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+    #define AP_MOTORS_PARAM_PREFIX "Q_M_"
+#else
+    #define AP_MOTORS_PARAM_PREFIX "MOT_"
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 // parameters for the motor class
@@ -823,12 +830,17 @@ bool AP_MotorsMulticopter::arming_checks(size_t buflen, char *buffer) const
         }
     }
 
+    // Check param config
     if (_spin_min > 0.3) {
-        hal.util->snprintf(buffer, buflen, "SPIN_MIN too high %.2f, max 0.3", _spin_min.get());
+        hal.util->snprintf(buffer, buflen, "%sSPIN_MIN too high %.2f > 0.3", AP_MOTORS_PARAM_PREFIX, _spin_min.get());
         return false;
     }
     if (_spin_arm > _spin_min) {
-        hal.util->snprintf(buffer, buflen, "SPIN_ARM higher than SPIN_MIN");
+        hal.util->snprintf(buffer, buflen, "%sSPIN_ARM > %sSPIN_MIN", AP_MOTORS_PARAM_PREFIX, AP_MOTORS_PARAM_PREFIX);
+        return false;
+    }
+    if (!check_mot_pwm_params()) {
+        hal.util->snprintf(buffer, buflen, "Check %sPWM_MIN and %sPWM_MAX", AP_MOTORS_PARAM_PREFIX, AP_MOTORS_PARAM_PREFIX);
         return false;
     }
 


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/21635 this moves the PWM range check in to the AP_Motors pre-arm. ~The only disadvantage is we loose the param prefix, `MOT_` or `Q_M_`, we could add it back with a vehicle dependent define.~