### PR TITLE
Populate COMMAND_ACK with sysid/compid from received message

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -645,7 +645,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi(const Location &roi_loc
     return MAV_RESULT_ACCEPTED;
 }
 
-MAV_RESULT GCS_MAVLINK_Copter::handle_preflight_reboot(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Copter::handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     // reject reboot if user has also specified they want the "Auto" ESC calibration on next reboot
     if (copter.g.esc_calibrate == (uint8_t)Copter::ESCCalibrationModes::ESCCAL_AUTO) {
@@ -654,7 +654,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_preflight_reboot(const mavlink_command_lon
     }
 
     // call parent
-    return GCS_MAVLINK::handle_preflight_reboot(packet);
+    return GCS_MAVLINK::handle_preflight_reboot(packet, msg);
 }
 
 bool GCS_MAVLINK_Copter::set_home_to_current_location(bool _lock) {

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -28,7 +28,7 @@ protected:
     void send_position_target_local_ned() override;
 
     MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
-    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
 #if HAL_MOUNT_ENABLED
     MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet) override;
 #endif

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -431,12 +431,6 @@ MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi(const Location &roi_loc)
     return MAV_RESULT_ACCEPTED;
 }
 
-MAV_RESULT GCS_MAVLINK_Blimp::handle_preflight_reboot(const mavlink_command_long_t &packet)
-{
-    // call parent
-    return GCS_MAVLINK::handle_preflight_reboot(packet);
-}
-
 bool GCS_MAVLINK_Blimp::set_home_to_current_location(bool _lock)
 {
     return blimp.set_home_to_current_location(_lock);

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -26,7 +26,6 @@ protected:
     void send_position_target_global_int() override;
 
     MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
-    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;

--- a/Tools/AP_Periph/GCS_MAVLink.cpp
+++ b/Tools/AP_Periph/GCS_MAVLink.cpp
@@ -67,7 +67,7 @@ uint8_t GCS_Periph::sysid_this_mav() const
     return periph.g.sysid_this_mav;
 }
 
-MAV_RESULT GCS_MAVLINK_Periph::handle_preflight_reboot(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Periph::handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     hal.scheduler->delay(10);
     periph.prepare_reboot();

--- a/Tools/AP_Periph/GCS_MAVLink.h
+++ b/Tools/AP_Periph/GCS_MAVLink.h
@@ -31,7 +31,7 @@ private:
     uint32_t telem_delay() const override { return 0; }
     void handleMessage(const mavlink_message_t &msg) override { handle_common_message(msg); }
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override { return true; }
-    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
 
 protected:
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -503,7 +503,7 @@ protected:
     void handle_common_message(const mavlink_message_t &msg);
     void handle_set_gps_global_origin(const mavlink_message_t &msg);
     void handle_setup_signing(const mavlink_message_t &msg) const;
-    virtual MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
 
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);


### PR DESCRIPTION
These fields are only available in the message, so make this a handler where we pass through the message.

This PR also removes the empty override for Blimp.

```
Before:

STABILIZE> Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
< COMMAND_ACK {command : 246, result : 0, progress : 0, result_param2 : 0, target_system : 0, target_component : 0}

After:
STABILIZE> Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
< COMMAND_ACK {command : 246, result : 0, progress : 0, result_param2 : 0, target_system : 255, target_component : 230}
```

Note that our other `COMMAND_ACK`s already fill this in correctly - but rebooting is done specially.
