### PR TITLE
AP_HAL_SITL: Accurate 10 counts

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -272,6 +272,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
         if (fill_count++ % 10 == 0) {
             // only fill every 10 loops. This still gives us a lot of
             // protection, but saves a lot of CPU
+            fill_count = 1u;
             fill_stack_nan();
         }
         callbacks->loop();


### PR DESCRIPTION
fill_count is a UINT8_T value.
Therefore, the next value after 255 will be 0 and will not be a 10-count cycle.
I will use 10-count cycles.

BEFORE
![Screenshot from 2022-09-14 23-35-15](https://user-images.githubusercontent.com/646194/190191815-3f24f27f-9027-4807-a80a-959da3466657.png)