### PR TITLE
Autotest: fixes bisect-helper for python 3.10

### DIFF
--- a/Tools/autotest/bisect-helper.py
+++ b/Tools/autotest/bisect-helper.py
@@ -65,7 +65,7 @@ import traceback
 def get_exception_stacktrace(e):
     if sys.version_info[0] >= 3:
         ret = "%s\n" % e
-        ret += ''.join(traceback.format_exception(etype=type(e),
+        ret += ''.join(traceback.format_exception(type(e),
                                                   value=e,
                                                   tb=e.__traceback__))
         return ret


### PR DESCRIPTION
Same fix as #20235 for the exception handler.