### PR TITLE
Plane: always report the airspeed estimate being used in VFR hud

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -248,8 +248,8 @@ float GCS_MAVLINK_Plane::vfr_hud_airspeed() const
     // ground speed.  When reporting we should send the true airspeed
     // value if possible:
 #if AP_AIRSPEED_ENABLED
-    if (plane.airspeed.enabled() && plane.airspeed.healthy()) {
-        return plane.airspeed.get_airspeed();
+    if (plane.ahrs.airspeed_sensor_enabled()) {
+        return plane.airspeed.get_airspeed(plane.ahrs.get_active_airspeed_index());
     }
 #endif
 


### PR DESCRIPTION
Currently a unused airspeed sensor (`ARSPD_USE` = 0) will be reported rather than the airspeed estimate that the vehicle is actually flying to. This changes to use the same criteria and index as `ahrs.airspeed_estimate`, however as stated in the existing comment we do not constrain with wind max as we would via ahrs. 

I'm actually quite tempted to remove this extra case all together and always report the exact ahrs airspeed the vehicle is flying to, I think that is more important than reporting the exact airspeed measured, as it is included in other messages, sort of anyway (`SCALED_PRESSURE`). 