### PR TITLE
APM_Control: Plane controllers: only autotune if not in assisted flight

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -20,6 +20,8 @@
 #include "AP_PitchController.h"
 #include <AP_AHRS/AP_AHRS.h>
 
+#include <../ArduPlane/quadplane.h>
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_PitchController::var_info[] = {
@@ -207,7 +209,14 @@ float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool d
     // remember the last output to trigger the I limit
     _last_out = out;
 
-    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min) {
+    // Only run autotune if in un-assisted forward flight
+#if HAL_QUADPLANE_ENABLED
+    const bool assisted_flight = QuadPlane::get_singleton()->in_assisted_flight();
+#else
+    const bool assisted_flight = false;
+#endif
+
+    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min && !assisted_flight) {
         // let autotune have a go at the values
         autotune->update(pinfo, scaler, angle_err_deg);
     }

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -21,6 +21,8 @@
 #include "AP_YawController.h"
 #include <AP_AHRS/AP_AHRS.h>
 
+#include <../ArduPlane/quadplane.h>
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_YawController::var_info[] = {
@@ -330,7 +332,14 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
     // remember the last output to trigger the I limit
     _last_out = out;
 
-    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min) {
+    // Only run autotune if in un-assisted forward flight
+#if HAL_QUADPLANE_ENABLED
+    const bool assisted_flight = QuadPlane::get_singleton()->in_assisted_flight();
+#else
+    const bool assisted_flight = false;
+#endif
+
+    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min && !assisted_flight) {
         // fake up an angular error based on a notional time constant of 0.5s
         const float angle_err_deg = desired_rate * gains.tau;
         // let autotune have a go at the values


### PR DESCRIPTION
Tuning FW gains is not valid if Q motors are also stabilising. 

Gone via singleton but could also pass a bool. 