### PR TITLE
Plane: only log steer and yaw PIDs if there doing something

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -42,8 +42,14 @@ void Plane::Log_Write_Attitude(void)
 
     logger.Write_PID(LOG_PIDR_MSG, rollController.get_pid_info());
     logger.Write_PID(LOG_PIDP_MSG, pitchController.get_pid_info());
-    logger.Write_PID(LOG_PIDY_MSG, yawController.get_pid_info());
-    logger.Write_PID(LOG_PIDS_MSG, steerController.get_pid_info());
+
+    if (yawController.enabled()) {
+        logger.Write_PID(LOG_PIDY_MSG, yawController.get_pid_info());
+    }
+
+    if (steerController.active()) {
+        logger.Write_PID(LOG_PIDS_MSG, steerController.get_pid_info());
+    }
 
     AP::ahrs().Log_Write();
 }

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -249,3 +249,9 @@ void AP_SteerController::reset_I()
 	_pid_info.I = 0;
 }
 
+// Returns true if controller has been run recently
+bool AP_SteerController::active() const
+{
+    return (AP_HAL::millis() - _last_t) < 1000;
+}
+

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -50,6 +50,9 @@ public:
         _reverse = reverse;
     }
 
+    // Returns true if controller has been run recently
+    bool active() const;
+
 private:
     AP_Float _tau;
 	AP_Float _K_FF;

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -14,6 +14,9 @@ public:
     AP_YawController(const AP_YawController &other) = delete;
     AP_YawController &operator=(const AP_YawController&) = delete;
 
+    // return true if rate control or damping is enabled
+    bool enabled() const { return rate_control_enabled() || (_K_D > 0.0); } 
+
     // return true if rate control is enabled
     bool rate_control_enabled(void) const { return _rate_enable != 0; }
 


### PR DESCRIPTION
Should result in a significant reduction in log size with full rate logging. 