### PR TITLE
SRV_Channel: adjust trim, check all channels for range limit

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -684,7 +684,7 @@ void SRV_Channels::adjust_trim(SRV_Channel::Aux_servo_function_t function, float
         } else if (change < 0 && trim_scaled > 0.4f) {
             new_trim--;
         } else {
-            return;
+            continue;
         }
         c.servo_trim.set(new_trim);
 


### PR DESCRIPTION
Currently if the first channel of a particular function is outside of the 40% to 60% limit the remainder of the channels are not checked. This could result auto trim not working with differential ailerons where travel in one direction is reduced by design. 