### PR TITLE
AP_Mount: remove set_mode overrides to fix mode defaulting at startup

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -53,7 +53,7 @@ public:
     enum MAV_MOUNT_MODE get_mode() const { return _mode; }
 
     // set mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode) { _mode = mode; }
+    void set_mode(enum MAV_MOUNT_MODE mode) { _mode = mode; }
 
     // set yaw_lock.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
     // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -104,18 +104,6 @@ void AP_Mount_SToRM32::update()
     }
 }
 
-// set_mode - sets mount's mode
-void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    // record the mode change
-    _mode = mode;
-}
-
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_SToRM32::get_attitude_quaternion(Quaternion& att_quat)
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -32,9 +32,6 @@ public:
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
     bool has_pan_control() const override { return yaw_range_valid(); }
 
-    // set_mode - sets mount's mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override;
-
 protected:
 
     // get attitude as a quaternion.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -133,18 +133,6 @@ void AP_Mount_SToRM32_serial::update()
     }
 }
 
-// set_mode - sets mount's mode
-void AP_Mount_SToRM32_serial::set_mode(enum MAV_MOUNT_MODE mode)
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    // record the mode change
-    _mode = mode;
-}
-
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_SToRM32_serial::get_attitude_quaternion(Quaternion& att_quat)
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -35,9 +35,6 @@ public:
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
     bool has_pan_control() const override { return yaw_range_valid(); };
 
-    // set_mode - sets mount's mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override;
-
 protected:
 
     // get attitude as a quaternion.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -103,18 +103,6 @@ void AP_Mount_SoloGimbal::update()
     }
 }
 
-// set_mode - sets mount's mode
-void AP_Mount_SoloGimbal::set_mode(enum MAV_MOUNT_MODE mode)
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    // record the mode change
-    _mode = mode;
-}
-
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_SoloGimbal::get_attitude_quaternion(Quaternion& att_quat)
 {

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -32,9 +32,6 @@ public:
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
     bool has_pan_control() const override { return false; }
 
-    // set_mode - sets mount's mode
-    void set_mode(enum MAV_MOUNT_MODE mode) override;
-
     // handle a GIMBAL_REPORT message
     void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t &msg) override;
     void handle_gimbal_torque_report(mavlink_channel_t chan, const mavlink_message_t &msg);


### PR DESCRIPTION
This fixes a bug in the Solo, SToRM32 MAVLink and (maybe) SToRM32 serial drivers that would cause the MNTx_DEFLT_MODE parameter to be ignored.

The user would set this parameter to the mode they would like the gimbal to be in after startup (e.g. RC_TARGETING) but it had no effect because these drivers override the set_mode() method so that it immediately returns if the gimbal is not yet "initialised".

The SToRM32_MAVLink gimbal, the gimbal is not "initialised" until the update() method has been called at least once and the find_gimbal() method has searched the mavlink routing tablet and found the gimbal (e.g. the gimbal must have sent at lesat one message to the autopilot)

There is no need to block setting the AP_Mount's driver's mode because this only controls the source of the angle targets sent to the gimbal.  It does not affect what kinds of messages are sent to the gimbal or when they are sent to the gimbal.

Thanks to @CraigElder for reporting this and confirming it resolved the issues he was seeing with the SToRM32 MAVLink driver (e.g. MNT1_TYPE = 4)

Testing still required:

- [ ] Solo gimbal
- [ ] SToRM32 serial gimbal