### PR TITLE
Add lookup tables for VTX power settings to fix many SmartAudio bugs

### DIFF
--- a/libraries/AP_VideoTX/AP_SmartAudio.h
+++ b/libraries/AP_VideoTX/AP_SmartAudio.h
@@ -66,7 +66,7 @@
 
 #define SMARTAUDIO_BANDCHAN_TO_INDEX(band, channel) (band * VTX_MAX_CHANNELS + (channel))
 
-// #define SA_DEBUG
+//#define SA_DEBUG
 
 class AP_SmartAudio
 {
@@ -85,7 +85,8 @@ public:
         uint16_t frequency;
         uint8_t  band;
 
-        uint8_t* power_levels;
+        uint8_t num_power_levels;
+        uint8_t power_levels[8];
         uint8_t  power_in_dbm;
 
         uint16_t pitmodeFrequency;
@@ -136,14 +137,10 @@ public:
     } PACKED;
 
     struct SettingsExtendedResponseFrame {
-        FrameHeader header;
-        uint8_t channel;
-        uint8_t power;
-        uint8_t operationMode;
-        uint16_t frequency;
-        uint8_t power_dbm;
-        uint8_t power_levels_len;
-        uint8_t power_dbm_levels;   // first in the list of dbm levels
+        SettingsResponseFrame settings;
+        uint8_t power_dbm;  // current power
+        uint8_t num_power_levels;
+        uint8_t power_levels[8];   // first in the list of dbm levels
         //uint8_t crc;
     } PACKED;
 
@@ -217,12 +214,14 @@ private:
 
 #ifdef SA_DEBUG
     // utility method for debugging.
-    void print_bytes_to_hex_string(const char* msg, const uint8_t buf[], uint8_t x,uint8_t offset);
+    void print_bytes_to_hex_string(const char* msg, const uint8_t buf[], uint8_t length);
 #endif
     void print_settings(const Settings* settings);
 
     void update_vtx_params();
     void update_vtx_settings(const Settings& settings);
+
+    bool ignore_crc() const { return AP::vtx().has_option(AP_VideoTX::VideoOptions::VTX_SA_IGNORE_CRC); }
 
     // looping over requests
     void loop();

--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -111,6 +111,7 @@ char AP_Tramp::handle_response(void)
 
             // update the vtx
             AP_VideoTX& vtx = AP::vtx();
+            bool update_pending = vtx.have_params_changed();
             vtx.set_frequency_mhz(freq);
 
             AP_VideoTX::VideoBand band;
@@ -128,7 +129,10 @@ char AP_Tramp::handle_response(void)
             }
 
             // make sure the configured values now reflect reality
-            vtx.set_defaults();
+            // if they do then announce if there were changes
+            if (!vtx.set_defaults() && update_pending && !vtx.have_params_changed()) {
+                vtx.announce_vtx_settings();
+            }
 
             debug("device config: freq: %u, power: %u, pitmode: %u",
                 unsigned(freq), unsigned(power), unsigned(pit_mode));

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -515,7 +515,7 @@ void AP_VideoTX::change_power(int8_t position)
     debug("looking for pos %d power level %d from %d", position, level, num_active_levels);
     uint16_t power = 0;
     for (uint8_t i = 0, j = 0; i < num_active_levels; i++, j++) {
-        while (_power_levels[j].active == PowerActive::Inactive && j < VTX_MAX_POWER_LEVELS-1) {
+        while (j < VTX_MAX_POWER_LEVELS-1 && _power_levels[j].active == PowerActive::Inactive) {
             j++;
         }
         if (i == level) {

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -17,6 +17,7 @@
 #include <AP_Param/AP_Param.h>
 
 #define VTX_MAX_CHANNELS 8
+#define VTX_MAX_POWER_LEVELS 9
 
 class AP_VideoTX {
 public:
@@ -44,6 +45,9 @@ public:
         VTX_PITMODE_ON_DISARM = (1 << 2),
         VTX_UNLOCKED          = (1 << 3),
         VTX_PULLDOWN          = (1 << 4),
+        VTX_SA_ONE_STOP_BIT   = (1 << 5),
+        VTX_SA_IGNORE_CRC     = (1 << 6),
+        VTX_CRSF_IGNORE_STAT  = (1 << 7),
     };
 
     static const char *band_names[];
@@ -58,6 +62,22 @@ public:
         MAX_BANDS
     };
 
+    enum class PowerActive {
+        Unknown,
+        Active,
+        Inactive
+    };
+
+    struct PowerLevel {
+        uint8_t level;
+        uint16_t mw;
+        uint8_t dbm;
+        uint8_t dac; // SmartAudio v1 dac value
+        PowerActive active;
+    };
+
+    static PowerLevel _power_levels[VTX_MAX_POWER_LEVELS];
+
     static const uint16_t VIDEO_CHANNELS[MAX_BANDS][VTX_MAX_CHANNELS];
 
     static uint16_t get_frequency_mhz(uint8_t band, uint8_t channel) { return VIDEO_CHANNELS[band][channel]; }
@@ -70,15 +90,31 @@ public:
     bool update_frequency() const { return _defaults_set && _frequency_mhz != _current_frequency; }
     void update_configured_frequency();
     // get / set power level
-    void set_power_mw(uint16_t power) { _current_power = power; }
-    void set_power_level(uint8_t level);
-    void set_power_dbm(uint8_t power);
+    void set_power_mw(uint16_t power);
+    void set_power_level(uint8_t level, PowerActive active=PowerActive::Active);
+    void set_power_dbm(uint8_t power, PowerActive active=PowerActive::Active);
+    void set_power_dac(uint16_t power, PowerActive active=PowerActive::Active);
+    // add a new dbm setting to those supported
+    uint8_t update_power_dbm(uint8_t power, PowerActive active=PowerActive::Active);
+    void update_all_power_dbm(uint8_t nlevels, const uint8_t levels[]);
     void set_configured_power_mw(uint16_t power);
     uint16_t get_configured_power_mw() const { return _power_mw; }
-    uint16_t get_power_mw() const { return _current_power; }
-    uint8_t get_configured_power_dbm() const;
-    uint8_t get_configured_power_level() const;
-    bool update_power() const { return _defaults_set && _power_mw != _current_power; }
+    uint16_t get_power_mw() const { return _power_levels[_current_power].mw; }
+
+    // get the power in dbm, rounding appropriately
+    uint8_t get_configured_power_dbm() const {
+        return _power_levels[find_current_power()].dbm;
+    }
+    // get the power "level"
+    uint8_t get_configured_power_level() const {
+        return _power_levels[find_current_power()].level & 0xF;
+    }
+    // get the power "dac"
+    uint8_t get_configured_power_dac() const {
+        return _power_levels[find_current_power()].dac;
+    }
+
+    bool update_power() const;
     // change the video power based on switch input
     void change_power(int8_t position);
     // get / set the frequency band
@@ -95,11 +131,13 @@ public:
     bool update_channel() const { return _defaults_set && _channel != _current_channel; }
     void update_configured_channel_and_band();
     // get / set vtx option
-    void set_options(uint8_t options) { _current_options = options; }
-    void set_configured_options(uint8_t options) { _options.set_and_save_ifchanged(options); }
-    uint8_t get_configured_options() const { return _options; }
-    uint8_t get_options() const { return _current_options; }
-    bool has_option(VideoOptions option) const { return _options.get() & uint8_t(option); }
+    void set_options(uint16_t options) { _current_options = options; }
+    void set_configured_options(uint16_t options) { _options.set_and_save_ifchanged(options); }
+    uint16_t get_configured_options() const { return _options; }
+    uint16_t get_options() const { return _current_options; }
+    bool has_option(VideoOptions option) const { return _options.get() & uint16_t(option); }
+    bool get_configured_pitmode() const { return _options.get() & uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE); }
+    bool get_pitmode() const { return _current_options & uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE); }
     bool update_options() const;
     // get / set whether the vtx is enabled
     void set_enabled(bool enabled);
@@ -112,6 +150,10 @@ public:
     bool set_defaults();
     // display the current VTX settings in the GCS
     void announce_vtx_settings() const;
+    // force the current values to reflect the configured values
+    void set_power_is_current();
+    void set_freq_is_current();
+    void set_options_are_current() {  _current_options = _options; }
 
     void set_configuration_finished(bool configuration_finished) { _configuration_finished = configuration_finished; }
     bool is_configuration_finished() { return _configuration_finished; }
@@ -119,6 +161,7 @@ public:
     static AP_VideoTX *singleton;
 
 private:
+    uint8_t find_current_power() const;
     // channel frequency
     AP_Int16 _frequency_mhz;
     uint16_t _current_frequency;
@@ -137,8 +180,8 @@ private:
     uint8_t _current_channel;
 
     // vtx options
-    AP_Int8 _options;
-    uint8_t _current_options;
+    AP_Int16 _options;
+    uint16_t _current_options;
 
     AP_Int8 _enabled;
     bool _current_enabled;
@@ -146,7 +189,7 @@ private:
     bool _initialized;
     // when defaults have been configured
     bool _defaults_set;
-    // true when configuration have been applied succesfully to the VTX
+    // true when configuration have been applied successfully to the VTX
     bool _configuration_finished;
 };
 


### PR DESCRIPTION
Split from https://github.com/ArduPilot/ardupilot/pull/19497

correct settings when power set is received
add support for capturing all supported power levels learn power levels in SmartAudio 2.1
add better support for VTX power levels
don't set power to 0 if in pitmode
add option for iNav compatibility
support non-conforming SmartAudio implementations
re-enable pitmode on SmartAudio 2.0
add support for "blind" VTX setting