### PR TITLE
AP_Filesystem_Param: Better estimation of filesize

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -469,8 +469,8 @@ int AP_Filesystem_Param::stat(const char *name, struct stat *stbuf)
         return -1;
     }
     memset(stbuf, 0, sizeof(*stbuf));
-    // give fixed size to avoid needing to scan entire file
-    stbuf->st_size = 1024*1024;
+    // give size estimation to avoid needing to scan entire file
+    stbuf->st_size = AP_Param::count_parameters() * 12;
     return 0;
 }
 


### PR DESCRIPTION
The actual filesize of the parameter downloadfile is around 15200 bytes. The indicated filesize is used in QGC for the progressbar. This patch does not try to compute the exact filesize but to do a better estimate. Only the full download is considered to avoid more complexity. So the actual fixed number is 1 MByte while the new estimation for 1350 parameters is 16200 bytes.