### PR TITLE
AP_Compass_AK09916: missing constructor/method for linux boards using I2C

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -220,6 +220,26 @@ AP_Compass_Backend *AP_Compass_AK09916::probe_ICM20948_I2C(uint8_t inv2_instance
     return sensor;
 }
 
+AP_Compass_Backend *AP_Compass_AK09916::probe_ICM20948(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, 
+                                             enum Rotation rotation)
+{
+    if (!dev) {
+        return nullptr;
+    }
+    AP_AK09916_BusDriver *bus = new AP_AK09916_BusDriver_HALDevice(std::move(dev));
+    if (!bus) {
+        return nullptr;
+    }
+
+    AP_Compass_AK09916 *sensor = new AP_Compass_AK09916(bus, false, rotation);
+    if (!sensor || !sensor->init()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
 bool AP_Compass_AK09916::init()
 {
     AP_HAL::Semaphore *bus_sem = _bus->get_semaphore();

--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -54,6 +54,11 @@ public:
                                              bool force_external,
                                              enum Rotation rotation);
 
+    /* Probe for AK09916 on auxiliary bus of ICM20948, connected through I2C */
+    static AP_Compass_Backend *probe_ICM20948(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                             enum Rotation rotation);
+
+
     /* Probe for AK09916 on auxiliary bus of ICM20948, connected through SPI by default */
     static AP_Compass_Backend *probe_ICM20948(uint8_t mpu9250_instance, enum Rotation rotation);
     static AP_Compass_Backend *probe_ICM20948_SPI(uint8_t mpu9250_instance,


### PR DESCRIPTION
Trying to use ICM20948 imu and compass  using I2C bus with  linux board(bbbmini) I detected a missing constructor/method to be used with PROBE_MAG_IMU_I2C.
