### PR TITLE
AP_MSP: move arming status to MSP telemetry base class

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -577,6 +577,16 @@ void AP_MSP_Telem_Backend::msp_handle_airspeed(const MSP::msp_airspeed_data_mess
 #endif
 }
 
+uint32_t AP_MSP_Telem_Backend::get_osd_flight_mode_bitmask(void)
+{
+    // Note: we only set the BOXARM bit (bit 0) which is the same for BF, INAV and DJI VTX
+    // When armed we simply return 1 (1 == 1 << 0)
+    if (hal.util->get_soft_armed()) {
+        return 1U;
+    }
+    return 0U;
+}
+
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_api_version(sbuf_t *dst)
 {
     const struct {

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.h
@@ -183,11 +183,9 @@ protected:
     void msp_handle_airspeed(const MSP::msp_airspeed_data_message_t &pkt);
 
     // implementation specific helpers
+    // we only set arming status
     // custom masks are needed for vendor specific settings
-    virtual uint32_t get_osd_flight_mode_bitmask(void)
-    {
-        return 0;
-    }
+    virtual uint32_t get_osd_flight_mode_bitmask(void);
 
     virtual bool is_scheduler_enabled() const = 0;                            // only osd backends should allow a push type telemetry
     virtual bool use_msp_thread() const {return true;};                       // is this backend hanlded by the MSP thread?

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -69,13 +69,8 @@ void AP_MSP_Telem_DJI::hide_osd_items(void)
 
 uint32_t AP_MSP_Telem_DJI::get_osd_flight_mode_bitmask(void)
 {
-    uint32_t mode_mask = 0;
+    uint32_t mode_mask = AP_MSP_Telem_Backend::get_osd_flight_mode_bitmask();
     const AP_Notify& notify = AP::notify();
-
-    // set arming status
-    if (notify.flags.armed) {
-        BIT_SET(mode_mask, DJI_FLAG_ARM);
-    }
 
     // check failsafe
     if (notify.flags.failsafe_battery || notify.flags.failsafe_gcs || notify.flags.failsafe_radio || notify.flags.ekf_bad ) {


### PR DESCRIPTION
**Issue**: while using MSP DisplayPort with a rooted DJI FPV Goggles (V1/V2) kit running the [msp-osd module](https://github.com/fpv-wtf/msp-osd) arming is not detected and the goggles do not exit low power mode

Both the default MSP telemetry backend and the MSP DisplayPort backend do not report arming status in the flight mode bitmask (BOXARM bit). Arming status is only reported in the "arming disarmed" flag which up to now seemed good enough.
The only backend that required the BOXARM bit to be set was the DJI one.

The PR changes this behaviour and sets the BOXARM bit for all backends (fortunately the BOXARM bit is the same for BF, INAV and DJI so this should not introduce new issues)

[betaflight BOXARM](https://github.com/betaflight/betaflight/blob/025ee87a7aca068e3659fd066b8a9afbed123361/src/main/fc/rc_modes.h#L29-L34)
[inav BOXARM](https://github.com/iNavFlight/inav/blob/359030d8c569bd49d48b2d9468fe4c1947e62df3/src/main/fc/rc_modes.h#L28-L34)
[custom inav dji BOXARM](https://github.com/iNavFlight/inav/blob/cdaf835822580af22392517c1f8fbda7a880c341/src/main/io/osd_dji_hd.c#L308-L311)
