### PR TITLE
change namespace of MultiCopter and FixedWing parameter structures

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -230,7 +230,7 @@ public:
 private:
 
     // key aircraft parameters passed to multiple libraries
-    AP_Vehicle::MultiCopter aparm;
+    AP_MultiCopter aparm;
 
     // Global parameters are all contained within the 'g' class.
     Parameters g;

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -51,7 +51,7 @@ float Plane::calc_speed_scaler(void)
     }
     if (!plane.ahrs.airspeed_sensor_enabled()  && 
         (plane.g2.flight_options & FlightOptions::SURPRESS_TKOFF_SCALING) &&
-        (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF)) { //scaling is surpressed during climb phase of automatic takeoffs with no airspeed sensor being used due to problems with inaccurate airspeed estimates
+        (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF)) { //scaling is surpressed during climb phase of automatic takeoffs with no airspeed sensor being used due to problems with inaccurate airspeed estimates
         return MIN(speed_scaler, 1.0f) ;
     }
     return speed_scaler;
@@ -767,8 +767,8 @@ void Plane::calc_nav_yaw_ground(void)
 {
     if (gps.ground_speed() < 1 && 
         is_zero(get_throttle_input()) &&
-        flight_stage != AP_Vehicle::FixedWing::FLIGHT_TAKEOFF &&
-        flight_stage != AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+        flight_stage != AP_FixedWing::FlightStage::TAKEOFF &&
+        flight_stage != AP_FixedWing::FlightStage::ABORT_LANDING) {
         // manual rudder control while still
         steer_state.locked_course = false;
         steer_state.locked_course_err = 0;
@@ -784,8 +784,8 @@ void Plane::calc_nav_yaw_ground(void)
     steer_state.last_steer_ms = now_ms;
 
     float steer_rate = (rudder_input()/4500.0f) * g.ground_steer_dps;
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF ||
-        flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+    if (flight_stage == AP_FixedWing::FlightStage::TAKEOFF ||
+        flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
         steer_rate = 0;
     }
     if (!is_zero(steer_rate)) {
@@ -794,8 +794,8 @@ void Plane::calc_nav_yaw_ground(void)
     } else if (!steer_state.locked_course) {
         // pilot has released the rudder stick or we are still - lock the course
         steer_state.locked_course = true;
-        if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_TAKEOFF &&
-            flight_stage != AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+        if (flight_stage != AP_FixedWing::FlightStage::TAKEOFF &&
+            flight_stage != AP_FixedWing::FlightStage::ABORT_LANDING) {
             steer_state.locked_course_err = 0;
         }
     }
@@ -889,7 +889,7 @@ void Plane::calc_nav_roll()
 void Plane::adjust_nav_pitch_throttle(void)
 {
     int8_t throttle = throttle_percentage();
-    if (throttle >= 0 && throttle < aparm.throttle_cruise && flight_stage != AP_Vehicle::FixedWing::FLIGHT_VTOL) {
+    if (throttle >= 0 && throttle < aparm.throttle_cruise && flight_stage != AP_FixedWing::FlightStage::VTOL) {
         float p = (aparm.throttle_cruise - throttle) / (float)aparm.throttle_cruise;
         nav_pitch_cd -= g.stab_pitch_down * 100.0f * p;
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -357,7 +357,7 @@ void GCS_MAVLINK_Plane::send_pid_tuning()
         pid_info = &plane.steerController.get_pid_info();
         send_pid_info(pid_info, PID_TUNING_STEER, pid_info->actual);
     }
-    if ((g.gcs_pid_mask & TUNING_BITS_LAND) && (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND)) {
+    if ((g.gcs_pid_mask & TUNING_BITS_LAND) && (plane.flight_stage == AP_FixedWing::FlightStage::LAND)) {
         AP_AHRS &ahrs = AP::ahrs();
         const Vector3f &gyro = ahrs.get_gyro();
         send_pid_info(plane.landing.get_pid_info(), PID_TUNING_LANDING, degrees(gyro.z));
@@ -1022,7 +1022,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
     case MAV_CMD_DO_GO_AROUND:
         {
             uint16_t mission_id = plane.mission.get_current_nav_cmd().id;
-            bool is_in_landing = (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) ||
+            bool is_in_landing = (plane.flight_stage == AP_FixedWing::FlightStage::LAND) ||
                                  (mission_id == MAV_CMD_NAV_LAND) ||
                                  (mission_id == MAV_CMD_NAV_VTOL_LAND);
             if (is_in_landing) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -165,7 +165,7 @@ public:
 private:
 
     // key aircraft parameters passed to multiple libraries
-    AP_Vehicle::FixedWing aparm;
+    AP_FixedWing aparm;
 
     // Global parameters are all contained within the 'g' and 'g2' classes.
     Parameters g;
@@ -191,7 +191,7 @@ private:
     // flight modes convenience array
     AP_Int8 *flight_modes = &g.flight_mode1;
 
-    AP_Vehicle::FixedWing::Rangefinder_State rangefinder_state;
+    AP_FixedWing::Rangefinder_State rangefinder_state;
 
 #if AP_RPM_ENABLED
     AP_RPM rpm_sensor;
@@ -561,7 +561,7 @@ private:
 #if LANDING_GEAR_ENABLED == ENABLED
     // landing gear state
     struct {
-        AP_Vehicle::FixedWing::FlightStage last_flight_stage;
+        AP_FixedWing::FlightStage last_flight_stage;
     } gear;
 #endif
 
@@ -594,7 +594,7 @@ private:
     int8_t  throttle_watt_limit_min; // for reverse thrust
     uint32_t throttle_watt_limit_timer_ms;
 
-    AP_Vehicle::FixedWing::FlightStage flight_stage = AP_Vehicle::FixedWing::FLIGHT_NORMAL;
+    AP_FixedWing::FlightStage flight_stage = AP_FixedWing::FlightStage::NORMAL;
 
     // probability of aircraft is currently in flight. range from 0 to
     // 1 where 1 is 100% sure we're in flight
@@ -1013,7 +1013,7 @@ private:
     void update_control_mode(void);
     void update_fly_forward(void);
     void update_flight_stage();
-    void set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs);
+    void set_flight_stage(AP_FixedWing::FlightStage fs);
 
     // navigation.cpp
     void loiter_angle_reset(void);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -448,7 +448,7 @@ void Plane::set_offset_altitude_location(const Location &start_loc, const Locati
     }
 #endif
 
-    if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (flight_stage != AP_FixedWing::FlightStage::LAND) {
         // if we are within GLIDE_SLOPE_MIN meters of the target altitude
         // then reset the offset to not use a glide slope. This allows for
         // more accurate flight of missions where the aircraft may lose or
@@ -539,7 +539,7 @@ float Plane::mission_alt_offset(void)
 {
     float ret = g.alt_offset;
     if (control_mode == &mode_auto &&
-            (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND || auto_state.wp_is_land_approach)) {
+            (flight_stage == AP_FixedWing::FlightStage::LAND || auto_state.wp_is_land_approach)) {
         // when landing after an aborted landing due to too high glide
         // slope we use an offset from the last landing attempt
         ret += landing.alt_offset;
@@ -641,7 +641,7 @@ float Plane::rangefinder_correction(void)
     }
 
     // for now we only support the rangefinder for landing 
-    bool using_rangefinder = (g.rangefinder_landing && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND);
+    bool using_rangefinder = (g.rangefinder_landing && flight_stage == AP_FixedWing::FlightStage::LAND);
     if (!using_rangefinder) {
         return 0;
     }
@@ -657,7 +657,7 @@ void Plane::rangefinder_terrain_correction(float &height)
 {
 #if AP_TERRAIN_AVAILABLE
     if (!g.rangefinder_landing ||
-        flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND ||
+        flight_stage != AP_FixedWing::FlightStage::LAND ||
         !terrain_enabled_in_current_mode()) {
         return;
     }
@@ -707,7 +707,7 @@ void Plane::rangefinder_height_update(void)
         } else {
             rangefinder_state.in_range = true;
             bool flightstage_good_for_rangefinder_landing = false;
-            if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+            if (flight_stage == AP_FixedWing::FlightStage::LAND) {
                 flightstage_good_for_rangefinder_landing = true;
             }
 #if HAL_QUADPLANE_ENABLED

--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -27,7 +27,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Plane::handle_avoidance(const AP_Avoidance::Ob
     bool flightmode_prohibits_action = false;
     if (plane.control_mode == &plane.mode_manual ||
         (plane.control_mode == &plane.mode_auto && !plane.auto_state.takeoff_complete) ||
-        (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) || // TODO: consider allowing action during approach
+        (plane.flight_stage == AP_FixedWing::FlightStage::LAND) || // TODO: consider allowing action during approach
         plane.control_mode == &plane.mode_autotune) {
         flightmode_prohibits_action = true;
     }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -246,7 +246,7 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
             return quadplane.verify_vtol_land();            
         }
 #endif
-        if (flight_stage == AP_Vehicle::FixedWing::FlightStage::FLIGHT_ABORT_LAND) {
+        if (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
             return landing.verify_abort_landing(prev_WP_loc, next_WP_loc, current_loc, auto_state.takeoff_altitude_rel_cm, throttle_suppressed);
 
         } else {
@@ -413,9 +413,9 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
 
     landing.do_land(cmd, relative_altitude);
 
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+    if (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
         // if we were in an abort we need to explicitly move out of the abort state, as it's sticky
-        set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_LAND);
+        set_flight_stage(AP_FixedWing::FlightStage::LAND);
     }
 
 #if AP_FENCE_ENABLED

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -4,7 +4,7 @@
 // for use in failsafe code.
 bool Plane::failsafe_in_landing_sequence() const
 {
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (flight_stage == AP_FixedWing::FlightStage::LAND) {
         return true;
     }
 #if HAL_QUADPLANE_ENABLED
@@ -238,7 +238,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
             FALLTHROUGH;
 #endif // HAL_QUADPLANE_ENABLED
         case Failsafe_Action_Land: {
-            bool already_landing = flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND;
+            bool already_landing = flight_stage == AP_FixedWing::FlightStage::LAND;
 #if HAL_QUADPLANE_ENABLED
             if (control_mode == &mode_qland || control_mode == &mode_loiter_qland) {
                 already_landing = true;
@@ -259,7 +259,7 @@ void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
             FALLTHROUGH;
         }
         case Failsafe_Action_RTL: {
-            bool already_landing = flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND;
+            bool already_landing = flight_stage == AP_FixedWing::FlightStage::LAND;
 #if HAL_QUADPLANE_ENABLED
             if (control_mode == &mode_qland || control_mode == &mode_loiter_qland ||
                 quadplane.in_vtol_land_sequence()) {

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -83,10 +83,10 @@ void Plane::update_is_flying_5Hz(void)
 
             switch (flight_stage)
             {
-            case AP_Vehicle::FixedWing::FLIGHT_TAKEOFF:
+            case AP_FixedWing::FlightStage::TAKEOFF:
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_NORMAL:
+            case AP_FixedWing::FlightStage::NORMAL:
                 if (in_preLaunch_flight_stage()) {
                     // while on the ground, an uncalibrated airspeed sensor can drift to 7m/s so
                     // ensure we aren't showing a false positive.
@@ -96,17 +96,17 @@ void Plane::update_is_flying_5Hz(void)
                 }
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_VTOL:
+            case AP_FixedWing::FlightStage::VTOL:
                 // TODO: detect ground impacts
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_LAND:
+            case AP_FixedWing::FlightStage::LAND:
                 if (landing.is_on_approach() && auto_state.sink_rate > 0.2f) {
                     is_flying_bool = true;
                 }
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND:
+            case AP_FixedWing::FlightStage::ABORT_LANDING:
                 if (auto_state.sink_rate < -0.5f) {
                     // steep climb
                     is_flying_bool = true;
@@ -121,7 +121,7 @@ void Plane::update_is_flying_5Hz(void)
         // when disarmed assume not flying and need overwhelming evidence that we ARE flying
         is_flying_bool = airspeed_movement && gps_confirmed_movement;
 
-        if ((flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF) || landing.is_flaring()) {
+        if ((flight_stage == AP_FixedWing::FlightStage::TAKEOFF) || landing.is_flaring()) {
             is_flying_bool = false;
         }
     }
@@ -257,7 +257,7 @@ void Plane::crash_detection_update(void)
         } else {
             switch (flight_stage)
             {
-            case AP_Vehicle::FixedWing::FLIGHT_TAKEOFF:
+            case AP_FixedWing::FlightStage::TAKEOFF:
                 if (g.takeoff_throttle_min_accel > 0 &&
                         !throttle_suppressed) {
                     // if you have an acceleration holding back throttle, but you met the
@@ -269,14 +269,14 @@ void Plane::crash_detection_update(void)
                 // TODO: handle auto missions without NAV_TAKEOFF mission cmd
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_NORMAL:
+            case AP_FixedWing::FlightStage::NORMAL:
                 if (!in_preLaunch_flight_stage() && been_auto_flying) {
                     crashed = true;
                     crash_state.debounce_time_total_ms = CRASH_DETECTION_DELAY_MS;
                 }
                 break;
 
-            case AP_Vehicle::FixedWing::FLIGHT_VTOL:
+            case AP_FixedWing::FlightStage::VTOL:
                 // we need a totally new method for this
                 crashed = false;
                 break;
@@ -337,6 +337,6 @@ bool Plane::in_preLaunch_flight_stage(void)
 #endif
     return (control_mode == &mode_auto &&
             throttle_suppressed &&
-            flight_stage == AP_Vehicle::FixedWing::FLIGHT_NORMAL &&
+            flight_stage == AP_FixedWing::FlightStage::NORMAL &&
             mission.get_current_nav_cmd().id == MAV_CMD_NAV_TAKEOFF);
 }

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -80,7 +80,7 @@ void ModeAuto::update()
 #endif
 
     if (nav_cmd_id == MAV_CMD_NAV_TAKEOFF ||
-        (nav_cmd_id == MAV_CMD_NAV_LAND && plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND)) {
+        (nav_cmd_id == MAV_CMD_NAV_LAND && plane.flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING)) {
         plane.takeoff_calc_roll();
         plane.takeoff_calc_pitch();
         plane.calc_throttle();

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -66,7 +66,7 @@ void ModeTakeoff::update()
             plane.prev_WP_loc = plane.current_loc;
             plane.next_WP_loc = plane.current_loc;
             takeoff_started = true;
-            plane.set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_NORMAL);
+            plane.set_flight_stage(AP_FixedWing::FlightStage::NORMAL);
         }
     }
 
@@ -87,7 +87,7 @@ void ModeTakeoff::update()
 
         plane.auto_state.takeoff_pitch_cd = level_pitch * 100;
 
-        plane.set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_TAKEOFF);
+        plane.set_flight_stage(AP_FixedWing::FlightStage::TAKEOFF);
 
         if (!plane.throttle_suppressed) {
             gcs().send_text(MAV_SEVERITY_INFO, "Takeoff to %.0fm at %.1fm to %.1f deg",
@@ -99,7 +99,7 @@ void ModeTakeoff::update()
     // we finish the initial level takeoff if we climb past
     // TKOFF_LVL_ALT or we pass the target location. The check for
     // target location prevents us flying forever if we can't climb
-    if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF &&
+    if (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF &&
         (plane.current_loc.alt - start_loc.alt >= level_alt*100 ||
          start_loc.get_distance(plane.current_loc) >= target_dist)) {
         // reached level alt, re-calculate bearing to cope with systems with no compass
@@ -112,14 +112,14 @@ void ModeTakeoff::update()
         plane.next_WP_loc.offset_bearing(direction, MAX(dist-dist_done, 0));
         plane.next_WP_loc.alt = start_loc.alt + target_alt*100.0;
 
-        plane.set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_NORMAL);
+        plane.set_flight_stage(AP_FixedWing::FlightStage::NORMAL);
         
 #if AP_FENCE_ENABLED
         plane.fence.auto_enable_fence_after_takeoff();
 #endif
     }
 
-    if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF) {
+    if (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100.0);
         plane.takeoff_calc_roll();
         plane.takeoff_calc_pitch();

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -224,7 +224,7 @@ void Plane::calc_airspeed_errors()
         }
 #endif
 
-    } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    } else if (flight_stage == AP_FixedWing::FlightStage::LAND) {
         // Landing airspeed target
         target_airspeed_cm = landing.get_target_airspeed_cm();
     } else if (control_mode == &mode_guided && new_airspeed_cm > 0) { //DO_CHANGE_SPEED overrides onboard guided speed commands, user would have re-enter guided mode to revert

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -19,6 +19,7 @@
 #include <AC_WPNav/AC_Loiter.h>
 #include <AC_Avoidance/AC_Avoid.h>
 #include <AP_Logger/LogStructure.h>
+#include <AP_Mission/AP_Mission.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include "qautotune.h"
 #include "defines.h"
@@ -173,7 +174,9 @@ public:
 
 private:
     AP_AHRS &ahrs;
-    AP_Vehicle::MultiCopter aparm;
+
+    // key aircraft parameters passed to multiple libraries
+    AP_MultiCopter aparm;
 
     AP_InertialNav inertial_nav{ahrs};
 

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -18,7 +18,7 @@ void Plane::read_rangefinder(void)
 #endif
     {
         // use the best available alt estimate via baro above home
-        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+        if (flight_stage == AP_FixedWing::FlightStage::LAND) {
             // ensure the rangefinder is powered-on when land alt is higher than home altitude.
             // This is done using the target alt which we know is below us and we are sinking to it
             height = height_above_target();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -40,13 +40,13 @@ void Plane::throttle_slew_limit(SRV_Channel::Aux_servo_function_t func)
     if (control_mode == &mode_auto) {
         if (auto_state.takeoff_complete == false && g.takeoff_throttle_slewrate != 0) {
             slewrate = g.takeoff_throttle_slewrate;
-        } else if (landing.get_throttle_slewrate() != 0 && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+        } else if (landing.get_throttle_slewrate() != 0 && flight_stage == AP_FixedWing::FlightStage::LAND) {
             slewrate = landing.get_throttle_slewrate();
         }
     }
     if (g.takeoff_throttle_slewrate != 0 &&
-        (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF ||
-         flight_stage == AP_Vehicle::FixedWing::FLIGHT_VTOL)) {
+        (flight_stage == AP_FixedWing::FlightStage::TAKEOFF ||
+         flight_stage == AP_FixedWing::FlightStage::VTOL)) {
         // for VTOL we use takeoff slewrate, which helps with transition
         slewrate = g.takeoff_throttle_slewrate;
     }
@@ -492,7 +492,7 @@ void Plane::throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle)
  */
 void Plane::set_servos_controlled(void)
 {
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (flight_stage == AP_FixedWing::FlightStage::LAND) {
         // allow landing to override servos if it would like to
         landing.override_servos();
     }
@@ -512,8 +512,8 @@ void Plane::set_servos_controlled(void)
     }
 
     bool flight_stage_determines_max_throttle = false;
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || 
-        flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND
+    if (flight_stage == AP_FixedWing::FlightStage::TAKEOFF || 
+        flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING
         ) {
         flight_stage_determines_max_throttle = true;
     }
@@ -654,19 +654,19 @@ void Plane::set_servos_flaps(void)
           possibility of oscillation
          */
         switch (flight_stage) {
-            case AP_Vehicle::FixedWing::FLIGHT_TAKEOFF:
-            case AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND:
+            case AP_FixedWing::FlightStage::TAKEOFF:
+            case AP_FixedWing::FlightStage::ABORT_LANDING:
                 if (g.takeoff_flap_percent != 0) {
                     auto_flap_percent = g.takeoff_flap_percent;
                 }
                 break;
-            case AP_Vehicle::FixedWing::FLIGHT_NORMAL:
+            case AP_FixedWing::FlightStage::NORMAL:
                 if (g.takeoff_flap_percent != 0 && in_preLaunch_flight_stage()) {
                     // TODO: move this to a new FLIGHT_PRE_TAKEOFF stage
                     auto_flap_percent = g.takeoff_flap_percent;
                 }
                 break;
-            case AP_Vehicle::FixedWing::FLIGHT_LAND:
+            case AP_FixedWing::FlightStage::LAND:
                 if (landing.get_flap_percent() != 0) {
                   auto_flap_percent = landing.get_flap_percent();
                 }
@@ -699,10 +699,10 @@ void Plane::set_landing_gear(void)
 {
     if (control_mode == &mode_auto && hal.util->get_soft_armed() && is_flying() && gear.last_flight_stage != flight_stage) {
         switch (flight_stage) {
-        case AP_Vehicle::FixedWing::FLIGHT_LAND:
+        case AP_FixedWing::FlightStage::LAND:
             g2.landing_gear.deploy_for_landing();
             break;
-        case AP_Vehicle::FixedWing::FLIGHT_NORMAL:
+        case AP_FixedWing::FlightStage::NORMAL:
             g2.landing_gear.retract_after_takeoff();
             break;
         default:

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -353,7 +353,7 @@ void Plane::check_long_failsafe()
     const uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_FixedWing::FlightStage::LAND) {
         uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
         if (failsafe.state == FAILSAFE_SHORT) {
             // time is relative to when short failsafe enabled
@@ -400,7 +400,7 @@ void Plane::check_short_failsafe()
     // -------------------
     if (g.fs_action_short != FS_ACTION_SHORT_DISABLED &&
        failsafe.state == FAILSAFE_NONE &&
-       flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+       flight_stage != AP_FixedWing::FlightStage::LAND) {
         // The condition is checked and the flag rc_failsafe is set in radio.cpp
         if(failsafe.rc_failsafe) {
             failsafe_short_on_event(FAILSAFE_SHORT, ModeReason::RADIO_FAILSAFE);

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -201,7 +201,7 @@ void Plane::takeoff_calc_pitch(void)
  */
 int16_t Plane::get_takeoff_pitch_min_cd(void)
 {
-    if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_TAKEOFF) {
+    if (flight_stage != AP_FixedWing::FlightStage::TAKEOFF) {
         return auto_state.takeoff_pitch_cd;
     }
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -118,7 +118,7 @@ protected:
 private:
 
     // key aircraft parameters passed to multiple libraries
-    AP_Vehicle::MultiCopter aparm;
+    AP_MultiCopter aparm;
 
     // Global parameters are all contained within the 'g' class.
     Parameters g;

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -50,6 +50,8 @@
 #include <AC_PID/AC_PID_2D.h>
 #include <AC_PID/AC_PID_Basic.h>
 #include <AC_PID/AC_PID.h>
+#include <AP_Vehicle/AP_MultiCopter.h>
+
 #include <Filter/NotchFilter.h>
 
 // Configuration
@@ -97,7 +99,7 @@ public:
 private:
 
     // key aircraft parameters passed to multiple libraries
-    AP_Vehicle::MultiCopter aparm;
+    AP_MultiCopter aparm;
 
     // Global parameters are all contained within the 'g' class.
     Parameters g;

--- a/Blimp/events.cpp
+++ b/Blimp/events.cpp
@@ -5,6 +5,7 @@
  *       boolean failsafe reflects the current state
  */
 
+#include <AP_Vehicle/AP_MultiCopter.h>
 
 bool Blimp::failsafe_option(FailsafeOption opt) const
 {

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -5,6 +5,8 @@
  * flight modes is in control_acro.cpp, control_stabilize.cpp, etc
  */
 
+#include <AP_Vehicle/AP_MultiCopter.h>
+
 /*
   constructor for Mode object
  */

--- a/Blimp/mode_velocity.cpp
+++ b/Blimp/mode_velocity.cpp
@@ -3,6 +3,8 @@
  * Init and run calls for velocity flight mode
  */
 
+#include <AP_Vehicle/AP_MultiCopter.h>
+
 // Runs the main velocity controller
 void ModeVelocity::run()
 {

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -14,6 +14,7 @@
  */
 
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_FixedWing.h>
 
 #include "LogReader.h"
 
@@ -45,7 +46,7 @@ public:
     virtual bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; }
     virtual uint8_t get_mode() const override { return 0; }
 
-    AP_Vehicle::FixedWing aparm;
+    AP_FixedWing aparm;
 
     AP_Int32 unused; // logging is magic for Replay; this is unused
     struct LogStructure log_structure[256] = {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -1,5 +1,6 @@
 #include "AC_AttitudeControl.h"
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -6,11 +6,11 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_AHRS/AP_AHRS_View.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AC_PID/AC_PID.h>
 #include <AC_PID/AC_P.h>
+#include <AP_Vehicle/AP_MultiCopter.h>
 
 #define AC_ATTITUDE_CONTROL_ANGLE_P                     4.5f             // default angle P gain for roll, pitch and yaw
 
@@ -48,7 +48,7 @@
 class AC_AttitudeControl {
 public:
     AC_AttitudeControl( AP_AHRS_View &ahrs,
-                        const AP_Vehicle::MultiCopter &aparm,
+                        const AP_MultiCopter &aparm,
                         AP_Motors& motors,
                         float dt) :
         _p_angle_roll(AC_ATTITUDE_CONTROL_ANGLE_P),
@@ -516,7 +516,7 @@ protected:
 
     // References to external libraries
     const AP_AHRS_View&  _ahrs;
-    const AP_Vehicle::MultiCopter &_aparm;
+    const AP_MultiCopter &_aparm;
     AP_Motors&          _motors;
 
     static AC_AttitudeControl *_singleton;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -32,7 +32,7 @@
 class AC_AttitudeControl_Heli : public AC_AttitudeControl {
 public:
     AC_AttitudeControl_Heli( AP_AHRS_View &ahrs,
-                        const AP_Vehicle::MultiCopter &aparm,
+                        const AP_MultiCopter &aparm,
                         AP_MotorsHeli& motors,
                         float dt) :
         AC_AttitudeControl(ahrs, aparm, motors, dt),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -235,7 +235,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     AP_GROUPEND
 };
 
-AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt) :
+AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt) :
     AC_AttitudeControl(ahrs, aparm, motors, dt),
     _motors_multi(motors),
     _pid_rate_roll(AC_ATC_MULTI_RATE_RP_P, AC_ATC_MULTI_RATE_RP_I, AC_ATC_MULTI_RATE_RP_D, 0.0f, AC_ATC_MULTI_RATE_RP_IMAX, AC_ATC_MULTI_RATE_RP_FILT_HZ, 0.0f, AC_ATC_MULTI_RATE_RP_FILT_HZ, dt),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -41,7 +41,7 @@
 
 class AC_AttitudeControl_Multi : public AC_AttitudeControl {
 public:
-	AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt);
+	AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt);
 
 	// empty destructor to suppress compiler warning
 	virtual ~AC_AttitudeControl_Multi() {}

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.h
@@ -5,7 +5,7 @@
 
 class AC_AttitudeControl_Multi_6DoF : public AC_AttitudeControl_Multi {
 public:
-    AC_AttitudeControl_Multi_6DoF(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt):
+    AC_AttitudeControl_Multi_6DoF(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt):
         AC_AttitudeControl_Multi(ahrs,aparm,motors,dt) {
 
         if (_singleton != nullptr) {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -259,7 +259,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     AP_GROUPEND
 };
 
-AC_AttitudeControl_Sub::AC_AttitudeControl_Sub(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt) :
+AC_AttitudeControl_Sub::AC_AttitudeControl_Sub(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt) :
     AC_AttitudeControl(ahrs, aparm, motors, dt),
     _motors_multi(motors),
     _pid_rate_roll(AC_ATC_SUB_RATE_RP_P, AC_ATC_SUB_RATE_RP_I, AC_ATC_SUB_RATE_RP_D, 0.0f, AC_ATC_SUB_RATE_RP_IMAX, AC_ATC_SUB_RATE_RP_FILT_HZ, 0.0f, AC_ATC_SUB_RATE_RP_FILT_HZ, dt),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
@@ -25,7 +25,7 @@
 
 class AC_AttitudeControl_Sub : public AC_AttitudeControl {
 public:
-    AC_AttitudeControl_Sub(AP_AHRS_View &ahrs, const AP_Vehicle::MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt);
+    AC_AttitudeControl_Sub(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors, float dt);
 
     // empty destructor to suppress compiler warning
     virtual ~AC_AttitudeControl_Sub() {}

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -3,7 +3,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Motors/AP_Motors.h>    // motors library
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -13,7 +13,6 @@
 #include <AP_InertialNav/AP_InertialNav.h>  // Inertial Navigation library
 #include "AC_AttitudeControl.h"     // Attitude control library
 
-
 // position controller default definitions
 #define POSCONTROL_ACCEL_XY                     100.0f  // default horizontal acceleration in cm/s/s.  This is overwritten by waypoint and loiter controllers
 #define POSCONTROL_JERK_XY                      5.0f    // default horizontal jerk m/s/s/s

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -2,7 +2,9 @@
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500     // restart tuning if pilot has left sticks in middle for 2 seconds
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -20,6 +20,7 @@
 #include "AC_AutoTune_Heli.h"
 
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   5000U     // timeout for tuning mode's testing step
 

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -21,6 +21,8 @@
 #include "AC_AutoTune.h"
 #include <AP_Math/chirp.h>
 
+#include <AP_Scheduler/AP_Scheduler.h>
+
 class AC_AutoTune_Heli : public AC_AutoTune
 {
 public:

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -1,6 +1,8 @@
 #include "AC_AutoTune_Multi.h"
 
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <GCS_MAVLink/GCS.h>
 
 /*
  * autotune support for multicopters

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -19,6 +19,7 @@
 #include <AP_Proximity/AP_Proximity.h>
 #include <AP_Beacon/AP_Beacon.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <stdio.h>
 
 #if !APM_BUILD_TYPE(APM_BUILD_ArduPlane)

--- a/libraries/AC_CustomControl/AC_CustomControl.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl.cpp
@@ -8,6 +8,7 @@
 #include "AC_CustomControl_Backend.h"
 // #include "AC_CustomControl_Empty.h"
 #include "AC_CustomControl_PID.h"
+#include <GCS_MAVLink/GCS.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AC_CustomControl::var_info[] = {

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -26,6 +26,8 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -45,7 +47,7 @@ extern const AP_HAL::HAL& hal;
 
 // constructor
 AP_AutoTune::AP_AutoTune(ATGains &_gains, ATType _type,
-                         const AP_Vehicle::FixedWing &parms,
+                         const AP_FixedWing &parms,
                          AC_PID &_rpid) :
     current(_gains),
     rpid(_rpid),

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <AP_Logger/AP_Logger.h>
 #include <AP_Logger/LogStructure.h>
-
+#include <AP_Param/AP_Param.h>
+#include <AP_Vehicle/AP_FixedWing.h>
 #include <Filter/SlewLimiter.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+
 #include <Filter/ModeFilter.h>
 
 class AP_AutoTune
@@ -41,9 +43,8 @@ public:
         float tau;
     };
 
-
     // constructor
-    AP_AutoTune(ATGains &_gains, ATType type, const AP_Vehicle::FixedWing &parms, class AC_PID &rpid);
+    AP_AutoTune(ATGains &_gains, ATType type, const AP_FixedWing &parms, class AC_PID &rpid);
 
     // called when autotune mode is entered
     void start(void);
@@ -67,7 +68,7 @@ private:
     // what type of autotune is this
     ATType type;
 
-    const AP_Vehicle::FixedWing &aparm;
+    const AP_FixedWing &aparm;
 
     // values to restore if we leave autotune mode
     ATGains restore;

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -19,6 +19,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_PitchController.h"
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -134,7 +136,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     AP_GROUPEND
 };
 
-AP_PitchController::AP_PitchController(const AP_Vehicle::FixedWing &parms)
+AP_PitchController::AP_PitchController(const AP_FixedWing &parms)
     : aparm(parms)
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include "AP_AutoTune.h"
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
@@ -9,7 +8,7 @@
 class AP_PitchController
 {
 public:
-    AP_PitchController(const AP_Vehicle::FixedWing &parms);
+    AP_PitchController(const AP_FixedWing &parms);
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_PitchController);
@@ -48,7 +47,7 @@ public:
     void convert_pid();
 
 private:
-    const AP_Vehicle::FixedWing &aparm;
+    const AP_FixedWing &aparm;
     AP_AutoTune::ATGains gains;
     AP_AutoTune *autotune;
     bool failed_autotune_alloc;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -20,6 +20,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_RollController.h"
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -118,7 +120,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 };
 
 // constructor
-AP_RollController::AP_RollController(const AP_Vehicle::FixedWing &parms)
+AP_RollController::AP_RollController(const AP_FixedWing &parms)
     : aparm(parms)
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include "AP_AutoTune.h"
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
@@ -9,7 +8,7 @@
 class AP_RollController
 {
 public:
-    AP_RollController(const AP_Vehicle::FixedWing &parms);
+    AP_RollController(const AP_FixedWing &parms);
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_RollController);
@@ -50,7 +49,7 @@ public:
     void convert_pid();
 
 private:
-    const AP_Vehicle::FixedWing &aparm;
+    const AP_FixedWing &aparm;
     AP_AutoTune::ATGains gains;
     AP_AutoTune *autotune;
     bool failed_autotune_alloc;

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AC_PID/AP_PIDInfo.h>
 
 class AP_SteerController {

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -20,6 +20,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_YawController.h"
 #include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -148,7 +150,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     AP_GROUPEND
 };
 
-AP_YawController::AP_YawController(const AP_Vehicle::FixedWing &parms)
+AP_YawController::AP_YawController(const AP_FixedWing &parms)
     : aparm(parms)
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AC_PID/AC_PID.h>
 #include "AP_AutoTune.h"
 
 class AP_YawController
 {
 public:
-    AP_YawController(const AP_Vehicle::FixedWing &parms);
+    AP_YawController(const AP_FixedWing &parms);
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_YawController);
@@ -52,7 +51,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    const AP_Vehicle::FixedWing &aparm;
+    const AP_FixedWing &aparm;
     AP_Float _K_A;
     AP_Float _K_I;
     AP_Float _K_D;

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -27,9 +27,9 @@
 #include "AP_ADSB_uAvionix_UCP.h"
 #include "AP_ADSB_Sagetech.h"
 #include "AP_ADSB_Sagetech_MXS.h"
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 
 #define VEHICLE_TIMEOUT_MS              5000   // if no updates in this time, drop it from the list

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -16,9 +16,9 @@
  *   AP_Airspeed.cpp - airspeed (pitot) driver
  */
 
-#include <AP_Vehicle/AP_Vehicle_Type.h>
-
 #include "AP_Airspeed.h"
+
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 // Dummy the AP_Airspeed class to allow building Airspeed only for plane, rover, sub, and copter & heli 2MB boards
 // This could be removed once the build system allows for APM_BUILD_TYPE in header files
@@ -37,7 +37,6 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger.h>
 #include <utility>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include "AP_Airspeed_MS4525.h"
 #include "AP_Airspeed_MS5525.h"
 #include "AP_Airspeed_SDP3X.h"

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -22,7 +22,7 @@
 
 #if AP_AIRSPEED_NMEA_ENABLED
 
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #if APM_BUILD_TYPE(APM_BUILD_Rover) || APM_BUILD_TYPE(APM_BUILD_ArduSub) 
 
 #include "AP_Airspeed.h"

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -55,7 +55,7 @@
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
   #include <AP_CANManager/AP_CANManager.h>
   #include <AP_Common/AP_Common.h>
-  #include <AP_Vehicle/AP_Vehicle.h>
+  #include <AP_Vehicle/AP_Vehicle_Type.h>
 
   #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
 

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #include <AP_Math/crc.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
 #include <AR_Motors/AP_MotorsUGV.h>
 #else

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -20,10 +20,13 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <AP_RTC/AP_RTC.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #include <stdio.h>
 

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -17,7 +17,7 @@
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS && HAL_CANMANAGER_ENABLED
 #include "AP_CANManager.h"
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #include <AP_UAVCAN/AP_UAVCAN.h>
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -22,7 +22,8 @@
 
 #if HAL_CANMANAGER_ENABLED
 
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_UAVCAN/AP_UAVCAN.h>
 #include <AP_KDECAN/AP_KDECAN.h>
 #include <AP_SerialManager/AP_SerialManager.h>

--- a/libraries/AP_CANManager/AP_CANTester.cpp
+++ b/libraries/AP_CANManager/AP_CANTester.cpp
@@ -24,7 +24,7 @@
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS > 1 && !HAL_MINIMIZE_FEATURES && HAL_CANMANAGER_ENABLED && HAL_ENABLE_CANTESTER
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <stdio.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_UAVCAN/AP_UAVCAN.h>
 #include <uavcan/protocol/dynamic_node_id_client.hpp>
 #include <uavcan/equipment/esc/Status.hpp>

--- a/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
+++ b/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
@@ -24,7 +24,7 @@
 #include "AP_CANManager.h"
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/utility/sparse-endian.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "TestKDECAN",  fmt, ##args); } while (0)
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -27,7 +27,7 @@
 
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <stdio.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define LOG_TAG "SLCAN"
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -2,12 +2,13 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/I2CDevice.h>
 #endif
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_CustomRotations/AP_CustomRotations.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include "AP_Compass_SITL.h"
 #include "AP_Compass_AK8963.h"

--- a/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
+++ b/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
@@ -16,7 +16,6 @@ void loop()
 #else
 
 #include <GCS_MAVLink/GCS_Dummy.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_FlashIface/AP_FlashIface.h>

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -1,7 +1,7 @@
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Logger/AP_Logger.h>
 #include "GyroFrame.h"

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -8,15 +8,16 @@
 #include <AP_HAL/DSP.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Notify/AP_Notify.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_AHRS/AP_AHRS_View.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_GyroFFT/AP_GyroFFT.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #if !APM_BUILD_TYPE(APM_BUILD_Rover)
 #include <AP_Motors/AP_Motors_Class.h>
 #endif
+#include <GCS_MAVLink/GCS.h>
 
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_BMI160.h"

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -164,7 +164,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
 };
 
     // constructor
-AP_Landing::AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_TECS *_tecs_Controller, AP_Navigation *_nav_controller, AP_Vehicle::FixedWing &_aparm,
+AP_Landing::AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_TECS *_tecs_Controller, AP_Navigation *_nav_controller, AP_FixedWing &_aparm,
                        set_target_altitude_proportion_fn_t _set_target_altitude_proportion_fn,
                        constrain_target_altitude_location_fn_t _constrain_target_altitude_location_fn,
                        adjusted_altitude_cm_fn_t _adjusted_altitude_cm_fn,
@@ -281,7 +281,7 @@ bool AP_Landing::verify_abort_landing(const Location &prev_WP_loc, Location &nex
      return false;
 }
 
-void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm)
+void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm)
 {
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -36,7 +36,7 @@ public:
     FUNCTOR_TYPEDEF(disarm_if_autoland_complete_fn_t, void);
     FUNCTOR_TYPEDEF(update_flight_stage_fn_t, void);
 
-    AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_TECS *_tecs_Controller, AP_Navigation *_nav_controller, AP_Vehicle::FixedWing &_aparm,
+    AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_TECS *_tecs_Controller, AP_Navigation *_nav_controller, AP_FixedWing &_aparm,
                set_target_altitude_proportion_fn_t _set_target_altitude_proportion_fn,
                constrain_target_altitude_location_fn_t _constrain_target_altitude_location_fn,
                adjusted_altitude_cm_fn_t _adjusted_altitude_cm_fn,
@@ -68,10 +68,10 @@ public:
             const int32_t auto_state_takeoff_altitude_rel_cm, bool &throttle_suppressed);
     bool verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);
-    void adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
+    void adjust_landing_slope_for_rangefinder_bump(AP_FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
     void setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     bool override_servos(void);
-    void check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
+    void check_if_need_to_abort(const AP_FixedWing::Rangefinder_State &rangefinder_state);
     bool request_go_around(void);
     bool is_flaring(void) const;
     bool is_on_approach(void) const;
@@ -137,7 +137,7 @@ private:
     AP_TECS *tecs_Controller;
     AP_Navigation *nav_controller;
     
-    AP_Vehicle::FixedWing &aparm;
+    AP_FixedWing &aparm;
 
     set_target_altitude_proportion_fn_t set_target_altitude_proportion_fn;
     constrain_target_altitude_location_fn_t constrain_target_altitude_location_fn;
@@ -187,11 +187,11 @@ private:
     bool type_slope_verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);
 
-    void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
+    void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
 
     void type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     int32_t type_slope_get_target_airspeed_cm(void);
-    void type_slope_check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
+    void type_slope_check_if_need_to_abort(const AP_FixedWing::Rangefinder_State &rangefinder_state);
     int32_t type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool type_slope_request_go_around(void);
     void type_slope_log(void) const;

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -181,7 +181,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     return false;
 }
 
-void AP_Landing::type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm)
+void AP_Landing::type_slope_adjust_landing_slope_for_rangefinder_bump(AP_FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm)
 {
     // check the rangefinder correction for a large change. When found, recalculate the glide slope. This is done by
     // determining the slope from your current location to the land point then following that back up to the approach

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -15,7 +15,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_MotorsMatrix.h"
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -17,7 +17,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Mount/SoloGimbalEKF.cpp
+++ b/libraries/AP_Mount/SoloGimbalEKF.cpp
@@ -11,9 +11,9 @@
 #include "SoloGimbalEKF.h"
 #if HAL_SOLO_GIMBAL_ENABLED
 #include <AP_Param/AP_Param.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_NavEKF/AP_Nav_Common.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Compass/AP_Compass.h>
 
 #include <stdio.h>
 

--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -23,7 +23,6 @@
 
 #include "AP_NavEKF/EKFGSF_yaw.h"
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
 EKFGSF_yaw::EKFGSF_yaw() {};

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -1,7 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF2_core.h"
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
 #include <AP_InternalError/AP_InternalError.h>

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -1,8 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF2_core.h"
-#include <AP_Vehicle/AP_Vehicle.h>
-#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF_GyroBias.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF_GyroBias.cpp
@@ -3,7 +3,6 @@
 
 #include "AP_NavEKF2.h"
 #include "AP_NavEKF2_core.h"
-#include <AP_Vehicle/AP_Vehicle.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -1,8 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF3_core.h"
-#include <AP_Vehicle/AP_Vehicle.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -166,7 +166,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     AP_GROUPEND
 };
 
-SoaringController::SoaringController(AP_TECS &tecs, const AP_Vehicle::FixedWing &parms) :
+SoaringController::SoaringController(AP_TECS &tecs, const AP_FixedWing &parms) :
     _tecs(tecs),
     _vario(parms,_polarParams),
     _speedToFly(_polarParams),

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -36,7 +36,7 @@ class SoaringController {
     Variometer _vario;
     SpeedToFly _speedToFly;
 
-    const AP_Vehicle::FixedWing &_aparm;
+    const AP_FixedWing &_aparm;
 
     // store aircraft location at last update
     Vector3f _prev_update_location;
@@ -81,7 +81,7 @@ protected:
     AP_Float soar_thermal_flap;
 
 public:
-    SoaringController(class AP_TECS &tecs, const AP_Vehicle::FixedWing &parms);
+    SoaringController(class AP_TECS &tecs, const AP_FixedWing &parms);
 
     enum class LoiterStatus {
         DISABLED,

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -6,7 +6,7 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 
 #include <AP_Logger/AP_Logger.h>
 
-Variometer::Variometer(const AP_Vehicle::FixedWing &parms, const PolarParams &polarParams) :
+Variometer::Variometer(const AP_FixedWing &parms, const PolarParams &polarParams) :
     _aparm(parms),
     _polarParams(polarParams)
 {

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -8,11 +8,11 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
 #include <Filter/AverageFilter.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_FixedWing.h>
 
 class Variometer {
 
-    const AP_Vehicle::FixedWing &_aparm;
+    const AP_FixedWing &_aparm;
 
     // store time of last update
     uint64_t _prev_update_time;
@@ -53,7 +53,7 @@ public:
         AP_Float B;
     };
 
-    Variometer(const AP_Vehicle::FixedWing &parms, const PolarParams &polarParams);
+    Variometer(const AP_FixedWing &parms, const PolarParams &polarParams);
 
     float alt;
     float reading;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -20,13 +20,14 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_FixedWing.h>
+#include <Filter/DerivativeFilter.h>
 #include <Filter/AverageFilter.h>
 
 class AP_Landing;
 class AP_TECS {
 public:
-    AP_TECS(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, const AP_Landing &landing, const uint32_t log_bitmask)
+    AP_TECS(AP_AHRS &ahrs, const AP_FixedWing &parms, const AP_Landing &landing, const uint32_t log_bitmask)
         : _ahrs(ahrs)
         , aparm(parms)
         , _landing(landing)
@@ -46,7 +47,7 @@ public:
     // Update the control loop calculations
     void update_pitch_throttle(int32_t hgt_dem_cm,
                                int32_t EAS_dem_cm,
-                               enum AP_Vehicle::FixedWing::FlightStage flight_stage,
+                               enum AP_FixedWing::FlightStage flight_stage,
                                float distance_beyond_land_wp,
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
@@ -157,7 +158,7 @@ private:
     // reference to the AHRS object
     AP_AHRS &_ahrs;
 
-    const AP_Vehicle::FixedWing &aparm;
+    const AP_FixedWing &aparm;
 
     // reference to const AP_Landing to access it's params
     const AP_Landing &_landing;
@@ -316,7 +317,7 @@ private:
     uint32_t _underspeed_start_ms;
 
     // auto mode flightstage
-    enum AP_Vehicle::FixedWing::FlightStage _flight_stage;
+    enum AP_FixedWing::FlightStage _flight_stage;
 
     // pitch demand before limiting
     float _pitch_dem_unc;

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+/*
+  common parameters for fixed wing aircraft
+*/
+struct AP_FixedWing {
+    AP_Int8 throttle_min;
+    AP_Int8 throttle_max;
+    AP_Int8 throttle_slewrate;
+    AP_Int8 throttle_cruise;
+    AP_Int8 takeoff_throttle_max;
+    AP_Int16 airspeed_min;
+    AP_Int16 airspeed_max;
+    AP_Int32 airspeed_cruise_cm;
+    AP_Int32 min_gndspeed_cm;
+    AP_Int8  crash_detection_enable;
+    AP_Int16 roll_limit_cd;
+    AP_Int16 pitch_limit_max_cd;
+    AP_Int16 pitch_limit_min_cd;
+    AP_Int8  autotune_level;
+    AP_Int8  stall_prevention;
+    AP_Int16 loiter_radius;
+
+    struct Rangefinder_State {
+        bool in_range:1;
+        bool have_initial_reading:1;
+        bool in_use:1;
+        float initial_range;
+        float correction;
+        float initial_correction;
+        float last_stable_correction;
+        uint32_t last_correction_time_ms;
+        uint8_t in_range_count;
+        float height_estimate;
+        float last_distance;
+    };
+
+
+    // stages of flight
+    enum class FlightStage {
+        TAKEOFF       = 1,
+        VTOL          = 2,
+        NORMAL        = 3,
+        LAND          = 4,
+        ABORT_LANDING = 7
+    };
+};

--- a/libraries/AP_Vehicle/AP_MultiCopter.h
+++ b/libraries/AP_Vehicle/AP_MultiCopter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+/*
+  common parameters for multicopters
+*/
+struct AP_MultiCopter {
+    AP_Int16 angle_max;
+};

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -101,59 +101,6 @@ public:
     // parameters for example.
     void notify_no_such_mode(uint8_t mode_number);
 
-    /*
-      common parameters for fixed wing aircraft
-     */
-    struct FixedWing {
-        AP_Int8 throttle_min;
-        AP_Int8 throttle_max;
-        AP_Int8 throttle_slewrate;
-        AP_Int8 throttle_cruise;
-        AP_Int8 takeoff_throttle_max;
-        AP_Int16 airspeed_min;
-        AP_Int16 airspeed_max;
-        AP_Int32 airspeed_cruise_cm;
-        AP_Int32 min_gndspeed_cm;
-        AP_Int8  crash_detection_enable;
-        AP_Int16 roll_limit_cd;
-        AP_Int16 pitch_limit_max_cd;
-        AP_Int16 pitch_limit_min_cd;
-        AP_Int8  autotune_level;
-        AP_Int8  stall_prevention;
-        AP_Int16 loiter_radius;
-
-        struct Rangefinder_State {
-            bool in_range:1;
-            bool have_initial_reading:1;
-            bool in_use:1;
-            float initial_range;
-            float correction;
-            float initial_correction;
-            float last_stable_correction;
-            uint32_t last_correction_time_ms;
-            uint8_t in_range_count;
-            float height_estimate;
-            float last_distance;
-        };
-
-
-        // stages of flight
-        enum FlightStage {
-            FLIGHT_TAKEOFF       = 1,
-            FLIGHT_VTOL          = 2,
-            FLIGHT_NORMAL        = 3,
-            FLIGHT_LAND          = 4,
-            FLIGHT_ABORT_LAND    = 7
-        };
-    };
-
-    /*
-      common parameters for multicopters
-     */
-    struct MultiCopter {
-        AP_Int16 angle_max;
-    };
-
     void get_common_scheduler_tasks(const AP_Scheduler::Task*& tasks, uint8_t& num_tasks);
     // implementations *MUST* fill in all passed-in fields or we get
     // Valgrind errors

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -32,9 +32,12 @@ extern const AP_HAL::HAL& hal;
 #include <AC_Sprayer/AC_Sprayer.h>
 #include <AP_Camera/AP_Camera.h>
 #include <AP_Camera/AP_RunCam.h>
+#include <AP_Compass/AP_Compass.h>
 #include <AP_Generator/AP_Generator.h>
 #include <AP_Gripper/AP_Gripper.h>
+#include <AP_GyroFFT/AP_GyroFFT.h>
 #include <AP_ADSB/AP_ADSB.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_LandingGear/AP_LandingGear.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
@@ -46,10 +49,10 @@ extern const AP_HAL::HAL& hal;
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mount/AP_Mount.h>
+#include <AP_Notify/AP_Notify.h>
 #include <AP_VideoTX/AP_VideoTX.h>
 #include <AP_Torqeedo/AP_Torqeedo.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
-
 #define SWITCH_DEBOUNCE_TIME_MS  200
 
 const AP_Param::GroupInfo RC_Channel::var_info[] = {

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -19,7 +19,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "SRV_Channel.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -19,7 +19,9 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
 #include "SRV_Channel.h"
 #include <AP_Logger/AP_Logger.h>
 

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -19,9 +19,10 @@
   of storage offsets to available storage
  */
 
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #include "StorageManager.h"
 


### PR DESCRIPTION
this stops the libraries knowing anything about AP_Vehicle - at least in the headers.