### PR TITLE
Rotoye BATMON: read currents higher than (+/-)32A, fix temperature registers

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -120,6 +120,15 @@ void AP_BattMonitor_SMBus::read_temp(void)
     _state.temperature = KELVIN_TO_C(0.1f * data);
 }
 
+void AP_BattMonitor_SMBus::read_current(void)
+{
+    uint16_t data;
+    if (read_word(BATTMONITOR_SMBUS_CURRENT, data)) {
+        _state.current_amps = -(float)((int16_t)data) * 0.001f;
+        _state.last_time_micros = AP_HAL::micros();
+    }
+}
+
 // reads the serial number if it's not already known
 // returns if the serial number was already known
 void AP_BattMonitor_SMBus::read_serial_number(void)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -74,6 +74,9 @@ protected:
     // reads the temperature word from the battery
     virtual void read_temp(void);
 
+    // reads the temperature word from the battery
+    virtual void read_current(void);
+
     // reads the serial number if it's not already known
     // returns if the serial number was already known
     void read_serial_number(void);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Generic.cpp
@@ -109,11 +109,7 @@ void AP_BattMonitor_SMBus_Generic::timer()
         return;
     }
 
-    // read current (A)
-    if (read_word(BATTMONITOR_SMBUS_CURRENT, data)) {
-        _state.current_amps = -(float)((int16_t)data) * 0.001f;
-        _state.last_time_micros = tnow;
-    }
+    read_current();
 
     read_full_charge_capacity();
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.cpp
@@ -3,45 +3,44 @@
 #include <AP_HAL/AP_HAL.h>
 
 // Specific to Rotoye Batmon
-#define BATTMONITOR_SMBUS_BOARD_TEMP 0x08
-#define BATTMONITOR_SMBUS_TEMP_EXTERNAL_1 0x48
-#define BATTMONITOR_SMBUS_TEMP_EXTERNAL_2 0x49
-#define BATTMONITOR_BATMON_DECI_CURRENT 0x41
+#define BATTMONITOR_SMBUS_BOARD_TEMP 0x08       // Temperature of BATMON PCB
+#define BATTMONITOR_SMBUS_TEMP_EXTERNAL_1 0x48  // Temperature of first external thermistor
+#define BATTMONITOR_SMBUS_TEMP_EXTERNAL_2 0x49  // Temperature of second external thermistor
+#define BATTMONITOR_BATMON_DECI_CURRENT 0x41    // Current drained in deciCurrent (int16)
 
 
 // return the maximum of the internal and external temperature sensors
 void AP_BattMonitor_SMBus_Rotoye::read_temp(void) {
-    uint16_t t_int = 0;
-    uint16_t t_ext = 0;
+    uint16_t t_ext_1 = 0;
 
-    /*  Both internal and external values will always be sent by Batmon.
-        If no external thermistor is used, a zero-value is sent. */
-    const bool have_temp_internal = read_word(BATTMONITOR_SMBUS_TEMP, t_int);
-    const bool have_temp_external = read_word(BATTMONITOR_SMBUS_TEMP_EXT, t_ext);
+    // If thermistor is not connected, an 0xFFFF value is sent
+    read_word(BATTMONITOR_SMBUS_TEMP_EXTERNAL_1, t_ext_1);
 
-    if (!have_temp_internal && !have_temp_external) {
+    if (t_ext_1 == 0xFFFF){
         _has_temperature = (AP_HAL::millis() - _state.temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
         return;
     }
-
     _has_temperature = true;
-
     _state.temperature_time = AP_HAL::millis();
-    _state.temperature = KELVIN_TO_C(0.1f * float(MAX(t_int, t_ext)));
+    _state.temperature = KELVIN_TO_C(0.1f * t_ext_1);
 }
 
 void AP_BattMonitor_SMBus_Rotoye::read_current(void) {
     uint16_t data;
+    float curmA;
+
     // Read current in mA for existing BATMONs according to SBS spec
     if (read_word(BATTMONITOR_SMBUS_CURRENT, data)) {
-        _state.current_amps = -(float)((int16_t)data) * 0.001f;
+        curmA = -(float)((int16_t)data) * 0.001f;
+
+        // Read current in deciAmps for newer BATMON firmware (>v5.09)
+        if (data == (uint16_t)INT16_MIN || data == INT16_MAX )
+            if (read_word(BATTMONITOR_BATMON_DECI_CURRENT, data)) {
+                if (data != 0xFFFF){ // backward compatibility for older BATMON versions
+                    curmA = -(float)((int16_t)data) * 0.1f;
+                }
+            }
+        _state.current_amps = curmA;
         _state.last_time_micros = AP_HAL::micros();
-    }
-    // Read current in dA for newer BATMON firmware (>v5.09)
-    if (read_word(BATTMONITOR_BATMON_DECI_CURRENT, data)) {
-        if (data != 0xFFFF){ // backward compatibility for older BATMON versions
-            _state.current_amps = -(float)((int16_t)data) * 0.1f;
-            _state.last_time_micros = AP_HAL::micros();
-        }
     }
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Rotoye.h
@@ -11,4 +11,5 @@ private:
     // Rotoye Batmon has two temperature readings
     void read_temp(void) override;
 
+    void read_current(void) override;
 };


### PR DESCRIPTION
1. read currents higher than (+/-)32A
2. Few fixes to the temperature registers. The internal temperature is for the PCB and not relevant to the autopilot. @hendjoshsr71 