### PR TITLE
Initialize jump-tracking in AP_Mission::init()

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -55,6 +55,9 @@ void AP_Mission::init()
     // command list will be cleared if they do not match
     check_eeprom_version();
 
+    // initialize the jump tracking array
+    init_jump_tracking();
+
     // If Mission Clear bit is set then it should clear the mission, otherwise retain the mission.
     if (AP_MISSION_MASK_MISSION_CLEAR & _options) {
         gcs().send_text(MAV_SEVERITY_INFO, "Clearing Mission");


### PR DESCRIPTION
The jump tracking array in AP_Mission only initializes when the mission is restarted, for example when disarming or when the waypoint is set to zero. This means it is possible for that array to never initialize, e.g. if you use Set WP to set the waypoint to anything other than zero after boot but before switching to Auto mode the first time.

It seems like AP_Mission::init() is an appropriate place to call init_jump_tracking.

I encountered this on a quadplane that uses RTL_AUTOLAND. It usually takes more than 30s after boot for me to connect, so it switches to auto mode and sets the waypoint to the landing sequence. Before takeoff, I set the waypoint to 1. In flight, my DO_JUMP commands were not working.

It's really easy to work around: I just set waypoint to 0 now instead of 1, but this should still be fixed.