### PR TITLE
In-flight FFT postfilter

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -579,6 +579,11 @@ void Copter::twentyfive_hz_logging()
         g2.arot.Log_Write_Autorotation();
     }
 #endif
+#if HAL_GYROFFT_ENABLED
+    if (should_log(MASK_LOG_FTN_FAST)) {
+        gyro_fft.write_log_messages();
+    }
+#endif
 }
 
 // three_hz_loop - 3.3hz loop
@@ -725,10 +730,10 @@ void Copter::update_altitude()
         Log_Write_Control_Tuning();
         if (!should_log(MASK_LOG_FTN_FAST)) {
             AP::ins().write_notch_log_messages();
-        }
 #if HAL_GYROFFT_ENABLED
-        gyro_fft.write_log_messages();
+            gyro_fft.write_log_messages();
 #endif
+        }
     }
 }
 

--- a/libraries/AP_GyroFFT/examples/ReplayGyroFFT/ReplayGyroFFT.cpp
+++ b/libraries/AP_GyroFFT/examples/ReplayGyroFFT/ReplayGyroFFT.cpp
@@ -1,0 +1,177 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL_Empty/AP_HAL_Empty.h>
+#include <AP_Arming/AP_Arming.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_GyroFFT/AP_GyroFFT.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
+#include <AP_Baro/AP_Baro.h>
+#include <AP_ExternalAHRS/AP_ExternalAHRS.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Arming/AP_Arming.h>
+#include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+static const uint32_t LOOP_RATE_HZ = 400;
+static const uint32_t LOOP_DELTA_US = 1000000 / LOOP_RATE_HZ;
+static const uint32_t RUN_TIME = 120;   // 2 mins
+static const uint32_t LOOP_ITERATIONS = LOOP_RATE_HZ * RUN_TIME;
+
+void setup();
+void loop();
+
+static AP_SerialManager serial_manager;
+static AP_BoardConfig board_config;
+static AP_InertialSensor ins;
+static AP_Baro baro;
+AP_Int32 logger_bitmask;
+static AP_Logger logger{logger_bitmask};
+#if HAL_EXTERNAL_AHRS_ENABLED
+static AP_ExternalAHRS external_ahrs;
+#endif
+static SITL::SIM sitl;
+static AP_Scheduler scheduler;
+
+// create fake gcs object
+GCS_Dummy _gcs;
+
+const struct LogStructure log_structure[] = {
+    LOG_COMMON_STRUCTURES
+};
+
+const AP_Param::GroupInfo GCS_MAVLINK_Parameters::var_info[] = {
+    AP_GROUPEND
+};
+
+class Arming : public AP_Arming {
+public:
+    Arming() : AP_Arming() {}
+    bool arm(AP_Arming::Method method, bool do_arming_checks=true) override {
+        armed = true;
+        return true;
+    }
+};
+
+static Arming arming;
+
+class ReplayGyroFFT {
+public:
+    void init() {
+        fft._enable.set(1);             // FFT_ENABLE
+        fft._window_size.set(64);       // FFT_WINDOW_SIZE
+        fft._snr_threshold_db.set(10);  // FFT_SNR_REF
+        fft._fft_min_hz.set(50);        // FFT_MINHZ
+        fft._fft_max_hz.set(450);       // FFT_MAXHZ
+
+        fft.init(LOOP_RATE_HZ);
+        fft.update_parameters();
+    }
+
+    void loop() {
+        fft.sample_gyros();
+        fft.update();
+        // calibrate the FFT
+        uint32_t now = AP_HAL::millis();
+        if (!arming.is_armed()) {
+            char buf[32];
+            if (!fft.pre_arm_check(buf, 32)) {
+                if (now - last_output_ms > 1000) {
+                    hal.console->printf("%s\n", buf);
+                    last_output_ms = now;
+                }
+            } else {
+                logger.PrepForArming();
+                arming.arm(AP_Arming::Method::RUDDER);
+                logger.set_vehicle_armed(true);
+                // apply throttle values to motors to make sure the fake IMU generates energetic enough data
+                for (uint8_t i=0; i<4; i++) {
+                    hal.rcout->write(i, 1500);
+                }
+            }
+        } else {
+            if (now - last_output_ms > 1000) {
+                hal.console->printf(".");
+                last_output_ms = now;
+            }
+        }
+        fft.write_log_messages();
+    }
+    AP_GyroFFT fft;
+    uint32_t last_output_ms;
+};
+
+static ReplayGyroFFT replay;
+
+void setup()
+{
+    hal.console->printf("ReplayGyroFFT\n");
+    board_config.init();   
+    serial_manager.init();
+
+    const bool generate = false;
+    if (generate) {
+        sitl.vibe_freq.set(Vector3f(250,250,250));  // SIM_VIB_FREQ
+        sitl.drift_speed.set(0);    // SIM_DRIFT_SPEED
+        sitl.drift_time.set(0);     // SIM_DRIFT_TIME
+        sitl.gyro_noise[0].set(20); // SIM_GYR1_RND
+    } else {
+        sitl.speedup.set(100);      // SIM_SPEEDUP
+        sitl.gyro_file_rw.set(SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF);   // SIM_GYR_FILE_RW
+    }
+    logger_bitmask.set(128);    // IMU
+    logger.Init(log_structure, ARRAY_SIZE(log_structure));
+    ins.init(LOOP_RATE_HZ);
+    baro.init();
+
+    replay.init();
+}
+
+static uint32_t loop_iter = LOOP_ITERATIONS;
+
+void loop()
+{
+    if (!hal.console->is_initialized()) {
+        return;
+    }
+
+    ins.wait_for_sample();
+    uint32_t sample_time_us = AP_HAL::micros();
+
+    ins.update();
+    ins.periodic();
+    logger.periodic_tasks();
+    ins.Write_IMU();
+    replay.loop();
+
+    uint32_t elapsed = AP_HAL::micros() - sample_time_us;
+    if (elapsed < LOOP_DELTA_US) {
+        hal.scheduler->delay_microseconds(LOOP_DELTA_US - elapsed);
+    }
+
+    if (sitl.gyro_file_rw != SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF && loop_iter-- == 0) {
+        hal.console->printf("\n");
+        exit(0);
+    }
+}
+
+AP_HAL_MAIN();
+
+#else
+
+#include <stdio.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+static void loop() { }
+static void setup()
+{
+    printf("Board not currently supported\n");
+}
+
+AP_HAL_MAIN();
+
+#endif

--- a/libraries/AP_GyroFFT/examples/ReplayGyroFFT/wscript
+++ b/libraries/AP_GyroFFT/examples/ReplayGyroFFT/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -206,6 +206,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     // default to CMAC
     const char *home_str = nullptr;
     const char *model_str = nullptr;
+    const char *vehicle_str = SKETCH;
     _use_fg_view = true;
     char *autotest_dir = nullptr;
     _fg_address = "127.0.0.1";
@@ -337,6 +338,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 #if STORAGE_USE_FRAM
         {"set-storage-fram-enabled", true,   0, CMDLINE_SET_STORAGE_FRAM_ENABLED},
 #endif
+        {"vehicle",           true,   0, 'v'},
         {0, false, 0, 0}
     };
 
@@ -361,7 +363,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 
     bool wiping_storage = false;
 
-    GetOptLong gopt(argc, argv, "hwus:r:CI:P:SO:M:F:c:",
+    GetOptLong gopt(argc, argv, "hwus:r:CI:P:SO:M:F:c:v:",
                     options);
     while (!is_replay && (opt = gopt.getoption()) != -1) {
         switch (opt) {
@@ -419,6 +421,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             break;
         case 'F':
             _fg_address = gopt.optarg;
+            break;
+        case 'v':
+            vehicle_str = gopt.optarg;
             break;
         case CMDLINE_GIMBAL:
             enable_gimbal = true;
@@ -590,20 +595,20 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         hal.set_wipe_storage(wiping_storage);
     }
 
-    fprintf(stdout, "Starting sketch '%s'\n", SKETCH);
+    fprintf(stdout, "Starting sketch '%s'\n", vehicle_str);
 
-    if (strcmp(SKETCH, "ArduCopter") == 0) {
+    if (strcmp(vehicle_str, "ArduCopter") == 0) {
         _vehicle = ArduCopter;
-    } else if (strcmp(SKETCH, "Rover") == 0) {
+    } else if (strcmp(vehicle_str, "Rover") == 0) {
         _vehicle = Rover;
         // set right default throttle for rover (allowing for reverse)
         pwm_input[2] = 1500;
-    } else if (strcmp(SKETCH, "ArduSub") == 0) {
+    } else if (strcmp(vehicle_str, "ArduSub") == 0) {
         _vehicle = ArduSub;
         for(uint8_t i = 0; i < 8; i++) {
             pwm_input[i] = 1500;
         }
-    } else if (strcmp(SKETCH, "Blimp") == 0) {
+    } else if (strcmp(vehicle_str, "Blimp") == 0) {
         _vehicle = Blimp;
         for(uint8_t i = 0; i < 8; i++) {
             pwm_input[i] = 1500;

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -91,7 +91,7 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         char *devtype = strtok_r(s, ":", &saveptr);
         char *args1 = strtok_r(nullptr, ":", &saveptr);
         char *args2 = strtok_r(nullptr, ":", &saveptr);
-#if !defined(HAL_BUILD_AP_PERIPH)
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
         if (_portNumber == 2 && AP::sitl()->adsb_plane_count >= 0) {
             // this is ordinarily port 5762.  The ADSB simulation assumed
             // this port, so if enabled we assume we'll be doing ADSB...

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -186,11 +186,12 @@ public:
 
     // FFT support access
 #if HAL_WITH_DSP
-    const Vector3f     &get_raw_gyro(void) const { return _gyro_raw[_primary_gyro]; }
+    const Vector3f& get_gyro_for_fft(void) const { return _gyro_for_fft[_primary_gyro]; }
     FloatBuffer&  get_raw_gyro_window(uint8_t instance, uint8_t axis) { return _gyro_window[instance][axis]; }
     FloatBuffer&  get_raw_gyro_window(uint8_t axis) { return get_raw_gyro_window(_primary_gyro, axis); }
     uint16_t get_raw_gyro_rate_hz() const { return get_raw_gyro_rate_hz(_primary_gyro); }
     uint16_t get_raw_gyro_rate_hz(uint8_t instance) const { return _gyro_raw_sample_rates[_primary_gyro]; }
+    bool has_fft_notch() const;
 #endif
     bool set_gyro_window_size(uint16_t size);
     // get accel offsets in m/s/s
@@ -525,9 +526,14 @@ private:
     Vector3f _gyro_filtered[INS_MAX_INSTANCES];
 #if HAL_WITH_DSP
     // Thread-safe public version of _last_raw_gyro
-    Vector3f _gyro_raw[INS_MAX_INSTANCES];
+    Vector3f _gyro_for_fft[INS_MAX_INSTANCES];
+    Vector3f _last_gyro_for_fft[INS_MAX_INSTANCES];
     FloatBuffer _gyro_window[INS_MAX_INSTANCES][XYZ_AXIS_COUNT];
     uint16_t _gyro_window_size;
+    // capture a gyro window after the filters
+    LowPassFilter2pVector3f _post_filter_gyro_filter[INS_MAX_INSTANCES];
+    bool _post_filter_fft;
+    uint8_t _fft_window_phase;
 #endif
     bool _new_accel_data[INS_MAX_INSTANCES];
     bool _new_gyro_data[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -59,6 +59,10 @@
 #define AP_SIM_INS_ENABLED AP_SIM_ENABLED
 #endif
 
+#ifndef AP_SIM_INS_FILE_ENABLED
+#define AP_SIM_INS_FILE_ENABLED AP_SIM_ENABLED
+#endif
+
 class AP_InertialSensor_Backend;
 class AuxiliaryBus;
 class AP_AHRS;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -142,8 +142,9 @@ protected:
     // rotate gyro vector, offset and publish
     void _publish_gyro(uint8_t instance, const Vector3f &gyro) __RAMFUNC__; /* front end */
 
-    // apply notch and lowpass gyro filters
+    // apply notch and lowpass gyro filters and sample for FFT
     void apply_gyro_filters(const uint8_t instance, const Vector3f &gyro);
+    void save_gyro_window(const uint8_t instance, const Vector3f &gyro, uint8_t phase);
 
     // this should be called every time a new gyro raw sample is
     // available - be it published or not the sample is raw in the

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_InertialSensor_SITL.h"
+#include <AP_Logger/AP_Logger.h>
 #include <SITL/SITL.h>
 #include <stdio.h>
 
@@ -185,6 +186,11 @@ void AP_InertialSensor_SITL::generate_accel()
 
         _notify_new_accel_sensor_rate_sample(accel_instance, accel);
 
+#if AP_SIM_INS_FILE_ENABLED
+        if (sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_WRITE) {
+            write_accel_to_file(accel);
+        }
+#endif
         accel_accum += accel;
     }
 
@@ -280,6 +286,12 @@ void AP_InertialSensor_SITL::generate_gyro()
 
         gyro_accum += gyro;
         _notify_new_gyro_sensor_rate_sample(gyro_instance, gyro);
+
+#if AP_SIM_INS_FILE_ENABLED
+        if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_WRITE) {
+            write_gyro_to_file(gyro);
+        }
+#endif
     }
     gyro_accum /= nsamples;
     _rotate_and_correct_gyro(gyro_instance, gyro_accum);
@@ -301,6 +313,12 @@ void AP_InertialSensor_SITL::timer_update(void)
     }
     if (now >= next_accel_sample) {
         if (((1U << accel_instance) & sitl->accel_fail_mask) == 0) {
+#if AP_SIM_INS_FILE_ENABLED
+            if (sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
+                || sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+                read_accel_from_file();
+            } else
+#endif
             generate_accel();
             if (next_accel_sample == 0) {
                 next_accel_sample = now + 1000000UL / accel_sample_hz;
@@ -313,7 +331,14 @@ void AP_InertialSensor_SITL::timer_update(void)
     }
     if (now >= next_gyro_sample) {
         if (((1U << gyro_instance) & sitl->gyro_fail_mask) == 0) {
+#if AP_SIM_INS_FILE_ENABLED
+            if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
+                || sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+                read_gyro_from_file();
+            } else
+#endif
             generate_gyro();
+
             if (next_gyro_sample == 0) {
                 next_gyro_sample = now + 1000000UL / gyro_sample_hz;
             } else {
@@ -359,6 +384,159 @@ void AP_InertialSensor_SITL::start()
     }
     bus_id++;
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
+
+#if AP_SIM_INS_FILE_ENABLED
+    if (sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
+        || sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+        hal.console->printf("Reading accel data from file for IMU[%u]\n", accel_instance);
+    }
+    if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
+        || sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ) {
+        hal.console->printf("Reading gyro data from file for IMU[%u]\n", gyro_instance);
+    }
+#endif
 }
+
+/*
+  temporary method to use file as GPS data
+ */
+#if AP_SIM_INS_FILE_ENABLED
+void AP_InertialSensor_SITL::read_gyro_from_file()
+{
+    if (gyro_fd == -1) {
+        char namebuf[32];
+        snprintf(namebuf, 32, "/tmp/gyro%d.dat", gyro_instance);
+        gyro_fd = open(namebuf, O_RDONLY|O_CLOEXEC);
+        if (gyro_fd == -1) {
+            AP_HAL::panic("gyro data file %s not found", namebuf);
+        }
+    }
+
+    float buf[8 * 3 * sizeof(float)];
+
+    uint8_t nsamples = enable_fast_sampling(gyro_instance) ? 8 : 1;
+    ssize_t ret = ::read(gyro_fd, buf, nsamples * 3 * sizeof(float));
+    if (ret == (ssize_t)(nsamples * 3 * sizeof(float))) {
+        read_gyro(buf, nsamples);
+    }
+
+    if (ret <= 0) {
+        if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+            //stop logging
+            if (AP_Logger::get_singleton()) {
+                AP::logger().StopLogging();
+            }
+            exit(0);
+        }
+        lseek(gyro_fd, 0, SEEK_SET);
+    }
+}
+
+void AP_InertialSensor_SITL::read_gyro(const float* buf, uint8_t nsamples)
+{
+    Vector3f gyro_accum;
+
+    for (uint8_t j = 0; j < nsamples; j++) {
+        float p = buf[j*3];
+        float q = buf[j*3+1];
+        float r = buf[j*3+2];
+
+        Vector3f gyro = Vector3f(p, q, r);
+
+        _notify_new_gyro_sensor_rate_sample(gyro_instance, gyro);
+
+        gyro_accum += gyro;
+    }
+    gyro_accum /= nsamples;
+    _rotate_and_correct_gyro(gyro_instance, gyro_accum);
+    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, AP_HAL::micros64());
+}
+
+void AP_InertialSensor_SITL::write_gyro_to_file(const Vector3f& gyro)
+{
+    if (gyro_fd == -1) {
+        char namebuf[32];
+        snprintf(namebuf, 32, "/tmp/gyro%d.dat", gyro_instance);
+        gyro_fd = open(namebuf, O_WRONLY|O_TRUNC|O_CREAT, S_IRWXU|S_IRGRP|S_IROTH);
+    }
+
+    float buf[] { gyro.x, gyro.y, gyro.z };
+
+    if (::write(gyro_fd, (void*)buf, sizeof(float) * 3) < 0) {
+        ::printf("Could not write to file\n");
+    }
+}
+
+void AP_InertialSensor_SITL::read_accel_from_file()
+{
+    if (accel_fd == -1) {
+        char namebuf[32];
+        snprintf(namebuf, 32, "/tmp/accel%d.dat", accel_instance);
+        accel_fd = open(namebuf, O_RDONLY|O_CLOEXEC);
+        if (accel_fd == -1) {
+            AP_HAL::panic("accel data file %s not found", namebuf);
+        }
+    }
+
+    float buf[4*3*sizeof(float)];
+
+    uint8_t nsamples = enable_fast_sampling(accel_instance) ? 4 : 1;
+    ssize_t ret = ::read(accel_fd, buf, nsamples * 3 * sizeof(float));
+    if (ret == (ssize_t)(nsamples * 3 * sizeof(float))) {
+        read_accel(buf, nsamples);
+    }
+
+    if (ret <= 0) {
+        if (sitl->accel_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+            //stop logging
+            if (AP_Logger::get_singleton()) {
+                AP::logger().StopLogging();
+            }
+            exit(0);
+        }
+        lseek(accel_fd, 0, SEEK_SET);
+    }
+}
+
+void AP_InertialSensor_SITL::read_accel(const float* buf, uint8_t nsamples)
+{
+    Vector3f accel_accum;
+
+    for (uint8_t j = 0; j < nsamples; j++) {
+        float p = buf[j*3];
+        float q = buf[j*3+1];
+        float r = buf[j*3+2];
+
+        Vector3f accel = Vector3f(p, q, r);
+
+        _notify_new_accel_sensor_rate_sample(accel_instance, accel);
+
+        accel_accum += accel;
+    }
+
+    accel_accum /= nsamples;
+    _rotate_and_correct_accel(accel_instance, accel_accum);
+    _notify_new_accel_raw_sample(accel_instance, accel_accum, AP_HAL::micros64());
+
+    _publish_temperature(accel_instance, get_temperature());
+}
+
+void AP_InertialSensor_SITL::write_accel_to_file(const Vector3f& accel)
+{
+
+    if (accel_fd == -1) {
+        char namebuf[32];
+        snprintf(namebuf, 32, "/tmp/accel%d.dat", accel_instance);
+        accel_fd = open(namebuf, O_WRONLY|O_TRUNC|O_CREAT, S_IRWXU|S_IRGRP|S_IROTH);
+    }
+
+    float buf[] { accel.x, accel.y, accel.z };
+
+    if (::write(accel_fd, (void*)buf, sizeof(float) * 3) < 0) {
+        ::printf("Could not write to file\n");
+    }
+}
+
+#endif  // AP_SIM_INS_FILE_ENABLED
 
 #endif // AP_SIM_INS_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -31,7 +31,15 @@ private:
     void generate_accel();
     void generate_gyro();
     float get_temperature(void);
-
+    void update_file();
+#if AP_SIM_INS_FILE_ENABLED
+    void read_gyro(const float* buf, uint8_t nsamples);
+    void read_gyro_from_file();
+    void write_gyro_to_file(const Vector3f& gyro);
+    void read_accel(const float* buf, uint8_t nsamples);
+    void read_accel_from_file();
+    void write_accel_to_file(const Vector3f& accel);
+#endif
     SITL::SIM *sitl;
 
     const uint16_t gyro_sample_hz;
@@ -46,6 +54,10 @@ private:
     float gyro_motor_phase[32];
     float accel_motor_phase[32];
     uint32_t temp_start_ms;
+#if AP_SIM_INS_FILE_ENABLED
+    int gyro_fd = -1;
+    int accel_fd = -1;
+#endif
 
     static uint8_t bus_id;
 };

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -272,6 +272,12 @@ void AP_Vehicle::setup()
 
     custom_rotations.init();
 
+#if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
+    for (uint8_t i = 0; i<ESC_TELEM_MAX_ESCS; i++) {
+        esc_noise[i].set_cutoff_frequency(2);
+    }
+#endif
+
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 }
 
@@ -383,6 +389,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if HAL_INS_ACCELCAL_ENABLED
     SCHED_TASK(one_Hz_update,                                                         1, 100, 252),
+#endif
+#if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
+    SCHED_TASK(check_motor_noise,      5,     50, 252),
 #endif
     SCHED_TASK(update_arming,          1,     50, 253),
 };
@@ -738,6 +747,35 @@ void AP_Vehicle::one_Hz_update(void)
         }
 #endif
     }
+}
+
+void AP_Vehicle::check_motor_noise()
+{
+#if HAL_GYROFFT_ENABLED && HAL_WITH_ESC_TELEM
+    if (!hal.util->get_soft_armed() || !gyro_fft.check_esc_noise() || !gyro_fft.using_post_filter_samples() || ins.has_fft_notch()) {
+        return;
+    }
+
+    float esc_data[ESC_TELEM_MAX_ESCS];
+    const uint8_t numf = AP::esc_telem().get_motor_frequencies_hz(ESC_TELEM_MAX_ESCS, esc_data);
+    bool output_error = false;
+
+    for (uint8_t i = 0; i<numf; i++) {
+        if (is_zero(esc_data[i])) {
+            continue;
+        }
+        float energy = gyro_fft.has_noise_at_frequency_hz(esc_data[i]);
+        energy = esc_noise[i].apply(energy, 0.2f);
+        if (energy > 40.0f && AP_HAL::millis() - last_motor_noise_ms > 5000) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Noise %.fdB on motor %u at %.fHz", energy, i+1, esc_data[i]);
+            output_error = true;
+        }
+    }
+
+    if (output_error) {
+        last_motor_noise_ms = AP_HAL::millis();
+    }
+#endif
 }
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -57,6 +57,7 @@
 #include <AP_AIS/AP_AIS.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
+#include <Filter/LowPassFilter.h>
 
 class AP_Vehicle : public AP_HAL::HAL::Callbacks {
 
@@ -372,6 +373,9 @@ protected:
     // call the arming library's update function
     void update_arming();
 
+    // check for motor noise at a particular frequency
+    void check_motor_noise();
+
     ModeReason control_mode_reason = ModeReason::UNKNOWN;
 
 #if AP_SIM_ENABLED
@@ -405,6 +409,11 @@ private:
     uint32_t _last_notch_update_ms[HAL_INS_NUM_HARMONIC_NOTCH_FILTERS]; // last time update_dynamic_notch() was run
 
     static AP_Vehicle *_singleton;
+
+#if HAL_GYROFFT_ENABLED && HAL_WITH_ESC_TELEM
+    LowPassFilterFloat esc_noise[ESC_TELEM_MAX_ESCS];
+    uint32_t last_motor_noise_ms;
+#endif
 
     bool done_safety_init;
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -525,7 +525,11 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @DisplayName: SIM-on_hardware Output Enable Mask
     // @Description: channels which are passed through to actual hardware when running on actual hardware
     AP_GROUPINFO("OH_MASK",     28, SIM, on_hardware_output_enable_mask, 0),
-
+#if AP_SIM_INS_FILE_ENABLED
+    // read and write IMU data to/from files
+    AP_GROUPINFO("GYR_FILE_RW", 29, SIM, gyro_file_rw, INSFileMode::INS_FILE_NONE),
+    AP_GROUPINFO("ACC_FILE_RW", 30, SIM, accel_file_rw, INSFileMode::INS_FILE_NONE),
+#endif
     // the IMUT parameters must be last due to the enable parameters
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SIM, AP_InertialSensor::TCal),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -506,6 +506,17 @@ public:
 
     // Master instance to use servos from with slave instances
     AP_Int8 ride_along_master;
+
+#if AP_SIM_INS_FILE_ENABLED
+    enum INSFileMode {
+        INS_FILE_NONE = 0,
+        INS_FILE_READ = 1,
+        INS_FILE_WRITE = 2,
+        INS_FILE_READ_STOP_ON_EOF = 3,
+    };
+    AP_Int8 gyro_file_rw;
+    AP_Int8 accel_file_rw;
+#endif
 };
 
 } // namespace SITL


### PR DESCRIPTION
This PR adds the ability to run the in-flight FFT after the filtering. This enables a couple of things:

- FFT driven notches that "clean-up" the remaining noise
- The ability to check whether there is significant noise at a motor frequency

Working reasonably well now and verified by SITL

To run:
```
./waf configure --board sitl --debug
./waf copter
./Tools/autotest/autotest.py fly.ArduCopter.GyroFFTPostFilter
```
This puts IMU data in /tmp. Then:
```
./waf build --target examples/ReplayGyroFFT
./build/sitl/examples/ReplayGyroFFT -M quad -C -v ArduCopter
```