### PR TITLE
SPort Passthrough telemetry via MAVLink (WIP, do not merge)

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -515,6 +515,9 @@ static const ap_message STREAM_EXTRA1_msgs[] = {
 };
 static const ap_message STREAM_EXTRA2_msgs[] = {
     MSG_VFR_HUD
+//OW
+    ,MSG_FRSKY_PASSTHROUGH_ARRAY
+//OWEND
 };
 static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_AHRS,

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,102 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.3.0-beta1 14-Sep-2022
+Changes from 4.2.3
+1) New autopilot support
+    a) AtomRCF405
+    b) CubeOrange-SimOnHardWare
+    c) DevEBoxH7v2
+    d) KakuteH7Mini-Nand
+    e) KakuteH7v2
+    f) Mamba F405 Mk4
+    g) SkystarsH7HD
+    h) bi-directional dshot (aka "bdshot") versions for CubeOrange, CubeYellow, KakuteF7, KakuteH7, MatekF405-Wing, Matek F765, PH4-mini, Pixhawk-1M
+2) EKF enhancements and fixes
+    a) EK3_GPS_VACC_MAX threshold to control when GPS altitude is used as alt source
+    b) EKF ring buffer fix for very slow sensor updates (those that update once every few seconds)
+    c) EKF3 source set change captured in Replay logs
+3) Gimbal enhancements
+    a) Angle limit params renamed and scaled to degrees (e.g. MNT1_ROLL_MIN, MNT1_PITCH_MIN, etc)
+    b) BrushlessPWM driver (set MNT1_TYPE = 7) is unstabilized Servo driver
+    c) Dual mount support (see MNT1_, MNT2 params)
+    d) Gremsy driver added (set MNT1_TYPE = 6)
+    e) MAVLink gimbalv2 support including sending GIMBAL_DEVICE_STATUS_UPDATE (replaces MOUNT_STATUS message)
+    f) "Mount Lock" auxiliary switch supports follow and lock modes in RC targetting (aka earth-frame and body-frame)    
+    g) RC channels to control gimbal set using RCx_OPTION = 212 (Roll), 213 (Pitch) or 214 (Yaw)
+    h) RC targetting rotation rate in deg/sec (see MNT1_RC_RATE which replaces MNT_JSTICK_SPD)
+    i) Yaw can be disabled on 3-axis gimbals (set MNTx_YAW_MIN = MNTx_YAW_MAX)
+4) Navigation and Flight mode enhancements
+    a) Auto mode ATTITUDE_TIME command allows specifying lean angle for specified number of seconds (GPS not required)
+    b) Auto mode support of DO_GIMBAL_MANAGER_PITCHYAW command
+    c) Auto mode LOITER_TURNS command max radius increased to 2.5km
+    d) AutoTune allows higher ANGLE_P gains
+    e) Guided mode support DO_CHANGE_SPEED commands
+    f) Manual modes throttle mix reduced (improves landing)
+    g) Payload touchdown detection reliability improved    
+    h) Takeoff detection improved to reduce chance of flip before takeoff if GPS moves
+    i) TKOFF_SLEW_TIME allows slower takeoffs in Auto, Guided, etc
+5) Notch filter enhancements
+    a) Attitude and filter logging at main loop rate
+    b) Batch sampler logging both pre and post-filter
+    c) FFT frame averaging
+    d) In-flight throttle notch parameter learning using averaged FFTs
+    e) Triple harmonic notch 
+5) RemoteId and SecureBoot enhancements
+    a) Remote update of secure boot's public keys (also allows remote unlocking of bootloader)
+6) Safety enhancements
+    a) Arming checks of FRAME_CLASS/TYPE made mandatory (even if ARMING_CHECK=0)
+    b) crash_dump.bin file saved to SD Card on startup (includes details re cause of software failures)
+    c) Dead-reckoning for 30sec on loss of GPS (requires wind estimation be enabled)
+    d) Dead-reckoning Lua script (On loss of GPS flies towards home for specified number of seconds)
+    e) Disabling Fence clears any active breaches (e.g. FENCE_TYPE = 0 will clear breaches)
+    f) "GPS Glitch" message clarified to "GPS Glitch or Compass error"
+    g) Pre-arm check that configured AHRS is being used (e.g. checks AHRS_EKF_TYPE not changed since boot)
+    h) Pre-arm check that gimbals are healthy (currently only for Gremsy gimbals, others in future release)
+    i) Pre-arm check that all motors are setup
+    j) Pre-arm check that scripts are running
+    k) Pre-arm check that terrain data loaded if RTL_ALT_TYPE set to Terrain
+    l) Pre-arm messages are correctly prefixed with "PreArm:" (instead of "Arm:")
+    m) RC auxiliary switch option for Arm / Emergency Stop
+    n) RC failsafe made pre-arm check (previously only triggered at arming)
+    o) RC failsafe option (see FS_OPTIONS) to continue in Guided obeyed even if GCS failsafe disabled
+    p) TKOFF_RPM_MIN checks all motors spinning before takeoff
+    q) Vibration compensation disabled in manual modes
+7) Scripting enhancements
+    a) CAN2 port bindings to allow scripts to communicate on 2nd CAN bus
+    b) ESC RPM bindings to allow scripts to report engine RPM
+    c) Gimbal bingings to allow scripts to control gimbal
+    d) Pre-arm check bindings (allows scripts to check if pre-arm checks have passed)
+    e) Semicolon (:) and period (.) supported (e.g both Logger:write() and Logger.write will work)
+8) Sensor driver enhancements
+    a) Benewake H30 radar support
+    b) BMI270 IMU performance improvements
+    c) IRC Tramp VTX suppor
+    d) Logging pause-able with auxiliary switch.  see RCx_OPTION = 165 (Pause Stream Logging)
+    e) Proximity sensor support for up to 3 sensors
+    f) Precision Landing consumes LANDING_TARGET MAVLink message's PositionX,Y,Z fields
+    g) RichenPower generator maintenance-required messages can be suppressed using GEN_OPTIONS param
+    h) TeraRanger Neo rangefinder support
+    i) GPS support to provide ellipsoid altitude instead of AMSL (see GPS_DRV_OPTIONS)
+    j) W25N01GV 1Gb flash support
+9) Bug fixes
+    a) Accel calibration throws away queued commands from GCS (avoids commands being run long after they were sent)
+    b) Airmode throttle mix at zero throttle fix
+    c) Cygbot proximity sensor fix to support different orientations (see PRXx_ORIENT)
+    d) Loiter fix to avoid potential wobble on 2nd takeoff (was not clearing non-zero attitude target from previous landing)
+    e) Lutan EFI message flood reduced
+    f) Missions download to GCS corruption avoided by checking serial buffer has space
+    g) Payload place fix so vehicle flies to specified Lat,Lon (if provided).  Previously it could get stuck
+    h) Safety switch disabled if IOMCU is disabled (see BRD_IO_ENABLE=0)
+    i) Script restart memory leak fixed
+    j) Takeoff vertical velocity limits enforced correctly even if PILOT_TKOFF_ALT set to a significant height
+10) Developer items
+    a) Custom controller support
+    b) Fast loop task list available in real-time using @SYS/tasks.txt
+    c) Parameter defaults sent to GCS with param FTP and recorded in onboard logs
+    d) ROS+ArduPilot environment installation script
+    e) Sim on Hardware allows simulator to run on autopilot (good for exhibitions)
+    f) Timer info available in real-time using @SYS/timers.txt
+------------------------------------------------------------------
 Copter 4.2.3 30-Aug-2022
 Changes from 4.2.3-rc3
 1) OpenDroneId bug fix to consume open-drone-id-system-update message

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.0-dev"
+#define THISFIRMWARE "ArduCopter V4.3.0-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,49 @@
+Release 4.3.0beta1 13th Sep 2022
+--------------------------------
+
+This is the first beta of the 4.3.0 stable release. There are a lot of
+changes since the 4.2.3 stable release. Key changes are:
+
+- added new boards AtomRCF405, KakuteH7Mini-Nand, SkystarsH7HD
+- added bi-directional dshot for several new boards
+- EK3_GPS_VACC_MAX threshold to control when GPS altitude is used as alt source
+- EKF ring buffer fix for slow sensor updates
+- EKF3 source set change captured in replay logs
+- numerous gimbal support improvements
+- improved RemoteId support
+- SecureBoot support with remote update of secure boot public keys
+- crash_dump.bin file saved to SD Card on startup (includes details re cause of software failures)
+- several new pre-arm checks (AHRS type, scripts, terrain)
+- numerous scripting improvements
+- fixed scripting restart leaking memory
+- Benewake H30 radar support
+- BMI270 IMU performance improvements
+- Logging pause with auxiliary switch
+- TeraRanger Neo rangefinder support
+- support for both AMSL and ellipsoid height in most GPS drivers
+- Custom controller support
+- parameter defaults sent with param FTP and onboard logs
+- Sim on Hardware allows simulator to run on autopilot
+- added Q_LAND_ALTCHG parameter
+- added climb before QRTL for safer QRTL from low altitudes
+- added support for logging pre and post filtered FFT data
+- support triple-notch harmonic notch filter
+- support up to 32 actuators (with SERVO_32_ENABLE parameter)
+- support EFI input over DroneCAN
+- by default only run notch filter on first IMU
+- added ESC_TLM_MAV_OFS parameter for mapping ESCs to MAVLink ESC telemetry
+- added Q_NAVALT_MIN for quadplane takeoff
+- added ICE redline governor
+- added in-flight FFT notch tuning option
+- added Sagetech ADSB support
+- added INS_HNTCH_FM_RAT parameter for handling under-hover throttle
+- improvements to filtering on ICM42xxx IMUs
+- added option parameters to NAV_VTOL_LAND mission item for fixed wing approach
+
+Please report flight tests of the 4.3.0beta series on discuss.ardupilot.org
+
+Happy flying!
+
 Release 4.2.3 21st August 2022
 ------------------------------
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.3.0dev"
+#define THISFIRMWARE "ArduPlane V4.3.0beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,87 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.3.0-beta1 14-Sep-2022
+Changes from 4.2.3
+1) Rover specific enhancements
+    a) Aux switch for SaveWP displays, "Mission Cleared" if vehicle not armed
+    b) Dock mode using modified precision landing library
+    c) Manual mode steering scaling with speed can be disabled using MANUAL_OPTIONS parameter
+    d) S-Curves for Auto, Guided, RTL
+2) Rover specific bug fixes
+    a) Wheel encoder timestamp fix (WRC_xx params may need to be changed)
+    b) Auto mode stick mixing fixed (see STICK_MIXING parameter)
+    c) Arming check removed to support mixed Ackerman and skid-stering vehicles
+3) New autopilot support
+    a) AtomRCF405
+    b) CubeOrange-SimOnHardWare
+    c) DevEBoxH7v2
+    d) KakuteH7Mini-Nand
+    e) KakuteH7v2
+    f) Mamba F405 Mk4
+    g) SkystarsH7HD
+    h) bi-directional dshot (aka "bdshot") versions for CubeOrange, CubeYellow, KakuteF7, KakuteH7, MatekF405-Wing, Matek F765, PH4-mini, Pixhawk-1M
+4) EKF enhancements and fixes
+    a) EK3_GPS_VACC_MAX threshold to control when GPS altitude is used as alt source
+    b) EKF ring buffer fix for very slow sensor updates (those that update once every few seconds)
+    c) EKF3 source set change captured in Replay logs
+5) Gimbal enhancements
+    a) Angle limit params renamed and scaled to degrees (e.g. MNT1_ROLL_MIN, MNT1_PITCH_MIN, etc)
+    b) BrushlessPWM driver (set MNT1_TYPE = 7) is unstabilized Servo driver
+    c) Dual mount support (see MNT1_, MNT2 params)
+    d) Gremsy driver added (set MNT1_TYPE = 6)
+    e) MAVLink gimbalv2 support including sending GIMBAL_DEVICE_STATUS_UPDATE (replaces MOUNT_STATUS message)
+    f) "Mount Lock" auxiliary switch supports follow and lock modes in RC targetting (aka earth-frame and body-frame)    
+    g) RC channels to control gimbal set using RCx_OPTION = 212 (Roll), 213 (Pitch) or 214 (Yaw)
+    h) RC targetting rotation rate in deg/sec (see MNT1_RC_RATE which replaces MNT_JSTICK_SPD)
+    i) Yaw can be disabled on 3-axis gimbals (set MNTx_YAW_MIN = MNTx_YAW_MAX)
+6) Notch filter enhancements
+    a) Attitude and filter logging at main loop rate
+    b) Batch sampler logging both pre and post-filter
+    c) FFT frame averaging
+    d) In-flight throttle notch parameter learning using averaged FFTs
+    e) Triple harmonic notch 
+7) RemoteId and SecureBoot enhancements
+    a) Remote update of secure boot's public keys (also allows remote unlocking of bootloader)
+8) Safety enhancements
+    a) crash_dump.bin file saved to SD Card on startup (includes details re cause of software failures)
+    b) Disabling Fence clears any active breaches (e.g. FENCE_TYPE = 0 will clear breaches)
+    c) "GPS Glitch" message clarified to "GPS Glitch or Compass error"
+    d) Pre-arm check that configured AHRS is being used (e.g. checks AHRS_EKF_TYPE not changed since boot)
+    e) Pre-arm check that gimbals are healthy (currently only for Gremsy gimbals, others in future release)
+    f) Pre-arm check that scripts are running
+    g) Pre-arm messages are correctly prefixed with "PreArm:" (instead of "Arm:")
+    h) RC auxiliary switch option for Arm / Emergency Stop
+9) Scripting enhancements
+    a) CAN2 port bindings to allow scripts to communicate on 2nd CAN bus
+    b) ESC RPM bindings to allow scripts to report engine RPM
+    c) Gimbal bingings to allow scripts to control gimbal
+    d) Pre-arm check bindings (allows scripts to check if pre-arm checks have passed)
+    e) Semicolon (:) and period (.) supported (e.g both Logger:write() and Logger.write will work)
+10) Sensor driver enhancements
+    a) Benewake H30 radar support
+    b) BMI270 IMU performance improvements
+    c) IRC Tramp VTX suppor
+    d) Logging pause-able with auxiliary switch.  see RCx_OPTION = 165 (Pause Stream Logging)
+    e) Proximity sensor support for up to 3 sensors
+    f) Precision Landing consumes LANDING_TARGET MAVLink message's PositionX,Y,Z fields
+    g) RichenPower generator maintenance-required messages can be suppressed using GEN_OPTIONS param
+    h) TeraRanger Neo rangefinder support
+    i) GPS support to provide ellipsoid altitude instead of AMSL (see GPS_DRV_OPTIONS)
+    j) W25N01GV 1Gb flash support
+11) Bug fixes
+    a) Accel calibration throws away queued commands from GCS (avoids commands being run long after they were sent)
+    b) Cygbot proximity sensor fix to support different orientations (see PRXx_ORIENT)
+    c) Lutan EFI message flood reduced
+    d) Missions download to GCS corruption avoided by checking serial buffer has space
+    e) Safety switch disabled if IOMCU is disabled (see BRD_IO_ENABLE=0)
+    f) Script restart memory leak fixed
+12) Developer items
+    a) Fast loop task list available in real-time using @SYS/tasks.txt
+    b) Parameter defaults sent to GCS with param FTP and recorded in onboard logs
+    c) ROS+ArduPilot environment installation script
+    d) Sim on Hardware allows simulator to run on autopilot (good for exhibitions)
+    e) Timer info available in real-time using @SYS/timers.txt
+------------------------------------------------------------------
 Rover 4.2.3 30-Aug-2022
 Changes from 4.2.3-rc3
 1) OpenDroneId bug fix to consume open-drone-id-system-update message

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.3.0-dev"
+#define THISFIRMWARE "ArduRover V4.3.0-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -264,27 +264,17 @@ class AutoTestCopter(AutoTest):
 
         self.do_RTL()
 
-    def watch_altitude_maintained(self, min_alt, max_alt, timeout=10):
-        '''watch alt, relative alt must remain between min_alt and max_alt'''
-        tstart = self.get_sim_time_cached()
-        while True:
-            if self.get_sim_time_cached() - tstart > timeout:
-                return
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
-            if m.alt <= min_alt:
-                raise NotAchievedException("Altitude not maintained: want >%f got=%f" % (min_alt, m.alt))
-
     def ModeAltHold(self):
         '''Test AltHold Mode'''
         self.takeoff(10, mode="ALT_HOLD")
-        self.watch_altitude_maintained(9, 11, timeout=5)
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
         # feed in full elevator and aileron input and make sure we
         # retain altitude:
         self.set_rc_from_map({
             1: 1000,
             2: 1000,
         })
-        self.watch_altitude_maintained(9, 11, timeout=5)
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
         self.set_rc_from_map({
             1: 1500,
             2: 1500,
@@ -4572,7 +4562,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode("STABILIZE")
         self.change_mode("GUIDED")
         self.set_rc(3, 1700)
-        self.watch_altitude_maintained(-1, 0.2) # should not take off in guided
+        self.watch_altitude_maintained(altitude_min=-1, altitude_max=0.2) # should not take off in guided
         self.run_cmd_do_set_mode(
             "ACRO",
             want_result=mavutil.mavlink.MAV_RESULT_FAILED)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5837,6 +5837,14 @@ class AutoTest(ABC):
             **kwargs
         )
 
+    def watch_altitude_maintained(self, altitude_min, altitude_max, minimum_duration=5, relative=True):
+        """Watch altitude is maintained or not between altitude_min and altitude_max during minimum_duration"""
+        return self.wait_altitude(altitude_min=altitude_min,
+                                  altitude_max=altitude_max,
+                                  relative=relative,
+                                  minimum_duration=minimum_duration,
+                                  timeout=minimum_duration + 1)
+
     def wait_climbrate(self, speed_min, speed_max, timeout=30, **kwargs):
         """Wait for a given vertical rate."""
         assert speed_min <= speed_max, "Minimum speed should be less than maximum speed."

--- a/bp_mavlink/ASLUAV.xml
+++ b/bp_mavlink/ASLUAV.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0"?>
+<!-- ASLUAV Mavlink Message Definition File -->
+<!-- Used for the ASLUAV fixed-wing autopilot (www.asl.ethz.ch), which implements extensions to the Pixhawk (https://docs.px4.io/en/flight_controller/pixhawk.html) autopilot -->
+<mavlink>
+  <include>common.xml</include>
+  <enums>
+    <enum name="MAV_CMD">
+      <!-- ASLUAV specific MAV_CMD_* commands -->
+      <entry name="MAV_CMD_RESET_MPPT" value="40001">
+        <description>Mission command to reset Maximum Power Point Tracker (MPPT)</description>
+        <param index="1">MPPT number</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_PAYLOAD_CONTROL" value="40002">
+        <description>Mission command to perform a power cycle on payload</description>
+        <param index="1">Complete power cycle</param>
+        <param index="2">VISensor power cycle</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+    </enum>
+    <enum name="GSM_LINK_TYPE">
+      <entry value="0" name="GSM_LINK_TYPE_NONE">
+        <description>no service</description>
+      </entry>
+      <entry value="1" name="GSM_LINK_TYPE_UNKNOWN">
+        <description>link type unknown</description>
+      </entry>
+      <entry value="2" name="GSM_LINK_TYPE_2G">
+        <description>2G (GSM/GRPS/EDGE) link</description>
+      </entry>
+      <entry value="3" name="GSM_LINK_TYPE_3G">
+        <description>3G link (WCDMA/HSDPA/HSPA) </description>
+      </entry>
+      <entry value="4" name="GSM_LINK_TYPE_4G">
+        <description>4G link (LTE)</description>
+      </entry>
+    </enum>
+    <enum name="GSM_MODEM_TYPE">
+      <entry value="0" name="GSM_MODEM_TYPE_UNKNOWN">
+        <description>not specified</description>
+      </entry>
+      <entry value="1" name="GSM_MODEM_TYPE_HUAWEI_E3372">
+        <description>HUAWEI LTE USB Stick E3372</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="223" name="COMMAND_INT_STAMPED">
+      <description>Message encoding a command with parameters as scaled integers and additional metadata. Scaling depends on the actual command value.</description>
+      <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
+      <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND, as defined by MAV_FRAME enum</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item, as defined by MAV_CMD enum</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+      <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (MSL, WGS84, AGL or relative to home - depending on frame).</field>
+    </message>
+    <message id="224" name="COMMAND_LONG_STAMPED">
+      <description>Send a command with up to seven parameters to the MAV and additional metadata</description>
+      <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
+      <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
+      <field type="uint8_t" name="target_system">System which should execute the command</field>
+      <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
+      <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
+      <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param3">Parameter 3, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param4">Parameter 4, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param5">Parameter 5, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
+    </message>
+    <message id="8002" name="SENS_POWER">
+      <description>Voltage and current sensor data</description>
+      <field type="float" name="adc121_vspb_volt" units="V"> Power board voltage sensor reading</field>
+      <field type="float" name="adc121_cspb_amp" units="A"> Power board current sensor reading</field>
+      <field type="float" name="adc121_cs1_amp" units="A"> Board current sensor 1 reading</field>
+      <field type="float" name="adc121_cs2_amp" units="A"> Board current sensor 2 reading</field>
+    </message>
+    <message id="8003" name="SENS_MPPT">
+      <description>Maximum Power Point Tracker (MPPT) sensor data for solar module power performance tracking</description>
+      <field type="uint64_t" name="mppt_timestamp" units="us"> MPPT last timestamp </field>
+      <field type="float" name="mppt1_volt" units="V"> MPPT1 voltage </field>
+      <field type="float" name="mppt1_amp" units="A"> MPPT1 current </field>
+      <field type="uint16_t" name="mppt1_pwm" units="us"> MPPT1 pwm </field>
+      <field type="uint8_t" name="mppt1_status"> MPPT1 status </field>
+      <field type="float" name="mppt2_volt" units="V"> MPPT2 voltage </field>
+      <field type="float" name="mppt2_amp" units="A"> MPPT2 current </field>
+      <field type="uint16_t" name="mppt2_pwm" units="us"> MPPT2 pwm </field>
+      <field type="uint8_t" name="mppt2_status"> MPPT2 status </field>
+      <field type="float" name="mppt3_volt" units="V">MPPT3 voltage </field>
+      <field type="float" name="mppt3_amp" units="A"> MPPT3 current </field>
+      <field type="uint16_t" name="mppt3_pwm" units="us"> MPPT3 pwm </field>
+      <field type="uint8_t" name="mppt3_status"> MPPT3 status </field>
+    </message>
+    <message id="8004" name="ASLCTRL_DATA">
+      <description>ASL-fixed-wing controller data</description>
+      <field type="uint64_t" name="timestamp" units="us"> Timestamp</field>
+      <field type="uint8_t" name="aslctrl_mode"> ASLCTRL control-mode (manual, stabilized, auto, etc...)</field>
+      <field type="float" name="h"> See sourcecode for a description of these values... </field>
+      <field type="float" name="hRef"> </field>
+      <field type="float" name="hRef_t"> </field>
+      <field type="float" name="PitchAngle" units="deg">Pitch angle</field>
+      <field type="float" name="PitchAngleRef" units="deg">Pitch angle reference</field>
+      <field type="float" name="q"> </field>
+      <field type="float" name="qRef"> </field>
+      <field type="float" name="uElev"> </field>
+      <field type="float" name="uThrot"> </field>
+      <field type="float" name="uThrot2"> </field>
+      <field type="float" name="nZ"> </field>
+      <field type="float" name="AirspeedRef" units="m/s">Airspeed reference</field>
+      <field type="uint8_t" name="SpoilersEngaged"> </field>
+      <field type="float" name="YawAngle" units="deg">Yaw angle</field>
+      <field type="float" name="YawAngleRef" units="deg">Yaw angle reference</field>
+      <field type="float" name="RollAngle" units="deg">Roll angle</field>
+      <field type="float" name="RollAngleRef" units="deg">Roll angle reference</field>
+      <field type="float" name="p"> </field>
+      <field type="float" name="pRef"> </field>
+      <field type="float" name="r"> </field>
+      <field type="float" name="rRef"> </field>
+      <field type="float" name="uAil"> </field>
+      <field type="float" name="uRud"> </field>
+    </message>
+    <message id="8005" name="ASLCTRL_DEBUG">
+      <description>ASL-fixed-wing controller debug data</description>
+      <field type="uint32_t" name="i32_1"> Debug data</field>
+      <field type="uint8_t" name="i8_1"> Debug data</field>
+      <field type="uint8_t" name="i8_2"> Debug data</field>
+      <field type="float" name="f_1"> Debug data </field>
+      <field type="float" name="f_2"> Debug data</field>
+      <field type="float" name="f_3"> Debug data</field>
+      <field type="float" name="f_4"> Debug data</field>
+      <field type="float" name="f_5"> Debug data</field>
+      <field type="float" name="f_6"> Debug data</field>
+      <field type="float" name="f_7"> Debug data</field>
+      <field type="float" name="f_8"> Debug data</field>
+    </message>
+    <message id="8006" name="ASLUAV_STATUS">
+      <description>Extended state information for ASLUAVs</description>
+      <field type="uint8_t" name="LED_status"> Status of the position-indicator LEDs</field>
+      <field type="uint8_t" name="SATCOM_status"> Status of the IRIDIUM satellite communication system</field>
+      <field type="uint8_t[8]" name="Servo_status"> Status vector for up to 8 servos</field>
+      <field type="float" name="Motor_rpm"> Motor RPM </field>
+      <!-- to be extended-->
+    </message>
+    <message id="8007" name="EKF_EXT">
+      <description>Extended EKF state estimates for ASLUAVs</description>
+      <field type="uint64_t" name="timestamp" units="us"> Time since system start</field>
+      <field type="float" name="Windspeed" units="m/s"> Magnitude of wind velocity (in lateral inertial plane)</field>
+      <field type="float" name="WindDir" units="rad"> Wind heading angle from North</field>
+      <field type="float" name="WindZ" units="m/s"> Z (Down) component of inertial wind velocity</field>
+      <field type="float" name="Airspeed" units="m/s"> Magnitude of air velocity</field>
+      <field type="float" name="beta" units="rad"> Sideslip angle</field>
+      <field type="float" name="alpha" units="rad"> Angle of attack</field>
+    </message>
+    <message id="8008" name="ASL_OBCTRL">
+      <description>Off-board controls/commands for ASLUAVs</description>
+      <field type="uint64_t" name="timestamp" units="us"> Time since system start</field>
+      <field type="float" name="uElev"> Elevator command [~]</field>
+      <field type="float" name="uThrot"> Throttle command [~]</field>
+      <field type="float" name="uThrot2"> Throttle 2 command [~]</field>
+      <field type="float" name="uAilL"> Left aileron command [~]</field>
+      <field type="float" name="uAilR"> Right aileron command [~]</field>
+      <field type="float" name="uRud"> Rudder command [~]</field>
+      <field type="uint8_t" name="obctrl_status"> Off-board computer status</field>
+    </message>
+    <message id="8009" name="SENS_ATMOS">
+      <description>Atmospheric sensors (temperature, humidity, ...) </description>
+      <field type="uint64_t" name="timestamp" units="us">Time since system boot</field>
+      <field type="float" name="TempAmbient" units="degC"> Ambient temperature</field>
+      <field type="float" name="Humidity" units="%"> Relative humidity</field>
+    </message>
+    <message id="8010" name="SENS_BATMON">
+      <description>Battery pack monitoring data for Li-Ion batteries</description>
+      <field type="uint64_t" name="batmon_timestamp" units="us">Time since system start</field>
+      <field type="float" name="temperature" units="degC">Battery pack temperature</field>
+      <field type="uint16_t" name="voltage" units="mV">Battery pack voltage</field>
+      <field type="int16_t" name="current" units="mA">Battery pack current</field>
+      <field type="uint8_t" name="SoC">Battery pack state-of-charge</field>
+      <field type="uint16_t" name="batterystatus">Battery monitor status report bits in Hex</field>
+      <field type="uint16_t" name="serialnumber">Battery monitor serial number in Hex</field>
+      <field type="uint32_t" name="safetystatus">Battery monitor safetystatus report bits in Hex</field>
+      <field type="uint32_t" name="operationstatus">Battery monitor operation status report bits in Hex</field>
+      <field type="uint16_t" name="cellvoltage1" units="mV">Battery pack cell 1 voltage</field>
+      <field type="uint16_t" name="cellvoltage2" units="mV">Battery pack cell 2 voltage</field>
+      <field type="uint16_t" name="cellvoltage3" units="mV">Battery pack cell 3 voltage</field>
+      <field type="uint16_t" name="cellvoltage4" units="mV">Battery pack cell 4 voltage</field>
+      <field type="uint16_t" name="cellvoltage5" units="mV">Battery pack cell 5 voltage</field>
+      <field type="uint16_t" name="cellvoltage6" units="mV">Battery pack cell 6 voltage</field>
+    </message>
+    <message id="8011" name="FW_SOARING_DATA">
+      <description>Fixed-wing soaring (i.e. thermal seeking) data</description>
+      <field type="uint64_t" name="timestamp" units="ms">Timestamp</field>
+      <field type="uint64_t" name="timestampModeChanged" units="ms">Timestamp since last mode change</field>
+      <field type="float" name="xW" units="m/s">Thermal core updraft strength</field>
+      <field type="float" name="xR" units="m">Thermal radius</field>
+      <field type="float" name="xLat" units="deg">Thermal center latitude</field>
+      <field type="float" name="xLon" units="deg">Thermal center longitude</field>
+      <field type="float" name="VarW">Variance W</field>
+      <field type="float" name="VarR">Variance R</field>
+      <field type="float" name="VarLat">Variance Lat</field>
+      <field type="float" name="VarLon">Variance Lon </field>
+      <field type="float" name="LoiterRadius" units="m">Suggested loiter radius</field>
+      <field type="float" name="LoiterDirection">Suggested loiter direction</field>
+      <field type="float" name="DistToSoarPoint" units="m">Distance to soar point</field>
+      <field type="float" name="vSinkExp" units="m/s">Expected sink rate at current airspeed, roll and throttle</field>
+      <field type="float" name="z1_LocalUpdraftSpeed" units="m/s">Measurement / updraft speed at current/local airplane position</field>
+      <field type="float" name="z2_DeltaRoll" units="deg">Measurement / roll angle tracking error</field>
+      <field type="float" name="z1_exp">Expected measurement 1</field>
+      <field type="float" name="z2_exp">Expected measurement 2</field>
+      <field type="float" name="ThermalGSNorth" units="m/s">Thermal drift (from estimator prediction step only)</field>
+      <field type="float" name="ThermalGSEast" units="m/s">Thermal drift (from estimator prediction step only)</field>
+      <field type="float" name="TSE_dot" units="m/s"> Total specific energy change (filtered)</field>
+      <field type="float" name="DebugVar1"> Debug variable 1</field>
+      <field type="float" name="DebugVar2"> Debug variable 2</field>
+      <field type="uint8_t" name="ControlMode">Control Mode [-]</field>
+      <field type="uint8_t" name="valid">Data valid [-]</field>
+    </message>
+    <message id="8012" name="SENSORPOD_STATUS">
+      <description>Monitoring of sensorpod status</description>
+      <field type="uint64_t" name="timestamp" units="ms">Timestamp in linuxtime (since 1.1.1970)</field>
+      <field type="uint8_t" name="visensor_rate_1">Rate of ROS topic 1</field>
+      <field type="uint8_t" name="visensor_rate_2">Rate of ROS topic 2</field>
+      <field type="uint8_t" name="visensor_rate_3">Rate of ROS topic 3</field>
+      <field type="uint8_t" name="visensor_rate_4">Rate of ROS topic 4</field>
+      <field type="uint8_t" name="recording_nodes_count">Number of recording nodes</field>
+      <field type="uint8_t" name="cpu_temp" units="degC">Temperature of sensorpod CPU in</field>
+      <field type="uint16_t" name="free_space">Free space available in recordings directory in [Gb] * 1e2</field>
+    </message>
+    <message id="8013" name="SENS_POWER_BOARD">
+      <description>Monitoring of power board status</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
+      <field type="uint8_t" name="pwr_brd_status">Power board status register</field>
+      <field type="uint8_t" name="pwr_brd_led_status">Power board leds status</field>
+      <field type="float" name="pwr_brd_system_volt" units="V">Power board system voltage</field>
+      <field type="float" name="pwr_brd_servo_volt" units="V">Power board servo voltage</field>
+      <field type="float" name="pwr_brd_digital_volt" units="V">Power board digital voltage</field>
+      <field type="float" name="pwr_brd_mot_l_amp" units="A">Power board left motor current sensor</field>
+      <field type="float" name="pwr_brd_mot_r_amp" units="A">Power board right motor current sensor</field>
+      <field type="float" name="pwr_brd_analog_amp" units="A">Power board analog current sensor</field>
+      <field type="float" name="pwr_brd_digital_amp" units="A">Power board digital current sensor</field>
+      <field type="float" name="pwr_brd_ext_amp" units="A">Power board extension current sensor</field>
+      <field type="float" name="pwr_brd_aux_amp" units="A">Power board aux current sensor</field>
+    </message>
+    <message id="8014" name="GSM_LINK_STATUS">
+      <description>Status of GSM modem (connected to onboard computer)</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (of OBC)</field>
+      <field type="uint8_t" name="gsm_modem_type" enum="GSM_MODEM_TYPE">GSM modem used</field>
+      <field type="uint8_t" name="gsm_link_type" enum="GSM_LINK_TYPE">GSM link type</field>
+      <field type="uint8_t" name="rssi">RSSI as reported by modem (unconverted)</field>
+      <field type="uint8_t" name="rsrp_rscp">RSRP (LTE) or RSCP (WCDMA) as reported by modem (unconverted)</field>
+      <field type="uint8_t" name="sinr_ecio">SINR (LTE) or ECIO (WCDMA) as reported by modem (unconverted)</field>
+      <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
+    </message>
+    <!-- Using mavlink 1 msg ID from the arudpilot reserved space, in order to save header size -->
+    <message id="8015" name="SATCOM_LINK_STATUS">
+      <description>Status of the SatCom link</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
+      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
+      <field type="uint16_t" name="failed_sessions">Number of failed sessions</field>
+      <field type="uint16_t" name="successful_sessions">Number of successful sessions</field>
+      <field type="uint8_t" name="signal_quality">Signal quality</field>
+      <field type="uint8_t" name="ring_pending">Ring call pending</field>
+      <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
+      <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
+    </message>
+    <message id="8016" name="SENSOR_AIRFLOW_ANGLES">
+      <description>Calibrated airflow angle measurements</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
+      <field type="float" name="angleofattack" units="deg">Angle of attack</field>
+      <field type="uint8_t" name="angleofattack_valid">Angle of attack measurement valid</field>
+      <field type="float" name="sideslip" units="deg">Sideslip angle</field>
+      <field type="uint8_t" name="sideslip_valid">Sideslip angle measurement valid</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/AVSSUAS.xml
+++ b/bp_mavlink/AVSSUAS.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+<!-- AVSS is a Canadian aerospace company commercializing safety technologies for Urban Air Mobility. -->
+<!-- AVSS is first commercially available products are parachute recovery systems for commercial drones. -->
+<!-- AVSS contact info: -->
+<!-- company URL: https://www.avss.co -->
+<!-- email contact: josh.boudreau@avss.co thomas.li@avss.co llxxgg@gmail.com-->
+<!-- mavlink messenger ID range: 60050 - 60099,  mavlink command ID range: 60050 - 60099-->
+<mavlink>
+  <include>common.xml</include>
+  <version>2</version>
+  <dialect>1</dialect>
+  <enums>
+    <enum name="MAV_CMD">
+      <!-- AVSS specific MAV_CMD_PRS* commands -->
+      <entry name="MAV_CMD_PRS_SET_ARM" value="60050" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Set PRS arm statuses.</description>
+        <param index="1" label="ARM status">PRS arm statuses</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_GET_ARM" value="60051" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Gets PRS arm statuses</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_GET_BATTERY" value="60052" isDestination="false" hasLocation="false">
+        <description>AVSS defined command.  Get the PRS battery voltage in millivolts</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_GET_ERR" value="60053" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Get the PRS error statuses.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_SET_ARM_ALTI" value="60070" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Set the ATS arming altitude in meters.</description>
+        <param index="1" label="Altitude" units="m">ATS arming altitude</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_GET_ARM_ALTI" value="60071" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Get the ATS arming altitude in meters.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry name="MAV_CMD_PRS_SHUTDOWN" value="60072" isDestination="false" hasLocation="false">
+        <description>AVSS defined command. Shuts down the PRS system.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+    </enum>
+    <enum name="MAV_AVSS_COMMAND_FAILURE_REASON">
+      <entry name="PRS_NOT_STEADY" value="1">
+        <description>AVSS defined command failure reason. PRS not steady.</description>
+      </entry>
+      <entry name="PRS_DTM_NOT_ARMED" value="2">
+        <description>AVSS defined command failure reason. PRS DTM not armed.</description>
+      </entry>
+      <entry name="PRS_OTM_NOT_ARMED" value="3">
+        <description>AVSS defined command failure reason. PRS OTM not armed.</description>
+      </entry>
+    </enum>
+    <enum name="AVSS_M300_OPERATION_MODE">
+      <entry name="MODE_M300_MANUAL_CTRL" value="0">
+        <description>In manual control mode</description>
+      </entry>
+      <entry name="MODE_M300_ATTITUDE" value="1">
+        <description>In attitude mode </description>
+      </entry>
+      <entry name="MODE_M300_P_GPS" value="6">
+        <description>In GPS mode</description>
+      </entry>
+      <entry name="MODE_M300_HOTPOINT_MODE" value="9">
+        <description>In hotpoint mode </description>
+      </entry>
+      <entry name="MODE_M300_ASSISTED_TAKEOFF" value="10">
+        <description>In assisted takeoff mode</description>
+      </entry>
+      <entry name="MODE_M300_AUTO_TAKEOFF" value="11">
+        <description>In auto takeoff mode</description>
+      </entry>
+      <entry name="MODE_M300_AUTO_LANDING" value="12">
+        <description>In auto landing mode</description>
+      </entry>
+      <entry name="MODE_M300_NAVI_GO_HOME" value="15">
+        <description>In go home mode</description>
+      </entry>
+      <entry name="MODE_M300_NAVI_SDK_CTRL" value="17">
+        <description>In sdk control mode</description>
+      </entry>
+      <entry name="MODE_M300_S_SPORT" value="31">
+        <description>In sport mode</description>
+      </entry>
+      <entry name="MODE_M300_FORCE_AUTO_LANDING" value="33">
+        <description>In force auto landing mode</description>
+      </entry>
+      <entry name="MODE_M300_T_TRIPOD" value="38">
+        <description>In tripod mode</description>
+      </entry>
+      <entry name="MODE_M300_SEARCH_MODE" value="40">
+        <description>In search mode</description>
+      </entry>
+      <entry name="MODE_M300_ENGINE_START" value="41">
+        <description>In engine mode</description>
+      </entry>
+    </enum>
+    <enum name="AVSS_HORSEFLY_OPERATION_MODE">
+      <entry name="MODE_HORSEFLY_MANUAL_CTRL" value="0">
+        <description>In manual control mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_AUTO_TAKEOFF" value="1">
+        <description>In auto takeoff mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_AUTO_LANDING" value="2">
+        <description>In auto landing mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_NAVI_GO_HOME" value="3">
+        <description>In go home mode</description>
+      </entry>
+      <entry name="MODE_HORSEFLY_DROP" value="4">
+        <description>In drop mode</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message name="AVSS_PRS_SYS_STATUS" id="60050">
+      <description> AVSS PRS system status.</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since PRS boot).</field>
+      <field name="error_status" type="uint32_t">PRS error statuses</field>
+      <field name="battery_status" type="uint32_t">Estimated battery run-time without a remote connection and PRS battery voltage</field>
+      <field name="arm_status" type="uint8_t">PRS arm statuses</field>
+      <field name="charge_status" type="uint8_t">PRS battery charge statuses</field>
+    </message>
+    <message name="AVSS_DRONE_POSITION" id="60051">
+      <description> Drone position.</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="lat" units="degE7" type="int32_t">Latitude, expressed</field>
+      <field name="lon" units="degE7" type="int32_t">Longitude, expressed</field>
+      <field name="alt" units="mm" type="int32_t">Altitude (MSL). Note that virtually all GPS modules provide both WGS84 and MSL.</field>
+      <field name="ground_alt" units="m" type="float">Altitude above ground, This altitude is measured by a ultrasound, Laser rangefinder or millimeter-wave radar</field>
+      <field name="barometer_alt" units="m" type="float">This altitude is measured by a barometer</field>
+    </message>
+    <message name="AVSS_DRONE_IMU" id="60052">
+      <description> Drone IMU data. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="q1" type="float">Quaternion component 1, w (1 in null-rotation)</field>
+      <field name="q2" type="float">Quaternion component 2, x (0 in null-rotation)</field>
+      <field name="q3" type="float">Quaternion component 3, y (0 in null-rotation)</field>
+      <field name="q4" type="float">Quaternion component 4, z (0 in null-rotation)</field>
+      <field name="xacc" units="m/s/s" type="float">X acceleration</field>
+      <field name="yacc" units="m/s/s" type="float">Y acceleration</field>
+      <field name="zacc" units="m/s/s" type="float">Z acceleration</field>
+      <field name="xgyro" units="rad/s" type="float">Angular speed around X axis</field>
+      <field name="ygyro" units="rad/s" type="float">Angular speed around Y axis</field>
+      <field name="zgyro" units="rad/s" type="float">Angular speed around Z axis</field>
+    </message>
+    <message name="AVSS_DRONE_OPERATION_MODE" id="60053">
+      <description> Drone operation mode.</description>
+      <field name="time_boot_ms" units="ms" type="uint32_t">Timestamp (time since FC boot).</field>
+      <field name="M300_operation_mode" type="uint8_t">DJI M300 operation mode</field>
+      <field name="horsefly_operation_mode" type="uint8_t">horsefly operation mode</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/all.xml
+++ b/bp_mavlink/all.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>ardupilotmega.xml</include>
+  <!-- ASLUAV.xml range of IDs:
+    messages: 8000 - 8999
+    commands: 40001 - 41999
+  -->
+  <include>ASLUAV.xml</include>
+  <include>common.xml</include>
+  <include>development.xml</include>
+  <include>icarous.xml</include>
+  <!-- matrixpilot.xml: ERROR: Duplicate message id 150 for FLEXIFUNCTION_SET (matrixpilot.xml:50) also used by SENSOR_OFFSETS (ardupilotmega.xml:1101) -->
+  <!-- <include>matrixpilot.xml</include> -->
+  <include>minimal.xml</include>
+  <!-- paparazzi.xml: : ERROR: Duplicate message id 180 for SCRIPT_ITEM (paparazzi.xml:9) also used by CAMERA_FEEDBACK (ardupilotmega.xml:1370) -->
+  <!-- <include>paparazzi.xml</include> -->
+  <include>python_array_test.xml</include>
+  <include>standard.xml</include>
+  <include>test.xml</include>
+  <include>ualberta.xml</include>
+  <include>uAvionix.xml</include>
+  <!-- loweheiser.xml range of IDs:
+       messages: 10150 - 10199
+       commands: 10150 - 10199
+  -->
+  <include>loweheiser.xml</include>
+  <!-- storm32.xml range of IDs:
+    messages: 60000 - 60049
+    commands: 60000 - 60049
+  -->
+  <include>storm32.xml</include>
+  <!-- AVSSUAS.xml range of IDs:
+    messages: 60050 - 60099 
+    commands: 60050 - 60099
+  -->
+  <include>AVSSUAS.xml</include>
+  <messages/>
+</mavlink>

--- a/bp_mavlink/ardupilotmega.xml
+++ b/bp_mavlink/ardupilotmega.xml
@@ -1,0 +1,1867 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>common.xml</include>
+  <!-- Vendors -->
+  <include>uAvionix.xml</include>
+  <include>icarous.xml</include>
+  <include>loweheiser.xml</include>
+  <dialect>2</dialect>
+  <!-- Note that ArduPilot-specific messages should use the command id range from 150 to 250, to leave plenty of room for growth of common.xml If you prototype a message here, then you should consider if it is general enough to move into common.xml later -->
+  <enums>
+    <enum name="ACCELCAL_VEHICLE_POS">
+      <entry value="1" name="ACCELCAL_VEHICLE_POS_LEVEL"/>
+      <entry value="2" name="ACCELCAL_VEHICLE_POS_LEFT"/>
+      <entry value="3" name="ACCELCAL_VEHICLE_POS_RIGHT"/>
+      <entry value="4" name="ACCELCAL_VEHICLE_POS_NOSEDOWN"/>
+      <entry value="5" name="ACCELCAL_VEHICLE_POS_NOSEUP"/>
+      <entry value="6" name="ACCELCAL_VEHICLE_POS_BACK"/>
+      <entry value="16777215" name="ACCELCAL_VEHICLE_POS_SUCCESS"/>
+      <entry value="16777216" name="ACCELCAL_VEHICLE_POS_FAILED"/>
+    </enum>
+    <enum name="HEADING_TYPE">
+      <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND"/>
+      <entry value="1" name="HEADING_TYPE_HEADING"/>
+    </enum>
+    <enum name="SPEED_TYPE">
+      <entry value="0" name="SPEED_TYPE_AIRSPEED"/>
+      <entry value="1" name="SPEED_TYPE_GROUNDSPEED"/>
+    </enum>
+    <!-- ardupilot specific MAV_CMD_* commands -->
+    <enum name="MAV_CMD">
+      <!-- 200 to 214 used by common.xml -->
+      <entry value="215" name="MAV_CMD_DO_SET_RESUME_REPEAT_DIST" hasLocation="false" isDestination="false">
+        <description>Set the distance to be repeated on mission resume</description>
+        <param index="1" label="Distance" units="m">Distance.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="216" name="MAV_CMD_DO_SPRAYER" hasLocation="false" isDestination="false">
+        <description>Control attached liquid sprayer</description>
+        <param index="1" label="Sprayer Enable" minValue="0" maxValue="1" increment="1">0: disable sprayer. 1: enable sprayer.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="217" name="MAV_CMD_DO_SEND_SCRIPT_MESSAGE" hasLocation="false" isDestination="false">
+        <description>Pass instructions onto scripting, a script should be checking for a new command</description>
+        <param index="1" label="ID" minValue="0" maxValue="65535" increment="1">uint16 ID value to be passed to scripting</param>
+        <param index="2" label="param 1">float value to be passed to scripting</param>
+        <param index="3" label="param 2">float value to be passed to scripting</param>
+        <param index="4" label="param 3">float value to be passed to scripting</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="218" name="MAV_CMD_DO_AUX_FUNCTION">
+        <description>Execute auxiliary function</description>
+        <param index="1" label="AuxiliaryFunction">Auxiliary Function.</param>
+        <param index="2" label="SwitchPosition" enum="MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL">Switch Level.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="83" name="MAV_CMD_NAV_ALTITUDE_WAIT" hasLocation="false" isDestination="false">
+        <description>Mission command to wait for an altitude or downwards vertical speed. This is meant for high altitude balloon launches, allowing the aircraft to be idle until either an altitude is reached or a negative vertical speed is reached (indicating early balloon burst). The wiggle time is how often to wiggle the control surfaces to prevent them seizing up.</description>
+        <param index="1" label="Altitude" units="m">Altitude.</param>
+        <param index="2" label="Descent Speed" units="m/s">Descent speed.</param>
+        <param index="3" label="Wiggle Time" units="s">How long to wiggle the control surfaces to prevent them seizing up.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42000" name="MAV_CMD_POWER_OFF_INITIATED" hasLocation="false" isDestination="false">
+        <description>A system wide power-off event has been initiated.</description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <!-- MAV_CMD_SOLO_BTN_* are here to provide vendor-specific support for 3DR Solo until a better solution is found to atomically make multiple commands with control flow -->
+      <entry value="42001" name="MAV_CMD_SOLO_BTN_FLY_CLICK" hasLocation="false" isDestination="false">
+        <description>FLY button has been clicked.</description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42002" name="MAV_CMD_SOLO_BTN_FLY_HOLD" hasLocation="false" isDestination="false">
+        <description>FLY button has been held for 1.5 seconds.</description>
+        <param index="1" label="Takeoff Altitude" units="m">Takeoff altitude.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42003" name="MAV_CMD_SOLO_BTN_PAUSE_CLICK" hasLocation="false" isDestination="false">
+        <description>PAUSE button has been clicked.</description>
+        <param index="1" label="Shot Mode" minValue="0" maxValue="1" increment="1">1 if Solo is in a shot mode, 0 otherwise.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42004" name="MAV_CMD_FIXED_MAG_CAL" hasLocation="false" isDestination="false">
+        <description>Magnetometer calibration based on fixed position
+        in earth field given by inclination, declination and intensity.</description>
+        <param index="1" label="Declination" units="deg">Magnetic declination.</param>
+        <param index="2" label="Inclination" units="deg">Magnetic inclination.</param>
+        <param index="3" label="Intensity" units="mgauss">Magnetic intensity.</param>
+        <param index="4" label="Yaw" units="deg">Yaw.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42005" name="MAV_CMD_FIXED_MAG_CAL_FIELD" hasLocation="false" isDestination="false">
+        <description>Magnetometer calibration based on fixed expected field values.</description>
+        <param index="1" label="Field X" units="mgauss">Field strength X.</param>
+        <param index="2" label="Field Y" units="mgauss">Field strength Y.</param>
+        <param index="3" label="Field Z" units="mgauss">Field strength Z.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <!-- 42006 MAV_CMD_FIXED_MAG_CAL_YAW moved to common.xml -->
+      <entry value="42007" name="MAV_CMD_SET_EKF_SOURCE_SET" hasLocation="false" isDestination="false">
+        <description>Set EKF sensor source set.</description>
+        <param index="1" label="SourceSetId" minValue="1" maxValue="3" increment="1">Source Set Id.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42424" name="MAV_CMD_DO_START_MAG_CAL" hasLocation="false" isDestination="false">
+        <description>Initiate a magnetometer calibration.</description>
+        <param index="1" label="Magnetometers Bitmask" minValue="0" maxValue="255" increment="1">Bitmask of magnetometers to calibrate. Use 0 to calibrate all sensors that can be started (sensors may not start if disabled, unhealthy, etc.). The command will NACK if calibration does not start for a sensor explicitly specified by the bitmask.</param>
+        <param index="2" label="Retry on Failure" minValue="0" maxValue="1" increment="1">Automatically retry on failure (0=no retry, 1=retry).</param>
+        <param index="3" label="Autosave" minValue="0" maxValue="1" increment="1">Save without user input (0=require input, 1=autosave).</param>
+        <param index="4" label="Delay" units="s">Delay.</param>
+        <param index="5" label="Autoreboot" minValue="0" maxValue="1" increment="1">Autoreboot (0=user reboot, 1=autoreboot).</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42425" name="MAV_CMD_DO_ACCEPT_MAG_CAL" hasLocation="false" isDestination="false">
+        <description>Accept a magnetometer calibration.</description>
+        <param index="1" label="Magnetometers Bitmask" minValue="0" maxValue="255" increment="1">Bitmask of magnetometers that calibration is accepted (0 means all).</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42426" name="MAV_CMD_DO_CANCEL_MAG_CAL" hasLocation="false" isDestination="false">
+        <description>Cancel a running magnetometer calibration.</description>
+        <param index="1" label="Magnetometers Bitmask" minValue="0" maxValue="255" increment="1">Bitmask of magnetometers to cancel a running calibration (0 means all).</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42429" name="MAV_CMD_ACCELCAL_VEHICLE_POS" hasLocation="false" isDestination="false">
+        <description>Used when doing accelerometer calibration. When sent to the GCS tells it what position to put the vehicle in. When sent to the vehicle says what position the vehicle is in.</description>
+        <param index="1" label="Position" enum="ACCELCAL_VEHICLE_POS">Position.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42428" name="MAV_CMD_DO_SEND_BANNER" hasLocation="false" isDestination="false">
+        <description>Reply with the version banner.</description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42427" name="MAV_CMD_SET_FACTORY_TEST_MODE" hasLocation="false" isDestination="false">
+        <description>Command autopilot to get into factory test/diagnostic mode.</description>
+        <param index="1" label="Test Mode" minValue="0" maxValue="1" increment="1">0: activate test mode, 1: exit test mode.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42501" name="MAV_CMD_GIMBAL_RESET" hasLocation="false" isDestination="false">
+        <description>Causes the gimbal to reset and boot as if it was just powered on.</description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42502" name="MAV_CMD_GIMBAL_AXIS_CALIBRATION_STATUS" hasLocation="false" isDestination="false">
+        <description>Reports progress and success or failure of gimbal axis calibration procedure.</description>
+        <param index="1" label="Axis" enum="GIMBAL_AXIS">Gimbal axis we're reporting calibration progress for.</param>
+        <param index="2" label="Progress" units="%" minValue="0" maxValue="100">Current calibration progress for this axis.</param>
+        <param index="3" label="Status" enum="GIMBAL_AXIS_CALIBRATION_STATUS">Status of the calibration.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42503" name="MAV_CMD_GIMBAL_REQUEST_AXIS_CALIBRATION" hasLocation="false" isDestination="false">
+        <description>Starts commutation calibration on the gimbal.</description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42505" name="MAV_CMD_GIMBAL_FULL_RESET" hasLocation="false" isDestination="false">
+        <description>Erases gimbal application and parameters.</description>
+        <param index="1">Magic number.</param>
+        <param index="2">Magic number.</param>
+        <param index="3">Magic number.</param>
+        <param index="4">Magic number.</param>
+        <param index="5">Magic number.</param>
+        <param index="6">Magic number.</param>
+        <param index="7">Magic number.</param>
+      </entry>
+      <!-- 42600 used by common.xml -->
+      <entry value="42650" name="MAV_CMD_FLASH_BOOTLOADER" hasLocation="false" isDestination="false">
+        <description>Update the bootloader</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Magic Number" increment="1">Magic number - set to 290876 to actually flash</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="42651" name="MAV_CMD_BATTERY_RESET" hasLocation="false" isDestination="false">
+        <description>Reset battery capacity for batteries that accumulate consumed battery via integration.</description>
+        <param index="1" label="battery mask">Bitmask of batteries to reset. Least significant bit is for the first battery.</param>
+        <param index="2" label="percentage" minValue="0" maxValue="100" increment="1">Battery percentage remaining to set.</param>
+      </entry>
+      <entry value="42700" name="MAV_CMD_DEBUG_TRAP" hasLocation="false" isDestination="false">
+        <description>Issue a trap signal to the autopilot process, presumably to enter the debugger.</description>
+        <param index="1">Magic number - set to 32451 to actually trap.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42701" name="MAV_CMD_SCRIPTING" hasLocation="false" isDestination="false">
+        <description>Control onboard scripting.</description>
+        <param index="1" enum="SCRIPTING_CMD">Scripting command to execute</param>
+      </entry>
+      <entry value="42702" name="MAV_CMD_NAV_SCRIPT_TIME" hasLocation="false" isDestination="false">
+        <description>Scripting command as NAV command with wait for completion.</description>
+        <param index="1" label="command">integer command number (0 to 255)</param>
+        <param index="2" label="timeout" units="s">timeout for operation in seconds. Zero means no timeout (0 to 255)</param>
+        <param index="3" label="arg1">argument1.</param>
+        <param index="4" label="arg2">argument2.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="42703" name="MAV_CMD_NAV_ATTITUDE_TIME" hasLocation="false" isDestination="false">
+        <description>Maintain an attitude for a specified time.</description>
+        <param index="1" label="time" units="s">Time to maintain specified attitude and climb rate</param>
+        <param index="2" label="roll" units="deg">Roll angle in degrees (positive is lean right, negative is lean left)</param>
+        <param index="3" label="pitch" units="deg">Pitch angle in degrees (positive is lean back, negative is lean forward)</param>
+        <param index="4" label="yaw" units="deg">Yaw angle</param>
+        <param index="5" label="climb_rate" units="m/s">Climb rate</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="43000" name="MAV_CMD_GUIDED_CHANGE_SPEED" hasLocation="false" isDestination="false">
+        <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1" label="speed type" enum="SPEED_TYPE">Airspeed or groundspeed.</param>
+        <param index="2" label="speed target" units="m/s">Target Speed</param>
+        <param index="3" label="speed rate-of-change" units="m/s/s">Acceleration rate, 0 to take effect instantly</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="43001" name="MAV_CMD_GUIDED_CHANGE_ALTITUDE" hasLocation="false" isDestination="false">
+        <description>Change target altitude at a given rate. This slews the vehicle at a controllable rate between it's previous altitude and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3" label="alt rate-of-change" units="m/s/s" minValue="0">Rate of change, toward new altitude. 0 for maximum rate change. Positive numbers only, as negative numbers will not converge on the new target alt.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7" label="target alt" units="m">Target Altitude</param>
+      </entry>
+      <entry value="43002" name="MAV_CMD_GUIDED_CHANGE_HEADING" hasLocation="false" isDestination="false">
+        <description>Change to target heading at a given rate, overriding previous heading/s. This slews the vehicle at a controllable rate between it's previous heading and the new one. (affects GUIDED only. Exiting GUIDED returns aircraft to normal behaviour defined elsewhere. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
+        <param index="1" label="heading type" enum="HEADING_TYPE">course-over-ground or raw vehicle heading.</param>
+        <param index="2" label="heading target" units="deg" minValue="0" maxValue="359.99">Target heading.</param>
+        <param index="3" label="heading rate-of-change" units="m/s/s">Maximum centripetal accelearation, ie rate of change,  toward new heading.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+    </enum>
+    <enum name="SCRIPTING_CMD">
+      <entry value="0" name="SCRIPTING_CMD_REPL_START">
+        <description>Start a REPL session.</description>
+      </entry>
+      <entry value="1" name="SCRIPTING_CMD_REPL_STOP">
+        <description>End a REPL session.</description>
+      </entry>
+      <entry value="2" name="SCRIPTING_CMD_STOP">
+        <description>Stop execution of scripts.</description>
+      </entry>
+      <entry value="3" name="SCRIPTING_CMD_STOP_AND_RESTART">
+        <description>Stop execution of scripts and restart.</description>
+      </entry>
+    </enum>
+    <enum name="SECURE_COMMAND_OP">
+      <entry value="0" name="SECURE_COMMAND_GET_SESSION_KEY">
+        <description>Get an 8 byte session key which is used for remote secure updates which operate on flight controller data such as bootloader public keys. Return data will be 8 bytes on success. The session key remains valid until either the flight controller reboots or another SECURE_COMMAND_GET_SESSION_KEY is run.</description>
+      </entry>
+      <entry value="1" name="SECURE_COMMAND_GET_REMOTEID_SESSION_KEY">
+        <description>Get an 8 byte session key which is used for remote secure updates which operate on RemoteID module data. Return data will be 8 bytes on success. The session key remains valid until either the remote ID module reboots or another SECURE_COMMAND_GET_REMOTEID_SESSION_KEY is run.</description>
+      </entry>
+      <entry value="2" name="SECURE_COMMAND_REMOVE_PUBLIC_KEYS">
+        <description>Remove range of public keys from the bootloader. Command data consists of two bytes, first byte if index of first public key to remove. Second byte is the number of keys to remove. If all keys are removed then secure boot is disabled and insecure firmware can be loaded.</description>
+      </entry>
+      <entry value="3" name="SECURE_COMMAND_GET_PUBLIC_KEYS">
+        <description>Get current public keys from the bootloader. Command data consists of two bytes, first byte is index of first public key to fetch, 2nd byte is number of keys to fetch. Total data needs to fit in data portion of reply (max 6 keys for 32 byte keys). Reply data has the index of the first key in the first byte, followed by the keys. Returned keys may be less than the number of keys requested if there are less keys installed than requested.</description>
+      </entry>
+      <entry value="4" name="SECURE_COMMAND_SET_PUBLIC_KEYS">
+        <description>Set current public keys in the bootloader. Data consists of a one byte public key index followed by the public keys. With 32 byte keys this allows for up to 6 keys to be set in one request. Keys outside of the range that is being set will remain unchanged.</description>
+      </entry>
+      <entry value="5" name="SECURE_COMMAND_GET_REMOTEID_CONFIG">
+        <description>Get config data for remote ID module. This command should be sent to the component ID of the flight controller which will forward it to the RemoteID module either over mavlink or DroneCAN. Data format is specific to the RemoteID implementation, see RemoteID firmware documentation for details.</description>
+      </entry>
+      <entry value="6" name="SECURE_COMMAND_SET_REMOTEID_CONFIG">
+        <description>Set config data for remote ID module. This command should be sent to the component ID of the flight controller which will forward it to the RemoteID module either over mavlink or DroneCAN. Data format is specific to the RemoteID implementation, see RemoteID firmware documentation for details.</description>
+      </entry>
+      <entry value="7" name="SECURE_COMMAND_FLASH_BOOTLOADER">
+        <description>Flash bootloader from local storage. Data is the filename to use for the bootloader. This is intended to be used with MAVFtp to upload a new bootloader to a microSD before flashing.</description>
+      </entry>
+    </enum>
+    <!-- AP_Limits Enums -->
+    <enum name="LIMITS_STATE">
+      <entry value="0" name="LIMITS_INIT">
+        <description>Pre-initialization.</description>
+      </entry>
+      <entry value="1" name="LIMITS_DISABLED">
+        <description>Disabled.</description>
+      </entry>
+      <entry value="2" name="LIMITS_ENABLED">
+        <description>Checking limits.</description>
+      </entry>
+      <entry value="3" name="LIMITS_TRIGGERED">
+        <description>A limit has been breached.</description>
+      </entry>
+      <entry value="4" name="LIMITS_RECOVERING">
+        <description>Taking action e.g. Return/RTL.</description>
+      </entry>
+      <entry value="5" name="LIMITS_RECOVERED">
+        <description>We're no longer in breach of a limit.</description>
+      </entry>
+    </enum>
+    <!-- AP_Limits Modules - power of 2 (1,2,4,8,16,32 etc) so we can send as bitfield -->
+    <enum name="LIMIT_MODULE" bitmask="true">
+      <entry value="1" name="LIMIT_GPSLOCK">
+        <description>Pre-initialization.</description>
+      </entry>
+      <entry value="2" name="LIMIT_GEOFENCE">
+        <description>Disabled.</description>
+      </entry>
+      <entry value="4" name="LIMIT_ALTITUDE">
+        <description>Checking limits.</description>
+      </entry>
+    </enum>
+    <!-- RALLY flags - power of 2 (1,2,4,8,16,32,64,128) so we can send as a bitfield -->
+    <enum name="RALLY_FLAGS" bitmask="true">
+      <description>Flags in RALLY_POINT message.</description>
+      <entry value="1" name="FAVORABLE_WIND">
+        <description>Flag set when requiring favorable winds for landing.</description>
+      </entry>
+      <entry value="2" name="LAND_IMMEDIATELY">
+        <description>Flag set when plane is to immediately descend to break altitude and land without GCS intervention. Flag not set when plane is to loiter at Rally point until commanded to land.</description>
+      </entry>
+    </enum>
+    <!-- Camera event types -->
+    <enum name="CAMERA_STATUS_TYPES">
+      <entry value="0" name="CAMERA_STATUS_TYPE_HEARTBEAT">
+        <description>Camera heartbeat, announce camera component ID at 1Hz.</description>
+      </entry>
+      <entry value="1" name="CAMERA_STATUS_TYPE_TRIGGER">
+        <description>Camera image triggered.</description>
+      </entry>
+      <entry value="2" name="CAMERA_STATUS_TYPE_DISCONNECT">
+        <description>Camera connection lost.</description>
+      </entry>
+      <entry value="3" name="CAMERA_STATUS_TYPE_ERROR">
+        <description>Camera unknown error.</description>
+      </entry>
+      <entry value="4" name="CAMERA_STATUS_TYPE_LOWBATT">
+        <description>Camera battery low. Parameter p1 shows reported voltage.</description>
+      </entry>
+      <entry value="5" name="CAMERA_STATUS_TYPE_LOWSTORE">
+        <description>Camera storage low. Parameter p1 shows reported shots remaining.</description>
+      </entry>
+      <entry value="6" name="CAMERA_STATUS_TYPE_LOWSTOREV">
+        <description>Camera storage low. Parameter p1 shows reported video minutes remaining.</description>
+      </entry>
+    </enum>
+    <!-- camera feedback flags, a little bit of future-proofing -->
+    <enum name="CAMERA_FEEDBACK_FLAGS">
+      <entry value="0" name="CAMERA_FEEDBACK_PHOTO">
+        <description>Shooting photos, not video.</description>
+      </entry>
+      <entry value="1" name="CAMERA_FEEDBACK_VIDEO">
+        <description>Shooting video, not stills.</description>
+      </entry>
+      <entry value="2" name="CAMERA_FEEDBACK_BADEXPOSURE">
+        <description>Unable to achieve requested exposure (e.g. shutter speed too low).</description>
+      </entry>
+      <entry value="3" name="CAMERA_FEEDBACK_CLOSEDLOOP">
+        <description>Closed loop feedback from camera, we know for sure it has successfully taken a picture.</description>
+      </entry>
+      <entry value="4" name="CAMERA_FEEDBACK_OPENLOOP">
+        <description>Open loop camera, an image trigger has been requested but we can't know for sure it has successfully taken a picture.</description>
+      </entry>
+    </enum>
+    <!-- Gimbal payload enumerations -->
+    <enum name="MAV_MODE_GIMBAL">
+      <entry value="0" name="MAV_MODE_GIMBAL_UNINITIALIZED">
+        <description>Gimbal is powered on but has not started initializing yet.</description>
+      </entry>
+      <entry value="1" name="MAV_MODE_GIMBAL_CALIBRATING_PITCH">
+        <description>Gimbal is currently running calibration on the pitch axis.</description>
+      </entry>
+      <entry value="2" name="MAV_MODE_GIMBAL_CALIBRATING_ROLL">
+        <description>Gimbal is currently running calibration on the roll axis.</description>
+      </entry>
+      <entry value="3" name="MAV_MODE_GIMBAL_CALIBRATING_YAW">
+        <description>Gimbal is currently running calibration on the yaw axis.</description>
+      </entry>
+      <entry value="4" name="MAV_MODE_GIMBAL_INITIALIZED">
+        <description>Gimbal has finished calibrating and initializing, but is relaxed pending reception of first rate command from copter.</description>
+      </entry>
+      <entry value="5" name="MAV_MODE_GIMBAL_ACTIVE">
+        <description>Gimbal is actively stabilizing.</description>
+      </entry>
+      <entry value="6" name="MAV_MODE_GIMBAL_RATE_CMD_TIMEOUT">
+        <description>Gimbal is relaxed because it missed more than 10 expected rate command messages in a row. Gimbal will move back to active mode when it receives a new rate command.</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_AXIS">
+      <entry value="0" name="GIMBAL_AXIS_YAW">
+        <description>Gimbal yaw axis.</description>
+      </entry>
+      <entry value="1" name="GIMBAL_AXIS_PITCH">
+        <description>Gimbal pitch axis.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_AXIS_ROLL">
+        <description>Gimbal roll axis.</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_AXIS_CALIBRATION_STATUS">
+      <entry value="0" name="GIMBAL_AXIS_CALIBRATION_STATUS_IN_PROGRESS">
+        <description>Axis calibration is in progress.</description>
+      </entry>
+      <entry value="1" name="GIMBAL_AXIS_CALIBRATION_STATUS_SUCCEEDED">
+        <description>Axis calibration succeeded.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_AXIS_CALIBRATION_STATUS_FAILED">
+        <description>Axis calibration failed.</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_AXIS_CALIBRATION_REQUIRED">
+      <entry value="0" name="GIMBAL_AXIS_CALIBRATION_REQUIRED_UNKNOWN">
+        <description>Whether or not this axis requires calibration is unknown at this time.</description>
+      </entry>
+      <entry value="1" name="GIMBAL_AXIS_CALIBRATION_REQUIRED_TRUE">
+        <description>This axis requires calibration.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_AXIS_CALIBRATION_REQUIRED_FALSE">
+        <description>This axis does not require calibration.</description>
+      </entry>
+    </enum>
+    <!-- GoPro System Enumerations -->
+    <enum name="GOPRO_HEARTBEAT_STATUS">
+      <entry value="0" name="GOPRO_HEARTBEAT_STATUS_DISCONNECTED">
+        <description>No GoPro connected.</description>
+      </entry>
+      <entry value="1" name="GOPRO_HEARTBEAT_STATUS_INCOMPATIBLE">
+        <description>The detected GoPro is not HeroBus compatible.</description>
+      </entry>
+      <entry value="2" name="GOPRO_HEARTBEAT_STATUS_CONNECTED">
+        <description>A HeroBus compatible GoPro is connected.</description>
+      </entry>
+      <entry value="3" name="GOPRO_HEARTBEAT_STATUS_ERROR">
+        <description>An unrecoverable error was encountered with the connected GoPro, it may require a power cycle.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_HEARTBEAT_FLAGS" bitmask="true">
+      <!-- each entry is a mask to test a bit in GOPRO_HEARTBEAT_STATUS.flags -->
+      <entry value="1" name="GOPRO_FLAG_RECORDING">
+        <description>GoPro is currently recording.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_REQUEST_STATUS">
+      <entry value="0" name="GOPRO_REQUEST_SUCCESS">
+        <description>The write message with ID indicated succeeded.</description>
+      </entry>
+      <entry value="1" name="GOPRO_REQUEST_FAILED">
+        <description>The write message with ID indicated failed.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_COMMAND">
+      <entry value="0" name="GOPRO_COMMAND_POWER">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="1" name="GOPRO_COMMAND_CAPTURE_MODE">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="2" name="GOPRO_COMMAND_SHUTTER">
+        <description>(___/Set).</description>
+      </entry>
+      <entry value="3" name="GOPRO_COMMAND_BATTERY">
+        <description>(Get/___).</description>
+      </entry>
+      <entry value="4" name="GOPRO_COMMAND_MODEL">
+        <description>(Get/___).</description>
+      </entry>
+      <entry value="5" name="GOPRO_COMMAND_VIDEO_SETTINGS">
+        <description>(Get/Set).</description>
+        <!-- Packet structure for the four values is as follows byte 0: GOPRO_RESOLUTION byte 1: GOPRO_FRAME_RATE byte 2: GOPRO_FIELD_OF_VIEW byte 3: GOPRO_VIDEO_SETTINGS_FLAGS -->
+      </entry>
+      <entry value="6" name="GOPRO_COMMAND_LOW_LIGHT">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="7" name="GOPRO_COMMAND_PHOTO_RESOLUTION">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="8" name="GOPRO_COMMAND_PHOTO_BURST_RATE">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="9" name="GOPRO_COMMAND_PROTUNE">
+        <description>(Get/Set).</description>
+      </entry>
+      <entry value="10" name="GOPRO_COMMAND_PROTUNE_WHITE_BALANCE">
+        <description>(Get/Set) Hero 3+ Only.</description>
+      </entry>
+      <entry value="11" name="GOPRO_COMMAND_PROTUNE_COLOUR">
+        <description>(Get/Set) Hero 3+ Only.</description>
+      </entry>
+      <entry value="12" name="GOPRO_COMMAND_PROTUNE_GAIN">
+        <description>(Get/Set) Hero 3+ Only.</description>
+      </entry>
+      <entry value="13" name="GOPRO_COMMAND_PROTUNE_SHARPNESS">
+        <description>(Get/Set) Hero 3+ Only.</description>
+      </entry>
+      <entry value="14" name="GOPRO_COMMAND_PROTUNE_EXPOSURE">
+        <description>(Get/Set) Hero 3+ Only.</description>
+      </entry>
+      <entry value="15" name="GOPRO_COMMAND_TIME">
+        <description>(Get/Set).</description>
+        <!-- Packet structure for the four values is as follows byte 0...3: uint32_t unix timestamp (byte 0 is MSB) -->
+      </entry>
+      <entry value="16" name="GOPRO_COMMAND_CHARGING">
+        <description>(Get/Set).</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_CAPTURE_MODE">
+      <entry value="0" name="GOPRO_CAPTURE_MODE_VIDEO">
+        <description>Video mode.</description>
+      </entry>
+      <entry value="1" name="GOPRO_CAPTURE_MODE_PHOTO">
+        <description>Photo mode.</description>
+      </entry>
+      <entry value="2" name="GOPRO_CAPTURE_MODE_BURST">
+        <description>Burst mode, Hero 3+ only.</description>
+      </entry>
+      <entry value="3" name="GOPRO_CAPTURE_MODE_TIME_LAPSE">
+        <description>Time lapse mode, Hero 3+ only.</description>
+      </entry>
+      <entry value="4" name="GOPRO_CAPTURE_MODE_MULTI_SHOT">
+        <description>Multi shot mode, Hero 4 only.</description>
+      </entry>
+      <entry value="5" name="GOPRO_CAPTURE_MODE_PLAYBACK">
+        <description>Playback mode, Hero 4 only, silver only except when LCD or HDMI is connected to black.</description>
+      </entry>
+      <entry value="6" name="GOPRO_CAPTURE_MODE_SETUP">
+        <description>Playback mode, Hero 4 only.</description>
+      </entry>
+      <entry value="255" name="GOPRO_CAPTURE_MODE_UNKNOWN">
+        <description>Mode not yet known.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_RESOLUTION">
+      <entry value="0" name="GOPRO_RESOLUTION_480p">
+        <description>848 x 480 (480p).</description>
+      </entry>
+      <entry value="1" name="GOPRO_RESOLUTION_720p">
+        <description>1280 x 720 (720p).</description>
+      </entry>
+      <entry value="2" name="GOPRO_RESOLUTION_960p">
+        <description>1280 x 960 (960p).</description>
+      </entry>
+      <entry value="3" name="GOPRO_RESOLUTION_1080p">
+        <description>1920 x 1080 (1080p).</description>
+      </entry>
+      <entry value="4" name="GOPRO_RESOLUTION_1440p">
+        <description>1920 x 1440 (1440p).</description>
+      </entry>
+      <entry value="5" name="GOPRO_RESOLUTION_2_7k_17_9">
+        <description>2704 x 1440 (2.7k-17:9).</description>
+      </entry>
+      <entry value="6" name="GOPRO_RESOLUTION_2_7k_16_9">
+        <description>2704 x 1524 (2.7k-16:9).</description>
+      </entry>
+      <entry value="7" name="GOPRO_RESOLUTION_2_7k_4_3">
+        <description>2704 x 2028 (2.7k-4:3).</description>
+      </entry>
+      <entry value="8" name="GOPRO_RESOLUTION_4k_16_9">
+        <description>3840 x 2160 (4k-16:9).</description>
+      </entry>
+      <entry value="9" name="GOPRO_RESOLUTION_4k_17_9">
+        <description>4096 x 2160 (4k-17:9).</description>
+      </entry>
+      <entry value="10" name="GOPRO_RESOLUTION_720p_SUPERVIEW">
+        <description>1280 x 720 (720p-SuperView).</description>
+      </entry>
+      <entry value="11" name="GOPRO_RESOLUTION_1080p_SUPERVIEW">
+        <description>1920 x 1080 (1080p-SuperView).</description>
+      </entry>
+      <entry value="12" name="GOPRO_RESOLUTION_2_7k_SUPERVIEW">
+        <description>2704 x 1520 (2.7k-SuperView).</description>
+      </entry>
+      <entry value="13" name="GOPRO_RESOLUTION_4k_SUPERVIEW">
+        <description>3840 x 2160 (4k-SuperView).</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_FRAME_RATE">
+      <entry value="0" name="GOPRO_FRAME_RATE_12">
+        <description>12 FPS.</description>
+      </entry>
+      <entry value="1" name="GOPRO_FRAME_RATE_15">
+        <description>15 FPS.</description>
+      </entry>
+      <entry value="2" name="GOPRO_FRAME_RATE_24">
+        <description>24 FPS.</description>
+      </entry>
+      <entry value="3" name="GOPRO_FRAME_RATE_25">
+        <description>25 FPS.</description>
+      </entry>
+      <entry value="4" name="GOPRO_FRAME_RATE_30">
+        <description>30 FPS.</description>
+      </entry>
+      <entry value="5" name="GOPRO_FRAME_RATE_48">
+        <description>48 FPS.</description>
+      </entry>
+      <entry value="6" name="GOPRO_FRAME_RATE_50">
+        <description>50 FPS.</description>
+      </entry>
+      <entry value="7" name="GOPRO_FRAME_RATE_60">
+        <description>60 FPS.</description>
+      </entry>
+      <entry value="8" name="GOPRO_FRAME_RATE_80">
+        <description>80 FPS.</description>
+      </entry>
+      <entry value="9" name="GOPRO_FRAME_RATE_90">
+        <description>90 FPS.</description>
+      </entry>
+      <entry value="10" name="GOPRO_FRAME_RATE_100">
+        <description>100 FPS.</description>
+      </entry>
+      <entry value="11" name="GOPRO_FRAME_RATE_120">
+        <description>120 FPS.</description>
+      </entry>
+      <entry value="12" name="GOPRO_FRAME_RATE_240">
+        <description>240 FPS.</description>
+      </entry>
+      <entry value="13" name="GOPRO_FRAME_RATE_12_5">
+        <description>12.5 FPS.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_FIELD_OF_VIEW">
+      <entry value="0" name="GOPRO_FIELD_OF_VIEW_WIDE">
+        <description>0x00: Wide.</description>
+      </entry>
+      <entry value="1" name="GOPRO_FIELD_OF_VIEW_MEDIUM">
+        <description>0x01: Medium.</description>
+      </entry>
+      <entry value="2" name="GOPRO_FIELD_OF_VIEW_NARROW">
+        <description>0x02: Narrow.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_VIDEO_SETTINGS_FLAGS" bitmask="true">
+      <entry value="1" name="GOPRO_VIDEO_SETTINGS_TV_MODE">
+        <description>0=NTSC, 1=PAL.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PHOTO_RESOLUTION">
+      <entry value="0" name="GOPRO_PHOTO_RESOLUTION_5MP_MEDIUM">
+        <description>5MP Medium.</description>
+      </entry>
+      <entry value="1" name="GOPRO_PHOTO_RESOLUTION_7MP_MEDIUM">
+        <description>7MP Medium.</description>
+      </entry>
+      <entry value="2" name="GOPRO_PHOTO_RESOLUTION_7MP_WIDE">
+        <description>7MP Wide.</description>
+      </entry>
+      <entry value="3" name="GOPRO_PHOTO_RESOLUTION_10MP_WIDE">
+        <description>10MP Wide.</description>
+      </entry>
+      <entry value="4" name="GOPRO_PHOTO_RESOLUTION_12MP_WIDE">
+        <description>12MP Wide.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PROTUNE_WHITE_BALANCE">
+      <entry value="0" name="GOPRO_PROTUNE_WHITE_BALANCE_AUTO">
+        <description>Auto.</description>
+      </entry>
+      <entry value="1" name="GOPRO_PROTUNE_WHITE_BALANCE_3000K">
+        <description>3000K.</description>
+      </entry>
+      <entry value="2" name="GOPRO_PROTUNE_WHITE_BALANCE_5500K">
+        <description>5500K.</description>
+      </entry>
+      <entry value="3" name="GOPRO_PROTUNE_WHITE_BALANCE_6500K">
+        <description>6500K.</description>
+      </entry>
+      <entry value="4" name="GOPRO_PROTUNE_WHITE_BALANCE_RAW">
+        <description>Camera Raw.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PROTUNE_COLOUR">
+      <entry value="0" name="GOPRO_PROTUNE_COLOUR_STANDARD">
+        <description>Auto.</description>
+      </entry>
+      <entry value="1" name="GOPRO_PROTUNE_COLOUR_NEUTRAL">
+        <description>Neutral.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PROTUNE_GAIN">
+      <entry value="0" name="GOPRO_PROTUNE_GAIN_400">
+        <description>ISO 400.</description>
+      </entry>
+      <entry value="1" name="GOPRO_PROTUNE_GAIN_800">
+        <description>ISO 800 (Only Hero 4).</description>
+      </entry>
+      <entry value="2" name="GOPRO_PROTUNE_GAIN_1600">
+        <description>ISO 1600.</description>
+      </entry>
+      <entry value="3" name="GOPRO_PROTUNE_GAIN_3200">
+        <description>ISO 3200 (Only Hero 4).</description>
+      </entry>
+      <entry value="4" name="GOPRO_PROTUNE_GAIN_6400">
+        <description>ISO 6400.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PROTUNE_SHARPNESS">
+      <entry value="0" name="GOPRO_PROTUNE_SHARPNESS_LOW">
+        <description>Low Sharpness.</description>
+      </entry>
+      <entry value="1" name="GOPRO_PROTUNE_SHARPNESS_MEDIUM">
+        <description>Medium Sharpness.</description>
+      </entry>
+      <entry value="2" name="GOPRO_PROTUNE_SHARPNESS_HIGH">
+        <description>High Sharpness.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_PROTUNE_EXPOSURE">
+      <entry value="0" name="GOPRO_PROTUNE_EXPOSURE_NEG_5_0">
+        <description>-5.0 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="1" name="GOPRO_PROTUNE_EXPOSURE_NEG_4_5">
+        <description>-4.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="2" name="GOPRO_PROTUNE_EXPOSURE_NEG_4_0">
+        <description>-4.0 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="3" name="GOPRO_PROTUNE_EXPOSURE_NEG_3_5">
+        <description>-3.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="4" name="GOPRO_PROTUNE_EXPOSURE_NEG_3_0">
+        <description>-3.0 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="5" name="GOPRO_PROTUNE_EXPOSURE_NEG_2_5">
+        <description>-2.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="6" name="GOPRO_PROTUNE_EXPOSURE_NEG_2_0">
+        <description>-2.0 EV.</description>
+      </entry>
+      <entry value="7" name="GOPRO_PROTUNE_EXPOSURE_NEG_1_5">
+        <description>-1.5 EV.</description>
+      </entry>
+      <entry value="8" name="GOPRO_PROTUNE_EXPOSURE_NEG_1_0">
+        <description>-1.0 EV.</description>
+      </entry>
+      <entry value="9" name="GOPRO_PROTUNE_EXPOSURE_NEG_0_5">
+        <description>-0.5 EV.</description>
+      </entry>
+      <entry value="10" name="GOPRO_PROTUNE_EXPOSURE_ZERO">
+        <description>0.0 EV.</description>
+      </entry>
+      <entry value="11" name="GOPRO_PROTUNE_EXPOSURE_POS_0_5">
+        <description>+0.5 EV.</description>
+      </entry>
+      <entry value="12" name="GOPRO_PROTUNE_EXPOSURE_POS_1_0">
+        <description>+1.0 EV.</description>
+      </entry>
+      <entry value="13" name="GOPRO_PROTUNE_EXPOSURE_POS_1_5">
+        <description>+1.5 EV.</description>
+      </entry>
+      <entry value="14" name="GOPRO_PROTUNE_EXPOSURE_POS_2_0">
+        <description>+2.0 EV.</description>
+      </entry>
+      <entry value="15" name="GOPRO_PROTUNE_EXPOSURE_POS_2_5">
+        <description>+2.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="16" name="GOPRO_PROTUNE_EXPOSURE_POS_3_0">
+        <description>+3.0 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="17" name="GOPRO_PROTUNE_EXPOSURE_POS_3_5">
+        <description>+3.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="18" name="GOPRO_PROTUNE_EXPOSURE_POS_4_0">
+        <description>+4.0 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="19" name="GOPRO_PROTUNE_EXPOSURE_POS_4_5">
+        <description>+4.5 EV (Hero 3+ Only).</description>
+      </entry>
+      <entry value="20" name="GOPRO_PROTUNE_EXPOSURE_POS_5_0">
+        <description>+5.0 EV (Hero 3+ Only).</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_CHARGING">
+      <entry value="0" name="GOPRO_CHARGING_DISABLED">
+        <description>Charging disabled.</description>
+      </entry>
+      <entry value="1" name="GOPRO_CHARGING_ENABLED">
+        <description>Charging enabled.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_MODEL">
+      <entry value="0" name="GOPRO_MODEL_UNKNOWN">
+        <description>Unknown gopro model.</description>
+      </entry>
+      <entry value="1" name="GOPRO_MODEL_HERO_3_PLUS_SILVER">
+        <description>Hero 3+ Silver (HeroBus not supported by GoPro).</description>
+      </entry>
+      <entry value="2" name="GOPRO_MODEL_HERO_3_PLUS_BLACK">
+        <description>Hero 3+ Black.</description>
+      </entry>
+      <entry value="3" name="GOPRO_MODEL_HERO_4_SILVER">
+        <description>Hero 4 Silver.</description>
+      </entry>
+      <entry value="4" name="GOPRO_MODEL_HERO_4_BLACK">
+        <description>Hero 4 Black.</description>
+      </entry>
+    </enum>
+    <enum name="GOPRO_BURST_RATE">
+      <entry value="0" name="GOPRO_BURST_RATE_3_IN_1_SECOND">
+        <description>3 Shots / 1 Second.</description>
+      </entry>
+      <entry value="1" name="GOPRO_BURST_RATE_5_IN_1_SECOND">
+        <description>5 Shots / 1 Second.</description>
+      </entry>
+      <entry value="2" name="GOPRO_BURST_RATE_10_IN_1_SECOND">
+        <description>10 Shots / 1 Second.</description>
+      </entry>
+      <entry value="3" name="GOPRO_BURST_RATE_10_IN_2_SECOND">
+        <description>10 Shots / 2 Second.</description>
+      </entry>
+      <entry value="4" name="GOPRO_BURST_RATE_10_IN_3_SECOND">
+        <description>10 Shots / 3 Second (Hero 4 Only).</description>
+      </entry>
+      <entry value="5" name="GOPRO_BURST_RATE_30_IN_1_SECOND">
+        <description>30 Shots / 1 Second.</description>
+      </entry>
+      <entry value="6" name="GOPRO_BURST_RATE_30_IN_2_SECOND">
+        <description>30 Shots / 2 Second.</description>
+      </entry>
+      <entry value="7" name="GOPRO_BURST_RATE_30_IN_3_SECOND">
+        <description>30 Shots / 3 Second.</description>
+      </entry>
+      <entry value="8" name="GOPRO_BURST_RATE_30_IN_6_SECOND">
+        <description>30 Shots / 6 Second.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL">
+      <entry value="0" name="MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL_LOW">
+        <description>Switch Low.</description>
+      </entry>
+      <entry value="1" name="MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL_MIDDLE">
+        <description>Switch Middle.</description>
+      </entry>
+      <entry value="2" name="MAV_CMD_DO_AUX_FUNCTION_SWITCH_LEVEL_HIGH">
+        <description>Switch High.</description>
+      </entry>
+    </enum>
+    <!-- led control pattern enums (enumeration of specific patterns) -->
+    <enum name="LED_CONTROL_PATTERN">
+      <entry value="0" name="LED_CONTROL_PATTERN_OFF">
+        <description>LED patterns off (return control to regular vehicle control).</description>
+      </entry>
+      <entry value="1" name="LED_CONTROL_PATTERN_FIRMWAREUPDATE">
+        <description>LEDs show pattern during firmware update.</description>
+      </entry>
+      <entry value="255" name="LED_CONTROL_PATTERN_CUSTOM">
+        <description>Custom Pattern using custom bytes fields.</description>
+      </entry>
+    </enum>
+    <!-- EKF_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
+    <enum name="EKF_STATUS_FLAGS" bitmask="true">
+      <description>Flags in EKF_STATUS message.</description>
+      <entry value="1" name="EKF_ATTITUDE">
+        <description>Set if EKF's attitude estimate is good.</description>
+      </entry>
+      <entry value="2" name="EKF_VELOCITY_HORIZ">
+        <description>Set if EKF's horizontal velocity estimate is good.</description>
+      </entry>
+      <entry value="4" name="EKF_VELOCITY_VERT">
+        <description>Set if EKF's vertical velocity estimate is good.</description>
+      </entry>
+      <entry value="8" name="EKF_POS_HORIZ_REL">
+        <description>Set if EKF's horizontal position (relative) estimate is good.</description>
+      </entry>
+      <entry value="16" name="EKF_POS_HORIZ_ABS">
+        <description>Set if EKF's horizontal position (absolute) estimate is good.</description>
+      </entry>
+      <entry value="32" name="EKF_POS_VERT_ABS">
+        <description>Set if EKF's vertical position (absolute) estimate is good.</description>
+      </entry>
+      <entry value="64" name="EKF_POS_VERT_AGL">
+        <description>Set if EKF's vertical position (above ground) estimate is good.</description>
+      </entry>
+      <entry value="128" name="EKF_CONST_POS_MODE">
+        <description>EKF is in constant position mode and does not know it's absolute or relative position.</description>
+      </entry>
+      <entry value="256" name="EKF_PRED_POS_HORIZ_REL">
+        <description>Set if EKF's predicted horizontal position (relative) estimate is good.</description>
+      </entry>
+      <entry value="512" name="EKF_PRED_POS_HORIZ_ABS">
+        <description>Set if EKF's predicted horizontal position (absolute) estimate is good.</description>
+      </entry>
+      <entry value="1024" name="EKF_UNINITIALIZED">
+        <description>Set if EKF has never been healthy.</description>
+      </entry>
+    </enum>
+    <enum name="PID_TUNING_AXIS">
+      <entry value="1" name="PID_TUNING_ROLL"/>
+      <entry value="2" name="PID_TUNING_PITCH"/>
+      <entry value="3" name="PID_TUNING_YAW"/>
+      <entry value="4" name="PID_TUNING_ACCZ"/>
+      <entry value="5" name="PID_TUNING_STEER"/>
+      <entry value="6" name="PID_TUNING_LANDING"/>
+    </enum>
+    <enum name="MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS">
+      <description>Special ACK block numbers control activation of dataflash log streaming.</description>
+      <!-- C uses signed integers for enumerations; these constants start at MAX_INT32_T and go down -->
+      <!-- 2^31-3 == 2147483645 -->
+      <entry value="2147483645" name="MAV_REMOTE_LOG_DATA_BLOCK_STOP">
+        <description>UAV to stop sending DataFlash blocks.</description>
+      </entry>
+      <!-- 2^31-2 == 2147483646 -->
+      <entry value="2147483646" name="MAV_REMOTE_LOG_DATA_BLOCK_START">
+        <description>UAV to start sending DataFlash blocks.</description>
+      </entry>
+      <!-- MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS_ENUM_END will be 2^31-1 == 2147483647 -->
+    </enum>
+    <enum name="MAV_REMOTE_LOG_DATA_BLOCK_STATUSES">
+      <description>Possible remote log data block statuses.</description>
+      <entry value="0" name="MAV_REMOTE_LOG_DATA_BLOCK_NACK">
+        <description>This block has NOT been received.</description>
+      </entry>
+      <entry value="1" name="MAV_REMOTE_LOG_DATA_BLOCK_ACK">
+        <description>This block has been received.</description>
+      </entry>
+    </enum>
+    <enum name="DEVICE_OP_BUSTYPE">
+      <description>Bus types for device operations.</description>
+      <entry value="0" name="DEVICE_OP_BUSTYPE_I2C">
+        <description>I2C Device operation.</description>
+      </entry>
+      <entry value="1" name="DEVICE_OP_BUSTYPE_SPI">
+        <description>SPI Device operation.</description>
+      </entry>
+    </enum>
+    <enum name="DEEPSTALL_STAGE">
+      <description>Deepstall flight stage.</description>
+      <entry value="0" name="DEEPSTALL_STAGE_FLY_TO_LANDING">
+        <description>Flying to the landing point.</description>
+      </entry>
+      <entry value="1" name="DEEPSTALL_STAGE_ESTIMATE_WIND">
+        <description>Building an estimate of the wind.</description>
+      </entry>
+      <entry value="2" name="DEEPSTALL_STAGE_WAIT_FOR_BREAKOUT">
+        <description>Waiting to breakout of the loiter to fly the approach.</description>
+      </entry>
+      <entry value="3" name="DEEPSTALL_STAGE_FLY_TO_ARC">
+        <description>Flying to the first arc point to turn around to the landing point.</description>
+      </entry>
+      <entry value="4" name="DEEPSTALL_STAGE_ARC">
+        <description>Turning around back to the deepstall landing point.</description>
+      </entry>
+      <entry value="5" name="DEEPSTALL_STAGE_APPROACH">
+        <description>Approaching the landing point.</description>
+      </entry>
+      <entry value="6" name="DEEPSTALL_STAGE_LAND">
+        <description>Stalling and steering towards the land point.</description>
+      </entry>
+    </enum>
+    <enum name="PLANE_MODE">
+      <description>A mapping of plane flight modes for custom_mode field of heartbeat.</description>
+      <entry value="0" name="PLANE_MODE_MANUAL"/>
+      <entry value="1" name="PLANE_MODE_CIRCLE"/>
+      <entry value="2" name="PLANE_MODE_STABILIZE"/>
+      <entry value="3" name="PLANE_MODE_TRAINING"/>
+      <entry value="4" name="PLANE_MODE_ACRO"/>
+      <entry value="5" name="PLANE_MODE_FLY_BY_WIRE_A"/>
+      <entry value="6" name="PLANE_MODE_FLY_BY_WIRE_B"/>
+      <entry value="7" name="PLANE_MODE_CRUISE"/>
+      <entry value="8" name="PLANE_MODE_AUTOTUNE"/>
+      <entry value="10" name="PLANE_MODE_AUTO"/>
+      <entry value="11" name="PLANE_MODE_RTL"/>
+      <entry value="12" name="PLANE_MODE_LOITER"/>
+      <entry value="13" name="PLANE_MODE_TAKEOFF"/>
+      <entry value="14" name="PLANE_MODE_AVOID_ADSB"/>
+      <entry value="15" name="PLANE_MODE_GUIDED"/>
+      <entry value="16" name="PLANE_MODE_INITIALIZING"/>
+      <entry value="17" name="PLANE_MODE_QSTABILIZE"/>
+      <entry value="18" name="PLANE_MODE_QHOVER"/>
+      <entry value="19" name="PLANE_MODE_QLOITER"/>
+      <entry value="20" name="PLANE_MODE_QLAND"/>
+      <entry value="21" name="PLANE_MODE_QRTL"/>
+      <entry value="22" name="PLANE_MODE_QAUTOTUNE"/>
+      <entry value="23" name="PLANE_MODE_QACRO"/>
+      <entry value="24" name="PLANE_MODE_THERMAL"/>
+    </enum>
+    <enum name="COPTER_MODE">
+      <description>A mapping of copter flight modes for custom_mode field of heartbeat.</description>
+      <entry value="0" name="COPTER_MODE_STABILIZE"/>
+      <entry value="1" name="COPTER_MODE_ACRO"/>
+      <entry value="2" name="COPTER_MODE_ALT_HOLD"/>
+      <entry value="3" name="COPTER_MODE_AUTO"/>
+      <entry value="4" name="COPTER_MODE_GUIDED"/>
+      <entry value="5" name="COPTER_MODE_LOITER"/>
+      <entry value="6" name="COPTER_MODE_RTL"/>
+      <entry value="7" name="COPTER_MODE_CIRCLE"/>
+      <entry value="9" name="COPTER_MODE_LAND"/>
+      <entry value="11" name="COPTER_MODE_DRIFT"/>
+      <entry value="13" name="COPTER_MODE_SPORT"/>
+      <entry value="14" name="COPTER_MODE_FLIP"/>
+      <entry value="15" name="COPTER_MODE_AUTOTUNE"/>
+      <entry value="16" name="COPTER_MODE_POSHOLD"/>
+      <entry value="17" name="COPTER_MODE_BRAKE"/>
+      <entry value="18" name="COPTER_MODE_THROW"/>
+      <entry value="19" name="COPTER_MODE_AVOID_ADSB"/>
+      <entry value="20" name="COPTER_MODE_GUIDED_NOGPS"/>
+      <entry value="21" name="COPTER_MODE_SMART_RTL"/>
+      <entry value="22" name="COPTER_MODE_FLOWHOLD"/>
+      <entry value="23" name="COPTER_MODE_FOLLOW"/>
+      <entry value="24" name="COPTER_MODE_ZIGZAG"/>
+      <entry value="25" name="COPTER_MODE_SYSTEMID"/>
+      <entry value="26" name="COPTER_MODE_AUTOROTATE"/>
+      <entry value="27" name="COPTER_MODE_AUTO_RTL"/>
+    </enum>
+    <enum name="SUB_MODE">
+      <description>A mapping of sub flight modes for custom_mode field of heartbeat.</description>
+      <entry value="0" name="SUB_MODE_STABILIZE"/>
+      <entry value="1" name="SUB_MODE_ACRO"/>
+      <entry value="2" name="SUB_MODE_ALT_HOLD"/>
+      <entry value="3" name="SUB_MODE_AUTO"/>
+      <entry value="4" name="SUB_MODE_GUIDED"/>
+      <entry value="7" name="SUB_MODE_CIRCLE"/>
+      <entry value="9" name="SUB_MODE_SURFACE"/>
+      <entry value="16" name="SUB_MODE_POSHOLD"/>
+      <entry value="19" name="SUB_MODE_MANUAL"/>
+    </enum>
+    <enum name="ROVER_MODE">
+      <description>A mapping of rover flight modes for custom_mode field of heartbeat.</description>
+      <entry value="0" name="ROVER_MODE_MANUAL"/>
+      <entry value="1" name="ROVER_MODE_ACRO"/>
+      <entry value="3" name="ROVER_MODE_STEERING"/>
+      <entry value="4" name="ROVER_MODE_HOLD"/>
+      <entry value="5" name="ROVER_MODE_LOITER"/>
+      <entry value="6" name="ROVER_MODE_FOLLOW"/>
+      <entry value="7" name="ROVER_MODE_SIMPLE"/>
+      <entry value="10" name="ROVER_MODE_AUTO"/>
+      <entry value="11" name="ROVER_MODE_RTL"/>
+      <entry value="12" name="ROVER_MODE_SMART_RTL"/>
+      <entry value="15" name="ROVER_MODE_GUIDED"/>
+      <entry value="16" name="ROVER_MODE_INITIALIZING"/>
+    </enum>
+    <enum name="TRACKER_MODE">
+      <description>A mapping of antenna tracker flight modes for custom_mode field of heartbeat.</description>
+      <entry value="0" name="TRACKER_MODE_MANUAL"/>
+      <entry value="1" name="TRACKER_MODE_STOP"/>
+      <entry value="2" name="TRACKER_MODE_SCAN"/>
+      <entry value="3" name="TRACKER_MODE_SERVO_TEST"/>
+      <entry value="10" name="TRACKER_MODE_AUTO"/>
+      <entry value="16" name="TRACKER_MODE_INITIALIZING"/>
+    </enum>
+    <enum name="OSD_PARAM_CONFIG_TYPE">
+      <description>The type of parameter for the OSD parameter editor.</description>
+      <entry value="0" name="OSD_PARAM_NONE"/>
+      <entry value="1" name="OSD_PARAM_SERIAL_PROTOCOL"/>
+      <entry value="2" name="OSD_PARAM_SERVO_FUNCTION"/>
+      <entry value="3" name="OSD_PARAM_AUX_FUNCTION"/>
+      <entry value="4" name="OSD_PARAM_FLIGHT_MODE"/>
+      <entry value="5" name="OSD_PARAM_FAILSAFE_ACTION"/>
+      <entry value="6" name="OSD_PARAM_FAILSAFE_ACTION_1"/>
+      <entry value="7" name="OSD_PARAM_FAILSAFE_ACTION_2"/>
+      <entry value="8" name="OSD_PARAM_NUM_TYPES"/>
+    </enum>
+    <enum name="OSD_PARAM_CONFIG_ERROR">
+      <description>The error type for the OSD parameter editor.</description>
+      <entry value="0" name="OSD_PARAM_SUCCESS"/>
+      <entry value="1" name="OSD_PARAM_INVALID_SCREEN"/>
+      <entry value="2" name="OSD_PARAM_INVALID_PARAMETER_INDEX"/>
+      <entry value="3" name="OSD_PARAM_INVALID_PARAMETER"/>
+    </enum>
+  </enums>
+  <messages>
+    <message id="150" name="SENSOR_OFFSETS">
+      <deprecated since="2022-02" replaced_by="MAG_CAL_REPORT, Accel Parameters, and Gyro Parameters"/>
+      <description>Offsets and calibrations values for hardware sensors. This makes it easier to debug the calibration process.</description>
+      <field type="int16_t" name="mag_ofs_x">Magnetometer X offset.</field>
+      <field type="int16_t" name="mag_ofs_y">Magnetometer Y offset.</field>
+      <field type="int16_t" name="mag_ofs_z">Magnetometer Z offset.</field>
+      <field type="float" name="mag_declination" units="rad">Magnetic declination.</field>
+      <field type="int32_t" name="raw_press">Raw pressure from barometer.</field>
+      <field type="int32_t" name="raw_temp">Raw temperature from barometer.</field>
+      <field type="float" name="gyro_cal_x">Gyro X calibration.</field>
+      <field type="float" name="gyro_cal_y">Gyro Y calibration.</field>
+      <field type="float" name="gyro_cal_z">Gyro Z calibration.</field>
+      <field type="float" name="accel_cal_x">Accel X calibration.</field>
+      <field type="float" name="accel_cal_y">Accel Y calibration.</field>
+      <field type="float" name="accel_cal_z">Accel Z calibration.</field>
+    </message>
+    <message id="151" name="SET_MAG_OFFSETS">
+      <deprecated since="2014-07" replaced_by="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS"/>
+      <description>Set the magnetometer offsets</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="int16_t" name="mag_ofs_x">Magnetometer X offset.</field>
+      <field type="int16_t" name="mag_ofs_y">Magnetometer Y offset.</field>
+      <field type="int16_t" name="mag_ofs_z">Magnetometer Z offset.</field>
+    </message>
+    <message id="152" name="MEMINFO">
+      <description>State of autopilot RAM.</description>
+      <field type="uint16_t" name="brkval">Heap top.</field>
+      <field type="uint16_t" name="freemem" units="bytes">Free memory.</field>
+      <extensions/>
+      <field type="uint32_t" name="freemem32" units="bytes">Free memory (32 bit).</field>
+    </message>
+    <message id="153" name="AP_ADC">
+      <description>Raw ADC output.</description>
+      <field type="uint16_t" name="adc1">ADC output 1.</field>
+      <field type="uint16_t" name="adc2">ADC output 2.</field>
+      <field type="uint16_t" name="adc3">ADC output 3.</field>
+      <field type="uint16_t" name="adc4">ADC output 4.</field>
+      <field type="uint16_t" name="adc5">ADC output 5.</field>
+      <field type="uint16_t" name="adc6">ADC output 6.</field>
+    </message>
+    <!-- Camera Controller Messages -->
+    <message id="154" name="DIGICAM_CONFIGURE">
+      <description>Configure on-board Camera Control System.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="mode">Mode enumeration from 1 to N //P, TV, AV, M, etc. (0 means ignore).</field>
+      <field type="uint16_t" name="shutter_speed">Divisor number //e.g. 1000 means 1/1000 (0 means ignore).</field>
+      <field type="uint8_t" name="aperture">F stop number x 10 //e.g. 28 means 2.8 (0 means ignore).</field>
+      <field type="uint8_t" name="iso">ISO enumeration from 1 to N //e.g. 80, 100, 200, Etc (0 means ignore).</field>
+      <field type="uint8_t" name="exposure_type">Exposure type enumeration from 1 to N (0 means ignore).</field>
+      <field type="uint8_t" name="command_id">Command Identity (incremental loop: 0 to 255). //A command sent multiple times will be executed or pooled just once.</field>
+      <field type="uint8_t" name="engine_cut_off" units="ds">Main engine cut-off time before camera trigger (0 means no cut-off).</field>
+      <field type="uint8_t" name="extra_param">Extra parameters enumeration (0 means ignore).</field>
+      <field type="float" name="extra_value">Correspondent value to given extra_param.</field>
+    </message>
+    <message id="155" name="DIGICAM_CONTROL">
+      <description>Control on-board Camera Control System to take shots.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="session">0: stop, 1: start or keep it up //Session control e.g. show/hide lens.</field>
+      <field type="uint8_t" name="zoom_pos">1 to N //Zoom's absolute position (0 means ignore).</field>
+      <field type="int8_t" name="zoom_step">-100 to 100 //Zooming step value to offset zoom from the current position.</field>
+      <field type="uint8_t" name="focus_lock">0: unlock focus or keep unlocked, 1: lock focus or keep locked, 3: re-lock focus.</field>
+      <field type="uint8_t" name="shot">0: ignore, 1: shot or start filming.</field>
+      <field type="uint8_t" name="command_id">Command Identity (incremental loop: 0 to 255)//A command sent multiple times will be executed or pooled just once.</field>
+      <field type="uint8_t" name="extra_param">Extra parameters enumeration (0 means ignore).</field>
+      <field type="float" name="extra_value">Correspondent value to given extra_param.</field>
+    </message>
+    <!-- Camera Mount Messages -->
+    <message id="156" name="MOUNT_CONFIGURE">
+      <description>Message to configure a camera mount, directional antenna, etc.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="mount_mode" enum="MAV_MOUNT_MODE">Mount operating mode.</field>
+      <field type="uint8_t" name="stab_roll">(1 = yes, 0 = no).</field>
+      <field type="uint8_t" name="stab_pitch">(1 = yes, 0 = no).</field>
+      <field type="uint8_t" name="stab_yaw">(1 = yes, 0 = no).</field>
+    </message>
+    <message id="157" name="MOUNT_CONTROL">
+      <description>Message to control a camera mount, directional antenna, etc.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="int32_t" name="input_a">Pitch (centi-degrees) or lat (degE7), depending on mount mode.</field>
+      <field type="int32_t" name="input_b">Roll (centi-degrees) or lon (degE7) depending on mount mode.</field>
+      <field type="int32_t" name="input_c">Yaw (centi-degrees) or alt (cm) depending on mount mode.</field>
+      <field type="uint8_t" name="save_position">If "1" it will save current trimmed position on EEPROM (just valid for NEUTRAL and LANDING).</field>
+    </message>
+    <message id="158" name="MOUNT_STATUS">
+      <description>Message with some status from autopilot to GCS about camera or antenna mount.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="int32_t" name="pointing_a" units="cdeg">Pitch.</field>
+      <field type="int32_t" name="pointing_b" units="cdeg">Roll.</field>
+      <field type="int32_t" name="pointing_c" units="cdeg">Yaw.</field>
+      <extensions/>
+      <field type="uint8_t" name="mount_mode" enum="MAV_MOUNT_MODE">Mount operating mode.</field>
+    </message>
+    <!-- geo-fence messages -->
+    <message id="160" name="FENCE_POINT">
+      <description>A fence point. Used to set a point when from GCS -&gt; MAV. Also used to return a point from MAV -&gt; GCS.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="idx">Point index (first point is 1, 0 is for return point).</field>
+      <field type="uint8_t" name="count">Total number of points (for sanity checking).</field>
+      <field type="float" name="lat" units="deg">Latitude of point.</field>
+      <field type="float" name="lng" units="deg">Longitude of point.</field>
+    </message>
+    <message id="161" name="FENCE_FETCH_POINT">
+      <description>Request a current fence point from MAV.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="idx">Point index (first point is 1, 0 is for return point).</field>
+    </message>
+    <message id="163" name="AHRS">
+      <description>Status of DCM attitude estimator.</description>
+      <field type="float" name="omegaIx" units="rad/s">X gyro drift estimate.</field>
+      <field type="float" name="omegaIy" units="rad/s">Y gyro drift estimate.</field>
+      <field type="float" name="omegaIz" units="rad/s">Z gyro drift estimate.</field>
+      <field type="float" name="accel_weight">Average accel_weight.</field>
+      <field type="float" name="renorm_val">Average renormalisation value.</field>
+      <field type="float" name="error_rp">Average error_roll_pitch value.</field>
+      <field type="float" name="error_yaw">Average error_yaw value.</field>
+    </message>
+    <message id="164" name="SIMSTATE">
+      <description>Status of simulation environment, if used.</description>
+      <field type="float" name="roll" units="rad">Roll angle.</field>
+      <field type="float" name="pitch" units="rad">Pitch angle.</field>
+      <field type="float" name="yaw" units="rad">Yaw angle.</field>
+      <field type="float" name="xacc" units="m/s/s">X acceleration.</field>
+      <field type="float" name="yacc" units="m/s/s">Y acceleration.</field>
+      <field type="float" name="zacc" units="m/s/s">Z acceleration.</field>
+      <field type="float" name="xgyro" units="rad/s">Angular speed around X axis.</field>
+      <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis.</field>
+      <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude.</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude.</field>
+    </message>
+    <message id="165" name="HWSTATUS">
+      <description>Status of key hardware.</description>
+      <field type="uint16_t" name="Vcc" units="mV">Board voltage.</field>
+      <field type="uint8_t" name="I2Cerr">I2C error count.</field>
+    </message>
+    <message id="166" name="RADIO">
+      <description>Status generated by radio.</description>
+      <field type="uint8_t" name="rssi">Local signal strength.</field>
+      <field type="uint8_t" name="remrssi">Remote signal strength.</field>
+      <field type="uint8_t" name="txbuf" units="%">How full the tx buffer is.</field>
+      <field type="uint8_t" name="noise">Background noise level.</field>
+      <field type="uint8_t" name="remnoise">Remote background noise level.</field>
+      <field type="uint16_t" name="rxerrors">Receive errors.</field>
+      <field type="uint16_t" name="fixed">Count of error corrected packets.</field>
+    </message>
+    <!-- AP_Limits status -->
+    <message id="167" name="LIMITS_STATUS">
+      <description>Status of AP_Limits. Sent in extended status stream when AP_Limits is enabled.</description>
+      <field type="uint8_t" name="limits_state" enum="LIMITS_STATE">State of AP_Limits.</field>
+      <field type="uint32_t" name="last_trigger" units="ms">Time (since boot) of last breach.</field>
+      <field type="uint32_t" name="last_action" units="ms">Time (since boot) of last recovery action.</field>
+      <field type="uint32_t" name="last_recovery" units="ms">Time (since boot) of last successful recovery.</field>
+      <field type="uint32_t" name="last_clear" units="ms">Time (since boot) of last all-clear.</field>
+      <field type="uint16_t" name="breach_count">Number of fence breaches.</field>
+      <field type="uint8_t" name="mods_enabled" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of enabled modules.</field>
+      <field type="uint8_t" name="mods_required" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of required modules.</field>
+      <field type="uint8_t" name="mods_triggered" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of triggered modules.</field>
+    </message>
+    <message id="168" name="WIND">
+      <description>Wind estimation.</description>
+      <field type="float" name="direction" units="deg">Wind direction (that wind is coming from).</field>
+      <field type="float" name="speed" units="m/s">Wind speed in ground plane.</field>
+      <field type="float" name="speed_z" units="m/s">Vertical wind speed.</field>
+    </message>
+    <message id="169" name="DATA16">
+      <description>Data packet, size 16.</description>
+      <field type="uint8_t" name="type">Data type.</field>
+      <field type="uint8_t" name="len" units="bytes">Data length.</field>
+      <field type="uint8_t[16]" name="data">Raw data.</field>
+    </message>
+    <message id="170" name="DATA32">
+      <description>Data packet, size 32.</description>
+      <field type="uint8_t" name="type">Data type.</field>
+      <field type="uint8_t" name="len" units="bytes">Data length.</field>
+      <field type="uint8_t[32]" name="data">Raw data.</field>
+    </message>
+    <message id="171" name="DATA64">
+      <description>Data packet, size 64.</description>
+      <field type="uint8_t" name="type">Data type.</field>
+      <field type="uint8_t" name="len" units="bytes">Data length.</field>
+      <field type="uint8_t[64]" name="data">Raw data.</field>
+    </message>
+    <message id="172" name="DATA96">
+      <description>Data packet, size 96.</description>
+      <field type="uint8_t" name="type">Data type.</field>
+      <field type="uint8_t" name="len" units="bytes">Data length.</field>
+      <field type="uint8_t[96]" name="data">Raw data.</field>
+    </message>
+    <message id="173" name="RANGEFINDER">
+      <description>Rangefinder reporting.</description>
+      <field type="float" name="distance" units="m">Distance.</field>
+      <field type="float" name="voltage" units="V">Raw voltage if available, zero otherwise.</field>
+    </message>
+    <message id="174" name="AIRSPEED_AUTOCAL">
+      <description>Airspeed auto-calibration.</description>
+      <field type="float" name="vx" units="m/s">GPS velocity north.</field>
+      <field type="float" name="vy" units="m/s">GPS velocity east.</field>
+      <field type="float" name="vz" units="m/s">GPS velocity down.</field>
+      <field type="float" name="diff_pressure" units="Pa">Differential pressure.</field>
+      <field type="float" name="EAS2TAS">Estimated to true airspeed ratio.</field>
+      <field type="float" name="ratio">Airspeed ratio.</field>
+      <field type="float" name="state_x">EKF state x.</field>
+      <field type="float" name="state_y">EKF state y.</field>
+      <field type="float" name="state_z">EKF state z.</field>
+      <field type="float" name="Pax">EKF Pax.</field>
+      <field type="float" name="Pby">EKF Pby.</field>
+      <field type="float" name="Pcz">EKF Pcz.</field>
+    </message>
+    <!-- Rally point messages -->
+    <message id="175" name="RALLY_POINT">
+      <description>A rally point. Used to set a point when from GCS -&gt; MAV. Also used to return a point from MAV -&gt; GCS.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="idx">Point index (first point is 0).</field>
+      <field type="uint8_t" name="count">Total number of points (for sanity checking).</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude of point.</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude of point.</field>
+      <field type="int16_t" name="alt" units="m">Transit / loiter altitude relative to home.</field>
+      <!-- Path planned landings are still in the future, but we want these fields ready: -->
+      <field type="int16_t" name="break_alt" units="m">Break altitude relative to home.</field>
+      <field type="uint16_t" name="land_dir" units="cdeg">Heading to aim for when landing.</field>
+      <field type="uint8_t" name="flags" enum="RALLY_FLAGS" display="bitmask">Configuration flags.</field>
+    </message>
+    <message id="176" name="RALLY_FETCH_POINT">
+      <description>Request a current rally point from MAV. MAV should respond with a RALLY_POINT message. MAV should not respond if the request is invalid.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="idx">Point index (first point is 0).</field>
+    </message>
+    <message id="177" name="COMPASSMOT_STATUS">
+      <description>Status of compassmot calibration.</description>
+      <field type="uint16_t" name="throttle" units="d%">Throttle.</field>
+      <field type="float" name="current" units="A">Current.</field>
+      <field type="uint16_t" name="interference" units="%">Interference.</field>
+      <field type="float" name="CompensationX">Motor Compensation X.</field>
+      <field type="float" name="CompensationY">Motor Compensation Y.</field>
+      <field type="float" name="CompensationZ">Motor Compensation Z.</field>
+    </message>
+    <message id="178" name="AHRS2">
+      <description>Status of secondary AHRS filter if available.</description>
+      <field type="float" name="roll" units="rad">Roll angle.</field>
+      <field type="float" name="pitch" units="rad">Pitch angle.</field>
+      <field type="float" name="yaw" units="rad">Yaw angle.</field>
+      <field type="float" name="altitude" units="m">Altitude (MSL).</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude.</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude.</field>
+    </message>
+    <!-- camera event message from CCB to autopilot: for image trigger events but also things like heartbeat, error, low power, full card, etc -->
+    <message id="179" name="CAMERA_STATUS">
+      <description>Camera Event.</description>
+      <field type="uint64_t" name="time_usec" units="us">Image timestamp (since UNIX epoch, according to camera clock).</field>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <!-- support multiple concurrent vehicles -->
+      <field type="uint8_t" name="cam_idx">Camera ID.</field>
+      <!-- component ID, to support multiple cameras -->
+      <field type="uint16_t" name="img_idx">Image index.</field>
+      <!-- per camera image index, should be unique+sequential within a mission, preferably non-wrapping -->
+      <field type="uint8_t" name="event_id" enum="CAMERA_STATUS_TYPES">Event type.</field>
+      <field type="float" name="p1">Parameter 1 (meaning depends on event_id, see CAMERA_STATUS_TYPES enum).</field>
+      <field type="float" name="p2">Parameter 2 (meaning depends on event_id, see CAMERA_STATUS_TYPES enum).</field>
+      <field type="float" name="p3">Parameter 3 (meaning depends on event_id, see CAMERA_STATUS_TYPES enum).</field>
+      <field type="float" name="p4">Parameter 4 (meaning depends on event_id, see CAMERA_STATUS_TYPES enum).</field>
+    </message>
+    <!-- camera feedback message - can be originated from CCB (in response to a CAMERA_STATUS), or directly from the autopilot as part of a DO_DIGICAM_CONTROL-->
+    <message id="180" name="CAMERA_FEEDBACK">
+      <description>Camera Capture Feedback.</description>
+      <field type="uint64_t" name="time_usec" units="us">Image timestamp (since UNIX epoch), as passed in by CAMERA_STATUS message (or autopilot if no CCB).</field>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <!-- support multiple concurrent vehicles -->
+      <field type="uint8_t" name="cam_idx">Camera ID.</field>
+      <!-- component ID, to support multiple cameras -->
+      <field type="uint16_t" name="img_idx">Image index.</field>
+      <!-- per camera image index, should be unique+sequential within a mission, preferably non-wrapping -->
+      <field type="int32_t" name="lat" units="degE7">Latitude.</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude.</field>
+      <field type="float" name="alt_msl" units="m">Altitude (MSL).</field>
+      <field type="float" name="alt_rel" units="m">Altitude (Relative to HOME location).</field>
+      <field type="float" name="roll" units="deg">Camera Roll angle (earth frame, +-180).</field>
+      <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
+      <field type="float" name="pitch" units="deg">Camera Pitch angle (earth frame, +-180).</field>
+      <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
+      <field type="float" name="yaw" units="deg">Camera Yaw (earth frame, 0-360, true).</field>
+      <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
+      <field type="float" name="foc_len" units="mm">Focal Length.</field>
+      <!-- per-image to support zooms. Zero means fixed focal length or unknown. Should be true mm, not scaled to 35mm film equivalent -->
+      <field type="uint8_t" name="flags" enum="CAMERA_FEEDBACK_FLAGS">Feedback flags.</field>
+      <!-- future proofing -->
+      <extensions/>
+      <field type="uint16_t" name="completed_captures">Completed image captures.</field>
+    </message>
+    <message id="181" name="BATTERY2">
+      <deprecated since="2017-04" replaced_by="BATTERY_STATUS"/>
+      <description>2nd Battery status</description>
+      <field type="uint16_t" name="voltage" units="mV">Voltage.</field>
+      <field type="int16_t" name="current_battery" units="cA">Battery current, -1: autopilot does not measure the current.</field>
+    </message>
+    <message id="182" name="AHRS3">
+      <description>Status of third AHRS filter if available. This is for ANU research group (Ali and Sean).</description>
+      <field type="float" name="roll" units="rad">Roll angle.</field>
+      <field type="float" name="pitch" units="rad">Pitch angle.</field>
+      <field type="float" name="yaw" units="rad">Yaw angle.</field>
+      <field type="float" name="altitude" units="m">Altitude (MSL).</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude.</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude.</field>
+      <field type="float" name="v1">Test variable1.</field>
+      <field type="float" name="v2">Test variable2.</field>
+      <field type="float" name="v3">Test variable3.</field>
+      <field type="float" name="v4">Test variable4.</field>
+    </message>
+    <message id="183" name="AUTOPILOT_VERSION_REQUEST">
+      <description>Request the autopilot version from the system/component.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+    </message>
+    <!-- remote log messages -->
+    <message id="184" name="REMOTE_LOG_DATA_BLOCK">
+      <description>Send a block of log data to remote location.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="seqno" enum="MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS">Log data block sequence number.</field>
+      <field type="uint8_t[200]" name="data">Log data block.</field>
+    </message>
+    <message id="185" name="REMOTE_LOG_BLOCK_STATUS">
+      <description>Send Status of each log block that autopilot board might have sent.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="seqno">Log data block sequence number.</field>
+      <field type="uint8_t" name="status" enum="MAV_REMOTE_LOG_DATA_BLOCK_STATUSES">Log data block status.</field>
+    </message>
+    <message id="186" name="LED_CONTROL">
+      <description>Control vehicle LEDs.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="instance">Instance (LED instance to control or 255 for all LEDs).</field>
+      <field type="uint8_t" name="pattern">Pattern (see LED_PATTERN_ENUM).</field>
+      <field type="uint8_t" name="custom_len">Custom Byte Length.</field>
+      <field type="uint8_t[24]" name="custom_bytes">Custom Bytes.</field>
+    </message>
+    <message id="191" name="MAG_CAL_PROGRESS">
+      <description>Reports progress of compass calibration.</description>
+      <field type="uint8_t" name="compass_id" instance="true">Compass being calibrated.</field>
+      <field type="uint8_t" name="cal_mask" display="bitmask">Bitmask of compasses being calibrated.</field>
+      <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Calibration Status.</field>
+      <field type="uint8_t" name="attempt">Attempt number.</field>
+      <field type="uint8_t" name="completion_pct" units="%">Completion percentage.</field>
+      <field type="uint8_t[10]" name="completion_mask">Bitmask of sphere sections (see http://en.wikipedia.org/wiki/Geodesic_grid).</field>
+      <field type="float" name="direction_x">Body frame direction vector for display.</field>
+      <field type="float" name="direction_y">Body frame direction vector for display.</field>
+      <field type="float" name="direction_z">Body frame direction vector for display.</field>
+    </message>
+    <!-- 192 MAG_CAL_REPORT moved to common.xml -->
+    <!-- EKF status message from autopilot to GCS. -->
+    <message id="193" name="EKF_STATUS_REPORT">
+      <description>EKF Status message including flags and variances.</description>
+      <field type="uint16_t" name="flags" enum="EKF_STATUS_FLAGS" display="bitmask">Flags.</field>
+      <!-- supported flags see EKF_STATUS_FLAGS enum -->
+      <field type="float" name="velocity_variance">Velocity variance.</field>
+      <!-- below 0.5 is good, 0.5~0.79 is warning, 0.8 or higher is bad -->
+      <field type="float" name="pos_horiz_variance">Horizontal Position variance.</field>
+      <field type="float" name="pos_vert_variance">Vertical Position variance.</field>
+      <field type="float" name="compass_variance">Compass variance.</field>
+      <field type="float" name="terrain_alt_variance">Terrain Altitude variance.</field>
+      <extensions/>
+      <field type="float" name="airspeed_variance">Airspeed variance.</field>
+    </message>
+    <!-- realtime PID tuning message -->
+    <message id="194" name="PID_TUNING">
+      <description>PID tuning information.</description>
+      <field type="uint8_t" name="axis" enum="PID_TUNING_AXIS" instance="true">Axis.</field>
+      <field type="float" name="desired">Desired rate.</field>
+      <field type="float" name="achieved">Achieved rate.</field>
+      <field type="float" name="FF">FF component.</field>
+      <field type="float" name="P">P component.</field>
+      <field type="float" name="I">I component.</field>
+      <field type="float" name="D">D component.</field>
+      <extensions/>
+      <field type="float" name="SRate">Slew rate.</field>
+      <field type="float" name="PDmod">P/D oscillation modifier.</field>
+    </message>
+    <message id="195" name="DEEPSTALL">
+      <description>Deepstall path planning.</description>
+      <field type="int32_t" name="landing_lat" units="degE7">Landing latitude.</field>
+      <field type="int32_t" name="landing_lon" units="degE7">Landing longitude.</field>
+      <field type="int32_t" name="path_lat" units="degE7">Final heading start point, latitude.</field>
+      <field type="int32_t" name="path_lon" units="degE7">Final heading start point, longitude.</field>
+      <field type="int32_t" name="arc_entry_lat" units="degE7">Arc entry point, latitude.</field>
+      <field type="int32_t" name="arc_entry_lon" units="degE7">Arc entry point, longitude.</field>
+      <field type="float" name="altitude" units="m">Altitude.</field>
+      <field type="float" name="expected_travel_distance" units="m">Distance the aircraft expects to travel during the deepstall.</field>
+      <field type="float" name="cross_track_error" units="m">Deepstall cross track error (only valid when in DEEPSTALL_STAGE_LAND).</field>
+      <field type="uint8_t" name="stage" enum="DEEPSTALL_STAGE">Deepstall stage.</field>
+    </message>
+    <message id="200" name="GIMBAL_REPORT">
+      <description>3 axis gimbal measurements.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="float" name="delta_time" units="s">Time since last update.</field>
+      <field type="float" name="delta_angle_x" units="rad">Delta angle X.</field>
+      <field type="float" name="delta_angle_y" units="rad">Delta angle Y.</field>
+      <field type="float" name="delta_angle_z" units="rad">Delta angle X.</field>
+      <field type="float" name="delta_velocity_x" units="m/s">Delta velocity X.</field>
+      <field type="float" name="delta_velocity_y" units="m/s">Delta velocity Y.</field>
+      <field type="float" name="delta_velocity_z" units="m/s">Delta velocity Z.</field>
+      <field type="float" name="joint_roll" units="rad">Joint ROLL.</field>
+      <field type="float" name="joint_el" units="rad">Joint EL.</field>
+      <field type="float" name="joint_az" units="rad">Joint AZ.</field>
+    </message>
+    <message id="201" name="GIMBAL_CONTROL">
+      <description>Control message for rate gimbal.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="float" name="demanded_rate_x" units="rad/s">Demanded angular rate X.</field>
+      <field type="float" name="demanded_rate_y" units="rad/s">Demanded angular rate Y.</field>
+      <field type="float" name="demanded_rate_z" units="rad/s">Demanded angular rate Z.</field>
+    </message>
+    <message id="214" name="GIMBAL_TORQUE_CMD_REPORT">
+      <description>100 Hz gimbal torque command telemetry.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="int16_t" name="rl_torque_cmd">Roll Torque Command.</field>
+      <field type="int16_t" name="el_torque_cmd">Elevation Torque Command.</field>
+      <field type="int16_t" name="az_torque_cmd">Azimuth Torque Command.</field>
+    </message>
+    <!-- GoPro Messages -->
+    <message id="215" name="GOPRO_HEARTBEAT">
+      <description>Heartbeat from a HeroBus attached GoPro.</description>
+      <field type="uint8_t" name="status" enum="GOPRO_HEARTBEAT_STATUS">Status.</field>
+      <field type="uint8_t" name="capture_mode" enum="GOPRO_CAPTURE_MODE">Current capture mode.</field>
+      <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS" display="bitmask">Additional status bits.</field>
+      <!-- see GOPRO_HEARTBEAT_FLAGS -->
+    </message>
+    <message id="216" name="GOPRO_GET_REQUEST">
+      <description>Request a GOPRO_COMMAND response from the GoPro.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="cmd_id" enum="GOPRO_COMMAND">Command ID.</field>
+    </message>
+    <message id="217" name="GOPRO_GET_RESPONSE">
+      <description>Response from a GOPRO_COMMAND get request.</description>
+      <field type="uint8_t" name="cmd_id" enum="GOPRO_COMMAND">Command ID.</field>
+      <field type="uint8_t" name="status" enum="GOPRO_REQUEST_STATUS">Status.</field>
+      <field type="uint8_t[4]" name="value">Value.</field>
+    </message>
+    <message id="218" name="GOPRO_SET_REQUEST">
+      <description>Request to set a GOPRO_COMMAND with a desired.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="cmd_id" enum="GOPRO_COMMAND">Command ID.</field>
+      <field type="uint8_t[4]" name="value">Value.</field>
+    </message>
+    <message id="219" name="GOPRO_SET_RESPONSE">
+      <description>Response from a GOPRO_COMMAND set request.</description>
+      <field type="uint8_t" name="cmd_id" enum="GOPRO_COMMAND">Command ID.</field>
+      <field type="uint8_t" name="status" enum="GOPRO_REQUEST_STATUS">Status.</field>
+    </message>
+    <!-- 219 to 224 RESERVED for more GOPRO-->
+    <!-- 225 EFI_STATUS moved to common.xml -->
+    <message id="226" name="RPM">
+      <description>RPM sensor output.</description>
+      <field type="float" name="rpm1">RPM Sensor1.</field>
+      <field type="float" name="rpm2">RPM Sensor2.</field>
+    </message>
+    <!-- ardupilot specific mavlink2 messages starting at 11000-->
+    <message id="11000" name="DEVICE_OP_READ">
+      <description>Read registers for a device.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="request_id">Request ID - copied to reply.</field>
+      <field type="uint8_t" name="bustype" enum="DEVICE_OP_BUSTYPE">The bus type.</field>
+      <field type="uint8_t" name="bus">Bus number.</field>
+      <field type="uint8_t" name="address">Bus address.</field>
+      <field type="char[40]" name="busname">Name of device on bus (for SPI).</field>
+      <field type="uint8_t" name="regstart">First register to read.</field>
+      <field type="uint8_t" name="count">Count of registers to read.</field>
+      <extensions/>
+      <field type="uint8_t" name="bank">Bank number.</field>
+    </message>
+    <message id="11001" name="DEVICE_OP_READ_REPLY">
+      <description>Read registers reply.</description>
+      <field type="uint32_t" name="request_id">Request ID - copied from request.</field>
+      <field type="uint8_t" name="result">0 for success, anything else is failure code.</field>
+      <field type="uint8_t" name="regstart">Starting register.</field>
+      <field type="uint8_t" name="count">Count of bytes read.</field>
+      <field type="uint8_t[128]" name="data">Reply data.</field>
+      <extensions/>
+      <field type="uint8_t" name="bank">Bank number.</field>
+    </message>
+    <message id="11002" name="DEVICE_OP_WRITE">
+      <description>Write registers for a device.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="request_id">Request ID - copied to reply.</field>
+      <field type="uint8_t" name="bustype" enum="DEVICE_OP_BUSTYPE">The bus type.</field>
+      <field type="uint8_t" name="bus">Bus number.</field>
+      <field type="uint8_t" name="address">Bus address.</field>
+      <field type="char[40]" name="busname">Name of device on bus (for SPI).</field>
+      <field type="uint8_t" name="regstart">First register to write.</field>
+      <field type="uint8_t" name="count">Count of registers to write.</field>
+      <field type="uint8_t[128]" name="data">Write data.</field>
+      <extensions/>
+      <field type="uint8_t" name="bank">Bank number.</field>
+    </message>
+    <message id="11003" name="DEVICE_OP_WRITE_REPLY">
+      <description>Write registers reply.</description>
+      <field type="uint32_t" name="request_id">Request ID - copied from request.</field>
+      <field type="uint8_t" name="result">0 for success, anything else is failure code.</field>
+    </message>
+    <message id="11004" name="SECURE_COMMAND">
+      <description>Send a secure command. Data should be signed with a private key corresponding with a public key known to the recipient. Signature should be over the concatenation of the sequence number (little-endian format), the operation (little-endian format) the data and the session key. For SECURE_COMMAND_GET_SESSION_KEY the session key should be zero length. The data array consists of the data followed by the signature. The sum of the data_length and the sig_length cannot be more than 220. The format of the data is command specific.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="sequence">Sequence ID for tagging reply.</field>
+      <field type="uint32_t" name="operation" enum="SECURE_COMMAND_OP">Operation being requested.</field>
+      <field type="uint8_t" name="data_length">Data length.</field>
+      <field type="uint8_t" name="sig_length">Signature length.</field>
+      <field type="uint8_t[220]" name="data">Signed data.</field>
+    </message>
+    <message id="11005" name="SECURE_COMMAND_REPLY">
+      <description>Reply from secure command.</description>
+      <field type="uint32_t" name="sequence">Sequence ID from request.</field>
+      <field type="uint32_t" name="operation" enum="SECURE_COMMAND_OP">Operation that was requested.</field>
+      <field type="uint8_t" name="result" enum="MAV_RESULT">Result of command.</field>
+      <field type="uint8_t" name="data_length">Data length.</field>
+      <field type="uint8_t[220]" name="data">Reply data.</field>
+    </message>
+    <!-- realtime Adaptive Controller tuning message -->
+    <message id="11010" name="ADAP_TUNING">
+      <description>Adaptive Controller tuning information.</description>
+      <field type="uint8_t" name="axis" enum="PID_TUNING_AXIS" instance="true">Axis.</field>
+      <field type="float" name="desired" units="deg/s">Desired rate.</field>
+      <field type="float" name="achieved" units="deg/s">Achieved rate.</field>
+      <field type="float" name="error">Error between model and vehicle.</field>
+      <field type="float" name="theta">Theta estimated state predictor.</field>
+      <field type="float" name="omega">Omega estimated state predictor.</field>
+      <field type="float" name="sigma">Sigma estimated state predictor.</field>
+      <field type="float" name="theta_dot">Theta derivative.</field>
+      <field type="float" name="omega_dot">Omega derivative.</field>
+      <field type="float" name="sigma_dot">Sigma derivative.</field>
+      <field type="float" name="f">Projection operator value.</field>
+      <field type="float" name="f_dot">Projection operator derivative.</field>
+      <field type="float" name="u">u adaptive controlled output command.</field>
+    </message>
+    <!-- camera vision based attitude and position delta message -->
+    <message id="11011" name="VISION_POSITION_DELTA">
+      <description>Camera vision based attitude and position deltas.</description>
+      <field name="time_usec" type="uint64_t" units="us">Timestamp (synced to UNIX time or since system boot).</field>
+      <field name="time_delta_usec" type="uint64_t" units="us">Time since the last reported camera frame.</field>
+      <field type="float[3]" name="angle_delta" units="rad">Defines a rotation vector [roll, pitch, yaw] to the current MAV_FRAME_BODY_FRD from the previous MAV_FRAME_BODY_FRD.</field>
+      <field type="float[3]" name="position_delta" units="m">Change in position to the current MAV_FRAME_BODY_FRD from the previous FRAME_BODY_FRD rotated to the current MAV_FRAME_BODY_FRD.</field>
+      <field type="float" name="confidence" units="%">Normalised confidence value from 0 to 100.</field>
+    </message>
+    <!-- Angle of Attack and Side Slip Angle message -->
+    <message id="11020" name="AOA_SSA">
+      <description>Angle of Attack and Side Slip Angle.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (since boot or Unix epoch).</field>
+      <field name="AOA" type="float" units="deg">Angle of Attack.</field>
+      <field name="SSA" type="float" units="deg">Side Slip Angle.</field>
+    </message>
+    <message id="11030" name="ESC_TELEMETRY_1_TO_4">
+      <description>ESC Telemetry Data for ESCs 1 to 4, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11031" name="ESC_TELEMETRY_5_TO_8">
+      <description>ESC Telemetry Data for ESCs 5 to 8, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11032" name="ESC_TELEMETRY_9_TO_12">
+      <description>ESC Telemetry Data for ESCs 9 to 12, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11033" name="OSD_PARAM_CONFIG">
+      <description>Configure an OSD parameter slot.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="request_id">Request ID - copied to reply.</field>
+      <field type="uint8_t" name="osd_screen">OSD parameter screen index.</field>
+      <field type="uint8_t" name="osd_index">OSD parameter display index.</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="uint8_t" name="config_type" enum="OSD_PARAM_CONFIG_TYPE">Config type.</field>
+      <field type="float" name="min_value">OSD parameter minimum value.</field>
+      <field type="float" name="max_value">OSD parameter maximum value.</field>
+      <field type="float" name="increment">OSD parameter increment.</field>
+    </message>
+    <message id="11034" name="OSD_PARAM_CONFIG_REPLY">
+      <description>Configure OSD parameter reply.</description>
+      <field type="uint32_t" name="request_id">Request ID - copied from request.</field>
+      <field type="uint8_t" name="result" enum="OSD_PARAM_CONFIG_ERROR">Config error type.</field>
+    </message>
+    <message id="11035" name="OSD_PARAM_SHOW_CONFIG">
+      <description>Read a configured an OSD parameter slot.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint32_t" name="request_id">Request ID - copied to reply.</field>
+      <field type="uint8_t" name="osd_screen">OSD parameter screen index.</field>
+      <field type="uint8_t" name="osd_index">OSD parameter display index.</field>
+    </message>
+    <message id="11036" name="OSD_PARAM_SHOW_CONFIG_REPLY">
+      <description>Read configured OSD parameter reply.</description>
+      <field type="uint32_t" name="request_id">Request ID - copied from request.</field>
+      <field type="uint8_t" name="result" enum="OSD_PARAM_CONFIG_ERROR">Config error type.</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="uint8_t" name="config_type" enum="OSD_PARAM_CONFIG_TYPE">Config type.</field>
+      <field type="float" name="min_value">OSD parameter minimum value.</field>
+      <field type="float" name="max_value">OSD parameter maximum value.</field>
+      <field type="float" name="increment">OSD parameter increment.</field>
+    </message>
+    <message id="11037" name="OBSTACLE_DISTANCE_3D">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Obstacle located as a 3D vector.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="sensor_type" enum="MAV_DISTANCE_SENSOR">Class id of the distance sensor type.</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame of reference.</field>
+      <field type="uint16_t" name="obstacle_id" instance="true"> Unique ID given to each obstacle so that its movement can be tracked. Use UINT16_MAX if object ID is unknown or cannot be determined.</field>
+      <field type="float" name="x" units="m"> X position of the obstacle.</field>
+      <field type="float" name="y" units="m"> Y position of the obstacle.</field>
+      <field type="float" name="z" units="m"> Z position of the obstacle.</field>
+      <field type="float" name="min_distance" units="m">Minimum distance the sensor can measure.</field>
+      <field type="float" name="max_distance" units="m">Maximum distance the sensor can measure.</field>
+    </message>
+    <message id="11038" name="WATER_DEPTH">
+      <description>Water depth</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
+      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor</field>
+      <field type="uint8_t" name="healthy">Sensor data healthy (0=unhealthy, 1=healthy)</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude</field>
+      <field type="float" name="alt" units="m">Altitude (MSL) of vehicle</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <field type="float" name="distance" units="m">Distance (uncorrected)</field>
+      <field type="float" name="temperature" units="degC">Water temperature</field>
+    </message>
+    <message id="11039" name="MCU_STATUS">
+      <description>The MCU status, giving MCU temperature and voltage. The min and max voltages are to allow for detecting power supply instability.</description>
+      <field type="uint8_t" name="id" instance="true">MCU instance</field>
+      <field type="int16_t" name="MCU_temperature" units="cdegC">MCU Internal temperature</field>
+      <field type="uint16_t" name="MCU_voltage" units="mV">MCU voltage</field>
+      <field type="uint16_t" name="MCU_voltage_min" units="mV">MCU voltage minimum</field>
+      <field type="uint16_t" name="MCU_voltage_max" units="mV">MCU voltage maximum</field>
+    </message>
+    <message id="11040" name="ESC_TELEMETRY_13_TO_16">
+      <description>ESC Telemetry Data for ESCs 13 to 16, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11041" name="ESC_TELEMETRY_17_TO_20">
+      <description>ESC Telemetry Data for ESCs 17 to 20, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11042" name="ESC_TELEMETRY_21_TO_24">
+      <description>ESC Telemetry Data for ESCs 21 to 24, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11043" name="ESC_TELEMETRY_25_TO_28">
+      <description>ESC Telemetry Data for ESCs 25 to 28, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+    <message id="11044" name="ESC_TELEMETRY_29_TO_32">
+      <description>ESC Telemetry Data for ESCs 29 to 32, matching data sent by BLHeli ESCs.</description>
+      <field type="uint8_t[4]" name="temperature" units="degC">Temperature.</field>
+      <field type="uint16_t[4]" name="voltage" units="cV">Voltage.</field>
+      <field type="uint16_t[4]" name="current" units="cA">Current.</field>
+      <field type="uint16_t[4]" name="totalcurrent" units="mAh">Total current.</field>
+      <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
+      <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/common.xml
+++ b/bp_mavlink/common.xml
@@ -1,0 +1,6072 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>minimal.xml</include>
+  <version>3</version>
+  <dialect>0</dialect>
+  <enums>
+    <enum name="FIRMWARE_VERSION_TYPE">
+      <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
+      <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
+        <description>development release</description>
+      </entry>
+      <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
+        <description>alpha release</description>
+      </entry>
+      <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
+        <description>beta release</description>
+      </entry>
+      <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
+        <description>release candidate</description>
+      </entry>
+      <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
+        <description>official stable release</description>
+      </entry>
+    </enum>
+    <enum name="HL_FAILURE_FLAG" bitmask="true">
+      <description>Flags to report failure cases over the high latency telemtry.</description>
+      <entry value="1" name="HL_FAILURE_FLAG_GPS">
+        <description>GPS failure.</description>
+      </entry>
+      <entry value="2" name="HL_FAILURE_FLAG_DIFFERENTIAL_PRESSURE">
+        <description>Differential pressure sensor failure.</description>
+      </entry>
+      <entry value="4" name="HL_FAILURE_FLAG_ABSOLUTE_PRESSURE">
+        <description>Absolute pressure sensor failure.</description>
+      </entry>
+      <entry value="8" name="HL_FAILURE_FLAG_3D_ACCEL">
+        <description>Accelerometer sensor failure.</description>
+      </entry>
+      <entry value="16" name="HL_FAILURE_FLAG_3D_GYRO">
+        <description>Gyroscope sensor failure.</description>
+      </entry>
+      <entry value="32" name="HL_FAILURE_FLAG_3D_MAG">
+        <description>Magnetometer sensor failure.</description>
+      </entry>
+      <entry value="64" name="HL_FAILURE_FLAG_TERRAIN">
+        <description>Terrain subsystem failure.</description>
+      </entry>
+      <entry value="128" name="HL_FAILURE_FLAG_BATTERY">
+        <description>Battery failure/critical low battery.</description>
+      </entry>
+      <entry value="256" name="HL_FAILURE_FLAG_RC_RECEIVER">
+        <description>RC receiver failure/no rc connection.</description>
+      </entry>
+      <entry value="512" name="HL_FAILURE_FLAG_OFFBOARD_LINK">
+        <description>Offboard link failure.</description>
+      </entry>
+      <entry value="1024" name="HL_FAILURE_FLAG_ENGINE">
+        <description>Engine failure.</description>
+      </entry>
+      <entry value="2048" name="HL_FAILURE_FLAG_GEOFENCE">
+        <description>Geofence violation.</description>
+      </entry>
+      <entry value="4096" name="HL_FAILURE_FLAG_ESTIMATOR">
+        <description>Estimator failure, for example measurement rejection or large variances.</description>
+      </entry>
+      <entry value="8192" name="HL_FAILURE_FLAG_MISSION">
+        <description>Mission failure.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_GOTO">
+      <description>Actions that may be specified in MAV_CMD_OVERRIDE_GOTO to override mission execution.</description>
+      <entry value="0" name="MAV_GOTO_DO_HOLD">
+        <description>Hold at the current position.</description>
+      </entry>
+      <entry value="1" name="MAV_GOTO_DO_CONTINUE">
+        <description>Continue with the next item in mission execution.</description>
+      </entry>
+      <entry value="2" name="MAV_GOTO_HOLD_AT_CURRENT_POSITION">
+        <description>Hold at the current position of the system</description>
+      </entry>
+      <entry value="3" name="MAV_GOTO_HOLD_AT_SPECIFIED_POSITION">
+        <description>Hold at the position specified in the parameters of the DO_HOLD action</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MODE">
+      <description>These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
+               simplifies the use of the mode flags. Note that manual input is enabled in all modes as a safety override.</description>
+      <entry value="0" name="MAV_MODE_PREFLIGHT">
+        <description>System is not ready to fly, booting, calibrating, etc. No flag is set.</description>
+      </entry>
+      <entry value="80" name="MAV_MODE_STABILIZE_DISARMED">
+        <description>System is allowed to be active, under assisted RC control.</description>
+      </entry>
+      <entry value="208" name="MAV_MODE_STABILIZE_ARMED">
+        <description>System is allowed to be active, under assisted RC control.</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_MANUAL_DISARMED">
+        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+      </entry>
+      <entry value="192" name="MAV_MODE_MANUAL_ARMED">
+        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+      </entry>
+      <entry value="88" name="MAV_MODE_GUIDED_DISARMED">
+        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+      </entry>
+      <entry value="216" name="MAV_MODE_GUIDED_ARMED">
+        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+      </entry>
+      <entry value="92" name="MAV_MODE_AUTO_DISARMED">
+        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by waypoints)</description>
+      </entry>
+      <entry value="220" name="MAV_MODE_AUTO_ARMED">
+        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by waypoints)</description>
+      </entry>
+      <entry value="66" name="MAV_MODE_TEST_DISARMED">
+        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+      </entry>
+      <entry value="194" name="MAV_MODE_TEST_ARMED">
+        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_SYS_STATUS_SENSOR" bitmask="true">
+      <description>These encode the sensors whose status is sent as part of the SYS_STATUS message.</description>
+      <entry value="1" name="MAV_SYS_STATUS_SENSOR_3D_GYRO">
+        <description>0x01 3D gyro</description>
+      </entry>
+      <entry value="2" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL">
+        <description>0x02 3D accelerometer</description>
+      </entry>
+      <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_MAG">
+        <description>0x04 3D magnetometer</description>
+      </entry>
+      <entry value="8" name="MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE">
+        <description>0x08 absolute pressure</description>
+      </entry>
+      <entry value="16" name="MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE">
+        <description>0x10 differential pressure</description>
+      </entry>
+      <entry value="32" name="MAV_SYS_STATUS_SENSOR_GPS">
+        <description>0x20 GPS</description>
+      </entry>
+      <entry value="64" name="MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW">
+        <description>0x40 optical flow</description>
+      </entry>
+      <entry value="128" name="MAV_SYS_STATUS_SENSOR_VISION_POSITION">
+        <description>0x80 computer vision position</description>
+      </entry>
+      <entry value="256" name="MAV_SYS_STATUS_SENSOR_LASER_POSITION">
+        <description>0x100 laser based position</description>
+      </entry>
+      <entry value="512" name="MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH">
+        <description>0x200 external ground truth (Vicon or Leica)</description>
+      </entry>
+      <entry value="1024" name="MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL">
+        <description>0x400 3D angular rate control</description>
+      </entry>
+      <entry value="2048" name="MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION">
+        <description>0x800 attitude stabilization</description>
+      </entry>
+      <entry value="4096" name="MAV_SYS_STATUS_SENSOR_YAW_POSITION">
+        <description>0x1000 yaw position</description>
+      </entry>
+      <entry value="8192" name="MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL">
+        <description>0x2000 z/altitude control</description>
+      </entry>
+      <entry value="16384" name="MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL">
+        <description>0x4000 x/y position control</description>
+      </entry>
+      <entry value="32768" name="MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS">
+        <description>0x8000 motor outputs / control</description>
+      </entry>
+      <entry value="65536" name="MAV_SYS_STATUS_SENSOR_RC_RECEIVER">
+        <description>0x10000 rc receiver</description>
+      </entry>
+      <entry value="131072" name="MAV_SYS_STATUS_SENSOR_3D_GYRO2">
+        <description>0x20000 2nd 3D gyro</description>
+      </entry>
+      <entry value="262144" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL2">
+        <description>0x40000 2nd 3D accelerometer</description>
+      </entry>
+      <entry value="524288" name="MAV_SYS_STATUS_SENSOR_3D_MAG2">
+        <description>0x80000 2nd 3D magnetometer</description>
+      </entry>
+      <entry value="1048576" name="MAV_SYS_STATUS_GEOFENCE">
+        <description>0x100000 geofence</description>
+      </entry>
+      <entry value="2097152" name="MAV_SYS_STATUS_AHRS">
+        <description>0x200000 AHRS subsystem health</description>
+      </entry>
+      <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
+        <description>0x400000 Terrain subsystem health</description>
+      </entry>
+      <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
+        <description>0x800000 Motors are reversed</description>
+      </entry>
+      <entry value="16777216" name="MAV_SYS_STATUS_LOGGING">
+        <description>0x1000000 Logging</description>
+      </entry>
+      <entry value="33554432" name="MAV_SYS_STATUS_SENSOR_BATTERY">
+        <description>0x2000000 Battery</description>
+      </entry>
+      <entry value="67108864" name="MAV_SYS_STATUS_SENSOR_PROXIMITY">
+        <description>0x4000000 Proximity</description>
+      </entry>
+      <entry value="134217728" name="MAV_SYS_STATUS_SENSOR_SATCOM">
+        <description>0x8000000 Satellite Communication </description>
+      </entry>
+      <entry value="268435456" name="MAV_SYS_STATUS_PREARM_CHECK">
+        <description>0x10000000 pre-arm check status. Always healthy when armed</description>
+      </entry>
+      <entry value="536870912" name="MAV_SYS_STATUS_OBSTACLE_AVOIDANCE">
+        <description>0x20000000 Avoidance/collision prevention</description>
+      </entry>
+      <entry value="1073741824" name="MAV_SYS_STATUS_SENSOR_PROPULSION">
+        <description>0x40000000 propulsion (actuator, esc, motor or propellor)</description>
+      </entry>
+    </enum>
+    <enum name="MAV_FRAME">
+      <description>Co-ordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.
+      
+      Global frames use the following naming conventions:
+      - "GLOBAL": Global co-ordinate frame with WGS84 latitude/longitude and altitude positive over mean sea level (MSL) by default. 
+        The following modifiers may be used with "GLOBAL":
+        - "RELATIVE_ALT": Altitude is relative to the vehicle home position rather than MSL.
+        - "TERRAIN_ALT": Altitude is relative to ground level rather than MSL.
+        - "INT": Latitude/longitude (in degrees) are scaled by multiplying by 1E7.
+
+      Local frames use the following naming conventions:
+      - "LOCAL": Origin of local frame is fixed relative to earth. Unless otherwise specified this origin is the origin of the vehicle position-estimator ("EKF").
+      - "BODY": Origin of local frame travels with the vehicle. NOTE, "BODY" does NOT indicate alignment of frame axis with vehicle attitude.
+      - "OFFSET": Deprecated synonym for "BODY" (origin travels with the vehicle). Not to be used for new frames.
+
+      Some deprecated frames do not follow these conventions (e.g. MAV_FRAME_BODY_NED and MAV_FRAME_BODY_OFFSET_NED).
+ </description>
+      <entry value="0" name="MAV_FRAME_GLOBAL">
+        <description>Global (WGS84) coordinate frame + MSL altitude. First value / x: latitude, second value / y: longitude, third value / z: positive altitude over mean sea level (MSL).</description>
+      </entry>
+      <entry value="1" name="MAV_FRAME_LOCAL_NED">
+        <description>NED local tangent frame (x: North, y: East, z: Down) with origin fixed relative to earth.</description>
+      </entry>
+      <entry value="2" name="MAV_FRAME_MISSION">
+        <description>NOT a coordinate frame, indicates a mission command.</description>
+      </entry>
+      <entry value="3" name="MAV_FRAME_GLOBAL_RELATIVE_ALT">
+        <description>Global (WGS84) coordinate frame + altitude relative to the home position. First value / x: latitude, second value / y: longitude, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+      </entry>
+      <entry value="4" name="MAV_FRAME_LOCAL_ENU">
+        <description>ENU local tangent frame (x: East, y: North, z: Up) with origin fixed relative to earth.</description>
+      </entry>
+      <entry value="5" name="MAV_FRAME_GLOBAL_INT">
+        <description>Global (WGS84) coordinate frame (scaled) + MSL altitude. First value / x: latitude in degrees*1E7, second value / y: longitude in degrees*1E7, third value / z: positive altitude over mean sea level (MSL).</description>
+      </entry>
+      <entry value="6" name="MAV_FRAME_GLOBAL_RELATIVE_ALT_INT">
+        <description>Global (WGS84) coordinate frame (scaled) + altitude relative to the home position. First value / x: latitude in degrees*1E7, second value / y: longitude in degrees*1E7, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+      </entry>
+      <entry value="7" name="MAV_FRAME_LOCAL_OFFSET_NED">
+        <description>NED local tangent frame (x: North, y: East, z: Down) with origin that travels with the vehicle.</description>
+      </entry>
+      <entry value="8" name="MAV_FRAME_BODY_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
+        <description>Same as MAV_FRAME_LOCAL_NED when used to represent position values. Same as MAV_FRAME_BODY_FRD when used with velocity/accelaration values.</description>
+      </entry>
+      <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
+        <description>This is the same as MAV_FRAME_BODY_FRD.</description>
+      </entry>
+      <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
+        <description>Global (WGS84) coordinate frame with AGL altitude (at the waypoint coordinate). First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+      </entry>
+      <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
+        <description>Global (WGS84) coordinate frame (scaled) with AGL altitude (at the waypoint coordinate). First value / x: latitude in degrees*1E7, second value / y: longitude in degrees*1E7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+      </entry>
+      <entry value="12" name="MAV_FRAME_BODY_FRD">
+        <description>FRD local tangent frame (x: Forward, y: Right, z: Down) with origin that travels with vehicle. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
+      </entry>
+      <entry value="13" name="MAV_FRAME_RESERVED_13">
+        <deprecated since="2019-04" replaced_by=""/>
+        <description>MAV_FRAME_BODY_FLU - Body fixed frame of reference, Z-up (x: Forward, y: Left, z: Up).</description>
+      </entry>
+      <entry value="14" name="MAV_FRAME_RESERVED_14">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FRD"/>
+        <description>MAV_FRAME_MOCAP_NED - Odometry local coordinate frame of data given by a motion capture system, Z-down (x: North, y: East, z: Down).</description>
+      </entry>
+      <entry value="15" name="MAV_FRAME_RESERVED_15">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FLU"/>
+        <description>MAV_FRAME_MOCAP_ENU - Odometry local coordinate frame of data given by a motion capture system, Z-up (x: East, y: North, z: Up).</description>
+      </entry>
+      <entry value="16" name="MAV_FRAME_RESERVED_16">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FRD"/>
+        <description>MAV_FRAME_VISION_NED - Odometry local coordinate frame of data given by a vision estimation system, Z-down (x: North, y: East, z: Down).</description>
+      </entry>
+      <entry value="17" name="MAV_FRAME_RESERVED_17">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FLU"/>
+        <description>MAV_FRAME_VISION_ENU - Odometry local coordinate frame of data given by a vision estimation system, Z-up (x: East, y: North, z: Up).</description>
+      </entry>
+      <entry value="18" name="MAV_FRAME_RESERVED_18">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FRD"/>
+        <description>MAV_FRAME_ESTIM_NED - Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-down (x: North, y: East, z: Down).</description>
+      </entry>
+      <entry value="19" name="MAV_FRAME_RESERVED_19">
+        <deprecated since="2019-04" replaced_by="MAV_FRAME_LOCAL_FLU"/>
+        <description>MAV_FRAME_ESTIM_ENU - Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: East, y: North, z: Up).</description>
+      </entry>
+      <entry value="20" name="MAV_FRAME_LOCAL_FRD">
+        <description>FRD local tangent frame (x: Forward, y: Right, z: Down) with origin fixed relative to earth. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
+      </entry>
+      <entry value="21" name="MAV_FRAME_LOCAL_FLU">
+        <description>FLU local tangent frame (x: Forward, y: Left, z: Up) with origin fixed relative to earth. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
+      </entry>
+    </enum>
+    <enum name="MAVLINK_DATA_STREAM_TYPE">
+      <entry value="0" name="MAVLINK_DATA_STREAM_IMG_JPEG">
+        <description/>
+      </entry>
+      <entry value="1" name="MAVLINK_DATA_STREAM_IMG_BMP">
+        <description/>
+      </entry>
+      <entry value="2" name="MAVLINK_DATA_STREAM_IMG_RAW8U">
+        <description/>
+      </entry>
+      <entry value="3" name="MAVLINK_DATA_STREAM_IMG_RAW32U">
+        <description/>
+      </entry>
+      <entry value="4" name="MAVLINK_DATA_STREAM_IMG_PGM">
+        <description/>
+      </entry>
+      <entry value="5" name="MAVLINK_DATA_STREAM_IMG_PNG">
+        <description/>
+      </entry>
+    </enum>
+    <!-- fenced mode enums -->
+    <enum name="FENCE_ACTION">
+      <entry value="0" name="FENCE_ACTION_NONE">
+        <description>Disable fenced mode</description>
+      </entry>
+      <entry value="1" name="FENCE_ACTION_GUIDED">
+        <description>Switched to guided mode to return point (fence point 0)</description>
+      </entry>
+      <entry value="2" name="FENCE_ACTION_REPORT">
+        <description>Report fence breach, but don't take action</description>
+      </entry>
+      <entry value="3" name="FENCE_ACTION_GUIDED_THR_PASS">
+        <description>Switched to guided mode to return point (fence point 0) with manual throttle control</description>
+      </entry>
+      <entry value="4" name="FENCE_ACTION_RTL">
+        <description>Switch to RTL (return to launch) mode and head for the return point.</description>
+      </entry>
+    </enum>
+    <enum name="FENCE_BREACH">
+      <entry value="0" name="FENCE_BREACH_NONE">
+        <description>No last fence breach</description>
+      </entry>
+      <entry value="1" name="FENCE_BREACH_MINALT">
+        <description>Breached minimum altitude</description>
+      </entry>
+      <entry value="2" name="FENCE_BREACH_MAXALT">
+        <description>Breached maximum altitude</description>
+      </entry>
+      <entry value="3" name="FENCE_BREACH_BOUNDARY">
+        <description>Breached fence boundary</description>
+      </entry>
+    </enum>
+    <enum name="FENCE_MITIGATE">
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Actions being taken to mitigate/prevent fence breach</description>
+      <entry value="0" name="FENCE_MITIGATE_UNKNOWN">
+        <description>Unknown</description>
+      </entry>
+      <entry value="1" name="FENCE_MITIGATE_NONE">
+        <description>No actions being taken</description>
+      </entry>
+      <entry value="2" name="FENCE_MITIGATE_VEL_LIMIT">
+        <description>Velocity limiting active to prevent breach</description>
+      </entry>
+    </enum>
+    <!-- Camera Mount mode Enumeration -->
+    <enum name="MAV_MOUNT_MODE">
+      <description>Enumeration of possible mount operation modes</description>
+      <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
+        <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
+      </entry>
+      <entry value="1" name="MAV_MOUNT_MODE_NEUTRAL">
+        <description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description>
+      </entry>
+      <entry value="2" name="MAV_MOUNT_MODE_MAVLINK_TARGETING">
+        <description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description>
+      </entry>
+      <entry value="3" name="MAV_MOUNT_MODE_RC_TARGETING">
+        <description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description>
+      </entry>
+      <entry value="4" name="MAV_MOUNT_MODE_GPS_POINT">
+        <description>Load neutral position and start to point to Lat,Lon,Alt</description>
+      </entry>
+      <entry value="5" name="MAV_MOUNT_MODE_SYSID_TARGET">
+        <description>Gimbal tracks system with specified system ID</description>
+      </entry>
+      <entry value="6" name="MAV_MOUNT_MODE_HOME_LOCATION">
+        <description>Gimbal tracks home location</description>
+      </entry>
+    </enum>
+    <!-- Gimbal Device Capability Enumeration.  Used by latest (2021) STorM32 and mavlink Gimbal v2 -->
+    <enum name="GIMBAL_DEVICE_CAP_FLAGS" bitmask="true">
+      <description>Gimbal device (low level) capability flags (bitmap)</description>
+      <entry value="1" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal device supports a retracted position</description>
+      </entry>
+      <entry value="2" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL">
+        <description>Gimbal device supports a horizontal, forward looking position, stabilized</description>
+      </entry>
+      <entry value="4" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_AXIS">
+        <description>Gimbal device supports rotating around roll axis.</description>
+      </entry>
+      <entry value="8" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Gimbal device supports to follow a roll angle relative to the vehicle</description>
+      </entry>
+      <entry value="16" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Gimbal device supports locking to an roll angle (generally that's the default with roll stabilized)</description>
+      </entry>
+      <entry value="32" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_AXIS">
+        <description>Gimbal device supports rotating around pitch axis.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Gimbal device supports to follow a pitch angle relative to the vehicle</description>
+      </entry>
+      <entry value="128" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Gimbal device supports locking to an pitch angle (generally that's the default with pitch stabilized)</description>
+      </entry>
+      <entry value="256" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_AXIS">
+        <description>Gimbal device supports rotating around yaw axis.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal device supports to follow a yaw angle relative to the vehicle (generally that's the default)</description>
+      </entry>
+      <entry value="1024" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal device supports locking to an absolute heading (often this is an option available)</description>
+      </entry>
+      <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_DEVICE_FLAGS" bitmask="true">
+      <description>Flags for gimbal device (lower level) operation.</description>
+      <entry value="1" name="GIMBAL_DEVICE_FLAGS_RETRACT">
+        <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_DEVICE_FLAGS_NEUTRAL">
+        <description>Set to neutral/default position, taking precedence over all other flags except RETRACT. Neutral is commonly forward-facing and horizontal (pitch=yaw=0) but may be any orientation.</description>
+      </entry>
+      <entry value="4" name="GIMBAL_DEVICE_FLAGS_ROLL_LOCK">
+        <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
+      </entry>
+      <entry value="8" name="GIMBAL_DEVICE_FLAGS_PITCH_LOCK">
+        <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
+      </entry>
+      <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
+      <description>Flags for high level gimbal manager operation The first 16 bits are identical to the GIMBAL_DEVICE_FLAGS.</description>
+      <entry value="1" name="GIMBAL_MANAGER_FLAGS_RETRACT">
+        <description>Based on GIMBAL_DEVICE_FLAGS_RETRACT</description>
+      </entry>
+      <entry value="2" name="GIMBAL_MANAGER_FLAGS_NEUTRAL">
+        <description>Based on GIMBAL_DEVICE_FLAGS_NEUTRAL</description>
+      </entry>
+      <entry value="4" name="GIMBAL_MANAGER_FLAGS_ROLL_LOCK">
+        <description>Based on GIMBAL_DEVICE_FLAGS_ROLL_LOCK</description>
+      </entry>
+      <entry value="8" name="GIMBAL_MANAGER_FLAGS_PITCH_LOCK">
+        <description>Based on GIMBAL_DEVICE_FLAGS_PITCH_LOCK</description>
+      </entry>
+      <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
+        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_DEVICE_ERROR_FLAGS" bitmask="true">
+      <description>Gimbal device (low level) error flags (bitmap, 0 means no error)</description>
+      <entry value="1" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_ROLL_LIMIT">
+        <description>Gimbal device is limited by hardware roll limit.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_PITCH_LIMIT">
+        <description>Gimbal device is limited by hardware pitch limit.</description>
+      </entry>
+      <entry value="4" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_YAW_LIMIT">
+        <description>Gimbal device is limited by hardware yaw limit.</description>
+      </entry>
+      <entry value="8" name="GIMBAL_DEVICE_ERROR_FLAGS_ENCODER_ERROR">
+        <description>There is an error with the gimbal encoders.</description>
+      </entry>
+      <entry value="16" name="GIMBAL_DEVICE_ERROR_FLAGS_POWER_ERROR">
+        <description>There is an error with the gimbal power source.</description>
+      </entry>
+      <entry value="32" name="GIMBAL_DEVICE_ERROR_FLAGS_MOTOR_ERROR">
+        <description>There is an error with the gimbal motor's.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_ERROR_FLAGS_SOFTWARE_ERROR">
+        <description>There is an error with the gimbal's software.</description>
+      </entry>
+      <entry value="128" name="GIMBAL_DEVICE_ERROR_FLAGS_COMMS_ERROR">
+        <description>There is an error with the gimbal's communication.</description>
+      </entry>
+      <entry value="256" name="GIMBAL_DEVICE_ERROR_FLAGS_CALIBRATION_RUNNING">
+        <description>Gimbal is currently calibrating.</description>
+      </entry>
+    </enum>
+    <!-- gripper action enum -->
+    <enum name="GRIPPER_ACTIONS">
+      <description>Gripper actions.</description>
+      <entry value="0" name="GRIPPER_ACTION_RELEASE">
+        <description>Gripper release cargo.</description>
+      </entry>
+      <entry value="1" name="GRIPPER_ACTION_GRAB">
+        <description>Gripper grab onto cargo.</description>
+      </entry>
+    </enum>
+    <!-- winch action enum -->
+    <enum name="WINCH_ACTIONS">
+      <description>Winch actions.</description>
+      <entry value="0" name="WINCH_RELAXED">
+        <description>Allow motor to freewheel.</description>
+      </entry>
+      <entry value="1" name="WINCH_RELATIVE_LENGTH_CONTROL">
+        <description>Wind or unwind specified length of line, optionally using specified rate.</description>
+      </entry>
+      <entry value="2" name="WINCH_RATE_CONTROL">
+        <description>Wind or unwind line at specified rate.</description>
+      </entry>
+      <entry value="3" name="WINCH_LOCK">
+        <description>Perform the locking sequence to relieve motor while in the fully retracted position. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+      <entry value="4" name="WINCH_DELIVER">
+        <description>Sequence of drop, slow down, touch down, reel up, lock. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+      <entry value="5" name="WINCH_HOLD">
+        <description>Engage motor and hold current position. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+      <entry value="6" name="WINCH_RETRACT">
+        <description>Return the reel to the fully retracted position. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+      <entry value="7" name="WINCH_LOAD_LINE">
+        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+      <entry value="8" name="WINCH_ABANDON_LINE">
+        <description>Spool out the entire length of the line. Only action and instance command parameters are used, others are ignored.</description>
+      </entry>
+    </enum>
+    <!-- UAVCAN node health enumeration -->
+    <enum name="UAVCAN_NODE_HEALTH">
+      <description>Generalized UAVCAN node health</description>
+      <entry value="0" name="UAVCAN_NODE_HEALTH_OK">
+        <description>The node is functioning properly.</description>
+      </entry>
+      <entry value="1" name="UAVCAN_NODE_HEALTH_WARNING">
+        <description>A critical parameter went out of range or the node has encountered a minor failure.</description>
+      </entry>
+      <entry value="2" name="UAVCAN_NODE_HEALTH_ERROR">
+        <description>The node has encountered a major failure.</description>
+      </entry>
+      <entry value="3" name="UAVCAN_NODE_HEALTH_CRITICAL">
+        <description>The node has suffered a fatal malfunction.</description>
+      </entry>
+    </enum>
+    <!-- UAVCAN node mode enumeration -->
+    <enum name="UAVCAN_NODE_MODE">
+      <description>Generalized UAVCAN node mode</description>
+      <entry value="0" name="UAVCAN_NODE_MODE_OPERATIONAL">
+        <description>The node is performing its primary functions.</description>
+      </entry>
+      <entry value="1" name="UAVCAN_NODE_MODE_INITIALIZATION">
+        <description>The node is initializing; this mode is entered immediately after startup.</description>
+      </entry>
+      <entry value="2" name="UAVCAN_NODE_MODE_MAINTENANCE">
+        <description>The node is under maintenance.</description>
+      </entry>
+      <entry value="3" name="UAVCAN_NODE_MODE_SOFTWARE_UPDATE">
+        <description>The node is in the process of updating its software.</description>
+      </entry>
+      <entry value="7" name="UAVCAN_NODE_MODE_OFFLINE">
+        <description>The node is no longer available online.</description>
+      </entry>
+    </enum>
+    <enum name="STORAGE_STATUS">
+      <description>Flags to indicate the status of camera storage.</description>
+      <entry value="0" name="STORAGE_STATUS_EMPTY">
+        <description>Storage is missing (no microSD card loaded for example.)</description>
+      </entry>
+      <entry value="1" name="STORAGE_STATUS_UNFORMATTED">
+        <description>Storage present but unformatted.</description>
+      </entry>
+      <entry value="2" name="STORAGE_STATUS_READY">
+        <description>Storage present and ready.</description>
+      </entry>
+      <entry value="3" name="STORAGE_STATUS_NOT_SUPPORTED">
+        <description>Camera does not supply storage status information. Capacity information in STORAGE_INFORMATION fields will be ignored.</description>
+      </entry>
+    </enum>
+    <enum name="AUTOTUNE_AXIS" bitmask="true">
+      <description>Enable axes that will be tuned via autotuning. Used in MAV_CMD_DO_AUTOTUNE_ENABLE.</description>
+      <entry value="0" name="AUTOTUNE_AXIS_DEFAULT">
+        <description>Flight stack tunes axis according to its default settings.</description>
+      </entry>
+      <entry value="1" name="AUTOTUNE_AXIS_ROLL">
+        <description>Autotune roll axis.</description>
+      </entry>
+      <entry value="2" name="AUTOTUNE_AXIS_PITCH">
+        <description>Autotune pitch axis.</description>
+      </entry>
+      <entry value="4" name="AUTOTUNE_AXIS_YAW">
+        <description>Autotune yaw axis.</description>
+      </entry>
+    </enum>
+    <!-- The MAV_CMD enum entries describe either: -->
+    <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
+    <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
+    <!-- ALL the entries in the MAV_CMD enum have a maximum of 7 parameters -->
+    <enum name="MAV_CMD">
+      <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries</description>
+      <entry value="16" name="MAV_CMD_NAV_WAYPOINT" hasLocation="true" isDestination="true">
+        <description>Navigate to waypoint.</description>
+        <param index="1" label="Hold" units="s" minValue="0">Hold time. (ignored by fixed wing, time to stay at waypoint for rotary wing)</param>
+        <param index="2" label="Accept Radius" units="m" minValue="0">Acceptance radius (if the sphere with this radius is hit, the waypoint counts as reached)</param>
+        <param index="3" label="Pass Radius" units="m">0 to pass through the WP, if &gt; 0 radius to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
+        <param index="4" label="Yaw" units="deg">Desired yaw angle at waypoint (rotary wing). NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM" hasLocation="true" isDestination="true">
+        <description>Loiter around this waypoint an unlimited amount of time</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3" label="Radius" units="m">Loiter radius around waypoint for forward-only moving vehicles (not multicopters). If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4" label="Yaw" units="deg">Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="18" name="MAV_CMD_NAV_LOITER_TURNS" hasLocation="true" isDestination="true">
+        <description>Loiter around this waypoint for X turns</description>
+        <param index="1" label="Turns" minValue="0">Number of turns.</param>
+        <param index="2">Empty</param>
+        <param index="3" label="Radius" units="m">Radius around waypoint. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="19" name="MAV_CMD_NAV_LOITER_TIME" hasLocation="true" isDestination="true">
+        <description>Loiter around this waypoint for X seconds</description>
+        <param index="1" label="Time" units="s" minValue="0">Loiter time.</param>
+        <param index="2">Empty</param>
+        <param index="3" label="Radius" units="m">Radius around waypoint. If positive loiter clockwise, else counter-clockwise.</param>
+        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle.  NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="20" name="MAV_CMD_NAV_RETURN_TO_LAUNCH" hasLocation="false" isDestination="false">
+        <description>Return to launch location</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="21" name="MAV_CMD_NAV_LAND" hasLocation="true" isDestination="true">
+        <description>Land at location.</description>
+        <param index="1" label="Abort Alt" units="m">Minimum target altitude if landing is aborted (0 = undefined/use system default).</param>
+        <param index="2" label="Land Mode" enum="PRECISION_LAND_MODE">Precision land mode.</param>
+        <param index="3">Empty.</param>
+        <param index="4" label="Yaw Angle" units="deg">Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude.</param>
+        <param index="6" label="Longitude">Longitude.</param>
+        <param index="7" label="Altitude" units="m">Landing altitude (ground level in current frame).</param>
+      </entry>
+      <entry value="22" name="MAV_CMD_NAV_TAKEOFF" hasLocation="true" isDestination="true">
+        <description>Takeoff from ground / hand. Vehicles that support multiple takeoff modes (e.g. VTOL quadplane) should take off using the currently configured mode.</description>
+        <param index="1" label="Pitch" units="deg">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4" label="Yaw" units="deg">Yaw angle (if magnetometer present), ignored without magnetometer. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL" hasLocation="true" isDestination="true">
+        <description>Land at local position (local frame only)</description>
+        <param index="1" label="Target" minValue="0" increment="1">Landing target number (if available)</param>
+        <param index="2" label="Offset" units="m" minValue="0">Maximum accepted offset from desired landing position - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
+        <param index="3" label="Descend Rate" units="m/s">Landing descend rate</param>
+        <param index="4" label="Yaw" units="rad">Desired yaw angle</param>
+        <param index="5" label="Y Position" units="m">Y-axis position</param>
+        <param index="6" label="X Position" units="m">X-axis position</param>
+        <param index="7" label="Z Position" units="m">Z-axis / ground level position</param>
+      </entry>
+      <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL" hasLocation="true" isDestination="true">
+        <description>Takeoff from local position (local frame only)</description>
+        <param index="1" label="Pitch" units="rad">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+        <param index="2">Empty</param>
+        <param index="3" label="Ascend Rate" units="m/s">Takeoff ascend rate</param>
+        <param index="4" label="Yaw" units="rad">Yaw angle (if magnetometer or another yaw estimation source present), ignored without one of these</param>
+        <param index="5" label="Y Position" units="m">Y-axis position</param>
+        <param index="6" label="X Position" units="m">X-axis position</param>
+        <param index="7" label="Z Position" units="m">Z-axis position</param>
+      </entry>
+      <entry value="25" name="MAV_CMD_NAV_FOLLOW" hasLocation="true" isDestination="false">
+        <description>Vehicle following, i.e. this waypoint represents the position of a moving vehicle</description>
+        <param index="1" label="Following" increment="1">Following logic to use (e.g. loitering or sinusoidal following) - depends on specific autopilot implementation</param>
+        <param index="2" label="Ground Speed" units="m/s">Ground speed of vehicle to be followed</param>
+        <param index="3" label="Radius" units="m">Radius around waypoint. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4" label="Yaw" units="deg">Desired yaw angle.</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT" hasLocation="false" isDestination="true">
+        <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
+        <param index="1" label="Action" minValue="0" maxValue="2" increment="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude.</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7" label="Altitude" units="m">Desired altitude</param>
+      </entry>
+      <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT" hasLocation="true" isDestination="true">
+        <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached. Additionally, if the Heading Required parameter is non-zero the aircraft will not leave the loiter until heading toward the next waypoint.</description>
+        <param index="1" label="Heading Required" minValue="0" maxValue="1" increment="1">Heading Required (0 = False)</param>
+        <param index="2" label="Radius" units="m">Loiter radius around waypoint for forward-only moving vehicles (not multicopters). If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
+        <param index="3">Empty</param>
+        <param index="4" label="Xtrack Location" minValue="0" maxValue="1" increment="1">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="32" name="MAV_CMD_DO_FOLLOW" hasLocation="false" isDestination="false">
+        <description>Begin following a target</description>
+        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4" label="Altitude Mode" minValue="0" maxValue="2" increment="1">Altitude mode: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home.</param>
+        <param index="5" label="Altitude" units="m">Altitude above home. (used if mode=2)</param>
+        <param index="6">Reserved</param>
+        <param index="7" label="Time to Land" units="s" minValue="0">Time to land in which the MAV should go to the default position hold mode after a message RX timeout.</param>
+      </entry>
+      <entry value="33" name="MAV_CMD_DO_FOLLOW_REPOSITION" hasLocation="false" isDestination="false">
+        <description>Reposition the MAV after a follow target command has been sent</description>
+        <param index="1" label="Camera Q1">Camera q1 (where 0 is on the ray from the camera to the tracking device)</param>
+        <param index="2" label="Camera Q2">Camera q2</param>
+        <param index="3" label="Camera Q3">Camera q3</param>
+        <param index="4" label="Camera Q4">Camera q4</param>
+        <param index="5" label="Altitude Offset" units="m">altitude offset from target</param>
+        <param index="6" label="X Offset" units="m">X offset from target</param>
+        <param index="7" label="Y Offset" units="m">Y offset from target</param>
+      </entry>
+      <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
+        <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1" label="ROI Mode" enum="MAV_ROI">Region of interest mode.</param>
+        <param index="2" label="WP Index" minValue="0" increment="1">Waypoint index/ target ID. (see MAV_ROI enum)</param>
+        <param index="3" label="ROI Index" minValue="0" increment="1">ROI index (allows a vehicle to manage multiple ROI's)</param>
+        <param index="4">Empty</param>
+        <param index="5" label="X">x the location of the fixed ROI (see MAV_FRAME)</param>
+        <param index="6" label="Y">y</param>
+        <param index="7" label="Z">z</param>
+      </entry>
+      <entry value="81" name="MAV_CMD_NAV_PATHPLANNING" hasLocation="true" isDestination="true">
+        <description>Control autonomous path planning on the MAV.</description>
+        <param index="1" label="Local Ctrl" minValue="0" maxValue="2" increment="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>
+        <param index="2" label="Global Ctrl" minValue="0" maxValue="3" increment="1">0: Disable full path planning (without resetting map), 1: Enable, 2: Enable and reset map/occupancy grid, 3: Enable and reset planned route, but not occupancy grid</param>
+        <param index="3">Empty</param>
+        <param index="4" label="Yaw" units="deg">Yaw angle at goal</param>
+        <param index="5" label="Latitude/X">Latitude/X of goal</param>
+        <param index="6" label="Longitude/Y">Longitude/Y of goal</param>
+        <param index="7" label="Altitude/Z">Altitude/Z of goal</param>
+      </entry>
+      <entry value="82" name="MAV_CMD_NAV_SPLINE_WAYPOINT" hasLocation="true" isDestination="true">
+        <description>Navigate to waypoint using a spline path.</description>
+        <param index="1" label="Hold" units="s" minValue="0">Hold time. (ignored by fixed wing, time to stay at waypoint for rotary wing)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude/X">Latitude/X of goal</param>
+        <param index="6" label="Longitude/Y">Longitude/Y of goal</param>
+        <param index="7" label="Altitude/Z">Altitude/Z of goal</param>
+      </entry>
+      <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
+        <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
+        <param index="1">Empty</param>
+        <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
+        <param index="3">Empty</param>
+        <param index="4" label="Yaw Angle" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="85" name="MAV_CMD_NAV_VTOL_LAND" hasLocation="true" isDestination="true">
+        <description>Land using VTOL mode</description>
+        <param index="1">See NAV_VTOL_LAND_OPTIONS enum</param>
+        <param index="2">Empty</param>
+        <param index="3" label="Approach Altitude" units="m">Approach altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
+        <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Ground Altitude" units="m">Altitude (ground level)</param>
+      </entry>
+      <!-- IDs 90 and 91 are reserved until the end of 2014,
+                    as they were used in some conflicting proposals
+                    between PX4 and ArduPilot and need to be kept
+                    unused to prevent errors -->
+      <entry value="92" name="MAV_CMD_NAV_GUIDED_ENABLE" hasLocation="false" isDestination="false">
+        <description>hand control over to an external controller</description>
+        <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">On / Off (&gt; 0.5f on)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="93" name="MAV_CMD_NAV_DELAY" hasLocation="false" isDestination="false">
+        <description>Delay the next navigation command a number of seconds or until a specified time</description>
+        <param index="1" label="Delay" units="s" minValue="-1" increment="1">Delay (-1 to enable time-of-day fields)</param>
+        <param index="2" label="Hour" minValue="-1" maxValue="23" increment="1">hour (24h format, UTC, -1 to ignore)</param>
+        <param index="3" label="Minute" minValue="-1" maxValue="59" increment="1">minute (24h format, UTC, -1 to ignore)</param>
+        <param index="4" label="Second" minValue="-1" maxValue="59" increment="1">second (24h format, UTC, -1 to ignore)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="94" name="MAV_CMD_NAV_PAYLOAD_PLACE" hasLocation="true" isDestination="true">
+        <description>Descend and place payload. Vehicle moves to specified location, descends until it detects a hanging payload has reached the ground, and then releases the payload. If ground is not detected before the reaching the maximum descent value (param1), the command will complete without releasing the payload.</description>
+        <param index="1" label="Max Descent" units="m" minValue="0">Maximum distance to descend.</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="95" name="MAV_CMD_NAV_LAST" hasLocation="false" isDestination="false">
+        <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="112" name="MAV_CMD_CONDITION_DELAY" hasLocation="false" isDestination="false">
+        <description>Delay mission state machine.</description>
+        <param index="1" label="Delay" units="s" minValue="0">Delay</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT" hasLocation="false" isDestination="true">
+        <description>Ascend/descend to target altitude at specified rate. Delay mission state machine until desired altitude reached.</description>
+        <param index="1" label="Rate" units="m/s">Descent / Ascend rate.</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7" label="Altitude" units="m">Target Altitude</param>
+      </entry>
+      <entry value="114" name="MAV_CMD_CONDITION_DISTANCE" hasLocation="false" isDestination="false">
+        <description>Delay mission state machine until within desired distance of next NAV point.</description>
+        <param index="1" label="Distance" units="m" minValue="0">Distance.</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="115" name="MAV_CMD_CONDITION_YAW" hasLocation="false" isDestination="false">
+        <description>Reach a certain target angle.</description>
+        <param index="1" label="Angle" units="deg">target angle, 0 is north</param>
+        <param index="2" label="Angular Speed" units="deg/s">angular speed</param>
+        <param index="3" label="Direction" minValue="-1" maxValue="1" increment="2">direction: -1: counter clockwise, 1: clockwise</param>
+        <param index="4" label="Relative" minValue="0" maxValue="1" increment="1">0: absolute angle, 1: relative offset</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="159" name="MAV_CMD_CONDITION_LAST" hasLocation="false" isDestination="false">
+        <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="176" name="MAV_CMD_DO_SET_MODE" hasLocation="false" isDestination="false">
+        <description>Set system mode.</description>
+        <param index="1" label="Mode" enum="MAV_MODE">Mode</param>
+        <param index="2" label="Custom Mode">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+        <param index="3" label="Custom Submode">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="177" name="MAV_CMD_DO_JUMP" hasLocation="false" isDestination="false">
+        <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
+        <param index="1" label="Number" minValue="0" increment="1">Sequence number</param>
+        <param index="2" label="Repeat" minValue="0" increment="1">Repeat count</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED" hasLocation="false" isDestination="false">
+        <description>Change speed and/or throttle set points.</description>
+        <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
+        <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
+        <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
+        <param index="4" label="Relative" minValue="0" maxValue="1" increment="1">0: absolute, 1: relative</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="179" name="MAV_CMD_DO_SET_HOME" hasLocation="true" isDestination="false">
+        <description>Changes the home location either to the current location or a specified location.</description>
+        <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="180" name="MAV_CMD_DO_SET_PARAMETER" hasLocation="false" isDestination="false">
+        <description>Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.</description>
+        <param index="1" label="Number" minValue="0" increment="1">Parameter number</param>
+        <param index="2" label="Value">Parameter value</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="181" name="MAV_CMD_DO_SET_RELAY" hasLocation="false" isDestination="false">
+        <description>Set a relay to a condition.</description>
+        <param index="1" label="Instance" minValue="0" increment="1">Relay instance number.</param>
+        <param index="2" label="Setting" minValue="0" increment="1">Setting. (1=on, 0=off, others possible depending on system hardware)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="182" name="MAV_CMD_DO_REPEAT_RELAY" hasLocation="false" isDestination="false">
+        <description>Cycle a relay on and off for a desired number of cycles with a desired period.</description>
+        <param index="1" label="Instance" minValue="0" increment="1">Relay instance number.</param>
+        <param index="2" label="Count" minValue="1" increment="1">Cycle count.</param>
+        <param index="3" label="Time" units="s" minValue="0">Cycle time.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="183" name="MAV_CMD_DO_SET_SERVO" hasLocation="false" isDestination="false">
+        <description>Set a servo to a desired PWM value.</description>
+        <param index="1" label="Instance" minValue="0" increment="1">Servo instance number.</param>
+        <param index="2" label="PWM" units="us" minValue="0" increment="1">Pulse Width Modulation.</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="184" name="MAV_CMD_DO_REPEAT_SERVO" hasLocation="false" isDestination="false">
+        <description>Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.</description>
+        <param index="1" label="Instance" minValue="0" increment="1">Servo instance number.</param>
+        <param index="2" label="PWM" units="us" minValue="0" increment="1">Pulse Width Modulation.</param>
+        <param index="3" label="Count" minValue="1" increment="1">Cycle count.</param>
+        <param index="4" label="Time" units="s" minValue="0">Cycle time.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION" hasLocation="false" isDestination="false">
+        <description>Terminate flight immediately</description>
+        <param index="1" label="Terminate" minValue="0" maxValue="1" increment="1">Flight termination activated if &gt; 0.5</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE" hasLocation="false" isDestination="false">
+        <description>Change altitude set point.</description>
+        <param index="1" label="Altitude" units="m">Altitude.</param>
+        <param index="2" label="Frame" enum="MAV_FRAME">Frame of new altitude.</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="189" name="MAV_CMD_DO_LAND_START" hasLocation="true" isDestination="false">
+        <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="190" name="MAV_CMD_DO_RALLY_LAND" hasLocation="false" isDestination="false">
+        <description>Mission command to perform a landing from a rally point.</description>
+        <param index="1" label="Altitude" units="m">Break altitude</param>
+        <param index="2" label="Speed" units="m/s">Landing speed</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="191" name="MAV_CMD_DO_GO_AROUND" hasLocation="false" isDestination="false">
+        <description>Mission command to safely abort an autonomous landing.</description>
+        <param index="1" label="Altitude" units="m">Altitude</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="192" name="MAV_CMD_DO_REPOSITION" hasLocation="true" isDestination="true">
+        <description>Reposition the vehicle to a specific WGS84 global position.</description>
+        <param index="1" label="Speed" units="m/s" minValue="-1">Ground speed, less than 0 (-1) for default</param>
+        <param index="2" label="Bitmask" enum="MAV_DO_REPOSITION_FLAGS">Bitmask of option flags.</param>
+        <param index="3" label="Radius" units="m">Loiter radius for planes. Positive values only, direction is controlled by Yaw value. A value of zero or NaN is ignored. </param>
+        <param index="4" label="Yaw" units="deg">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE" hasLocation="false" isDestination="false">
+        <description>If in a GPS controlled position mode, hold the current position or continue.</description>
+        <param index="1" label="Continue" minValue="0" maxValue="1" increment="1">0: Pause current mission or reposition command, hold current position. 1: Continue mission. A VTOL capable vehicle should enter hover mode (multicopter and VTOL planes). A plane should loiter with the default loiter radius.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="194" name="MAV_CMD_DO_SET_REVERSE" hasLocation="false" isDestination="false">
+        <description>Set moving direction to forward or reverse.</description>
+        <param index="1" label="Reverse" minValue="0" maxValue="1" increment="1">Direction (0=Forward, 1=Reverse)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="195" name="MAV_CMD_DO_SET_ROI_LOCATION" hasLocation="true" isDestination="false">
+        <description>Sets the region of interest (ROI) to a location. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude">Latitude of ROI location</param>
+        <param index="6" label="Longitude">Longitude of ROI location</param>
+        <param index="7" label="Altitude" units="m">Altitude of ROI location</param>
+      </entry>
+      <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
+        <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Pitch Offset">Pitch offset from next waypoint, positive pitching up</param>
+        <param index="6" label="Roll Offset">Roll offset from next waypoint, positive rolling to the right</param>
+        <param index="7" label="Yaw Offset">Yaw offset from next waypoint, positive yawing to the right</param>
+      </entry>
+      <entry value="197" name="MAV_CMD_DO_SET_ROI_NONE" hasLocation="false" isDestination="false">
+        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="198" name="MAV_CMD_DO_SET_ROI_SYSID">
+        <description>Mount tracks system with specified system ID. Determination of target vehicle position may be done with GLOBAL_POSITION_INT or any other means.</description>
+        <param index="1" label="System ID" minValue="1" maxValue="255" increment="1">System ID</param>
+      </entry>
+      <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO" hasLocation="false" isDestination="false">
+        <description>Control onboard camera system.</description>
+        <param index="1" label="ID" minValue="-1" increment="1">Camera ID (-1 for all)</param>
+        <param index="2" label="Transmission" minValue="0" maxValue="2" increment="1">Transmission: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+        <param index="3" label="Interval" units="s" minValue="0">Transmission mode: 0: video stream, &gt;0: single images every n seconds</param>
+        <param index="4" label="Recording" minValue="0" maxValue="2" increment="1">Recording: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="201" name="MAV_CMD_DO_SET_ROI" hasLocation="true" isDestination="false">
+        <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1" label="ROI Mode" enum="MAV_ROI">Region of interest mode.</param>
+        <param index="2" label="WP Index" minValue="0" increment="1">Waypoint index/ target ID (depends on param 1).</param>
+        <param index="3" label="ROI Index" minValue="0" increment="1">Region of interest index. (allows a vehicle to manage multiple ROI's)</param>
+        <param index="4">Empty</param>
+        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
+        <param index="6">y</param>
+        <param index="7">z</param>
+      </entry>
+      <!-- Camera Controller Mission Commands Enumeration -->
+      <entry value="202" name="MAV_CMD_DO_DIGICAM_CONFIGURE" hasLocation="false" isDestination="false">
+        <description>Configure digital camera. This is a fallback message for systems that have not yet implemented PARAM_EXT_XXX messages and camera definition files (see https://mavlink.io/en/services/camera_def.html ).</description>
+        <param index="1" label="Mode" minValue="0" increment="1">Modes: P, TV, AV, M, Etc.</param>
+        <param index="2" label="Shutter Speed" minValue="0" increment="1">Shutter speed: Divisor number for one second.</param>
+        <param index="3" label="Aperture" minValue="0">Aperture: F stop number.</param>
+        <param index="4" label="ISO" minValue="0" increment="1">ISO number e.g. 80, 100, 200, Etc.</param>
+        <param index="5" label="Exposure">Exposure type enumerator.</param>
+        <param index="6" label="Command Identity">Command Identity.</param>
+        <param index="7" label="Engine Cut-off" units="ds" minValue="0" increment="1">Main engine cut-off time before camera trigger. (0 means no cut-off)</param>
+      </entry>
+      <entry value="203" name="MAV_CMD_DO_DIGICAM_CONTROL" hasLocation="false" isDestination="false">
+        <description>Control digital camera. This is a fallback message for systems that have not yet implemented PARAM_EXT_XXX messages and camera definition files (see https://mavlink.io/en/services/camera_def.html ).</description>
+        <param index="1" label="Session Control">Session control e.g. show/hide lens</param>
+        <param index="2" label="Zoom Absolute">Zoom's absolute position</param>
+        <param index="3" label="Zoom Relative">Zooming step value to offset zoom from the current position</param>
+        <param index="4" label="Focus">Focus Locking, Unlocking or Re-locking</param>
+        <param index="5" label="Shoot Command">Shooting Command</param>
+        <param index="6" label="Command Identity">Command Identity</param>
+        <param index="7" label="Shot ID">Test shot identifier. If set to 1, image will only be captured, but not counted towards internal frame count.</param>
+      </entry>
+      <!-- Camera Mount Mission Commands Enumeration -->
+      <entry value="204" name="MAV_CMD_DO_MOUNT_CONFIGURE" hasLocation="false" isDestination="false">
+        <description>Mission command to configure a camera or antenna mount</description>
+        <param index="1" label="Mode" enum="MAV_MOUNT_MODE">Mount operation mode</param>
+        <param index="2" label="Stabilize Roll" minValue="0" maxValue="1" increment="1">stabilize roll? (1 = yes, 0 = no)</param>
+        <param index="3" label="Stabilize Pitch" minValue="0" maxValue="1" increment="1">stabilize pitch? (1 = yes, 0 = no)</param>
+        <param index="4" label="Stabilize Yaw" minValue="0" maxValue="1" increment="1">stabilize yaw? (1 = yes, 0 = no)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <!-- this one is messed up! altitude should be param 7, not param4 -->
+      <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
+        <description>Mission command to control a camera or antenna mount</description>
+        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
+        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
+        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
+        <param index="4">WIP: alt in meters depending on mount mode.</param>
+        <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
+      </entry>
+      <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.</description>
+        <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
+        <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
+        <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">
+        <description>Mission command to enable the geofence</description>
+        <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="208" name="MAV_CMD_DO_PARACHUTE" hasLocation="false" isDestination="false">
+        <description>Mission item/command to release a parachute or enable/disable auto release.</description>
+        <param index="1" label="Action" enum="PARACHUTE_ACTION">Action</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="209" name="MAV_CMD_DO_MOTOR_TEST" hasLocation="false" isDestination="false">
+        <description>Mission command to perform motor test.</description>
+        <param index="1" label="Instance" minValue="1" increment="1">Motor instance number. (from 1 to max number of motors on the vehicle)</param>
+        <param index="2" label="Throttle Type" enum="MOTOR_TEST_THROTTLE_TYPE">Throttle type.</param>
+        <param index="3" label="Throttle">Throttle.</param>
+        <param index="4" label="Timeout" units="s" minValue="0">Timeout.</param>
+        <param index="5" label="Motor Count" minValue="0" increment="1">Motor count. (number of motors to test to test in sequence, waiting for the timeout above between them; 0=1 motor, 1=1 motor, 2=2 motors...)</param>
+        <param index="6" label="Test Order" enum="MOTOR_TEST_ORDER">Motor test order.</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="210" name="MAV_CMD_DO_INVERTED_FLIGHT" hasLocation="false" isDestination="false">
+        <description>Change to/from inverted flight.</description>
+        <param index="1" label="Inverted" minValue="0" maxValue="1" increment="1">Inverted flight. (0=normal, 1=inverted)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="211" name="MAV_CMD_DO_GRIPPER" hasLocation="false" isDestination="false">
+        <description>Mission command to operate a gripper.</description>
+        <param index="1" label="Instance" minValue="1" increment="1">Gripper instance number.</param>
+        <param index="2" label="Action" enum="GRIPPER_ACTIONS">Gripper action to perform.</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="212" name="MAV_CMD_DO_AUTOTUNE_ENABLE" hasLocation="false" isDestination="false">
+        <description>Enable/disable autotune.</description>
+        <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Enable (1: enable, 0:disable).</param>
+        <param index="2" label="Axis" enum="AUTOTUNE_AXIS">Specify which axes are autotuned. 0 indicates autopilot default settings.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="213" name="MAV_CMD_NAV_SET_YAW_SPEED" hasLocation="false" isDestination="false">
+        <description>Sets a desired vehicle turn angle and speed change.</description>
+        <param index="1" label="Yaw" units="deg">Yaw angle to adjust steering by.</param>
+        <param index="2" label="Speed" units="m/s">Speed.</param>
+        <param index="3" label="Angle" minValue="0" maxValue="1" increment="1">Final angle. (0=absolute, 1=relative)</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="214" name="MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL" hasLocation="false" isDestination="false">
+        <description>Mission command to set camera trigger interval for this flight. If triggering is enabled, the camera is triggered each time this interval expires. This command can also be used to set the shutter integration time for the camera.</description>
+        <param index="1" label="Trigger Cycle" units="ms" minValue="-1" increment="1">Camera trigger cycle time. -1 or 0 to ignore.</param>
+        <param index="2" label="Shutter Integration" units="ms" minValue="-1" increment="1">Camera shutter integration time. Should be less than trigger cycle time. -1 or 0 to ignore.</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
+        <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
+        <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
+        <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
+        <param index="3" label="Q3">quaternion param q3, y (0 in null-rotation)</param>
+        <param index="4" label="Q4">quaternion param q4, z (0 in null-rotation)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="221" name="MAV_CMD_DO_GUIDED_MASTER" hasLocation="false" isDestination="false">
+        <description>set id of master controller</description>
+        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID</param>
+        <param index="2" label="Component ID" minValue="0" maxValue="255" increment="1">Component ID</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS" hasLocation="false" isDestination="false">
+        <description>Set limits for external control</description>
+        <param index="1" label="Timeout" units="s" minValue="0">Timeout - maximum time that external controller will be allowed to control vehicle. 0 means no timeout.</param>
+        <param index="2" label="Min Altitude" units="m">Altitude (MSL) min - if vehicle moves below this alt, the command will be aborted and the mission will continue. 0 means no lower altitude limit.</param>
+        <param index="3" label="Max Altitude" units="m">Altitude (MSL) max - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit.</param>
+        <param index="4" label="Horiz. Move Limit" units="m" minValue="0">Horizontal move limit - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal move limit.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="223" name="MAV_CMD_DO_ENGINE_CONTROL" hasLocation="false" isDestination="false">
+        <description>Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines</description>
+        <param index="1" label="Start Engine" minValue="0" maxValue="1" increment="1">0: Stop engine, 1:Start Engine</param>
+        <param index="2" label="Cold Start" minValue="0" maxValue="1" increment="1">0: Warm start, 1:Cold start. Controls use of choke where applicable</param>
+        <param index="3" label="Height Delay" units="m" minValue="0">Height delay. This is for commanding engine start only after the vehicle has gained the specified height. Used in VTOL vehicles during takeoff to start engine after the aircraft is off the ground. Zero for no delay.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="224" name="MAV_CMD_DO_SET_MISSION_CURRENT" hasLocation="false" isDestination="false">
+        <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+        <param index="1" label="Number" minValue="0" increment="1">Mission sequence value to set</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="240" name="MAV_CMD_DO_LAST" hasLocation="false" isDestination="false">
+        <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="241" name="MAV_CMD_PREFLIGHT_CALIBRATION" hasLocation="false" isDestination="false">
+        <description>Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero.</description>
+        <param index="1" label="Gyro Temperature" minValue="0" maxValue="3" increment="1">1: gyro calibration, 3: gyro temperature calibration</param>
+        <param index="2" label="Magnetometer" minValue="0" maxValue="1" increment="1">1: magnetometer calibration</param>
+        <param index="3" label="Ground Pressure" minValue="0" maxValue="1" increment="1">1: ground pressure calibration</param>
+        <param index="4" label="Remote Control" minValue="0" maxValue="1" increment="1">1: radio RC calibration, 2: RC trim calibration</param>
+        <param index="5" label="Accelerometer" minValue="0" maxValue="4" increment="1">1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration, 4: simple accelerometer calibration</param>
+        <param index="6" label="Compmot or Airspeed" minValue="0" maxValue="2" increment="1">1: APM: compass/motor interference calibration (PX4: airspeed calibration, deprecated), 2: airspeed calibration</param>
+        <param index="7" label="ESC or Baro" minValue="0" maxValue="3" increment="1">1: ESC calibration, 3: barometer temperature calibration</param>
+      </entry>
+      <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS" hasLocation="false" isDestination="false">
+        <description>Set sensor offsets. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1" label="Sensor Type" minValue="0" maxValue="6" increment="1">Sensor to adjust the offsets for: 0: gyros, 1: accelerometer, 2: magnetometer, 3: barometer, 4: optical flow, 5: second magnetometer, 6: third magnetometer</param>
+        <param index="2" label="X Offset">X axis offset (or generic dimension 1), in the sensor's raw units</param>
+        <param index="3" label="Y Offset">Y axis offset (or generic dimension 2), in the sensor's raw units</param>
+        <param index="4" label="Z Offset">Z axis offset (or generic dimension 3), in the sensor's raw units</param>
+        <param index="5" label="4th Dimension">Generic dimension 4, in the sensor's raw units</param>
+        <param index="6" label="5th Dimension">Generic dimension 5, in the sensor's raw units</param>
+        <param index="7" label="6th Dimension">Generic dimension 6, in the sensor's raw units</param>
+      </entry>
+      <entry value="243" name="MAV_CMD_PREFLIGHT_UAVCAN" hasLocation="false" isDestination="false">
+        <description>Trigger UAVCAN configuration (actuator ID assignment and direction mapping). Note that this maps to the legacy UAVCAN v0 function UAVCAN_ENUMERATE, which is intended to be executed just once during initial vehicle configuration (it is not a normal pre-flight command and has been poorly named).</description>
+        <param index="1" label="Actuator ID">1: Trigger actuator ID assignment and direction mapping. 0: Cancel command.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="245" name="MAV_CMD_PREFLIGHT_STORAGE" hasLocation="false" isDestination="false">
+        <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1" label="Parameter Storage" minValue="0" maxValue="2" increment="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+        <param index="2" label="Mission Storage" minValue="0" maxValue="2" increment="1">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+        <param index="3" label="Logging Rate" units="Hz" minValue="-1" increment="1">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, &gt; 1: logging rate (e.g. set to 1000 for 1000 Hz logging)</param>
+        <param index="4">Reserved</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="246" name="MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN" hasLocation="false" isDestination="false">
+        <description>Request the reboot or shutdown of system components.</description>
+        <param index="1" label="Autopilot" minValue="0" maxValue="3" increment="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
+        <param index="2" label="Companion" minValue="0" maxValue="3" increment="1">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
+        <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+        <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
+      </entry>
+      <entry value="252" name="MAV_CMD_OVERRIDE_GOTO" hasLocation="true" isDestination="true">
+        <description>Override current mission with command to pause mission, pause mission and move to position, continue/resume mission. When param 1 indicates that the mission is paused (MAV_GOTO_DO_HOLD), param 2 defines whether it holds in place or moves to another position.</description>
+        <param index="1" label="Continue" enum="MAV_GOTO">MAV_GOTO_DO_HOLD: pause mission and either hold or move to specified position (depending on param2), MAV_GOTO_DO_CONTINUE: resume mission.</param>
+        <param index="2" label="Position" enum="MAV_GOTO">MAV_GOTO_HOLD_AT_CURRENT_POSITION: hold at current position, MAV_GOTO_HOLD_AT_SPECIFIED_POSITION: hold at specified position.</param>
+        <param index="3" label="Frame" enum="MAV_FRAME">Coordinate frame of hold point.</param>
+        <param index="4" label="Yaw" units="deg">Desired yaw angle.</param>
+        <param index="5" label="Latitude/X">Latitude/X position.</param>
+        <param index="6" label="Longitude/Y">Longitude/Y position.</param>
+        <param index="7" label="Altitude/Z">Altitude/Z position.</param>
+      </entry>
+      <entry value="260" name="MAV_CMD_OBLIQUE_SURVEY" hasLocation="false" isDestination="false">
+        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey (Replaces CAM_TRIGG_DIST for this purpose). The camera is triggered each time this distance is exceeded, then the mount moves to the next position. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV). This command can also be used to set the shutter integration time for the camera.</description>
+        <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
+        <param index="2" label="Shutter" units="ms" minValue="0" increment="1" default="0">Camera shutter integration time. 0 to ignore</param>
+        <param index="3" label="Min Interval" units="ms" minValue="0" maxValue="10000" increment="1" default="0">The minimum interval in which the camera is capable of taking subsequent pictures repeatedly. 0 to ignore.</param>
+        <param index="4" label="Positions" minValue="2" increment="1">Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5).</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">Angle limits that the camera can be rolled to left and right of center.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Fixed pitch angle that the camera will hold in oblique mode if the mount is actuated in the pitch axis.</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="300" name="MAV_CMD_MISSION_START" hasLocation="false" isDestination="false">
+        <description>start running a mission</description>
+        <param index="1" label="First Item" minValue="0" increment="1">first_item: the first mission item to run</param>
+        <param index="2" label="Last Item" minValue="0" increment="1">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
+      </entry>
+      <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM" hasLocation="false" isDestination="false">
+        <description>Arms / Disarms a component</description>
+        <param index="1" label="Arm" minValue="0" maxValue="1" increment="1">0: disarm, 1: arm</param>
+        <param index="2" label="Force" minValue="0" maxValue="21196" increment="21196">0: arm-disarm unless prevented by safety checks (i.e. when landed), 21196: force arming/disarming (e.g. allow arming to override preflight checks and disarming in flight)</param>
+      </entry>
+      <entry value="401" name="MAV_CMD_RUN_PREARM_CHECKS" hasLocation="false" isDestination="false">
+        <description>Instructs system to run pre-arm checks.  This command should return MAV_RESULT_TEMPORARILY_REJECTED in the case the system is armed, otherwse MAV_RESULT_ACCEPTED.  Note that the return value from executing this command does not indicate whether the vehicle is armable or not, just whether the system has successfully run/is currently running the checks.  The result of the checks is reflected in the SYS_STATUS message.</description>
+      </entry>
+      <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
+        <description>Request the home position from the vehicle.</description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="500" name="MAV_CMD_START_RX_PAIR" hasLocation="false" isDestination="false">
+        <description>Starts receiver pairing.</description>
+        <param index="1" label="Spektrum">0:Spektrum.</param>
+        <param index="2" label="RC Type" enum="RC_TYPE">RC type.</param>
+      </entry>
+      <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL" hasLocation="false" isDestination="false">
+        <description>Request the interval between messages for a particular MAVLink message ID. The receiver should ACK the command and then emit its response in a MESSAGE_INTERVAL message.</description>
+        <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
+      </entry>
+      <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL" hasLocation="false" isDestination="false">
+        <description>Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM.</description>
+        <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
+        <param index="2" label="Interval" units="us" minValue="-1" increment="1">The interval between two messages. Set to -1 to disable and 0 to request default rate.</param>
+        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requestor, 2: broadcast.</param>
+      </entry>
+      <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">
+        <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
+        <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
+        <param index="2" label="Req Param 1">Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="3" label="Req Param 2">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="4" label="Req Param 3">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="5" label="Req Param 4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="6" label="Req Param 5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.</param>
+      </entry>
+      <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request MAVLink protocol version compatibility. All receivers should ACK the command and then emit their capabilities in an PROTOCOL_VERSION message</description>
+        <param index="1" label="Protocol" minValue="0" maxValue="1" increment="1">1: Request supported protocol versions by all nodes on the network</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request autopilot capabilities. The receiver should ACK the command and then emit its capabilities in an AUTOPILOT_VERSION message</description>
+        <param index="1" label="Version" minValue="0" maxValue="1" increment="1">1: Request autopilot version</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request camera information (CAMERA_INFORMATION).</description>
+        <param index="1" label="Capabilities" minValue="0" maxValue="1" increment="1">0: No action 1: Request camera capabilities</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request camera settings (CAMERA_SETTINGS).</description>
+        <param index="1" label="Settings" minValue="0" maxValue="1" increment="1">0: No Action 1: Request camera settings</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request storage information (STORAGE_INFORMATION). Use the command's target_component to target a specific component's storage.</description>
+        <param index="1" label="Storage ID" minValue="0" increment="1">Storage ID (0 for all, 1 for first, 2 for second, etc.)</param>
+        <param index="2" label="Information" minValue="0" maxValue="1" increment="1">0: No Action 1: Request storage information</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="526" name="MAV_CMD_STORAGE_FORMAT" hasLocation="false" isDestination="false">
+        <description>Format a storage medium. Once format is complete, a STORAGE_INFORMATION message is sent. Use the command's target_component to target a specific component's storage.</description>
+        <param index="1" label="Storage ID" minValue="0" increment="1">Storage ID (1 for first, 2 for second, etc.)</param>
+        <param index="2" label="Format" minValue="0" maxValue="1" increment="1">0: No action 1: Format storage</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+        <param index="1" label="Capture Status" minValue="0" maxValue="1" increment="1">0: No Action 1: Request camera capture status</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request flight information (FLIGHT_INFORMATION)</description>
+        <param index="1" label="Flight Information" minValue="0" maxValue="1" increment="1">1: Request flight information</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="529" name="MAV_CMD_RESET_CAMERA_SETTINGS" hasLocation="false" isDestination="false">
+        <description>Reset all camera settings to Factory Default</description>
+        <param index="1" label="Reset" minValue="0" maxValue="1" increment="1">0: No Action 1: Reset all settings</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="530" name="MAV_CMD_SET_CAMERA_MODE" hasLocation="false" isDestination="false">
+        <description>Set camera running mode. Use NaN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2" label="Camera Mode" enum="CAMERA_MODE">Camera mode</param>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="600" name="MAV_CMD_JUMP_TAG" hasLocation="false" isDestination="false">
+        <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
+        <param index="1" label="Tag" minValue="0" increment="1">Tag.</param>
+      </entry>
+      <entry value="601" name="MAV_CMD_DO_JUMP_TAG" hasLocation="false" isDestination="false">
+        <description>Jump to the matching tag in the mission list. Repeat this action for the specified number of times. A mission should contain a single matching tag for each jump. If this is not the case then a jump to a missing tag should complete the mission, and a jump where there are multiple matching tags should always select the one with the lowest mission sequence number.</description>
+        <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
+        <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
+      </entry>
+      <!-- entry value 900 reserved for MAV_CMD_PARAM_TRANSACTION (development.xml) -->
+      <entry value="1000" name="MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>High level setpoint to be sent to a gimbal manager to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: a gimbal is never to react to this command but only the gimbal manager.</description>
+        <param index="1" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch angle (positive to pitch up, relative to vehicle for FOLLOW mode, relative to world horizon for LOCK mode).</param>
+        <param index="2" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw angle (positive to yaw to the right, relative to vehicle for FOLLOW mode, absolute to North for LOCK mode).</param>
+        <param index="3" label="Pitch rate" units="deg/s">Pitch rate (positive to pitch up).</param>
+        <param index="4" label="Yaw rate" units="deg/s">Yaw rate (positive to yaw to the right).</param>
+        <param index="5" label="Gimbal manager flags" enum="GIMBAL_MANAGER_FLAGS">Gimbal manager flags to use.</param>
+        <param index="7" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. Send command multiple times for more than one gimbal (but not all gimbals).</param>
+      </entry>
+      <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
+        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
+        <param index="3" label="Total Images" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1), otherwise set to 0. Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted.</param>
+        <param index="5" reserved="true" default="NaN"/>
+        <param index="6" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">
+        <description>Stop image capture sequence Use NaN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2" reserved="true" default="NaN"/>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL" hasLocation="false" isDestination="false">
+        <description>Enable or disable on-board camera triggering system.</description>
+        <param index="1" label="Enable" minValue="-1" maxValue="1" increment="1">Trigger enable/disable (0 for disable, 1 for start), -1 to ignore</param>
+        <param index="2" label="Reset" minValue="-1" maxValue="1" increment="1">1 to reset the trigger sequence, -1 or 0 to ignore</param>
+        <param index="3" label="Pause" minValue="-1" maxValue="1" increment="2">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
+      </entry>
+      <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE" hasLocation="false" isDestination="false">
+        <description>Starts video capture (recording).</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams)</param>
+        <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency)</param>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="5" reserved="true" default="NaN"/>
+        <param index="6" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE" hasLocation="false" isDestination="false">
+        <description>Stop the current video capture (recording).</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams)</param>
+        <param index="2" reserved="true" default="NaN"/>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="5" reserved="true" default="NaN"/>
+        <param index="6" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING" hasLocation="false" isDestination="false">
+        <description>Start video streaming</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+      </entry>
+      <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING" hasLocation="false" isDestination="false">
+        <description>Stop the given video stream</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+      </entry>
+      <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request video stream information (VIDEO_STREAM_INFORMATION)</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+      </entry>
+      <entry value="2505" name="MAV_CMD_REQUEST_VIDEO_STREAM_STATUS" hasLocation="false" isDestination="false">
+        <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>Request video stream status (VIDEO_STREAM_STATUS)</description>
+        <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+      </entry>
+      <entry value="2510" name="MAV_CMD_LOGGING_START" hasLocation="false" isDestination="false">
+        <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
+        <param index="1" label="Format" minValue="0" increment="1">Format: 0: ULog</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <entry value="2511" name="MAV_CMD_LOGGING_STOP" hasLocation="false" isDestination="false">
+        <description>Request to stop streaming log data over MAVLink</description>
+        <param index="1">Reserved (set to 0)</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION" hasLocation="false" isDestination="false">
+        <description/>
+        <param index="1" label="Landing Gear ID" minValue="-1" increment="1">Landing gear ID (default: 0, -1 for all)</param>
+        <param index="2" label="Landing Gear Position">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="5" reserved="true" default="NaN"/>
+        <param index="6" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
+      <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY" hasLocation="false" isDestination="false">
+        <description>Request to start/stop transmitting over the high latency telemetry</description>
+        <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Control transmission over high latency telemetry (0: stop, 1: start)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="2800" name="MAV_CMD_PANORAMA_CREATE" hasLocation="false" isDestination="false">
+        <description>Create a panorama at the current position</description>
+        <param index="1" label="Horizontal Angle" units="deg">Viewing angle horizontal of the panorama (+- 0.5 the total angle)</param>
+        <param index="2" label="Vertical Angle" units="deg">Viewing angle vertical of panorama.</param>
+        <param index="3" label="Horizontal Speed" units="deg/s">Speed of the horizontal rotation.</param>
+        <param index="4" label="Vertical Speed" units="deg/s">Speed of the vertical rotation.</param>
+      </entry>
+      <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
+        <description>Request VTOL transition</description>
+        <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+      </entry>
+      <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
+        <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.
+        </description>
+        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">Vehicle system id, this way ground station can request arm authorization on behalf of any vehicle</param>
+      </entry>
+      <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD" hasLocation="false" isDestination="false">
+        <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocities along all three axes.
+                  </description>
+      </entry>
+      <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE" hasLocation="true" isDestination="false">
+        <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+                  </description>
+        <param index="1" label="Radius" units="m">Radius of desired circle in CIRCLE_MODE</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Target latitude of center of circle in CIRCLE_MODE</param>
+        <param index="6" label="Longitude">Target longitude of center of circle in CIRCLE_MODE</param>
+      </entry>
+      <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT" hasLocation="true" isDestination="true">
+        <description>Fence return point (there can only be one such point in a geofence definition). If rally points are supported they should be used instead.</description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="5001" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION" hasLocation="true" isDestination="false">
+        <description>Fence vertex for an inclusion polygon (the polygon must not be self-intersecting). The vehicle must stay within this area. Minimum of 3 vertices required.
+        </description>
+        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group, must be the same for all points in each polygon</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5002" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION" hasLocation="true" isDestination="false">
+        <description>Fence vertex for an exclusion polygon (the polygon must not be self-intersecting). The vehicle must stay outside this area. Minimum of 3 vertices required.
+        </description>
+        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5003" name="MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION" hasLocation="true" isDestination="false">
+        <description>Circular fence area. The vehicle must stay inside this area.
+        </description>
+        <param index="1" label="Radius" units="m">Radius.</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5004" name="MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION" hasLocation="true" isDestination="false">
+        <description>Circular fence area. The vehicle must stay outside this area.
+        </description>
+        <param index="1" label="Radius" units="m">Radius.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5100" name="MAV_CMD_NAV_RALLY_POINT" hasLocation="true" isDestination="false">
+        <description>Rally point. You can have multiple rally points defined.
+        </description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <!-- Values in the range [5200, 5210) should be reserved for UAVCAN.  -->
+      <!-- BEGIN UAVCAN range -->
+      <entry value="5200" name="MAV_CMD_UAVCAN_GET_NODE_INFO" hasLocation="false" isDestination="false">
+        <description>Commands the vehicle to respond with a sequence of messages UAVCAN_NODE_INFO, one message per every UAVCAN node that is online. Note that some of the response messages can be lost, which the receiver can detect easily by checking whether every received UAVCAN_NODE_STATUS has a matching message UAVCAN_NODE_INFO received earlier; if not, this command should be sent again in order to request re-transmission of the node information messages.</description>
+        <param index="1">Reserved (set to 0)</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <!-- END of UAVCAN range -->
+      <entry value="10001" name="MAV_CMD_DO_ADSB_OUT_IDENT" hasLocation="false" isDestination="false">
+        <description>Trigger the start of an ADSB-out IDENT. This should only be used when requested to do so by an Air Traffic Controller in controlled airspace. This starts the IDENT which is then typically held for 18 seconds by the hardware per the Mode A, C, and S transponder spec.</description>
+        <param index="1">Reserved (set to 0)</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
+      <!-- BEGIN of payload range (30000 to 30999) -->
+      <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY" hasLocation="true" isDestination="true">
+        <description>Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.</description>
+        <param index="1" label="Operation Mode" minValue="0" maxValue="2" increment="1">Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.</param>
+        <param index="2" label="Approach Vector" units="deg" minValue="-1" maxValue="360">Desired approach vector in compass heading. A negative value indicates the system can define the approach vector at will.</param>
+        <param index="3" label="Ground Speed" minValue="-1">Desired ground speed at release time. This can be overridden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
+        <param index="4" label="Altitude Clearance" units="m" minValue="-1">Minimum altitude clearance to the release position. A negative value indicates the system can define the clearance at will.</param>
+        <param index="5" label="Latitude" units="degE7">Latitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)</param>
+        <param index="6" label="Longitude" units="degE7">Longitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY" hasLocation="false" isDestination="false">
+        <description>Control the payload deployment.</description>
+        <param index="1" label="Operation Mode" minValue="0" maxValue="101" increment="1">Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deployment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <!-- from ardupilotmega.xml (hence ID is in that range) -->
+      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW" hasLocation="true" isDestination="false">
+        <description>Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.</description>
+        <param index="1" label="Yaw" units="deg">Yaw of vehicle in earth frame.</param>
+        <param index="2" label="CompassMask">CompassMask, 0 for all.</param>
+        <param index="3" label="Latitude" units="deg">Latitude.</param>
+        <param index="4" label="Longitude" units="deg">Longitude.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="42600" name="MAV_CMD_DO_WINCH" hasLocation="false" isDestination="false">
+        <description>Command to operate winch.</description>
+        <param index="1" label="Instance" minValue="1" increment="1">Winch instance number.</param>
+        <param index="2" label="Action" enum="WINCH_ACTIONS">Action to perform.</param>
+        <param index="3" label="Length" units="m">Length of cable to release (negative to wind).</param>
+        <param index="4" label="Rate" units="m/s">Release rate (negative to wind).</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <!-- END of payload range (30000 to 30999) -->
+      <!-- BEGIN user defined range (31000 to 31999) -->
+      <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1" hasLocation="true" isDestination="true">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2" hasLocation="true" isDestination="true">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3" hasLocation="true" isDestination="true">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4" hasLocation="true" isDestination="true">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5" hasLocation="true" isDestination="true">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31005" name="MAV_CMD_SPATIAL_USER_1" hasLocation="true" isDestination="false">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31006" name="MAV_CMD_SPATIAL_USER_2" hasLocation="true" isDestination="false">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31007" name="MAV_CMD_SPATIAL_USER_3" hasLocation="true" isDestination="false">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31008" name="MAV_CMD_SPATIAL_USER_4" hasLocation="true" isDestination="false">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31009" name="MAV_CMD_SPATIAL_USER_5" hasLocation="true" isDestination="false">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5" label="Latitude">Latitude unscaled</param>
+        <param index="6" label="Longitude">Longitude unscaled</param>
+        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+      </entry>
+      <entry value="31010" name="MAV_CMD_USER_1" hasLocation="false" isDestination="false">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31011" name="MAV_CMD_USER_2" hasLocation="false" isDestination="false">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31012" name="MAV_CMD_USER_3" hasLocation="false" isDestination="false">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31013" name="MAV_CMD_USER_4" hasLocation="false" isDestination="false">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31014" name="MAV_CMD_USER_5" hasLocation="false" isDestination="false">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <!-- END of user range (31000 to 31999) -->
+      <entry value="32000" name="MAV_CMD_CAN_FORWARD" hasLocation="false" isDestination="false">
+        <description>Request forwarding of CAN packets from the given CAN bus to this interface. CAN Frames are sent using CAN_FRAME and CANFD_FRAME messages</description>
+        <param index="1" label="bus">Bus number (0 to disable forwarding, 1 for first bus, 2 for 2nd bus, 3 for 3rd bus).</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+    </enum>
+    <enum name="MAV_DATA_STREAM">
+      <description>A data stream is not a fixed set of messages, but rather a
+     recommendation to the autopilot software. Individual autopilots may or may not obey
+     the recommended messages.</description>
+      <entry value="0" name="MAV_DATA_STREAM_ALL">
+        <description>Enable all data streams</description>
+      </entry>
+      <entry value="1" name="MAV_DATA_STREAM_RAW_SENSORS">
+        <description>Enable IMU_RAW, GPS_RAW, GPS_STATUS packets.</description>
+      </entry>
+      <entry value="2" name="MAV_DATA_STREAM_EXTENDED_STATUS">
+        <description>Enable GPS_STATUS, CONTROL_STATUS, AUX_STATUS</description>
+      </entry>
+      <entry value="3" name="MAV_DATA_STREAM_RC_CHANNELS">
+        <description>Enable RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW</description>
+      </entry>
+      <entry value="4" name="MAV_DATA_STREAM_RAW_CONTROLLER">
+        <description>Enable ATTITUDE_CONTROLLER_OUTPUT, POSITION_CONTROLLER_OUTPUT, NAV_CONTROLLER_OUTPUT.</description>
+      </entry>
+      <entry value="6" name="MAV_DATA_STREAM_POSITION">
+        <description>Enable LOCAL_POSITION, GLOBAL_POSITION/GLOBAL_POSITION_INT messages.</description>
+      </entry>
+      <entry value="10" name="MAV_DATA_STREAM_EXTRA1">
+        <description>Dependent on the autopilot</description>
+      </entry>
+      <entry value="11" name="MAV_DATA_STREAM_EXTRA2">
+        <description>Dependent on the autopilot</description>
+      </entry>
+      <entry value="12" name="MAV_DATA_STREAM_EXTRA3">
+        <description>Dependent on the autopilot</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ROI">
+      <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
+      <description>The ROI (region of interest) for the vehicle. This can be
+                be used by the vehicle for camera/vehicle attitude alignment (see
+                MAV_CMD_NAV_ROI).</description>
+      <entry value="0" name="MAV_ROI_NONE">
+        <description>No region of interest.</description>
+      </entry>
+      <entry value="1" name="MAV_ROI_WPNEXT">
+        <description>Point toward next waypoint, with optional pitch/roll/yaw offset.</description>
+      </entry>
+      <entry value="2" name="MAV_ROI_WPINDEX">
+        <description>Point toward given waypoint.</description>
+      </entry>
+      <entry value="3" name="MAV_ROI_LOCATION">
+        <description>Point toward fixed location.</description>
+      </entry>
+      <entry value="4" name="MAV_ROI_TARGET">
+        <description>Point toward of given id.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD_ACK">
+      <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
+      <entry value="0" name="MAV_CMD_ACK_OK">
+        <description>Command / mission item is ok.</description>
+      </entry>
+      <entry value="1" name="MAV_CMD_ACK_ERR_FAIL">
+        <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
+      </entry>
+      <entry value="2" name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
+        <description>The system is refusing to accept this command from this source / communication partner.</description>
+      </entry>
+      <entry value="3" name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
+        <description>Command or mission item is not supported, other commands would be accepted.</description>
+      </entry>
+      <entry value="4" name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
+        <description>The coordinate frame of this command / mission item is not supported.</description>
+      </entry>
+      <entry value="5" name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
+        <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
+      </entry>
+      <entry value="6" name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
+        <description>The X or latitude value is out of range.</description>
+      </entry>
+      <entry value="7" name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
+        <description>The Y or longitude value is out of range.</description>
+      </entry>
+      <entry value="8" name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
+        <description>The Z or altitude value is out of range.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_PARAM_TYPE">
+      <description>Specifies the datatype of a MAVLink parameter.</description>
+      <entry value="1" name="MAV_PARAM_TYPE_UINT8">
+        <description>8-bit unsigned integer</description>
+      </entry>
+      <entry value="2" name="MAV_PARAM_TYPE_INT8">
+        <description>8-bit signed integer</description>
+      </entry>
+      <entry value="3" name="MAV_PARAM_TYPE_UINT16">
+        <description>16-bit unsigned integer</description>
+      </entry>
+      <entry value="4" name="MAV_PARAM_TYPE_INT16">
+        <description>16-bit signed integer</description>
+      </entry>
+      <entry value="5" name="MAV_PARAM_TYPE_UINT32">
+        <description>32-bit unsigned integer</description>
+      </entry>
+      <entry value="6" name="MAV_PARAM_TYPE_INT32">
+        <description>32-bit signed integer</description>
+      </entry>
+      <entry value="7" name="MAV_PARAM_TYPE_UINT64">
+        <description>64-bit unsigned integer</description>
+      </entry>
+      <entry value="8" name="MAV_PARAM_TYPE_INT64">
+        <description>64-bit signed integer</description>
+      </entry>
+      <entry value="9" name="MAV_PARAM_TYPE_REAL32">
+        <description>32-bit floating-point</description>
+      </entry>
+      <entry value="10" name="MAV_PARAM_TYPE_REAL64">
+        <description>64-bit floating-point</description>
+      </entry>
+    </enum>
+    <enum name="MAV_PARAM_EXT_TYPE">
+      <description>Specifies the datatype of a MAVLink extended parameter.</description>
+      <entry value="1" name="MAV_PARAM_EXT_TYPE_UINT8">
+        <description>8-bit unsigned integer</description>
+      </entry>
+      <entry value="2" name="MAV_PARAM_EXT_TYPE_INT8">
+        <description>8-bit signed integer</description>
+      </entry>
+      <entry value="3" name="MAV_PARAM_EXT_TYPE_UINT16">
+        <description>16-bit unsigned integer</description>
+      </entry>
+      <entry value="4" name="MAV_PARAM_EXT_TYPE_INT16">
+        <description>16-bit signed integer</description>
+      </entry>
+      <entry value="5" name="MAV_PARAM_EXT_TYPE_UINT32">
+        <description>32-bit unsigned integer</description>
+      </entry>
+      <entry value="6" name="MAV_PARAM_EXT_TYPE_INT32">
+        <description>32-bit signed integer</description>
+      </entry>
+      <entry value="7" name="MAV_PARAM_EXT_TYPE_UINT64">
+        <description>64-bit unsigned integer</description>
+      </entry>
+      <entry value="8" name="MAV_PARAM_EXT_TYPE_INT64">
+        <description>64-bit signed integer</description>
+      </entry>
+      <entry value="9" name="MAV_PARAM_EXT_TYPE_REAL32">
+        <description>32-bit floating-point</description>
+      </entry>
+      <entry value="10" name="MAV_PARAM_EXT_TYPE_REAL64">
+        <description>64-bit floating-point</description>
+      </entry>
+      <entry value="11" name="MAV_PARAM_EXT_TYPE_CUSTOM">
+        <description>Custom Type</description>
+      </entry>
+    </enum>
+    <enum name="MAV_RESULT">
+      <description>Result from a MAVLink command (MAV_CMD)</description>
+      <entry value="0" name="MAV_RESULT_ACCEPTED">
+        <description>Command is valid (is supported and has valid parameters), and was executed.</description>
+      </entry>
+      <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
+        <description>Command is valid, but cannot be executed at this time. This is used to indicate a problem that should be fixed just by waiting (e.g. a state machine is busy, can't arm because have not got GPS lock, etc.). Retrying later should work.</description>
+      </entry>
+      <entry value="2" name="MAV_RESULT_DENIED">
+        <description>Command is invalid (is supported but has invalid parameters). Retrying same command and parameters will not work.</description>
+      </entry>
+      <entry value="3" name="MAV_RESULT_UNSUPPORTED">
+        <description>Command is not supported (unknown).</description>
+      </entry>
+      <entry value="4" name="MAV_RESULT_FAILED">
+        <description>Command is valid, but execution has failed. This is used to indicate any non-temporary or unexpected problem, i.e. any problem that must be fixed before the command can succeed/be retried. For example, attempting to write a file when out of memory, attempting to arm when sensors are not calibrated, etc.</description>
+      </entry>
+      <entry value="5" name="MAV_RESULT_IN_PROGRESS">
+        <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation. There is no need for the sender to retry the command, but if done during execution, the component will return MAV_RESULT_IN_PROGRESS with an updated progress.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MISSION_RESULT">
+      <description>Result of mission operation (in a MISSION_ACK message).</description>
+      <entry value="0" name="MAV_MISSION_ACCEPTED">
+        <description>mission accepted OK</description>
+      </entry>
+      <entry value="1" name="MAV_MISSION_ERROR">
+        <description>Generic error / not accepting mission commands at all right now.</description>
+      </entry>
+      <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
+        <description>Coordinate frame is not supported.</description>
+      </entry>
+      <entry value="3" name="MAV_MISSION_UNSUPPORTED">
+        <description>Command is not supported.</description>
+      </entry>
+      <entry value="4" name="MAV_MISSION_NO_SPACE">
+        <description>Mission items exceed storage space.</description>
+      </entry>
+      <entry value="5" name="MAV_MISSION_INVALID">
+        <description>One of the parameters has an invalid value.</description>
+      </entry>
+      <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
+        <description>param1 has an invalid value.</description>
+      </entry>
+      <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
+        <description>param2 has an invalid value.</description>
+      </entry>
+      <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
+        <description>param3 has an invalid value.</description>
+      </entry>
+      <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
+        <description>param4 has an invalid value.</description>
+      </entry>
+      <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
+        <description>x / param5 has an invalid value.</description>
+      </entry>
+      <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
+        <description>y / param6 has an invalid value.</description>
+      </entry>
+      <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
+        <description>z / param7 has an invalid value.</description>
+      </entry>
+      <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
+        <description>Mission item received out of sequence</description>
+      </entry>
+      <entry value="14" name="MAV_MISSION_DENIED">
+        <description>Not accepting any mission commands from this communication partner.</description>
+      </entry>
+      <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
+        <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
+      </entry>
+    </enum>
+    <enum name="MAV_SEVERITY">
+      <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>
+      <entry value="0" name="MAV_SEVERITY_EMERGENCY">
+        <description>System is unusable. This is a "panic" condition.</description>
+      </entry>
+      <entry value="1" name="MAV_SEVERITY_ALERT">
+        <description>Action should be taken immediately. Indicates error in non-critical systems.</description>
+      </entry>
+      <entry value="2" name="MAV_SEVERITY_CRITICAL">
+        <description>Action must be taken immediately. Indicates failure in a primary system.</description>
+      </entry>
+      <entry value="3" name="MAV_SEVERITY_ERROR">
+        <description>Indicates an error in secondary/redundant systems.</description>
+      </entry>
+      <entry value="4" name="MAV_SEVERITY_WARNING">
+        <description>Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.</description>
+      </entry>
+      <entry value="5" name="MAV_SEVERITY_NOTICE">
+        <description>An unusual event has occurred, though not an error condition. This should be investigated for the root cause.</description>
+      </entry>
+      <entry value="6" name="MAV_SEVERITY_INFO">
+        <description>Normal operational messages. Useful for logging. No action is required for these messages.</description>
+      </entry>
+      <entry value="7" name="MAV_SEVERITY_DEBUG">
+        <description>Useful non-operational messages that can assist in debugging. These should not occur during normal operation.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_POWER_STATUS" bitmask="true">
+      <description>Power supply status flags (bitmask)</description>
+      <entry value="1" name="MAV_POWER_STATUS_BRICK_VALID">
+        <description>main brick power supply valid</description>
+      </entry>
+      <entry value="2" name="MAV_POWER_STATUS_SERVO_VALID">
+        <description>main servo power supply valid for FMU</description>
+      </entry>
+      <entry value="4" name="MAV_POWER_STATUS_USB_CONNECTED">
+        <description>USB power is connected</description>
+      </entry>
+      <entry value="8" name="MAV_POWER_STATUS_PERIPH_OVERCURRENT">
+        <description>peripheral supply is in over-current state</description>
+      </entry>
+      <entry value="16" name="MAV_POWER_STATUS_PERIPH_HIPOWER_OVERCURRENT">
+        <description>hi-power peripheral supply is in over-current state</description>
+      </entry>
+      <entry value="32" name="MAV_POWER_STATUS_CHANGED">
+        <description>Power status has changed since boot</description>
+      </entry>
+    </enum>
+    <enum name="SERIAL_CONTROL_DEV">
+      <description>SERIAL_CONTROL device types</description>
+      <entry value="0" name="SERIAL_CONTROL_DEV_TELEM1">
+        <description>First telemetry port</description>
+      </entry>
+      <entry value="1" name="SERIAL_CONTROL_DEV_TELEM2">
+        <description>Second telemetry port</description>
+      </entry>
+      <entry value="2" name="SERIAL_CONTROL_DEV_GPS1">
+        <description>First GPS port</description>
+      </entry>
+      <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
+        <description>Second GPS port</description>
+      </entry>
+      <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
+        <description>system shell</description>
+      </entry>
+      <entry value="100" name="SERIAL_CONTROL_SERIAL0">
+        <description>SERIAL0</description>
+      </entry>
+      <entry value="101" name="SERIAL_CONTROL_SERIAL1">
+        <description>SERIAL1</description>
+      </entry>
+      <entry value="102" name="SERIAL_CONTROL_SERIAL2">
+        <description>SERIAL2</description>
+      </entry>
+      <entry value="103" name="SERIAL_CONTROL_SERIAL3">
+        <description>SERIAL3</description>
+      </entry>
+      <entry value="104" name="SERIAL_CONTROL_SERIAL4">
+        <description>SERIAL4</description>
+      </entry>
+      <entry value="105" name="SERIAL_CONTROL_SERIAL5">
+        <description>SERIAL5</description>
+      </entry>
+      <entry value="106" name="SERIAL_CONTROL_SERIAL6">
+        <description>SERIAL6</description>
+      </entry>
+      <entry value="107" name="SERIAL_CONTROL_SERIAL7">
+        <description>SERIAL7</description>
+      </entry>
+      <entry value="108" name="SERIAL_CONTROL_SERIAL8">
+        <description>SERIAL8</description>
+      </entry>
+      <entry value="109" name="SERIAL_CONTROL_SERIAL9">
+        <description>SERIAL9</description>
+      </entry>
+    </enum>
+    <enum name="SERIAL_CONTROL_FLAG" bitmask="true">
+      <description>SERIAL_CONTROL flags (bitmask)</description>
+      <entry value="1" name="SERIAL_CONTROL_FLAG_REPLY">
+        <description>Set if this is a reply</description>
+      </entry>
+      <entry value="2" name="SERIAL_CONTROL_FLAG_RESPOND">
+        <description>Set if the sender wants the receiver to send a response as another SERIAL_CONTROL message</description>
+      </entry>
+      <entry value="4" name="SERIAL_CONTROL_FLAG_EXCLUSIVE">
+        <description>Set if access to the serial port should be removed from whatever driver is currently using it, giving exclusive access to the SERIAL_CONTROL protocol. The port can be handed back by sending a request without this flag set</description>
+      </entry>
+      <entry value="8" name="SERIAL_CONTROL_FLAG_BLOCKING">
+        <description>Block on writes to the serial port</description>
+      </entry>
+      <entry value="16" name="SERIAL_CONTROL_FLAG_MULTI">
+        <description>Send multiple replies until port is drained</description>
+      </entry>
+    </enum>
+    <enum name="MAV_DISTANCE_SENSOR">
+      <description>Enumeration of distance sensor types</description>
+      <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
+        <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
+      </entry>
+      <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
+        <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
+      </entry>
+      <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
+        <description>Infrared rangefinder, e.g. Sharp units</description>
+      </entry>
+      <entry value="3" name="MAV_DISTANCE_SENSOR_RADAR">
+        <description>Radar type, e.g. uLanding units</description>
+      </entry>
+      <entry value="4" name="MAV_DISTANCE_SENSOR_UNKNOWN">
+        <description>Broken or unknown type, e.g. analog units</description>
+      </entry>
+    </enum>
+    <enum name="MAV_SENSOR_ORIENTATION">
+      <description>Enumeration of sensor orientation, according to its rotations</description>
+      <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
+        <description>Roll: 0, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
+        <description>Roll: 0, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
+        <description>Roll: 0, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
+        <description>Roll: 0, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
+        <description>Roll: 0, Pitch: 0, Yaw: 180</description>
+      </entry>
+      <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
+        <description>Roll: 0, Pitch: 0, Yaw: 225</description>
+      </entry>
+      <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
+        <description>Roll: 0, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
+        <description>Roll: 0, Pitch: 0, Yaw: 315</description>
+      </entry>
+      <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
+        <description>Roll: 180, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
+        <description>Roll: 180, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
+        <description>Roll: 180, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
+        <description>Roll: 180, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
+        <description>Roll: 0, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
+        <description>Roll: 180, Pitch: 0, Yaw: 225</description>
+      </entry>
+      <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
+        <description>Roll: 180, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
+        <description>Roll: 180, Pitch: 0, Yaw: 315</description>
+      </entry>
+      <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
+        <description>Roll: 90, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
+        <description>Roll: 90, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
+        <description>Roll: 90, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
+        <description>Roll: 90, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
+        <description>Roll: 270, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
+        <description>Roll: 270, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
+        <description>Roll: 270, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
+        <description>Roll: 270, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
+        <description>Roll: 0, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
+        <description>Roll: 0, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
+        <description>Roll: 0, Pitch: 180, Yaw: 90</description>
+      </entry>
+      <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
+        <description>Roll: 0, Pitch: 180, Yaw: 270</description>
+      </entry>
+      <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
+        <description>Roll: 90, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
+        <description>Roll: 180, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
+        <description>Roll: 270, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
+        <description>Roll: 90, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
+        <description>Roll: 270, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
+        <description>Roll: 90, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
+        <description>Roll: 180, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
+        <description>Roll: 270, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
+        <description>Roll: 90, Pitch: 180, Yaw: 90</description>
+      </entry>
+      <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
+        <description>Roll: 90, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293">
+        <description>Roll: 90, Pitch: 68, Yaw: 293</description>
+      </entry>
+      <entry value="39" name="MAV_SENSOR_ROTATION_PITCH_315">
+        <description>Pitch: 315</description>
+      </entry>
+      <entry value="40" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_315">
+        <description>Roll: 90, Pitch: 315</description>
+      </entry>
+      <entry value="100" name="MAV_SENSOR_ROTATION_CUSTOM">
+        <description>Custom orientation</description>
+      </entry>
+    </enum>
+    <enum name="MAV_PROTOCOL_CAPABILITY" bitmask="true">
+      <description>Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.</description>
+      <entry value="1" name="MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT">
+        <description>Autopilot supports MISSION float message type.</description>
+      </entry>
+      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
+        <description>Autopilot supports the new param float message type.</description>
+      </entry>
+      <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
+        <deprecated since="2020-06" replaced_by="">This flag must always be set if missions are supported, because missions must always use MISSION_ITEM_INT (rather than MISSION_ITEM, which is deprecated).</deprecated>
+        <description>Autopilot supports MISSION_ITEM_INT scaled integer message type.</description>
+      </entry>
+      <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
+        <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
+      </entry>
+      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
+        <description>Autopilot supports the new param union message type.</description>
+      </entry>
+      <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
+        <description>Autopilot supports the File Transfer Protocol v1: https://mavlink.io/en/services/ftp.html.</description>
+      </entry>
+      <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
+        <description>Autopilot supports commanding attitude offboard.</description>
+      </entry>
+      <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
+        <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
+      </entry>
+      <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
+        <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
+      </entry>
+      <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
+        <description>Autopilot supports terrain protocol / data handling.</description>
+      </entry>
+      <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
+        <description>Autopilot supports direct actuator control.</description>
+      </entry>
+      <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
+        <description>Autopilot supports the MAV_CMD_DO_FLIGHTTERMINATION command (flight termination).</description>
+      </entry>
+      <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
+        <description>Autopilot supports onboard compass calibration.</description>
+      </entry>
+      <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
+        <description>Autopilot supports MAVLink version 2.</description>
+      </entry>
+      <entry value="16384" name="MAV_PROTOCOL_CAPABILITY_MISSION_FENCE">
+        <description>Autopilot supports mission fence protocol.</description>
+      </entry>
+      <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
+        <description>Autopilot supports mission rally point protocol.</description>
+      </entry>
+      <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION">
+        <description>Autopilot supports the flight information protocol.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MISSION_TYPE">
+      <description>Type of mission items being requested/sent in mission protocol.</description>
+      <entry value="0" name="MAV_MISSION_TYPE_MISSION">
+        <description>Items are mission commands for main mission.</description>
+      </entry>
+      <entry value="1" name="MAV_MISSION_TYPE_FENCE">
+        <description>Specifies GeoFence area(s). Items are MAV_CMD_NAV_FENCE_ GeoFence items.</description>
+      </entry>
+      <entry value="2" name="MAV_MISSION_TYPE_RALLY">
+        <description>Specifies the rally points for the vehicle. Rally points are alternative RTL points. Items are MAV_CMD_NAV_RALLY_POINT rally point items.</description>
+      </entry>
+      <entry value="255" name="MAV_MISSION_TYPE_ALL">
+        <description>Only used in MISSION_CLEAR_ALL to clear all mission types.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ESTIMATOR_TYPE">
+      <description>Enumeration of estimator types</description>
+      <entry value="0" name="MAV_ESTIMATOR_TYPE_UNKNOWN">
+        <description>Unknown type of the estimator.</description>
+      </entry>
+      <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
+        <description>This is a naive estimator without any real covariance feedback.</description>
+      </entry>
+      <entry value="2" name="MAV_ESTIMATOR_TYPE_VISION">
+        <description>Computer vision based estimate. Might be up to scale.</description>
+      </entry>
+      <entry value="3" name="MAV_ESTIMATOR_TYPE_VIO">
+        <description>Visual-inertial estimate.</description>
+      </entry>
+      <entry value="4" name="MAV_ESTIMATOR_TYPE_GPS">
+        <description>Plain GPS estimate.</description>
+      </entry>
+      <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
+        <description>Estimator integrating GPS and inertial sensing.</description>
+      </entry>
+      <entry value="6" name="MAV_ESTIMATOR_TYPE_MOCAP">
+        <description>Estimate from external motion capturing system.</description>
+      </entry>
+      <entry value="7" name="MAV_ESTIMATOR_TYPE_LIDAR">
+        <description>Estimator based on lidar sensor input.</description>
+      </entry>
+      <entry value="8" name="MAV_ESTIMATOR_TYPE_AUTOPILOT">
+        <description>Estimator on autopilot.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_TYPE">
+      <description>Enumeration of battery types</description>
+      <entry value="0" name="MAV_BATTERY_TYPE_UNKNOWN">
+        <description>Not specified.</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_TYPE_LIPO">
+        <description>Lithium polymer battery</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_TYPE_LIFE">
+        <description>Lithium-iron-phosphate battery</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_TYPE_LION">
+        <description>Lithium-ION battery</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_TYPE_NIMH">
+        <description>Nickel metal hydride battery</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_FUNCTION">
+      <description>Enumeration of battery functions</description>
+      <entry value="0" name="MAV_BATTERY_FUNCTION_UNKNOWN">
+        <description>Battery function is unknown</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
+        <description>Battery supports all flight systems</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
+        <description>Battery for the propulsion system</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
+        <description>Avionics battery</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
+        <description>Payload battery</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_CHARGE_STATE">
+      <description>Enumeration for battery charge states.</description>
+      <entry value="0" name="MAV_BATTERY_CHARGE_STATE_UNDEFINED">
+        <description>Low battery state is not provided</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_CHARGE_STATE_OK">
+        <description>Battery is not in low state. Normal operation.</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_CHARGE_STATE_LOW">
+        <description>Battery state is low, warn and monitor close.</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_CHARGE_STATE_CRITICAL">
+        <description>Battery state is critical, return or abort immediately.</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_CHARGE_STATE_EMERGENCY">
+        <description>Battery state is too low for ordinary abort sequence. Perform fastest possible emergency stop to prevent damage.</description>
+      </entry>
+      <entry value="5" name="MAV_BATTERY_CHARGE_STATE_FAILED">
+        <description>Battery failed, damage unavoidable. Possible causes (faults) are listed in MAV_BATTERY_FAULT.</description>
+      </entry>
+      <entry value="6" name="MAV_BATTERY_CHARGE_STATE_UNHEALTHY">
+        <description>Battery is diagnosed to be defective or an error occurred, usage is discouraged / prohibited. Possible causes (faults) are listed in MAV_BATTERY_FAULT.</description>
+      </entry>
+      <entry value="7" name="MAV_BATTERY_CHARGE_STATE_CHARGING">
+        <description>Battery is charging.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_MODE">
+      <description>Battery mode. Note, the normal operation mode (i.e. when flying) should be reported as MAV_BATTERY_MODE_UNKNOWN to allow message trimming in normal flight.</description>
+      <entry value="0" name="MAV_BATTERY_MODE_UNKNOWN">
+        <description>Battery mode not supported/unknown battery mode/normal operation.</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_MODE_AUTO_DISCHARGING">
+        <description>Battery is auto discharging (towards storage level).</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_MODE_HOT_SWAP">
+        <description>Battery in hot-swap mode (current limited to prevent spikes that might damage sensitive electrical circuits).</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_FAULT" bitmask="true">
+      <description>Smart battery supply status/fault flags (bitmask) for health indication. The battery must also report either MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY if any of these are set.</description>
+      <entry value="1" name="MAV_BATTERY_FAULT_DEEP_DISCHARGE">
+        <description>Battery has deep discharged.</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_FAULT_SPIKES">
+        <description>Voltage spikes.</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_FAULT_CELL_FAIL">
+        <description>One or more cells have failed. Battery should also report MAV_BATTERY_CHARGE_STATE_FAILE (and should not be used).</description>
+      </entry>
+      <entry value="8" name="MAV_BATTERY_FAULT_OVER_CURRENT">
+        <description>Over-current fault.</description>
+      </entry>
+      <entry value="16" name="MAV_BATTERY_FAULT_OVER_TEMPERATURE">
+        <description>Over-temperature fault.</description>
+      </entry>
+      <entry value="32" name="MAV_BATTERY_FAULT_UNDER_TEMPERATURE">
+        <description>Under-temperature fault.</description>
+      </entry>
+      <entry value="64" name="MAV_BATTERY_FAULT_INCOMPATIBLE_VOLTAGE">
+        <description>Vehicle voltage is not compatible with this battery (batteries on same power rail should have similar voltage).</description>
+      </entry>
+      <entry value="128" name="MAV_BATTERY_FAULT_INCOMPATIBLE_FIRMWARE">
+        <description>Battery firmware is not compatible with current autopilot firmware.</description>
+      </entry>
+      <entry value="256" name="BATTERY_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
+        <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
+      </entry>
+    </enum>
+    <enum name="MAV_GENERATOR_STATUS_FLAG" bitmask="true">
+      <description>Flags to report status/failure cases for a power generator (used in GENERATOR_STATUS). Note that FAULTS are conditions that cause the generator to fail. Warnings are conditions that require attention before the next use (they indicate the system is not operating properly).</description>
+      <entry value="1" name="MAV_GENERATOR_STATUS_FLAG_OFF">
+        <description>Generator is off.</description>
+      </entry>
+      <entry value="2" name="MAV_GENERATOR_STATUS_FLAG_READY">
+        <description>Generator is ready to start generating power.</description>
+      </entry>
+      <entry value="4" name="MAV_GENERATOR_STATUS_FLAG_GENERATING">
+        <description>Generator is generating power.</description>
+      </entry>
+      <entry value="8" name="MAV_GENERATOR_STATUS_FLAG_CHARGING">
+        <description>Generator is charging the batteries (generating enough power to charge and provide the load).</description>
+      </entry>
+      <entry value="16" name="MAV_GENERATOR_STATUS_FLAG_REDUCED_POWER">
+        <description>Generator is operating at a reduced maximum power.</description>
+      </entry>
+      <entry value="32" name="MAV_GENERATOR_STATUS_FLAG_MAXPOWER">
+        <description>Generator is providing the maximum output.</description>
+      </entry>
+      <entry value="64" name="MAV_GENERATOR_STATUS_FLAG_OVERTEMP_WARNING">
+        <description>Generator is near the maximum operating temperature, cooling is insufficient.</description>
+      </entry>
+      <entry value="128" name="MAV_GENERATOR_STATUS_FLAG_OVERTEMP_FAULT">
+        <description>Generator hit the maximum operating temperature and shutdown.</description>
+      </entry>
+      <entry value="256" name="MAV_GENERATOR_STATUS_FLAG_ELECTRONICS_OVERTEMP_WARNING">
+        <description>Power electronics are near the maximum operating temperature, cooling is insufficient.</description>
+      </entry>
+      <entry value="512" name="MAV_GENERATOR_STATUS_FLAG_ELECTRONICS_OVERTEMP_FAULT">
+        <description>Power electronics hit the maximum operating temperature and shutdown.</description>
+      </entry>
+      <entry value="1024" name="MAV_GENERATOR_STATUS_FLAG_ELECTRONICS_FAULT">
+        <description>Power electronics experienced a fault and shutdown.</description>
+      </entry>
+      <entry value="2048" name="MAV_GENERATOR_STATUS_FLAG_POWERSOURCE_FAULT">
+        <description>The power source supplying the generator failed e.g. mechanical generator stopped, tether is no longer providing power, solar cell is in shade, hydrogen reaction no longer happening.</description>
+      </entry>
+      <entry value="4096" name="MAV_GENERATOR_STATUS_FLAG_COMMUNICATION_WARNING">
+        <description>Generator controller having communication problems.</description>
+      </entry>
+      <entry value="8192" name="MAV_GENERATOR_STATUS_FLAG_COOLING_WARNING">
+        <description>Power electronic or generator cooling system error.</description>
+      </entry>
+      <entry value="16384" name="MAV_GENERATOR_STATUS_FLAG_POWER_RAIL_FAULT">
+        <description>Generator controller power rail experienced a fault.</description>
+      </entry>
+      <entry value="32768" name="MAV_GENERATOR_STATUS_FLAG_OVERCURRENT_FAULT">
+        <description>Generator controller exceeded the overcurrent threshold and shutdown to prevent damage.</description>
+      </entry>
+      <entry value="65536" name="MAV_GENERATOR_STATUS_FLAG_BATTERY_OVERCHARGE_CURRENT_FAULT">
+        <description>Generator controller detected a high current going into the batteries and shutdown to prevent battery damage.</description>
+      </entry>
+      <entry value="131072" name="MAV_GENERATOR_STATUS_FLAG_OVERVOLTAGE_FAULT">
+        <description>Generator controller exceeded it's overvoltage threshold and shutdown to prevent it exceeding the voltage rating.</description>
+      </entry>
+      <entry value="262144" name="MAV_GENERATOR_STATUS_FLAG_BATTERY_UNDERVOLT_FAULT">
+        <description>Batteries are under voltage (generator will not start).</description>
+      </entry>
+      <entry value="524288" name="MAV_GENERATOR_STATUS_FLAG_START_INHIBITED">
+        <description>Generator start is inhibited by e.g. a safety switch.</description>
+      </entry>
+      <entry value="1048576" name="MAV_GENERATOR_STATUS_FLAG_MAINTENANCE_REQUIRED">
+        <description>Generator requires maintenance.</description>
+      </entry>
+      <entry value="2097152" name="MAV_GENERATOR_STATUS_FLAG_WARMING_UP">
+        <description>Generator is not ready to generate yet.</description>
+      </entry>
+      <entry value="4194304" name="MAV_GENERATOR_STATUS_FLAG_IDLE">
+        <description>Generator is idle.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_VTOL_STATE">
+      <description>Enumeration of VTOL states</description>
+      <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
+        <description>MAV is not configured as VTOL</description>
+      </entry>
+      <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
+        <description>VTOL is in transition from multicopter to fixed-wing</description>
+      </entry>
+      <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
+        <description>VTOL is in transition from fixed-wing to multicopter</description>
+      </entry>
+      <entry value="3" name="MAV_VTOL_STATE_MC">
+        <description>VTOL is in multicopter state</description>
+      </entry>
+      <entry value="4" name="MAV_VTOL_STATE_FW">
+        <description>VTOL is in fixed-wing state</description>
+      </entry>
+    </enum>
+    <enum name="MAV_LANDED_STATE">
+      <description>Enumeration of landed detector states</description>
+      <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
+        <description>MAV landed state is unknown</description>
+      </entry>
+      <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
+        <description>MAV is landed (on ground)</description>
+      </entry>
+      <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
+        <description>MAV is in air</description>
+      </entry>
+      <entry value="3" name="MAV_LANDED_STATE_TAKEOFF">
+        <description>MAV currently taking off</description>
+      </entry>
+      <entry value="4" name="MAV_LANDED_STATE_LANDING">
+        <description>MAV currently landing</description>
+      </entry>
+    </enum>
+    <enum name="ADSB_ALTITUDE_TYPE">
+      <description>Enumeration of the ADSB altimeter types</description>
+      <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
+        <description>Altitude reported from a Baro source using QNH reference</description>
+      </entry>
+      <entry value="1" name="ADSB_ALTITUDE_TYPE_GEOMETRIC">
+        <description>Altitude reported from a GNSS source</description>
+      </entry>
+    </enum>
+    <enum name="ADSB_EMITTER_TYPE">
+      <description>ADSB classification for the type of vehicle emitting the transponder signal</description>
+      <entry value="0" name="ADSB_EMITTER_TYPE_NO_INFO"/>
+      <entry value="1" name="ADSB_EMITTER_TYPE_LIGHT"/>
+      <entry value="2" name="ADSB_EMITTER_TYPE_SMALL"/>
+      <entry value="3" name="ADSB_EMITTER_TYPE_LARGE"/>
+      <entry value="4" name="ADSB_EMITTER_TYPE_HIGH_VORTEX_LARGE"/>
+      <entry value="5" name="ADSB_EMITTER_TYPE_HEAVY"/>
+      <entry value="6" name="ADSB_EMITTER_TYPE_HIGHLY_MANUV"/>
+      <entry value="7" name="ADSB_EMITTER_TYPE_ROTOCRAFT"/>
+      <entry value="8" name="ADSB_EMITTER_TYPE_UNASSIGNED"/>
+      <entry value="9" name="ADSB_EMITTER_TYPE_GLIDER"/>
+      <entry value="10" name="ADSB_EMITTER_TYPE_LIGHTER_AIR"/>
+      <entry value="11" name="ADSB_EMITTER_TYPE_PARACHUTE"/>
+      <entry value="12" name="ADSB_EMITTER_TYPE_ULTRA_LIGHT"/>
+      <entry value="13" name="ADSB_EMITTER_TYPE_UNASSIGNED2"/>
+      <entry value="14" name="ADSB_EMITTER_TYPE_UAV"/>
+      <entry value="15" name="ADSB_EMITTER_TYPE_SPACE"/>
+      <entry value="16" name="ADSB_EMITTER_TYPE_UNASSGINED3"/>
+      <entry value="17" name="ADSB_EMITTER_TYPE_EMERGENCY_SURFACE"/>
+      <entry value="18" name="ADSB_EMITTER_TYPE_SERVICE_SURFACE"/>
+      <entry value="19" name="ADSB_EMITTER_TYPE_POINT_OBSTACLE"/>
+    </enum>
+    <enum name="ADSB_FLAGS" bitmask="true">
+      <description>These flags indicate status such as data validity of each data source. Set = data valid</description>
+      <entry value="1" name="ADSB_FLAGS_VALID_COORDS"/>
+      <entry value="2" name="ADSB_FLAGS_VALID_ALTITUDE"/>
+      <entry value="4" name="ADSB_FLAGS_VALID_HEADING"/>
+      <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"/>
+      <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"/>
+      <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"/>
+      <entry value="64" name="ADSB_FLAGS_SIMULATED"/>
+      <entry value="128" name="ADSB_FLAGS_VERTICAL_VELOCITY_VALID"/>
+      <entry value="256" name="ADSB_FLAGS_BARO_VALID"/>
+      <entry value="32768" name="ADSB_FLAGS_SOURCE_UAT"/>
+    </enum>
+    <enum name="MAV_DO_REPOSITION_FLAGS" bitmask="true">
+      <description>Bitmap of options for the MAV_CMD_DO_REPOSITION</description>
+      <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
+        <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
+      </entry>
+    </enum>
+    <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
+    <enum name="ESTIMATOR_STATUS_FLAGS" bitmask="true">
+      <description>Flags in ESTIMATOR_STATUS message</description>
+      <entry value="1" name="ESTIMATOR_ATTITUDE">
+        <description>True if the attitude estimate is good</description>
+      </entry>
+      <entry value="2" name="ESTIMATOR_VELOCITY_HORIZ">
+        <description>True if the horizontal velocity estimate is good</description>
+      </entry>
+      <entry value="4" name="ESTIMATOR_VELOCITY_VERT">
+        <description>True if the  vertical velocity estimate is good</description>
+      </entry>
+      <entry value="8" name="ESTIMATOR_POS_HORIZ_REL">
+        <description>True if the horizontal position (relative) estimate is good</description>
+      </entry>
+      <entry value="16" name="ESTIMATOR_POS_HORIZ_ABS">
+        <description>True if the horizontal position (absolute) estimate is good</description>
+      </entry>
+      <entry value="32" name="ESTIMATOR_POS_VERT_ABS">
+        <description>True if the vertical position (absolute) estimate is good</description>
+      </entry>
+      <entry value="64" name="ESTIMATOR_POS_VERT_AGL">
+        <description>True if the vertical position (above ground) estimate is good</description>
+      </entry>
+      <entry value="128" name="ESTIMATOR_CONST_POS_MODE">
+        <description>True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)</description>
+      </entry>
+      <entry value="256" name="ESTIMATOR_PRED_POS_HORIZ_REL">
+        <description>True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate</description>
+      </entry>
+      <entry value="512" name="ESTIMATOR_PRED_POS_HORIZ_ABS">
+        <description>True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate</description>
+      </entry>
+      <entry value="1024" name="ESTIMATOR_GPS_GLITCH">
+        <description>True if the EKF has detected a GPS glitch</description>
+      </entry>
+      <entry value="2048" name="ESTIMATOR_ACCEL_ERROR">
+        <description>True if the EKF has detected bad accelerometer data</description>
+      </entry>
+    </enum>
+    <!-- motor test type enum -->
+    <enum name="MOTOR_TEST_ORDER">
+      <description>Sequence that motors are tested when using MAV_CMD_DO_MOTOR_TEST.</description>
+      <entry name="MOTOR_TEST_ORDER_DEFAULT" value="0">
+        <description>Default autopilot motor test method.</description>
+      </entry>
+      <entry name="MOTOR_TEST_ORDER_SEQUENCE" value="1">
+        <description>Motor numbers are specified as their index in a predefined vehicle-specific sequence.</description>
+      </entry>
+      <entry name="MOTOR_TEST_ORDER_BOARD" value="2">
+        <description>Motor numbers are specified as the output as labeled on the board.</description>
+      </entry>
+    </enum>
+    <!-- motor test throttle type enum -->
+    <enum name="MOTOR_TEST_THROTTLE_TYPE">
+      <description>Defines how throttle value is represented in MAV_CMD_DO_MOTOR_TEST.</description>
+      <entry value="0" name="MOTOR_TEST_THROTTLE_PERCENT">
+        <description>Throttle as a percentage (0 ~ 100)</description>
+      </entry>
+      <entry value="1" name="MOTOR_TEST_THROTTLE_PWM">
+        <description>Throttle as an absolute PWM value (normally in range of 1000~2000).</description>
+      </entry>
+      <entry value="2" name="MOTOR_TEST_THROTTLE_PILOT">
+        <description>Throttle pass-through from pilot's transmitter.</description>
+      </entry>
+      <entry value="3" name="MOTOR_TEST_COMPASS_CAL">
+        <description>Per-motor compass calibration test.</description>
+      </entry>
+    </enum>
+    <!-- GPS_INPUT ignore flags enum -->
+    <enum name="GPS_INPUT_IGNORE_FLAGS" bitmask="true">
+      <entry value="1" name="GPS_INPUT_IGNORE_FLAG_ALT">
+        <description>ignore altitude field</description>
+      </entry>
+      <entry value="2" name="GPS_INPUT_IGNORE_FLAG_HDOP">
+        <description>ignore hdop field</description>
+      </entry>
+      <entry value="4" name="GPS_INPUT_IGNORE_FLAG_VDOP">
+        <description>ignore vdop field</description>
+      </entry>
+      <entry value="8" name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ">
+        <description>ignore horizontal velocity field (vn and ve)</description>
+      </entry>
+      <entry value="16" name="GPS_INPUT_IGNORE_FLAG_VEL_VERT">
+        <description>ignore vertical velocity field (vd)</description>
+      </entry>
+      <entry value="32" name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY">
+        <description>ignore speed accuracy field</description>
+      </entry>
+      <entry value="64" name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY">
+        <description>ignore horizontal accuracy field</description>
+      </entry>
+      <entry value="128" name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY">
+        <description>ignore vertical accuracy field</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_ACTION">
+      <description>Possible actions an aircraft can take to avoid a collision.</description>
+      <entry value="0" name="MAV_COLLISION_ACTION_NONE">
+        <description>Ignore any potential collisions</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_ACTION_REPORT">
+        <description>Report potential collision</description>
+      </entry>
+      <entry value="2" name="MAV_COLLISION_ACTION_ASCEND_OR_DESCEND">
+        <description>Ascend or Descend to avoid threat</description>
+      </entry>
+      <entry value="3" name="MAV_COLLISION_ACTION_MOVE_HORIZONTALLY">
+        <description>Move horizontally to avoid threat</description>
+      </entry>
+      <entry value="4" name="MAV_COLLISION_ACTION_MOVE_PERPENDICULAR">
+        <description>Aircraft to move perpendicular to the collision's velocity vector</description>
+      </entry>
+      <entry value="5" name="MAV_COLLISION_ACTION_RTL">
+        <description>Aircraft to fly directly back to its launch point</description>
+      </entry>
+      <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
+        <description>Aircraft to stop in place</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_THREAT_LEVEL">
+      <description>Aircraft-rated danger from this threat.</description>
+      <entry value="0" name="MAV_COLLISION_THREAT_LEVEL_NONE">
+        <description>Not a threat</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_THREAT_LEVEL_LOW">
+        <description>Craft is mildly concerned about this threat</description>
+      </entry>
+      <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
+        <description>Craft is panicking, and may take actions to avoid threat</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_SRC">
+      <description>Source of information about this collision.</description>
+      <entry value="0" name="MAV_COLLISION_SRC_ADSB">
+        <description>ID field references ADSB_VEHICLE packets</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT">
+        <description>ID field references MAVLink SRC ID</description>
+      </entry>
+    </enum>
+    <enum name="GPS_FIX_TYPE">
+      <description>Type of GPS fix</description>
+      <entry value="0" name="GPS_FIX_TYPE_NO_GPS">
+        <description>No GPS connected</description>
+      </entry>
+      <entry value="1" name="GPS_FIX_TYPE_NO_FIX">
+        <description>No position information, GPS is connected</description>
+      </entry>
+      <entry value="2" name="GPS_FIX_TYPE_2D_FIX">
+        <description>2D position</description>
+      </entry>
+      <entry value="3" name="GPS_FIX_TYPE_3D_FIX">
+        <description>3D position</description>
+      </entry>
+      <entry value="4" name="GPS_FIX_TYPE_DGPS">
+        <description>DGPS/SBAS aided 3D position</description>
+      </entry>
+      <entry value="5" name="GPS_FIX_TYPE_RTK_FLOAT">
+        <description>RTK float, 3D position</description>
+      </entry>
+      <entry value="6" name="GPS_FIX_TYPE_RTK_FIXED">
+        <description>RTK Fixed, 3D position</description>
+      </entry>
+      <entry value="7" name="GPS_FIX_TYPE_STATIC">
+        <description>Static fixed, typically used for base stations</description>
+      </entry>
+      <entry value="8" name="GPS_FIX_TYPE_PPP">
+        <description>PPP, 3D position.</description>
+      </entry>
+    </enum>
+    <enum name="RTK_BASELINE_COORDINATE_SYSTEM">
+      <description>RTK GPS baseline coordinate system, used for RTK corrections</description>
+      <entry value="0" name="RTK_BASELINE_COORDINATE_SYSTEM_ECEF">
+        <description>Earth-centered, Earth-fixed</description>
+      </entry>
+      <entry value="1" name="RTK_BASELINE_COORDINATE_SYSTEM_NED">
+        <description>RTK basestation centered, north, east, down</description>
+      </entry>
+    </enum>
+    <enum name="LANDING_TARGET_TYPE">
+      <description>Type of landing target</description>
+      <entry value="0" name="LANDING_TARGET_TYPE_LIGHT_BEACON">
+        <description>Landing target signaled by light beacon (ex: IR-LOCK)</description>
+      </entry>
+      <entry value="1" name="LANDING_TARGET_TYPE_RADIO_BEACON">
+        <description>Landing target signaled by radio beacon (ex: ILS, NDB)</description>
+      </entry>
+      <entry value="2" name="LANDING_TARGET_TYPE_VISION_FIDUCIAL">
+        <description>Landing target represented by a fiducial marker (ex: ARTag)</description>
+      </entry>
+      <entry value="3" name="LANDING_TARGET_TYPE_VISION_OTHER">
+        <description>Landing target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
+      </entry>
+    </enum>
+    <enum name="VTOL_TRANSITION_HEADING">
+      <description>Direction of VTOL transition</description>
+      <entry value="0" name="VTOL_TRANSITION_HEADING_VEHICLE_DEFAULT">
+        <description>Respect the heading configuration of the vehicle.</description>
+      </entry>
+      <entry value="1" name="VTOL_TRANSITION_HEADING_NEXT_WAYPOINT">
+        <description>Use the heading pointing towards the next waypoint.</description>
+      </entry>
+      <entry value="2" name="VTOL_TRANSITION_HEADING_TAKEOFF">
+        <description>Use the heading on takeoff (while sitting on the ground).</description>
+      </entry>
+      <entry value="3" name="VTOL_TRANSITION_HEADING_SPECIFIED">
+        <description>Use the specified heading in parameter 4.</description>
+      </entry>
+      <entry value="4" name="VTOL_TRANSITION_HEADING_ANY">
+        <description>Use the current heading when reaching takeoff altitude (potentially facing the wind when weather-vaning is active).</description>
+      </entry>
+    </enum>
+    <enum name="CAMERA_CAP_FLAGS" bitmask="true">
+      <description>Camera capability flags (Bitmap)</description>
+      <entry value="1" name="CAMERA_CAP_FLAGS_CAPTURE_VIDEO">
+        <description>Camera is able to record video</description>
+      </entry>
+      <entry value="2" name="CAMERA_CAP_FLAGS_CAPTURE_IMAGE">
+        <description>Camera is able to capture images</description>
+      </entry>
+      <entry value="4" name="CAMERA_CAP_FLAGS_HAS_MODES">
+        <description>Camera has separate Video and Image/Photo modes (MAV_CMD_SET_CAMERA_MODE)</description>
+      </entry>
+      <entry value="8" name="CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE">
+        <description>Camera can capture images while in video mode</description>
+      </entry>
+      <entry value="16" name="CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE">
+        <description>Camera can capture videos while in Photo/Image mode</description>
+      </entry>
+      <entry value="32" name="CAMERA_CAP_FLAGS_HAS_IMAGE_SURVEY_MODE">
+        <description>Camera has image survey mode (MAV_CMD_SET_CAMERA_MODE)</description>
+      </entry>
+      <entry value="64" name="CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM">
+        <description>Camera has basic zoom control (MAV_CMD_SET_CAMERA_ZOOM)</description>
+      </entry>
+      <entry value="128" name="CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS">
+        <description>Camera has basic focus control (MAV_CMD_SET_CAMERA_FOCUS)</description>
+      </entry>
+      <entry value="256" name="CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM">
+        <description>Camera has video streaming capabilities (request VIDEO_STREAM_INFORMATION with MAV_CMD_REQUEST_MESSAGE for video streaming info)</description>
+      </entry>
+      <entry value="512" name="CAMERA_CAP_FLAGS_HAS_TRACKING_POINT">
+        <description>Camera supports tracking of a point on the camera view.</description>
+      </entry>
+      <entry value="1024" name="CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
+        <description>Camera supports tracking of a selection rectangle on the camera view.</description>
+      </entry>
+      <entry value="2048" name="CAMERA_CAP_FLAGS_HAS_TRACKING_GEO_STATUS">
+        <description>Camera supports tracking geo status (CAMERA_TRACKING_GEO_STATUS).</description>
+      </entry>
+    </enum>
+    <enum name="VIDEO_STREAM_STATUS_FLAGS" bitmask="true">
+      <description>Stream status flags (Bitmap)</description>
+      <entry value="1" name="VIDEO_STREAM_STATUS_FLAGS_RUNNING">
+        <description>Stream is active (running)</description>
+      </entry>
+      <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
+        <description>Stream is thermal imaging</description>
+      </entry>
+    </enum>
+    <enum name="VIDEO_STREAM_TYPE">
+      <description>Video stream types</description>
+      <entry value="0" name="VIDEO_STREAM_TYPE_RTSP">
+        <description>Stream is RTSP</description>
+      </entry>
+      <entry value="1" name="VIDEO_STREAM_TYPE_RTPUDP">
+        <description>Stream is RTP UDP (URI gives the port number)</description>
+      </entry>
+      <entry value="2" name="VIDEO_STREAM_TYPE_TCP_MPEG">
+        <description>Stream is MPEG on TCP</description>
+      </entry>
+      <entry value="3" name="VIDEO_STREAM_TYPE_MPEG_TS_H264">
+        <description>Stream is h.264 on MPEG TS (URI gives the port number)</description>
+      </entry>
+    </enum>
+    <enum name="PARAM_ACK">
+      <description>Result from PARAM_EXT_SET message (or a PARAM_SET within a transaction).</description>
+      <entry value="0" name="PARAM_ACK_ACCEPTED">
+        <description>Parameter value ACCEPTED and SET</description>
+      </entry>
+      <entry value="1" name="PARAM_ACK_VALUE_UNSUPPORTED">
+        <description>Parameter value UNKNOWN/UNSUPPORTED</description>
+      </entry>
+      <entry value="2" name="PARAM_ACK_FAILED">
+        <description>Parameter failed to set</description>
+      </entry>
+      <entry value="3" name="PARAM_ACK_IN_PROGRESS">
+        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_ACK_TRANSACTION or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating taht the the parameter was recieved and does not need to be resent.</description>
+      </entry>
+    </enum>
+    <enum name="CAMERA_MODE">
+      <description>Camera Modes.</description>
+      <entry value="0" name="CAMERA_MODE_IMAGE">
+        <description>Camera is in image/photo capture mode.</description>
+      </entry>
+      <entry value="1" name="CAMERA_MODE_VIDEO">
+        <description>Camera is in video capture mode.</description>
+      </entry>
+      <entry value="2" name="CAMERA_MODE_IMAGE_SURVEY">
+        <description>Camera is in image survey capture mode. It allows for camera controller to do specific settings for surveys.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ARM_AUTH_DENIED_REASON">
+      <entry value="0" name="MAV_ARM_AUTH_DENIED_REASON_GENERIC">
+        <description>Not a specific reason</description>
+      </entry>
+      <entry value="1" name="MAV_ARM_AUTH_DENIED_REASON_NONE">
+        <description>Authorizer will send the error as string to GCS</description>
+      </entry>
+      <entry value="2" name="MAV_ARM_AUTH_DENIED_REASON_INVALID_WAYPOINT">
+        <description>At least one waypoint have a invalid value</description>
+      </entry>
+      <entry value="3" name="MAV_ARM_AUTH_DENIED_REASON_TIMEOUT">
+        <description>Timeout in the authorizer process(in case it depends on network)</description>
+      </entry>
+      <entry value="4" name="MAV_ARM_AUTH_DENIED_REASON_AIRSPACE_IN_USE">
+        <description>Airspace of the mission in use by another vehicle, second result parameter can have the waypoint id that caused it to be denied.</description>
+      </entry>
+      <entry value="5" name="MAV_ARM_AUTH_DENIED_REASON_BAD_WEATHER">
+        <description>Weather is not good to fly</description>
+      </entry>
+    </enum>
+    <enum name="RC_TYPE">
+      <description>RC type</description>
+      <entry value="0" name="RC_TYPE_SPEKTRUM_DSM2">
+        <description>Spektrum DSM2</description>
+      </entry>
+      <entry value="1" name="RC_TYPE_SPEKTRUM_DSMX">
+        <description>Spektrum DSMX</description>
+      </entry>
+    </enum>
+    <enum name="POSITION_TARGET_TYPEMASK" bitmask="true">
+      <description>Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 9 is set the floats afx afy afz should be interpreted as force instead of acceleration.</description>
+      <entry value="1" name="POSITION_TARGET_TYPEMASK_X_IGNORE">
+        <description>Ignore position x</description>
+      </entry>
+      <entry value="2" name="POSITION_TARGET_TYPEMASK_Y_IGNORE">
+        <description>Ignore position y</description>
+      </entry>
+      <entry value="4" name="POSITION_TARGET_TYPEMASK_Z_IGNORE">
+        <description>Ignore position z</description>
+      </entry>
+      <entry value="8" name="POSITION_TARGET_TYPEMASK_VX_IGNORE">
+        <description>Ignore velocity x</description>
+      </entry>
+      <entry value="16" name="POSITION_TARGET_TYPEMASK_VY_IGNORE">
+        <description>Ignore velocity y</description>
+      </entry>
+      <entry value="32" name="POSITION_TARGET_TYPEMASK_VZ_IGNORE">
+        <description>Ignore velocity z</description>
+      </entry>
+      <entry value="64" name="POSITION_TARGET_TYPEMASK_AX_IGNORE">
+        <description>Ignore acceleration x</description>
+      </entry>
+      <entry value="128" name="POSITION_TARGET_TYPEMASK_AY_IGNORE">
+        <description>Ignore acceleration y</description>
+      </entry>
+      <entry value="256" name="POSITION_TARGET_TYPEMASK_AZ_IGNORE">
+        <description>Ignore acceleration z</description>
+      </entry>
+      <entry value="512" name="POSITION_TARGET_TYPEMASK_FORCE_SET">
+        <description>Use force instead of acceleration</description>
+      </entry>
+      <entry value="1024" name="POSITION_TARGET_TYPEMASK_YAW_IGNORE">
+        <description>Ignore yaw</description>
+      </entry>
+      <entry value="2048" name="POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE">
+        <description>Ignore yaw rate</description>
+      </entry>
+    </enum>
+    <enum name="ATTITUDE_TARGET_TYPEMASK" bitmask="true">
+      <description>Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b00000000 indicates that none of the setpoint dimensions should be ignored.</description>
+      <entry value="1" name="ATTITUDE_TARGET_TYPEMASK_BODY_ROLL_RATE_IGNORE">
+        <description>Ignore body roll rate</description>
+      </entry>
+      <entry value="2" name="ATTITUDE_TARGET_TYPEMASK_BODY_PITCH_RATE_IGNORE">
+        <description>Ignore body pitch rate</description>
+      </entry>
+      <entry value="4" name="ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE">
+        <description>Ignore body yaw rate</description>
+      </entry>
+      <entry value="64" name="ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE">
+        <description>Ignore throttle</description>
+      </entry>
+      <entry value="128" name="ATTITUDE_TARGET_TYPEMASK_ATTITUDE_IGNORE">
+        <description>Ignore attitude</description>
+      </entry>
+    </enum>
+    <enum name="UTM_FLIGHT_STATE">
+      <description>Airborne status of UAS.</description>
+      <entry value="1" name="UTM_FLIGHT_STATE_UNKNOWN">
+        <description>The flight state can't be determined.</description>
+      </entry>
+      <entry value="2" name="UTM_FLIGHT_STATE_GROUND">
+        <description>UAS on ground.</description>
+      </entry>
+      <entry value="3" name="UTM_FLIGHT_STATE_AIRBORNE">
+        <description>UAS airborne.</description>
+      </entry>
+      <entry value="16" name="UTM_FLIGHT_STATE_EMERGENCY">
+        <description>UAS is in an emergency flight state.</description>
+      </entry>
+      <entry value="32" name="UTM_FLIGHT_STATE_NOCTRL">
+        <description>UAS has no active controls.</description>
+      </entry>
+    </enum>
+    <enum name="UTM_DATA_AVAIL_FLAGS" bitmask="true">
+      <description>Flags for the global position report.</description>
+      <entry value="1" name="UTM_DATA_AVAIL_FLAGS_TIME_VALID">
+        <description>The field time contains valid data.</description>
+      </entry>
+      <entry value="2" name="UTM_DATA_AVAIL_FLAGS_UAS_ID_AVAILABLE">
+        <description>The field uas_id contains valid data.</description>
+      </entry>
+      <entry value="4" name="UTM_DATA_AVAIL_FLAGS_POSITION_AVAILABLE">
+        <description>The fields lat, lon and h_acc contain valid data.</description>
+      </entry>
+      <entry value="8" name="UTM_DATA_AVAIL_FLAGS_ALTITUDE_AVAILABLE">
+        <description>The fields alt and v_acc contain valid data.</description>
+      </entry>
+      <entry value="16" name="UTM_DATA_AVAIL_FLAGS_RELATIVE_ALTITUDE_AVAILABLE">
+        <description>The field relative_alt contains valid data.</description>
+      </entry>
+      <entry value="32" name="UTM_DATA_AVAIL_FLAGS_HORIZONTAL_VELO_AVAILABLE">
+        <description>The fields vx and vy contain valid data.</description>
+      </entry>
+      <entry value="64" name="UTM_DATA_AVAIL_FLAGS_VERTICAL_VELO_AVAILABLE">
+        <description>The field vz contains valid data.</description>
+      </entry>
+      <entry value="128" name="UTM_DATA_AVAIL_FLAGS_NEXT_WAYPOINT_AVAILABLE">
+        <description>The fields next_lat, next_lon and next_alt contain valid data.</description>
+      </entry>
+    </enum>
+    <enum name="PRECISION_LAND_MODE">
+      <description>Precision land modes (used in MAV_CMD_NAV_LAND).</description>
+      <entry value="0" name="PRECISION_LAND_MODE_DISABLED">
+        <description>Normal (non-precision) landing.</description>
+      </entry>
+      <entry value="1" name="PRECISION_LAND_MODE_OPPORTUNISTIC">
+        <description>Use precision landing if beacon detected when land command accepted, otherwise land normally.</description>
+      </entry>
+      <entry value="2" name="PRECISION_LAND_MODE_REQUIRED">
+        <description>Use precision landing, searching for beacon if not found when land command accepted (land normally if beacon cannot be found).</description>
+      </entry>
+    </enum>
+    <!-- parachute action enum -->
+    <enum name="PARACHUTE_ACTION">
+      <description>Parachute actions. Trigger release and enable/disable auto-release.</description>
+      <entry value="0" name="PARACHUTE_DISABLE">
+        <description>Disable auto-release of parachute (i.e. release triggered by crash detectors).</description>
+      </entry>
+      <entry value="1" name="PARACHUTE_ENABLE">
+        <description>Enable auto-release of parachute.</description>
+      </entry>
+      <entry value="2" name="PARACHUTE_RELEASE">
+        <description>Release parachute and kill motors.</description>
+      </entry>
+    </enum>
+    <!-- TUNNEL related enums, used by STorM32 gimbal-->
+    <enum name="MAV_TUNNEL_PAYLOAD_TYPE">
+      <entry value="0" name="MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN">
+        <description>Encoding of payload unknown.</description>
+      </entry>
+      <entry value="200" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED0">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="201" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED1">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="202" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED2">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="203" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED3">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="204" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED4">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="205" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED5">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="206" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED6">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="207" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED7">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="208" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED8">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="209" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED9">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_ID_TYPE">
+      <entry value="0" name="MAV_ODID_ID_TYPE_NONE">
+        <description>No type defined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_ID_TYPE_SERIAL_NUMBER">
+        <description>Manufacturer Serial Number (ANSI/CTA-2063 format).</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_ID_TYPE_CAA_REGISTRATION_ID">
+        <description>CAA (Civil Aviation Authority) registered ID. Format: [ICAO Country Code].[CAA Assigned ID].</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_ID_TYPE_UTM_ASSIGNED_UUID">
+        <description>UTM (Unmanned Traffic Management) assigned UUID (RFC4122).</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_ID_TYPE_SPECIFIC_SESSION_ID">
+        <description>A 20 byte ID for a specific flight/session. The exact ID type is indicated by the first byte of uas_id and these type values are managed by ICAO.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_UA_TYPE">
+      <entry value="0" name="MAV_ODID_UA_TYPE_NONE">
+        <description>No UA (Unmanned Aircraft) type defined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_UA_TYPE_AEROPLANE">
+        <description>Aeroplane/Airplane. Fixed wing.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR">
+        <description>Helicopter or multirotor.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_UA_TYPE_GYROPLANE">
+        <description>Gyroplane.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_UA_TYPE_HYBRID_LIFT">
+        <description>VTOL (Vertical Take-Off and Landing). Fixed wing aircraft that can take off vertically.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_UA_TYPE_ORNITHOPTER">
+        <description>Ornithopter.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_UA_TYPE_GLIDER">
+        <description>Glider.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_UA_TYPE_KITE">
+        <description>Kite.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_UA_TYPE_FREE_BALLOON">
+        <description>Free Balloon.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_UA_TYPE_CAPTIVE_BALLOON">
+        <description>Captive Balloon.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_UA_TYPE_AIRSHIP">
+        <description>Airship. E.g. a blimp.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_UA_TYPE_FREE_FALL_PARACHUTE">
+        <description>Free Fall/Parachute (unpowered).</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_UA_TYPE_ROCKET">
+        <description>Rocket.</description>
+      </entry>
+      <entry value="13" name="MAV_ODID_UA_TYPE_TETHERED_POWERED_AIRCRAFT">
+        <description>Tethered powered aircraft.</description>
+      </entry>
+      <entry value="14" name="MAV_ODID_UA_TYPE_GROUND_OBSTACLE">
+        <description>Ground Obstacle.</description>
+      </entry>
+      <entry value="15" name="MAV_ODID_UA_TYPE_OTHER">
+        <description>Other type of aircraft not listed earlier.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_STATUS">
+      <entry value="0" name="MAV_ODID_STATUS_UNDECLARED">
+        <description>The status of the (UA) Unmanned Aircraft is undefined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_STATUS_GROUND">
+        <description>The UA is on the ground.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_STATUS_AIRBORNE">
+        <description>The UA is in the air.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_STATUS_EMERGENCY">
+        <description>The UA is having an emergency.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_HEIGHT_REF">
+      <entry value="0" name="MAV_ODID_HEIGHT_REF_OVER_TAKEOFF">
+        <description>The height field is relative to the take-off location.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_HEIGHT_REF_OVER_GROUND">
+        <description>The height field is relative to ground.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_HOR_ACC">
+      <entry value="0" name="MAV_ODID_HOR_ACC_UNKNOWN">
+        <description>The horizontal accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_HOR_ACC_10NM">
+        <description>The horizontal accuracy is smaller than 10 Nautical Miles. 18.52 km.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_HOR_ACC_4NM">
+        <description>The horizontal accuracy is smaller than 4 Nautical Miles. 7.408 km.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_HOR_ACC_2NM">
+        <description>The horizontal accuracy is smaller than 2 Nautical Miles. 3.704 km.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_HOR_ACC_1NM">
+        <description>The horizontal accuracy is smaller than 1 Nautical Miles. 1.852 km.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_HOR_ACC_0_5NM">
+        <description>The horizontal accuracy is smaller than 0.5 Nautical Miles. 926 m.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_HOR_ACC_0_3NM">
+        <description>The horizontal accuracy is smaller than 0.3 Nautical Miles. 555.6 m.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_HOR_ACC_0_1NM">
+        <description>The horizontal accuracy is smaller than 0.1 Nautical Miles. 185.2 m.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_HOR_ACC_0_05NM">
+        <description>The horizontal accuracy is smaller than 0.05 Nautical Miles. 92.6 m.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_HOR_ACC_30_METER">
+        <description>The horizontal accuracy is smaller than 30 meter.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_HOR_ACC_10_METER">
+        <description>The horizontal accuracy is smaller than 10 meter.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_HOR_ACC_3_METER">
+        <description>The horizontal accuracy is smaller than 3 meter.</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_HOR_ACC_1_METER">
+        <description>The horizontal accuracy is smaller than 1 meter.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_VER_ACC">
+      <entry value="0" name="MAV_ODID_VER_ACC_UNKNOWN">
+        <description>The vertical accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_VER_ACC_150_METER">
+        <description>The vertical accuracy is smaller than 150 meter.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_VER_ACC_45_METER">
+        <description>The vertical accuracy is smaller than 45 meter.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_VER_ACC_25_METER">
+        <description>The vertical accuracy is smaller than 25 meter.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_VER_ACC_10_METER">
+        <description>The vertical accuracy is smaller than 10 meter.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_VER_ACC_3_METER">
+        <description>The vertical accuracy is smaller than 3 meter.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_VER_ACC_1_METER">
+        <description>The vertical accuracy is smaller than 1 meter.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_SPEED_ACC">
+      <entry value="0" name="MAV_ODID_SPEED_ACC_UNKNOWN">
+        <description>The speed accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_SPEED_ACC_10_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 10 meters per second.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_SPEED_ACC_3_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 3 meters per second.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_SPEED_ACC_1_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 1 meters per second.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_SPEED_ACC_0_3_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 0.3 meters per second.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_TIME_ACC">
+      <entry value="0" name="MAV_ODID_TIME_ACC_UNKNOWN">
+        <description>The timestamp accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_TIME_ACC_0_1_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.1 second.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_TIME_ACC_0_2_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.2 second.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_TIME_ACC_0_3_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.3 second.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_TIME_ACC_0_4_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.4 second.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_TIME_ACC_0_5_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.5 second.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_TIME_ACC_0_6_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.6 second.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_TIME_ACC_0_7_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.7 second.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_TIME_ACC_0_8_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.8 second.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_TIME_ACC_0_9_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 0.9 second.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_TIME_ACC_1_0_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.0 second.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_TIME_ACC_1_1_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.1 second.</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_TIME_ACC_1_2_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.2 second.</description>
+      </entry>
+      <entry value="13" name="MAV_ODID_TIME_ACC_1_3_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.3 second.</description>
+      </entry>
+      <entry value="14" name="MAV_ODID_TIME_ACC_1_4_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.4 second.</description>
+      </entry>
+      <entry value="15" name="MAV_ODID_TIME_ACC_1_5_SECOND">
+        <description>The timestamp accuracy is smaller than or equal to 1.5 second.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_AUTH_TYPE">
+      <entry value="0" name="MAV_ODID_AUTH_TYPE_NONE">
+        <description>No authentication type is specified.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_AUTH_TYPE_UAS_ID_SIGNATURE">
+        <description>Signature for the UAS (Unmanned Aircraft System) ID.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_AUTH_TYPE_OPERATOR_ID_SIGNATURE">
+        <description>Signature for the Operator ID.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_AUTH_TYPE_MESSAGE_SET_SIGNATURE">
+        <description>Signature for the entire message set.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_AUTH_TYPE_NETWORK_REMOTE_ID">
+        <description>Authentication is provided by Network Remote ID.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_AUTH_TYPE_SPECIFIC_AUTHENTICATION">
+        <description>The exact authentication type is indicated by the first byte of authentication_data and these type values are managed by ICAO.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_DESC_TYPE">
+      <entry value="0" name="MAV_ODID_DESC_TYPE_TEXT">
+        <description>Free-form text description of the purpose of the flight.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_DESC_TYPE_EMERGENCY">
+        <description>Optional additional clarification when status == MAV_ODID_STATUS_EMERGENCY.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_DESC_TYPE_EXTENDED_STATUS">
+        <description>Optional additional clarification when status != MAV_ODID_STATUS_EMERGENCY.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_OPERATOR_LOCATION_TYPE">
+      <entry value="0" name="MAV_ODID_OPERATOR_LOCATION_TYPE_TAKEOFF">
+        <description>The location of the operator is the same as the take-off location.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_OPERATOR_LOCATION_TYPE_LIVE_GNSS">
+        <description>The location of the operator is based on live GNSS data.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_OPERATOR_LOCATION_TYPE_FIXED">
+        <description>The location of the operator is a fixed location.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_CLASSIFICATION_TYPE">
+      <entry value="0" name="MAV_ODID_CLASSIFICATION_TYPE_UNDECLARED">
+        <description>The classification type for the UA is undeclared.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_CLASSIFICATION_TYPE_EU">
+        <description>The classification type for the UA follows EU (European Union) specifications.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_CATEGORY_EU">
+      <entry value="0" name="MAV_ODID_CATEGORY_EU_UNDECLARED">
+        <description>The category for the UA, according to the EU specification, is undeclared.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_CATEGORY_EU_OPEN">
+        <description>The category for the UA, according to the EU specification, is the Open category.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_CATEGORY_EU_SPECIFIC">
+        <description>The category for the UA, according to the EU specification, is the Specific category.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_CATEGORY_EU_CERTIFIED">
+        <description>The category for the UA, according to the EU specification, is the Certified category.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_CLASS_EU">
+      <entry value="0" name="MAV_ODID_CLASS_EU_UNDECLARED">
+        <description>The class for the UA, according to the EU specification, is undeclared.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_CLASS_EU_CLASS_0">
+        <description>The class for the UA, according to the EU specification, is Class 0.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_CLASS_EU_CLASS_1">
+        <description>The class for the UA, according to the EU specification, is Class 1.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_CLASS_EU_CLASS_2">
+        <description>The class for the UA, according to the EU specification, is Class 2.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_CLASS_EU_CLASS_3">
+        <description>The class for the UA, according to the EU specification, is Class 3.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_CLASS_EU_CLASS_4">
+        <description>The class for the UA, according to the EU specification, is Class 4.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_CLASS_EU_CLASS_5">
+        <description>The class for the UA, according to the EU specification, is Class 5.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_CLASS_EU_CLASS_6">
+        <description>The class for the UA, according to the EU specification, is Class 6.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_OPERATOR_ID_TYPE">
+      <entry value="0" name="MAV_ODID_OPERATOR_ID_TYPE_CAA">
+        <description>CAA (Civil Aviation Authority) registered operator ID.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_ARM_STATUS">
+      <entry value="0" name="MAV_ODID_GOOD_TO_ARM">
+        <description>Passing arming checks.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_PRE_ARM_FAIL_GENERIC">
+        <description>Generic arming failure, see error string for details.</description>
+      </entry>
+    </enum>
+    <!-- AIS related enums-->
+    <enum name="AIS_TYPE">
+      <description>Type of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html</description>
+      <entry value="0" name="AIS_TYPE_UNKNOWN">
+        <description>Not available (default).</description>
+      </entry>
+      <entry value="1" name="AIS_TYPE_RESERVED_1"/>
+      <entry value="2" name="AIS_TYPE_RESERVED_2"/>
+      <entry value="3" name="AIS_TYPE_RESERVED_3"/>
+      <entry value="4" name="AIS_TYPE_RESERVED_4"/>
+      <entry value="5" name="AIS_TYPE_RESERVED_5"/>
+      <entry value="6" name="AIS_TYPE_RESERVED_6"/>
+      <entry value="7" name="AIS_TYPE_RESERVED_7"/>
+      <entry value="8" name="AIS_TYPE_RESERVED_8"/>
+      <entry value="9" name="AIS_TYPE_RESERVED_9"/>
+      <entry value="10" name="AIS_TYPE_RESERVED_10"/>
+      <entry value="11" name="AIS_TYPE_RESERVED_11"/>
+      <entry value="12" name="AIS_TYPE_RESERVED_12"/>
+      <entry value="13" name="AIS_TYPE_RESERVED_13"/>
+      <entry value="14" name="AIS_TYPE_RESERVED_14"/>
+      <entry value="15" name="AIS_TYPE_RESERVED_15"/>
+      <entry value="16" name="AIS_TYPE_RESERVED_16"/>
+      <entry value="17" name="AIS_TYPE_RESERVED_17"/>
+      <entry value="18" name="AIS_TYPE_RESERVED_18"/>
+      <entry value="19" name="AIS_TYPE_RESERVED_19"/>
+      <entry value="20" name="AIS_TYPE_WIG">
+        <description>Wing In Ground effect.</description>
+      </entry>
+      <entry value="21" name="AIS_TYPE_WIG_HAZARDOUS_A"/>
+      <entry value="22" name="AIS_TYPE_WIG_HAZARDOUS_B"/>
+      <entry value="23" name="AIS_TYPE_WIG_HAZARDOUS_C"/>
+      <entry value="24" name="AIS_TYPE_WIG_HAZARDOUS_D"/>
+      <entry value="25" name="AIS_TYPE_WIG_RESERVED_1"/>
+      <entry value="26" name="AIS_TYPE_WIG_RESERVED_2"/>
+      <entry value="27" name="AIS_TYPE_WIG_RESERVED_3"/>
+      <entry value="28" name="AIS_TYPE_WIG_RESERVED_4"/>
+      <entry value="29" name="AIS_TYPE_WIG_RESERVED_5"/>
+      <entry value="30" name="AIS_TYPE_FISHING"/>
+      <entry value="31" name="AIS_TYPE_TOWING"/>
+      <entry value="32" name="AIS_TYPE_TOWING_LARGE">
+        <description>Towing: length exceeds 200m or breadth exceeds 25m.</description>
+      </entry>
+      <entry value="33" name="AIS_TYPE_DREDGING">
+        <description>Dredging or other underwater ops.</description>
+      </entry>
+      <entry value="34" name="AIS_TYPE_DIVING"/>
+      <entry value="35" name="AIS_TYPE_MILITARY"/>
+      <entry value="36" name="AIS_TYPE_SAILING"/>
+      <entry value="37" name="AIS_TYPE_PLEASURE"/>
+      <entry value="38" name="AIS_TYPE_RESERVED_20"/>
+      <entry value="39" name="AIS_TYPE_RESERVED_21"/>
+      <entry value="40" name="AIS_TYPE_HSC">
+        <description>High Speed Craft.</description>
+      </entry>
+      <entry value="41" name="AIS_TYPE_HSC_HAZARDOUS_A"/>
+      <entry value="42" name="AIS_TYPE_HSC_HAZARDOUS_B"/>
+      <entry value="43" name="AIS_TYPE_HSC_HAZARDOUS_C"/>
+      <entry value="44" name="AIS_TYPE_HSC_HAZARDOUS_D"/>
+      <entry value="45" name="AIS_TYPE_HSC_RESERVED_1"/>
+      <entry value="46" name="AIS_TYPE_HSC_RESERVED_2"/>
+      <entry value="47" name="AIS_TYPE_HSC_RESERVED_3"/>
+      <entry value="48" name="AIS_TYPE_HSC_RESERVED_4"/>
+      <entry value="49" name="AIS_TYPE_HSC_UNKNOWN"/>
+      <entry value="50" name="AIS_TYPE_PILOT"/>
+      <entry value="51" name="AIS_TYPE_SAR">
+        <description>Search And Rescue vessel.</description>
+      </entry>
+      <entry value="52" name="AIS_TYPE_TUG"/>
+      <entry value="53" name="AIS_TYPE_PORT_TENDER"/>
+      <entry value="54" name="AIS_TYPE_ANTI_POLLUTION">
+        <description>Anti-pollution equipment.</description>
+      </entry>
+      <entry value="55" name="AIS_TYPE_LAW_ENFORCEMENT"/>
+      <entry value="56" name="AIS_TYPE_SPARE_LOCAL_1"/>
+      <entry value="57" name="AIS_TYPE_SPARE_LOCAL_2"/>
+      <entry value="58" name="AIS_TYPE_MEDICAL_TRANSPORT"/>
+      <entry value="59" name="AIS_TYPE_NONECOMBATANT">
+        <description>Noncombatant ship according to RR Resolution No. 18.</description>
+      </entry>
+      <entry value="60" name="AIS_TYPE_PASSENGER"/>
+      <entry value="61" name="AIS_TYPE_PASSENGER_HAZARDOUS_A"/>
+      <entry value="62" name="AIS_TYPE_PASSENGER_HAZARDOUS_B"/>
+      <entry value="63" name="AIS_TYPE_AIS_TYPE_PASSENGER_HAZARDOUS_C"/>
+      <entry value="64" name="AIS_TYPE_PASSENGER_HAZARDOUS_D"/>
+      <entry value="65" name="AIS_TYPE_PASSENGER_RESERVED_1"/>
+      <entry value="66" name="AIS_TYPE_PASSENGER_RESERVED_2"/>
+      <entry value="67" name="AIS_TYPE_PASSENGER_RESERVED_3"/>
+      <entry value="68" name="AIS_TYPE_AIS_TYPE_PASSENGER_RESERVED_4"/>
+      <entry value="69" name="AIS_TYPE_PASSENGER_UNKNOWN"/>
+      <entry value="70" name="AIS_TYPE_CARGO"/>
+      <entry value="71" name="AIS_TYPE_CARGO_HAZARDOUS_A"/>
+      <entry value="72" name="AIS_TYPE_CARGO_HAZARDOUS_B"/>
+      <entry value="73" name="AIS_TYPE_CARGO_HAZARDOUS_C"/>
+      <entry value="74" name="AIS_TYPE_CARGO_HAZARDOUS_D"/>
+      <entry value="75" name="AIS_TYPE_CARGO_RESERVED_1"/>
+      <entry value="76" name="AIS_TYPE_CARGO_RESERVED_2"/>
+      <entry value="77" name="AIS_TYPE_CARGO_RESERVED_3"/>
+      <entry value="78" name="AIS_TYPE_CARGO_RESERVED_4"/>
+      <entry value="79" name="AIS_TYPE_CARGO_UNKNOWN"/>
+      <entry value="80" name="AIS_TYPE_TANKER"/>
+      <entry value="81" name="AIS_TYPE_TANKER_HAZARDOUS_A"/>
+      <entry value="82" name="AIS_TYPE_TANKER_HAZARDOUS_B"/>
+      <entry value="83" name="AIS_TYPE_TANKER_HAZARDOUS_C"/>
+      <entry value="84" name="AIS_TYPE_TANKER_HAZARDOUS_D"/>
+      <entry value="85" name="AIS_TYPE_TANKER_RESERVED_1"/>
+      <entry value="86" name="AIS_TYPE_TANKER_RESERVED_2"/>
+      <entry value="87" name="AIS_TYPE_TANKER_RESERVED_3"/>
+      <entry value="88" name="AIS_TYPE_TANKER_RESERVED_4"/>
+      <entry value="89" name="AIS_TYPE_TANKER_UNKNOWN"/>
+      <entry value="90" name="AIS_TYPE_OTHER"/>
+      <entry value="91" name="AIS_TYPE_OTHER_HAZARDOUS_A"/>
+      <entry value="92" name="AIS_TYPE_OTHER_HAZARDOUS_B"/>
+      <entry value="93" name="AIS_TYPE_OTHER_HAZARDOUS_C"/>
+      <entry value="94" name="AIS_TYPE_OTHER_HAZARDOUS_D"/>
+      <entry value="95" name="AIS_TYPE_OTHER_RESERVED_1"/>
+      <entry value="96" name="AIS_TYPE_OTHER_RESERVED_2"/>
+      <entry value="97" name="AIS_TYPE_OTHER_RESERVED_3"/>
+      <entry value="98" name="AIS_TYPE_OTHER_RESERVED_4"/>
+      <entry value="99" name="AIS_TYPE_OTHER_UNKNOWN"/>
+    </enum>
+    <enum name="AIS_NAV_STATUS">
+      <description>Navigational status of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html</description>
+      <entry value="0" name="UNDER_WAY">
+        <description>Under way using engine.</description>
+      </entry>
+      <entry value="1" name="AIS_NAV_ANCHORED"/>
+      <entry value="2" name="AIS_NAV_UN_COMMANDED"/>
+      <entry value="3" name="AIS_NAV_RESTRICTED_MANOEUVERABILITY"/>
+      <entry value="4" name="AIS_NAV_DRAUGHT_CONSTRAINED"/>
+      <entry value="5" name="AIS_NAV_MOORED"/>
+      <entry value="6" name="AIS_NAV_AGROUND"/>
+      <entry value="7" name="AIS_NAV_FISHING"/>
+      <entry value="8" name="AIS_NAV_SAILING"/>
+      <entry value="9" name="AIS_NAV_RESERVED_HSC"/>
+      <entry value="10" name="AIS_NAV_RESERVED_WIG"/>
+      <entry value="11" name="AIS_NAV_RESERVED_1"/>
+      <entry value="12" name="AIS_NAV_RESERVED_2"/>
+      <entry value="13" name="AIS_NAV_RESERVED_3"/>
+      <entry value="14" name="AIS_NAV_AIS_SART">
+        <description>Search And Rescue Transponder.</description>
+      </entry>
+      <entry value="15" name="AIS_NAV_UNKNOWN">
+        <description>Not available (default).</description>
+      </entry>
+    </enum>
+    <enum name="AIS_FLAGS" bitmask="true">
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>These flags are used in the AIS_VESSEL.fields bitmask to indicate validity of data in the other message fields. When set, the data is valid.</description>
+      <entry value="1" name="AIS_FLAGS_POSITION_ACCURACY">
+        <description>1 = Position accuracy less than 10m, 0 = position accuracy greater than 10m.</description>
+      </entry>
+      <entry value="2" name="AIS_FLAGS_VALID_COG"/>
+      <entry value="4" name="AIS_FLAGS_VALID_VELOCITY"/>
+      <entry value="8" name="AIS_FLAGS_HIGH_VELOCITY">
+        <description>1 = Velocity over 52.5765m/s (102.2 knots)</description>
+      </entry>
+      <entry value="16" name="AIS_FLAGS_VALID_TURN_RATE"/>
+      <entry value="32" name="AIS_FLAGS_TURN_RATE_SIGN_ONLY">
+        <description>Only the sign of the returned turn rate value is valid, either greater than 5deg/30s or less than -5deg/30s</description>
+      </entry>
+      <entry value="64" name="AIS_FLAGS_VALID_DIMENSIONS"/>
+      <entry value="128" name="AIS_FLAGS_LARGE_BOW_DIMENSION">
+        <description>Distance to bow is larger than 511m</description>
+      </entry>
+      <entry value="256" name="AIS_FLAGS_LARGE_STERN_DIMENSION">
+        <description>Distance to stern is larger than 511m</description>
+      </entry>
+      <entry value="512" name="AIS_FLAGS_LARGE_PORT_DIMENSION">
+        <description>Distance to port side is larger than 63m</description>
+      </entry>
+      <entry value="1024" name="AIS_FLAGS_LARGE_STARBOARD_DIMENSION">
+        <description>Distance to starboard side is larger than 63m</description>
+      </entry>
+      <entry value="2048" name="AIS_FLAGS_VALID_CALLSIGN"/>
+      <entry value="4096" name="AIS_FLAGS_VALID_NAME"/>
+    </enum>
+    <enum name="MAV_WINCH_STATUS_FLAG" bitmask="true">
+      <description>Winch status flags used in WINCH_STATUS</description>
+      <entry value="1" name="MAV_WINCH_STATUS_HEALTHY">
+        <description>Winch is healthy</description>
+      </entry>
+      <entry value="2" name="MAV_WINCH_STATUS_FULLY_RETRACTED">
+        <description>Winch thread is fully retracted</description>
+      </entry>
+      <entry value="4" name="MAV_WINCH_STATUS_MOVING">
+        <description>Winch motor is moving</description>
+      </entry>
+      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
+        <description>Winch clutch is engaged allowing motor to move freely</description>
+      </entry>
+    </enum>
+    <enum name="MAG_CAL_STATUS">
+      <entry value="0" name="MAG_CAL_NOT_STARTED"/>
+      <entry value="1" name="MAG_CAL_WAITING_TO_START"/>
+      <entry value="2" name="MAG_CAL_RUNNING_STEP_ONE"/>
+      <entry value="3" name="MAG_CAL_RUNNING_STEP_TWO"/>
+      <entry value="4" name="MAG_CAL_SUCCESS"/>
+      <entry value="5" name="MAG_CAL_FAILED"/>
+      <entry value="6" name="MAG_CAL_BAD_ORIENTATION"/>
+      <entry value="7" name="MAG_CAL_BAD_RADIUS"/>
+    </enum>
+    <enum name="CAN_FILTER_OP">
+      <entry value="0" name="CAN_FILTER_REPLACE"/>
+      <entry value="1" name="CAN_FILTER_ADD"/>
+      <entry value="2" name="CAN_FILTER_REMOVE"/>
+    </enum>
+    <enum name="NAV_VTOL_LAND_OPTIONS">
+      <entry value="0" name="NAV_VTOL_LAND_OPTIONS_DEFAULT">
+        <description>Default autopilot landing behaviour.</description>
+      </entry>
+      <entry value="1" name="NAV_VTOL_LAND_OPTIONS_FW_SPIRAL_APPROACH">
+        <description>Use a fixed wing spiral desent approach before landing.</description>
+      </entry>
+      <entry value="2" name="NAV_VTOL_LAND_OPTIONS_FW_APPROACH">
+        <description>Use a fixed wing approach before detransitioning and landing vertically.</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="1" name="SYS_STATUS">
+      <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows whether the system is currently active or not and if an emergency occurred. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occurred it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
+      <field type="uint32_t" name="onboard_control_sensors_present" enum="MAV_SYS_STATUS_SENSOR" display="bitmask" print_format="0x%04x">Bitmap showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present.</field>
+      <field type="uint32_t" name="onboard_control_sensors_enabled" enum="MAV_SYS_STATUS_SENSOR" display="bitmask" print_format="0x%04x">Bitmap showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled.</field>
+      <field type="uint32_t" name="onboard_control_sensors_health" enum="MAV_SYS_STATUS_SENSOR" display="bitmask" print_format="0x%04x">Bitmap showing which onboard controllers and sensors have an error (or are operational). Value of 0: error. Value of 1: healthy.</field>
+      <field type="uint16_t" name="load" units="d%">Maximum usage in percent of the mainloop time. Values: [0-1000] - should always be below 1000</field>
+      <field type="uint16_t" name="voltage_battery" units="mV">Battery voltage, UINT16_MAX: Voltage not sent by autopilot</field>
+      <field type="int16_t" name="current_battery" units="cA">Battery current, -1: Current not sent by autopilot</field>
+      <field type="int8_t" name="battery_remaining" units="%">Battery energy remaining, -1: Battery remaining energy not sent by autopilot</field>
+      <field type="uint16_t" name="drop_rate_comm" units="c%">Communication drop rate, (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+      <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+      <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
+    </message>
+    <message id="2" name="SYSTEM_TIME">
+      <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
+      <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+    </message>
+    <message id="4" name="PING">
+      <deprecated since="2011-08" replaced_by="SYSTEM_TIME">to be removed / merged with SYSTEM_TIME</deprecated>
+      <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections. The ping microservice is documented at https://mavlink.io/en/services/ping.html</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint32_t" name="seq">PING sequence</field>
+      <field type="uint8_t" name="target_system">0: request ping from all receiving systems. If greater than 0: message is a ping response and number is the system id of the requesting system</field>
+      <field type="uint8_t" name="target_component">0: request ping from all receiving components. If greater than 0: message is a ping response and number is the component id of the requesting component.</field>
+    </message>
+    <message id="5" name="CHANGE_OPERATOR_CONTROL">
+      <description>Request to control this MAV</description>
+      <field type="uint8_t" name="target_system">System the GCS requests control for</field>
+      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+      <field type="uint8_t" name="version" units="rad">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
+      <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
+    </message>
+    <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
+      <description>Accept / deny control of this MAV</description>
+      <field type="uint8_t" name="gcs_system_id">ID of the GCS this message </field>
+      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+      <field type="uint8_t" name="ack">0: ACK, 1: NACK: Wrong passkey, 2: NACK: Unsupported passkey encryption method, 3: NACK: Already under control</field>
+    </message>
+    <message id="7" name="AUTH_KEY">
+      <description>Emit an encrypted signature / key identifying this system. PLEASE NOTE: This protocol has been kept simple, so transmitting the key requires an encrypted channel for true safety.</description>
+      <field type="char[32]" name="key">key</field>
+    </message>
+    <message id="11" name="SET_MODE">
+      <deprecated since="2015-12" replaced_by="MAV_CMD_DO_SET_MODE">Use COMMAND_LONG with MAV_CMD_DO_SET_MODE instead</deprecated>
+      <description>Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
+      <field type="uint8_t" name="target_system">The system setting the mode</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode.</field>
+      <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
+    </message>
+    <!-- IDs 15-17 reserved for PARAM_VALUE_UNION and other param messages -->
+    <!-- IDs 19 reserved for PARAM_ACK_TRANSACTION (development.xml) -->
+    <message id="20" name="PARAM_REQUEST_READ">
+      <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -&gt; value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also https://mavlink.io/en/services/parameter.html for a full documentation of QGroundControl and IMU code.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
+    </message>
+    <message id="21" name="PARAM_REQUEST_LIST">
+      <description>Request all parameters of this component. After this request, all parameters are emitted. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="22" name="PARAM_VALUE">
+      <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float" name="param_value">Onboard parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
+      <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
+      <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
+    </message>
+    <message id="23" name="PARAM_SET">
+      <description>Set a parameter value (write new value to permanent storage).
+        The receiving component should acknowledge the new parameter value by broadcasting a PARAM_VALUE message (broadcasting ensures that multiple GCS all have an up-to-date list of all parameters). If the sending GCS did not receive a PARAM_VALUE within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html.
+        </description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float" name="param_value">Onboard parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
+    </message>
+    <message id="24" name="GPS_RAW_INT">
+      <description>The global position, as returned by the Global Positioning System (GPS). This is
+                NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GPS fix type.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84, EGM96 ellipsoid)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84, EGM96 ellipsoid)</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up. Note that virtually all GPS modules provide the MSL altitude in addition to the WGS84 altitude.</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="cog" units="cdeg">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+      <extensions/>
+      <field type="int32_t" name="alt_ellipsoid" units="mm">Altitude (above WGS84, EGM96 ellipsoid). Positive for up.</field>
+      <field type="uint32_t" name="h_acc" units="mm">Position uncertainty.</field>
+      <field type="uint32_t" name="v_acc" units="mm">Altitude uncertainty.</field>
+      <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
+      <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
+    </message>
+    <message id="25" name="GPS_STATUS">
+      <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible</field>
+      <field type="uint8_t[20]" name="satellite_prn">Global satellite ID</field>
+      <field type="uint8_t[20]" name="satellite_used">0: Satellite not used, 1: used for localization</field>
+      <field type="uint8_t[20]" name="satellite_elevation" units="deg">Elevation (0: right on top of receiver, 90: on the horizon) of satellite</field>
+      <field type="uint8_t[20]" name="satellite_azimuth" units="deg">Direction of satellite, 0: 0 deg, 255: 360 deg.</field>
+      <field type="uint8_t[20]" name="satellite_snr" units="dB">Signal to noise ratio of satellite</field>
+    </message>
+    <message id="26" name="SCALED_IMU">
+      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration</field>
+      <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
+      <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
+      <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>
+    </message>
+    <message id="27" name="RAW_IMU">
+      <description>The RAW IMU readings for a 9DOF sensor, which is identified by the id (default IMU1). This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="int16_t" name="xacc">X acceleration (raw)</field>
+      <field type="int16_t" name="yacc">Y acceleration (raw)</field>
+      <field type="int16_t" name="zacc">Z acceleration (raw)</field>
+      <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
+      <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
+      <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
+      <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
+      <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
+      <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
+      <extensions/>
+      <field type="uint8_t" name="id" instance="true">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>
+    </message>
+    <message id="28" name="RAW_PRESSURE">
+      <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
+      <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistent)</field>
+      <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistent)</field>
+      <field type="int16_t" name="temperature">Raw Temperature measurement (raw)</field>
+    </message>
+    <message id="29" name="SCALED_PRESSURE">
+      <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
+      <field type="float" name="press_diff" units="hPa">Differential pressure 1</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
+    </message>
+    <message id="30" name="ATTITUDE">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="roll" units="rad">Roll angle (-pi..+pi)</field>
+      <field type="float" name="pitch" units="rad">Pitch angle (-pi..+pi)</field>
+      <field type="float" name="yaw" units="rad">Yaw angle (-pi..+pi)</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
+    </message>
+    <message id="31" name="ATTITUDE_QUATERNION">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
+      <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
+      <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
+      <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
+      <extensions/>
+      <field type="float[4]" name="repr_offset_q">Rotation offset by which the attitude quaternion and angular speed vector should be rotated for user display (quaternion with [w, x, y, z] order, zero-rotation is [1, 0, 0, 0], send [0, 0, 0, 0] if field not supported). This field is intended for systems in which the reference attitude may change during flight. For example, tailsitters VTOLs rotate their reference attitude by 90 degrees between hover mode and fixed wing mode, thus repr_offset_q is equal to [1, 0, 0, 0] in hover mode and equal to [0.7071, 0, 0.7071, 0] in fixed wing mode.</field>
+    </message>
+    <message id="32" name="LOCAL_POSITION_NED">
+      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="x" units="m">X Position</field>
+      <field type="float" name="y" units="m">Y Position</field>
+      <field type="float" name="z" units="m">Z Position</field>
+      <field type="float" name="vx" units="m/s">X Speed</field>
+      <field type="float" name="vy" units="m/s">Y Speed</field>
+      <field type="float" name="vz" units="m/s">Z Speed</field>
+    </message>
+    <message id="33" name="GLOBAL_POSITION_INT">
+      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
+               is designed as scaled integer message since the resolution of float is not sufficient.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude, expressed</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Note that virtually all GPS modules provide both WGS84 and MSL.</field>
+      <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+      <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude, positive north)</field>
+      <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude, positive east)</field>
+      <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude, positive down)</field>
+      <field type="uint16_t" name="hdg" units="cdeg">Vehicle heading (yaw angle), 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+    </message>
+    <message id="34" name="RC_CHANNELS_SCALED">
+      <description>The scaled values of the RC channels received: (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
+      <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled.</field>
+      <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled.</field>
+      <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled.</field>
+      <field type="int16_t" name="chan4_scaled">RC channel 4 value scaled.</field>
+      <field type="int16_t" name="chan5_scaled">RC channel 5 value scaled.</field>
+      <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled.</field>
+      <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled.</field>
+      <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+    </message>
+    <message id="35" name="RC_CHANNELS_RAW">
+      <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. A value of UINT16_MAX implies the channel is unused. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
+      <field type="uint16_t" name="chan1_raw" units="us">RC channel 1 value.</field>
+      <field type="uint16_t" name="chan2_raw" units="us">RC channel 2 value.</field>
+      <field type="uint16_t" name="chan3_raw" units="us">RC channel 3 value.</field>
+      <field type="uint16_t" name="chan4_raw" units="us">RC channel 4 value.</field>
+      <field type="uint16_t" name="chan5_raw" units="us">RC channel 5 value.</field>
+      <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value.</field>
+      <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value.</field>
+      <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+    </message>
+    <message id="36" name="SERVO_OUTPUT_RAW">
+      <description>Superseded by ACTUATOR_OUTPUT_STATUS. The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
+      <field type="uint32_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
+      <field type="uint16_t" name="servo1_raw" units="us">Servo output 1 value</field>
+      <field type="uint16_t" name="servo2_raw" units="us">Servo output 2 value</field>
+      <field type="uint16_t" name="servo3_raw" units="us">Servo output 3 value</field>
+      <field type="uint16_t" name="servo4_raw" units="us">Servo output 4 value</field>
+      <field type="uint16_t" name="servo5_raw" units="us">Servo output 5 value</field>
+      <field type="uint16_t" name="servo6_raw" units="us">Servo output 6 value</field>
+      <field type="uint16_t" name="servo7_raw" units="us">Servo output 7 value</field>
+      <field type="uint16_t" name="servo8_raw" units="us">Servo output 8 value</field>
+      <extensions/>
+      <field type="uint16_t" name="servo9_raw" units="us">Servo output 9 value</field>
+      <field type="uint16_t" name="servo10_raw" units="us">Servo output 10 value</field>
+      <field type="uint16_t" name="servo11_raw" units="us">Servo output 11 value</field>
+      <field type="uint16_t" name="servo12_raw" units="us">Servo output 12 value</field>
+      <field type="uint16_t" name="servo13_raw" units="us">Servo output 13 value</field>
+      <field type="uint16_t" name="servo14_raw" units="us">Servo output 14 value</field>
+      <field type="uint16_t" name="servo15_raw" units="us">Servo output 15 value</field>
+      <field type="uint16_t" name="servo16_raw" units="us">Servo output 16 value</field>
+    </message>
+    <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
+      <description>Request a partial list of mission items from the system/component. https://mavlink.io/en/services/mission.html. If start and end index are the same, just send one waypoint.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int16_t" name="start_index">Start index</field>
+      <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
+      <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int16_t" name="start_index">Start index. Must be smaller / equal to the largest index of the current onboard list.</field>
+      <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="39" name="MISSION_ITEM">
+      <deprecated since="2020-06" replaced_by="MISSION_ITEM_INT"/>
+      <description>Message encoding a mission item. This message is emitted to announce
+                the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). NaN may be used to indicate an optional/default value (e.g. to use the system's current latitude or yaw rather than a specific value). See also https://mavlink.io/en/services/mission.html.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="float" name="x">PARAM5 / local: X coordinate, global: latitude</field>
+      <field type="float" name="y">PARAM6 / local: Y coordinate, global: longitude</field>
+      <field type="float" name="z">PARAM7 / local: Z coordinate, global: altitude (relative or absolute, depending on frame).</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="40" name="MISSION_REQUEST">
+      <deprecated since="2020-06" replaced_by="MISSION_REQUEST_INT">A system that gets this request should respond with MISSION_ITEM_INT (as though MISSION_REQUEST_INT was received).</deprecated>
+      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM message. https://mavlink.io/en/services/mission.html</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="41" name="MISSION_SET_CURRENT">
+      <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="42" name="MISSION_CURRENT">
+      <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="43" name="MISSION_REQUEST_LIST">
+      <description>Request the overall list of mission items from the system/component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="44" name="MISSION_COUNT">
+      <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of waypoints.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="count">Number of mission items in the sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="45" name="MISSION_CLEAR_ALL">
+      <description>Delete all mission items at once.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="46" name="MISSION_ITEM_REACHED">
+      <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next waypoint.</description>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="47" name="MISSION_ACK">
+      <description>Acknowledgment message during waypoint handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">Mission result.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
+      <description>Sets the GPS co-ordinates of the vehicle local origin (0,0,0) position. Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed. This enables transform between the local coordinate frame and the global (GPS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
+      <extensions/>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="49" name="GPS_GLOBAL_ORIGIN">
+      <description>Publishes the GPS co-ordinates of the vehicle local origin (0,0,0) position. Emitted whenever a new GPS-Local position mapping is requested or set - e.g. following SET_GPS_GLOBAL_ORIGIN message.</description>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
+      <extensions/>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="50" name="PARAM_MAP_RC">
+      <description>Bind a RC channel to a parameter. The parameter should change according to the RC channel value.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
+      <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically corresponds to a potentiometer-knob on the RC.</field>
+      <field type="float" name="param_value0">Initial parameter value</field>
+      <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
+      <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
+      <field type="float" name="param_value_max">Maximum param value. The protocol does not define if this overwrites an onboard maximum value. (Depends on implementation)</field>
+    </message>
+    <message id="51" name="MISSION_REQUEST_INT">
+      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM_INT message. https://mavlink.io/en/services/mission.html</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="54" name="SAFETY_SET_ALLOWED_AREA">
+      <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/waypoints to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+      <field type="float" name="p1x" units="m">x position 1 / Latitude 1</field>
+      <field type="float" name="p1y" units="m">y position 1 / Longitude 1</field>
+      <field type="float" name="p1z" units="m">z position 1 / Altitude 1</field>
+      <field type="float" name="p2x" units="m">x position 2 / Latitude 2</field>
+      <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
+      <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
+    </message>
+    <message id="55" name="SAFETY_ALLOWED_AREA">
+      <description>Read out the safety zone the MAV currently assumes.</description>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+      <field type="float" name="p1x" units="m">x position 1 / Latitude 1</field>
+      <field type="float" name="p1y" units="m">y position 1 / Longitude 1</field>
+      <field type="float" name="p1z" units="m">z position 1 / Altitude 1</field>
+      <field type="float" name="p2x" units="m">x position 2 / Latitude 2</field>
+      <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
+      <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
+    </message>
+    <message id="61" name="ATTITUDE_QUATERNION_COV">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
+      <field type="float[9]" name="covariance">Row-major representation of a 3x3 attitude covariance matrix (states: roll, pitch, yaw; first three entries are the first ROW, next three entries are the second row, etc.). If unknown, assign NaN value to first element in the array.</field>
+    </message>
+    <message id="62" name="NAV_CONTROLLER_OUTPUT">
+      <description>The state of the fixed wing navigation and position controller.</description>
+      <field type="float" name="nav_roll" units="deg">Current desired roll</field>
+      <field type="float" name="nav_pitch" units="deg">Current desired pitch</field>
+      <field type="int16_t" name="nav_bearing" units="deg">Current desired heading</field>
+      <field type="int16_t" name="target_bearing" units="deg">Bearing to current waypoint/target</field>
+      <field type="uint16_t" name="wp_dist" units="m">Distance to active waypoint</field>
+      <field type="float" name="alt_error" units="m">Current altitude error</field>
+      <field type="float" name="aspd_error" units="m/s">Current airspeed error</field>
+      <field type="float" name="xtrack_error" units="m">Current crosstrack error on x-y plane</field>
+    </message>
+    <message id="63" name="GLOBAL_POSITION_INT_COV">
+      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="int32_t" name="alt" units="mm">Altitude in meters above MSL</field>
+      <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+      <field type="float" name="vx" units="m/s">Ground X Speed (Latitude)</field>
+      <field type="float" name="vy" units="m/s">Ground Y Speed (Longitude)</field>
+      <field type="float" name="vz" units="m/s">Ground Z Speed (Altitude)</field>
+      <field type="float[36]" name="covariance">Row-major representation of a 6x6 position and velocity 6x6 cross-covariance matrix (states: lat, lon, alt, vx, vy, vz; first six entries are the first ROW, next six entries are the second row, etc.). If unknown, assign NaN value to first element in the array.</field>
+    </message>
+    <message id="64" name="LOCAL_POSITION_NED_COV">
+      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+      <field type="float" name="x" units="m">X Position</field>
+      <field type="float" name="y" units="m">Y Position</field>
+      <field type="float" name="z" units="m">Z Position</field>
+      <field type="float" name="vx" units="m/s">X Speed</field>
+      <field type="float" name="vy" units="m/s">Y Speed</field>
+      <field type="float" name="vz" units="m/s">Z Speed</field>
+      <field type="float" name="ax" units="m/s/s">X Acceleration</field>
+      <field type="float" name="ay" units="m/s/s">Y Acceleration</field>
+      <field type="float" name="az" units="m/s/s">Z Acceleration</field>
+      <field type="float[45]" name="covariance">Row-major representation of position, velocity and acceleration 9x9 cross-covariance matrix upper right triangle (states: x, y, z, vx, vy, vz, ax, ay, az; first nine entries are the first ROW, next eight entries are the second row, etc.). If unknown, assign NaN value to first element in the array.</field>
+    </message>
+    <message id="65" name="RC_CHANNELS">
+      <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.  A value of UINT16_MAX implies the channel is unused. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
+      <field type="uint16_t" name="chan1_raw" units="us">RC channel 1 value.</field>
+      <field type="uint16_t" name="chan2_raw" units="us">RC channel 2 value.</field>
+      <field type="uint16_t" name="chan3_raw" units="us">RC channel 3 value.</field>
+      <field type="uint16_t" name="chan4_raw" units="us">RC channel 4 value.</field>
+      <field type="uint16_t" name="chan5_raw" units="us">RC channel 5 value.</field>
+      <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value.</field>
+      <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value.</field>
+      <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value.</field>
+      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value.</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value.</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value.</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value.</field>
+      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value.</field>
+      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value.</field>
+      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value.</field>
+      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value.</field>
+      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value.</field>
+      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+    </message>
+    <message id="66" name="REQUEST_DATA_STREAM">
+      <description>Request a data stream.</description>
+      <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
+      <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
+      <field type="uint8_t" name="req_stream_id">The ID of the requested data stream</field>
+      <field type="uint16_t" name="req_message_rate" units="Hz">The requested message rate</field>
+      <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
+    </message>
+    <message id="67" name="DATA_STREAM">
+      <description>Data stream status information.</description>
+      <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
+      <field type="uint16_t" name="message_rate" units="Hz">The message rate</field>
+      <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
+    </message>
+    <message id="69" name="MANUAL_CONTROL">
+      <description>This message provides an API for manually controlling the vehicle using standard joystick axes nomenclature, along with a joystick-like input device. Unused axes can be disabled an buttons are also transmit as boolean values of their </description>
+      <field type="uint8_t" name="target">The system to be controlled.</field>
+      <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>
+      <field type="int16_t" name="y">Y-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to left(-1000)-right(1000) movement on a joystick and the roll of a vehicle.</field>
+      <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
+      <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
+      <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
+    </message>
+    <message id="70" name="RC_CHANNELS_OVERRIDE">
+      <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.  Note carefully the semantic differences between the first 8 channels and the subsequent channels</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="chan1_raw" units="us">RC channel 1 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan2_raw" units="us">RC channel 2 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan3_raw" units="us">RC channel 3 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan4_raw" units="us">RC channel 4 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan5_raw" units="us">RC channel 5 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value. A value of UINT16_MAX means to ignore this field. A value of 0 means to release this channel back to the RC radio.</field>
+      <extensions/>
+      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value. A value of 0 or UINT16_MAX means to ignore this field. A value of UINT16_MAX-1 means to release this channel back to the RC radio.</field>
+    </message>
+    <message id="73" name="MISSION_ITEM_INT">
+      <description>Message encoding a mission item. This message is emitted to announce
+                the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). NaN or INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current latitude, yaw rather than a specific value). See also https://mavlink.io/en/services/mission.html.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+      <field type="int32_t" name="y">PARAM6 / y position: local: x position in meters * 1e4, global: longitude in degrees *10^7</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+    </message>
+    <message id="74" name="VFR_HUD">
+      <description>Metrics typically displayed on a HUD for fixed wing aircraft.</description>
+      <field type="float" name="airspeed" units="m/s">Vehicle speed in form appropriate for vehicle type. For standard aircraft this is typically calibrated airspeed (CAS) or indicated airspeed (IAS) - either of which can be used by a pilot to estimate stall speed.</field>
+      <field type="float" name="groundspeed" units="m/s">Current ground speed.</field>
+      <field type="int16_t" name="heading" units="deg">Current heading in compass units (0-360, 0=north).</field>
+      <field type="uint16_t" name="throttle" units="%">Current throttle setting (0 to 100).</field>
+      <field type="float" name="alt" units="m">Current altitude (MSL).</field>
+      <field type="float" name="climb" units="m/s">Current climb rate.</field>
+    </message>
+    <message id="75" name="COMMAND_INT">
+      <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
+      <field type="uint8_t" name="current">Not used.</field>
+      <field type="uint8_t" name="autocontinue">Not used (set 0).</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+      <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame).</field>
+    </message>
+    <message id="76" name="COMMAND_LONG">
+      <description>Send a command with up to seven parameters to the MAV. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <field type="uint8_t" name="target_system">System which should execute the command</field>
+      <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of command to send).</field>
+      <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
+      <field type="float" name="param1">Parameter 1 (for the specific command).</field>
+      <field type="float" name="param2">Parameter 2 (for the specific command).</field>
+      <field type="float" name="param3">Parameter 3 (for the specific command).</field>
+      <field type="float" name="param4">Parameter 4 (for the specific command).</field>
+      <field type="float" name="param5">Parameter 5 (for the specific command).</field>
+      <field type="float" name="param6">Parameter 6 (for the specific command).</field>
+      <field type="float" name="param7">Parameter 7 (for the specific command).</field>
+    </message>
+    <message id="77" name="COMMAND_ACK">
+      <description>Report status of a command. Includes feedback whether the command was executed. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of acknowledged command).</field>
+      <field type="uint8_t" name="result" enum="MAV_RESULT">Result of command.</field>
+      <extensions/>
+      <field type="uint8_t" name="progress">Also used as result_param1, it can be set with a enum containing the errors reasons of why the command was denied or the progress percentage or 255 if unknown the progress when result is MAV_RESULT_IN_PROGRESS.</field>
+      <field type="int32_t" name="result_param2">Additional parameter of the result, example: which parameter of MAV_CMD_NAV_WAYPOINT caused it to be denied.</field>
+      <field type="uint8_t" name="target_system">System which requested the command to be executed</field>
+      <field type="uint8_t" name="target_component">Component which requested the command to be executed</field>
+    </message>
+    <message id="81" name="MANUAL_SETPOINT">
+      <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="roll" units="rad/s">Desired roll rate</field>
+      <field type="float" name="pitch" units="rad/s">Desired pitch rate</field>
+      <field type="float" name="yaw" units="rad/s">Desired yaw rate</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
+      <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
+      <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
+    </message>
+    <message id="82" name="SET_ATTITUDE_TARGET">
+      <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="type_mask" enum="ATTITUDE_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="body_roll_rate" units="rad/s">Body roll rate</field>
+      <field type="float" name="body_pitch_rate" units="rad/s">Body pitch rate</field>
+      <field type="float" name="body_yaw_rate" units="rad/s">Body yaw rate</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+    </message>
+    <message id="83" name="ATTITUDE_TARGET">
+      <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="type_mask" enum="ATTITUDE_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="body_roll_rate" units="rad/s">Body roll rate</field>
+      <field type="float" name="body_pitch_rate" units="rad/s">Body pitch rate</field>
+      <field type="float" name="body_yaw_rate" units="rad/s">Body yaw rate</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+    </message>
+    <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
+      <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="float" name="x" units="m">X Position in NED frame</field>
+      <field type="float" name="y" units="m">Y Position in NED frame</field>
+      <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
+      <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
+      <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
+      <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>
+      <field type="float" name="afx" units="m/s/s">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy" units="m/s/s">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw" units="rad">yaw setpoint</field>
+      <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+    </message>
+    <message id="85" name="POSITION_TARGET_LOCAL_NED">
+      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="float" name="x" units="m">X Position in NED frame</field>
+      <field type="float" name="y" units="m">Y Position in NED frame</field>
+      <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
+      <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
+      <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
+      <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>
+      <field type="float" name="afx" units="m/s/s">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy" units="m/s/s">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw" units="rad">yaw setpoint</field>
+      <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+    </message>
+    <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
+      <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot). The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
+      <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
+      <field type="float" name="alt" units="m">Altitude (MSL, Relative to home, or AGL - depending on frame)</field>
+      <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
+      <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
+      <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>
+      <field type="float" name="afx" units="m/s/s">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy" units="m/s/s">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw" units="rad">yaw setpoint</field>
+      <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+    </message>
+    <message id="87" name="POSITION_TARGET_GLOBAL_INT">
+      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot). The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
+      <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
+      <field type="float" name="alt" units="m">Altitude (MSL, AGL or relative to home altitude, depending on frame)</field>
+      <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
+      <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
+      <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>
+      <field type="float" name="afx" units="m/s/s">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy" units="m/s/s">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw" units="rad">yaw setpoint</field>
+      <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+    </message>
+    <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
+      <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="x" units="m">X Position</field>
+      <field type="float" name="y" units="m">Y Position</field>
+      <field type="float" name="z" units="m">Z Position</field>
+      <field type="float" name="roll" units="rad">Roll</field>
+      <field type="float" name="pitch" units="rad">Pitch</field>
+      <field type="float" name="yaw" units="rad">Yaw</field>
+    </message>
+    <message id="90" name="HIL_STATE">
+      <deprecated since="2013-07" replaced_by="HIL_STATE_QUATERNION">Suffers from missing airspeed fields and singularities due to Euler angles</deprecated>
+      <description>Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <field type="float" name="rollspeed" units="rad/s">Body frame roll / phi angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Body frame pitch / theta angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Body frame yaw / psi angular speed</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="int32_t" name="alt" units="mm">Altitude</field>
+      <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude)</field>
+      <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude)</field>
+      <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude)</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration</field>
+    </message>
+    <message id="91" name="HIL_CONTROLS">
+      <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="roll_ailerons">Control output -1 .. 1</field>
+      <field type="float" name="pitch_elevator">Control output -1 .. 1</field>
+      <field type="float" name="yaw_rudder">Control output -1 .. 1</field>
+      <field type="float" name="throttle">Throttle 0 .. 1</field>
+      <field type="float" name="aux1">Aux 1, -1 .. 1</field>
+      <field type="float" name="aux2">Aux 2, -1 .. 1</field>
+      <field type="float" name="aux3">Aux 3, -1 .. 1</field>
+      <field type="float" name="aux4">Aux 4, -1 .. 1</field>
+      <field type="uint8_t" name="mode" enum="MAV_MODE">System mode.</field>
+      <field type="uint8_t" name="nav_mode">Navigation mode (MAV_NAV_MODE)</field>
+    </message>
+    <message id="92" name="HIL_RC_INPUTS_RAW">
+      <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint16_t" name="chan1_raw" units="us">RC channel 1 value</field>
+      <field type="uint16_t" name="chan2_raw" units="us">RC channel 2 value</field>
+      <field type="uint16_t" name="chan3_raw" units="us">RC channel 3 value</field>
+      <field type="uint16_t" name="chan4_raw" units="us">RC channel 4 value</field>
+      <field type="uint16_t" name="chan5_raw" units="us">RC channel 5 value</field>
+      <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value</field>
+      <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value</field>
+      <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value</field>
+      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+    </message>
+    <message id="93" name="HIL_ACTUATOR_CONTROLS">
+      <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float[16]" name="controls">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
+      <field type="uint8_t" name="mode" enum="MAV_MODE_FLAG" display="bitmask">System mode. Includes arming state.</field>
+      <field type="uint64_t" name="flags" display="bitmask">Flags as bitfield, 1: indicate simulation using lockstep.</field>
+    </message>
+    <message id="100" name="OPTICAL_FLOW">
+      <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="int16_t" name="flow_x" units="dpix">Flow in x-sensor direction</field>
+      <field type="int16_t" name="flow_y" units="dpix">Flow in y-sensor direction</field>
+      <field type="float" name="flow_comp_m_x" units="m/s">Flow in x-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_y" units="m/s">Flow in y-sensor direction, angular-speed compensated</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
+      <field type="float" name="ground_distance" units="m">Ground distance. Positive value: distance known. Negative value: Unknown distance</field>
+      <extensions/>
+      <field type="float" name="flow_rate_x" units="rad/s">Flow rate about X axis</field>
+      <field type="float" name="flow_rate_y" units="rad/s">Flow rate about Y axis</field>
+    </message>
+    <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
+      <description>Global position/attitude estimate from a vision source.</description>
+      <field type="uint64_t" name="usec" units="us">Timestamp (UNIX time or since system boot)</field>
+      <field type="float" name="x" units="m">Global X position</field>
+      <field type="float" name="y" units="m">Global Y position</field>
+      <field type="float" name="z" units="m">Global Z position</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Row-major representation of pose 6x6 cross-covariance matrix upper right triangle (states: x_global, y_global, z_global, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+      <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
+    </message>
+    <message id="102" name="VISION_POSITION_ESTIMATE">
+      <description>Local position/attitude estimate from a vision source.</description>
+      <field type="uint64_t" name="usec" units="us">Timestamp (UNIX time or time since system boot)</field>
+      <field type="float" name="x" units="m">Local X position</field>
+      <field type="float" name="y" units="m">Local Y position</field>
+      <field type="float" name="z" units="m">Local Z position</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Row-major representation of pose 6x6 cross-covariance matrix upper right triangle (states: x, y, z, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+      <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
+    </message>
+    <message id="103" name="VISION_SPEED_ESTIMATE">
+      <description>Speed estimate from a vision source.</description>
+      <field type="uint64_t" name="usec" units="us">Timestamp (UNIX time or time since system boot)</field>
+      <field type="float" name="x" units="m/s">Global X speed</field>
+      <field type="float" name="y" units="m/s">Global Y speed</field>
+      <field type="float" name="z" units="m/s">Global Z speed</field>
+      <extensions/>
+      <field type="float[9]" name="covariance">Row-major representation of 3x3 linear velocity covariance matrix (states: vx, vy, vz; 1st three entries - 1st row, etc.). If unknown, assign NaN value to first element in the array.</field>
+      <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
+    </message>
+    <message id="104" name="VICON_POSITION_ESTIMATE">
+      <description>Global position estimate from a Vicon motion system source.</description>
+      <field type="uint64_t" name="usec" units="us">Timestamp (UNIX time or time since system boot)</field>
+      <field type="float" name="x" units="m">Global X position</field>
+      <field type="float" name="y" units="m">Global Y position</field>
+      <field type="float" name="z" units="m">Global Z position</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Row-major representation of 6x6 pose cross-covariance matrix upper right triangle (states: x, y, z, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+    </message>
+    <message id="105" name="HIGHRES_IMU">
+      <description>The IMU readings in SI units in NED body frame</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="xacc" units="m/s/s">X acceleration</field>
+      <field type="float" name="yacc" units="m/s/s">Y acceleration</field>
+      <field type="float" name="zacc" units="m/s/s">Z acceleration</field>
+      <field type="float" name="xgyro" units="rad/s">Angular speed around X axis</field>
+      <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis</field>
+      <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis</field>
+      <field type="float" name="xmag" units="gauss">X Magnetic field</field>
+      <field type="float" name="ymag" units="gauss">Y Magnetic field</field>
+      <field type="float" name="zmag" units="gauss">Z Magnetic field</field>
+      <field type="float" name="abs_pressure" units="hPa">Absolute pressure</field>
+      <field type="float" name="diff_pressure" units="hPa">Differential pressure</field>
+      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+      <field type="float" name="temperature" units="degC">Temperature</field>
+      <field type="uint16_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
+      <extensions/>
+      <field type="uint8_t" name="id" instance="true">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
+    </message>
+    <message id="106" name="OPTICAL_FLOW_RAD">
+      <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="sensor_id" instance="true">Sensor ID</field>
+      <field type="uint32_t" name="integration_time_us" units="us">Integration time. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+      <field type="float" name="integrated_x" units="rad">Flow around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+      <field type="float" name="integrated_y" units="rad">Flow around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+      <field type="float" name="integrated_xgyro" units="rad">RH rotation around X axis</field>
+      <field type="float" name="integrated_ygyro" units="rad">RH rotation around Y axis</field>
+      <field type="float" name="integrated_zgyro" units="rad">RH rotation around Z axis</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+      <field type="uint32_t" name="time_delta_distance_us" units="us">Time since the distance was sampled.</field>
+      <field type="float" name="distance" units="m">Distance to the center of the flow field. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+    </message>
+    <message id="107" name="HIL_SENSOR">
+      <description>The IMU readings in SI units in NED body frame</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="xacc" units="m/s/s">X acceleration</field>
+      <field type="float" name="yacc" units="m/s/s">Y acceleration</field>
+      <field type="float" name="zacc" units="m/s/s">Z acceleration</field>
+      <field type="float" name="xgyro" units="rad/s">Angular speed around X axis in body frame</field>
+      <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis in body frame</field>
+      <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis in body frame</field>
+      <field type="float" name="xmag" units="gauss">X Magnetic field</field>
+      <field type="float" name="ymag" units="gauss">Y Magnetic field</field>
+      <field type="float" name="zmag" units="gauss">Z Magnetic field</field>
+      <field type="float" name="abs_pressure" units="hPa">Absolute pressure</field>
+      <field type="float" name="diff_pressure" units="hPa">Differential pressure (airspeed)</field>
+      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+      <field type="float" name="temperature" units="degC">Temperature</field>
+      <field type="uint32_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
+      <extensions/>
+      <field type="uint8_t" name="id">Sensor ID (zero indexed). Used for multiple sensor inputs</field>
+    </message>
+    <message id="108" name="SIM_STATE">
+      <description>Status of simulation environment, if used</description>
+      <field type="float" name="q1">True attitude quaternion component 1, w (1 in null-rotation)</field>
+      <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
+      <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
+      <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
+      <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="xacc" units="m/s/s">X acceleration</field>
+      <field type="float" name="yacc" units="m/s/s">Y acceleration</field>
+      <field type="float" name="zacc" units="m/s/s">Z acceleration</field>
+      <field type="float" name="xgyro" units="rad/s">Angular speed around X axis</field>
+      <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis</field>
+      <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis</field>
+      <field type="float" name="lat" units="deg">Latitude</field>
+      <field type="float" name="lon" units="deg">Longitude</field>
+      <field type="float" name="alt" units="m">Altitude</field>
+      <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
+      <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
+      <field type="float" name="vn" units="m/s">True velocity in north direction in earth-fixed NED frame</field>
+      <field type="float" name="ve" units="m/s">True velocity in east direction in earth-fixed NED frame</field>
+      <field type="float" name="vd" units="m/s">True velocity in down direction in earth-fixed NED frame</field>
+    </message>
+    <message id="109" name="RADIO_STATUS">
+      <description>Status generated by radio and injected into MAVLink stream.</description>
+      <field type="uint8_t" name="rssi">Local (message sender) recieved signal strength indication in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="remrssi">Remote (message receiver) signal strength indication in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="txbuf" units="%">Remaining free transmitter buffer space.</field>
+      <field type="uint8_t" name="noise">Local background noise level. These are device dependent RSSI values (scale as approx 2x dB on SiK radios). Values: [0-254], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="remnoise">Remote background noise level. These are device dependent RSSI values (scale as approx 2x dB on SiK radios). Values: [0-254], 255: invalid/unknown.</field>
+      <field type="uint16_t" name="rxerrors">Count of radio packet receive errors (since boot).</field>
+      <field type="uint16_t" name="fixed">Count of error corrected radio packets (since boot).</field>
+    </message>
+    <message id="110" name="FILE_TRANSFER_PROTOCOL">
+      <description>File transfer message</description>
+      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+    </message>
+    <message id="111" name="TIMESYNC">
+      <description>Time synchronization message.</description>
+      <field type="int64_t" name="tc1">Time sync timestamp 1</field>
+      <field type="int64_t" name="ts1">Time sync timestamp 2</field>
+    </message>
+    <message id="112" name="CAMERA_TRIGGER">
+      <description>Camera-IMU triggering and synchronisation message.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp for image frame (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint32_t" name="seq">Image frame sequence</field>
+    </message>
+    <message id="113" name="HIL_GPS">
+      <description>The global position, as returned by the Global Positioning System (GPS). This is
+                 NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up.</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: 65535</field>
+      <field type="int16_t" name="vn" units="cm/s">GPS velocity in north direction in earth-fixed NED frame</field>
+      <field type="int16_t" name="ve" units="cm/s">GPS velocity in east direction in earth-fixed NED frame</field>
+      <field type="int16_t" name="vd" units="cm/s">GPS velocity in down direction in earth-fixed NED frame</field>
+      <field type="uint16_t" name="cog" units="cdeg">Course over ground (NOT heading, but direction of movement), 0.0..359.99 degrees. If unknown, set to: 65535</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+      <extensions/>
+      <field type="uint8_t" name="id">GPS ID (zero indexed). Used for multiple GPS inputs</field>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>
+    </message>
+    <message id="114" name="HIL_OPTICAL_FLOW">
+      <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="uint32_t" name="integration_time_us" units="us">Integration time. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+      <field type="float" name="integrated_x" units="rad">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+      <field type="float" name="integrated_y" units="rad">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+      <field type="float" name="integrated_xgyro" units="rad">RH rotation around X axis</field>
+      <field type="float" name="integrated_ygyro" units="rad">RH rotation around Y axis</field>
+      <field type="float" name="integrated_zgyro" units="rad">RH rotation around Z axis</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+      <field type="uint32_t" name="time_delta_distance_us" units="us">Time since the distance was sampled.</field>
+      <field type="float" name="distance" units="m">Distance to the center of the flow field. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+    </message>
+    <message id="115" name="HIL_STATE_QUATERNION">
+      <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
+      <field type="float" name="rollspeed" units="rad/s">Body frame roll / phi angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Body frame pitch / theta angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Body frame yaw / psi angular speed</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="int32_t" name="alt" units="mm">Altitude</field>
+      <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude)</field>
+      <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude)</field>
+      <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude)</field>
+      <field type="uint16_t" name="ind_airspeed" units="cm/s">Indicated airspeed</field>
+      <field type="uint16_t" name="true_airspeed" units="cm/s">True airspeed</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration</field>
+    </message>
+    <message id="116" name="SCALED_IMU2">
+      <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration</field>
+      <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
+      <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
+      <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>
+    </message>
+    <message id="117" name="LOG_REQUEST_LIST">
+      <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called. If there are no log files available this request shall be answered with one LOG_ENTRY message with id = 0 and num_logs = 0.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="start">First log id (0 for first available)</field>
+      <field type="uint16_t" name="end">Last log id (0xffff for last available)</field>
+    </message>
+    <message id="118" name="LOG_ENTRY">
+      <description>Reply to LOG_REQUEST_LIST</description>
+      <field type="uint16_t" name="id">Log id</field>
+      <field type="uint16_t" name="num_logs">Total number of logs</field>
+      <field type="uint16_t" name="last_log_num">High log number</field>
+      <field type="uint32_t" name="time_utc" units="s">UTC timestamp of log since 1970, or 0 if not available</field>
+      <field type="uint32_t" name="size" units="bytes">Size of the log (may be approximate)</field>
+    </message>
+    <message id="119" name="LOG_REQUEST_DATA">
+      <description>Request a chunk of a log</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+      <field type="uint32_t" name="ofs">Offset into the log</field>
+      <field type="uint32_t" name="count" units="bytes">Number of bytes</field>
+    </message>
+    <message id="120" name="LOG_DATA">
+      <description>Reply to LOG_REQUEST_DATA</description>
+      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+      <field type="uint32_t" name="ofs">Offset into the log</field>
+      <field type="uint8_t" name="count" units="bytes">Number of bytes (zero for end of log)</field>
+      <field type="uint8_t[90]" name="data">log data</field>
+    </message>
+    <message id="121" name="LOG_ERASE">
+      <description>Erase all logs</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="122" name="LOG_REQUEST_END">
+      <description>Stop log transfer and resume normal logging</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="123" name="GPS_INJECT_DATA">
+      <description>Data for injecting into the onboard GPS (used for DGPS)</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="len" units="bytes">Data length</field>
+      <field type="uint8_t[110]" name="data">Raw data (110 is enough for 12 satellites of RTCMv2)</field>
+    </message>
+    <message id="124" name="GPS2_RAW">
+      <description>Second GPS data.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GPS fix type.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up.</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="cog" units="cdeg">Course over ground (NOT heading, but direction of movement): 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+      <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
+      <field type="uint32_t" name="dgps_age" units="ms">Age of DGPS info</field>
+      <extensions/>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
+      <field type="int32_t" name="alt_ellipsoid" units="mm">Altitude (above WGS84, EGM96 ellipsoid). Positive for up.</field>
+      <field type="uint32_t" name="h_acc" units="mm">Position uncertainty.</field>
+      <field type="uint32_t" name="v_acc" units="mm">Altitude uncertainty.</field>
+      <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
+      <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
+    </message>
+    <message id="125" name="POWER_STATUS">
+      <description>Power supply status</description>
+      <field type="uint16_t" name="Vcc" units="mV">5V rail voltage.</field>
+      <field type="uint16_t" name="Vservo" units="mV">Servo rail voltage.</field>
+      <field type="uint16_t" name="flags" enum="MAV_POWER_STATUS" display="bitmask">Bitmap of power supply status flags.</field>
+    </message>
+    <message id="126" name="SERIAL_CONTROL">
+      <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
+      <field type="uint8_t" name="device" enum="SERIAL_CONTROL_DEV">Serial control device type.</field>
+      <field type="uint8_t" name="flags" enum="SERIAL_CONTROL_FLAG" display="bitmask">Bitmap of serial control flags.</field>
+      <field type="uint16_t" name="timeout" units="ms">Timeout for reply data</field>
+      <field type="uint32_t" name="baudrate" units="bits/s">Baudrate of transfer. Zero means no change.</field>
+      <field type="uint8_t" name="count" units="bytes">how many bytes in this transfer</field>
+      <field type="uint8_t[70]" name="data">serial data</field>
+    </message>
+    <message id="127" name="GPS_RTK">
+      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+      <field type="uint32_t" name="time_last_baseline_ms" units="ms">Time since boot of last baseline message received.</field>
+      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+      <field type="uint32_t" name="tow" units="ms">GPS Time of Week of last baseline</field>
+      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+      <field type="uint8_t" name="rtk_rate" units="Hz">Rate of baseline messages being received by GPS</field>
+      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+      <field type="uint8_t" name="baseline_coords_type" enum="RTK_BASELINE_COORDINATE_SYSTEM">Coordinate system of baseline</field>
+      <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component.</field>
+      <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component.</field>
+      <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component.</field>
+      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+    </message>
+    <message id="128" name="GPS2_RTK">
+      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+      <field type="uint32_t" name="time_last_baseline_ms" units="ms">Time since boot of last baseline message received.</field>
+      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+      <field type="uint32_t" name="tow" units="ms">GPS Time of Week of last baseline</field>
+      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+      <field type="uint8_t" name="rtk_rate" units="Hz">Rate of baseline messages being received by GPS</field>
+      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+      <field type="uint8_t" name="baseline_coords_type" enum="RTK_BASELINE_COORDINATE_SYSTEM">Coordinate system of baseline</field>
+      <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component.</field>
+      <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component.</field>
+      <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component.</field>
+      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+    </message>
+    <message id="129" name="SCALED_IMU3">
+      <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="int16_t" name="xacc" units="mG">X acceleration</field>
+      <field type="int16_t" name="yacc" units="mG">Y acceleration</field>
+      <field type="int16_t" name="zacc" units="mG">Z acceleration</field>
+      <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
+      <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
+      <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0: IMU does not provide temperature values. If the IMU is at 0C it must send 1 (0.01C).</field>
+    </message>
+    <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
+      <description>Handshake message to initiate, control and stop image streaming when using the Image Transmission Protocol: https://mavlink.io/en/services/image_transmission.html.</description>
+      <field type="uint8_t" name="type" enum="MAVLINK_DATA_STREAM_TYPE">Type of requested/acknowledged data.</field>
+      <field type="uint32_t" name="size" units="bytes">total data size (set on ACK only).</field>
+      <field type="uint16_t" name="width">Width of a matrix or image.</field>
+      <field type="uint16_t" name="height">Height of a matrix or image.</field>
+      <field type="uint16_t" name="packets">Number of packets being sent (set on ACK only).</field>
+      <field type="uint8_t" name="payload" units="bytes">Payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only).</field>
+      <field type="uint8_t" name="jpg_quality" units="%">JPEG quality. Values: [1-100].</field>
+    </message>
+    <message id="131" name="ENCAPSULATED_DATA">
+      <description>Data packet for images sent using the Image Transmission Protocol: https://mavlink.io/en/services/image_transmission.html.</description>
+      <field type="uint16_t" name="seqnr">sequence number (starting with 0 on every transmission)</field>
+      <field type="uint8_t[253]" name="data">image data bytes</field>
+    </message>
+    <message id="132" name="DISTANCE_SENSOR">
+      <description>Distance sensor information for an onboard rangefinder.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint16_t" name="min_distance" units="cm">Minimum distance the sensor can measure</field>
+      <field type="uint16_t" name="max_distance" units="cm">Maximum distance the sensor can measure</field>
+      <field type="uint16_t" name="current_distance" units="cm">Current distance reading</field>
+      <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
+      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor</field>
+      <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces. downward-facing: ROTATION_PITCH_270, upward-facing: ROTATION_PITCH_90, backward-facing: ROTATION_PITCH_180, forward-facing: ROTATION_NONE, left-facing: ROTATION_YAW_90, right-facing: ROTATION_YAW_270</field>
+      <field type="uint8_t" name="covariance" units="cm^2">Measurement variance. Max standard deviation is 6cm. 255 if unknown.</field>
+      <extensions/>
+      <field type="float" name="horizontal_fov" units="rad">Horizontal Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>
+      <field type="float" name="vertical_fov" units="rad">Vertical Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>
+      <field type="float[4]" name="quaternion">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if the orientation is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid."</field>
+      <field type="uint8_t" name="signal_quality" units="%">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.</field>
+    </message>
+    <message id="133" name="TERRAIN_REQUEST">
+      <description>Request for terrain data and terrain status. See terrain protocol docs: https://mavlink.io/en/services/terrain.html</description>
+      <field type="int32_t" name="lat" units="degE7">Latitude of SW corner of first grid</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude of SW corner of first grid</field>
+      <field type="uint16_t" name="grid_spacing" units="m">Grid spacing</field>
+      <field type="uint64_t" name="mask" display="bitmask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
+    </message>
+    <message id="134" name="TERRAIN_DATA">
+      <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST. See terrain protocol docs: https://mavlink.io/en/services/terrain.html</description>
+      <field type="int32_t" name="lat" units="degE7">Latitude of SW corner of first grid</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude of SW corner of first grid</field>
+      <field type="uint16_t" name="grid_spacing" units="m">Grid spacing</field>
+      <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
+      <field type="int16_t[16]" name="data" units="m">Terrain data MSL</field>
+    </message>
+    <message id="135" name="TERRAIN_CHECK">
+      <description>Request that the vehicle report terrain height at the given location (expected response is a TERRAIN_REPORT). Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+    </message>
+    <message id="136" name="TERRAIN_REPORT">
+      <description>Streamed from drone to report progress of terrain map download (initiated by TERRAIN_REQUEST), or sent as a response to a TERRAIN_CHECK request. See terrain protocol docs: https://mavlink.io/en/services/terrain.html</description>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
+      <field type="float" name="terrain_height" units="m">Terrain height MSL</field>
+      <field type="float" name="current_height" units="m">Current vehicle height above lat/lon terrain height</field>
+      <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
+      <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
+    </message>
+    <message id="137" name="SCALED_PRESSURE2">
+      <description>Barometer readings for 2nd barometer</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
+      <field type="float" name="press_diff" units="hPa">Differential pressure</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
+    </message>
+    <message id="138" name="ATT_POS_MOCAP">
+      <description>Motion capture attitude and position</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="x" units="m">X position (NED)</field>
+      <field type="float" name="y" units="m">Y position (NED)</field>
+      <field type="float" name="z" units="m">Z position (NED)</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Row-major representation of a pose 6x6 cross-covariance matrix upper right triangle (states: x, y, z, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+    </message>
+    <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
+      <description>Set the vehicle attitude and body angular rates.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+    </message>
+    <message id="140" name="ACTUATOR_CONTROL_TARGET">
+      <description>Set the vehicle attitude and body angular rates.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+    </message>
+    <message id="141" name="ALTITUDE">
+      <description>The current system altitude.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="altitude_monotonic" units="m">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
+      <field type="float" name="altitude_amsl" units="m">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output MSL by default and not the WGS84 altitude.</field>
+      <field type="float" name="altitude_local" units="m">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
+      <field type="float" name="altitude_relative" units="m">This is the altitude above the home position. It resets on each change of the current home position.</field>
+      <field type="float" name="altitude_terrain" units="m">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
+      <field type="float" name="bottom_clearance" units="m">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
+    </message>
+    <message id="142" name="RESOURCE_REQUEST">
+      <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
+      <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
+      <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
+      <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
+      <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
+      <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
+    </message>
+    <message id="143" name="SCALED_PRESSURE3">
+      <description>Barometer readings for 3rd barometer</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
+      <field type="float" name="press_diff" units="hPa">Differential pressure</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
+    </message>
+    <message id="144" name="FOLLOW_TARGET">
+      <description>Current motion information from a designated system</description>
+      <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m">Altitude (MSL)</field>
+      <field type="float[3]" name="vel" units="m/s">target velocity (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s">linear target acceleration (0,0,0) for unknown</field>
+      <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
+      <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
+      <field type="float[3]" name="position_cov">eph epv</field>
+      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+    </message>
+    <message id="146" name="CONTROL_SYSTEM_STATE">
+      <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="x_acc" units="m/s/s">X acceleration in body frame</field>
+      <field type="float" name="y_acc" units="m/s/s">Y acceleration in body frame</field>
+      <field type="float" name="z_acc" units="m/s/s">Z acceleration in body frame</field>
+      <field type="float" name="x_vel" units="m/s">X velocity in body frame</field>
+      <field type="float" name="y_vel" units="m/s">Y velocity in body frame</field>
+      <field type="float" name="z_vel" units="m/s">Z velocity in body frame</field>
+      <field type="float" name="x_pos" units="m">X position in local frame</field>
+      <field type="float" name="y_pos" units="m">Y position in local frame</field>
+      <field type="float" name="z_pos" units="m">Z position in local frame</field>
+      <field type="float" name="airspeed" units="m/s">Airspeed, set to -1 if unknown</field>
+      <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
+      <field type="float[3]" name="pos_variance">Variance in local position</field>
+      <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
+      <field type="float" name="roll_rate" units="rad/s">Angular rate in roll axis</field>
+      <field type="float" name="pitch_rate" units="rad/s">Angular rate in pitch axis</field>
+      <field type="float" name="yaw_rate" units="rad/s">Angular rate in yaw axis</field>
+    </message>
+    <message id="147" name="BATTERY_STATUS">
+      <description>Battery information</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature of the battery. INT16_MAX for unknown temperature.</field>
+      <field type="uint16_t[10]" name="voltages" units="mV">Battery voltage of cells 1 to 10 (see voltages_ext for cells 11-14). Cells in this field above the valid cell count for this battery should have the UINT16_MAX value. If individual cell voltages are unknown or not measured for this battery, then the overall battery voltage should be filled in cell 0, with all others set to UINT16_MAX. If the voltage of the battery is greater than (UINT16_MAX - 1), then cell 0 should be set to (UINT16_MAX - 1), and cell 1 to the remaining voltage. This can be extended to multiple cells if the total voltage is greater than 2 * (UINT16_MAX - 1).</field>
+      <field type="int16_t" name="current_battery" units="cA">Battery current, -1: autopilot does not measure the current</field>
+      <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, -1: autopilot does not provide consumption estimate</field>
+      <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, -1: autopilot does not provide energy consumption estimate</field>
+      <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy. Values: [0-100], -1: autopilot does not estimate the remaining battery.</field>
+      <extensions/>
+      <field type="int32_t" name="time_remaining" units="s">Remaining battery time, 0: autopilot does not provide remaining battery time estimate</field>
+      <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
+      <field type="uint16_t[4]" name="voltages_ext" units="mV">Battery voltages for cells 11 to 14. Cells above the valid cell count for this battery should have a value of 0, where zero indicates not supported (note, this is different than for the voltages field and allows empty byte truncation). If the measured value is 0 then 1 should be sent instead.</field>
+      <field type="uint8_t" name="mode" enum="MAV_BATTERY_MODE">Battery mode. Default (0) is that battery mode reporting is not supported or battery is in normal-use mode.</field>
+      <field type="uint32_t" name="fault_bitmask" display="bitmask" enum="MAV_BATTERY_FAULT">Fault/health indications. These should be set when charge_state is MAV_BATTERY_CHARGE_STATE_FAILED or MAV_BATTERY_CHARGE_STATE_UNHEALTHY (if not, fault reporting is not supported).</field>
+    </message>
+    <message id="148" name="AUTOPILOT_VERSION">
+      <description>Version and capability of autopilot software. This should be emitted in response to a request with MAV_CMD_REQUEST_MESSAGE.</description>
+      <field type="uint64_t" name="capabilities" enum="MAV_PROTOCOL_CAPABILITY" display="bitmask">Bitmap of capabilities</field>
+      <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
+      <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
+      <field type="uint32_t" name="os_sw_version">Operating system version number</field>
+      <field type="uint32_t" name="board_version">HW / board version (last 8 bits should be silicon ID, if any). The first 16 bits of this field specify https://github.com/PX4/PX4-Bootloader/blob/master/board_types.txt</field>
+      <field type="uint8_t[8]" name="flight_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint8_t[8]" name="middleware_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
+      <field type="uint16_t" name="product_id">ID of the product</field>
+      <field type="uint64_t" name="uid">UID if provided by hardware (see uid2)</field>
+      <extensions/>
+      <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
+    </message>
+    <message id="149" name="LANDING_TARGET">
+      <description>The location of a landing target. See: https://mavlink.io/en/services/landing_target.html</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="angle_x" units="rad">X-axis angular offset of the target from the center of the image</field>
+      <field type="float" name="angle_y" units="rad">Y-axis angular offset of the target from the center of the image</field>
+      <field type="float" name="distance" units="m">Distance to the target from the vehicle</field>
+      <field type="float" name="size_x" units="rad">Size of target along x-axis</field>
+      <field type="float" name="size_y" units="rad">Size of target along y-axis</field>
+      <extensions/>
+      <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
+      <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
+      <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
+      <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
+      <field type="uint8_t" name="position_valid">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
+    </message>
+    <!-- imported from ardupilotmega.xml (2019) -->
+    <message id="162" name="FENCE_STATUS">
+      <description>Status of geo-fencing. Sent in extended status stream when fencing enabled.</description>
+      <field type="uint8_t" name="breach_status">Breach status (0 if currently inside fence, 1 if outside).</field>
+      <field type="uint16_t" name="breach_count">Number of fence breaches.</field>
+      <field type="uint8_t" name="breach_type" enum="FENCE_BREACH">Last breach type.</field>
+      <field type="uint32_t" name="breach_time" units="ms">Time (since boot) of last breach.</field>
+      <extensions/>
+      <field type="uint8_t" name="breach_mitigation" enum="FENCE_MITIGATE">Active action to prevent fence breach</field>
+    </message>
+    <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
+    <!-- 192 MAG_CAL_REPORT imported from ardupilotmega.xml -->
+    <message id="192" name="MAG_CAL_REPORT">
+      <description>Reports results of completed compass calibration. Sent until MAG_CAL_ACK received.</description>
+      <field type="uint8_t" name="compass_id" instance="true">Compass being calibrated.</field>
+      <field type="uint8_t" name="cal_mask" display="bitmask">Bitmask of compasses being calibrated.</field>
+      <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Calibration Status.</field>
+      <field type="uint8_t" name="autosaved">0=requires a MAV_CMD_DO_ACCEPT_MAG_CAL, 1=saved to parameters.</field>
+      <field type="float" name="fitness" units="mgauss">RMS milligauss residuals.</field>
+      <field type="float" name="ofs_x">X offset.</field>
+      <field type="float" name="ofs_y">Y offset.</field>
+      <field type="float" name="ofs_z">Z offset.</field>
+      <field type="float" name="diag_x">X diagonal (matrix 11).</field>
+      <field type="float" name="diag_y">Y diagonal (matrix 22).</field>
+      <field type="float" name="diag_z">Z diagonal (matrix 33).</field>
+      <field type="float" name="offdiag_x">X off-diagonal (matrix 12 and 21).</field>
+      <field type="float" name="offdiag_y">Y off-diagonal (matrix 13 and 31).</field>
+      <field type="float" name="offdiag_z">Z off-diagonal (matrix 32 and 23).</field>
+      <extensions/>
+      <field type="float" name="orientation_confidence">Confidence in orientation (higher is better).</field>
+      <field type="uint8_t" name="old_orientation" enum="MAV_SENSOR_ORIENTATION">orientation before calibration.</field>
+      <field type="uint8_t" name="new_orientation" enum="MAV_SENSOR_ORIENTATION">orientation after calibration.</field>
+      <field type="float" name="scale_factor">field radius correction factor</field>
+    </message>
+    <!-- 225 EFI_STATUS imported from ardupilotmega.xml -->
+    <message id="225" name="EFI_STATUS">
+      <description>EFI status output</description>
+      <field type="uint8_t" name="health">EFI health status</field>
+      <field type="float" name="ecu_index">ECU index</field>
+      <field type="float" name="rpm">RPM</field>
+      <field type="float" name="fuel_consumed" units="cm^3">Fuel consumed</field>
+      <field type="float" name="fuel_flow" units="cm^3/min">Fuel flow rate</field>
+      <field type="float" name="engine_load" units="%">Engine load</field>
+      <field type="float" name="throttle_position" units="%">Throttle position</field>
+      <field type="float" name="spark_dwell_time" units="ms">Spark dwell time</field>
+      <field type="float" name="barometric_pressure" units="kPa">Barometric pressure</field>
+      <field type="float" name="intake_manifold_pressure" units="kPa">Intake manifold pressure(</field>
+      <field type="float" name="intake_manifold_temperature" units="degC">Intake manifold temperature</field>
+      <field type="float" name="cylinder_head_temperature" units="degC">Cylinder head temperature</field>
+      <field type="float" name="ignition_timing" units="deg">Ignition timing (Crank angle degrees)</field>
+      <field type="float" name="injection_time" units="ms">Injection time</field>
+      <field type="float" name="exhaust_gas_temperature" units="degC">Exhaust gas temperature</field>
+      <field type="float" name="throttle_out" units="%">Output throttle</field>
+      <field type="float" name="pt_compensation">Pressure/temperature compensation</field>
+      <extensions/>
+      <field type="float" name="ignition_voltage" units="V">Supply voltage to EFI sparking system.  Zero in this value means "unknown", so if the supply voltage really is zero volts use 0.0001 instead.</field>
+    </message>
+    <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
+    <message id="230" name="ESTIMATOR_STATUS">
+      <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovation test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovation test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint16_t" name="flags" enum="ESTIMATOR_STATUS_FLAGS" display="bitmask">Bitmap indicating which EKF outputs are valid.</field>
+      <field type="float" name="vel_ratio">Velocity innovation test ratio</field>
+      <field type="float" name="pos_horiz_ratio">Horizontal position innovation test ratio</field>
+      <field type="float" name="pos_vert_ratio">Vertical position innovation test ratio</field>
+      <field type="float" name="mag_ratio">Magnetometer innovation test ratio</field>
+      <field type="float" name="hagl_ratio">Height above terrain innovation test ratio</field>
+      <field type="float" name="tas_ratio">True airspeed innovation test ratio</field>
+      <field type="float" name="pos_horiz_accuracy" units="m">Horizontal position 1-STD accuracy relative to the EKF local origin</field>
+      <field type="float" name="pos_vert_accuracy" units="m">Vertical position 1-STD accuracy relative to the EKF local origin</field>
+    </message>
+    <message id="231" name="WIND_COV">
+      <description>Wind covariance estimate from vehicle.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="wind_x" units="m/s">Wind in X (NED) direction</field>
+      <field type="float" name="wind_y" units="m/s">Wind in Y (NED) direction</field>
+      <field type="float" name="wind_z" units="m/s">Wind in Z (NED) direction</field>
+      <field type="float" name="var_horiz" units="m/s">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
+      <field type="float" name="var_vert" units="m/s">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
+      <field type="float" name="wind_alt" units="m">Altitude (MSL) that this measurement was taken at</field>
+      <field type="float" name="horiz_accuracy" units="m">Horizontal speed 1-STD accuracy</field>
+      <field type="float" name="vert_accuracy" units="m">Vertical speed 1-STD accuracy</field>
+    </message>
+    <message id="232" name="GPS_INPUT">
+      <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the system.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="gps_id" instance="true">ID of the GPS for multiple GPS inputs</field>
+      <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS" display="bitmask">Bitmap indicating which GPS input flags fields to ignore.  All other fields must be provided.</field>
+      <field type="uint32_t" name="time_week_ms" units="ms">GPS time (from start of GPS week)</field>
+      <field type="uint16_t" name="time_week">GPS week number</field>
+      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m">Altitude (MSL). Positive for up.</field>
+      <field type="float" name="hdop">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="float" name="vdop">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="float" name="vn" units="m/s">GPS velocity in north direction in earth-fixed NED frame</field>
+      <field type="float" name="ve" units="m/s">GPS velocity in east direction in earth-fixed NED frame</field>
+      <field type="float" name="vd" units="m/s">GPS velocity in down direction in earth-fixed NED frame</field>
+      <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy</field>
+      <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy</field>
+      <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
+      <extensions/>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>
+    </message>
+    <message id="233" name="GPS_RTCM_DATA">
+      <description>RTCM message for injecting into the onboard GPS (used for DGPS)</description>
+      <field type="uint8_t" name="flags">LSB: 1 means message is fragmented, next 2 bits are the fragment ID, the remaining 5 bits are used for the sequence ID. Messages are only to be flushed to the GPS when the entire message has been reconstructed on the autopilot. The fragment ID specifies which order the fragments should be assembled into a buffer, while the sequence ID is used to detect a mismatch between different buffers. The buffer is considered fully reconstructed when either all 4 fragments are present, or all the fragments before the first fragment with a non full payload is received. This management is used to ensure that normal GPS operation doesn't corrupt RTCM data, and to recover from a unreliable transport delivery order.</field>
+      <field type="uint8_t" name="len" units="bytes">data length</field>
+      <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
+    </message>
+    <message id="234" name="HIGH_LATENCY">
+      <deprecated since="2020-10" replaced_by="HIGH_LATENCY2"/>
+      <description>Message appropriate for high latency connections like Iridium</description>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">Bitmap of enabled system modes.</field>
+      <field type="uint32_t" name="custom_mode" display="bitmask">A bitfield for use for autopilot-specific flags.</field>
+      <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+      <field type="int16_t" name="roll" units="cdeg">roll</field>
+      <field type="int16_t" name="pitch" units="cdeg">pitch</field>
+      <field type="uint16_t" name="heading" units="cdeg">heading</field>
+      <field type="int8_t" name="throttle" units="%">throttle (percentage)</field>
+      <field type="int16_t" name="heading_sp" units="cdeg">heading setpoint</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude</field>
+      <field type="int16_t" name="altitude_amsl" units="m">Altitude above mean sea level</field>
+      <field type="int16_t" name="altitude_sp" units="m">Altitude setpoint relative to the home position</field>
+      <field type="uint8_t" name="airspeed" units="m/s">airspeed</field>
+      <field type="uint8_t" name="airspeed_sp" units="m/s">airspeed setpoint</field>
+      <field type="uint8_t" name="groundspeed" units="m/s">groundspeed</field>
+      <field type="int8_t" name="climb_rate" units="m/s">climb rate</field>
+      <field type="uint8_t" name="gps_nsat">Number of satellites visible. If unknown, set to 255</field>
+      <field type="uint8_t" name="gps_fix_type" enum="GPS_FIX_TYPE">GPS Fix type.</field>
+      <field type="uint8_t" name="battery_remaining" units="%">Remaining battery (percentage)</field>
+      <field type="int8_t" name="temperature" units="degC">Autopilot temperature (degrees C)</field>
+      <field type="int8_t" name="temperature_air" units="degC">Air temperature (degrees C) from airspeed sensor</field>
+      <field type="uint8_t" name="failsafe">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
+      <field type="uint8_t" name="wp_num">current waypoint number</field>
+      <field type="uint16_t" name="wp_distance" units="m">distance to target</field>
+    </message>
+    <message id="235" name="HIGH_LATENCY2">
+      <description>Message appropriate for high latency connections like Iridium (version 2)</description>
+      <field type="uint32_t" name="timestamp" units="ms">Timestamp (milliseconds since boot or Unix epoch)</field>
+      <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the MAV (quadrotor, helicopter, etc.)</field>
+      <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class. Use MAV_AUTOPILOT_INVALID for components that are not flight controllers.</field>
+      <field type="uint16_t" name="custom_mode" display="bitmask">A bitfield for use for autopilot-specific flags (2 byte version).</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude</field>
+      <field type="int16_t" name="altitude" units="m">Altitude above mean sea level</field>
+      <field type="int16_t" name="target_altitude" units="m">Altitude setpoint</field>
+      <field type="uint8_t" name="heading" units="deg/2">Heading</field>
+      <field type="uint8_t" name="target_heading" units="deg/2">Heading setpoint</field>
+      <field type="uint16_t" name="target_distance" units="dam">Distance to target waypoint or position</field>
+      <field type="uint8_t" name="throttle" units="%">Throttle</field>
+      <field type="uint8_t" name="airspeed" units="m/s*5">Airspeed</field>
+      <field type="uint8_t" name="airspeed_sp" units="m/s*5">Airspeed setpoint</field>
+      <field type="uint8_t" name="groundspeed" units="m/s*5">Groundspeed</field>
+      <field type="uint8_t" name="windspeed" units="m/s*5">Windspeed</field>
+      <field type="uint8_t" name="wind_heading" units="deg/2">Wind heading</field>
+      <field type="uint8_t" name="eph" units="dm">Maximum error horizontal position since last message</field>
+      <field type="uint8_t" name="epv" units="dm">Maximum error vertical position since last message</field>
+      <field type="int8_t" name="temperature_air" units="degC">Air temperature from airspeed sensor</field>
+      <field type="int8_t" name="climb_rate" units="dm/s">Maximum climb rate magnitude since last message</field>
+      <field type="int8_t" name="battery" units="%">Battery level (-1 if field not provided).</field>
+      <field type="uint16_t" name="wp_num">Current waypoint number</field>
+      <field type="uint16_t" name="failure_flags" enum="HL_FAILURE_FLAG" display="bitmask">Bitmap of failure flags.</field>
+      <field type="int8_t" name="custom0">Field for custom payload.</field>
+      <field type="int8_t" name="custom1">Field for custom payload.</field>
+      <field type="int8_t" name="custom2">Field for custom payload.</field>
+    </message>
+    <message id="241" name="VIBRATION">
+      <description>Vibration levels and accelerometer clipping</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="vibration_x">Vibration levels on X-axis</field>
+      <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
+      <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
+      <field type="uint32_t" name="clipping_0">first accelerometer clipping count</field>
+      <field type="uint32_t" name="clipping_1">second accelerometer clipping count</field>
+      <field type="uint32_t" name="clipping_2">third accelerometer clipping count</field>
+    </message>
+    <message id="242" name="HOME_POSITION">
+      <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitly set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
+      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
+      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
+      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
+      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+      <field type="float" name="approach_x" units="m">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_y" units="m">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_z" units="m">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <extensions/>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="243" name="SET_HOME_POSITION">
+      <deprecated since="2022-02" replaced_by="MAV_CMD_DO_SET_HOME">This message is being superseded by MAV_CMD_DO_SET_HOME.  Using the command protocols allows a GCS to detect setting of the home position has failed.</deprecated>
+      <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitly set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
+      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
+      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
+      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
+      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+      <field type="float" name="approach_x" units="m">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_y" units="m">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_z" units="m">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <extensions/>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="244" name="MESSAGE_INTERVAL">
+      <description>The interval between messages for a particular MAVLink message ID. This message is the response to the MAV_CMD_GET_MESSAGE_INTERVAL command. This interface replaces DATA_STREAM.</description>
+      <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
+      <field type="int32_t" name="interval_us" units="us">The interval between two messages. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.</field>
+    </message>
+    <message id="245" name="EXTENDED_SYS_STATE">
+      <description>Provides state for additional features</description>
+      <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
+      <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+    </message>
+    <message id="246" name="ADSB_VEHICLE">
+      <description>The location and information of an ADSB vehicle</description>
+      <field type="uint32_t" name="ICAO_address">ICAO address</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">ADSB altitude type.</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude(ASL)</field>
+      <field type="uint16_t" name="heading" units="cdeg">Course over ground</field>
+      <field type="uint16_t" name="hor_velocity" units="cm/s">The horizontal velocity</field>
+      <field type="int16_t" name="ver_velocity" units="cm/s">The vertical velocity. Positive is up</field>
+      <field type="char[9]" name="callsign">The callsign, 8+null</field>
+      <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">ADSB emitter type.</field>
+      <field type="uint8_t" name="tslc" units="s">Time since last communication in seconds</field>
+      <field type="uint16_t" name="flags" enum="ADSB_FLAGS" display="bitmask">Bitmap to indicate various statuses including valid data fields</field>
+      <field type="uint16_t" name="squawk">Squawk code</field>
+    </message>
+    <message id="247" name="COLLISION">
+      <description>Information about a potential collision</description>
+      <field type="uint8_t" name="src" enum="MAV_COLLISION_SRC">Collision data source</field>
+      <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
+      <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
+      <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
+      <field type="float" name="time_to_minimum_delta" units="s">Estimated time until collision occurs</field>
+      <field type="float" name="altitude_minimum_delta" units="m">Closest vertical distance between vehicle and object</field>
+      <field type="float" name="horizontal_minimum_delta" units="m">Closest horizontal distance between vehicle and object</field>
+    </message>
+    <message id="248" name="V2_EXTENSION">
+      <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
+      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+      <field type="uint16_t" name="message_type">A code that identifies the software component that understands this message (analogous to USB device classes or mime type strings). If this code is less than 32768, it is considered a 'registered' protocol extension and the corresponding entry should be added to https://github.com/mavlink/mavlink/definition_files/extension_message_ids.xml. Software creators can register blocks of message IDs as needed (useful for GCS specific metadata, etc...). Message_types greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
+      <field type="uint8_t[249]" name="payload">Variable length payload. The length must be encoded in the payload as part of the message_type protocol, e.g. by including the length as payload data, or by terminating the payload data with a non-zero marker. This is required in order to reconstruct zero-terminated payloads that are (or otherwise would be) trimmed by MAVLink 2 empty-byte truncation. The entire content of the payload block is opaque unless you understand the encoding message_type. The particular encoding used can be extension specific and might not always be documented as part of the MAVLink specification.</field>
+    </message>
+    <message id="249" name="MEMORY_VECT">
+      <description>Send raw controller memory. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint16_t" name="address">Starting address of the debug variables</field>
+      <field type="uint8_t" name="ver">Version code of the type variable. 0=unknown, type ignored and assumed int16_t. 1=as below</field>
+      <field type="uint8_t" name="type">Type code of the memory variables. for ver = 1: 0=16 x int16_t, 1=16 x uint16_t, 2=16 x Q15, 3=16 x 1Q14</field>
+      <field type="int8_t[32]" name="value">Memory contents at specified address</field>
+    </message>
+    <message id="250" name="DEBUG_VECT">
+      <description>To debug something using a named 3D vector.</description>
+      <field type="char[10]" name="name" instance="true">Name</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="float" name="x">x</field>
+      <field type="float" name="y">y</field>
+      <field type="float" name="z">z</field>
+    </message>
+    <message id="251" name="NAMED_VALUE_FLOAT">
+      <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="char[10]" name="name" instance="true">Name of the debug variable</field>
+      <field type="float" name="value">Floating point value</field>
+    </message>
+    <message id="252" name="NAMED_VALUE_INT">
+      <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="char[10]" name="name" instance="true">Name of the debug variable</field>
+      <field type="int32_t" name="value">Signed integer value</field>
+    </message>
+    <message id="253" name="STATUSTEXT">
+      <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
+      <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424.</field>
+      <field type="char[50]" name="text">Status text message, without null termination character</field>
+      <extensions/>
+      <field type="uint16_t" name="id">Unique (opaque) identifier for this statustext message.  May be used to reassemble a logical long-statustext message from a sequence of chunks.  A value of zero indicates this is the only chunk in the sequence and the message can be emitted immediately.</field>
+      <field type="uint8_t" name="chunk_seq">This chunk's sequence number; indexing is from zero.  Any null character in the text field is taken to mean this was the last chunk.</field>
+    </message>
+    <message id="254" name="DEBUG">
+      <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="ind">index of debug variable</field>
+      <field type="float" name="value">DEBUG value</field>
+    </message>
+    <!-- messages with ID 256 and above are only available in MAVLink2 -->
+    <message id="256" name="SETUP_SIGNING">
+      <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
+      <field type="uint8_t" name="target_system">system id of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint8_t[32]" name="secret_key">signing key</field>
+      <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
+    </message>
+    <message id="257" name="BUTTON_CHANGE">
+      <description>Report button state change.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint32_t" name="last_change_ms" units="ms">Time of last change of button state.</field>
+      <field type="uint8_t" name="state" display="bitmask">Bitmap for state of buttons.</field>
+    </message>
+    <message id="258" name="PLAY_TUNE">
+      <description>Control vehicle tone generation (buzzer).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[30]" name="tune">tune in board specific format</field>
+      <extensions/>
+      <field type="char[200]" name="tune2">tune extension (appended to tune)</field>
+    </message>
+    <message id="259" name="CAMERA_INFORMATION">
+      <description>Information about a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
+      <field type="uint32_t" name="firmware_version">Version of the camera firmware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff)</field>
+      <field type="float" name="focal_length" units="mm">Focal length</field>
+      <field type="float" name="sensor_size_h" units="mm">Image sensor size horizontal</field>
+      <field type="float" name="sensor_size_v" units="mm">Image sensor size vertical</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Horizontal image resolution</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Vertical image resolution</field>
+      <field type="uint8_t" name="lens_id">Reserved for a lens ID</field>
+      <field type="uint32_t" name="flags" enum="CAMERA_CAP_FLAGS" display="bitmask">Bitmap of camera capability flags.</field>
+      <field type="uint16_t" name="cam_definition_version">Camera definition version (iteration)</field>
+      <field type="char[140]" name="cam_definition_uri">Camera definition URI (if any, otherwise only basic functions will be available). HTTP- (http://) and MAVLink FTP- (mavlinkftp://) formatted URIs are allowed (and both must be supported by any GCS that implements the Camera Protocol).</field>
+    </message>
+    <message id="260" name="CAMERA_SETTINGS">
+      <description>Settings of a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode</field>
+      <extensions/>
+      <field type="float" name="zoomLevel">Current zoom level (0.0 to 100.0, NaN if not known)</field>
+      <field type="float" name="focusLevel">Current focus level (0.0 to 100.0, NaN if not known)</field>
+    </message>
+    <message id="261" name="STORAGE_INFORMATION">
+      <description>Information about a storage medium. This message is sent in response to a request with MAV_CMD_REQUEST_MESSAGE and whenever the status of the storage changes (STORAGE_STATUS). Use MAV_CMD_REQUEST_MESSAGE.param2 to indicate the index/id of requested storage: 0 for all, 1 for first, 2 for second, etc.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="storage_id" instance="true">Storage ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="storage_count">Number of storage devices</field>
+      <field type="uint8_t" name="status" enum="STORAGE_STATUS">Status of storage</field>
+      <field type="float" name="total_capacity" units="MiB">Total capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
+      <field type="float" name="used_capacity" units="MiB">Used capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
+      <field type="float" name="available_capacity" units="MiB">Available storage capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
+      <field type="float" name="read_speed" units="MiB/s">Read speed.</field>
+      <field type="float" name="write_speed" units="MiB/s">Write speed.</field>
+      <extensions/>
+      <field type="uint8_t" name="type" enum="STORAGE_TYPE">Type of storage</field>
+      <field type="char[32]" name="name">Textual storage name to be used in UI (microSD 1, Internal Memory, etc.) This is a NULL terminated string. If it is exactly 32 characters long, add a terminating NULL. If this string is empty, the generic type is shown to the user.</field>
+    </message>
+    <message id="262" name="CAMERA_CAPTURE_STATUS">
+      <description>Information about the status of a capture. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="image_status">Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)</field>
+      <field type="uint8_t" name="video_status">Current status of video capturing (0: idle, 1: capture in progress)</field>
+      <field type="float" name="image_interval" units="s">Image capture interval</field>
+      <field type="uint32_t" name="recording_time_ms" units="ms">Time since recording started</field>
+      <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>
+      <extensions/>
+      <field type="int32_t" name="image_count">Total number of images captured ('forever', or until reset using MAV_CMD_STORAGE_FORMAT).</field>
+    </message>
+    <message id="263" name="CAMERA_IMAGE_CAPTURED">
+      <description>Information about a captured image. This is emitted every time a message is captured. It may be re-requested using MAV_CMD_REQUEST_MESSAGE, using param2 to indicate the sequence number for the missing image.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint64_t" name="time_utc" units="us">Timestamp (time since UNIX epoch) in UTC. 0 for unknown.</field>
+      <field type="uint8_t" name="camera_id">Deprecated/unused. Component IDs are used to differentiate multiple cameras.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude where image was taken</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude where capture was taken</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL) where image was taken</field>
+      <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+      <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="int32_t" name="image_index">Zero based index of this image (i.e. a new image will have index CAMERA_CAPTURE_STATUS.image count -1)</field>
+      <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
+      <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
+    </message>
+    <message id="264" name="FLIGHT_INFORMATION">
+      <description>Information about flight since last arming.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint64_t" name="arming_time_utc" units="us">Timestamp at arming (time since UNIX epoch) in UTC, 0 for unknown</field>
+      <field type="uint64_t" name="takeoff_time_utc" units="us">Timestamp at takeoff (time since UNIX epoch) in UTC, 0 for unknown</field>
+      <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
+    </message>
+    <message id="265" name="MOUNT_ORIENTATION">
+      <description>Orientation of a mount</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>
+      <field type="float" name="pitch" units="deg">Pitch in global frame (set to NaN for invalid).</field>
+      <field type="float" name="yaw" units="deg">Yaw relative to vehicle (set to NaN for invalid).</field>
+      <extensions/>
+      <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame relative to Earth's North, north is 0 (set to NaN for invalid).</field>
+    </message>
+    <message id="266" name="LOGGING_DATA">
+      <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+      <field type="uint8_t" name="length" units="bytes">data length</field>
+      <field type="uint8_t" name="first_message_offset" units="bytes">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+      <field type="uint8_t[249]" name="data">logged data</field>
+    </message>
+    <message id="267" name="LOGGING_DATA_ACKED">
+      <description>A message containing logged data which requires a LOGGING_ACK to be sent back</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+      <field type="uint8_t" name="length" units="bytes">data length</field>
+      <field type="uint8_t" name="first_message_offset" units="bytes">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+      <field type="uint8_t[249]" name="data">logged data</field>
+    </message>
+    <message id="268" name="LOGGING_ACK">
+      <description>An ack for a LOGGING_DATA_ACKED message</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
+    </message>
+    <message id="269" name="VIDEO_STREAM_INFORMATION">
+      <description>Information about video stream. It may be requested using MAV_CMD_REQUEST_MESSAGE, where param2 indicates the video stream id: 0 for all streams, 1 for first, 2 for second, etc.</description>
+      <field type="uint8_t" name="stream_id" instance="true">Video Stream ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="count">Number of streams available.</field>
+      <field type="uint8_t" name="type" enum="VIDEO_STREAM_TYPE">Type of stream.</field>
+      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags.</field>
+      <field type="float" name="framerate" units="Hz">Frame rate.</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution.</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution.</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate.</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise.</field>
+      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view.</field>
+      <field type="char[32]" name="name">Stream name.</field>
+      <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).</field>
+    </message>
+    <message id="270" name="VIDEO_STREAM_STATUS">
+      <description>Information about the status of a video stream. It may be requested using MAV_CMD_REQUEST_MESSAGE.</description>
+      <field type="uint8_t" name="stream_id" instance="true">Video Stream ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
+      <field type="float" name="framerate" units="Hz">Frame rate</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
+      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
+    </message>
+    <message id="283" name="GIMBAL_DEVICE_INFORMATION">
+      <description>Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc..</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="char[32]" name="vendor_name">Name of the gimbal vendor.</field>
+      <field type="char[32]" name="model_name">Name of the gimbal model.</field>
+      <field type="char[32]" name="custom_name">Custom name of the gimbal given to it by the user.</field>
+      <field type="uint32_t" name="firmware_version">Version of the gimbal firmware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff).</field>
+      <field type="uint32_t" name="hardware_version">Version of the gimbal hardware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff).</field>
+      <field type="uint64_t" name="uid" invalid="0">UID of gimbal hardware (0 if unknown).</field>
+      <field type="uint16_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint16_t" name="custom_cap_flags" display="bitmask">Bitmap for use for gimbal-specific capability flags.</field>
+      <field type="float" name="roll_min" units="rad">Minimum hardware roll angle (positive: rolling to the right, negative: rolling to the left)</field>
+      <field type="float" name="roll_max" units="rad">Maximum hardware roll angle (positive: rolling to the right, negative: rolling to the left)</field>
+      <field type="float" name="pitch_min" units="rad">Minimum hardware pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="pitch_max" units="rad">Maximum hardware pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="yaw_min" units="rad">Minimum hardware yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="yaw_max" units="rad">Maximum hardware yaw angle (positive: to the right, negative: to the left)</field>
+    </message>
+    <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal device component. Angles and rates can be set to NaN according to use case.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
+      <field type="float[4]" name="q" invalid="[NaN]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, set all fields to NaN if only angular velocity should be used)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity, positive is rolling to the right, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity, positive is pitching up, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity, positive is yawing to the right, NaN to be ignored.</field>
+    </message>
+    <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component. The angles encoded in the quaternion are relative to absolute North if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right) or relative to the vehicle heading if the flag is not set. This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (NaN if unknown)</field>
+      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+    </message>
+    <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
+      <description>Low level message containing autopilot state relevant for a gimbal device. This message is to be sent from the gimbal manager to the gimbal device component. The data of this message server for the gimbal's estimator corrections in particular horizon compensation, as well as the autopilot's control intention e.g. feed forward angular control in z-axis.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint64_t" name="time_boot_us" units="us">Timestamp (time since system boot).</field>
+      <field type="float[4]" name="q">Quaternion components of autopilot attitude: w, x, y, z (1 0 0 0 is the null-rotation, Hamilton convention).</field>
+      <field type="uint32_t" name="q_estimated_delay_us" units="us">Estimated delay of the attitude data.</field>
+      <field type="float" name="vx" units="m/s">X Speed in NED (North, East, Down).</field>
+      <field type="float" name="vy" units="m/s">Y Speed in NED (North, East, Down).</field>
+      <field type="float" name="vz" units="m/s">Z Speed in NED (North, East, Down).</field>
+      <field type="uint32_t" name="v_estimated_delay_us" units="us">Estimated delay of the speed data.</field>
+      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s" invalid="NaN">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
+      <field type="uint16_t" name="estimator_status" enum="ESTIMATOR_STATUS_FLAGS" display="bitmask">Bitmap indicating which estimator outputs are valid.</field>
+      <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE" invalid="MAV_LANDED_STATE_UNDEFINED">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+    </message>
+    <message id="299" name="WIFI_CONFIG_AP">
+      <description>Configure WiFi AP SSID, password, and mode. This message is re-emitted as an acknowledgement by the AP. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE</description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Blank to leave it unchanged when setting. Current SSID when sent back as a response.</field>
+      <field type="char[64]" name="password">Password. Blank for an open AP. MD5 hash when message is sent back as a response.</field>
+    </message>
+    <message id="301" name="AIS_VESSEL">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>The location and information of an AIS vessel</description>
+      <field type="uint32_t" name="MMSI">Mobile Marine Service Identifier, 9 decimal digits</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="uint16_t" name="COG" units="cdeg">Course over ground</field>
+      <field type="uint16_t" name="heading" units="cdeg">True heading</field>
+      <field type="uint16_t" name="velocity" units="cm/s">Speed over ground</field>
+      <field type="int8_t" name="turn_rate" units="cdeg/s">Turn rate</field>
+      <field type="uint8_t" name="navigational_status" enum="AIS_NAV_STATUS">Navigational status</field>
+      <field type="uint8_t" name="type" enum="AIS_TYPE">Type of vessels</field>
+      <field type="uint16_t" name="dimension_bow" units="m">Distance from lat/lon location to bow</field>
+      <field type="uint16_t" name="dimension_stern" units="m">Distance from lat/lon location to stern</field>
+      <field type="uint8_t" name="dimension_port" units="m">Distance from lat/lon location to port side</field>
+      <field type="uint8_t" name="dimension_starboard" units="m">Distance from lat/lon location to starboard side</field>
+      <field type="char[7]" name="callsign">The vessel callsign</field>
+      <field type="char[20]" name="name">The vessel name</field>
+      <field type="uint16_t" name="tslc" units="s">Time since last communication in seconds</field>
+      <field type="uint16_t" name="flags" enum="AIS_FLAGS" display="bitmask">Bitmask to indicate various statuses including valid data fields</field>
+    </message>
+    <!-- UAVCAN related messages. Please keep the range [310, 320) reserved for UAVCAN. -->
+    <message id="310" name="UAVCAN_NODE_STATUS">
+      <description>General status information of an UAVCAN node. Please refer to the definition of the UAVCAN message "uavcan.protocol.NodeStatus" for the background information. The UAVCAN specification is available at http://uavcan.org.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint32_t" name="uptime_sec" units="s">Time since the start-up of the node.</field>
+      <field type="uint8_t" name="health" enum="UAVCAN_NODE_HEALTH">Generalized node health status.</field>
+      <field type="uint8_t" name="mode" enum="UAVCAN_NODE_MODE">Generalized operating mode.</field>
+      <field type="uint8_t" name="sub_mode">Not used currently.</field>
+      <field type="uint16_t" name="vendor_specific_status_code">Vendor-specific status information.</field>
+    </message>
+    <message id="311" name="UAVCAN_NODE_INFO">
+      <description>General information describing a particular UAVCAN node. Please refer to the definition of the UAVCAN service "uavcan.protocol.GetNodeInfo" for the background information. This message should be emitted by the system whenever a new node appears online, or an existing node reboots. Additionally, it can be emitted upon request from the other end of the MAVLink channel (see MAV_CMD_UAVCAN_GET_NODE_INFO). It is also not prohibited to emit this message unconditionally at a low frequency. The UAVCAN specification is available at http://uavcan.org.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint32_t" name="uptime_sec" units="s">Time since the start-up of the node.</field>
+      <field type="char[80]" name="name">Node name string. For example, "sapog.px4.io".</field>
+      <field type="uint8_t" name="hw_version_major">Hardware major version number.</field>
+      <field type="uint8_t" name="hw_version_minor">Hardware minor version number.</field>
+      <field type="uint8_t[16]" name="hw_unique_id">Hardware unique 128-bit ID.</field>
+      <field type="uint8_t" name="sw_version_major">Software major version number.</field>
+      <field type="uint8_t" name="sw_version_minor">Software minor version number.</field>
+      <field type="uint32_t" name="sw_vcs_commit">Version control system (VCS) revision identifier (e.g. git short commit hash). Zero if unknown.</field>
+    </message>
+    <message id="320" name="PARAM_EXT_REQUEST_READ">
+      <description>Request to read the value of a parameter with either the param_id string id or param_index. PARAM_EXT_VALUE should be emitted in response.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index" invalid="-1">Parameter index. Set to -1 to use the Parameter ID field as identifier (else param_id will be ignored)</field>
+    </message>
+    <message id="321" name="PARAM_EXT_REQUEST_LIST">
+      <description>Request all parameters of this component. All parameters should be emitted in response as PARAM_EXT_VALUE.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="322" name="PARAM_EXT_VALUE">
+      <description>Emit the value of a parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows them to re-request missing parameters after a loss or timeout.</description>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[128]" name="param_value">Parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
+      <field type="uint16_t" name="param_count">Total number of parameters</field>
+      <field type="uint16_t" name="param_index">Index of this parameter</field>
+    </message>
+    <message id="323" name="PARAM_EXT_SET">
+      <description>Set a parameter value. In order to deal with message loss (and retransmission of PARAM_EXT_SET), when setting a parameter value and the new value is the same as the current value, you will immediately get a PARAM_ACK_ACCEPTED response. If the current state is PARAM_ACK_IN_PROGRESS, you will accordingly receive a PARAM_ACK_IN_PROGRESS in response.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[128]" name="param_value">Parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
+    </message>
+    <message id="324" name="PARAM_EXT_ACK">
+      <description>Response from a PARAM_EXT_SET message.</description>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[128]" name="param_value">Parameter value (new value if PARAM_ACK_ACCEPTED, current value otherwise)</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
+      <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
+    </message>
+    <message id="330" name="OBSTACLE_DISTANCE">
+      <description>Obstacle distances in front of the sensor, starting from the left in increment degrees to the right</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="sensor_type" enum="MAV_DISTANCE_SENSOR">Class id of the distance sensor type.</field>
+      <field type="uint16_t[72]" name="distances" units="cm">Distance of obstacles around the vehicle with index 0 corresponding to north + angle_offset, unless otherwise specified in the frame. A value of 0 is valid and means that the obstacle is practically touching the sensor. A value of max_distance +1 means no obstacle is present. A value of UINT16_MAX for unknown/not used. In a array element, one unit corresponds to 1cm.</field>
+      <field type="uint8_t" name="increment" units="deg">Angular width in degrees of each array element. Increment direction is clockwise. This field is ignored if increment_f is non-zero.</field>
+      <field type="uint16_t" name="min_distance" units="cm">Minimum distance the sensor can measure.</field>
+      <field type="uint16_t" name="max_distance" units="cm">Maximum distance the sensor can measure.</field>
+      <extensions/>
+      <field type="float" name="increment_f" units="deg">Angular width in degrees of each array element as a float. If non-zero then this value is used instead of the uint8_t increment field. Positive is clockwise direction, negative is counter-clockwise.</field>
+      <field type="float" name="angle_offset" units="deg">Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive is clockwise direction, negative is counter-clockwise.</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame of reference for the yaw rotation and offset of the sensor data. Defaults to MAV_FRAME_GLOBAL, which is north aligned. For body-mounted sensors use MAV_FRAME_BODY_FRD, which is vehicle front aligned.</field>
+    </message>
+    <message id="331" name="ODOMETRY">
+      <description>Odometry message to communicate odometry information with an external interface. Fits ROS REP 147 standard for aerial vehicles (http://www.ros.org/reps/rep-0147.html).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="frame_id" enum="MAV_FRAME">Coordinate frame of reference for the pose data.</field>
+      <field type="uint8_t" name="child_frame_id" enum="MAV_FRAME">Coordinate frame of reference for the velocity in free space (twist) data.</field>
+      <field type="float" name="x" units="m">X Position</field>
+      <field type="float" name="y" units="m">Y Position</field>
+      <field type="float" name="z" units="m">Z Position</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float" name="vx" units="m/s">X linear speed</field>
+      <field type="float" name="vy" units="m/s">Y linear speed</field>
+      <field type="float" name="vz" units="m/s">Z linear speed</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
+      <field type="float[21]" name="pose_covariance">Row-major representation of a 6x6 pose cross-covariance matrix upper right triangle (states: x, y, z, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+      <field type="float[21]" name="velocity_covariance">Row-major representation of a 6x6 velocity cross-covariance matrix upper right triangle (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
+      <extensions/>
+      <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>
+    </message>
+    <message id="335" name="ISBD_LINK_STATUS">
+      <description>Status of the Iridium SBD link.</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session. The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint16_t" name="failed_sessions">Number of failed SBD sessions.</field>
+      <field type="uint16_t" name="successful_sessions">Number of successful SBD sessions.</field>
+      <field type="uint8_t" name="signal_quality">Signal quality equal to the number of bars displayed on the ISU signal strength indicator. Range is 0 to 5, where 0 indicates no signal and 5 indicates maximum signal strength.</field>
+      <field type="uint8_t" name="ring_pending">1: Ring call pending, 0: No call pending.</field>
+      <field type="uint8_t" name="tx_session_pending">1: Transmission session pending, 0: No transmission session pending.</field>
+      <field type="uint8_t" name="rx_session_pending">1: Receiving session pending, 0: No receiving session pending.</field>
+    </message>
+    <message id="339" name="RAW_RPM">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>RPM sensor data message.</description>
+      <field type="uint8_t" name="index">Index of this RPM sensor (0-indexed)</field>
+      <field type="float" name="frequency" units="rpm">Indicated rate</field>
+    </message>
+    <message id="340" name="UTM_GLOBAL_POSITION">
+      <description>The global position resulting from GPS and sensor fusion.</description>
+      <field type="uint64_t" name="time" units="us">Time of applicability of position (microseconds since UNIX epoch).</field>
+      <field type="uint8_t[18]" name="uas_id">Unique UAS ID.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (WGS84)</field>
+      <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+      <field type="int16_t" name="vx" units="cm/s">Ground X speed (latitude, positive north)</field>
+      <field type="int16_t" name="vy" units="cm/s">Ground Y speed (longitude, positive east)</field>
+      <field type="int16_t" name="vz" units="cm/s">Ground Z speed (altitude, positive down)</field>
+      <field type="uint16_t" name="h_acc" units="mm">Horizontal position uncertainty (standard deviation)</field>
+      <field type="uint16_t" name="v_acc" units="mm">Altitude uncertainty (standard deviation)</field>
+      <field type="uint16_t" name="vel_acc" units="cm/s">Speed uncertainty (standard deviation)</field>
+      <field type="int32_t" name="next_lat" units="degE7">Next waypoint, latitude (WGS84)</field>
+      <field type="int32_t" name="next_lon" units="degE7">Next waypoint, longitude (WGS84)</field>
+      <field type="int32_t" name="next_alt" units="mm">Next waypoint, altitude (WGS84)</field>
+      <field type="uint16_t" name="update_rate" units="cs">Time until next update. Set to 0 if unknown or in data driven mode.</field>
+      <field type="uint8_t" name="flight_state" enum="UTM_FLIGHT_STATE">Flight state</field>
+      <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS" display="bitmask">Bitwise OR combination of the data available flags.</field>
+    </message>
+    <message id="350" name="DEBUG_FLOAT_ARRAY">
+      <description>Large debug/prototyping array. The message uses the maximum available payload for data. The array_id and name fields are used to discriminate between messages in code and in user interfaces (respectively). Do not use in production code.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>
+      <field type="uint16_t" name="array_id" instance="true">Unique ID used to discriminate between arrays</field>
+      <extensions/>
+      <field type="float[58]" name="data">data</field>
+    </message>
+    <message id="370" name="SMART_BATTERY_INFO">
+      <description>Smart Battery information (static/infrequent update). Use for updates from: smart battery to flight stack, flight stack to GCS. Use BATTERY_STATUS for smart battery frequent updates.</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+      <field type="int32_t" name="capacity_full_specification" units="mAh">Capacity when full according to manufacturer, -1: field not provided.</field>
+      <field type="int32_t" name="capacity_full" units="mAh">Capacity when full (accounting for battery degradation), -1: field not provided.</field>
+      <field type="uint16_t" name="cycle_count">Charge/discharge cycle count. UINT16_MAX: field not provided.</field>
+      <field type="char[16]" name="serial_number">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
+      <field type="char[50]" name="device_name">Static device name in ASCII characters, 0 terminated. All 0: field not provided. Encode as manufacturer name then product name separated using an underscore.</field>
+      <field type="uint16_t" name="weight" units="g">Battery weight. 0: field not provided.</field>
+      <field type="uint16_t" name="discharge_minimum_voltage" units="mV">Minimum per-cell voltage when discharging. If not supplied set to UINT16_MAX value.</field>
+      <field type="uint16_t" name="charging_minimum_voltage" units="mV">Minimum per-cell voltage when charging. If not supplied set to UINT16_MAX value.</field>
+      <field type="uint16_t" name="resting_minimum_voltage" units="mV">Minimum per-cell voltage when resting. If not supplied set to UINT16_MAX value.</field>
+      <extensions/>
+      <field type="uint16_t" name="charging_maximum_voltage" units="mV">Maximum per-cell voltage when charged. 0: field not provided.</field>
+      <field type="uint8_t" name="cells_in_series">Number of battery cells in series. 0: field not provided.</field>
+      <field type="uint32_t" name="discharge_maximum_current" units="mA">Maximum pack discharge current. 0: field not provided.</field>
+      <field type="uint32_t" name="discharge_maximum_burst_current" units="mA">Maximum pack discharge burst current. 0: field not provided.</field>
+      <field type="char[11]" name="manufacture_date">Manufacture date (DD/MM/YYYY) in ASCII characters, 0 terminated. All 0: field not provided.</field>
+    </message>
+    <message id="373" name="GENERATOR_STATUS">
+      <description>Telemetry of power generation system. Alternator or mechanical generator.</description>
+      <field type="uint64_t" name="status" display="bitmask" enum="MAV_GENERATOR_STATUS_FLAG">Status flags.</field>
+      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. UINT16_MAX: field not provided.</field>
+      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. NaN: field not provided.</field>
+      <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in. NaN: field not provided</field>
+      <field type="float" name="power_generated" units="W">The power being generated. NaN: field not provided</field>
+      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator, or battery bus if battery bus is controlled by generator and at a different voltage to main bus.</field>
+      <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter. INT16_MAX: field not provided.</field>
+      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. NaN: field not provided</field>
+      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. INT16_MAX: field not provided.</field>
+      <field type="uint32_t" name="runtime" units="s">Seconds this generator has run since it was rebooted. UINT32_MAX: field not provided.</field>
+      <field type="int32_t" name="time_until_maintenance" units="s">Seconds until this generator requires maintenance.  A negative value indicates maintenance is past-due. INT32_MAX: field not provided.</field>
+    </message>
+    <message id="375" name="ACTUATOR_OUTPUT_STATUS">
+      <description>The raw values of the actuator outputs (e.g. on Pixhawk, from MAIN, AUX ports). This message supersedes SERVO_OUTPUT_RAW.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot).</field>
+      <field type="uint32_t" name="active" display="bitmask">Active outputs</field>
+      <field type="float[32]" name="actuator">Servo / motor output array values. Zero values indicate unused channels.</field>
+    </message>
+    <message id="385" name="TUNNEL">
+      <description>Message for transporting "arbitrary" variable-length data from one component to another (broadcast is not forbidden, but discouraged). The encoding of the data is usually extension specific, i.e. determined by the source, and is usually not documented as part of the MAVLink specification.</description>
+      <field type="uint8_t" name="target_system">System ID (can be 0 for broadcast, but this is discouraged)</field>
+      <field type="uint8_t" name="target_component">Component ID (can be 0 for broadcast, but this is discouraged)</field>
+      <field type="uint16_t" name="payload_type" enum="MAV_TUNNEL_PAYLOAD_TYPE">A code that identifies the content of the payload (0 for unknown, which is the default). If this code is less than 32768, it is a 'registered' payload type and the corresponding code should be added to the MAV_TUNNEL_PAYLOAD_TYPE enum. Software creators can register blocks of types as needed. Codes greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
+      <field type="uint8_t" name="payload_length">Length of the data transported in payload</field>
+      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by payload_length. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
+    </message>
+    <message id="386" name="CAN_FRAME">
+      <description>A forwarded CAN frame as requested by MAV_CMD_CAN_FORWARD.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="bus">bus number</field>
+      <field type="uint8_t" name="len">Frame length</field>
+      <field type="uint32_t" name="id">Frame ID</field>
+      <field type="uint8_t[8]" name="data">Frame data</field>
+    </message>
+    <message id="387" name="CANFD_FRAME">
+      <description>A forwarded CANFD frame as requested by MAV_CMD_CAN_FORWARD. These are separated from CAN_FRAME as they need different handling (eg. TAO handling)</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="bus">bus number</field>
+      <field type="uint8_t" name="len">Frame length</field>
+      <field type="uint32_t" name="id">Frame ID</field>
+      <field type="uint8_t[64]" name="data">Frame data</field>
+    </message>
+    <message id="388" name="CAN_FILTER_MODIFY">
+      <description>Modify the filter of what CAN messages to forward over the mavlink. This can be used to make CAN forwarding work well on low bandwith links. The filtering is applied on bits 8 to 24 of the CAN id (2nd and 3rd bytes) which corresponds to the DroneCAN message ID for DroneCAN. Filters with more than 16 IDs can be constructed by sending multiple CAN_FILTER_MODIFY messages.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="uint8_t" name="target_component">Component ID.</field>
+      <field type="uint8_t" name="bus">bus number</field>
+      <field type="uint8_t" name="operation" enum="CAN_FILTER_OP">what operation to perform on the filter list. See CAN_FILTER_OP enum.</field>
+      <field type="uint8_t" name="num_ids">number of IDs in filter list</field>
+      <field type="uint16_t[16]" name="ids">filter IDs, length num_ids</field>
+    </message>
+    <!-- Rover specific messages -->
+    <message id="9000" name="WHEEL_DISTANCE">
+      <description>Cumulative distance traveled for each reported wheel.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (synced to UNIX time or since system boot).</field>
+      <field type="uint8_t" name="count">Number of wheels reported.</field>
+      <field type="double[16]" name="distance" units="m">Distance reported by individual wheel encoders. Forward rotations increase values, reverse rotations decrease them. Not all wheels will necessarily have wheel encoders; the mapping of encoders to wheel positions must be agreed/understood by the endpoints.</field>
+    </message>
+    <message id="9005" name="WINCH_STATUS">
+      <description>Winch status.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (synced to UNIX time or since system boot).</field>
+      <field type="float" name="line_length" units="m">Length of line released. NaN if unknown</field>
+      <field type="float" name="speed" units="m/s">Speed line is being released or retracted. Positive values if being released, negative values if being retracted, NaN if unknown</field>
+      <field type="float" name="tension" units="kg">Tension on the line. NaN if unknown</field>
+      <field type="float" name="voltage" units="V">Voltage of the battery supplying the winch. NaN if unknown</field>
+      <field type="float" name="current" units="A">Current draw from the winch. NaN if unknown</field>
+      <field type="int16_t" name="temperature" units="degC">Temperature of the motor. INT16_MAX if unknown</field>
+      <field type="uint32_t" name="status" display="bitmask" enum="MAV_WINCH_STATUS_FLAG">Status flags</field>
+    </message>
+    <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Basic ID message. This and the below messages are primarily meant for feeding data to/from an OpenDroneID implementation. E.g. https://github.com/opendroneid/opendroneid-core-c. These messages are compatible with the ASTM F3411 Remote ID standard and the ASD-STAN prEN 4709-002 Direct Remote ID standard. Additional information and usage of these messages is documented at https://mavlink.io/en/services/opendroneid.html.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="id_type" enum="MAV_ODID_ID_TYPE">Indicates the format for the uas_id field of this message.</field>
+      <field type="uint8_t" name="ua_type" enum="MAV_ODID_UA_TYPE">Indicates the type of UA (Unmanned Aircraft).</field>
+      <field type="uint8_t[20]" name="uas_id">UAS (Unmanned Aircraft System) ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12901" name="OPEN_DRONE_ID_LOCATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Location message. The float data types are 32-bit IEEE 754. The Location message provides the location, altitude, direction and speed of the aircraft.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="status" enum="MAV_ODID_STATUS">Indicates whether the unmanned aircraft is on the ground or in the air.</field>
+      <field type="uint16_t" name="direction" units="cdeg" invalid="36100">Direction over ground (not heading, but direction of movement) measured clockwise from true North: 0 - 35999 centi-degrees. If unknown: 36100 centi-degrees.</field>
+      <field type="uint16_t" name="speed_horizontal" units="cm/s">Ground speed. Positive only. If unknown: 25500 cm/s. If speed is larger than 25425 cm/s, use 25425 cm/s.</field>
+      <field type="int16_t" name="speed_vertical" units="cm/s">The vertical speed. Up is positive. If unknown: 6300 cm/s. If speed is larger than 6200 cm/s, use 6200 cm/s. If lower than -6200 cm/s, use -6200 cm/s.</field>
+      <field type="int32_t" name="latitude" units="degE7" invalid="0">Current latitude of the unmanned aircraft. If unknown: 0 (both Lat/Lon).</field>
+      <field type="int32_t" name="longitude" units="degE7" invalid="0">Current longitude of the unmanned aircraft. If unknown: 0 (both Lat/Lon).</field>
+      <field type="float" name="altitude_barometric" units="m" invalid="-1000">The altitude calculated from the barometric pressue. Reference is against 29.92inHg or 1013.2mb. If unknown: -1000 m.</field>
+      <field type="float" name="altitude_geodetic" units="m" invalid="-1000">The geodetic altitude as defined by WGS84. If unknown: -1000 m.</field>
+      <field type="uint8_t" name="height_reference" enum="MAV_ODID_HEIGHT_REF">Indicates the reference point for the height field.</field>
+      <field type="float" name="height" units="m" invalid="-1000">The current height of the unmanned aircraft above the take-off location or the ground as indicated by height_reference. If unknown: -1000 m.</field>
+      <field type="uint8_t" name="horizontal_accuracy" enum="MAV_ODID_HOR_ACC">The accuracy of the horizontal position.</field>
+      <field type="uint8_t" name="vertical_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the vertical position.</field>
+      <field type="uint8_t" name="barometer_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the barometric altitude.</field>
+      <field type="uint8_t" name="speed_accuracy" enum="MAV_ODID_SPEED_ACC">The accuracy of the horizontal and vertical speed.</field>
+      <field type="float" name="timestamp" units="s" invalid="0xFFFF">Seconds after the full hour with reference to UTC time. Typically the GPS outputs a time-of-week value in milliseconds. First convert that to UTC and then convert for this field using ((float) (time_week_ms % (60*60*1000))) / 1000. If unknown: 0xFFFF.</field>
+      <field type="uint8_t" name="timestamp_accuracy" enum="MAV_ODID_TIME_ACC">The accuracy of the timestamps.</field>
+    </message>
+    <message id="12902" name="OPEN_DRONE_ID_AUTHENTICATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System). The Authentication message can have two different formats. For data page 0, the fields PageCount, Length and TimeStamp are present and AuthData is only 17 bytes. For data page 1 through 15, PageCount, Length and TimeStamp are not present and the size of AuthData is 23 bytes.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH_TYPE">Indicates the type of authentication.</field>
+      <field type="uint8_t" name="data_page">Allowed range is 0 - 15.</field>
+      <field type="uint8_t" name="last_page_index">This field is only present for page 0. Allowed range is 0 - 15. See the description of struct ODID_Auth_data at https://github.com/opendroneid/opendroneid-core-c/blob/master/libopendroneid/opendroneid.h.</field>
+      <field type="uint8_t" name="length" units="bytes">This field is only present for page 0. Total bytes of authentication_data from all data pages. See the description of struct ODID_Auth_data at https://github.com/opendroneid/opendroneid-core-c/blob/master/libopendroneid/opendroneid.h.</field>
+      <field type="uint32_t" name="timestamp" units="s">This field is only present for page 0. 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.</field>
+      <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. For page 0, the size is only 17 bytes. For other pages, the size is 23 bytes. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12903" name="OPEN_DRONE_ID_SELF_ID">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Self ID message. The Self ID Message is an opportunity for the operator to (optionally) declare their identity and purpose of the flight. This message can provide additional information that could reduce the threat profile of a UA (Unmanned Aircraft) flying in a particular area or manner. This message can also be used to provide optional additional clarification in an emergency/remote ID system failure situation.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="description_type" enum="MAV_ODID_DESC_TYPE">Indicates the type of the description field.</field>
+      <field type="char[23]" name="description">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12904" name="OPEN_DRONE_ID_SYSTEM">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the operator location/altitude and possible aircraft group and/or category/class information.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="operator_location_type" enum="MAV_ODID_OPERATOR_LOCATION_TYPE">Specifies the operator location type.</field>
+      <field type="uint8_t" name="classification_type" enum="MAV_ODID_CLASSIFICATION_TYPE">Specifies the classification type of the UA.</field>
+      <field type="int32_t" name="operator_latitude" units="degE7" invalid="0">Latitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="int32_t" name="operator_longitude" units="degE7" invalid="0">Longitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="uint16_t" name="area_count">Number of aircraft in the area, group or formation (default 1).</field>
+      <field type="uint16_t" name="area_radius" units="m">Radius of the cylindrical area of the group or formation (default 0).</field>
+      <field type="float" name="area_ceiling" units="m" invalid="-1000">Area Operations Ceiling relative to WGS84. If unknown: -1000 m.</field>
+      <field type="float" name="area_floor" units="m" invalid="-1000">Area Operations Floor relative to WGS84. If unknown: -1000 m.</field>
+      <field type="uint8_t" name="category_eu" enum="MAV_ODID_CATEGORY_EU">When classification_type is MAV_ODID_CLASSIFICATION_TYPE_EU, specifies the category of the UA.</field>
+      <field type="uint8_t" name="class_eu" enum="MAV_ODID_CLASS_EU">When classification_type is MAV_ODID_CLASSIFICATION_TYPE_EU, specifies the class of the UA.</field>
+      <field type="float" name="operator_altitude_geo" units="m" invalid="-1000">Geodetic altitude of the operator relative to WGS84. If unknown: -1000 m.</field>
+      <field type="uint32_t" name="timestamp" units="s">32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.</field>
+    </message>
+    <message id="12905" name="OPEN_DRONE_ID_OPERATOR_ID">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Operator ID message, which contains the CAA (Civil Aviation Authority) issued operator ID.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="operator_id_type" enum="MAV_ODID_OPERATOR_ID_TYPE">Indicates the type of the operator_id field.</field>
+      <field type="char[20]" name="operator_id">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12918" name="OPEN_DRONE_ID_ARM_STATUS">
+      <description>Status from the transmitter telling the flight controller if the remote ID system is ready for arming.</description>
+      <field type="uint8_t" name="status" enum="MAV_ODID_ARM_STATUS">Status level indicating if arming is allowed.</field>
+      <field type="char[50]" name="error">Text error message, should be empty if status is good to arm. Fill with nulls in unused portion.</field>
+    </message>
+    <!-- The message ids 12906 - 12914 are reserved for OpenDroneID. -->
+    <message id="12915" name="OPEN_DRONE_ID_MESSAGE_PACK">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>An OpenDroneID message pack is a container for multiple encoded OpenDroneID messages (i.e. not in the format given for the above message descriptions but after encoding into the compressed OpenDroneID byte format). Used e.g. when transmitting on Bluetooth 5.0 Long Range/Extended Advertising or on WiFi Neighbor Aware Networking or on WiFi Beacon.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
+      <field type="uint8_t" name="single_message_size" units="bytes">This field must currently always be equal to 25 (bytes), since all encoded OpenDroneID messages are specificed to have this length.</field>
+      <field type="uint8_t" name="msg_pack_size">Number of encoded messages in the pack (not the number of bytes). Allowed range is 1 - 9.</field>
+      <field type="uint8_t[225]" name="messages">Concatenation of encoded OpenDroneID messages. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12919" name="OPEN_DRONE_ID_SYSTEM_UPDATE">
+      <description>Update the data in the OPEN_DRONE_ID_SYSTEM message with new location information. This can be sent to update the location information for the operator when no other information in the SYSTEM message has changed. This message allows for efficient operation on radio links which have limited uplink bandwidth while meeting requirements for update frequency of the operator location.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="int32_t" name="operator_latitude" units="degE7" invalid="0">Latitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="int32_t" name="operator_longitude" units="degE7" invalid="0">Longitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="float" name="operator_altitude_geo" units="m" invalid="-1000">Geodetic altitude of the operator relative to WGS84. If unknown: -1000 m.</field>
+      <field type="uint32_t" name="timestamp" units="s">32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.</field>
+    </message>
+    <message id="12920" name="HYGROMETER_SENSOR">
+      <description>Temperature and humidity from hygrometer.</description>
+      <field type="uint8_t" name="id" instance="true">Hygrometer ID</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature</field>
+      <field type="uint16_t" name="humidity" units="c%">Humidity</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/development.xml
+++ b/bp_mavlink/development.xml
@@ -22,5 +22,13 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
       <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
     </message>
+    <!-- //OW -->
+    <message id="236" name="FRSKY_PASSTHROUGH_ARRAY">
+      <description>Frsky SPort passthrough container.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="count">Number of passthrough packets in this message.</field>
+      <field type="uint8_t[240]" name="packet_buf">Passthrough packet buf. A packet has 6 bytes: uint16_t id + uint32_t data. The array has space for 40 packets.</field>
+    </message>
+    <!-- //OWEND -->
   </messages>
 </mavlink>

--- a/bp_mavlink/development.xml
+++ b/bp_mavlink/development.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- XML file for prototyping definitions for standard.xml  -->
+  <include>standard.xml</include>
+  <version>0</version>
+  <dialect>0</dialect>
+  <enums>
+    <!-- none defined (yet) -->
+  </enums>
+  <messages>
+    <message id="53" name="MISSION_CHECKSUM">
+      <description>Checksum for the current mission, rally point or geofence plan, or for the "combined" plan (a GCS can use these checksums to determine if it has matching plans).
+        This message must be broadcast with the appropriate checksum following any change to a mission, geofence or rally point definition
+        (immediately after the MISSION_ACK that completes the upload sequence).
+        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the checksum is required.
+        The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
+        The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
+        The checksum for a mission, geofence or rally point definition is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
+        frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
+        The checksum for the whole plan (MAV_MISSION_TYPE_ALL) is calculated using the same approach, running over each sub-plan in the following order: mission, geofence then rally point.
+      </description>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/icarous.xml
+++ b/bp_mavlink/icarous.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- ICAROUS message definitions                                     -->
+  <!-- https://github.com/nasa/icarous                                 -->
+  <!-- email contacts: Swee Balachandran: swee.balachandran@nianet.org -->
+  <!--                 Cesar Munoz: cesar.a.munoz@nasa.gov             -->
+  <!-- mavlink ID range 42000 - 42099                                  -->
+  <enums>
+    <enum name="ICAROUS_TRACK_BAND_TYPES">
+      <entry name="ICAROUS_TRACK_BAND_TYPE_NONE" value="0"/>
+      <entry name="ICAROUS_TRACK_BAND_TYPE_NEAR" value="1"/>
+      <entry name="ICAROUS_TRACK_BAND_TYPE_RECOVERY" value="2"/>
+    </enum>
+    <enum name="ICAROUS_FMS_STATE">
+      <entry name="ICAROUS_FMS_STATE_IDLE" value="0"/>
+      <entry name="ICAROUS_FMS_STATE_TAKEOFF" value="1"/>
+      <entry name="ICAROUS_FMS_STATE_CLIMB" value="2"/>
+      <entry name="ICAROUS_FMS_STATE_CRUISE" value="3"/>
+      <entry name="ICAROUS_FMS_STATE_APPROACH" value="4"/>
+      <entry name="ICAROUS_FMS_STATE_LAND" value="5"/>
+    </enum>
+  </enums>
+  <messages>
+    <message id="42000" name="ICAROUS_HEARTBEAT">
+      <description>ICAROUS heartbeat</description>
+      <field type="uint8_t" name="status" enum="ICAROUS_FMS_STATE">See the FMS_STATE enum.</field>
+    </message>
+    <message id="42001" name="ICAROUS_KINEMATIC_BANDS">
+      <description>Kinematic multi bands (track) output from Daidalus</description>
+      <field type="int8_t" name="numBands">Number of track bands</field>
+      <field type="uint8_t" name="type1" enum="ICAROUS_TRACK_BAND_TYPES">See the TRACK_BAND_TYPES enum.</field>
+      <field type="float" name="min1" units="deg">min angle (degrees)</field>
+      <field type="float" name="max1" units="deg">max angle (degrees)</field>
+      <field type="uint8_t" name="type2" enum="ICAROUS_TRACK_BAND_TYPES">See the TRACK_BAND_TYPES enum.</field>
+      <field type="float" name="min2" units="deg">min angle (degrees)</field>
+      <field type="float" name="max2" units="deg">max angle (degrees)</field>
+      <field type="uint8_t" name="type3" enum="ICAROUS_TRACK_BAND_TYPES">See the TRACK_BAND_TYPES enum.</field>
+      <field type="float" name="min3" units="deg">min angle (degrees)</field>
+      <field type="float" name="max3" units="deg">max angle (degrees)</field>
+      <field type="uint8_t" name="type4" enum="ICAROUS_TRACK_BAND_TYPES">See the TRACK_BAND_TYPES enum.</field>
+      <field type="float" name="min4" units="deg">min angle (degrees)</field>
+      <field type="float" name="max4" units="deg">max angle (degrees)</field>
+      <field type="uint8_t" name="type5" enum="ICAROUS_TRACK_BAND_TYPES">See the TRACK_BAND_TYPES enum.</field>
+      <field type="float" name="min5" units="deg">min angle (degrees)</field>
+      <field type="float" name="max5" units="deg">max angle (degrees)</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/loweheiser.xml
+++ b/bp_mavlink/loweheiser.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- Loweheiser contact info: -->
+  <!-- company URL: https://www.loweheiser.com/ -->
+  <!-- company LinkeIn: https://www.linkedin.com/company/loweheiser -->
+  <!-- email contact: info@loweheiser.com -->
+  <!-- mavlink ID range: 10150 - 10199 -->
+  <include>minimal.xml</include>
+  <enums>
+    <enum name="MAV_CMD">
+      <!-- Loweheiser specific MAV_CMD_* commands -->
+      <entry name="MAV_CMD_LOWEHEISER_SET_STATE" value="10151">
+        <description>Set Loweheiser desired states</description>
+        <param index="1">EFI Index</param>
+        <param index="2">Desired Engine/EFI State (0: Power Off, 1:Running)</param>
+        <param index="3">Desired Governor State (0:manual throttle, 1:Governed throttle)</param>
+        <param index="4">Manual throttle level, 0% - 100%</param>
+        <param index="5">Electronic Start up (0:Off, 1:On)</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="10151" name="LOWEHEISER_GOV_EFI">
+      <description>Composite EFI and Governor data from Loweheiser equipment.  This message is created by the EFI unit based on its own data and data received from a governor attached to that EFI unit.</description>
+      <!-- Generator fields -->
+      <field type="float" name="volt_batt" units="V">Generator Battery voltage.</field>
+      <field type="float" name="curr_batt" units="A">Generator Battery current.</field>
+      <field type="float" name="curr_gen" units="A">Current being produced by generator.</field>
+      <field type="float" name="curr_rot" units="A">Load current being consumed by the UAV (sum of curr_gen and curr_batt)</field>
+      <field type="float" name="fuel_level" units="l">Generator fuel remaining in litres.</field>
+      <field type="float" name="throttle" units="%">Throttle Output.</field>
+      <field type="uint32_t" name="runtime" units="s">Seconds this generator has run since it was rebooted.</field>
+      <field type="int32_t" name="until_maintenance" units="s">Seconds until this generator requires maintenance.  A negative value indicates maintenance is past due.</field>
+      <field type="float" name="rectifier_temp" units="degC">The Temperature of the rectifier.</field>
+      <field type="float" name="generator_temp" units="degC">The temperature of the mechanical motor, fuel cell core or generator.</field>
+      <!-- EFI fields -->
+      <field type="float" name="efi_batt" units="V"> EFI Supply Voltage.</field>
+      <field type="float" name="efi_rpm" units="rpm">Motor RPM.</field>
+      <field type="float" name="efi_pw" units="ms">Injector pulse-width in miliseconds.</field>
+      <field type="float" name="efi_fuel_flow">Fuel flow rate in litres/hour.</field>
+      <field type="float" name="efi_fuel_consumed" units="l">Fuel consumed.</field>
+      <field type="float" name="efi_baro" units="kPa">Atmospheric pressure.</field>
+      <field type="float" name="efi_mat" units="degC">Manifold Air Temperature.</field>
+      <field type="float" name="efi_clt" units="degC">Cylinder Head Temperature.</field>
+      <field type="float" name="efi_tps" units="%">Throttle Position.</field>
+      <field type="float" name="efi_exhaust_gas_temperature" units="degC">Exhaust gas temperature.</field>
+      <!-- Status fields -->
+      <field type="uint8_t" name="efi_index" instance="true">EFI index.</field>
+      <field type="uint16_t" name="generator_status">Generator status.</field>
+      <field type="uint16_t" name="efi_status">EFI status.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/matrixpilot.xml
+++ b/bp_mavlink/matrixpilot.xml
@@ -1,0 +1,349 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>common.xml</include>
+  <!-- note that UDB specific messages should use the command id
+      range from 150 to 250, to leave plenty of room for growth
+      of common.xml 
+
+      If you prototype a message here, then you should consider if it
+      is general enough to move into common.xml later
+    -->
+  <enums>
+    <enum name="MAV_PREFLIGHT_STORAGE_ACTION">
+      <description>Action required when performing CMD_PREFLIGHT_STORAGE</description>
+      <entry value="0" name="MAV_PFS_CMD_READ_ALL">
+        <description>Read all parameters from storage</description>
+      </entry>
+      <entry value="1" name="MAV_PFS_CMD_WRITE_ALL">
+        <description>Write all parameters to storage</description>
+      </entry>
+      <entry value="2" name="MAV_PFS_CMD_CLEAR_ALL">
+        <description>Clear all  parameters in storage</description>
+      </entry>
+      <entry value="3" name="MAV_PFS_CMD_READ_SPECIFIC">
+        <description>Read specific parameters from storage</description>
+      </entry>
+      <entry value="4" name="MAV_PFS_CMD_WRITE_SPECIFIC">
+        <description>Write specific parameters to storage</description>
+      </entry>
+      <entry value="5" name="MAV_PFS_CMD_CLEAR_SPECIFIC">
+        <description>Clear specific parameters in storage</description>
+      </entry>
+      <entry value="6" name="MAV_PFS_CMD_DO_NOTHING">
+        <description>do nothing</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD">
+      <entry value="0" name="MAV_CMD_PREFLIGHT_STORAGE_ADVANCED">
+        <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1">Storage action: Action defined by MAV_PREFLIGHT_STORAGE_ACTION_ADVANCED</param>
+        <param index="2">Storage area as defined by parameter database</param>
+        <param index="3">Storage flags as defined by parameter database</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="150" name="FLEXIFUNCTION_SET">
+      <description>Depreciated but used as a compiler flag.  Do not remove</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="151" name="FLEXIFUNCTION_READ_REQ">
+      <description>Reqest reading of flexifunction data</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int16_t" name="read_req_type">Type of flexifunction data requested</field>
+      <field type="int16_t" name="data_index">index into data where needed</field>
+    </message>
+    <message id="152" name="FLEXIFUNCTION_BUFFER_FUNCTION">
+      <description>Flexifunction type and parameters for component at function index from buffer</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="func_index">Function index</field>
+      <field type="uint16_t" name="func_count">Total count of functions</field>
+      <field type="uint16_t" name="data_address">Address in the flexifunction data, Set to 0xFFFF to use address in target memory</field>
+      <field type="uint16_t" name="data_size">Size of the </field>
+      <field type="int8_t[48]" name="data">Settings data</field>
+    </message>
+    <message id="153" name="FLEXIFUNCTION_BUFFER_FUNCTION_ACK">
+      <description>Flexifunction type and parameters for component at function index from buffer</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="func_index">Function index</field>
+      <field type="uint16_t" name="result">result of acknowledge, 0=fail, 1=good</field>
+    </message>
+    <message id="155" name="FLEXIFUNCTION_DIRECTORY">
+      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="directory_type">0=inputs, 1=outputs</field>
+      <field type="uint8_t" name="start_index">index of first directory entry to write</field>
+      <field type="uint8_t" name="count">count of directory entries to write</field>
+      <field type="int8_t[48]" name="directory_data">Settings data</field>
+    </message>
+    <message id="156" name="FLEXIFUNCTION_DIRECTORY_ACK">
+      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="directory_type">0=inputs, 1=outputs</field>
+      <field type="uint8_t" name="start_index">index of first directory entry to write</field>
+      <field type="uint8_t" name="count">count of directory entries to write</field>
+      <field type="uint16_t" name="result">result of acknowledge, 0=fail, 1=good</field>
+    </message>
+    <message id="157" name="FLEXIFUNCTION_COMMAND">
+      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="command_type">Flexifunction command type</field>
+    </message>
+    <message id="158" name="FLEXIFUNCTION_COMMAND_ACK">
+      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <field type="uint16_t" name="command_type">Command acknowledged</field>
+      <field type="uint16_t" name="result">result of acknowledge</field>
+    </message>
+    <message id="170" name="SERIAL_UDB_EXTRA_F2_A">
+      <description>Backwards compatible MAVLink version of SERIAL_UDB_EXTRA - F2: Format Part A</description>
+      <field type="uint32_t" name="sue_time">Serial UDB Extra Time</field>
+      <field type="uint8_t" name="sue_status">Serial UDB Extra Status</field>
+      <field type="int32_t" name="sue_latitude">Serial UDB Extra Latitude</field>
+      <field type="int32_t" name="sue_longitude">Serial UDB Extra Longitude</field>
+      <field type="int32_t" name="sue_altitude">Serial UDB Extra Altitude</field>
+      <field type="uint16_t" name="sue_waypoint_index">Serial UDB Extra Waypoint Index</field>
+      <field type="int16_t" name="sue_rmat0">Serial UDB Extra Rmat 0</field>
+      <field type="int16_t" name="sue_rmat1">Serial UDB Extra Rmat 1</field>
+      <field type="int16_t" name="sue_rmat2">Serial UDB Extra Rmat 2</field>
+      <field type="int16_t" name="sue_rmat3">Serial UDB Extra Rmat 3</field>
+      <field type="int16_t" name="sue_rmat4">Serial UDB Extra Rmat 4</field>
+      <field type="int16_t" name="sue_rmat5">Serial UDB Extra Rmat 5</field>
+      <field type="int16_t" name="sue_rmat6">Serial UDB Extra Rmat 6</field>
+      <field type="int16_t" name="sue_rmat7">Serial UDB Extra Rmat 7</field>
+      <field type="int16_t" name="sue_rmat8">Serial UDB Extra Rmat 8</field>
+      <field type="uint16_t" name="sue_cog">Serial UDB Extra GPS Course Over Ground</field>
+      <field type="int16_t" name="sue_sog">Serial UDB Extra Speed Over Ground</field>
+      <field type="uint16_t" name="sue_cpu_load">Serial UDB Extra CPU Load</field>
+      <field type="uint16_t" name="sue_air_speed_3DIMU">Serial UDB Extra 3D IMU Air Speed</field>
+      <field type="int16_t" name="sue_estimated_wind_0">Serial UDB Extra Estimated Wind 0</field>
+      <field type="int16_t" name="sue_estimated_wind_1">Serial UDB Extra Estimated Wind 1</field>
+      <field type="int16_t" name="sue_estimated_wind_2">Serial UDB Extra Estimated Wind 2</field>
+      <field type="int16_t" name="sue_magFieldEarth0">Serial UDB Extra Magnetic Field Earth 0 </field>
+      <field type="int16_t" name="sue_magFieldEarth1">Serial UDB Extra Magnetic Field Earth 1 </field>
+      <field type="int16_t" name="sue_magFieldEarth2">Serial UDB Extra Magnetic Field Earth 2 </field>
+      <field type="int16_t" name="sue_svs">Serial UDB Extra Number of Sattelites in View</field>
+      <field type="int16_t" name="sue_hdop">Serial UDB Extra GPS Horizontal Dilution of Precision</field>
+    </message>
+    <message id="171" name="SERIAL_UDB_EXTRA_F2_B">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA - F2: Part B</description>
+      <field type="uint32_t" name="sue_time">Serial UDB Extra Time</field>
+      <field type="int16_t" name="sue_pwm_input_1">Serial UDB Extra PWM Input Channel 1</field>
+      <field type="int16_t" name="sue_pwm_input_2">Serial UDB Extra PWM Input Channel 2</field>
+      <field type="int16_t" name="sue_pwm_input_3">Serial UDB Extra PWM Input Channel 3</field>
+      <field type="int16_t" name="sue_pwm_input_4">Serial UDB Extra PWM Input Channel 4</field>
+      <field type="int16_t" name="sue_pwm_input_5">Serial UDB Extra PWM Input Channel 5</field>
+      <field type="int16_t" name="sue_pwm_input_6">Serial UDB Extra PWM Input Channel 6</field>
+      <field type="int16_t" name="sue_pwm_input_7">Serial UDB Extra PWM Input Channel 7</field>
+      <field type="int16_t" name="sue_pwm_input_8">Serial UDB Extra PWM Input Channel 8</field>
+      <field type="int16_t" name="sue_pwm_input_9">Serial UDB Extra PWM Input Channel 9</field>
+      <field type="int16_t" name="sue_pwm_input_10">Serial UDB Extra PWM Input Channel 10</field>
+      <field type="int16_t" name="sue_pwm_input_11">Serial UDB Extra PWM Input Channel 11</field>
+      <field type="int16_t" name="sue_pwm_input_12">Serial UDB Extra PWM Input Channel 12</field>
+      <field type="int16_t" name="sue_pwm_output_1">Serial UDB Extra PWM Output Channel 1</field>
+      <field type="int16_t" name="sue_pwm_output_2">Serial UDB Extra PWM Output Channel 2</field>
+      <field type="int16_t" name="sue_pwm_output_3">Serial UDB Extra PWM Output Channel 3</field>
+      <field type="int16_t" name="sue_pwm_output_4">Serial UDB Extra PWM Output Channel 4</field>
+      <field type="int16_t" name="sue_pwm_output_5">Serial UDB Extra PWM Output Channel 5</field>
+      <field type="int16_t" name="sue_pwm_output_6">Serial UDB Extra PWM Output Channel 6</field>
+      <field type="int16_t" name="sue_pwm_output_7">Serial UDB Extra PWM Output Channel 7</field>
+      <field type="int16_t" name="sue_pwm_output_8">Serial UDB Extra PWM Output Channel 8</field>
+      <field type="int16_t" name="sue_pwm_output_9">Serial UDB Extra PWM Output Channel 9</field>
+      <field type="int16_t" name="sue_pwm_output_10">Serial UDB Extra PWM Output Channel 10</field>
+      <field type="int16_t" name="sue_pwm_output_11">Serial UDB Extra PWM Output Channel 11</field>
+      <field type="int16_t" name="sue_pwm_output_12">Serial UDB Extra PWM Output Channel 12</field>
+      <field type="int16_t" name="sue_imu_location_x">Serial UDB Extra IMU Location X</field>
+      <field type="int16_t" name="sue_imu_location_y">Serial UDB Extra IMU Location Y</field>
+      <field type="int16_t" name="sue_imu_location_z">Serial UDB Extra IMU Location Z</field>
+      <field type="int16_t" name="sue_location_error_earth_x">Serial UDB Location Error Earth X</field>
+      <field type="int16_t" name="sue_location_error_earth_y">Serial UDB Location Error Earth Y</field>
+      <field type="int16_t" name="sue_location_error_earth_z">Serial UDB Location Error Earth Z</field>
+      <field type="uint32_t" name="sue_flags">Serial UDB Extra Status Flags</field>
+      <field type="int16_t" name="sue_osc_fails">Serial UDB Extra Oscillator Failure Count</field>
+      <field type="int16_t" name="sue_imu_velocity_x">Serial UDB Extra IMU Velocity X</field>
+      <field type="int16_t" name="sue_imu_velocity_y">Serial UDB Extra IMU Velocity Y</field>
+      <field type="int16_t" name="sue_imu_velocity_z">Serial UDB Extra IMU Velocity Z</field>
+      <field type="int16_t" name="sue_waypoint_goal_x">Serial UDB Extra Current Waypoint Goal X</field>
+      <field type="int16_t" name="sue_waypoint_goal_y">Serial UDB Extra Current Waypoint Goal Y</field>
+      <field type="int16_t" name="sue_waypoint_goal_z">Serial UDB Extra Current Waypoint Goal Z</field>
+      <field type="int16_t" name="sue_aero_x">Aeroforce in UDB X Axis</field>
+      <field type="int16_t" name="sue_aero_y">Aeroforce in UDB Y Axis</field>
+      <field type="int16_t" name="sue_aero_z">Aeroforce in UDB Z axis</field>
+      <field type="int16_t" name="sue_barom_temp">SUE barometer temperature</field>
+      <field type="int32_t" name="sue_barom_press">SUE barometer pressure</field>
+      <field type="int32_t" name="sue_barom_alt">SUE barometer altitude</field>
+      <field type="int16_t" name="sue_bat_volt">SUE battery voltage</field>
+      <field type="int16_t" name="sue_bat_amp">SUE battery current</field>
+      <field type="int16_t" name="sue_bat_amp_hours">SUE battery milli amp hours used</field>
+      <field type="int16_t" name="sue_desired_height">Sue autopilot desired height</field>
+      <field type="int16_t" name="sue_memory_stack_free">Serial UDB Extra Stack Memory Free</field>
+    </message>
+    <message id="172" name="SERIAL_UDB_EXTRA_F4">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F4: format</description>
+      <field type="uint8_t" name="sue_ROLL_STABILIZATION_AILERONS">Serial UDB Extra Roll Stabilization with Ailerons Enabled</field>
+      <field type="uint8_t" name="sue_ROLL_STABILIZATION_RUDDER">Serial UDB Extra Roll Stabilization with Rudder Enabled</field>
+      <field type="uint8_t" name="sue_PITCH_STABILIZATION">Serial UDB Extra Pitch Stabilization Enabled</field>
+      <field type="uint8_t" name="sue_YAW_STABILIZATION_RUDDER">Serial UDB Extra Yaw Stabilization using Rudder Enabled</field>
+      <field type="uint8_t" name="sue_YAW_STABILIZATION_AILERON">Serial UDB Extra Yaw Stabilization using Ailerons Enabled</field>
+      <field type="uint8_t" name="sue_AILERON_NAVIGATION">Serial UDB Extra Navigation with Ailerons Enabled</field>
+      <field type="uint8_t" name="sue_RUDDER_NAVIGATION">Serial UDB Extra Navigation with Rudder Enabled</field>
+      <field type="uint8_t" name="sue_ALTITUDEHOLD_STABILIZED">Serial UDB Extra Type of Alitude Hold when in Stabilized Mode</field>
+      <field type="uint8_t" name="sue_ALTITUDEHOLD_WAYPOINT">Serial UDB Extra Type of Alitude Hold when in Waypoint Mode</field>
+      <field type="uint8_t" name="sue_RACING_MODE">Serial UDB Extra Firmware racing mode enabled</field>
+    </message>
+    <message id="173" name="SERIAL_UDB_EXTRA_F5">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F5: format</description>
+      <field type="float" name="sue_YAWKP_AILERON">Serial UDB YAWKP_AILERON Gain for Proporional control of navigation</field>
+      <field type="float" name="sue_YAWKD_AILERON">Serial UDB YAWKD_AILERON Gain for Rate control of navigation</field>
+      <field type="float" name="sue_ROLLKP">Serial UDB Extra ROLLKP Gain for Proportional control of roll stabilization</field>
+      <field type="float" name="sue_ROLLKD">Serial UDB Extra ROLLKD Gain for Rate control of roll stabilization</field>
+    </message>
+    <message id="174" name="SERIAL_UDB_EXTRA_F6">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F6: format</description>
+      <field type="float" name="sue_PITCHGAIN">Serial UDB Extra PITCHGAIN Proportional Control</field>
+      <field type="float" name="sue_PITCHKD">Serial UDB Extra Pitch Rate Control</field>
+      <field type="float" name="sue_RUDDER_ELEV_MIX">Serial UDB Extra Rudder to Elevator Mix</field>
+      <field type="float" name="sue_ROLL_ELEV_MIX">Serial UDB Extra Roll to Elevator Mix</field>
+      <field type="float" name="sue_ELEVATOR_BOOST">Gain For Boosting Manual Elevator control When Plane Stabilized</field>
+    </message>
+    <message id="175" name="SERIAL_UDB_EXTRA_F7">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F7: format</description>
+      <field type="float" name="sue_YAWKP_RUDDER">Serial UDB YAWKP_RUDDER Gain for Proporional control of navigation</field>
+      <field type="float" name="sue_YAWKD_RUDDER">Serial UDB YAWKD_RUDDER Gain for Rate control of navigation</field>
+      <field type="float" name="sue_ROLLKP_RUDDER">Serial UDB Extra ROLLKP_RUDDER Gain for Proportional control of roll stabilization</field>
+      <field type="float" name="sue_ROLLKD_RUDDER">Serial UDB Extra ROLLKD_RUDDER Gain for Rate control of roll stabilization</field>
+      <field type="float" name="sue_RUDDER_BOOST">SERIAL UDB EXTRA Rudder Boost Gain to Manual Control when stabilized</field>
+      <field type="float" name="sue_RTL_PITCH_DOWN">Serial UDB Extra Return To Landing - Angle to Pitch Plane Down</field>
+    </message>
+    <message id="176" name="SERIAL_UDB_EXTRA_F8">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F8: format</description>
+      <field type="float" name="sue_HEIGHT_TARGET_MAX">Serial UDB Extra HEIGHT_TARGET_MAX</field>
+      <field type="float" name="sue_HEIGHT_TARGET_MIN">Serial UDB Extra HEIGHT_TARGET_MIN</field>
+      <field type="float" name="sue_ALT_HOLD_THROTTLE_MIN">Serial UDB Extra ALT_HOLD_THROTTLE_MIN</field>
+      <field type="float" name="sue_ALT_HOLD_THROTTLE_MAX">Serial UDB Extra ALT_HOLD_THROTTLE_MAX</field>
+      <field type="float" name="sue_ALT_HOLD_PITCH_MIN">Serial UDB Extra ALT_HOLD_PITCH_MIN</field>
+      <field type="float" name="sue_ALT_HOLD_PITCH_MAX">Serial UDB Extra ALT_HOLD_PITCH_MAX</field>
+      <field type="float" name="sue_ALT_HOLD_PITCH_HIGH">Serial UDB Extra ALT_HOLD_PITCH_HIGH</field>
+    </message>
+    <message id="177" name="SERIAL_UDB_EXTRA_F13">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F13: format</description>
+      <field type="int16_t" name="sue_week_no">Serial UDB Extra GPS Week Number</field>
+      <field type="int32_t" name="sue_lat_origin">Serial UDB Extra MP Origin Latitude</field>
+      <field type="int32_t" name="sue_lon_origin">Serial UDB Extra MP Origin Longitude</field>
+      <field type="int32_t" name="sue_alt_origin">Serial UDB Extra MP Origin Altitude Above Sea Level</field>
+    </message>
+    <message id="178" name="SERIAL_UDB_EXTRA_F14">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F14: format</description>
+      <field type="uint8_t" name="sue_WIND_ESTIMATION">Serial UDB Extra Wind Estimation Enabled</field>
+      <field type="uint8_t" name="sue_GPS_TYPE">Serial UDB Extra Type of GPS Unit</field>
+      <field type="uint8_t" name="sue_DR">Serial UDB Extra Dead Reckoning Enabled</field>
+      <field type="uint8_t" name="sue_BOARD_TYPE">Serial UDB Extra Type of UDB Hardware</field>
+      <field type="uint8_t" name="sue_AIRFRAME">Serial UDB Extra Type of Airframe</field>
+      <field type="int16_t" name="sue_RCON">Serial UDB Extra Reboot Register of DSPIC</field>
+      <field type="int16_t" name="sue_TRAP_FLAGS">Serial UDB Extra  Last dspic Trap Flags</field>
+      <field type="uint32_t" name="sue_TRAP_SOURCE">Serial UDB Extra Type Program Address of Last Trap</field>
+      <field type="int16_t" name="sue_osc_fail_count">Serial UDB Extra Number of Ocillator Failures</field>
+      <field type="uint8_t" name="sue_CLOCK_CONFIG">Serial UDB Extra UDB Internal Clock Configuration</field>
+      <field type="uint8_t" name="sue_FLIGHT_PLAN_TYPE">Serial UDB Extra Type of Flight Plan</field>
+    </message>
+    <message id="179" name="SERIAL_UDB_EXTRA_F15">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F15 format</description>
+      <field type="uint8_t[40]" name="sue_ID_VEHICLE_MODEL_NAME">Serial UDB Extra Model Name Of Vehicle</field>
+      <field type="uint8_t[20]" name="sue_ID_VEHICLE_REGISTRATION">Serial UDB Extra Registraton Number of Vehicle</field>
+    </message>
+    <message id="180" name="SERIAL_UDB_EXTRA_F16">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F16 format</description>
+      <field type="uint8_t[40]" name="sue_ID_LEAD_PILOT">Serial UDB Extra Name of Expected Lead Pilot</field>
+      <field type="uint8_t[70]" name="sue_ID_DIY_DRONES_URL">Serial UDB Extra URL of Lead Pilot or Team</field>
+    </message>
+    <message id="181" name="ALTITUDES">
+      <description>The altitude measured by sensors and IMU</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int32_t" name="alt_gps">GPS altitude (MSL) in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int32_t" name="alt_imu">IMU altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int32_t" name="alt_barometric">barometeric altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int32_t" name="alt_optical_flow">Optical flow altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int32_t" name="alt_range_finder">Rangefinder Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int32_t" name="alt_extra">Extra altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+    </message>
+    <message id="182" name="AIRSPEEDS">
+      <description>The airspeed measured by sensors and IMU</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int16_t" name="airspeed_imu">Airspeed estimate from IMU, cm/s</field>
+      <field type="int16_t" name="airspeed_pitot">Pitot measured forward airpseed, cm/s</field>
+      <field type="int16_t" name="airspeed_hot_wire">Hot wire anenometer measured airspeed, cm/s</field>
+      <field type="int16_t" name="airspeed_ultrasonic">Ultrasonic measured airspeed, cm/s</field>
+      <field type="int16_t" name="aoa">Angle of attack sensor, degrees * 10</field>
+      <field type="int16_t" name="aoy">Yaw angle sensor, degrees * 10</field>
+    </message>
+    <message id="183" name="SERIAL_UDB_EXTRA_F17">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F17 format</description>
+      <field type="float" name="sue_feed_forward">SUE Feed Forward Gain</field>
+      <field type="float" name="sue_turn_rate_nav">SUE Max Turn Rate when Navigating</field>
+      <field type="float" name="sue_turn_rate_fbw">SUE Max Turn Rate in Fly By Wire Mode</field>
+    </message>
+    <message id="184" name="SERIAL_UDB_EXTRA_F18">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F18 format</description>
+      <field type="float" name="angle_of_attack_normal">SUE Angle of Attack Normal</field>
+      <field type="float" name="angle_of_attack_inverted">SUE Angle of Attack Inverted</field>
+      <field type="float" name="elevator_trim_normal">SUE Elevator Trim Normal</field>
+      <field type="float" name="elevator_trim_inverted">SUE Elevator Trim Inverted</field>
+      <field type="float" name="reference_speed">SUE reference_speed</field>
+    </message>
+    <message id="185" name="SERIAL_UDB_EXTRA_F19">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F19 format</description>
+      <field type="uint8_t" name="sue_aileron_output_channel">SUE aileron output channel</field>
+      <field type="uint8_t" name="sue_aileron_reversed">SUE aileron reversed</field>
+      <field type="uint8_t" name="sue_elevator_output_channel">SUE elevator output channel</field>
+      <field type="uint8_t" name="sue_elevator_reversed">SUE elevator reversed</field>
+      <field type="uint8_t" name="sue_throttle_output_channel">SUE throttle output channel</field>
+      <field type="uint8_t" name="sue_throttle_reversed">SUE throttle reversed</field>
+      <field type="uint8_t" name="sue_rudder_output_channel">SUE rudder output channel</field>
+      <field type="uint8_t" name="sue_rudder_reversed">SUE rudder reversed</field>
+    </message>
+    <message id="186" name="SERIAL_UDB_EXTRA_F20">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F20 format</description>
+      <field type="uint8_t" name="sue_number_of_inputs">SUE Number of Input Channels</field>
+      <field type="int16_t" name="sue_trim_value_input_1">SUE UDB PWM Trim Value on Input 1</field>
+      <field type="int16_t" name="sue_trim_value_input_2">SUE UDB PWM Trim Value on Input 2</field>
+      <field type="int16_t" name="sue_trim_value_input_3">SUE UDB PWM Trim Value on Input 3</field>
+      <field type="int16_t" name="sue_trim_value_input_4">SUE UDB PWM Trim Value on Input 4</field>
+      <field type="int16_t" name="sue_trim_value_input_5">SUE UDB PWM Trim Value on Input 5</field>
+      <field type="int16_t" name="sue_trim_value_input_6">SUE UDB PWM Trim Value on Input 6</field>
+      <field type="int16_t" name="sue_trim_value_input_7">SUE UDB PWM Trim Value on Input 7</field>
+      <field type="int16_t" name="sue_trim_value_input_8">SUE UDB PWM Trim Value on Input 8</field>
+      <field type="int16_t" name="sue_trim_value_input_9">SUE UDB PWM Trim Value on Input 9</field>
+      <field type="int16_t" name="sue_trim_value_input_10">SUE UDB PWM Trim Value on Input 10</field>
+      <field type="int16_t" name="sue_trim_value_input_11">SUE UDB PWM Trim Value on Input 11</field>
+      <field type="int16_t" name="sue_trim_value_input_12">SUE UDB PWM Trim Value on Input 12</field>
+    </message>
+    <message id="187" name="SERIAL_UDB_EXTRA_F21">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F21 format</description>
+      <field type="int16_t" name="sue_accel_x_offset">SUE X accelerometer offset</field>
+      <field type="int16_t" name="sue_accel_y_offset">SUE Y accelerometer offset</field>
+      <field type="int16_t" name="sue_accel_z_offset">SUE Z accelerometer offset</field>
+      <field type="int16_t" name="sue_gyro_x_offset">SUE X gyro offset</field>
+      <field type="int16_t" name="sue_gyro_y_offset">SUE Y gyro offset</field>
+      <field type="int16_t" name="sue_gyro_z_offset">SUE Z gyro offset</field>
+    </message>
+    <message id="188" name="SERIAL_UDB_EXTRA_F22">
+      <description>Backwards compatible version of SERIAL_UDB_EXTRA F22 format</description>
+      <field type="int16_t" name="sue_accel_x_at_calibration">SUE X accelerometer at calibration time</field>
+      <field type="int16_t" name="sue_accel_y_at_calibration">SUE Y accelerometer at calibration time</field>
+      <field type="int16_t" name="sue_accel_z_at_calibration">SUE Z accelerometer at calibration time</field>
+      <field type="int16_t" name="sue_gyro_x_at_calibration">SUE X gyro at calibration time</field>
+      <field type="int16_t" name="sue_gyro_y_at_calibration">SUE Y gyro at calibration time</field>
+      <field type="int16_t" name="sue_gyro_z_at_calibration">SUE Z gyro at calibration time</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/minimal.xml
+++ b/bp_mavlink/minimal.xml
@@ -1,0 +1,709 @@
+<?xml version="1.0"?>
+<mavlink>
+  <version>3</version>
+  <enums>
+    <enum name="MAV_AUTOPILOT">
+      <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
+      <entry value="0" name="MAV_AUTOPILOT_GENERIC">
+        <description>Generic autopilot, full support for everything</description>
+      </entry>
+      <entry value="1" name="MAV_AUTOPILOT_RESERVED">
+        <description>Reserved for future use.</description>
+      </entry>
+      <entry value="2" name="MAV_AUTOPILOT_SLUGS">
+        <description>SLUGS autopilot, http://slugsuav.soe.ucsc.edu</description>
+      </entry>
+      <entry value="3" name="MAV_AUTOPILOT_ARDUPILOTMEGA">
+        <description>ArduPilot - Plane/Copter/Rover/Sub/Tracker, https://ardupilot.org</description>
+      </entry>
+      <entry value="4" name="MAV_AUTOPILOT_OPENPILOT">
+        <description>OpenPilot, http://openpilot.org</description>
+      </entry>
+      <entry value="5" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY">
+        <description>Generic autopilot only supporting simple waypoints</description>
+      </entry>
+      <entry value="6" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY">
+        <description>Generic autopilot supporting waypoints and other simple navigation commands</description>
+      </entry>
+      <entry value="7" name="MAV_AUTOPILOT_GENERIC_MISSION_FULL">
+        <description>Generic autopilot supporting the full mission command set</description>
+      </entry>
+      <entry value="8" name="MAV_AUTOPILOT_INVALID">
+        <description>No valid autopilot, e.g. a GCS or other MAVLink component</description>
+      </entry>
+      <entry value="9" name="MAV_AUTOPILOT_PPZ">
+        <description>PPZ UAV - http://nongnu.org/paparazzi</description>
+      </entry>
+      <entry value="10" name="MAV_AUTOPILOT_UDB">
+        <description>UAV Dev Board</description>
+      </entry>
+      <entry value="11" name="MAV_AUTOPILOT_FP">
+        <description>FlexiPilot</description>
+      </entry>
+      <entry value="12" name="MAV_AUTOPILOT_PX4">
+        <description>PX4 Autopilot - http://px4.io/</description>
+      </entry>
+      <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
+        <description>SMACCMPilot - http://smaccmpilot.org</description>
+      </entry>
+      <entry value="14" name="MAV_AUTOPILOT_AUTOQUAD">
+        <description>AutoQuad -- http://autoquad.org</description>
+      </entry>
+      <entry value="15" name="MAV_AUTOPILOT_ARMAZILA">
+        <description>Armazila -- http://armazila.com</description>
+      </entry>
+      <entry value="16" name="MAV_AUTOPILOT_AEROB">
+        <description>Aerob -- http://aerob.ru</description>
+      </entry>
+      <entry value="17" name="MAV_AUTOPILOT_ASLUAV">
+        <description>ASLUAV autopilot -- http://www.asl.ethz.ch</description>
+      </entry>
+      <entry value="18" name="MAV_AUTOPILOT_SMARTAP">
+        <description>SmartAP Autopilot - http://sky-drones.com</description>
+      </entry>
+      <entry value="19" name="MAV_AUTOPILOT_AIRRAILS">
+        <description>AirRails - http://uaventure.com</description>
+      </entry>
+      <entry value="20" name="MAV_AUTOPILOT_REFLEX">
+        <description>Fusion Reflex - https://fusion.engineering</description>
+      </entry>
+    </enum>
+    <enum name="MAV_TYPE">
+      <description>MAVLINK component type reported in HEARTBEAT message. Flight controllers must report the type of the vehicle on which they are mounted (e.g. MAV_TYPE_OCTOROTOR). All other components must report a value appropriate for their type (e.g. a camera must use MAV_TYPE_CAMERA).</description>
+      <entry value="0" name="MAV_TYPE_GENERIC">
+        <description>Generic micro air vehicle</description>
+      </entry>
+      <entry value="1" name="MAV_TYPE_FIXED_WING">
+        <description>Fixed wing aircraft.</description>
+      </entry>
+      <entry value="2" name="MAV_TYPE_QUADROTOR">
+        <description>Quadrotor</description>
+      </entry>
+      <entry value="3" name="MAV_TYPE_COAXIAL">
+        <description>Coaxial helicopter</description>
+      </entry>
+      <entry value="4" name="MAV_TYPE_HELICOPTER">
+        <description>Normal helicopter with tail rotor.</description>
+      </entry>
+      <entry value="5" name="MAV_TYPE_ANTENNA_TRACKER">
+        <description>Ground installation</description>
+      </entry>
+      <entry value="6" name="MAV_TYPE_GCS">
+        <description>Operator control unit / ground control station</description>
+      </entry>
+      <entry value="7" name="MAV_TYPE_AIRSHIP">
+        <description>Airship, controlled</description>
+      </entry>
+      <entry value="8" name="MAV_TYPE_FREE_BALLOON">
+        <description>Free balloon, uncontrolled</description>
+      </entry>
+      <entry value="9" name="MAV_TYPE_ROCKET">
+        <description>Rocket</description>
+      </entry>
+      <entry value="10" name="MAV_TYPE_GROUND_ROVER">
+        <description>Ground rover</description>
+      </entry>
+      <entry value="11" name="MAV_TYPE_SURFACE_BOAT">
+        <description>Surface vessel, boat, ship</description>
+      </entry>
+      <entry value="12" name="MAV_TYPE_SUBMARINE">
+        <description>Submarine</description>
+      </entry>
+      <entry value="13" name="MAV_TYPE_HEXAROTOR">
+        <description>Hexarotor</description>
+      </entry>
+      <entry value="14" name="MAV_TYPE_OCTOROTOR">
+        <description>Octorotor</description>
+      </entry>
+      <entry value="15" name="MAV_TYPE_TRICOPTER">
+        <description>Tricopter</description>
+      </entry>
+      <entry value="16" name="MAV_TYPE_FLAPPING_WING">
+        <description>Flapping wing</description>
+      </entry>
+      <entry value="17" name="MAV_TYPE_KITE">
+        <description>Kite</description>
+      </entry>
+      <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
+        <description>Onboard companion controller</description>
+      </entry>
+      <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
+        <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
+      </entry>
+      <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
+        <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
+      </entry>
+      <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
+        <description>Tiltrotor VTOL</description>
+      </entry>
+      <!-- Entries up to 25 reserved for other VTOL airframes -->
+      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
+        <description>VTOL reserved 2</description>
+      </entry>
+      <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
+        <description>VTOL reserved 3</description>
+      </entry>
+      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
+        <description>VTOL reserved 4</description>
+      </entry>
+      <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
+        <description>VTOL reserved 5</description>
+      </entry>
+      <entry value="26" name="MAV_TYPE_GIMBAL">
+        <description>Gimbal</description>
+      </entry>
+      <entry value="27" name="MAV_TYPE_ADSB">
+        <description>ADSB system</description>
+      </entry>
+      <entry value="28" name="MAV_TYPE_PARAFOIL">
+        <description>Steerable, nonrigid airfoil</description>
+      </entry>
+      <entry value="29" name="MAV_TYPE_DODECAROTOR">
+        <description>Dodecarotor</description>
+      </entry>
+      <entry value="30" name="MAV_TYPE_CAMERA">
+        <description>Camera</description>
+      </entry>
+      <entry value="31" name="MAV_TYPE_CHARGING_STATION">
+        <description>Charging station</description>
+      </entry>
+      <entry value="32" name="MAV_TYPE_FLARM">
+        <description>FLARM collision avoidance system</description>
+      </entry>
+      <entry value="33" name="MAV_TYPE_SERVO">
+        <description>Servo</description>
+      </entry>
+      <entry value="34" name="MAV_TYPE_ODID">
+        <description>Open Drone ID. See https://mavlink.io/en/services/opendroneid.html.</description>
+      </entry>
+      <entry value="35" name="MAV_TYPE_DECAROTOR">
+        <description>Decarotor</description>
+      </entry>
+      <entry value="36" name="MAV_TYPE_BATTERY">
+        <description>Battery</description>
+      </entry>
+      <entry value="37" name="MAV_TYPE_PARACHUTE">
+        <description>Parachute</description>
+      </entry>
+      <entry value="38" name="MAV_TYPE_LOG">
+        <description>Log</description>
+      </entry>
+      <entry value="39" name="MAV_TYPE_OSD">
+        <description>OSD</description>
+      </entry>
+      <entry value="40" name="MAV_TYPE_IMU">
+        <description>IMU</description>
+      </entry>
+      <entry value="41" name="MAV_TYPE_GPS">
+        <description>GPS</description>
+      </entry>
+      <entry value="42" name="MAV_TYPE_WINCH">
+        <description>Winch</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MODE_FLAG" bitmask="true">
+      <description>These flags encode the MAV mode.</description>
+      <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
+        <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
+        <description>0b01000000 remote control input is enabled.</description>
+      </entry>
+      <entry value="32" name="MAV_MODE_FLAG_HIL_ENABLED">
+        <description>0b00100000 hardware in the loop simulation. All motors / actuators are blocked, but internal software is full operational.</description>
+      </entry>
+      <entry value="16" name="MAV_MODE_FLAG_STABILIZE_ENABLED">
+        <description>0b00010000 system stabilizes electronically its attitude (and optionally position). It needs however further control inputs to move around.</description>
+      </entry>
+      <entry value="8" name="MAV_MODE_FLAG_GUIDED_ENABLED">
+        <description>0b00001000 guided mode enabled, system flies waypoints / mission items.</description>
+      </entry>
+      <entry value="4" name="MAV_MODE_FLAG_AUTO_ENABLED">
+        <description>0b00000100 autonomous mode enabled, system finds its own goal positions. Guided flag can be set or not, depends on the actual implementation.</description>
+      </entry>
+      <entry value="2" name="MAV_MODE_FLAG_TEST_ENABLED">
+        <description>0b00000010 system has a test mode enabled. This flag is intended for temporary system tests and should not be used for stable implementations.</description>
+      </entry>
+      <entry value="1" name="MAV_MODE_FLAG_CUSTOM_MODE_ENABLED">
+        <description>0b00000001 Reserved for future use.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MODE_FLAG_DECODE_POSITION" bitmask="true">
+      <description>These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.</description>
+      <entry value="128" name="MAV_MODE_FLAG_DECODE_POSITION_SAFETY">
+        <description>First bit:  10000000</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_FLAG_DECODE_POSITION_MANUAL">
+        <description>Second bit: 01000000</description>
+      </entry>
+      <entry value="32" name="MAV_MODE_FLAG_DECODE_POSITION_HIL">
+        <description>Third bit:  00100000</description>
+      </entry>
+      <entry value="16" name="MAV_MODE_FLAG_DECODE_POSITION_STABILIZE">
+        <description>Fourth bit: 00010000</description>
+      </entry>
+      <entry value="8" name="MAV_MODE_FLAG_DECODE_POSITION_GUIDED">
+        <description>Fifth bit:  00001000</description>
+      </entry>
+      <entry value="4" name="MAV_MODE_FLAG_DECODE_POSITION_AUTO">
+        <description>Sixth bit:   00000100</description>
+      </entry>
+      <entry value="2" name="MAV_MODE_FLAG_DECODE_POSITION_TEST">
+        <description>Seventh bit: 00000010</description>
+      </entry>
+      <entry value="1" name="MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE">
+        <description>Eighth bit: 00000001</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STATE">
+      <entry value="0" name="MAV_STATE_UNINIT">
+        <description>Uninitialized system, state is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_STATE_BOOT">
+        <description>System is booting up.</description>
+      </entry>
+      <entry value="2" name="MAV_STATE_CALIBRATING">
+        <description>System is calibrating and not flight-ready.</description>
+      </entry>
+      <entry value="3" name="MAV_STATE_STANDBY">
+        <description>System is grounded and on standby. It can be launched any time.</description>
+      </entry>
+      <entry value="4" name="MAV_STATE_ACTIVE">
+        <description>System is active and might be already airborne. Motors are engaged.</description>
+      </entry>
+      <entry value="5" name="MAV_STATE_CRITICAL">
+        <description>System is in a non-normal flight mode. It can however still navigate.</description>
+      </entry>
+      <entry value="6" name="MAV_STATE_EMERGENCY">
+        <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
+      </entry>
+      <entry value="7" name="MAV_STATE_POWEROFF">
+        <description>System just initialized its power-down sequence, will shut down now.</description>
+      </entry>
+      <entry value="8" name="MAV_STATE_FLIGHT_TERMINATION">
+        <description>System is terminating itself.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COMPONENT">
+      <description>Component ids (values) for the different types and instances of onboard hardware/software that might make up a MAVLink system (autopilot, cameras, servos, GPS systems, avoidance systems etc.).
+      Components must use the appropriate ID in their source address when sending messages. Components can also use IDs to determine if they are the intended recipient of an incoming message. The MAV_COMP_ID_ALL value is used to indicate messages that must be processed by all components.
+      When creating new entries, components that can have multiple instances (e.g. cameras, servos etc.) should be allocated sequential values. An appropriate number of values should be left free after these components to allow the number of instances to be expanded.</description>
+      <entry value="0" name="MAV_COMP_ID_ALL">
+        <description>Target id (target_component) used to broadcast messages to all components of the receiving system. Components should attempt to process messages with this component ID and forward to components on any other interfaces. Note: This is not a valid *source* component id for a message.</description>
+      </entry>
+      <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
+        <description>System flight controller component ("autopilot"). Only one autopilot is expected in a particular system.</description>
+      </entry>
+      <!-- Component ids from 25-99 are reserved for private OEM component definitions (and may be incompatible with other private components). Note that if this range is later reduced, higher ids will be reallocated first. -->
+      <entry value="25" name="MAV_COMP_ID_USER1">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="26" name="MAV_COMP_ID_USER2">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="27" name="MAV_COMP_ID_USER3">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="28" name="MAV_COMP_ID_USER4">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="29" name="MAV_COMP_ID_USER5">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="30" name="MAV_COMP_ID_USER6">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="31" name="MAV_COMP_ID_USER7">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="32" name="MAV_COMP_ID_USER8">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="33" name="MAV_COMP_ID_USER9">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="34" name="MAV_COMP_ID_USER10">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="35" name="MAV_COMP_ID_USER11">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="36" name="MAV_COMP_ID_USER12">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="37" name="MAV_COMP_ID_USER13">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="38" name="MAV_COMP_ID_USER14">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="39" name="MAV_COMP_ID_USER15">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="40" name="MAV_COMP_ID_USER16">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="41" name="MAV_COMP_ID_USER17">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="42" name="MAV_COMP_ID_USER18">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="43" name="MAV_COMP_ID_USER19">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="44" name="MAV_COMP_ID_USER20">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="45" name="MAV_COMP_ID_USER21">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="46" name="MAV_COMP_ID_USER22">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="47" name="MAV_COMP_ID_USER23">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="48" name="MAV_COMP_ID_USER24">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="49" name="MAV_COMP_ID_USER25">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="50" name="MAV_COMP_ID_USER26">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="51" name="MAV_COMP_ID_USER27">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="52" name="MAV_COMP_ID_USER28">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="53" name="MAV_COMP_ID_USER29">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="54" name="MAV_COMP_ID_USER30">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="55" name="MAV_COMP_ID_USER31">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="56" name="MAV_COMP_ID_USER32">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="57" name="MAV_COMP_ID_USER33">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="58" name="MAV_COMP_ID_USER34">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="59" name="MAV_COMP_ID_USER35">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="60" name="MAV_COMP_ID_USER36">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="61" name="MAV_COMP_ID_USER37">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="62" name="MAV_COMP_ID_USER38">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="63" name="MAV_COMP_ID_USER39">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="64" name="MAV_COMP_ID_USER40">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="65" name="MAV_COMP_ID_USER41">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="66" name="MAV_COMP_ID_USER42">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="67" name="MAV_COMP_ID_USER43">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="68" name="MAV_COMP_ID_TELEMETRY_RADIO">
+        <description>Telemetry radio (e.g. SiK radio, or other component that emits RADIO_STATUS messages).</description>
+      </entry>
+      <entry value="69" name="MAV_COMP_ID_USER45">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="70" name="MAV_COMP_ID_USER46">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="71" name="MAV_COMP_ID_USER47">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="72" name="MAV_COMP_ID_USER48">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="73" name="MAV_COMP_ID_USER49">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="74" name="MAV_COMP_ID_USER50">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="75" name="MAV_COMP_ID_USER51">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="76" name="MAV_COMP_ID_USER52">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="77" name="MAV_COMP_ID_USER53">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="78" name="MAV_COMP_ID_USER54">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="79" name="MAV_COMP_ID_USER55">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="80" name="MAV_COMP_ID_USER56">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="81" name="MAV_COMP_ID_USER57">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="82" name="MAV_COMP_ID_USER58">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="83" name="MAV_COMP_ID_USER59">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="84" name="MAV_COMP_ID_USER60">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="85" name="MAV_COMP_ID_USER61">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="86" name="MAV_COMP_ID_USER62">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="87" name="MAV_COMP_ID_USER63">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="88" name="MAV_COMP_ID_USER64">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="89" name="MAV_COMP_ID_USER65">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="90" name="MAV_COMP_ID_USER66">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="91" name="MAV_COMP_ID_USER67">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="92" name="MAV_COMP_ID_USER68">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="93" name="MAV_COMP_ID_USER69">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="94" name="MAV_COMP_ID_USER70">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="95" name="MAV_COMP_ID_USER71">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="96" name="MAV_COMP_ID_USER72">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="97" name="MAV_COMP_ID_USER73">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="98" name="MAV_COMP_ID_USER74">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="99" name="MAV_COMP_ID_USER75">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="100" name="MAV_COMP_ID_CAMERA">
+        <description>Camera #1.</description>
+      </entry>
+      <entry value="101" name="MAV_COMP_ID_CAMERA2">
+        <description>Camera #2.</description>
+      </entry>
+      <entry value="102" name="MAV_COMP_ID_CAMERA3">
+        <description>Camera #3.</description>
+      </entry>
+      <entry value="103" name="MAV_COMP_ID_CAMERA4">
+        <description>Camera #4.</description>
+      </entry>
+      <entry value="104" name="MAV_COMP_ID_CAMERA5">
+        <description>Camera #5.</description>
+      </entry>
+      <entry value="105" name="MAV_COMP_ID_CAMERA6">
+        <description>Camera #6.</description>
+      </entry>
+      <entry value="140" name="MAV_COMP_ID_SERVO1">
+        <description>Servo #1.</description>
+      </entry>
+      <entry value="141" name="MAV_COMP_ID_SERVO2">
+        <description>Servo #2.</description>
+      </entry>
+      <entry value="142" name="MAV_COMP_ID_SERVO3">
+        <description>Servo #3.</description>
+      </entry>
+      <entry value="143" name="MAV_COMP_ID_SERVO4">
+        <description>Servo #4.</description>
+      </entry>
+      <entry value="144" name="MAV_COMP_ID_SERVO5">
+        <description>Servo #5.</description>
+      </entry>
+      <entry value="145" name="MAV_COMP_ID_SERVO6">
+        <description>Servo #6.</description>
+      </entry>
+      <entry value="146" name="MAV_COMP_ID_SERVO7">
+        <description>Servo #7.</description>
+      </entry>
+      <entry value="147" name="MAV_COMP_ID_SERVO8">
+        <description>Servo #8.</description>
+      </entry>
+      <entry value="148" name="MAV_COMP_ID_SERVO9">
+        <description>Servo #9.</description>
+      </entry>
+      <entry value="149" name="MAV_COMP_ID_SERVO10">
+        <description>Servo #10.</description>
+      </entry>
+      <entry value="150" name="MAV_COMP_ID_SERVO11">
+        <description>Servo #11.</description>
+      </entry>
+      <entry value="151" name="MAV_COMP_ID_SERVO12">
+        <description>Servo #12.</description>
+      </entry>
+      <entry value="152" name="MAV_COMP_ID_SERVO13">
+        <description>Servo #13.</description>
+      </entry>
+      <entry value="153" name="MAV_COMP_ID_SERVO14">
+        <description>Servo #14.</description>
+      </entry>
+      <entry value="154" name="MAV_COMP_ID_GIMBAL">
+        <description>Gimbal #1.</description>
+      </entry>
+      <entry value="155" name="MAV_COMP_ID_LOG">
+        <description>Logging component.</description>
+      </entry>
+      <entry value="156" name="MAV_COMP_ID_ADSB">
+        <description>Automatic Dependent Surveillance-Broadcast (ADS-B) component.</description>
+      </entry>
+      <entry value="157" name="MAV_COMP_ID_OSD">
+        <description>On Screen Display (OSD) devices for video links.</description>
+      </entry>
+      <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
+        <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter microservice.</description>
+      </entry>
+      <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
+        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_GIMBAL">All gimbals should use MAV_COMP_ID_GIMBAL.</deprecated>
+        <description>Gimbal ID for QX1.</description>
+      </entry>
+      <entry value="160" name="MAV_COMP_ID_FLARM">
+        <description>FLARM collision alert component.</description>
+      </entry>
+      <entry value="161" name="MAV_COMP_ID_PARACHUTE">
+        <description>Parachute component.</description>
+      </entry>
+      <entry value="171" name="MAV_COMP_ID_GIMBAL2">
+        <description>Gimbal #2.</description>
+      </entry>
+      <entry value="172" name="MAV_COMP_ID_GIMBAL3">
+        <description>Gimbal #3.</description>
+      </entry>
+      <entry value="173" name="MAV_COMP_ID_GIMBAL4">
+        <description>Gimbal #4</description>
+      </entry>
+      <entry value="174" name="MAV_COMP_ID_GIMBAL5">
+        <description>Gimbal #5.</description>
+      </entry>
+      <entry value="175" name="MAV_COMP_ID_GIMBAL6">
+        <description>Gimbal #6.</description>
+      </entry>
+      <entry value="180" name="MAV_COMP_ID_BATTERY">
+        <description>Battery #1.</description>
+      </entry>
+      <entry value="181" name="MAV_COMP_ID_BATTERY2">
+        <description>Battery #2.</description>
+      </entry>
+      <entry value="189" name="MAV_COMP_ID_MAVCAN">
+        <description>CAN over MAVLink client.</description>
+      </entry>
+      <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
+        <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>
+      </entry>
+      <entry value="191" name="MAV_COMP_ID_ONBOARD_COMPUTER">
+        <description>Component that lives on the onboard computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      </entry>
+      <entry value="192" name="MAV_COMP_ID_ONBOARD_COMPUTER2">
+        <description>Component that lives on the onboard computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      </entry>
+      <entry value="193" name="MAV_COMP_ID_ONBOARD_COMPUTER3">
+        <description>Component that lives on the onboard computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      </entry>
+      <entry value="194" name="MAV_COMP_ID_ONBOARD_COMPUTER4">
+        <description>Component that lives on the onboard computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      </entry>
+      <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
+        <description>Component that finds an optimal path between points based on a certain constraint (e.g. minimum snap, shortest path, cost, etc.).</description>
+      </entry>
+      <entry value="196" name="MAV_COMP_ID_OBSTACLE_AVOIDANCE">
+        <description>Component that plans a collision free path between two points.</description>
+      </entry>
+      <entry value="197" name="MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY">
+        <description>Component that provides position estimates using VIO techniques.</description>
+      </entry>
+      <entry value="198" name="MAV_COMP_ID_PAIRING_MANAGER">
+        <description>Component that manages pairing of vehicle and GCS.</description>
+      </entry>
+      <entry value="200" name="MAV_COMP_ID_IMU">
+        <description>Inertial Measurement Unit (IMU) #1.</description>
+      </entry>
+      <entry value="201" name="MAV_COMP_ID_IMU_2">
+        <description>Inertial Measurement Unit (IMU) #2.</description>
+      </entry>
+      <entry value="202" name="MAV_COMP_ID_IMU_3">
+        <description>Inertial Measurement Unit (IMU) #3.</description>
+      </entry>
+      <entry value="220" name="MAV_COMP_ID_GPS">
+        <description>GPS #1.</description>
+      </entry>
+      <entry value="221" name="MAV_COMP_ID_GPS2">
+        <description>GPS #2.</description>
+      </entry>
+      <entry value="236" name="MAV_COMP_ID_ODID_TXRX_1">
+        <description>Open Drone ID transmitter/receiver (Bluetooth/WiFi/Internet).</description>
+      </entry>
+      <entry value="237" name="MAV_COMP_ID_ODID_TXRX_2">
+        <description>Open Drone ID transmitter/receiver (Bluetooth/WiFi/Internet).</description>
+      </entry>
+      <entry value="238" name="MAV_COMP_ID_ODID_TXRX_3">
+        <description>Open Drone ID transmitter/receiver (Bluetooth/WiFi/Internet).</description>
+      </entry>
+      <entry value="240" name="MAV_COMP_ID_UDP_BRIDGE">
+        <description>Component to bridge MAVLink to UDP (i.e. from a UART).</description>
+      </entry>
+      <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
+        <description>Component to bridge to UART (i.e. from UDP).</description>
+      </entry>
+      <entry value="242" name="MAV_COMP_ID_TUNNEL_NODE">
+        <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
+      </entry>
+      <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
+        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID.</deprecated>
+        <description>Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="0" name="HEARTBEAT">
+      <description>The heartbeat message shows that a system or component is present and responding. The type and autopilot fields (along with the message component id), allow the receiving system to treat further messages from this system appropriately (e.g. by laying out the user interface based on the autopilot). This microservice is documented at https://mavlink.io/en/services/heartbeat.html</description>
+      <field type="uint8_t" name="type" enum="MAV_TYPE">Vehicle or component type. For a flight controller component the vehicle type (quadrotor, helicopter, etc.). For other components the component type (e.g. camera, gimbal, etc.). This should be used in preference to component id for identifying the component type.</field>
+      <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class. Use MAV_AUTOPILOT_INVALID for components that are not flight controllers.</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
+      <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
+      <field type="uint8_t" name="system_status" enum="MAV_STATE">System status flag.</field>
+      <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/paparazzi.xml
+++ b/bp_mavlink/paparazzi.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>common.xml</include>
+  <version>3</version>
+  <enums>
+    </enums>
+  <messages>
+    <!-- Messages specifically designated for the Paparazzi autopilot -->
+    <message id="180" name="SCRIPT_ITEM">
+      <description>Message encoding a mission script item. This message is emitted upon a request for the next script item.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <field type="char[50]" name="name">The name of the mission script, NULL terminated.</field>
+    </message>
+    <message id="181" name="SCRIPT_REQUEST">
+      <description>Request script item with the sequence number seq. The response of the system to this message should be a SCRIPT_ITEM message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="182" name="SCRIPT_REQUEST_LIST">
+      <description>Request the overall list of mission items from the system/component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="183" name="SCRIPT_COUNT">
+      <description>This message is emitted as response to SCRIPT_REQUEST_LIST by the MAV to get the number of mission scripts.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="count">Number of script items in the sequence</field>
+    </message>
+    <message id="184" name="SCRIPT_CURRENT">
+      <description>This message informs about the currently active SCRIPT.</description>
+      <field type="uint16_t" name="seq">Active Sequence</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/python_array_test.xml
+++ b/bp_mavlink/python_array_test.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!-- MESSAGE IDs 150 - 240: Space for custom messages in individual projectname_messages.xml files -->
+<mavlink>
+  <include>common.xml</include>
+  <messages>
+    <message id="17150" name="ARRAY_TEST_0">
+      <description>Array test #0.</description>
+      <field type="uint8_t" name="v1">Stub field</field>
+      <field type="int8_t[4]" name="ar_i8">Value array</field>
+      <field type="uint8_t[4]" name="ar_u8">Value array</field>
+      <field type="uint16_t[4]" name="ar_u16">Value array</field>
+      <field type="uint32_t[4]" name="ar_u32">Value array</field>
+    </message>
+    <message id="17151" name="ARRAY_TEST_1">
+      <description>Array test #1.</description>
+      <field type="uint32_t[4]" name="ar_u32">Value array</field>
+    </message>
+    <message id="17153" name="ARRAY_TEST_3">
+      <description>Array test #3.</description>
+      <field type="uint8_t" name="v">Stub field</field>
+      <field type="uint32_t[4]" name="ar_u32">Value array</field>
+    </message>
+    <message id="17154" name="ARRAY_TEST_4">
+      <description>Array test #4.</description>
+      <field type="uint32_t[4]" name="ar_u32">Value array</field>
+      <field type="uint8_t" name="v">Stub field</field>
+    </message>
+    <message id="17155" name="ARRAY_TEST_5">
+      <description>Array test #5.</description>
+      <field type="char[5]" name="c1">Value array</field>
+      <field type="char[5]" name="c2">Value array</field>
+    </message>
+    <message id="17156" name="ARRAY_TEST_6">
+      <description>Array test #6.</description>
+      <field type="uint8_t" name="v1">Stub field</field>
+      <field type="uint16_t" name="v2">Stub field</field>
+      <field type="uint32_t" name="v3">Stub field</field>
+      <field type="uint32_t[2]" name="ar_u32">Value array</field>
+      <field type="int32_t[2]" name="ar_i32">Value array</field>
+      <field type="uint16_t[2]" name="ar_u16">Value array</field>
+      <field type="int16_t[2]" name="ar_i16">Value array</field>
+      <field type="uint8_t[2]" name="ar_u8">Value array</field>
+      <field type="int8_t[2]" name="ar_i8">Value array</field>
+      <field type="char[32]" name="ar_c">Value array</field>
+      <field type="double[2]" name="ar_d">Value array</field>
+      <field type="float[2]" name="ar_f">Value array</field>
+    </message>
+    <message id="17157" name="ARRAY_TEST_7">
+      <description>Array test #7.</description>
+      <field type="double[2]" name="ar_d">Value array</field>
+      <field type="float[2]" name="ar_f">Value array</field>
+      <field type="uint32_t[2]" name="ar_u32">Value array</field>
+      <field type="int32_t[2]" name="ar_i32">Value array</field>
+      <field type="uint16_t[2]" name="ar_u16">Value array</field>
+      <field type="int16_t[2]" name="ar_i16">Value array</field>
+      <field type="uint8_t[2]" name="ar_u8">Value array</field>
+      <field type="int8_t[2]" name="ar_i8">Value array</field>
+      <field type="char[32]" name="ar_c">Value array</field>
+    </message>
+    <message id="17158" name="ARRAY_TEST_8">
+      <description>Array test #8.</description>
+      <field type="uint32_t" name="v3">Stub field</field>
+      <field type="double[2]" name="ar_d">Value array</field>
+      <field type="uint16_t[2]" name="ar_u16">Value array</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/standard.xml
+++ b/bp_mavlink/standard.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- MAVLink standard messages -->
+  <include>common.xml</include>
+  <dialect>0</dialect>
+  <!-- use common.xml enums -->
+  <enums/>
+  <!-- use common.xml messages -->
+  <messages/>
+</mavlink>

--- a/bp_mavlink/storm32.xml
+++ b/bp_mavlink/storm32.xml
@@ -1,0 +1,569 @@
+<?xml version="1.0"?>
+<!--
+Contact:
+  - github user name: @olliw42 (to ping)
+  - send a PM to user OlliW at https://www.rcgroups.com (most quick)
+  - raise an issue in the https://github.com/olliw42/storm32bgc github repository
+Range of IDs:
+  messages: 60000 - 60049
+  commands: 60000 - 60049
+Documentation:  
+  STORM32 and QSHOT additions
+  6. Okt. 2021
+  All messages are technically WIP, but some are quite stable now.
+  Quite stable means that it is in practical use, but may see extension.
+  A more detailed description of the concept underlying the STORM32 and QSHOT messages can be found here:
+  http://www.olliw.eu/2020/mavlink-gimbal-protocol-v2/
+-->
+<mavlink>
+  <include>ardupilotmega.xml</include>
+  <version>1</version>
+  <dialect>0</dialect>
+  <!--
+  STORM32 enums
+  -->
+  <enums>
+    <!-- ***************************
+    STORM32 tunnel enum, this is merely a redefinition for convennience
+    *************************** -->
+    <enum name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE">
+      <!-- Stable -->
+      <entry value="200" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH1_IN">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="201" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH1_OUT">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="202" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH2_IN">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="203" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH2_OUT">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="204" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH3_IN">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="205" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_CH3_OUT">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="206" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED6">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="207" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED7">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="208" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED8">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="209" name="MAV_STORM32_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED9">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    STORM32 gimbal prearm check flags
+    *************************** -->
+    <enum name="MAV_STORM32_GIMBAL_PREARM_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>STorM32 gimbal prearm check flags.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_IS_NORMAL">
+        <description>STorM32 gimbal is in normal state.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_IMUS_WORKING">
+        <description>The IMUs are healthy and working normally.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_MOTORS_WORKING">
+        <description>The motors are active and working normally.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_ENCODERS_WORKING">
+        <description>The encoders are healthy and working normally.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_VOLTAGE_OK">
+        <description>A battery voltage is applied and is in range.</description>
+      </entry>
+      <entry value="32" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_VIRTUALCHANNELS_RECEIVING">
+        <description>???.</description>
+      </entry>
+      <entry value="64" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_MAVLINK_RECEIVING">
+        <description>Mavlink messages are being received.</description>
+      </entry>
+      <entry value="128" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_STORM32LINK_QFIX">
+        <description>The STorM32Link data indicates QFix.</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_STORM32LINK_WORKING">
+        <description>The STorM32Link is working.</description>
+      </entry>
+      <entry value="512" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_CAMERA_CONNECTED">
+        <description>The camera has been found and is connected.</description>
+      </entry>
+      <entry value="1024" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_AUX0_LOW">
+        <description>The signal on the AUX0 input pin is low.</description>
+      </entry>
+      <entry value="2048" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_AUX1_LOW">
+        <description>The signal on the AUX1 input pin is low.</description>
+      </entry>
+      <entry value="4096" name="MAV_STORM32_GIMBAL_PREARM_FLAGS_NTLOGGER_WORKING">
+        <description>The NTLogger is working normally.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_CAMERA_PREARM_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>STorM32 camera prearm check flags.</description>
+      <entry value="1" name="MAV_STORM32_CAMERA_PREARM_FLAGS_CONNECTED">
+        <description>The camera has been found and is connected.</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    STORM32 gimbal device enums
+    *************************** -->
+    <enum name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>Gimbal device capability flags.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal device supports a retracted position.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL">
+        <description>Gimbal device supports a horizontal, forward looking position, stabilized. Can also be used to reset the gimbal's orientation.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_AXIS">
+        <description>Gimbal device supports rotating around roll axis.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Gimbal device supports to follow a roll angle relative to the vehicle.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Gimbal device supports locking to an roll angle (generally that's the default).</description>
+      </entry>
+      <entry value="32" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_AXIS">
+        <description>Gimbal device supports rotating around pitch axis.</description>
+      </entry>
+      <entry value="64" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Gimbal device supports to follow a pitch angle relative to the vehicle.</description>
+      </entry>
+      <entry value="128" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Gimbal device supports locking to an pitch angle (generally that's the default).</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_AXIS">
+        <description>Gimbal device supports rotating around yaw axis.</description>
+      </entry>
+      <entry value="512" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal device supports to follow a yaw angle relative to the vehicle (generally that's the default).</description>
+      </entry>
+      <entry value="1024" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal device supports locking to a heading angle.</description>
+      </entry>
+      <entry value="2048" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_INFINITE_YAW">
+        <description>Gimbal device supports yawing/panning infinitely (e.g. using a slip ring).</description>
+      </entry>
+      <entry value="65536" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_ABSOLUTE_YAW">
+        <description>Gimbal device supports absolute yaw angles (this usually requires support by an autopilot, and can be dynamic, i.e., go on and off during runtime).</description>
+      </entry>
+      <entry value="131072" name="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS_HAS_RC">
+        <description>Gimbal device supports control via an RC input signal.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_DEVICE_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>Flags for gimbal device operation. Used for setting and reporting, unless specified otherwise. Settings which are in violation of the capability flags are ignored by the gimbal device.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_RETRACT">
+        <description>Retracted safe position (no stabilization), takes presedence over NEUTRAL flag. If supported by the gimbal, the angles in the retracted position can be set in addition.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_NEUTRAL">
+        <description>Neutral position (horizontal, forward looking, with stabiliziation).</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_ROLL_LOCK">
+        <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_PITCH_LOCK">
+        <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to earth (not relative to drone). When the YAW_ABSOLUTE flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute), else it is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_CAN_ACCEPT_YAW_ABSOLUTE">
+        <description>Gimbal device can accept absolute yaw angle input. This flag cannot be set, is only for reporting (attempts to set it are rejected by the gimbal device).</description>
+      </entry>
+      <entry value="512" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE">
+        <description>Yaw angle is absolute (is only accepted if CAN_ACCEPT_YAW_ABSOLUTE is set). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute), else it is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="1024" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_RC_EXCLUSIVE">
+        <description>RC control. The RC input signal fed to the gimbal device exclusively controls the gimbal's orientation. Overrides RC_MIXED flag if that is also set.</description>
+      </entry>
+      <entry value="2048" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_RC_MIXED">
+        <description>RC control. The RC input signal fed to the gimbal device is mixed into the gimbal's orientation. Is overriden by RC_EXCLUSIVE flag if that is also set.</description>
+      </entry>
+      <entry value="65535" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_NONE">
+        <description>UINT16_MAX = ignore.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>Gimbal device error and condition flags (0 means no error or other condition).</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_AT_ROLL_LIMIT">
+        <description>Gimbal device is limited by hardware roll limit.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_AT_PITCH_LIMIT">
+        <description>Gimbal device is limited by hardware pitch limit.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_AT_YAW_LIMIT">
+        <description>Gimbal device is limited by hardware yaw limit.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_ENCODER_ERROR">
+        <description>There is an error with the gimbal device's encoders.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_POWER_ERROR">
+        <description>There is an error with the gimbal device's power source.</description>
+      </entry>
+      <entry value="32" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_MOTOR_ERROR">
+        <description>There is an error with the gimbal device's motors.</description>
+      </entry>
+      <entry value="64" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_SOFTWARE_ERROR">
+        <description>There is an error with the gimbal device's software.</description>
+      </entry>
+      <entry value="128" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_COMMS_ERROR">
+        <description>There is an error with the gimbal device's communication.</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_CALIBRATION_RUNNING">
+        <description>Gimbal device is currently calibrating (not an error).</description>
+      </entry>
+      <entry value="32768" name="MAV_STORM32_GIMBAL_DEVICE_ERROR_FLAGS_NO_MANAGER">
+        <description>Gimbal device is not assigned to a gimbal manager (not an error).</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    STORM32 gimbal manager enums
+    *************************** -->
+    <enum name="MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
+      <!-- WIP -->
+      <description>Gimbal manager capability flags.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS_HAS_PROFILES">
+        <description>The gimbal manager supports several profiles.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_CHANGE">
+        <description>The gimbal manager supports changing the gimbal manager during run time, i.e. can be enabled/disabled.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_MANAGER_FLAGS" bitmask="true">
+      <!-- Quite stable -->
+      <description>Flags for gimbal manager operation. Used for setting and reporting, unless specified otherwise. If a setting is accepted by the gimbal manger, is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
+      <entry value="0" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_NONE">
+        <description>0 = ignore.</description>
+      </entry>
+      <entry value="1" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_RC_ACTIVE">
+        <description>Request to set RC input to active, or report RC input is active. Implies RC mixed. RC exclusive is achieved by setting all clients to inactive.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_ONBOARD_ACTIVE">
+        <description>Request to set onboard/companion computer client to active, or report this client is active.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_AUTOPILOT_ACTIVE">
+        <description>Request to set autopliot client to active, or report this client is active.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_GCS_ACTIVE">
+        <description>Request to set GCS client to active, or report this client is active.</description>
+      </entry>
+      <entry value="16" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_CAMERA_ACTIVE">
+        <description>Request to set camera client to active, or report this client is active.</description>
+      </entry>
+      <entry value="32" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_GCS2_ACTIVE">
+        <description>Request to set GCS2 client to active, or report this client is active.</description>
+      </entry>
+      <entry value="64" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_CAMERA2_ACTIVE">
+        <description>Request to set camera2 client to active, or report this client is active.</description>
+      </entry>
+      <entry value="128" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_CUSTOM_ACTIVE">
+        <description>Request to set custom client to active, or report this client is active.</description>
+      </entry>
+      <entry value="256" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_CLIENT_CUSTOM2_ACTIVE">
+        <description>Request to set custom2 client to active, or report this client is active.</description>
+      </entry>
+      <entry value="512" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_SET_SUPERVISON">
+        <description>Request supervision. This flag is only for setting, it is not reported.</description>
+      </entry>
+      <entry value="1024" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_SET_RELEASE">
+        <description>Release supervision. This flag is only for setting, it is not reported.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_MANAGER_CLIENT">
+      <!-- Quite stable -->
+      <description>Gimbal manager client ID. In a prioritizing profile, the priorities are determined by the implementation; they could e.g. be custom1 &gt; onboard &gt; GCS &gt; autopilot/camera &gt; GCS2 &gt; custom2.</description>
+      <entry value="0" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_NONE">
+        <description>For convenience.</description>
+      </entry>
+      <entry value="1" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_ONBOARD">
+        <description>This is the onboard/companion computer client.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_AUTOPILOT">
+        <description>This is the autopilot client.</description>
+      </entry>
+      <entry value="3" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_GCS">
+        <description>This is the GCS client.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_CAMERA">
+        <description>This is the camera client.</description>
+      </entry>
+      <entry value="5" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_GCS2">
+        <description>This is the GCS2 client.</description>
+      </entry>
+      <entry value="6" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_CAMERA2">
+        <description>This is the camera2 client.</description>
+      </entry>
+      <entry value="7" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_CUSTOM">
+        <description>This is the custom client.</description>
+      </entry>
+      <entry value="8" name="MAV_STORM32_GIMBAL_MANAGER_CLIENT_CUSTOM2">
+        <description>This is the custom2 client.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_MANAGER_SETUP_FLAGS" bitmask="true">
+      <!-- WIP -->
+      <description>Flags for gimbal manager set up. Used for setting and reporting, unless specified otherwise.</description>
+      <entry value="16384" name="MAV_STORM32_GIMBAL_MANAGER_SETUP_FLAGS_ENABLE">
+        <description>Enable gimbal manager. This flag is only for setting, is not reported.</description>
+      </entry>
+      <entry value="32768" name="MAV_STORM32_GIMBAL_MANAGER_SETUP_FLAGS_DISABLE">
+        <description>Disable gimbal manager. This flag is only for setting, is not reported.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_MANAGER_PROFILE">
+      <!-- WIP -->
+      <description>Gimbal manager profiles. Only standard profiles are defined. Any implementation can define it's own profile in addition, and should use enum values &gt; 16.</description>
+      <entry value="0" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_DEFAULT">
+        <description>Default profile. Implementation specific.</description>
+      </entry>
+      <entry value="1" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_CUSTOM">
+        <description>Custom profile. Configurable profile according to the STorM32 definition. Is configured with STORM32_GIMBAL_MANAGER_PROFIL.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_COOPERATIVE">
+        <description>Default cooperative profile. Uses STorM32 custom profile with default settings to achieve cooperative behavior.</description>
+      </entry>
+      <entry value="3" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_EXCLUSIVE">
+        <description>Default exclusive profile. Uses STorM32 custom profile with default settings to achieve exclusive behavior.</description>
+      </entry>
+      <entry value="4" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_PRIORITY_COOPERATIVE">
+        <description>Default priority profile with cooperative behavior for equal priority. Uses STorM32 custom profile with default settings to achieve priority-based behavior.</description>
+      </entry>
+      <entry value="5" name="MAV_STORM32_GIMBAL_MANAGER_PROFILE_PRIORITY_EXCLUSIVE">
+        <description>Default priority profile with exclusive behavior for equal priority. Uses STorM32 custom profile with default settings to achieve priority-based behavior.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STORM32_GIMBAL_ACTION">
+      <!-- WIP -->
+      <description>Gimbal actions.</description>
+      <entry value="1" name="MAV_STORM32_GIMBAL_ACTION_RECENTER">
+        <description>Trigger the gimbal device to recenter the gimbal.</description>
+      </entry>
+      <entry value="2" name="MAV_STORM32_GIMBAL_ACTION_CALIBRATION">
+        <description>Trigger the gimbal device to run a calibration.</description>
+      </entry>
+      <entry value="3" name="MAV_STORM32_GIMBAL_ACTION_DISCOVER_MANAGER">
+        <description>Trigger gimbal device to (re)discover the gimbal manager during run time.</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    QSHOT manager mode enums
+    *************************** -->
+    <enum name="MAV_QSHOT_MODE">
+      <!-- Quite stable, will grow however -->
+      <description>Enumeration of possible shot modes.</description>
+      <entry value="0" name="MAV_QSHOT_MODE_UNDEFINED">
+        <description>Undefined shot mode. Can be used to determine if qshots should be used or not.</description>
+      </entry>
+      <entry value="1" name="MAV_QSHOT_MODE_DEFAULT">
+        <description>Start normal gimbal operation. Is usally used to return back from a shot.</description>
+      </entry>
+      <entry value="2" name="MAV_QSHOT_MODE_GIMBAL_RETRACT">
+        <description>Load and keep safe gimbal position and stop stabilization.</description>
+      </entry>
+      <entry value="3" name="MAV_QSHOT_MODE_GIMBAL_NEUTRAL">
+        <description>Load neutral gimbal position and keep it while stabilizing.</description>
+      </entry>
+      <entry value="4" name="MAV_QSHOT_MODE_GIMBAL_MISSION">
+        <description>Start mission with gimbal control.</description>
+      </entry>
+      <entry value="5" name="MAV_QSHOT_MODE_GIMBAL_RC_CONTROL">
+        <description>Start RC gimbal control.</description>
+      </entry>
+      <entry value="6" name="MAV_QSHOT_MODE_POI_TARGETING">
+        <description>Start gimbal tracking the point specified by Lat, Lon, Alt.</description>
+      </entry>
+      <entry value="7" name="MAV_QSHOT_MODE_SYSID_TARGETING">
+        <description>Start gimbal tracking the system with specified system ID.</description>
+      </entry>
+      <entry value="8" name="MAV_QSHOT_MODE_CABLECAM_2POINT">
+        <description>Start 2-point cable cam quick shot.</description>
+      </entry>
+      <entry value="9" name="MAV_QSHOT_MODE_HOME_TARGETING">
+        <description>Start gimbal tracking the home location.</description>
+      </entry>
+    </enum>
+    <!-- ***************************
+    STORM32 and QSHOT cmds
+    *************************** -->
+    <enum name="MAV_CMD">
+      <!-- leave room for 60000 gimbal device configure -->
+      <!-- leave room for 60001 gimbal manager configure -->
+      <entry value="60002" name="MAV_CMD_STORM32_DO_GIMBAL_MANAGER_CONTROL_PITCHYAW" hasLocation="false" isDestination="false">
+        <!-- Quite stable -->
+        <description>Command to a gimbal manager to control the gimbal tilt and pan angles. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. A gimbal device is never to react to this command.</description>
+        <param index="1" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle (positive: tilt up, NaN to be ignored).</param>
+        <param index="2" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</param>
+        <param index="3" label="Pitch rate" units="deg/s">Pitch/tilt rate (positive: tilt up, NaN to be ignored).</param>
+        <param index="4" label="Yaw rate" units="deg/s">Yaw/pan rate (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</param>
+        <param index="5" label="Gimbal device flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags.</param>
+        <param index="6" label="Gimbal manager flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS">Gimbal manager flags.</param>
+        <param index="7" label="Gimbal ID and client ID">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals). The client is copied into bits 8-15.</param>
+      </entry>
+      <entry value="60010" name="MAV_CMD_STORM32_DO_GIMBAL_MANAGER_SETUP" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- WIP -->
+        <description>Command to configure a gimbal manager. A gimbal device is never to react to this command. The selected profile is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
+        <param index="1" label="Profile" enum="MAV_STORM32_GIMBAL_MANAGER_PROFILE">Gimbal manager profile (0 = default).</param>
+        <param index="2" label="Setup flags" enum="MAV_STORM32_GIMBAL_MANAGER_SETUP_FLAGS">Gimbal manager setup flags (0 = none).</param>
+        <param index="7" label="Gimbal ID">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals). Send command multiple times for more than one but not all gimbals.</param>
+      </entry>
+      <entry value="60011" name="MAV_CMD_STORM32_DO_GIMBAL_ACTION" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- WIP -->
+        <description>Command to initiate gimbal actions. Usually performed by the gimbal device, but some can also be done by the gimbal manager. It is hence best to broadcast this command.</description>
+        <param index="1" label="Action" enum="MAV_STORM32_GIMBAL_ACTION">Gimbal action to initiate (0 = none).</param>
+        <param index="7" label="Gimbal ID">Gimbal ID of the gimbal to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals). Send command multiple times for more than one but not all gimbals.</param>
+      </entry>
+      <entry value="60020" name="MAV_CMD_QSHOT_DO_CONFIGURE" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- WIP -->
+        <description>Command to set the shot manager mode.</description>
+        <param index="1" label="Mode" enum="MAV_QSHOT_MODE">Set shot mode.</param>
+        <param index="2" label="Shot state or command">Set shot state or command. The allowed values are specific to the selected shot mode.</param>
+      </entry>
+    </enum>
+  </enums>
+  <!--
+  STORM32 messages
+  -->
+  <messages>
+    <!-- ***************************
+    STORM32 gimbal device messages
+    *************************** -->
+    <!-- leave room for 60000 gimbal device information -->
+    <message id="60001" name="STORM32_GIMBAL_DEVICE_STATUS">
+      <!-- Quite stable -->
+      <description>Message reporting the current status of a gimbal device. This message should be broadcasted by a gimbal device component at a low regular rate (e.g. 4 Hz). For higher rates it should be emitted with a target.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint16_t" name="flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags currently applied.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame depends on the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag.</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (the frame depends on the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN if unknown).</field>
+      <field type="float" name="yaw_absolute" units="deg" invalid="NaN">Yaw in absolute frame relative to Earth's North, north is 0 (NaN if unknown).</field>
+      <field type="uint16_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure).</field>
+    </message>
+    <message id="60002" name="STORM32_GIMBAL_DEVICE_CONTROL">
+      <!-- Quite stable -->
+      <description>Message to a gimbal device to control its attitude. This message is to be sent from the gimbal manager to the gimbal device. Angles and rates can be set to NaN according to use case.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="float[4]" name="q" invalid="[NaN:]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, set first element to NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+    </message>
+    <!-- ***************************
+    STORM32 gimbal manager messages
+    *************************** -->
+    <message id="60010" name="STORM32_GIMBAL_MANAGER_INFORMATION">
+      <!-- Quite stable, may grow however -->
+      <description>Information about a gimbal manager. This message should be requested by a ground station using MAV_CMD_REQUEST_MESSAGE. It mirrors some fields of the STORM32_GIMBAL_DEVICE_INFORMATION message, but not all. If the additional information is desired, also STORM32_GIMBAL_DEVICE_INFORMATION should be requested.</description>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID (component ID or 1-6 for non-MAVLink gimbal) that this gimbal manager is responsible for.</field>
+      <field type="uint32_t" name="device_cap_flags" enum="MAV_STORM32_GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Gimbal device capability flags.</field>
+      <field type="uint32_t" name="manager_cap_flags" enum="MAV_STORM32_GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Gimbal manager capability flags.</field>
+      <field type="float" name="roll_min" units="rad" invalid="NaN">Hardware minimum roll angle (positive: roll to the right, NaN if unknown).</field>
+      <field type="float" name="roll_max" units="rad" invalid="NaN">Hardware maximum roll angle (positive: roll to the right, NaN if unknown).</field>
+      <field type="float" name="pitch_min" units="rad" invalid="NaN">Hardware minimum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
+      <field type="float" name="pitch_max" units="rad" invalid="NaN">Hardware maximum pitch/tilt angle (positive: tilt up, NaN if unknown).</field>
+      <field type="float" name="yaw_min" units="rad" invalid="NaN">Hardware minimum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
+      <field type="float" name="yaw_max" units="rad" invalid="NaN">Hardware maximum yaw/pan angle (positive: pan to the right, relative to the vehicle/gimbal base, NaN if unknown).</field>
+    </message>
+    <message id="60011" name="STORM32_GIMBAL_MANAGER_STATUS">
+      <!-- Quite stable, may grow however -->
+      <description>Message reporting the current status of a gimbal manager. This message should be broadcast at a low regular rate (e.g. 1 Hz, may be increase momentarily to e.g. 5 Hz for a period of 1 sec after a change).</description>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID (component ID or 1-6 for non-MAVLink gimbal) that this gimbal manager is responsible for.</field>
+      <field type="uint8_t" name="supervisor" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client who is currently supervisor (0 = none).</field>
+      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS">Gimbal device flags currently applied.</field>
+      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS">Gimbal manager flags currently applied.</field>
+      <field type="uint8_t" name="profile" enum="MAV_STORM32_GIMBAL_MANAGER_PROFILE">Profile currently applied (0 = default).</field>
+    </message>
+    <message id="60012" name="STORM32_GIMBAL_MANAGER_CONTROL">
+      <!-- Quite stable -->
+      <description>Message to a gimbal manager to control the gimbal attitude. Angles and rates can be set to NaN according to use case. A gimbal device is never to react to this message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
+      <field type="uint8_t" name="client" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client which is contacting the gimbal manager (must be set).</field>
+      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS" invalid="0">Gimbal manager flags (0 to be ignored).</field>
+      <field type="float[4]" name="q" invalid="[NaN:]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is determined by the GIMBAL_MANAGER_FLAGS_ABSOLUTE_YAW flag, set first element to NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: roll to the right, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+    </message>
+    <message id="60013" name="STORM32_GIMBAL_MANAGER_CONTROL_PITCHYAW">
+      <!-- Quite stable -->
+      <description>Message to a gimbal manager to control the gimbal tilt and pan angles. Angles and rates can be set to NaN according to use case. A gimbal device is never to react to this message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
+      <field type="uint8_t" name="client" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client which is contacting the gimbal manager (must be set).</field>
+      <field type="uint16_t" name="device_flags" enum="MAV_STORM32_GIMBAL_DEVICE_FLAGS" invalid="UINT16_MAX">Gimbal device flags (UINT16_MAX to be ignored).</field>
+      <field type="uint16_t" name="manager_flags" enum="MAV_STORM32_GIMBAL_MANAGER_FLAGS" invalid="0">Gimbal manager flags (0 to be ignored).</field>
+      <field type="float" name="pitch" units="rad" invalid="NaN">Pitch/tilt angle (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="yaw" units="rad" invalid="NaN">Yaw/pan angle (positive: pan the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+      <field type="float" name="pitch_rate" units="rad/s" invalid="NaN">Pitch/tilt angular rate (positive: tilt up, NaN to be ignored).</field>
+      <field type="float" name="yaw_rate" units="rad/s" invalid="NaN">Yaw/pan angular rate (positive: pan to the right, the frame is determined by the STORM32_GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
+    </message>
+    <message id="60014" name="STORM32_GIMBAL_MANAGER_CORRECT_ROLL">
+      <!-- Quite stable -->
+      <description>Message to a gimbal manager to correct the gimbal roll angle. This message is typically used to manually correct for a tilted horizon in operation. A gimbal device is never to react to this message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
+      <field type="uint8_t" name="client" enum="MAV_STORM32_GIMBAL_MANAGER_CLIENT">Client which is contacting the gimbal manager (must be set).</field>
+      <field type="float" name="roll" units="rad">Roll angle (positive to roll to the right).</field>
+    </message>
+    <message id="60015" name="STORM32_GIMBAL_MANAGER_PROFILE">
+      <wip/>
+      <!-- WIP -->
+      <description>Message to set a gimbal manager profile. A gimbal device is never to react to this command. The selected profile is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="gimbal_id" instance="true">Gimbal ID of the gimbal manager to address (component ID or 1-6 for non-MAVLink gimbal, 0 for all gimbals, send command multiple times for more than one but not all gimbals).</field>
+      <field type="uint8_t" name="profile" enum="MAV_STORM32_GIMBAL_MANAGER_PROFILE">Profile to be applied (0 = default).</field>
+      <field type="uint8_t[8]" name="priorities">Priorities for custom profile.</field>
+      <field type="uint8_t" name="profile_flags">Profile flags for custom profile (0 = default).</field>
+      <field type="uint8_t" name="rc_timeout">Rc timeouts for custom profile (0 = infinite, in uints of 100 ms).</field>
+      <field type="uint8_t[8]" name="timeouts">Timeouts for custom profile (0 = infinite, in uints of 100 ms).</field>
+    </message>
+    <!-- ***************************
+    QSHOT manager messages
+    *************************** -->
+    <message id="60020" name="QSHOT_STATUS">
+      <wip/>
+      <!-- WIP -->
+      <description>Information about the shot operation.</description>
+      <field type="uint16_t" name="mode" enum="MAV_QSHOT_MODE">Current shot mode.</field>
+      <field type="uint16_t" name="shot_state">Current state in the shot. States are specific to the selected shot mode.</field>
+    </message>
+    <!-- ***************************
+    General messages
+    *************************** -->
+    <message id="60025" name="COMPONENT_PREARM_STATUS">
+      <!-- Quite stable -->
+      <description>Message reporting the status of the prearm checks. The flags are component specific.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="enabled_flags" invalid="UINT32_MAX">Currently enabled prearm checks. 0 means no checks are being performed, UINT32_MAX means not known.</field>
+      <field type="uint32_t" name="fail_flags">Currently not passed prearm checks. 0 means all checks have been passed.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/test.xml
+++ b/bp_mavlink/test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<mavlink>
+  <version>3</version>
+  <messages>
+    <message id="17000" name="TEST_TYPES">
+      <description>Test all field types</description>
+      <field type="char" name="c">char</field>
+      <field type="char[10]" name="s">string</field>
+      <field type="uint8_t" name="u8">uint8_t</field>
+      <field type="uint16_t" name="u16">uint16_t</field>
+      <field print_format="0x%08x" type="uint32_t" name="u32">uint32_t</field>
+      <field type="uint64_t" name="u64">uint64_t</field>
+      <field type="int8_t" name="s8">int8_t</field>
+      <field type="int16_t" name="s16">int16_t</field>
+      <field type="int32_t" name="s32">int32_t</field>
+      <field type="int64_t" name="s64">int64_t</field>
+      <field type="float" name="f">float</field>
+      <field type="double" name="d">double</field>
+      <field type="uint8_t[3]" name="u8_array">uint8_t_array</field>
+      <field type="uint16_t[3]" name="u16_array">uint16_t_array</field>
+      <field type="uint32_t[3]" name="u32_array">uint32_t_array</field>
+      <field type="uint64_t[3]" name="u64_array">uint64_t_array</field>
+      <field type="int8_t[3]" name="s8_array">int8_t_array</field>
+      <field type="int16_t[3]" name="s16_array">int16_t_array</field>
+      <field type="int32_t[3]" name="s32_array">int32_t_array</field>
+      <field type="int64_t[3]" name="s64_array">int64_t_array</field>
+      <field type="float[3]" name="f_array">float_array</field>
+      <field type="double[3]" name="d_array">double_array</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/uAvionix.xml
+++ b/bp_mavlink/uAvionix.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- uAvionix contact info:                                     -->
+  <!-- company URL: http://www.uAvionix.com                       -->
+  <!-- email contact: matt@uAvionix.com or jeff@uAvionix.com      -->
+  <!-- mavlink ID range: 10000 - 10099                            -->
+  <include>common.xml</include>
+  <enums>
+    <enum name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE" bitmask="true">
+      <description>State flags for ADS-B transponder dynamic report</description>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_INTENT_CHANGE"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_NICBARO_CROSSCHECKED"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_DYNAMIC_STATE_IDENT"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_RF_SELECT" bitmask="true">
+      <description>Transceiver RF control flags for ADS-B transponder dynamic reports</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_RF_SELECT_STANDBY"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_RF_SELECT_RX_ENABLED"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_RF_SELECT_TX_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX">
+      <description>Status for ADS-B transponder dynamic input</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_NONE_0"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_NONE_1"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_2D"/>
+      <entry value="3" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_3D"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_DGPS"/>
+      <entry value="5" name="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX_RTK"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_RF_HEALTH" bitmask="true">
+      <description>Status flags for ADS-B transponder dynamic output</description>
+      <entry value="0" name="UAVIONIX_ADSB_RF_HEALTH_INITIALIZING"/>
+      <entry value="1" name="UAVIONIX_ADSB_RF_HEALTH_OK"/>
+      <entry value="2" name="UAVIONIX_ADSB_RF_HEALTH_FAIL_TX"/>
+      <entry value="16" name="UAVIONIX_ADSB_RF_HEALTH_FAIL_RX"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE">
+      <description>Definitions for aircraft size</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_NO_DATA"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L15M_W23M"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L25M_W28P5M"/>
+      <entry value="3" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L25_34M"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L35_33M"/>
+      <entry value="5" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L35_38M"/>
+      <entry value="6" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L45_39P5M"/>
+      <entry value="7" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L45_45M"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L55_45M"/>
+      <entry value="9" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L55_52M"/>
+      <entry value="10" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L65_59P5M"/>
+      <entry value="11" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L65_67M"/>
+      <entry value="12" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L75_W72P5M"/>
+      <entry value="13" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L75_W80M"/>
+      <entry value="14" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L85_W80M"/>
+      <entry value="15" name="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE_L85_W90M"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">
+      <description>GPS lataral offset encoding</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_NO_DATA"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_LEFT_2M"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_LEFT_4M"/>
+      <entry value="3" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_LEFT_6M"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_RIGHT_0M"/>
+      <entry value="5" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_RIGHT_2M"/>
+      <entry value="6" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_RIGHT_4M"/>
+      <entry value="7" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT_RIGHT_6M"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">
+      <description>GPS longitudinal offset encoding</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON_NO_DATA"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON_APPLIED_BY_SENSOR"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_EMERGENCY_STATUS">
+      <description>Emergency status encoding</description>
+      <entry value="0" name="UAVIONIX_ADSB_OUT_NO_EMERGENCY"/>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_GENERAL_EMERGENCY"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_LIFEGUARD_EMERGENCY"/>
+      <entry value="3" name="UAVIONIX_ADSB_OUT_MINIMUM_FUEL_EMERGENCY"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_NO_COMM_EMERGENCY"/>
+      <entry value="5" name="UAVIONIX_ADSB_OUT_UNLAWFUL_INTERFERANCE_EMERGENCY"/>
+      <entry value="6" name="UAVIONIX_ADSB_OUT_DOWNED_AIRCRAFT_EMERGENCY"/>
+      <entry value="7" name="UAVIONIX_ADSB_OUT_RESERVED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_CONTROL_STATE" bitmask="true">
+      <description>State flags for ADS-B transponder dynamic report</description>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_EXTERNAL_BARO_CROSSCHECKED"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_ON_GROUND"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_IDENT_BUTTON_ACTIVE"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_A_ENABLED"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_C_ENABLED"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_S_ENABLED"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_1090ES_TX_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_XBIT" bitmask="true">
+      <description>State flags for X-Bit and reserved fields.</description>
+      <entry value="128" name="UAVIONIX_ADSB_XBIT_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_STATE" bitmask="true">
+      <description>State flags for ADS-B transponder status report</description>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_STATUS_STATE_ON_GROUND"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_STATUS_STATE_INTERROGATED_SINCE_LAST"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_STATUS_STATE_XBIT_ENABLED"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_STATUS_STATE_IDENT_ACTIVE"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_A_ENABLED"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_C_ENABLED"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_S_ENABLED"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_STATUS_STATE_1090ES_TX_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_NIC_NACP">
+      <description>State flags for ADS-B transponder status report</description>
+      <entry value="1" name="UAVIONIX_ADSB_NIC_CR_20_NM"/>
+      <entry value="2" name="UAVIONIX_ADSB_NIC_CR_8_NM"/>
+      <entry value="3" name="UAVIONIX_ADSB_NIC_CR_4_NM"/>
+      <entry value="4" name="UAVIONIX_ADSB_NIC_CR_2_NM"/>
+      <entry value="5" name="UAVIONIX_ADSB_NIC_CR_1_NM"/>
+      <entry value="6" name="UAVIONIX_ADSB_NIC_CR_0_3_NM"/>
+      <entry value="7" name="UAVIONIX_ADSB_NIC_CR_0_2_NM"/>
+      <entry value="8" name="UAVIONIX_ADSB_NIC_CR_0_1_NM"/>
+      <entry value="9" name="UAVIONIX_ADSB_NIC_CR_75_M"/>
+      <entry value="10" name="UAVIONIX_ADSB_NIC_CR_25_M"/>
+      <entry value="11" name="UAVIONIX_ADSB_NIC_CR_7_5_M"/>
+      <entry value="16" name="UAVIONIX_ADSB_NACP_EPU_10_NM"/>
+      <entry value="32" name="UAVIONIX_ADSB_NACP_EPU_4_NM"/>
+      <entry value="48" name="UAVIONIX_ADSB_NACP_EPU_2_NM"/>
+      <entry value="64" name="UAVIONIX_ADSB_NACP_EPU_1_NM"/>
+      <entry value="80" name="UAVIONIX_ADSB_NACP_EPU_0_5_NM"/>
+      <entry value="96" name="UAVIONIX_ADSB_NACP_EPU_0_3_NM"/>
+      <entry value="112" name="UAVIONIX_ADSB_NACP_EPU_0_1_NM"/>
+      <entry value="128" name="UAVIONIX_ADSB_NACP_EPU_0_05_NM"/>
+      <entry value="144" name="UAVIONIX_ADSB_NACP_EPU_30_M"/>
+      <entry value="160" name="UAVIONIX_ADSB_NACP_EPU_10_M"/>
+      <entry value="176" name="UAVIONIX_ADSB_NACP_EPU_3_M"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_FAULT" bitmask="true">
+      <description>State flags for ADS-B transponder fault report</description>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_GPS_NO_POS"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_GPS_UNAVAIL"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_TX_SYSTEM_FAIL"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_MAINT_REQ"/>
+    </enum>
+  </enums>
+  <messages>
+    <message id="10001" name="UAVIONIX_ADSB_OUT_CFG">
+      <description>Static data to configure the ADS-B transponder (send within 10 sec of a POR and every 10 sec thereafter)</description>
+      <field type="uint32_t" name="ICAO">Vehicle address (24 bit)</field>
+      <field type="char[9]" name="callsign">Vehicle identifier (8 characters, null terminated, valid characters are A-Z, 0-9, " " only)</field>
+      <field type="uint8_t" name="emitterType" enum="ADSB_EMITTER_TYPE">Transmitting vehicle type. See ADSB_EMITTER_TYPE enum</field>
+      <field type="uint8_t" name="aircraftSize" enum="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE">Aircraft length and width encoding (table 2-35 of DO-282B)</field>
+      <field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
+      <field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
+      <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
+      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT" display="bitmask">ADS-B transponder reciever and transmit enable flags</field>
+    </message>
+    <message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
+      <description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>
+      <field type="uint32_t" name="utcTime" units="s">UTC time in seconds since GPS epoch (Jan 6, 1980). If unknown set to UINT32_MAX</field>
+      <field type="int32_t" name="gpsLat" units="degE7">Latitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
+      <field type="int32_t" name="gpsLon" units="degE7">Longitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
+      <field type="int32_t" name="gpsAlt" units="mm">Altitude (WGS84). UP +ve. If unknown set to INT32_MAX</field>
+      <field type="uint8_t" name="gpsFix" enum="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX">0-1: no fix, 2: 2D fix, 3: 3D fix, 4: DGPS, 5: RTK</field>
+      <field type="uint8_t" name="numSats">Number of satellites visible. If unknown set to UINT8_MAX</field>
+      <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude (MSL) relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
+      <field type="uint32_t" name="accuracyHor" units="mm">Horizontal accuracy in mm (m * 1E-3). If unknown set to UINT32_MAX</field>
+      <field type="uint16_t" name="accuracyVert" units="cm">Vertical accuracy in cm. If unknown set to UINT16_MAX</field>
+      <field type="uint16_t" name="accuracyVel" units="mm/s">Velocity accuracy in mm/s (m * 1E-3). If unknown set to UINT16_MAX</field>
+      <field type="int16_t" name="velVert" units="cm/s">GPS vertical speed in cm/s. If unknown set to INT16_MAX</field>
+      <field type="int16_t" name="velNS" units="cm/s">North-South velocity over ground in cm/s North +ve. If unknown set to INT16_MAX</field>
+      <field type="int16_t" name="VelEW" units="cm/s">East-West velocity over ground in cm/s East +ve. If unknown set to INT16_MAX</field>
+      <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
+      <field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE" display="bitmask">ADS-B transponder dynamic input state flags</field>
+      <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
+    </message>
+    <message id="10003" name="UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT">
+      <description>Transceiver heartbeat with health report (updated every 10s)</description>
+      <field type="uint8_t" name="rfHealth" enum="UAVIONIX_ADSB_RF_HEALTH" display="bitmask">ADS-B transponder messages</field>
+    </message>
+    <message id="10004" name="UAVIONIX_ADSB_OUT_CFG_REGISTRATION">
+      <description>Aircraft Registration.</description>
+      <field type="char[9]" name="registration">Aircraft Registration (ASCII string A-Z, 0-9 only), e.g. "N8644B ". Trailing spaces (0x20) only. This is null-terminated.</field>
+    </message>
+    <message id="10005" name="UAVIONIX_ADSB_OUT_CFG_FLIGHTID">
+      <description>Flight Identification for ADSB-Out vehicles.</description>
+      <field type="char[9]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable. Reflects Control message setting. This is null-terminated.</field>
+    </message>
+    <message id="10006" name="UAVIONIX_ADSB_GET">
+      <description>Request messages.</description>
+      <field type="uint32_t" name="ReqMessageId">Message ID to request. Supports any message in this 10000-10099 range</field>
+    </message>
+    <message id="10007" name="UAVIONIX_ADSB_OUT_CONTROL">
+      <description>Control message with all data sent in UCP control message.</description>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_CONTROL_STATE" display="bitmask">ADS-B transponder control state flags</field>
+      <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude (MSL) relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
+      <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
+      <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
+      <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
+      <field type="uint8_t" name="x_bit" enum="UAVIONIX_ADSB_XBIT" display="bitmask">X-Bit enable (military transponders only)</field>
+    </message>
+    <message id="10008" name="UAVIONIX_ADSB_OUT_STATUS">
+      <description>Status message with information from UCP Heartbeat and Status messages.</description>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_STATUS_STATE" display="bitmask">ADS-B transponder status state flags</field>
+      <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
+      <field type="uint8_t" name="NIC_NACp" enum="UAVIONIX_ADSB_OUT_STATUS_NIC_NACP">Integrity and Accuracy of traffic reported as a 4-bit value for each field (NACp 7:4, NIC 3:0) and encoded by Containment Radius (HPL) and Estimated Position Uncertainty (HFOM), respectively</field>
+      <field type="uint8_t" name="boardTemp">Board temperature in C</field>
+      <field type="uint8_t" name="fault" enum="UAVIONIX_ADSB_OUT_STATUS_FAULT" display="bitmask">ADS-B transponder fault flags</field>
+      <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/bp_mavlink/ualberta.xml
+++ b/bp_mavlink/ualberta.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>common.xml</include>
+  <enums>
+    <enum name="UALBERTA_AUTOPILOT_MODE">
+      <description>Available autopilot modes for ualberta uav</description>
+      <entry value="1" name="MODE_MANUAL_DIRECT">
+        <description>Raw input pulse widts sent to output</description>
+      </entry>
+      <entry value="2" name="MODE_MANUAL_SCALED">
+        <description>Inputs are normalized using calibration, the converted back to raw pulse widths for output</description>
+      </entry>
+      <entry value="3" name="MODE_AUTO_PID_ATT">
+        <description> dfsdfs</description>
+      </entry>
+      <entry value="4" name="MODE_AUTO_PID_VEL">
+        <description> dfsfds</description>
+      </entry>
+      <entry value="5" name="MODE_AUTO_PID_POS">
+        <description> dfsdfsdfs</description>
+      </entry>
+    </enum>
+    <enum name="UALBERTA_NAV_MODE">
+      <description>Navigation filter mode</description>
+      <entry value="1" name="NAV_AHRS_INIT"/>
+      <entry value="2" name="NAV_AHRS">
+        <description>AHRS mode</description>
+      </entry>
+      <entry value="3" name="NAV_INS_GPS_INIT">
+        <description>INS/GPS initialization mode</description>
+      </entry>
+      <entry value="4" name="NAV_INS_GPS">
+        <description>INS/GPS mode</description>
+      </entry>
+    </enum>
+    <enum name="UALBERTA_PILOT_MODE">
+      <description>Mode currently commanded by pilot</description>
+      <entry value="1" name="PILOT_MANUAL">
+        <description> sdf</description>
+      </entry>
+      <entry value="2" name="PILOT_AUTO">
+        <description> dfs</description>
+      </entry>
+      <entry value="3" name="PILOT_ROTO">
+        <description> Rotomotion mode </description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="220" name="NAV_FILTER_BIAS">
+      <description>Accelerometer and Gyro biases from the navigation filter</description>
+      <field type="uint64_t" name="usec">Timestamp (microseconds)</field>
+      <field type="float" name="accel_0">b_f[0]</field>
+      <field type="float" name="accel_1">b_f[1]</field>
+      <field type="float" name="accel_2">b_f[2]</field>
+      <field type="float" name="gyro_0">b_f[0]</field>
+      <field type="float" name="gyro_1">b_f[1]</field>
+      <field type="float" name="gyro_2">b_f[2]</field>
+    </message>
+    <message id="221" name="RADIO_CALIBRATION">
+      <description>Complete set of calibration parameters for the radio</description>
+      <field type="uint16_t[3]" name="aileron">Aileron setpoints: left, center, right</field>
+      <field type="uint16_t[3]" name="elevator">Elevator setpoints: nose down, center, nose up</field>
+      <field type="uint16_t[3]" name="rudder">Rudder setpoints: nose left, center, nose right</field>
+      <field type="uint16_t[2]" name="gyro">Tail gyro mode/gain setpoints: heading hold, rate mode</field>
+      <field type="uint16_t[5]" name="pitch">Pitch curve setpoints (every 25%)</field>
+      <field type="uint16_t[5]" name="throttle">Throttle curve setpoints (every 25%)</field>
+    </message>
+    <message id="222" name="UALBERTA_SYS_STATUS">
+      <description>System status specific to ualberta uav</description>
+      <field type="uint8_t" name="mode">System mode, see UALBERTA_AUTOPILOT_MODE ENUM</field>
+      <field type="uint8_t" name="nav_mode">Navigation mode, see UALBERTA_NAV_MODE ENUM</field>
+      <field type="uint8_t" name="pilot">Pilot mode, see UALBERTA_PILOT_MODE</field>
+    </message>
+  </messages>
+</mavlink>

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -171,6 +171,13 @@ bool AP_ESC_Telem::get_rpm(uint8_t esc_index, float& rpm) const
         && (now - rpmdata.last_update_us < ESC_RPM_DATA_TIMEOUT_US)) {
         const float slew = MIN(1.0f, (now - rpmdata.last_update_us) * rpmdata.update_rate_hz * (1.0f / 1e6f));
         rpm = (rpmdata.prev_rpm + (rpmdata.rpm - rpmdata.prev_rpm) * slew);
+
+#if AP_SCRIPTING_ENABLED
+        if ((1U<<esc_index) & rpm_scale_mask) {
+            rpm *= rpm_scale_factor[esc_index];
+        }
+#endif
+
         return true;
     }
     return false;
@@ -506,6 +513,19 @@ void AP_ESC_Telem::update()
         }
     }
 }
+
+#if AP_SCRIPTING_ENABLED
+/*
+  set RPM scale factor from script
+*/
+void AP_ESC_Telem::set_rpm_scale(const uint8_t esc_index, const float scale_factor)
+{
+    if (esc_index < ESC_TELEM_MAX_ESCS) {
+        rpm_scale_factor[esc_index] = scale_factor;
+        rpm_scale_mask |= (1U<<esc_index);
+    }
+}
+#endif
 
 AP_ESC_Telem *AP_ESC_Telem::_singleton = nullptr;
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -100,6 +100,14 @@ public:
     // callback to update the rpm in the frontend, should be called by the driver when new data is available
     // can also be called from scripting
     void update_rpm(const uint8_t esc_index, const float new_rpm, const float error_rate);
+
+#if AP_SCRIPTING_ENABLED
+    /*
+      set RPM scale factor from script
+     */
+    void set_rpm_scale(const uint8_t esc_index, const float scale_factor);
+#endif
+
 private:
 
     // callback to update the data in the frontend, should be called by the driver when new data is available
@@ -114,6 +122,12 @@ private:
     uint32_t _last_rpm_log_us[ESC_TELEM_MAX_ESCS];
     uint8_t next_idx;
 
+#if AP_SCRIPTING_ENABLED
+    // allow for scaling of RPMs via lua scripts
+    float rpm_scale_factor[ESC_TELEM_MAX_ESCS];
+    uint32_t rpm_scale_mask;
+#endif
+    
     bool _have_data;
 
     AP_Int8 mavlink_offset;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Protocol.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Protocol.cpp
@@ -1,0 +1,504 @@
+#include "AP_Frsky_SPort_Protocol.h"
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_GPS/AP_GPS.h>
+#include <AP_HAL/utility/RingBuffer.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
+#include <AP_Notify/AP_Notify.h>
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_RPM/AP_RPM.h>
+#include <AP_Terrain/AP_Terrain.h>
+#include <AC_Fence/AC_Fence.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+#include <GCS_MAVLink/GCS.h>
+#if APM_BUILD_TYPE(APM_BUILD_Rover)
+#include <AP_WindVane/AP_WindVane.h>
+#endif
+
+
+/*
+for FrSky SPort Passthrough
+*/
+// data bits preparation
+// for parameter data
+#define PARAM_ID_OFFSET             24
+#define PARAM_VALUE_LIMIT           0xFFFFFF
+// for gps status data
+#define GPS_SATS_LIMIT              0xF
+#define GPS_STATUS_LIMIT            0x3
+#define GPS_STATUS_OFFSET           4
+#define GPS_HDOP_OFFSET             6
+#define GPS_ADVSTATUS_OFFSET        14
+#define GPS_ALTMSL_OFFSET           22
+// for battery data
+#define BATT_VOLTAGE_LIMIT          0x1FF
+#define BATT_CURRENT_OFFSET         9
+#define BATT_TOTALMAH_LIMIT         0x7FFF
+#define BATT_TOTALMAH_OFFSET        17
+// for autopilot status data
+#define AP_CONTROL_MODE_LIMIT       0x1F
+#define AP_SIMPLE_OFFSET            5
+#define AP_SSIMPLE_OFFSET           6
+#define AP_FLYING_OFFSET            7
+#define AP_ARMED_OFFSET             8
+#define AP_BATT_FS_OFFSET           9
+#define AP_EKF_FS_OFFSET            10
+#define AP_FS_OFFSET                12
+#define AP_FENCE_PRESENT_OFFSET     13
+#define AP_FENCE_BREACH_OFFSET      14
+#define AP_THROTTLE_OFFSET          19
+#define AP_IMU_TEMP_MIN             19.0f
+#define AP_IMU_TEMP_MAX             82.0f
+#define AP_IMU_TEMP_OFFSET          26
+// for home position related data
+#define HOME_ALT_OFFSET             12
+#define HOME_BEARING_LIMIT          0x7F
+#define HOME_BEARING_OFFSET         25
+// for velocity and yaw data
+#define VELANDYAW_XYVEL_OFFSET      9
+#define VELANDYAW_YAW_LIMIT         0x7FF
+#define VELANDYAW_YAW_OFFSET        17
+#define VELANDYAW_ARSPD_OFFSET      28
+// for attitude (roll, pitch) and range data
+#define ATTIANDRNG_ROLL_LIMIT       0x7FF
+#define ATTIANDRNG_PITCH_LIMIT      0x3FF
+#define ATTIANDRNG_PITCH_OFFSET     11
+#define ATTIANDRNG_RNGFND_OFFSET    21
+// for terrain data
+#define TERRAIN_UNHEALTHY_OFFSET    13
+// for wind data
+#define WIND_ANGLE_LIMIT            0x7F
+#define WIND_SPEED_OFFSET           7
+#define WIND_APPARENT_ANGLE_OFFSET  15
+#define WIND_APPARENT_SPEED_OFFSET  23
+// for waypoint data
+#define WP_NUMBER_LIMIT             2047
+#define WP_DISTANCE_LIMIT           1023000
+#define WP_DISTANCE_OFFSET          11
+#define WP_BEARING_OFFSET           23
+
+
+extern const AP_HAL::HAL& hal;
+
+
+AP_Frsky_SPort_Protocol *AP_Frsky_SPort_Protocol::singleton;
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_param(uint8_t* param_id)
+{
+    uint8_t _param_id = *param_id; // cache it because it gets changed inside the switch
+    uint32_t param_value = 0;
+
+    switch (_param_id) {
+    case NONE:
+    case FRAME_TYPE:
+        param_value = gcs().frame_type(); // see MAV_TYPE in Mavlink definition file common.h
+        *param_id = BATT_CAPACITY_1;
+        break;
+    case BATT_CAPACITY_1:
+        param_value = (uint32_t)roundf(AP::battery().pack_capacity_mah(0)); // battery pack capacity in mAh
+        *param_id = AP::battery().num_instances() > 1 ? BATT_CAPACITY_2 : TELEMETRY_FEATURES;
+        break;
+    case BATT_CAPACITY_2:
+        param_value = (uint32_t)roundf(AP::battery().pack_capacity_mah(1)); // battery pack capacity in mAh
+        *param_id = TELEMETRY_FEATURES;
+        break;
+    case TELEMETRY_FEATURES:
+#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+        BIT_SET(param_value, PassthroughFeatures::BIDIR);
+#endif
+#if AP_SCRIPTING_ENABLED
+        BIT_SET(param_value, PassthroughFeatures::SCRIPTING);
+#endif
+        *param_id = FRAME_TYPE;
+        break;
+    }
+    //Reserve first 8 bits for param ID, use other 24 bits to store parameter value
+    return (_param_id << PARAM_ID_OFFSET) | (param_value & PARAM_VALUE_LIMIT);
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_gps_latlng(bool &send_latitude)
+{
+    const Location &loc = AP::gps().location(0); // use the first gps instance (same as in send_mavlink_gps_raw)
+
+    // alternate between latitude and longitude
+    if (send_latitude == true) {
+        send_latitude = false;
+        if (loc.lat < 0) {
+            return ((labs(loc.lat)/100)*6) | 0x40000000;
+        } else {
+            return ((labs(loc.lat)/100)*6);
+        }
+    } else {
+        send_latitude = true;
+        if (loc.lng < 0) {
+            return ((labs(loc.lng)/100)*6) | 0xC0000000;
+        } else {
+            return ((labs(loc.lng)/100)*6) | 0x80000000;
+        }
+    }
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_gps_status(void)
+{
+    const AP_GPS &gps = AP::gps();
+
+    // number of GPS satellites visible (limit to 15 (0xF) since the value is stored on 4 bits)
+    uint32_t gps_status = (gps.num_sats() < GPS_SATS_LIMIT) ? gps.num_sats() : GPS_SATS_LIMIT;
+    // GPS receiver status (limit to 0-3 (0x3) since the value is stored on 2 bits: NO_GPS = 0, NO_FIX = 1, GPS_OK_FIX_2D = 2, GPS_OK_FIX_3D or GPS_OK_FIX_3D_DGPS or GPS_OK_FIX_3D_RTK_FLOAT or GPS_OK_FIX_3D_RTK_FIXED = 3)
+    gps_status |= ((gps.status() < GPS_STATUS_LIMIT) ? gps.status() : GPS_STATUS_LIMIT)<<GPS_STATUS_OFFSET;
+    // GPS horizontal dilution of precision in dm
+    gps_status |= prep_number(roundf(gps.get_hdop() * 0.1f),2,1)<<GPS_HDOP_OFFSET;
+    // GPS receiver advanced status (0: no advanced fix, 1: GPS_OK_FIX_3D_DGPS, 2: GPS_OK_FIX_3D_RTK_FLOAT, 3: GPS_OK_FIX_3D_RTK_FIXED)
+    gps_status |= ((gps.status() > GPS_STATUS_LIMIT) ? gps.status()-GPS_STATUS_LIMIT : 0)<<GPS_ADVSTATUS_OFFSET;
+    // Altitude MSL in dm
+    const Location &loc = gps.location();
+    gps_status |= prep_number(roundf(loc.alt * 0.1f),2,2)<<GPS_ALTMSL_OFFSET;
+    return gps_status;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_batt(uint8_t instance)
+{
+    const AP_BattMonitor &_battery = AP::battery();
+
+    float current, consumed_mah;
+    if (!_battery.current_amps(current, instance)) {
+        current = 0;
+    }
+    if (!_battery.consumed_mah(consumed_mah, instance)) {
+        consumed_mah = 0;
+    }
+
+    // battery voltage in decivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
+    uint32_t batt = (((uint16_t)roundf(_battery.voltage(instance) * 10.0f)) & BATT_VOLTAGE_LIMIT);
+    // battery current draw in deciamps
+    batt |= prep_number(roundf(current * 10.0f), 2, 1)<<BATT_CURRENT_OFFSET;
+    // battery current drawn since power on in mAh (limit to 32767 (0x7FFF) since value is stored on 15 bits)
+    batt |= ((consumed_mah < BATT_TOTALMAH_LIMIT) ? ((uint16_t)roundf(consumed_mah) & BATT_TOTALMAH_LIMIT) : BATT_TOTALMAH_LIMIT)<<BATT_TOTALMAH_OFFSET;
+    return batt;
+}
+
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_ap_status(void)
+{
+    // IMU temperature: offset -19, 0 means temp =< 19°, 63 means temp => 82°
+    uint8_t imu_temp = 0;
+#if HAL_INS_ENABLED
+    imu_temp = (uint8_t) roundf(constrain_float(AP::ins().get_temperature(0), AP_IMU_TEMP_MIN, AP_IMU_TEMP_MAX) - AP_IMU_TEMP_MIN);
+#endif
+
+    // control/flight mode number (limit to 31 (0x1F) since the value is stored on 5 bits)
+    uint32_t ap_status = (uint8_t)((gcs().custom_mode()+1) & AP_CONTROL_MODE_LIMIT);
+    // simple/super simple modes flags
+    ap_status |= (uint8_t)(gcs().simple_input_active())<<AP_SIMPLE_OFFSET;
+    ap_status |= (uint8_t)(gcs().supersimple_input_active())<<AP_SSIMPLE_OFFSET;
+    // is_flying flag
+    ap_status |= (uint8_t)(AP_Notify::flags.flying) << AP_FLYING_OFFSET;
+    // armed flag
+    ap_status |= (uint8_t)(AP_Notify::flags.armed)<<AP_ARMED_OFFSET;
+    // battery failsafe flag
+    ap_status |= (uint8_t)(AP_Notify::flags.failsafe_battery)<<AP_BATT_FS_OFFSET;
+    // bad ekf flag
+    ap_status |= (uint8_t)(AP_Notify::flags.ekf_bad)<<AP_EKF_FS_OFFSET;
+    // generic failsafe
+    ap_status |= (uint8_t)(AP_Notify::flags.failsafe_battery||AP_Notify::flags.failsafe_ekf||AP_Notify::flags.failsafe_gcs||AP_Notify::flags.failsafe_radio)<<AP_FS_OFFSET;
+#if AP_FENCE_ENABLED
+    // fence status
+    AC_Fence *fence = AP::fence();
+    if (fence != nullptr) {
+        ap_status |= (uint8_t)(fence->enabled() && fence->present()) << AP_FENCE_PRESENT_OFFSET;
+        ap_status |= (uint8_t)(fence->get_breaches()>0) << AP_FENCE_BREACH_OFFSET;
+    }
+#endif
+    // signed throttle [-100,100] scaled down to [-63,63] on 7 bits, MSB for sign + 6 bits for 0-63
+    ap_status |= prep_number(gcs().get_hud_throttle()*0.63, 2, 0)<<AP_THROTTLE_OFFSET;
+    // IMU temperature
+    ap_status |= imu_temp << AP_IMU_TEMP_OFFSET;
+    return ap_status;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_home(void)
+{
+    uint32_t home = 0;
+    Location loc;
+    Location home_loc;
+    bool got_position = false;
+    float _relative_home_altitude = 0;
+
+    {
+        AP_AHRS &_ahrs = AP::ahrs();
+        WITH_SEMAPHORE(_ahrs.get_semaphore());
+        got_position = _ahrs.get_location(loc);
+        home_loc = _ahrs.get_home();
+    }
+
+    if (got_position) {
+        // check home_loc is valid
+        if (home_loc.lat != 0 || home_loc.lng != 0) {
+            // distance between vehicle and home_loc in meters
+            home = prep_number(roundf(home_loc.get_distance(loc)), 3, 2);
+            // angle from front of vehicle to the direction of home_loc in 3 degree increments (just in case, limit to 127 (0x7F) since the value is stored on 7 bits)
+            home |= (((uint8_t)roundf(loc.get_bearing_to(home_loc) * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
+        }
+        // altitude between vehicle and home_loc
+        _relative_home_altitude = loc.alt;
+        if (!loc.relative_alt) {
+            // loc.alt has home altitude added, remove it
+            _relative_home_altitude -= home_loc.alt;
+        }
+    }
+    // altitude above home in decimeters
+    home |= prep_number(roundf(_relative_home_altitude * 0.1f), 3, 2)<<HOME_ALT_OFFSET;
+    return home;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_velandyaw(bool airspeed_enabled, bool send_airspeed)
+{
+    float vspd = get_vspeed_ms();
+    // vertical velocity in dm/s
+    uint32_t velandyaw = prep_number(roundf(vspd * 10), 2, 1);
+    float airspeed_m;       // m/s
+    float hspeed_m;         // m/s
+    bool airspeed_estimate_true;
+    AP_AHRS &_ahrs = AP::ahrs();
+    {
+        WITH_SEMAPHORE(_ahrs.get_semaphore());
+        hspeed_m = _ahrs.groundspeed(); // default is to use groundspeed
+        airspeed_estimate_true = AP::ahrs().airspeed_estimate_true(airspeed_m);
+    }
+    // airspeed estimate + airspeed option disabled (default) => send airspeed (we give priority to airspeed over groundspeed)
+    // airspeed estimate + airspeed option enabled => alternate airspeed/groundspeed, i.e send airspeed only when _passthrough.send_airspeed==true
+    if (airspeed_estimate_true && (!airspeed_enabled || send_airspeed)) {
+        hspeed_m = airspeed_m;
+    }
+    // horizontal velocity in dm/s
+    velandyaw |= prep_number(roundf(hspeed_m * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
+    // yaw from [0;36000] centidegrees to .2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
+    velandyaw |= ((uint16_t)roundf(_ahrs.yaw_sensor * 0.05f) & VELANDYAW_YAW_LIMIT)<<VELANDYAW_YAW_OFFSET;
+    // flag the airspeed bit if required
+    if (airspeed_estimate_true && airspeed_enabled && send_airspeed) {
+        velandyaw |= 1U<<VELANDYAW_ARSPD_OFFSET;
+    }
+    return velandyaw;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_attiandrng(void)
+{
+    const RangeFinder *_rng = RangeFinder::get_singleton();
+
+    AP_AHRS &_ahrs = AP::ahrs();
+    // roll from [-18000;18000] centidegrees to unsigned .2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
+    uint32_t attiandrng = ((uint16_t)roundf((_ahrs.roll_sensor + 18000) * 0.05f) & ATTIANDRNG_ROLL_LIMIT);
+    // pitch from [-9000;9000] centidegrees to unsigned .2 degree increments [0;900] (just in case, limit to 1023 (0x3FF) since the value is stored on 10 bits)
+    attiandrng |= ((uint16_t)roundf((_ahrs.pitch_sensor + 9000) * 0.05f) & ATTIANDRNG_PITCH_LIMIT)<<ATTIANDRNG_PITCH_OFFSET;
+    // rangefinder measurement in cm
+    attiandrng |= prep_number(_rng ? _rng->distance_cm_orient(ROTATION_PITCH_270) : 0, 3, 1)<<ATTIANDRNG_RNGFND_OFFSET;
+    return attiandrng;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_rpm(void)
+{
+    const AP_RPM *ap_rpm = AP::rpm();
+    if (ap_rpm == nullptr) {
+        return 0;
+    }
+    uint32_t value = 0;
+    // we send: rpm_value*0.1 as 16 bits signed
+    float rpm;
+    // bits 0-15 for rpm 0
+    if (ap_rpm->get_rpm(0,rpm)) {
+        value |= (int16_t)roundf(rpm * 0.1);
+    }
+    // bits 16-31 for rpm 1
+    if (ap_rpm->get_rpm(1,rpm)) {
+        value |= (int16_t)roundf(rpm * 0.1) << 16;
+    }
+    return value;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_terrain(void)
+{
+    uint32_t value = 0;
+#if AP_TERRAIN_AVAILABLE
+    AP_Terrain *terrain = AP::terrain();
+    if (terrain == nullptr || !terrain->enabled()) {
+        return value;
+    }
+    float height_above_terrain;
+    if (terrain->height_above_terrain(height_above_terrain, true)) {
+        // vehicle height above terrain
+        value |= prep_number(roundf(height_above_terrain * 10), 3, 2);
+    }
+    // terrain unhealthy flag
+    value |= (uint8_t)(terrain->status() == AP_Terrain::TerrainStatus::TerrainStatusUnhealthy) << TERRAIN_UNHEALTHY_OFFSET;
+#endif
+    return value;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_wind(void)
+{
+#if !APM_BUILD_TYPE(APM_BUILD_Rover)
+    Vector3f v;
+    {
+        AP_AHRS &ahrs = AP::ahrs();
+        WITH_SEMAPHORE(ahrs.get_semaphore());
+        v = ahrs.wind_estimate();
+    }
+    // wind angle in 3 degree increments 0,360 (unsigned)
+    uint32_t value = prep_number(roundf(wrap_360(degrees(atan2f(-v.y, -v.x))) * (1.0f/3.0f)), 2, 0);
+    // wind speed in dm/s
+    value |= prep_number(roundf(v.length() * 10), 2, 1) << WIND_SPEED_OFFSET;
+#else
+    const AP_WindVane* windvane = AP_WindVane::get_singleton();
+    uint32_t value = 0;
+    if (windvane != nullptr && windvane->enabled()) {
+        // true wind angle in 3 degree increments 0,360 (unsigned)
+        value = prep_number(roundf(wrap_360(degrees(windvane->get_true_wind_direction_rad())) * (1.0f/3.0f)), 2, 0);
+        // true wind speed in dm/s
+        value |= prep_number(roundf(windvane->get_true_wind_speed() * 10), 2, 1) << WIND_SPEED_OFFSET;
+        // apparent wind angle in 3 degree increments -180,180 (signed)
+        value |= prep_number(roundf(degrees(windvane->get_apparent_wind_direction_rad()) * (1.0f/3.0f)), 2, 0);
+        // apparent wind speed in dm/s
+        value |= prep_number(roundf(windvane->get_apparent_wind_speed() * 10), 2, 1) << WIND_APPARENT_SPEED_OFFSET;
+    }
+#endif
+    return value;
+}
+
+
+uint32_t AP_Frsky_SPort_Protocol::calc_waypoint(void)
+{
+    const AP_Mission *mission = AP::mission();
+    const AP_Vehicle *vehicle = AP::vehicle();
+    if (mission == nullptr || vehicle == nullptr) {
+        return 0U;
+    }
+    float wp_distance;
+    if (!vehicle->get_wp_distance_m(wp_distance)) {
+        return 0U;
+    }
+    float angle;
+    if (!vehicle->get_wp_bearing_deg(angle)) {
+        return 0U;
+    }
+    // waypoint current nav index
+    uint32_t value = MIN(mission->get_current_nav_index(), WP_NUMBER_LIMIT);
+    // distance to next waypoint
+    value |= prep_number(wp_distance, 3, 2) << WP_DISTANCE_OFFSET;
+    // bearing encoded in 3 degrees increments
+    value |= ((uint8_t)roundf(wrap_360(angle) * 0.333f)) << WP_BEARING_OFFSET;
+    return value;
+}
+
+
+void AP_Frsky_SPort_Protocol::pack_packet(uint8_t* buf, uint8_t count, uint16_t id, uint32_t data)
+{
+    memcpy(&(buf[count*6]), &id, 2);
+    memcpy(&(buf[count*6 + 2]), &data, 4);
+}
+
+
+float AP_Frsky_SPort_Protocol::get_vspeed_ms(void)
+{
+    {
+        // release semaphore as soon as possible
+        AP_AHRS &_ahrs = AP::ahrs();
+        Vector3f v;
+        WITH_SEMAPHORE(_ahrs.get_semaphore());
+        if (_ahrs.get_velocity_NED(v)) {
+            return -v.z;
+        }
+    }
+
+    auto &_baro = AP::baro();
+    WITH_SEMAPHORE(_baro.get_semaphore());
+    return _baro.get_climb_rate();
+}
+
+
+uint16_t AP_Frsky_SPort_Protocol::prep_number(int32_t number, uint8_t digits, uint8_t power)
+{
+    uint16_t res = 0;
+    uint32_t abs_number = abs(number);
+
+    if ((digits == 2) && (power == 0)) { // number encoded on 7 bits, client side needs to know if expected range is 0,127 or -63,63
+        uint8_t max_value = number < 0 ? (0x1<<6)-1 : (0x1<<7)-1;
+        res = constrain_int16(abs_number,0,max_value);
+        if (number < 0) {   // if number is negative, add sign bit in front
+            res |= 1U<<6;
+        }
+    } else if ((digits == 2) && (power == 1)) { // number encoded on 8 bits: 7 bits for digits + 1 for 10^power
+        if (abs_number < 100) {
+            res = abs_number<<1;
+        } else if (abs_number < 1270) {
+            res = ((uint8_t)roundf(abs_number * 0.1f)<<1)|0x1;
+        } else { // transmit max possible value (0x7F x 10^1 = 1270)
+            res = 0xFF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<8;
+        }
+    } else if ((digits == 2) && (power == 2)) { // number encoded on 9 bits: 7 bits for digits + 2 for 10^power
+        if (abs_number < 100) {
+            res = abs_number<<2;
+        } else if (abs_number < 1000) {
+            res = ((uint8_t)roundf(abs_number * 0.1f)<<2)|0x1;
+        } else if (abs_number < 10000) {
+            res = ((uint8_t)roundf(abs_number * 0.01f)<<2)|0x2;
+        } else if (abs_number < 127000) {
+            res = ((uint8_t)roundf(abs_number * 0.001f)<<2)|0x3;
+        } else { // transmit max possible value (0x7F x 10^3 = 127000)
+            res = 0x1FF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<9;
+        }
+    } else if ((digits == 3) && (power == 1)) { // number encoded on 11 bits: 10 bits for digits + 1 for 10^power
+        if (abs_number < 1000) {
+            res = abs_number<<1;
+        } else if (abs_number < 10240) {
+            res = ((uint16_t)roundf(abs_number * 0.1f)<<1)|0x1;
+        } else { // transmit max possible value (0x3FF x 10^1 = 10230)
+            res = 0x7FF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<11;
+        }
+    } else if ((digits == 3) && (power == 2)) { // number encoded on 12 bits: 10 bits for digits + 2 for 10^power
+        if (abs_number < 1000) {
+            res = abs_number<<2;
+        } else if (abs_number < 10000) {
+            res = ((uint16_t)roundf(abs_number * 0.1f)<<2)|0x1;
+        } else if (abs_number < 100000) {
+            res = ((uint16_t)roundf(abs_number * 0.01f)<<2)|0x2;
+        } else if (abs_number < 1024000) {
+            res = ((uint16_t)roundf(abs_number * 0.001f)<<2)|0x3;
+        } else { // transmit max possible value (0x3FF x 10^3 = 1023000)
+            res = 0xFFF;
+        }
+        if (number < 0) { // if number is negative, add sign bit in front
+            res |= 0x1<<12;
+        }
+    }
+    return res;
+}
+
+
+namespace AP
+{
+AP_Frsky_SPort_Protocol *frsky_sport_protocol()
+{
+    return AP_Frsky_SPort_Protocol::get_singleton();
+}
+};

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Protocol.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Protocol.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+
+class AP_Frsky_SPort_Protocol
+{
+public:
+
+    AP_Frsky_SPort_Protocol()
+    {
+        singleton = this;
+    }
+
+    static AP_Frsky_SPort_Protocol *get_singleton(void) {
+        return singleton;
+    }
+
+    enum PassthroughParam : uint8_t {
+        NONE =                0,
+        FRAME_TYPE =          1,
+        BATT_FS_VOLTAGE =     2,
+        BATT_FS_CAPACITY =    3,
+        BATT_CAPACITY_1 =     4,
+        BATT_CAPACITY_2 =     5,
+        TELEMETRY_FEATURES =  6
+    };
+
+    enum PassthroughFeatures : uint8_t {
+        BIDIR =                 0,
+        SCRIPTING =             1,
+    };
+
+    enum {
+        GPS_LONG_LATI_FIRST_ID    = 0x0800,
+        DIY_FIRST_ID              = 0x5000,
+    };
+
+    uint32_t calc_gps_latlng(bool &send_latitude);
+    uint32_t calc_gps_status(void);
+    uint32_t calc_batt(uint8_t instance);
+    uint32_t calc_ap_status(void);
+    uint32_t calc_home(void);
+    uint32_t calc_attiandrng(void);
+    uint32_t calc_rpm(void);
+    uint32_t calc_terrain(void);
+    uint32_t calc_wind(void);
+    uint32_t calc_waypoint(void);
+
+    uint32_t calc_param(uint8_t* param_id);
+    uint32_t calc_velandyaw(bool airspeed_enabled, bool send_airspeed);
+
+    void pack_packet(uint8_t* buf, uint8_t count, uint16_t id, uint32_t data);
+
+    float get_vspeed_ms(void);
+    uint16_t prep_number(int32_t number, uint8_t digits, uint8_t power);
+
+    static AP_Frsky_SPort_Protocol *singleton;
+};
+
+namespace AP {
+    AP_Frsky_SPort_Protocol *frsky_sport_protocol();
+};

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1119,6 +1119,10 @@ function esc_telem:get_rpm(instance) end
 ---@param param3 number -- error rate
 function esc_telem:update_rpm(esc_index, rpm, error_rate) end
 
+-- set scale factor for RPM on a motor
+---@param param1 motor index (0 is first motor)
+---@param param2 scale factor
+function esc_telem:set_rpm_scale(esc_index, scale_factor) end
 
 -- desc
 ---@class optical_flow

--- a/libraries/AP_Scripting/examples/esc_rpm_scale.lua
+++ b/libraries/AP_Scripting/examples/esc_rpm_scale.lua
@@ -1,0 +1,11 @@
+--[[
+set scale factor for RPM on some ESCs to allow for different pole count on some ESCs
+--]]
+
+-- set ESC 4 (index 3) to 2.0 times reported RPM
+esc_telem:set_rpm_scale(3, 2.0)
+
+-- set ESC 6 (index 5) to 2.0 times reported RPM
+esc_telem:set_rpm_scale(5, 2.0)
+
+gcs:send_text(0,"Setup motor poles")

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -311,6 +311,7 @@ singleton AP_ESC_Telem method get_voltage boolean uint8_t 0 NUM_SERVO_CHANNELS f
 singleton AP_ESC_Telem method get_consumption_mah boolean uint8_t 0 NUM_SERVO_CHANNELS float'Null
 singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null
 singleton AP_ESC_Telem method update_rpm void uint8_t 0 NUM_SERVO_CHANNELS uint16_t'skip_check float'skip_check
+singleton AP_ESC_Telem method set_rpm_scale void uint8_t 0 NUM_SERVO_CHANNELS float'skip_check
 
 include AP_Param/AP_Param.h
 singleton AP_Param rename param

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -305,6 +305,9 @@ public:
     void send_extended_sys_state() const;
     void send_local_position() const;
     void send_vfr_hud();
+//OW
+    void send_frsky_passthrough_array();
+//OWEND
     void send_vibration() const;
     void send_gimbal_device_attitude_status() const;
     void send_named_float(const char *name, float value) const;

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -82,5 +82,8 @@ enum ap_message : uint8_t {
     MSG_UAVIONIX_ADSB_OUT_STATUS,
     MSG_ATTITUDE_TARGET,
     MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE,
+//OW
+    MSG_FRSKY_PASSTHROUGH_ARRAY,
+//OWEND
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -494,7 +494,7 @@ void FlightAxis::update(const struct sitl_input &input)
     Vector3f airspeed3d = dcm.mul_transpose(airspeed_3d_ef);
 
     if (last_imu_rotation != ROTATION_NONE) {
-        airspeed3d = sitl->ahrs_rotation_inv * airspeed3d;
+        airspeed3d = sitl->ahrs_rotation * airspeed3d;
     }
     airspeed_pitot = MAX(airspeed3d.x,0);
 

--- a/wscript
+++ b/wscript
@@ -638,7 +638,10 @@ def _build_dynamic_sources(bld):
     if not bld.env.BOOTLOADER:
         bld(
             features='mavgen',
-            source='modules/mavlink/message_definitions/v1.0/all.xml',
+            # //OW
+            #source='modules/mavlink/message_definitions/v1.0/all.xml',
+            source='bp_mavlink/all.xml',
+            # //OWEND
             output_dir='libraries/GCS_MAVLink/include/mavlink/v2.0/',
             name='mavlink',
             # this below is not ideal, mavgen tool should set this, but that's not


### PR DESCRIPTION
@yaapu FYI

this here is a 1st attempt at something which I carry with me since a while, namely to stream native Frsky SPort passthrough telemetry packets via mavlink. The corresponding mavlink message shall host an array of sport packets, somewhat similar to the multi passthrough packet.

The motivation is at least 4 fold:
- On bandwidth limited mavlink radio links, sending all the stuff which one wants to have for the typically telemetry  consumes quite some bandwidth in the rx->tx direction. While it obviously can be adapted and shrunk down, a typical order of magnitude would be ca 1500 bytes/sec. However, the passthrough telemetry protocol also essentially provides all the basic data, but in a much more compressed way (see also below). Therefore, if that data could be send instead of the original mavlink messages much bandwidth could be saved - or, also often much desired, more fluent telemetry updates could be achieved.
- The passthrough protocol has been over the years highly optimized to provide what the majority of users want to get, and it in fact provides info which is not so easy to get via mavlink or may not even be available. Examples would be some parameter values such as BATT capacity values and other. They of course can be retrieved with mavlink too, however with significant burden both implementation-wise and link-wise. An example of info not consistently available with mavlink is the is_flying flag. Therefore, passthrough via mavlink would significantly easy the situation.
- A passthrough via mavlink message could serve as a viable, and in many situations maybe better, alternative  to the HIGH_LATENCY messages. In fact, these messages are obviously very specific to very specific use cases, and hardly can serve as more general telemetry messages for high-latency situations. This is so because much info is either not provided while other info is duplicated in the two versions of HIGH_LATENCY. A passthrough mavlink message however is very generic and hence can carry varying and different types of data. Moreover, it is very future proof as the link does not have to be modified upon additions to the passthrough protocol.
- This argument is due to @yaapu. Currently, mavlink-to-passthrough converters (such as Mav2PT) need to be adapted or modified whenever a change or addition to the passthrough protocol is made. This obviously makes maintenance and upgrading a significant task, as there are so many parties involved. With such a message only e.g. ArduPilot and the yappu app need to be adapted, but not all the things which are in between. 

The 1st implementation shared here has been demonstrated to work in combination with mLRS (https://github.com/olliw42/mLRS/tree/dev-crsfpassthruarray). The following pictures shall demonstrate this. The first two pictures show the mavlink data which is streamed on serial2 (which is connected to mLRS), which should demonstrated that there is really  not much data send. The last two pictures show that much data is however received by the yappu telemetry app (in fact, some of the data would not be available with just a mavlink-to-passthrough conversion).

MissionPlanner reports 327 bytes/sec for the TUNNEL messages send at 4 Hz. This is obviously much less than the typical ca 1500 bytes/sec.

![crsfpassthruarray-sr2params](https://user-images.githubusercontent.com/6089567/191811176-05a4499e-be88-4f96-a48a-ebd240392576.jpg)

![crsfpassthruarray-snif](https://user-images.githubusercontent.com/6089567/191811212-fa00ed9f-12ee-4bd0-81be-d876a0a23648.jpg)

![IMG_20220922_184445](https://user-images.githubusercontent.com/6089567/191811231-e51b5a0d-6b70-4f53-86af-4b082e654710.jpg)

![IMG_20220922_184515](https://user-images.githubusercontent.com/6089567/191811249-ee1eebe2-651b-41ff-85de-5254f57adc2c.jpg)

The current implementation has however a number of pain points, which would have to be overcome:
- It uses the TUNNEL mavlink message. While this is technically fine, I think one should better define a new specific mavlink message. An attempt can be found in bp_mavlink/development.xml, called FRSKY_PASSTHROUGH_ARRAY. The main reason is that it would not possible with the current mavlink standard to request this message to be streamed. A dedicated message would overcome this limitation. I used the TUNNEL message since it is there on all involved parties. While it should IMHO be done, bringing up a new mavlink message is a tedious process. For development TUNNEL shall be ok. 
- The streaming is currently linked into Extra2, together with VFR_HUD. It would probably be more appropriate, and more desirable to have an extra streaming channel for that. At least I would like this much better. I choose Extra2 solely for the reason that it had the least number of messages currently.
- I had to duplicate much of the passthrough code. The existing classes could not be used with significant quirks - at least as far as I understand the code. For instance, AP_Frsky_SPort_Passthrough could not be new-ed, since it would not work with a nullptr for _port. And so on. However, separating out the protocol parts could actually lead to a clean up and better structure of the existing ArduPilot code, as the passthrough protocol stuff is currently spread over several files & classes.
- there are //OW's around, which really help me to navigate through the code, but which of course have to go. Pl be gentle with me here.
- There are probably many more pain points, which I miss, and which we hopefully can resolve.

The most important question to be settled for now is IMHO if this concept has any future in ArduPilot at all. (if not I am happy to go with my BetaPilot, but let's see LOL).

Olli



