### PR TITLE
AP_GPS: Fix novatel driver to handle DOP correctly, and fix overly optimistic horizontal accuracy estimate

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -59,13 +59,11 @@ AP_GPS_NOVA::AP_GPS_NOVA(AP_GPS &_gps, AP_GPS::GPS_State &_state,
     }
 }
 
-const char* const AP_GPS_NOVA::_initialisation_blob[6] {
+const char* const AP_GPS_NOVA::_initialisation_blob[4] {
     "\r\n\r\nunlogall\r\n", // cleanup enviroment
-    "log bestposb ontime 0.2 0 nohold\r\n", // get bestpos
-    "log bestvelb ontime 0.2 0 nohold\r\n", // get bestvel
-    "log psrdopb onchanged\r\n", // tersus
-    "log psrdopb ontime 0.2\r\n", // comnav
-    "log psrdopb\r\n" // poll message, as dop only changes when a sat is dropped/added to the visible list
+    "log bestposb ontime 0.2 0 nohold\r\n",
+    "log bestvelb ontime 0.2 0 nohold\r\n",
+    "log psrdopb ontime 0.2 0 nohold\r\n",
 };
 
 // Process all bytes available from the stream
@@ -210,7 +208,7 @@ AP_GPS_NOVA::process_message(void)
 
         state.num_sats = bestposu.svsused;
 
-        state.horizontal_accuracy = (float) ((bestposu.latsdev + bestposu.lngsdev)/2);
+        state.horizontal_accuracy =  norm(bestposu.latsdev, bestposu.lngsdev);
         state.vertical_accuracy = (float) bestposu.hgtsdev;
         state.have_horizontal_accuracy = true;
         state.have_vertical_accuracy = true;

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -55,7 +55,7 @@ private:
     
     uint8_t _init_blob_index = 0;
     uint32_t _init_blob_time = 0;
-    static const char* const _initialisation_blob[6];
+    static const char* const _initialisation_blob[4];
    
     uint32_t crc_error_counter = 0;
 


### PR DESCRIPTION
There's an error with the init blob for novatel in that it sends 3 different configuration strings for psrdop, which conflict with each other. If using actual Novatel hardware what you end up getting is a single DOP message once while doing the configuration, and then no more DOP messages. While I like onchanged for the dop message the best, it wasn't clear to me that all the other vendors would suppoprt it, so I consolidated on 5Hz updates for it.

This also corrects an error with the horizontal accuracy estimate. It was just splitting the difference between the  east/west and north/south error. However these terms are actually defining something more like an ellipse. Doing the pathagorean distance gives a more accurate (IE: reduces the over estiamte of accuracy) result, and makes us actually match what novatels software presents as the 2D accuracy.

This was tested on a Novatel OEM719.