### PR TITLE
Rover: correct scurve navigation could not resume route after avoidance objects

### DIFF
--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -146,6 +146,10 @@ public:
     // get lon1-lon2, wrapping at -180e7 to 180e7
     static int32_t diff_longitude(int32_t lon1, int32_t lon2);
 
+    // find the projection of point with lookahead on a line segment
+    // lookahead > 0
+    bool get_los_point(const Location &origin, const Location &destination, const float lookahead, Location &return_loc) const;
+
 private:
 
     // scaling factor from 1e-7 degrees to meters at equator

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -83,6 +83,15 @@ const AP_Param::GroupInfo AR_WPNav::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("JERK", 10, AR_WPNav, _jerk_max, 0),
 
+
+    // @Param: LOOKAHEAD
+    // @DisplayName: LOS lookahead distance
+    // @Units: m
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("LOOKAHEAD", 11, AR_WPNav, _lookahead, 10),
+
     AP_GROUPEND
 };
 
@@ -199,13 +208,13 @@ void AR_WPNav::set_nudge_speed_max(float nudge_speed_max)
 
 // set desired location and (optionally) next_destination
 // next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav::set_desired_location(const struct Location& destination, Location next_destination)
+bool AR_WPNav::set_desired_location(const struct Location& destination, Location next_destination, bool oa_state)
 {
     // re-initialise if inactive, previous destination has been interrupted or different controller was used
     if (!is_active() || !_reached_destination || (_nav_control_type != NavControllerType::NAV_SCURVE)) {
-        if (!set_origin_and_destination_to_stopping_point()) {
-            return false;
-        }
+        // if (!set_origin_and_destination_to_stopping_point()) {
+        //     return false;
+        // }
         // clear scurves
         _scurve_prev_leg.init();
         _scurve_this_leg.init();
@@ -216,7 +225,9 @@ bool AR_WPNav::set_desired_location(const struct Location& destination, Location
     _scurve_prev_leg = _scurve_this_leg;
 
     // initialise some variables
-    _origin = _destination;
+    if (!oa_state) {
+        _origin = _destination;
+    }
     _destination = destination;
     _orig_and_dest_valid = true;
     _reached_destination = false;
@@ -342,13 +353,13 @@ bool AR_WPNav::set_desired_location_expect_fast_update(const Location &destinati
 {
     // initialise if not active
     if (!is_active() || (_nav_control_type != NavControllerType::NAV_PSC_INPUT_SHAPING)) {
-        if (!set_origin_and_destination_to_stopping_point()) {
-            return false;
-        }
+        // if (!set_origin_and_destination_to_stopping_point()) {
+        //     return false;
+        // }
     }
 
     // initialise some variables
-    _origin = _destination;
+    //_origin = _destination;
     _destination = destination;
     _orig_and_dest_valid = true;
     _reached_destination = false;

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -41,7 +41,7 @@ public:
 
     // set desired location and (optionally) next_destination
     // next_destination should be provided if known to allow smooth cornering
-    virtual bool set_desired_location(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
+    virtual bool set_desired_location(const Location &destination, Location next_destination = Location(), bool oa_state = false) WARN_IF_UNUSED;
 
     // set desired location to a reasonable stopping point, return true on success
     bool set_desired_location_to_stopping_location()  WARN_IF_UNUSED;
@@ -147,6 +147,7 @@ protected:
     AR_PivotTurn _pivot;            // pivot turn controller
     AP_Float _accel_max;            // max acceleration.  If zero then attitude controller's specified max accel is used
     AP_Float _jerk_max;             // max jerk (change in acceleration).  If zero then value is same as accel_max
+    AP_Float _lookahead;            // using LOS guide law for resume original route
 
     // references
     AR_AttitudeControl& _atc;       // rover attitude control library

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -53,8 +53,14 @@ void AR_WPNav_OA::update(float dt)
 
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_active) {
+                Location new_pos;
+                if (current_loc.get_los_point(_origin_oabak, _destination_oabak, _lookahead, new_pos))
+                {
+                    _origin = new_pos;
+                }
+
                 // object avoidance has become inactive so reset target to original destination
-                if (!AR_WPNav::set_desired_location(_destination_oabak)) {
+                if (!AR_WPNav::set_desired_location(_destination_oabak, {}, true)) {
                     // this should never happen because we should have an EKF origin and the destination must be valid
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     stop_vehicle = true;
@@ -137,9 +143,9 @@ void AR_WPNav_OA::update(float dt)
 
 // set desired location and (optionally) next_destination
 // next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav_OA::set_desired_location(const struct Location& destination, Location next_destination)
+bool AR_WPNav_OA::set_desired_location(const struct Location& destination, Location next_destination, bool oa_state)
 {
-    const bool ret = AR_WPNav::set_desired_location(destination, next_destination);
+    const bool ret = AR_WPNav::set_desired_location(destination, next_destination, oa_state);
 
     if (ret) {
         // disable object avoidance, it will be re-enabled (if necessary) on next update

--- a/libraries/AR_WPNav/AR_WPNav_OA.h
+++ b/libraries/AR_WPNav/AR_WPNav_OA.h
@@ -13,7 +13,7 @@ public:
 
     // set desired location and (optionally) next_destination
     // next_destination should be provided if known to allow smooth cornering
-    bool set_desired_location(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
+    bool set_desired_location(const Location &destination, Location next_destination = Location(), bool oa_state = false) override WARN_IF_UNUSED;
 
     // true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
     bool reached_destination() const override;


### PR DESCRIPTION
This is only a draft, but test efficient. 