### PR TITLE
AP_Mount: add Siyi gimbal driver

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -100,6 +100,7 @@ BUILD_OPTIONS = [
     Feature('Gimbal', 'ALEXMOS', 'HAL_MOUNT_ALEXMOS_ENABLED', 'Enable Alexmos Gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'GREMSY', 'HAL_MOUNT_GREMSY_ENABLED', 'Enable Gremsy Gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'SERVO', 'HAL_MOUNT_SERVO_ENABLED', 'Enable Servo Gimbal', 0, "MOUNT"),
+    Feature('Gimbal', 'SIYI', 'HAL_MOUNT_SIYI_ENABLED', 'Enable Siyi Gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'SOLOGIMBAL', 'HAL_SOLO_GIMBAL_ENABLED', 'Enable Solo Gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'STORM32_MAVLINK', 'HAL_MOUNT_STORM32MAVLINK_ENABLED', 'Enable SToRM32 MAVLink Gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'STORM32_SERIAL', 'HAL_MOUNT_STORM32SERIAL_ENABLED', 'Enable SToRM32 Serial Gimbal', 0, "MOUNT"),

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -12,6 +12,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_Mount/AP_Mount.h>
 #include "AP_Camera_SoloGimbal.h"
 
 // ------------------------------
@@ -21,7 +22,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Param: TRIGG_TYPE
     // @DisplayName: Camera shutter (trigger) type
     // @Description: how to trigger the camera to take a picture
-    // @Values: 0:Servo,1:Relay, 2:GoPro in Solo Gimbal
+    // @Values: 0:Servo,1:Relay, 2:GoPro in Solo Gimbal, 3:Mount (Siyi)
     // @User: Standard
     AP_GROUPINFO("TRIGG_TYPE",  0, AP_Camera, _trigger_type, 0),
 
@@ -160,6 +161,15 @@ void AP_Camera::trigger_pic()
         AP_Camera_SoloGimbal::gopro_shutter_toggle();
         break;
 #endif
+#if HAL_MOUNT_ENABLED
+    case CamTrigType::mount: {
+        AP_Mount* mount = AP::mount();
+        if (mount != nullptr) {
+            mount->take_picture(0);
+        }
+        break;
+    }
+#endif
     default:
         break;
     }
@@ -192,6 +202,7 @@ AP_Camera::trigger_pic_cleanup()
             break;
         }
         case CamTrigType::gopro:
+        case CamTrigType::mount:
             // nothing to do
             break;
         }
@@ -501,6 +512,69 @@ void AP_Camera::take_picture()
     GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
 }
 
+// start/stop recording video.  returns true on success
+// start_recording should be true to start recording, false to stop recording
+bool AP_Camera::record_video(bool start_recording)
+{
+#if HAL_MOUNT_ENABLED
+    // only mount implements recording video
+    if (get_trigger_type() == CamTrigType::mount) {
+        AP_Mount* mount = AP::mount();
+        if (mount != nullptr) {
+            return mount->record_video(0, start_recording);
+        }
+    }
+#endif
+    return false;
+}
+
+// zoom in, out or hold.  returns true on success
+// zoom out = -1, hold = 0, zoom in = 1
+bool AP_Camera::set_zoom_step(int8_t zoom_step)
+{
+#if HAL_MOUNT_ENABLED
+    // only mount implements set_zoom_step
+    if (get_trigger_type() == CamTrigType::mount) {
+        AP_Mount* mount = AP::mount();
+        if (mount != nullptr) {
+            return mount->set_zoom_step(0, zoom_step);
+        }
+    }
+#endif
+    return false;
+}
+
+// focus in, out or hold.  returns true on success
+// focus in = -1, focus hold = 0, focus out = 1
+bool AP_Camera::set_manual_focus_step(int8_t focus_step)
+{
+#if HAL_MOUNT_ENABLED
+    // only mount implements set_manual_focus_step
+    if (get_trigger_type() == CamTrigType::mount) {
+        AP_Mount* mount = AP::mount();
+        if (mount != nullptr) {
+            return mount->set_manual_focus_step(0, focus_step);
+        }
+    }
+#endif
+    return false;
+}
+
+// auto focus.  returns true on success
+bool AP_Camera::set_auto_focus()
+{
+#if HAL_MOUNT_ENABLED
+    // only mount implements set_auto_focus
+    if (get_trigger_type() == CamTrigType::mount) {
+        AP_Mount* mount = AP::mount();
+        if (mount != nullptr) {
+            return mount->set_auto_focus(0);
+        }
+    }
+#endif
+    return false;
+}
+
 void AP_Camera::prep_mavlink_msg_camera_feedback(uint64_t timestamp_us)
 {
     const AP_AHRS &ahrs = AP::ahrs();
@@ -549,10 +623,11 @@ AP_Camera::CamTrigType AP_Camera::get_trigger_type(void)
         case CamTrigType::servo:
         case CamTrigType::relay:
         case CamTrigType::gopro:
+        case CamTrigType::mount:
             return (CamTrigType)type;
         default:
             return CamTrigType::servo;
-    }   
+    }
 }
 
 // singleton instance

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -61,6 +61,21 @@ public:
 
     void take_picture();
 
+    // start/stop recording video
+    // start_recording should be true to start recording, false to stop recording
+    bool record_video(bool start_recording);
+
+    // zoom in, out or hold
+    // zoom out = -1, hold = 0, zoom in = 1
+    bool set_zoom_step(int8_t zoom_step);
+
+    // focus in, out or hold
+    // focus in = -1, focus hold = 0, focus out = 1
+    bool set_manual_focus_step(int8_t focus_step);
+
+    // auto focus
+    bool set_auto_focus();
+
     // Update - to be called periodically @at least 50Hz
     void update();
 
@@ -81,6 +96,7 @@ public:
         servo   = 0,
         relay   = 1,
         gopro   = 2,
+        mount   = 3,
     };
 
     AP_Camera::CamTrigType get_trigger_type(void);

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -11,6 +11,7 @@
 #include "AP_Mount_SToRM32.h"
 #include "AP_Mount_SToRM32_serial.h"
 #include "AP_Mount_Gremsy.h"
+#include "AP_Mount_Siyi.h"
 #include <stdio.h>
 #include <AP_Math/location.h>
 #include <SRV_Channel/SRV_Channel.h>
@@ -109,6 +110,14 @@ void AP_Mount::init()
             _backends[instance] = new AP_Mount_Servo(*this, _params[instance], false, instance);
             _num_instances++;
 #endif
+
+#if HAL_MOUNT_SIYI_ENABLED
+        // check for Siyi gimbal
+        } else if (mount_type == Mount_Type_Siyi) {
+            _backends[instance] = new AP_Mount_Siyi(*this, _params[instance], instance);
+            _num_instances++;
+#endif // HAL_MOUNT_SIYI_ENABLED
+
         }
 
         // init new instance

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -437,6 +437,64 @@ void AP_Mount::set_roi_target(uint8_t instance, const Location &target_loc)
     }
 }
 
+//
+// camera controls for gimbals that include a camera
+//
+
+// take a picture.  returns true on success
+bool AP_Mount::take_picture(uint8_t instance)
+{
+    // call instance's take_picture
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->take_picture();
+}
+
+// start or stop video recording.  returns true on success
+// set start_recording = true to start record, false to stop recording
+bool AP_Mount::record_video(uint8_t instance, bool start_recording)
+{
+    // call instance's record_video
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->record_video(start_recording);
+}
+
+// set camera zoom step.  returns true on success
+// zoom out = -1, hold = 0, zoom in = 1
+bool AP_Mount::set_zoom_step(uint8_t instance, int8_t zoom_step)
+{
+    // call instance's set_zoom_step
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->set_zoom_step(zoom_step);
+}
+
+// set focus in, out or hold.  returns true on success
+// focus in = -1, focus hold = 0, focus out = 1
+bool AP_Mount::set_manual_focus_step(uint8_t instance, int8_t focus_step)
+{
+    // call instance's set_manual_focus_step
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->set_manual_focus_step(focus_step);
+}
+
+// auto focus.  returns true on success
+bool AP_Mount::set_auto_focus(uint8_t instance)
+{
+    // call instance's set_auto_focus
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->set_auto_focus();
+}
+
+
 bool AP_Mount::check_primary() const
 {
     return check_instance(_primary);

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -162,6 +162,28 @@ public:
     // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
 
+    //
+    // camera controls for gimbals that include a camera
+    //
+
+    // take a picture
+    bool take_picture(uint8_t instance);
+
+    // start or stop video recording
+    // set start_recording = true to start record, false to stop recording
+    bool record_video(uint8_t instance, bool start_recording);
+
+    // set camera zoom step
+    // zoom out = -1, hold = 0, zoom in = 1
+    bool set_zoom_step(uint8_t instance, int8_t zoom_step);
+
+    // set focus in, out or hold
+    // focus in = -1, focus hold = 0, focus out = 1
+    bool set_manual_focus_step(uint8_t instance, int8_t focus_step);
+
+    // auto focus
+    bool set_auto_focus(uint8_t instance);
+
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -48,6 +48,7 @@ class AP_Mount_Alexmos;
 class AP_Mount_SToRM32;
 class AP_Mount_SToRM32_serial;
 class AP_Mount_Gremsy;
+class AP_Mount_Siyi;
 
 /*
   This is a workaround to allow the MAVLink backend access to the
@@ -64,6 +65,7 @@ class AP_Mount
     friend class AP_Mount_SToRM32;
     friend class AP_Mount_SToRM32_serial;
     friend class AP_Mount_Gremsy;
+    friend class AP_Mount_Siyi;
 
 public:
     AP_Mount();
@@ -86,7 +88,8 @@ public:
         Mount_Type_SToRM32 = 4,         /// SToRM32 mount using MAVLink protocol
         Mount_Type_SToRM32_serial = 5,  /// SToRM32 mount using custom serial protocol
         Mount_Type_Gremsy = 6,          /// Gremsy gimbal using MAVLink v2 Gimbal protocol
-        Mount_Type_BrushlessPWM = 7     /// Brushless (stabilized) gimbal using PWM protocol
+        Mount_Type_BrushlessPWM = 7,    /// Brushless (stabilized) gimbal using PWM protocol
+        Mount_Type_Siyi = 8,            /// Siyi gimbal using custom serial protocol
     };
 
     // init - detect and initialise all mounts

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -96,7 +96,7 @@ void AP_Mount_Alexmos::update()
     control_axis(_angle_rad);
 }
 
-// has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+// has_pan_control - returns true if this mount can control its pan (required for multicopters)
 bool AP_Mount_Alexmos::has_pan_control() const
 {
     return _gimbal_3axis && yaw_range_valid();

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -104,6 +104,28 @@ public:
     // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
     virtual void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) {}
 
+    //
+    // camera controls for gimbals that include a camera
+    //
+
+    // take a picture.  returns true on success
+    virtual bool take_picture() { return false; }
+
+    // start or stop video recording.  returns true on success
+    // set start_recording = true to start record, false to stop recording
+    virtual bool record_video(bool start_recording) { return false; }
+
+    // set camera zoom step.  returns true on success
+    // zoom out = -1, hold = 0, zoom in = 1
+    virtual bool set_zoom_step(int8_t zoom_step) { return false; }
+
+    // set focus in, out or hold.  returns true on success
+    // focus in = -1, focus hold = 0, focus out = 1
+    virtual bool set_manual_focus_step(int8_t focus_step) { return false; }
+
+    // auto focus.  returns true on success
+    virtual bool set_auto_focus() { return false; }
+
 protected:
 
     enum class MountTargetType {

--- a/libraries/AP_Mount/AP_Mount_Params.cpp
+++ b/libraries/AP_Mount/AP_Mount_Params.cpp
@@ -9,7 +9,7 @@ const AP_Param::GroupInfo AP_Mount_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Mount Type
     // @Description: Mount Type
-    // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial, 6:Gremsy, 7:BrushlessPWM
+    // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial, 6:Gremsy, 7:BrushlessPWM, 8:Siyi
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE", 1, AP_Mount_Params, type, 0, AP_PARAM_FLAG_ENABLE),

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -29,7 +29,7 @@ public:
     // update mount position - should be called periodically
     void update() override;
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
     bool has_pan_control() const override { return yaw_range_valid(); }
 
 protected:

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -32,7 +32,7 @@ public:
     // update mount position - should be called periodically
     void update() override;
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
     bool has_pan_control() const override { return yaw_range_valid(); };
 
 protected:

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1,0 +1,627 @@
+#include "AP_Mount_Siyi.h"
+
+#if HAL_MOUNT_SIYI_ENABLED
+#include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define AP_MOUNT_SIYI_HEADER1       0x55    // first header byte
+#define AP_MOUNT_SIYI_HEADER2       0x66    // second header byte
+#define AP_MOUNT_SIYI_PACKETLEN_MIN 10      // minimum number of bytes in a packet.  this is a packet with no data bytes
+#define AP_MOUNT_SIYI_DATALEN_MAX   (AP_MOUNT_SIYI_PACKETLEN_MAX-AP_MOUNT_SIYI_PACKETLEN_MIN) // max bytes for data portion of packet
+#define AP_MOUNT_SIYI_SERIAL_RESEND_MS   1000    // resend angle targets to gimbal once per second
+#define AP_MOUNT_SIYI_MSG_BUF_DATA_START 8  // data starts at this byte in _msg_buf
+#define AP_MOUNT_SIYI_RATE_MAX_RADS radians(90) // maximum physical rotation rate of gimbal in radans/sec
+#define AP_MOUNT_SIYI_PITCH_P       1.50    // pitch controller P gain (converts pitch angle error to target rate)
+#define AP_MOUNT_SIYI_YAW_P         1.50    // yaw controller P gain (converts yaw angle error to target rate)
+#define AP_MOUNT_SIYI_LOCK_RESEND_COUNT 5   // lock value is resent to gimbal every 5 iterations
+
+#define AP_MOUNT_SIYI_DEBUG 0
+#define debug(fmt, args ...) do { if (AP_MOUNT_SIYI_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Siyi: " fmt, ## args); } } while (0)
+
+// init - performs any required initialisation for this instance
+void AP_Mount_Siyi::init()
+{
+    const AP_SerialManager& serial_manager = AP::serialmanager();
+
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_SToRM32, 0);
+    if (_uart != nullptr) {
+        _initialised = true;
+        set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());
+    }
+
+}
+
+// update mount position - should be called periodically
+void AP_Mount_Siyi::update()
+{
+    // exit immediately if not initialised
+    if (!_initialised) {
+        return;
+    }
+
+    // reading incoming packets from gimbal
+    read_incoming_packets();
+
+    // request firmware version at 1hz
+    uint32_t now_ms = AP_HAL::millis();
+    if (!_got_firmware_version) {
+        if ((now_ms - _last_send_ms) >= 1000) {
+            request_firmware_version();
+            _last_send_ms = now_ms;
+        }
+        return;
+    }
+
+    // request attitude at regular intervals
+    if ((now_ms - _last_req_current_angle_rad_ms) >= 50) {
+        request_gimbal_attitude();
+        _last_req_current_angle_rad_ms = now_ms;
+    }
+
+    // update based on mount mode
+    switch (get_mode()) {
+        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
+        case MAV_MOUNT_MODE_RETRACT: {
+            const Vector3f &angle_bf_target = _params.retract_angles.get();
+            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            break;
+        }
+
+        // move mount to a neutral position, typically pointing forward
+        case MAV_MOUNT_MODE_NEUTRAL: {
+            const Vector3f &angle_bf_target = _params.neutral_angles.get();
+            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            break;
+        }
+
+        // point to the angles given by a mavlink message
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                send_target_angles(mavt_target.angle_rad.pitch, mavt_target.angle_rad.yaw, mavt_target.angle_rad.yaw_is_ef);
+                break;
+            case MountTargetType::RATE:
+                send_target_rates(mavt_target.rate_rads.pitch, mavt_target.rate_rads.yaw, mavt_target.rate_rads.yaw_is_ef);
+                break;
+            }
+            break;
+
+        // RC radio manual angle control, but with stabilization from the AHRS
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's rc inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                send_target_rates(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
+            } else if (get_rc_angle_target(rc_target)) {
+                send_target_angles(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
+            }
+            break;
+        }
+
+        // point mount to a GPS point given by the mission planner
+        case MAV_MOUNT_MODE_GPS_POINT: {
+            MountTarget angle_target_rad {};
+            if (get_angle_target_to_roi(angle_target_rad)) {
+                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+            }
+            break;
+        }
+
+        case MAV_MOUNT_MODE_HOME_LOCATION: {
+            MountTarget angle_target_rad {};
+            if (get_angle_target_to_home(angle_target_rad)) {
+                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+            }
+            break;
+        }
+
+        case MAV_MOUNT_MODE_SYSID_TARGET:{
+            MountTarget angle_target_rad {};
+            if (get_angle_target_to_sysid(angle_target_rad)) {
+                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+            }
+            break;
+        }
+
+        default:
+            // we do not know this mode so raise internal error
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            break;
+    }
+}
+
+// return true if healthy
+bool AP_Mount_Siyi::healthy() const
+{
+    // unhealthy until gimbal has been found and replied with firmware version info
+    if (!_initialised || !_got_firmware_version) {
+        return false;
+    }
+
+    // unhealthy if attitude information NOT received recently
+    if (AP_HAL::millis() - _last_current_angle_rad_ms > 1000) {
+        return false;
+    }
+
+    // if we get this far return healthy
+    return true;
+}
+
+// get attitude as a quaternion.  returns true on success
+bool AP_Mount_Siyi::get_attitude_quaternion(Quaternion& att_quat)
+{
+    att_quat.from_euler(_current_angle_rad.x, _current_angle_rad.y, _current_angle_rad.z);
+    return true;
+}
+
+// reading incoming packets from gimbal and confirm they are of the correct format
+// results are held in the _parsed_msg structure
+void AP_Mount_Siyi::read_incoming_packets()
+{
+    // check for bytes on the serial port
+    int16_t nbytes = MIN(_uart->available(), 1024U);
+    if (nbytes <= 0 ) {
+        return;
+    }
+
+    // flag to allow cases below to reset parser state
+    bool reset_parser = false;
+
+    // process bytes received
+    for (int16_t i = 0; i < nbytes; i++) {
+        const int16_t b = _uart->read();
+
+        // sanity check byte
+        if ((b < 0) || (b > 0xFF)) {
+            continue;
+        }
+
+        _msg_buff[_msg_buff_len++] = b;
+
+        // protect against overly long messages
+        if (_msg_buff_len >= AP_MOUNT_SIYI_PACKETLEN_MAX) {
+            reset_parser = true;
+        }
+
+        // process byte depending upon current state
+        switch (_parsed_msg.state) {
+
+        case ParseState::WAITING_FOR_HEADER_LOW:
+            if (b == AP_MOUNT_SIYI_HEADER1) {
+                _parsed_msg.state = ParseState::WAITING_FOR_HEADER_HIGH;
+            } else {
+                reset_parser = true;
+            }
+            break;
+
+        case ParseState::WAITING_FOR_HEADER_HIGH:
+            if (b == AP_MOUNT_SIYI_HEADER2) {
+                _parsed_msg.state = ParseState::WAITING_FOR_CTRL;
+            } else {
+                reset_parser = true;
+            }
+            break;
+
+        case ParseState::WAITING_FOR_CTRL:
+            _parsed_msg.state = ParseState::WAITING_FOR_DATALEN_LOW;
+            break;
+
+        case ParseState::WAITING_FOR_DATALEN_LOW:
+            _parsed_msg.data_len = b;
+            _parsed_msg.state = ParseState::WAITING_FOR_DATALEN_HIGH;
+            break;
+
+        case ParseState::WAITING_FOR_DATALEN_HIGH:
+            _parsed_msg.data_len |= ((uint16_t)b << 8);
+            // sanity check data length
+            if (_parsed_msg.data_len <= AP_MOUNT_SIYI_DATALEN_MAX) {
+                _parsed_msg.state = ParseState::WAITING_FOR_SEQ_LOW;
+            } else {
+                reset_parser = true;
+                debug("data len too large:%u (>%u)", (unsigned)_parsed_msg.data_len, (unsigned)AP_MOUNT_SIYI_DATALEN_MAX);
+            }
+            break;
+
+        case ParseState::WAITING_FOR_SEQ_LOW:
+            _parsed_msg.state = ParseState::WAITING_FOR_SEQ_HIGH;
+            break;
+
+        case ParseState::WAITING_FOR_SEQ_HIGH:
+            _parsed_msg.state = ParseState::WAITING_FOR_CMDID;
+            break;
+
+        case ParseState::WAITING_FOR_CMDID:
+            _parsed_msg.command_id = b;
+            _parsed_msg.data_bytes_received = 0;
+            if (_parsed_msg.data_len > 0) {
+                _parsed_msg.state = ParseState::WAITING_FOR_DATA;
+            } else {
+                _parsed_msg.state = ParseState::WAITING_FOR_CRC_LOW;
+            }
+            break;
+
+        case ParseState::WAITING_FOR_DATA:
+            _parsed_msg.data_bytes_received++;
+            if (_parsed_msg.data_bytes_received >= _parsed_msg.data_len) {
+                _parsed_msg.state = ParseState::WAITING_FOR_CRC_LOW;
+            }
+            break;
+
+        case ParseState::WAITING_FOR_CRC_LOW:
+            _parsed_msg.crc16 = b;
+            _parsed_msg.state = ParseState::WAITING_FOR_CRC_HIGH;
+            break;
+
+        case ParseState::WAITING_FOR_CRC_HIGH:
+            _parsed_msg.crc16 |= ((uint16_t)b << 8);
+
+            // check crc
+            const uint16_t expected_crc = crc16_ccitt(_msg_buff, _msg_buff_len-2, 0);
+            if (expected_crc == _parsed_msg.crc16) {
+                // successfully received a message, do something with it
+                process_packet();
+            } else {
+                debug("crc expected:%x got:%x", (unsigned)expected_crc, (unsigned)_parsed_msg.crc16);
+            }
+            reset_parser = true;
+            break;
+        }
+
+        // handle reset of parser
+        if (reset_parser) {
+            _parsed_msg.state = ParseState::WAITING_FOR_HEADER_LOW;
+            _msg_buff_len = 0;
+        }
+    }
+}
+
+// process successfully decoded packets held in the _parsed_msg structure
+void AP_Mount_Siyi::process_packet()
+{
+    // flag to warn of unexpected data buffer length
+    bool unexpected_len = false;
+
+    // process packet depending upon command id
+    switch ((SiyiCommandId)_parsed_msg.command_id) {
+
+    case SiyiCommandId::ACQUIRE_FIRMWARE_VERSION: {
+        if (_parsed_msg.data_bytes_received != 12) {
+            unexpected_len = true;
+            break;
+        }
+        _got_firmware_version = true;
+
+        // display camera firmware version
+        debug("Mount: SiyiCam fw:%u.%u.%u",
+              (unsigned)_msg_buff[_msg_buff_data_start+1],      // firmware major version
+              (unsigned)_msg_buff[_msg_buff_data_start+2],      // firmware minor version
+              (unsigned)_msg_buff[_msg_buff_data_start+3]);     // firmware revision
+
+        // display gimbal info to user
+        gcs().send_text(MAV_SEVERITY_INFO, "Mount: Siyi fw:%u.%u.%u",
+                (unsigned)_msg_buff[_msg_buff_data_start+5],    // firmware major version
+                (unsigned)_msg_buff[_msg_buff_data_start+6],    // firmware minor version
+                (unsigned)_msg_buff[_msg_buff_data_start+7]);   // firmware revision
+
+        // display zoom firmware version
+        debug("Mount: SiyiZoom fw:%u.%u.%u",
+              (unsigned)_msg_buff[_msg_buff_data_start+9],      // firmware major version
+              (unsigned)_msg_buff[_msg_buff_data_start+10],     // firmware minor version
+              (unsigned)_msg_buff[_msg_buff_data_start+11]);    // firmware revision
+        break;
+    }
+
+    case SiyiCommandId::HARDWARE_ID:
+        // unsupported
+        break;
+
+    case SiyiCommandId::AUTO_FOCUS:
+#if AP_MOUNT_SIYI_DEBUG
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+            break;
+        }
+        debug("AutoFocus:%u", (unsigned)_msg_buff[_msg_buff_data_start]);
+#endif
+        break;
+
+    case SiyiCommandId::MANUAL_ZOOM_AND_AUTO_FOCUS: {
+        if (_parsed_msg.data_bytes_received != 2) {
+            unexpected_len = true;
+            break;
+        }
+        const float zoom_mult = UINT16_VALUE(_msg_buff[_msg_buff_data_start+1], _msg_buff[_msg_buff_data_start]) * 0.1;
+        debug("ZoomMult:%4.1f", (double)zoom_mult);
+        break;
+    }
+
+    case SiyiCommandId::MANUAL_FOCUS:
+#if AP_MOUNT_SIYI_DEBUG
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+            break;
+        }
+        debug("ManualFocus:%u", (unsigned)_msg_buff[_msg_buff_data_start]);
+#endif
+        break;
+
+    case SiyiCommandId::GIMBAL_ROTATION:
+#if AP_MOUNT_SIYI_DEBUG
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+            break;
+        }
+        debug("GimbRot:%u", (unsigned)_msg_buff[_msg_buff_data_start]);
+#endif
+        break;
+
+    case SiyiCommandId::CENTER:
+#if AP_MOUNT_SIYI_DEBUG
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+            break;
+        }
+        debug("Center:%u", (unsigned)_msg_buff[_msg_buff_data_start]);
+#endif
+        break;
+
+    case SiyiCommandId::ACQUIRE_GIMBAL_CONFIG_INFO: {
+        if (_parsed_msg.data_bytes_received != 5) {
+            unexpected_len = true;
+            break;
+        }
+        // update recording state and warn user of mismatch
+        const bool recording = _msg_buff[_msg_buff_data_start+3] > 0;
+        if (recording != _last_record_video) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Siyi: recording %s", recording ? "ON" : "OFF");
+        }
+        _last_record_video = recording;
+        debug("GimConf hdr:%u rec:%u foll:%u", (unsigned)_msg_buff[_msg_buff_data_start+1],
+                                               (unsigned)_msg_buff[_msg_buff_data_start+3],
+                                               (unsigned)_msg_buff[_msg_buff_data_start+4]);
+        break;
+    }
+
+    case SiyiCommandId::FUNCTION_FEEDBACK_INFO: {
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+            break;
+        }
+        const uint8_t func_feedback_info = _msg_buff[_msg_buff_data_start];
+        const char* err_prefix = "Mount: Siyi";
+        switch ((FunctionFeedbackInfo)func_feedback_info) {
+        case FunctionFeedbackInfo::SUCCESS:
+            debug("FnFeedB success");
+            break;
+        case FunctionFeedbackInfo::FAILED_TO_TAKE_PHOTO:
+            gcs().send_text(MAV_SEVERITY_ERROR, "%s failed to take picture", err_prefix);
+            break;
+        case FunctionFeedbackInfo::HDR_ON:
+            debug("HDR on");
+            break;
+        case FunctionFeedbackInfo::HDR_OFF:
+            debug("HDR off");
+            break;
+        case FunctionFeedbackInfo::FAILED_TO_RECORD_VIDEO:
+            gcs().send_text(MAV_SEVERITY_ERROR, "%s failed to record video", err_prefix);
+            break;
+        default:
+            debug("FnFeedB unexpected val:%u", (unsigned)func_feedback_info);
+        }
+        break;
+    }
+
+    case SiyiCommandId::PHOTO:
+        // no ack should ever be sent by the gimbal
+        break;
+
+    case SiyiCommandId::ACQUIRE_GIMBAL_ATTITUDE: {
+        if (_parsed_msg.data_bytes_received != 12) {
+            unexpected_len = true;
+            break;
+        }
+        _last_current_angle_rad_ms = AP_HAL::millis();
+        _current_angle_rad.z = -radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+1], _msg_buff[_msg_buff_data_start]) * 0.1);   // yaw angle
+        _current_angle_rad.y = radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+3], _msg_buff[_msg_buff_data_start+2]) * 0.1);  // pitch angle
+        _current_angle_rad.x = radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+5], _msg_buff[_msg_buff_data_start+4]) * 0.1);  // roll angle
+        //const float yaw_rate_degs = -(int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+7], _msg_buff[_msg_buff_data_start+6]) * 0.1;   // yaw rate
+        //const float pitch_rate_deg = (int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+9], _msg_buff[_msg_buff_data_start+8]) * 0.1;   // pitch rate
+        //const float roll_rate_deg = (int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+11], _msg_buff[_msg_buff_data_start+10]) * 0.1;  // roll rate
+        break;
+    }
+
+    default:
+        debug("Unhandled CmdId:%u", (unsigned)_parsed_msg.command_id);
+        break;
+    }
+
+    // handle unexpected data buffer lenth
+    if (unexpected_len) {
+        debug("CmdId:%u unexpected len:%u", (unsigned)_parsed_msg.command_id, (unsigned)_parsed_msg.data_bytes_received);
+    }
+}
+
+// methods to send commands to gimbal
+// returns true on success, false if outgoing serial buffer is full
+bool AP_Mount_Siyi::send_packet(SiyiCommandId cmd_id, const uint8_t* databuff, uint8_t databuff_len)
+{
+    // calculate and sanity check packet size
+    const uint16_t packet_size = AP_MOUNT_SIYI_PACKETLEN_MIN + databuff_len;
+    if (packet_size > AP_MOUNT_SIYI_PACKETLEN_MAX) {
+        debug("send_packet data buff too large");
+        return false;
+    }
+
+    // check for sufficient space in outgoing buffer
+    if (_uart->txspace() < packet_size) {
+        return false;
+    }
+
+    // buffer for holding outgoing packet
+    uint8_t send_buff[packet_size];
+    uint8_t send_buff_ofs = 0;
+
+    // packet header
+    send_buff[send_buff_ofs++] = AP_MOUNT_SIYI_HEADER1;
+    send_buff[send_buff_ofs++] = AP_MOUNT_SIYI_HEADER2;
+
+    // CTRL.  Always request ACK
+    send_buff[send_buff_ofs++] = 1;
+
+    // Data_len.  protocol supports uint16_t but messages are never longer than 22 bytes
+    send_buff[send_buff_ofs++] = databuff_len;
+    send_buff[send_buff_ofs++] = 0;
+
+    // SEQ (sequence)
+    send_buff[send_buff_ofs++] = LOWBYTE(_last_seq);
+    send_buff[send_buff_ofs++] = HIGHBYTE(_last_seq++);
+
+    // CMD_ID
+    send_buff[send_buff_ofs++] = (uint8_t)cmd_id;
+
+    // DATA
+    if (databuff_len != 0) {
+        memcpy(&send_buff[send_buff_ofs], databuff, databuff_len);
+        send_buff_ofs += databuff_len;
+    }
+
+    // CRC16
+    const uint16_t crc = crc16_ccitt(send_buff, send_buff_ofs, 0);
+    send_buff[send_buff_ofs++] = LOWBYTE(crc);
+    send_buff[send_buff_ofs++] = HIGHBYTE(crc);
+
+    // send packet
+    _uart->write(send_buff, send_buff_ofs);
+
+    return true;
+}
+
+// send a packet with a single data byte to gimbal
+// returns true on success, false if outgoing serial buffer is full
+bool AP_Mount_Siyi::send_1byte_packet(SiyiCommandId cmd_id, uint8_t data_byte)
+{
+    return send_packet(cmd_id, &data_byte, 1);
+}
+
+// rotate gimbal.  pitch_rate and yaw_rate are scalars in the range -100 ~ +100
+// yaw_is_ef should be true if gimbal should maintain an earth-frame target (aka lock)
+void AP_Mount_Siyi::rotate_gimbal(int8_t pitch_scalar, int8_t yaw_scalar, bool yaw_is_ef)
+{
+    // send lock/follow value if it has changed
+    if ((yaw_is_ef != _last_lock) || (_lock_send_counter >= AP_MOUNT_SIYI_LOCK_RESEND_COUNT)) {
+        set_lock(yaw_is_ef);
+        _lock_send_counter = 0;
+        _last_lock = yaw_is_ef;
+    } else {
+        _lock_send_counter++;
+    }
+
+    const uint8_t yaw_and_pitch_rates[] {(uint8_t)yaw_scalar, (uint8_t)pitch_scalar};
+    send_packet(SiyiCommandId::GIMBAL_ROTATION, yaw_and_pitch_rates, ARRAY_SIZE(yaw_and_pitch_rates));
+}
+
+// center gimbal
+void AP_Mount_Siyi::center_gimbal()
+{
+    send_1byte_packet(SiyiCommandId::CENTER, 1);
+}
+
+// set gimbal's lock vs follow mode
+// lock should be true if gimbal should maintain an earth-frame target
+// lock is false to follow / maintain a body-frame target
+void AP_Mount_Siyi::set_lock(bool lock)
+{
+    send_1byte_packet(SiyiCommandId::PHOTO, lock ? (uint8_t)PhotoFunction::LOCK_MODE : (uint8_t)PhotoFunction::FOLLOW_MODE);
+}
+
+// send target pitch and yaw rates to gimbal
+// yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
+void AP_Mount_Siyi::send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef)
+{
+    const float pitch_rate_scalar = constrain_float(100.0 * pitch_rads / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
+    const float yaw_rate_scalar = constrain_float(100.0 * yaw_rads / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
+    rotate_gimbal(pitch_rate_scalar, yaw_rate_scalar, yaw_is_ef);
+}
+
+// send target pitch and yaw angles to gimbal
+// yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
+void AP_Mount_Siyi::send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef)
+{
+    // stop gimbal if no recent actual angles
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _last_current_angle_rad_ms >= 200) {
+        rotate_gimbal(0, 0, false);
+        return;
+    }
+
+    // use simple P controller to convert pitch angle error (in radians) to a target rate scalar (-100 to +100)
+    const float pitch_err_rad = (pitch_rad - _current_angle_rad.y);
+    const float pitch_rate_scalar = constrain_float(100.0 * pitch_err_rad * AP_MOUNT_SIYI_PITCH_P / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
+
+    // convert yaw angle to body-frame the use simple P controller to convert yaw angle error to a target rate scalar (-100 to +100)
+    const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().yaw) : yaw_rad;
+    const float yaw_err_rad = (yaw_bf_rad - _current_angle_rad.z);
+    const float yaw_rate_scalar = constrain_float(100.0 * yaw_err_rad * AP_MOUNT_SIYI_YAW_P / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
+
+    // rotate gimbal.  pitch_rate and yaw_rate are scalars in the range -100 ~ +100
+    rotate_gimbal(pitch_rate_scalar, yaw_rate_scalar, yaw_is_ef);
+}
+
+// take a picture.  returns true on success
+bool AP_Mount_Siyi::take_picture()
+{
+    return send_1byte_packet(SiyiCommandId::PHOTO, (uint8_t)PhotoFunction::TAKE_PICTURE);
+}
+
+// start or stop video recording.  returns true on success
+// set start_recording = true to start record, false to stop recording
+bool AP_Mount_Siyi::record_video(bool start_recording)
+{
+    // exit immediately if not initialised to reduce mismatch
+    // between internal and actual state of recording
+    if (!_initialised) {
+        return false;
+    }
+
+    // check desired recording state has changed
+    bool ret = true;
+    if (_last_record_video != start_recording) {
+        _last_record_video = start_recording;
+
+        // request recording start or stop (sadly the same message is used)
+        const uint8_t func_type = (uint8_t)PhotoFunction::RECORD_VIDEO_TOGGLE;
+        ret = send_packet(SiyiCommandId::PHOTO, &func_type, 1);
+    }
+
+    // request recording state update from gimbal
+    request_configuration();
+
+    return ret;
+}
+
+// set camera zoom step.  returns true on success
+// zoom out = -1, hold = 0, zoom in = 1
+bool AP_Mount_Siyi::set_zoom_step(int8_t zoom_step)
+{
+    return send_1byte_packet(SiyiCommandId::MANUAL_ZOOM_AND_AUTO_FOCUS, (uint8_t)zoom_step);
+}
+
+// set focus in, out or hold.  returns true on success
+// focus in = -1, focus hold = 0, focus out = 1
+bool AP_Mount_Siyi::set_manual_focus_step(int8_t focus_step)
+{
+    return send_1byte_packet(SiyiCommandId::MANUAL_FOCUS, (uint8_t)focus_step);
+}
+
+// auto focus.  returns true on success
+bool AP_Mount_Siyi::set_auto_focus()
+{
+    return send_1byte_packet(SiyiCommandId::AUTO_FOCUS, 1);
+}
+
+#endif // HAL_MOUNT_SIYI_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -1,0 +1,209 @@
+/*
+  Siyi gimbal driver using custom serial protocol
+
+  Packet format (courtesy of Siyi's SDK document)
+
+  -------------------------------------------------------------------------------------------
+  Field     Index   Bytes       Description
+  -------------------------------------------------------------------------------------------
+  STX       0       2           0x5566: starting mark
+  CTRL      2       1           bit 0: need_ack.  set if the current data packet needs ack
+                                bit 1: ack_pack.  set if the current data packate IS an ack
+                                bit 2-7: reserved
+  Data_len  3       2           Data field byte length.  Low byte in the front
+  SEQ       5       2           Frame sequence (0 ~ 65535).  Low byte in the front.  May be used to detect packet loss
+  CMD_ID    7       1           Command ID
+  DATA      8       Data_len    Data
+  CRC16             2           CRC16 check the complete data package.  Low byte in the front
+ */
+
+#pragma once
+
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_SIYI_ENABLED
+#define HAL_MOUNT_SIYI_ENABLED HAL_MOUNT_ENABLED
+#endif
+
+#if HAL_MOUNT_SIYI_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
+
+#define AP_MOUNT_SIYI_PACKETLEN_MAX     22  // maximum number of bytes in a packet sent to or received from the gimbal
+
+class AP_Mount_Siyi : public AP_Mount_Backend
+{
+
+public:
+    // Constructor
+    using AP_Mount_Backend::AP_Mount_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Mount_Siyi);
+
+    // init - performs any required initialisation for this instance
+    void init() override;
+
+    // update mount position - should be called periodically
+    void update() override;
+
+    // return true if healthy
+    bool healthy() const override;
+
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
+    bool has_pan_control() const override { return yaw_range_valid(); };
+
+    //
+    // camera controls
+    //
+
+    // take a picture.  returns true on success
+    bool take_picture() override;
+
+    // start or stop video recording
+    // set start_recording = true to start record, false to stop recording
+    bool record_video(bool start_recording) override;
+
+    // set camera zoom step.  returns true on success
+    // zoom out = -1, hold = 0, zoom in = 1
+    bool set_zoom_step(int8_t zoom_step) override;
+
+    // set focus in, out or hold.  returns true on success
+    // focus in = -1, focus hold = 0, focus out = 1
+    bool set_manual_focus_step(int8_t focus_step) override;
+
+    // auto focus.  returns true on success
+    bool set_auto_focus() override;
+
+protected:
+
+    // get attitude as a quaternion.  returns true on success
+    bool get_attitude_quaternion(Quaternion& att_quat) override;
+
+private:
+
+    // serial protocol command ids
+    enum class SiyiCommandId {
+        ACQUIRE_FIRMWARE_VERSION = 0x01,
+        HARDWARE_ID = 0x02,
+        AUTO_FOCUS = 0x04,
+        MANUAL_ZOOM_AND_AUTO_FOCUS = 0x05,
+        MANUAL_FOCUS = 0x06,
+        GIMBAL_ROTATION = 0x07,
+        CENTER = 0x08,
+        ACQUIRE_GIMBAL_CONFIG_INFO = 0x0A,
+        FUNCTION_FEEDBACK_INFO = 0x0B,
+        PHOTO = 0x0C,
+        ACQUIRE_GIMBAL_ATTITUDE = 0x0D
+    };
+
+    // Function Feedback Info packet info_type values
+    enum class FunctionFeedbackInfo : uint8_t {
+        SUCCESS = 0,
+        FAILED_TO_TAKE_PHOTO = 1,
+        HDR_ON = 2,
+        HDR_OFF = 3,
+        FAILED_TO_RECORD_VIDEO = 4
+    };
+
+    // Photo Function packet func_type values
+    enum class PhotoFunction : uint8_t {
+        TAKE_PICTURE = 0,
+        HDR_TOGGLE = 1,
+        RECORD_VIDEO_TOGGLE = 2,
+        LOCK_MODE = 3,
+        FOLLOW_MODE = 4,
+        FPV_MODE = 5
+    };
+
+    // parsing state
+    enum class ParseState : uint8_t {
+        WAITING_FOR_HEADER_LOW,
+        WAITING_FOR_HEADER_HIGH,
+        WAITING_FOR_CTRL,
+        WAITING_FOR_DATALEN_LOW,
+        WAITING_FOR_DATALEN_HIGH,
+        WAITING_FOR_SEQ_LOW,
+        WAITING_FOR_SEQ_HIGH,
+        WAITING_FOR_CMDID,
+        WAITING_FOR_DATA,
+        WAITING_FOR_CRC_LOW,
+        WAITING_FOR_CRC_HIGH,
+    };
+
+    // reading incoming packets from gimbal and confirm they are of the correct format
+    // results are held in the _parsed_msg structure
+    void read_incoming_packets();
+
+    // process successfully decoded packets held in the _parsed_msg structure
+    void process_packet();
+
+    // send packet to gimbal
+    // returns true on success, false if outgoing serial buffer is full
+    bool send_packet(SiyiCommandId cmd_id, const uint8_t* databuff, uint8_t databuff_len);
+    bool send_1byte_packet(SiyiCommandId cmd_id, uint8_t data_byte);
+
+    // request info from gimbal
+    void request_firmware_version() { send_packet(SiyiCommandId::ACQUIRE_FIRMWARE_VERSION, nullptr, 0); }
+    void request_hardware_id() { send_packet(SiyiCommandId::HARDWARE_ID, nullptr, 0); }
+    void request_configuration() { send_packet(SiyiCommandId::ACQUIRE_GIMBAL_CONFIG_INFO, nullptr, 0); }
+    void request_function_feedback_info() { send_packet(SiyiCommandId::FUNCTION_FEEDBACK_INFO, nullptr, 0); }
+    void request_gimbal_attitude() { send_packet(SiyiCommandId::ACQUIRE_GIMBAL_ATTITUDE, nullptr, 0); }
+
+    // rotate gimbal.  pitch_rate and yaw_rate are scalars in the range -100 ~ +100
+    // yaw_is_ef should be true if gimbal should maintain an earth-frame target (aka lock)
+    void rotate_gimbal(int8_t pitch_scalar, int8_t yaw_scalar, bool yaw_is_ef);
+
+    // center gimbal
+    void center_gimbal();
+
+    // set gimbal's lock vs follow mode
+    // lock should be true if gimbal should maintain an earth-frame target
+    // lock is false to follow / maintain a body-frame target
+    void set_lock(bool lock);
+
+    // send target pitch and yaw rates to gimbal
+    // yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
+    void send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef);
+
+    // send target pitch and yaw angles to gimbal
+    // yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
+    void send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
+
+    // internal variables
+    AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
+    bool _initialised;                              // true once the driver has been initialised
+    bool _got_firmware_version;                     // true once gimbal firmware version has been received
+
+    // buffer holding bytes from latest packet.  This is only used to calculate the crc
+    uint8_t _msg_buff[AP_MOUNT_SIYI_PACKETLEN_MAX];
+    uint8_t _msg_buff_len;
+    const uint8_t _msg_buff_data_start = 8;         // data starts at this byte of _msg_buff
+
+    // parser state and unpacked fields
+    struct PACKED {
+        uint16_t data_len;                          // expected number of data bytes
+        uint8_t command_id;                         // command id
+        uint16_t data_bytes_received;               // number of data bytes received so far
+        uint16_t crc16;                             // latest message's crc
+        ParseState state;                           // state of incoming message processing
+    } _parsed_msg;
+
+    // variables for sending packets to gimbal
+    uint32_t _last_send_ms;                         // system time (in milliseconds) of last packet sent to gimbal
+    uint16_t _last_seq;                             // last sequence number used (should be increment for each send)
+    bool     _last_lock;                            // last lock value sent to gimbal
+    uint8_t  _lock_send_counter;                    // counter used to resend lock status to gimbal at regular intervals
+
+    // actual attitude received from gimbal
+    Vector3f _current_angle_rad;                    // current angles in radians received from gimbal (x=roll, y=pitch, z=yaw)
+    uint32_t _last_current_angle_rad_ms;            // system time _current_angle_rad was updated
+    uint32_t _last_req_current_angle_rad_ms;        // system time that this driver last requested current angle
+
+    // variables for camera state
+    bool _last_record_video;                        // last record_video state sent to gimbal
+};
+
+#endif // HAL_MOUNT_SIYISERIAL_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -29,7 +29,7 @@ public:
     // update mount position - should be called periodically
     void update() override;
 
-    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
     bool has_pan_control() const override { return false; }
 
     // handle a GIMBAL_REPORT message

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -98,10 +98,10 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
-    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount1, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 75:SurfaceTrackingUpDown, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:VisOdom Align, 81:Disarm, 83:ZigZag Auto, 84:Air Mode, 85:Generator, 90:EKF Pos Source, 94:VTX Power, 99:AUTO RTL, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 151:Turtle, 152:simple heading reset, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with AirMode  (4.2 and higher), 158:Optflow Calibration, 159:Force Flying, 161:Turbine Start(heli), 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
-    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim (4.1 and lower), 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 27:Retract Mount1, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 81:Disarm, 90:EKF Pos Source, 94:VTX Power, 97:Windvane home heading direction offset, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 153:ArmDisarm (4.2 and higher), 155: set steering trim to current servo and RC, 156:Torqeedo Clear Err, 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 201:Roll, 202:Pitch, 207:MainSail, 208:Flap, 211:Walking Height, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
-    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 11:Fence, 16:ModeAuto, 22:Parachute Release, 24:Auto Mission Reset, 27:Retract Mount1, 28:Relay On/Off, 29:Landing Gear, 30:Lost Plane Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm (4.1 and lower), 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 52: ModeACRO, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 81:Disarm, 82:QAssist 3pos, 84:Air Mode, 85:Generator, 86: Non Auto Terrain Follow Disable, 87:Crow Select, 88:Soaring Enable, 89:Landing Flare, 90:EKF Pos Source, 91:Airspeed Ratio Calibration, 92:FBWA, 94:VTX Power, 95:FBWA taildragger takeoff mode, 96:trigger re-reading of mode switch, 98: ModeTraining, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 107: EnableFixedWingAutotune, 108: ModeQRTL, 150: CRUISE, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with Quadplane AirMode (4.2 and higher), 155: set roll pitch and yaw trim to current servo and RC, 157: Force FS Action to FBWA, 158:Optflow Calibration, 160:Weathervane Enable, 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 208:Flap, 209: Forward Throttle, 210: Airbrakes, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
-    // @Values{Blimp}: 0:Do Nothing, 18:Land, 46:RC Override Enable, 65:GPS Disable, 81:Disarm, 90:EKF Pos Source, 100:KillIMU1, 101:KillIMU2, 153:ArmDisarm, 164:Pause Stream Logging
+    // @Values{Copter}: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount1, 28:Relay On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 37:Throw, 38:ADSB Avoidance En, 39:PrecLoiter, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 43:InvertedFlight, 46:RC Override Enable, 47:User Function 1, 48:User Function 2, 49:User Function 3, 52:Acro, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 60:ZigZag, 61:ZigZag SaveWP, 62:Compass Learn, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 68:Stabilize, 69:PosHold, 70:AltHold, 71:FlowHold, 72:Circle, 73:Drift, 75:SurfaceTrackingUpDown, 76:Standby Mode, 78:RunCam Control, 79:RunCam OSD Control, 80:VisOdom Align, 81:Disarm, 83:ZigZag Auto, 84:Air Mode, 85:Generator, 90:EKF Pos Source, 94:VTX Power, 99:AUTO RTL, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 151:Turtle, 152:simple heading reset, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with AirMode  (4.2 and higher), 158:Optflow Calibration, 159:Force Flying, 161:Turbine Start(heli), 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Rover}: 0:Do Nothing, 4:RTL, 5:Save Trim (4.1 and lower), 7:Save WP, 9:Camera Trigger, 11:Fence, 16:Auto, 19:Gripper, 24:Auto Mission Reset, 27:Retract Mount1, 28:Relay On/Off, 30:Lost Rover Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm (4.1 and lower), 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple Mode, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 74:Sailboat motoring 3pos, 78:RunCam Control, 79:RunCam OSD Control, 80:Viso Align, 81:Disarm, 90:EKF Pos Source, 94:VTX Power, 97:Windvane home heading direction offset, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 153:ArmDisarm (4.2 and higher), 155: set steering trim to current servo and RC, 156:Torqeedo Clear Err, 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus, 201:Roll, 202:Pitch, 207:MainSail, 208:Flap, 211:Walking Height, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Plane}: 0:Do Nothing, 4:ModeRTL, 9:Camera Trigger, 11:Fence, 16:ModeAuto, 22:Parachute Release, 24:Auto Mission Reset, 27:Retract Mount1, 28:Relay On/Off, 29:Landing Gear, 30:Lost Plane Sound, 31:Motor Emergency Stop, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 38:ADSB Avoidance En, 41:ArmDisarm (4.1 and lower), 43:InvertedFlight, 46:RC Override Enable, 51:ModeManual, 52: ModeACRO, 55:ModeGuided, 56:ModeLoiter, 58:Clear Waypoints, 62:Compass Learn, 64:Reverse Throttle, 65:GPS Disable, 66:Relay5 On/Off, 67:Relay6 On/Off, 72:ModeCircle, 77:ModeTakeoff, 78:RunCam Control, 79:RunCam OSD Control, 81:Disarm, 82:QAssist 3pos, 84:Air Mode, 85:Generator, 86: Non Auto Terrain Follow Disable, 87:Crow Select, 88:Soaring Enable, 89:Landing Flare, 90:EKF Pos Source, 91:Airspeed Ratio Calibration, 92:FBWA, 94:VTX Power, 95:FBWA taildragger takeoff mode, 96:trigger re-reading of mode switch, 98: ModeTraining, 100:KillIMU1, 101:KillIMU2, 102:Camera Mode Toggle, 105:GPS Disable Yaw, 106:Disable Airspeed Use, 107: EnableFixedWingAutotune, 108: ModeQRTL, 150: CRUISE, 153:ArmDisarm (4.2 and higher), 154:ArmDisarm with Quadplane AirMode (4.2 and higher), 155: set roll pitch and yaw trim to current servo and RC, 157: Force FS Action to FBWA, 158:Optflow Calibration, 160:Weathervane Enable, 162:FFT Tune, 163:Mount Lock, 164:Pause Stream Logging, 165:Arm/Emergency Motor Stop, 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus, 208:Flap, 209: Forward Throttle, 210: Airbrakes, 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw, 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Blimp}: 0:Do Nothing, 18:Land, 46:RC Override Enable, 65:GPS Disable, 81:Disarm, 90:EKF Pos Source, 100:KillIMU1, 101:KillIMU2, 153:ArmDisarm, 164:Pause Stream Logging, 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus
     // @User: Standard
     AP_GROUPINFO_FRAME("OPTION",  6, RC_Channel, option, 0, AP_PARAM_FRAME_COPTER|AP_PARAM_FRAME_ROVER|AP_PARAM_FRAME_PLANE|AP_PARAM_FRAME_BLIMP),
 
@@ -532,7 +532,10 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
 #endif
     case AUX_FUNC::LOG_PAUSE:
     case AUX_FUNC::ARM_EMERGENCY_STOP:
-
+    case AUX_FUNC::CAMERA_REC_VIDEO:
+    case AUX_FUNC::CAMERA_ZOOM:
+    case AUX_FUNC::CAMERA_MANUAL_FOCUS:
+    case AUX_FUNC::CAMERA_AUTO_FOCUS:
         run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
         break;
     default:
@@ -594,6 +597,10 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::FFT_NOTCH_TUNE, "FFT Notch Tuning"},
     { AUX_FUNC::MOUNT_LOCK, "MountLock"},
     { AUX_FUNC::LOG_PAUSE, "Pause Stream Logging"},
+    { AUX_FUNC::CAMERA_REC_VIDEO, "Camera Record Video"},
+    { AUX_FUNC::CAMERA_ZOOM, "Camera Zoom"},
+    { AUX_FUNC::CAMERA_MANUAL_FOCUS, "Camera Manual Focus"},
+    { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
 };
 
 /* lookup the announcement for switch change */
@@ -741,6 +748,71 @@ void RC_Channel::do_aux_function_camera_trigger(const AuxSwitchPos ch_flag)
     if (ch_flag == AuxSwitchPos::HIGH) {
         camera->take_picture();
     }
+}
+
+bool RC_Channel::do_aux_function_record_video(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    return camera->record_video(ch_flag == AuxSwitchPos::HIGH);
+}
+
+bool RC_Channel::do_aux_function_camera_zoom(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    int8_t zoom_step = 0;   // zoom out = -1, hold = 0, zoom in = 1
+    switch (ch_flag) {
+    case AuxSwitchPos::HIGH:
+        zoom_step = 1;  // zoom in
+        break;
+    case AuxSwitchPos::MIDDLE:
+        zoom_step = 0;  // zoom hold
+        break;
+    case AuxSwitchPos::LOW:
+        zoom_step = -1; // zoom out
+        break;
+    }
+    return camera->set_zoom_step(zoom_step);
+}
+
+bool RC_Channel::do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    int8_t focus_step = 0;  // focus in = -1, focus hold = 0, focus out = 1
+    switch (ch_flag) {
+    case AuxSwitchPos::HIGH:
+        // wide shot, focus out
+        focus_step = 1;
+        break;
+    case AuxSwitchPos::MIDDLE:
+        focus_step = 0;
+        break;
+    case AuxSwitchPos::LOW:
+        // close shot, focus in
+        focus_step = -1;
+        break;
+    }
+    return camera->set_manual_focus_step(focus_step);
+}
+
+bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    if (ch_flag == AuxSwitchPos::HIGH) {
+        return camera->set_auto_focus();
+    }
+    return false;
 }
 #endif
 
@@ -1203,6 +1275,18 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
         }
         break;
     }
+    case AUX_FUNC::CAMERA_REC_VIDEO:
+        return do_aux_function_record_video(ch_flag);
+
+    case AUX_FUNC::CAMERA_ZOOM:
+        return do_aux_function_camera_zoom(ch_flag);
+
+    case AUX_FUNC::CAMERA_MANUAL_FOCUS:
+        return do_aux_function_camera_manual_focus(ch_flag);
+
+    case AUX_FUNC::CAMERA_AUTO_FOCUS:
+        return do_aux_function_camera_auto_focus(ch_flag);
+
 #endif
 
 #if HAL_MOUNT_ENABLED

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -230,6 +230,10 @@ public:
         MOUNT_LOCK =         163, // Mount yaw lock vs follow
         LOG_PAUSE =          164, // Pauses logging if under logging rate control
         ARM_EMERGENCY_STOP = 165, // ARM on high, MOTOR_ESTOP on low
+        CAMERA_REC_VIDEO =   166, // start recording on high, stop recording on low
+        CAMERA_ZOOM =        167, // camera zoom high = zoom in, middle = hold, low = zoom out
+        CAMERA_MANUAL_FOCUS = 168,// camera manual focus.  high = long shot, middle = stop focus, low = close shot
+        CAMERA_AUTO_FOCUS =  169, // camera auto focus
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input
@@ -318,6 +322,10 @@ protected:
     void do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);
     void do_aux_function_avoid_proximity(const AuxSwitchPos ch_flag);
     void do_aux_function_camera_trigger(const AuxSwitchPos ch_flag);
+    bool do_aux_function_record_video(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_zoom(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_control(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_osd_control(const AuxSwitchPos ch_flag);
     void do_aux_function_fence(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
This adds support for the Siyi ZR10 using its custom [serial protocol which is documented here](https://www.dropbox.com/s/7o08yt9r5g6mp0j/ZR10%20SDK%202022-9-19-randy-updated.docx?dl=0).  For reference there is a long [user discussion re this gimbal here](https://discuss.ardupilot.org/t/zr10-2k-qhd-30x-hybrid-zoom-gimbal-camera-siyis-first-industry-gimbal-camera-and-it-wont-be-the-last/86069/77).

The hardware connection is shown below:
![siyi-gimbal-autopilot](https://user-images.githubusercontent.com/1498098/191892526-1c86240f-e15b-41ed-ab9c-f5e5211f5eb7.png)

ArduPilot configuration is:

- SERIALx_PROTOCOL = 8 (SToRM32) (where "x" is the serial port number connected to the gimbal)
- SERIALx_BAUD = 115
- MNT1_TYPE = 8 (Siyi)
- MNT1_PITCH_MIN = -90
- MNT1_PITCH_MAX = 25
- MNT1_YAW_MIN = -80
- MNT1_YAW_MAX = 80
- MNT1_RC_RATE = 90 (deg/s) to control speed of gimbal curing RC targeting
- RCx_OPTION = 163 (Mount Lock) to switch between "lock" and "follow" during RC targeting
- RCx_OPTION = 213 (Mount Pitch) to control pitch angle with channel "x" during RC targeting
- RCx_OPTION = 214 (Mount Yaw) to control yaw angle with channel "x" during RC targeting
- Optionally these auxiliary functions are available
  - RCx_OPTION = 166 (Camera Record Video) to start/stop recording of video
  - RCx_OPTION = 167 (Camera Zoom) to zoom in and out
  - RCx_OPTION = 168 (Camera Manual Focus) to adjust focus in and out
  - RCx_OPTION = 167 (Camera Auto Focus) to trigger auto focus
- reboot the autopilot

This has been bench tested including:

1. Retracted and Neutral modes work.  E.g. the gimbal points at the body-frame angles held in MNT1_RETRACT_XYZ and MNT1_NEUTRAL_XYZ
2. ROI pointed at the correct target
3. RC Targeting worked for both angle control and rate control
4. Mount Lock / Follow (e.g. RCx_OPTION = 163) worked allowing RC targetting to work in earth-frame or body-frame
5. "Mount: unhealthy" is printed on the GCS HUD if the gimbal is powered off
6. Mount version is correctly displayed via SendText upon connection
7. Tested taking pictures, videos and zoom controls

Some know limitations of the gimbal:

- Gimbal does not support angle targets.  This meant I needed to implement a simple P controller to correct angle error using rates controls.  The manufacturer says they will add this in a future release
- Gimbal does not accept roll targets

Some know issues we should clear-up before merging

- [x] Custom build server needs an item to build this gimbal
- [x] Some debug is printed every 10 seconds displaying how many bytes have been processed, number of packets successfully parsed and the error count.  These are there to help with support because a number of users and partners are keen to test this driver
- [x] The firmware version output should be compressed to a single line
- [x] Camera controls are included in the driver but are not used (yet).  I plan a follow-up PR for an AP_Camera backend to communicate with this gimbal.  I'm happy to remove these methods if people prefer.

One final note is that this driver re-uses SERIALx_PROTOCOL = SToRM32 Serial (8).  I hope to re-name this to something more generic in a future PR.  Similar to how we have a single "Rangefinder" protocol, we should have a single "Mount" protocol and re-use this for all mounts/gimbals with a serial protocol (Alexmos, SToRM32, Siyi)

If anyone wishes to help with testing here are some pre-built binaries:

- [copter-440dev-cuavx7-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/6e832hc87yijdaf/copter-440dev-cuavx7-siyi-gimbal-28Sep2022.zip?dl=0)
- [copter-440dev-cubeorange-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/9r0jcz2clxwhuc0/copter-440dev-cubeorange-siyi-gimbal-28Sep2022.zip?dl=0)
- [copter-440dev-duandal-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/fxxgwhyq5isg9o2/copter-440dev-duandal-siyi-gimbal-28Sep2022.zip?dl=0)
- [copter-440dev-matekh743-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/bd1662k30kkjk26/copter-440dev-matekh743-siyi-gimbal-28Sep2022.zip?dl=0)
- [copter-440dev-pixhawk4-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/2vmi6muxv1fx6sw/copter-440dev-pixhawk4-siyi-gimbal-28Sep2022.zip?dl=0)
- [plane-440dev-cuavx7-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/guihdwv4qjae0e4/plane-440dev-cuavx7-siyi-gimbal-28Sep2022.zip?dl=0)
- [tradheli-440dev-cubeorange-siyi-gimbal-28Sep2022](https://www.dropbox.com/s/7ryrokmhcz8sqk8/tradheli-440dev-cubeorange-siyi-gimbal-28Sep2022.zip?dl=0)