### PR TITLE
RC_Channel: Notify function error if ADS-B is not implemented

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -510,7 +510,9 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::MOUNT2_PITCH:
     case AUX_FUNC::MOUNT2_YAW:
         break;
+#if HAL_ADSB_ENABLED
     case AUX_FUNC::AVOID_ADSB:
+#endif
     case AUX_FUNC::AVOID_PROXIMITY:
     case AUX_FUNC::FENCE:
     case AUX_FUNC::GPS_DISABLE:
@@ -1021,9 +1023,11 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
         do_aux_function_mission_reset(ch_flag);
         break;
 
+#if HAL_ADSB_ENABLED
     case AUX_FUNC::AVOID_ADSB:
         do_aux_function_avoid_adsb(ch_flag);
         break;
+#endif
 
     case AUX_FUNC::FFT_NOTCH_TUNE:
         do_aux_function_fft_notch_tune(ch_flag);


### PR DESCRIPTION
Unimplemented RC option can be selected.
Notify the operator with a message that an unimplemented RC option has been selected.

AFTER
![Screenshot from 2022-09-25 10-23-41](https://user-images.githubusercontent.com/646194/192125048-a5c7ead9-724c-4b6d-a87c-120e19994dd0.png)

BEFORE
![Screenshot from 2022-09-25 10-46-43](https://user-images.githubusercontent.com/646194/192125042-965d7569-a483-4c45-8ae1-9bc56f5ae8c8.png)
