### PR TITLE
Plane: remove throttle and rudder from CTUN as in AETR

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -258,6 +258,11 @@ void Plane::update_logging25(void)
 #endif
     }
 
+    if (should_log(MASK_LOG_RC) || should_log(MASK_LOG_CTUN)) {
+        // Originally logged under RC, now included with CTUN as duplicated fields were removed from CTUN
+        Log_Write_AETR();
+    }
+
     if (should_log(MASK_LOG_NTUN)) {
         Log_Write_Nav_Tuning();
         Log_Write_Guided();

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -72,8 +72,6 @@ struct PACKED log_Control_Tuning {
     int16_t roll;
     int16_t nav_pitch_cd;
     int16_t pitch;
-    float throttle_out;
-    float rudder_out;
     float throttle_dem;
     float airspeed_estimate;
     float synthetic_airspeed;
@@ -99,8 +97,6 @@ void Plane::Log_Write_Control_Tuning()
         roll            : (int16_t)ahrs.roll_sensor,
         nav_pitch_cd    : (int16_t)nav_pitch_cd,
         pitch           : (int16_t)ahrs.pitch_sensor,
-        throttle_out    : SRV_Channels::get_output_scaled(SRV_Channel::k_throttle),
-        rudder_out      : SRV_Channels::get_output_scaled(SRV_Channel::k_rudder),
         throttle_dem    : TECS_controller.get_throttle_demand(),
         airspeed_estimate : est_airspeed,
         synthetic_airspeed : synthetic_airspeed,
@@ -243,7 +239,6 @@ void Plane::Log_Write_RC(void)
     if (rssi.enabled()) {
         logger.Write_RSSI();
     }
-    Log_Write_AETR();
 }
 
 void Plane::Log_Write_Guided(void)
@@ -295,16 +290,14 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: Roll: achieved roll
 // @Field: NavPitch: desired pitch
 // @Field: Pitch: achieved pitch
-// @Field: ThO: scaled output throttle
-// @Field: RdrOut: scaled output rudder
 // @Field: ThD: demanded speed-height-controller throttle
 // @Field: As: airspeed estimate (or measurement if airspeed sensor healthy and ARSPD_USE>0)
 // @Field: SAs: synthetic airspeed measurement derived from non-airspeed sensors, NaN if not available
 // @Field: E2T: equivalent to true airspeed ratio
 // @Field: GU: groundspeed undershoot when flying with minimum groundspeed
 
-    { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
-      "CTUN", "Qccccffffffi",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThO,RdrOut,ThD,As,SAs,E2T,GU", "sdddd---nn-n", "FBBBB---00-B" , true },
+    { LOG_CTUN_MSG, sizeof(log_Control_Tuning),
+      "CTUN", "Qccccffffi",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThD,As,SAs,E2T,GU", "sdddd-nn-n", "FBBBB-00-B" , true },
 
 // @LoggerMessage: NTUN
 // @Description: Navigation Tuning information - e.g. vehicle destination


### PR DESCRIPTION
Were logging the same values in two places at the same rate. This removes throttle and rudder from `CTUN` as there in `AETR`. So as not to loose data this now always logs `AETR` if `CTUN` is enabled. 

Would quite like to remove roll and pitch desired and actual too, there in `ATT`, however `ATT` switches to Quadplane view where as CTUN does not. Having both sets could be useful.