### PR TITLE
Copter, Plane, Rover to 4.4.0-DEV

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.0-dev"
+#define THISFIRMWARE "ArduCopter V4.4.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 3
+#define FW_MINOR 4
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.3.0dev"
+#define THISFIRMWARE "ArduPlane V4.4.0dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 3
+#define FW_MINOR 4
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.3.0-dev"
+#define THISFIRMWARE "ArduRover V4.4.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 3
+#define FW_MINOR 4
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 


### PR DESCRIPTION
This updates the version for Copter (including TradHeli), Plane and Rover to 4.4.0-DEV now that we have branched for 4.3.0-beta testing.

I have not updated AntennaTracker or Sub because we haven't branched for those releases yet.