### PR TITLE
AP_Scripting: gimbal/mount POI example

### DIFF
--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -118,16 +118,16 @@ public:
     // only use with small angles.  I.e. length of v should less than 0.17 radians (i.e. 10 degrees)
     void        rotate_fast(const Vector3<T> &v);
 
-    // get euler roll angle
+    // get euler roll angle in radians
     T       get_euler_roll() const;
 
-    // get euler pitch angle
+    // get euler pitch angle in radians
     T       get_euler_pitch() const;
 
-    // get euler yaw angle
+    // get euler yaw angle in radians
     T       get_euler_yaw() const;
 
-    // create eulers from a quaternion
+    // create eulers (in radians) from a quaternion
     void        to_euler(float &roll, float &pitch, float &yaw) const;
     void        to_euler(double &roll, double &pitch, double &yaw) const;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -379,6 +379,18 @@ void AP_Mount::send_gimbal_device_attitude_status(mavlink_channel_t chan)
     }
 }
 
+// get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
+// returns true on success
+bool AP_Mount::get_attitude_euler(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_bf_deg)
+{
+    if (!check_instance(instance)) {
+        return false;
+    }
+
+    // send command to backend
+    return _backends[instance]->get_attitude_euler(roll_deg, pitch_deg, yaw_bf_deg);
+}
+
 // run pre-arm check.  returns false on failure and fills in failure_msg
 // any failure_msg returned will not include a prefix
 bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -154,6 +154,10 @@ public:
     // send a GIMBAL_DEVICE_ATTITUDE_STATUS message to GCS
     void send_gimbal_device_attitude_status(mavlink_channel_t chan);
 
+    // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
+    // returns true on success
+    bool get_attitude_euler(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_bf_deg);
+
     // run pre-arm check.  returns false on failure and fills in failure_msg
     // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -6,6 +6,24 @@ extern const AP_HAL::HAL& hal;
 
 #define AP_MOUNT_UPDATE_DT 0.02     // update rate in seconds.  update() should be called at this rate
 
+// get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
+// returns true on success
+bool AP_Mount_Backend::get_attitude_euler(float& roll_deg, float& pitch_deg, float& yaw_bf_deg)
+{
+    // by default re-use get_attitude_quaternion and convert to Euler angles
+    Quaternion att_quat;
+    if (!get_attitude_quaternion(att_quat)) {
+        return false;
+    }
+
+    float roll_rad, pitch_rad, yaw_rad;
+    att_quat.to_euler(roll_rad, pitch_rad, yaw_rad);
+    roll_deg = degrees(roll_rad);
+    pitch_deg = degrees(pitch_rad);
+    yaw_bf_deg = degrees(yaw_rad);
+    return true;
+}
+
 // set angle target in degrees
 // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
 void AP_Mount_Backend::set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame)

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -49,6 +49,10 @@ public:
     // returns true if this mount can control its pan (required for multicopters)
     virtual bool has_pan_control() const = 0;
 
+    // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
+    // returns true on success
+    bool get_attitude_euler(float& roll_deg, float& pitch_deg, float& yaw_bf_deg);
+
     // get mount's mode
     enum MAV_MOUNT_MODE get_mode() const { return _mode; }
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -662,6 +662,12 @@ function Location_ud:get_vector_from_origin_NEU() end
 function Location_ud:offset_bearing(bearing_deg, distance) end
 
 -- desc
+---@param bearing_deg number
+---@param pitch_deg number
+---@param distance number
+function Location_ud:offset_bearing_and_pitch(bearing_deg, pitch_deg, distance) end
+
+-- desc
 ---@param ofs_north number
 ---@param ofs_east number
 function Location_ud:offset(ofs_north, ofs_east) end

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -824,6 +824,12 @@ function mount:set_mode(instance, mode) end
 ---@return integer
 function mount:get_mode(instance) end
 
+-- desc
+---@param instance integer
+---@return number|nil
+---@return number|nil
+---@return number|nil
+function mount:get_attitude_euler(instance, roll_deg, pitch_deg, yaw_bf_deg) end
 
 -- desc
 ---@class motors

--- a/libraries/AP_Scripting/examples/mount-poi.lua
+++ b/libraries/AP_Scripting/examples/mount-poi.lua
@@ -1,0 +1,187 @@
+-- mount-poi.lua: finds the point-of-interest that the gimbal mount is pointing at using the vehicle's current Location, mount attitude and terrain database
+--
+-- How To Use
+--   1. set RCx_OPTION to 300 to enable triggering the POI calculation from an auxiliary switch
+--   2. optionally set POI_DIST_MAX to the maximum distance (in meters) that the POI point could be from the vehicle
+--   3. fly the vehicle and point the camera gimbal at a point on the ground
+--   4. raise the RC auxiliary switch and check the GCS's messages tab for the latitude, longitude and alt (above sea-level)
+--
+-- How It Works
+--   1. retrieve the POI_DIST_MAX and TERRAIN_SPACING param values
+--   2. get the vehicle Location (lat, lon, height above sea-level), initialise test-loc and prev-test-loc
+--   3. get the vehicle's current alt-above-terrain
+--   4. get gimbal attitude (only pitch and yaw are used)
+--   5. "test_loc" is initialised to the vehicle's location
+--   6. "prev_test_loc" is a backup of test_loc
+--   7. test_loc is moved along the line defined by the gimbal's pitch and yaw by TERRAIN_SPACING (meters)
+--   8. retrieve the terrain's altitude (above sea-level) at the test_loc
+--   9. repeat step 6, 7 and 8 until the test_loc's altitude falls below the terrain altitude
+--  10. interpolate between test_loc and prev_test_loc to find the lat, lon, alt (above sea-level) where alt-above-terrain is zero
+--  11. display the POI to the user
+
+-- global definitions
+local ALT_FRAME_ABSOLUTE = 0
+local UPDATE_INTERVAL_MS = 100
+
+-- add new param POI_DIST_MAX
+local PARAM_TABLE_KEY = 78
+assert(param:add_table(PARAM_TABLE_KEY, "POI_", 1), "could not add param table")
+assert(param:add_param(PARAM_TABLE_KEY, 1, "DIST_MAX", 10000), "could not add POI_DIST_MAX param")
+
+local poi_dist_max = Parameter()
+assert(poi_dist_max:init("POI_DIST_MAX"), "could not find POI_DIST_MAX param")
+
+-- bind to other parameters this script depends upon
+TERRAIN_SPACING = Parameter("TERRAIN_SPACING")
+
+-- local variables and definitions
+local user_update_interval_ms = 10000   -- send user updates every 10 sec
+local last_user_update_ms = 0           -- system time that update was last sent to user
+local last_rc_switch_pos = 0            -- last known rc switch position.  Used to detect change in RC switch position
+
+-- helper functions
+function wrap_360(angle_deg)
+  local res = math.fmod(angle_deg, 360.0)
+  if res < 0 then
+    res = res + 360.0
+  end
+  return res
+end
+
+function wrap_180(angle_deg)
+  local res = wrap_360(angle_deg)
+  if res > 180 then
+    res = res - 360
+  end
+  return res
+end
+
+function swap_float(f1, f2)
+  return f2, f1
+end
+
+function interpolate(low_output, high_output, var_value, var_low, var_high)
+  -- support either polarity
+  if (var_low > var_high) then
+    var_low, var_high = swap_float(var_low, var_high)
+    low_output, high_output = swap_float(low_output, high_output)
+  end
+  if (var_value <= var_low) then
+    return low_output
+  end
+  if (var_value > var_high) then
+    return high_output
+  end
+  local p = (var_value - var_low) / (var_high - var_low)
+  return (low_output + p * (high_output - low_output))
+end
+
+
+-- the main update function that performs a simplified version of RTL
+function update()
+
+  -- get current system time
+  local now_ms = millis()
+
+  -- find RC channel used to trigger POI
+  rc_switch_ch = rc:find_channel_for_option(300) --scripting ch 1
+  if (rc_switch_ch == nil) then
+      gcs:send_text(3, 'MountPOI: RCx_OPTION = 300 not set')    -- MAV_SEVERITY_ERROR
+      return update, 10000  -- check again in 10 seconds
+  end
+
+  -- check if user has raised RC switch
+  local rc_switch_pos = rc_switch_ch:get_aux_switch_pos()
+  if rc_switch_pos == last_rc_switch_pos then
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  -- switch has changed position
+  last_rc_switch_pos = rc_switch_pos
+  if rc_switch_pos ~= 2 then
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  -- POI has been requested
+
+  -- retrieve vehicle location
+  local vehicle_loc = ahrs:get_location()
+  if vehicle_loc == nil then
+    gcs:send_text(3, "POI: vehicle pos unavailable") -- MAV_SEVERITY_ERROR
+    return update, UPDATE_INTERVAL_MS
+  end
+  
+  -- change vehicle location to ASML
+  vehicle_loc:change_alt_frame(ALT_FRAME_ABSOLUTE)
+
+  -- retrieve gimbal attitude
+  local roll_deg, pitch_deg, yaw_bf_deg = mount:get_attitude_euler(0)
+  if pitch_deg == nil or yaw_bf_deg == nil then
+    gcs:send_text(3, "POI: gimbal attitude unavailable") -- MAV_SEVERITY_ERROR
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  -- project forward from vehicle looking for terrain
+  -- start testing at vehicle's location
+  local test_loc = vehicle_loc:copy()
+  local prev_test_loc = test_loc:copy()
+
+  -- get terrain altitude (asml) at test_loc
+  local terrain_amsl_m = terrain:height_amsl(test_loc, true)  -- terrain alt (above amsl) at test_loc
+  local prev_terrain_amsl_m = terrain_amsl_m    -- terrain alt (above amsl) at prev_test_loc
+
+  -- fail if terrain alt cannot be retrieved
+  if terrain_amsl_m == nil then
+    gcs:send_text(3, "POI: failed to get terrain alt") -- MAV_SEVERITY_ERROR
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  -- get gimbal mount's pitch and yaw
+  local mount_pitch_deg = pitch_deg
+  local mount_yaw_ef_deg = wrap_180(yaw_bf_deg + math.deg(ahrs:get_yaw()))
+  local dist_increment_m = TERRAIN_SPACING:get()
+
+  -- initialise total distance test_loc has moved
+  local total_dist = 0
+  local dist_max = poi_dist_max:get()
+
+  -- iteratively move test_loc forward until its alt-above-sea-level is below terrain-alt-above-sea-level
+  while (total_dist < dist_max) and ((test_loc:alt() * 0.01) > terrain_amsl_m) do
+    total_dist = total_dist + dist_increment_m
+
+    -- take backup of previous test location and terrain asml
+    prev_test_loc = test_loc:copy()
+    prev_terrain_amsl_m = terrain_amsl_m
+
+    -- move test location forward
+    test_loc:offset_bearing_and_pitch(mount_yaw_ef_deg, mount_pitch_deg, dist_increment_m)
+
+    -- get terrain's alt-above-sea-level (at test_loc)
+    terrain_amsl_m = terrain:height_amsl(test_loc, true)
+
+    -- fail if terrain alt cannot be retrieved
+    if terrain_amsl_m == nil then
+      gcs:send_text(3, "POI: failed to get terrain alt") -- MAV_SEVERITY_ERROR
+      return update, UPDATE_INTERVAL_MS
+    end
+  end
+
+  -- check for errors
+  if (total_dist >= dist_max) then
+    gcs:send_text(3, "POI: unable to find terrain within " .. tostring(dist_max) .. " m")
+  elseif not terrain_amsl_m then
+    gcs:send_text(3, "POI: failed to retrieve terrain alt")
+  else
+    -- test location has dropped below terrain
+    -- interpolate along line between prev_test_loc and test_loc
+    local dist_interp_m = interpolate(0, dist_increment_m, 0, prev_test_loc:alt() * 0.01 - prev_terrain_amsl_m, test_loc:alt() * 0.01 - terrain_amsl_m)
+    local poi_loc = prev_test_loc:copy()
+    poi_loc:offset_bearing_and_pitch(mount_yaw_ef_deg, mount_pitch_deg, dist_interp_m)
+    local poi_terr_asml_m = terrain:height_amsl(poi_loc, true) 
+    gcs:send_text(6, string.format("POI %.7f, %.7f, %.2f (asml)", poi_loc:lat()/10000000.0, poi_loc:lng()/10000000.0, poi_loc:alt() * 0.01))
+  end
+
+  return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -13,6 +13,7 @@ userdata Location field loiter_xtrack boolean read write
 userdata Location method get_distance float Location
 userdata Location method offset void float'skip_check float'skip_check
 userdata Location method offset_bearing void float'skip_check float'skip_check
+userdata Location method offset_bearing_and_pitch void float'skip_check float'skip_check float'skip_check
 userdata Location method get_vector_from_origin_NEU boolean Vector3f'Null
 userdata Location method get_bearing float Location
 userdata Location method get_distance_NED Vector3f Location

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -547,6 +547,7 @@ singleton AP_Mount method set_mode void uint8_t 0 UINT8_MAX MAV_MOUNT_MODE'enum 
 singleton AP_Mount method set_angle_target void uint8_t 0 UINT8_MAX float'skip_check float'skip_check float'skip_check boolean
 singleton AP_Mount method set_rate_target void uint8_t 0 UINT8_MAX float'skip_check float'skip_check float'skip_check boolean
 singleton AP_Mount method set_roi_target void uint8_t 0 UINT8_MAX Location
+singleton AP_Mount method get_attitude_euler boolean uint8_t 0 UINT8_MAX float'Null float'Null float'Null
 
 singleton AP_Logger rename logger
 singleton AP_Logger manual write AP_Logger_Write


### PR DESCRIPTION
This Lua script example allows the user to more accurately determine the lat, lon and alt (above sea level) of the point in the center of the camera's frame.  E.g. the pilot can aim the camera at a point (on the ground) and pull an auxiliary switch high and the Location is then displayed on the ground station's messages tab.  The location is calculated using the vehicle's position, the gimbal's attitude and the terrain database.

I'm hoping to use this at the upcoming [Japan Inovation Challenge](https://japan-innovation-challenge.com/en/) to more easily determine the Lat, Lon, Alt of the mannequin

This can be tested in SITL by doing the following

- cd ardupilot/ArduCopter
- mkdir scripts
- cp ../Tools/libraries/AP_Scripting/examples/mount-poi.lua scripts
- ../Tools/autotest/sim_vehicle.py --map --console
- param set SCR_ENABLE 1 (to enable scripting)
- param set MNT1_TYPE 1 (to enable servo gimbal)
- param set RC9_OPTION 300 (to setup RC 9 auxiliary function to SCRIPTING_1 which triggers POI calculation)
- restart SITL
- GUIDED (to switch to Guided mode)
- arm throttle
- takeoff 20
- module load message
- message COMMAND_INT 0 0 11 195 0 0 0 0 0 0 -353632632 1491663846 0 (to aim the gimbal at the given lat, lon and alt-above-terrain, [other example commands are here](https://ardupilot.org/dev/docs/mavlink-gimbal-mount.html#mav-cmd-do-set-roi-location-to-point-at-a-location))
- rc 9 2000 (to trigger POI calculation, POI lat, lon and alt should be displayed.  These should be close to the lat, lon provided in the message command above)

This has been tested in SITL and seems correct.  Below are some screen shots of a test in MP.  I used MP's right-mouse-button-menu's "Point camera here" and pointed approximately where the red Xs are.  Then I typed the POI lat, lon and alt into the command list (as waypoints) so I could see where the lat, lon, alt were on the map.
![image](https://user-images.githubusercontent.com/1498098/192200626-b527a9a3-760d-40e4-9ce4-75e9c56310c8.png)

