### PR TITLE
SITL SerialDevice optionally checks baudrates match

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7338,7 +7338,7 @@ class AutoTestCopter(AutoTest):
             ("USD1_v1", 11),
             ("leddarone", 12),
             ("maxsonarseriallv", 13),
-            ("nmea", 17),
+            ("nmea", 17, {"baud": 9600}),
             ("wasp", 18),
             ("benewake_tf02", 19),
             ("blping", 23),
@@ -7357,14 +7357,20 @@ class AutoTestCopter(AutoTest):
                                                          (1, '--uartF', 5),
                                                          (2, '--uartG', 6)]:
                 if len(do_drivers) > offs:
-                    (sim_name, rngfnd_param_value) = do_drivers[offs]
+                    if len(do_drivers[offs]) > 2:
+                        (sim_name, rngfnd_param_value, kwargs) = do_drivers[offs]
+                    else:
+                        (sim_name, rngfnd_param_value) = do_drivers[offs]
+                        kwargs = {}
                     command_line_args.append("%s=sim:%s" %
                                              (cmdline_argument, sim_name))
-                    serial_param_name = "SERIAL%u_PROTOCOL" % serial_num
-                    self.set_parameters({
-                        serial_param_name: 9, # rangefinder
+                    sets = {
+                        "SERIAL%u_PROTOCOL" % serial_num: 9, # rangefinder
                         "RNGFND%u_TYPE" % (offs+1): rngfnd_param_value,
-                    })
+                    }
+                    if "baud" in kwargs:
+                        sets["SERIAL%u_BAUD" % serial_num] = kwargs["baud"]
+                    self.set_parameters(sets)
             self.customise_SITL_commandline(command_line_args)
             self.fly_rangefinder_drivers_fly([x[0] for x in do_drivers])
             self.context_pop()

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5932,6 +5932,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "RNGFND1_TYPE" : 17,     # NMEA must attach uart to SITL
             "RNGFND1_ORIENT" : 25,   # Set to downward facing
             "SERIAL7_PROTOCOL" : 9,  # Rangefinder on uartH
+            "SERIAL7_BAUD" : 9600,   # Rangefinder specific baudrate
 
             "RNGFND3_TYPE" : 2,      # MaxbotixI2C
             "RNGFND3_ADDR" : 112,    # 0x70 address from SIM_I2C.cpp

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -157,6 +157,10 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         free(s);
     }
 
+    if (_sim_serial_device != nullptr) {
+        _sim_serial_device->set_autopilot_baud(baud);
+    }
+
     if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
         _readbuffer.clear();
         _writebuffer.clear();

--- a/libraries/SITL/SIM_RF_NMEA.h
+++ b/libraries/SITL/SIM_RF_NMEA.h
@@ -18,6 +18,7 @@
 ./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:nmea --speedup=1
 
 param set SERIAL5_PROTOCOL 9
+param set SERIAL5_BAUD 9600
 param set RNGFND1_TYPE 17
 graph RANGEFINDER.distance
 graph GLOBAL_POSITION_INT.relative_alt/1000-RANGEFINDER.distance
@@ -35,6 +36,8 @@ namespace SITL {
 
 class RF_NMEA : public SerialRangeFinder {
 public:
+
+    uint32_t device_baud() const override { return 9600; }
 
     uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
 

--- a/libraries/SITL/SIM_SerialDevice.cpp
+++ b/libraries/SITL/SIM_SerialDevice.cpp
@@ -64,6 +64,10 @@ ssize_t SerialDevice::read_from_autopilot(char *buffer, const size_t size) const
 
 ssize_t SerialDevice::write_to_autopilot(const char *buffer, const size_t size) const
 {
+    if (device_baud() != 0 && autopilot_baud != 0 && device_baud() != autopilot_baud) {
+        return -1;
+    }
+
     const ssize_t ret = to_autopilot->write((uint8_t*)buffer, size);
     // ::fprintf(stderr, "write to autopilot: (");
     // for (ssize_t i=0; i<ret; i++) {
@@ -79,6 +83,10 @@ ssize_t SerialDevice::write_to_autopilot(const char *buffer, const size_t size) 
 
 ssize_t SerialDevice::read_from_device(char *buffer, const size_t size) const
 {
+    if (device_baud() != 0 && autopilot_baud != 0 && device_baud() != autopilot_baud) {
+        return -1;
+    }
+
     const ssize_t ret = to_autopilot->read((uint8_t*)buffer, size);
     return ret;
 }

--- a/libraries/SITL/SIM_SerialDevice.h
+++ b/libraries/SITL/SIM_SerialDevice.h
@@ -32,10 +32,12 @@ public:
     // methods for autopilot to use to talk to device:
     ssize_t read_from_device(char *buffer, size_t size) const;
     ssize_t write_to_device(const char *buffer, size_t size) const;
+    void set_autopilot_baud(uint32_t baud) { autopilot_baud = baud; }
 
     // methods for simulated device to use:
     ssize_t read_from_autopilot(char *buffer, size_t size) const;
     virtual ssize_t write_to_autopilot(const char *buffer, size_t size) const;
+    virtual uint32_t device_baud() const { return 0; }  // 0 meaning unset
 
 protected:
 
@@ -45,6 +47,10 @@ protected:
     ByteBuffer *from_autopilot;
 
     bool init_sitl_pointer();
+
+private:
+
+    uint32_t autopilot_baud;
 };
 
 }


### PR DESCRIPTION
... and drops reads and writes if they don't match.

Example implementation for NMEA rangefinder is included.
