### PR TITLE
AP_Compass: fixed AP_Periph compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -888,8 +888,10 @@ void Compass::mag_state::copy_from(const Compass::mag_state& state)
     external.set_and_save_ifchanged(state.external);
     orientation.set_and_save_ifchanged(state.orientation);
     offset.set_and_save_ifchanged(state.offset);
+#ifndef HAL_BUILD_AP_PERIPH
     diagonals.set_and_save_ifchanged(state.diagonals);
     offdiagonals.set_and_save_ifchanged(state.offdiagonals);
+#endif
     scale_factor.set_and_save_ifchanged(state.scale_factor);
     dev_id.set_and_save_ifchanged(state.dev_id);
     motor_compensation.set_and_save_ifchanged(state.motor_compensation);
@@ -1676,6 +1678,7 @@ Compass::set_and_save_offsets(uint8_t i, const Vector3f &offsets)
     }
 }
 
+#ifndef HAL_BUILD_AP_PERIPH
 void
 Compass::set_and_save_diagonals(uint8_t i, const Vector3f &diagonals)
 {
@@ -1695,6 +1698,7 @@ Compass::set_and_save_offdiagonals(uint8_t i, const Vector3f &offdiagonals)
         _state[id].offdiagonals.set_and_save(offdiagonals);
     }
 }
+#endif // HAL_BUILD_AP_PERIPH
 
 void
 Compass::set_and_save_scale_factor(uint8_t i, float scale_factor)

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -213,11 +213,13 @@ public:
     const Vector3f &get_offsets(uint8_t i) const { return _get_state(Priority(i)).offset; }
     const Vector3f &get_offsets(void) const { return get_offsets(_first_usable); }
 
+#ifndef HAL_BUILD_AP_PERIPH
     const Vector3f &get_diagonals(uint8_t i) const { return _get_state(Priority(i)).diagonals; }
     const Vector3f &get_diagonals(void) const { return get_diagonals(_first_usable); }
 
     const Vector3f &get_offdiagonals(uint8_t i) const { return _get_state(Priority(i)).offdiagonals; }
     const Vector3f &get_offdiagonals(void) const { return get_offdiagonals(_first_usable); }
+#endif
 
     // learn offsets accessor
     bool learn_offsets_enabled() const { return _learn == LEARN_INFLIGHT; }
@@ -481,8 +483,10 @@ private:
         Compass::Priority priority;
         AP_Int8     orientation;
         AP_Vector3f offset;
+#ifndef HAL_BUILD_AP_PERIPH
         AP_Vector3f diagonals;
         AP_Vector3f offdiagonals;
+#endif
         AP_Float    scale_factor;
 
         // device id detected at init.

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -74,8 +74,10 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     Compass::mag_state &state = _compass._state[Compass::StateIndex(i)];
 
     const Vector3f &offsets = state.offset.get();
+#ifndef HAL_BUILD_AP_PERIPH
     const Vector3f &diagonals = state.diagonals.get();
     const Vector3f &offdiagonals = state.offdiagonals.get();
+#endif
 
     // add in the basic offsets
     mag += offsets;
@@ -86,6 +88,7 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
         mag *= state.scale_factor;
     }
 
+#ifndef HAL_BUILD_AP_PERIPH
     // apply eliptical correction
     Matrix3f mat(
         diagonals.x, offdiagonals.x, offdiagonals.y,
@@ -94,6 +97,7 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     );
 
     mag = mat * mag;
+#endif
 
 #if COMPASS_MOT_ENABLED
     const Vector3f &mot = state.motor_compensation.get();

--- a/libraries/AP_HAL_ChibiOS/hwdef/HerePro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HerePro/hwdef.dat
@@ -199,7 +199,8 @@ define CAN_APP_NODE_NAME "com.cubepilot.herepro"
 
 define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 
-define COMPASS_CAL_ENABLED 1
+# disabled compass cal as it doesn't work for now
+# define COMPASS_CAL_ENABLED 1
 
 define HAL_ENABLE_SLCAN 1
 # passthrough CAN1


### PR DESCRIPTION
diagonals are no longer initialised to 1.0, which leaves us with zero compass after matrix mul
broken by this PR: https://github.com/ArduPilot/ardupilot/pull/21290
