### PR TITLE
Sub: update baro calibration even if armed

### DIFF
--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -6,7 +6,7 @@ void Sub::read_barometer()
     barometer.update();
     // If we are reading a positive altitude, the sensor needs calibration
     // Even a few meters above the water we should have no significant depth reading
-    if(!motors.armed() && barometer.get_altitude() > 0) {
+    if(barometer.get_altitude() > 0) {
         barometer.update_calibration();
     }
 


### PR DESCRIPTION
This is harmless and prevents a "bounce-back" effect when the depth is badly calibrated. This can happen when rebooting the vehicle underwater without a proper depth calibration.