### PR TITLE
Squelch warning about sending RPM mavlink message if RPM not compiled in

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1,6 +1,7 @@
 #include "Copter.h"
 
 #include "GCS_Mavlink.h"
+#include <AP_RPM/AP_RPM_config.h>
 
 MAV_TYPE GCS_Copter::frame_type() const
 {
@@ -533,7 +534,9 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_MAG_CAL_PROGRESS,
     MSG_EKF_STATUS_REPORT,
     MSG_VIBRATION,
+#if AP_RPM_ENABLED
     MSG_RPM,
+#endif
     MSG_ESC_TELEMETRY,
     MSG_GENERATOR_STATUS,
     MSG_WINCH_STATUS,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1,6 +1,7 @@
 #include "GCS_Mavlink.h"
 
 #include "Plane.h"
+#include <AP_RPM/AP_RPM_config.h>
 
 MAV_TYPE GCS_Plane::frame_type() const
 {
@@ -567,7 +568,9 @@ static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,
     MSG_SIMSTATE,
     MSG_AHRS2,
+#if AP_RPM_ENABLED
     MSG_RPM,
+#endif
     MSG_AOA_SSA,
     MSG_PID_TUNING,
     MSG_LANDING,

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1,6 +1,7 @@
 #include "Sub.h"
 
 #include "GCS_Mavlink.h"
+#include <AP_RPM/AP_RPM_config.h>
 
 MAV_TYPE GCS_Sub::frame_type() const
 {

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -1,6 +1,7 @@
 #include "Blimp.h"
 
 #include "GCS_Mavlink.h"
+#include <AP_RPM/AP_RPM_config.h>
 
 MAV_TYPE GCS_Blimp::frame_type() const
 {
@@ -357,7 +358,9 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_MAG_CAL_PROGRESS,
     MSG_EKF_STATUS_REPORT,
     MSG_VIBRATION,
+#if AP_RPM_ENABLED
     MSG_RPM,
+#endif
     MSG_ESC_TELEMETRY,
     MSG_GENERATOR_STATUS,
 };

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -2,6 +2,7 @@
 
 #include "GCS_Mavlink.h"
 
+#include <AP_RPM/AP_RPM_config.h>
 #include <AP_RangeFinder/AP_RangeFinder_Backend.h>
 
 MAV_TYPE GCS_Rover::frame_type() const
@@ -564,7 +565,9 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_MAG_CAL_PROGRESS,
     MSG_EKF_STATUS_REPORT,
     MSG_VIBRATION,
+#if AP_RPM_ENABLED
     MSG_RPM,
+#endif
     MSG_WHEEL_DISTANCE,
     MSG_ESC_TELEMETRY,
 };

--- a/libraries/AP_RPM/RPM_SITL.cpp
+++ b/libraries/AP_RPM/RPM_SITL.cpp
@@ -13,14 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "RPM_SITL.h"
 
-extern const AP_HAL::HAL& hal;
+#if AP_RPM_SIM_ENABLED
 
-/* 
+#include <AP_HAL/AP_HAL.h>
+
+/*
    open the sensor in constructor
 */
 AP_RPM_SITL::AP_RPM_SITL(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
@@ -46,4 +45,4 @@ void AP_RPM_SITL::update(void)
 
 }
 
-#endif // CONFIG_HAL_BOARD
+#endif // AP_RPM_SIM_ENABLED

--- a/libraries/AP_RPM/RPM_SITL.h
+++ b/libraries/AP_RPM/RPM_SITL.h
@@ -14,9 +14,10 @@
  */
 #pragma once
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-
 #include "AP_RPM.h"
+
+#if AP_RPM_SIM_ENABLED
+
 #include "RPM_Backend.h"
 #include <SITL/SITL.h>
 
@@ -33,4 +34,4 @@ private:
     uint8_t instance;
 };
 
-#endif // CONFIG_HAL_BOARD
+#endif // AP_RPM_SIM_ENABLED


### PR DESCRIPTION
Tested in SITL using

```
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -601,6 +601,8 @@ class sitl(Board):
         cfg.define('AP_GENERATOR_RICHENPOWER_ENABLED', 1)
         cfg.define('AP_OPENDRONEID_ENABLED', 1)
         cfg.define('AP_SIGNED_FIRMWARE', 0)
+        cfg.define('AP_RPM_ENABLED', 0)
+        cfg.define('AP_ICENGINE_ENABLED', 0)
 
         if self.with_can:
             cfg.define('HAL_NUM_CAN_IFACES', 2)
```
