### PR TITLE
EKF3: fix EKF reported altitude against public origin

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2602,6 +2602,54 @@ class AutoTestCopter(AutoTest):
         self.wait_disarmed()
         self.progress("MOTORS DISARMED OK")
 
+    def GuidedEKFLaneChange(self):
+        '''test lane change with GPS diff on startup'''
+        self.set_parameters({
+            "EK3_SRC1_POSZ": 3,
+            "EK3_AFFINITY" : 1,
+            "GPS_TYPE2" : 1,
+            "SIM_GPS2_DISABLE" : 0,
+            "SIM_GPS2_GLTCH_Z" : -30
+            })
+        self.reboot_sitl()
+
+        self.change_mode("GUIDED")
+        self.wait_ready_to_arm()
+
+        self.progress("waiting for both EKF lanes to init")
+        self.delay_sim_time(10)
+
+        self.set_parameters({
+            "SIM_GPS2_GLTCH_Z" : 0
+            })
+
+        self.progress("waiting for EKF to do a position Z reset")
+        self.delay_sim_time(20)
+
+        self.arm_vehicle()
+        self.user_takeoff(alt_min=20)
+        m = self.mav.recv_match(type='GPS_RAW_INT', blocking=True)
+        gps_alt = m.alt*0.001
+        self.progress("Initial guided alt=%.1fm" % gps_alt)
+
+        self.context_collect('STATUSTEXT')
+        self.progress("force a lane change")
+        self.set_parameters({
+            "INS_ACCOFFS_X" : 5
+            })
+        self.wait_statustext("EKF3 lane switch 1", timeout=10, check_context=True)
+
+        self.delay_sim_time(10)
+        m = self.mav.recv_match(type='GPS_RAW_INT', blocking=True)
+        gps_alt2 = m.alt*0.001
+        alt_change = gps_alt - gps_alt2
+        self.progress("GPS Alt change by %.1fm" % abs(alt_change))
+
+        if abs(alt_change) > 2:
+            raise NotAchievedException("Altitude changed on lane switch %.1fm" % alt_change)
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
     def MotorFail(self, fail_servo=0, fail_mul=0.0, holdtime=30):
         """Test flight with reduced motor efficiency"""
 
@@ -9081,6 +9129,7 @@ class AutoTestCopter(AutoTest):
             self.GPSTypes,
             self.MultipleGPS,
             self.WatchAlts,
+            self.GuidedEKFLaneChange,
         ])
         return ret
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3440,22 +3440,6 @@ class AutoTestPlane(AutoTest):
         attempt_fence_breached_disable(start_mode="FBWA", end_mode="FBWA", expected_mode="GUIDED", action=6)
         attempt_fence_breached_disable(start_mode="FBWA", end_mode="FBWA", expected_mode="GUIDED", action=7)
 
-    def run_auxfunc(self,
-                    function,
-                    level,
-                    want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED):
-        self.run_cmd(
-            mavutil.mavlink.MAV_CMD_DO_AUX_FUNCTION,
-            function,  # p1
-            level,  # p2
-            0,  # p3
-            0,  # p4
-            0,  # p5
-            0,  # p6
-            0,  # p7
-            want_result=want_result
-        )
-
     def MAV_DO_AUX_FUNCTION(self):
         '''Test triggering Auxiliary Functions via mavlink'''
         self.context_collect('STATUSTEXT')

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3400,6 +3400,22 @@ class AutoTest(ABC):
     def get_mission_count(self):
         return self.get_parameter("MIS_TOTAL")
 
+    def run_auxfunc(self,
+                    function,
+                    level,
+                    want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED):
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_AUX_FUNCTION,
+            function,  # p1
+            level,  # p2
+            0,  # p3
+            0,  # p4
+            0,  # p5
+            0,  # p6
+            0,  # p7
+            want_result=want_result
+        )
+
     def assert_mission_count(self, expected):
         count = self.get_mission_count()
         if count != expected:

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1375,6 +1375,10 @@ bool NavEKF3::getOriginLLH(struct Location &loc) const
     if (!core) {
         return false;
     }
+    if (common_origin_valid) {
+        loc = common_EKF_origin;
+        return true;
+    }
     return core[primary].getOriginLLH(loc);
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -268,6 +268,12 @@ bool NavEKF3_core::getPosD(float &posD) const
         posD = outputDataNew.position.z + posOffsetNED.z + 0.01f * (float)EKF_origin.alt - (float)ekfGpsRefHgt;
     }
 
+    // adjust posD for difference between our origin and the public_origin
+    Location local_origin;
+    if (getOriginLLH(local_origin)) {
+        posD += (public_origin.alt - local_origin.alt) * 0.01;
+    }
+
     // Return the current height solution status
     return filterStatus.flags.vert_pos;
 


### PR DESCRIPTION
This fixes an issue that happens with the following scenario:
 - EK3_AFFINITY=1, giving GPS affinity
 - EK3_SRC1_POSZ=3 using GPS altitude
 - dual GPS enabled
 - at startup the two GPS modules give different AMSL alt
 - this causes XKF1[0].OH and XKF1[1].OH to differ by the GPS height difference
 - the difference in AMSL alt between the GPS modules goes away before takeoff
 - this causes XKF1.PD to compensate for the difference in origin
 - takeoff copter in GUIDED mode
 - we get a temporary glitch that causes a lane change
 - on the new lane the reported above-origin alt changes, causing copter to change altitude (in the provided log it led to a crash)

This PR adds a test that reproduces the issue in SITL and also a fix so that the reported origin uses the public origin and getPosD() in EKF3 adjusts for the difference in origin alt between public origin and the local lane origin
