### PR TITLE
Add two new board IDs I am working on

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -180,6 +180,8 @@ AP_HW_AEROFOX_AIRSPEED               1077
 AP_HW_ATOMRCF405                     1078
 AP_HW_CUBEPILOT_CANMOD               1079
 AP_HW_AEROFOX_PMU                     1080
+AP_HW_FlywooGOKU_F405-RX             1081
+AP_HW_FlywooGOKU_F405                1082
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -180,7 +180,7 @@ AP_HW_AEROFOX_AIRSPEED               1077
 AP_HW_ATOMRCF405                     1078
 AP_HW_CUBEPILOT_CANMOD               1079
 AP_HW_AEROFOX_PMU                     1080
-AP_HW_FlywooGOKU_F405-RX             1081
+AP_HW_FlywooGOKU_F405_RX             1081
 AP_HW_FlywooGOKU_F405                1082
 
 AP_HW_CUBEORANGE_PERIPH              1400


### PR DESCRIPTION
I am working on adding in two new boards they are GOKU Versatile F405 1-2S 12A AIO W / build-in ELRS 2.4g RX (MPU6000) and GOKU Versatile F405 1-2S 12A AIO  (MPU6000). Should I add them in separate like I have done above as one has built in ELRS and the other does not? I have most of the hwdef files completed but am struggling with the timers and dma settings. This board is almost identical to this FC (JHEMCU GSF405A 1S-2S AIO F4 FLIGHT CONTROL W/ 5A ESC & ELRS 2.4G RX - 25.5×25.5MM) with the exception of a cpl more motor outputs on the GOKU. Please be kind this is my first stab at doing a lot of this as well as github! @peterbarker 