### PR TITLE
AP_Arming: Remote ID pre-arm check with Remote ID enabled

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1401,7 +1401,7 @@ bool AP_Arming::opendroneid_checks(bool display_failure)
     auto &opendroneid = AP::opendroneid();
 
     char failure_msg[50] {};
-    if (!opendroneid.pre_arm_check(failure_msg, sizeof(failure_msg))) {
+    if (opendroneid.enabled() && !opendroneid.pre_arm_check(failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "OpenDroneID: %s", failure_msg);
         return false;
     }


### PR DESCRIPTION
I set the DID enable setting to DISABLED.
However, I ran a pre-arm check.
I prearm check when the DID enable setting is ENABLED.
In Japan, there are vehicles that must transmit remote ID and vehicles that do not have to.
I prefer to choose not to transmit even if the driver is built in.

AFTER
![Screenshot from 2022-10-02 08-01-37](https://user-images.githubusercontent.com/646194/193431640-5452093e-8349-437e-a9c7-795b94b47b7b.png)

BEFORE
![Screenshot from 2022-10-02 07-59-50](https://user-images.githubusercontent.com/646194/193431652-b0af11e9-c180-4254-8838-72614b0c9b6c.png)