### PR TITLE
Copter: Reorder Alt_hold state switch statement for clarity

### DIFF
--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -131,6 +131,17 @@ void ModeLoiter::run()
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
         break;
 
+    case AltHold_Landed_Ground_Idle:
+        attitude_control->reset_yaw_target_and_rate();
+        FALLTHROUGH;
+
+    case AltHold_Landed_Pre_Takeoff:
+        attitude_control->reset_rate_controller_I_terms_smoothly();
+        loiter_nav->init_target();
+        attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
+        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        break;
+
     case AltHold_Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
@@ -148,17 +159,6 @@ void ModeLoiter::run()
 
         // call attitude controller
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
-        break;
-
-    case AltHold_Landed_Ground_Idle:
-        attitude_control->reset_yaw_target_and_rate();
-        FALLTHROUGH;
-
-    case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms_smoothly();
-        loiter_nav->init_target();
-        attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHold_Flying:

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -115,6 +115,22 @@ void ModePosHold::run()
         init_wind_comp_estimate();
         break;
 
+    case AltHold_Landed_Ground_Idle:
+        loiter_nav->clear_pilot_desired_acceleration();
+        loiter_nav->init_target();
+        attitude_control->reset_yaw_target_and_rate();
+        init_wind_comp_estimate();
+        FALLTHROUGH;
+
+    case AltHold_Landed_Pre_Takeoff:
+        attitude_control->reset_rate_controller_I_terms_smoothly();
+        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+
+        // set poshold state to pilot override
+        roll_mode = RPMode::PILOT_OVERRIDE;
+        pitch_mode = RPMode::PILOT_OVERRIDE;
+        break;
+
     case AltHold_Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
@@ -130,22 +146,6 @@ void ModePosHold::run()
         // init and update loiter although pilot is controlling lean angles
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
-
-        // set poshold state to pilot override
-        roll_mode = RPMode::PILOT_OVERRIDE;
-        pitch_mode = RPMode::PILOT_OVERRIDE;
-        break;
-
-    case AltHold_Landed_Ground_Idle:
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
-        attitude_control->reset_yaw_target_and_rate();
-        init_wind_comp_estimate();
-        FALLTHROUGH;
-
-    case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
 
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -80,6 +80,15 @@ void ModeSport::run()
         pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
+    case AltHold_Landed_Ground_Idle:
+        attitude_control->reset_yaw_target_and_rate();
+        FALLTHROUGH;
+
+    case AltHold_Landed_Pre_Takeoff:
+        attitude_control->reset_rate_controller_I_terms_smoothly();
+        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        break;
+
     case AltHold_Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
@@ -91,15 +100,6 @@ void ModeSport::run()
 
         // set position controller targets adjusted for pilot input
         takeoff.do_pilot_takeoff(target_climb_rate);
-        break;
-
-    case AltHold_Landed_Ground_Idle:
-        attitude_control->reset_yaw_target_and_rate();
-        FALLTHROUGH;
-
-    case AltHold_Landed_Pre_Takeoff:
-        attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHold_Flying:


### PR DESCRIPTION
This is a simple clean up of Loiter, PosHold and Sport modes to make the state machine easer to read and understand.

No behaviour changes, just some moved code in the switch statement where each section starts and ends in a break.