### PR TITLE
Copter: Message length within 50 bytes

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -292,7 +292,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
     }
 
     if (!new_flightmode->init(ignore_checks)) {
-        mode_change_failed(new_flightmode, "initialisation failed");
+        mode_change_failed(new_flightmode, "init failed");
         return false;
     }
 


### PR DESCRIPTION
This "Mode change to AUTOTUNE failed: initialisation failed" message was split in two.
The split "led" was displayed on the MP's HUD.
One message is 50 bytes.
I will change the short name to flight mode.
I want to use 1 message for message display and voice notification.

AFTER
![Screenshot from 2022-10-02 11-23-03](https://user-images.githubusercontent.com/646194/193435262-867fa570-248a-4077-b60e-758bc2ac6248.png)
