### PR TITLE
AP_TECS: reset vdot filter if not been called

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -308,6 +308,7 @@ void AP_TECS::update_50hz(void)
         _height_filter.dd_height = 0.0f;
         DT            = 0.02f; // when first starting TECS, use a
         // small time constant
+        _vdot_filter.reset();
     }
     _update_50hz_last_usec = now;
 


### PR DESCRIPTION
Does what it says on the tin. We stop calling the `update_50hz` function if not in a auto throttle mode, in that case we end up with a big gap and should reset the filter.

From a TECS point of view we might be better to just always call the update function so there is never a need to reset. It would be even nicer if the AHRS could provide the filtered heights and accelerations calculated in this function. 