### PR TITLE
ChibiOS: added warnings for incorrect 1M/2M firmware

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -23,6 +23,7 @@ jobs:
             periph-build,
             iofirmware,
             CubeOrange-bootloader,
+            fmuv3-bootloader,
             revo-bootloader,
             stm32h7-debug,
             fmuv3,

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -54,6 +54,8 @@ jobs:
             config: CubeOrange-ODID
           - gcc: 6
             config: signing
+          - gcc: 6
+            config: fmuv3-bootloader
         include:
           - config: stm32h7
             toolchain: chibios-py2

--- a/Tools/AP_Bootloader/mcu_f4.h
+++ b/Tools/AP_Bootloader/mcu_f4.h
@@ -29,12 +29,12 @@ const mcu_des_t mcu_descriptions[] = {
 };
 
 const mcu_rev_t silicon_revs[] = {
-    {MCU_REV_STM32F4_REV_3, '3', false}, /* Revision 3 */
+    {MCU_REV_STM32F4_REV_3, '3'}, /* Revision 3 */
 
-    {MCU_REV_STM32F4_REV_A, 'A', true}, /* Revision A */
-    {MCU_REV_STM32F4_REV_Z, 'Z', true}, /* Revision Z */
-    {MCU_REV_STM32F4_REV_Y, 'Y', true}, /* Revision Y */
-    {MCU_REV_STM32F4_REV_1, '1', true}, /* Revision 1 */
+    {MCU_REV_STM32F4_REV_A, 'A'}, /* Revision A */
+    {MCU_REV_STM32F4_REV_Z, 'Z'}, /* Revision Z */
+    {MCU_REV_STM32F4_REV_Y, 'Y'}, /* Revision Y */
+    {MCU_REV_STM32F4_REV_1, '1'}, /* Revision 1 */
 };
 
 #endif // STM32F4

--- a/Tools/AP_Bootloader/mcu_h7.h
+++ b/Tools/AP_Bootloader/mcu_h7.h
@@ -13,10 +13,10 @@ mcu_des_t mcu_descriptions[] = {
 };
 
 const mcu_rev_t silicon_revs[] = {
-    {0x1001, 'Z', false},
-    {0x1003, 'Y', false},
-    {0x2001, 'X', false},
-    {0x2003, 'V', false},
+    {0x1001, 'Z'},
+    {0x1003, 'Y'},
+    {0x2001, 'X'},
+    {0x2003, 'V'},
 };
 
 #endif // STM32H7

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -274,24 +274,6 @@ uint32_t get_mcu_desc(uint32_t max, uint8_t *revstr)
     return  strp - revstr;
 }
 
-/*
-  see if we should limit flash to 1M on devices with older revisions
- */
-bool check_limit_flash_1M(void)
-{
-#ifdef STM32F427xx
-    uint32_t idcode = (*(uint32_t *)DBGMCU_BASE);
-    uint16_t revid = ((idcode & REVID_MASK) >> 16);
-
-    for (int i = 0; i < ARRAY_SIZE(silicon_revs); i++) {
-        if (silicon_revs[i].revid == revid) {
-            return silicon_revs[i].limit_flash_size_1M;
-        }
-    }
-#endif
-    return false;
-}
-
 void led_on(unsigned led)
 {
 #ifdef HAL_GPIO_PIN_LED_BOOTLOADER

--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -36,7 +36,6 @@ bool flash_write_buffer(uint32_t address, const uint32_t *v, uint8_t nwords);
 
 uint32_t get_mcu_id(void);
 uint32_t get_mcu_desc(uint32_t len, uint8_t *buf);
-bool check_limit_flash_1M(void);
 
 uint32_t board_get_rtc_signature(void);
 void board_set_rtc_signature(uint32_t sig);
@@ -62,5 +61,4 @@ typedef struct mcu_des_t {
 typedef struct mcu_rev_t {
     uint16_t revid;
     char  rev;
-    bool limit_flash_size_1M;
 } mcu_rev_t;

--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -51,7 +51,7 @@ def build_board(board):
     if args.signing_key is not None:
         print("Building secure bootloader")
         configure_args.append("--signed-fw")
-    if args.debug is not None:
+    if args.debug:
         print("Building with debug symbols")
         configure_args.append("--debug")
     if not run_program(["./waf", "configure"] + configure_args):

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -245,6 +245,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "fmuv3-bootloader" ]; then
+        echo "Building fmuv3 bootloader"
+        $waf configure --board fmuv3 --bootloader
+        $waf clean
+        $waf bootloader
+        continue
+    fi
+    
     if [ "$t" == "stm32f7" ]; then
         echo "Building mRoX21-777/"
         $waf configure --Werror --board mRoX21-777

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-bdshot/hwdef.dat
@@ -1,6 +1,7 @@
 # Bi-directional dshot version of MatekF405
 
 include ../MatekF405/hwdef.dat
+include ../include/minimal_GPS.inc
 
 undef PC6 PC9 PA8
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1-1M/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1-1M/hwdef.dat
@@ -3,6 +3,10 @@
 
 include ../Pixhawk1/hwdef.dat
 
+# only include UBLOX and NMEA GPS drivers
+define AP_GPS_NMEA_ENABLED 1
+include ../include/minimal_GPS.inc
+
 FLASH_SIZE_KB 1024
 define HAL_MINIMIZE_FEATURES 1
 undef STORAGE_FLASH_PAGE

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1-1M/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1-1M/hwdef.dat
@@ -6,3 +6,6 @@ include ../Pixhawk1/hwdef.dat
 FLASH_SIZE_KB 1024
 define HAL_MINIMIZE_FEATURES 1
 undef STORAGE_FLASH_PAGE
+
+# produce this error if we are on a 2M board and using 1M firmware
+define BOARD_CHECK_F427_USE_2M "2M flash - use Pixhawk1 firmware"

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/hwdef.dat
@@ -33,3 +33,7 @@ COMPASS LSM303D SPI:lsm9ds0_am ROTATION_NONE
 
 # also probe for external compasses
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+
+# produce this error if we are on a 1M board
+undef BOARD_CHECK_F427_USE_1M
+define BOARD_CHECK_F427_USE_1M "ERROR: 1M flash use Pixhawk1-1M"

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.c
@@ -558,3 +558,20 @@ unsigned int stm32_rand_generate_nonblocking(unsigned char* output, unsigned int
 }
 
 #endif // #if HAL_USE_HW_RNG && defined(RNG)
+
+/*
+  see if we should limit flash to 1M on devices with older revisions of STM32F427
+ */
+bool check_limit_flash_1M(void)
+{
+#ifdef STM32F427xx
+    const uint16_t revid = (*(uint32_t *)DBGMCU_BASE) >> 16;
+    static const uint16_t badrevs[4] = { 0x1000, 0x1001, 0x1003, 0x1007 };
+    for (uint8_t i=0; i<4; i++) {
+        if (revid == badrevs[i]) {
+            return true;
+        }
+    }
+#endif
+    return false;
+}

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
@@ -54,6 +54,11 @@ uint64_t stm32_get_utc_usec(void);
 // hook for FAT timestamps    
 uint32_t get_fattime(void);
 
+/*
+  see if we should limit flash to 1M on devices with older revisions of STM32F427
+ */
+bool check_limit_flash_1M(void);
+
 // one-time programmable area
 #if defined(FLASH_OTP_BASE)
 #define OTP_BASE FLASH_OTP_BASE

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv2/hwdef.dat
@@ -16,3 +16,6 @@ undef STORAGE_FLASH_PAGE
 
 # minimal drivers to reduce flash usage
 include ../include/minimal.inc
+
+# produce this error if we are on a 2M board and using 1M firmware
+define BOARD_CHECK_F427_USE_2M "2M flash - use fmuv3 firmware"

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -472,3 +472,6 @@ ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin
 # for users running fmuv3 on their Solo:
 define HAL_OREO_LED_ENABLED (BOARD_FLASH_SIZE > 1024)
 define HAL_SOLO_GIMBAL_ENABLED (HAL_MOUNT_ENABLED && BOARD_FLASH_SIZE > 1024)
+
+# produce this error if we are on a 1M board
+define BOARD_CHECK_F427_USE_1M "ERROR: 1M flash use fmuv2"

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro-bdshot/hwdef.dat
@@ -2,6 +2,7 @@
 # Buzzer timer is required so becomes single tone
 
 include ../omnibusf4pro/hwdef.dat
+include ../include/minimal_GPS.inc
 
 undef PB0 PB1 PA3 PB4 PA2 PA1
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -13,6 +13,7 @@
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 #include <AP_HAL_ChibiOS/sdcard.h>
+#include <AP_HAL_ChibiOS/hwdef/common/stm32_util.h>
 #endif
 
 #define SCHED_TASK(func, rate_hz, max_time_micros, prio) SCHED_TASK_CLASS(AP_Vehicle, &vehicle, func, rate_hz, max_time_micros, prio)
@@ -364,6 +365,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if HAL_EFI_ENABLED
     SCHED_TASK_CLASS(AP_EFI,       &vehicle.efi,            update,                   50, 200, 250),
 #endif
+#if HAL_INS_ACCELCAL_ENABLED
+    SCHED_TASK(one_Hz_update,                                                         1, 100, 252),
+#endif
     SCHED_TASK(update_arming,          1,     50, 253),
 };
 
@@ -679,6 +683,36 @@ void AP_Vehicle::accel_cal_update()
 void AP_Vehicle::update_arming()
 {
     AP::arming().update();
+}
+
+/*
+  one Hz checks common to all vehicles
+ */
+void AP_Vehicle::one_Hz_update(void)
+{
+    one_Hz_counter++;
+
+    /*
+      every 10s check if using a 2M firmware on a 1M board
+     */
+    if (one_Hz_counter % 10U == 0) {
+#if defined(BOARD_CHECK_F427_USE_1M) && (BOARD_FLASH_SIZE>1024)
+        if (!hal.util->get_soft_armed() && check_limit_flash_1M()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, BOARD_CHECK_F427_USE_1M);
+        }
+#endif
+    }
+
+    /*
+      every 30s check if using a 1M firmware on a 2M board
+     */
+    if (one_Hz_counter % 30U == 0) {
+#if defined(BOARD_CHECK_F427_USE_1M) && (BOARD_FLASH_SIZE<=1024)
+        if (!hal.util->get_soft_armed() && !check_limit_flash_1M()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, BOARD_CHECK_F427_USE_2M);
+        }
+#endif
+    }
 }
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -444,6 +444,10 @@ private:
     // run notch update at either loop rate or 200Hz
     void update_dynamic_notch_at_specified_rate();
 
+    // decimation for 1Hz update
+    uint8_t one_Hz_counter;
+    void one_Hz_update();
+
     bool likely_flying;         // true if vehicle is probably flying
     uint32_t _last_flying_ms;   // time when likely_flying last went true
     uint32_t _last_notch_update_ms[HAL_INS_NUM_HARMONIC_NOTCH_FILTERS]; // last time update_dynamic_notch() was run
@@ -451,6 +455,7 @@ private:
     static AP_Vehicle *_singleton;
 
     bool done_safety_init;
+
 
     uint32_t _last_internal_errors;  // backup of AP_InternalError::internal_errors bitmask
 


### PR DESCRIPTION
This adds a warning when running a firmware meant for 2M boards on a board with 1M flash. This can happen if you have an old enough bootloader that it doesn't limit flash size to 1M. This is sent at level CRITICAL so it displays on the HUD:
![image](https://user-images.githubusercontent.com/831867/193759802-5a8d41d5-c621-4a4f-a04f-786168443e91.png)
the PR also adds an INFO warning every 30s if you are running a 1M firmware on a board that can use 2M. Sending as INFO means it just shows in the messages tab:
![image](https://user-images.githubusercontent.com/831867/193760001-52956dd5-268b-40a3-a580-fe44116b1688.png)
