### PR TITLE
build: fixed stm32 build with g++ 11.3

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -704,6 +704,7 @@ def build(bld):
                 'fiprintf','printf',
                 'fopen', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
                 'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',
-                'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf' ]
+                'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf',
+                '_gettimeofday', '_times', '_times_r', '_gettimeofday_r', 'time', 'clock' ]
     for w in wraplist:
         bld.env.LINKFLAGS += ['-Wl,--wrap,%s' % w]

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -89,6 +89,7 @@ default_ports = ['/dev/serial/by-id/usb-Ardu*',
                  '/dev/serial/by-id/usb-*-BL_*',
                  '/dev/serial/by-id/usb-*_BL_*',
                  '/dev/serial/by-id/usb-Swift-Flyer*',
+                 '/dev/serial/by-id/usb-CubePilot*',
                  '/dev/tty.usbmodem*']
 
 if "cygwin" in _platform or is_WSL:

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -85,7 +85,13 @@ void malloc_init(void)
     // check for changes which indicate a write to an uninitialised
     // object.  We start at address 0x1 as writing the first byte
     // causes a fault
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#if defined(__GNUC__) &&  __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     memset((void*)0x00000001, 0, 1023);
+#pragma GCC diagnostic pop
 #endif
 
     uint8_t i;

--- a/libraries/AP_Scripting/lua/src/lauxlib.c
+++ b/libraries/AP_Scripting/lua/src/lauxlib.c
@@ -1044,3 +1044,15 @@ LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver, size_t sz) {
                   (LUAI_UACNUMBER)ver, (LUAI_UACNUMBER)*v);
 }
 
+
+/*
+  32 bit random number generator for lua internals
+ */
+uint32_t lua_random32(void)
+{
+    static uint32_t m_z = 1234;
+    static uint32_t m_w = 76542;
+    m_z = 36969 * (m_z & 0xFFFFu) + (m_z >> 16);
+    m_w = 18000 * (m_w & 0xFFFFu) + (m_w >> 16);
+    return ((m_z << 16) + m_w);
+}

--- a/libraries/AP_Scripting/lua/src/lauxlib.h
+++ b/libraries/AP_Scripting/lua/src/lauxlib.h
@@ -36,6 +36,8 @@ typedef struct luaL_Reg {
 
 #define LUAL_NUMSIZES	(sizeof(lua_Integer)*16 + sizeof(lua_Number))
 
+uint32_t lua_random32(void);
+
 LUALIB_API void (luaL_checkversion_) (lua_State *L, lua_Number ver, size_t sz);
 #define luaL_checkversion(L)  \
 	  luaL_checkversion_(L, LUA_VERSION_NUM, LUAL_NUMSIZES)

--- a/libraries/AP_Scripting/lua/src/lstate.c
+++ b/libraries/AP_Scripting/lua/src/lstate.c
@@ -26,6 +26,7 @@
 #include "lstring.h"
 #include "ltable.h"
 #include "ltm.h"
+#include "lauxlib.h"
 
 // lua code does lots of casting, these warnings are not helpful
 #pragma GCC diagnostic ignored "-Wcast-align"
@@ -44,9 +45,13 @@
 ** a macro to help the creation of a unique random seed when a state is
 ** created; the seed is used to randomize hashes.
 */
+#if defined(ARDUPILOT_BUILD)
+#define luai_makeseed() lua_random32()
+#else
 #if !defined(luai_makeseed)
 #include <time.h>
 #define luai_makeseed()		cast(unsigned int, time(NULL))
+#endif
 #endif
 
 

--- a/libraries/AP_Scripting/lua/src/ltablib.c
+++ b/libraries/AP_Scripting/lua/src/ltablib.c
@@ -256,6 +256,9 @@ typedef unsigned int IdxT;
 ** is to copy them to an array of a known type and use the array values.
 */
 static unsigned int l_randomizePivot (void) {
+#if defined(ARDUPILOT_BUILD)
+  return lua_random32();
+#else
   clock_t c = clock();
   time_t t = time(NULL);
   unsigned int buff[sof(c) + sof(t)];
@@ -265,6 +268,7 @@ static unsigned int l_randomizePivot (void) {
   for (i = 0; i < sof(buff); i++)
     rnd += buff[i];
   return rnd;
+#endif
 }
 
 #endif					/* } */

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -579,7 +579,12 @@ int GCS_MAVLINK::gen_dir_entry(char *dest, size_t space, const char *path, const
     }
 
     if (is_file) {
-        const size_t full_path_len = strlen(path) + strnlen(entry->d_name, 256); // FIXME: Really should do better then just hardcoding 256
+#ifdef MAX_NAME_LEN
+        const uint8_t max_name_len = MIN(unsigned(MAX_NAME_LEN), 255U);
+#else
+        const uint8_t max_name_len = 255U;
+#endif
+        const size_t full_path_len = strlen(path) + strnlen(entry->d_name, max_name_len);
         char full_path[full_path_len + 2];
         hal.util->snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
         struct stat st;


### PR DESCRIPTION
With the 11.3 compiler we gain about 6.5k of flash on 2M boards. It also found some bugs. The key bug was two places in lua where it tried to use clock() and time() to get a random number, which actually gave constants.
This may well impact performance of the heap in lua
We need to flight test builds with the 11.3 compiler to see if we can switch to it for 4.4.x

