### PR TITLE
Correct compilation when most features out, one in

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -373,12 +373,14 @@ for t in $CI_BUILD_TARGET; do
              --no-disable-all \
              --no-disable-none \
              --no-disable-in-turn \
+             --no-enable-in-turn \
              --board=CubeOrange \
              --build-targets=copter \
              --build-targets=plane
         echo "Checking all/none options in build_options.py work"
         time ./Tools/autotest/test_build_options.py \
              --no-disable-in-turn \
+             --no-enable-in-turn \
              --build-targets=copter \
              --build-targets=plane
         continue

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -147,7 +147,7 @@ BUILD_OPTIONS = [
     Feature('Rangefinder', 'RANGEFINDER_NMEA', 'AP_RANGEFINDER_NMEA_ENABLED', "Enable Rangefinder - NMEA", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_PULSEDLIGHTLRF', 'AP_RANGEFINDER_PULSEDLIGHTLRF_ENABLED', "Enable Rangefinder - PulsedLightLRF", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_PWM', 'AP_RANGEFINDER_PWM_ENABLED', "Enable Rangefinder - PWM", 0, "RANGEFINDER"),   # NOQA: E501
-    Feature('Rangefinder', 'RANGEFINDER_SIM', 'AP_RANGEFINDER_SIM_ENABLED', "Enable Rangefinder - SIM", 0, "RANGEFINDER"),   # NOQA: E501
+    # Feature('Rangefinder', 'RANGEFINDER_SIM', 'AP_RANGEFINDER_SIM_ENABLED', "Enable Rangefinder - SIM", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_TRI2C', 'AP_RANGEFINDER_TRI2C_ENABLED', "Enable Rangefinder - TeraRangerI2C", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_TR_SERIAL', 'AP_RANGEFINDER_TERARANGER_SERIAL_ENABLED', "Enable Rangefinder - TeraRanger Serial", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_UAVCAN', 'AP_RANGEFINDER_UAVCAN_ENABLED', "Enable Rangefinder - UAVCAN", 0, "RANGEFINDER"),   # NOQA: E501

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -55,7 +55,7 @@ BUILD_OPTIONS = [
     Feature('Ident', 'AIS', 'AP_AIS_ENABLED', 'Enable AIS', 0, None),
 
     Feature('Telemetry', 'CRSF', 'HAL_CRSF_TELEM_ENABLED', 'Enable CRSF Telemetry', 0, None),
-    Feature('Telemetry', 'CRSFText', 'HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED', 'Enable CRSF Text Param Selection', 0, 'CRSF'),
+    Feature('Telemetry', 'CRSFText', 'HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED', 'Enable CRSF Text Param Selection', 0, 'CRSF,OSD_PARAM'),  # NOQA: E501
     Feature('Telemetry', 'HIGHLAT2', 'HAL_HIGH_LATENCY2_ENABLED', 'Enable HighLatency2 Support', 0, None),
     Feature('Telemetry', 'HOTT', 'HAL_HOTT_TELEM_ENABLED', 'Enable HOTT Telemetry', 0, None),
     Feature('Telemetry', 'SPEKTRUM', 'HAL_SPEKTRUM_TELEM_ENABLED', 'Enable Spektrum Telemetry', 0, None),

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -225,4 +225,4 @@ BUILD_OPTIONS = [
     Feature('Payload', 'Camera', 'AP_CAMERA_ENABLED', 'Enable Camera Trigger support', 0, None),
 ]
 
-BUILD_OPTIONS.sort(key=lambda x: x.category)
+BUILD_OPTIONS.sort(key=lambda x: (x.category + x.label))

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -71,7 +71,9 @@ BUILD_OPTIONS = [
 
     Feature('ICE', 'ICE Engine', 'AP_ICENGINE_ENABLED', 'Enable Internal Combustion Engine support', 0, 'RPM'),
     Feature('ICE', 'EFI', 'HAL_EFI_ENABLED', 'Enable EFI Monitoring', 0, None),
-    Feature('ICE', 'EFI_NMPWU', 'HAL_EFI_NWPWU_ENABLED', 'Enable EFI NMPMU', 0, None),
+    Feature('ICE', 'EFI_NMPWU', 'HAL_EFI_NWPWU_ENABLED', 'Enable EFI NMPMU', 0, 'EFI'),
+    Feature('ICE', 'EFI_CURRAWONGECU', 'HAL_EFI_CURRAWONG_ECU_ENABLED', 'Enable EFI Currawong ECU', 0, 'EFI'),
+    Feature('ICE', 'EFI_DRONECAN', 'HAL_EFI_DRONECAN_ENABLED', 'Enable EFI DroneCAN', 0, 'EFI'),
     Feature('ICE', 'GENERATOR', 'HAL_GENERATOR_ENABLED', 'Enable Generator', 0, None),
 
     Feature('OSD', 'OSD', 'OSD_ENABLED', 'Enable OSD', 0, None),

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -171,7 +171,7 @@ BUILD_OPTIONS = [
     Feature('Sensors', 'BMP388', 'AP_BARO_BMP388_ENABLED', 'Enable BMP388 Barometric Sensor', 1, None),
     Feature('Sensors', 'DPS280', 'AP_BARO_DPS280_ENABLED', 'Enable DPS280 Barometric Sensor', 1, None),
     Feature('Sensors', 'DUMMY', 'AP_BARO_DUMMY_ENABLED', 'Enable DUMMY Barometric Sensor', 0, None),
-    Feature('Sensors', 'EXTERNALAHRS', 'AP_BARO_EXTERNALAHRS_ENABLED', 'Enable EXTERNALAHRS Barometric Sensor', 0, None),
+    Feature('Sensors', 'EXTERNALAHRS', 'AP_BARO_EXTERNALAHRS_ENABLED', 'Enable EXTERNALAHRS Barometric Sensor', 0, 'AHRS_EXT'),
     Feature('Sensors', 'FBM320', 'AP_BARO_FBM320_ENABLED', 'Enable FBM320 Barometric Sensor', 1, None),
     Feature('Sensors', 'ICM20789', 'AP_BARO_ICM20789_ENABLED', 'Enable ICM20789 Barometric Sensor', 1, None),
     Feature('Sensors', 'KELLERLD', 'AP_BARO_KELLERLD_ENABLED', 'Enable KELLERLD Barometric Sensor', 1, None),

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -126,8 +126,8 @@ BUILD_OPTIONS = [
 
     Feature('Rangefinder', 'RANGEFINDER', 'AP_RANGEFINDER_ENABLED', "Enable Rangefinders", 0, None),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_ANALOG', 'AP_RANGEFINDER_ANALOG_ENABLED', "Enable Rangefinder - Analog", 0, "RANGEFINDER"),   # NOQA: E501
-    Feature('Rangefinder', 'RANGEFINDER_BBB_PRU', 'AP_RANGEFINDER_BBB_PRU_ENABLED', "Enable Rangefinder - BBB PRU", 0, "RANGEFINDER"),   # NOQA: E501
-    Feature('Rangefinder', 'RANGEFINDER_BEBOP', 'AP_RANGEFINDER_BEBOP_ENABLED', "Enable Rangefinder - Bebop", 0, "RANGEFINDER"),   # NOQA: E501
+    # Feature('Rangefinder', 'RANGEFINDER_BBB_PRU', 'AP_RANGEFINDER_BBB_PRU_ENABLED', "Enable Rangefinder - BBB PRU", 0, "RANGEFINDER"),   # NOQA: E501
+    # Feature('Rangefinder', 'RANGEFINDER_BEBOP', 'AP_RANGEFINDER_BEBOP_ENABLED', "Enable Rangefinder - Bebop", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_BENEWAKE_CAN', 'AP_RANGEFINDER_BENEWAKE_CAN_ENABLED', "Enable Rangefinder - Benewake (CAN)", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_BENEWAKE_TF02', 'AP_RANGEFINDER_BENEWAKE_TF02_ENABLED', "Enable Rangefinder - Benewake -TF02", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_BENEWAKE_TF03', 'AP_RANGEFINDER_BENEWAKE_TF03_ENABLED', "Enable Rangefinder - Benewake - TF03", 0, "RANGEFINDER"),   # NOQA: E501

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -258,6 +258,7 @@ bool AP_RPM::arming_checks(size_t buflen, char *buffer) const
 {
     for (uint8_t i=0; i<RPM_MAX_INSTANCES; i++) {
         switch (_params[i].type) {
+#if AP_RPM_PIN_ENABLED
         case RPM_TYPE_PWM:
         case RPM_TYPE_PIN:
             if (_params[i].pin == -1) {
@@ -274,6 +275,7 @@ bool AP_RPM::arming_checks(size_t buflen, char *buffer) const
                 return false;
             }
             break;
+#endif
         }
     }
     return true;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
@@ -17,13 +17,13 @@
 #if AP_RANGEFINDER_SIM_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
+#include <SITL/SITL.h>
 
 /*
   constructor - registers instance at top RangeFinder driver
  */
 AP_RangeFinder_SITL::AP_RangeFinder_SITL(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, uint8_t instance) :
     AP_RangeFinder_Backend(_state, _params),
-    sitl(AP::sitl()),
     _instance(instance)
 {}
 
@@ -32,7 +32,7 @@ AP_RangeFinder_SITL::AP_RangeFinder_SITL(RangeFinder::RangeFinder_State &_state,
  */
 void AP_RangeFinder_SITL::update(void)
 {
-    const float dist = sitl->get_rangefinder(_instance);
+    const float dist = AP::sitl()->get_rangefinder(_instance);
 
     // negative distance means nothing is connected
     if (is_negative(dist)) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.h
@@ -24,8 +24,6 @@
 
 #if AP_RANGEFINDER_SIM_ENABLED
 
-#include <SITL/SITL.h>
-
 class AP_RangeFinder_SITL : public AP_RangeFinder_Backend {
 public:
     // constructor. This incorporates initialisation as well.
@@ -39,9 +37,6 @@ protected:
     MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
         return MAV_DISTANCE_SENSOR_UNKNOWN;
     }
-
-private:
-    SITL::SIM *sitl;
 
     uint8_t _instance;
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -352,7 +352,7 @@ void AP_UAVCAN::init(uint8_t driver_index, bool enable_filters)
 #if AP_RANGEFINDER_UAVCAN_ENABLED
     AP_RangeFinder_UAVCAN::subscribe_msgs(this);
 #endif
-#if HAL_EFI_ENABLED
+#if HAL_EFI_DRONECAN_ENABLED
     AP_EFI_DroneCAN::subscribe_msgs(this);
 #endif
 

--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -334,7 +334,7 @@ void AirSim::recv_fdm(const sitl_input& input)
     }
 
     // Update Rangefinder data, max sensors limit as defined
-    uint8_t rng_sensor_count = MIN(state.rng.rng_distances.length, RANGEFINDER_MAX_INSTANCES);
+    uint8_t rng_sensor_count = MIN(state.rng.rng_distances.length, ARRAY_SIZE(rangefinder_m));
     for (uint8_t i=0; i<rng_sensor_count; i++) {
         rangefinder_m[i] = state.rng.rng_distances.data[i];
     }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -70,7 +70,7 @@ Aircraft::Aircraft(const char *frame_str) :
     }
 
     // init rangefinder array to -1 to signify no data
-    for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++){
+    for (uint8_t i = 0; i < ARRAY_SIZE(rangefinder_m); i++){
         rangefinder_m[i] = -1.0f;
     }
 }
@@ -954,7 +954,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
 
     {
         const float range = rangefinder_range();
-        for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+        for (uint8_t i=0; i<ARRAY_SIZE(rangefinder_m); i++) {
             rangefinder_m[i] = range;
         }
     }

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -205,7 +205,7 @@ protected:
     } scanner;
 
     // Rangefinder
-    float rangefinder_m[RANGEFINDER_MAX_INSTANCES];
+    float rangefinder_m[SITL_NUM_RANGEFINDERS];
 
     // Windvane apparent wind
     struct {

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -663,7 +663,7 @@ Vector3f SIM::convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro)
 
 // get the rangefinder reading for the desired rotation, returns -1 for no data
 float SIM::get_rangefinder(uint8_t instance) {
-    if (instance < RANGEFINDER_MAX_INSTANCES) {
+    if (instance < ARRAY_SIZE(state.rangefinder_m)) {
         return state.rangefinder_m[instance];
     }
     return -1;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -26,7 +26,6 @@
 #include "SIM_IntelligentEnergy24.h"
 #include "SIM_Ship.h"
 #include "SIM_GPS.h"
-#include <AP_RangeFinder/AP_RangeFinder.h>
 
 namespace SITL {
 
@@ -78,7 +77,8 @@ struct sitl_fdm {
         struct float_array ranges;
     } scanner;
 
-    float rangefinder_m[RANGEFINDER_MAX_INSTANCES];
+    #define SITL_NUM_RANGEFINDERS 10
+    float rangefinder_m[SITL_NUM_RANGEFINDERS];
     float airspeed_raw_pressure[AIRSPEED_MAX_SENSORS];
 
     struct {


### PR DESCRIPTION
Adds a feature to `test_build_options.py` which disables all features *except* one feature and its dependencies.

This PR also contains fixes for various problems found by this new test - mostly build_options.py dependencies, but also some transitive-include bugs.
