### PR TITLE
Factor accel trim calibration from GCS to INS

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -82,8 +82,6 @@ public:
     // a function called by the main thread at the main loop rate:
     void periodic();
 
-    bool calibrate_trim(Vector3f &trim_rad);
-
     /// calibrating - returns true if the gyros or accels are currently being calibrated
     bool calibrating() const;
 
@@ -280,9 +278,16 @@ public:
     void acal_update();
 #endif
 
-    // simple accel calibration
 #if HAL_GCS_ENABLED
+    bool calibrate_gyros();
+
+    MAV_RESULT calibrate_trim();
+
+    // simple accel calibration
     MAV_RESULT simple_accel_cal();
+private:
+    uint32_t last_accel_cal_ms;
+public:
 #endif
 
     bool accel_cal_requires_reboot() const { return _accel_cal_requires_reboot; }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -734,8 +734,6 @@ private:
     };
     void log_mavlink_stats();
 
-    uint32_t last_accel_cal_ms; // used to rate limit accel cals for bad links
-
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);
 
     // send a (textual) message to the GCS that a received message has


### PR DESCRIPTION
This refactors the accel trim calibration from being driven by GCS_MAVLink to living inside of AP_InertialSensor. This has a couple of benefits:

- It makes the simple accel and trim calibration live near each other, and keeps the MAVLink side simple and the same
- It allows us to inline some INS code that was only called in this code path
- It allows us to fix an edge case that wasn't caught with the rate limiting code
- Stops a degenerate case where you can try and do multiple different types of accel cal at once

To expand on the rate limiting issue that drove this effort, what could happen was if two commands for setting the trim were sent rapidly to the aircraft what would happen is the aircraft would begin the calibration and block the MAVLink thread. While doing the gyro calibration MAVLink would be handled from the delay callback. This allows a second command to be sent that resulted in a fail being sent because a second gyro calibration can't be sent while doing the first. The target was to be sending a temporary fail, or in progress.

This was bench tested on a CubeBlack with MAVProxy issuing the `ahrstrim` and `accelcalsimple` both giving them time between issuing them, and spamming, as well as using my degenerate test case that rapidly issues 2 commands, where before we would get a `MAV_RESULT_FAILED` then `MAV_RESULT_ACCEPTED`. Now we get `MAV_RESULT_TEMPORARILY_REJECTED` then `MAV_RESULT_ACCEPTED` which from a GCS perspective is far more useful because I can now trust that `MAV_RESULT_FAILED` means we actually failed. 