### PR TITLE
Plane: Quadplane: SLT: enforce TECS pitch limits to beat race

### DIFF
--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -87,6 +87,8 @@ public:
 
     bool show_vtol_view() const override;
 
+    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) override;
+
     bool set_FW_roll_limit(int32_t& roll_limit_cd) override;
 
     bool allow_update_throttle_mix() const override;


### PR DESCRIPTION
Because we set the TECS pitch limit after we have already got the pitch output in the first loop after starting to transition to forward flight we were getting one step where it was not applied. This results in a ugly twitch. 

Master:
![image](https://user-images.githubusercontent.com/33176108/193955215-6711fb59-889c-426b-b985-fd1c85e144e6.png)

This PR:
![image](https://user-images.githubusercontent.com/33176108/193955363-7c9d8b96-14d2-4c08-b379-2bd04d9617ed.png)

So the TECS output is unchanged in that first step, but we now enforce the desired pitch to the intended limit.

We still have a aggressive snap to 0 deg and then to 3 deg (Q_TRAN_PIT_MAX) as the pitch limit expands, which could be improved. But we no longer pitch past 0 and the back up again.