### PR TITLE
AP_Scripting: add winch binding and example script

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -905,6 +905,28 @@ function RC_Channel_ud:norm_input() end
 ---@return number
 function RC_Channel_ud:norm_input_dz() end
 
+-- desc
+---@class winch
+winch = {}
+
+-- desc
+---@return number
+function winch:get_rate_max() end
+
+-- desc
+---@param param1 number
+function winch:set_desired_rate(param1) end
+
+-- desc
+---@param param1 number
+function winch:release_length(param1) end
+
+-- desc
+function winch:relax() end
+
+-- desc
+---@return boolean
+function winch:healthy() end
 
 -- desc
 ---@class mount

--- a/libraries/AP_Scripting/examples/winch-test.lua
+++ b/libraries/AP_Scripting/examples/winch-test.lua
@@ -1,0 +1,97 @@
+-- mount-test.lua: allows the winch to be deployed or retracted at a fixed speed using an auxiliary switch
+--
+-- How To Use
+--   1. set RCx_OPTION to 300 to enable controlling the winch rate from an auxiliary switch
+--   2. optionally set WINCH_RATE_UP to the fixed retract speed (in m/s)
+--   3. optionally set WINCH_RATE_DN to the fixed deploy speed (in m/s)
+--   4. raise the RC auxiliary switch to retract the winch's line
+--   5. lower the RC auxiliary switch to deploy the winch's line
+--   6. center the RC auxiliary switch to stop the winch
+-- Alternatively a servo *output* can be used in place of the auxiliary switch input by setting WINCH_SRV_SRC_FN to match a servo channel's function.  For example
+--   a. set SERVO10_FUNCTION = 28 (Gripper)
+--   b. set WINCH_SRV_SRC_FN to 28
+--   c. use Mission Planner's Data screen's Servo/Relay tab to set the SERVO10 output to Low, Mid or High values
+--   Note: the full list of SERVOx_FUNCTION values that will work are 0:None, 1:Manual, 22:SprayerPump, 23:SprayerSpinner, 28/Gripper, 51:RCIN1 to 66:RCIN16
+--
+
+-- global definitions
+local UPDATE_INTERVAL_MS = 100
+
+-- add new parameters
+local PARAM_TABLE_KEY = 80
+assert(param:add_table(PARAM_TABLE_KEY, "WINCH_", 3), "could not add param table")
+assert(param:add_param(PARAM_TABLE_KEY, 1, "RATE_UP", 0.5), "could not add WINCH_RATE_UP param")
+assert(param:add_param(PARAM_TABLE_KEY, 2, "RATE_DN", 2), "could not add WINCH_RATE_DN param")
+assert(param:add_param(PARAM_TABLE_KEY, 3, "SRV_SRC_FN", -1), "could not add WINCH_SRV_SRC_FN param")
+
+local winch_rate_up = Parameter("WINCH_RATE_UP")
+local winch_rate_dn = Parameter("WINCH_RATE_DN")
+local winch_srv_src_fn = Parameter("WINCH_SRV_SRC_FN")
+
+-- local variables and definitions
+local last_rc_switch_pos = -1   -- last known rc switch position.  Used to detect change in RC switch position
+
+-- the main update function
+function update()
+
+  local rc_switch_pos = 1   -- default to middle position
+
+  -- check if servo output is used (as an input)
+  if winch_srv_src_fn:get() > 0 then
+    if not SRV_Channels:find_channel(winch_srv_src_fn:get()) then
+      gcs:send_text(3, string.format("Winch: SERVOx_FUNCTION = %d not found", winch_srv_src_fn:get()))    -- MAV_SEVERITY_ERROR
+      return update, 10000  -- check again in 10 seconds
+    end
+    local output_pwm = SRV_Channels:get_output_pwm(winch_srv_src_fn:get())
+    if output_pwm <= 0 then
+      -- servo output all zero so ignore
+      return update, UPDATE_INTERVAL_MS
+    end
+    if output_pwm <= 1300 then
+      rc_switch_pos = 0   -- LOW
+    elseif output_pwm >= 1700 then
+      rc_switch_pos = 2   -- HIGH
+    end
+  else
+    -- find RC channel used to control winch
+    local rc_switch_ch = rc:find_channel_for_option(300) --scripting ch 1
+    if (rc_switch_ch == nil) then
+      gcs:send_text(3, "Winch: RCx_OPTION = 300 not set")    -- MAV_SEVERITY_ERROR
+      return update, 10000  -- check again in 10 seconds
+    end
+
+    -- get RC switch position
+    rc_switch_pos = rc_switch_ch:get_aux_switch_pos()
+  end
+
+  -- initialise RC switch at startup
+  if last_rc_switch_pos == -1 then
+    last_rc_switch_pos = rc_switch_pos
+  end
+
+  -- check if user has moved RC switch
+  if rc_switch_pos == last_rc_switch_pos then
+    return update, UPDATE_INTERVAL_MS
+  end
+  last_rc_switch_pos = rc_switch_pos
+
+  -- set winch rate based on switch position
+  if rc_switch_pos == 0 then -- LOW, deploy winch line
+    local rate_dn = math.abs(winch_rate_dn:get())
+    winch:set_desired_rate(rate_dn)
+    gcs:send_text(6, string.format("Winch: lowering at %.1f m/s", rate_dn))
+  end
+  if rc_switch_pos == 1 then -- MIDDLE, stop winch
+    winch:set_desired_rate(0)
+    gcs:send_text(6, "Winch: stopped")
+  end
+  if rc_switch_pos == 2 then -- HIGH, retract winch line
+    local rate_up = math.abs(winch_rate_up:get())
+    winch:set_desired_rate(-rate_up)
+    gcs:send_text(6, string.format("Winch: raising at %.1f m/s", rate_up))
+  end
+
+  return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -551,6 +551,15 @@ singleton AP_Mount method set_rate_target void uint8_t 0 UINT8_MAX float'skip_ch
 singleton AP_Mount method set_roi_target void uint8_t 0 UINT8_MAX Location
 singleton AP_Mount method get_attitude_euler boolean uint8_t 0 UINT8_MAX float'Null float'Null float'Null
 
+include AP_Winch/AP_Winch.h depends APM_BUILD_COPTER_OR_HELI
+singleton AP_Winch depends APM_BUILD_COPTER_OR_HELI
+singleton AP_Winch rename winch
+singleton AP_Winch method healthy boolean
+singleton AP_Winch method relax void
+singleton AP_Winch method release_length void float'skip_check
+singleton AP_Winch method set_desired_rate void float'skip_check
+singleton AP_Winch method get_rate_max float
+
 -- ----EFI Library----
 include AP_EFI/AP_EFI.h depends HAL_EFI_ENABLED
 include AP_EFI/AP_EFI_Scripting.h depends HAL_EFI_ENABLED


### PR DESCRIPTION
This adds bindings and documentation allowing Lua scripts to control a winch.

An example script is also included that raises or lowers the winch at configurable rates using an auxiliary switch or a servo **output** (see explanation below).

I require this functionality for an [upcoming search and rescue event](https://japan-innovation-challenge.com/en/) which stipulates the pilot must remotely operate the vehicle from >4km away.  My team will use the 3G/LTE mobile phone network, Mission Planner and a Real Flight joystick to control the vehicle.  The issue is that, like many joysticks, the RealFlight joystick only has 5 channels with full range meaning we do not have an RC channel free to set the winch deploy/retract rate.

The example script gets around this issue by allowing the user to set the desired deploy and retract speeds in WINCH_RATE_UP/DN parameters.  If they have a 3 position auxiliary switch they can then choose whether to retract, hold or deploy the winch line.  Where it gets weird is if absolutely no RC switch is available the user can setup a servo **output** to be used in place of the RC input.  Mission Planner's Servo/Relay tab can then be used to set that servo output which is then consumed as an input like an aux function switch.

Of course we should consider whether we have enough winch users to justify the additional flash cost of the winch bindings.

This has been tested in SITL