### PR TITLE
AP_Periph: correct build for EFI can

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -2527,7 +2527,7 @@ void AP_Periph_FW::can_efi_update(void)
         // assume single set of cylinder status
         pkt.cylinder_status.len = 1;
         auto &c = pkt.cylinder_status.data[0];
-        const auto &state_c = state.cylinder_status[0];
+        const auto &state_c = state.cylinder_status;
         c.ignition_timing_deg = state_c.ignition_timing_deg;
         c.injection_time_ms = state_c.injection_time_ms;
         c.cylinder_head_temperature = state_c.cylinder_head_temperature;


### PR DESCRIPTION
no longer an array