### PR TITLE
Backport compass calibration fixes

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -334,7 +334,9 @@ bool Compass::is_calibrating() const
             case CompassCalibrator::Status::FAILED:
             case CompassCalibrator::Status::BAD_ORIENTATION:
             case CompassCalibrator::Status::BAD_RADIUS:
-                break;
+                // this backend isn't calibrating,
+                // but maybe the next one is:
+                continue;
             case CompassCalibrator::Status::WAITING_TO_START:
             case CompassCalibrator::Status::RUNNING_STEP_ONE:
             case CompassCalibrator::Status::RUNNING_STEP_TWO:

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -333,8 +333,11 @@ bool Compass::is_calibrating() const
             case CompassCalibrator::Status::SUCCESS:
             case CompassCalibrator::Status::FAILED:
             case CompassCalibrator::Status::BAD_ORIENTATION:
+            case CompassCalibrator::Status::BAD_RADIUS:
                 break;
-            default:
+            case CompassCalibrator::Status::WAITING_TO_START:
+            case CompassCalibrator::Status::RUNNING_STEP_ONE:
+            case CompassCalibrator::Status::RUNNING_STEP_TWO:
                 return true;
         }
     }


### PR DESCRIPTION
 - the BAD_RADIUS case wasn't being handled correctly
 - we were only considered calibrating if the first backend was calibrating
