### PR TITLE
AP_Bootloader: reserve board ID for JHEMCUGF16F405

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -180,6 +180,7 @@ AP_HW_AEROFOX_AIRSPEED               1077
 AP_HW_ATOMRCF405                     1078
 AP_HW_CUBEPILOT_CANMOD               1079
 AP_HW_AEROFOX_PMU                     1080
+AP_HW_JHEMCUGF16F405                 1081
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
Added a line in board_types.txt to reserve the board ID 1081 for the JHEMCU GF16 F405