### PR TITLE
AC_AutoTune: The agressiveness range maximum is 0.20(NFC)

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -86,7 +86,7 @@ const AP_Param::GroupInfo AC_AutoTune_Multi::var_info[] = {
     // @Param: AGGR
     // @DisplayName: Autotune aggressiveness
     // @Description: Autotune aggressiveness. Defines the bounce back used to detect size of the D term.
-    // @Range: 0.05 0.10
+    // @Range: 0.05 0.20
     // @User: Standard
     AP_GROUPINFO("AGGR", 2, AC_AutoTune_Multi, aggressiveness, 0.1f),
 


### PR DESCRIPTION
The aggressiveness ranges from 0.05 to 0.20.
When other values are set, the value is 0.05 or 0.20.