### PR TITLE
AP_BattMoniter: allow runtime alocation

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -150,6 +150,7 @@ public:
         bool        powerOffNotified;          // only send powering off notification once
         uint32_t    time_remaining;            // remaining battery time
         bool        has_time_remaining;        // time_remaining is only valid if this is true
+        Type        configured_type;           // type this instance is configured as
         const struct AP_Param::GroupInfo *var_info;
     };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -28,6 +28,8 @@ AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonit
         _state(mon_state),
         _params(params)
 {
+    // clear out the cell voltages
+    memset(&_state.cell_voltages, 0xFF, sizeof(AP_BattMonitor::cells));
 }
 
 // capacity_remaining_pct - returns true if the battery % is available and writes to the percentage argument

--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
@@ -25,9 +25,7 @@ class AP_BattMonitor_ESC :public AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_ESC(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params):
-        AP_BattMonitor_Backend(mon, mon_state, params)
-    {};
+    using AP_BattMonitor_Backend::AP_BattMonitor_Backend;
 
     virtual ~AP_BattMonitor_ESC(void) {};
 


### PR DESCRIPTION
This allows runtime allocation of battery monitors meaning there is no longer any need to reboot too see var pointer params, although of course params will have to be fetched again. ~This is allocation only, you cannot change from one type to another at run time.~

