### PR TITLE
AP_BoardConfig: fixed BRD_SAFETY_MASK (4.2 backport)

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -142,11 +142,7 @@ public:
 
     // return the value of BRD_SAFETY_MASK
     uint16_t get_safety_mask(void) const {
-#if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM)
         return uint16_t(state.ignore_safety_channels.get());
-#else
-        return 0;
-#endif
     }
 
 #if HAL_HAVE_BOARD_VOLTAGE


### PR DESCRIPTION
this was broken by the change to BRD_PWM_COUNT