### PR TITLE
AP_Airspeed: use DEVID to maintain lineup of CAN sensors

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -54,3 +54,8 @@ bool AP_Airspeed_Backend::bus_is_confgured(void) const
 {
     return frontend.param[instance].bus.configured();
 }
+
+void AP_Airspeed_Backend::set_bus_id(uint32_t id)
+{
+    frontend.param[instance].bus_id.set_and_save(int32_t(id));
+}

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -91,9 +91,7 @@ protected:
     }
 
     // set bus ID of this instance, for ARSPD_DEVID parameters
-    void set_bus_id(uint32_t id) {
-        frontend.param[instance].bus_id.set(int32_t(id));
-    }
+    void set_bus_id(uint32_t id);
 
     enum class DevType {
         SITL     = 0x01,

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -39,7 +39,7 @@ void AP_Airspeed_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
     }
 }
 
-AP_Airspeed_Backend* AP_Airspeed_UAVCAN::probe(AP_Airspeed &_frontend, uint8_t _instance)
+AP_Airspeed_Backend* AP_Airspeed_UAVCAN::probe(AP_Airspeed &_frontend, uint8_t _instance, uint32_t previous_devid)
 {
     WITH_SEMAPHORE(_sem_registry);
 
@@ -47,23 +47,28 @@ AP_Airspeed_Backend* AP_Airspeed_UAVCAN::probe(AP_Airspeed &_frontend, uint8_t _
 
     for (uint8_t i = 0; i < AIRSPEED_MAX_SENSORS; i++) {
         if (_detected_modules[i].driver == nullptr && _detected_modules[i].ap_uavcan != nullptr) {
+            const auto bus_id = AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_UAVCAN,
+                                                            _detected_modules[i].ap_uavcan->get_driver_index(),
+                                                            _detected_modules[i].node_id, 0);
+            if (previous_devid != 0 && previous_devid != bus_id) {
+                // match with previous ID only
+                continue;
+            }
             backend = new AP_Airspeed_UAVCAN(_frontend, _instance);
             if (backend == nullptr) {
-                AP::can().log_text(AP_CANManager::LOG_INFO, 
-                                      LOG_TAG,
-                                      "Failed register UAVCAN Airspeed Node %d on Bus %d\n",
-                                      _detected_modules[i].node_id,
-                                      _detected_modules[i].ap_uavcan->get_driver_index());
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Failed register UAVCAN Airspeed Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
             } else {
                 _detected_modules[i].driver = backend;
-                AP::can().log_text(AP_CANManager::LOG_INFO, 
-                                      LOG_TAG,
-                                      "Registered UAVCAN Airspeed Node %d on Bus %d\n",
-                                      _detected_modules[i].node_id,
-                                      _detected_modules[i].ap_uavcan->get_driver_index());
-                backend->set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_UAVCAN,
-                                                                _detected_modules[i].ap_uavcan->get_driver_index(),
-                                                                _detected_modules[i].node_id, 0));
+                AP::can().log_text(AP_CANManager::LOG_INFO,
+                                   LOG_TAG,
+                                   "Registered UAVCAN Airspeed Node %d on Bus %d\n",
+                                   _detected_modules[i].node_id,
+                                   _detected_modules[i].ap_uavcan->get_driver_index());
+                backend->set_bus_id(bus_id);
             }
             break;
         }

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
@@ -28,7 +28,7 @@ public:
 
     static void subscribe_msgs(AP_UAVCAN* ap_uavcan);
 
-    static AP_Airspeed_Backend* probe(AP_Airspeed &_fronted, uint8_t _instance);
+    static AP_Airspeed_Backend* probe(AP_Airspeed &_fronted, uint8_t _instance, uint32_t previous_devid);
 
 private:
 


### PR DESCRIPTION
persist DEVID and use it to ensure that we keep the order of DroneCAN sensors between boots. It still allows for a sensor to be swapped out for a new one, while keeping slot of the one that hasn't been removed