### PR TITLE
Plane: scale angle gains in POSITION1 state with airspeed

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -665,6 +665,11 @@ private:
      */
     float get_scaled_wp_speed(float target_bearing_deg) const;
 
+    /*
+      setup scaling of roll and pitch angle P gains to match fixed wing gains
+     */
+    void setup_rp_fw_angle_gains(void);
+
 public:
     void motor_test_output();
     MAV_RESULT mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type,

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -376,6 +376,19 @@ public:
     // Sets the yaw rate shaping time constant
     void set_yaw_rate_tc(float input_tc) { _rate_y_tc = input_tc; }
 
+    // setup a one loop angle P scale multiplier. This replaces any previous scale applied
+    // so should only be used when only one source of scaling is needed
+    void set_angle_P_scale(const Vector3f &angle_P_scale) { _angle_P_scale = angle_P_scale; }
+
+    // setup a one loop angle P scale multiplier, multiplying by any
+    // previously applied scale from this loop. This allows for more
+    // than one type of scale factor to be applied for different
+    // purposes
+    void set_angle_P_scale_mult(const Vector3f &angle_P_scale) { _angle_P_scale *= angle_P_scale; }
+
+    // get the value of the angle P scale that was used in the last loop, for logging
+    const Vector3f &get_angle_P_scale_logging(void) const { return _angle_P_scale_used; }
+    
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -494,6 +507,12 @@ protected:
     // rate controller input smoothing time constant
     float               _rate_rp_tc;
     float               _rate_y_tc;
+
+    // angle P scaling vector for roll, pitch, yaw
+    Vector3f            _angle_P_scale{1,1,1};
+
+    // angle scale used for last loop, used for logging
+    Vector3f            _angle_P_scale_used;
 
     // References to external libraries
     const AP_AHRS_View&  _ahrs;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -43,6 +43,7 @@ public:
     AP_Float &kI(void) { return rate_pid.kI(); }
     AP_Float &kD(void) { return rate_pid.kD(); }
     AP_Float &kFF(void) { return rate_pid.ff(); }
+    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -50,6 +50,7 @@ public:
     AP_Float &kI(void) { return rate_pid.kI(); }
     AP_Float &kD(void) { return rate_pid.kD(); }
     AP_Float &kFF(void) { return rate_pid.ff(); }
+    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -8,7 +8,8 @@
     LOG_ATTITUDE_MSG, \
     LOG_ORGN_MSG, \
     LOG_POS_MSG, \
-    LOG_RATE_MSG
+    LOG_RATE_MSG, \
+    LOG_ATSC_MSG
 
 // @LoggerMessage: AHR2
 // @Description: Backup AHRS data
@@ -168,6 +169,20 @@ struct PACKED log_Video_Stabilisation {
     float Q4;
 };
 
+// @LoggerMessage: ATSC
+// @Description: Scale factors for attitude controller
+// @Field: TimeUS: Time since system startup
+// @Field: AngPScX: Angle P scale X
+// @Field: AngPScY: Angle P scale Y
+// @Field: AngPScZ: Angle P scale Z
+struct PACKED log_ATSC {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float scaleP_x;
+    float scaleP_y;
+    float scaleP_z;
+};
+
 
 #define LOG_STRUCTURE_FROM_AHRS \
     { LOG_AHR2_MSG, sizeof(log_AHRS), \
@@ -182,6 +197,8 @@ struct PACKED log_Video_Stabilisation {
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \
         "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" , true }, \
+    { LOG_ATSC_MSG, sizeof(log_ATSC), \
+        "ATSC", "Qfff",  "TimeUS,AngPScX,AngPScY,AngPScZ", "s---", "F000" , true }, \
     { LOG_VIDEO_STABILISATION_MSG, sizeof(log_Video_Stabilisation), \
         "VSTB", "Qffffffffff",  "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,Q1,Q2,Q3,Q4", "sEEEooo????", "F000000????" },
 


### PR DESCRIPTION
During POSITION1 we still have significant airspeed and using the VTOL Q_A_ANG_P gain may be too high when the fixed wing controller is still dominant and the fixed wing time constant equates to a much smaller angle P gain.
When tuning the VTOL controller we tune in hover, with low airspeed and correspondingly low fixed wing control. It is really not surprising that when we use those gains at high airspeed in POSITION1 that we sometimes see P gain oscillation

This is a simple change to keep using the fixed wing angle gains until we get to the POSITION2 state