### PR TITLE
Copter: Message Level to WARNING Level

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -224,7 +224,7 @@ void Copter::yaw_imbalance_check()
         const uint32_t now = millis();
         if (now - last_yaw_warn_ms > YAW_IMBALANCE_WARN_MS) {
             last_yaw_warn_ms = now;
-            gcs().send_text(MAV_SEVERITY_INFO, "Yaw Imbalance %0.0f%%", I *100);
+            gcs().send_text(MAV_SEVERITY_WARNING, "Yaw Imbalance %0.0f%%", I *100);
         }
     }
 }

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -224,7 +224,7 @@ void Copter::yaw_imbalance_check()
         const uint32_t now = millis();
         if (now - last_yaw_warn_ms > YAW_IMBALANCE_WARN_MS) {
             last_yaw_warn_ms = now;
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.0f%%", I *100);
+            gcs().send_text(MAV_SEVERITY_INFO, "Yaw Imbalance %0.0f%%", I *100);
         }
     }
 }


### PR DESCRIPTION
I am SITL in the RF QUADCOPTER.
I see "Yaw Imbalance" while flying in ALT HOLD mode.
I am flying fine.
I think the level of this message is not "EMERGENCY" but "INFORMATION" level.

![yaw](https://user-images.githubusercontent.com/646194/194756035-e5a82f3c-e89d-4929-a149-71a8c7f1c237.png)