### PR TITLE
Airspeed: remove support for probe list in favor of AP_AIRSPEED_BACKEND_DEFAULT_ENABLED

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -312,6 +312,12 @@ AP_Airspeed::AP_Airspeed()
 {
     AP_Param::setup_object_defaults(this, var_info);
 
+#if defined(HAL_BUILD_AP_PERIPH) && (HAL_AIRSPEED_BUS_DEFAULT != 0)
+    // bus is not in the table to save flash on periph, this means that it does not load the default in the setup call above.
+    // it will be 0 in that case, if default is not set here manually.
+    param[0].bus.set_default(HAL_AIRSPEED_BUS_DEFAULT);
+#endif
+
     if (_singleton != nullptr) {
         AP_HAL::panic("AP_Airspeed must be singleton");
     }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -272,7 +272,6 @@ private:
 
     void Log_Airspeed();
 
-    bool add_backend(AP_Airspeed_Backend *backend);
 };
 
 namespace AP {

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
@@ -39,26 +39,6 @@ AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, uint8_t _instance, co
     range_inH2O(_range_inH2O)
 {}
 
-/*
-  probe for a sensor on a given i2c address
- */
-AP_Airspeed_Backend *AP_Airspeed_DLVR::probe(AP_Airspeed &_frontend,
-                                             uint8_t _instance,
-                                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev,
-                                             const float _range_inH2O)
-{
-    if (!_dev) {
-        return nullptr;
-    }
-    AP_Airspeed_DLVR *sensor = new AP_Airspeed_DLVR(_frontend, _instance, _range_inH2O);
-    if (!sensor) {
-        return nullptr;
-    }
-    sensor->dev = std::move(_dev);
-    sensor->setup();
-    return sensor;
-}
-
 // initialise the sensor
 void AP_Airspeed_DLVR::setup()
 {

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
@@ -37,10 +37,8 @@ class AP_Airspeed_DLVR : public AP_Airspeed_Backend
 public:
 
     AP_Airspeed_DLVR(AP_Airspeed &frontend, uint8_t _instance, const float _range_inH2O);
-    static AP_Airspeed_Backend *probe(AP_Airspeed &frontend, uint8_t _instance, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev, const float _range_inH2O);
-
     ~AP_Airspeed_DLVR(void) {}
-    
+
     // probe and initialise the sensor
     bool init() override;
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Hitec-Airspeed/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Hitec-Airspeed/hwdef.dat
@@ -117,8 +117,8 @@ define CAN_APP_NODE_NAME "org.ardupilot.Hitec-Airspeed"
 # don't share any DMA channels (there are enough for everyone)
 DMA_NOSHARE *
 
-# default to DLVR 10in
-AIRSPEED DLVR I2C:0:0x28 10
+define AP_AIRSPEED_BACKEND_DEFAULT_ENABLED 0
+define AP_AIRSPEED_DLVR_ENABLED 1
 define AIRSPEED_MAX_SENSORS 1
 define HAL_AIRSPEED_BUS_DEFAULT 0
 define HAL_PERIPH_ENABLE_AIRSPEED


### PR DESCRIPTION
Airspeed probe list was added before we had per back end enable defines. Hitec Airspeed was the only user, this updates its HWDEF with the equivalent defines. This simplifys the airspeed code and saves a bit of flash. 