### PR TITLE
Attitude control: move input shaping down to AC_P controller

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -50,22 +50,7 @@ public:
     AC_AttitudeControl( AP_AHRS_View &ahrs,
                         const AP_Vehicle::MultiCopter &aparm,
                         AP_Motors& motors,
-                        float dt) :
-        _p_angle_roll(AC_ATTITUDE_CONTROL_ANGLE_P),
-        _p_angle_pitch(AC_ATTITUDE_CONTROL_ANGLE_P),
-        _p_angle_yaw(AC_ATTITUDE_CONTROL_ANGLE_P),
-        _dt(dt),
-        _angle_boost(0),
-        _use_sqrt_controller(true),
-        _throttle_rpy_mix_desired(AC_ATTITUDE_CONTROL_THR_MIX_DEFAULT),
-        _throttle_rpy_mix(AC_ATTITUDE_CONTROL_THR_MIX_DEFAULT),
-        _ahrs(ahrs),
-        _aparm(aparm),
-        _motors(motors)
-        {
-            _singleton = this;
-            AP_Param::setup_object_defaults(this, var_info);
-        }
+                        float dt);
 
     static AC_AttitudeControl *get_singleton(void) {
         return _singleton;
@@ -202,7 +187,11 @@ public:
 
     // Specifies whether the attitude controller should use the square root controller in the attitude correction.
     // This is used during Autotune to ensure the P term is tuned without being influenced by the acceleration limit of the square root controller.
-    void use_sqrt_controller(bool use_sqrt_cont) { _use_sqrt_controller = use_sqrt_cont; }
+    void use_sqrt_controller(bool use_sqrt_cont) {
+        _p_angle_roll.set_disable_sqrt_controller(!use_sqrt_cont);
+        _p_angle_pitch.set_disable_sqrt_controller(!use_sqrt_cont);
+        _p_angle_yaw.set_disable_sqrt_controller(!use_sqrt_cont);
+    }
 
     // Return 321-intrinsic euler angles in centidegrees representing the rotation from NED earth frame to the
     // attitude controller's target attitude.
@@ -474,10 +463,6 @@ protected:
     // This represents the throttle increase applied for tilt compensation.
     // Used only for logging.
     float               _angle_boost;
-
-    // Specifies whether the attitude controller should use the square root controller in the attitude correction.
-    // This is used during Autotune to ensure the P term is tuned without being influenced by the acceleration limit of the square root controller.
-    bool                _use_sqrt_controller;
 
     // Filtered Alt_Hold lean angle max - used to limit lean angle when throttle is saturated using Alt_Hold
     float               _althold_lean_angle_max = 0.0f;

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Range: 0.3 1
     // @Increment: 0.01
     // @User: Advanced
-    AP_SUBGROUPINFO(_p_hs, "HS_", 2, AC_Autorotation, AC_P),
+    AP_SUBGROUPINFO(_p_hs, "HS_", 2, AC_Autorotation, AC_P_Basic),
 
     // @Param: HS_SET_PT
     // @DisplayName: Target Head Speed
@@ -105,7 +105,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Range: 0.1 6.0
     // @Increment: 0.1
     // @User: Advanced
-    AP_SUBGROUPINFO(_p_fw_vel, "FW_V_", 10, AC_Autorotation, AC_P),
+    AP_SUBGROUPINFO(_p_fw_vel, "FW_V_", 10, AC_Autorotation, AC_P_Basic),
 
     // @Param: FW_V_FF
     // @DisplayName: Velocity (horizontal) feed forward

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -7,7 +7,7 @@
 #include <AP_Motors/AP_MotorsHeli_RSC.h>
 #include <Filter/Filter.h>
 #include <Filter/LowPassFilter.h>
-#include <AC_PID/AC_P.h>
+#include <AC_PID/AC_P_Basic.h>
 
 
 class AC_Autorotation
@@ -74,8 +74,8 @@ private:
 
     //--------Parameter Values--------
     AP_Int8  _param_enable;
-    AC_P _p_hs;
-    AC_P _p_fw_vel;
+    AC_P_Basic _p_hs;
+    AC_P_Basic _p_fw_vel;
     AP_Int16 _param_head_speed_set_point;
     AP_Int16 _param_target_speed;
     AP_Float _param_col_entry_cutoff_freq;

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
@@ -10,7 +10,7 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 12.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_angle_roll2, "ANG_RLL_", 1, AC_CustomControl_PID, AC_P),
+    AP_SUBGROUPINFO(_p_angle_roll2, "ANG_RLL_", 1, AC_CustomControl_PID, AC_P_Basic),
 
     // @Param: ANG_PIT_P
     // @DisplayName: Pitch axis angle controller P gain
@@ -18,7 +18,7 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 12.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_angle_pitch2, "ANG_PIT_", 2, AC_CustomControl_PID, AC_P),
+    AP_SUBGROUPINFO(_p_angle_pitch2, "ANG_PIT_", 2, AC_CustomControl_PID, AC_P_Basic),
 
     // @Param: ANG_YAW_P
     // @DisplayName: Yaw axis angle controller P gain
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 6.000
     // @User: Standard    
-    AP_SUBGROUPINFO(_p_angle_yaw2, "ANG_YAW_", 3, AC_CustomControl_PID, AC_P),
+    AP_SUBGROUPINFO(_p_angle_yaw2, "ANG_YAW_", 3, AC_CustomControl_PID, AC_P_Basic),
 
 
     // @Param: RAT_RLL_P

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.h
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.h
@@ -3,7 +3,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AC_PID/AC_PID.h>
-#include <AC_PID/AC_P.h>
+#include <AC_PID/AC_P_Basic.h>
 
 #include "AC_CustomControl_Backend.h"
 
@@ -28,9 +28,9 @@ protected:
     // put controller related variable here
 
     // angle P controller  objects
-    AC_P                _p_angle_roll2;
-    AC_P                _p_angle_pitch2;
-    AC_P                _p_angle_yaw2;
+    AC_P_Basic                _p_angle_roll2;
+    AC_P_Basic                _p_angle_pitch2;
+    AC_P_Basic                _p_angle_yaw2;
 
 	// rate PID controller  objects
     AC_PID _pid_atti_rate_roll;

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -2,67 +2,37 @@
 
 /// @file	AC_PD.h
 /// @brief	Generic P controller with EEPROM-backed storage of constants.
-
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <stdlib.h>
 #include <cmath>
+#include "AC_P_Basic.h"
 
 /// @class	AC_P
 /// @brief	Object managing one P controller
-class AC_P {
+class AC_P : public AC_P_Basic {
 public:
 
-    /// Constructor for P that saves its settings to EEPROM
-    ///
-    /// @note	PIs must be named to avoid either multiple parameters with the
-    ///			same name, or an overly complex constructor.
-    ///
-    /// @param  initial_p       Initial value for the P term.
-    ///
-    AC_P(const float &initial_p = 0.0f)
-    {
-		AP_Param::setup_object_defaults(this, var_info);
-        _kp.set_and_default(initial_p);
-    }
+    AC_P(const float &initial_p, const AP_Float& accel_max_cds, const float sqrt_accel_min, const float sqrt_accel_max, const float dt);
 
     CLASS_NO_COPY(AC_P);
 
-    /// Iterate the P controller, return the new control value
-    ///
-    /// Positive error produces positive output.
-    ///
-    /// @param error	The measured error value
-    /// @param dt		The time delta in milliseconds (note
-    ///					that update interval cannot be more
-    ///					than 65.535 seconds due to limited range
-    ///					of the data type).
-    ///
-    /// @returns		The updated control output.
-    ///
-    float       get_p(float error) const;
+    float update(float error) const;
 
-    /// Load gain properties
-    ///
-    void        load_gains();
-
-    /// Save gain properties
-    ///
-    void        save_gains();
-
-    /// @name	parameter accessors
-    //@{
-
-    /// Overload the function call operator to permit relatively easy initialisation
-    void operator() (const float p) { _kp.set(p); }
-
-    // accessors
-    AP_Float    &kP() { return _kp; }
-    const AP_Float &kP() const { return _kp; }
-    void        kP(const float v) { _kp.set(v); }
-
-    static const struct AP_Param::GroupInfo        var_info[];
+    void set_disable_sqrt_controller(bool b) { _disable_sqrt_control = b; }
 
 private:
-    AP_Float        _kp;
+
+    float get_accel_max_radss() const { return radians(_accel_max_cds * 0.01); }
+
+    float _dt;
+    const AP_Float& _accel_max_cds;
+
+    const float _sqrt_accel_min;
+    const float _sqrt_accel_max;
+
+    // Specifies whether the attitude controller should use the square root controller in the attitude correction.
+    // This is used during Autotune to ensure the P term is tuned without being influenced by the acceleration limit of the square root controller.
+    bool _disable_sqrt_control;
+
 };

--- a/libraries/AC_PID/AC_P_Basic.cpp
+++ b/libraries/AC_PID/AC_P_Basic.cpp
@@ -1,0 +1,28 @@
+/// @file	AC_P.cpp
+/// @brief	Generic P algorithm
+
+#include <AP_Math/AP_Math.h>
+#include "AC_P_Basic.h"
+
+const AP_Param::GroupInfo AC_P_Basic::var_info[] = {
+    // @Param: P
+    // @DisplayName: PI Proportional Gain
+    // @Description: P Gain which produces an output value that is proportional to the current error value
+    AP_GROUPINFO("P",    0, AC_P_Basic, _kp, 0),
+    AP_GROUPEND
+};
+
+float AC_P_Basic::get_p(float error) const
+{
+    return (float)error * _kp;
+}
+
+void AC_P_Basic::load_gains()
+{
+    _kp.load();
+}
+
+void AC_P_Basic::save_gains()
+{
+    _kp.save();
+}

--- a/libraries/AC_PID/AC_P_Basic.h
+++ b/libraries/AC_PID/AC_P_Basic.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/// @file	AC_P_Basic.h
+/// @brief	Generic P controller with EEPROM-backed storage of constants.
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <stdlib.h>
+#include <cmath>
+
+/// @class	AC_P_Basic
+/// @brief	Object managing one P controller
+class AC_P_Basic {
+public:
+
+    /// Constructor for P that saves its settings to EEPROM
+    ///
+    /// @note	PIs must be named to avoid either multiple parameters with the
+    ///			same name, or an overly complex constructor.
+    ///
+    /// @param  initial_p       Initial value for the P term.
+    ///
+    AC_P_Basic(const float &initial_p = 0.0f)
+    {
+		AP_Param::setup_object_defaults(this, var_info);
+        _kp.set_and_default(initial_p);
+    }
+
+    CLASS_NO_COPY(AC_P_Basic);
+
+    /// Iterate the P controller, return the new control value
+    ///
+    /// Positive error produces positive output.
+    ///
+    /// @param error	The measured error value
+    /// @param dt		The time delta in milliseconds (note
+    ///					that update interval cannot be more
+    ///					than 65.535 seconds due to limited range
+    ///					of the data type).
+    ///
+    /// @returns		The updated control output.
+    ///
+    float       get_p(float error) const;
+
+    /// Load gain properties
+    ///
+    void        load_gains();
+
+    /// Save gain properties
+    ///
+    void        save_gains();
+
+    /// @name	parameter accessors
+    //@{
+
+    /// Overload the function call operator to permit relatively easy initialisation
+    void operator() (const float p) { _kp.set(p); }
+
+    // accessors
+    AP_Float    &kP() { return _kp; }
+    const AP_Float &kP() const { return _kp; }
+    void        kP(const float v) { _kp.set(v); }
+
+    static const struct AP_Param::GroupInfo        var_info[];
+
+private:
+    AP_Float        _kp;
+};

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -245,7 +245,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Range: 1.000 10.000
     // @Increment: 0.1
     // @User: Standard
-    AP_SUBGROUPINFO(_steer_angle_p, "_STR_ANG_", 6, AR_AttitudeControl, AC_P),
+    AP_SUBGROUPINFO(_steer_angle_p, "_STR_ANG_", 6, AR_AttitudeControl, AC_P_Basic),
 
     // @Param: _STR_ACC_MAX
     // @DisplayName: Steering control angular acceleration maximum

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -2,7 +2,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AC_PID/AC_PID.h>
-#include <AC_PID/AC_P.h>
+#include <AC_PID/AC_P_Basic.h>
 
 class AR_AttitudeControl {
 public:
@@ -78,7 +78,7 @@ public:
     float get_sail_out_from_heel(float desired_heel, float dt);
 
     // low level control accessors for reporting and logging
-    AC_P& get_steering_angle_p() { return _steer_angle_p; }
+    AC_P_Basic& get_steering_angle_p() { return _steer_angle_p; }
     AC_PID& get_steering_rate_pid() { return _steer_rate_pid; }
     AC_PID& get_pitch_to_throttle_pid() { return _pitch_to_throttle_pid; }
     AC_PID& get_sailboat_heel_pid() { return _sailboat_heel_pid; }
@@ -117,7 +117,7 @@ public:
 private:
 
     // parameters
-    AC_P     _steer_angle_p;        // steering angle controller
+    AC_P_Basic _steer_angle_p;        // steering angle controller
     AC_PID   _steer_rate_pid;       // steering rate controller
     AC_PID   _throttle_speed_pid;   // throttle speed controller
     AC_PID   _pitch_to_throttle_pid;// balancebot pitch controller

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -118,7 +118,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0.01 1.00
     // @Increment: 0.01
     // @User: Standard
-    AP_SUBGROUPINFO(_p_pos, "_POS_", 9, AP_Follow, AC_P),
+    AP_SUBGROUPINFO(_p_pos, "_POS_", 9, AP_Follow, AC_P_Basic),
 
 #if !(APM_BUILD_TYPE(APM_BUILD_Rover)) 
     // @Param: _ALT_TYPE

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -20,7 +20,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AC_PID/AC_P.h>
+#include <AC_PID/AC_P_Basic.h>
 #include <AP_RTC/JitterCorrection.h>
 
 class AP_Follow
@@ -70,7 +70,7 @@ public:
     bool get_target_dist_and_vel_ned(Vector3f &dist_ned, Vector3f &dist_with_ofs, Vector3f &vel_ned);
 
     // get position controller.  this controller is not used within this library but it is convenient to hold it here
-    const AC_P& get_pos_p() const { return _p_pos; }
+    const AC_P_Basic& get_pos_p() const { return _p_pos; }
 
     //
     // yaw/heading related methods
@@ -127,7 +127,7 @@ private:
     AP_Vector3f _offset;            // offset from lead vehicle in meters
     AP_Int8     _yaw_behave;        // following vehicle's yaw/heading behaviour (see YAW_BEHAVE enum)
     AP_Int8     _alt_type;          // altitude source for follow mode
-    AC_P        _p_pos;             // position error P controller
+    AC_P_Basic  _p_pos;             // position error P controller
 
     // local variables
     bool _healthy;                  // true if we are receiving mavlink messages (regardless of whether they have target position info within them)


### PR DESCRIPTION
This renames the existing `AC_P` to `AC_P_Basic` and then `AC_P` inherits from that adding some input shaping moved down form Attitude control. 

The goal is to work towards using a similar angle controller for FW flight to make a gain scheduling approach easier. In that case we would overload this `AC_P` with `AC_P_Scheduling` in plane allowing to vary the gain and rate limits with airspeed. Ideally we could then use the same class in forward flight to move towards a unified angle controller. For that we would need none symmetrical rate limits, and either to accept that the existing time constant becomes a P gain or to work out a way to deal with both time constant and gain at run time. 