### PR TITLE
Disable temperature based fifo check on ICM20602

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -226,6 +226,7 @@ void AP_InertialSensor_Invensense::start()
         gdev = DEVTYPE_INS_ICM20602;
         adev = DEVTYPE_INS_ICM20602;
         _enable_offset_checking = true;
+        _disable_temp_fifo_check = true;
         break;
     case Invensense_ICM20601:
         gdev = DEVTYPE_INS_ICM20601;
@@ -546,7 +547,7 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         accel *= _accel_scale;
 
         int16_t t2 = int16_val(data, 3);
-        if (!_check_raw_temp(t2)) {
+        if (!_disable_temp_fifo_check && !_check_raw_temp(t2)) {
             if (!hal.scheduler->in_expected_delay()) {
                 debug("temp reset IMU[%u] %d %d", _accel_instance, _raw_temp, t2);
             }
@@ -591,7 +592,7 @@ bool AP_InertialSensor_Invensense::_accumulate_sensor_rate_sampling(uint8_t *sam
 
         // use temperatue to detect FIFO corruption
         int16_t t2 = int16_val(data, 3);
-        if (!_check_raw_temp(t2)) {
+        if (!_disable_temp_fifo_check && !_check_raw_temp(t2)) {
             if (!hal.scheduler->in_expected_delay()) {
                 debug("temp reset IMU[%u] %d %d", _accel_instance, _raw_temp, t2);
             }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -169,6 +169,9 @@ private:
     // buffer for fifo read
     uint8_t *_fifo_buffer;
 
+    // disable temperature based fifo check
+    bool _disable_temp_fifo_check;
+
     /*
       accumulators for sensor_rate sampling
       See description in _accumulate_sensor_rate_sampling()


### PR DESCRIPTION
There have been numerous reports of ICM20602 sensor showing temp reset message and reseting FIFO. It has been found that although the Temperature data is invalid, the rest of the data in FIFO is valid. The data was collected with FIFO disabled, and still occasional invalid Temperature data was observed.
