### PR TITLE
AP_Mount: Group name MNT and MNT2

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -20,7 +20,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
 
     // @Group: 1
     // @Path: AP_Mount_Params.cpp
-    AP_SUBGROUPINFO(_params[0], "1", 43, AP_Mount, AP_Mount_Params),
+    AP_SUBGROUPINFO(_params[0], "", 43, AP_Mount, AP_Mount_Params),
 
 #if AP_MOUNT_MAX_INSTANCES > 1
     // @Group: 2


### PR DESCRIPTION
I see a fault in DISCORD where the existing MP gimbal settings screen is not available.

DISCORD MESSAGE: 
Camera gimbal settings seem to be  gone from QGC with Plane 4.3. Doesn’t show up even if I set MNT1_TYPE to 1. In Missions Planner many of the gimbal controls are dimmed out. Is there something I have missed? Thanks!

I look at the unnumbered items in group 1. I number 2 in group 2.
MNT1 needs to change the existing MP.
I make MNT and MNT2.
With this change, I can set MNT on the gimbal screen of the existing MP.

AFTER
![Screenshot from 2022-10-12 00-24-46](https://user-images.githubusercontent.com/646194/195136120-3255c796-57d9-4e54-9e13-cd1f1a6c18ea.png)

![Screenshot from 2022-10-12 00-23-58](https://user-images.githubusercontent.com/646194/195136157-cf6bcdf3-45cc-4ef4-a250-9ff087263c0d.png)