### PR TITLE
AP_RCProtocol: use unions for common stream protocols

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -37,8 +37,10 @@ extern const AP_HAL::HAL& hal;
 
 // common memory for backends using common stream type baud 115200 non inverted
 union csp_obj_t {
+#ifdef IOMCU_FW
     AP_RCProtocol_FPort fport;
     AP_RCProtocol_FPort2 fport2;
+#endif
     AP_RCProtocol_IBUS ibus;
     AP_RCProtocol_SRXL srxl;
 #ifndef IOMCU_FW
@@ -63,7 +65,10 @@ void AP_RCProtocol::init()
 #ifndef IOMCU_FW
     backend[AP_RCProtocol::SBUS_NI] = new AP_RCProtocol_SBUS(*this, false, 100000);
     backend[AP_RCProtocol::CRSF] = new AP_RCProtocol_CRSF(*this);
+    backend[AP_RCProtocol::FPORT2] = new AP_RCProtocol_FPort2(*this, true);
+    backend[AP_RCProtocol::FPORT] = new AP_RCProtocol_FPort(*this, true);
 #endif
+
 
     // find buffer size to allocate for common stream protocols
     for (uint8_t i=0; i<AP_RCProtocol::NONE; i++) {
@@ -88,6 +93,7 @@ AP_RCProtocol_Backend* AP_RCProtocol::get_csp_object(AP_RCProtocol::rcprotocol_t
     }
     // reassign union to correct type
     switch (protocol) {
+#ifdef IOMCU_FW
         case AP_RCProtocol::FPORT:
             if (curr_csp_protocol != protocol) {
                 new (&csp_obj.fport) AP_RCProtocol_FPort(*this, false);
@@ -100,6 +106,7 @@ AP_RCProtocol_Backend* AP_RCProtocol::get_csp_object(AP_RCProtocol::rcprotocol_t
                 curr_csp_protocol = protocol;
             }
             return (AP_RCProtocol_Backend*)&csp_obj.fport2;
+#endif
         case AP_RCProtocol::IBUS:
             if (curr_csp_protocol != protocol) {
                 new (&csp_obj.ibus) AP_RCProtocol_IBUS(*this);
@@ -147,12 +154,14 @@ void AP_RCProtocol::destroy_csp_object(AP_RCProtocol::rcprotocol_t protocol)
     // destroy obj
     curr_csp_protocol = AP_RCProtocol::NONE;
     switch (protocol) {
+#ifdef IOMCU_FW
         case AP_RCProtocol::FPORT:
             csp_obj.fport.~AP_RCProtocol_FPort();
             break;
         case AP_RCProtocol::FPORT2:
             csp_obj.fport2.~AP_RCProtocol_FPort2();
             break;
+#endif
         case AP_RCProtocol::IBUS:
             csp_obj.ibus.~AP_RCProtocol_IBUS();
             break;

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -162,11 +162,16 @@ private:
 
     void destroy_csp_object(AP_RCProtocol::rcprotocol_t protocol);
 
-    const uint16_t common_stream_protocols =(1 << (uint8_t)FPORT) |
+    const uint16_t common_stream_protocols =
+#ifdef IOMCU_FW
+                                            (1 << (uint8_t)FPORT) |
                                             (1 << (uint8_t)FPORT2) |
+#endif
                                             (1 << (uint8_t)IBUS) |
                                             (1 << (uint8_t)SRXL) |
+#ifndef IOMCU_FW
                                             (1 << (uint8_t)SRXL2) |
+#endif
                                             (1 << (uint8_t)ST24) |
                                             (1 << (uint8_t)SUMD);
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -30,6 +30,7 @@
 #endif
 
 class AP_RCProtocol_Backend;
+class SoftSerial;
 
 class AP_RCProtocol {
 public:
@@ -152,6 +153,32 @@ private:
 
     // return true if a specific protocol is enabled
     bool protocol_enabled(enum rcprotocol_t protocol) const;
+
+    bool is_common_stream_protocol(rcprotocol_t protocol);
+
+    bool common_stream_protocol_detect(uint8_t b);
+
+    AP_RCProtocol_Backend* get_csp_object(AP_RCProtocol::rcprotocol_t protocol);
+
+    void destroy_csp_object(AP_RCProtocol::rcprotocol_t protocol);
+
+    const uint16_t common_stream_protocols =(1 << (uint8_t)FPORT) |
+                                            (1 << (uint8_t)FPORT2) |
+                                            (1 << (uint8_t)IBUS) |
+                                            (1 << (uint8_t)SRXL) |
+                                            (1 << (uint8_t)SRXL2) |
+                                            (1 << (uint8_t)ST24) |
+                                            (1 << (uint8_t)SUMD);
+
+    // buffer memory for backends on common stream protocol
+    uint8_t* csp_buffer;
+    size_t csp_buffer_size;
+    size_t csp_buffer_ofs;
+    rcprotocol_t curr_csp_protocol = NONE;
+    SoftSerial *csp_ss;
+    ssize_t csp_break_byte_idx;
+    uint32_t csp_break_byte_delay_us;
+    uint32_t csp_last_byte_us;
 
     enum rcprotocol_t _detected_protocol = NONE;
     uint16_t _disabled_for_pulses;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -27,6 +27,9 @@ public:
     AP_RCProtocol_Backend(AP_RCProtocol &_frontend);
     virtual ~AP_RCProtocol_Backend() {}
     virtual void process_pulse(uint32_t width_s0, uint32_t width_s1) {}
+    virtual void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay) {
+        process_byte(byte, baudrate);
+    }
     virtual void process_byte(uint8_t byte, uint32_t baudrate) {}
     virtual void process_handshake(uint32_t baudrate) {}
     uint16_t read(uint8_t chan);
@@ -91,6 +94,9 @@ public:
         return true;
     }
     
+    virtual size_t get_max_frame_size() const {
+        return 0;
+    }
 protected:
     struct Channels11Bit_8Chan {
 #if __BYTE_ORDER != __LITTLE_ENDIAN

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -225,10 +225,21 @@ void AP_RCProtocol_FPort::process_pulse(uint32_t width_s0, uint32_t width_s1)
     }
 }
 
-// support byte input
-void AP_RCProtocol_FPort::_process_byte(uint32_t timestamp_us, uint8_t b)
+void AP_RCProtocol_FPort::process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us)
 {
-    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    _process_byte(AP_HAL::micros(), byte, delay_us);
+}
+
+// support byte input
+void AP_RCProtocol_FPort::_process_byte(uint32_t timestamp_us, uint8_t b, uint32_t delay_us)
+{
+    bool have_frame_gap;
+
+    if (delay_us == 0) {
+        have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    } else {
+        have_frame_gap = (delay_us >= 2000U);
+    }
 
     byte_input.last_byte_us = timestamp_us;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
@@ -29,15 +29,17 @@ struct FPort_Frame;
 class AP_RCProtocol_FPort : public AP_RCProtocol_Backend {
 public:
     AP_RCProtocol_FPort(AP_RCProtocol &_frontend, bool inverted);
+    void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay) override;
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
+    size_t get_max_frame_size() const override { return FPORT_CONTROL_FRAME_SIZE; }
 
 private:
     void decode_control(const FPort_Frame &frame);
     void decode_downlink(const FPort_Frame &frame);
     bool check_checksum(void);
 
-    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay = 0);
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
     uint32_t saved_width;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -205,11 +205,21 @@ void AP_RCProtocol_FPort2::process_pulse(uint32_t width_s0, uint32_t width_s1)
     }
 }
 
-// support byte input
-void AP_RCProtocol_FPort2::_process_byte(uint32_t timestamp_us, uint8_t b)
+void AP_RCProtocol_FPort2::process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us)
 {
-    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    _process_byte(AP_HAL::micros(), byte, delay_us);
+}
 
+// support byte input
+void AP_RCProtocol_FPort2::_process_byte(uint32_t timestamp_us, uint8_t b, uint32_t delay_us)
+{
+    bool have_frame_gap;
+
+    if (delay_us == 0) {
+        have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    } else {
+        have_frame_gap = (delay_us >= 2000U);
+    }
     byte_input.last_byte_us = timestamp_us;
 
     if (have_frame_gap) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
@@ -30,14 +30,15 @@ class AP_RCProtocol_FPort2 : public AP_RCProtocol_Backend {
 public:
     AP_RCProtocol_FPort2(AP_RCProtocol &_frontend, bool inverted);
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
-
+    size_t get_max_frame_size() const override { return FPORT2_CONTROL_FRAME_SIZE; }
 private:
     void decode_control(const FPort2_Frame &frame);
     void decode_downlink(const FPort2_Frame &frame);
     bool check_checksum(void);
 
-    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay_us = 0);
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
     uint32_t saved_width;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
@@ -64,10 +64,21 @@ void AP_RCProtocol_IBUS::process_pulse(uint32_t w0, uint32_t w1)
     }
 }
 
-// support byte input
-void AP_RCProtocol_IBUS::_process_byte(uint32_t timestamp_us, uint8_t b)
+
+void AP_RCProtocol_IBUS::process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us)
 {
-    const bool have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    _process_byte(AP_HAL::micros(), byte, delay_us);
+}
+
+// support byte input
+void AP_RCProtocol_IBUS::_process_byte(uint32_t timestamp_us, uint8_t b, uint32_t delay_us)
+{
+    bool have_frame_gap;
+    if (delay_us == 0) {
+        have_frame_gap = (timestamp_us - byte_input.last_byte_us >= 2000U);
+    } else {
+        have_frame_gap = (delay_us >= 2000U);
+    }
     byte_input.last_byte_us = timestamp_us;
 
     if (have_frame_gap) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
@@ -27,9 +27,11 @@ class AP_RCProtocol_IBUS : public AP_RCProtocol_Backend
 public:
     AP_RCProtocol_IBUS(AP_RCProtocol &_frontend);
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
+    size_t get_max_frame_size() const override { return IBUS_FRAME_SIZE; }
 private:
-    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay_us = 0);
     bool ibus_decode(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe);
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
@@ -40,9 +40,11 @@ class AP_RCProtocol_SRXL : public AP_RCProtocol_Backend {
 public:
     AP_RCProtocol_SRXL(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
+    size_t get_max_frame_size() const override { return SRXL_FRAMELEN_MAX; }
 private:
-    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay_us = 0);
     int srxl_channels_get_v1v2(uint16_t max_values, uint8_t *num_values, uint16_t *values, bool *failsafe_state);
     int srxl_channels_get_v5(uint16_t max_values, uint8_t *num_values, uint16_t *values, bool *failsafe_state);
     uint8_t buffer[SRXL_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -43,6 +43,7 @@ public:
     static void change_baud_rate(uint32_t baudrate);
     // configure the VTX from Spektrum data
     static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
+    size_t get_max_frame_size() const override { return SRXL2_FRAMELEN_MAX; }
 
 private:
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
@@ -148,4 +148,7 @@ private:
     ReceiverFcPacket _rxpacket;
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
+
+public:
+    size_t get_max_frame_size() const override { return ST24_MAX_FRAMELEN; }
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
@@ -79,9 +79,20 @@ void AP_RCProtocol_SUMD::process_pulse(uint32_t width_s0, uint32_t width_s1)
     }
 }
 
-void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
+void AP_RCProtocol_SUMD::process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us)
 {
-    if (timestamp_us - last_packet_us > 5000U) {
+    _process_byte(AP_HAL::micros(), byte, delay_us);
+}
+
+void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay_us)
+{
+    bool have_frame_gap = false;
+    if (delay_us == 0) {
+        have_frame_gap = timestamp_us - last_packet_us > 5000U;
+    } else {
+        have_frame_gap = delay_us > 5000U;
+    }
+    if (have_frame_gap) {
         _decode_state = SUMD_DECODE_STATE_UNSYNCED;
     }
     switch (_decode_state) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
@@ -26,10 +26,11 @@ class AP_RCProtocol_SUMD : public AP_RCProtocol_Backend {
 public:
     AP_RCProtocol_SUMD(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_byte_with_delay(uint8_t byte, uint32_t baudrate, uint32_t delay_us) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 
 private:
-    void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_byte(uint32_t timestamp_us, uint8_t byte, uint32_t delay_us = 0);
     static uint8_t sumd_crc8(uint8_t crc, uint8_t value);
 
 #pragma pack(push, 1)
@@ -67,4 +68,6 @@ private:
     uint32_t last_packet_us;
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
+public:
+    size_t get_max_frame_size() const override { return sizeof(ReceiverFcPacketHoTT); }
 };


### PR DESCRIPTION
Potential replacement for https://github.com/ArduPilot/ardupilot/pull/21871 .

This is easier to comment out, doesn't much impact parsing logic, and actually gives more savings.

Before:
write_log:397: t=17396 num=1126 mem=608 terr=1 nerr=1 crc=1 opcode=0 rd=0 wr=0 ur=0 ndel=0

After with FPort2 enabled as well:
write_log:397: t=12606 num=467 mem=1008 terr=1 nerr=1 crc=1 opcode=0 rd=0 wr=0 ur=0 ndel=0

After with FPort2 enabled and With DShot PR:
write_log:405: t=12731 num=477 mem=640 terr=1 nerr=1 crc=1 opcode=0 rd=0 wr=0 ur=0 ndel=0

How it works:
* We have a union that contains classes of all protocols that share same stream conditions. We create a common buffer that is 1 more frame length than required for detection, e.g. protocol requiring 3 frames for detection will require 4 frame length worth of space at the max.
* All bytes are buffered as they come until common buffer is full, we start filling from start again if its full.
* At each new byte we run the entire buffer through each Common Stream Protocol (CSP) type. We record breaks longer than 2ms and pass it on to protocol driver for internal use, otherwise constant 1us delay is sent.
* If a valid frame is detected in a protocol, we stop morphing the union into its various member types, and lock onto the one detected until we start searching again.
*  During Normal Operation behavior is similar to as was before its just another backend,  except the memory occupied is in the union instance.
* We can potentially gain few more bytes by removing SoftSerial instance in common stream protocols.