### PR TITLE
AP_Scripting: set lua nullptr after delete

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -235,6 +235,7 @@ void AP_Scripting::thread(void) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "Scripting: %s", "stopped");
         }
         delete lua;
+        lua = nullptr;
 
         // clear allocated i2c devices
         for (uint8_t i=0; i<SCRIPTING_MAX_NUM_I2C_DEVICE; i++) {


### PR DESCRIPTION
Another PR that doesn't fix the scripting issue. 