### PR TITLE
RC: Button: add instance to aux function prints

### DIFF
--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -279,7 +279,7 @@ void AP_Button::run_aux_functions(bool force)
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
         const char *str = rc_channel->string_for_aux_function(func);
         if (str != nullptr) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Button: executing (%s)", str);
+            gcs().send_text(MAV_SEVERITY_INFO, "Button %i: executing (%s %s)", i+1, str, rc_channel->string_for_aux_pos(pos));
         }
 #endif
         rc_channel->run_aux_function(func, pos, RC_Channel::AuxFuncTriggerSource::BUTTON);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -606,7 +606,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
 };
 
 /* lookup the announcement for switch change */
-const char *RC_Channel::string_for_aux_function(AUX_FUNC function) const     
+const char *RC_Channel::string_for_aux_function(AUX_FUNC function) const
 {
      for (const struct LookupTable &entry : lookuptable) {
         if (entry.option == function) {
@@ -614,6 +614,20 @@ const char *RC_Channel::string_for_aux_function(AUX_FUNC function) const
         }
      }
      return nullptr;
+}
+
+/* find string for postion */
+const char *RC_Channel::string_for_aux_pos(AuxSwitchPos pos) const
+{
+    switch (pos) {
+        case AuxSwitchPos::HIGH:
+            return "HIGH";
+        case AuxSwitchPos::MIDDLE:
+            return "MIDDLE";
+        case AuxSwitchPos::LOW:
+            return "LOW";
+    }
+    return "";
 }
 
 #endif // AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
@@ -650,19 +664,7 @@ bool RC_Channel::read_aux()
     // announce the change to the GCS:
     const char *aux_string = string_for_aux_function(_option);
     if (aux_string != nullptr) {
-        const char *temp =  nullptr;
-        switch (new_position) {
-        case AuxSwitchPos::HIGH:
-            temp = "HIGH";           
-            break;
-        case AuxSwitchPos::MIDDLE:
-            temp = "MIDDLE";
-            break;
-        case AuxSwitchPos::LOW:
-            temp = "LOW";          
-            break;
-        }
-        gcs().send_text(MAV_SEVERITY_INFO, "%s %s", aux_string, temp);
+        gcs().send_text(MAV_SEVERITY_INFO, "RC%i: %s %s", ch_in+1, aux_string, string_for_aux_pos(new_position));
     }
 #endif
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -298,6 +298,7 @@ public:
 
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
     const char *string_for_aux_function(AUX_FUNC function) const;
+    const char *string_for_aux_pos(AuxSwitchPos pos) const;
 #endif
     // pwm value under which we consider that Radio value is invalid
     static const uint16_t RC_MIN_LIMIT_PWM = 800;


### PR DESCRIPTION
This adds instance to aux function prints:
```
 RC6: MotorEStop HIGH
```
Of course one should know which switch one has toggled, but this is useful for setup if there are multiple switchs doing one thing.

This also adds the aux pos and button index to the same button print.

```
Button 1: executing (ParachuteRelease HIGH)
```

I find these prints extremely useful, especially when getting up-to speed with someone else's setup and pre-flight radio checks. I'm tempted to remove the requirement for having the name string and just print the function number in that case. 

EG if we did not have the `MotorEStop` string in our table you would get:
```
 RC6: Option 31 HIGH
```

In that case It would probably also make sense to only print if `run_aux_function` returns true for a valid option. We would have to make sure we don't print switch messages for analog stuff like flaps and throttle.