### PR TITLE
AP_Notify: DISABLED is a value less than or equal to 0

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -176,8 +176,8 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
 
     // @Param: BUZZ_PIN
     // @DisplayName: Buzzer pin
-    // @Description: Enables to connect active buzzer to arbitrary pin. Requires 3-pin buzzer or additional MOSFET! Some the Wiki's "GPIOs" page for how to determine the pin number for a given autopilot.
-    // @Values: -1:Disabled
+    // @Description: Enables to connect active buzzer to arbitrary pin. Requires 3-pin buzzer or additional MOSFET! Some the Wiki's "GPIOs" page for how to determine the pin number for a given autopilot. If this value is less than or equal to 0, it is Disabled.
+    // @Values: 0:Disabled
     // @User: Advanced
     AP_GROUPINFO("BUZZ_PIN", 5, AP_Notify, _buzzer_pin, HAL_BUZZER_PIN),
 


### PR DESCRIPTION
DISABLED is a value less than or equal to 0.
This value is determined by the following process.
Therefore, it is not -1.
I have added a description of the value.

USED PROCESS:
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Notify/Buzzer.cpp#L32