### PR TITLE
Use Float16_t in AP_Mission

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1648,8 +1648,8 @@ void ModeAuto::do_nav_script_time(const AP_Mission::Mission_Command& cmd)
         nav_scripting.start_ms = millis();
         nav_scripting.command = cmd.content.nav_script_time.command;
         nav_scripting.timeout_s = cmd.content.nav_script_time.timeout_s;
-        nav_scripting.arg1 = cmd.content.nav_script_time.arg1;
-        nav_scripting.arg2 = cmd.content.nav_script_time.arg2;
+        nav_scripting.arg1 = cmd.content.nav_script_time.arg1.get();
+        nav_scripting.arg2 = cmd.content.nav_script_time.arg2.get();
         set_submode(SubMode::NAV_SCRIPT_TIME);
     } else {
         // for safety we set nav_scripting to done to protect against the mission getting stuck

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1205,8 +1205,8 @@ bool Plane::nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2
     const auto &c = mission.get_current_nav_cmd().content.nav_script_time;
     id = nav_scripting.id;
     cmd = c.command;
-    arg1 = c.arg1;
-    arg2 = c.arg2;
+    arg1 = c.arg1.get();
+    arg2 = c.arg2.get();
     return true;
 }
 

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -889,8 +889,8 @@ void ModeAuto::do_nav_script_time(const AP_Mission::Mission_Command& cmd)
         nav_scripting.start_ms = millis();
         nav_scripting.command = cmd.content.nav_script_time.command;
         nav_scripting.timeout_s = cmd.content.nav_script_time.timeout_s;
-        nav_scripting.arg1 = cmd.content.nav_script_time.arg1;
-        nav_scripting.arg2 = cmd.content.nav_script_time.arg2;
+        nav_scripting.arg1 = cmd.content.nav_script_time.arg1.get();
+        nav_scripting.arg2 = cmd.content.nav_script_time.arg2.get();
     } else {
         // for safety we set nav_scripting to done to protect against the mission getting stuck
         nav_scripting.done = true;

--- a/libraries/AP_Common/float16.cpp
+++ b/libraries/AP_Common/float16.cpp
@@ -1,0 +1,68 @@
+#include "float16.h"
+/*
+  float16 implementation
+
+  algorithm with thanks to libcanard:
+  https://github.com/dronecan/libcanard
+*/
+
+
+float Float16_t::get(void) const
+{
+    union FP32 {
+        uint32_t u;
+        float f;
+    };
+    const union FP32 magic = { (254UL - 15UL) << 23U };
+    const union FP32 was_inf_nan = { (127UL + 16UL) << 23U };
+    union FP32 out;
+
+    out.u = (v16 & 0x7FFFU) << 13U;
+    out.f *= magic.f;
+    if (out.f >= was_inf_nan.f) {
+        out.u |= 255UL << 23U;
+    }
+    out.u |= (v16 & 0x8000UL) << 16U;
+
+    return out.f;
+}
+
+void Float16_t::set(float value)
+{
+    union FP32
+    {
+        uint32_t u;
+        float f;
+    };
+
+    const union FP32 f32inf = { 255UL << 23U };
+    const union FP32 f16inf = { 31UL << 23U };
+    const union FP32 magic = { 15UL << 23U };
+    const uint32_t sign_mask = 0x80000000UL;
+    const uint32_t round_mask = 0xFFFFF000UL;
+
+    union FP32 in;
+    in.f = value;
+    uint32_t sign = in.u & sign_mask;
+    in.u ^= sign;
+
+    v16 = 0;
+
+    if (in.u >= f32inf.u)
+    {
+        v16 = (in.u > f32inf.u) ? (uint16_t)0x7FFFU : (uint16_t)0x7C00U;
+    }
+    else
+    {
+        in.u &= round_mask;
+        in.f *= magic.f;
+        in.u -= round_mask;
+        if (in.u > f16inf.u)
+        {
+            in.u = f16inf.u;
+        }
+        v16 = (uint16_t)(in.u >> 13U);
+    }
+
+    v16 |= (uint16_t)(sign >> 16U);
+}

--- a/libraries/AP_Common/float16.h
+++ b/libraries/AP_Common/float16.h
@@ -1,0 +1,15 @@
+/*
+  implement a Float16 type
+ */
+
+#pragma once
+#include <stdint.h>
+
+struct float16_s {
+    float get(void) const;
+    void set(float value);
+
+    uint16_t v16;
+};
+
+typedef struct float16_s Float16_t;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1214,6 +1214,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.scripting.p3 = packet.param4;
         break;
 
+#if AP_SCRIPTING_ENABLED
     case MAV_CMD_NAV_SCRIPT_TIME:
         cmd.content.nav_script_time.command = packet.param1;
         cmd.content.nav_script_time.timeout_s = packet.param2;
@@ -1222,6 +1223,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.nav_script_time.arg3 = int16_t(packet.x);
         cmd.content.nav_script_time.arg4 = int16_t(packet.y);
         break;
+#endif
 
     case MAV_CMD_NAV_ATTITUDE_TIME:
         cmd.content.nav_attitude_time.time_sec = constrain_float(packet.param1, 0, UINT16_MAX);
@@ -1708,6 +1710,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param4 = cmd.content.scripting.p3;
         break;
 
+#if AP_SCRIPTING_ENABLED
     case MAV_CMD_NAV_SCRIPT_TIME:
         packet.param1 = cmd.content.nav_script_time.command;
         packet.param2 = cmd.content.nav_script_time.timeout_s;
@@ -1716,6 +1719,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.x = cmd.content.nav_script_time.arg3;
         packet.y = cmd.content.nav_script_time.arg4;
         break;
+#endif
 
     case MAV_CMD_NAV_ATTITUDE_TIME:
         packet.param1 = cmd.content.nav_attitude_time.time_sec;
@@ -2470,8 +2474,10 @@ const char *AP_Mission::Mission_Command::type() const
         return "Jump";
     case MAV_CMD_DO_GO_AROUND:
         return "Go Around";
+#if AP_SCRIPTING_ENABLED
     case MAV_CMD_NAV_SCRIPT_TIME:
         return "NavScriptTime";
+#endif
     case MAV_CMD_NAV_ATTITUDE_TIME:
         return "NavAttitudeTime";
     case MAV_CMD_DO_PAUSE_CONTINUE:
@@ -2642,7 +2648,9 @@ bool AP_Mission::calc_rewind_pos(Mission_Command& rewind_cmd)
 void AP_Mission::format_conversion(uint8_t tag_byte, const Mission_Command &cmd, PackedContent &packed_content) const
 {
     // currently only one conversion needed, more can be added
+#if AP_SCRIPTING_ENABLED
     if (tag_byte == 0 && cmd.id == MAV_CMD_NAV_SCRIPT_TIME) {
+        // PARAMETER_CONVERSION: conversion code added Oct 2022
         struct nav_script_time_Command_tag0 old_fmt;
         struct nav_script_time_Command new_fmt;
         memcpy((void*)&old_fmt, packed_content.bytes, sizeof(old_fmt));
@@ -2654,6 +2662,7 @@ void AP_Mission::format_conversion(uint8_t tag_byte, const Mission_Command &cmd,
         new_fmt.arg4 = 0;
         memcpy(packed_content.bytes, (void*)&new_fmt, sizeof(new_fmt));
     }
+#endif
 }
 
 // singleton instance

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1207,8 +1207,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_NAV_SCRIPT_TIME:
         cmd.content.nav_script_time.command = packet.param1;
         cmd.content.nav_script_time.timeout_s = packet.param2;
-        cmd.content.nav_script_time.arg1 = packet.param3;
-        cmd.content.nav_script_time.arg2 = packet.param4;
+        cmd.content.nav_script_time.arg1.set(packet.param3);
+        cmd.content.nav_script_time.arg2.set(packet.param4);
+        cmd.content.nav_script_time.arg3.set(packet.x);
+        cmd.content.nav_script_time.arg4.set(packet.y);
         break;
 
     case MAV_CMD_NAV_ATTITUDE_TIME:
@@ -1699,8 +1701,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_NAV_SCRIPT_TIME:
         packet.param1 = cmd.content.nav_script_time.command;
         packet.param2 = cmd.content.nav_script_time.timeout_s;
-        packet.param3 = cmd.content.nav_script_time.arg1;
-        packet.param4 = cmd.content.nav_script_time.arg2;
+        packet.param3 = cmd.content.nav_script_time.arg1.get();
+        packet.param4 = cmd.content.nav_script_time.arg2.get();
+        packet.x = cmd.content.nav_script_time.arg3.get();
+        packet.y = cmd.content.nav_script_time.arg4.get();
         break;
 
     case MAV_CMD_NAV_ATTITUDE_TIME:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -221,6 +221,7 @@ public:
         float p3;
     };
 
+#if AP_SCRIPTING_ENABLED
     // Scripting NAV command old version of storage format
     struct PACKED nav_script_time_Command_tag0 {
         uint8_t command;
@@ -239,6 +240,7 @@ public:
         int16_t arg3;
         int16_t arg4;
     };
+#endif
 
     // Scripting NAV command (with verify)
     struct PACKED nav_attitude_time_Command {
@@ -329,8 +331,10 @@ public:
         // do scripting
         scripting_Command scripting;
 
+#if AP_SCRIPTING_ENABLED
         // nav scripting
         nav_script_time_Command nav_script_time;
+#endif
 
         // nav attitude time
         nav_attitude_time_Command nav_attitude_time;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -52,6 +52,8 @@
 #define AP_MISSION_MAX_WP_HISTORY           7       // The maximum number of previous wp commands that will be stored from the active missions history
 #define LAST_WP_PASSED (AP_MISSION_MAX_WP_HISTORY-2)
 
+union PackedContent;
+
 /// @class    AP_Mission
 /// @brief    Object managing Mission
 class AP_Mission
@@ -219,14 +221,23 @@ public:
         float p3;
     };
 
-    // Scripting NAV command (with verify)
+    // Scripting NAV command old version of storage format
+    struct PACKED nav_script_time_Command_tag0 {
+        uint8_t command;
+        uint8_t timeout_s;
+        float arg1;
+        float arg2;
+    };
+
+    // Scripting NAV command, new version of storage format
     struct PACKED nav_script_time_Command {
         uint8_t command;
         uint8_t timeout_s;
         Float16_t arg1;
         Float16_t arg2;
-        Float16_t arg3;
-        Float16_t arg4;
+        // last 2 arguments need to be integers due to MISSION_ITEM_INT encoding
+        int16_t arg3;
+        int16_t arg4;
     };
 
     // Scripting NAV command (with verify)
@@ -782,6 +793,12 @@ private:
     bool start_command_do_sprayer(const AP_Mission::Mission_Command& cmd);
     bool start_command_do_scripting(const AP_Mission::Mission_Command& cmd);
     bool start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Mission_Command& cmd);
+
+    /*
+      handle format conversion of storage format to allow us to update
+      format to take advantage of new packing
+     */
+    void format_conversion(uint8_t tag_byte, const Mission_Command &cmd, PackedContent &packed_content) const;
 };
 
 namespace AP

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -235,7 +235,7 @@ public:
         int16_t roll_deg;
         int8_t pitch_deg;
         int16_t yaw_deg;
-        float climb_rate;
+        int16_t climb_rate;
     };
 
     // MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW support

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -20,6 +20,7 @@
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
+#include <AP_Common/float16.h>
 
 // definitions
 #define AP_MISSION_EEPROM_VERSION           0x65AE  // version number stored in first four bytes of eeprom.  increment this by one when eeprom format is changed
@@ -222,8 +223,10 @@ public:
     struct PACKED nav_script_time_Command {
         uint8_t command;
         uint8_t timeout_s;
-        float arg1;
-        float arg2;
+        Float16_t arg1;
+        Float16_t arg2;
+        Float16_t arg3;
+        Float16_t arg4;
     };
 
     // Scripting NAV command (with verify)


### PR DESCRIPTION
This is an experiment in using a float16 type in AP_Mission storage. It would allow us to store more parameters in the fixed 10 bytes (or 12 for mission command IDs below 256)
In this example NAV_SCRIPT_TIME is able to store an extra two parameters. Due to the use of MISSION_ITEM_INT those two parameters need to be integers
update: I initially meant this just to be a demo of using float16, but after discussions with @rmackay9 I think we could merge this. It would break the mission format for people with NAV_SCRIPT_TIME in missions, but that might be acceptable given small number of users

update: now added a mechanism to auto-convert the structure format to cope with existing stored missions