### PR TITLE
AP_RangeFinder: save little flash by using const string

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -839,8 +839,10 @@ bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_le
             continue;
         }
 
+        const char str[] = "Rangefinder ";
+
         if (drivers[i] == nullptr) {
-            hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X: Not Detected", i + 1);
+            hal.util->snprintf(failure_msg, failure_msg_len, "%s%X: Not Detected", str, i + 1);
             return false;
         }
 
@@ -872,10 +874,10 @@ bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_le
 
         switch (drivers[i]->status()) {
         case Status::NoData:
-            hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X: No Data", i + 1);
+            hal.util->snprintf(failure_msg, failure_msg_len, "%s%X: No Data", str, i + 1);
             return false;
         case Status::NotConnected:
-            hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X: Not Connected", i + 1);
+            hal.util->snprintf(failure_msg, failure_msg_len, "%s%X: Not Connected", str, i + 1);
             return false;
         case Status::OutOfRangeLow:
         case Status::OutOfRangeHigh:


### PR DESCRIPTION
Hey there! I am a beginner at ArduPilot. I just found this code where _Rangefinder_ was being used multiple times in `sprintf` calls. We can save some flash by storing it in a const char array and then using it wherever needed.
Can anyone please review it?
Thanks in advance! Looking forward to make more contributions to ArduPilot.
