### PR TITLE
CI: add Scripting docs check

### DIFF
--- a/.github/workflows/test_scripting_docs.yml
+++ b/.github/workflows/test_scripting_docs.yml
@@ -1,0 +1,45 @@
+name: test scripting docs
+
+on:
+  push:
+    paths: # only run for scripting changes
+      - 'libraries/AP_Scripting/tests/docs_check.py'
+      - 'libraries/AP_Scripting/generator/**'
+
+  pull_request:
+    paths: # only run for scripting changes
+      - 'libraries/AP_Scripting/tests/docs_check.py'
+      - 'libraries/AP_Scripting/generator/**'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-scripting-docs:
+    runs-on: ubuntu-20.04
+    container: ardupilot/ardupilot-dev-base:latest
+    steps:
+      # git checkout the PR
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: copy docs
+        run: |
+          PATH="/github/home/.local/bin:$PATH"
+          mv "libraries/AP_Scripting/docs/docs.lua" "libraries/AP_Scripting/docs/current_docs.lua"
+
+      - name: build sitl # we don't really need to build the full code, just trigger docs re-gen with --scripting-docs, timeout after 10 seconds
+        shell: bash
+        run: |
+          PATH="/github/home/.local/bin:$PATH"
+          ./waf configure --board sitl
+          timeout 10 ./waf antennatracker --scripting-docs || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
+
+      - name: run compare
+        run: |
+          PATH="/github/home/.local/bin:$PATH"
+          python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs.lua" "./libraries/AP_Scripting/docs/current_docs.lua"

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -75,6 +75,18 @@ local EFI_State_ud = {}
 function EFI_State() end
 
 -- set field
+---@param value number
+function EFI_State_ud:pt_compensation(value) end
+
+-- set field
+---@param value number
+function EFI_State_ud:throttle_out(value) end
+
+-- set field
+---@param value number
+function EFI_State_ud:ignition_voltage(value) end
+
+-- set field
 ---@param value Cylinder_Status_ud
 function EFI_State_ud:cylinder_status(value) end
 
@@ -174,20 +186,24 @@ function Cylinder_Status_ud:ignition_timing_deg(value) end
 ---@class efi
 efi = {}
 
--- EFI handle scripting update
----@param efi_state EFI_State_ud
-function efi:handle_scripting(efi_state) end
-
+-- desc
+---@param instance integer
+---@return AP_EFI_Backend_ud
+function efi:get_backend(instance) end
 
 -- CAN bus interaction
 ---@class CAN
 CAN = {}
 
--- get a CAN bus device handler
+-- get a CAN bus device handler first scripting driver
 ---@param buffer_len uint32_t_ud -- buffer length 1 to 25
 ---@return ScriptingCANBuffer_ud
 function CAN:get_device(buffer_len) end
 
+-- get a CAN bus device handler second scripting driver
+---@param buffer_len uint32_t_ud -- buffer length 1 to 25
+---@return ScriptingCANBuffer_ud
+function CAN:get_device2(buffer_len) end
 
 -- Auto generated binding
 
@@ -236,6 +252,9 @@ function CANFrame_ud:isRemoteTransmissionRequest() end
 ---@return boolean
 function CANFrame_ud:isExtended() end
 
+-- desc
+---@return integer
+function CANFrame_ud:id_signed() end
 
 -- desc
 ---@class motor_factor_table_ud
@@ -788,6 +807,14 @@ function Location_ud:offset(ofs_north, ofs_east) end
 ---@return number
 function Location_ud:get_distance(loc) end
 
+-- desc
+---@class AP_EFI_Backend_ud
+local AP_EFI_Backend_ud = {}
+
+-- desc
+---@param state EFI_State_ud
+---@return boolean
+function AP_EFI_Backend_ud:handle_scripting(state) end
 
 -- desc
 ---@class ScriptingCANBuffer_ud
@@ -965,10 +992,10 @@ function mount:get_mode(instance) end
 
 -- desc
 ---@param instance integer
----@return number|nil
----@return number|nil
----@return number|nil
-function mount:get_attitude_euler(instance, roll_deg, pitch_deg, yaw_bf_deg) end
+---@return number|nil -- roll_deg
+---@return number|nil -- pitch_deg
+---@return number|nil -- yaw_bf_deg
+function mount:get_attitude_euler(instance) end
 
 -- desc
 ---@class motors
@@ -1536,6 +1563,10 @@ function serialLED:set_num_neopixel(chan, num_leds) end
 vehicle = {}
 
 -- desc
+---@return boolean
+function vehicle:has_ekf_failsafed() end
+
+-- desc
 ---@return number|nil
 ---@return number|nil
 function vehicle:get_pan_tilt_norm() end
@@ -1709,6 +1740,13 @@ function vehicle:set_target_throttle_rate_rpy(param1, param2, param3, param4) en
 function vehicle:nav_script_time_done(param1) end
 
 -- desc
+---@return integer|nil
+---@return integer|nil
+---@return number|nil
+---@return number|nil
+function vehicle:nav_script_time() end
+
+-- desc
 ---@class onvif
 onvif = {}
 
@@ -1781,7 +1819,7 @@ function relay:enabled(instance) end
 
 -- return state of a relay
 ---@param instance integer
----@return uint8_t
+---@return integer
 function relay:get(instance) end
 
 -- desc
@@ -2147,6 +2185,14 @@ function arming:disarm() end
 ahrs = {}
 
 -- desc
+---@return Quaternion_ud|nil
+function ahrs:get_quaternion() end
+
+-- desc
+---@return integer
+function ahrs:get_posvelyaw_source_set() end
+
+-- desc
 ---@return boolean
 function ahrs:initialised() end
 
@@ -2213,6 +2259,10 @@ function ahrs:healthy() end
 function ahrs:home_is_set() end
 
 -- desc
+---@return number
+function ahrs:get_relative_position_D_home() end
+
+-- desc
 ---@return Vector3f_ud|nil
 function ahrs:get_relative_position_NED_origin() end
 
@@ -2251,6 +2301,10 @@ function ahrs:get_home() end
 -- desc
 ---@return Location_ud|nil
 function ahrs:get_location() end
+
+-- same as `get_location` will be removed
+---@return Location_ud|nil
+function ahrs:get_position() end
 
 -- desc
 ---@return number

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -347,7 +347,7 @@ singleton AP_Param method add_table boolean uint8_t 0 200 string uint8_t 1 63
 singleton AP_Param method add_param boolean uint8_t 0 200 uint8_t 1 63 string float'skip_check
 
 include AP_Scripting/AP_Scripting_helpers.h
-userdata Parameter creation lua_new_Parameter
+userdata Parameter creation lua_new_Parameter 1
 userdata Parameter method init boolean string
 userdata Parameter method init_by_info boolean uint16_t 0 UINT16_MAX uint32_t'skip_check ap_var_type'enum AP_PARAM_INT8 AP_PARAM_FLOAT
 userdata Parameter method get boolean float'Null
@@ -438,7 +438,7 @@ include AP_HAL/I2CDevice.h
 ap_object AP_HAL::I2CDevice semaphore-pointer
 ap_object AP_HAL::I2CDevice method set_retries void uint8_t 0 20
 ap_object AP_HAL::I2CDevice method write_register boolean uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX
-ap_object AP_HAL::I2CDevice manual read_registers AP_HAL__I2CDevice_read_registers
+ap_object AP_HAL::I2CDevice manual read_registers AP_HAL__I2CDevice_read_registers 2
 ap_object AP_HAL::I2CDevice method set_address void uint8_t 0 UINT8_MAX
 
 
@@ -481,8 +481,8 @@ include AP_InertialSensor/AP_InertialSensor.h
 singleton AP_InertialSensor rename ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
 
-singleton CAN manual get_device lua_get_CAN_device
-singleton CAN manual get_device2 lua_get_CAN_device2
+singleton CAN manual get_device lua_get_CAN_device 1
+singleton CAN manual get_device2 lua_get_CAN_device2 1
 singleton CAN depends HAL_MAX_CAN_PROTOCOL_DRIVERS
 
 include AP_Scripting/AP_Scripting_CANSensor.h depends HAL_MAX_CAN_PROTOCOL_DRIVERS
@@ -606,15 +606,15 @@ singleton AP_EFI method get_backend AP_EFI_Backend uint8_t 0 UINT8_MAX
 -- ----END EFI Library----
 
 singleton AP_Logger rename logger
-singleton AP_Logger manual write AP_Logger_Write
+singleton AP_Logger manual write AP_Logger_Write 7
 
-singleton i2c manual get_device lua_get_i2c_device
+singleton i2c manual get_device lua_get_i2c_device 4
 
-global manual millis lua_millis
-global manual micros lua_micros
-global manual mission_receive lua_mission_receive
+global manual millis lua_millis 0
+global manual micros lua_micros 0
+global manual mission_receive lua_mission_receive 0
 
-userdata uint32_t creation lua_new_uint32_t
+userdata uint32_t creation lua_new_uint32_t 1
 userdata uint32_t manual_operator __add uint32_t___add
 userdata uint32_t manual_operator __sub uint32_t___sub
 userdata uint32_t manual_operator __mul uint32_t___mul
@@ -631,6 +631,6 @@ userdata uint32_t manual_operator __lt uint32_t___lt
 userdata uint32_t manual_operator __le uint32_t___le
 userdata uint32_t manual_operator __bnot uint32_t___bnot
 userdata uint32_t manual_operator __tostring uint32_t___tostring
-userdata uint32_t manual toint uint32_t_toint
-userdata uint32_t manual tofloat uint32_t_tofloat
+userdata uint32_t manual toint uint32_t_toint 0
+userdata uint32_t manual tofloat uint32_t_tofloat 0
 

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -365,6 +365,7 @@ struct method_alias {
   char *name;
   char *alias;
   int line;
+  int num_args;
   enum alias_type type;
 };
 
@@ -405,6 +406,7 @@ struct userdata {
   int flags; // flags from the userdata_flags enum
   char *dependency;
   char *creation; // name of a manual creation function if set, note that this will not be used internally
+  int creation_args; // number of args for custom creation function
 };
 
 static struct userdata *parsed_userdata;
@@ -856,13 +858,21 @@ void handle_manual(struct userdata *node, enum alias_type type) {
   }
   char *cpp_function_name = next_token();
   if (cpp_function_name == NULL) {
-    error(ERROR_SINGLETON, "Expected a cpp name for manual %s method",node->name);
+    error(ERROR_SINGLETON, "Expected a cpp name for manual method %s %s", node->name, name);
   }
   struct method_alias *alias = allocate(sizeof(struct method_alias));
   string_copy(&(alias->name), cpp_function_name);
   string_copy(&(alias->alias), name);
   alias->line = state.line_num;
   alias->type = type;
+
+  if (type != ALIAS_TYPE_MANUAL_OPERATOR) {
+    char *num_args = next_token();
+    if (num_args == NULL) {
+      error(ERROR_SINGLETON, "Expected number of args for manual method %s %s", node->name, name);
+    }
+    alias->num_args = atoi(num_args);
+  }
   alias->next = node->method_aliases;
   node->method_aliases = alias;
 }
@@ -970,10 +980,16 @@ void handle_userdata(void) {
       if (node->creation != NULL) {
         error(ERROR_SINGLETON, "Userdata only support a single creation function");
       }
-      char *creation = strtok(NULL, "");
+      char *creation = next_token();
       if (creation == NULL) {
         error(ERROR_USERDATA, "Expected a creation string for %s",node->name);
       }
+      char *num_args = next_token();
+      if (num_args == NULL) {
+        error(ERROR_SINGLETON, "Expected number of args for creation method %s", node->name);
+      }
+      node->creation_args = atoi(num_args);
+
       string_copy(&(node->creation), creation);
 
   } else if (strcmp(type, keyword_manual_operator) == 0) {
@@ -2503,7 +2519,19 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
       if (emit_creation) {
         // creation function
         fprintf(docs, "---@return %s\n", name);
-        fprintf(docs, "function %s() end\n\n", node->rename ? node->rename : node->sanatized_name);
+        fprintf(docs, "function %s(", node->rename ? node->rename : node->sanatized_name);
+        if (node->creation == NULL) {
+          fprintf(docs, ") end\n\n");
+        } else {
+          for (int i = 0; i < node->creation_args; ++i) {
+            fprintf(docs, "param%i", i+1);
+            if (i < node->creation_args-1) {
+              fprintf(docs, ", ");
+            }
+          }
+          fprintf(docs, ") end\n\n");
+        }
+
       }
     } else {
       // global
@@ -2557,7 +2585,6 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
     // aliases
     struct method_alias *alias = node->method_aliases;
     while(alias) {
-      // dont do manual bindings
       if (alias->type == ALIAS_TYPE_NONE) {
         // find the method this is a alias of
         struct method * method = node->methods;
@@ -2569,6 +2596,17 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
         }
 
         emit_docs_method(name, alias->alias, method);
+
+      } else if (alias->type == ALIAS_TYPE_MANUAL) {
+          // Cant do a great job, don't know types or return
+          fprintf(docs, "-- desc\nfunction %s:%s(", name, alias->alias);
+          for (int i = 0; i < alias->num_args; ++i) {
+            fprintf(docs, "param%i", i+1);
+            if (i < alias->num_args-1) {
+              fprintf(docs, ", ");
+            }
+          }
+          fprintf(docs, ") end\n\n");
       }
       alias = alias->next;
     }
@@ -2796,6 +2834,25 @@ int main(int argc, char **argv) {
   emit_docs(parsed_ap_objects, TRUE, FALSE);
 
   emit_docs(parsed_singletons, FALSE, FALSE);
+
+  // global aliases
+  if (parsed_globals != NULL) {
+    struct method_alias *alias = parsed_globals->method_aliases;
+    while(alias) {
+      if (alias->type == ALIAS_TYPE_MANUAL) {
+          // Cant do a great job, don't know types or return
+          fprintf(docs, "-- desc\nfunction %s(", alias->alias);
+          for (int i = 0; i < alias->num_args; ++i) {
+            fprintf(docs, "param%i", i+1);
+            if (i < alias->num_args-1) {
+              fprintf(docs, ", ");
+            }
+          }
+          fprintf(docs, ") end\n\n");
+      }
+      alias = alias->next;
+    }
+  }
 
   fclose(docs);
 

--- a/libraries/AP_Scripting/tests/docs_check.py
+++ b/libraries/AP_Scripting/tests/docs_check.py
@@ -1,0 +1,132 @@
+'''
+Reads two lua docs files and checks for differences
+
+python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs expected.lua" "./libraries/AP_Scripting/docs/docs.lua"
+
+AP_FLAKE8_CLEAN
+'''
+
+import optparse, sys
+
+class method(object):
+    def __init__(self, global_name, local_name, num_args, full_line):
+        self.global_name = global_name
+        self.local_name = local_name
+        self.num_args = num_args
+        self.full_line = full_line
+
+    def __str__(self):
+        ret_str = "%s\n" % (self.full_line)
+        if len(self.local_name):
+            ret_str += "\tClass: %s\n" % (self.global_name)
+            ret_str += "\tFunction: %s\n" % (self.local_name)
+        else:
+            ret_str += "\tGlobal: %s\n" % (self.global_name)
+        ret_str +=  "\tNum Args: %s\n\n" % (self.num_args)
+        return ret_str
+
+    def __eq__(self, other):
+        return (self.global_name == other.global_name) and (self.local_name == other.local_name) and (self.num_args == other.num_args)
+
+def parse_file(file_name):
+    methods = []
+    with open(file_name) as fp:
+        while True:
+            line = fp.readline()
+            if not line:
+                break
+
+            # only consider functions
+            if not line.startswith("function"):
+                continue
+
+            # remove any comment
+            line = line.split('--', 1)[0]
+
+            # remove any trailing whitespace
+            line = line.strip()
+
+            # remove "function"
+            function_line = line.split(' ', 1)[1]
+
+            # remove "end"
+            function_line = function_line.rsplit(' ', 1)[0]
+
+            # remove spaces
+            function_line = function_line.replace(" ", "")
+
+            # get arguments
+            function_name, args = function_line.split("(",1)
+            args = args[0:args.find(")")-1]
+
+            if len(args) == 0:
+                num_args = 0
+            else:
+                num_args = args.count(",") + 1
+
+            # get global/class name and function name
+            local_name = ""
+            if function_name.count(":") == 1:
+                global_name, local_name = function_name.split(":",1)
+            else:
+                global_name = function_name
+
+            methods.append(method(global_name, local_name, num_args, line))
+
+    return methods
+
+def compare(expected_file_name, got_file_name):
+
+    # parse in methods
+    expected_methods = parse_file(expected_file_name)
+    got_methods = parse_file(got_file_name)
+
+    pass_check = True
+
+    # make sure each expected method is included once
+    for meth in expected_methods:
+        found = False
+        for got in got_methods:
+            if got == meth:
+                if found:
+                    print("Multiple definitions of:")
+                    print(meth)
+                    pass_check = False
+                found = True
+
+        if not found:
+            print("Missing definition of:")
+            print(meth)
+            pass_check = False
+
+
+    # make sure no unexpected methods are included
+    for got in got_methods:
+        found = False
+        for meth in expected_methods:
+            if got == meth:
+                found = True
+                break
+        if not found:
+            print("Unexpected definition of:")
+            print(got)
+            pass_check = False
+
+    if not pass_check:
+        raise Exception("Docs do not match")
+    else:
+        print("Docs check passed")
+
+if __name__ == '__main__':
+
+    parser = optparse.OptionParser(__file__)
+
+    opts, args = parser.parse_args()
+
+    if len(args) != 2:
+        print('Usage: %s "expected docs path" "current docs path"' % parser.usage)
+        sys.exit(0)
+
+    compare(args[0], args[1])
+
+


### PR DESCRIPTION
This adds a check that scripting docs are upto date. It re-generates the docs using the generator and then spots the difference between the current docs and the generated ones. It ignores argument names and comments.

This should currently fail because there is a bunch of stuff missing. It will also fail because there is no definition for the expected number of arguments for manual bindings, this will also need to be added. 

Could expand further in the future to also check fields, argument/return types. 

