### PR TITLE
Use first defined RCIN serial port

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -124,6 +124,7 @@ public:
 
     // add a UART for RCIN
     void add_uart(AP_HAL::UARTDriver* uart);
+    bool has_uart() const { return added.uart != nullptr; }
 
 #ifdef IOMCU_FW
     // set allowed RC protocols

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -543,7 +543,11 @@ void AP_SerialManager::init()
 
 #ifndef HAL_BUILD_AP_PERIPH
                 case SerialProtocol_RCIN:
-                    AP::RC().add_uart(uart);
+                    if (AP::RC().has_uart()) {
+                        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Duplicate RCIN configured on SERIAL%u", i);
+                    } else {
+                        AP::RC().add_uart(uart);
+                    }
                     break;
 #endif
                     


### PR DESCRIPTION
Currently last past the post wins which is almost certainly not what the user expects or wants. This also attempts to print out a warning about the duplicate definition.