### PR TITLE
Plane: GCS_Mavlink: use base class DO_SET_HOME

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -676,6 +676,14 @@ bool GCS_MAVLINK_Plane::set_home_to_current_location(bool _lock)
     if (_lock) {
         AP::ahrs().lock_home();
     }
+    if ((plane.control_mode == &plane.mode_rtl)
+#if HAL_QUADPLANE_ENABLED
+            || (plane.control_mode == &plane.mode_qrtl)
+#endif
+                                                        ) {
+        // if in RTL head to the updated home location
+        plane.control_mode->enter();
+    }
     return true;
 }
 bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool _lock)
@@ -685,6 +693,14 @@ bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool _lock)
     }
     if (_lock) {
         AP::ahrs().lock_home();
+    }
+    if ((plane.control_mode == &plane.mode_rtl)
+#if HAL_QUADPLANE_ENABLED
+            || (plane.control_mode == &plane.mode_qrtl)
+#endif
+                                                        ) {
+        // if in RTL head to the updated home location
+        plane.control_mode->enter();
     }
     return true;
 }
@@ -1010,40 +1026,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
             }
         }
         return MAV_RESULT_FAILED;
-
-    case MAV_CMD_DO_SET_HOME: {
-        // param1 : use current (1=use current location, 0=use specified location)
-        // param5 : latitude
-        // param6 : longitude
-        // param7 : altitude (absolute)
-        if (is_equal(packet.param1,1.0f)) {
-            if (!plane.set_home_persistently(AP::gps().location())) {
-                return MAV_RESULT_FAILED;
-            }
-            AP::ahrs().lock_home();
-        } else {
-            // ensure param1 is zero
-            if (!is_zero(packet.param1)) {
-                return MAV_RESULT_FAILED;
-            }
-            Location new_home_loc;
-            if (!location_from_command_t(packet, MAV_FRAME_GLOBAL, new_home_loc)) {
-                return MAV_RESULT_DENIED;
-            }
-            if (!set_home(new_home_loc, true)) {
-                return MAV_RESULT_FAILED;
-            }
-        }
-        if ((plane.control_mode == &plane.mode_rtl)
-#if HAL_QUADPLANE_ENABLED
-                || (plane.control_mode == &plane.mode_qrtl)
-#endif
-                                                            ) {
-            // if in RTL head to the updated home location
-            plane.control_mode->enter();
-        }
-        return MAV_RESULT_ACCEPTED;
-    }
 
     case MAV_CMD_DO_AUTOTUNE_ENABLE:
         // param1 : enable/disable


### PR DESCRIPTION
This moves to use the base class method as the overrides are already in place for `set_home_to_current_location` and `set_home`. They were already being used for the command int this brings command long to that same behavior. 

Base class methods is here:
https://github.com/ArduPilot/ardupilot/blob/3abdc6ad25fbf4f197a755cef6d12c17ab36d8c3/libraries/GCS_MAVLink/GCS_Common.cpp#L4467-L4491

The only difference is the checking if lat/lon are zero when deciding to set home to current location. 