### PR TITLE
AP_Scripting: generation flash savings

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1226,7 +1226,6 @@ void emit_userdata_allocators(void) {
     fprintf(source, "int new_%s(lua_State *L) {\n", node->sanatized_name);
     fprintf(source, "    luaL_checkstack(L, 2, \"Out of stack\");\n"); // ensure we have sufficent stack to push the return
     fprintf(source, "    void *ud = lua_newuserdata(L, sizeof(%s));\n", node->name);
-    fprintf(source, "    memset(ud, 0, sizeof(%s));\n", node->name);
     fprintf(source, "    new (ud) %s();\n", node->name);
     fprintf(source, "    luaL_getmetatable(L, \"%s\");\n", node->rename ? node->rename :  node->name);
     fprintf(source, "    lua_setmetatable(L, -2);\n");
@@ -1244,8 +1243,7 @@ void emit_ap_object_allocators(void) {
     start_dependency(source, node->dependency);
     fprintf(source, "int new_%s(lua_State *L) {\n", node->sanatized_name);
     fprintf(source, "    luaL_checkstack(L, 2, \"Out of stack\");\n"); // ensure we have sufficent stack to push the return
-    fprintf(source, "    void *ud = lua_newuserdata(L, sizeof(%s *));\n", node->name);
-    fprintf(source, "    memset(ud, 0, sizeof(%s *));\n", node->name); // FIXME: memset is a ridiculously large hammer here
+    fprintf(source, "    lua_newuserdata(L, sizeof(%s *));\n", node->name);
     fprintf(source, "    luaL_getmetatable(L, \"%s\");\n", node->name);
     fprintf(source, "    lua_setmetatable(L, -2);\n");
     fprintf(source, "    return 1;\n");

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1242,11 +1242,7 @@ void emit_ap_object_allocators(void) {
   while (node) {
     start_dependency(source, node->dependency);
     fprintf(source, "int new_%s(lua_State *L) {\n", node->sanatized_name);
-    fprintf(source, "    luaL_checkstack(L, 2, \"Out of stack\");\n"); // ensure we have sufficent stack to push the return
-    fprintf(source, "    lua_newuserdata(L, sizeof(%s *));\n", node->name);
-    fprintf(source, "    luaL_getmetatable(L, \"%s\");\n", node->name);
-    fprintf(source, "    lua_setmetatable(L, -2);\n");
-    fprintf(source, "    return 1;\n");
+    fprintf(source, "    return new_ap_object(L, sizeof(%s *), \"%s\");\n", node->name, node->name);
     fprintf(source, "}\n");
     end_dependency(source, node->dependency);
     fprintf(source, "\n");
@@ -2419,6 +2415,15 @@ void emit_argcheck_helper(void) {
   fprintf(source, "    luaL_argcheck(L, (lua_unint32 >= min_val) && (lua_unint32 <= max_val), arg_num, \"out of range\");\n");
   fprintf(source, "    return lua_unint32;\n");
   fprintf(source, "}\n\n");
+
+  fprintf(source, "int new_ap_object(lua_State *L, size_t size, const char * name) {\n");
+  fprintf(source, "    luaL_checkstack(L, 2, \"Out of stack\");\n");
+  fprintf(source, "    lua_newuserdata(L, size);\n");
+  fprintf(source, "    luaL_getmetatable(L, name);\n");
+  fprintf(source, "    lua_setmetatable(L, -2);\n");
+  fprintf(source, "    return 1;\n");
+  fprintf(source, "}\n\n");
+
 }
 
 void emit_not_supported_helper(void) {
@@ -2851,6 +2856,7 @@ int main(int argc, char **argv) {
   fprintf(header, "lua_Integer get_integer(lua_State *L, int arg_num, lua_Integer min_val, lua_Integer max_val);\n");
   fprintf(header, "float get_number(lua_State *L, int arg_num, float min_val, float max_val);\n");
   fprintf(header, "uint32_t get_uint32(lua_State *L, int arg_num, uint32_t min_val, uint32_t max_val);\n");
+  fprintf(header, "int new_ap_object(lua_State *L, size_t size, const char * name);\n");
 
   fclose(header);
   header = NULL;

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -326,10 +326,10 @@ int lua_get_i2c_device(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    const lua_Integer bus_in = get_integer(L, 1 + arg_offset, 0, 4, "bus out of range");
+    const lua_Integer bus_in = get_integer(L, 1 + arg_offset, 0, 4);
     const uint8_t bus = static_cast<uint8_t>(bus_in);
 
-    const lua_Integer address_in = get_integer(L, 2 + arg_offset, 0, 128, "address out of range");
+    const lua_Integer address_in = get_integer(L, 2 + arg_offset, 0, 128);
     const uint8_t address = static_cast<uint8_t>(address_in);
 
     // optional arguments, use the same defaults as the hal get_device function
@@ -384,12 +384,12 @@ int AP_HAL__I2CDevice_read_registers(lua_State *L) {
         return luaL_error(L, "Internal error, null pointer");
     }
 
-    const lua_Integer raw_first_reg = get_integer(L, 2, 0, UINT8_MAX, "argument out of range");
+    const lua_Integer raw_first_reg = get_integer(L, 2, 0, UINT8_MAX);
     const uint8_t first_reg = static_cast<uint8_t>(raw_first_reg);
 
     uint8_t recv_length = 1;
     if (multi_register) {
-        const lua_Integer raw_recv_length = get_integer(L, 3, 0, UINT8_MAX, "argument out of range");
+        const lua_Integer raw_recv_length = get_integer(L, 3, 0, UINT8_MAX);
         recv_length = static_cast<uint8_t>(raw_recv_length);
     }
 
@@ -423,7 +423,7 @@ int lua_get_CAN_device(lua_State *L) {
 
     binding_argcheck(L, 1 + arg_offset);
 
-    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25, "argument out of range");
+    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25);
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev == nullptr) {
@@ -446,7 +446,7 @@ int lua_get_CAN_device2(lua_State *L) {
 
     binding_argcheck(L, 1 + arg_offset);
 
-    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25, "argument out of range");
+    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25);
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev2 == nullptr) {

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -326,12 +326,10 @@ int lua_get_i2c_device(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    const lua_Integer bus_in = luaL_checkinteger(L, 1 + arg_offset);
-    luaL_argcheck(L, ((bus_in >= 0) && (bus_in <= 4)), 1 + arg_offset, "bus out of range");
+    const lua_Integer bus_in = get_integer(L, 1 + arg_offset, 0, 4, "bus out of range");
     const uint8_t bus = static_cast<uint8_t>(bus_in);
 
-    const lua_Integer address_in = luaL_checkinteger(L, 2 + arg_offset);
-    luaL_argcheck(L, ((address_in >= 0) && (address_in <= 128)), 2 + arg_offset, "address out of range");
+    const lua_Integer address_in = get_integer(L, 2 + arg_offset, 0, 128, "address out of range");
     const uint8_t address = static_cast<uint8_t>(address_in);
 
     // optional arguments, use the same defaults as the hal get_device function
@@ -386,14 +384,12 @@ int AP_HAL__I2CDevice_read_registers(lua_State *L) {
         return luaL_error(L, "Internal error, null pointer");
     }
 
-    const lua_Integer raw_first_reg = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_first_reg >= MAX(0, 0)) && (raw_first_reg <= MIN(UINT8_MAX, UINT8_MAX))), 2, "argument out of range");
+    const lua_Integer raw_first_reg = get_integer(L, 2, 0, UINT8_MAX, "argument out of range");
     const uint8_t first_reg = static_cast<uint8_t>(raw_first_reg);
 
     uint8_t recv_length = 1;
     if (multi_register) {
-        const lua_Integer raw_recv_length = luaL_checkinteger(L, 3);
-        luaL_argcheck(L, ((raw_recv_length >= MAX(0, 0)) && (raw_recv_length <= MIN(UINT8_MAX, UINT8_MAX))), 3, "argument out of range");
+        const lua_Integer raw_recv_length = get_integer(L, 3, 0, UINT8_MAX, "argument out of range");
         recv_length = static_cast<uint8_t>(raw_recv_length);
     }
 
@@ -427,8 +423,7 @@ int lua_get_CAN_device(lua_State *L) {
 
     binding_argcheck(L, 1 + arg_offset);
 
-    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1 + arg_offset);
-    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1 + arg_offset, "argument out of range");
+    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25, "argument out of range");
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev == nullptr) {
@@ -451,8 +446,7 @@ int lua_get_CAN_device2(lua_State *L) {
 
     binding_argcheck(L, 1 + arg_offset);
 
-    const uint32_t raw_buffer_len = coerce_to_uint32_t(L, 1 + arg_offset);
-    luaL_argcheck(L, ((raw_buffer_len >= 1U) && (raw_buffer_len <= 25U)), 1 + arg_offset, "argument out of range");
+    const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25, "argument out of range");
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
     if (AP::scripting()->_CAN_dev2 == nullptr) {


### PR DESCRIPTION
A number of efficiency improvements that each save a bit of flash. 32c27e06886e214579f0ffd58691a6b8a79d26fb and b134eacf82ccfe8f73b88cca44440ab994acef6e make up the majority of the saving.

The best way to review is probably a compare of the generated bindings before and after. 

There is still some more that could be saved, but its getting harder to find.