### PR TITLE
Baro: cope with MS5607 substitution for MS5611 in "Pixhawk 2.4.x"

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -118,6 +118,9 @@ baro_types = {
     0x0E : "DEVTYPE_BARO_MSP",
     0x0F : "DEVTYPE_BARO_ICP101XX",
     0x10 : "DEVTYPE_BARO_ICP201XX",
+    0x11 : "DEVTYPE_BARO_MS5607",
+    0x12 : "DEVTYPE_BARO_MS5837",
+    0x13 : "DEVTYPE_BARO_MS5637",
 }
 
 airspeed_types = {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -264,8 +264,9 @@ bool AP_Arming::barometer_checks(bool report)
 #endif
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BARO)) {
-        if (!AP::baro().all_healthy()) {
-            check_failed(ARMING_CHECK_BARO, report, "Barometer not healthy");
+        char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+        if (!AP::baro().arming_checks(sizeof(buffer), buffer)) {
+            check_failed(ARMING_CHECK_BARO, report, "Baro: %s", buffer);
             return false;
         }
     }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -78,6 +78,9 @@ public:
     // check if all baros are healthy - used for SYS_STATUS report
     bool all_healthy(void) const;
 
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool arming_checks(size_t buflen, char *buffer) const;
+
     // get primary sensor
     uint8_t get_primary(void) const { return _primary; }
 
@@ -204,6 +207,16 @@ public:
     void handle_external(const AP_ExternalAHRS::baro_data_message_t &pkt);
 #endif
 
+    enum Options : uint16_t {
+        TreatMS5611AsMS5607     = (1U << 0U),
+    };
+
+    // check if an option is set
+    bool option_enabled(const Options option) const
+    {
+        return (uint16_t(_options.get()) & uint16_t(option)) != 0;
+    }
+
 private:
     // singleton
     static AP_Baro *_singleton;
@@ -297,6 +310,12 @@ private:
     void _probe_i2c_barometers(void);
     AP_Int8                            _filter_range;  // valid value range from mean value
     AP_Int32                           _baro_probe_ext;
+
+#ifndef HAL_BUILD_AP_PERIPH
+    AP_Float                           _alt_error_max;
+#endif
+
+    AP_Int16                           _options;
 
     // semaphore for API access from threads
     HAL_Semaphore                      _rsem;

--- a/libraries/AP_Baro/AP_Baro_Backend.h
+++ b/libraries/AP_Baro/AP_Baro_Backend.h
@@ -58,6 +58,9 @@ public:
         DEVTYPE_BARO_MSP      = 0x0E,
         DEVTYPE_BARO_ICP101XX = 0x0F,
         DEVTYPE_BARO_ICP201XX = 0x10,
+        DEVTYPE_BARO_MS5607   = 0x11,
+        DEVTYPE_BARO_MS5837   = 0x12,
+        DEVTYPE_BARO_MS5637   = 0x13,
     };
     
 protected:


### PR DESCRIPTION
some vendors are using MS5607 instead of MS5611 in "Pixhawk 2.4" boards. The pressure is off by about 2x, but there is no register to distinguish between the two. This causes severe problems with airspeed calibration and height estimate
this adds a GPS alt arming check, and an option to treat MS5611 as MS5607
