### PR TITLE
AP_Logger: split MCU from POWR into new messages, POWR log nan if voltages not available

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -343,30 +343,38 @@ void AP_Logger::Write_Power(void)
         // encode armed state in bit 3
         safety_and_armed |= 1U<<2;
     }
-    float MCU_temp = 0;
-    float MCU_voltage = 0;
-    float MCU_vmin = 0;
-    float MCU_vmax = 0;
-#if HAL_WITH_MCU_MONITORING
-    MCU_temp = hal.analogin->mcu_temperature();
-    MCU_voltage = hal.analogin->mcu_voltage();
-    MCU_vmin = hal.analogin->mcu_voltage_min();
-    MCU_vmax = hal.analogin->mcu_voltage_max();
-#endif
-    const struct log_POWR pkt{
+    const uint64_t now = AP_HAL::micros64();
+    const struct log_POWR powr_pkt{
         LOG_PACKET_HEADER_INIT(LOG_POWR_MSG),
-        time_us : AP_HAL::micros64(),
+        time_us : now,
+#if HAL_HAVE_BOARD_VOLTAGE
         Vcc     : hal.analogin->board_voltage(),
+#else
+        Vcc     : quiet_nanf(),
+#endif
+#if HAL_HAVE_SERVO_VOLTAGE
         Vservo  : hal.analogin->servorail_voltage(),
+#else
+        Vservo  : quiet_nanf(),
+#endif
         flags   : hal.analogin->power_status_flags(),
         accumulated_flags   : hal.analogin->accumulated_power_status_flags(),
         safety_and_arm : safety_and_armed,
-        MCU_temp : MCU_temp,
-        MCU_voltage : MCU_voltage,
-        MCU_voltage_min : MCU_vmin,
-        MCU_voltage_max : MCU_vmax,
     };
-    WriteBlock(&pkt, sizeof(pkt));
+    WriteBlock(&powr_pkt, sizeof(powr_pkt));
+
+#if HAL_WITH_MCU_MONITORING
+    const struct log_MCU mcu_pkt{
+        LOG_PACKET_HEADER_INIT(LOG_MCU_MSG),
+        time_us : now,
+        MCU_temp : hal.analogin->mcu_temperature(),
+        MCU_voltage : hal.analogin->mcu_voltage(),
+        MCU_voltage_min : hal.analogin->mcu_voltage_min(),
+        MCU_voltage_max : hal.analogin->mcu_voltage_max(),
+    };
+    WriteBlock(&mcu_pkt, sizeof(mcu_pkt));
+#endif
+
 #endif
 }
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -332,6 +332,11 @@ struct PACKED log_POWR {
     uint16_t flags;
     uint16_t accumulated_flags;
     uint8_t safety_and_arm;
+};
+
+struct PACKED log_MCU {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
     float MCU_temp;
     float MCU_voltage;
     float MCU_voltage_min;
@@ -974,10 +979,14 @@ struct PACKED log_VER {
 // @Field: Flags: System power flags
 // @Field: AccFlags: Accumulated System power flags; all flags which have ever been set
 // @Field: Safety: Hardware Safety Switch status
-// @Field: MTemp: MCU Temperature
-// @Field: MVolt: MCU Voltage
-// @Field: MVmin: MCU Voltage min
-// @Field: MVmax: MCU Voltage max
+
+// @LoggerMessage: MCU
+// @Description: MCU voltage and temprature monitering
+// @Field: TimeUS: Time since system startup
+// @Field: MTemp: Temperature
+// @Field: MVolt: Voltage
+// @Field: MVmin: Voltage min
+// @Field: MVmax: Voltage max
 
 // @LoggerMessage: RAD
 // @Description: Telemetry radio statistics
@@ -1249,7 +1258,9 @@ LOG_STRUCTURE_FROM_GPS \
 LOG_STRUCTURE_FROM_BARO \
 LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_POWR_MSG, sizeof(log_POWR), \
-      "POWR","QffHHBffff","TimeUS,Vcc,VServo,Flags,AccFlags,Safety,MTemp,MVolt,MVmin,MVmax", "svv---Ovvv", "F00---0000", true }, \
+      "POWR","QffHHB","TimeUS,Vcc,VServo,Flags,AccFlags,Safety", "svv---", "F00---", true }, \
+    { LOG_MCU_MSG, sizeof(log_MCU), \
+      "MCU","Qffff","TimeUS,MTemp,MVolt,MVmin,MVmax", "sOvvv", "F0000", true }, \
     { LOG_CMD_MSG, sizeof(log_Cmd), \
       "CMD", "QHHHffffLLfB","TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt,Frame", "s-------DUm-", "F-------GG0-" }, \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \
@@ -1359,6 +1370,7 @@ enum LogMessages : uint8_t {
     LOG_RSSI_MSG,
     LOG_IDS_FROM_BARO,
     LOG_POWR_MSG,
+    LOG_MCU_MSG,
     LOG_IDS_FROM_AHRS,
     LOG_SIMSTATE_MSG,
     LOG_CMD_MSG,


### PR DESCRIPTION
~~Saves lots of empty logs fields.~~

~~Quite tempted to split into multiple messages.~~

~~The only change here is that we would no longer log the safety flag, it would be the only none-zero thing.~~

Now just removes stuff that is not there rather than trying to selectively log. 