### PR TITLE
AP_AHRS: pre-arm msg loses extra AHRS prefix

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2077,7 +2077,7 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
 
     // ensure we're using the configured backend, but bypass in compass-less cases:
     if (ekf_type() != active_EKF_type() && AP::compass().use_for_yaw()) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "AHRS: not using configured AHRS type");
+        hal.util->snprintf(failure_msg, failure_msg_len, "not using configured AHRS type");
         return false;
     }
 


### PR DESCRIPTION
Callers of the AHRS::pre_arm_check() method prefix the returns string with "AHRS:" so we don't need again.

Below is a screen shot of a test in SITL after setting AHRS_EKF_TYPE = 2

![image](https://user-images.githubusercontent.com/1498098/196930055-74357ced-007a-47ff-bdb2-7808d228e434.png)
