### PR TITLE
AP_Arming: allow scripting channels to be disabled

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -875,10 +875,12 @@ bool AP_Arming::servo_checks(bool report) const
             const SRV_Channel::Aux_servo_function_t ch_function = c->get_function();
 
             // motors, e-stoppable functions, neopixels and ProfiLEDs may be digital outputs and thus can be disabled
+            // scripting can use its functions as labels for LED setup
             const bool disabled_ok = SRV_Channel::is_motor(ch_function) ||
                                      SRV_Channel::should_e_stop(ch_function) ||
                                      (ch_function >= SRV_Channel::k_LED_neopixel1 && ch_function <= SRV_Channel::k_LED_neopixel4) ||
-                                     (ch_function >= SRV_Channel::k_ProfiLED_1 && ch_function <= SRV_Channel::k_ProfiLED_Clock);
+                                     (ch_function >= SRV_Channel::k_ProfiLED_1 && ch_function <= SRV_Channel::k_ProfiLED_Clock) ||
+                                     (ch_function >= SRV_Channel::k_scripting1 && ch_function <= SRV_Channel::k_scripting16);
 
             // for all other functions raise a pre-arm failure
             if (!disabled_ok) {


### PR DESCRIPTION
Currently the various LED lua scripts cause arming failures. This is because the scripting funciton is just used as a label to assign a LED channel.

For example from LED_roll.lua:
```
--[[
 use SERVOn_FUNCTION 94 for LED. We can control up to 16 separate strips of LEDs
 by putting them on different channels
--]]
local chan = SRV_Channels:find_channel(94)

if not chan then
    gcs:send_text(6, "LEDs: channel not set")
    return
end

-- find_channel returns 0 to 15, convert to 1 to 16
chan = chan + 1

-- initialisation code
serialLED:set_num_neopixel(chan,  num_leds)
```

Bug report on facebook:

https://www.facebook.com/groups/ArduPilot.org/permalink/5810753962281082/

"On my Hexsoon EDU-450, I've set up the LED's according to the instructions but get this warning when I try to arm. It's clearly not a disabled channel as can be seen in the servo output list. Anyone know how to correct this? For now, I disabled all the pre-arm checks, but I don't like overriding that safety feature. Thanks!`

https://github.com/ArduPilot/ardupilot/pull/20584