### PR TITLE
AP_LeakDetector: add manual leak-pin selection to extend board compatibility

### DIFF
--- a/libraries/AP_LeakDetector/AP_LeakDetector.cpp
+++ b/libraries/AP_LeakDetector/AP_LeakDetector.cpp
@@ -19,6 +19,14 @@ const AP_Param::GroupInfo AP_LeakDetector::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("1_LOGIC", 2, AP_LeakDetector, _default_reading[0], 0),
 
+    // @Param: 1_TYPE
+    // @DisplayName: Leak detector pin type (analog/digital)
+    // @Description: Enables leak detector 1. Use this parameter to indicate the signal type (0:analog, 1:digital) of an appropriately configured input pin, then specify its pin number using the LEAK1_PIN parameter. NOT FOR USE by default with Pixhawk, Pixhawk 4 or Navigator flight controllers.
+    // @Values: -1:Disabled,0:Analog,1:Digital
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("1_TYPE", 7, AP_LeakDetector, _type[0], DISABLED), 
+
 #if LEAKDETECTOR_MAX_INSTANCES > 1
     // @Param: 2_PIN
     // @DisplayName: Pin that leak detector is connected to
@@ -34,6 +42,14 @@ const AP_Param::GroupInfo AP_LeakDetector::var_info[] = {
     // @Values: 0:Low,1:High
     // @User: Standard
     AP_GROUPINFO("2_LOGIC", 4, AP_LeakDetector, _default_reading[1], 0),
+
+    // @Param: 2_TYPE
+    // @DisplayName: Leak detector pin type (analog/digital)
+    // @Description: Enables leak detector 2. Use this parameter to indicate the signal type (0:analog, 1:digital) of an appropriately configured input pin, then specify its pin number using the LEAK2_PIN parameter. NOT FOR USE by default with Pixhawk, Pixhawk 4 or Navigator flight controllers.
+    // @Values: -1:Disabled,0:Analog,1:Digital
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("2_TYPE", 8, AP_LeakDetector, _type[1], DISABLED),
 #endif
 
 #if LEAKDETECTOR_MAX_INSTANCES > 2
@@ -51,6 +67,14 @@ const AP_Param::GroupInfo AP_LeakDetector::var_info[] = {
     // @Values: 0:Low,1:High
     // @User: Standard
     AP_GROUPINFO("3_LOGIC", 6, AP_LeakDetector, _default_reading[2], 0),
+
+    // @Param: 3_TYPE
+    // @DisplayName: Leak detector pin type (analog/digital)
+    // @Description: Enables leak detector 3. Use this parameter to indicate the signal type (0:analog, 1:digital) of an appropriately configured input pin, then specify its pin number using the LEAK3_PIN parameter. NOT FOR USE by default with Pixhawk, Pixhawk 4 or Navigator flight controllers.
+    // @Values: -1:Disabled,0:Analog,1:Digital
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("3_TYPE", 9, AP_LeakDetector, _type[2], DISABLED),
 #endif
 
     AP_GROUPEND
@@ -72,23 +96,28 @@ void AP_LeakDetector::init()
         switch (_pin[i]) {
 #if (CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_FMUV3 || \
      CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_FMUV5)
-        case 50 ... 55:
-            _state[i].instance = i;
-            _drivers[i] = new AP_LeakDetector_Digital(*this, _state[i]);
-            break;
-        case 13 ... 15:
-            _state[i].instance = i;
-            _drivers[i] = new AP_LeakDetector_Analog(*this, _state[i]);
-            break;
+            case 13 ... 15:
+                _type[i].set_default(ANALOG);
+                break;
+            case 50 ... 55:
+                _type[i].set_default(DIGITAL);
+                break;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIGATOR
-        case 27:
-            _state[i].instance = i;
-            _drivers[i] = new AP_LeakDetector_Digital(*this, _state[i]);
-            break;
+            case 27:
+                _type[i].set_default(DIGITAL);
+                break;
 #endif
-        default:
-            _drivers[i] = NULL;
-            break;
+        }
+
+        switch(_type[i]) {
+            case ANALOG:
+                _state[i].instance = i;
+                _drivers[i] = new AP_LeakDetector_Analog(*this, _state[i]);
+                break;
+            case DIGITAL:
+                _state[i].instance = i;
+                _drivers[i] = new AP_LeakDetector_Digital(*this, _state[i]);
+                break;
         }
     }
 }

--- a/libraries/AP_LeakDetector/AP_LeakDetector.h
+++ b/libraries/AP_LeakDetector/AP_LeakDetector.h
@@ -45,7 +45,12 @@ private:
     bool _status; // Current status, true if leak detected, false if all sensors dry
     uint32_t _last_detect_ms;
 
-    AP_Int8 _type[LEAKDETECTOR_MAX_INSTANCES]; // Analog, Digital, Mavlink
+    enum _signal_types {
+        DISABLED=-1,
+        ANALOG=0,
+        DIGITAL=1
+    };
+    AP_Int8 _type[LEAKDETECTOR_MAX_INSTANCES]; // Signal type configured at the input pin (analog, digital, disabled)
     AP_Int8 _pin[LEAKDETECTOR_MAX_INSTANCES]; // Pin that detector is connected to
     AP_Int8 _default_reading[LEAKDETECTOR_MAX_INSTANCES]; // Default reading when leak detector is dry
 };


### PR DESCRIPTION
This pull request addresses issue #22013.

At present, the AP_LeakDetector library used in ArduSub contains compilation directives that only allow this sensor to initialize on FMUv3, FMUv5, or Linux navigator boards. Sensor initialization is neglected for all other board types, without providing any sort of notice to the user.

The changes proposed will here remove the initialization's dependence on board type. In this updated code, leak detectors can be initialized over connection to arbitrary pin number on any type of board. A new advanced parameter, `LEAKx_TYPE`, has been introduced that can be used to enable manual configuration of the leak detector pin. In order to use this feature, a user would set the `LEAKx_TYPE` parameter to indicate the signal type (analog or digital) of an appropriately configured pin on their board. The number of this pin should then be set as the value of the existing `LEAKx_PIN` parameter.
