### PR TITLE
SRV_Channel: pwm_from_angle: return trim for 0 high_out

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -99,6 +99,9 @@ uint16_t SRV_Channel::pwm_from_range(float scaled_value) const
 // convert a -angle_max..angle_max to a pwm
 uint16_t SRV_Channel::pwm_from_angle(float scaled_value) const
 {
+    if (high_out == 0) {
+        return servo_trim;
+    }
     if (reversed) {
         scaled_value = -scaled_value;
     }


### PR DESCRIPTION
When changing output function from disabled to scaled output `high_out` is zero until we call `update_aux_servo_function` which is done a a lower rate than the outputs. So we end up with a divide by 0 for a few loops. 

`pwm_from_range` already checks for `high_out` of 0.

https://github.com/ArduPilot/ardupilot/pull/21347 (although I suspect setting a function to scaled output is not the only way to hit this.)

Found when checking we can do full range servo for https://github.com/ArduPilot/ardupilot/issues/22011
