### PR TITLE
Add turtle mode safety features

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1642,6 +1642,9 @@ protected:
     const char *name4() const override { return "TRTL"; }
 
 private:
+    void arm_motors();
+    void disarm_motors();
+
     float motors_output;
     Vector2f motors_input;
 };


### PR DESCRIPTION
This adds a couple of safety features to turtle mode:
- You now will not be able to enter turtle mode unless the throttle is at zero
- When you enter turtle mode the motors stay disarmed but the notfiy LEDs flash
- When you raise the throttle the motors arm, when you lower the throttle the motors disarm
- You can only spin up the motors with the throttle raised

Fixes #22005 