### PR TITLE
AP_Notify: use existing method for setting rgb and rate

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -241,21 +241,13 @@ void RGBLed::handle_led_control(const mavlink_message_t &msg)
 
     _led_override.start_ms = AP_HAL::millis();
 
+    uint8_t rate_hz = 0;
     switch (packet.custom_len) {
-    case 3:
-        _led_override.rate_hz = 0;
-        _led_override.r = packet.custom_bytes[0];
-        _led_override.g = packet.custom_bytes[1];
-        _led_override.b = packet.custom_bytes[2];
-        break;
     case 4:
-        _led_override.rate_hz = packet.custom_bytes[3];
-        _led_override.r = packet.custom_bytes[0];
-        _led_override.g = packet.custom_bytes[1];
-        _led_override.b = packet.custom_bytes[2];
-        break;
-    default:
-        // not understood
+        rate_hz = packet.custom_bytes[3];
+        FALLTHROUGH;
+    case 3:
+        rgb_control(packet.custom_bytes[0], packet.custom_bytes[1], packet.custom_bytes[2], rate_hz);
         break;
     }
 }

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -26,7 +26,7 @@ public:
     RGBLed(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, uint8_t led_dim);
 
     // set_rgb - set color as a combination of red, green and blue levels from 0 ~ 15
-    virtual void set_rgb(uint8_t red, uint8_t green, uint8_t blue);
+    void set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
     // update - updates led according to timed_updated.  Should be
     // called at 50Hz
@@ -37,7 +37,7 @@ public:
 
     // RGB control
     // give RGB and flash rate, used with scripting
-    virtual void rgb_control(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz) override;
+    void rgb_control(uint8_t r, uint8_t g, uint8_t b, uint8_t rate_hz) override;
 
 protected:
     // methods implemented in hardware specific classes


### PR DESCRIPTION
... also remove some `virtual` designators where they're not over-rtidden
