### PR TITLE
APM_Control: factor out an AP_PitchRollController base class

### DIFF
--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
-#include "AP_AutoTune.h"
-#include <AP_Math/AP_Math.h>
-#include <AC_PID/AC_PID.h>
+#include "AP_PitchRollController.h"
 
-class AP_PitchController
+class AP_PitchController : public AP_PitchRollController
 {
 public:
     AP_PitchController(const AP_Vehicle::FixedWing &parms);
@@ -17,48 +13,13 @@ public:
     float get_rate_out(float desired_rate, float scaler);
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
-    void reset_I();
-
-    /*
-      reduce the integrator, used when we have a low scale factor in a quadplane hover
-    */
-    void decay_I()
-    {
-        // this reduces integrator by 95% over 2s
-        _pid_info.I *= 0.995f;
-        rate_pid.set_integrator(rate_pid.get_i() * 0.995);
-    }
-
-    void autotune_start(void);
-    void autotune_restore(void);
-
-    const AP_PIDInfo& get_pid_info(void) const
-    {
-        return _pid_info;
-    }
-
     static const struct AP_Param::GroupInfo var_info[];
-
-    AP_Float &kP(void) { return rate_pid.kP(); }
-    AP_Float &kI(void) { return rate_pid.kI(); }
-    AP_Float &kD(void) { return rate_pid.kD(); }
-    AP_Float &kFF(void) { return rate_pid.ff(); }
-    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 
 private:
-    const AP_Vehicle::FixedWing &aparm;
-    AP_AutoTune::ATGains gains;
-    AP_AutoTune *autotune;
-    bool failed_autotune_alloc;
-    AP_Int16 _max_rate_neg;
-    AP_Float _roll_ff;
-    float _last_out;
-    AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
-    float angle_err_deg;
 
-    AP_PIDInfo _pid_info;
+    AP_Float _roll_ff;
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
     float _get_coordination_rate_offset(float &aspeed, bool &inverted) const;

--- a/libraries/APM_Control/AP_PitchRollController.cpp
+++ b/libraries/APM_Control/AP_PitchRollController.cpp
@@ -1,0 +1,9 @@
+#include "AP_PitchRollController.h"
+
+AP_PitchRollController::AP_PitchRollController(const AP_Vehicle::FixedWing &parms, AP_AutoTune::ATType _autotune_axis, const char *_axis_name)
+    : aparm(parms),
+      autotune_axis{_autotune_axis},
+      axis_name{_axis_name}
+{
+    rate_pid.set_slew_limit_scale(45);
+}

--- a/libraries/APM_Control/AP_PitchRollController.h
+++ b/libraries/APM_Control/AP_PitchRollController.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+#include "AP_AutoTune.h"
+#include <AP_Math/AP_Math.h>
+#include <AC_PID/AC_PID.h>
+
+// base class for pitch and roll controller
+class AP_PitchRollController
+{
+
+public:
+
+    AP_PitchRollController(const AP_Vehicle::FixedWing &parms, AP_AutoTune::ATType _autotune_axis, const char *_axis_name);
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_PitchRollController);
+
+    /*
+      reduce the integrator, used when we have a low scale factor in a quadplane hover
+    */
+    void decay_I()
+    {
+        // this reduces integrator by 95% over 2s
+        _pid_info.I *= 0.995f;
+        rate_pid.set_integrator(rate_pid.get_i() * 0.995);
+    }
+
+    void autotune_start(void);
+    void autotune_restore(void);
+
+    void reset_I();
+
+    const AP_PIDInfo& get_pid_info(void) const
+    {
+        return _pid_info;
+    }
+
+    // tuning accessors
+    AP_Float &kP(void) { return rate_pid.kP(); }
+    AP_Float &kI(void) { return rate_pid.kI(); }
+    AP_Float &kD(void) { return rate_pid.kD(); }
+    AP_Float &kFF(void) { return rate_pid.ff(); }
+    AP_Float &tau(void) { return gains.tau; }
+
+protected:
+    const AP_Vehicle::FixedWing &aparm;
+    AP_AutoTune::ATGains gains;
+    AP_AutoTune *autotune;
+    bool failed_autotune_alloc;
+    float _last_out;
+    AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
+    float angle_err_deg;
+
+    AP_PIDInfo _pid_info;
+
+private:
+
+    AP_AutoTune::ATType autotune_axis;
+    const char *axis_name;
+};

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -119,10 +119,9 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 // constructor
 AP_RollController::AP_RollController(const AP_Vehicle::FixedWing &parms)
-    : aparm(parms)
+    : AP_PitchRollController(parms, AP_AutoTune::AUTOTUNE_ROLL, "roll")
 {
     AP_Param::setup_object_defaults(this, var_info);
-    rate_pid.set_slew_limit_scale(45);
 }
 
 
@@ -245,7 +244,7 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
     return _get_rate_out(desired_rate, scaler, disable_integrator, ground_mode);
 }
 
-void AP_RollController::reset_I()
+void AP_PitchRollController::reset_I()
 {
     _pid_info.I = 0;
     rate_pid.reset_I();
@@ -284,13 +283,13 @@ void AP_RollController::convert_pid()
 /*
   start an autotune
  */
-void AP_RollController::autotune_start(void)
+void AP_PitchRollController::autotune_start(void)
 {
     if (autotune == nullptr) {
-        autotune = new AP_AutoTune(gains, AP_AutoTune::AUTOTUNE_ROLL, aparm, rate_pid);
+        autotune = new AP_AutoTune(gains, autotune_axis, aparm, rate_pid);
         if (autotune == nullptr) {
             if (!failed_autotune_alloc) {
-                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AutoTune: failed roll allocation");
+                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AutoTune: failed %s allocation", axis_name);
             }
             failed_autotune_alloc = true;
         }
@@ -303,7 +302,7 @@ void AP_RollController::autotune_start(void)
 /*
   restore autotune gains
  */
-void AP_RollController::autotune_restore(void)
+void AP_PitchRollController::autotune_restore(void)
 {
     if (autotune != nullptr) {
         autotune->stop();

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle.h>
-#include "AP_AutoTune.h"
-#include <AP_Math/AP_Math.h>
-#include <AC_PID/AC_PID.h>
+#include "AP_PitchRollController.h"
 
-class AP_RollController
+class AP_RollController : public AP_PitchRollController
 {
 public:
     AP_RollController(const AP_Vehicle::FixedWing &parms);
@@ -17,53 +13,11 @@ public:
     float get_rate_out(float desired_rate, float scaler);
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
-    void reset_I();
-
-    /*
-      reduce the integrator, used when we have a low scale factor in a quadplane hover
-    */
-    void decay_I()
-    {
-        // this reduces integrator by 95% over 2s
-        _pid_info.I *= 0.995f;
-        rate_pid.set_integrator(rate_pid.get_i() * 0.995);
-    }
-
-    void autotune_start(void);
-    void autotune_restore(void);
-
-    const AP_PIDInfo& get_pid_info(void) const
-    {
-        return _pid_info;
-    }
-
     static const struct AP_Param::GroupInfo var_info[];
-
-
-    // tuning accessors
-    void kP(float v) { rate_pid.kP().set(v); }
-    void kI(float v) { rate_pid.kI().set(v); }
-    void kD(float v) { rate_pid.kD().set(v); }
-    void kFF(float v) {rate_pid.ff().set(v); }
-
-    AP_Float &kP(void) { return rate_pid.kP(); }
-    AP_Float &kI(void) { return rate_pid.kI(); }
-    AP_Float &kD(void) { return rate_pid.kD(); }
-    AP_Float &kFF(void) { return rate_pid.ff(); }
-    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 
 private:
-    const AP_Vehicle::FixedWing &aparm;
-    AP_AutoTune::ATGains gains;
-    AP_AutoTune *autotune;
-    bool failed_autotune_alloc;
-    float _last_out;
-    AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 0.02, 150, 1};
-    float angle_err_deg;
-
-    AP_PIDInfo _pid_info;
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode);
 };


### PR DESCRIPTION
Saves ~100 bytes on MatekF405