### PR TITLE
AP_InternalError: only panic in SITL if debug enabled

### DIFF
--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -9,7 +9,7 @@ extern const AP_HAL::HAL &hal;
 static AP_InternalError instance;
 
 void AP_InternalError::error(const AP_InternalError::error_t e, uint16_t line) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && defined(HAL_DEBUG_BUILD)
     switch (e) {
     case AP_InternalError::error_t::watchdog_reset:
     case AP_InternalError::error_t::main_loop_stuck:


### PR DESCRIPTION
a user recently had a flow of control panic in quadplane in cygwin/missionplanner SITL. The panic this caused means we don't get logging information on what line of code was triggered

the panic in SITL for internal errors is only useful if you have debug information and can then attach a debugger. Without debug information it is much better to behave the same as a real vehicle and report an internal error (with line number)