### PR TITLE
Remove passing of fence state into AFS

### DIFF
--- a/ArduCopter/failsafe.cpp
+++ b/ArduCopter/failsafe.cpp
@@ -79,11 +79,6 @@ void Copter::failsafe_check()
 void Copter::afs_fs_check(void)
 {
     // perform AFS failsafe checks
-#if AP_FENCE_ENABLED
-    const bool fence_breached = fence.get_breaches() != 0;
-#else
-    const bool fence_breached = false;
-#endif
-    g2.afs.check(fence_breached, last_radio_update_ms);
+    g2.afs.check(last_radio_update_ms);
 }
 #endif

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -277,13 +277,7 @@ void Plane::update_logging25(void)
 #if ADVANCED_FAILSAFE == ENABLED
 void Plane::afs_fs_check(void)
 {
-    // perform AFS failsafe checks
-#if AP_FENCE_ENABLED
-    const bool fence_breached = fence.get_breaches() != 0;
-#else
-    const bool fence_breached = false;
-#endif
-    afs.check(fence_breached, failsafe.AFS_last_valid_rc_ms);
+    afs.check(failsafe.AFS_last_valid_rc_ms);
 }
 #endif
 

--- a/Rover/failsafe.cpp
+++ b/Rover/failsafe.cpp
@@ -149,6 +149,6 @@ void Rover::handle_battery_failsafe(const char* type_str, const int8_t action)
 void Rover::afs_fs_check(void)
 {
     // perform AFS failsafe checks
-    g2.afs.check(fence.get_breaches() != 0, failsafe.last_valid_rc_ms);
+    g2.afs.check(failsafe.last_valid_rc_ms);
 }
 #endif

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -306,11 +306,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
 
     // if we are not terminating or if there is a separate terminate
     // pin configured then toggle the heartbeat pin at 10Hz
-    if (_heartbeat_pin != -1 && (_terminate_pin != -1 || !_terminate)) {
-        _heartbeat_pin_value = !_heartbeat_pin_value;
-        hal.gpio->pinMode(_heartbeat_pin, HAL_GPIO_OUTPUT);
-        hal.gpio->write(_heartbeat_pin, _heartbeat_pin_value);
-    }    
+    heartbeat();
 
     // set the terminate pin
     if (_terminate_pin != -1) {

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -165,21 +165,24 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
 // check for Failsafe conditions. This is called at 10Hz by the main
 // ArduPlane code
 void
-AP_AdvancedFailsafe::check(bool geofence_breached, uint32_t last_valid_rc_ms)
-{    
+AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
+{
     if (!_enable) {
         return;
     }
 
+#if AP_FENCE_ENABLED
     // we always check for fence breach
     if(_enable_geofence_fs) {
-        if (geofence_breached || check_altlimit()) {
+        const AC_Fence *ap_fence = AP::fence();
+        if ((ap_fence != nullptr && ap_fence->get_breaches() != 0) || check_altlimit()) {
             if (!_terminate) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to fence breach");
                 _terminate.set_and_notify(1);
             }
         }
     }
+#endif
 
     // update max range check
     max_range_update();

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -72,7 +72,7 @@ public:
     bool enabled() { return _enable; }
 
     // check that everything is OK
-    void check(bool geofence_breached, uint32_t last_valid_rc_ms);
+    void check(uint32_t last_valid_rc_ms);
 
     // generate heartbeat msgs, so external failsafe boards are happy
     // during sensor calibration


### PR DESCRIPTION
We now have a singleton which all Plane, Rover and Copter all use - so use that singleton in AFS.

I tidied the AFS test and checked it under Copter (needs a few not-included hacks as AFS isn't enabled on Copter by default).

Also removes code in lieu of calling a method which does exactly the same thing.

Note the equivalent behaviour to the old code - if you don't have fence compiled in then you won't breach the geofence, even if your AFS parameters say "check the geofence".  Note the same parameter gates checking the qnh altitude limit, however.
