### PR TITLE
Plane: allow mode switch on fence breach for RTL_AUTOLAND

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -248,8 +248,12 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 
 #if AP_FENCE_ENABLED
     // may not be allowed to change mode if recovering from fence breach
-    if (hal.util->get_soft_armed() && fence.enabled() && fence.option_enabled(AC_Fence::OPTIONS::DISABLE_MODE_CHANGE) &&
-                                            fence.get_breaches() && in_fence_recovery()) {
+    if (hal.util->get_soft_armed() &&
+        fence.enabled() &&
+        fence.option_enabled(AC_Fence::OPTIONS::DISABLE_MODE_CHANGE) &&
+        fence.get_breaches() &&
+        in_fence_recovery() &&
+        reason != ModeReason::RTL_COMPLETE_SWITCHING_TO_FIXEDWING_AUTOLAND) {
         gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, in fence recovery", new_mode.name());
         AP_Notify::events.user_mode_change_failed = 1;
         return false;


### PR DESCRIPTION
when we are in a fence breach we by default disallow mode changes, but we need to allow for the switch to AUTO if the reason is we are entering a landing sequence, which is part of the RTL process which is the fence action
this bug was introduced in 4.3.0