### PR TITLE
Cleanup Dronecan generate build step

### DIFF
--- a/Tools/AP_Bootloader/wscript
+++ b/Tools/AP_Bootloader/wscript
@@ -12,27 +12,20 @@ def build(bld):
     
     # build external libcanard library
     bld.stlib(source='../../modules/DroneCAN/libcanard/canard.c',
+              use='dronecan',
               target='libcanard')
 
     bld.ap_program(
-        use=['ap','libcanard','AP_Bootloader_libs'],
-        program_groups='bootloader',
-        includes=[bld.env.SRCROOT + '/modules/DroneCAN/libcanard',
-                  bld.env.BUILDROOT + '/modules/DroneCAN/libcanard/dsdlc_generated']
-        )
+        use=['ap','libcanard','AP_Bootloader_libs', 'dronecan'],
+        program_groups='bootloader'
+    )
 
     bld.ap_stlib(
         name= 'AP_Bootloader_libs',
+        use='dronecan',
+        dynamic_source='modules/DroneCAN/libcanard/dsdlc_generated/src/**.c',
         ap_vehicle='AP_Bootloader',
         ap_libraries= flashiface_lib + [
         'AP_Math',
         'AP_CheckFirmware'
         ])
-    
-    bld(
-        # build libcanard headers
-        source=bld.path.ant_glob("modules/DroneCAN/DSDL/**/*.uavcan"),
-        rule="python3 ${SRCROOT}/modules/DroneCAN/libcanard/dsdl_compiler/libcanard_dsdlc --header_only --outdir ${BUILDROOT}/modules/DroneCAN/libcanard/dsdlc_generated ${SRCROOT}/modules/DroneCAN/DSDL/uavcan ${SRCROOT}/modules/DroneCAN/DSDL/ardupilot ${SRCROOT}/modules/DroneCAN/DSDL/com ${SRCROOT}/modules/DroneCAN/DSDL/dronecan",
-        group='dynamic_sources',
-    )
-        

--- a/Tools/AP_Periph/wscript
+++ b/Tools/AP_Periph/wscript
@@ -70,6 +70,7 @@ def build(bld):
         name= 'AP_Periph_libs',
         ap_vehicle='AP_Periph',
         ap_libraries= libraries,
+        use='dronecan',
         exclude_src=[
             'libraries/AP_HAL_ChibiOS/Storage.cpp'
         ]
@@ -78,14 +79,11 @@ def build(bld):
     # build external libcanard library
     bld.stlib(source=['../../modules/DroneCAN/libcanard/canard.c'] +
                      bld.bldnode.ant_glob('modules/DroneCAN/libcanard/dsdlc_generated/src/**.c'),
-              includes=[bld.env.SRCROOT + '/modules/DroneCAN/libcanard', 
-                        bld.env.BUILDROOT + '/modules/DroneCAN/libcanard/dsdlc_generated/include'],
+              use='dronecan',
               target='libcanard')
 
     bld.ap_program(
         program_name='AP_Periph',
-        use=['AP_Periph_libs', 'libcanard'],
+        use=['AP_Periph_libs', 'libcanard', 'dronecan'],
         program_groups=['bin','AP_Periph'],
-        includes=[bld.env.SRCROOT + '/modules/DroneCAN/libcanard',
-                  bld.env.BUILDROOT + '/modules/DroneCAN/libcanard/dsdlc_generated/include']
     )

--- a/Tools/AP_Periph/wscript
+++ b/Tools/AP_Periph/wscript
@@ -68,6 +68,7 @@ def build(bld):
                      ]
     bld.ap_stlib(
         name= 'AP_Periph_libs',
+        dynamic_source='modules/DroneCAN/libcanard/dsdlc_generated/src/**.c',
         ap_vehicle='AP_Periph',
         ap_libraries= libraries,
         use='dronecan',
@@ -77,8 +78,8 @@ def build(bld):
     )
 
     # build external libcanard library
-    bld.stlib(source=['../../modules/DroneCAN/libcanard/canard.c'] +
-                     bld.bldnode.ant_glob('modules/DroneCAN/libcanard/dsdlc_generated/src/**.c'),
+    bld.stlib(source='../../modules/DroneCAN/libcanard/canard.c',
+              name='libcanard',
               use='dronecan',
               target='libcanard')
 

--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -156,6 +156,14 @@ def process_ap_libraries(self):
         if vehicle:
             self.use.append(_vehicle_tgen_name(l, vehicle))
 
+@before_method('process_source')
+@feature('cxxstlib')
+def dynamic_post(self):
+    if not getattr(self, 'dynamic_source', None):
+        return
+    self.source = Utils.to_list(self.source)
+    self.source.extend(self.bld.bldnode.ant_glob(self.dynamic_source))
+
 class ap_library_check_headers(Task.Task):
     color = 'PINK'
     before  = 'cxx c'

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -415,9 +415,6 @@ class Board:
                 UAVCAN_NULLPTR = 'nullptr'
             )
 
-            env.INCLUDES += [
-                cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath()
-            ]
 
         if cfg.options.build_dates:
             env.build_dates = True

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -459,10 +459,6 @@ def setup_canmgr_build(cfg):
     else:
         env.DEFINES += ['UAVCAN_SUPPORT_CANFD=0']
 
-
-    env.INCLUDES += [
-        cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath(),
-        ]
     cfg.get_board().with_can = True
 
 def load_env_vars(env):

--- a/Tools/ardupilotwaf/dronecangen.py
+++ b/Tools/ardupilotwaf/dronecangen.py
@@ -10,7 +10,7 @@ import os
 import os.path
 from xml.etree import ElementTree as et
 
-class uavcangen(Task.Task):
+class dronecangen(Task.Task):
     """generate uavcan header files"""
     color   = 'BLUE'
     before  = 'cxx c'
@@ -24,31 +24,30 @@ class uavcangen(Task.Task):
         ret = self.exec_command(['{}'.format(python),
                                  '{}'.format(dsdlc),
                                  '-O{}'.format(out)] + [x.abspath() for x in self.inputs])
-
         if ret != 0:
             # ignore if there was a signal to the interpreter rather
             # than a real error in the script. Some environments use a
             # signed and some an unsigned return for this
             if ret > 128 or ret < 0:
-                Logs.warn('uavcangen crashed with code: {}'.format(ret))
+                Logs.warn('dronecangen crashed with code: {}'.format(ret))
                 ret = 0
             else:
-                Logs.error('uavcangen returned {} error code'.format(ret))
+                Logs.error('dronecangen returned {} error code'.format(ret))
         return ret
 
     def post_run(self):
-        super(uavcangen, self).post_run()
-        for header in self.generator.output_dir.ant_glob("*.hpp **/*.hpp", remove=False):
+        super(dronecangen, self).post_run()
+        for header in self.generator.output_dir.ant_glob("*.h **/*.h", remove=False):
             header.sig = header.cache_sig = self.cache_sig
 
 def options(opt):
     opt.load('python')
 
-@feature('uavcangen')
-@before_method('process_source')
-def process_uavcangen(self):
+@feature('dronecangen')
+@before_method('process_rule')
+def process_dronecangen(self):
     if not hasattr(self, 'output_dir'):
-        self.bld.fatal('uavcangen: missing option output_dir')
+        self.bld.fatal('dronecangen: missing option output_dir')
 
     inputs = self.to_nodes(self.source)
     outputs = []
@@ -58,7 +57,7 @@ def process_uavcangen(self):
     if not isinstance(self.output_dir, Node.Node):
         self.output_dir = self.bld.bldnode.find_or_declare(self.output_dir)
 
-    task = self.create_task('uavcangen', inputs, outputs)
+    task = self.create_task('dronecangen', inputs, outputs)
     task.env['OUTPUT_DIR'] = self.output_dir.abspath()
 
     task.env.env = dict(os.environ)
@@ -71,6 +70,6 @@ def configure(cfg):
     cfg.check_python_version(minver=(2,7,0))
 
     env = cfg.env
-    env.DSDL_COMPILER_DIR = cfg.srcnode.make_node('modules/uavcan/libuavcan/dsdl_compiler').abspath()
-    env.DSDL_COMPILER = env.DSDL_COMPILER_DIR + '/libuavcan_dsdlc'
+    env.DSDL_COMPILER_DIR = cfg.srcnode.make_node('modules/DroneCAN/dronecan_dsdlc/').abspath()
+    env.DSDL_COMPILER = env.DSDL_COMPILER_DIR + '/dronecan_dsdlc.py'
     cfg.msg('DSDL compiler', env.DSDL_COMPILER)

--- a/wscript
+++ b/wscript
@@ -443,7 +443,10 @@ def configure(cfg):
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')
     cfg.load('mavgen')
-    cfg.load('uavcangen')
+    if cfg.options.board in cfg.ap_periph_boards():
+        cfg.load('dronecangen')
+    else:
+        cfg.load('uavcangen')
 
     cfg.env.SUBMODULE_UPDATE = cfg.options.submodule_update
 
@@ -541,26 +544,6 @@ def configure(cfg):
 
     _collect_autoconfig_files(cfg)
 
-def generate_dronecan_dsdlc(cfg):
-    dsdlc_gen_path = cfg.bldnode.make_node('modules/DroneCAN/libcanard/dsdlc_generated').abspath()
-    src = cfg.srcnode.ant_glob('modules/DroneCAN/DSDL/* libraries/AP_UAVCAN/dsdl/*', dir=True, src=False)
-    dsdlc_path = cfg.srcnode.make_node('modules/DroneCAN/dronecan_dsdlc/dronecan_dsdlc.py').abspath()
-    if not os.path.exists(dsdlc_path):
-        print("Please update submodules with: git submodule update --recursive --init")
-        sys.exit(1)
-    src = ' '.join([s.abspath() for s in src])
-    cmd = '{} {} -O {} {}'.format(cfg.env.get_flat('PYTHON'),
-                        dsdlc_path,
-                        dsdlc_gen_path,
-                        src)
-    print("Generating DSDLC for CANARD: " + cmd)
-    ret = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if ret.returncode != 0:
-        print('Failed to run: ', cmd)
-        print(ret.stdout.decode('utf-8'))
-        print(ret.stderr.decode('utf-8'))
-        raise RuntimeError('Failed to generate DSDL C bindings')
-
 def collect_dirs_to_recurse(bld, globs, **kw):
     dirs = []
     globs = Utils.to_list(globs)
@@ -657,9 +640,20 @@ def _build_dynamic_sources(bld):
             name='uavcan',
             export_includes=[
                 bld.bldnode.make_node('modules/uavcan/libuavcan/include/dsdlc_generated').abspath(),
+                bld.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath()
             ]
         )
-
+    elif bld.env.AP_PERIPH:
+        bld(
+            features='dronecangen',
+            source=bld.srcnode.ant_glob('modules/DroneCAN/DSDL/* libraries/AP_UAVCAN/dsdl/*', dir=True, src=False),
+            output_dir='modules/DroneCAN/libcanard/dsdlc_generated/',
+            name='dronecan',
+            export_includes=[
+                bld.bldnode.make_node('modules/DroneCAN/libcanard/dsdlc_generated/include').abspath(),
+                bld.srcnode.find_dir('modules/DroneCAN/libcanard/').abspath(),
+            ]
+        )
 
     def write_version_header(tsk):
         bld = tsk.generator.bld
@@ -764,12 +758,6 @@ def _load_pre_build(bld):
     if bld.cmd == 'clean':
         return
     brd = bld.get_board()
-    if bld.env.AP_PERIPH:
-        dsdlc_gen_path = bld.bldnode.make_node('modules/DroneCAN/libcanard/dsdlc_generated/include').abspath()
-        #check if canard dsdlc directory empty
-        # check if directory exists
-        if not os.path.exists(dsdlc_gen_path) or not os.listdir(dsdlc_gen_path):
-            generate_dronecan_dsdlc(bld)
     if getattr(brd, 'pre_build', None):
         brd.pre_build(bld)    
 

--- a/wscript
+++ b/wscript
@@ -779,6 +779,8 @@ def build(bld):
 
     if bld.get_board().with_can:
         bld.env.AP_LIBRARIES_OBJECTS_KW['use'] += ['uavcan']
+    if bld.env.AP_PERIPH:
+        bld.env.AP_LIBRARIES_OBJECTS_KW['use'] += ['dronecan']
 
     _build_cmd_tweaks(bld)
 


### PR DESCRIPTION
* moves bootloader to use dronecan dsdl compiler
* adds dynamic source option to ap_stlib, making it much convenient to add generated source code.
* do dronecan_dsdlc operation as a bld() task rather than pre build task, which doesn't recompile if dsdl is changed.