### PR TITLE
AP_Scripting: implement tricks on a switch on top of trajectory tracking

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -537,7 +537,7 @@ void Plane::update_alt()
     update_flight_stage();
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting.enabled) {
+    if (nav_scripting_active()) {
         // don't call TECS while we are in a trick
         return;
     }

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -536,6 +536,13 @@ void Plane::update_alt()
 
     update_flight_stage();
 
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting.enabled) {
+        // don't call TECS while we are in a trick
+        return;
+    }
+#endif
+
     if (control_mode->does_auto_throttle() && !throttle_suppressed) {
 
         float distance_beyond_land_wp = 0;

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -508,8 +508,7 @@ void Plane::stabilize()
     if (control_mode == &mode_training) {
         stabilize_training(speed_scaler);
 #if AP_SCRIPTING_ENABLED
-    } else if ((control_mode == &mode_auto &&
-               mission.get_current_nav_cmd().id == MAV_CMD_NAV_SCRIPT_TIME) || (nav_scripting.enabled && nav_scripting.current_ms > 0)) {
+    } else if (nav_scripting_active()) {
         // scripting is in control of roll and pitch rates and throttle
         const float aileron = rollController.get_rate_out(nav_scripting.roll_rate_dps, speed_scaler);
         const float elevator = pitchController.get_rate_out(nav_scripting.pitch_rate_dps, speed_scaler);
@@ -518,9 +517,6 @@ void Plane::stabilize()
         if (yawController.rate_control_enabled()) {
             const float rudder = yawController.get_rate_out(nav_scripting.yaw_rate_dps, speed_scaler, false);
             steering_control.rudder = rudder;
-        }
-        if (AP_HAL::millis() - nav_scripting.current_ms > 50) { //set_target_throttle_rate_rpy has not been called from script in last 50ms
-            nav_scripting.current_ms = 0;
         }
 #endif
     } else if (control_mode == &mode_acro) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -518,9 +518,7 @@ private:
         float throttle_pct;
         uint32_t start_ms;
         uint32_t current_ms;
-        bool done;
     } nav_scripting;
-    
 #endif
 
     struct {
@@ -1127,7 +1125,7 @@ private:
 
 #if AP_SCRIPTING_ENABLED
     // support for NAV_SCRIPT_TIME mission command
-    bool nav_scripting_active(void) const;
+    bool nav_scripting_active(void);
     bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) override;
     void nav_script_time_done(uint16_t id) override;
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -370,7 +370,7 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
     auto_state.takeoff_pitch_cd        = (int16_t)cmd.p1 * 100;
     if (auto_state.takeoff_pitch_cd <= 0) {
         // if the mission doesn't specify a pitch use 4 degrees
-        auto_state.takeoff_pitch_cd = 400;
+        auto_state.takeoff_pitch_cd = 1500;
     }
     auto_state.takeoff_altitude_rel_cm = next_WP_loc.alt - home.alt;
     next_WP_loc.lat = home.lat + 10;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1226,7 +1226,7 @@ void Plane::set_target_throttle_rate_rpy(float throttle_pct, float roll_rate_dps
     nav_scripting.roll_rate_dps = constrain_float(roll_rate_dps, -g.acro_roll_rate, g.acro_roll_rate);
     nav_scripting.pitch_rate_dps = constrain_float(pitch_rate_dps, -g.acro_pitch_rate, g.acro_pitch_rate);
     nav_scripting.yaw_rate_dps = constrain_float(yaw_rate_dps, -g.acro_yaw_rate, g.acro_yaw_rate);
-    nav_scripting.throttle_pct = throttle_pct;
+    nav_scripting.throttle_pct = constrain_float(throttle_pct, aparm.throttle_min, aparm.throttle_max);
     nav_scripting.current_ms = AP_HAL::millis();
 }
 

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -29,7 +29,7 @@ void ModeCruise::update()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting.enabled) {
+    if (plane.nav_scripting_active()) {
         // while a trick is running unlock heading and zero altitude offset
         locked_heading = false;
         lock_timer_ms = 0;
@@ -53,7 +53,7 @@ void ModeCruise::update()
 void ModeCruise::navigate()
 {
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting.enabled) {
+    if (plane.nav_scripting_active()) {
         // don't try to navigate while running trick
         return;
     }

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -28,6 +28,15 @@ void ModeCruise::update()
         lock_timer_ms = 0;
     }
 
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting.enabled) {
+        // while a trick is running unlock heading and zero altitude offset
+        locked_heading = false;
+        lock_timer_ms = 0;
+        plane.set_target_altitude_current();
+    }
+#endif
+    
     if (!locked_heading) {
         plane.nav_roll_cd = plane.channel_roll->norm_input() * plane.roll_limit_cd;
         plane.update_load_factor();
@@ -43,6 +52,12 @@ void ModeCruise::update()
  */
 void ModeCruise::navigate()
 {
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting.enabled) {
+        // don't try to navigate while running trick
+        return;
+    }
+#endif
     if (!locked_heading &&
         plane.channel_roll->get_control_in() == 0 &&
         plane.rudder_input() == 0 &&

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -29,7 +29,7 @@ void ModeLoiter::update()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting.enabled) {
+    if (plane.nav_scripting_active()) {
         // while a trick is running we reset altitude
         plane.set_target_altitude_current();
         plane.next_WP_loc.set_alt_cm(plane.target_altitude.amsl_cm, Location::AltFrame::ABSOLUTE);
@@ -100,7 +100,7 @@ void ModeLoiter::navigate()
     }
 
 #if AP_SCRIPTING_ENABLED
-    if (plane.nav_scripting.enabled) {
+    if (plane.nav_scripting_active()) {
         // don't try to navigate while running trick
         return;
     }

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -27,6 +27,14 @@ void ModeLoiter::update()
         plane.calc_nav_pitch();
         plane.calc_throttle();
     }
+
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting.enabled) {
+        // while a trick is running we reset altitude
+        plane.set_target_altitude_current();
+        plane.next_WP_loc.set_alt_cm(plane.target_altitude.amsl_cm, Location::AltFrame::ABSOLUTE);
+    }
+#endif
 }
 
 bool ModeLoiter::isHeadingLinedUp(const Location loiterCenterLoc, const Location targetLoc)
@@ -90,6 +98,13 @@ void ModeLoiter::navigate()
         // update the WP alt from the global target adjusted by update_fbwb_speed_height
         plane.next_WP_loc.set_alt_cm(plane.target_altitude.amsl_cm, Location::AltFrame::ABSOLUTE);
     }
+
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting.enabled) {
+        // don't try to navigate while running trick
+        return;
+    }
+#endif
 
     // Zero indicates to use WP_LOITER_RAD
     plane.update_loiter(0);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -562,7 +562,7 @@ void Plane::set_servos_controlled(void)
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
         }
 #if AP_SCRIPTING_ENABLED
-    } else if (plane.nav_scripting.current_ms > 0 && nav_scripting.enabled) {
+    } else if (nav_scripting_active()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.nav_scripting.throttle_pct);
 #endif
     } else if (control_mode == &mode_stabilize ||

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -27,6 +27,7 @@ parameters (described below).
 | 12 | Humpty Bump              | radius | height     |           |            | Yes        |
 | 13 | Straight Flight          | length | bank angle |           |            | No         |
 | 14 | Scale Figure Eight       | radius | bank angle |           |            | No         |
+| 15 | Immelmann Turn           | radius | roll rate  |           |            | Yes         |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -11,27 +11,27 @@ The following table gives the available manoeuvres. Each manoeuvre has
 an ID number which is used in the AUTO mission or in the TRIKn_ID
 parameters (described below).
 
-| ID | Name                     | Arg1   | Arg2        | Arg3      | Arg4       | Turnaround |
-| -- | ------------------------ | ------ | ----------  | -------   | ---------- | ---------- |
-| 1  | Figure Eight             | radius | bank angle  |           |            | No         |
-| 2  | Loop                     | radius | bank angle  | num loops |            | No         |
-| 3  | Horizontal Rectangle     | length | width       | radius    | bank angle | No         |
-| 4  | Climbing Circle          | radius | height      |           |            | No         |
-| 5  | vertical Box             | length | height      | radius    |            | No         |
-| 6  | Banked Circle            | radius | bank angle  | height    |            | No         |
-| 7  | Straight Roll            | length | num rolls   |           |            | No         |
-| 8  | Rolling Circle           | radius | num rolls   |           |            | No         |
-| 9  | Half Cuban Eight         | radius |             |           |            | Yes        |
-| 10 | Half Reverse Cuban Eight | radius |             |           |            | Yes        |
-| 11 | Cuban Eight              | radius |             |           |            | No         |
-| 12 | Humpty Bump              | radius | height      |           |            | Yes        |
-| 13 | Straight Flight          | length | bank angle  |           |            | No         |
-| 14 | Scale Figure Eight       | radius | bank angle  |           |            | No         |
-| 15 | Immelmann Turn           | radius | roll rate   |           |            | Yes        |
-| 16 | Split-S                  | radius | roll rate   |           |            | Yes        |
-| 17 | Upline-45                | radius | height gain |           |            | No         |
-| 18 | Downline-45              | radius | height loss |           |            | No         |
-| 19 | Stall Turn               | radius | height      | direction |            | Yes        |
+| ID | Name                     | Arg1   | Arg2        | Arg3       | Arg4       | Turnaround |
+| -- | ------------------------ | ------ | ----------  | -------    | ---------- | ---------- |
+| 1  | Figure Eight             | radius | bank angle  |            |            | No         |
+| 2  | Loop                     | radius | bank angle  | num loops  |            | No         |
+| 3  | Horizontal Rectangle     | length | width       | radius     | bank angle | No         |
+| 4  | Climbing Circle          | radius | height      | bank angle |            | No         |
+| 5  | vertical Box             | length | height      | radius     |            | No         |
+| 6  | Banked Circle            | radius | bank angle  | height     |            | No         |
+| 7  | Straight Roll            | length | num rolls   |            |            | No         |
+| 8  | Rolling Circle           | radius | num rolls   |            |            | No         |
+| 9  | Half Cuban Eight         | radius |             |            |            | Yes        |
+| 10 | Half Reverse Cuban Eight | radius |             |            |            | Yes        |
+| 11 | Cuban Eight              | radius |             |            |            | No         |
+| 12 | Humpty Bump              | radius | height      |            |            | Yes        |
+| 13 | Straight Flight          | length | bank angle  |            |            | No         |
+| 14 | Scale Figure Eight       | radius | bank angle  |            |            | No         |
+| 15 | Immelmann Turn           | radius | roll rate   |            |            | Yes        |
+| 16 | Split-S                  | radius | roll rate   |            |            | Yes        |
+| 17 | Upline-45                | radius | height gain |            |            | No         |
+| 18 | Downline-45              | radius | height loss |            |            | No         |
+| 19 | Stall Turn               | radius | height      | direction  |            | Yes        |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -27,7 +27,7 @@ parameters (described below).
 | 12 | Humpty Bump              | radius | height     |           |            | Yes        |
 | 13 | Straight Flight          | length | bank angle |           |            | No         |
 | 14 | Scale Figure Eight       | radius | bank angle |           |            | No         |
-| 15 | Immelmann Turn           | radius | roll rate  |           |            | Yes         |
+| 15 | Immelmann Turn           | radius | roll rate  |           |            | Yes        |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -18,7 +18,7 @@ parameters (described below).
 | 3  | Horizontal Rectangle     | length | width       | radius     | bank angle | No         |
 | 4  | Climbing Circle          | radius | height      | bank angle |            | No         |
 | 5  | vertical Box             | length | height      | radius     |            | No         |
-| 6  | Banked Circle            | radius | bank angle  | height     |            | No         |
+| 6  | Unused                   |        |             |            |            | No         |
 | 7  | Straight Roll            | length | num rolls   |            |            | No         |
 | 8  | Rolling Circle           | radius | num rolls   |            |            | No         |
 | 9  | Half Cuban Eight         | radius |             |            |            | Yes        |

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -1,0 +1,134 @@
+# Scripted Aerobatics
+
+The lua script "plane_aerobatics.lua" implements scripted aerobatics,
+allowing fixed wing aircraft to execute a number of aerobatic
+manoeuvres either in AUTO mission or by triggering using pilot commands
+using RC switches.
+
+## Available Manoeuvres
+
+The following table gives the available manoeuvres. Each manoeuvre has
+an ID number which is used in the AUTO mission or in the TRIKn_ID
+parameters (described below).
+
+| ID | Name                     | Arg1   | Arg2       | Arg3   | Arg4 | Turnaround |
+| -- | ------------------------ | ------ | ---------- | -------| ---- | ---------- |
+| 1  | Figure Eight             | radius | bank angle |        |      | No         |
+| 2  | Loop                     | radius |            |        |      | No         |
+| 3  | Horizontal Rectangle     | length | width      | radius |      | No         |
+| 4  | Climbing Circle          | radius | height     |        |      | No         |
+| 5  | vertical Box             | length | height     | radius |      | No         |
+| 6  | Banked Circle            | radius | bank angle |        |      | No         |
+| 7  | Straight Roll            | length | num rolls  |        |      | No         |
+| 8  | Rolling Circle           | radius | num rolls  |        |      | No         |
+| 9  | Half Cuban Eight         | radius |            |        |      | Yes        |
+| 10 | Half Reverse Cuban Eight | radius |            |        |      | Yes        |
+| 11 | Cuban Eight              | radius |            |        |      | No         |
+| 12 | Humpty Bump              | radius | height     |        |      | Yes        |
+| 13 | Straight Flight          | length | bank angle |        |      | No         |
+| 14 | Scale Figure Eight       | radius | bank angle |        |      | No         |
+
+The "Turnaround" column indicates if the manoeuvre results in a course
+reversal, which impacts how it is used in AUTO missions.
+
+## Loading the script
+
+Put the plane_aerobatics.lua script on your microSD card in the
+APM/SCRIPTS directory. You can use MAVFtp to do this.
+
+Then set
+
+ - SCR_ENABLE = 1
+ - SCR_HEAP_SIZE = 200000
+ - SCR_VM_I_COUNT = 200000
+
+You will need to refresh parameters after setting SCR_ENABLE. Then
+reboot to start scripting.
+
+## Aircraft Setup
+
+The aircraft needs to be setup to perform well in ACRO mode. You need
+to enable the yaw rate controller by setting:
+
+ - YAW_RATE_ENABLE = 1
+ - ACRO_YAW_RATE = 90
+
+The ACRO_YAW_RATE depends on the capabilities of the aircraft, but
+around 90 degrees/second is reasonable.
+
+You need to tune the yaw rate controller by flying in AUTOTUNE mode
+and moving the rudder stick from side to side until the yaw rate
+tuning is reported as being finished.
+
+## Use In AUTO Missions
+
+To use in an AUTO mission you can create waypoint missions containing
+NAV_SCRIPT_TIME elements (shown as SCRIPT_TIME in MissionPlanner). These mission items take the following arguments:
+
+ - the command ID from the table above
+ - the timeout in seconds
+ - up to four arguments as shown in the above table
+
+The aerobatics system will use the location of the previous and next
+waypoints to line up the manoeuvre. You need to plane a normal
+waypoint just before the location where you want to start the
+manoeuvre, then the NAV_SCRIPT_TIME and then a normal waypoint after
+the manoeuvre.
+
+## Use with "tricks on a switch"
+
+You can trigger the manoeuvres using RC switches, allowing you to have
+up to 11 tricks pre-programmed on your transmitter ready for use in
+fixed wing flight. You can trigger the tricks in the following flight
+modes:
+
+ - CIRCLE
+ - STABILIZE
+ - ACRO
+ - FBWA
+ - FBWB
+ - CRUISE
+ - LOITER
+
+To setup tricks you need to first set the parameter TRIK_ENABLE to 1.
+
+After setting TRIK_ENABLE, either restart scripting or reboot. Then
+set TRIK_COUNT to the number of tricks you want to make available,
+with a maximum of 11.
+
+After setting TRIK_COUNT, reboot and refresh parameters. You will find
+you will now have 5 parameters per trick.
+
+ - TRIKn_ID
+ - TRIKn_ARG1
+ - TRIKn_ARG2
+ - TRIKn_ARG3
+ - TRIKn_ARG4
+
+The ID parameter is the manoeuvre from the above table, and the arguments are the arguments to each manoeuvre.
+
+Now you need to setup your two control channels. You should have one 3
+position switch for activating tricks, and one knob or switch to
+select tricks. It is best to use a knob for the trick selector so you can have up to 11 tricks.
+
+Work out which RC input channel you want to use for activation (a 3 position switch) and set
+
+ - RCn_OPTION = 300
+
+Then work out what RC input channel you want to use for selection and set
+
+ - RCn_OPTION = 301
+
+## Flying with tricks
+
+When the activation channel (the one marked with option 300) is in the
+middle position then when you move the knob it will display the
+currently selected trick.
+
+To activate a trick you move the activation channel to the top
+position, and the trick will run.
+
+Moving the activation switch to the bottom position cancels any
+running trick and stops the trick system.
+
+Changing flight modes will also cancel any active trick.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -11,22 +11,22 @@ The following table gives the available manoeuvres. Each manoeuvre has
 an ID number which is used in the AUTO mission or in the TRIKn_ID
 parameters (described below).
 
-| ID | Name                     | Arg1   | Arg2       | Arg3   | Arg4       | Turnaround |
-| -- | ------------------------ | ------ | ---------- | -------| ---------- | ---------- |
-| 1  | Figure Eight             | radius | bank angle |        |            | No         |
-| 2  | Loop                     | radius |            |        |            | No         |
-| 3  | Horizontal Rectangle     | length | width      | radius | bank angle | No         |
-| 4  | Climbing Circle          | radius | height     |        |            | No         |
-| 5  | vertical Box             | length | height     | radius |            | No         |
-| 6  | Banked Circle            | radius | bank angle | height |            | No         |
-| 7  | Straight Roll            | length | num rolls  |        |            | No         |
-| 8  | Rolling Circle           | radius | num rolls  |        |            | No         |
-| 9  | Half Cuban Eight         | radius |            |        |            | Yes        |
-| 10 | Half Reverse Cuban Eight | radius |            |        |            | Yes        |
-| 11 | Cuban Eight              | radius |            |        |            | No         |
-| 12 | Humpty Bump              | radius | height     |        |            | Yes        |
-| 13 | Straight Flight          | length | bank angle |        |            | No         |
-| 14 | Scale Figure Eight       | radius | bank angle |        |            | No         |
+| ID | Name                     | Arg1   | Arg2       | Arg3      | Arg4       | Turnaround |
+| -- | ------------------------ | ------ | ---------- | -------   | ---------- | ---------- |
+| 1  | Figure Eight             | radius | bank angle |           |            | No         |
+| 2  | Loop                     | radius | bank angle | num loops |            | No         |
+| 3  | Horizontal Rectangle     | length | width      | radius    | bank angle | No         |
+| 4  | Climbing Circle          | radius | height     |           |            | No         |
+| 5  | vertical Box             | length | height     | radius    |            | No         |
+| 6  | Banked Circle            | radius | bank angle | height    |            | No         |
+| 7  | Straight Roll            | length | num rolls  |           |            | No         |
+| 8  | Rolling Circle           | radius | num rolls  |           |            | No         |
+| 9  | Half Cuban Eight         | radius |            |           |            | Yes        |
+| 10 | Half Reverse Cuban Eight | radius |            |           |            | Yes        |
+| 11 | Cuban Eight              | radius |            |           |            | No         |
+| 12 | Humpty Bump              | radius | height     |           |            | Yes        |
+| 13 | Straight Flight          | length | bank angle |           |            | No         |
+| 14 | Scale Figure Eight       | radius | bank angle |           |            | No         |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -30,7 +30,8 @@ parameters (described below).
 | 15 | Immelmann Turn           | radius | roll rate   |           |            | Yes        |
 | 16 | Split-S                  | radius | roll rate   |           |            | Yes        |
 | 17 | Upline-45                | radius | height gain |           |            | No         |
-| 17 | Downline-45              | radius | height loss |           |            | No         |
+| 18 | Downline-45              | radius | height loss |           |            | No         |
+| 19 | Stall Turn               | radius | height      | direction |            | Yes        |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -11,22 +11,22 @@ The following table gives the available manoeuvres. Each manoeuvre has
 an ID number which is used in the AUTO mission or in the TRIKn_ID
 parameters (described below).
 
-| ID | Name                     | Arg1   | Arg2       | Arg3   | Arg4 | Turnaround |
-| -- | ------------------------ | ------ | ---------- | -------| ---- | ---------- |
-| 1  | Figure Eight             | radius | bank angle |        |      | No         |
-| 2  | Loop                     | radius |            |        |      | No         |
-| 3  | Horizontal Rectangle     | length | width      | radius |      | No         |
-| 4  | Climbing Circle          | radius | height     |        |      | No         |
-| 5  | vertical Box             | length | height     | radius |      | No         |
-| 6  | Banked Circle            | radius | bank angle |        |      | No         |
-| 7  | Straight Roll            | length | num rolls  |        |      | No         |
-| 8  | Rolling Circle           | radius | num rolls  |        |      | No         |
-| 9  | Half Cuban Eight         | radius |            |        |      | Yes        |
-| 10 | Half Reverse Cuban Eight | radius |            |        |      | Yes        |
-| 11 | Cuban Eight              | radius |            |        |      | No         |
-| 12 | Humpty Bump              | radius | height     |        |      | Yes        |
-| 13 | Straight Flight          | length | bank angle |        |      | No         |
-| 14 | Scale Figure Eight       | radius | bank angle |        |      | No         |
+| ID | Name                     | Arg1   | Arg2       | Arg3   | Arg4       | Turnaround |
+| -- | ------------------------ | ------ | ---------- | -------| ---------- | ---------- |
+| 1  | Figure Eight             | radius | bank angle |        |            | No         |
+| 2  | Loop                     | radius |            |        |            | No         |
+| 3  | Horizontal Rectangle     | length | width      | radius | bank angle | No         |
+| 4  | Climbing Circle          | radius | height     |        |            | No         |
+| 5  | vertical Box             | length | height     | radius |            | No         |
+| 6  | Banked Circle            | radius | bank angle | height |            | No         |
+| 7  | Straight Roll            | length | num rolls  |        |            | No         |
+| 8  | Rolling Circle           | radius | num rolls  |        |            | No         |
+| 9  | Half Cuban Eight         | radius |            |        |            | Yes        |
+| 10 | Half Reverse Cuban Eight | radius |            |        |            | Yes        |
+| 11 | Cuban Eight              | radius |            |        |            | No         |
+| 12 | Humpty Bump              | radius | height     |        |            | Yes        |
+| 13 | Straight Flight          | length | bank angle |        |            | No         |
+| 14 | Scale Figure Eight       | radius | bank angle |        |            | No         |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/README.md
@@ -11,23 +11,26 @@ The following table gives the available manoeuvres. Each manoeuvre has
 an ID number which is used in the AUTO mission or in the TRIKn_ID
 parameters (described below).
 
-| ID | Name                     | Arg1   | Arg2       | Arg3      | Arg4       | Turnaround |
-| -- | ------------------------ | ------ | ---------- | -------   | ---------- | ---------- |
-| 1  | Figure Eight             | radius | bank angle |           |            | No         |
-| 2  | Loop                     | radius | bank angle | num loops |            | No         |
-| 3  | Horizontal Rectangle     | length | width      | radius    | bank angle | No         |
-| 4  | Climbing Circle          | radius | height     |           |            | No         |
-| 5  | vertical Box             | length | height     | radius    |            | No         |
-| 6  | Banked Circle            | radius | bank angle | height    |            | No         |
-| 7  | Straight Roll            | length | num rolls  |           |            | No         |
-| 8  | Rolling Circle           | radius | num rolls  |           |            | No         |
-| 9  | Half Cuban Eight         | radius |            |           |            | Yes        |
-| 10 | Half Reverse Cuban Eight | radius |            |           |            | Yes        |
-| 11 | Cuban Eight              | radius |            |           |            | No         |
-| 12 | Humpty Bump              | radius | height     |           |            | Yes        |
-| 13 | Straight Flight          | length | bank angle |           |            | No         |
-| 14 | Scale Figure Eight       | radius | bank angle |           |            | No         |
-| 15 | Immelmann Turn           | radius | roll rate  |           |            | Yes        |
+| ID | Name                     | Arg1   | Arg2        | Arg3      | Arg4       | Turnaround |
+| -- | ------------------------ | ------ | ----------  | -------   | ---------- | ---------- |
+| 1  | Figure Eight             | radius | bank angle  |           |            | No         |
+| 2  | Loop                     | radius | bank angle  | num loops |            | No         |
+| 3  | Horizontal Rectangle     | length | width       | radius    | bank angle | No         |
+| 4  | Climbing Circle          | radius | height      |           |            | No         |
+| 5  | vertical Box             | length | height      | radius    |            | No         |
+| 6  | Banked Circle            | radius | bank angle  | height    |            | No         |
+| 7  | Straight Roll            | length | num rolls   |           |            | No         |
+| 8  | Rolling Circle           | radius | num rolls   |           |            | No         |
+| 9  | Half Cuban Eight         | radius |             |           |            | Yes        |
+| 10 | Half Reverse Cuban Eight | radius |             |           |            | Yes        |
+| 11 | Cuban Eight              | radius |             |           |            | No         |
+| 12 | Humpty Bump              | radius | height      |           |            | Yes        |
+| 13 | Straight Flight          | length | bank angle  |           |            | No         |
+| 14 | Scale Figure Eight       | radius | bank angle  |           |            | No         |
+| 15 | Immelmann Turn           | radius | roll rate   |           |            | Yes        |
+| 16 | Split-S                  | radius | roll rate   |           |            | Yes        |
+| 17 | Upline-45                | radius | height gain |           |            | No         |
+| 17 | Downline-45              | radius | height loss |           |            | No         |
 
 The "Turnaround" column indicates if the manoeuvre results in a course
 reversal, which impacts how it is used in AUTO missions.

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -403,6 +403,9 @@ function PathComponent()
    function self.get_final_orientation()
       return Quaternion()
    end
+   function self.get_roll_correction(t)
+      return 0
+   end
    return self
 end
 
@@ -488,6 +491,17 @@ function path_horizontal_arc(_radius, _angle, _height_gain)
       q:from_axis_angle(makeVector3f(0,0,1), sgn(radius)*math.rad(angle))
       return q
    end
+
+   --[[
+      roll correction for the rotation caused by height gain
+   --]]
+   function self.get_roll_correction(t)
+      if height_gain == 0 then
+         return 0
+      end
+      local gamma=math.atan(height_gain*(angle/360)/(2*math.pi*radius))
+      return -t*360*math.sin(gamma)
+   end
    return self
 end
 
@@ -501,7 +515,7 @@ function Path(_path_component, _roll_component)
    local path_component = _path_component
    local roll_component = _roll_component
    function self.get_roll(t, time_s)
-      return wrap_180(roll_component.get_roll(t, time_s))
+      return wrap_180(roll_component.get_roll(t, time_s) + path_component.get_roll_correction(t))
    end
    function self.get_pos(t)
       return path_component.get_pos(t)

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -653,10 +653,6 @@ function path_composer(_subpaths)
       start_time[i] = total_time
       end_time[i] = total_time + proportions[i]
       total_time = total_time + proportions[i]
-      gcs:send_text(0,string.format("sp[%d]: rpy=(%.1f,%.1f,%.1f)", i,
-                                    start_orientation[i]:get_euler_roll(),
-                                    math.deg(start_orientation[i]:get_euler_pitch()),
-                                    start_orientation[i]:get_euler_yaw()))
    end
 
    -- return position and angle for the composed path at time t

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -408,33 +408,38 @@ function figure_eight(t, r, bank_angle, arg3, arg4)
       pos = makeVector3f(T*t, 0.0, 0.0)
       roll = 0.0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0)/T) then
-      pos = makeVector3f(r*math.cos(T*t/r - math.sqrt(2) - math.pi/2)+rsqr2, r_sign*(r + r*math.sin(T*t/r - math.sqrt(2) - math.pi/2)), 0)
+      pos = makeVector3f(r*math.cos(T*t/r - math.sqrt(2) - math.pi/2)+rsqr2, (r + r*math.sin(T*t/r - math.sqrt(2) - math.pi/2)), 0)
       roll = math.rad(bank_angle)
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
       roll = 0.0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + 3*r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
       roll = 0.0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
       roll = 0.0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0)/T) then
-      pos = makeVector3f(r*math.cos(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4) - r*math.sqrt(2.0), r_sign*(r + r*math.sin(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4)), 0)
+      pos = makeVector3f(r*math.cos(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4) - r*math.sqrt(2.0), (r + r*math.sin(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4)), 0)
       roll = -math.rad(bank_angle)
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
       roll = 0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + 3*r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
       roll = 0.0
    elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)),  r_sign*(r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
+      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)),  (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
       roll = 0.0
    else
-      pos = makeVector3f(r*math.cos(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))+rsqr2, r_sign*(r + r*math.sin(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))), 0)
+      pos = makeVector3f(r*math.cos(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))+rsqr2, (r + r*math.sin(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))), 0)
       roll = math.rad(bank_angle)
    end
+
+   if r_sign == -1 then
+      pos:y(-pos:y())
+   end
+
    return pos, roll
 
 end
@@ -463,7 +468,6 @@ function straight_flight(t, length, bank_angle, arg3, arg4)
 end
 
 function rolling_circle(t, radius, num_rolls, arg3, arg4)
-   --t = t*math.pi*2
    local vec = Vector3f()
    if radius < 0.0 then
       vec = makeVector3f(math.sin(2*math.pi*t), -1.0+math.cos(2*math.pi*t), 0)
@@ -473,15 +477,14 @@ function rolling_circle(t, radius, num_rolls, arg3, arg4)
    return vec:scale(math.abs(radius)), t*num_rolls*2*math.pi
 end
 
-function banked_circle(t, radius, bank_angle, arg3, arg4)
-   --t = t*math.pi*2
+function banked_circle(t, radius, bank_angle, height, arg4)
    local vec = Vector3f()
-   if radius < 0.0 then
-      vec = makeVector3f(math.sin(2*math.pi*t), -1.0+math.cos(2*math.pi*t), 0)
-   else
-      vec = makeVector3f(math.sin(2*math.pi*t), 1.0-math.cos(2*math.pi*t), 0)
+   local rad = math.abs(radius)
+   vec = makeVector3f(rad*math.sin(2*math.pi*t), -rad*(-1.0+math.cos(2*math.pi*t)), -height*t)
+   if radius < 0 then
+      vec:y(-vec:y())
    end
-   return vec:scale(math.abs(radius)), math.deg(bank_angle)
+   return vec, bank_angle
 end
 
 function half_cuban_eight(t, r, unused, arg3, arg4)
@@ -635,18 +638,23 @@ function scale_figure_eight(t, r, bank_angle, arg3, arg4)
    local pos
    local roll
    if (t < (math.pi/2)/T) then
-      pos = makeVector3f(r*math.cos(T*t - math.pi/2), r_sign*(r  +r*math.sin(T*t - math.pi/2)), 0)
+      pos = makeVector3f(r*math.cos(T*t - math.pi/2), (r  +r*math.sin(T*t - math.pi/2)), 0)
       roll = math.rad(bank_angle)
    elseif (t < (5*math.pi/2)/T) then
-      pos = makeVector3f(2*r + r*math.cos(T*t + math.pi/2), r_sign*(r -r*math.sin(T*t + math.pi/2)), 0)
+      pos = makeVector3f(2*r + r*math.cos(T*t + math.pi/2), (r -r*math.sin(T*t + math.pi/2)), 0)
       roll = -math.rad(bank_angle)
    elseif (t < (4*math.pi)/T) then
-      pos = makeVector3f(r*math.cos(T*t - math.pi/2), r_sign*(r + r*math.sin(T*t - math.pi/2)), 0)
+      pos = makeVector3f(r*math.cos(T*t - math.pi/2), (r + r*math.sin(T*t - math.pi/2)), 0)
       roll = math.rad(bank_angle)
    else
       pos = makeVector3f(r*(T*t - 4*math.pi), 0, 0)
       roll = 0
    end
+
+   if r_sign == -1 then
+      pos:y(-pos:y())
+   end
+
    return pos, roll
 end
 
@@ -683,15 +691,13 @@ end
 
 --todo: change y coordinate to z for vertical box
 --function aerobatic_box(t, l, w, r):
-function horizontal_rectangle(t, total_length, total_width, r, arg4)
+function horizontal_rectangle(t, total_length, total_width, r, bank_angle)
    
    local r_sign = sgn(r)
    assert(math.abs(r_sign) > 0.1)
    local r = math.abs(r)
-   gcs:send_text(0,string.format("rect %f %f", r_sign, r))
 
-
-   local bank_angle = math.abs(arg4)
+   local bank_angle = math.abs(bank_angle)
    local l = total_length - 2*r
    local w = total_width - 2*r
    local perim = 2*l + 2*w + 2*math.pi*r
@@ -699,21 +705,25 @@ function horizontal_rectangle(t, total_length, total_width, r, arg4)
    if (t < 0.5*l/(perim)) then
       pos = makeVector3f(perim*t, 0.0, 0.0)
    elseif (t < (0.5*l + 0.5*math.pi*r)/perim) then
-      pos = makeVector3f(0.5*l + r*math.sin((perim*t - 0.5*l)/r), r_sign*(r*(1 - math.cos((perim*t - 0.5*l)/r))), 0.0)
+      pos = makeVector3f(0.5*l + r*math.sin((perim*t - 0.5*l)/r), (r*(1 - math.cos((perim*t - 0.5*l)/r))), 0.0)
    elseif (t < (0.5*l + 0.5*math.pi*r + w)/perim) then
-      pos = makeVector3f(0.5*l + r, r_sign*(r + (perim*t - (0.5*l + 0.5*math.pi*r))), 0.0)
+      pos = makeVector3f(0.5*l + r, (r + (perim*t - (0.5*l + 0.5*math.pi*r))), 0.0)
    elseif(t < (0.5*l + math.pi*r + w)/perim) then
-      pos = makeVector3f(0.5*l + r + r*(-1 + math.cos((perim*t - (0.5*l + 0.5*math.pi*r + w))/r)), r_sign*(r + w + r*(math.sin((perim*t - (0.5*l + 0.5*math.pi*r + w))/r))), 0.0)
+      pos = makeVector3f(0.5*l + r + r*(-1 + math.cos((perim*t - (0.5*l + 0.5*math.pi*r + w))/r)), (r + w + r*(math.sin((perim*t - (0.5*l + 0.5*math.pi*r + w))/r))), 0.0)
    elseif(t < (1.5*l + math.pi*r + w)/perim) then
-      pos = makeVector3f(0.5*l - (perim*t - (0.5*l + math.pi*r + w)), r_sign*(2*r + w), 0.0)
+      pos = makeVector3f(0.5*l - (perim*t - (0.5*l + math.pi*r + w)), (2*r + w), 0.0)
    elseif(t < (1.5*l + 1.5*math.pi*r + w)/perim) then
-      pos = makeVector3f(-0.5*l + r*(-math.sin((perim*t - (1.5*l + math.pi*r + w))/r)), r_sign*(2*r + w + r*(-1 + math.cos((perim*t - (1.5*l + math.pi*r + w))/r))), 0.0)
+      pos = makeVector3f(-0.5*l + r*(-math.sin((perim*t - (1.5*l + math.pi*r + w))/r)), (2*r + w + r*(-1 + math.cos((perim*t - (1.5*l + math.pi*r + w))/r))), 0.0)
    elseif(t < (1.5*l + 1.5*math.pi*r + 2*w)/perim) then
-      pos = makeVector3f(-0.5*l -r, r_sign*(w + r - (perim*t - (1.5*l + 1.5*math.pi*r + w))), 0.0)
+      pos = makeVector3f(-0.5*l -r, (w + r - (perim*t - (1.5*l + 1.5*math.pi*r + w))), 0.0)
    elseif(t < (1.5*l + 2*math.pi*r + 2*w)/perim) then
-      pos = makeVector3f(-0.5*l -r + r*(1 - math.cos((perim*t - (1.5*l + 1.5*math.pi*r + 2*w))/r)), r_sign*(r + r*(-math.sin((perim*t - (1.5*l + 1.5*math.pi*r + 2*w))/r))), 0.0)
+      pos = makeVector3f(-0.5*l -r + r*(1 - math.cos((perim*t - (1.5*l + 1.5*math.pi*r + 2*w))/r)), (r + r*(-math.sin((perim*t - (1.5*l + 1.5*math.pi*r + 2*w))/r))), 0.0)
    else
       pos = makeVector3f(-0.5*l + perim*t - (1.5*l + 2*math.pi*r + 2*w), 0.0, 0.0)
+   end
+
+   if r_sign == -1 then
+      pos:y(-pos:y())
    end
 
    return pos, math.rad(bank_angle)
@@ -931,6 +941,14 @@ function log_pose(logname, pos, quat)
                 math.deg(quat:get_euler_roll()),
                 math.deg(quat:get_euler_pitch()),
                 math.deg(quat:get_euler_yaw()))
+end
+
+--[[
+   check if a number is Nan.
+--]]
+function isNaN(value)
+   -- NaN is lua is not equal to itself
+   return value ~= value
 end
 
 local path_var = {}
@@ -1193,6 +1211,10 @@ function do_path()
    throttle = speed_PI.update(target_speed)
    throttle = constrain(throttle, 0, 100.0)
 
+   if isNaN(throttle) or isNaN(tot_ang_vel_bf_dps:x()) or isNaN(tot_ang_vel_bf_dps:y()) or isNaN(tot_ang_vel_bf_dps:z()) then
+      gcs:send_text(0,string.format("Path NaN - aborting"))
+      return false
+   end
 
    vehicle:set_target_throttle_rate_rpy(throttle, tot_ang_vel_bf_dps:x(), tot_ang_vel_bf_dps:y(), tot_ang_vel_bf_dps:z())
    

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -535,7 +535,7 @@ end
 
 function upline_45(t, r, height_gain, arg3, arg4)
    if t == 0 then
-      local h = height_gain - 2*r*math.sin(math.rad(45))
+      local h = (height_gain - 2*r*(1.0-math.cos(math.rad(45))))/math.sin(math.rad(45))
       assert(h >= 0)
       path_var.composer = path_composer({
             { path_vertical_arc(r, 45),  roll_angle(0) },
@@ -548,7 +548,8 @@ end
 
 function downline_45(t, r, height_loss, arg3, arg4)
    if t == 0 then
-      local h = height_loss - 2*r*math.sin(math.rad(45))
+      local h = (height_loss - 2*r*(1.0-math.cos(math.rad(45))))/math.sin(math.rad(45))
+
       assert(h >= 0)
       path_var.composer = path_composer({
             { path_vertical_arc(-r, 45),  roll_angle(0) },

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -497,7 +497,7 @@ function Path(_path_component, _roll_component)
    local path_component = _path_component
    local roll_component = _roll_component
    function self.get_roll(t, time_s)
-      return roll_component.get_roll(t, time_s)
+      return wrap_180(roll_component.get_roll(t, time_s))
    end
    function self.get_pos(t)
       return path_component.get_pos(t)
@@ -849,6 +849,175 @@ function vertical_aerobatic_box(total_length, total_width, r, bank_angle)
          { path_straight(0.5*l),       roll_angle_exit(-bank_angle) },
    })
 end
+
+function two_point_roll(length, arg2, arg3, arg4)
+   return make_paths("two_point_roll", {
+            { path_straight((length*3)/7),         roll_angle(180) },
+            { path_straight(length/7),             roll_angle(0) },
+            { path_straight((length*3)/7),         roll_angle(180) },
+      })
+end
+
+function procedure_turn(radius, bank_angle, step_out, arg4)
+   local rabs = math.abs(radius)
+   return make_paths("procedure_turn", {
+            { path_straight(rabs),                  roll_angle(0) },
+            { path_horizontal_arc(radius,  90),     roll_angle_entry_exit(bank_angle) },
+            { path_straight(step_out),              roll_angle(0) },
+            { path_horizontal_arc(-radius,  270),   roll_angle_entry_exit(-bank_angle) },
+            { path_straight(4*rabs),                roll_angle(0) },
+      })
+end
+
+function p23_1(radius, height, width, arg4) -- top hat
+   return make_paths("p23_1", {
+            { path_vertical_arc(radius, 90),              roll_angle(0) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(0) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(90) },
+			{ path_straight((height-2*radius)/9),         roll_angle(0) },
+			{ path_straight((height-2*radius)*2/9),       roll_angle(90) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(0) },			
+            { path_vertical_arc(-radius, 90),             roll_angle(0) },
+            { path_straight((width-2*radius)/3),          roll_angle(0) },
+            { path_straight((width-2*radius)/3),          roll_angle(180) },
+            { path_straight((width-2*radius)/3),          roll_angle(0) },
+            { path_vertical_arc(-radius, 90),             roll_angle(0) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(0) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(90) },
+			{ path_straight((height-2*radius)/9),         roll_angle(0) },
+			{ path_straight((height-2*radius)*2/9),       roll_angle(90) },
+            { path_straight((height-2*radius)*2/9),       roll_angle(0) },			
+            { path_vertical_arc(radius, 90),              roll_angle(0) },						
+      })
+end
+
+function p23_2(radius, height, arg3, arg4)  -- half square
+   return make_paths("p23_2", {
+            { path_vertical_arc(-radius, 90),         roll_angle(0) },
+            { path_straight((height-2*radius)/3),     roll_angle(0) },
+            { path_straight((height-2*radius)/3),     roll_angle(180) },
+            { path_straight((height-2*radius)/3),     roll_angle(0) },
+            { path_vertical_arc(-radius, 90),         roll_angle(0) },					
+      })
+end
+
+function p23_3(radius, height, arg3, arg4)   -- humpty
+   return make_paths("p23_3", {
+            { path_vertical_arc(radius, 90),          roll_angle(0) },
+            { path_straight((height-2*radius)/8),     roll_angle(0) },
+            { path_straight((height-2*radius)*6/8),   roll_angle(360) },
+            { path_straight((height-2*radius)/8),     roll_angle(0) },
+            { path_vertical_arc(radius, 180),         roll_angle(0) },	
+            { path_straight((height-2*radius)/3),     roll_angle(0) },
+            { path_straight((height-2*radius)/3),     roll_angle(180) },
+            { path_straight((height-2*radius)/3),     roll_angle(0) },
+            { path_vertical_arc(radius, 90),          roll_angle(0) },								
+      })
+end
+
+function p23_4(radius, height, arg3, arg4)   -- on corner  
+   local l = ((height - (2 * radius)) * math.sin(math.rad(45)))							 
+   return make_paths("p23_4", {
+            { path_vertical_arc(-radius, 45),          roll_angle(0) },
+            { path_straight(l/3),                      roll_angle(0) },
+            { path_straight(l/3),                      roll_angle(180) },
+            { path_straight(l/3),                      roll_angle(0) },
+            { path_vertical_arc(-radius, 90),          roll_angle(0) },	
+            { path_straight(l/3),                      roll_angle(0) },
+            { path_straight(l/3),                      roll_angle(180) },
+            { path_straight(l/3),                      roll_angle(0) },
+            { path_vertical_arc(-radius, 45),          roll_angle(0) },								
+      })
+end
+
+function p23_5(radius, height_gain, arg3, arg4)   -- 45 up - should be 1 1/2 snaps....
+												  -- 1 1/2 rolls not working
+   local l = (height_gain - 2*radius*(1.0-math.cos(math.rad(45))))/math.sin(math.rad(45))
+   return make_paths("p23_5", {
+            { path_vertical_arc(-radius, 45),        roll_angle(0) },
+            { path_straight(l/3),                    roll_angle(0) },
+            { path_straight(l/3),                    roll_angle(540) },
+            { path_straight(l/3),                    roll_angle(0) },
+            { path_vertical_arc(radius, 45),         roll_angle(0) },			
+      })
+end
+
+function p23_6(radius, height_gain, arg3, arg4)   -- 3 sided
+   local l = (height_gain - 2*radius) / ((2*math.sin(math.rad(45))) + 1)
+   return make_paths("p23_6", {
+            { path_vertical_arc(-radius, 45),      roll_angle(0) },
+            { path_straight(l),                    roll_angle(0) },
+            { path_vertical_arc(-radius, 45),      roll_angle(0) },
+            { path_straight(l),                    roll_angle(0) },
+            { path_vertical_arc(-radius, 45),      roll_angle(0) },			
+            { path_straight(l),                    roll_angle(0) },
+            { path_vertical_arc(-radius, 45),      roll_angle(0) },			
+      })
+end
+
+--[[
+   NZ clubman schedule
+--]]
+function nz_clubman()
+   return path_composer("nz_clubman", {
+         straight_roll(20, 0),
+         procedure_turn(20, 45, 60),
+         straight_roll(150, 0),
+         half_reverse_cuban_eight(40),
+         straight_roll(150, 0),
+         cuban_eight(40),
+         straight_roll(80, 0),
+         half_reverse_cuban_eight(40),
+         straight_roll(140, 0),
+         half_reverse_cuban_eight(40),
+         straight_roll(120, 0),
+         half_reverse_cuban_eight(40),
+         straight_roll(40, 0),
+         two_point_roll(180),
+         straight_roll(40, 0),
+         half_reverse_cuban_eight(40),
+         straight_roll(20, 0),
+         upline_45(20, 120),
+         straight_roll(20, 0),
+         split_s(60, 90),
+         straight_roll(40, 0),
+         straight_roll(180, 1),
+         straight_flight(40, 0),
+         half_cuban_eight(40),
+         straight_roll(100, 0),
+         loop(40, 0, 2),
+         straight_roll(100, 0),
+         immelmann_turn(60, 90),
+         straight_roll(20, 0),
+         downline_45(20, 120),
+         straight_roll(20, 0),
+         half_cuban_eight(40),
+         straight_roll(100, 0),
+   })
+end
+
+--[[
+   F3A p23, preliminary schedule 2023
+--]]
+function f3a_p23()
+   return path_composer("f3a_p23", {
+         straight_roll(40, 0),
+         p23_1(30, 200, 200),  -- top hat
+         straight_roll(40, 0),
+         p23_2(30, 200),       -- half sq
+         straight_roll(90, 0),
+         p23_3(30, 200),       -- humpty
+         straight_roll(50, 0),
+         p23_4(30, 200),       -- on corner
+         straight_roll(40, 0),
+         p23_5(30, 200),       -- 45 up
+         straight_roll(40, 0),
+         p23_6(30, 200),       -- 3 sided
+         straight_roll(20, 0),
+
+   })
+end
+
 
 function test_all_paths()
    return path_composer("test_all_paths", {
@@ -1303,6 +1472,8 @@ command_table[17]= PathFunction(upline_45, "Upline-45")
 command_table[18]= PathFunction(downline_45, "Downline-45")
 command_table[19]= PathFunction(stall_turn, "Stall Turn")
 command_table[200] = PathFunction(test_all_paths, "Test Suite")
+command_table[201] = PathFunction(nz_clubman, "NZ Clubman")
+command_table[202] = PathFunction(f3a_p23, "FAI F3A P23")
 
 -- get a location structure from a waypoint number
 function get_location(i)

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -614,6 +614,7 @@ end
 --  orientation: maneuver frame orientation
 --returns: requested position in maneuver frame
 function rotate_path(path_f, t, arg1, arg2, arg3, arg4, orientation, offset)
+   t = constrain(t, 0, 1)
    point, angle = path_f(t, arg1, arg2, arg3, arg4)
    orientation:earth_to_body(point)
    --TODO: rotate angle?
@@ -805,7 +806,7 @@ function do_path()
 
    path_var.last_time = now
 
-   if path_var.path_t > 1.0 then --done
+   if path_var.path_t + 2*local_n_dt > 1.0 then
       return false
    end
 
@@ -850,9 +851,10 @@ function do_path()
    --[[
       recalculate the current path position and angle based on actual delta time
    --]]
-   p2, r2 = rotate_path(path, path_var.path_t + path_t_delta,
-      arg1, arg2, arg3, arg4,
-      path_var.initial_ori, path_var.initial_ef_pos)
+   p2, r2 = rotate_path(path,
+                        constrain(path_var.path_t + path_t_delta, 0, 1),
+                        arg1, arg2, arg3, arg4,
+                        path_var.initial_ori, path_var.initial_ef_pos)
 
    -- tangents needs to be recalculated
    tangent1_ef = p1 - p0

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -100,11 +100,13 @@ local MODE_AUTO = 10
 local LOOP_RATE = 20
 local DO_JUMP = 177
 local k_throttle = 70
+local NAME_FLOAT_RATE = 2
 
 local TRIM_ARSPD_CM = Parameter("TRIM_ARSPD_CM")
 
 local last_id = 0
 local current_task = nil
+local last_named_float_t = 0
 
 local path_var = {}
 
@@ -1431,7 +1433,12 @@ function do_path()
    end
 
    vehicle:set_target_throttle_rate_rpy(throttle, tot_ang_vel_bf_dps:x(), tot_ang_vel_bf_dps:y(), tot_ang_vel_bf_dps:z())
-   
+
+   if now - last_named_float_t > 1.0 / NAME_FLOAT_RATE then
+      last_named_float_t = now
+      gcs:send_named_float("PERR", pos_error_ef:length())
+   end
+
    return true
 end
 

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -1244,7 +1244,7 @@ function do_path()
    --]]
 
    next_target_pos_ef = next_target_pos_ef
-   local p0, r0, s0 = rotate_path(path, path_var.path_t + 0*local_n_dt,
+   local p0, r0, s0 = rotate_path(path, path_var.path_t,
                               path_var.initial_ori, path_var.initial_ef_pos)
    local p1, r1, s1 = rotate_path(path, path_var.path_t + 1*local_n_dt,
                               path_var.initial_ori, path_var.initial_ef_pos)
@@ -1276,14 +1276,18 @@ function do_path()
       return false
    end
    local path_t_delta = constrain(path_dist/path_var.length, 0.2*local_n_dt, 4*local_n_dt)
-   path_var.path_t = path_var.path_t + path_t_delta
 
    --[[
       recalculate the current path position and angle based on actual delta time
    --]]
-   p2, r2, s2 = rotate_path(path,
+   p1, r1, s1 = rotate_path(path,
                             constrain(path_var.path_t + path_t_delta, 0, 1),
                             path_var.initial_ori, path_var.initial_ef_pos)
+   p2, r2, s2 = rotate_path(path,
+                            constrain(path_var.path_t + 2*path_t_delta, 0, 1),
+                            path_var.initial_ori, path_var.initial_ef_pos)
+
+   path_var.path_t = path_var.path_t + path_t_delta
 
    -- tangents needs to be recalculated
    tangent1_ef = p1 - p0

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -704,7 +704,44 @@ function humpty_bump(t, r, h, arg3, arg4)
    return path_var.composer.run(t)
 end
 
-   ---------------------------------------------------
+function split_s(t, r, roll_rate, arg3, arg4)
+   if t == 0 then
+      local speed = path_var.target_speed
+      path_var.composer = path_composer({
+            { path_straight(speed*180.0/roll_rate), roll_angle(180) },
+            { path_vertical_arc(-r, 180),           roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+function upline_45(t, r, height_gain, arg3, arg4)
+   if t == 0 then
+      local h = height_gain - 2*r*math.sin(math.rad(45))
+      assert(h >= 0)
+      path_var.composer = path_composer({
+            { path_vertical_arc(r, 45),  roll_angle(0) },
+            { path_straight(h),          roll_angle(0) },
+            { path_vertical_arc(-r, 45), roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+function downline_45(t, r, height_loss, arg3, arg4)
+   if t == 0 then
+      local h = height_loss - 2*r*math.sin(math.rad(45))
+      assert(h >= 0)
+      path_var.composer = path_composer({
+            { path_vertical_arc(-r, 45),  roll_angle(0) },
+            { path_straight(h),           roll_angle(0) },
+            { path_vertical_arc(r, 45),   roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+---------------------------------------------------
 
 --[[
    target speed is taken as max of target airspeed and current 3D
@@ -1130,6 +1167,9 @@ command_table[12]= PathFunction(humpty_bump, "Humpty Bump")
 command_table[13]= PathFunction(straight_flight, "Straight Flight")
 command_table[14]= PathFunction(scale_figure_eight, "Scale Figure Eight")
 command_table[15]= PathFunction(immelmann_turn, "Immelmann Turn")
+command_table[16]= PathFunction(split_s, "Split-S")
+command_table[17]= PathFunction(upline_45, "Upline-45")
+command_table[18]= PathFunction(downline_45, "Downline-45")
 
 -- get a location structure from a waypoint number
 function get_location(i)

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -271,57 +271,6 @@ function climbing_circle(t, radius, height, arg3, arg4)
    return vec, 0.0
 end
 
-function figure_eight(t, r, bank_angle, arg3, arg4)
-
-   local r_sign = sgn(r)
-   assert(math.abs(r_sign) > 0.1)
-   local r = math.abs(r)
-
-   local T = 3.0*math.pi*r + r*math.sqrt(2) + 2*r
-
-   local rsqr2 = r*math.sqrt(2)
-   local pos
-   local roll
-   if (t < rsqr2/T) then
-      pos = makeVector3f(T*t, 0.0, 0.0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0)/T) then
-      pos = makeVector3f(r*math.cos(T*t/r - math.sqrt(2) - math.pi/2)+rsqr2, (r + r*math.sin(T*t/r - math.sqrt(2) - math.pi/2)), 0)
-      roll = math.rad(bank_angle)
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + 3*r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2))), 0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0)/T) then
-      pos = makeVector3f(r*math.cos(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4) - r*math.sqrt(2.0), (r + r*math.sin(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4)), 0)
-      roll = -math.rad(bank_angle)
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
-      roll = 0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + 3*r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)),  (r  +r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2))), 0)
-      roll = 0.0
-   else
-      pos = makeVector3f(r*math.cos(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))+rsqr2, (r + r*math.sin(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))), 0)
-      roll = math.rad(bank_angle)
-   end
-
-   if r_sign == -1 then
-      pos:y(-pos:y())
-   end
-
-   return pos, roll
-
-end
-
 function loop(t, radius, bank_angle, arg3, arg4)
    local num_loops = math.abs(arg3)
    if(arg3 <= 0.0) then
@@ -337,114 +286,6 @@ function straight_roll(t, length, num_rolls, arg3, arg4)
 
    local vec = makeVector3f(t*length, 0.0, 0.0)
    return vec, t*num_rolls*2*math.pi
-end
-
-function half_cuban_eight(t, r, unused, arg3, arg4)
-   local T = 3.0*math.pi*r/2.0 + 2*r*math.sqrt(2) + r
-
-   local trsqr2 = 2*r*math.sqrt(2)
-
-   local pos
-   local roll
-   if (t < trsqr2/T) then
-      pos = makeVector3f(T*t, 0.0, 0.0)
-      roll = 0.0
-   elseif (t < (trsqr2 + 5.0*math.pi*r/4.0)/T) then
-      pos = makeVector3f(r*math.cos(T*t/r - 2*math.sqrt(2) - math.pi/2)+trsqr2, 0, -r - r*math.sin(T*t/r - 2*math.sqrt(2) - math.pi/2))
-      roll = 0.0
-   elseif (t < (trsqr2 + 5.0*math.pi*r/4.0 + r/4)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = 0.0
-   elseif (t < (trsqr2 + 5.0*math.pi*r/4.0 + 3*r/4)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = (t - (trsqr2 + 5.0*math.pi*r/4.0 + r/4)/T)*2*math.pi*T/(r)
-   elseif (t < (trsqr2 + 5.0*math.pi*r/4.0 + r)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = math.pi
-   else
-      pos = makeVector3f(r*math.cos(-T*t/r +5.0*math.pi/4.0 + 2*math.sqrt(2) + 1 - math.pi/4), 0, -r  -r*math.sin(-T*t/r +5.0*math.pi/4.0 + 2*math.sqrt(2) + 1 - math.pi/4))
-      roll = math.pi
-      --roll = 0
-   end
-
-   return pos, roll
-
-end
-
-function cuban_eight(t, r, unused, arg3, arg4)
-   local T = 3.0*math.pi*r + r*math.sqrt(2) + 2*r
-
-   local rsqr2 = r*math.sqrt(2)
-
-   local pos
-   local roll
-   if (t < rsqr2/T) then
-      pos = makeVector3f(T*t, 0.0, 0.0)
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0)/T) then
-      pos = makeVector3f(r*math.cos(T*t/r - math.sqrt(2) - math.pi/2)+rsqr2, 0, -r - r*math.sin(T*t/r - math.sqrt(2) - math.pi/2))
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = 0.0
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + 3*r/4)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = (t - (rsqr2 + 5.0*math.pi*r/4.0 + r/4)/T)*2*math.pi*T/(r)
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r)/T) then
-      pos = makeVector3f(r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = math.pi
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0)/T) then
-      pos = makeVector3f(r*math.cos(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4) - r*math.sqrt(2.0), 0, -r - r*math.sin(-T*t/r +5.0*math.pi/4.0 + math.sqrt(2) + 1 - math.pi/4))
-      roll = math.pi
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2)))
-      roll = math.pi
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + 3*r/4.0)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2)))
-      roll = math.pi +(t - (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r/4.0)/T)*2 *math.pi*T/(r)
-   elseif (t < (rsqr2 + 5.0*math.pi*r/4.0 + r + 3*math.pi*r/2.0 + r)/T) then
-      pos = makeVector3f(-r/math.sqrt(2) + (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2)*(r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*t/r - 5*math.pi/4 - math.sqrt(2) - 1 - 3*math.pi/2.0 )*(-r*math.sqrt(2)))
-      roll = 0.0
-   else
-      pos = makeVector3f(r*math.cos(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 ))+rsqr2, 0, -r - r*math.sin(T*t/r - (6*math.pi/4.0 + math.sqrt(2) +2 )))
-      roll = 0.0
-   end
-   return pos, roll
-
-end
-
-function half_reverse_cuban_eight(t, r, arg2, arg3, arg4)
-   local T = 3.0*math.pi*r/2.0 + 2*r*math.sqrt(2) + r
-
-   local trsqr2 = 2*r*math.sqrt(2)
-
-   local pos
-   local roll
-
-
-   if(t < (math.pi*r/4)/T) then
-      pos = makeVector3f(r*math.cos(-T*(1-t)/r +5.0*math.pi/4.0 + 2*math.sqrt(2) + 1 - math.pi/4), 0, -r  -r*math.sin(-T*(1-t)/r +5.0*math.pi/4.0 + 2*math.sqrt(2) + 1 - math.pi/4))
-      
-      roll = 0
-   elseif (t < (math.pi*r/4 + r/4)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = 0
-   elseif (t < (math.pi*r/4 + 3*r/4)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = (t - (math.pi*r/4 + r/4)/T)*2*math.pi*T/(r)
-   elseif (t < (math.pi*r/4 + r)/T) then
-      pos = makeVector3f(3*r/math.sqrt(2) + (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)), 0, -r  -r/math.sqrt(2) - (T*(1-t)/r - 5*math.pi/4 - 2*math.sqrt(2))*(-r*math.sqrt(2)))
-      roll = math.pi
-   elseif (t < (3*math.pi*r/2 + r) /T) then
-      pos = makeVector3f(r*math.cos(T*(1-t)/r - 2*math.sqrt(2) - math.pi/2)+trsqr2, 0, -r - r*math.sin(T*(1-t)/r - 2*math.sqrt(2) - math.pi/2))
-      roll = math.pi
-   else
-      pos = makeVector3f(T*(1-t), 0.0, 0.0)
-      roll = math.pi
-   end
-
-   return pos, roll
-
 end
 
 --todo: change y coordinate to z for vertical box
@@ -560,7 +401,7 @@ function path_vertical_arc(_radius, _angle)
       return makeVector3f(math.abs(radius)*math.sin(t2ang), 0, -radius*(1.0 - math.cos(t2ang)))
    end
    function self.get_length()
-      return math.abs(radius) * 2 * math.pi * angle / 360.0
+      return math.abs(radius) * 2 * math.pi * math.abs(angle) / 360.0
    end
    function self.get_final_orientation()
       local q = Quaternion()
@@ -691,7 +532,6 @@ function path_composer(_subpaths)
       local speed = start_speed[i] + subpath_t * (end_speed[i] - start_speed[i])
       pos   = subpaths[i][1].get_pos(subpath_t)
       angle = subpaths[i][2].get_roll(subpath_t, lengths[i]/speed)
-      logger.write("SUBA", "i,t,st,time_s,ang", "Bffff", i, t, subpath_t, lengths[i]/speed, angle)
       start_orientation[i]:earth_to_body(pos)
       return pos + start_pos[i], math.rad(angle + start_angle[i]), speed
    end
@@ -818,6 +658,21 @@ function scale_figure_eight(t, r, bank_angle, arg3, arg4)
    return path_var.composer.run(t)
 end
 
+function figure_eight(t, r, bank_angle, arg3, arg4)
+   if t == 0 then
+      local rabs = math.abs(r)
+      path_var.composer = path_composer({
+            { path_straight(rabs*math.sqrt(2)), roll_angle(0) },
+            { path_horizontal_arc(r,  225),    roll_angle_entry_exit(bank_angle) },
+            { path_straight(2*rabs),           roll_angle(0) },
+            { path_horizontal_arc(-r,  270),   roll_angle_entry_exit(-bank_angle) },
+            { path_straight(2*rabs),           roll_angle(0) },
+            { path_horizontal_arc(r,    45),   roll_angle_entry_exit(bank_angle) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
 
 --[[
    stall turn is not really correct, as we don't fully stall. Needs to be
@@ -833,6 +688,54 @@ function stall_turn(t, radius, height, direction, min_speed)
             { path_horizontal_arc(5*direction, 180),  roll_angle(0), min_speed },
             { path_straight(h),                       roll_angle(0) },
             { path_vertical_arc(radius, 90),          roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+function half_cuban_eight(t, r, arg2, arg3, arg4)
+   if t == 0 then
+      local rabs = math.abs(r)
+      path_var.composer = path_composer({
+            { path_straight(2*rabs*math.sqrt(2)), roll_angle(0) },
+            { path_vertical_arc(r,  225),  roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(180) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_vertical_arc(-r, 45),   roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+function cuban_eight(t, r, arg2, arg3, arg4)
+   if t == 0 then
+      local rabs = math.abs(r)
+      path_var.composer = path_composer({
+            { path_straight(rabs*math.sqrt(2)), roll_angle(0) },
+            { path_vertical_arc(r,  225),  roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(180) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_vertical_arc(-r, 270),  roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(180) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_vertical_arc(r, 45),    roll_angle(0) },
+      })
+   end
+   return path_var.composer.run(t)
+end
+
+function half_reverse_cuban_eight(t, r, arg2, arg3, arg4)
+   if t == 0 then
+      local rabs = math.abs(r)
+      path_var.composer = path_composer({
+            { path_vertical_arc(r,  45),   roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_straight(2*rabs/3),     roll_angle(180) },
+            { path_straight(2*rabs/3),     roll_angle(0) },
+            { path_vertical_arc(-r, 225),  roll_angle(0) },
       })
    end
    return path_var.composer.run(t)
@@ -1271,6 +1174,7 @@ command_table[16]= PathFunction(split_s, "Split-S")
 command_table[17]= PathFunction(upline_45, "Upline-45")
 command_table[18]= PathFunction(downline_45, "Downline-45")
 command_table[19]= PathFunction(stall_turn, "Stall Turn")
+-- command_table[100] = PathFunction(clubman_schedule, "Clubman Schedule")
 
 -- get a location structure from a waypoint number
 function get_location(i)

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -582,8 +582,12 @@ function vertical_aerobatic_box(t, total_length, total_width, r, arg4)
 end 
 ---------------------------------------------------
 
+--[[
+   target speed is taken as max of target airspeed and current 3D
+   velocity at the start of the maneuver
+--]]
 function target_groundspeed()
-   return ahrs:get_EAS2TAS()*TRIM_ARSPD_CM:get()*0.01
+   return math.max(ahrs:get_EAS2TAS()*TRIM_ARSPD_CM:get()*0.01, ahrs:get_velocity_NED():length())
 end
 
 --Estimate the length of the path in metres
@@ -969,8 +973,7 @@ function do_path()
    --[[
       run the throttle based speed controller
    --]]
-   local target_speed = target_groundspeed()--TRIM_ARSPD_CM:get()*0.01
-   throttle = speed_PI.update(target_speed)
+   throttle = speed_PI.update(path_var.target_speed)
    throttle = constrain(throttle, 0, 100.0)
 
    if isNaN(throttle) or isNaN(tot_ang_vel_bf_dps:x()) or isNaN(tot_ang_vel_bf_dps:y()) or isNaN(tot_ang_vel_bf_dps:z()) then

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/view_paths.py
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/view_paths.py
@@ -39,6 +39,8 @@ def view_path(viewer, path, color):
         dist = math.sqrt(dx**2+dy**2+dz**2)+0.001
         if dist <= 0:
             continue
+        if math.isnan(p1.q[0]) or math.isnan(p1.q[1]) or math.isnan(p1.q[2]) or math.isnan(p1.q[3]):
+            continue
         pname = 'p%u' % i
         viewer.append_box('root', pname, (dist, 0.1, 0.002), frame=(p1.pos,qtuple(p1.q)))
         viewer.set_material('root', pname, color_rgba=color)

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/view_paths.py
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/view_paths.py
@@ -9,12 +9,15 @@ from pymavlink.rotmat import Vector3, Matrix3
 from pymavlink import mavutil
 import math, sys
 
+# quaternion to rotate to fix NED to ENU conversion
+q_NED_ENU = Quaternion([0, -math.sqrt(2.0)*0.5, -math.sqrt(2)*0.5, 0])
+
 def qtuple(q):
     '''
     return a quaternion tuple. We mirror on the Z axis by changing
     the sign of two elements to cope with the different conventions
     '''
-    return (q[0],-q[1],-q[2],q[3])
+    return (q[0],q[1],q[2],q[3])
 
 config = ViewerConfig()
 config.set_window_size(320, 240)
@@ -47,8 +50,10 @@ def view_path(viewer, path, color):
 
 class LogPoint(object):
     def __init__(self, x,y,z,q,t):
-        self.pos = (x,y,z)
-        self.q = q
+        # convert from NED to ENU
+        global q_NED_ENU
+        self.pos = (y,x,-z)
+        self.q = q_NED_ENU * q
         self.t = t
 
 def show_log(viewer,filename):
@@ -63,15 +68,15 @@ def show_log(viewer,filename):
     scale = 0.01
 
     while True:
-        m = mlog.recv_match(type=['POST', 'POSB', 'POSM','ATT'])
+        m = mlog.recv_match(type=['POST', 'POSB', 'POSM', 'ATT'])
         if m is None:
             break
         if m.get_type() == 'POST' and ATT is not None:
-            path_POST.append(LogPoint(m.px*scale, m.py*scale, -m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
+            path_POST.append(LogPoint(m.px*scale, m.py*scale, m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
         if m.get_type() == 'POSB' and ATT is not None:
-            path_POSB.append(LogPoint(m.px*scale, m.py*scale, -m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
+            path_POSB.append(LogPoint(m.px*scale, m.py*scale, m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
         if m.get_type() == 'POSM' and ATT is not None:
-            path_POSM.append(LogPoint(m.px*scale, m.py*scale, -m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
+            path_POSM.append(LogPoint(m.px*scale, m.py*scale, m.pz*scale, Quaternion([m.q1, m.q2, m.q3, m.q4]), m.TimeUS*1.0e-6))
         if m.get_type() == 'ATT':
             ATT = m
     view_path(viewer, path_POST, (0.7,0.1,0.1,1))


### PR DESCRIPTION
this re-implements tricks on a switch with the new accurate trajectory tracking code.

It adds new parameters:

 - TRIK_ENABLE=0/1
 - TRIK_COUNT for number of tricks
 - TRIK_ACT_FN for the rc option to use to activate tricks (default 300)
 - TRIK_SEL_FN for the rc option to use to select which trick (default 301)

So if you want to use a 3 position switch on RC7 to activate and use a knob on RC8 for selection then you would set:

- RC7_OPTION = 300
- RC8_OPTION = 301

then if tricks are enabled the following parameters are created per trick:

 - TRIKn_ID
 - TRIKn_ARG1
 - TRIKn_ARG2
 - TRIKn_ARG3
 - TRIKn_ARG4

You can have a maximum of 11 tricks.

The ID numbers are from the trajectory table. The arguments are path specific.