### PR TITLE
AP_Camera/Scripting: mount-poi.lua adds camera icon to GCS map

### DIFF
--- a/Tools/autotest/default_params/copter-gimbal.parm
+++ b/Tools/autotest/default_params/copter-gimbal.parm
@@ -1,5 +1,5 @@
 # copter with simulated 3-axis servo gimbal
-MNT_TYPE 1
+MNT1_TYPE 1
 RC6_OPTION 213
 SERVO5_FUNCTION 8
 SERVO6_FUNCTION 7

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -100,6 +100,9 @@ public:
 
     AP_Camera::CamTrigType get_trigger_type(void);
 
+    // send camera feedback message to all components
+    static void send_camera_feedback(uint8_t cam_idx, uint16_t img_idx, const Location& loc);
+
 private:
 
     static AP_Camera *_singleton;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -963,6 +963,18 @@ function winch:relax() end
 ---@return boolean
 function winch:healthy() end
 
+
+-- desc
+---@class camera
+camera = {}
+
+-- desc
+---@param param1 integer
+---@param param2 integer
+---@param param3 Location_ud
+function camera:send_camera_feedback(param1, param2, param3) end
+
+
 -- desc
 ---@class mount
 mount = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -553,6 +553,11 @@ singleton AP_Mount method set_rate_target void uint8_t 0 UINT8_MAX float'skip_ch
 singleton AP_Mount method set_roi_target void uint8_t 0 UINT8_MAX Location
 singleton AP_Mount method get_attitude_euler boolean uint8_t 0 UINT8_MAX float'Null float'Null float'Null
 
+include AP_Camera/AP_Camera.h
+singleton AP_Camera depends AP_CAMERA_ENABLED == 1
+singleton AP_Camera rename camera
+singleton AP_Camera method send_camera_feedback void uint8_t 0 UINT8_MAX uint16_t 0 UINT16_MAX Location
+
 include AP_Winch/AP_Winch.h depends APM_BUILD_COPTER_OR_HELI
 singleton AP_Winch depends APM_BUILD_COPTER_OR_HELI
 singleton AP_Winch rename winch


### PR DESCRIPTION
This PR enhances the AP_Camera and AP_Scripting libraries so that the mount_poi.lua script can place camera icons on the GCS map.  Below is a test in SITL where I pointed the gimbal mount at the edge of the Canberra flight area and invoked the mount_poi script using RC9.

The left camera icon appears off the corner of the field because I sent the camera to point at the lat,lon of the corner but at 5m above home so this is the expected behaviour.

![poi-cam-feedback](https://user-images.githubusercontent.com/1498098/197933361-90969005-55ac-4944-b1ee-f1203abb4c3f.png)


I'm very open to suggestions on an improved implementation.  One idea is to instead add a new AP_Camera::take_picture() method that accepts a Location.  This Location could then be stored in feedback.loc and the rest of the picture taking logic including logging could remain as it currently is.



