### PR TITLE
GCS_MAVLink: correct potential uint underflow n stream slowdown

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -792,7 +792,11 @@ void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg, bool log_rad
         stream_slowdown_ms -= 40;
     } else if (packet.txbuf > 90 && stream_slowdown_ms != 0) {
         // the buffer has enough space, speed up a bit
-        stream_slowdown_ms -= 20;
+        if (stream_slowdown_ms > 20) {
+            stream_slowdown_ms -= 20;
+        } else {
+            stream_slowdown_ms = 0;
+        }
     }
 
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS


### PR DESCRIPTION
Right now we only add and subtract multiples of 20 to stream_slowdown_ms - but this is a bear-trap.
