### PR TITLE
Added EFI mavlink binding for LUA script

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -216,6 +216,8 @@ singleton GCS rename gcs
 singleton GCS method send_text void MAV_SEVERITY'enum MAV_SEVERITY_EMERGENCY MAV_SEVERITY_DEBUG "%s"'literal string
 singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM_NUM_BUFFERS uint32_t'skip_check int32_t -1 INT32_MAX
 singleton GCS method send_named_float void string float'skip_check
+singleton GCS method get_EFI_state float uint8_t 0 16 uint8_t 0 UINT8_MAX
+-- Acecore
 
 include AP_ONVIF/AP_ONVIF.h depends ENABLE_ONVIF == 1
 singleton AP_ONVIF depends ENABLE_ONVIF == 1

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -409,8 +409,11 @@ public:
 
     MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
 
-protected:
+    void handle_EFI_message(const mavlink_message_t &msg);		//Acecore
 
+    __mavlink_efi_status_t efi_data;		//Acecore
+
+protected:
     bool mavlink_coordinate_frame_to_location_alt_frame(MAV_FRAME coordinate_frame,
                                                         Location::AltFrame &frame);
 
@@ -650,7 +653,6 @@ protected:
     bool location_from_command_t(const mavlink_command_int_t &in, Location &out);
 
 private:
-
     const AP_SerialManager::UARTState *uartstate;
 
     // last time we got a non-zero RSSI from RADIO_STATUS
@@ -1138,6 +1140,8 @@ public:
     void enable_high_latency_connections(bool enabled);
 #endif // HAL_HIGH_LATENCY2_ENABLED
 
+    float get_EFI_state(uint8_t index, uint8_t channel);		//Acecore
+
 protected:
 
     virtual uint8_t sysid_this_mav() const = 0;
@@ -1155,7 +1159,6 @@ protected:
     GCS_MAVLINK *_chan[MAVLINK_COMM_NUM_BUFFERS];
 
 private:
-
     static GCS *_singleton;
 
     void create_gcs_mavlink_backend(GCS_MAVLINK_Parameters &params,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -792,11 +792,7 @@ void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg, bool log_rad
         stream_slowdown_ms -= 40;
     } else if (packet.txbuf > 90 && stream_slowdown_ms != 0) {
         // the buffer has enough space, speed up a bit
-        if (stream_slowdown_ms > 20) {
-            stream_slowdown_ms -= 20;
-        } else {
-            stream_slowdown_ms = 0;
-        }
+        stream_slowdown_ms -= 20;
     }
 
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
@@ -3790,19 +3786,15 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
         handle_statustext(msg);
         break;
 
-#if AP_NOTIFY_MAVLINK_LED_CONTROL_SUPPORT_ENABLED
     case MAVLINK_MSG_ID_LED_CONTROL:
         // send message to Notify
         AP_Notify::handle_led_control(msg);
         break;
-#endif
 
-#if AP_NOTIFY_MAVLINK_PLAY_TUNE_SUPPORT_ENABLED
     case MAVLINK_MSG_ID_PLAY_TUNE:
         // send message to Notify
         AP_Notify::handle_play_tune(msg);
         break;
-#endif
 
 #if HAL_RALLY_ENABLED
     case MAVLINK_MSG_ID_RALLY_POINT:
@@ -3927,8 +3919,16 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
         AP_CheckFirmware::handle_msg(chan, msg);
         break;
 #endif
-    }
 
+    case MAVLINK_MSG_ID_EFI_STATUS:		//Acecore
+    	handle_EFI_message(msg);
+    	break;
+    }
+}
+
+void GCS_MAVLINK::handle_EFI_message(const mavlink_message_t &msg)		//Acecore
+{
+	mavlink_msg_efi_status_decode(&msg, &efi_data);
 }
 
 void GCS_MAVLINK::handle_common_mission_message(const mavlink_message_t &msg)
@@ -6436,3 +6436,64 @@ MAV_RESULT GCS_MAVLINK::handle_control_high_latency(const mavlink_command_long_t
     return MAV_RESULT_ACCEPTED;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED
+
+float GCS::get_EFI_state(uint8_t index, uint8_t channel)		//Acecore
+{
+	GCS_MAVLINK *GSC_MAVLINK_class = chan(channel);
+
+	switch(index)
+	{
+	case 0:
+		return GSC_MAVLINK_class->efi_data.ecu_index;
+		break;
+	case 1:
+		return GSC_MAVLINK_class->efi_data.rpm;
+		break;
+	case 2:
+		return GSC_MAVLINK_class->efi_data.fuel_consumed;
+		break;
+	case 3:
+		return GSC_MAVLINK_class->efi_data.fuel_flow;
+		break;
+	case 4:
+		return GSC_MAVLINK_class->efi_data.engine_load;
+		break;
+	case 5:
+		return GSC_MAVLINK_class->efi_data.throttle_position;
+		break;
+	case 6:
+		return GSC_MAVLINK_class->efi_data.spark_dwell_time;
+		break;
+	case 7:
+		return GSC_MAVLINK_class->efi_data.barometric_pressure;
+		break;
+	case 8:
+		return GSC_MAVLINK_class->efi_data.intake_manifold_pressure;
+		break;
+	case 9:
+		return GSC_MAVLINK_class->efi_data.intake_manifold_temperature;
+		break;
+	case 10:
+		return GSC_MAVLINK_class->efi_data.cylinder_head_temperature;
+		break;
+	case 11:
+		return GSC_MAVLINK_class->efi_data.ignition_timing;
+		break;
+	case 12:
+		return GSC_MAVLINK_class->efi_data.injection_time;
+		break;
+	case 13:
+		return GSC_MAVLINK_class->efi_data.exhaust_gas_temperature;
+		break;
+	case 14:
+		return GSC_MAVLINK_class->efi_data.throttle_out;
+		break;
+	case 15:
+		return GSC_MAVLINK_class->efi_data.pt_compensation;
+		break;
+	case 16:
+		return GSC_MAVLINK_class->efi_data.ignition_voltage;
+		break;
+	}
+	return 0.0;
+}


### PR DESCRIPTION
Added new method for decoding EFI MavLink messages. Added new getter to get the EFI data received over MavLink. This getter will also be available for LUA scripts.