### PR TITLE
Plane: use mission loiter radius when checking target waypoint

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -672,6 +672,9 @@ private:
         // Direction for loiter. 1 for clockwise, -1 for counter-clockwise
         int8_t direction;
 
+        // Loiter radius in meters
+        uint16_t radius;
+
         // when loitering and an altitude is involved, this flag is true when it has been reached at least once
         bool reached_target_alt;
 
@@ -1020,7 +1023,7 @@ private:
     float mode_auto_target_airspeed_cm();
     void calc_gndspeed_undershoot();
     void update_loiter(uint16_t radius);
-    void update_loiter_update_nav(uint16_t radius);
+    void update_loiter_update_nav();
     void update_cruise();
     void update_fbwb_speed_height(void);
     void setup_turn_angle(void);

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -34,7 +34,7 @@ bool ModeLoiter::isHeadingLinedUp(const Location loiterCenterLoc, const Location
     // Return true if current heading is aligned to vector to targetLoc.
     // Tolerance is initially 10 degrees and grows at 10 degrees for each loiter circle completed.
 
-    const uint16_t loiterRadius = abs(plane.aparm.loiter_radius);
+    const uint16_t loiterRadius = plane.loiter.radius;
     if (loiterCenterLoc.get_distance(targetLoc) < loiterRadius + loiterRadius*0.05) {
         /* Whenever next waypoint is within the loiter radius plus 5%,
            maintaining loiter would prevent us from ever pointing toward the next waypoint.

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -291,7 +291,7 @@ void Plane::calc_gndspeed_undershoot()
 }
 
 // method intended to be used by update_loiter
-void Plane::update_loiter_update_nav(uint16_t radius)
+void Plane::update_loiter_update_nav()
 {
 #if HAL_QUADPLANE_ENABLED
     if (loiter.start_time_ms != 0 &&
@@ -316,7 +316,7 @@ void Plane::update_loiter_update_nav(uint16_t radius)
     if ((loiter.start_time_ms == 0 &&
          (control_mode == &mode_auto || control_mode == &mode_guided) &&
          auto_state.crosstrack &&
-         current_loc.get_distance(next_WP_loc) > radius*3) ||
+         current_loc.get_distance(next_WP_loc) > loiter.radius*3) ||
         quadplane_qrtl_switch) {
         /*
           if never reached loiter point and using crosstrack and somewhat far away from loiter point
@@ -329,7 +329,7 @@ void Plane::update_loiter_update_nav(uint16_t radius)
         nav_controller->update_waypoint(prev_WP_loc, next_WP_loc);
         return;
     }
-    nav_controller->update_loiter(next_WP_loc, radius, loiter.direction);
+    nav_controller->update_loiter(next_WP_loc, loiter.radius, loiter.direction);
 }
 
 void Plane::update_loiter(uint16_t radius)
@@ -343,8 +343,9 @@ void Plane::update_loiter(uint16_t radius)
             loiter.direction = (aparm.loiter_radius < 0) ? -1 : 1;
         }
     }
+    loiter.radius = radius;
 
-    update_loiter_update_nav(radius);
+    update_loiter_update_nav();
 
     if (loiter.start_time_ms == 0) {
         if (reached_loiter_target() ||


### PR DESCRIPTION
The loiter algorithm checks to see if the next waypoint is within the loiter radius, and if so, breaks out of the loiter (since the bearing will never line up with the target). Before this patch, this check always used WP_LOITER_RAD, even if the mission item had a different loiter radius.

This caused loiters to be skipped if their radius was smaller than WP_LOITER_RAD and there was a waypoint less than WP_LOITER_RAD from the center. Alternatively, if the mission radius was larger than WP_LOITER_RAD and the next waypoint was placed between this radius and WP_LOITER_RAD, the vehicle would complete several rotations before the heading tolerance increased enough to trigger the exit.