### PR TITLE
AP_Scripting: greatly reduce memory in aerobatic scripting

### DIFF
--- a/libraries/AP_Scripting/lua/src/lstring.c
+++ b/libraries/AP_Scripting/lua/src/lstring.c
@@ -22,7 +22,7 @@
 #include "lstring.h"
 
 
-#define MEMERRMSG       "not enough mem,increase scr_heap_size"
+#define MEMERRMSG       "not enough mem, increase SCR_HEAP_SIZE"
 
 
 /*


### PR DESCRIPTION
rework aerobatics script to make objects fall out of scope to allow gc to do its job on low memory
