### PR TITLE
Allow force erasing flash on F7/H7 boards

### DIFF
--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -139,9 +139,9 @@ uint32_t flash_func_sector_size(uint32_t sector)
     return stm32_flash_getpagesize(flash_base_page+sector);
 }
 
-bool flash_func_erase_sector(uint32_t sector)
+bool flash_func_erase_sector(uint32_t sector, bool force_erase)
 {
-    if (!stm32_flash_ispageerased(flash_base_page+sector)) {
+    if (force_erase || !stm32_flash_ispageerased(flash_base_page+sector)) {
         return stm32_flash_erasepage(flash_base_page+sector);
     }
     return true;

--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -25,7 +25,7 @@ uint32_t flash_func_read_word(uint32_t offset);
 bool flash_func_write_word(uint32_t offset, uint32_t v);
 bool flash_func_write_words(uint32_t offset, uint32_t *v, uint8_t n);
 uint32_t flash_func_sector_size(uint32_t sector);
-bool flash_func_erase_sector(uint32_t sector);
+bool flash_func_erase_sector(uint32_t sector, bool force_erase = false);
 uint32_t flash_func_read_otp(uint32_t idx);
 uint32_t flash_func_read_sn(uint32_t idx);
 void flash_set_keep_unlocked(bool);


### PR DESCRIPTION
I pulled target power once while flashing firmware, which lead to corrupting the ECC on flash. The bootloader contains an optimization to not erase an already empty flash page. Unfortunately to verify this it has to read it, which then fails the ECC check and results in a fault. This PR adds a path to the bootloader protocol that skips the check for empty flash and instead just always erases the flash. It is dependent upon the uploading software to select the force erase path, but it at least provides a fallback way to recover boards without JTAG.

Tested on CubeOrange.