### PR TITLE
Move sprayer, gripper and runcam defines into minimize_features.inc

### DIFF
--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -26,7 +26,7 @@
 #define AC_SPRAYER_DEFAULT_SHUT_OFF_DELAY   1000    ///< shut-off delay in milli seconds.  This reduces the likelihood of constantly turning on/off the pump
 
 #ifndef HAL_SPRAYER_ENABLED
-#define HAL_SPRAYER_ENABLED !HAL_MINIMIZE_FEATURES
+#define HAL_SPRAYER_ENABLED 1
 #endif
 
 #if HAL_SPRAYER_ENABLED

--- a/libraries/AP_Camera/AP_RunCam.h
+++ b/libraries/AP_Camera/AP_RunCam.h
@@ -25,7 +25,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #ifndef HAL_RUNCAM_ENABLED
-#define HAL_RUNCAM_ENABLED !HAL_MINIMIZE_FEATURES
+#define HAL_RUNCAM_ENABLED 1
 #endif
 
 #if HAL_RUNCAM_ENABLED

--- a/libraries/AP_Gripper/AP_Gripper_config.h
+++ b/libraries/AP_Gripper/AP_Gripper_config.h
@@ -3,7 +3,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 #ifndef AP_GRIPPER_ENABLED
-#define AP_GRIPPER_ENABLED !HAL_MINIMIZE_FEATURES
+#define AP_GRIPPER_ENABLED 1
 #endif
 
 #ifndef AP_GRIPPER_BACKEND_DEFAULT_ENABLED

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
@@ -153,9 +153,8 @@ define STM32_PWM_USE_ADVANCED TRUE
 # disable SMBUS battery monitors to save flash
 define AP_BATTMON_SMBUS_ENABLE 0
 
-# disable parachute and sprayer to save flash
+# disable parachute to save flash
 define HAL_PARACHUTE_ENABLED 0
-define HAL_SPRAYER_ENABLED 0
 
 # save FLASH, but leave above when flash issue is fixed
 include ../include/minimize_features.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-CAN/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-CAN/hwdef.dat
@@ -170,7 +170,6 @@ include ../include/minimize_features.inc
 
 define AP_BATTMON_SMBUS_ENABLE 0
 define HAL_PARACHUTE_ENABLED 0
-define HAL_SPRAYER_ENABLED 0
 
 define HAL_WITH_DSP FALSE
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/OMNIBUSF7V2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OMNIBUSF7V2/hwdef.dat
@@ -130,7 +130,6 @@ define AP_BATTMON_SMBUS_ENABLE 0
 
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
-define HAL_SPRAYER_ENABLED 0
 
 # save FLASH, but leave above when flash issue is fixed
 include ../include/minimize_features.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
@@ -14,3 +14,6 @@ define HAL_CRSF_TELEM_ENABLED 0
 
 # Gripper isn't a vital feature for smaller boards
 define AP_GRIPPER_ENABLED 0
+
+# Sprayer isn't a vital feature for smaller boards
+define HAL_SPRAYER_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
@@ -11,3 +11,6 @@ define HAL_HIGH_LATENCY2_ENABLED 0
 
 # Crossfire telemetry must be explicitly enabled on minimized boards:
 define HAL_CRSF_TELEM_ENABLED 0
+
+# Gripper isn't a vital feature for smaller boards
+define AP_GRIPPER_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
@@ -17,3 +17,6 @@ define AP_GRIPPER_ENABLED 0
 
 # Sprayer isn't a vital feature for smaller boards
 define HAL_SPRAYER_ENABLED 0
+
+# RunCam control isn't available on smaller boards
+define HAL_RUNCAM_ENABLED 0


### PR DESCRIPTION
The two hwdefs modified also include minimize_features.inc so the defines are redundant there.
