### PR TITLE
Plane: added AUTOTUNE_AXES function to normal tune

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1232,6 +1232,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_Follow/AP_Follow.cpp
     AP_SUBGROUPINFO(follow, "FOLL", 33, ParametersG2, AP_Follow),
 #endif
+
+    // @Param: AUTOTUNE_AXES
+    // @DisplayName: Autotune axis bitmask
+    // @Description: 1-byte bitmap of axes to autotune
+    // @Bitmask: 0:Roll,1:Pitch,2:Yaw
+    // @User: Standard
+    AP_GROUPINFO("AUTOTUNE_AXES", 34, ParametersG2, axis_bitmask, 7),
+
+
     
     AP_GROUPEND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -562,6 +562,8 @@ public:
     AP_Int8         man_expo_rudder;
 
     AP_Int32        oneshot_mask;
+    
+    AP_Int8         axis_bitmask; // axes to be autotuned
 
     // just to make compilation easier when all things are compiled out...
     uint8_t unused_integer;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1192,6 +1192,12 @@ private:
         ENABLED_NO_PITCH_TARGET,
         ENABLED_PITCH_TARGET
     };
+    
+    enum class AutoTuneAxis {
+        ROLL  = 1U <<0,
+        PITCH = 1U <<1,
+        YAW   = 1U <<2,
+    };
 
     FlareMode flare_mode;
     bool throttle_at_zero(void) const;

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -160,10 +160,24 @@ void Plane::reset_control_switch()
  */
 void Plane::autotune_start(void)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Started autotune");
-    rollController.autotune_start();
-    pitchController.autotune_start();
-    yawController.autotune_start();
+    const bool tune_roll = g2.axis_bitmask.get() & int8_t(AutoTuneAxis::ROLL);
+    const bool tune_pitch = g2.axis_bitmask.get() & int8_t(AutoTuneAxis::PITCH);
+    const bool tune_yaw = g2.axis_bitmask.get() & int8_t(AutoTuneAxis::YAW);
+    if (tune_roll || tune_pitch || tune_yaw) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Started autotune");
+        if (tune_roll) { 
+            rollController.autotune_start();
+        }
+        if (tune_pitch) { 
+            pitchController.autotune_start();
+        }
+        if (tune_yaw) { 
+            yawController.autotune_start();
+        }
+        gcs().send_text(MAV_SEVERITY_INFO, "Autotuning %s%s%s", tune_roll?"roll ":"", tune_pitch?"pitch ":"", tune_yaw?"yaw":"");
+    } else {
+        gcs().send_text(MAV_SEVERITY_INFO, "No axis selected for tuning!");
+    }        
 }
 
 /*


### PR DESCRIPTION
Tridge, turns out this was not in the code after all, only for QuadPlane....useful for aerobatic tuning where you have manually tweaked an axis and dont want it disturbed