### PR TITLE
Fix SIRF GPS defines

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -812,7 +812,7 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
             return new AP_GPS_SBP(*this, state[instance], _port[instance]);
         }
 #endif //AP_GPS_SBP_ENABLED
-#if !HAL_MINIMIZE_FEATURES && AP_GPS_SIRF_ENABLED
+#if AP_GPS_SIRF_ENABLED
         if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_SIRF) &&
                  AP_GPS_SIRF::_detect(dstate->sirf_detect_state, data)) {
             return new AP_GPS_SIRF(*this, state[instance], _port[instance]);

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
@@ -32,3 +32,6 @@ define HAL_SOARING_ENABLED 0
 
 # HOTT telemetry is quite rare, so we don't include it on smaller boards
 define HAL_HOTT_TELEM_ENABLED 0
+
+# smaller boards lose SIRF GPS support
+define AP_GPS_SIRF_ENABLED 0


### PR DESCRIPTION
this allows SIRF to be specified even on minimised boards if it is requested
