### PR TITLE
HAL_ChibiOS: fixed BRD_SAFETY_MASK 

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -211,8 +211,8 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 #if HAL_WITH_IO_MCU
     // @Param: IO_ENABLE
     // @DisplayName: Enable IO co-processor
-    // @Description: This allows for the IO co-processor on FMUv1 and FMUv2 to be disabled
-    // @Values: 0:Disabled,1:Enabled
+    // @Description: This allows for the IO co-processor on boards with an IOMCU to be disabled. Setting to 2 will enable the IOMCU but not attempt to update firmware on startup
+    // @Values: 0:Disabled,1:Enabled,2:EnableNoFWUpdate
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("IO_ENABLE", 10, AP_BoardConfig, state.io_enable, 1),

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2092,9 +2092,14 @@ void RCOutput::safety_update(void)
     }
 #elif HAL_WITH_IO_MCU
     safety_state = _safety_switch_state();
-    iomcu.set_safety_mask(safety_mask);
 #endif
 
+#if HAL_WITH_IO_MCU
+    // regardless of if we have a FMU safety pin, if we have an IOMCU we need
+    // to pass the BRD_SAFETY_MASK to the IOMCU
+    iomcu.set_safety_mask(safety_mask);
+#endif
+    
 #ifdef HAL_GPIO_PIN_LED_SAFETY
     led_counter = (led_counter+1) % 16;
     const uint16_t led_pattern = safety_state==AP_HAL::Util::SAFETY_DISARMED?0x5500:0xFFFF;


### PR DESCRIPTION
fix for boards that have both FMU safety switch and IOMCU
