### PR TITLE
[ArduSub] Add scripting support to motors

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -134,7 +134,7 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     sub.enable_motor_output();
 
     // finally actually arm the motors
-    sub.motors.armed(true);
+    sub.motors->armed(true);
 
     // log flight mode in case it was changed while vehicle was disarmed
     AP::logger().Write_Mode(sub.control_mode, sub.control_mode_reason);
@@ -155,7 +155,7 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
 bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks)
 {
     // return immediately if we are already disarmed
-    if (!sub.motors.armed()) {
+    if (!sub.motors->armed()) {
         return false;
     }
 
@@ -180,7 +180,7 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
     }
 
     // send disarm command to motors
-    sub.motors.armed(false);
+    sub.motors->armed(false);
 
     // reset the mission
     sub.mission.reset();

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -101,7 +101,7 @@ void Sub::fast_loop()
     //don't run rate controller in manual or motordetection modes
     if (control_mode != MANUAL && control_mode != MOTOR_DETECT) {
         // run low level rate controllers that only require IMU data
-        attitude_control.rate_controller_run();
+        attitude_control->rate_controller_run();
     }
 
     // send outputs to the motors library
@@ -166,7 +166,7 @@ void Sub::update_batt_compass()
 
     if (AP::compass().enabled()) {
         // update compass with throttle value - used for compassmot
-        compass.set_throttle(motors.get_throttle());
+        compass.set_throttle(motors->get_throttle());
         compass.read();
     }
 }
@@ -178,12 +178,12 @@ void Sub::ten_hz_logging_loop()
     // log attitude data if we're not already logging at the higher rate
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
-        ahrs_view.Write_Rate(motors, attitude_control, pos_control);
+        ahrs_view->Write_Rate(*motors, *attitude_control, *pos_control);
         if (should_log(MASK_LOG_PID)) {
-            logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDY_MSG, attitude_control.get_rate_yaw_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_z_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDR_MSG, attitude_control->get_rate_roll_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDP_MSG, attitude_control->get_rate_pitch_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDY_MSG, attitude_control->get_rate_yaw_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDA_MSG, pos_control->get_accel_z_pid().get_pid_info());
         }
     }
     if (should_log(MASK_LOG_MOTBATT)) {
@@ -196,13 +196,13 @@ void Sub::ten_hz_logging_loop()
         logger.Write_RCOUT();
     }
     if (should_log(MASK_LOG_NTUN) && (mode_requires_GPS(control_mode) || !mode_has_manual_throttle(control_mode))) {
-        pos_control.write_log();
+        pos_control->write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {
         AP::ins().Write_Vibration();
     }
     if (should_log(MASK_LOG_CTUN)) {
-        attitude_control.control_monitor_log();
+        attitude_control->control_monitor_log();
     }
 }
 
@@ -212,12 +212,12 @@ void Sub::twentyfive_hz_logging()
 {
     if (should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
-        ahrs_view.Write_Rate(motors, attitude_control, pos_control);
+        ahrs_view->Write_Rate(*motors, *attitude_control, *pos_control);
         if (should_log(MASK_LOG_PID)) {
-            logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDY_MSG, attitude_control.get_rate_yaw_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_z_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDR_MSG, attitude_control->get_rate_roll_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDP_MSG, attitude_control->get_rate_pitch_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDY_MSG, attitude_control->get_rate_yaw_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDA_MSG, pos_control->get_accel_z_pid().get_pid_info());
         }
     }
 
@@ -259,17 +259,17 @@ void Sub::one_hz_loop()
     ap.pre_arm_check = arm_check;
     AP_Notify::flags.pre_arm_check = arm_check;
     AP_Notify::flags.pre_arm_gps_check = position_ok();
-    AP_Notify::flags.flying = motors.armed();
+    AP_Notify::flags.flying = motors->armed();
 
     if (should_log(MASK_LOG_ANY)) {
         Log_Write_Data(LogDataID::AP_STATE, ap.value);
     }
 
-    if (!motors.armed()) {
+    if (!motors->armed()) {
         // make it possible to change ahrs orientation at runtime during initial config
         ahrs.update_orientation();
 
-        motors.update_throttle_range();
+        motors->update_throttle_range();
     }
 
     // update assigned functions and enable auxiliary servos
@@ -292,7 +292,7 @@ void Sub::read_AHRS()
     //-----------------------------------------------
     // <true> tells AHRS to skip INS update as we have already done it in fast_loop()
     ahrs.update(true);
-    ahrs_view.update(true);
+    ahrs_view->update(true);
 }
 
 // read baro and rangefinder altitude at 10hz
@@ -329,7 +329,7 @@ bool Sub::control_check_barometer()
 bool Sub::get_wp_distance_m(float &distance) const
 {
     // see GCS_MAVLINK_Sub::send_nav_controller_output()
-    distance = sub.wp_nav.get_wp_distance_to_destination() * 0.01;
+    distance = sub.wp_nav->get_wp_distance_to_destination() * 0.01;
     return true;
 }
 
@@ -337,7 +337,7 @@ bool Sub::get_wp_distance_m(float &distance) const
 bool Sub::get_wp_bearing_deg(float &bearing) const
 {
     // see GCS_MAVLINK_Sub::send_nav_controller_output()
-    bearing = sub.wp_nav.get_wp_bearing_to_destination() * 0.01;
+    bearing = sub.wp_nav->get_wp_bearing_to_destination() * 0.01;
     return true;
 }
 

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -37,7 +37,7 @@ void Sub::get_pilot_desired_lean_angles(float roll_in, float pitch_in, float &ro
 float Sub::get_pilot_desired_yaw_rate(float stick_angle) const
 {
     // convert pilot input to the desired yaw rate
-    float max = degrees(attitude_control.get_ang_vel_yaw_max_rads()) * 100.f;
+    float max = degrees(attitude_control->get_ang_vel_yaw_max_rads()) * 100.f;
     return constrain_float(stick_angle * g.acro_yaw_p , -max, max);
 }
 
@@ -47,7 +47,7 @@ void Sub::check_ekf_yaw_reset()
     float yaw_angle_change_rad;
     uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
     if (new_ekfYawReset_ms != ekfYawReset_ms) {
-        attitude_control.inertial_frame_reset();
+        attitude_control->inertial_frame_reset();
         ekfYawReset_ms = new_ekfYawReset_ms;
     }
 }
@@ -129,14 +129,14 @@ float Sub::get_surface_tracking_climb_rate(int16_t target_rate, float current_al
     last_call_ms = now;
 
     // adjust rangefinder target alt if motors have not hit their limits
-    if ((target_rate<0 && !motors.limit.throttle_lower) || (target_rate>0 && !motors.limit.throttle_upper)) {
+    if ((target_rate<0 && !motors->limit.throttle_lower) || (target_rate>0 && !motors->limit.throttle_upper)) {
         target_rangefinder_alt += target_rate * dt;
     }
 
     // do not let target altitude get too far from current altitude above ground
     target_rangefinder_alt = constrain_float(target_rangefinder_alt,
-        rangefinder_state.alt_cm - pos_control.get_pos_error_z_down_cm(),
-        rangefinder_state.alt_cm + pos_control.get_pos_error_z_up_cm());
+        rangefinder_state.alt_cm - pos_control->get_pos_error_z_down_cm(),
+        rangefinder_state.alt_cm + pos_control->get_pos_error_z_up_cm());
 
     // calc desired velocity correction from target rangefinder alt vs actual rangefinder alt (remove the error already passed to Altitude controller to avoid oscillations)
     distance_error = (target_rangefinder_alt - rangefinder_state.alt_cm) - (current_alt_target - current_alt);
@@ -169,8 +169,8 @@ void Sub::update_poscon_alt_max()
     }
 #endif
     // pass limit to pos controller
-    pos_control.set_alt_min(min_alt_cm);
-    pos_control.set_alt_max(max_alt_cm);
+    pos_control->set_alt_min(min_alt_cm);
+    pos_control->set_alt_max(max_alt_cm);
 }
 
 // rotate vector from vehicle's perspective to North-East frame

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -34,17 +34,17 @@ void Sub::Log_Write_Control_Tuning()
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CONTROL_TUNING_MSG),
         time_us             : AP_HAL::micros64(),
-        throttle_in         : attitude_control.get_throttle_in(),
-        angle_boost         : attitude_control.angle_boost(),
-        throttle_out        : motors.get_throttle(),
-        throttle_hover      : motors.get_throttle_hover(),
-        desired_alt         : pos_control.get_pos_target_z_cm() / 100.0f,
+        throttle_in         : attitude_control->get_throttle_in(),
+        angle_boost         : attitude_control->angle_boost(),
+        throttle_out        : motors->get_throttle(),
+        throttle_hover      : motors->get_throttle_hover(),
+        desired_alt         : pos_control->get_pos_target_z_cm() / 100.0f,
         inav_alt            : inertial_nav.get_altitude() / 100.0f,
         baro_alt            : barometer.get_altitude(),
         desired_rangefinder_alt   : (int16_t)target_rangefinder_alt,
         rangefinder_alt           : rangefinder_state.alt_cm,
         terr_alt            : terr_alt,
-        target_climb_rate   : (int16_t)pos_control.get_vel_target_z_cms(),
+        target_climb_rate   : (int16_t)pos_control->get_vel_target_z_cms(),
         climb_rate          : climb_rate
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
@@ -53,7 +53,7 @@ void Sub::Log_Write_Control_Tuning()
 // Write an attitude packet
 void Sub::Log_Write_Attitude()
 {
-    Vector3f targets = attitude_control.get_att_target_euler_cd();
+    Vector3f targets = attitude_control->get_att_target_euler_cd();
     targets.z = wrap_360_cd(targets.z);
     ahrs.Write_Attitude(targets);
 
@@ -80,10 +80,10 @@ void Sub::Log_Write_MotBatt()
     struct log_MotBatt pkt_mot = {
         LOG_PACKET_HEADER_INIT(LOG_MOTBATT_MSG),
         time_us         : AP_HAL::micros64(),
-        lift_max        : (float)(motors.get_lift_max()),
-        bat_volt        : (float)(motors.get_batt_voltage_filt()),
+        lift_max        : (float)(motors->get_lift_max()),
+        bat_volt        : (float)(motors->get_batt_voltage_filt()),
         bat_res         : (float)(battery.get_resistance()),
-        th_limit        : (float)(motors.get_throttle_limit())
+        th_limit        : (float)(motors->get_throttle_limit())
     };
     logger.WriteBlock(&pkt_mot, sizeof(pkt_mot));
 }
@@ -315,15 +315,15 @@ const struct LogStructure Sub::log_structure[] = {
       "CTUN", "Qfffffffccfhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----00BBBBBB" },
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt),
       "MOTB", "Qffff",  "TimeUS,LiftMax,BatVolt,BatRes,ThLimit", "s-vw-", "F-00-" },
-    { LOG_DATA_INT16_MSG, sizeof(log_Data_Int16t),         
+    { LOG_DATA_INT16_MSG, sizeof(log_Data_Int16t),
       "D16",   "QBh",         "TimeUS,Id,Value", "s--", "F--" },
-    { LOG_DATA_UINT16_MSG, sizeof(log_Data_UInt16t),         
+    { LOG_DATA_UINT16_MSG, sizeof(log_Data_UInt16t),
       "DU16",  "QBH",         "TimeUS,Id,Value", "s--", "F--" },
-    { LOG_DATA_INT32_MSG, sizeof(log_Data_Int32t),         
+    { LOG_DATA_INT32_MSG, sizeof(log_Data_Int32t),
       "D32",   "QBi",         "TimeUS,Id,Value", "s--", "F--" },
-    { LOG_DATA_UINT32_MSG, sizeof(log_Data_UInt32t),         
+    { LOG_DATA_UINT32_MSG, sizeof(log_Data_UInt32t),
       "DU32",  "QBI",         "TimeUS,Id,Value", "s--", "F--" },
-    { LOG_DATA_FLOAT_MSG, sizeof(log_Data_Float),         
+    { LOG_DATA_FLOAT_MSG, sizeof(log_Data_Float),
       "DFLT",  "QBf",         "TimeUS,Id,Value", "s--", "F--" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -26,17 +26,10 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 Sub::Sub()
     : logger(g.log_bitmask),
           control_mode(MANUAL),
-          motors(MAIN_LOOP_RATE),
           auto_mode(Auto_WP),
           guided_mode(Guided_WP),
           auto_yaw_mode(AUTO_YAW_LOOK_AT_NEXT_WP),
           inertial_nav(ahrs),
-          ahrs_view(ahrs, ROTATION_NONE),
-          attitude_control(ahrs_view, aparm, motors, scheduler.get_loop_period_s()),
-          pos_control(ahrs_view, inertial_nav, motors, attitude_control, scheduler.get_loop_period_s()),
-          wp_nav(inertial_nav, ahrs_view, pos_control, attitude_control),
-          loiter_nav(inertial_nav, ahrs_view, pos_control, attitude_control),
-          circle_nav(inertial_nav, ahrs_view, pos_control),
           param_loader(var_info)
 {
     // init sensor error logging flags

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -253,7 +253,8 @@ private:
     // Baro sensor instance index of the external water pressure sensor
     uint8_t depth_sensor_idx;
 
-    AP_Motors6DOF motors;
+    AP_Motors6DOF *motors;
+    const struct AP_Param::GroupInfo *motors_var_info;
 
     // Auto
     AutoMode auto_mode;   // controls which auto controller is run
@@ -335,17 +336,17 @@ private:
     // Inertial Navigation
     AP_InertialNav_NavEKF inertial_nav;
 
-    AP_AHRS_View ahrs_view;
+    AP_AHRS_View *ahrs_view;
 
     // Attitude, Position and Waypoint navigation objects
     // To-Do: move inertial nav up or other navigation variables down here
-    AC_AttitudeControl_Sub attitude_control;
+    AC_AttitudeControl_Sub *attitude_control;
 
-    AC_PosControl_Sub pos_control;
+    AC_PosControl_Sub *pos_control;
 
-    AC_WPNav wp_nav;
-    AC_Loiter loiter_nav;
-    AC_Circle circle_nav;
+    AC_WPNav *wp_nav;
+    AC_Loiter *loiter_nav;
+    AC_Circle *circle_nav;
 
     // Camera
 #if CAMERA == ENABLED
@@ -555,6 +556,7 @@ private:
     void terrain_update();
     void terrain_logging();
     void init_ardupilot() override;
+    void allocate_motors(void);
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
                              uint8_t &task_count,
                              uint32_t &log_bit) override;

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -9,7 +9,7 @@ void Sub::update_home_from_EKF()
     }
 
     // special logic if home is set in-flight
-    if (motors.armed()) {
+    if (motors->armed()) {
         set_home_to_current_location_inflight();
     } else {
         // move home to current ekf location (this will set home_state to HOME_SET)

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -299,7 +299,7 @@ void Sub::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
     if (target_loc.lat == 0 && target_loc.lng == 0) {
         // To-Do: make this simpler
         Vector3f temp_pos;
-        wp_nav.get_wp_stopping_point_xy(temp_pos.xy());
+        wp_nav->get_wp_stopping_point_xy(temp_pos.xy());
         const Location temp_loc(temp_pos, Location::AltFrame::ABOVE_ORIGIN);
         target_loc.lat = temp_loc.lat;
         target_loc.lng = temp_loc.lng;
@@ -419,7 +419,7 @@ void Sub::do_guided_limits(const AP_Mission::Mission_Command& cmd)
 bool Sub::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
     // check if we have reached the waypoint
-    if (!wp_nav.reached_wp_destination()) {
+    if (!wp_nav->reached_wp_destination()) {
         return false;
     }
 
@@ -448,7 +448,7 @@ bool Sub::verify_surface(const AP_Mission::Mission_Command& cmd)
     switch (auto_surface_state) {
         case AUTO_SURFACE_STATE_GO_TO_LOCATION:
             // check if we've reached the location
-            if (wp_nav.reached_wp_destination()) {
+            if (wp_nav->reached_wp_destination()) {
                 // Set target to current xy and zero depth
                 // TODO get xy target from current wp destination, because current location may be acceptance-radius away from original destination
                 Location target_location(cmd.content.location.lat, cmd.content.location.lng, 0, Location::AltFrame::ABOVE_HOME);
@@ -461,7 +461,7 @@ bool Sub::verify_surface(const AP_Mission::Mission_Command& cmd)
             break;
 
         case AUTO_SURFACE_STATE_ASCEND:
-            if (wp_nav.reached_wp_destination()) {
+            if (wp_nav->reached_wp_destination()) {
                 retval = true;
             }
             break;
@@ -478,7 +478,7 @@ bool Sub::verify_surface(const AP_Mission::Mission_Command& cmd)
 }
 
 bool Sub::verify_RTL() {
-    return wp_nav.reached_wp_destination();
+    return wp_nav->reached_wp_destination();
 }
 
 bool Sub::verify_loiter_unlimited()
@@ -490,7 +490,7 @@ bool Sub::verify_loiter_unlimited()
 bool Sub::verify_loiter_time()
 {
     // return immediately if we haven't reached our destination
-    if (!wp_nav.reached_wp_destination()) {
+    if (!wp_nav->reached_wp_destination()) {
         return false;
     }
 
@@ -508,7 +508,7 @@ bool Sub::verify_circle(const AP_Mission::Mission_Command& cmd)
 {
     // check if we've reached the edge
     if (auto_mode == Auto_CircleMoveToEdge) {
-        if (wp_nav.reached_wp_destination()) {
+        if (wp_nav->reached_wp_destination()) {
             Vector3f curr_pos = inertial_nav.get_position();
             Vector3f circle_center = pv_location_to_vector(cmd.content.location);
 
@@ -530,7 +530,7 @@ bool Sub::verify_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // check if we have completed circling
-    return fabsf(circle_nav.get_angle_total()/M_2PI) >= LOWBYTE(cmd.p1);
+    return fabsf(circle_nav->get_angle_total()/M_2PI) >= LOWBYTE(cmd.p1);
 }
 
 #if NAV_GUIDED == ENABLED
@@ -597,7 +597,7 @@ bool Sub::verify_wait_delay()
 
 bool Sub::verify_within_distance()
 {
-    if (wp_nav.get_wp_distance_to_destination() < (uint32_t)MAX(condition_value,0)) {
+    if (wp_nav->get_wp_distance_to_destination() < (uint32_t)MAX(condition_value,0)) {
         condition_value = 0;
         return true;
     }
@@ -651,7 +651,7 @@ bool Sub::do_guided(const AP_Mission::Mission_Command& cmd)
 void Sub::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.content.speed.target_ms > 0) {
-        wp_nav.set_speed_xy(cmd.content.speed.target_ms * 100.0f);
+        wp_nav->set_speed_xy(cmd.content.speed.target_ms * 100.0f);
     }
 }
 

--- a/ArduSub/control_acro.cpp
+++ b/ArduSub/control_acro.cpp
@@ -9,7 +9,7 @@
 bool Sub::acro_init()
 {
     // set target altitude to zero for reporting
-    pos_control.set_pos_target_z_cm(0);
+    pos_control->set_pos_target_z_cm(0);
 
     // attitude hold inputs become thrust inputs in acro mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)
@@ -25,28 +25,28 @@ void Sub::acro_run()
     float target_roll, target_pitch, target_yaw;
 
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
+    if (!motors->armed()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
         return;
     }
 
-    motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // convert the input to the desired body frame rate
     get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
 
     // run attitude controller
-    attitude_control.input_rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+    attitude_control->input_rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
 
     // output pilot's throttle without angle boost
-    attitude_control.set_throttle_out(channel_throttle->norm_input(), false, g.throttle_filt);
+    attitude_control->set_throttle_out(channel_throttle->norm_input(), false, g.throttle_filt);
 
     //control_in is range 0-1000
     //radio_in is raw pwm value
-    motors.set_forward(channel_forward->norm_input());
-    motors.set_lateral(channel_lateral->norm_input());
+    motors->set_forward(channel_forward->norm_input());
+    motors->set_lateral(channel_lateral->norm_input());
 }
 
 
@@ -125,7 +125,7 @@ void Sub::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int16
         }
 
         // convert earth-frame level rates to body-frame level rates
-        attitude_control.euler_rate_to_ang_vel(attitude_control.get_att_target_euler_cd()*radians(0.01f), rate_ef_level, rate_bf_level);
+        attitude_control->euler_rate_to_ang_vel(attitude_control->get_att_target_euler_cd()*radians(0.01f), rate_ef_level, rate_bf_level);
 
         // combine earth frame rate corrections with rate requests
         if (g.acro_trainer == ACRO_TRAINER_LIMITED) {

--- a/ArduSub/control_circle.cpp
+++ b/ArduSub/control_circle.cpp
@@ -14,13 +14,13 @@ bool Sub::circle_init()
     circle_pilot_yaw_override = false;
 
     // initialize speeds and accelerations
-    pos_control.set_max_speed_accel_xy(wp_nav.get_default_speed_xy(), wp_nav.get_wp_acceleration());
-    pos_control.set_correction_speed_accel_xy(wp_nav.get_default_speed_xy(), wp_nav.get_wp_acceleration());
-    pos_control.set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control.set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise circle controller including setting the circle center based on vehicle speed
-    circle_nav.init();
+    circle_nav->init();
 
     return true;
 }
@@ -33,16 +33,16 @@ void Sub::circle_run()
     float target_climb_rate = 0;
 
     // update parameters, to allow changing at runtime
-    pos_control.set_max_speed_accel_xy(wp_nav.get_default_speed_xy(), wp_nav.get_wp_acceleration());
-    pos_control.set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
+    if (!motors->armed()) {
         // To-Do: add some initialisation of position controllers
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
         return;
     }
 
@@ -57,10 +57,10 @@ void Sub::circle_run()
     target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
 
     // set motors to full range
-    motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // run circle controller
-    failsafe_terrain_set_status(circle_nav.update());
+    failsafe_terrain_set_status(circle_nav->update());
 
     ///////////////////////
     // update xy outputs //
@@ -69,17 +69,17 @@ void Sub::circle_run()
     translate_circle_nav_rp(lateral_out, forward_out);
 
     // Send to forward/lateral outputs
-    motors.set_lateral(lateral_out);
-    motors.set_forward(forward_out);
+    motors->set_lateral(lateral_out);
+    motors->set_forward(forward_out);
 
     // call attitude controller
     if (circle_pilot_yaw_override) {
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_yaw_rate);
     } else {
-        attitude_control.input_euler_angle_roll_pitch_yaw(channel_roll->get_control_in(), channel_pitch->get_control_in(), circle_nav.get_yaw(), true);
+        attitude_control->input_euler_angle_roll_pitch_yaw(channel_roll->get_control_in(), channel_pitch->get_control_in(), circle_nav->get_yaw(), true);
     }
 
     // update altitude target and call position controller
-    pos_control.set_pos_target_z_from_climb_rate_cm(target_climb_rate);
-    pos_control.update_z_controller();
+    pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+    pos_control->update_z_controller();
 }

--- a/ArduSub/control_manual.cpp
+++ b/ArduSub/control_manual.cpp
@@ -4,7 +4,7 @@
 bool Sub::manual_init()
 {
     // set target altitude to zero for reporting
-    pos_control.set_pos_target_z_cm(0);
+    pos_control->set_pos_target_z_cm(0);
 
     // attitude hold inputs become thrust inputs in manual mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)
@@ -18,19 +18,19 @@ bool Sub::manual_init()
 void Sub::manual_run()
 {
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
+    if (!motors->armed()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
         return;
     }
 
-    motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
-    motors.set_roll(channel_roll->norm_input());
-    motors.set_pitch(channel_pitch->norm_input());
-    motors.set_yaw(channel_yaw->norm_input() * g.acro_yaw_p / ACRO_YAW_P);
-    motors.set_throttle(channel_throttle->norm_input());
-    motors.set_forward(channel_forward->norm_input());
-    motors.set_lateral(channel_lateral->norm_input());
+    motors->set_roll(channel_roll->norm_input());
+    motors->set_pitch(channel_pitch->norm_input());
+    motors->set_yaw(channel_yaw->norm_input() * g.acro_yaw_p / ACRO_YAW_P);
+    motors->set_throttle(channel_throttle->norm_input());
+    motors->set_forward(channel_forward->norm_input());
+    motors->set_lateral(channel_lateral->norm_input());
 }

--- a/ArduSub/control_motordetect.cpp
+++ b/ArduSub/control_motordetect.cpp
@@ -56,12 +56,12 @@ bool Sub::motordetect_init()
 void Sub::motordetect_run()
 {
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+    if (!motors->armed()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Force all motors to stop
         for(uint8_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motors.motor_is_enabled(i)) {
-                motors.output_test_num(i, 1500);
+            if (motors->motor_is_enabled(i)) {
+                motors->output_test_num(i, 1500);
             }
         }
         md_state = STANDBY;
@@ -81,8 +81,8 @@ void Sub::motordetect_run()
     case SETTLING:
         // Force all motors to stop
         for (uint8_t i=0; i <AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motors.motor_is_enabled(i)) {
-                motors.output_test_num(i, 1500);
+            if (motors->motor_is_enabled(i)) {
+                motors->output_test_num(i, 1500);
             }
         }
         // wait until gyro product is under a certain(experimental) threshold
@@ -100,7 +100,7 @@ void Sub::motordetect_run()
     // Thrusts motor for 500ms
     case THRUSTING:
         if (AP_HAL::millis() < (thrusting_timer + 500)) {
-            if (!motors.output_test_num(current_motor, 1500 + 300*current_direction)) {
+            if (!motors->output_test_num(current_motor, 1500 + 300*current_direction)) {
                 md_state = DONE;
             };
 
@@ -132,13 +132,13 @@ void Sub::motordetect_run()
 
         Vector3f directions(roll, pitch, yaw);
         // Good read, not inverted
-        if (directions == motors.get_motor_angular_factors(current_motor)) {
+        if (directions == motors->get_motor_angular_factors(current_motor)) {
             gcs().send_text(MAV_SEVERITY_INFO, "Thruster %d is ok!", current_motor + 1);
         }
         // Good read, inverted
-        else if (-directions == motors.get_motor_angular_factors(current_motor)) {
+        else if (-directions == motors->get_motor_angular_factors(current_motor)) {
             gcs().send_text(MAV_SEVERITY_INFO, "Thruster %d is reversed! Saving it!", current_motor + 1);
-            motors.set_reversed(current_motor, true);
+            motors->set_reversed(current_motor, true);
         }
         // Bad read!
         else {
@@ -160,7 +160,7 @@ void Sub::motordetect_run()
         // Test the next motor, if it exists
         current_motor++;
         current_direction = UP;
-        if (!motors.motor_is_enabled(current_motor)) {
+        if (!motors->motor_is_enabled(current_motor)) {
             md_state = DONE;
             gcs().send_text(MAV_SEVERITY_WARNING, "Motor direction detection is complete.");
         }

--- a/ArduSub/control_poshold.cpp
+++ b/ArduSub/control_poshold.cpp
@@ -15,22 +15,22 @@ bool Sub::poshold_init()
     }
 
     // initialize vertical speeds and acceleration
-    pos_control.set_max_speed_accel_xy(wp_nav.get_default_speed_xy(), wp_nav.get_wp_acceleration());
-    pos_control.set_correction_speed_accel_xy(wp_nav.get_default_speed_xy(), wp_nav.get_wp_acceleration());
-    pos_control.set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control.set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
-    pos_control.init_xy_controller_stopping_point();
+    pos_control->init_xy_controller_stopping_point();
     // Stop all thrusters
-    attitude_control.set_throttle_out(0.75,true,100.0);
+    attitude_control->set_throttle_out(0.75,true,100.0);
 
-    pos_control.init_z_controller();
+    pos_control->init_z_controller();
 
     // initialise position and desired velocity
     float pos = stopping_distance();
     float zero = 0;
-    pos_control.input_pos_vel_accel_z(pos, zero, zero);
+    pos_control->input_pos_vel_accel_z(pos, zero, zero);
 
     last_pilot_heading = ahrs.yaw_sensor;
 
@@ -43,19 +43,19 @@ void Sub::poshold_run()
 {
     uint32_t tnow = AP_HAL::millis();
     // When unarmed, disable motors and stabilization
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+    if (!motors->armed()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out(0.75f ,true, g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
-        pos_control.relax_velocity_controller_xy();
-        pos_control.relax_z_controller(0.5f);
+        attitude_control->set_throttle_out(0.75f ,true, g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
+        pos_control->relax_velocity_controller_xy();
+        pos_control->relax_z_controller(0.5f);
         last_pilot_heading = ahrs.yaw_sensor;
         return;
     }
 
     // set motors to full range
-    motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     ///////////////////////
     // update xy outputs //
@@ -68,12 +68,12 @@ void Sub::poshold_run()
     if (position_ok()) {
         // Allow pilot to reposition the sub
         if (fabsf(pilot_lateral) > 0.1 || fabsf(pilot_forward) > 0.1) {
-            pos_control.init_xy_controller_stopping_point();
+            pos_control->init_xy_controller_stopping_point();
         }
         translate_pos_control_rp(lateral_out, forward_out);
-        pos_control.update_xy_controller();
+        pos_control->update_xy_controller();
     } else {
-        pos_control.init_xy_controller_stopping_point();
+        pos_control->init_xy_controller_stopping_point();
     }
     /////////////////////
     // Update attitude //
@@ -89,7 +89,7 @@ void Sub::poshold_run()
 
     // update attitude controller targets
     if (!is_zero(target_yaw_rate)) { // call attitude controller with rate yaw determined by pilot input
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
         last_pilot_heading = ahrs.yaw_sensor;
         last_pilot_yaw_input_ms = tnow; // time when pilot last changed heading
 
@@ -101,18 +101,18 @@ void Sub::poshold_run()
             target_yaw_rate = 0; // Stop rotation on yaw axis
 
             // call attitude controller with target yaw rate = 0 to decelerate on yaw axis
-            attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+            attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
             last_pilot_heading = ahrs.yaw_sensor; // update heading to hold
 
         } else { // call attitude controller holding absolute absolute bearing
-            attitude_control.input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, last_pilot_heading, true);
+            attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, last_pilot_heading, true);
         }
     }
 
     // Update z axis //
     control_depth();
 
-    motors.set_forward(motors.get_forward() + forward_out + pilot_forward);
-    motors.set_lateral(motors.get_lateral() + lateral_out + pilot_lateral);
+    motors->set_forward(motors->get_forward() + forward_out + pilot_forward);
+    motors->set_lateral(motors->get_lateral() + lateral_out + pilot_lateral);
 }
 #endif  // POSHOLD_ENABLED == ENABLED

--- a/ArduSub/control_stabilize.cpp
+++ b/ArduSub/control_stabilize.cpp
@@ -4,7 +4,7 @@
 bool Sub::stabilize_init()
 {
     // set target altitude to zero for reporting
-    pos_control.set_pos_target_z_cm(0);
+    pos_control->set_pos_target_z_cm(0);
     if(prev_control_mode != control_mode_t::ALT_HOLD) {
         last_roll = 0;
         last_pitch = 0;
@@ -18,10 +18,10 @@ bool Sub::stabilize_init()
 void Sub::stabilize_run()
 {
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
+    if (!motors->armed()) {
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
         last_pilot_heading = ahrs.yaw_sensor;
         last_roll = 0;
         last_pitch = 0;
@@ -31,10 +31,10 @@ void Sub::stabilize_run()
     handle_attitude();
 
     // output pilot's throttle
-    attitude_control.set_throttle_out(channel_throttle->norm_input(), false, g.throttle_filt);
+    attitude_control->set_throttle_out(channel_throttle->norm_input(), false, g.throttle_filt);
 
     //control_in is range -1000-1000
     //radio_in is raw pwm value
-    motors.set_forward(channel_forward->norm_input());
-    motors.set_lateral(channel_lateral->norm_input());
+    motors->set_forward(channel_forward->norm_input());
+    motors->set_lateral(channel_lateral->norm_input());
 }

--- a/ArduSub/control_surface.cpp
+++ b/ArduSub/control_surface.cpp
@@ -8,11 +8,11 @@ bool Sub::surface_init()
     }
 
     // initialize vertical speeds and acceleration
-    pos_control.set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control.set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
-    pos_control.init_z_controller();
+    pos_control->init_z_controller();
 
     return true;
 
@@ -24,12 +24,12 @@ void Sub::surface_run()
     float target_yaw_rate;
 
     // if not armed set throttle to zero and exit immediately
-    if (!motors.armed()) {
-        motors.output_min();
-        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control.set_throttle_out(0,true,g.throttle_filt);
-        attitude_control.relax_attitude_controllers();
-        pos_control.init_z_controller();
+    if (!motors->armed()) {
+        motors->output_min();
+        motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
+        pos_control->init_z_controller();
         return;
     }
 
@@ -46,19 +46,19 @@ void Sub::surface_run()
     target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->norm_input()) * 100;
 
     // call attitude controller
-    attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
 
     // set target climb rate
-    float cmb_rate = constrain_float(fabsf(wp_nav.get_default_speed_up()), 1, pos_control.get_max_speed_up_cms());
+    float cmb_rate = constrain_float(fabsf(wp_nav->get_default_speed_up()), 1, pos_control->get_max_speed_up_cms());
 
     // record desired climb rate for logging
     desired_climb_rate = cmb_rate;
 
     // update altitude target and call position controller
-    pos_control.set_pos_target_z_from_climb_rate_cm(cmb_rate);
-    pos_control.update_z_controller();
+    pos_control->set_pos_target_z_from_climb_rate_cm(cmb_rate);
+    pos_control->update_z_controller();
 
     // pilot has control for repositioning
-    motors.set_forward(channel_forward->norm_input());
-    motors.set_lateral(channel_lateral->norm_input());
+    motors->set_forward(channel_forward->norm_input());
+    motors->set_lateral(channel_lateral->norm_input());
 }

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -48,8 +48,8 @@ void Sub::mainloop_failsafe_check()
         // disarm the motors.
         in_failsafe = true;
         // reduce motors to minimum (we do not immediately disarm because we want to log the failure)
-        if (motors.armed()) {
-            motors.output_min();
+        if (motors->armed()) {
+            motors->output_min();
         }
         AP::logger().Write_Error(LogErrorSubsystem::CPU,LogErrorCode::FAILSAFE_OCCURRED);
     }
@@ -57,9 +57,9 @@ void Sub::mainloop_failsafe_check()
     if (failsafe_enabled && in_failsafe && tnow - failsafe_last_timestamp > 1000000) {
         // disarm motors every second
         failsafe_last_timestamp = tnow;
-        if (motors.armed()) {
-            motors.armed(false);
-            motors.output();
+        if (motors->armed()) {
+            motors->armed(false);
+            motors->output();
         }
     }
 }
@@ -298,7 +298,7 @@ void Sub::failsafe_leak_check()
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_LEAK, LogErrorCode::FAILSAFE_OCCURRED);
 
     // Handle failsafe action
-    if (failsafe.leak && g.failsafe_leak == FS_LEAK_SURFACE && motors.armed()) {
+    if (failsafe.leak && g.failsafe_leak == FS_LEAK_SURFACE && motors->armed()) {
         set_mode(SURFACE, ModeReason::LEAK_FAILSAFE);
     }
 }
@@ -341,7 +341,7 @@ void Sub::failsafe_gcs_check()
     }
 
     // do nothing if we have already triggered the failsafe action, or if the motors are disarmed
-    if (failsafe.gcs || !motors.armed()) {
+    if (failsafe.gcs || !motors->armed()) {
         return;
     }
 
@@ -351,11 +351,11 @@ void Sub::failsafe_gcs_check()
     // handle failsafe action
     if (g.failsafe_gcs == FS_GCS_DISARM) {
         arming.disarm(AP_Arming::Method::GCSFAILSAFE);
-    } else if (g.failsafe_gcs == FS_GCS_HOLD && motors.armed()) {
+    } else if (g.failsafe_gcs == FS_GCS_HOLD && motors->armed()) {
         if (!set_mode(ALT_HOLD, ModeReason::GCS_FAILSAFE)) {
             arming.disarm(AP_Arming::Method::GCS_FAILSAFE_HOLDFAILED);
         }
-    } else if (g.failsafe_gcs == FS_GCS_SURFACE && motors.armed()) {
+    } else if (g.failsafe_gcs == FS_GCS_SURFACE && motors->armed()) {
         if (!set_mode(SURFACE, ModeReason::GCS_FAILSAFE)) {
             arming.disarm(AP_Arming::Method::GCS_FAILSAFE_SURFACEFAILED);
         }
@@ -373,7 +373,7 @@ void Sub::failsafe_crash_check()
     uint32_t tnow = AP_HAL::millis();
 
     // return immediately if disarmed, or crash checking disabled
-    if (!motors.armed() || g.fs_crash_check == FS_CRASH_DISABLED) {
+    if (!motors->armed() || g.fs_crash_check == FS_CRASH_DISABLED) {
         last_crash_check_pass_ms = tnow;
         failsafe.crash = false;
         return;
@@ -387,7 +387,7 @@ void Sub::failsafe_crash_check()
     }
 
     // check for angle error over 30 degrees
-    const float angle_error = attitude_control.get_att_error_angle_deg();
+    const float angle_error = attitude_control->get_att_error_angle_deg();
     if (angle_error <= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
         last_crash_check_pass_ms = tnow;
         failsafe.crash = false;

--- a/ArduSub/fence.cpp
+++ b/ArduSub/fence.cpp
@@ -9,7 +9,7 @@
 void Sub::fence_check()
 {
     // ignore any fence activity when not armed
-    if (!motors.armed()) {
+    if (!motors->armed()) {
         return;
     }
 

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -153,7 +153,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
     // Act based on the function assigned to this button
     switch (get_button(_button)->function(shift)) {
     case JSButton::button_function_t::k_arm_toggle:
-        if (motors.armed()) {
+        if (motors->armed()) {
             arming.disarm(AP_Arming::Method::MAVLINK);
         } else {
             arming.arm(AP_Arming::Method::MAVLINK);
@@ -364,7 +364,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
         last_pilot_heading = degrees(attitudeTarget.get_euler_yaw()) * 100;
         break;
     case JSButton::button_function_t::k_input_hold_set:
-        if(!motors.armed()) {
+        if(!motors->armed()) {
             break;
         }
         if(roll_pitch_flag) {

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -3,7 +3,7 @@
 // enable_motor_output() - enable and output lowest possible value to motors
 void Sub::enable_motor_output()
 {
-    motors.output_min();
+    motors->output_min();
 }
 
 // motors_output - send output to motors library which will adjust and send to ESCs and servos
@@ -17,8 +17,8 @@ void Sub::motors_output()
     if (ap.motor_test) {
         verify_motor_test();
     } else {
-        motors.set_interlock(true);
-        motors.output();
+        motors->set_interlock(true);
+        motors->output();
     }
 }
 
@@ -43,7 +43,7 @@ bool Sub::init_motor_test()
     }
 
     // Make sure we are on the ground
-    if (!motors.armed()) {
+    if (!motors->armed()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Arm motors before testing motors.");
         return false;
     }
@@ -117,13 +117,13 @@ bool Sub::handle_do_motor_test(mavlink_command_long_t command) {
     }
 
     if (is_equal(throttle_type, (float)MOTOR_TEST_THROTTLE_PWM)) {
-        return motors.output_test_num(motor_number, throttle); // true if motor output is set
+        return motors->output_test_num(motor_number, throttle); // true if motor output is set
     }
 
     if (is_equal(throttle_type, (float)MOTOR_TEST_THROTTLE_PERCENT)) {
         throttle = constrain_float(throttle, 0.0f, 100.0f);
         throttle = channel_throttle->get_radio_min() + throttle / 100.0f * (channel_throttle->get_radio_max() - channel_throttle->get_radio_min());
-        return motors.output_test_num(motor_number, throttle); // true if motor output is set
+        return motors->output_test_num(motor_number, throttle); // true if motor output is set
     }
 
     return false;
@@ -134,11 +134,11 @@ bool Sub::handle_do_motor_test(mavlink_command_long_t command) {
 void Sub::translate_wpnav_rp(float &lateral_out, float &forward_out)
 {
     // get roll and pitch targets in centidegrees
-    int32_t lateral = wp_nav.get_roll();
-    int32_t forward = -wp_nav.get_pitch(); // output is reversed
+    int32_t lateral = wp_nav->get_roll();
+    int32_t forward = -wp_nav->get_pitch(); // output is reversed
 
     // constrain target forward/lateral values
-    // The outputs of wp_nav.get_roll and get_pitch should already be constrained to these values
+    // The outputs of wp_nav->get_roll and get_pitch should already be constrained to these values
     lateral = constrain_int16(lateral, -aparm.angle_max, aparm.angle_max);
     forward = constrain_int16(forward, -aparm.angle_max, aparm.angle_max);
 
@@ -151,8 +151,8 @@ void Sub::translate_wpnav_rp(float &lateral_out, float &forward_out)
 void Sub::translate_circle_nav_rp(float &lateral_out, float &forward_out)
 {
     // get roll and pitch targets in centidegrees
-    int32_t lateral = circle_nav.get_roll();
-    int32_t forward = -circle_nav.get_pitch(); // output is reversed
+    int32_t lateral = circle_nav->get_roll();
+    int32_t forward = -circle_nav->get_pitch(); // output is reversed
 
     // constrain target forward/lateral values
     lateral = constrain_int16(lateral, -aparm.angle_max, aparm.angle_max);
@@ -167,8 +167,8 @@ void Sub::translate_circle_nav_rp(float &lateral_out, float &forward_out)
 void Sub::translate_pos_control_rp(float &lateral_out, float &forward_out)
 {
     // get roll and pitch targets in centidegrees
-    int32_t lateral = pos_control.get_roll_cd();
-    int32_t forward = -pos_control.get_pitch_cd(); // output is reversed
+    int32_t lateral = pos_control->get_roll_cd();
+    int32_t forward = -pos_control->get_pitch_cd(); // output is reversed
 
     // constrain target forward/lateral values
     lateral = constrain_int16(lateral, -aparm.angle_max, aparm.angle_max);

--- a/ArduSub/radio.cpp
+++ b/ArduSub/radio.cpp
@@ -49,11 +49,11 @@ void Sub::init_rc_in()
 // init_rc_out -- initialise motors and check if pilot wants to perform ESC calibration
 void Sub::init_rc_out()
 {
-    motors.set_update_rate(g.rc_speed);
-    motors.set_loop_rate(scheduler.get_loop_rate_hz());
-    motors.init((AP_Motors::motor_frame_class)g.frame_configuration.get(), AP_Motors::motor_frame_type::MOTOR_FRAME_TYPE_PLUS);
-    motors.convert_pwm_min_max_param(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
-    motors.update_throttle_range();
+    motors->set_update_rate(g.rc_speed);
+    motors->set_loop_rate(scheduler.get_loop_rate_hz());
+    motors->init((AP_Motors::motor_frame_class)g.frame_configuration.get(), AP_Motors::motor_frame_type::MOTOR_FRAME_TYPE_PLUS);
+    motors->convert_pwm_min_max_param(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
+    motors->update_throttle_range();
 
     // enable output to motors
     if (arming.rc_calibration_checks(true)) {

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -55,8 +55,8 @@ void Sub::read_rangefinder()
     }
 
     // send rangefinder altitude and health to waypoint navigation library
-    wp_nav.set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
-    circle_nav.set_rangefinder_alt(rangefinder_state.enabled && wp_nav.rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    wp_nav->set_rangefinder_alt(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
+    circle_nav->set_rangefinder_alt(rangefinder_state.enabled && wp_nav->rangefinder_used(), rangefinder_state.alt_healthy, rangefinder_state.alt_cm_filt.get());
 
 #else
     rangefinder_state.enabled = false;

--- a/ArduSub/surface_bottom_detector.cpp
+++ b/ArduSub/surface_bottom_detector.cpp
@@ -12,7 +12,7 @@ static float current_depth = 0;
 // ToDo: doesn't need to be called this fast
 void Sub::update_surface_and_bottom_detector()
 {
-    if (!motors.armed()) { // only update when armed
+    if (!motors->armed()) { // only update when armed
         set_surfaced(false);
         set_bottomed(false);
         return;
@@ -35,7 +35,7 @@ void Sub::update_surface_and_bottom_detector()
         }
 
 
-        if (motors.limit.throttle_lower && vel_stationary) {
+        if (motors->limit.throttle_lower && vel_stationary) {
             // bottom criteria met - increment the counter and check if we've triggered
             if (bottom_detector_count < ((float)BOTTOM_DETECTOR_TRIGGER_SEC)*MAIN_LOOP_RATE) {
                 bottom_detector_count++;
@@ -49,7 +49,7 @@ void Sub::update_surface_and_bottom_detector()
 
         // with no external baro, the only thing we have to go by is a vertical velocity estimate
     } else if (vel_stationary) {
-        if (motors.limit.throttle_upper) {
+        if (motors->limit.throttle_upper) {
 
             // surface criteria met, increment counter and see if we've triggered
             if (surface_detector_count < ((float)SURFACE_DETECTOR_TRIGGER_SEC)*MAIN_LOOP_RATE) {
@@ -58,7 +58,7 @@ void Sub::update_surface_and_bottom_detector()
                 set_surfaced(true);
             }
 
-        } else if (motors.limit.throttle_lower) {
+        } else if (motors->limit.throttle_lower) {
             // bottom criteria met, increment counter and see if we've triggered
             if (bottom_detector_count < ((float)BOTTOM_DETECTOR_TRIGGER_SEC)*MAIN_LOOP_RATE) {
                 bottom_detector_count++;

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -59,31 +59,35 @@ fi
 
 # Checking Ubuntu release to adapt software version to install
 RELEASE_CODENAME=$(lsb_release -c -s)
-PYTHON_V="python"  # starting from ubuntu 20.04, python isn't symlink to default python interpreter
-PIP=pip2
+PYTHON_V="python3"  # starting from ubuntu 20.04, python isn't symlink to default python interpreter
+PIP=pip3
 
-if [ ${RELEASE_CODENAME} == 'xenial' ]; then
-    SITLFML_VERSION="2.3v5"
-    SITLCFML_VERSION="2.3"
-elif [ ${RELEASE_CODENAME} == 'disco' ]; then
+if [ ${RELEASE_CODENAME} == 'bionic' ] ; then
+    SITLFML_VERSION="2.4"
+    SITLCFML_VERSION="2.4"
+    PYTHON_V="python"
+    PIP=pip2
+elif [ ${RELEASE_CODENAME} == 'buster' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
-elif [ ${RELEASE_CODENAME} == 'eoan' ]; then
-    SITLFML_VERSION="2.5"
-    SITLCFML_VERSION="2.5"
+    PYTHON_V="python"
+    PIP=pip2
 elif [ ${RELEASE_CODENAME} == 'focal' ] || [ ${RELEASE_CODENAME} == 'ulyssa' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
     PYTHON_V="python3"
     PIP=pip3
-elif [ ${RELEASE_CODENAME} == 'groovy' ] || [ ${RELEASE_CODENAME} == 'hirsute' ]; then
+elif [ ${RELEASE_CODENAME} == 'jammy' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
     PYTHON_V="python3"
     PIP=pip3
-elif [ ${RELEASE_CODENAME} == 'trusty' ]; then
-    SITLFML_VERSION="2"
-    SITLCFML_VERSION="2"
+elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
+         [ ${RELEASE_CODENAME} == 'bullseye' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+    PYTHON_V="python3"
+    PIP=pip3
 else
     # We assume APT based system, so let's try with apt-cache first.
     SITLCFML_VERSION=$(apt-cache search -n '^libcsfml-audio' | cut -d" " -f1 | head -1 | grep -Eo '[+-]?[0-9]+([.][0-9]+)?')
@@ -107,10 +111,10 @@ fi
 if [ "$ARM_PKG_CONFIG_NOT_PRESENT" -eq 1 ]; then
     INSTALL_PKG_CONFIG=""
     # No need to install Ubuntu's pkg-config-arm-linux-gnueabihf, instead install the base pkg-config.
-    sudo apt-get install pkg-config
+    $APT_GET install pkg-config
     if [ -f /usr/share/pkg-config-crosswrapper ]; then
         # We are on non-Ubuntu so simulate effect of installing pkg-config-arm-linux-gnueabihf.
-        sudo ln -s /usr/share/pkg-config-crosswrapper /usr/bin/arm-linux-gnueabihf-pkg-config
+        sudo ln -sf /usr/share/pkg-config-crosswrapper /usr/bin/arm-linux-gnueabihf-pkg-config
     else
         echo "Warning: unable to link to pkg-config-crosswrapper"
     fi
@@ -121,10 +125,20 @@ fi
 
 # Lists of packages to install
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
-PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder"
+if [ ${RELEASE_CODENAME} == 'bionic' ]; then
+    # use fixed version for package that drop python2 support
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 requests==2.27.1 monotonic==1.6 geocoder empy configparser==4.0.2 click==7.1.2 decorator==4.4.2 dronecan"
+else
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder empy dronecan"
+fi
+
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then
-  PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
+    if [ ${RELEASE_CODENAME} == 'bionic' ]; then
+        PYTHON_PKGS="$PYTHON_PKGS pygame==2.0.3 intelhex"
+    else
+        PYTHON_PKGS="$PYTHON_PKGS pygame intelhex"
+    fi
 fi
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
@@ -140,27 +154,50 @@ fi
 
 # ArduPilot official Toolchain for STM32 boards
 function install_arm_none_eabi_toolchain() {
-  # GNU Tools for ARM Embedded Processors
-  # (see https://launchpad.net/gcc-arm-embedded/)
-  ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
-  ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
-  ARM_TARBALL_URL="https://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
-  if [ ! -d $OPT/$ARM_ROOT ]; then
-    (
-        cd $OPT;
-        heading "Installing toolchain for STM32 Boards"
-        echo "Downloading from ArduPilot server"
-        sudo wget $ARM_TARBALL_URL
-        echo "Installing..."
-        sudo tar xjf ${ARM_TARBALL}
-        echo "... Cleaning"
-        sudo rm ${ARM_TARBALL};
-    )
-  fi
-  echo "Registering STM32 Toolchain for ccache"
-  sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
-  sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
-  echo "Done!"
+    # GNU Tools for ARM Embedded Processors
+    # (see https://launchpad.net/gcc-arm-embedded/)
+    ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
+    case $(uname -m) in
+        x86_64)
+            if [ ! -d $OPT/$ARM_ROOT ]; then
+                (
+                    cd $OPT
+                    heading "Installing toolchain for STM32 Boards"
+                    echo "Installing toolchain for STM32 Boards"
+                    echo "Downloading from ArduPilot server"
+                    sudo wget --progress=dot:giga https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+                    echo "Installing..."
+                    sudo chmod -R 777 gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+                    sudo tar xjf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+                    echo "... Cleaning"
+                    sudo rm gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+                )
+            fi
+            echo "Registering STM32 Toolchain for ccache"
+            sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
+            sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
+            echo "Done!";;
+
+        aarch64)
+            if [ ! -d $OPT/$ARM_ROOT ]; then
+                (
+                    cd $OPT
+                    heading "Installing toolchain for STM32 Boards"
+                    echo "Installing toolchain for STM32 Boards"
+                    echo "Downloading from ArduPilot server"
+                    sudo wget --progress=dot:giga https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-aarch64-linux.tar.bz2
+                    echo "Installing..."
+                    sudo chmod -R 777 gcc-arm-none-eabi-10-2020-q4-major-aarch64-linux.tar.bz2
+                    sudo tar xjf gcc-arm-none-eabi-10-2020-q4-major-aarch64-linux.tar.bz2
+                    echo "... Cleaning"
+                    sudo rm gcc-arm-none-eabi-10-2020-q4-major-aarch64-linux.tar.bz2
+                )
+            fi
+            echo "Registering STM32 Toolchain for ccache"
+            sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-g++
+            sudo ln -s -f $CCACHE_PATH /usr/lib/ccache/arm-none-eabi-gcc
+            echo "Done!";;
+    esac
 }
 
 function maybe_prompt_user() {
@@ -181,10 +218,14 @@ sudo usermod -a -G dialout $USER
 echo "Done!"
 
 # Add back python symlink to python interpreter on Ubuntu >= 20.04
-if [ ${RELEASE_CODENAME} == 'focal' ] || [ ${RELEASE_CODENAME} == 'ulyssa' ]; then
+if [ ${RELEASE_CODENAME} == 'focal' ] ||
+       [ ${RELEASE_CODENAME} == 'ulyssa' ];
+then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
-elif [ ${RELEASE_CODENAME} == 'groovy' ] || [ ${RELEASE_CODENAME} == 'hirsute' ]; then
+elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
+         [ ${RELEASE_CODENAME} == 'bullseye' ] ||
+         [ ${RELEASE_CODENAME} == 'jammy' ]; then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 else
@@ -193,18 +234,29 @@ fi
 
 # Check for graphical package for MAVProxy
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-  if [ ${RELEASE_CODENAME} == 'groovy' ] || [ ${RELEASE_CODENAME} == 'hirsute' ]; then
-    SITL_PKGS+=" python3-wxgtk4.0"
-    SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
-  elif [ ${RELEASE_CODENAME} == 'focal' ] || [ ${RELEASE_CODENAME} == 'ulyssa' ]; then
-    SITL_PKGS+=" python3-wxgtk4.0"
-    SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  if [ ${RELEASE_CODENAME} == 'bullseye' ]; then
+    SITL_PKGS+=" libjpeg62-turbo-dev"
+  elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
+           [ ${RELEASE_CODENAME} == 'focal' ] ||
+           [ ${RELEASE_CODENAME} == 'ulyssa'  ]; then
+    SITL_PKGS+=" libjpeg8-dev"
   elif apt-cache search python-wxgtk3.0 | grep wx; then
       SITL_PKGS+=" python-wxgtk3.0"
+  elif apt-cache search python3-wxgtk4.0 | grep wx; then
+      # see below
+      :
   else
       # we only support back to trusty:
       SITL_PKGS+=" python-wxgtk2.8"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng12-0 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  fi
+  if [ ${RELEASE_CODENAME} == 'bullseye' ] ||
+         [ ${RELEASE_CODENAME} == 'groovy' ] ||
+         [ ${RELEASE_CODENAME} == 'focal' ] ||
+         [ ${RELEASE_CODENAME} == 'ulyssa' ] ||
+         [ ${RELEASE_CODENAME} == 'jammy' ]; then
+    SITL_PKGS+=" python3-wxgtk4.0"
+    SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   fi
 fi
 
@@ -222,15 +274,23 @@ fi
 
 # Install all packages
 $APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS $COVERAGE_PKGS
+# Update Pip and Setuptools on old distro
+if [ ${RELEASE_CODENAME} == 'bionic' ]; then
+    # use fixed version for package that drop python2 support
+    $PIP install --user -U pip==20.3 setuptools==44.0.0
+fi
 $PIP install --user -U $PYTHON_PKGS
 
 if [[ -z "${DO_AP_STM_ENV}" ]] && maybe_prompt_user "Install ArduPilot STM32 toolchain [N/y]?" ; then
     DO_AP_STM_ENV=1
 fi
 
-heading "Removing modemmanager package that could conflict with firmware uploading"
+heading "Removing modemmanager and brltty package that could conflict with firmware uploading"
 if package_is_installed "modemmanager"; then
     $APT_GET remove modemmanager
+fi
+if package_is_installed "brltty"; then
+    $APT_GET remove brltty
 fi
 echo "Done!"
 
@@ -249,13 +309,16 @@ echo "Done!"
 SHELL_LOGIN=".profile"
 if $IS_DOCKER; then
     echo "Inside docker, we add the tools path into .bashrc directly"
-    SHELL_LOGIN=".bashrc"
+    SHELL_LOGIN=".ardupilot_env"
+    echo "# ArduPilot env file. Need to be loaded by your Shell." > ~/$SHELL_LOGIN
 fi
 
 heading "Adding ArduPilot Tools to environment"
 
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
+
+if [[ $DO_AP_STM_ENV -eq 1 ]]; then
 exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
 grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
@@ -265,6 +328,7 @@ grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
         echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
     fi
 }
+fi
 
 exportline2="export PATH=$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\$PATH";
 grep -Fxq "$exportline2" ~/$SHELL_LOGIN 2>/dev/null || {
@@ -307,4 +371,10 @@ if [[ $SKIP_AP_GIT_CHECK -ne 1 ]]; then
     echo "Done!"
   fi
 fi
+
+if $IS_DOCKER; then
+    echo "Finalizing ArduPilot env for Docker"
+    echo "source ~/.ardupilot_env">> ~/.bashrc
+fi
+
 echo "---------- $0 end ----------"

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -12,3 +12,4 @@
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
+#include "AP_MotorsMatrix_6DoF_ScriptingSub.h"

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -26,7 +26,8 @@ public:
         SUB_FRAME_SIMPLEROV_3,
         SUB_FRAME_SIMPLEROV_4,
         SUB_FRAME_SIMPLEROV_5,
-        SUB_FRAME_CUSTOM
+        SUB_FRAME_CUSTOM,
+        SUB_FRAME_SCRIPTING
     } sub_frame_t;
 
     const char* get_frame_string() const override { return _frame_class_string; };

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_ScriptingSub.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_ScriptingSub.cpp
@@ -1,0 +1,325 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef ENABLE_SCRIPTING
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_MotorsMatrix_6DoF_ScriptingSub.h"
+#include <AP_Vehicle/AP_Vehicle.h>
+
+extern const AP_HAL::HAL& hal;
+
+void AP_MotorsMatrix_6DoF_ScriptingSub::output_to_motors()
+{
+    switch (_spool_state) {
+        case SpoolState::SHUT_DOWN:
+        case SpoolState::GROUND_IDLE:
+        {
+            // no output, cant spin up for ground idle because we don't know which way motors should be spining
+            for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled[i]) {
+                    _actuator[i] = 0.0f;
+                }
+            }
+            break;
+        }
+        case SpoolState::SPOOLING_UP:
+        case SpoolState::THROTTLE_UNLIMITED:
+        case SpoolState::SPOOLING_DOWN:
+            // set motor output based on thrust requests
+            for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled[i]) {
+                    if (_reversible[i]) {
+                        // revesible motor can provide both positive and negative thrust, +- spin max, spin min does not apply
+                        if (is_positive(_thrust_rpyt_out[i])) {
+                            _actuator[i] = apply_thrust_curve_and_volt_scaling(_thrust_rpyt_out[i]) * _spin_max;
+
+                        } else if (is_negative(_thrust_rpyt_out[i])) {
+                            _actuator[i] = -apply_thrust_curve_and_volt_scaling(-_thrust_rpyt_out[i]) * _spin_max;
+
+                        } else {
+                            _actuator[i] = 0.0f;
+                        }
+                    } else {
+                        // motor can only provide trust in a single direction, spin min to spin max as 'normal' copter
+                         _actuator[i] = thrust_to_actuator(_thrust_rpyt_out[i]);
+                    }
+                }
+            }
+            break;
+    }
+
+    // Send to each motor
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            SRV_Channels::set_output_scaled(SRV_Channels::get_motor_function(i), _actuator[i] * 4500);
+        }
+    }
+}
+
+// output_armed - sends commands to the motors
+void AP_MotorsMatrix_6DoF_ScriptingSub::output_armed_stabilizing()
+{
+    uint8_t i;                          // general purpose counter
+    float   roll_thrust;                // roll thrust input value, +/- 1.0
+    float   pitch_thrust;               // pitch thrust input value, +/- 1.0
+    float   yaw_thrust;                 // yaw thrust input value, +/- 1.0
+    float   throttle_thrust;            // throttle thrust input value, 0.0 - 1.0
+    float   forward_thrust;             // forward thrust input value, +/- 1.0
+    float   right_thrust;               // right thrust input value, +/- 1.0
+
+    // note that the throttle, forwards and right inputs are not in bodyframe, they are in the frame of the 'normal' 4DoF copter were pretending to be
+
+    // apply voltage and air pressure compensation
+    const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
+    roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
+    pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
+    yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
+    throttle_thrust = get_throttle() * compensation_gain;
+
+    // scale horizontal thrust with throttle, this mimics a normal copter
+    // so we don't break the lean angle proportional acceleration assumption made by the position controller
+    forward_thrust = get_forward() * throttle_thrust;
+    right_thrust = get_lateral() * throttle_thrust;
+
+
+    // set throttle limit flags
+    if (throttle_thrust <= 0) {
+        throttle_thrust = 0;
+        // we cant thrust down, the vehicle can do it, but it would break a lot of assumptions further up the control stack
+        // 1G decent probably plenty anyway....
+        limit.throttle_lower = true;
+    }
+    if (throttle_thrust >= 1) {
+        throttle_thrust = 1;
+        limit.throttle_upper = true;
+    }
+
+    // rotate the thrust into bodyframe
+    Matrix3f rot;
+    Vector3f thrust_vec;
+    rot.from_euler312(_roll_offset, _pitch_offset, 0.0f);
+
+
+    /*
+        upwards thrust, independent of orientation
+    */
+    thrust_vec.x = 0.0f;
+    thrust_vec.y = 0.0f;
+    thrust_vec.z = throttle_thrust;
+    thrust_vec = rot * thrust_vec;
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] =  thrust_vec.x * _forward_factor[i];
+            _thrust_rpyt_out[i] += thrust_vec.y * _right_factor[i];
+            _thrust_rpyt_out[i] += thrust_vec.z * _throttle_factor[i];
+
+            if (fabsf(_thrust_rpyt_out[i]) >= 1) {
+                // if we hit this the mixer is probably scaled incorrectly
+                limit.throttle_upper = true;
+            }
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i],-1.0f,1.0f);
+        }
+    }
+
+
+    /*
+        rotations: roll, pitch and yaw
+    */
+    float rpy_ratio = 1.0f;  // scale factor, output will be scaled by this ratio so it can all fit evenly
+    float thrust[AP_MOTORS_MAX_NUM_MOTORS];
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            thrust[i] =  roll_thrust * _roll_factor[i];
+            thrust[i] += pitch_thrust * _pitch_factor[i];
+            thrust[i] += yaw_thrust * _yaw_factor[i];
+            float total_thrust = _thrust_rpyt_out[i] + thrust[i];
+            // control input will be limited by motor range
+            if (total_thrust > 1.0f) {
+                rpy_ratio = MIN(rpy_ratio,(1.0f - _thrust_rpyt_out[i]) / thrust[i]);
+            } else if (total_thrust < -1.0f) {
+                rpy_ratio = MIN(rpy_ratio,(-1.0f -_thrust_rpyt_out[i]) / thrust[i]);
+            }
+        }
+    }
+
+    // set limit flags if output is being scaled
+    if (rpy_ratio < 1) {
+        limit.roll = true;
+        limit.pitch = true;
+        limit.yaw = true;
+    }
+
+    // scale back rotations evenly so it will all fit
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i] + thrust[i] * rpy_ratio,-1.0f,1.0f);
+        }
+    }
+
+    /*
+        forward and lateral, independent of orentaiton
+    */
+    thrust_vec.x = forward_thrust;
+    thrust_vec.y = right_thrust;
+    thrust_vec.z = 0.0f;
+    thrust_vec = rot * thrust_vec;
+
+    float horz_ratio = 1.0f;
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            thrust[i] =  thrust_vec.x * _forward_factor[i];
+            thrust[i] += thrust_vec.y * _right_factor[i];
+            thrust[i] += thrust_vec.z * _throttle_factor[i];
+            float total_thrust = _thrust_rpyt_out[i] + thrust[i];
+            // control input will be limited by motor range
+            if (total_thrust > 1.0f) {
+                horz_ratio = MIN(horz_ratio,(1.0f - _thrust_rpyt_out[i]) / thrust[i]);
+            } else if (total_thrust < -1.0f) {
+                horz_ratio = MIN(horz_ratio,(-1.0f -_thrust_rpyt_out[i]) / thrust[i]);
+            }
+        }
+    }
+
+    // scale back evenly so it will all fit
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i] + thrust[i] * horz_ratio,-1.0f,1.0f);
+        }
+    }
+
+    /*
+        apply deadzone to revesible motors, this stops motors from reversing direction too often
+        re-use yaw headroom param for deadzone, constain to a max of 25%
+    */
+    const float deadzone = constrain_float(_yaw_headroom.get() * 0.001f,0.0f,0.25f);
+    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i] && _reversible[i]) {
+            if (is_negative(_thrust_rpyt_out[i])) {
+                if ((_thrust_rpyt_out[i] > -deadzone) && is_positive(_last_thrust_out[i])) {
+                    _thrust_rpyt_out[i] = 0.0f;
+                } else {
+                    _last_thrust_out[i] = _thrust_rpyt_out[i];
+                }
+            } else if (is_positive(_thrust_rpyt_out[i])) {
+                if ((_thrust_rpyt_out[i] < deadzone) && is_negative(_last_thrust_out[i])) {
+                    _thrust_rpyt_out[i] = 0.0f;
+                } else {
+                    _last_thrust_out[i] = _thrust_rpyt_out[i];
+                }
+            }
+        }
+    }
+
+}
+
+// sets the roll and pitch offset, this rotates the thrust vector in body frame
+// these are typically set such that the throttle thrust vector is earth frame up
+void AP_MotorsMatrix_6DoF_ScriptingSub::set_roll_pitch(float roll_deg, float pitch_deg)
+{
+    _roll_offset = radians(roll_deg);
+    _pitch_offset = radians(pitch_deg);
+}
+
+// add_motor, take roll, pitch, yaw, throttle(up), forward, right factors along with a bool if the motor is reversible and the testing order, called from scripting
+void AP_MotorsMatrix_6DoF_ScriptingSub::add_motor(int8_t motor_num, float roll_factor, float pitch_factor, float yaw_factor, float throttle_factor, float forward_factor, float right_factor, bool reversible, uint8_t testing_order)
+{
+    if (initialised_ok()) {
+        // don't allow matrix to be changed after init
+        return;
+    }
+
+    // ensure valid motor number is provided
+    if (motor_num >= 0 && motor_num < AP_MOTORS_MAX_NUM_MOTORS) {
+        motor_enabled[motor_num] = true;
+
+        _roll_factor[motor_num] = roll_factor;
+        _pitch_factor[motor_num] = pitch_factor;
+        _yaw_factor[motor_num] = yaw_factor;
+
+        _throttle_factor[motor_num] = throttle_factor;
+        _forward_factor[motor_num] = forward_factor;
+        _right_factor[motor_num] = right_factor;
+
+        // set order that motor appears in test
+        _test_order[motor_num] = testing_order;
+
+        // ensure valid motor number is provided
+        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channels::set_aux_channel_default(function, motor_num);
+
+        uint8_t chan;
+        if (!SRV_Channels::find_channel(function, chan)) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+            return;
+        }
+
+        _reversible[motor_num] = reversible;
+        if (_reversible[motor_num]) {
+            // reversible, set to angle type hard code trim to 1500
+            SRV_Channels::set_angle(function, 4500);
+            SRV_Channels::set_trim_to_pwm_for(function, 1500);
+        } else {
+            SRV_Channels::set_range(function, 4500);
+        }
+        SRV_Channels::set_output_min_max(function, get_pwm_output_min(), get_pwm_output_max());
+    }
+}
+
+bool AP_MotorsMatrix_6DoF_ScriptingSub::init(uint8_t expected_num_motors) {
+    uint8_t num_motors = 0;
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            num_motors++;
+        }
+    }
+
+    set_initialised_ok(expected_num_motors == num_motors);
+
+    if (!initialised_ok()) {
+        _mav_type = MAV_TYPE_GENERIC;
+        return false;
+    }
+
+    switch (num_motors) {
+        case 3:
+            _mav_type = MAV_TYPE_TRICOPTER;
+            break;
+        case 4:
+            _mav_type = MAV_TYPE_QUADROTOR;
+            break;
+        case 6:
+            _mav_type = MAV_TYPE_HEXAROTOR;
+            break;
+        case 8:
+            _mav_type = MAV_TYPE_OCTOROTOR;
+            break;
+        case 10:
+            _mav_type = MAV_TYPE_DECAROTOR;
+            break;
+        case 12:
+            _mav_type = MAV_TYPE_DODECAROTOR;
+            break;
+        default:
+            _mav_type = MAV_TYPE_GENERIC;
+    }
+
+    return true;
+}
+
+// singleton instance
+AP_MotorsMatrix_6DoF_ScriptingSub *AP_MotorsMatrix_6DoF_ScriptingSub::_singleton;
+
+#endif // ENABLE_SCRIPTING

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_ScriptingSub.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_ScriptingSub.h
@@ -1,0 +1,67 @@
+#pragma once
+#ifdef ENABLE_SCRIPTING
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <RC_Channel/RC_Channel.h>
+#include "AP_Motors6DOF.h"
+
+class AP_MotorsMatrix_6DoF_ScriptingSub : public AP_Motors6DOF {
+public:
+
+    /// Constructor
+    AP_MotorsMatrix_6DoF_ScriptingSub(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_Motors6DOF(loop_rate, speed_hz)
+    {
+        if (_singleton != nullptr) {
+            AP_HAL::panic("AP_MotorsMatrix 6DoF must be singleton");
+        }
+        _singleton = this;
+    };
+
+    // get singleton instance
+    static AP_MotorsMatrix_6DoF_ScriptingSub *get_singleton() {
+        return _singleton;
+    }
+
+    // output_to_motors - sends minimum values out to the motors
+    void output_to_motors() override;
+
+    // sets the roll and pitch offset, this rotates the thrust vector in body frame
+    // these are typically set such that the throttle thrust vector is earth frame up
+    void set_roll_pitch(float roll_deg, float pitch_deg) override;
+
+    // add_motor using raw roll, pitch, throttle and yaw factors, to be called from scripting
+    void add_motor(int8_t motor_num, float roll_factor, float pitch_factor, float yaw_factor, float throttle_factor, float forward_factor, float right_factor, bool reversible, uint8_t testing_order);
+
+    // if the expected number of motors have been setup then set as initalized
+    bool init(uint8_t expected_num_motors) override;
+
+    const char* get_frame_string() const override { return "6DoF scripting"; }
+
+protected:
+    // output - sends commands to the motors
+    void output_armed_stabilizing() override;
+
+    // nothing to do for setup, scripting will mark as initalized when done
+    void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override {};
+
+    float _forward_factor[AP_MOTORS_MAX_NUM_MOTORS];      // each motors contribution to forward thrust
+    float _right_factor[AP_MOTORS_MAX_NUM_MOTORS];        // each motors contribution to right thrust
+
+    // true if motor is revesible, it can go from -Spin max to +Spin max, if false motor is can go from Spin min to Spin max
+    bool _reversible[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // store last values to allow deadzone
+    float _last_thrust_out[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // Current offset angles, radians
+    float _roll_offset;
+    float _pitch_offset;
+
+private:
+    static AP_MotorsMatrix_6DoF_ScriptingSub *_singleton;
+
+};
+
+#endif // ENABLE_SCRIPTING


### PR DESCRIPTION
Following the discussion in this [thread](https://discuss.bluerobotics.com/t/is-it-possible-to-adapt-at-runtime-the-motors-contribution-to-the-6dof/13079/6), I am trying to add support for dynamic thruster configuration in ArduSub. 

I am using this [PR](https://github.com/ArduPilot/ardupilot/pull/16105/files#) as reference. Basically, I am trying to copy what was done there. 

So far, I was able to set the Sub motors with the `allocate_motors` method for the regular sub frames. I am able to compile everything, but I am getting segmentation faults when I run it with SITL. The simulation starts, the robot appears in the desired place but after a while I get the following error.

![image](https://user-images.githubusercontent.com/20564040/199761477-c1098392-26fd-4644-b9ac-7c2b0b0e2202.png)

I have no idea how to continue with this. Does anyone have any thoughts about?

I am not sure if in the `allocate_motors` method it is necessary to call `convert_old_parameters` (I know that this is probably not the problem).

I started this draft PR to continue the discussion about this feature. Any help would be appreciated. 

