### PR TITLE
hwdef: build skyviper-f412-rev1 only for Copter

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -128,3 +128,5 @@ define HAL_BARO_20789_I2C_ADDR_PRESS 0x63
 # Disable un-needed hardware drivers
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
+
+AUTOBUILD_TARGETS Copter


### PR DESCRIPTION
This is already on the blacklist, so the firmware server won't build it ATM.  But it really ought only be for Copter
