### PR TITLE
AP_Scripting: improve knifeedge handling in aerobatics

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -175,11 +175,27 @@ void SITL_State::_fdm_input_step(void)
 
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
+    float speedup = sitl_model->get_speedup();
+    if (speedup < 1) {
+        // for purposes of sleeps treat low speedups as 1
+        speedup = 1.0;
+    }
     while (AP_HAL::micros64() < wait_time_usec) {
         if (hal.scheduler->in_main_thread() ||
             Scheduler::from(hal.scheduler)->semaphore_wait_hack_required()) {
             _fdm_input_step();
         } else {
+#ifdef CYGWIN_BUILD
+            if (speedup > 2) {
+                // this effectively does a yield of the CPU. The
+                // granularity of sleeps on cygwin is very high, so
+                // this is needed for good thread performance. We
+                // don't do this at low speedups as it causes the cpu
+                // to run hot
+                usleep(0);
+                continue;
+            }
+#endif
             usleep(1000);
         }
     }
@@ -187,7 +203,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
     // MAVProxy/pymavlink take too long to process packets and it ends
     // up seeing traffic well into our past and hits time-out
     // conditions.
-    if (sitl_model->get_speedup() > 1) {
+    if (speedup > 1 && hal.scheduler->in_main_thread()) {
         while (true) {
             const int queue_length = ((HALSITL::UARTDriver*)hal.serial(0))->get_system_outqueue_length();
             // ::fprintf(stderr, "queue_length=%d\n", (signed)queue_length);

--- a/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/examples/Aerobatics/Trajectory/plane_aerobatics.lua
@@ -1768,7 +1768,7 @@ function do_path()
 
       path_var.path_t = 0.0
       path_var.tangent = makeVector3f(1,0,0)
-      path_var.initial_maneuver_to_earth:earth_to_body(path_var.tangent)
+      path_var.initial_maneuver_to_earth:inverse():earth_to_body(path_var.tangent)
 
       path_var.pos = path_var.initial_ef_pos:copy()
       path_var.roll = 0.0

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -530,7 +530,18 @@ void FlightAxis::update(const struct sitl_input &input)
             time_now_us = new_time_us;
         }
     } else {
-        time_now_us = new_time_us;
+        uint64_t dt_us = new_time_us - time_now_us;
+        const uint64_t glitch_threshold_us = 50000;
+        const uint64_t glitch_max_us = 2000000;
+        if (dt_us > glitch_threshold_us && dt_us < glitch_max_us) {
+            // we've had a network glitch, compensate by advancing initial time
+            float adjustment_s = (dt_us-glitch_threshold_us)*1.0e-6;
+            initial_time_s += adjustment_s;
+            printf("glitch %.2fs\n", adjustment_s);
+            dt_us = glitch_threshold_us;
+            glitch_count++;
+        }
+        time_now_us += dt_us;
     }
 
     last_time_s = state.m_currentPhysicsTime_SEC;
@@ -553,8 +564,8 @@ void FlightAxis::report_FPS(void)
             uint64_t frames = socket_frame_counter - last_socket_frame_counter;
             last_socket_frame_counter = socket_frame_counter;
             double dt = state.m_currentPhysicsTime_SEC - last_frame_count_s;
-            printf("%.2f/%.2f FPS avg=%.2f\n",
-                   frames / dt, 1000 / dt, 1.0/average_frame_time_s);
+            printf("%.2f/%.2f FPS avg=%.2f glitches=%u\n",
+                   frames / dt, 1000 / dt, 1.0/average_frame_time_s, unsigned(glitch_count));
         } else {
             printf("Initial position %f %f %f\n", position.x, position.y, position.z);
         }

--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -182,6 +182,7 @@ private:
     bool heli_demix;
     bool rev4_servos;
     bool controller_started;
+    uint32_t glitch_count;
     uint64_t frame_counter;
     uint64_t activation_frame_counter;
     uint64_t socket_frame_counter;


### PR DESCRIPTION
- cope with timing glitches in RealFlight
- fixed aborting trick on mode change
- fixed cygwin timing with lua scripts
- fixed thread performance at high SITL speedups

The cygwin change allows cygwin to run with high speedups. When SIM_SPEEDUP>2 the cpu will run flatout, which is needed as sleeps have much too high granularity. So users will notice their CPUs are pegged, but they will also achieve high speedups

@peterbarker changing the usleep from usleep(1000) to usleep(1000/speedup) helps things quite a lot at high speedups (on linux). But it breaks the dataflash erase test test.CopterTests2b.DataFlashErase. Any idea why? 
