### PR TITLE
AP_RangeFinder: added support for VL53L4X TOF sensors

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -158,6 +158,7 @@ BUILD_OPTIONS = [
     Feature('Rangefinder', 'RANGEFINDER_USD1_SERIAL', 'AP_RANGEFINDER_USD1_SERIAL_ENABLED', "Enable Rangefinder - USD1 (SERIAL)", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_VL53L0X', 'AP_RANGEFINDER_VL53L0X_ENABLED', "Enable Rangefinder - VL53L0X", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_VL53L1X', 'AP_RANGEFINDER_VL53L1X_ENABLED', "Enable Rangefinder - VL53L1X", 0, "RANGEFINDER"),   # NOQA: E501
+    Feature('Rangefinder', 'RANGEFINDER_VL53L4X', 'AP_RANGEFINDER_VL53L4X_ENABLED', "Enable Rangefinder - VL53L4X", 0, "RANGEFINDER"),   # NOQA: E501
     Feature('Rangefinder', 'RANGEFINDER_WASP', 'AP_RANGEFINDER_WASP_ENABLED', "Enable Rangefinder - Wasp", 0, "RANGEFINDER"),   # NOQA: E501
 
     Feature('Sensors', 'OPTICALFLOW', 'AP_OPTICALFLOW_ENABLED', 'Enable Optical Flow', 0, None),

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -33,6 +33,7 @@
 #include "AP_RangeFinder_TeraRanger_Serial.h"
 #include "AP_RangeFinder_VL53L0X.h"
 #include "AP_RangeFinder_VL53L1X.h"
+#include "AP_RangeFinder_VL53L4X.h"
 #include "AP_RangeFinder_NMEA.h"
 #include "AP_RangeFinder_Wasp.h"
 #include "AP_RangeFinder_Benewake_TF02.h"
@@ -187,6 +188,7 @@ void RangeFinder::init(enum Rotation orientation_default)
         // init called a 2nd time?
         return;
     }
+
     init_done = true;
 
     // set orientation defaults
@@ -348,6 +350,15 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
                 }
 #endif
             }
+        break;
+    case Type::VL53L4X:
+#if AP_RANGEFINDER_VL53L4X_ENABLED
+        FOREACH_I2C(i) {
+            if (_add_backend(AP_RangeFinder_VL53L4X::detect(state[instance], params[instance], hal.i2c_mgr->get_device(i, params[instance].address)), instance)) {
+                break;
+            }
+        }
+#endif
         break;
     case Type::BenewakeTFminiPlus: {
 #if AP_RANGEFINDER_BENEWAKE_TFMINIPLUS_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -102,6 +102,7 @@ public:
         USD1_CAN = 33,
         Benewake_CAN = 34,
         TeraRanger_Serial = 35,
+        VL53L4X = 36,
         SIM = 100,
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4X.cpp
@@ -1,0 +1,465 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  driver for ST VL53L4X lidar
+
+  mostly based on https://github.com/adafruit/Adafruit_CircuitPython_VL53L4CD
+ */
+#include "AP_RangeFinder_VL53L4X.h"
+
+#if AP_RANGEFINDER_VL53L4X_ENABLED
+
+#include <utility>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/sparse-endian.h>
+#include <stdio.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+const uint8_t VL53L4X_DEFAULT_CONFIGURATION[] = {
+    0x12,  // 0x2d : I2C_HV__CONFIG                                 set bit 2 and 5 to 1 for fast plus mode (1MHz I2C), else don't touch
+    0x01,  // 0x2e : I2C_HV__EXTSUP_CONFIG                          bit 0 if I2C pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD)
+    0x00,  // 0x2f : GPIO_HV_PAD__CTRL                              bit 0 if GPIO pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD)
+    0x11,  // 0x30 : GPIO_HV_MUX__CTRL                              set bit 4 to 0 for active high interrupt and 1 for active low (bits 3:0 must be 0x1)
+    0x02,  // 0x31 : GPIO__TIO_HV_STATUS                            bit 1 = interrupt depending on the polarity
+    0x00,  // 0x32 : GPIO__FIO_HV_STATUS
+    0x02,  // 0x33 : ANA_CONFIG_SPAD_SEL_PSWIDTH
+    0x08,  // 0x34 : ANA_CONFIG__VCSEL_PULSE_WIDTH_OFFSET
+    0x00,  // 0x35 : ANA_CONFIG__FAST_OSC__CONFIG_CTRL
+    0x08,  // 0x36 : SIGMA_ESTIMATOR__EFFECTIVE_PULSE_WIDTH_NS
+    0x10,  // 0x37 : SIGMA_ESTIMATOR__EFFECTIVE_AMBIENT_WIDTH_NS
+    0x01,  // 0x38 : SIGMA_ESTIMATOR__SIGMA_REF_MM
+    0x01,  // 0x39 : ALGO__CROSSTALK_COMPENSATION_VALID_HEIGHT_MM
+    0x00,  // 0x3a : SPARE_HOST_CONFIG__STATIC_CONFIG_SPARE_0
+    0x00,  // 0x3b : SPARE_HOST_CONFIG__STATIC_CONFIG_SPARE_1
+    0x00,  // 0x3c : ALGO__RANGE_IGNORE_THRESHOLD_MCPS_HI
+    0x00,  // 0x3d : ALGO__RANGE_IGNORE_THRESHOLD_MCPS_LO
+    0xFF,  // 0x3e : ALGO__RANGE_IGNORE_VALID_HEIGHT_MM
+    0x00,  // 0x3f : ALGO__RANGE_MIN_CLIP
+    0x0F,  // 0x40 : ALGO__CONSISTENCY_CHECK__TOLERANCE
+    0x00,  // 0x41 : SPARE_HOST_CONFIG__STATIC_CONFIG_SPARE_2
+    0x00,  // 0x42 : SD_CONFIG__RESET_STAGES_MSB
+    0x00,  // 0x43 : SD_CONFIG__RESET_STAGES_LSB
+    0x00,  // 0x44 : GPH_CONFIG__STREAM_COUNT_UPDATE_VALUE
+    0x00,  // 0x45 : GLOBAL_CONFIG__STREAM_DIVIDER
+    0x20,  // 0x46 : SYSTEM__INTERRUPT_CONFIG_GPIO                  interrupt configuration 0->level low detection, 1-> level high, 2-> Out of window, 3->In window, 0x20-> New sample ready , TBC
+    0x0B,  // 0x47 : CAL_CONFIG__VCSEL_START
+    0x00,  // 0x48 : CAL_CONFIG__REPEAT_RATE_HI
+    0x00,  // 0x49 : CAL_CONFIG__REPEAT_RATE_LO
+    0x02,  // 0x4a : GLOBAL_CONFIG__VCSEL_WIDTH
+    0x14,  // 0x4b : PHASECAL_CONFIG__TIMEOUT_MACROP
+    0x21,  // 0x4c : PHASECAL_CONFIG__TARGET
+    0x00,  // 0x4d : PHASECAL_CONFIG__OVERRIDE
+    0x00,  // 0x4e :
+    0x02,  // 0x4f : DSS_CONFIG__ROI_MODE_CONTROL
+    0x00,  // 0x50 : SYSTEM__THRESH_RATE_HIGH_HI
+    0x00,  // 0x51 : SYSTEM__THRESH_RATE_HIGH_LO
+    0x00,  // 0x52 : SYSTEM__THRESH_RATE_LOW_HI
+    0x00,  // 0x53 : SYSTEM__THRESH_RATE_LOW_LO
+    0xC8,  // 0x54 : DSS_CONFIG__MANUAL_EFFECTIVE_SPADS_SELECT_HI
+    0x00,  // 0x55 : DSS_CONFIG__MANUAL_EFFECTIVE_SPADS_SELECT_LO
+    0x00,  // 0x56 : DSS_CONFIG__MANUAL_BLOCK_SELECT
+    0x38,  // 0x57 : DSS_CONFIG__APERTURE_ATTENUATION
+    0xFF,  // 0x58 : DSS_CONFIG__MAX_SPADS_LIMIT
+    0x01,  // 0x59 : DSS_CONFIG__MIN_SPADS_LIMIT
+    0x00,  // 0x5a : MM_CONFIG__TIMEOUT_MACROP_A_HI
+    0x08,  // 0x5b : MM_CONFIG__TIMEOUT_MACROP_A_LO
+    0x00,  // 0x5c : MM_CONFIG__TIMEOUT_MACROP_B_HI
+    0x00,  // 0x5d : MM_CONFIG__TIMEOUT_MACROP_B_LO
+    0x01,  // 0x5e : RANGE_CONFIG__TIMEOUT_MACROP_A_HI
+    0xCC,  // 0x5f : RANGE_CONFIG__TIMEOUT_MACROP_A_LO
+    0x07,  // 0x60 : RANGE_CONFIG__VCSEL_PERIOD_A
+    0x01,  // 0x61 : RANGE_CONFIG__TIMEOUT_MACROP_B_HI
+    0xF1,  // 0x62 : RANGE_CONFIG__TIMEOUT_MACROP_B_LO
+    0x05,  // 0x63 : RANGE_CONFIG__VCSEL_PERIOD_B
+    0x00,  // 0x64 : RANGE_CONFIG__SIGMA_THRESH_HI                  Sigma threshold MSB (mm in 14.2 format for MSB+LSB), default value 90 mm
+    0xA0,  // 0x65 : RANGE_CONFIG__SIGMA_THRESH_LO                  Sigma threshold LSB
+    0x00,  // 0x66 : RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS_HI Min count Rate MSB (MCPS in 9.7 format for MSB+LSB)
+    0x80,  // 0x67 : RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS_LO Min count Rate LSB
+    0x08,  // 0x68 : RANGE_CONFIG__VALID_PHASE_LOW
+    0x38,  // 0x69 : RANGE_CONFIG__VALID_PHASE_HIGH
+    0x00,  // 0x6a :
+    0x00,  // 0x6b :
+    0x00,  // 0x6c : SYSTEM__INTERMEASUREMENT_PERIOD_3              Intermeasurement period MSB, 32 bits register
+    0x00,  // 0x6d : SYSTEM__INTERMEASUREMENT_PERIOD_2              Intermeasurement period
+    0x0F,  // 0x6e : SYSTEM__INTERMEASUREMENT_PERIOD_1              Intermeasurement period
+    0x89,  // 0x6f : SYSTEM__INTERMEASUREMENT_PERIOD_0              Intermeasurement period LSB
+    0x00,  // 0x70 : SYSTEM__FRACTIONAL_ENABLE
+    0x00,  // 0x71 : SYSTEM__GROUPED_PARAMETER_HOLD_0
+    0x00,  // 0x72 : SYSTEM__THRESH_HIGH_HI                         distance threshold high MSB (in mm, MSB+LSB)
+    0x00,  // 0x73 : SYSTEM__THRESH_HIGH_LO                         distance threshold high LSB
+    0x00,  // 0x74 : SYSTEM__THRESH_LOW_HI                          distance threshold low MSB ( in mm, MSB+LSB)
+    0x00,  // 0x75 : SYSTEM__THRESH_LOW_LO                          distance threshold low LSB
+    0x00,  // 0x76 : SYSTEM__ENABLE_XTALK_PER_QUADRANT
+    0x01,  // 0x77 : SYSTEM__SEED_CONFIG
+    0x07,  // 0x78 : SD_CONFIG__WOI_SD0
+    0x05,  // 0x79 : SD_CONFIG__WOI_SD1
+    0x06,  // 0x7a : SD_CONFIG__INITIAL_PHASE_SD0
+    0x06,  // 0x7b : SD_CONFIG__INITIAL_PHASE_SD1
+    0x00,  // 0x7c : SYSTEM__GROUPED_PARAMETER_HOLD_1
+    0x00,  // 0x7d : SD_CONFIG__FIRST_ORDER_SELECT
+    0x02,  // 0x7e : SD_CONFIG__QUANTIFIER
+    0xC7,  // 0x7f : ROI_CONFIG__USER_ROI_CENTRE_SPAD
+    0xFF,  // 0x80 : ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE
+    0x8B,  // 0x81 : SYSTEM__SEQUENCE_CONFIG
+    0x00,  // 0x82 : SYSTEM__GROUPED_PARAMETER_HOLD
+    0x00,  // 0x83 : POWER_MANAGEMENT__GO1_POWER_FORCE
+    0x00,  // 0x84 : SYSTEM__STREAM_COUNT_CTRL
+    0x01,  // 0x85 : FIRMWARE__ENABLE
+    0x00,  // 0x86 : SYSTEM__INTERRUPT_CLEAR                        clear interrupt, 0x01=clear
+    0x00,  // 0x87 : SYSTEM__MODE_START                             ranging, 0x00=stop, 0x40=start
+};
+
+static const uint8_t MEASUREMENT_TIME_MS = 50; // Start continuous readings at a rate of one measurement every 50 ms
+
+AP_RangeFinder_VL53L4X::AP_RangeFinder_VL53L4X(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev)
+    : AP_RangeFinder_Backend(_state, _params)
+    , dev(std::move(_dev)) {}
+
+
+// detect tests if a VL53L4X is present and returns the sensor instance
+AP_RangeFinder_Backend *AP_RangeFinder_VL53L4X::detect(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+{
+    if (!dev) {
+        return nullptr;
+    }
+
+    AP_RangeFinder_VL53L4X *sensor = new AP_RangeFinder_VL53L4X(_state, _params, std::move(dev));
+
+    if (!sensor) {
+        delete sensor;
+        return nullptr;
+    }
+
+    sensor->dev->get_semaphore()->take_blocking();
+
+    if (!sensor->check_id() || !sensor->init()) {
+        sensor->dev->get_semaphore()->give();
+        delete sensor;
+        return nullptr;
+    }
+
+    sensor->dev->get_semaphore()->give();
+    return sensor;
+}
+
+// init writes the default configration, calibrate the sensor and starts the measurements
+bool AP_RangeFinder_VL53L4X::init()
+{
+    // we need to do resets and delays in order to configure the sensor, don't do this if we are trying to fast boot
+    if (hal.util->was_watchdog_armed()) {
+        return false;
+    }
+
+    // reset the chip, we make assumptions later on that we are on a clean power on of the sensor
+    if (!(reset() && wait_for_boot())) {
+        return false;
+    }
+
+    for (uint16_t reg = 0x002D; reg <= 0x0087; reg++) {
+        if (!write_register(reg, VL53L4X_DEFAULT_CONFIGURATION[reg - 0x002D])) {
+            return false;
+        }
+        hal.scheduler->delay(1);
+    }
+
+    if (!read_register16(RESULT_OSC_CALIBRATE_VAL, osc_calibrate_val)) {
+        return false;
+    }
+
+    if (!start_continuous()) {
+        return false;
+    }
+
+    if (!write_register(SYSTEM_START, 0x00)) {
+        return false;
+    }
+
+    // writing calibration VHV value
+    if (!(
+            write_register(VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND, 0x09) &&
+            write_register(VHV_CONFIG_INIT, 0x00) &&
+            write_register16(DSS_CONFIG_TARGET_TOTAL_RATE_MCPS, 0x0500)
+        )) {
+        return false;
+    }
+
+    // start measurements regular
+    if (!set_inter_measurement(MEASUREMENT_TIME_MS) || !set_timing_budget(50) || !start_continuous()) {
+        return false;
+    }
+
+    // call timer() every MEASUREMENT_TIME_MS. We expect new data to be available every MEASUREMENT_TIME_MS
+    dev->register_periodic_callback(MEASUREMENT_TIME_MS * 1000, FUNCTOR_BIND_MEMBER(&AP_RangeFinder_VL53L4X::timer, void));
+    return true;
+}
+
+// reset softresets the sensor using i2c commands
+bool AP_RangeFinder_VL53L4X::reset(void)
+{
+    if (dev->get_bus_id() != 0x29) {
+        // if sensor is on a different port than the default do not  reset sensor otherwise we will lose the addess.
+        // we assume it is already confirgured.
+        return true;
+    }
+    if (!write_register(SOFT_RESET, 0x00)) {
+        return false;
+    }
+    hal.scheduler->delay(1);
+    if (!write_register(SOFT_RESET, 0x01)) {
+        return false;
+    }
+    hal.scheduler->delay(1000);
+    return true;
+}
+
+// wait_for_boot checks the sensor if it is ready to configure
+bool AP_RangeFinder_VL53L4X::wait_for_boot(void)
+{
+    uint8_t res;
+    for (uint16_t i = 0; i < 1000; i++) {
+        if (read_register(FIRMWARE_SYSTEM_STATUS, res) && res == 0x03) {
+            return true;
+        }
+        hal.scheduler->delay(1);
+    }
+    return false;
+}
+
+// check_id checks for the correct model of the VL53L4 TOF sensor
+bool AP_RangeFinder_VL53L4X::check_id(void)
+{
+    uint16_t v;
+    if (!read_register16(IDENTIFICATION_MODEL_ID, v)) {
+        return false;
+    }
+    if (v != 0xEBAA) {
+        return false;
+    }
+    return true;
+}
+
+// interrupt_polarity returns the interrupt polarity set in register GPIO_HV_MUX_CTRL
+bool AP_RangeFinder_VL53L4X::interrupt_polarity(uint8_t *value)
+{
+    uint8_t v;
+    if (!read_register(GPIO_HV_MUX_CTRL, v)) {
+        return false;
+    }
+    v = v & 0x10;
+    *value = !(v >> 4);
+
+    return true;
+}
+
+// set_timing_budget sets the allowed time for meassurements
+bool AP_RangeFinder_VL53L4X::set_timing_budget(uint32_t budget_ms)
+{
+    // budget_ms must be between 10ms and 200ms
+    // budget_ms must be below inter measurement period
+
+    uint16_t osc_freq = 0;
+    if (!read_register16(OSC_MEASURED_FAST_OSC_FREQUENCY, osc_freq)) {
+        return false;
+    }
+
+    uint32_t timing_budget_us = budget_ms * 1000;
+    uint32_t macro_period_us = calc_macro_period(osc_freq);
+
+    timing_budget_us -= 4300;
+    timing_budget_us /= 2;
+
+    uint16_t ms_byte = 0;
+    timing_budget_us <<= 12;
+    uint32_t tmp = macro_period_us * 16;
+    uint32_t ls_byte = ((timing_budget_us + ((tmp >> 6) >> 1)) / (tmp >> 6)) - 1;
+    while ((ls_byte & 0xFFFFFF00) > 0) {
+        ls_byte >>= 1;
+        ms_byte += 1;
+    }
+    ms_byte = (ms_byte << 8) + (ls_byte & 0xFF);
+    if (!write_register16(RANGE_CONFIG_A, ms_byte)) {
+        return false;
+    }
+
+    ms_byte = 0;
+    tmp = macro_period_us * 12;
+    ls_byte = ((timing_budget_us + ((tmp >> 6) >> 1)) / (tmp >> 6)) - 1;
+    while ((ls_byte & 0xFFFFFF00) > 0) {
+        ls_byte >>= 1;
+        ms_byte += 1;
+    }
+    ms_byte = (ms_byte << 8) + (ls_byte & 0xFF);
+
+    return write_register16(RANGE_CONFIG_B, ms_byte);
+}
+
+// set_inter_measurement determines how often the sensor takes a measurement
+bool AP_RangeFinder_VL53L4X::set_inter_measurement(uint32_t period_ms)
+{
+    uint32_t clock_pll = osc_calibrate_val & 0x3FF;
+    uint32_t int_meas = 1.055f * period_ms * clock_pll;
+
+    if (!write_register32(INTERMEASUREMENT_MS, int_meas)) {
+        return false;
+    }
+    return true;
+}
+
+// start_continuous starts continuous ranging measurements
+bool AP_RangeFinder_VL53L4X::start_continuous()
+{
+    if (!write_register(SYSTEM_START, 0x40)) {
+        return false;
+    }
+
+    uint16_t tries = 2500;
+    while (!data_ready()) {
+        tries--;
+        hal.scheduler->delay(1);
+        if (tries == 0) {
+            return false;
+        }
+    }
+
+    if (!write_register(SYSTEM_INTERRUPT_CLEAR, 0x01)) {
+        return false;
+    }
+
+    return true;
+}
+
+// data_ready checks register if interrupt is triggered. it is independet from the polarity
+bool AP_RangeFinder_VL53L4X::data_ready(void)
+{
+    uint8_t polarity;
+    if (!interrupt_polarity(&polarity)) {
+        return false;
+    }
+
+    uint8_t status;
+    if (!read_register(GPIO_TIO_HV_STATUS, status)) {
+        return false;
+    }
+    return (status & 0x01) == polarity;
+}
+
+// get_reading returns the distance result
+bool AP_RangeFinder_VL53L4X::get_reading(uint16_t &reading_mm)
+{
+    uint8_t tries = 25;
+    while (!data_ready()) {
+        tries--;
+        hal.scheduler->delay(1);
+        if (tries == 0) {
+            return false;
+        }
+    }
+
+    uint8_t range_status = 0;
+
+    if (!(read_register(RESULT_RANGE_STATUS, range_status) &&
+          read_register16(RESULT_DISTANCE, reading_mm))) {
+        return false;
+    }
+
+    if (!write_register(SYSTEM_INTERRUPT_CLEAR, 0x01)) { // sys_interrupt_clear_range
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t AP_RangeFinder_VL53L4X::calc_macro_period(uint16_t osc_freq) const
+{
+    uint32_t pll_period_us = ((uint32_t)0x40000000) / osc_freq;
+    uint32_t macro_period_us = ((uint32_t)2304 )* pll_period_us;
+    return macro_period_us  >> 6;
+}
+
+
+// timer called at 20Hz
+void AP_RangeFinder_VL53L4X::timer(void)
+{
+    uint16_t range_mm;
+    if (get_reading(range_mm)) {
+        WITH_SEMAPHORE(_sem);
+        sum_mm += range_mm;
+        counter++;
+    }
+}
+
+
+// update the state of the sensor and calculates the avarage
+void AP_RangeFinder_VL53L4X::update(void)
+{
+    WITH_SEMAPHORE(_sem);
+    if (counter > 0) {
+        state.distance_m = (sum_mm * 0.001f) / counter;
+        state.last_reading_ms = AP_HAL::millis();
+        update_status();
+        sum_mm = 0;
+        counter = 0;
+    } else if (AP_HAL::millis() - state.last_reading_ms > 200) {
+        // if no updates for 0.2s set no-data
+        set_status(RangeFinder::Status::NoData);
+    }
+}
+
+
+bool AP_RangeFinder_VL53L4X::read_register(uint16_t reg, uint8_t &value)
+{
+    uint8_t b[2] = { uint8_t(reg >> 8), uint8_t(reg & 0xFF) };
+    return dev->transfer(b, 2, &value, 1);
+}
+
+bool AP_RangeFinder_VL53L4X::read_register16(uint16_t reg, uint16_t & value)
+{
+    uint16_t v = 0;
+    uint8_t b[2] = { uint8_t(reg >> 8), uint8_t(reg & 0xFF) };
+    if (!dev->transfer(b, 2, (uint8_t *)&v, 2)) {
+        return false;
+    }
+    value = be16toh(v);
+    return true;
+}
+
+bool AP_RangeFinder_VL53L4X::write_register(uint16_t reg, uint8_t value)
+{
+    uint8_t b[3] = { uint8_t(reg >> 8), uint8_t(reg & 0xFF), value };
+    return dev->transfer(b, 3, nullptr, 0);
+}
+
+bool AP_RangeFinder_VL53L4X::write_register16(uint16_t reg, uint16_t value)
+{
+    uint8_t b[4] = { uint8_t(reg >> 8), uint8_t(reg & 0xFF), uint8_t(value >> 8), uint8_t(value & 0xFF) };
+    return dev->transfer(b, 4, nullptr, 0);
+}
+
+bool AP_RangeFinder_VL53L4X::write_register32(uint16_t reg, uint32_t value)
+{
+    uint8_t b[6] = { uint8_t(reg >> 8),
+                     uint8_t(reg & 0xFF),
+                     uint8_t((value >> 24) & 0xFF),
+                     uint8_t((value >> 16) & 0xFF),
+                     uint8_t((value >>  8) & 0xFF),
+                     uint8_t((value)       & 0xFF)
+                   };
+    return dev->transfer(b, 6, nullptr, 0);
+}
+
+#endif  // AP_RANGEFINDER_VL53L4X_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4X.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "AP_RangeFinder.h"
+#include "AP_RangeFinder_Backend.h"
+
+#ifndef AP_RANGEFINDER_VL53L4X_ENABLED
+#define AP_RANGEFINDER_VL53L4X_ENABLED AP_RANGEFINDER_BACKEND_DEFAULT_ENABLED
+#endif
+
+#if AP_RANGEFINDER_VL53L4X_ENABLED
+
+#include <AP_HAL/I2CDevice.h>
+
+class AP_RangeFinder_VL53L4X : public AP_RangeFinder_Backend
+{
+
+public:
+    // static detection function
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev);
+
+    // update state
+    void update(void) override;
+
+protected:
+
+    virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override
+    {
+        return MAV_DISTANCE_SENSOR_LASER;
+    }
+
+private:
+    enum DeviceError : uint8_t {
+        NOUPDATE                    = 0,
+        VCSELCONTINUITYTESTFAILURE  = 1,
+        VCSELWATCHDOGTESTFAILURE    = 2,
+        NOVHVVALUEFOUND             = 3,
+        MSRCNOTARGET                = 4,
+        RANGEPHASECHECK             = 5,
+        SIGMATHRESHOLDCHECK         = 6,
+        PHASECONSISTENCY            = 7,
+        MINCLIP                     = 8,
+        RANGECOMPLETE               = 9,
+        ALGOUNDERFLOW               = 10,
+        ALGOOVERFLOW                = 11,
+        RANGEIGNORETHRESHOLD        = 12,
+        USERROICLIP                 = 13,
+        REFSPADCHARNOTENOUGHDPADS   = 14,
+        REFSPADCHARMORETHANTARGET   = 15,
+        REFSPADCHARLESSTHANTARGET   = 16,
+        MULTCLIPFAIL                = 17,
+        GPHSTREAMCOUNT0READY        = 18,
+        RANGECOMPLETE_NO_WRAP_CHECK = 19,
+        EVENTCONSISTENCY            = 20,
+        MINSIGNALEVENTCHECK         = 21,
+        RANGECOMPLETE_MERGED_PULSE  = 22,
+    };
+
+    enum regAddr : uint16_t {
+        SOFT_RESET = 0x0000,
+        I2C_SLAVE_DEVICE_ADDRESS = 0x0001,
+        VHV_CONFIG_TIMEOUT_MACROP_LOOP_BOUND = 0x0008,
+        XTALK_PLANE_OFFSET_KCPS = 0x0016,
+        XTALK_X_PLANE_GRADIENT_KCPS = 0x0018,
+        XTALK_Y_PLANE_GRADIENT_KCPS = 0x001A,
+        RANGE_OFFSET_MM = 0x001E,
+        INNER_OFFSET_MM = 0x0020,
+        OUTER_OFFSET_MM = 0x0022,
+        I2C_FAST_MODE_PLUS = 0x002D,
+        GPIO_HV_MUX_CTRL = 0x0030,
+        GPIO_TIO_HV_STATUS = 0x0031,
+        SYSTEM_INTERRUPT = 0x0046,
+        RANGE_CONFIG_A = 0x005E,
+        RANGE_CONFIG_B = 0x0061,
+        RANGE_CONFIG_SIGMA_THRESH = 0x0064,
+        MIN_COUNT_RATE_RTN_LIMIT_MCPS = 0x0066,
+        INTERMEASUREMENT_MS = 0x006C,
+        THRESH_HIGH = 0x0072,
+        THRESH_LOW = 0x0074,
+        SYSTEM_INTERRUPT_CLEAR = 0x0086,
+        SYSTEM_START = 0x0087,
+        RESULT_RANGE_STATUS = 0x0089,
+        RESULT_SPAD_NB = 0x008C,
+        RESULT_SIGNAL_RATE = 0x008E,
+        RESULT_AMBIENT_RATE = 0x0090,
+        RESULT_SIGMA = 0x0092,
+        RESULT_DISTANCE = 0x0096,
+        RESULT_OSC_CALIBRATE_VAL = 0x00DE,
+        FIRMWARE_SYSTEM_STATUS = 0x00E5,
+        IDENTIFICATION_MODEL_ID = 0x010F,
+        DSS_CONFIG_TARGET_TOTAL_RATE_MCPS = 0x0024,
+        OSC_MEASURED_FAST_OSC_FREQUENCY = 0x0006,
+        VHV_CONFIG_INIT = 0x000B,
+    };
+
+    // constructor
+    AP_RangeFinder_VL53L4X(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
+    bool init();
+    void timer();
+
+    // check sensor ID
+    bool check_id(void);
+
+    // get a reading
+    bool get_reading(uint16_t &reading_cm);
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+
+    uint16_t osc_calibrate_val;
+    uint32_t sum_mm;
+    uint32_t counter;
+
+    bool read_register(uint16_t reg, uint8_t &value) WARN_IF_UNUSED;
+    bool read_register16(uint16_t reg, uint16_t &value) WARN_IF_UNUSED;
+    bool write_register(uint16_t reg, uint8_t value) WARN_IF_UNUSED;
+    bool write_register16(uint16_t reg, uint16_t value) WARN_IF_UNUSED;
+    bool write_register32(uint16_t reg, uint32_t value) WARN_IF_UNUSED;
+    bool data_ready(void);
+    bool reset(void) WARN_IF_UNUSED;
+    bool set_timing_budget(uint32_t budget_ms) WARN_IF_UNUSED;
+    bool start_continuous() WARN_IF_UNUSED;
+    bool set_inter_measurement(uint32_t period_ms) WARN_IF_UNUSED;
+    uint32_t calc_macro_period(uint16_t osc_freq) const;
+    bool interrupt_polarity(uint8_t *value);
+    bool wait_for_boot(void);
+};
+
+#endif  // AP_RANGEFINDER_VL53L4X_ENABLED


### PR DESCRIPTION
As already wrote in discord:
I'm currently writing my bachelor thesis and generally my goal is/was to get started in autonomous indoor scanning. Because we had some failures we keep it simple in the beginning.
Our drone should use `VL53L4CX` for object avoidance and a TeraRanger EVO as Rangefinder for scanning the room. Currently we are using the TeraRanger EVO for altitude sonar as well but would like to replace it with a `VL53L4CX`.
Because currently ArduPilot only has support for STs `VL53L0X` and `VL53L1X` I wrote this PR for the `VL53L4X` family. They support a operating range of 1.3m and 6m. They are widely available thanks to Adafruit.

Feel free to comment. There should also be a purposal to support multiple `VL53L4X` sensors for all directions.