### PR TITLE
Include cleanups

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -37,7 +37,6 @@
 #include <AP_Declination/AP_Declination.h>     // ArduPilot Mega Declination Helper Library
 
 // Application dependencies
-#include <AP_SerialManager/AP_SerialManager.h>   // Serial manager library
 #include <AP_GPS/AP_GPS.h>             // ArduPilot GPS library
 #include <AP_Logger/AP_Logger.h>          // ArduPilot Mega Flash Memory Library
 #include <AP_Baro/AP_Baro.h>

--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -28,6 +28,7 @@
 #if !AP_AIS_DUMMY_METHODS_ENABLED
 
 #include <AP_Logger/AP_Logger.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
 

--- a/libraries/AP_AIS/AP_AIS.h
+++ b/libraries/AP_AIS/AP_AIS.h
@@ -22,7 +22,6 @@
 // 2 compiled in with dummy methods, none functional, except rover which never uses dummy methods functionality
 
 #include <AP_Param/AP_Param.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Common/AP_ExpandingArray.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -27,6 +27,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Mission/AP_Mission.h>
+#include <AC_Fence/AC_Fence.h>
 
 AP_AdvancedFailsafe *AP_AdvancedFailsafe::_singleton;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -26,6 +26,7 @@
 #if APM_BUILD_TYPE(APM_BUILD_Rover) || APM_BUILD_TYPE(APM_BUILD_ArduSub) 
 
 #include "AP_Airspeed.h"
+#include <AP_SerialManager/AP_SerialManager.h>
 
 #define TIMEOUT_MS 2000
 

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.h
@@ -11,7 +11,6 @@
 
 #include "AP_Airspeed_Backend.h"
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 class AP_Airspeed_NMEA : public AP_Airspeed_Backend
 {

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -3,7 +3,6 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_Arming {
 public:

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -24,6 +24,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -26,6 +26,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <GCS_MAVLink/GCS.h>
 
 #define DEVOM_SYNC_BYTE        0xAA

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.h
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 #ifndef AP_DEVO_TELEM_ENABLED
     #define AP_DEVO_TELEM_ENABLED   0

--- a/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
+++ b/libraries/AP_LTM_Telem/AP_LTM_Telem.cpp
@@ -24,6 +24,7 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_RSSI/AP_RSSI.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.h
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <AP_RCTelemetry/AP_RCTelemetry.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_OSD/AP_OSD.h>
 
 #include "msp.h"

--- a/libraries/AP_MSP/msp.h
+++ b/libraries/AP_MSP/msp.h
@@ -17,7 +17,6 @@
 #endif
 
 #include <AP_HAL/UARTDriver.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 #include "msp_osd.h"
 #include "msp_protocol.h"

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -2,9 +2,6 @@
 
 #if HAL_MOUNT_ALEXMOS_ENABLED
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_AHRS/AP_AHRS.h>
-
-extern const AP_HAL::HAL& hal;
 
 void AP_Mount_Alexmos::init()
 {

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -2,6 +2,7 @@
 
 #if HAL_MOUNT_GREMSY_ENABLED
 
+#include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -11,8 +11,6 @@
 
 #if HAL_MOUNT_GREMSY_ENABLED
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -13,8 +13,6 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <RC_Channel/RC_Channel.h>
-#include <AP_AHRS/AP_AHRS.h>
 
 class AP_Mount_SToRM32 : public AP_Mount_Backend
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -6,8 +6,6 @@
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
-extern const AP_HAL::HAL& hal;
-
 AP_Mount_SToRM32_serial::AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
     AP_Mount_Backend(frontend, params, instance),
     _reply_type(ReplyType_UNKNOWN)

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -12,10 +12,8 @@
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define AP_MOUNT_STORM32_SERIAL_RESEND_MS   1000    // resend angle targets to gimbal once per second
 

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -1,6 +1,9 @@
 #include "AP_Mount_Servo.h"
 #if HAL_MOUNT_SERVO_ENABLED
 
+#include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
 extern const AP_HAL::HAL& hal;
 
 // init - performs any required initialisation for this instance

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -13,8 +13,6 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <AP_AHRS/AP_AHRS.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <SRV_Channel/SRV_Channel.h>
 
 class AP_Mount_Servo : public AP_Mount_Backend

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -1,5 +1,3 @@
-#include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include "AP_Mount_SoloGimbal.h"
 #if HAL_SOLO_GIMBAL_ENABLED
 
@@ -7,8 +5,6 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
-
-extern const AP_HAL::HAL& hal;
 
 AP_Mount_SoloGimbal::AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
     AP_Mount_Backend(frontend, params, instance),

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -5,7 +5,6 @@
 
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_AHRS/AP_AHRS.h>
 
 #include "AP_Mount_Backend.h"
 #if HAL_SOLO_GIMBAL_ENABLED

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -31,8 +31,6 @@
 #define NMEA_MAX_OUTPUTS 3
 #endif
 
-#include <AP_SerialManager/AP_SerialManager.h>
-
 class AP_NMEA_Output {
 
 public:

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -27,7 +27,7 @@
 #include <AP_MSP/msp.h>
 #include <AP_Baro/AP_Baro.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AC_Fence/AC_Fence.h>
+#include <AC_Fence/AC_Fence_config.h>
 
 #ifndef OSD_ENABLED
 #define OSD_ENABLED !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -13,6 +13,7 @@
 #include <AP_NavEKF3/AP_NavEKF3.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 void setup();
 void loop();

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -32,6 +32,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_RTC/AP_RTC.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #ifdef HAVE_AP_BLHELI_SUPPORT
 #include <AP_BLheli/AP_BLHeli.h>
 #endif

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.h
@@ -22,7 +22,6 @@
 
 #if HAL_SPEKTRUM_TELEM_ENABLED
 
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_RCTelemetry.h"
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -54,6 +54,7 @@
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -20,7 +20,7 @@
 
 #include <AP_Filesystem/posix_compat.h>
 #include <AP_Scripting/AP_Scripting.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_HAL/Semaphores.h>
 
 #include "lua/src/lua.hpp"

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -1,10 +1,11 @@
 #include "AP_Soaring.h"
-#include <AP_Logger/AP_Logger.h>
-#include <GCS_MAVLink/GCS.h>
-#include <stdint.h>
-extern const AP_HAL::HAL& hal;
 
 #if HAL_SOARING_ENABLED
+
+#include <AP_Logger/AP_Logger.h>
+#include <AP_TECS/AP_TECS.h>
+#include <GCS_MAVLink/GCS.h>
+#include <stdint.h>
 
 // ArduSoar parameters
 const AP_Param::GroupInfo SoaringController::var_info[] = {

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -9,19 +9,19 @@
 
 #pragma once
 
-#include <AP_AHRS/AP_AHRS.h>
-#include <AP_Param/AP_Param.h>
-#include <AP_Math/AP_Math.h>
-#include "ExtendedKalmanFilter.h"
-#include "Variometer.h"
-#include <AP_TECS/AP_TECS.h>
-#include "SpeedToFly.h"
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_SOARING_ENABLED
  #define HAL_SOARING_ENABLED !HAL_MINIMIZE_FEATURES
 #endif
 
 #if HAL_SOARING_ENABLED
+
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include "ExtendedKalmanFilter.h"
+#include "Variometer.h"
+#include "SpeedToFly.h"
 
 #define INITIAL_THERMAL_RADIUS 80.0
 #define INITIAL_STRENGTH_COVARIANCE 0.0049
@@ -32,7 +32,7 @@
 class SoaringController {
     Variometer::PolarParams _polarParams;
     ExtendedKalmanFilter _ekf{};
-    AP_TECS &_tecs;
+    class AP_TECS &_tecs;
     Variometer _vario;
     SpeedToFly _speedToFly;
 
@@ -81,7 +81,7 @@ protected:
     AP_Float soar_thermal_flap;
 
 public:
-    SoaringController(AP_TECS &tecs, const AP_Vehicle::FixedWing &parms);
+    SoaringController(class AP_TECS &tecs, const AP_Vehicle::FixedWing &parms);
 
     enum class LoiterStatus {
         DISABLED,

--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -19,6 +19,7 @@
 #include <AP_Math/crc.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 #if HAL_SMARTAUDIO_ENABLED
 

--- a/libraries/AP_VideoTX/AP_SmartAudio.h
+++ b/libraries/AP_VideoTX/AP_SmartAudio.h
@@ -24,7 +24,6 @@
 #if HAL_SMARTAUDIO_ENABLED
 
 #include <AP_Param/AP_Param.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_VideoTX.h"
 

--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -19,6 +19,7 @@
 #include <AP_Math/crc.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 #if AP_TRAMP_ENABLED
 

--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -27,7 +27,6 @@
 #if AP_TRAMP_ENABLED
 
 #include <AP_Param/AP_Param.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_VideoTX.h"
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -20,7 +20,10 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 #include <AP_Math/AP_Math.h>
 
 class AP_VisualOdom_Backend;

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -19,6 +19,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define VISUALODOM_RESET_IGNORE_DURATION_MS 1000    // sensor data is ignored for 1sec after a position reset

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -24,6 +24,7 @@
 #include <AP_Mount/AP_Mount.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AP_Airspeed/AP_Airspeed_config.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 #include "ap_message.h"
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -20,10 +20,7 @@
 #include <AP_Filesystem/AP_Filesystem_config.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
-#include <AP_OpenDroneID/AP_OpenDroneID.h>
 #include <AP_Mount/AP_Mount.h>
-#include <AC_Fence/AC_Fence.h>
-#include <AP_Airspeed/AP_Airspeed_config.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
 #include "ap_message.h"

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -47,6 +47,7 @@
 #include <AP_Scripting/AP_Scripting.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Winch/AP_Winch.h>
+#include <AP_OpenDroneID/AP_OpenDroneID.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <AP_RPM/AP_RPM.h>


### PR DESCRIPTION
Try to reduce build times by narrowing dependencies.

```
Board              AP_Periph  blimp  copter  heli  plane  rover  sub
Durandal                      -112   0       0     0      0      0
Hitec-Airspeed     0                                             
KakuteH7-bdshot               0      0       0     0      0      0
MatekF405                     0      0       0     0      0      0
Pixhawk1-1M                   0      0       0     0      0      0
f103-QiotekPeriph  0                                             
f303-Universal     0                                             
```

The blimp change is strange - elf_diff sees the total size difference but doesn't see a difference in any symbols

