### PR TITLE
Create AP_AHRS base class for use in AP_Mount

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "cSpell.language": "en-GB",
-    "astyle.astylerc": "${workspaceFolder}/Tools/CodeStyle/astylerc"
+    "astyle.astylerc": "${workspaceFolder}/Tools/CodeStyle/astylerc",
+    "files.trimTrailingWhitespace": false
 }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3250,4 +3250,9 @@ AP_AHRS &ahrs()
     return *AP_AHRS::get_singleton();
 }
 
+const AP_AHRS_Base &ahrs_base()
+{
+    return *AP_AHRS::get_singleton();
+}
+
 }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include "AP_AHRS_Base.h"
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 
@@ -57,7 +58,7 @@ class AP_AHRS_View;
 // fwd declare GSF estimator
 class EKFGSF_yaw;
 
-class AP_AHRS {
+class AP_AHRS : public AP_AHRS_Base {
     friend class AP_AHRS_View;
 public:
 
@@ -91,7 +92,7 @@ public:
     }
 
     // return the smoothed gyro vector corrected for drift
-    const Vector3f &get_gyro(void) const;
+    const Vector3f &get_gyro(void) const override;
 
     // return the current drift correction integrator value
     const Vector3f &get_gyro_drift(void) const;
@@ -104,7 +105,7 @@ public:
     void            reset();
 
     // dead-reckoning support
-    bool get_location(struct Location &loc) const;
+    bool get_location(struct Location &loc) const override;
 
     // get latest altitude estimate above ground level in meters and validity flag
     bool get_hagl(float &hagl) const WARN_IF_UNUSED;
@@ -210,7 +211,7 @@ public:
     bool set_origin(const Location &loc) WARN_IF_UNUSED;
 
     // returns the inertial navigation origin in lat/lon/alt
-    bool get_origin(Location &ret) const WARN_IF_UNUSED;
+    bool get_origin(Location &origin) const override WARN_IF_UNUSED;
 
     bool have_inertial_nav() const;
 
@@ -446,6 +447,13 @@ public:
      * home-related functionality
      */
 
+    // get the home location
+    bool get_home(struct Location &home) const override {
+        if (_home_is_set) {
+            home = _home;
+        }
+        return _home_is_set;
+    }
     // get the home location. This is const to prevent any changes to
     // home without telling AHRS about the change
     const struct Location &get_home(void) const {
@@ -480,27 +488,27 @@ public:
     float pitch;
     float yaw;
 
-    float get_roll() const { return roll; }
-    float get_pitch() const { return pitch; }
-    float get_yaw() const { return yaw; }
+    float get_roll() const override { return roll; }
+    float get_pitch() const override { return pitch; }
+    float get_yaw() const override { return yaw; }
 
     // helper trig value accessors
-    float cos_roll() const  {
+    float cos_roll() const override {
         return _cos_roll;
     }
-    float cos_pitch() const {
+    float cos_pitch() const override {
         return _cos_pitch;
     }
-    float cos_yaw() const   {
+    float cos_yaw() const override {
         return _cos_yaw;
     }
-    float sin_roll() const  {
+    float sin_roll() const override {
         return _sin_roll;
     }
-    float sin_pitch() const {
+    float sin_pitch() const override {
         return _sin_pitch;
     }
-    float sin_yaw() const   {
+    float sin_yaw() const override {
         return _sin_yaw;
     }
 
@@ -509,7 +517,7 @@ public:
     int32_t pitch_sensor;
     int32_t yaw_sensor;
 
-    const Matrix3f &get_rotation_body_to_ned(void) const;
+    const Matrix3f &get_rotation_body_to_ned(void) const override;
 
     // return a Quaternion representing our current attitude in NED frame
     void get_quat_body_to_ned(Quaternion &quat) const {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -841,5 +841,8 @@ private:
 };
 
 namespace AP {
+    // accessor to the _full_ AHRS instance
     AP_AHRS &ahrs();
+    // read-only accessor to the AHRS core data
+    const AP_AHRS_Base &ahrs_base();
 };

--- a/libraries/AP_AHRS/AP_AHRS_Base.h
+++ b/libraries/AP_AHRS/AP_AHRS_Base.h
@@ -1,0 +1,57 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  Base class interface for the AHRS (Attitude Heading Reference System)
+ *  frontend for ArduPilot. Designed to provide the minimum accessors required
+ *  for other libraries that require vehicle position and orientation.
+ *
+ *  This class differs from AP_AHRS_View in that AP_AHRS_View is intended to
+ *  provide a view of vehicle pitch that is rotated 90 degrees in pitch, for use
+ *  in tailsitter attitude control.
+ */
+
+#pragma once
+
+#include <AP_Common/Location.h>
+
+
+class AP_AHRS_Base {
+public:
+
+    virtual bool get_home(struct Location &home) const WARN_IF_UNUSED = 0;
+    virtual bool get_location(struct Location &loc) const WARN_IF_UNUSED = 0;
+    virtual bool get_origin(struct Location &origin) const WARN_IF_UNUSED = 0;
+
+    virtual const Vector3f &get_gyro(void) const = 0;
+
+    // roll euler angle, in radians
+    virtual float get_roll() const = 0;
+    // pitch euler angle, in radians
+    virtual float get_pitch() const = 0;
+    // yaw euler angle, in radians
+    virtual float get_yaw() const = 0;
+
+    // helper trig value accessors
+    virtual float cos_roll() const = 0;
+    virtual float cos_pitch() const = 0;
+    virtual float cos_yaw() const = 0;
+    virtual float sin_roll() const = 0;
+    virtual float sin_pitch() const = 0;
+    virtual float sin_yaw() const = 0;
+
+    virtual const Matrix3f &get_rotation_body_to_ned(void) const = 0;
+
+};

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -16,7 +16,12 @@
  */
 
 /*
- *  AHRS View class - for creating a 2nd view of the vehicle attitude
+ *  AHRS View class - for creating a 2nd view of the vehicle attitude.
+ *
+ *  This class allows some parts of the code to see a rotated view of the
+ *  aircraft attitude. This allows the AC_AttitudeControl code to see a view
+ *  rotated by 90 degrees in pitch from the view seen by the fixed wing code.
+ *  This is required to support the tailsitter frame type in quadplanes.
  *
  */
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -307,7 +307,7 @@ bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountTa
 {
     // exit immediately if vehicle's location is unavailable
     Location current_loc;
-    if (!AP::ahrs().get_location(current_loc)) {
+    if (!AP::ahrs_base().get_location(current_loc)) {
         return false;
     }
 
@@ -353,7 +353,7 @@ float AP_Mount_Backend::get_bf_yaw_angle(const MountTarget& angle_rad) const
 {
     if (angle_rad.yaw_is_ef) {
         // convert to body-frame
-        return wrap_PI(angle_rad.yaw - AP::ahrs().yaw);
+        return wrap_PI(angle_rad.yaw - AP::ahrs_base().get_yaw());
     }
 
     // target is already body-frame
@@ -369,7 +369,7 @@ float AP_Mount_Backend::get_ef_yaw_angle(const MountTarget& angle_rad) const
     }
 
     // convert to earth-frame
-    return wrap_PI(angle_rad.yaw + AP::ahrs().yaw);
+    return wrap_PI(angle_rad.yaw + AP::ahrs_base().get_yaw());
 }
 
 // update angle targets using a given rate target
@@ -417,10 +417,11 @@ uint16_t AP_Mount_Backend::get_gimbal_device_flags() const
 bool AP_Mount_Backend::get_angle_target_to_home(MountTarget& angle_rad) const
 {
     // exit immediately if home is not set
-    if (!AP::ahrs().home_is_set()) {
+    Location home;
+    if (!AP::ahrs_base().get_home(home)) {
         return false;
     }
-    return get_angle_target_to_location(AP::ahrs().get_home(), angle_rad);
+    return get_angle_target_to_location(home, angle_rad);
 }
 
 // get angle targets (in radians) to a vehicle with sysid of  _target_sysid

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -132,21 +132,21 @@ bool AP_Mount_Servo::get_attitude_quaternion(Quaternion& att_quat)
 // update body-frame angle outputs from earth-frame angle targets
 void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
 {
-    const AP_AHRS &ahrs = AP::ahrs();
+    const auto &ahrs = AP::ahrs_base();
 
     // roll and pitch are based on the ahrs roll and pitch angle plus any requested angle
     _angle_bf_output_deg.x = degrees(angle_rad.roll);
     _angle_bf_output_deg.y = degrees(angle_rad.pitch);
     _angle_bf_output_deg.z = degrees(get_bf_yaw_angle(angle_rad));
     if (requires_stabilization) {
-        _angle_bf_output_deg.x -= degrees(ahrs.roll);
-        _angle_bf_output_deg.y -= degrees(ahrs.pitch);
+        _angle_bf_output_deg.x -= degrees(ahrs.get_roll());
+        _angle_bf_output_deg.y -= degrees(ahrs.get_pitch());
     }
 
     // lead filter
     const Vector3f &gyro = ahrs.get_gyro();
 
-    if (requires_stabilization && !is_zero(_params.roll_stb_lead) && fabsf(ahrs.pitch) < M_PI/3.0f) {
+    if (requires_stabilization && !is_zero(_params.roll_stb_lead) && fabsf(ahrs.get_pitch()) < M_PI/3.0f) {
         // Compute rate of change of euler roll angle
         float roll_rate = gyro.x + (ahrs.sin_pitch() / ahrs.cos_pitch()) * (gyro.y * ahrs.sin_roll() + gyro.z * ahrs.cos_roll());
         _angle_bf_output_deg.x -= degrees(roll_rate) * _params.roll_stb_lead;

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -580,7 +580,7 @@ void AP_Mount_Siyi::send_target_angles(float pitch_rad, float yaw_rad, bool yaw_
     const float pitch_rate_scalar = constrain_float(100.0 * pitch_err_rad * AP_MOUNT_SIYI_PITCH_P / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
 
     // convert yaw angle to body-frame the use simple P controller to convert yaw angle error to a target rate scalar (-100 to +100)
-    const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().yaw) : yaw_rad;
+    const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs_base().get_yaw()) : yaw_rad;
     const float yaw_err_rad = (yaw_bf_rad - _current_angle_rad.z);
     const float yaw_rate_scalar = constrain_float(100.0 * yaw_err_rad * AP_MOUNT_SIYI_YAW_P / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
 


### PR DESCRIPTION
We want to be able to use `AP_Mount` in `AP_Periph`. However, `AP_Mount` currently references the `AP_AHRS` singleton, which is not available in `AP_Periph`.

This PR:
* creates an abstract base class for `AP_AHRS` that provides the minimum accessors required for `AP_Mount`;
* adds a new `AP::ahrs_base()` accessor; and
* updates the `AP_Mount` backend and drivers to use the new `AP::ahrs_base()` accessor.

FYI: @tridge, @rmackay9, @joshanne 