### PR TITLE
AP_Baro: add Bus6 to BARO_EXT_BUS values

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: _EXT_BUS
     // @DisplayName: External baro bus
     // @Description: This selects the bus number for looking for an I2C barometer. When set to -1 it will probe all external i2c buses based on the GND_PROBE_EXT parameter.
-    // @Values: -1:Disabled,0:Bus0,1:Bus1
+    // @Values: -1:Disabled,0:Bus0,1:Bus1,6:Bus6
     // @User: Advanced
     AP_GROUPINFO("_EXT_BUS", 7, AP_Baro, _ext_bus, HAL_BARO_EXTERNAL_BUS_DEFAULT),
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
 
     // @Param: _EXT_BUS
     // @DisplayName: External baro bus
-    // @Description: This selects the bus number for looking for an I2C barometer. When set to -1 it will probe all external i2c buses based on the GND_PROBE_EXT parameter.
+    // @Description: This selects the bus number for looking for an I2C barometer. When set to -1 it will probe all external i2c buses based on the BARO_PROBE_EXT parameter.
     // @Values: -1:Disabled,0:Bus0,1:Bus1,6:Bus6
     // @User: Advanced
     AP_GROUPINFO("_EXT_BUS", 7, AP_Baro, _ext_bus, HAL_BARO_EXTERNAL_BUS_DEFAULT),
@@ -176,7 +176,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
 #if defined(HAL_PROBE_EXTERNAL_I2C_BAROS) || defined(AP_BARO_MSP_ENABLED)
     // @Param: _PROBE_EXT
     // @DisplayName: External barometers to probe
-    // @Description: This sets which types of external i2c barometer to look for. It is a bitmask of barometer types. The I2C buses to probe is based on GND_EXT_BUS. If BARO_EXT_BUS is -1 then it will probe all external buses, otherwise it will probe just the bus number given in GND_EXT_BUS.
+    // @Description: This sets which types of external i2c barometer to look for. It is a bitmask of barometer types. The I2C buses to probe is based on BARO_EXT_BUS. If BARO_EXT_BUS is -1 then it will probe all external buses, otherwise it will probe just the bus number given in BARO_EXT_BUS.
     // @Bitmask: 0:BMP085,1:BMP280,2:MS5611,3:MS5607,4:MS5637,5:FBM320,6:DPS280,7:LPS25H,8:Keller,9:MS5837,10:BMP388,11:SPL06,12:MSP
     // @User: Advanced
     AP_GROUPINFO("_PROBE_EXT", 14, AP_Baro, _baro_probe_ext, HAL_BARO_PROBE_EXT_DEFAULT),
@@ -813,7 +813,7 @@ void AP_Baro::_probe_i2c_barometers(void)
         // no internal i2c baros, so this is safe
         mask |= hal.i2c_mgr->get_bus_mask_internal();
     }
-    // if the user has set GND_EXT_BUS then probe the bus given by that parameter
+    // if the user has set BARO_EXT_BUS then probe the bus given by that parameter
     int8_t ext_bus = _ext_bus;
     if (ext_bus >= 0) {
         mask = 1U << (uint8_t)ext_bus;


### PR DESCRIPTION
Bus 6 is the external bus for the Navigator board.