### PR TITLE
AP_Mount: gremsy driver sends vehicle attitude at 50hz

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -9,7 +9,7 @@ extern const AP_HAL::HAL& hal;
 
 #define AP_MOUNT_GREMSY_RESEND_MS  1000     // resend angle targets to gimbal at least once per second
 #define AP_MOUNT_GREMSY_SEARCH_MS  60000    // search for gimbal for 1 minute after startup
-#define AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US    10000  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 100hz
+#define AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US    20000  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 50hz
 
 AP_Mount_Gremsy::AP_Mount_Gremsy(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
     AP_Mount_Backend(frontend, params, instance)


### PR DESCRIPTION
This reduces the rate at which the AUTOPILOT_STATE_FOR_GIMBAL_DEVICE mavlink messages are sent to the Gremsy gimbal from 100hz to 50hz.  There has been one report that the gimbal's internal buffer is being overloaded at the higher rate.

I have lightly tested this on my vehicle (CubeOrange+GremsyPixyU) and it seems fine although it seemed fine before as well.