### PR TITLE
AP_Param: allow for removal of script parameters

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3021,6 +3021,18 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
         return false;
     }
 
+    // fill in idx of any gaps, leaving them hidden, this allows
+    // scripts to remove parameters
+    for (uint8_t j=1; j<param_num; j++) {
+        auto &g = const_cast<GroupInfo*>(info.group_info)[j];
+        if (g.idx == 0xff) {
+            g.idx = j;
+            g.flags = AP_PARAM_FLAG_HIDDEN;
+            g.offset = j*sizeof(float);
+            g.type = AP_PARAM_FLOAT;
+        }
+    }
+
     auto &ginfo = const_cast<GroupInfo*>(info.group_info)[param_num];
 
     if (ginfo.name == _empty_string) {


### PR DESCRIPTION
when a parameter is removed it leaves a gap in the index numbers. We need to cope with that gap when we add the parameters  in the script to allow params to be re-ordered or removed
