### PR TITLE
AP_Frsky_Telem: fix compilation when frsky bidir is disabled

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -73,6 +73,7 @@ BUILD_OPTIONS = [
     Feature('Telemetry', 'FrSky D', 'AP_FRSKY_D_TELEM_ENABLED', 'Enable FrSkyD Telemetry', 0, 'FrSky'),
     Feature('Telemetry', 'FrSky SPort', 'AP_FRSKY_SPORT_TELEM_ENABLED', 'Enable FrSkySPort Telemetry', 0, 'FrSky'),  # noqa
     Feature('Telemetry', 'FrSky SPort PassThrough', 'AP_FRSKY_SPORT_PASSTHROUGH_ENABLED', 'Enable FrSkySPort PassThrough Telemetry', 0, 'FrSky SPort,FrSky'),  # noqa
+    Feature('Telemetry', 'Bidirectional FrSky Telemetry', 'HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL', 'Enable Bidirectional FrSky telemetry', 0, 'FrSky SPort'),  # noqa
     Feature('Telemetry', 'GHST', 'AP_GHST_TELEM_ENABLED', 'Enable Ghost Telemetry', 0, "RC_GHST"), # noqa
 
     Feature('Notify', 'PLAY_TUNE', 'AP_NOTIFY_MAVLINK_PLAY_TUNE_SUPPORT_ENABLED', 'Enable MAVLink Play Tune', 0, None),  # noqa

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -121,6 +121,7 @@ class ExtractFeatures(object):
             ('AP_FRSKY_D_TELEM_ENABLED', 'AP_Frsky_D::send',),
             ('AP_FRSKY_SPORT_TELEM_ENABLED', 'AP_Frsky_SPort::send_sport_frame',),
             ('AP_FRSKY_SPORT_PASSTHROUGH_ENABLED', 'AP::frsky_passthrough_telem',),
+            ('HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL', 'AP_Frsky_SPort_Passthrough::set_telem_data'),
 
             ('MODE_{type}_ENABLED', r'Mode(?P<type>.+)::init',),
             ('MODE_GUIDED_NOGPS_ENABLED', r'ModeGuidedNoGPS::init',),

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.cpp
@@ -14,9 +14,9 @@
 */
 #include "AP_Frsky_Parameters.h"
 
-#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
 
 const AP_Param::GroupInfo AP_Frsky_Parameters::var_info[] = {
+#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
     // @Param: UPLINK_ID
     // @DisplayName: Uplink sensor id
     // @Description: Change the uplink sensor id (SPort only)
@@ -37,6 +37,7 @@ const AP_Param::GroupInfo AP_Frsky_Parameters::var_info[] = {
     // @Values: -1:Disable,7:7,8:8,9:9,10:10,11:11,12:12,13:13,14:14,15:15,16:16,17:17,18:18,19:19,20:20,21:21,22:22,23:23,24:24,25:25,26:26
     // @User: Advanced
     AP_GROUPINFO("DNLINK2_ID",  3, AP_Frsky_Parameters, _dnlink2_id, 7),
+#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
 
     // @Param: DNLINK_ID
     // @DisplayName: Default downlink sensor id
@@ -58,5 +59,3 @@ AP_Frsky_Parameters::AP_Frsky_Parameters()
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
-
-#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Parameters.h
@@ -16,7 +16,6 @@
 
 #include "AP_Frsky_Telem.h"
 
-#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 
@@ -33,11 +32,11 @@ public:
 
 private:
     // settable parameters
-    AP_Int8 _uplink_id;
     AP_Int8 _dnlink_id;
+#if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+    AP_Int8 _uplink_id;
     AP_Int8 _dnlink1_id;
     AP_Int8 _dnlink2_id;
+#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
     AP_Int8 _options;
 };
-
-#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -20,8 +20,8 @@
 
 #if HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
 #include "AP_Frsky_MAVlite.h"
-#include "AP_Frsky_Parameters.h"
 #endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+#include "AP_Frsky_Parameters.h"
 
 /*
 for FrSky SPort Passthrough
@@ -941,6 +941,16 @@ void AP_Frsky_SPort_Passthrough::process_tx_queue()
 }
 
 /*
+ * Send a mavlite message
+ * Message is chunked in sport packets pushed in the tx queue
+ * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
+ */
+bool AP_Frsky_SPort_Passthrough::send_message(const AP_Frsky_MAVlite_Message &txmsg)
+{
+    return mavlite_to_sport.process(_SPort_bidir.tx_packet_queue, txmsg);
+}
+#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
+/*
  * Utility method to apply constraints in changing sensor id values
  * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
  */
@@ -955,17 +965,6 @@ void AP_Frsky_SPort_Passthrough::set_sensor_id(AP_Int8 param_idx, uint8_t &senso
     }
     sensor = calc_sensor_id(idx);
 }
-
-/*
- * Send a mavlite message
- * Message is chunked in sport packets pushed in the tx queue
- * for FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
- */
-bool AP_Frsky_SPort_Passthrough::send_message(const AP_Frsky_MAVlite_Message &txmsg)
-{
-    return mavlite_to_sport.process(_SPort_bidir.tx_packet_queue, txmsg);
-}
-#endif //HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL
 
 namespace AP
 {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.h
@@ -149,7 +149,6 @@ private:
     AP_Frsky_MAVlite_SPortToMAVlite sport_to_mavlite;
     AP_Frsky_MAVlite_MAVliteToSPort mavlite_to_sport;
 
-    void set_sensor_id(AP_Int8 idx, uint8_t &sensor);
     // tx/rx sport packet processing
     void queue_rx_packet(const AP_Frsky_SPort::sport_packet_t sp);
     void process_rx_queue(void);
@@ -160,7 +159,7 @@ private:
     bool send_message(const AP_Frsky_MAVlite_Message &txmsg);
     AP_Frsky_MAVliteMsgHandler mavlite{FUNCTOR_BIND_MEMBER(&AP_Frsky_SPort_Passthrough::send_message, bool, const AP_Frsky_MAVlite_Message &)};
 #endif
-
+    void set_sensor_id(AP_Int8 idx, uint8_t &sensor);
     void send_sport_frame(uint8_t frame, uint16_t appid, uint32_t data);
 
     // true if we need to respond to the last polling byte


### PR DESCRIPTION
This allows to build with "define HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL 0".