### PR TITLE
AP_RangeFinder: fix Benewake TFMiniPlus reset hex commands

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -69,7 +69,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_Benewake_TFMiniPlus::detect(
 bool AP_RangeFinder_Benewake_TFMiniPlus::init()
 {
     const uint8_t CMD_FW_VERSION[] =         { 0x5A, 0x04, 0x01, 0x5F };
-    const uint8_t CMD_SYSTEM_RESET[] =       { 0x5A, 0x04, 0x04, 0x62 };
+    const uint8_t CMD_SYSTEM_RESET[] =       { 0x5A, 0x04, 0x02, 0x60 };
     const uint8_t CMD_OUTPUT_FORMAT_CM[] =   { 0x5A, 0x05, 0x05, 0x01, 0x65 };
     const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { 0x5A, 0x05, 0x07, 0x01, 0x67 };
     const uint8_t CMD_FRAME_RATE_250HZ[] =   { 0x5A, 0x06, 0x03, 0xFA, 0x00, 0x5D };


### PR DESCRIPTION
previous hex command was referring to an older Benewake firmware. Older than the minimum required.

related issue https://github.com/ArduPilot/ardupilot/issues/22165