### PR TITLE
HAL_SITL: only do the cygwin speedup hack for scripting while armed

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -308,6 +308,7 @@ void Scheduler::stop_clock(uint64_t time_usec)
 void *Scheduler::thread_create_trampoline(void *ctx)
 {
     struct thread_attr *a = (struct thread_attr *)ctx;
+    a->thread = pthread_self();
     a->f[0]();
     
     WITH_SEMAPHORE(_thread_sem);
@@ -407,4 +408,16 @@ void Scheduler::check_thread_stacks(void)
             }
         }
     }
+}
+
+// get the name of the current thread, or nullptr if not known
+const char *Scheduler::get_current_thread_name(void) const
+{
+    const pthread_t self = pthread_self();
+    for (struct thread_attr *a=threads; a; a=a->next) {
+        if (a->thread == self) {
+            return a->name;
+        }
+    }
+    return nullptr;
 }

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -67,6 +67,9 @@ public:
     // a couple of helper functions to cope with SITL's time stepping
     bool semaphore_wait_hack_required() const;
 
+    // get the name of the current thread, or nullptr if not known
+    const char *get_current_thread_name(void) const;
+
 private:
     SITL_State *_sitlState;
     uint8_t _nested_atomic_ctr;
@@ -105,6 +108,7 @@ private:
         void *stack;
         const uint8_t *stack_min;
         const char *name;
+        pthread_t thread;
     };
     static struct thread_attr *threads;
     static const uint8_t stackfill = 0xEB;


### PR DESCRIPTION
this stops us chewing lots of CPU while disarmed, and also stops the logging thread from chewing a lot of CPU