### PR TITLE
AR_WPNav_OA: do not allow stop vehicle when oa is processing

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -65,6 +65,8 @@ void AR_WPNav_OA::update(float dt)
             break;
 
         case AP_OAPathPlanner::OA_PROCESSING:
+            _oa_active = false;
+            break;
         case AP_OAPathPlanner::OA_ERROR:
             // during processing or in case of error, slow vehicle to a stop
             stop_vehicle = true;


### PR DESCRIPTION
Is it a problem that the temporary stopping is caused by obstacle avoidance?