### PR TITLE
Rover: add MANUAL_STR_EXPO

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -678,6 +678,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPPTR(mode_dock_ptr, "DOCK", 54, ParametersG2, ModeDock),
 #endif
 
+    // @Param: MANUAL_STR_EXPO
+    // @DisplayName: Manual Steering Expo
+    // @Description: Manual steering expo to allow faster steering when stick at edges
+    // @Values: 0:Disabled,0.1:Very Low,0.2:Low,0.3:Medium,0.4:High,0.5:Very High
+    // @Range: -0.5 0.95
+    // @User: Advanced
+    AP_GROUPINFO("MANUAL_STR_EXPO", 55, ParametersG2, manual_steering_expo, 0),
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -425,8 +425,11 @@ public:
     // guided options bitmask
     AP_Int32 guided_options;
 
-    // Rover options
+    // manual mode options
     AP_Int32 manual_options;
+
+    // manual mode steering expo
+    AP_Float manual_steering_expo;
 };
 
 extern const AP_Param::Info var_info[];

--- a/Rover/mode_manual.cpp
+++ b/Rover/mode_manual.cpp
@@ -12,6 +12,9 @@ void ModeManual::update()
     get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
     get_pilot_desired_lateral(desired_lateral);
 
+    // apply manual steering expo
+    desired_steering = 4500.0 * input_expo(desired_steering / 4500, g2.manual_steering_expo);
+
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
         rover.balancebot_pitch_control(desired_throttle);


### PR DESCRIPTION
This adds a new MANUAL_STR_EXPO parameter that allows configuring an expo on the steering control while in manual mode.  This is meant to address issue https://github.com/ArduPilot/ardupilot/issues/22173

This has been lightly tested on a real vehicle and seems to work.

FYI @IamPete1, @xianglunkai