### PR TITLE
AP_NMEA_Output: use fixed buffer

### DIFF
--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -124,7 +124,7 @@ void AP_NMEA_Output::update()
              loc.lng < 0 ? 'W' : 'E');
 
     // format GGA message
-    int gga_size = snprintf(_gga, sizeof(_gga),
+    int gga_size = snprintf(_gga_out_buffer, sizeof(_gga_out_buffer),
                                "$GPGGA,%s,%s,%s,%01d,%02d,%04.1f,%07.2f,M,0.0,M,,",
                                tstring,
                                lat_string,
@@ -133,11 +133,11 @@ void AP_NMEA_Output::update()
                                pos_valid ? 6 : 3,
                                2.0,
                                loc.alt * 0.01f);
-    if (gga_size < 0 || ((unsigned) gga_size) >= sizeof(_gga)) {
+    if (gga_size < 0 || ((unsigned) gga_size) >= sizeof(_gga_out_buffer)) {
        return;
     }
     char gga_end[6];
-    snprintf(gga_end, sizeof(gga_end), "*%02X\r\n", (unsigned) _nmea_checksum(_gga));
+    snprintf(gga_end, sizeof(gga_end), "*%02X\r\n", (unsigned) _nmea_checksum(_gga_out_buffer));
 
     // get speed
     Vector2f speed = ahrs.groundspeed_vector();
@@ -145,7 +145,7 @@ void AP_NMEA_Output::update()
     float heading = wrap_360(degrees(atan2f(speed.x, speed.y)));
 
     // format RMC message
-    int rmc_size = snprintf(_rmc, sizeof(_rmc),
+    int rmc_size = snprintf(_rmc_out_buffer, sizeof(_rmc_out_buffer),
                                "$GPRMC,%s,%c,%s,%s,%.2f,%.2f,%s,,",
                                tstring,
                                pos_valid ? 'A' : 'V',
@@ -154,11 +154,11 @@ void AP_NMEA_Output::update()
                                speed_knots,
                                heading,
                                dstring);
-    if (rmc_size < 0 || ((unsigned) rmc_size) >= sizeof(_rmc)) {
+    if (rmc_size < 0 || ((unsigned) rmc_size) >= sizeof(_rmc_out_buffer)) {
         return;
     }
     char rmc_end[6];
-    snprintf(rmc_end, sizeof(rmc_end), "*%02X\r\n", (unsigned) _nmea_checksum(_rmc));
+    snprintf(rmc_end, sizeof(rmc_end), "*%02X\r\n", (unsigned) _nmea_checksum(_rmc_out_buffer));
 
     const uint32_t space_required = gga_size + sizeof(gga_end)-1 + rmc_size + sizeof(rmc_end)-1;
 
@@ -168,10 +168,10 @@ void AP_NMEA_Output::update()
             continue;
         }
 
-        _uart[i]->write(_gga);
+        _uart[i]->write(_gga_out_buffer);
         _uart[i]->write(gga_end);
 
-        _uart[i]->write(_rmc);
+        _uart[i]->write(_rmc_out_buffer);
         _uart[i]->write(rmc_end);
     }
 }

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -88,7 +88,7 @@ void AP_NMEA_Output::update()
 
     // format time string
     char tstring[11];
-    snprintf(tstring,sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+    snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
    
     // format date string
     char dstring[7];
@@ -124,7 +124,7 @@ void AP_NMEA_Output::update()
              loc.lng < 0 ? 'W' : 'E');
 
     // format GGA message
-    int gga_size = snprintf(_gga,sizeof(_gga),
+    int gga_size = snprintf(_gga, sizeof(_gga),
                                "$GPGGA,%s,%s,%s,%01d,%02d,%04.1f,%07.2f,M,0.0,M,,",
                                tstring,
                                lat_string,
@@ -145,7 +145,7 @@ void AP_NMEA_Output::update()
     float heading = wrap_360(degrees(atan2f(speed.x, speed.y)));
 
     // format RMC message
-    int rmc_size = snprintf(_rmc,sizeof(_rmc),
+    int rmc_size = snprintf(_rmc, sizeof(_rmc),
                                "$GPRMC,%s,%c,%s,%s,%.2f,%.2f,%s,,",
                                tstring,
                                pos_valid ? 'A' : 'V',

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -50,6 +50,8 @@ private:
     AP_HAL::UARTDriver* _uart[NMEA_MAX_OUTPUTS];
 
     uint32_t _last_run_ms;
+    char _gga[74];
+    char _rmc[108];
 };
 
 #endif  // !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -31,6 +31,9 @@
 #define NMEA_MAX_OUTPUTS 3
 #endif
 
+#define NMEA_GGA_BUFFER_SIZE 74
+#define NMEA_RMC_BUFFER_SIZE 108
+
 class AP_NMEA_Output {
 
 public:
@@ -50,8 +53,8 @@ private:
     AP_HAL::UARTDriver* _uart[NMEA_MAX_OUTPUTS];
 
     uint32_t _last_run_ms;
-    char _gga[74];
-    char _rmc[108];
+    char _gga_out_buffer[NMEA_GGA_BUFFER_SIZE];
+    char _rmc_out_buffer[NMEA_RMC_BUFFER_SIZE];
 };
 
 #endif  // !HAL_MINIMIZE_FEATURES


### PR DESCRIPTION
#12514 
the output buffers are now private class members. 

I did test the changes with SITL on ubuntu

Output before the changes
`$GPRMC,104933.491,A,3521.79573,S,14909.91425,E,0.05,321.30,101122,,*1D
$GPGGA,104933.592,3521.79573,S,14909.91425,E,1,06,02.0,0584.07,M,0.0,M,,*4D
$GPRMC,104933.592,A,3521.79573,S,14909.91425,E,0.05,321.28,101122,,*16`

and after 
`$GPGGA,073902.819,3521.79573,S,14909.91425,E,1,06,02.0,0584.07,M,0.0,M,,*40
$GPRMC,073902.819,A,3521.79573,S,14909.91425,E,0.04,319.17,111122,,*1C`

and at max speed backward producing the longest message (**speed=-FLT_MAX**)
`$GPGGA,073732.646,3521.79573,S,14909.91424,E,1,06,02.0,0584.07,M,0.0,M,,*48
$GPRMC,073732.646,A,3521.79573,S,14909.91424,E,-340282346638528859811704183484516925440.00,142.30,111122,,*39`
