### PR TITLE
Remove GCS includes from headers

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -20,6 +20,7 @@
 
 #include "AC_AutoTune.h"
 #include <AP_Math/chirp.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include <AP_Scheduler/AP_Scheduler.h>
 

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -30,7 +30,7 @@
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
 #include <AP_EFI/AP_EFI_NWPMU.h>
 #include "AP_CANTester.h"
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/CANSocketIface.h>
 #elif CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -24,7 +24,10 @@
 #include <AP_Param/AP_Param.h>
 #include "AP_SLCANIface.h"
 #include "AP_CANDriver.h"
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 
 class AP_CANManager
 {

--- a/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
+++ b/libraries/AP_CANManager/AP_CANTester_KDECAN.cpp
@@ -25,6 +25,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define debug_can(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "TestKDECAN",  fmt, ##args); } while (0)
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -28,6 +28,7 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <stdio.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <GCS_MAVLink/GCS.h>
 
 #define LOG_TAG "SLCAN"
 

--- a/libraries/AP_CheckFirmware/AP_CheckFirmware.h
+++ b/libraries/AP_CheckFirmware/AP_CheckFirmware.h
@@ -6,8 +6,9 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_OpenDroneID/AP_OpenDroneID_config.h>
 #include <AP_HAL/AP_HAL.h>
-#ifndef HAL_BOOTLOADER_BUILD
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #endif
 
 #ifndef AP_CHECK_FIRMWARE_ENABLED

--- a/libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp
+++ b/libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp
@@ -7,7 +7,11 @@
 #if AP_CHECK_FIRMWARE_ENABLED && AP_SIGNED_FIRMWARE && !defined(HAL_BOOTLOADER_BUILD)
 
 #include "monocypher.h"
-#include <AP_Math/crc.h>
+#include <AP_Math/AP_Math.h>
+
+#if HAL_GCS_ENABLED
+#include <GCS_MAVLink/GCS.h>
+#endif
 
 extern const AP_HAL::HAL &hal;
 

--- a/libraries/AP_EFI/AP_EFI_NWPMU.cpp
+++ b/libraries/AP_EFI/AP_EFI_NWPMU.cpp
@@ -18,6 +18,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include "AP_EFI_NWPMU.h"
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_MAVliteMsgHandler.cpp
@@ -2,6 +2,7 @@
 
 #include <AC_Fence/AC_Fence.h>
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -20,6 +20,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include <AP_HAL/utility/sparse-endian.h>
 

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -20,9 +20,6 @@
 #include "AP_HAL_ChibiOS_Namespace.h"
 #include "AP_HAL_ChibiOS.h"
 #include <ch.h>
-#if !defined(HAL_BOOTLOADER_BUILD)
-#include <GCS_MAVLink/GCS.h>
-#endif
 
 class ExpandingString;
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2960,6 +2960,11 @@ def add_bootloader_defaults(f):
 #define HAL_GYROFFT_ENABLED 0
 #endif
 
+// bootloaders don't talk to the GCS:
+#ifndef HAL_GCS_ENABLED
+#define HAL_GCS_ENABLED 0
+#endif
+
 #define HAL_MAX_CAN_PROTOCOL_DRIVERS 0
 ''')
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -19,6 +19,7 @@
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
 #include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -36,6 +36,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RSSI/AP_RSSI.h>
+#include <GCS_MAVLink/GCS.h>
 
 // macro for easy use of var_info2
 #define AP_SUBGROUPINFO2(element, name, idx, thisclazz, elclazz) { AP_PARAM_GROUP, idx, name, AP_VAROFFSET(thisclazz, element), { group_info : elclazz::var_info2 }, AP_PARAM_FLAG_NESTED_OFFSET }

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -349,8 +349,10 @@ public:
 
     static const ParamMetadata _param_metadata[];
 
+#if HAL_GCS_ENABLED
     AP_OSD_ParamSetting(uint8_t param_number, bool enabled, uint8_t x, uint8_t y, int16_t key, int8_t idx, int32_t group,
         int8_t type = OSD_PARAM_NONE, float min = 0.0f, float max = 1.0f, float incr = 0.001f);
+#endif
     AP_OSD_ParamSetting(uint8_t param_number);
     AP_OSD_ParamSetting(const Initializer& initializer);
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -22,11 +22,13 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <RC_Channel/RC_Channel.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_config.h>
 #include <AP_OLC/AP_OLC.h>
 #include <AP_MSP/msp.h>
 #include <AP_Baro/AP_Baro.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 #include <AC_Fence/AC_Fence_config.h>
 
 #ifndef OSD_ENABLED
@@ -410,8 +412,8 @@ public:
     void draw(void) override;
 #endif
 #if HAL_GCS_ENABLED
-    void handle_write_msg(const mavlink_osd_param_config_t& packet, const GCS_MAVLINK& link);
-    void handle_read_msg(const mavlink_osd_param_show_config_t& packet, const GCS_MAVLINK& link);
+    void handle_write_msg(const mavlink_osd_param_config_t& packet, const class GCS_MAVLINK& link);
+    void handle_read_msg(const mavlink_osd_param_show_config_t& packet, const class GCS_MAVLINK& link);
 #endif
     // get a setting and associated metadata
     AP_OSD_ParamSetting* get_setting(uint8_t param_idx);
@@ -595,7 +597,7 @@ public:
 #endif
     // handle OSD parameter configuration
 #if HAL_GCS_ENABLED
-    void handle_msg(const mavlink_message_t &msg, const GCS_MAVLINK& link);
+    void handle_msg(const mavlink_message_t &msg, const class GCS_MAVLINK& link);
 #endif
 
     // allow threads to lock against OSD update

--- a/libraries/AP_OSD/AP_OSD_Backend.cpp
+++ b/libraries/AP_OSD/AP_OSD_Backend.cpp
@@ -16,6 +16,7 @@
 
 #include <AP_OSD/AP_OSD_Backend.h>
 #include <AP_HAL/Util.h>
+#include <GCS_MAVLink/GCS.h>
 #include <ctype.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -22,6 +22,8 @@
 
 #if HAL_WITH_MSP_DISPLAYPORT
 
+#include <GCS_MAVLink/GCS.h>
+
 static const struct AP_Param::defaults_table_struct defaults_table[] = {
     /*
     { "PARAM_NAME",       value_float }

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -30,6 +30,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -23,6 +23,7 @@
 
 #include "AP_OSD.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <ctype.h>
 

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -33,8 +33,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID_DroneCAN.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID_DroneCAN.cpp
@@ -30,7 +30,7 @@
 #include <dronecan/remoteid/System.hpp>
 #include <dronecan/remoteid/ArmStatus.hpp>
 
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
 
 static uavcan::Publisher<dronecan::remoteid::Location>* dc_location[HAL_MAX_CAN_PROTOCOL_DRIVERS];
 static uavcan::Publisher<dronecan::remoteid::BasicID>* dc_basic_id[HAL_MAX_CAN_PROTOCOL_DRIVERS];

--- a/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.cpp
@@ -5,6 +5,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_UAVCAN/AP_UAVCAN.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include <uavcan/equipment/range_sensor/Measurement.hpp>
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -12,6 +12,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <AR_Motors/AP_MotorsUGV.h>
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
+#include <GCS_MAVLink/GCS.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 #include <AP_HAL_ChibiOS/sdcard.h>
 #include <AP_HAL_ChibiOS/hwdef/common/stm32_util.h>


### PR DESCRIPTION
Remove many inclusions of GCS.h header, notably the one in the HAL Util.h file.  This stops us creating dependencies where none exist, improving cache efficency



```
Board                     AP_Periph  blimp  copter  heli  iofirmware  plane  rover  sub
AIRLink                              112    0       0                 0      0      0
ARKV6X                               112    0       0                 0      0      0
ARK_GPS                   0                                                         
AeroFox-Airspeed          0                                                         
AeroFox-PMU               0                                                         
AtomRCF405NAVI                       0      0       0                 0      0      0
BeastF7                              0      0       0                 0      0      0
BeastF7v2                            0      0       0                 0      0      0
BeastH7                              0      0       0                 0      0      0
BeastH7v2                            0      0       0                 0      0      0
BirdCANdy                 0                                                         
CUAV-Nora                            120    0       0                 0      0      0
CUAV-Nora-bdshot                     120    0       0                 0      0      0
CUAV-X7                              120    0       0                 0      0      0
CUAV-X7-bdshot                       120    0       0                 0      0      0
CUAV_GPS                  0                                                         
CUAVv5                               120    0       0                 0      0      0
CUAVv5-bdshot                        120    0       0                 0      0      0
CUAVv5Nano                           120    0       0                 0      0      0
CUAVv5Nano-bdshot                    112    0       0                 0      0      0
CarbonixF405              0                                                         
CarbonixL496              0                                                         
CubeBlack                            112    0       0                 0      0      0
CubeBlack+                           120    0       0                 0      0      0
CubeBlack-periph          0                                                         
CubeGreen-solo                              0                                       
CubeOrange                           112    0       0                 0      0      0
CubeOrange-ODID                      120    0       0                 0      0      0
CubeOrange-SimOnHardWare                    0                                       
CubeOrange-bdshot                    120    0       0                 0      0      0
CubeOrange-joey                      112    0       0                 0      0      0
CubeOrange-periph         0                                                         
CubeOrange-periph-heavy   0                                                         
CubeOrangePlus                       120    0       0                 0      0      0
CubePilot-CANMod          0                                                         
CubePurple                           112    0       0                 0      0      0
CubeSolo                                    0                                       
CubeYellow                           112    0       0                 0      0      0
CubeYellow-bdshot                    120    0       0                 0      0      0
DevEBoxH7v2                          0      0       0                 0      0      0
DrotekP3Pro                          112    0       0                 0      0      0
Durandal                             120    0       0                 0      0      0
Durandal-bdshot                      112    0       0                 0      0      0
F35Lightning                         0      0       0                 0      0      0
F4BY                                 0      0       0                 0      0      0
FlyingMoonF407                       0      0       0                 0      0      0
FlyingMoonF427                       120    0       0                 0      0      0
FlywooF745                           0      0       0                 0      0      0
FlywooF745Nano                       0      0       0                 0      0      0
FreeflyRTK                0                                                         
G4-ESC                    0                                                         
H757I_EVAL                                                                          
H757I_EVAL_intf                                                                     
HerePro                   0                                                         
Hitec-Airspeed            0                                                         
HitecMosaic               0                                                         
HolybroG4_GPS             0                                                         
HolybroGPS                0                                                         
JHEMCU-GSF405A                       0      0       0                 0      0      0
JHEMCU-GSF405A-RX2                   0      0       0                 0      0      0
KakuteF4                             0      0       0                 0      0      0
KakuteF4Mini                         0      0       0                 0      0      0
KakuteF7                             0      0       0                 0      0      0
KakuteF7-bdshot                      0      0       0                 0      0      0
KakuteF7Mini                         0      0       0                 0      0      0
KakuteH7                             0      0       0                 0      0      0
KakuteH7-bdshot                      0      0       0                 0      0      0
KakuteH7Mini                         0      0       0                 0      0      0
KakuteH7Mini-Nand                    0      0       0                 0      0      0
KakuteH7v2                           0      0       0                 0      0      0
MambaF405-2022                       0      0       0                 0      0      0
MambaF405US-I2C                      0      0       0                 0      0      0
MambaF405v2                          0      0       0                 0      0      0
MambaH743v4                          0      0       0                 0      0      0
MatekF405                            0      0       0                 0      0      0
MatekF405-CAN                        0      0       0                 0      0      0
MatekF405-STD                        0      0       0                 0      0      0
MatekF405-TE                         0      0       0                 0      0      0
MatekF405-Wing                       0      0       0                 0      0      0
MatekF405-Wing-bdshot                0      0       0                 0      0      0
MatekF405-bdshot                     0      0       0                 0      0      0
MatekF765-SE                         112    0       0                 0      0      0
MatekF765-Wing                       0      0       0                 0      0      0
MatekF765-Wing-bdshot                0      0       0                 0      0      0
MatekH743                            112    0       0                 0      0      0
MatekH743-bdshot                     112    0       0                 0      0      0
MatekH743-periph          0                                                         
MatekL431-Airspeed        0                                                         
MatekL431-DShot           0                                                         
MatekL431-EFI             0                                                         
MatekL431-GPS             0                                                         
MatekL431-Periph          0                                                         
MatekL431-Rangefinder     0                                                         
MatekL431-bdshot          0                                                         
MazzyStarDrone                       0      0       0                 0      0      0
Nucleo-G491               0                                                         
Nucleo-L476               0                                                         
Nucleo-L496               0                                                         
NucleoH743                                                                          
NucleoH755                                                                          
OMNIBUSF7V2                          0      0       0                 0      0      0
OmnibusNanoV6                        0      0       0                 0      0      0
OmnibusNanoV6-bdshot                 0      0       0                 0      0      0
PH4-mini                             112    0       0                 0      0      0
PH4-mini-bdshot                      120    0       0                 0      0      0
Pix32v5                              112    0       0                 0      0      0
PixC4-Jetson                         120    0       0                 0      0      0
PixSurveyA1                          112    0       0                 0      0      0
Pixhawk1                             112    0       0                 0      0      0
Pixhawk1-1M                          0      0       0                 0      0      0
Pixhawk1-1M-bdshot                   0      0       0                 0      0      0
Pixhawk4                             120    0       0                 0      0      0
Pixhawk4-bdshot                      120    0       0                 0      0      0
Pixhawk5X                            120    0       0                 0      0      0
Pixhawk6C                            120    0       0                 0      0      0
Pixhawk6X                            112    0       0                 0      0      0
Pixhawk6X-ODID                       112    0       0                 0      0      0
Pixracer                             112    0       0                 0      0      0
Pixracer-bdshot                      112    0       0                 0      0      0
Pixracer-periph           0                                                         
QioTekZealotF427                     120    0       0                 0      0      0
QioTekZealotH743                     120    0       0                 0      0      0
R9Pilot                              0      0       0                 0      0      0
ReaperF745v2                         0      0       0                 0      0      0
SITL_arm_linux_gnueabihf             0      0       0                 0      0      0
SITL_x86_64_linux_gnu                0      0       0                 0      0      0
SPRacingH7                           0      0       0                 0      0      0
Sierra-F405               0                                                         
Sierra-F412               0                                                         
Sierra-F9P                0                                                         
Sierra-L431               0                                                         
SkystarsH7HD                         0      0       0                 0      0      0
SkystarsH7HD-bdshot                  0      0       0                 0      0      0
SuccexF4                             0      0       0                 0      0      0
Swan-K1                                                               0             
TBS-Colibri-F7                       112    0       0                 0      0      0
VRBrain-v51                          0      0       0                 0      0      0
VRBrain-v52                          0      0       0                 0      0      0
VRBrain-v54                          0      0       0                 0      0      0
VRCore-v10                           0      0       0                 0      0      0
VRUBrain-v51                         0      0       0                 0      0      0
ZubaxGNSS                 0                                                         
airbotf4                             0      0       0                 0      0      0
bbbmini                              0      0       0                 0      0      0
blue                                 0      0       0                 0      0      0
crazyflie2                           0      0       0                 0      0      0
edge                                 0      0       0                 0      0      0
erlebrain2                           0      0       0                 0      0      0
f103-ADSB                 0                                                         
f103-Airspeed             0                                                         
f103-GPS                  0                                                         
f103-HWESC                0                                                         
f103-QiotekPeriph         0                                                         
f103-RangeFinder          0                                                         
f103-Trigger              0                                                         
f303-GPS                  0                                                         
f303-HWESC                0                                                         
f303-M10025               0                                                         
f303-M10070               0                                                         
f303-MatekGPS             0                                                         
f303-PWM                  0                                                         
f303-TempSensor           0                                                         
f303-Universal            0                                                         
f405-MatekAirspeed        0                                                         
f405-MatekGPS             0                                                         
fmuv2                                0      0       0                 0      0      0
fmuv3                                112    0       0                 0      0      0
fmuv3-bdshot                         112    0       0                 0      0      0
fmuv5                                112    0       0                 0      0      0
iomcu                                                     0                         
iomcu_f103_8MHz                                           0                         
luminousbee4                         0      0       0                 0      0      0
luminousbee5                         112    0       0                 0      0      0
mRo-M10095                0                                                         
mRoControlZeroClassic                112    0       0                 0      0      0
mRoControlZeroF7                     112    0       0                 0      0      0
mRoControlZeroH7                     112    0       0                 0      0      0
mRoControlZeroH7-bdshot              120    0       0                 0      0      0
mRoControlZeroOEMH7                  120    0       0                 0      0      0
mRoNexus                             112    0       0                 0      0      0
mRoPixracerPro                       120    0       0                 0      0      0
mRoPixracerPro-bdshot                120    0       0                 0      0      0
mRoX21                               120    0       0                 0      0      0
mRoX21-777                           112    0       0                 0      0      0
mindpx-v2                            112    0       0                 0      0      0
mini-pix                             0      0       0                 0      0      0
modalai_fc-v1                        120    0       0                 0      0      0
navigator                            0      0       0                 0      0      0
navio                                0      0       0                 0      0      0
navio2                               0      0       0                 0      0      0
obal                                 0      0       0                 0      0      0
omnibusf4                            0      0       0                 0      0      0
omnibusf4pro                         0      0       0                 0      0      0
omnibusf4pro-bdshot                  0      0       0                 0      0      0
omnibusf4pro-one                     0      0       0                 0      0      0
omnibusf4v6                          0      0       0                 0      0      0
pxf                                  0      0       0                 0      0      0
pxfmini                              0      0       0                 0      0      0
revo-mini                            0      0       0                 0      0      0
revo-mini-bdshot                     0      0       0                 0      0      0
revo-mini-i2c                        0      0       0                 0      0      0
revo-mini-i2c-bdshot                 0      0       0                 0      0      0
revo-mini-sd                                                                        
skyviper-f412-rev1                          0                                       
skyviper-journey                            0                                       
skyviper-v2450                              0                                       
sparky2                              0      0       0                 0      0      0
speedybeef4                          0      0       0                 0      0      0
speedybeef4v3                        0      0       0                 0      0      0
```