### PR TITLE
GCS_MAVLink: Not transmit if radio channel receiver is not connected or RC override

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5596,6 +5596,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         break;
 
     case MSG_RC_CHANNELS:
+        if (!rc().has_had_rc_receiver() && !rc().has_had_rc_override()) {
+            // Not transmit if radio channel receiver is not connected or RC override.
+            break;
+        }
+
         CHECK_PAYLOAD_SIZE(RC_CHANNELS);
         send_rc_channels();
         break;


### PR DESCRIPTION
I did not connect the radio receiver to the CUBE ORANGE.
I saw the RC_CHANNELS message in the MAVLINK inspector.
I did not have a radio override either.
Telemetry bandwidth is finite.
I do not send RC_CHANNELS message if there is no radio channel signal.
MAVLINK V2 can shorten the message length if it is followed by a trailing zero.
Since the RSSI is set to 255, the message length will not be shortened.

AFTER
![Screenshot from 2022-11-12 17-39-50](https://user-images.githubusercontent.com/646194/201466893-22afd11c-433b-47f5-be6a-e541ff7d037a.png)

BEFORE
![Screenshot from 2022-11-12 17-17-48](https://user-images.githubusercontent.com/646194/201466886-c5a338e1-833b-4a07-b4cd-d04052f422b8.png)


