### PR TITLE
Copter: user configurable RC failsafe timeout

### DIFF
--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -113,10 +113,9 @@ void Copter::read_radio()
         return;
     }
 
-    const uint32_t elapsed = tnow_ms - last_radio_update_ms;
-    // turn on throttle failsafe if no update from the RC Radio for 500ms or 1000ms if we are using RC_OVERRIDE
-    const uint32_t timeout = RC_Channels::has_active_overrides() ? FS_RADIO_RC_OVERRIDE_TIMEOUT_MS : FS_RADIO_TIMEOUT_MS;
-    if (elapsed < timeout) {
+    // trigger failsafe if no update from the RC Radio for RC_FS_TIMEOUT seconds
+    const uint32_t elapsed_ms = tnow_ms - last_radio_update_ms;
+    if (elapsed_ms < rc().get_fs_timeout_ms()) {
         // not timed out yet
         return;
     }
@@ -129,7 +128,7 @@ void Copter::read_radio()
         return;
     }
 
-    // Nobody ever talks to us.  Log an error and enter failsafe.
+    // Log an error and enter failsafe.
     AP::logger().Write_Error(LogErrorSubsystem::RADIO, LogErrorCode::RADIO_LATE_FRAME);
     set_failsafe_radio(true);
 }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -601,7 +601,10 @@ public:
     // get last aux cached value for scripting. Returns false if never set, otherwise 0,1,2
     bool get_aux_cached(RC_Channel::aux_func_t aux_fn, uint8_t &pos);
 #endif
-    
+
+    // get failsafe timeout in milliseconds
+    uint32_t get_fs_timeout_ms() const { return MAX(_fs_timeout * 1000, 100); }
+
 protected:
 
     enum class Option {
@@ -637,6 +640,7 @@ private:
     AP_Float _override_timeout;
     AP_Int32  _options;
     AP_Int32  _protocols;
+    AP_Float _fs_timeout;
 
     RC_Channel *flight_mode_channel() const;
 

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -98,6 +98,14 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @User: Advanced
     // @Bitmask: 0:All,1:PPM,2:IBUS,3:SBUS,4:SBUS_NI,5:DSM,6:SUMD,7:SRXL,8:SRXL2,9:CRSF,10:ST24,11:FPORT,12:FPORT2,13:FastSBUS
     AP_GROUPINFO("_PROTOCOLS", 34, RC_CHANNELS_SUBCLASS, _protocols, 1),
-    
+
+    // @Param: _FS_TIMEOUT
+    // @DisplayName: RC Failsafe timeout
+    // @Description: RC failsafe will trigger this many seconds after loss of RC
+    // @User: Standard
+    // @Range: 0.5 10.0
+    // @Units: s
+    AP_GROUPINFO_FRAME("_FS_TIMEOUT", 35, RC_CHANNELS_SUBCLASS, _fs_timeout, 1.0, AP_PARAM_FRAME_COPTER),
+
     AP_GROUPEND
 };


### PR DESCRIPTION
This adds a user configurable RC failsafe timeout (aka throttle failsafe).  Both @CraigElder and I have been flying with joysticks over 4G/LTE and have noticed that the RC failsafe triggers too easily.

If FS_THR_TIMEOUT is zero then the current behaviour is used (0.5sec for regular RC, 1sec for RC_OVERRIDES).  If non-zero then the FS_THR_TIMEOUT value (in seconds) is used for both regular RC and RC_OVERRIDES.

This has been lightly tested in SITL and seems to work.

Ideally I would like to make this change for Rover as well although Rover already has FS_TIMEOUT that applies to all failsafe so slightly more thought is required.