### PR TITLE
Tools: blacklist the SkystarsH7HD board,use only bd-shot version

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -150,6 +150,7 @@ class BoardList(object):
             "MazzyStarDrone",
             "omnibusf4pro-one",
             "skyviper-f412-rev1",
+            "SkystarsH7HD",
             "*-ODID",
             "*-ODID-heli",
         ]


### PR DESCRIPTION
non bdshot version has many issues and was not fully tested, AndyP created the bdshot version once he obtained a sample device and recommends removing this from the build, I agree...