### PR TITLE
AP_Math: make rand_vec a little more efficient

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -348,17 +348,14 @@ float rand_float(void)
 #endif
 }
 
+// generate a random Vector3f with each value between -1.0 and 1.0
 Vector3f rand_vec3f(void)
 {
-    Vector3f v {
+    return Vector3f{
         rand_float(),
         rand_float(),
         rand_float()
     };
-    if (!v.is_zero()) {
-        v.normalize();
-    }
-    return v;
 }
 #endif
 

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -350,10 +350,12 @@ float rand_float(void)
 
 Vector3f rand_vec3f(void)
 {
-    Vector3f v = Vector3f(rand_float(),
-                          rand_float(),
-                          rand_float());
-    if (!is_zero(v.length())) {
+    Vector3f v {
+        rand_float(),
+        rand_float(),
+        rand_float()
+    };
+    if (!v.is_zero()) {
         v.normalize();
     }
     return v;

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -325,7 +325,7 @@ uint16_t get_random16(void);
 // generate a random float between -1 and 1, for use in SITL
 float rand_float(void);
 
-// generate a random Vector3f of size 1
+// generate a random Vector3f with each value between -1.0 and 1.0
 Vector3f rand_vec3f(void);
 
 // return true if two rotations are equal


### PR DESCRIPTION
Marking this for DevCallEU to ask why this is normalized when the sole caller would appear to not want that (compass noise, each axis should be independent)
