### PR TITLE
Copter: remove some unused definitions

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -130,16 +130,6 @@
  # define FS_GCS                        DISABLED
 #endif
 
-// Radio failsafe while using RC_override
-#ifndef FS_RADIO_RC_OVERRIDE_TIMEOUT_MS
- # define FS_RADIO_RC_OVERRIDE_TIMEOUT_MS  1000    // RC Radio failsafe triggers after 1 second while using RC_override from ground station
-#endif
-
-// Radio failsafe
-#ifndef FS_RADIO_TIMEOUT_MS
- #define FS_RADIO_TIMEOUT_MS            500     // RC Radio Failsafe triggers after 500 milliseconds with No RC Input
-#endif
-
 // missing terrain data failsafe
 #ifndef FS_TERRAIN_TIMEOUT_MS
  #define FS_TERRAIN_TIMEOUT_MS          5000     // 5 seconds of missing terrain data will trigger failsafe (RTL)

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -84,10 +84,6 @@
  # define RANGEFINDER_FILT_DEFAULT 0.5f     // filter for rangefinder distance
 #endif
 
-#ifndef SURFACE_TRACKING_VELZ_MAX
- # define SURFACE_TRACKING_VELZ_MAX 150     // max vertical speed change while surface tracking with rangefinder
-#endif
-
 #ifndef SURFACE_TRACKING_TIMEOUT_MS
  # define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
 #endif
@@ -108,26 +104,9 @@
  # define MAV_SYSTEM_ID          1
 #endif
 
-
-//////////////////////////////////////////////////////////////////////////////
-// Battery monitoring
-//
-#ifndef BOARD_VOLTAGE_MIN
- # define BOARD_VOLTAGE_MIN             4.3f        // min board voltage in volts for pre-arm checks
-#endif
-
-#ifndef BOARD_VOLTAGE_MAX
- # define BOARD_VOLTAGE_MAX             5.8f        // max board voltage in volts for pre-arm checks
-#endif
-
 // prearm GPS hdop check
 #ifndef GPS_HDOP_GOOD_DEFAULT
  # define GPS_HDOP_GOOD_DEFAULT         140     // minimum hdop that represents a good position.  used during pre-arm checks if fence is enabled
-#endif
-
-// GCS failsafe
-#ifndef FS_GCS
- # define FS_GCS                        DISABLED
 #endif
 
 // missing terrain data failsafe


### PR DESCRIPTION
As kindly pointed out by @amilcarlucas the [RC failsafe timeout PR](https://github.com/ArduPilot/ardupilot/pull/22200) neglected to remove the older definitions.  A few other unused definitions have also been removed.

This should be a non-functional change.