### PR TITLE
Rework plane aerobatics multi point roll

### DIFF
--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
@@ -42,15 +42,12 @@ the ground track.
 | 19 | Stall Turn               | radius | height      | direction   |            | Yes        |
 | 20 | Procedure Turn           | radius | bank angle  | step-out    |            | Yes        |
 | 21 | Derry Turn               | radius | bank angle  |             |            | No         |
-| 22 | Two Point Roll           | length |             |             |            | No         |
 | 23 | Half Climbing Circle     | radius | height      | bank angle  |            | Yes        |
 | 24 | Crossbox Humpty          | radius | height      |             |            | Yes        |
 | 25 | Laydown Humpty           | radius | height      |             |            | Yes        |
 | 25 | Barrel Roll              | radius | length      | num spirals |            | No         |
 | 26 | Straight Hold            | length | bank angle  |             |            | No         |
-| 29 | Four Point Roll          | length |             |             |            | No         |
-| 30 | Eight Point Roll         | length |             |             |            | No         |
-| 31 | Multi Point Roll         | length | num points  |             |            | No         |
+| 31 | Multi Point Roll         | length | num points  | hold frac   |            | No         |
 
 Note: In the script you will find other (specialised) manouvers which do not appear in the 
 'command table'. These tend to be specialised manouvers which may expect an inverted entry or 

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -1185,28 +1185,25 @@ function vertical_aerobatic_box(total_length, total_width, r, bank_angle)
    })
 end
 
-function multi_point_roll(length, N, arg3, arg4)
+function multi_point_roll(length, N, hold_frac, arg4)
    local paths = {}
-   local len_roll = length * (N-1) / (N*4-1)
-   local len_hold = length / (N*4-1)
+   local roll_frac = (1 - hold_frac)
+   local frac_sum = roll_frac * N + hold_frac * (N - 1)
+   local len_scaler = length / frac_sum
+   local len_roll = roll_frac * len_scaler
+   local len_hold = hold_frac * len_scaler
    local ang = 360 / N
    for i = 1, N do
       paths[#paths+1] = { path_straight(len_roll), roll_angle(ang) }
-      paths[#paths+1] = { path_straight(len_hold), roll_angle(0) }
+      if (i < N) then
+         paths[#paths+1] = { path_straight(len_hold), roll_angle(0) }
+      end
    end
    return make_paths("multi_point_roll", paths)
 end
 
-function two_point_roll(length, arg2, arg3, arg4)
-   return multi_point_roll(length, 2)
-end
-
-function four_point_roll(length, arg2, arg3, arg4)
-   return multi_point_roll(length, 4)
-end
-
 function eight_point_roll(length, arg2, arg3, arg4)
-   return multi_point_roll(length, 8)
+   return multi_point_roll(length, 8, 0.5)
 end
 
 function procedure_turn(radius, bank_angle, step_out, arg4)
@@ -1531,7 +1528,7 @@ function nz_clubman()                               -- positioned for a flight l
           { straight_align,           { -180, 0 } },
           { half_reverse_cuban_eight, { 90 } },
           { straight_align,           { -120, 0 } },
-          { two_point_roll,           { 240 },         message="Two Point Roll"},
+          { multi_point_roll,         { 240, 2, 0.5 }, message="Two Point Roll"},
           { straight_align,           { 150, 0 } },
           { half_reverse_cuban_eight, { 90 } },
           { straight_align,           { 106, 0 } },
@@ -2335,15 +2332,15 @@ command_table[18]= PathFunction(downline_45, "Downline-45")
 command_table[19]= PathFunction(stall_turn, "Stall Turn")
 command_table[20]= PathFunction(procedure_turn, "Procedure Turn")
 command_table[21]= PathFunction(derry_turn, "Derry Turn")
-command_table[22]= PathFunction(two_point_roll, "Two Point Roll")
+-- 22 was Two Point Roll - use multi point roll instead
 command_table[23]= PathFunction(half_climbing_circle, "Half Climbing Circle")
 command_table[24]= PathFunction(crossbox_humpty, "Crossbox Humpty")
 command_table[25]= PathFunction(laydown_humpty, "Laydown Humpty")
 command_table[26]= PathFunction(barrel_roll, "Barrel Roll")
 command_table[27]= PathFunction(straight_flight, "Straight Hold")
 command_table[28]= PathFunction(partial_circle, "Partial Circle")
-command_table[29]= PathFunction(four_point_roll, "Four Point Roll")
-command_table[30]= PathFunction(eight_point_roll, "Eight Point Roll")
+-- 29 was Four Point Roll - use multi point roll instead
+-- 30 was Eight Point Roll - use multi point roll instead
 command_table[31]= PathFunction(multi_point_roll, "Multi Point Roll")
 command_table[32]= PathFunction(side_step, "Side Step")
 command_table[200] = PathFunction(test_all_paths, "Test Suite")


### PR DESCRIPTION
This fixes a bug in the Lua scripted multi point roll that was causing the length to complete to not match the specified length.

It also enables time fraction spent holding the roll angle at each roll point to be adjusted and eliminates the specialise functions for 2,4 and 8 point roll that can all be performed using the multi-point roll.

It has been tested in SITL. The following figure shows an eight point roll flown on a South heading with a length of 250m and a hold fraction of 0.3
<img width="1066" alt="Screen Shot 2022-11-20 at 10 50 52 am" src="https://user-images.githubusercontent.com/3596952/202876080-f3670d54-ef9a-4784-9b36-5909f95241cb.png">
