### PR TITLE
AP_GPS: improve support for uBlox-M10

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2054,6 +2054,13 @@ bool AP_GPS::is_healthy(uint8_t instance) const
         return false;
     }
 
+#ifdef HAL_BUILD_AP_PERIPH
+    /*
+      on AP_Periph handling of timing is done by the flight controller
+      receiving the DroneCAN messages
+     */
+    return drivers[instance] != nullptr && drivers[instance]->is_healthy();
+#else
     /*
       allow two lost frames before declaring the GPS unhealthy, but
       require the average frame rate to be close to 5Hz. We allow for
@@ -2075,6 +2082,7 @@ bool AP_GPS::is_healthy(uint8_t instance) const
 
     return delay_ok && drivers[instance] != nullptr &&
            drivers[instance]->is_healthy();
+#endif // HAL_BUILD_AP_PERIPH
 }
 
 bool AP_GPS::prepare_for_arming(void) {


### PR DESCRIPTION
this sets up the M10 to use the BaiDou B1C signal instead of B1, and disables glonass. This is needed to get a consistent 5Hz lock
bench tested on MatekL431-GPS with M10
flight tested with dual M10 based MatekL431-GPS on a CubeOrange, with good results

Before the fix:
![image](https://user-images.githubusercontent.com/831867/203149057-6b0716d7-4564-4ec8-8b10-46288bc1734c.png)
with the fix:
![image](https://user-images.githubusercontent.com/831867/203149212-cd5b800a-0075-415e-aaab-e5804dcda874.png)
before the fix the GPS would frequently report as unhealthy, preventing arming