### PR TITLE
EKF3 Rangefinder Use Bugfix

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -90,7 +90,7 @@ void NavEKF3_core::readRangeFinder(void)
                 // indicate we have updated the measurement
                 rngValidMeaTime_ms = imuSampleTime_ms;
 
-            } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+            } else if (onGround && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
                 rangeDataNew.rng = rngOnGnd;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1089,7 +1089,7 @@ void NavEKF3_core::selectHeightForFusion()
         // determine if we are above or below the height switch region
         ftype rangeMaxUse = 1e-4 * (ftype)_rng->max_distance_cm_orient(ROTATION_PITCH_270) * (ftype)frontend->_useRngSwHgt;
         bool aboveUpperSwHgt = (terrainState - stateStruct.position.z) > rangeMaxUse;
-        bool belowLowerSwHgt = (terrainState - stateStruct.position.z) < 0.7f * rangeMaxUse;
+        bool belowLowerSwHgt = ((terrainState - stateStruct.position.z) < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
 
         // If the terrain height is consistent and we are moving slowly, then it can be
         // used as a height reference in combination with a range finder


### PR DESCRIPTION
When using range finder as the primary height sensor when low and slow via the EK3_RNG_USE_HGT and EK3_RNG_USE_SPD parameters a condition can occur where if the range finder is not returning valid readings and the takeOffDetected test is tricked into thinking the vehicle is on ground, the range finder value is set to the RNGFNDx_GNDCLEAR value which results in rapid switching of the EKF's height estimate as shown in this user log with

EK3_RNG_USE_HGT  50.000000
EK3_RNG_USE_SPD  5.000000

![image](https://user-images.githubusercontent.com/3596952/203019834-d6445f71-3af2-4e59-81b8-4983d8176609.png)

After this change is applied, the rapid height estimate switching is eliminated

![image](https://user-images.githubusercontent.com/3596952/203020045-ab2b07fb-cc27-4eb4-a7bf-7be98ed799ab.png)
