### PR TITLE
Land detector big prop's

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -394,6 +394,55 @@ const AP_Param::Info Copter::var_info[] = {
     // @Values: 0:No repositioning, 1:Repositioning
     // @User: Advanced
     GSCALAR(land_repositioning, "LAND_REPOSITION",     LAND_REPOSITION_DEFAULT),
+    
+    	// ADDED BY FRANKY
+    // @Param: LAND_DET_TRIG_S
+	// @DisplayName: number of seconds to detect a landing
+    // @Description: number of seconds to detect a landing
+    // @Units: s
+    // @Range: 0.1 2
+    // @User: Advanced
+    GSCALAR(land_detector_trigger_sec,"LAND_DET_TRIG_S", LAND_DETECTOR_TRIGGER_SEC_DEFAULT),
+
+    // @Param: LAND_DET_MB_TRIG
+    // @DisplayName: number of seconds that means we might be landed
+    // @Description: number of seconds that means we might be landed.
+    // @Units: s
+    // @Range: 0.1 2
+    // @User: Advanced
+    GSCALAR(land_detector_maybe_trigger_sec,"LAND_DET_MB_TRIG", LAND_DETECTOR_MAYBE_TRIGGER_SEC_DEFAULT),
+
+    // @Param: LAND_DET_ACC_LPF
+    // @DisplayName: Frequency cutoff of land detector
+    // @Description: Frequency cutoff of land detector accelerometer filter.
+    // @Units: Hz
+    // @Range: 0.1 2
+    // @User: Advanced
+    GSCALAR(land_detector_accel_lpf_cutoff, "LAND_DET_ACC_LPF", LAND_DETECTOR_ACCEL_LPF_CUTOFF_DEFAULT),
+
+    // @Param: LAND_DET_ACC_MAX
+    // @DisplayName: nuvehicle acceleration must be under 1m/s/s
+    // @Description: vehicle acceleration must be under 1m/s/s
+    // @Units: m/s/s
+    // @Range: 0.1 2
+    // @User: Advanced
+	GSCALAR(land_detector_accel_max, "LAND_DET_ACC_MAX", LAND_DETECTOR_ACCEL_MAX_DEFAULT),
+
+   // @Param: LAND_DET_RNGFND
+    // @DisplayName: land detector options
+    // @Description: Defines id land detection uses lidar or acceleration
+    // @Units: 
+    // @Range: 0 1
+    // @User: Advanced
+	GSCALAR(land_detector_rngfnd, "LAND_DET_RNGFND", LAND_DETECTOR_RNGFND_DEFAULT),
+ 
+ // @Param: LAND_DET_MOT_LOW
+    // @DisplayName: land detector motor low
+    // @Description: If using a RNGFND this value is used instead Mot_at_lower_limit a condition to trigg Land Detection
+    // @Range: 0 0.15
+    // @User: Advanced
+	GSCALAR(land_detector_mot_low, "LAND_DET_MOT_LOW", LAND_DETECTOR_MOT_LOW_DEFAULT),
+
 
     // @Param: FS_EKF_ACTION
     // @DisplayName: EKF Failsafe Action

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -378,6 +378,12 @@ public:
         // 254,255: reserved
 
         k_param_vehicle = 257, // vehicle common block of parameters
+		k_param_land_detector_trigger_sec, //Parameter added in odrer to fine tune land detector
+		k_param_land_detector_maybe_trigger_sec,
+		k_param_land_detector_accel_lpf_cutoff,
+		k_param_land_detector_accel_max,
+		k_param_land_detector_rngfnd, //switch to regular land detetion mode and big prop's mode
+		k_param_land_detector_mot_low, //If using a RNGFND this value is added on Mot_at_lower_limit a condition to trigg Land Detection
 
         // the k_param_* space is 9-bits in size
         // 511: reserved
@@ -455,6 +461,14 @@ public:
     AP_Int8         fs_crash_check;
     AP_Float        fs_ekf_thresh;
     AP_Int16        gcs_pid_mask;
+    
+    AP_Float		land_detector_accel_lpf_cutoff;
+	AP_Float		land_detector_trigger_sec;
+	AP_Float		land_detector_maybe_trigger_sec;
+	AP_Float		land_detector_accel_max;
+	AP_Int8			land_detector_rngfnd;
+	AP_Float		land_detector_mot_low;
+
 
 #if MODE_THROW_ENABLED == ENABLED
     AP_Enum<ModeThrow::PreThrowMotorState>         throw_motor_start;

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -402,20 +402,26 @@
 //////////////////////////////////////////////////////////////////////////////
 // Landing Detector
 //
-#ifndef LAND_DETECTOR_TRIGGER_SEC
- # define LAND_DETECTOR_TRIGGER_SEC         1.0f    // number of seconds to detect a landing
+#ifndef LAND_DETECTOR_TRIGGER_SEC_DEFAULT
+ # define LAND_DETECTOR_TRIGGER_SEC_DEFAULT         1.0f    // number of seconds to detect a landing
 #endif
-#ifndef LAND_AIRMODE_DETECTOR_TRIGGER_SEC
- # define LAND_AIRMODE_DETECTOR_TRIGGER_SEC 3.0f    // number of seconds to detect a landing in air mode
+#ifndef LAND_AIRMODE_DETECTOR_TRIGGER_SEC_DEFAULT
+ # define LAND_AIRMODE_DETECTOR_TRIGGER_SEC_DEFAULT 3.0f    // number of seconds to detect a landing in air mode
 #endif
-#ifndef LAND_DETECTOR_MAYBE_TRIGGER_SEC
- # define LAND_DETECTOR_MAYBE_TRIGGER_SEC   0.2f    // number of seconds that means we might be landed (used to reset horizontal position targets to prevent tipping over)
+#ifndef LAND_DETECTOR_MAYBE_TRIGGER_SEC_DEFAULT
+ # define LAND_DETECTOR_MAYBE_TRIGGER_SEC_DEFAULT   0.2f    // number of seconds that means we might be landed (used to reset horizontal position targets to prevent tipping over)
 #endif
-#ifndef LAND_DETECTOR_ACCEL_LPF_CUTOFF
-# define LAND_DETECTOR_ACCEL_LPF_CUTOFF     1.0f    // frequency cutoff of land detector accelerometer filter
+#ifndef LAND_DETECTOR_ACCEL_LPF_CUTOFF_DEFAULT
+# define LAND_DETECTOR_ACCEL_LPF_CUTOFF_DEFAULT     1.0f    // frequency cutoff of land detector accelerometer filter
 #endif
-#ifndef LAND_DETECTOR_ACCEL_MAX
-# define LAND_DETECTOR_ACCEL_MAX            1.0f    // vehicle acceleration must be under 1m/s/s
+#ifndef LAND_DETECTOR_ACCEL_MAX_DEFAULT
+# define LAND_DETECTOR_ACCEL_MAX_DEFAULT            1.0f    // vehicle acceleration must be under 1m/s/s
+#endif
+#ifndef LAND_DETECTOR_RNGFND_DEFAULT
+# define LAND_DETECTOR_RNGFND_DEFAULT				0    // enable land detector on range finder instead of acceleration
+#endif
+#ifndef LAND_DETECTOR_MOT_LOW_DEFAULT
+# define LAND_DETECTOR_MOT_LOW_DEFAULT				0.1f    //If using a RNGFND this value is added on Mot_at_lower_limit a condition to trigg Land Detection
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Automatic landing for big quad/octoquad-copters (30" props).
Auto LAND mode needs a dependable DISARM protocol to eliminate the scary bouncing and destructive flip over of the copter upon landing.
As of today, the Arducopter master branch (4.3.0) provides a fairly good estimation of the touchdown status of the copter which is mostly based on real-time analysis of the 3-dimensionnal acceleration measurements of the frame. Lower frame acceleration values meaning that the copter is touching the ground among some other consolidation criteria like the descent speed close to zero needed to trigger DISARM.
The lowpass filtered acceleration threshold does work well on regular drones but is appears to be rather erratic on big drones. We realized that the low frequency vibrations of the big props do blur the acceleration measurements of the frame, cancelling safe auto landing abilities for the big drones.
This is especially true on the field when trying to land on a somewhat slanted ground level: when the copter is not convinced that it is time to DISARM, it bounces right away, in a desperate will to level the frame… In a few cases, it generates a quick flip over and high associated costs for big drones…
In the first place, we added a lowpass filter frequency parameter named LAND_DETECTOR_ACCEL_LPF_CUTOFF to the code to shift the cutoff frequency to the appropriate bandpass acceleration of the flying big copter. Getting from the hard coded default of 1 Hz to i.e. 0.2 Hz did enhanced the big copter ability to automatically DISARM with auto LAND, but still, in the case of non-leveled terrain, it does not suppresses the bounces and potential flip over…
At last, we considered that Ardupilot should be aware of its actual distance to the ground to be able to DISARM safely and repeatedly. Barometric altitude is not suitable for this endeavor, but the LIDAR (or SONAR) precision range finders should do the job (it is worth equipping a big drone with a LIDAR if it enables safe auto landings).
Today, after a number of flight tests on both 10” (regular) and 30” (big) octoquadcopters, we propose a land_detector.cpp code modification that comes with a couple of new configuration parameters to activate rangefinder based auto landing. 
The parameter named LAND_DET_RNGFND set to 1 cancels the acceleration based DISARM algorithm and enables range finder based DISARM (as long as the copter is equipped with a functional range finder). The algorithm takes the pre-existing LAND_RNGFND1_GNDCLEAR parameter to adjust the height threshold relative to the ground that triggers DISARM.
Notice that the dead range limitation of the commonly used LIDARs (10 to 30 cm) is not very much of a problem on big drones where is it easy to setup the LIDAR device to about 40 cm above ground.
Soon after enabling a dependable distance to the ground measurement in the algorithm, we discovered in the logs that the DISARM consolidation in the Arducopter code was waiting for the « motor_at_lower_limit » boolean value to trigger (waiting for the engines to spin down). The point is that on big props, it takes a much longer time for a propeller to slow down, and by the time it slows down, it still provides some sustentation, this is good to shorten this precarious state.
So we added a parameter named LAND_DET_MOT_LOW that is increasing the low motor speed threshold value requested by the algorithm to DISARM. On 30” props, an increase of about +10 % (with respect to the motor low limit value) is a good figure to take the DISARM decision at the right time.
To finalize the smooth and safe auto landings, one has to adjust the existing LAND_ALT_LOW and LAND_SPEED parameters to lower values (i.e. 1 m and 10 cm/s) with a good deal of adjust/try cycles.

