### PR TITLE
AP_Scripting: remove lua acess to ap object creation

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2347,13 +2347,6 @@ void emit_sandbox(void) {
     end_dependency(source, data->dependency);
     data = data->next;
   }
-  data = parsed_ap_objects;
-  while (data) {
-    start_dependency(source, data->dependency);
-    fprintf(source, "    {\"%s\", new_%s},\n", data->name, data->sanatized_name);
-    end_dependency(source, data->dependency);
-    data = data->next;
-  }
   if (parsed_globals) {
     struct method_alias *manual_aliases = parsed_globals->method_aliases;
     while (manual_aliases) {


### PR DESCRIPTION
It does not make sense to expose ap object creation to lua scripts, the script itself cannot populate the object as it can with userdata, so it would error out as null the first time it was used. 

Removes the following from the loaded global function table:
```
#if (AP_EFI_SCRIPTING_ENABLED == 1)
    {"AP_EFI_Backend", new_AP_EFI_Backend},
#endif // (AP_EFI_SCRIPTING_ENABLED == 1)
#if HAL_MAX_CAN_PROTOCOL_DRIVERS
    {"ScriptingCANBuffer", new_ScriptingCANBuffer},
#endif // HAL_MAX_CAN_PROTOCOL_DRIVERS
    {"AP_HAL::AnalogSource", new_AP_HAL__AnalogSource},
    {"AP_HAL::I2CDevice", new_AP_HAL__I2CDevice},
    {"AP_HAL::UARTDriver", new_AP_HAL__UARTDriver},
    {"RC_Channel", new_RC_Channel},
```

Currently you could do:
```
local efi_backend = AP_EFI_Backend()
```
Now you cannot, the only way to get a EFI backend is with:
```
local efi_backend = efi:get_backend(0)
```

some that are removed wouldn't work anyway, for example `AP_HAL::UARTDriver()` is not a valid lua string. 