### PR TITLE
ELRS improvements

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -143,7 +143,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #endif
     FAST_TASK(Log_Video_Stabilisation),
 
-    SCHED_TASK(rc_loop,              100,    130,  3),
+    SCHED_TASK(rc_loop,              250,    130,  3),
     SCHED_TASK(throttle_loop,         50,     75,  6),
     SCHED_TASK_CLASS(AP_GPS,               &copter.gps,                 update,          50, 200,   9),
 #if AP_OPTICALFLOW_ENABLED

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -134,6 +134,8 @@ public:
         return 57;
     }
 
+    virtual uint32_t get_baud_rate() const { return 0; }
+
     /*
       return true if this UART has DMA enabled on both RX and TX
      */

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -140,6 +140,8 @@ public:
         return _baudrate/(9*1024);
     }
 
+    uint32_t get_baud_rate() const override { return _baudrate; }
+
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
     void uart_info(ExpandingString &str) override;

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -101,12 +101,12 @@ public:
 #if AP_RCPROTOCOL_FPORT2_ENABLED
         case FPORT2:
 #endif
+        case CRSF:
             return true;
         case IBUS:
         case SUMD:
         case SRXL:
         case SRXL2:
-        case CRSF:
         case ST24:
         case NONE:
             return false;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -153,7 +153,11 @@ static const char* get_frame_type(uint8_t byte, uint8_t subtype = 0)
 #define CRSF_DIGITAL_CHANNEL_MAX 1811
 
 
-constexpr uint16_t AP_RCProtocol_CRSF::elrs_air_rates[8];
+const uint16_t AP_RCProtocol_CRSF::RF_MODE_RATES[RFMode::RF_MODE_MAX_MODES] = {
+    4, 50, 150, 250,    // CRSF
+    4, 25, 50, 100, 150, 200, 250, 500  // ELRS
+};
+
 AP_RCProtocol_CRSF* AP_RCProtocol_CRSF::_singleton;
 
 AP_RCProtocol_CRSF::AP_RCProtocol_CRSF(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend)
@@ -181,11 +185,23 @@ AP_RCProtocol_CRSF::~AP_RCProtocol_CRSF() {
     _singleton = nullptr;
 }
 
-void AP_RCProtocol_CRSF::process_pulse(uint32_t width_s0, uint32_t width_s1)
-{
-    uint8_t b;
-    if (ss.process_pulse(width_s0, width_s1, b)) {
-        _process_byte(ss.get_byte_timestamp_us(), b);
+// get the protocol string
+const char* AP_RCProtocol_CRSF::get_protocol_string(ProtocolType protocol) const {
+    if (protocol == ProtocolType::PROTOCOL_ELRS) {
+        return "ELRS";
+    } else if (_crsf_v3_active) {
+        return "CRSFv3";
+    } else {
+        return "CRSFv2";
+    }
+}
+
+// return the link rate as defined by the LinkStatistics
+uint16_t AP_RCProtocol_CRSF::get_link_rate(ProtocolType protocol) const {
+    if (protocol == ProtocolType::PROTOCOL_ELRS) {
+        return RF_MODE_RATES[_link_status.rf_mode + RFMode::ELRS_RF_MODE_4HZ];
+    } else {
+        return RF_MODE_RATES[_link_status.rf_mode];
     }
 }
 
@@ -386,7 +402,7 @@ bool AP_RCProtocol_CRSF::decode_crsf_packet()
             // now wait for 4ms to account for RX transmission and processing
             hal.scheduler->delay(4);
             // change the baud rate
-            uart->begin(_new_baud_rate, 128, 128);
+            uart->begin(_new_baud_rate);
         }
         _new_baud_rate = 0;
     }
@@ -559,7 +575,7 @@ void AP_RCProtocol_CRSF::start_uart()
     _uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
     _uart->set_blocking_writes(false);
     _uart->set_options(_uart->get_options() & ~AP_HAL::UARTDriver::OPTION_RXINV);
-    _uart->begin(CRSF_BAUDRATE, 128, 128);
+    _uart->begin(get_bootstrap_baud_rate());
 }
 
 // change the baudrate of the protocol if we are able
@@ -570,7 +586,7 @@ bool AP_RCProtocol_CRSF::change_baud_rate(uint32_t baudrate)
         return false;
     }
 #if !defined(STM32H7)
-    if (baudrate > CRSF_BAUDRATE && !uart->is_dma_enabled()) {
+    if (baudrate > get_bootstrap_baud_rate() && !uart->is_dma_enabled()) {
         return false;
     }
 #endif
@@ -581,6 +597,23 @@ bool AP_RCProtocol_CRSF::change_baud_rate(uint32_t baudrate)
     _new_baud_rate = baudrate;
 
     return true;
+}
+
+// change the bootstrap baud rate to ELRS standard if configured
+void AP_RCProtocol_CRSF::process_handshake(uint32_t baudrate)
+{
+    AP_HAL::UARTDriver *uart = get_current_UART();
+
+    // only change the baudrate if we are bootstrapping CRSF
+    if (uart == nullptr
+        || baudrate != CRSF_BAUDRATE
+        || baudrate == get_bootstrap_baud_rate()
+        || uart->get_baud_rate() == get_bootstrap_baud_rate()
+        || (get_rc_protocols_mask() & ((1U<<(uint8_t(AP_RCProtocol::CRSF)+1))+1)) == 0) {
+        return;
+    }
+
+    uart->begin(get_bootstrap_baud_rate());
 }
 
 //returns uplink link quality on 0-255 scale

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -20,6 +20,7 @@
 
 #include "AP_RCProtocol.h"
 #include <AP_Math/AP_Math.h>
+#include <RC_Channel/RC_Channel.h>
 #include "SoftSerial.h"
 
 #define CRSF_MAX_CHANNELS   24U      // Maximum number of channels from crsf datastream
@@ -27,6 +28,7 @@
 #define CSRF_HEADER_LEN     2U       // header length
 #define CRSF_FRAME_PAYLOAD_MAX (CRSF_FRAMELEN_MAX - CSRF_HEADER_LEN)     // maximum size of the frame length field in a packet
 #define CRSF_BAUDRATE      416666U
+#define ELRS_BAUDRATE      420000U
 #define CRSF_TX_TIMEOUT    500000U   // the period after which the transmitter is considered disconnected (matches copters failsafe)
 #define CRSF_RX_TIMEOUT    150000U   // the period after which the receiver is considered disconnected (>ping frequency)
 
@@ -35,11 +37,14 @@ public:
     AP_RCProtocol_CRSF(AP_RCProtocol &_frontend);
     virtual ~AP_RCProtocol_CRSF();
     void process_byte(uint8_t byte, uint32_t baudrate) override;
-    void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
+    void process_handshake(uint32_t baudrate) override;
     void update(void) override;
     // support for CRSF v3
     bool change_baud_rate(uint32_t baudrate);
-    bool is_crsf_v3_active() const { return _crsf_v3_active; }
+    // bootstrap baudrate
+    uint32_t get_bootstrap_baud_rate() const {
+        return rc().use_420kbaud_for_elrs() ? ELRS_BAUDRATE : CRSF_BAUDRATE;
+    }
 
     // is the receiver active, used to detect power loss and baudrate changes
     bool is_rx_active() const override {
@@ -233,7 +238,13 @@ public:
         // uint16_t digital_switch_channel[]:10; // digital switch channel
     } PACKED;
 
-    enum class RFMode : uint8_t {
+    enum class ProtocolType {
+        PROTOCOL_CRSF,
+        PROTOCOL_TRACER,
+        PROTOCOL_ELRS
+    };
+
+    enum RFMode {
         CRSF_RF_MODE_4HZ = 0,
         CRSF_RF_MODE_50HZ,
         CRSF_RF_MODE_150HZ,
@@ -246,10 +257,9 @@ public:
         ELRS_RF_MODE_200HZ,
         ELRS_RF_MODE_250HZ,
         ELRS_RF_MODE_500HZ,
+        RF_MODE_MAX_MODES,
         RF_MODE_UNKNOWN,
     };
-    // nominal ELRS air rates
-    static constexpr uint16_t elrs_air_rates[8] = {4, 25, 50, 100, 150, 200, 250, 500};
 
     struct LinkStatus {
         int16_t rssi = -1;
@@ -262,6 +272,12 @@ public:
     const volatile LinkStatus& get_link_status() const {
         return _link_status;
     }
+
+    // return the link rate as defined by the LinkStatistics
+    uint16_t get_link_rate(ProtocolType protocol) const;
+
+    // return the protocol string
+    const char* get_protocol_string(ProtocolType protocol) const;
 
 private:
     struct Frame _frame;
@@ -304,9 +320,9 @@ private:
 
     volatile struct LinkStatus _link_status;
 
-    AP_HAL::UARTDriver *_uart;
+    static const uint16_t RF_MODE_RATES[RFMode::RF_MODE_MAX_MODES];
 
-    SoftSerial ss{CRSF_BAUDRATE, SoftSerial::SERIAL_CONFIG_8N1};
+    AP_HAL::UARTDriver *_uart;
 };
 
 namespace AP {

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -232,17 +232,13 @@ public:
     };
 
     // get the protocol string
-    const char* get_protocol_string() const {
-        if (_crsf_version.is_elrs) {
-            return "ELRS";
-        } else {
-            const AP_RCProtocol_CRSF* crsf = AP::crsf();
-            if (crsf && crsf->is_crsf_v3_active()) {
-                return "CRSFv3";
-            }
-            return "CRSFv2";
-        }
-    };
+    const char* get_protocol_string() const { return AP::crsf()->get_protocol_string(_crsf_version.protocol); }
+
+    // is the current protocol ELRS?
+    bool is_elrs() const { return _crsf_version.protocol == AP_RCProtocol_CRSF::ProtocolType::PROTOCOL_ELRS; }
+    // is the current protocol Tracer?
+    bool is_tracer() const { return _crsf_version.protocol == AP_RCProtocol_CRSF::ProtocolType::PROTOCOL_TRACER; }
+
     // Process a frame from the CRSF protocol decoder
     static bool process_frame(AP_RCProtocol_CRSF::FrameType frame_type, void* data);
     // process any changed settings and schedule for transmission
@@ -346,9 +342,8 @@ private:
         uint8_t major;
         uint8_t retry_count;
         bool use_rf_mode;
-        bool is_tracer;
+        AP_RCProtocol_CRSF::ProtocolType protocol;
         bool pending = true;
-        bool is_elrs;
     } _crsf_version;
 
     struct {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -550,6 +550,10 @@ public:
         return get_singleton() != nullptr && (_options & uint32_t(Option::CRSF_FM_DISARM_STAR)) != 0;
     }
 
+    bool use_420kbaud_for_elrs(void) const {
+        return get_singleton() != nullptr && (_options & uint32_t(Option::ELRS_420KBAUD)) != 0;
+    }
+
     // returns true if overrides should time out.  If true is returned
     // then returned_timeout_ms will contain the timeout in
     // milliseconds, with 0 meaning overrides are disabled.
@@ -626,6 +630,7 @@ protected:
         MULTI_RECEIVER_SUPPORT  = (1U << 10), // allow multiple receivers
         USE_CRSF_LQ_AS_RSSI     = (1U << 11), // returns CRSF link quality as RSSI value, instead of RSSI
         CRSF_FM_DISARM_STAR     = (1U << 12), // when disarmed, add a star at the end of the flight mode in CRSF telemetry
+        ELRS_420KBAUD           = (1U << 13), // use 420kbaud for ELRS protocol
     };
 
     void new_override_received() {

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC options
     // @Description: RC input options
     // @User: Advanced
-    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:CRSF RSSI shows Link Quality, 12:CRSF flight mode disarm star
+    // @Bitmask: 0:Ignore RC Receiver, 1:Ignore MAVLink Overrides, 2:Ignore Receiver Failsafe bit but allow other RC failsafes if setup, 3:FPort Pad, 4:Log RC input bytes, 5:Arming check throttle for 0 input, 6:Skip the arming check for neutral Roll/Pitch/Yaw sticks, 7:Allow Switch reverse, 8:Use passthrough for CRSF telemetry, 9:Suppress CRSF mode/rate message for ELRS systems,10:Enable multiple receiver support, 11:Use Link Quality for RSSI with CRSF, 12:Annotate CRSF flight mode with * on disarm, 13: Use 420kbaud for ELRS protocol
     AP_GROUPINFO("_OPTIONS", 33, RC_CHANNELS_SUBCLASS, _options, (uint32_t)RC_Channels::Option::ARMING_CHECK_THROTTLE),
 
     // @Param: _PROTOCOLS


### PR DESCRIPTION
Shave off a few of the rough edges when using ELRS including radio failsafes that occur at higher frame rates

It seems the main change that people need to make for ELRS is to set the UART RX baudrate to 416666 when upgrading

Adds a bit to RC_OPTIONS to allow CRSF to bootstrap at 420000

Prompted by https://github.com/ExpressLRS/ExpressLRS/issues/1773