### PR TITLE
AP_TECS: Remove unused TECS_LAND_PTRIM parameter

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -264,14 +264,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("PTCH_FF_K", 30, AP_TECS, _pitch_ff_k, 0.0),
 
-    // @Param: LAND_PTRIM
-    // @DisplayName: Pitch angle for level flight in landing configuration
-    // @Description: This sets the pitch angle required to fly straight and level with flaps and gear in the landing configuration. It is used to calculate the lower pitch limit applied during landing up until the flare. This can be set to the average value of the AOA.AOA log data taken from a landing approach.
-    // @Range: -10 15
-    // @Units: deg
-    // @Increment: 1
-    // @User: Advanced
-    AP_GROUPINFO("LAND_PTRIM", 31, AP_TECS, _land_pitch_trim, 0),
+    // 31 previously used by TECS_LAND_PTRIM
 
     // @Param: FLARE_HGT
     // @DisplayName: Flare holdoff height

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -196,7 +196,6 @@ private:
     AP_Int8  _land_pitch_max;
     AP_Float _maxSinkRate_approach;
     AP_Int32 _options;
-    AP_Int8  _land_pitch_trim;
     AP_Float _flare_holdoff_hgt;
     AP_Float _hgt_dem_tconst;
 


### PR DESCRIPTION
The TECS_LAND_PTRIM  parameter is not used in the code. It was included by mistake in https://github.com/ArduPilot/ardupilot/pull/22191 and belongs with a yet to be submitted set of changes that will improve flare control for aircraft using flaps.