### PR TITLE
GCS_MAVLink: correct consumption of ODOMETRY velocity

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3416,7 +3416,9 @@ void GCS_MAVLINK::handle_odometry(const mavlink_message_t &msg)
     const uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.time_usec, PAYLOAD_SIZE(chan, ODOMETRY));
     visual_odom->handle_vision_position_estimate(m.time_usec, timestamp_ms, m.x, m.y, m.z, q, posErr, angErr, m.reset_counter);
 
-    const Vector3f vel{m.vx, m.vy, m.vz};
+    // convert velocity vector from FRD to NED frame
+    Vector3f vel{m.vx, m.vy, m.vz};
+    vel = q * vel;
     visual_odom->handle_vision_speed_estimate(m.time_usec, timestamp_ms, vel, m.reset_counter);
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3412,7 +3412,7 @@ void GCS_MAVLINK::handle_odometry(const mavlink_message_t &msg)
         posErr = cbrtf(sq(m.pose_covariance[0])+sq(m.pose_covariance[6])+sq(m.pose_covariance[11]));
         angErr = cbrtf(sq(m.pose_covariance[15])+sq(m.pose_covariance[18])+sq(m.pose_covariance[20]));
     }
-    
+
     const uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.time_usec, PAYLOAD_SIZE(chan, ODOMETRY));
     visual_odom->handle_vision_position_estimate(m.time_usec, timestamp_ms, m.x, m.y, m.z, q, posErr, angErr, m.reset_counter);
 

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -210,6 +210,7 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
 
     // send ODOMETRY message
     if (should_send(ViconTypeMask::ODOMETRY) && get_free_msg_buf_index(msg_buf_index)) {
+        const Vector3f vel_corrected_frd = attitude.inverse() * vel_corrected;
         mavlink_msg_odometry_pack_chan(
             system_id,
             component_id,
@@ -222,9 +223,9 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
             pos_corrected.y,
             pos_corrected.z,
             &attitude[0],
-            vel_corrected.x,
-            vel_corrected.y,
-            vel_corrected.z,
+            vel_corrected_frd.x,
+            vel_corrected_frd.y,
+            vel_corrected_frd.z,
             gyro.x,
             gyro.y,
             gyro.z,


### PR DESCRIPTION
This corrects AP's consumption of the [ODOMETRY](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5787) mavlink message so that the velocity vector is converted from the FRD frame ([the only frame we accept for the velocity](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp#L3402)) to the NED frame which is what the VisualOdometry and EKF require.

This has been bench tested on a quadcopter with a [ModalAI VOXL-CAM](https://ardupilot.org/copter/docs/common-modalai-voxl.html) mounted to the front of the vehicle.  Debug was added to print the raw velocity and final velocity values to confirm they were in the correct frame.

A bit anecdotal but the EKF status reporting appears much healthier after this change.

flight test video is here https://www.youtube.com/watch?v=CikqIRzXlRc