### PR TITLE
Tools: allocate board ID for Sierra F1 Autopilot

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -185,7 +185,7 @@ AP_HW_JHEMCUGF16F405                 1081
 AP_HW_SPEEDYBEEF4V3                  1082
 AP_HW_PixPilot-V6                    1083
 AP_HW_JFB100                         1084
-AP_HW_Sierra_F1                      1085
+AP_HW_Sierra_F1                      1087
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -185,6 +185,7 @@ AP_HW_JHEMCUGF16F405                 1081
 AP_HW_SPEEDYBEEF4V3                  1082
 AP_HW_PixPilot-V6                    1083
 AP_HW_JFB100                         1084
+AP_HW_Sierra_F1                      1085
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
Reserve board ID 1085 for Sierra F1 AP. 