### PR TITLE
hwdef: correct compilation of CubeOrange bdshot variants

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-bdshot/hwdef.dat
@@ -13,4 +13,4 @@ PD14 TIM4_CH3 TIM4 PWM(6) GPIO(55) BIDIR
 
 NODMA I2C*
 define STM32_I2C_USE_DMA FALSE
-env DEFAULT_PARAMETERS library/AP_HAL_ChibiOS/hwdef/CubeOrange/defaults.parm
+env DEFAULT_PARAMETERS libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/defaults.parm

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-bdshot/hwdef.dat
@@ -14,4 +14,4 @@ PD14 TIM4_CH3 TIM4 PWM(6) GPIO(55) BIDIR
 NODMA I2C*
 define STM32_I2C_USE_DMA FALSE
 
-env DEFAULT_PARAMETERS library/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/defaults.parm
+env DEFAULT_PARAMETERS libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/defaults.parm


### PR DESCRIPTION
These were merged in a state where they would never have compiled.

Oops.

Notionally we could have a CI check which compiles any board which is being added...
