### PR TITLE
AP_Scripting: allow for user functions to be added in schedule text files

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4028,7 +4028,7 @@ class AutoTestPlane(AutoTest):
         # check all messages to see if we got all tricks
         tricks = ["Loop", "HalfReverseCubanEight", "ScaleFigureEight", "Immelmann",
                   "Split-S", "RollingCircle", "HumptyBump", "HalfCubanEight",
-                  "BarrelRoll", "HalfReverseCubanEight",
+                  "BarrelRoll", "CrossBoxTopHat", "TriangularLoop",
                   "Finishing SuperAirShow!"]
         texts = [m.text for m in messages]
         for t in tricks:

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
@@ -43,7 +43,6 @@ the ground track.
 | 20 | Procedure Turn           | radius | bank angle  | step-out    |            | Yes        |
 | 21 | Derry Turn               | radius | bank angle  |             |            | No         |
 | 23 | Half Climbing Circle     | radius | height      | bank angle  |            | Yes        |
-| 24 | Crossbox Humpty          | radius | height      |             |            | Yes        |
 | 25 | Laydown Humpty           | radius | height      |             |            | Yes        |
 | 25 | Barrel Roll              | radius | length      | num spirals |            | No         |
 | 26 | Straight Hold            | length | bank angle  |             |            | No         |

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -1157,22 +1157,6 @@ function humpty_bump(r, h, arg3, arg4)
    })
 end
 
-function crossbox_humpty(r, h, arg3, arg4)
-   assert(h >= 2*r)
-   local rabs = math.abs(r)
-   return make_paths("crossbox_humpty", {
-            { path_vertical_arc(r, 90),          roll_angle(0) },
-            { path_straight((h-2*rabs)/3),       roll_angle(0) },
-            { path_straight((h-2*rabs)/3),       roll_angle(90),  roll_ref=90 },
-            { path_straight((h-2*rabs)/3),       roll_angle(0) },
-            { path_vertical_arc(-r, 180),        roll_angle(0) },
-            { path_straight((h-2*rabs)/3),       roll_angle(0) },
-            { path_straight((h-2*rabs)/3),       roll_angle(90), roll_ref=-90 },
-            { path_straight((h-2*rabs)/3),       roll_angle(0) },
-            { path_vertical_arc(r, 90),          roll_angle(0), roll_ref=180 },
-   })
-end
-
 function laydown_humpty(r, h, arg3, arg4)
    assert(h >= 2*r)
    local rabs = math.abs(r)
@@ -2609,7 +2593,7 @@ command_table[20]= PathFunction(procedure_turn, "Procedure Turn")
 command_table[21]= PathFunction(derry_turn, "Derry Turn")
 -- 22 was Two Point Roll - use multi point roll instead
 command_table[23]= PathFunction(half_climbing_circle, "Half Climbing Circle")
-command_table[24]= PathFunction(crossbox_humpty, "Crossbox Humpty")
+-- 24 was crossbox-humpty
 command_table[25]= PathFunction(laydown_humpty, "Laydown Humpty")
 command_table[26]= PathFunction(barrel_roll, "Barrel Roll")
 command_table[27]= PathFunction(straight_flight, "Straight Hold")
@@ -2652,7 +2636,6 @@ load_table["procedure_turn"] = procedure_turn
 load_table["derry_turn"] = derry_turn
 load_table["two_point_roll"] = two_point_roll
 load_table["half_climbing_circle"] = half_climbing_circle
-load_table["crossbox_humpty"] = crossbox_humpty
 load_table["laydown_humpty"] = laydown_humpty
 load_table["straight_align"] = straight_align
 load_table["figure_eight"] = figure_eight

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/trick72.txt
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/trick72.txt
@@ -7,6 +7,51 @@
 # you can use name: to give your sequence a name
 name: SuperAirShow
 
+# you can add new path functions, following the same syntax
+# as in the main plane_aerobatics.lua
+function triangular_loop(radius, height, arg3, arg4)   -- triangle
+   local h1 = radius * math.sin(math.rad(45))
+   local h2 = (2 * radius) - (radius * math.cos(math.rad(45)))
+   local h3 = height - (2 * radius)
+   local side = h3 / math.cos(math.rad(45))
+   --local base = (h3 + (2 * (radius - radius * math.cos(math.rad(45))))) - (2 * radius)   
+   local base = (2 * (h3 + radius)) - 2 * radius
+   return make_paths("triangular_loop", {
+            { path_straight(base * 1/5),                   roll_angle(180) },
+            { path_straight(base * 2/5),                   roll_angle(0) },         
+            { path_vertical_arc(radius, 135) ,             roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(90) },
+            { path_straight(side*1/9),                     roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(90) },
+            { path_straight(side*2/9),                     roll_angle(0) },
+            { path_vertical_arc(radius, 90),               roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(90) },
+            { path_straight(side*1/9),                     roll_angle(0) },
+            { path_straight(side*2/9),                     roll_angle(90) },
+            { path_straight(side*2/9),                     roll_angle(0) },
+            { path_vertical_arc(radius, 135),              roll_angle(0) },
+            { path_straight(base * 2/5),                   roll_angle(0) }, 
+            { path_straight(base * 1/5),                   roll_angle(180) },
+            { path_straight(base * 2/5),                   roll_angle(0) },  
+      })
+end
+
+# a cross-box tophat, used to get us back on track after the barrell roll
+function crossbox_tophat(radius, height, width, arg4) -- top hat
+   local w = width - 2*radius
+   return make_paths('crossbox_tophat', {
+            { path_vertical_arc(radius, 90),      roll_angle(0) },
+            { path_straight((height-2*radius)),   roll_sequence({{1,0}, {1, 90}, {1, 0}}), set_orient=qorient(0,90,90) },
+            { path_vertical_arc(-radius, 90),     roll_angle(0), set_orient=qorient(180,0,90) },
+            { path_straight(w),                   roll_angle(0) },
+            { path_vertical_arc(radius, 90),      roll_angle(0), set_orient=qorient(0,-90,90) },
+            { path_straight((height-2*radius)),   roll_sequence({{1,0}, {1, -90}, {1, 0}}), set_orient=qorient(0,-90,180) },
+            { path_vertical_arc(radius, 90),      roll_angle(0), set_orient=qorient(0,0,180) },
+      })
+end
+
 # you can add messages to display on the GCS/OSD while flying
 message: Loop
 loop 25 0 1
@@ -48,9 +93,10 @@ align_center
 message: BarrelRoll
 barrel_roll 30 100 2
 
-message: ProcedureTurn
 align_box 1
-procedure_turn 30 45 30
+message: CrossBoxTopHat
+crossbox_tophat 20 60 60
 
-# get back to the start point
-straight_align 0
+align_center
+message: TriangularLoop
+triangular_loop 20 60

--- a/libraries/AP_Scripting/examples/test_load.lua
+++ b/libraries/AP_Scripting/examples/test_load.lua
@@ -1,0 +1,34 @@
+--[[
+ test the load function for loading new code from strings
+--]]
+
+gcs:send_text(0,"Testing load() method")
+
+-- a function written as a string. This could come from a file
+-- or any other source (eg. mavlink)
+-- Note that the [[ xxx ]] syntax is just a multi-line string
+local func_str = [[
+function TestFunc(x,y)
+  return math.sin(x) + math.cos(y)
+end
+]]
+
+function test_load()
+   -- load the code into the global environment
+   local f,errloc,err = load(func_str,"TestFunc", "t", _ENV)
+   if not f then
+      gcs:send_text(0,string.format("Error %s: %s", errloc, err))
+      return
+   end
+   -- run the code within a protected call to catch any errors
+   local success, err = pcall(f)
+   if not success then
+      gcs:send_text(0, string.format("Failed to load TestFunc: %s", err))
+      return
+   end
+
+   -- we now have the new function
+   gcs:send_text(0, string.format("TestFunc(3,4) -> %f", TestFunc(3,4)))
+end
+
+test_load()

--- a/libraries/AP_Scripting/lua/src/lauxlib.c
+++ b/libraries/AP_Scripting/lua/src/lauxlib.c
@@ -720,11 +720,13 @@ LUALIB_API int luaL_loadfilex (lua_State *L, const char *filename,
   }
   if (skipcomment(&lf, &c))  /* read initial portion */
     lf.buff[lf.n++] = '\n';  /* add line to correct line numbers */
+#if LUA_SUPPORT_LOAD_BINARY
   if (c == LUA_SIGNATURE[0] && filename) {  /* binary file? */
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     skipcomment(&lf, &c);  /* re-read initial portion */
   }
+#endif
   if (c != EOF)
     lf.buff[lf.n++] = c;  /* 'c' is the first character of the stream */
   status = lua_load(L, getF, &lf, lua_tostring(L, -1), mode);

--- a/libraries/AP_Scripting/lua/src/lbaselib.c
+++ b/libraries/AP_Scripting/lua/src/lbaselib.c
@@ -461,7 +461,7 @@ static const luaL_Reg base_funcs[] = {
 //  {"getmetatable", luaB_getmetatable},
   {"ipairs", luaB_ipairs},
 //  {"loadfile", luaB_loadfile},
-//  {"load", luaB_load},
+  {"load", luaB_load},
 #if defined(LUA_COMPAT_LOADSTRING)
   {"loadstring", luaB_load},
 #endif

--- a/libraries/AP_Scripting/lua/src/ldo.c
+++ b/libraries/AP_Scripting/lua/src/ldo.c
@@ -768,11 +768,15 @@ static void f_parser (lua_State *L, void *ud) {
   LClosure *cl;
   struct SParser *p = cast(struct SParser *, ud);
   int c = zgetc(p->z);  /* read first character */
+#if LUA_SUPPORT_LOAD_BINARY
+  // support loading pre-compiled luac
   if (c == LUA_SIGNATURE[0]) {
     checkmode(L, p->mode, "binary");
     cl = luaU_undump(L, p->z, p->name);
   }
-  else {
+  else
+#endif
+  {
     checkmode(L, p->mode, "text");
     cl = luaY_parser(L, p->z, &p->buff, &p->dyd, p->name, c);
   }

--- a/libraries/AP_Scripting/lua/src/luaconf.h
+++ b/libraries/AP_Scripting/lua/src/luaconf.h
@@ -11,6 +11,12 @@
 #include <limits.h>
 #include <stddef.h>
 
+/*
+  don't support binary load() by default
+ */
+#ifndef LUA_SUPPORT_LOAD_BINARY
+#define LUA_SUPPORT_LOAD_BINARY 0
+#endif
 
 /*
 ** ===================================================================


### PR DESCRIPTION
This exposes the load() lua function so we can load new lua code from within a lua script
We then use this to allow for new manoeuvrers to be added in text schedules. This means users can create very
complex aerobatic schedules without having to edit the base plane_aerobatics.lua

The trick72.txt airshow has been modified to use the new capability so it is tested in CI

this costs 424 bytes on H7:
![image](https://user-images.githubusercontent.com/831867/204068626-48ac9e20-badf-4e56-b128-85be1cbc6358.png)

with the change to remove binary load support this ends up saving nearly 2k of flash, leaving this PR overall 1.7k smaller
![image](https://user-images.githubusercontent.com/831867/204110734-5f1cd4c9-a47c-460d-8c57-aafcc2a0bb44.png)
