### PR TITLE
Fix TECS bug preventing flare for subsequent landings

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1262,13 +1262,6 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
         _PITCHminf = MAX(_land_pitch_min, _PITCHminf);
     }
 
-    if (_landing.is_flaring()) {
-        // ensure we don't violate the limits for flare pitch
-        if (_land_pitch_max != 0) {
-            _PITCHmaxf = MIN(_land_pitch_max, _PITCHmaxf);
-        }
-    }
-
     if (flight_stage == AP_FixedWing::FlightStage::TAKEOFF || flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
         if (!_flags.reached_speed_takeoff && _TAS_state >= _TAS_dem_adj) {
             // we have reached our target speed in takeoff, allow for

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -401,8 +401,9 @@ private:
     // Time since last update of main TECS loop (seconds)
     float _DT;
 
-    // counter for demanded sink rate on land final
-    uint8_t _flare_counter;
+    // true when class variables used for flare control have been initialised
+    // on flare entry
+    bool _flare_initialised;
 
     // slew height demand lag filter value when transition to land
     float hgt_dem_lag_filter_slew;


### PR DESCRIPTION
This bug was reported by https://github.com/ArduPilot/ardupilot/pull/22191#issuecomment-1325428328 

The failure to reset the counter after exiting flare was preventing subsequent flares being performed unless the vehicle was power cycled after landing.

The  flare control no longer requires a counter to schedule the pitch limits, so this has been replaced with a boolean as suggested by https://github.com/ArduPilot/ardupilot/pull/22191#issuecomment-1325443278