### PR TITLE
SITL: tidy simulated proximity sensor constructors

### DIFF
--- a/libraries/SITL/SIM_PS_LightWare.h
+++ b/libraries/SITL/SIM_PS_LightWare.h
@@ -34,7 +34,7 @@ namespace SITL {
 class PS_LightWare : public SerialProximitySensor {
 public:
 
-    PS_LightWare() { }
+    using SerialProximitySensor::SerialProximitySensor;
 
 private:
 

--- a/libraries/SITL/SIM_PS_LightWare_SF45B.h
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.h
@@ -57,13 +57,13 @@ namespace SITL {
 class PS_LightWare_SF45B : public PS_LightWare {
 public:
 
+    using PS_LightWare::PS_LightWare;
+
     uint32_t packet_for_location(const Location &location,
                                  uint8_t *data,
                                  uint8_t buflen) override;
 
     void update(const Location &location) override;
-
-    PS_LightWare_SF45B() : PS_LightWare() { }
 
 private:
 

--- a/libraries/SITL/SIM_PS_RPLidarA2.h
+++ b/libraries/SITL/SIM_PS_RPLidarA2.h
@@ -58,6 +58,8 @@ namespace SITL {
 class PS_RPLidarA2 : public SerialProximitySensor {
 public:
 
+    using SerialProximitySensor::SerialProximitySensor;
+
     uint32_t packet_for_location(const Location &location,
                                  uint8_t *data,
                                  uint8_t buflen) override;

--- a/libraries/SITL/SIM_PS_TeraRangerTower.h
+++ b/libraries/SITL/SIM_PS_TeraRangerTower.h
@@ -56,6 +56,8 @@ namespace SITL {
 class PS_TeraRangerTower : public SerialProximitySensor {
 public:
 
+    using SerialProximitySensor::SerialProximitySensor;
+
     uint32_t packet_for_location(const Location &location,
                                  uint8_t *data,
                                  uint8_t buflen) override;


### PR DESCRIPTION
This was a bit of a mystery for me - there's some strange things around `using` when other subclasses override a constructor.
