### PR TITLE
AP_Periph: Add timeout to ESC output when CAN packets are lost

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -222,6 +222,9 @@ public:
     SRV_Channels servo_channels;
     bool rcout_has_new_data_to_update;
 
+    uint32_t last_esc_raw_command_ms;
+    uint8_t  last_esc_num_channels;
+
     void rcout_init();
     void rcout_init_1Hz();
     void rcout_esc(int16_t *rc, uint8_t num_channels);

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -373,6 +373,14 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @RebootRequired: True
     GSCALAR(esc_pwm_type, "ESC_PWM_TYPE",     0),
 
+    // @Param: ESC_CMD_TIMO
+    // @DisplayName: ESC Command Timeout
+    // @Description: This is the duration (ms) with which to hold the last driven ESC command before timing out and zeroing the ESC outputs. To disable zeroing of outputs in event of CAN loss, use 0. Use values greater than the expected duration between two CAN frames to ensure Periph is not starved of ESC Raw Commands.
+    // @Range: 0 10000
+    // @Units: ms
+    // @User: Advanced
+    GSCALAR(esc_command_timeout_ms, "ESC_CMD_TIMO",     200),
+
 #if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
     // @Param: ESC_TELEM_PORT
     // @DisplayName: ESC Telemetry Serial Port

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -62,6 +62,7 @@ public:
         k_param_esc_telem_rate,
         k_param_can_slcan_cport,
         k_param_temperature_sensor,
+        k_param_esc_command_timeout_ms,
     };
 
     AP_Int16 format_version;
@@ -122,6 +123,7 @@ public:
 
 #ifdef HAL_PERIPH_ENABLE_RC_OUT
     AP_Int8 esc_pwm_type;
+    AP_Int16 esc_command_timeout_ms;
 #if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
     AP_Int8 esc_telem_port;
 #endif

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -774,6 +774,10 @@ static void handle_esc_rawcommand(CanardInstance* ins, CanardRxTransfer* transfe
         return;
     }
     periph.rcout_esc(cmd.cmd.data, cmd.cmd.len);
+
+    // Update internal copy for disabling output to ESC when CAN packets are lost
+    periph.last_esc_num_channels = cmd.cmd.len;
+    periph.last_esc_raw_command_ms = AP_HAL::millis();
 }
 
 static void handle_act_command(CanardInstance* ins, CanardRxTransfer* transfer)

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -126,6 +126,18 @@ void AP_Periph_FW::rcout_handle_safety_state(uint8_t safety_state)
 
 void AP_Periph_FW::rcout_update()
 {
+    uint32_t now_ms = AP_HAL::millis();
+    const uint16_t esc_timeout_ms = 100U;
+    const bool has_esc_rawcommand_timed_out = (now_ms - last_esc_raw_command_ms) >= esc_timeout_ms;
+    if (last_esc_num_channels > 0 && has_esc_rawcommand_timed_out) {
+        // If we've seen ESCs previously, and a timeout has occurred, then zero the outputs
+        int16_t esc_output[last_esc_num_channels] {};
+        rcout_esc(esc_output, last_esc_num_channels);
+
+        // register that the output has been changed
+        rcout_has_new_data_to_update = true;
+    }
+
     if (!rcout_has_new_data_to_update) {
         return;
     }
@@ -136,7 +148,6 @@ void AP_Periph_FW::rcout_update()
     SRV_Channels::output_ch_all();
     SRV_Channels::push();
 #if HAL_WITH_ESC_TELEM
-    uint32_t now_ms = AP_HAL::millis();
     if (now_ms - last_esc_telem_update_ms >= esc_telem_update_period_ms) {
         last_esc_telem_update_ms = now_ms;
         esc_telem_update();
@@ -145,4 +156,3 @@ void AP_Periph_FW::rcout_update()
 }
 
 #endif // HAL_PERIPH_ENABLE_RC_OUT
-

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -127,8 +127,9 @@ void AP_Periph_FW::rcout_handle_safety_state(uint8_t safety_state)
 void AP_Periph_FW::rcout_update()
 {
     uint32_t now_ms = AP_HAL::millis();
-    const uint16_t esc_timeout_ms = 100U;
-    const bool has_esc_rawcommand_timed_out = (now_ms - last_esc_raw_command_ms) >= esc_timeout_ms;
+
+    const uint16_t esc_timeout_ms = g.esc_command_timeout_ms >= 0 ? g.esc_command_timeout_ms : 0; // Don't allow negative timeouts!
+    const bool has_esc_rawcommand_timed_out = esc_timeout_ms != 0 && ((now_ms - last_esc_raw_command_ms) >= esc_timeout_ms);
     if (last_esc_num_channels > 0 && has_esc_rawcommand_timed_out) {
         // If we've seen ESCs previously, and a timeout has occurred, then zero the outputs
         int16_t esc_output[last_esc_num_channels] {};


### PR DESCRIPTION
Fixes a periph continuing to drive an ESC output to the last received value when the esc_rawcommand packets are lost. If the packets are continuously dropped or the bus is lost for whatever reason, this could result in the ESC output doing some very untoward things.

This change is tested on MatekL431-DShot configured for DSHOT600 output to an ESC, and reporting telemetry back to the flight controller.