### PR TITLE
AP_Mount: fix for Siyi A8

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -294,7 +294,8 @@ void AP_Mount_Siyi::process_packet()
     switch ((SiyiCommandId)_parsed_msg.command_id) {
 
     case SiyiCommandId::ACQUIRE_FIRMWARE_VERSION: {
-        if (_parsed_msg.data_bytes_received != 12) {
+        if (_parsed_msg.data_bytes_received != 12 &&    // ZR10 firmware version reply is 12bytes
+            _parsed_msg.data_bytes_received != 8) {     // A8 firmware version reply is 8 bytes
 #if AP_MOUNT_SIYI_DEBUG
             unexpected_len = true;
 #endif
@@ -315,10 +316,14 @@ void AP_Mount_Siyi::process_packet()
                 (unsigned)_msg_buff[_msg_buff_data_start+7]);   // firmware revision
 
         // display zoom firmware version
-        debug("Mount: SiyiZoom fw:%u.%u.%u",
-              (unsigned)_msg_buff[_msg_buff_data_start+9],      // firmware major version
-              (unsigned)_msg_buff[_msg_buff_data_start+10],     // firmware minor version
-              (unsigned)_msg_buff[_msg_buff_data_start+11]);    // firmware revision
+#if AP_MOUNT_SIYI_DEBUG
+        if (_parsed_msg.data_bytes_received >= 12) {
+            debug("Mount: SiyiZoom fw:%u.%u.%u",
+                (unsigned)_msg_buff[_msg_buff_data_start+9],      // firmware major version
+                (unsigned)_msg_buff[_msg_buff_data_start+10],     // firmware minor version
+                (unsigned)_msg_buff[_msg_buff_data_start+11]);    // firmware revision
+        }
+#endif
         break;
     }
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -305,23 +305,23 @@ void AP_Mount_Siyi::process_packet()
 
         // display camera firmware version
         debug("Mount: SiyiCam fw:%u.%u.%u",
-              (unsigned)_msg_buff[_msg_buff_data_start+1],      // firmware major version
-              (unsigned)_msg_buff[_msg_buff_data_start+2],      // firmware minor version
-              (unsigned)_msg_buff[_msg_buff_data_start+3]);     // firmware revision
+              (unsigned)_msg_buff[_msg_buff_data_start+2],      // firmware major version
+              (unsigned)_msg_buff[_msg_buff_data_start+1],      // firmware minor version
+              (unsigned)_msg_buff[_msg_buff_data_start+0]);     // firmware revision
 
         // display gimbal info to user
         gcs().send_text(MAV_SEVERITY_INFO, "Mount: Siyi fw:%u.%u.%u",
-                (unsigned)_msg_buff[_msg_buff_data_start+5],    // firmware major version
-                (unsigned)_msg_buff[_msg_buff_data_start+6],    // firmware minor version
-                (unsigned)_msg_buff[_msg_buff_data_start+7]);   // firmware revision
+                (unsigned)_msg_buff[_msg_buff_data_start+6],    // firmware major version
+                (unsigned)_msg_buff[_msg_buff_data_start+5],    // firmware minor version
+                (unsigned)_msg_buff[_msg_buff_data_start+4]);   // firmware revision
 
         // display zoom firmware version
 #if AP_MOUNT_SIYI_DEBUG
         if (_parsed_msg.data_bytes_received >= 12) {
             debug("Mount: SiyiZoom fw:%u.%u.%u",
-                (unsigned)_msg_buff[_msg_buff_data_start+9],      // firmware major version
-                (unsigned)_msg_buff[_msg_buff_data_start+10],     // firmware minor version
-                (unsigned)_msg_buff[_msg_buff_data_start+11]);    // firmware revision
+                (unsigned)_msg_buff[_msg_buff_data_start+10],    // firmware major version
+                (unsigned)_msg_buff[_msg_buff_data_start+9],     // firmware minor version
+                (unsigned)_msg_buff[_msg_buff_data_start+8]);    // firmware revision
         }
 #endif
         break;


### PR DESCRIPTION
This PR includes two fixes for the AP_Mount Siyi driver:

1. add support for the A8 gimbal which uses a shortened firmware version reply message ([discussion](https://discuss.ardupilot.org/t/siyi-a8-mini-4k-ai-mini-zoom-gimbal-camera-ai-identify-tracking-4k-1-1-7-inch-8mp-sony-sensor-6x-zoom/92133/30))
2. fixes a bug in the firmware version banner displayed when the autopilot first connects with the gimbal

This has been successfully tested on real hardware (a CubeOrange with a SiyiA8 attached).  Below is a screen shot of the corrected version display.
![version-display-fix-after](https://user-images.githubusercontent.com/1498098/204441411-4447d0ae-c498-4530-aa1f-2fae960c9fee.png)

I've marked this for backporting to 4.3 because it is a relatively low risk change and I think it is quite important that we support this gimbal.