### PR TITLE
add support for mavlink in-progress message

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -402,9 +402,9 @@ uint8_t GCS_MAVLINK_Tracker::sysid_my_gcs() const
     return tracker.g.sysid_my_gcs;
 }
 
-MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro()
+MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
-    MAV_RESULT ret = GCS_MAVLINK::_handle_command_preflight_calibration_baro();
+    MAV_RESULT ret = GCS_MAVLINK::_handle_command_preflight_calibration_baro(msg);
     if (ret == MAV_RESULT_ACCEPTED) {
         // zero the altitude difference on next baro update
         tracker.nav_status.need_altitude_calibration = true;

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -19,7 +19,7 @@ protected:
     uint8_t sysid_my_gcs() const override;
 
     MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_long_t &packet) override;
-    MAV_RESULT _handle_command_preflight_calibration_baro() override;
+    MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     int32_t global_position_int_relative_alt() const override {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -645,14 +645,14 @@ void GCS_MAVLINK_Copter::handle_landing_target(const mavlink_landing_target_t &p
 #endif
 }
 
-MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     if (is_equal(packet.param6,1.0f)) {
         // compassmot calibration
         return copter.mavlink_compassmot(*this);
     }
 
-    return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
+    return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
 

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -21,7 +21,7 @@ protected:
     bool params_ready() const override;
     void send_banner() override;
 
-    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
 
     void send_attitude_target() override;
     void send_position_target_global_int() override;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -696,10 +696,10 @@ void GCS_MAVLINK_Plane::handle_change_alt_request(AP_Mission::Mission_Command &c
 }
 
 
-MAV_RESULT GCS_MAVLINK_Plane::handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Plane::handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     plane.in_calibration = true;
-    MAV_RESULT ret = GCS_MAVLINK::handle_command_preflight_calibration(packet);
+    MAV_RESULT ret = GCS_MAVLINK::handle_command_preflight_calibration(packet, msg);
     plane.in_calibration = false;
 
     return ret;

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -20,7 +20,7 @@ protected:
     uint8_t sysid_my_gcs() const override;
     bool sysid_enforce() const override;
 
-    MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_do_set_mission_current(const mavlink_command_long_t &packet) override;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -416,7 +416,7 @@ bool GCS_MAVLINK_Sub::handle_guided_request(AP_Mission::Mission_Command &cmd)
     return sub.do_guided(cmd);
 }
 
-MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration_baro()
+MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
     if (sub.motors.armed()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Disarm before calibration.");
@@ -431,7 +431,7 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration_baro()
     return MAV_RESULT_ACCEPTED;
 }
 
-MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     if (is_equal(packet.param6,1.0f)) {
         // compassmot calibration
@@ -440,7 +440,7 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
         return MAV_RESULT_UNSUPPORTED;
     }
 
-    return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
+    return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
 MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -19,8 +19,8 @@ protected:
     uint8_t sysid_my_gcs() const override;
 
     MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
-    MAV_RESULT _handle_command_preflight_calibration_baro() override;
-    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg) override;
+    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     // override sending of scaled_pressure3 to send on-board temperature:

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -417,9 +417,9 @@ void GCS_MAVLINK_Blimp::send_banner()
     send_text(MAV_SEVERITY_INFO, "Frame: %s", blimp.get_frame_string());
 }
 
-MAV_RESULT GCS_MAVLINK_Blimp::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Blimp::_handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
-    return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
+    return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
 

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -21,7 +21,7 @@ protected:
     bool params_ready() const override;
     void send_banner() override;
 
-    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
 
     void send_position_target_global_int() override;
 

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -608,7 +608,7 @@ bool GCS_MAVLINK_Rover::handle_guided_request(AP_Mission::Mission_Command &cmd)
     return rover.mode_guided.set_desired_location(cmd.content.location);
 }
 
-MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     if (is_equal(packet.param6, 1.0f)) {
         if (rover.g2.windvane.start_direction_calibration()) {
@@ -624,7 +624,7 @@ MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlin
         }
     }
 
-    return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
+    return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
 bool GCS_MAVLINK_Rover::set_home_to_current_location(bool _lock) {

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -15,7 +15,7 @@ protected:
     uint8_t sysid_my_gcs() const override;
     bool sysid_enforce() const override;
 
-    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -5746,11 +5746,13 @@ class AutoTest(ABC):
         )
         self.run_cmd_get_ack(command, want_result, timeout, quiet=quiet, mav=mav)
 
-    def run_cmd_get_ack(self, command, want_result, timeout, quiet=False, mav=None):
+    def run_cmd_get_ack(self, command, want_result, timeout, quiet=False, mav=None, ignore_in_progress=None):
         # note that the caller should ensure that this cached
         # timestamp is reasonably up-to-date!
         if mav is None:
             mav = self.mav
+        if ignore_in_progress is None:
+            ignore_in_progress = want_result != mavutil.mavlink.MAV_RESULT_IN_PROGRESS
         tstart = self.get_sim_time_cached()
         while True:
             if mav != self.mav:
@@ -5766,6 +5768,8 @@ class AutoTest(ABC):
             if not quiet:
                 self.progress("ACK received: %s (%fs)" % (str(m), delta_time))
             if m.command == command:
+                if m.result == mavutil.mavlink.MAV_RESULT_IN_PROGRESS and ignore_in_progress:
+                    continue
                 if m.result != want_result:
                     raise ValueError("Expected %s got %s" % (
                         mavutil.mavlink.enums["MAV_RESULT"][want_result].name,
@@ -11928,14 +11932,18 @@ switch value'''
         text = ""
 
         self.context_collect('STATUSTEXT')
-        self.run_cmd(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
-                     0, # p1
-                     0, # p2
-                     1, # p3, baro
-                     0, # p4
-                     0, # p5
-                     0, # p6
-                     0) # p7
+        command = mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION
+        self.send_cmd(command,
+                      0, # p1
+                      0, # p2
+                      1, # p3, baro
+                      0, # p4
+                      0, # p5
+                      0, # p6
+                      0) # p7
+        # this is a test for asynchronous handling of mavlink messages:
+        self.run_cmd_get_ack(command, mavutil.mavlink.MAV_RESULT_IN_PROGRESS, 2)
+        self.run_cmd_get_ack(command, mavutil.mavlink.MAV_RESULT_ACCEPTED, 5)
 
         received_frsky_texts = []
         last_len_received_statustexts = 0

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -893,6 +893,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
 void AP_Airspeed::update() {};
 bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) { return false; }
 void AP_Airspeed::calibrate(bool in_startup) {}
+AP_Airspeed::CalibrationState AP_Airspeed::get_calibration_state() const { return CalibrationState::NOT_STARTED; }
 bool AP_Airspeed::use(uint8_t i) const { return false; }
 bool AP_Airspeed::enabled(uint8_t i) const { return false; }
 bool AP_Airspeed::healthy(uint8_t i) const { return false; }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -201,7 +201,16 @@ public:
 #if AP_AIRSPEED_MSP_ENABLED
     void handle_msp(const MSP::msp_airspeed_data_message_t &pkt);
 #endif
-    
+
+    enum class CalibrationState {
+        NOT_STARTED,
+        IN_PROGRESS,
+        SUCCESS,
+        FAILED
+    };
+    // get aggregate calibration state for the Airspeed library:
+    CalibrationState get_calibration_state() const;
+
 private:
     static AP_Airspeed *_singleton;
 
@@ -216,6 +225,8 @@ private:
     AP_Float _wind_gate;
 
     AP_Airspeed_Params param[AIRSPEED_MAX_SENSORS];
+
+    CalibrationState calibration_state[AIRSPEED_MAX_SENSORS];
 
     struct airspeed_state {
         float   raw_airspeed;

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -296,6 +296,14 @@ bool AP_Filesystem::format(void)
     return false;
 #endif
 }
+AP_Filesystem_Backend::FormatStatus AP_Filesystem::get_format_status(void) const
+{
+#if AP_FILESYSTEM_FORMAT_ENABLED
+    return LOCAL_BACKEND.fs.get_format_status();
+#else
+    return AP_Filesystem_Backend::FormatStatus::NOT_STARTED;
+#endif
+}
 
 namespace AP
 {

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -116,9 +116,12 @@ public:
     // returns null-terminated string; cr or lf terminates line
     bool fgets(char *buf, uint8_t buflen, int fd);
 
-    // format filesystem
+    // format filesystem.  This is async, monitor get_format_status for progress
     bool format(void);
-    
+
+    // retrieve status of format process:
+    AP_Filesystem_Backend::FormatStatus get_format_status() const;
+
     /*
       load a full file. Use delete to free the data
      */

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -862,8 +862,8 @@ bool AP_Filesystem_FATFS::format(void)
     WITH_SEMAPHORE(sem);
     hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&AP_Filesystem_FATFS::format_handler, void));
     // the format is handled asyncronously, we inform user of success
-    // via a text message
-    format_pending = true;
+    // via a text message.  format_status can be polled for progress
+    format_status = FormatStatus::PENDING;
     return true;
 #else
     return false;
@@ -876,11 +876,11 @@ bool AP_Filesystem_FATFS::format(void)
 void AP_Filesystem_FATFS::format_handler(void)
 {
 #if FF_USE_MKFS
-    if (!format_pending) {
+    if (format_status != FormatStatus::PENDING) {
         return;
     }
     WITH_SEMAPHORE(sem);
-    format_pending = false;
+    format_status = FormatStatus::IN_PROGRESS;
     GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Formatting SDCard");
     uint8_t *buf = (uint8_t *)hal.util->malloc_type(FF_MAX_SS, AP_HAL::Util::MEM_DMA_SAFE);
     if (buf == nullptr) {
@@ -890,13 +890,22 @@ void AP_Filesystem_FATFS::format_handler(void)
     auto ret = f_mkfs("0:", 0, buf, FF_MAX_SS);
     hal.util->free_type(buf, FF_MAX_SS, AP_HAL::Util::MEM_DMA_SAFE);
     if (ret == FR_OK) {
+        format_status = FormatStatus::SUCCESS;
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Format: OK");
     } else {
+        format_status = FormatStatus::FAILURE;
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Format: Failed (%d)", int(ret));
     }
     sdcard_stop();
     sdcard_retry();
 #endif
+}
+
+// returns true if we are currently formatting the SD card:
+AP_Filesystem_Backend::FormatStatus AP_Filesystem_FATFS::get_format_status(void) const
+{
+    // note that format_handler holds sem, so we can't take it here.
+    return format_status;
 }
 
 /*

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -48,10 +48,11 @@ public:
     // unmount filesystem for reboot
     void unmount(void) override;
 
-    // format sdcard
+    // format sdcard.  This is async, monitor get_format_status for progress
     bool format(void) override;
+    AP_Filesystem_Backend::FormatStatus get_format_status() const override;
 
 private:
     void format_handler(void);
-    bool format_pending;
+    FormatStatus format_status;
 };

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -73,9 +73,18 @@ public:
     // unmount filesystem for reboot
     virtual void unmount(void) {}
 
-    // format sdcard
+    enum class FormatStatus {
+        NOT_STARTED,
+        PENDING,
+        IN_PROGRESS,
+        SUCCESS,
+        FAILURE,
+    };
+
+    // format sdcard.  This is async, monitor get_format_status for progress
     virtual bool format(void) { return false; }
-    
+    virtual AP_Filesystem_Backend::FormatStatus get_format_status() const { return FormatStatus::NOT_STARTED; }
+
     /*
       load a full file. Use delete to free the data
      */

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -157,11 +157,14 @@ public:
     enum class Type {
         NONE,
         AIRSPEED_CAL,
+        SD_FORMAT,
     };
 
     // these can fail if there's no space on the channel to send the ack:
     bool conclude(MAV_RESULT result);
     bool send_in_progress();
+    // abort task without sending any further ACKs:
+    void abort() { task = Type::NONE; }
 
     Type task;
     MAV_CMD mav_cmd;
@@ -511,6 +514,7 @@ protected:
     virtual MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_set_home(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_aux_function(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
     void handle_mission_request_list(const mavlink_message_t &msg);
     void handle_mission_request(const mavlink_message_t &msg) const;
     void handle_mission_request_int(const mavlink_message_t &msg) const;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -151,6 +151,39 @@ private:
 };
 #endif
 
+class GCS_MAVLINK_InProgress
+{
+public:
+    enum class Type {
+        NONE,
+        AIRSPEED_CAL,
+    };
+
+    // these can fail if there's no space on the channel to send the ack:
+    bool conclude(MAV_RESULT result);
+    bool send_in_progress();
+
+    Type task;
+    MAV_CMD mav_cmd;
+
+    static class GCS_MAVLINK_InProgress *get_task(MAV_CMD cmd, Type t, uint8_t sysid, uint8_t compid);
+
+    static void check_tasks();
+
+private:
+
+    uint8_t requesting_sysid;
+    uint8_t requesting_compid;
+    mavlink_channel_t chan;
+
+    bool send_ack(MAV_RESULT result);
+
+    static GCS_MAVLINK_InProgress in_progress_tasks[1];
+
+    // allocate a task-tracking ID
+    static uint32_t last_check_ms;
+};
+
 ///
 /// @class	GCS_MAVLINK
 /// @brief	MAVLink transport control class
@@ -571,10 +604,10 @@ protected:
 
     // generally this should not be overridden; Plane overrides it to ensure
     // failsafe isn't triggered during calibration
-    virtual MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
 
-    virtual MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet);
-    virtual MAV_RESULT _handle_command_preflight_calibration_baro();
+    virtual MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
+    virtual MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg);
 
     MAV_RESULT handle_command_preflight_can(const mavlink_command_long_t &packet);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -105,6 +105,9 @@ uint8_t GCS_MAVLINK::mavlink_private = 0;
 
 GCS *GCS::_singleton = nullptr;
 
+GCS_MAVLINK_InProgress GCS_MAVLINK_InProgress::in_progress_tasks[1];
+uint32_t GCS_MAVLINK_InProgress::last_check_ms;
+
 GCS_MAVLINK::GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters,
                          AP_HAL::UARTDriver &uart)
 {
@@ -1214,6 +1217,108 @@ int8_t GCS_MAVLINK::deferred_message_to_send_index(uint16_t now16_ms)
     return next_deferred_message_to_send_cache;
 }
 
+bool GCS_MAVLINK_InProgress::send_ack(MAV_RESULT result)
+{
+    if (!HAVE_PAYLOAD_SPACE(chan, COMMAND_ACK)) {
+        // can't fit the ACK, come back to this later
+        return false;
+    }
+
+    mavlink_msg_command_ack_send(
+        chan,
+        mav_cmd,
+        result,
+        0,
+        0,
+        requesting_sysid,
+        requesting_compid
+        );
+
+    return true;
+}
+
+bool GCS_MAVLINK_InProgress::send_in_progress()
+{
+    return send_ack(MAV_RESULT_IN_PROGRESS);
+}
+
+bool GCS_MAVLINK_InProgress::conclude(MAV_RESULT result)
+{
+    if (!send_ack(result)) {
+        return false;
+    }
+    task = Type::NONE;
+    return true;
+}
+
+GCS_MAVLINK_InProgress *GCS_MAVLINK_InProgress::get_task(MAV_CMD mav_cmd, GCS_MAVLINK_InProgress::Type t, uint8_t sysid, uint8_t compid)
+{
+    // we can't have two outstanding tasks for the same command from
+    // the same mavlink node or the result is ambiguous:
+    for (auto &_task : in_progress_tasks) {
+        if (_task.task == Type::NONE) {
+            continue;
+        }
+        if (_task.mav_cmd == mav_cmd &&
+            _task.requesting_sysid == sysid &&
+            _task.requesting_compid == compid) {
+            return nullptr;
+        }
+    }
+
+    for (auto &_task : in_progress_tasks) {
+        if (_task.task != Type::NONE) {
+            continue;
+        }
+        _task.task = t;
+        _task.mav_cmd = mav_cmd;
+        _task.requesting_sysid = sysid;
+        _task.requesting_compid = compid;
+        return &_task;
+    }
+    return nullptr;
+}
+
+
+void GCS_MAVLINK_InProgress::check_tasks()
+{
+    // run these checks only intermittently (rate-limits the
+    // MAV_RESULT_IN_PROGRESS messages):
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_check_ms < 1000) {
+        return;
+    }
+    last_check_ms = now_ms;
+
+    for (auto &task : in_progress_tasks) {
+        switch (task.task) {
+        case Type::NONE:
+            break;
+        case Type::AIRSPEED_CAL: {
+#if AP_AIRSPEED_ENABLED
+            const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+            switch (airspeed->get_calibration_state()) {
+            case AP_Airspeed::CalibrationState::NOT_STARTED:
+                // we shouldn't get here
+                task.conclude(MAV_RESULT_FAILED);
+                break;
+            case AP_Airspeed::CalibrationState::IN_PROGRESS:
+                task.send_in_progress();
+                break;
+            case AP_Airspeed::CalibrationState::FAILED:
+                task.conclude(MAV_RESULT_FAILED);
+                break;
+            case AP_Airspeed::CalibrationState::SUCCESS:
+                task.conclude(MAV_RESULT_ACCEPTED);
+                break;
+            }
+#endif
+            break;
+        }
+        }
+    }
+}
+
 void GCS_MAVLINK::update_send()
 {
 #if !defined(HAL_BUILD_AP_PERIPH) || HAL_LOGGING_ENABLED
@@ -1234,6 +1339,9 @@ void GCS_MAVLINK::update_send()
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
     uint32_t retry_deferred_body_start = AP_HAL::micros();
 #endif
+
+    // check for any in-progress tasks; check_tasks does its own rate-limiting
+    GCS_MAVLINK_InProgress::check_tasks();
 
     const uint32_t start = AP_HAL::millis();
     const uint16_t start16 = start & 0xFFFF;
@@ -4122,7 +4230,7 @@ bool GCS_MAVLINK::calibrate_gyros()
 #endif
 }
 
-MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro()
+MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
     // fast barometer calibration
     gcs().send_text(MAV_SEVERITY_INFO, "Updating barometer calibration");
@@ -4130,16 +4238,21 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro()
     gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 
 #if AP_AIRSPEED_ENABLED
+
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed != nullptr) {
+        GCS_MAVLINK_InProgress *task = GCS_MAVLINK_InProgress::get_task(MAV_CMD_PREFLIGHT_CALIBRATION, GCS_MAVLINK_InProgress::Type::AIRSPEED_CAL, msg.sysid, msg.compid);
+        if (task == nullptr) {
+            return MAV_RESULT_TEMPORARILY_REJECTED;
+        }
         airspeed->calibrate(false);
     }
 #endif
 
-    return MAV_RESULT_ACCEPTED;
+    return MAV_RESULT_IN_PROGRESS;
 }
 
-MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     MAV_RESULT ret = MAV_RESULT_UNSUPPORTED;
 
@@ -4152,7 +4265,7 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
     }
 
     if (is_equal(packet.param3,1.0f)) {
-        return _handle_command_preflight_calibration_baro();
+        return _handle_command_preflight_calibration_baro(msg);
     }
 
     rc().calibrating(is_positive(packet.param4));
@@ -4224,7 +4337,7 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
     return ret;
 }
 
-MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
 {
     if (hal.util->get_soft_armed()) {
         // *preflight*, remember?
@@ -4232,7 +4345,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_comma
         return MAV_RESULT_FAILED;
     }
     // now call subclass methods:
-    return _handle_command_preflight_calibration(packet);
+    return _handle_command_preflight_calibration(packet, msg);
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_run_prearm_checks(const mavlink_command_long_t &packet)
@@ -4629,11 +4742,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         result = handle_command_do_set_roi(packet);
         break;
 
-    case MAV_CMD_PREFLIGHT_CALIBRATION:
-        result = handle_command_preflight_calibration(packet);
-        break;
-
-
     case MAV_CMD_DO_SET_MISSION_CURRENT:
         result = handle_command_do_set_mission_current(packet);
         break;
@@ -4821,6 +4929,10 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
 
     case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
         result = handle_preflight_reboot(packet, msg);
+        break;
+
+    case MAV_CMD_PREFLIGHT_CALIBRATION:
+        result = handle_command_preflight_calibration(packet, msg);
         break;
 
     default:


### PR DESCRIPTION
```
MANUAL> Got COMMAND_ACK: PREFLIGHT_CALIBRATION: IN_PROGRESS
Calibration response (5)
AP: Updating barometer calibration
AP: Barometer calibration complete
AP: Airspeed 1 calibration started
AP: GPS 1: detected as u-blox at 230400 baud
Got COMMAND_ACK: PREFLIGHT_CALIBRATION: IN_PROGRESS
Calibration response (5)
AP: EKF2 IMU0 MAG0 initial yaw alignment complete
AP: EKF2 IMU1 MAG0 initial yaw alignment complete
Got COMMAND_ACK: PREFLIGHT_CALIBRATION: IN_PROGRESS
Calibration response (5)
AP: EKF3 IMU0 initialised
AP: EKF3 IMU1 initialised
AP: Airspeed 1 calibrated
Got COMMAND_ACK: PREFLIGHT_CALIBRATION: ACCEPTED
Calibrated
AP: EKF3 IMU0 tilt alignment complete
AP: EKF3 IMU1 tilt alignment complete
AP: EKF3 IMU0 MAG0 initial yaw alignment complete
AP: EKF3 IMU1 MAG0 initial yaw alignment complete
```
