### PR TITLE
EFI: added LUA binding for MAVLink EFI messages

### DIFF
--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -23,6 +23,7 @@
 #include "AP_EFI_DroneCAN.h"
 #include "AP_EFI_Currawong_ECU.h"
 #include "AP_EFI_Scripting.h"
+#include "AP_EFI_MAV.h"
 
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
@@ -38,7 +39,7 @@ const AP_Param::GroupInfo AP_EFI::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: EFI communication type
     // @Description: What method of communication is used for EFI #1
-    // @Values: 0:None,1:Serial-MS,2:NWPMU,3:Serial-Lutan,5:DroneCAN,6:Currawong-ECU,7:Scripting
+    // @Values: 0:None,1:Serial-MS,2:NWPMU,3:Serial-Lutan,5:DroneCAN,6:Currawong-ECU,7:Scripting,8:MAV
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("_TYPE", 1, AP_EFI, type, 0, AP_PARAM_FLAG_ENABLE),
@@ -112,6 +113,9 @@ void AP_EFI::init(void)
 #if AP_EFI_SCRIPTING_ENABLED
         backend = new AP_EFI_Scripting(*this);
 #endif
+        break;
+    case Type::MAV:
+        backend = new AP_EFI_MAV(*this);
         break;
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unknown EFI type");
@@ -275,6 +279,12 @@ void AP_EFI::get_state(EFI_State &_state)
 {
     WITH_SEMAPHORE(sem);
     _state = state;
+}
+
+void AP_EFI::handle_EFI_message(const mavlink_message_t &msg) {
+    if (backend) {
+        backend->handle_EFI_message(msg);
+    }
 }
 
 namespace AP {

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -84,6 +84,7 @@ public:
         DroneCAN = 5,
         CurrawongECU = 6,
         SCRIPTING  = 7,
+        MAV = 8,
     };
 
     static AP_EFI *get_singleton(void) {
@@ -96,6 +97,8 @@ public:
 #if AP_SCRIPTING_ENABLED
     AP_EFI_Backend* get_backend(uint8_t idx) { return idx==0?backend:nullptr; }
 #endif
+
+    void handle_EFI_message(const mavlink_message_t &msg);
 
 protected:
 

--- a/libraries/AP_EFI/AP_EFI_Backend.h
+++ b/libraries/AP_EFI/AP_EFI_Backend.h
@@ -17,6 +17,7 @@
 #include "AP_EFI.h"
 #include "AP_EFI_State.h"
 #include <AP_HAL/Semaphores.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_EFI; //forward declaration
 
@@ -30,6 +31,8 @@ public:
 
     // Update the state structure
     virtual void update() = 0;
+
+    virtual void handle_EFI_message(const mavlink_message_t &msg) {};
 
 #if AP_SCRIPTING_ENABLED
     virtual bool handle_scripting(const EFI_State &efi_state) { return false; }

--- a/libraries/AP_EFI/AP_EFI_MAV.cpp
+++ b/libraries/AP_EFI/AP_EFI_MAV.cpp
@@ -1,0 +1,49 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_EFI_MAV.h"
+#include <AP_Math/AP_Math.h>
+
+AP_EFI_MAV::AP_EFI_MAV(AP_EFI &_frontend) :  AP_EFI_Backend(_frontend) {
+    //Nothing to do here
+}
+
+//Called from frontend to update with the readings received by handler
+void AP_EFI_MAV::update() {
+    copy_to_frontend();
+}
+
+//Decode MavLink message
+void AP_EFI_MAV::handle_EFI_message(const mavlink_message_t &msg) {
+    mavlink_efi_status_t state;
+    mavlink_msg_efi_status_decode(&msg, &state);
+
+    internal_state.ecu_index = state.ecu_index;
+    //internal_state.??? = state.rpm;
+    //internal_state.??? = state.fuel_consumed;
+    //internal_state.??? = state.fuel_flow;
+    internal_state.engine_load_percent = state.engine_load;
+    internal_state.throttle_position_percent = state.throttle_position;
+    internal_state.spark_dwell_time_ms = state.spark_dwell_time;
+    //internal_state.??? = state.barometric_pressure;
+    internal_state.intake_manifold_pressure_kpa = state.intake_manifold_pressure;
+    internal_state.intake_manifold_temperature = C_TO_KELVIN(state.intake_manifold_temperature);
+    internal_state.cylinder_status.cylinder_head_temperature = C_TO_KELVIN(state.cylinder_head_temperature);
+    internal_state.cylinder_status.ignition_timing_deg = state.ignition_timing;
+    internal_state.cylinder_status.injection_time_ms = state.injection_time;
+    internal_state.cylinder_status.exhaust_gas_temperature = C_TO_KELVIN(state.exhaust_gas_temperature);
+    internal_state.throttle_out = state.throttle_out;
+    internal_state.pt_compensation = state.pt_compensation;
+    //internal_state.??? = state.health;
+    internal_state.ignition_voltage = state.ignition_voltage;
+}

--- a/libraries/AP_EFI/AP_EFI_MAV.h
+++ b/libraries/AP_EFI/AP_EFI_MAV.h
@@ -1,0 +1,26 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "AP_EFI.h"
+#include "AP_EFI_Backend.h"
+
+class AP_EFI_MAV : public AP_EFI_Backend {
+public:
+    AP_EFI_MAV(AP_EFI &_frontend);
+
+    void update() override;
+
+    void handle_EFI_message(const mavlink_message_t &msg) override;
+};

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3,84 +3,46 @@
 -- generate with --scripting-docs, eg  ./waf copter --scripting-docs
 -- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations
 
--- set and get for field types share function names
----@diagnostic disable: duplicate-set-field
-
--- manual bindings
-
+-- desc
 ---@class uint32_t_ud
 local uint32_t_ud = {}
 
--- create uint32_t_ud with optional value
----@param value? number|integer
 ---@return uint32_t_ud
-function uint32_t(value) end
+function uint32_t(param1) end
 
--- Convert to number
----@return number
+-- desc
 function uint32_t_ud:tofloat() end
 
--- Convert to integer
----@return integer
+-- desc
 function uint32_t_ud:toint() end
 
--- system time in milliseconds
----@return uint32_t_ud -- milliseconds
-function millis() end
 
--- system time in microseconds
----@return uint32_t_ud -- microseconds
-function micros() end
-
--- receive mission command from running mission
----@return uint32_t_ud|nil -- command start time milliseconds
----@return integer|nil -- command param 1
----@return number|nil -- command param 2
----@return number|nil -- command param 3
----@return number|nil -- command param 4
-function mission_receive() end
-
-
--- data flash logging to SD card
----@class logger
-logger = {}
-
--- write value to data flash log with given types and names, optional units and multipliers, timestamp will be automatically added
----@param name string -- up to 4 characters
----@param labels string -- comma separated value labels, up to 58 characters
----@param format string -- type format string, see https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Logger/README.md
----@param units? string -- optional units string
----@param multipliers? string -- optional multipliers string
----@param data1 integer|number|uint32_t_ud|string -- data to be logged, type to match format string
-function logger:write(name, labels, format, units, multipliers, data1, ...) end
-
-
--- i2c bus interaction
----@class i2c
-i2c = {}
-
--- get a i2c device handler
----@param bus integer -- bus number
----@param address integer -- device address 0 to 128
----@param clock? uint32_t_ud -- optional bus clock, default 400000
----@param smbus? boolean -- optional sumbus flag, default false
----@return AP_HAL__I2CDevice_ud
-function i2c:get_device(bus, address, clock, smbus) end
-
--- EFI state structure
+-- desc
 ---@class EFI_State_ud
 local EFI_State_ud = {}
 
 ---@return EFI_State_ud
 function EFI_State() end
 
+-- get field
+---@return number
+function EFI_State_ud:pt_compensation() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:pt_compensation(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:throttle_out() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:throttle_out(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:ignition_voltage() end
 
 -- set field
 ---@param value number
@@ -90,122 +52,182 @@ function EFI_State_ud:ignition_voltage(value) end
 ---@param value Cylinder_Status_ud
 function EFI_State_ud:cylinder_status(value) end
 
+-- get field
+---@return integer
+function EFI_State_ud:ecu_index() end
+
 -- set field
 ---@param value integer
 function EFI_State_ud:ecu_index(value) end
+
+-- get field
+---@return integer
+function EFI_State_ud:throttle_position_percent() end
 
 -- set field
 ---@param value integer
 function EFI_State_ud:throttle_position_percent(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:estimated_consumed_fuel_volume_cm3() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:estimated_consumed_fuel_volume_cm3(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:fuel_consumption_rate_cm3pm() end
 
 -- set field
 ---@param value number
 function EFI_State_ud:fuel_consumption_rate_cm3pm(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:fuel_pressure() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:fuel_pressure(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:oil_temperature() end
 
 -- set field
 ---@param value number
 function EFI_State_ud:oil_temperature(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:oil_pressure() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:oil_pressure(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:coolant_temperature() end
 
 -- set field
 ---@param value number
 function EFI_State_ud:coolant_temperature(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:intake_manifold_temperature() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:intake_manifold_temperature(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:intake_manifold_pressure_kpa() end
 
 -- set field
 ---@param value number
 function EFI_State_ud:intake_manifold_pressure_kpa(value) end
 
+-- get field
+---@return number
+function EFI_State_ud:atmospheric_pressure_kpa() end
+
 -- set field
 ---@param value number
 function EFI_State_ud:atmospheric_pressure_kpa(value) end
+
+-- get field
+---@return number
+function EFI_State_ud:spark_dwell_time_ms() end
 
 -- set field
 ---@param value number
 function EFI_State_ud:spark_dwell_time_ms(value) end
 
+-- get field
+---@return uint32_t_ud
+function EFI_State_ud:engine_speed_rpm() end
+
 -- set field
 ---@param value uint32_t_ud
 function EFI_State_ud:engine_speed_rpm(value) end
+
+-- get field
+---@return integer
+function EFI_State_ud:engine_load_percent() end
 
 -- set field
 ---@param value integer
 function EFI_State_ud:engine_load_percent(value) end
 
+-- get field
+---@return boolean
+function EFI_State_ud:general_error() end
+
 -- set field
 ---@param value boolean
 function EFI_State_ud:general_error(value) end
+
+-- get field
+---@return uint32_t_ud
+function EFI_State_ud:last_updated_ms() end
 
 -- set field
 ---@param value uint32_t_ud
 function EFI_State_ud:last_updated_ms(value) end
 
 
--- EFI Cylinder_Status structure
+-- desc
 ---@class Cylinder_Status_ud
 local Cylinder_Status_ud = {}
 
 ---@return Cylinder_Status_ud
 function Cylinder_Status() end
 
+-- get field
+---@return number
+function Cylinder_Status_ud:lambda_coefficient() end
+
 -- set field
 ---@param value number
 function Cylinder_Status_ud:lambda_coefficient(value) end
+
+-- get field
+---@return number
+function Cylinder_Status_ud:exhaust_gas_temperature() end
 
 -- set field
 ---@param value number
 function Cylinder_Status_ud:exhaust_gas_temperature(value) end
 
+-- get field
+---@return number
+function Cylinder_Status_ud:cylinder_head_temperature() end
+
 -- set field
 ---@param value number
 function Cylinder_Status_ud:cylinder_head_temperature(value) end
+
+-- get field
+---@return number
+function Cylinder_Status_ud:injection_time_ms() end
 
 -- set field
 ---@param value number
 function Cylinder_Status_ud:injection_time_ms(value) end
 
+-- get field
+---@return number
+function Cylinder_Status_ud:ignition_timing_deg() end
+
 -- set field
 ---@param value number
 function Cylinder_Status_ud:ignition_timing_deg(value) end
 
--- desc
----@class efi
-efi = {}
-
--- desc
----@param instance integer
----@return AP_EFI_Backend_ud
-function efi:get_backend(instance) end
-
--- CAN bus interaction
----@class CAN
-CAN = {}
-
--- get a CAN bus device handler first scripting driver
----@param buffer_len uint32_t_ud -- buffer length 1 to 25
----@return ScriptingCANBuffer_ud
-function CAN:get_device(buffer_len) end
-
--- get a CAN bus device handler second scripting driver
----@param buffer_len uint32_t_ud -- buffer length 1 to 25
----@return ScriptingCANBuffer_ud
-function CAN:get_device2(buffer_len) end
-
--- Auto generated binding
 
 -- desc
 ---@class CANFrame_ud
@@ -255,6 +277,7 @@ function CANFrame_ud:isExtended() end
 -- desc
 ---@return integer
 function CANFrame_ud:id_signed() end
+
 
 -- desc
 ---@class motor_factor_table_ud
@@ -320,9 +343,9 @@ function PWMSource_ud:get_pwm_avg_us() end
 function PWMSource_ud:get_pwm_us() end
 
 -- desc
----@param pin_number integer
+---@param param1 integer
 ---@return boolean
-function PWMSource_ud:set_pin(pin_number) end
+function PWMSource_ud:set_pin(param1) end
 
 
 -- desc
@@ -426,184 +449,43 @@ function mavlink_mission_item_int_t_ud:param1(value) end
 local Parameter_ud = {}
 
 ---@return Parameter_ud
----@param name? string
-function Parameter(name) end
+function Parameter(param1) end
 
 -- desc
----@param value number
+---@param param1 number
 ---@return boolean
-function Parameter_ud:set_default(value) end
+function Parameter_ud:set_default(param1) end
 
 -- desc
 ---@return boolean
 function Parameter_ud:configured() end
 
 -- desc
----@param value number
+---@param param1 number
 ---@return boolean
-function Parameter_ud:set_and_save(value) end
+function Parameter_ud:set_and_save(param1) end
 
 -- desc
----@param value number
+---@param param1 number
 ---@return boolean
-function Parameter_ud:set(value) end
+function Parameter_ud:set(param1) end
 
 -- desc
 ---@return number|nil
 function Parameter_ud:get() end
 
 -- desc
----@param key integer
----@param group_element uint32_t_ud
----@param type integer
----| '1' # AP_PARAM_INT8
----| '2' # AP_PARAM_INT16
----| '3' # AP_PARAM_INT32
----| '4' # AP_PARAM_FLOAT
+---@param param1 integer
+---@param param2 uint32_t_ud
+---@param param3 integer
 ---@return boolean
-function Parameter_ud:init_by_info(key, group_element, type) end
+function Parameter_ud:init_by_info(param1, param2, param3) end
 
 -- desc
----@param name string
+---@param param1 string
 ---@return boolean
-function Parameter_ud:init(name) end
+function Parameter_ud:init(param1) end
 
-
--- desc
----@class Vector2f_ud
-local Vector2f_ud = {}
-
----@return Vector2f_ud
-function Vector2f() end
-
--- copy
----@return Vector2f_ud
-function Vector2f_ud:copy() end
-
--- get field
----@return number
-function Vector2f_ud:y() end
-
--- set field
----@param value number
-function Vector2f_ud:y(value) end
-
--- get field
----@return number
-function Vector2f_ud:x() end
-
--- set field
----@param value number
-function Vector2f_ud:x(value) end
-
--- desc
----@param angle_rad number
-function Vector2f_ud:rotate(angle_rad) end
-
--- desc
----@return boolean
-function Vector2f_ud:is_zero() end
-
--- desc
----@return boolean
-function Vector2f_ud:is_inf() end
-
--- desc
----@return boolean
-function Vector2f_ud:is_nan() end
-
--- desc
-function Vector2f_ud:normalize() end
-
--- desc
----@return number
-function Vector2f_ud:length() end
-
--- desc
----@return number
-function Vector2f_ud:angle() end
-
--- desc
----@class Vector3f_ud
-local Vector3f_ud = {}
-
----@return Vector3f_ud
-function Vector3f() end
-
--- copy
----@return Vector3f_ud
-function Vector3f_ud:copy() end
-
--- get field
----@return number
-function Vector3f_ud:z() end
-
--- set field
----@param value number
-function Vector3f_ud:z(value) end
-
--- get field
----@return number
-function Vector3f_ud:y() end
-
--- set field
----@param value number
-function Vector3f_ud:y(value) end
-
--- get field
----@return number
-function Vector3f_ud:x() end
-
--- set field
----@param value number
-function Vector3f_ud:x(value) end
-
--- desc
----@param scale_factor number
----@return Vector3f_ud
-function Vector3f_ud:scale(scale_factor) end
-
--- desc
----@param vector Vector3f_ud
----@return Vector3f_ud
-function Vector3f_ud:cross(vector) end
-
--- desc
----@param vector Vector3f_ud
----@return number
-function Vector3f_ud:dot(vector) end
-
--- desc
----@return boolean
-function Vector3f_ud:is_zero() end
-
--- desc
----@return boolean
-function Vector3f_ud:is_inf() end
-
--- desc
----@return boolean
-function Vector3f_ud:is_nan() end
-
--- desc
-function Vector3f_ud:normalize() end
-
--- desc
----@return number
-function Vector3f_ud:length() end
-
--- Computes angle between this vector and vector v2
----@param v2 Vector3f_ud 
----@return number
-function Vector3f_ud:angle(v2) end
-
--- desc
----@param param1 number -- XY rotation in radians
-function Vector3f_ud:rotate_xy(param1) end
-
--- desc
----@return Vector2f_ud
-function Vector3f_ud:xy() end
 
 -- desc
 ---@class Quaternion_ud
@@ -644,52 +526,191 @@ function Quaternion_ud:q1() end
 ---@param value number
 function Quaternion_ud:q1(value) end
 
--- Applies rotation to vector argument
----@param vec Vector3f_ud
-function Quaternion_ud:earth_to_body(vec) end
+-- desc
+---@param param1 Vector3f_ud
+---@param param2 number
+function Quaternion_ud:from_angular_velocity(param1, param2) end
 
--- Returns inverse of quaternion
+-- desc
+---@param param1 Vector3f_ud
+---@param param2 number
+function Quaternion_ud:from_axis_angle(param1, param2) end
+
+-- desc
+---@param param1 Vector3f_ud
+function Quaternion_ud:to_axis_angle(param1) end
+
+-- desc
+---@param param1 Vector3f_ud
+function Quaternion_ud:earth_to_body(param1) end
+
+-- desc
 ---@return Quaternion_ud
 function Quaternion_ud:inverse() end
 
--- Integrates angular velocity over small time delta
----@param angular_velocity Vector3f_ud
----@param time_delta number
-function Quaternion_ud:from_angular_velocity(angular_velocity, time_delta) end
+-- desc
+---@param param1 number
+---@param param2 number
+---@param param3 number
+function Quaternion_ud:from_euler(param1, param2, param3) end
 
--- Constructs Quaternion from axis and angle
----@param axis Vector3f_ud
----@param angle number
-function Quaternion_ud:from_axis_angle(axis, angle) end
-
--- Converts Quaternion to axis-angle representation
----@param axis_angle Vector3f_ud
-function Quaternion_ud:to_axis_angle(axis_angle) end
-
--- Construct quaternion from Euler angles
----@param roll number
----@param pitch number
----@param yaw number
-function Quaternion_ud:from_euler(roll, pitch, yaw) end
-
--- Returns yaw component of quaternion
+-- desc
 ---@return number
 function Quaternion_ud:get_euler_yaw() end
 
--- Returns pitch component of quaternion
+-- desc
 ---@return number
 function Quaternion_ud:get_euler_pitch() end
 
--- Returns roll component of quaternion
+-- desc
 ---@return number
 function Quaternion_ud:get_euler_roll() end
 
--- Mutates quaternion have length 1
+-- desc
 function Quaternion_ud:normalize() end
 
--- Returns length or norm of quaternion
+-- desc
 ---@return number
 function Quaternion_ud:length() end
+
+
+-- desc
+---@class Vector2f_ud
+local Vector2f_ud = {}
+
+---@return Vector2f_ud
+function Vector2f() end
+
+-- get field
+---@return number
+function Vector2f_ud:y() end
+
+-- set field
+---@param value number
+function Vector2f_ud:y(value) end
+
+-- get field
+---@return number
+function Vector2f_ud:x() end
+
+-- set field
+---@param value number
+function Vector2f_ud:x(value) end
+
+-- desc
+---@return Vector2f_ud
+function Vector2f_ud:copy() end
+
+-- desc
+---@param param1 number
+function Vector2f_ud:rotate(param1) end
+
+-- desc
+---@return number
+function Vector2f_ud:angle() end
+
+-- desc
+---@return boolean
+function Vector2f_ud:is_zero() end
+
+-- desc
+---@return boolean
+function Vector2f_ud:is_inf() end
+
+-- desc
+---@return boolean
+function Vector2f_ud:is_nan() end
+
+-- desc
+function Vector2f_ud:normalize() end
+
+-- desc
+---@return number
+function Vector2f_ud:length() end
+
+
+-- desc
+---@class Vector3f_ud
+local Vector3f_ud = {}
+
+---@return Vector3f_ud
+function Vector3f() end
+
+-- get field
+---@return number
+function Vector3f_ud:z() end
+
+-- set field
+---@param value number
+function Vector3f_ud:z(value) end
+
+-- get field
+---@return number
+function Vector3f_ud:y() end
+
+-- set field
+---@param value number
+function Vector3f_ud:y(value) end
+
+-- get field
+---@return number
+function Vector3f_ud:x() end
+
+-- set field
+---@param value number
+function Vector3f_ud:x(value) end
+
+-- desc
+---@param param1 Vector3f_ud
+---@return number
+function Vector3f_ud:angle(param1) end
+
+-- desc
+---@param param1 number
+function Vector3f_ud:rotate_xy(param1) end
+
+-- desc
+---@return Vector2f_ud
+function Vector3f_ud:xy() end
+
+-- desc
+---@return Vector3f_ud
+function Vector3f_ud:copy() end
+
+-- desc
+---@param param1 number
+---@return Vector3f_ud
+function Vector3f_ud:scale(param1) end
+
+-- desc
+---@param param1 Vector3f_ud
+---@return Vector3f_ud
+function Vector3f_ud:cross(param1) end
+
+-- desc
+---@param param1 Vector3f_ud
+---@return number
+function Vector3f_ud:dot(param1) end
+
+-- desc
+---@return boolean
+function Vector3f_ud:is_zero() end
+
+-- desc
+---@return boolean
+function Vector3f_ud:is_inf() end
+
+-- desc
+---@return boolean
+function Vector3f_ud:is_nan() end
+
+-- desc
+function Vector3f_ud:normalize() end
+
+-- desc
+---@return number
+function Vector3f_ud:length() end
+
 
 -- desc
 ---@class Location_ud
@@ -697,10 +718,6 @@ local Location_ud = {}
 
 ---@return Location_ud
 function Location() end
-
--- copy
----@return Location_ud
-function Location_ud:copy() end
 
 -- get field
 ---@return boolean
@@ -758,71 +775,69 @@ function Location_ud:lat() end
 ---@param value integer
 function Location_ud:lat(value) end
 
--- get altitude frame
+-- desc
+---@return Location_ud
+function Location_ud:copy() end
+
+-- desc
+---@param param1 integer
+---@return boolean
+function Location_ud:change_alt_frame(param1) end
+
+-- desc
 ---@return integer
----| '0' # ABSOLUTE
----| '1' # ABOVE_HOME
----| '2' # ABOVE_ORIGIN
----| '3' # ABOVE_TERRAIN
 function Location_ud:get_alt_frame() end
 
 -- desc
----@param desired_frame integer
----| '0' # ABSOLUTE
----| '1' # ABOVE_HOME
----| '2' # ABOVE_ORIGIN
----| '3' # ABOVE_TERRAIN
----@return boolean
-function Location_ud:change_alt_frame(desired_frame) end
-
--- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return Vector2f_ud
-function Location_ud:get_distance_NE(loc) end
+function Location_ud:get_distance_NE(param1) end
 
 -- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return Vector3f_ud
-function Location_ud:get_distance_NED(loc) end
+function Location_ud:get_distance_NED(param1) end
 
 -- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return number
-function Location_ud:get_bearing(loc) end
+function Location_ud:get_bearing(param1) end
 
 -- desc
 ---@return Vector3f_ud|nil
 function Location_ud:get_vector_from_origin_NEU() end
 
 -- desc
----@param bearing_deg number
----@param distance number
-function Location_ud:offset_bearing(bearing_deg, distance) end
+---@param param1 number
+---@param param2 number
+---@param param3 number
+function Location_ud:offset_bearing_and_pitch(param1, param2, param3) end
 
 -- desc
----@param bearing_deg number
----@param pitch_deg number
----@param distance number
-function Location_ud:offset_bearing_and_pitch(bearing_deg, pitch_deg, distance) end
+---@param param1 number
+---@param param2 number
+function Location_ud:offset_bearing(param1, param2) end
 
 -- desc
----@param ofs_north number
----@param ofs_east number
-function Location_ud:offset(ofs_north, ofs_east) end
+---@param param1 number
+---@param param2 number
+function Location_ud:offset(param1, param2) end
 
 -- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return number
-function Location_ud:get_distance(loc) end
+function Location_ud:get_distance(param1) end
+
 
 -- desc
 ---@class AP_EFI_Backend_ud
 local AP_EFI_Backend_ud = {}
 
 -- desc
----@param state EFI_State_ud
+---@param param1 EFI_State_ud
 ---@return boolean
-function AP_EFI_Backend_ud:handle_scripting(state) end
+function AP_EFI_Backend_ud:handle_scripting(param1) end
+
 
 -- desc
 ---@class ScriptingCANBuffer_ud
@@ -833,10 +848,10 @@ local ScriptingCANBuffer_ud = {}
 function ScriptingCANBuffer_ud:read_frame() end
 
 -- desc
----@param frame CANFrame_ud
----@param timeout_us uint32_t_ud
+---@param param1 CANFrame_ud
+---@param param2 uint32_t_ud
 ---@return boolean
-function ScriptingCANBuffer_ud:write_frame(frame, timeout_us) end
+function ScriptingCANBuffer_ud:write_frame(param1, param2) end
 
 
 -- desc
@@ -856,9 +871,9 @@ function AP_HAL__AnalogSource_ud:voltage_latest() end
 function AP_HAL__AnalogSource_ud:voltage_average() end
 
 -- desc
----@param pin_number integer
+---@param param1 integer
 ---@return boolean
-function AP_HAL__AnalogSource_ud:set_pin(pin_number) end
+function AP_HAL__AnalogSource_ud:set_pin(param1) end
 
 
 -- desc
@@ -866,25 +881,21 @@ function AP_HAL__AnalogSource_ud:set_pin(pin_number) end
 local AP_HAL__I2CDevice_ud = {}
 
 -- desc
----@param address integer
-function AP_HAL__I2CDevice_ud:set_address(address) end
-
--- If no read length is provided a single register will be read and returned.
--- If read length is provided a table of register values are returned.
----@param register_num integer
----@param read_length? integer
----@return integer|table|nil
-function AP_HAL__I2CDevice_ud:read_registers(register_num, read_length) end
+---@param param1 integer
+function AP_HAL__I2CDevice_ud:set_address(param1) end
 
 -- desc
----@param register_num integer
----@param value integer
+---@param param1 integer
+---@param param2 integer
 ---@return boolean
-function AP_HAL__I2CDevice_ud:write_register(register_num, value) end
+function AP_HAL__I2CDevice_ud:write_register(param1, param2) end
 
 -- desc
----@param retries integer
-function AP_HAL__I2CDevice_ud:set_retries(retries) end
+---@param param1 integer
+function AP_HAL__I2CDevice_ud:set_retries(param1) end
+
+-- desc
+function AP_HAL__I2CDevice_ud:read_registers(param1, param2) end
 
 
 -- desc
@@ -892,28 +903,25 @@ function AP_HAL__I2CDevice_ud:set_retries(retries) end
 local AP_HAL__UARTDriver_ud = {}
 
 -- desc
----@param flow_control_setting integer
----| '0' # disabled
----| '1' # enabled
----| '2' # auto
-function AP_HAL__UARTDriver_ud:set_flow_control(flow_control_setting) end
+---@param param1 integer
+function AP_HAL__UARTDriver_ud:set_flow_control(param1) end
 
 -- desc
 ---@return uint32_t_ud
 function AP_HAL__UARTDriver_ud:available() end
 
 -- desc
----@param value integer
+---@param param1 integer
 ---@return uint32_t_ud
-function AP_HAL__UARTDriver_ud:write(value) end
+function AP_HAL__UARTDriver_ud:write(param1) end
 
 -- desc
 ---@return integer
 function AP_HAL__UARTDriver_ud:read() end
 
 -- desc
----@param baud_rate uint32_t_ud
-function AP_HAL__UARTDriver_ud:begin(baud_rate) end
+---@param param1 uint32_t_ud
+function AP_HAL__UARTDriver_ud:begin(param1) end
 
 
 -- desc
@@ -921,24 +929,58 @@ function AP_HAL__UARTDriver_ud:begin(baud_rate) end
 local RC_Channel_ud = {}
 
 -- desc
----@return number
-function RC_Channel_ud:norm_input_ignore_trim() end
+---@param param1 integer
+function RC_Channel_ud:set_override(param1) end
 
 -- desc
----@param PWM integer
-function RC_Channel_ud:set_override(PWM) end
+---@return number
+function RC_Channel_ud:norm_input_ignore_trim() end
 
 -- desc
 ---@return integer
 function RC_Channel_ud:get_aux_switch_pos() end
 
--- desc return input on a channel from -1 to 1, centered on the trim. Ignores the deadzone
+-- desc
+---@return number
+function RC_Channel_ud:norm_input_dz() end
+
+-- desc
 ---@return number
 function RC_Channel_ud:norm_input() end
 
--- desc return input on a channel from -1 to 1, centered on the trim. Returns zero when within deadzone of the trim
----@return number
-function RC_Channel_ud:norm_input_dz() end
+
+-- desc
+---@class i2c
+i2c = {}
+
+-- desc
+function i2c:get_device(param1, param2, param3, param4) end
+
+
+-- desc
+---@class logger
+logger = {}
+
+-- desc
+function logger:write(param1, param2, param3, param4, param5, param6, param7) end
+
+
+-- desc
+---@class efi
+efi = {}
+
+-- desc
+---@return EFI_State_ud
+function efi:get_state() end
+
+-- desc
+function efi:update() end
+
+-- desc
+---@param param1 integer
+---@return AP_EFI_Backend_ud
+function efi:get_backend(param1) end
+
 
 -- desc
 ---@class winch
@@ -963,55 +1005,86 @@ function winch:relax() end
 ---@return boolean
 function winch:healthy() end
 
+
 -- desc
 ---@class mount
 mount = {}
 
 -- desc
----@param instance integer
----@param target_loc Location_ud
-function mount:set_roi_target(instance, target_loc) end
+---@param param1 integer
+---@return number|nil
+---@return number|nil
+---@return number|nil
+function mount:get_attitude_euler(param1) end
 
 -- desc
----@param instance integer
----@param roll_degs number
----@param pitch_degs number
----@param yaw_degs number
----@param yaw_is_earth_frame boolean
-function mount:set_rate_target(instance, roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame) end
+---@param param1 integer
+---@param param2 Location_ud
+function mount:set_roi_target(param1, param2) end
 
 -- desc
----@param instance integer
----@param roll_deg number
----@param pitch_deg number
----@param yaw_deg number
----@param yaw_is_earth_frame boolean
-function mount:set_angle_target(instance, roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame) end
+---@param param1 integer
+---@param param2 number
+---@param param3 number
+---@param param4 number
+---@param param5 boolean
+function mount:set_rate_target(param1, param2, param3, param4, param5) end
 
 -- desc
----@param instance integer
----@param mode integer
-function mount:set_mode(instance, mode) end
+---@param param1 integer
+---@param param2 number
+---@param param3 number
+---@param param4 number
+---@param param5 boolean
+function mount:set_angle_target(param1, param2, param3, param4, param5) end
 
 -- desc
----@param instance integer
+---@param param1 integer
+---@param param2 integer
+function mount:set_mode(param1, param2) end
+
+-- desc
+---@param param1 integer
 ---@return integer
-function mount:get_mode(instance) end
+function mount:get_mode(param1) end
+
 
 -- desc
----@param instance integer
----@return number|nil -- roll_deg
----@return number|nil -- pitch_deg
----@return number|nil -- yaw_bf_deg
-function mount:get_attitude_euler(instance) end
+---@class AC_AttitudeControl
+AC_AttitudeControl = {}
 
 -- desc
----@class motors
-motors = {}
+---@return number
+---@return number
+---@return number
+function AC_AttitudeControl:get_rpy_srate() end
+
 
 -- desc
----@param param1 string
-function motors:set_frame_string(param1) end
+---@class follow
+follow = {}
+
+-- desc
+---@return number|nil
+function follow:get_target_heading_deg() end
+
+-- desc
+---@return Location_ud|nil
+---@return Vector3f_ud|nil
+function follow:get_target_location_and_velocity_ofs() end
+
+-- desc
+---@return Location_ud|nil
+---@return Vector3f_ud|nil
+function follow:get_target_location_and_velocity() end
+
+-- desc
+---@return uint32_t_ud
+function follow:get_last_update_ms() end
+
+-- desc
+---@return boolean
+function follow:have_target() end
 
 
 -- desc
@@ -1044,8 +1117,21 @@ function FWVersion:string() end
 
 
 -- desc
+---@class motors
+motors = {}
+
+-- desc
+---@param param1 string
+function motors:set_frame_string(param1) end
+
+
+-- desc
 ---@class periph
 periph = {}
+
+-- desc
+---@param param1 string
+function periph:can_printf(param1) end
 
 -- desc
 ---@return uint32_t_ud
@@ -1055,18 +1141,26 @@ function periph:get_vehicle_state() end
 ---@return number
 function periph:get_yaw_earth() end
 
+
 -- desc
----@param text string
-function periph:can_printf(text) end
+---@class CAN
+CAN = {}
+
+-- desc
+function CAN:get_device2(param1) end
+
+-- desc
+function CAN:get_device(param1) end
+
 
 -- desc
 ---@class ins
 ins = {}
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number
-function ins:get_temperature(instance) end
+function ins:get_temperature(param1) end
 
 
 -- desc
@@ -1074,18 +1168,18 @@ function ins:get_temperature(instance) end
 Motors_dynamic = {}
 
 -- desc
----@param factor_table motor_factor_table_ud
-function Motors_dynamic:load_factors(factor_table) end
+---@param param1 motor_factor_table_ud
+function Motors_dynamic:load_factors(param1) end
 
 -- desc
----@param motor_num integer
----@param testing_order integer
-function Motors_dynamic:add_motor(motor_num, testing_order) end
+---@param param1 integer
+---@param param2 integer
+function Motors_dynamic:add_motor(param1, param2) end
 
 -- desc
----@param expected_num_motors integer
+---@param param1 integer
 ---@return boolean
-function Motors_dynamic:init(expected_num_motors) end
+function Motors_dynamic:init(param1) end
 
 
 -- desc
@@ -1097,32 +1191,28 @@ analog = {}
 function analog:channel() end
 
 
--- Control of general purpose input/output pins
+-- desc
 ---@class gpio
 gpio = {}
 
--- set GPIO pin mode
----@param pin_number integer
----@param mode integer
----| '0' # input
----| '1' # output
-function gpio:pinMode(pin_number, mode) end
+-- desc
+---@param param1 integer
+---@param param2 integer
+function gpio:pinMode(param1, param2) end
 
--- toggle GPIO output
----@param pin_number integer
-function gpio:toggle(pin_number) end
+-- desc
+---@param param1 integer
+function gpio:toggle(param1) end
 
--- write GPIO output
----@param pin_number integer
----@param value integer
----| '0' # low
----| '1' # high
-function gpio:write(pin_number, value) end
+-- desc
+---@param param1 integer
+---@param param2 integer
+function gpio:write(param1, param2) end
 
--- read GPIO input
----@param pin_number integer
----@return boolean -- pin state
-function gpio:read(pin_number) end
+-- desc
+---@param param1 integer
+---@return boolean
+function gpio:read(param1) end
 
 
 -- desc
@@ -1130,21 +1220,21 @@ function gpio:read(pin_number) end
 Motors_6DoF = {}
 
 -- desc
----@param motor_num integer
----@param roll_factor number
----@param pitch_factor number
----@param yaw_factor number
----@param throttle_factor number
----@param forward_factor number
----@param right_factor number
----@param reversible boolean
----@param testing_order integer
-function Motors_6DoF:add_motor(motor_num, roll_factor, pitch_factor, yaw_factor, throttle_factor, forward_factor, right_factor, reversible, testing_order) end
+---@param param1 integer
+---@param param2 number
+---@param param3 number
+---@param param4 number
+---@param param5 number
+---@param param6 number
+---@param param7 number
+---@param param8 boolean
+---@param param9 integer
+function Motors_6DoF:add_motor(param1, param2, param3, param4, param5, param6, param7, param8, param9) end
 
 -- desc
----@param expected_num_motors integer
+---@param param1 integer
 ---@return boolean
-function Motors_6DoF:init(expected_num_motors) end
+function Motors_6DoF:init(param1) end
 
 
 -- desc
@@ -1152,17 +1242,17 @@ function Motors_6DoF:init(expected_num_motors) end
 attitude_control = {}
 
 -- desc
----@param roll_deg number
----@param pitch_deg number
-function attitude_control:set_offset_roll_pitch(roll_deg, pitch_deg) end
+---@param param1 number
+---@param param2 number
+function attitude_control:set_offset_roll_pitch(param1, param2) end
 
 -- desc
----@param bool boolean
-function attitude_control:set_forward_enable(bool) end
+---@param param1 boolean
+function attitude_control:set_forward_enable(param1) end
 
 -- desc
----@param bool boolean
-function attitude_control:set_lateral_enable(bool) end
+---@param param1 boolean
+function attitude_control:set_lateral_enable(param1) end
 
 
 -- desc
@@ -1170,19 +1260,19 @@ function attitude_control:set_lateral_enable(bool) end
 frsky_sport = {}
 
 -- desc
----@param number integer
----@param digits integer
----@param power integer
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
 ---@return integer
-function frsky_sport:prep_number(number, digits, power) end
+function frsky_sport:prep_number(param1, param2, param3) end
 
 -- desc
----@param sensor integer
----@param frame integer
----@param appid integer
----@param data integer
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
+---@param param4 integer
 ---@return boolean
-function frsky_sport:sport_telemetry_push(sensor, frame, appid, data) end
+function frsky_sport:sport_telemetry_push(param1, param2, param3, param4) end
 
 
 -- desc
@@ -1190,23 +1280,23 @@ function frsky_sport:sport_telemetry_push(sensor, frame, appid, data) end
 MotorsMatrix = {}
 
 -- desc
----@param motor_num integer
----@param throttle_factor number
+---@param param1 integer
+---@param param2 number
 ---@return boolean
-function MotorsMatrix:set_throttle_factor(motor_num, throttle_factor) end
+function MotorsMatrix:set_throttle_factor(param1, param2) end
 
 -- desc
----@param motor_num integer
----@param roll_factor number
----@param pitch_factor number
----@param yaw_factor number
----@param testing_order integer
-function MotorsMatrix:add_motor_raw(motor_num, roll_factor, pitch_factor, yaw_factor, testing_order) end
+---@param param1 integer
+---@param param2 number
+---@param param3 number
+---@param param4 number
+---@param param5 integer
+function MotorsMatrix:add_motor_raw(param1, param2, param3, param4, param5) end
 
 -- desc
----@param expected_num_motors integer
+---@param param1 integer
 ---@return boolean
-function MotorsMatrix:init(expected_num_motors) end
+function MotorsMatrix:init(param1) end
 
 
 -- desc
@@ -1238,9 +1328,9 @@ function LED:get_rgb() end
 button = {}
 
 -- desc
----@param button_number integer
+---@param param1 integer
 ---@return boolean
-function button:get_button_state(button_number) end
+function button:get_button_state(param1) end
 
 
 -- desc
@@ -1248,9 +1338,9 @@ function button:get_button_state(button_number) end
 RPM = {}
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function RPM:get_rpm(instance) end
+function RPM:get_rpm(param1) end
 
 
 -- desc
@@ -1265,15 +1355,15 @@ mission = {}
 function mission:clear() end
 
 -- desc
----@param index integer
----@param item mavlink_mission_item_int_t_ud
+---@param param1 integer
+---@param param2 mavlink_mission_item_int_t_ud
 ---@return boolean
-function mission:set_item(index, item) end
+function mission:set_item(param1, param2) end
 
 -- desc
----@param index integer
+---@param param1 integer
 ---@return mavlink_mission_item_int_t_ud|nil
-function mission:get_item(index) end
+function mission:get_item(param1) end
 
 -- desc
 ---@return integer
@@ -1292,9 +1382,9 @@ function mission:get_current_nav_id() end
 function mission:get_prev_nav_cmd_id() end
 
 -- desc
----@param index integer
+---@param param1 integer
 ---@return boolean
-function mission:set_current_cmd(index) end
+function mission:set_current_cmd(param1) end
 
 -- desc
 ---@return integer
@@ -1310,92 +1400,94 @@ function mission:state() end
 param = {}
 
 -- desc
----@param name string
----@param value number
+---@param param1 integer
+---@param param2 integer
+---@param param3 string
+---@param param4 number
 ---@return boolean
-function param:set_and_save(name, value) end
+function param:add_param(param1, param2, param3, param4) end
 
 -- desc
----@param name string
----@param value number
+---@param param1 integer
+---@param param2 string
+---@param param3 integer
 ---@return boolean
-function param:set(name, value) end
+function param:add_table(param1, param2, param3) end
 
 -- desc
----@param name string
+---@param param1 string
+---@param param2 number
+---@return boolean
+function param:set_default(param1, param2) end
+
+-- desc
+---@param param1 string
+---@param param2 number
+---@return boolean
+function param:set_and_save(param1, param2) end
+
+-- desc
+---@param param1 string
+---@param param2 number
+---@return boolean
+function param:set(param1, param2) end
+
+-- desc
+---@param param1 string
 ---@return number|nil
-function param:get(name) end
+function param:get(param1) end
 
--- desc
----@param name string
----@param value number
----@return boolean
-function param:set_default(name, value) end
-
--- desc
----@param table_key integer
----@param prefix string
----@param num_params integer
----@return boolean
-function param:add_table(table_key, prefix, num_params) end
-
--- desc
----@param table_key integer
----@param param_num integer
----@param name string
----@param default_value number
----@return boolean
-function param:add_param(table_key, param_num, name, default_value) end
 
 -- desc
 ---@class esc_telem
 esc_telem = {}
 
 -- desc
----@param instance integer
+---@param param1 integer
+---@param param2 number
+function esc_telem:set_rpm_scale(param1, param2) end
+
+-- desc
+---@param param1 integer
+---@param param2 integer
+---@param param3 number
+function esc_telem:update_rpm(param1, param2, param3) end
+
+-- desc
+---@param param1 integer
 ---@return uint32_t_ud|nil
-function esc_telem:get_usage_seconds(instance) end
+function esc_telem:get_usage_seconds(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function esc_telem:get_consumption_mah(instance) end
+function esc_telem:get_consumption_mah(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function esc_telem:get_voltage(instance) end
+function esc_telem:get_voltage(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function esc_telem:get_current(instance) end
+function esc_telem:get_current(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer|nil
-function esc_telem:get_motor_temperature(instance) end
+function esc_telem:get_motor_temperature(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer|nil
-function esc_telem:get_temperature(instance) end
+function esc_telem:get_temperature(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function esc_telem:get_rpm(instance) end
+function esc_telem:get_rpm(param1) end
 
--- update RPM for an ESC
----@param param1 integer -- ESC number
----@param param2 integer -- RPM
----@param param3 number -- error rate
-function esc_telem:update_rpm(esc_index, rpm, error_rate) end
-
--- set scale factor for RPM on a motor
----@param param1 motor index (0 is first motor)
----@param param2 scale factor
-function esc_telem:set_rpm_scale(esc_index, scale_factor) end
 
 -- desc
 ---@class optical_flow
@@ -1435,12 +1527,10 @@ function baro:get_pressure() end
 ---@class serial
 serial = {}
 
--- Returns the UART instance that allows connections from scripts (those with SERIALx_PROTOCOL = 28`).
--- For instance = 0, returns first such UART, second for instance = 1, and so on.
--- If such an instance is not found, returns nil.
----@param instance integer -- the 0-based index of the UART instance to return.
----@return AP_HAL__UARTDriver_ud -- the requested UART instance available for scripting, or nil if none.
-function serial:find_serial(instance) end
+-- desc
+---@param param1 integer
+---@return AP_HAL__UARTDriver_ud
+function serial:find_serial(param1) end
 
 
 -- desc
@@ -1448,37 +1538,34 @@ function serial:find_serial(instance) end
 rc = {}
 
 -- desc
----@param chan_num integer
+---@param param1 integer
+---@return integer|nil
+function rc:get_aux_cached(param1) end
+
+-- desc
+---@param param1 integer
 ---@return RC_Channel_ud
-function rc:get_channel(chan_num) end
+function rc:get_channel(param1) end
 
 -- desc
 ---@return boolean
 function rc:has_valid_input() end
 
--- return cached level of aux function
----@param aux_fn integer
----@return integer|nil
-function rc:get_aux_cached(aux_fn) end
-
 -- desc
----@param aux_fun integer
----@param ch_flag integer
----| '0' # low
----| '1' # middle
----| '2' # high
+---@param param1 integer
+---@param param2 integer
 ---@return boolean
-function rc:run_aux_function(aux_fun, ch_flag) end
+function rc:run_aux_function(param1, param2) end
 
 -- desc
----@param aux_fun integer
+---@param param1 integer
 ---@return RC_Channel_ud
-function rc:find_channel_for_option(aux_fun) end
+function rc:find_channel_for_option(param1) end
 
 -- desc
----@param chan_num integer
+---@param param1 integer
 ---@return integer|nil
-function rc:get_pwm(chan_num) end
+function rc:get_pwm(param1) end
 
 
 -- desc
@@ -1486,55 +1573,55 @@ function rc:get_pwm(chan_num) end
 SRV_Channels = {}
 
 -- desc
----@param function_num integer
----@param range integer
-function SRV_Channels:set_range(function_num, range) end
+---@param param1 integer
+---@param param2 integer
+function SRV_Channels:set_range(param1, param2) end
 
 -- desc
----@param function_num integer
----@param angle integer
-function SRV_Channels:set_angle(function_num, angle) end
+---@param param1 integer
+---@param param2 integer
+function SRV_Channels:set_angle(param1, param2) end
 
 -- desc
----@param function_num integer
----@param value number
-function SRV_Channels:set_output_norm(function_num, value) end
+---@param param1 integer
+---@param param2 number
+function SRV_Channels:set_output_norm(param1, param2) end
 
 -- desc
----@param function_num integer
+---@param param1 integer
 ---@return number
-function SRV_Channels:get_output_scaled(function_num) end
+function SRV_Channels:get_output_scaled(param1) end
 
 -- desc
----@param function_num integer
+---@param param1 integer
 ---@return integer|nil
-function SRV_Channels:get_output_pwm(function_num) end
+function SRV_Channels:get_output_pwm(param1) end
 
 -- desc
----@param function_num integer
----@param value number
-function SRV_Channels:set_output_scaled(function_num, value) end
+---@param param1 integer
+---@param param2 number
+function SRV_Channels:set_output_scaled(param1, param2) end
 
 -- desc
----@param chan integer
----@param pwm integer
----@param timeout_ms integer
-function SRV_Channels:set_output_pwm_chan_timeout(chan, pwm, timeout_ms) end
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
+function SRV_Channels:set_output_pwm_chan_timeout(param1, param2, param3) end
 
 -- desc
----@param chan integer
----@param pwm integer
-function SRV_Channels:set_output_pwm_chan(chan, pwm) end
+---@param param1 integer
+---@param param2 integer
+function SRV_Channels:set_output_pwm_chan(param1, param2) end
 
 -- desc
----@param function_num integer
----@param pwm integer
-function SRV_Channels:set_output_pwm(function_num, pwm) end
+---@param param1 integer
+---@param param2 integer
+function SRV_Channels:set_output_pwm(param1, param2) end
 
 -- desc
----@param function_num integer
+---@param param1 integer
 ---@return integer|nil
-function SRV_Channels:find_channel(function_num) end
+function SRV_Channels:find_channel(param1) end
 
 
 -- desc
@@ -1542,28 +1629,28 @@ function SRV_Channels:find_channel(function_num) end
 serialLED = {}
 
 -- desc
----@param chan integer
-function serialLED:send(chan) end
+---@param param1 integer
+function serialLED:send(param1) end
 
 -- desc
----@param chan integer
----@param led_index integer
----@param red integer
----@param green integer
----@param blue integer
-function serialLED:set_RGB(chan, led_index, red, green, blue) end
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
+---@param param4 integer
+---@param param5 integer
+function serialLED:set_RGB(param1, param2, param3, param4, param5) end
 
 -- desc
----@param chan integer
----@param num_leds integer
+---@param param1 integer
+---@param param2 integer
 ---@return boolean
-function serialLED:set_num_profiled(chan, num_leds) end
+function serialLED:set_num_profiled(param1, param2) end
 
 -- desc
----@param chan integer
----@param num_leds integer
+---@param param1 integer
+---@param param2 integer
 ---@return boolean
-function serialLED:set_num_neopixel(chan, num_leds) end
+function serialLED:set_num_neopixel(param1, param2) end
 
 
 -- desc
@@ -1573,6 +1660,47 @@ vehicle = {}
 -- desc
 ---@return boolean
 function vehicle:has_ekf_failsafed() end
+
+-- desc
+---@param param1 Vector2f_ud
+---@return boolean
+function vehicle:set_velocity_match(param1) end
+
+-- desc
+---@param param1 integer
+---@return boolean
+function vehicle:nav_scripting_enable(param1) end
+
+-- desc
+---@param param1 number
+---@return boolean
+function vehicle:set_desired_speed(param1) end
+
+-- desc
+---@param param1 number
+---@param param2 number
+---@return boolean
+function vehicle:set_desired_turn_rate_and_speed(param1, param2) end
+
+-- desc
+---@param param1 number
+---@param param2 number
+---@param param3 number
+---@param param4 number
+function vehicle:set_target_throttle_rate_rpy(param1, param2, param3, param4) end
+
+-- desc
+---@param param1 integer
+function vehicle:nav_script_time_done(param1) end
+
+-- desc
+---@return integer|nil
+---@return integer|nil
+---@return number|nil
+---@return number|nil
+---@return integer|nil
+---@return integer|nil
+function vehicle:nav_script_time() end
 
 -- desc
 ---@return number|nil
@@ -1592,107 +1720,99 @@ function vehicle:get_wp_bearing_deg() end
 function vehicle:get_wp_distance_m() end
 
 -- desc
----@param steering number
----@param throttle number
+---@param param1 number
+---@param param2 number
 ---@return boolean
-function vehicle:set_steering_and_throttle(steering, throttle) end
+function vehicle:set_steering_and_throttle(param1, param2) end
 
 -- desc
----@param rate_dps number
+---@param param1 number
 ---@return boolean
-function vehicle:set_circle_rate(rate_dps) end
+function vehicle:set_circle_rate(param1) end
 
 -- desc
 ---@return number|nil
 function vehicle:get_circle_radius() end
 
 -- desc
----@param roll_deg number
----@param pitch_deg number
----@param yaw_deg number
----@param climb_rate_ms number
----@param use_yaw_rate boolean
----@param yaw_rate_degs number
+---@param param1 number
+---@param param2 number
+---@param param3 number
+---@param param4 number
+---@param param5 boolean
+---@param param6 number
 ---@return boolean
-function vehicle:set_target_angle_and_climbrate(roll_deg, pitch_deg, yaw_deg, climb_rate_ms, use_yaw_rate, yaw_rate_degs) end
+function vehicle:set_target_angle_and_climbrate(param1, param2, param3, param4, param5, param6) end
 
 -- desc
----@param vel_ned Vector3f_ud
+---@param param1 Vector3f_ud
 ---@return boolean
-function vehicle:set_target_velocity_NED(vel_ned) end
+function vehicle:set_target_velocity_NED(param1) end
 
 -- desc
----@param target_vel Vector3f_ud
----@param target_accel Vector3f_ud
----@param use_yaw boolean
----@param yaw_deg number
----@param use_yaw_rate boolean
----@param yaw_rate_degs number
----@param yaw_relative boolean
+---@param param1 Vector3f_ud
+---@param param2 Vector3f_ud
+---@param param3 boolean
+---@param param4 number
+---@param param5 boolean
+---@param param6 number
+---@param param7 boolean
 ---@return boolean
-function vehicle:set_target_velaccel_NED(target_vel, target_accel, use_yaw, yaw_deg, use_yaw_rate, yaw_rate_degs, yaw_relative) end
+function vehicle:set_target_velaccel_NED(param1, param2, param3, param4, param5, param6, param7) end
 
 -- desc
----@param target_pos Vector3f_ud
----@param target_vel Vector3f_ud
----@param target_accel Vector3f_ud
----@param use_yaw boolean
----@param yaw_deg number
----@param use_yaw_rate boolean
----@param yaw_rate_degs number
----@param yaw_relative boolean
+---@param param1 Vector3f_ud
+---@param param2 Vector3f_ud
+---@param param3 Vector3f_ud
+---@param param4 boolean
+---@param param5 number
+---@param param6 boolean
+---@param param7 number
+---@param param8 boolean
 ---@return boolean
-function vehicle:set_target_posvelaccel_NED(target_pos, target_vel, target_accel, use_yaw, yaw_deg, use_yaw_rate, yaw_rate_degs, yaw_relative) end
+function vehicle:set_target_posvelaccel_NED(param1, param2, param3, param4, param5, param6, param7, param8) end
 
 -- desc
----@param target_pos Vector3f_ud
----@param target_vel Vector3f_ud
+---@param param1 Vector3f_ud
+---@param param2 Vector3f_ud
 ---@return boolean
-function vehicle:set_target_posvel_NED(target_pos, target_vel) end
+function vehicle:set_target_posvel_NED(param1, param2) end
 
 -- desc
----@param target_pos Vector3f_ud
----@param use_yaw boolean
----@param yaw_deg number
----@param use_yaw_rate boolean
----@param yaw_rate_degs number
----@param yaw_relative boolean
----@param terrain_alt boolean
+---@param param1 Vector3f_ud
+---@param param2 boolean
+---@param param3 number
+---@param param4 boolean
+---@param param5 number
+---@param param6 boolean
+---@param param7 boolean
 ---@return boolean
-function vehicle:set_target_pos_NED(target_pos, use_yaw, yaw_deg, use_yaw_rate, yaw_rate_degs, yaw_relative, terrain_alt) end
+function vehicle:set_target_pos_NED(param1, param2, param3, param4, param5, param6, param7) end
 
 -- desc
----@param current_target Location_ud -- current target, from get_target_location()
----@param new_target Location_ud -- new target
+---@param param1 Location_ud
+---@param param2 Location_ud
 ---@return boolean
-function vehicle:update_target_location(current_target, new_target) end
+function vehicle:update_target_location(param1, param2) end
 
 -- desc
 ---@return Location_ud|nil
 function vehicle:get_target_location() end
 
 -- desc
----@param target_loc Location_ud
+---@param param1 Location_ud
 ---@return boolean
-function vehicle:set_target_location(target_loc) end
+function vehicle:set_target_location(param1) end
 
 -- desc
----@param alt number
+---@param param1 number
 ---@return boolean
-function vehicle:start_takeoff(alt) end
+function vehicle:start_takeoff(param1) end
 
 -- desc
----@param control_output integer
----| '1' # Roll
----| '2' # Pitch
----| '3' # Throttle
----| '4' # Yaw
----| '5' # Lateral
----| '6' # MainSail
----| '7' # WingSail
----| '8' # Walking_Height
+---@param param1 integer
 ---@return number|nil
-function vehicle:get_control_output(control_output) end
+function vehicle:get_control_output(param1) end
 
 -- desc
 ---@return uint32_t_ud
@@ -1711,48 +1831,10 @@ function vehicle:get_control_mode_reason() end
 function vehicle:get_mode() end
 
 -- desc
----@param mode_number integer
----@return boolean
-function vehicle:set_mode(mode_number) end
-
--- desc
----@param param1 Vector2f_ud
----@return boolean
-function vehicle:set_velocity_match(param1) end
-
--- desc
 ---@param param1 integer
 ---@return boolean
-function vehicle:nav_scripting_enable(param1) end
+function vehicle:set_mode(param1) end
 
--- desc sets autopilot nav speed (Copter and Rover)
----@param param1 number
----@return boolean
-function vehicle:set_desired_speed(param1) end
-
--- desc
----@param param1 number
----@param param2 number
----@return boolean
-function vehicle:set_desired_turn_rate_and_speed(param1, param2) end
-
--- desc
----@param param1 number -- throttle percent
----@param param2 number -- roll rate deg/s
----@param param3 number -- pitch rate deg/s
----@param param4 number -- yaw rate deg/s
-function vehicle:set_target_throttle_rate_rpy(param1, param2, param3, param4) end
-
--- desc
----@param param1 integer
-function vehicle:nav_script_time_done(param1) end
-
--- desc
----@return integer|nil
----@return integer|nil
----@return number|nil
----@return number|nil
-function vehicle:nav_script_time() end
 
 -- desc
 ---@class onvif
@@ -1767,76 +1849,67 @@ function onvif:get_pan_tilt_limit_max() end
 function onvif:get_pan_tilt_limit_min() end
 
 -- desc
----@param pan number
----@param tilt number
----@param zoom number
+---@param param1 number
+---@param param2 number
+---@param param3 number
 ---@return boolean
-function onvif:set_absolutemove(pan, tilt, zoom) end
+function onvif:set_absolutemove(param1, param2, param3) end
 
 -- desc
----@param username string
----@param password string
----@param httphostname string
+---@param param1 string
+---@param param2 string
+---@param param3 string
 ---@return boolean
-function onvif:start(username, password, httphostname) end
+function onvif:start(param1, param2, param3) end
 
 
--- MAVLink interaction with ground control station
+-- desc
 ---@class gcs
 gcs = {}
 
--- send named float value using NAMED_VALUE_FLOAT message
----@param name string -- up to 10 chars long
----@param value number -- value to send
-function gcs:send_named_float(name, value) end
+-- desc
+---@param param1 string
+---@param param2 number
+function gcs:send_named_float(param1, param2) end
 
--- set message interval for a given serial port and message id
----@param port_num integer -- serial port number
----@param msg_id uint32_t_ud -- MAVLink message id
----@param interval_us integer -- interval in micro seconds
+-- desc
+---@param param1 integer
+---@param param2 uint32_t_ud
+---@param param3 integer
 ---@return integer
----| '0' # Accepted
----| '4' # Failed
-function gcs:set_message_interval(port_num, msg_id, interval_us) end
+function gcs:set_message_interval(param1, param2, param3) end
 
--- send text with severity level
----@param severity integer
----| '0' # Emergency: System is unusable. This is a "panic" condition.
----| '1' # Alert: Action should be taken immediately. Indicates error in non-critical systems.
----| '2' # Critical: Action must be taken immediately. Indicates failure in a primary system.
----| '3' # Error: Indicates an error in secondary/redundant systems.
----| '4' # Warning: Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.
----| '5' # Notice: An unusual event has occurred, though not an error condition. This should be investigated for the root cause.
----| '6' # Info: Normal operational messages. Useful for logging. No action is required for these messages.
----| '7' # Debug: Useful non-operational messages that can assist in debugging. These should not occur during normal operation.
----@param text string
-function gcs:send_text(severity, text) end
+-- desc
+---@param param1 integer
+---@param param2 string
+function gcs:send_text(param1, param2) end
+
 
 -- desc
 ---@class relay
 relay = {}
 
 -- desc
----@param instance integer
-function relay:toggle(instance) end
-
--- desc
----@param instance integer
----@return boolean
-function relay:enabled(instance) end
-
--- return state of a relay
----@param instance integer
+---@param param1 integer
 ---@return integer
-function relay:get(instance) end
+function relay:get(param1) end
 
 -- desc
----@param instance integer
-function relay:off(instance) end
+---@param param1 integer
+function relay:toggle(param1) end
 
 -- desc
----@param instance integer
-function relay:on(instance) end
+---@param param1 integer
+---@return boolean
+function relay:enabled(param1) end
+
+-- desc
+---@param param1 integer
+function relay:off(param1) end
+
+-- desc
+---@param param1 integer
+function relay:on(param1) end
 
 
 -- desc
@@ -1847,20 +1920,20 @@ function relay:on(instance) end
 terrain = {}
 
 -- desc
----@param extrapolate boolean
+---@param param1 boolean
 ---@return number|nil
-function terrain:height_above_terrain(extrapolate) end
+function terrain:height_above_terrain(param1) end
 
 -- desc
----@param extrapolate boolean
+---@param param1 boolean
 ---@return number|nil
-function terrain:height_terrain_difference_home(extrapolate) end
+function terrain:height_terrain_difference_home(param1) end
 
 -- desc
----@param loc Location_ud
----@param corrected boolean
+---@param param1 Location_ud
+---@param param2 boolean
 ---@return number|nil
-function terrain:height_amsl(loc, corrected) end
+function terrain:height_amsl(param1, param2) end
 
 -- desc
 ---@return integer
@@ -1876,44 +1949,44 @@ function terrain:enabled() end
 rangefinder = {}
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return Vector3f_ud
-function rangefinder:get_pos_offset_orient(orientation) end
+function rangefinder:get_pos_offset_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return boolean
-function rangefinder:has_data_orient(orientation) end
+function rangefinder:has_data_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return integer
-function rangefinder:status_orient(orientation) end
+function rangefinder:status_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return integer
-function rangefinder:ground_clearance_cm_orient(orientation) end
+function rangefinder:ground_clearance_cm_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return integer
-function rangefinder:min_distance_cm_orient(orientation) end
+function rangefinder:min_distance_cm_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return integer
-function rangefinder:max_distance_cm_orient(orientation) end
+function rangefinder:max_distance_cm_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return integer
-function rangefinder:distance_cm_orient(orientation) end
+function rangefinder:distance_cm_orient(param1) end
 
 -- desc
----@param orientation integer
+---@param param1 integer
 ---@return boolean
-function rangefinder:has_orientation(orientation) end
+function rangefinder:has_orientation(param1) end
 
 -- desc
 ---@return integer
@@ -1925,10 +1998,10 @@ function rangefinder:num_sensors() end
 proximity = {}
 
 -- desc
----@param object_number integer
+---@param param1 integer
 ---@return number|nil
 ---@return number|nil
-function proximity:get_object_angle_and_distance(object_number) end
+function proximity:get_object_angle_and_distance(param1) end
 
 -- desc
 ---@return number|nil
@@ -1953,22 +2026,22 @@ function proximity:get_status() end
 notify = {}
 
 -- desc
----@param red integer
----@param green integer
----@param blue integer
----@param id integer
-function notify:handle_rgb_id(red, green, blue, id) end
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
+---@param param4 integer
+function notify:handle_rgb_id(param1, param2, param3, param4) end
 
 -- desc
----@param red integer
----@param green integer
----@param blue integer
----@param rate_hz integer
-function notify:handle_rgb(red, green, blue, rate_hz) end
+---@param param1 integer
+---@param param2 integer
+---@param param3 integer
+---@param param4 integer
+function notify:handle_rgb(param1, param2, param3, param4) end
 
 -- desc
----@param tune string
-function notify:play_tune(tune) end
+---@param param1 string
+function notify:play_tune(param1) end
 
 
 -- desc
@@ -1987,89 +2060,89 @@ gps = {}
 function gps:first_unconfigured_gps() end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return Vector3f_ud
-function gps:get_antenna_offset(instance) end
+function gps:get_antenna_offset(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return boolean
-function gps:have_vertical_velocity(instance) end
+function gps:have_vertical_velocity(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return uint32_t_ud
-function gps:last_message_time_ms(instance) end
+function gps:last_message_time_ms(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return uint32_t_ud
-function gps:last_fix_time_ms(instance) end
+function gps:last_fix_time_ms(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function gps:get_vdop(instance) end
+function gps:get_vdop(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function gps:get_hdop(instance) end
+function gps:get_hdop(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return uint32_t_ud
-function gps:time_week_ms(instance) end
+function gps:time_week_ms(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function gps:time_week(instance) end
+function gps:time_week(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function gps:num_sats(instance) end
+function gps:num_sats(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number
-function gps:ground_course(instance) end
+function gps:ground_course(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number
-function gps:ground_speed(instance) end
+function gps:ground_speed(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return Vector3f_ud
-function gps:velocity(instance) end
+function gps:velocity(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function gps:vertical_accuracy(instance) end
+function gps:vertical_accuracy(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function gps:horizontal_accuracy(instance) end
+function gps:horizontal_accuracy(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function gps:speed_accuracy(instance) end
+function gps:speed_accuracy(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return Location_ud
-function gps:location(instance) end
+function gps:location(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function gps:status(instance) end
+function gps:status(param1) end
 
 -- desc
 ---@return integer
@@ -2085,69 +2158,69 @@ function gps:num_sensors() end
 battery = {}
 
 -- desc
----@param instance integer
----@param percentage number
+---@param param1 integer
+---@param param2 number
 ---@return boolean
-function battery:reset_remaining(instance, percentage) end
+function battery:reset_remaining(param1, param2) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer|nil
-function battery:get_cycle_count(instance) end
+function battery:get_cycle_count(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function battery:get_temperature(instance) end
+function battery:get_temperature(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return boolean
-function battery:overpower_detected(instance) end
+function battery:overpower_detected(param1) end
 
 -- desc
 ---@return boolean
 function battery:has_failsafed() end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer
-function battery:pack_capacity_mah(instance) end
+function battery:pack_capacity_mah(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return integer|nil
-function battery:capacity_remaining_pct(instance) end
+function battery:capacity_remaining_pct(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function battery:consumed_wh(instance) end
+function battery:consumed_wh(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function battery:consumed_mah(instance) end
+function battery:consumed_mah(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number|nil
-function battery:current_amps(instance) end
+function battery:current_amps(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number
-function battery:voltage_resting_estimate(instance) end
+function battery:voltage_resting_estimate(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return number
-function battery:voltage(instance) end
+function battery:voltage(param1) end
 
 -- desc
----@param instance integer
+---@param param1 integer
 ---@return boolean
-function battery:healthy(instance) end
+function battery:healthy(param1) end
 
 -- desc
 ---@return integer
@@ -2159,13 +2232,13 @@ function battery:num_instances() end
 arming = {}
 
 -- desc
----@param auth_id integer
----@param fail_msg string
-function arming:set_aux_auth_failed(auth_id, fail_msg) end
+---@param param1 integer
+---@param param2 string
+function arming:set_aux_auth_failed(param1, param2) end
 
 -- desc
----@param auth_id integer
-function arming:set_aux_auth_passed(auth_id) end
+---@param param1 integer
+function arming:set_aux_auth_passed(param1) end
 
 -- desc
 ---@return integer|nil
@@ -2177,11 +2250,11 @@ function arming:arm() end
 
 -- desc
 ---@return boolean
-function arming:is_armed() end
+function arming:pre_arm_checks() end
 
 -- desc
 ---@return boolean
-function arming:pre_arm_checks() end
+function arming:is_armed() end
 
 -- desc
 ---@return boolean
@@ -2205,28 +2278,28 @@ function ahrs:get_posvelyaw_source_set() end
 function ahrs:initialised() end
 
 -- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return boolean
-function ahrs:set_origin(loc) end
+function ahrs:set_origin(param1) end
 
 -- desc
 ---@return Location_ud|nil
 function ahrs:get_origin() end
 
 -- desc
----@param loc Location_ud
+---@param param1 Location_ud
 ---@return boolean
-function ahrs:set_home(loc) end
+function ahrs:set_home(param1) end
 
 -- desc
----@param source integer
+---@param param1 integer
 ---@return Vector3f_ud|nil
 ---@return Vector3f_ud|nil
-function ahrs:get_vel_innovations_and_variances_for_source(source) end
+function ahrs:get_vel_innovations_and_variances_for_source(param1) end
 
 -- desc
----@param source_set_idx integer
-function ahrs:set_posvelyaw_source_set(source_set_idx) end
+---@param param1 integer
+function ahrs:set_posvelyaw_source_set(param1) end
 
 -- desc
 ---@return number|nil
@@ -2241,14 +2314,14 @@ function ahrs:get_variances() end
 function ahrs:get_EAS2TAS() end
 
 -- desc
----@param vector Vector3f_ud
+---@param param1 Vector3f_ud
 ---@return Vector3f_ud
-function ahrs:body_to_earth(vector) end
+function ahrs:body_to_earth(param1) end
 
 -- desc
----@param vector Vector3f_ud
+---@param param1 Vector3f_ud
 ---@return Vector3f_ud
-function ahrs:earth_to_body(vector) end
+function ahrs:earth_to_body(param1) end
 
 -- desc
 ---@return Vector3f_ud
@@ -2310,10 +2383,6 @@ function ahrs:get_home() end
 ---@return Location_ud|nil
 function ahrs:get_location() end
 
--- same as `get_location` will be removed
----@return Location_ud|nil
-function ahrs:get_position() end
-
 -- desc
 ---@return number
 function ahrs:get_yaw() end
@@ -2327,37 +2396,16 @@ function ahrs:get_pitch() end
 function ahrs:get_roll() end
 
 -- desc
----@class AC_AttitudeControl
-AC_AttitudeControl = {}
-
--- return slew rates for VTOL controller
----@return number -- roll slew rate
----@return number -- pitch slew rate
----@return number -- yaw slew rate
-function AC_AttitudeControl:get_rpy_srate() end
-
--- desc
----@class follow
-follow = {}
-
--- desc
----@return number|nil
-function follow:get_target_heading_deg() end
-
--- desc
 ---@return Location_ud|nil
----@return Vector3f_ud|nil
-function follow:get_target_location_and_velocity_ofs() end
+function ahrs:get_position() end
+
 
 -- desc
----@return Location_ud|nil
----@return Vector3f_ud|nil
-function follow:get_target_location_and_velocity() end
+function mission_receive() end
 
 -- desc
----@return uint32_t_ud
-function follow:get_last_update_ms() end
+function micros() end
 
 -- desc
----@return boolean
-function follow:have_target() end
+function millis() end
+

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -569,40 +569,42 @@ include AP_EFI/AP_EFI_Scripting.h depends HAL_EFI_ENABLED
 include AP_EFI/AP_EFI_config.h
 
 userdata Cylinder_Status depends (AP_EFI_SCRIPTING_ENABLED == 1)
-userdata Cylinder_Status field ignition_timing_deg float'skip_check write
-userdata Cylinder_Status field injection_time_ms float'skip_check write
-userdata Cylinder_Status field cylinder_head_temperature float'skip_check write
-userdata Cylinder_Status field exhaust_gas_temperature float'skip_check write
-userdata Cylinder_Status field lambda_coefficient float'skip_check write
+userdata Cylinder_Status field ignition_timing_deg float'skip_check read write
+userdata Cylinder_Status field injection_time_ms float'skip_check read write
+userdata Cylinder_Status field cylinder_head_temperature float'skip_check read write
+userdata Cylinder_Status field exhaust_gas_temperature float'skip_check read write
+userdata Cylinder_Status field lambda_coefficient float'skip_check read write
 
 userdata EFI_State depends (AP_EFI_SCRIPTING_ENABLED == 1)
-userdata EFI_State field last_updated_ms uint32_t'skip_check write
-userdata EFI_State field general_error boolean write
-userdata EFI_State field engine_load_percent uint8_t'skip_check write
-userdata EFI_State field engine_speed_rpm uint32_t'skip_check write
-userdata EFI_State field spark_dwell_time_ms float'skip_check write
-userdata EFI_State field atmospheric_pressure_kpa float'skip_check write
-userdata EFI_State field intake_manifold_pressure_kpa float'skip_check write
-userdata EFI_State field intake_manifold_temperature float'skip_check write
-userdata EFI_State field coolant_temperature float'skip_check write
-userdata EFI_State field oil_pressure float'skip_check write
-userdata EFI_State field oil_temperature float'skip_check write
-userdata EFI_State field fuel_pressure float'skip_check write
-userdata EFI_State field fuel_consumption_rate_cm3pm float'skip_check write
-userdata EFI_State field estimated_consumed_fuel_volume_cm3 float'skip_check write
-userdata EFI_State field throttle_position_percent uint8_t'skip_check write
-userdata EFI_State field ecu_index uint8_t'skip_check write
+userdata EFI_State field last_updated_ms uint32_t'skip_check read write
+userdata EFI_State field general_error boolean read write
+userdata EFI_State field engine_load_percent uint8_t read write 0 UINT8_MAX
+userdata EFI_State field engine_speed_rpm uint32_t'skip_check read write
+userdata EFI_State field spark_dwell_time_ms float'skip_check read write
+userdata EFI_State field atmospheric_pressure_kpa float'skip_check read write
+userdata EFI_State field intake_manifold_pressure_kpa float'skip_check read write
+userdata EFI_State field intake_manifold_temperature float'skip_check read write
+userdata EFI_State field coolant_temperature float'skip_check read write
+userdata EFI_State field oil_pressure float'skip_check read write
+userdata EFI_State field oil_temperature float'skip_check read write
+userdata EFI_State field fuel_pressure float'skip_check read write
+userdata EFI_State field fuel_consumption_rate_cm3pm float'skip_check read write
+userdata EFI_State field estimated_consumed_fuel_volume_cm3 float'skip_check read write
+userdata EFI_State field throttle_position_percent uint8_t read write 0 UINT8_MAX
+userdata EFI_State field ecu_index uint8_t read write 0 UINT8_MAX
 userdata EFI_State field cylinder_status Cylinder_Status write
-userdata EFI_State field ignition_voltage float'skip_check write
-userdata EFI_State field throttle_out float'skip_check write
-userdata EFI_State field pt_compensation float'skip_check write
+userdata EFI_State field ignition_voltage float'skip_check read write
+userdata EFI_State field throttle_out float'skip_check read write
+userdata EFI_State field pt_compensation float'skip_check read write
 
 ap_object AP_EFI_Backend depends (AP_EFI_SCRIPTING_ENABLED == 1)
 ap_object AP_EFI_Backend method handle_scripting boolean EFI_State
 
 singleton AP_EFI depends (AP_EFI_SCRIPTING_ENABLED == 1)
 singleton AP_EFI rename efi
-singleton AP_EFI method get_backend AP_EFI_Backend uint8_t'skip_check
+singleton AP_EFI method get_backend AP_EFI_Backend uint8_t 0 UINT8_MAX
+singleton AP_EFI method update void
+singleton AP_EFI method get_state void EFI_State'Ref
 
 -- ----END EFI Library----
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3939,6 +3939,15 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
         AP_CheckFirmware::handle_msg(chan, msg);
         break;
 #endif
+
+    case MAVLINK_MSG_ID_EFI_STATUS:
+#if HAL_EFI_ENABLED
+        AP_EFI *efi = AP::EFI();
+        if (efi) {
+            efi->handle_EFI_message(msg);
+        }
+#endif
+    	break;
     }
 
 }


### PR DESCRIPTION
Added a new class (AP_EFI_MAV). This class will decode the EFI MavLink messages and update the data to the frontend.
The frontend is binded for the LUA script, this is done in bindings.desc.
The MAVLink decode method (`handle_EFI_message(msg)`) is called from GCS_Common.cpp.