### PR TITLE
AP_Math: add missing include

### DIFF
--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 uint16_t crc_crc4(uint16_t *data);
 uint8_t crc_crc8(const uint8_t *p, uint8_t len);
 uint8_t crc8_dvb_s2(uint8_t crc, uint8_t a);


### PR DESCRIPTION
This file has no includes at all, so was relying on previously included files for the stdint types.
