### PR TITLE
CAN: support Himark CAN servos

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -112,6 +112,7 @@ public:
         DNA_IGNORE_UNHEALTHY_NODE = (1U<<3),
         USE_ACTUATOR_PWM          = (1U<<4),
         SEND_GNSS                 = (1U<<5),
+        USE_HIMARK_SERVO          = (1U<<6),
     };
 
     // check if a option is set
@@ -131,6 +132,7 @@ private:
     ///// SRV output /////
     void SRV_send_actuator();
     void SRV_send_esc();
+    void SRV_send_himark();
 
     ///// LED /////
     void led_out_send();
@@ -273,6 +275,7 @@ private:
     Canard::Publisher<uavcan_equipment_safety_ArmingStatus> arming_status{canard_iface};
     Canard::Publisher<uavcan_equipment_gnss_RTCMStream> rtcm_stream{canard_iface};
     Canard::Publisher<ardupilot_indication_NotifyState> notify_state{canard_iface};
+    Canard::Publisher<com_himark_servo_ServoCmd> himark_out{canard_iface};
 
 #if AP_DRONECAN_SEND_GPS
     Canard::Publisher<uavcan_equipment_gnss_Fix2> gnss_fix2{canard_iface};
@@ -322,6 +325,7 @@ private:
     void handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg);
     void handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg);
     void handle_ESC_status(const CanardRxTransfer& transfer, const uavcan_equipment_esc_Status& msg);
+    void handle_himark_servoinfo(const CanardRxTransfer& transfer, const com_himark_servo_ServoInfo &msg);
     static bool is_esc_data_index_valid(const uint8_t index);
     void handle_debug(const CanardRxTransfer& transfer, const uavcan_protocol_debug_LogMessage& msg);
     void handle_param_get_set_response(const CanardRxTransfer& transfer, const uavcan_protocol_param_GetSetResponse& rsp);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -255,7 +255,8 @@ public:
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
-    void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct);
+    void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct,
+                           float pos_cmd, float voltage, float current, float mot_temp, float pcb_temp, uint8_t error);
     void Write_Compass();
     void Write_Mode(uint8_t mode, const ModeReason reason);
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -451,7 +451,8 @@ bool AP_Logger_Backend::Write_Mode(uint8_t mode, const ModeReason reason)
 /*
   write servo status from CAN servo
  */
-void AP_Logger::Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct)
+void AP_Logger::Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct,
+                                  float pos_cmd, float voltage, float current, float mot_temp, float pcb_temp, uint8_t error)
 {
     const struct log_CSRV pkt {
         LOG_PACKET_HEADER_INIT(LOG_CSRV_MSG),
@@ -460,7 +461,13 @@ void AP_Logger::Write_ServoStatus(uint64_t time_us, uint8_t id, float position, 
         position    : position,
         force       : force,
         speed       : speed,
-        power_pct   : power_pct
+        power_pct   : power_pct,
+        pos_cmd     : pos_cmd,
+        voltage     : voltage,
+        current     : current,
+        mot_temp    : mot_temp,
+        pcb_temp    : pcb_temp,
+        error       : error,
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -491,6 +491,12 @@ struct PACKED log_CSRV {
     float force;
     float speed;
     uint8_t power_pct;
+    float pos_cmd;
+    float voltage;
+    float current;
+    float mot_temp;
+    float pcb_temp;
+    uint8_t error;
 };
 
 struct PACKED log_ARSP {
@@ -754,6 +760,12 @@ struct PACKED log_VER {
 // @Field: Force: Force being applied
 // @Field: Speed: Current servo movement speed
 // @Field: Pow: Amount of rated power being applied
+// @Field: PosCmd: commanded servo position
+// @Field: V: Voltage
+// @Field: A: Current
+// @Field: MotT: motor temperature
+// @Field: PCBT: PCB temperature
+// @Field: Err: error flags
 
 // @LoggerMessage: DMS
 // @Description: DataFlash-Over-MAVLink statistics
@@ -1271,7 +1283,7 @@ LOG_STRUCTURE_FROM_AVOIDANCE \
       "TERR","QBLLHffHHf","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded,ROfs", "s-DU-mm--m", "F-GG-00--0", true }, \
 LOG_STRUCTURE_FROM_ESC_TELEM \
     { LOG_CSRV_MSG, sizeof(log_CSRV), \
-      "CSRV","QBfffB","TimeUS,Id,Pos,Force,Speed,Pow", "s#---%", "F-0000", true }, \
+      "CSRV","QBfffBfffffB","TimeUS,Id,Pos,Force,Speed,Pow,PosCmd,V,A,MotT,PCBT,Err", "s#---%dvAOO-", "F-000000000-", true }, \
     { LOG_PIDR_MSG, sizeof(log_PID), \
       "PIDR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS, true },  \
     { LOG_PIDP_MSG, sizeof(log_PID), \

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -382,14 +382,24 @@ void AP_PiccoloCAN::update()
             CBSServo_Info_t &servo = _servo_info[ii];
 
             if (servo.newTelemetry) {
-
+                union {
+                    Servo_ErrorBits_t ebits;
+                    uint8_t errors;
+                } err;
+                err.ebits = servo.statusA.errors;
                 logger->Write_ServoStatus(
                     timestamp,
                     ii,
                     (float) servo.statusA.position,         // Servo position (represented in microsecond units)
                     (float) servo.statusB.current * 0.01f, // Servo force (actually servo current, 0.01A per bit)
                     (float) servo.statusB.speed,            // Servo speed (degrees per second)
-                    (uint8_t) abs(servo.statusB.dutyCycle)  // Servo duty cycle (absolute value as it can be +/- 100%)
+                    (uint8_t) abs(servo.statusB.dutyCycle),  // Servo duty cycle (absolute value as it can be +/- 100%)
+                    servo.statusA.command,
+                    servo.statusB.voltage*0.01,
+                    servo.statusB.current*0.01,
+                    servo.statusB.temperature,
+                    servo.statusB.temperature,
+                    err.errors
                 );
 
                 servo.newTelemetry = false;


### PR DESCRIPTION
These servos use a different UAVCAN message than other UAVCAN servos. 
The command format is a linear array (max 17 servos) and status gives info on voltage, current, commanded position, temperature etc. Having commanded position as well as actual position is great for analysing errors

To use you need to set CAN_D1_UC_OPTION=32 to enable use of the Himark servo output protocol

Example logging:
![image](https://user-images.githubusercontent.com/831867/205207910-18f47f3c-a250-4a90-b9c4-1a82fd934e88.png)

This is the setup on the servos (for SERVO3, idx 2)
![image](https://user-images.githubusercontent.com/831867/205209444-ca16318c-c797-4cc9-9253-96d87a63aa0c.png)

This has been successfully test flown with a CUAV-X7 with 5 servos for fixed wing control surfaces