### PR TITLE
Plane: ensure we init z controller when inactive

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -963,7 +963,7 @@ void QuadPlane::run_z_controller(void)
         // never run Z controller in tailsitter transtion
         return;
     }
-    if ((now - last_pidz_active_ms) > 20) {
+    if ((now - last_pidz_active_ms) > 20 || !pos_control->is_active_z()) {
         // set vertical speed and acceleration limits
         pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_velocity_z_max_up, pilot_accel_z);
 


### PR DESCRIPTION
this prevents us getting the AC_PosControl internal error, which is turning up as a common false positive, usually on arming when we can get a long loop
I test flew this on a Striver mini today