### PR TITLE
AP_Landing: prevent a landing division by zero

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -284,7 +284,7 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     }
 
     // time before landing that we will flare
-    float flare_time = aim_height / tecs_Controller->get_land_sinkrate();
+    float flare_time = aim_height / MAX(tecs_Controller->get_land_sinkrate(), 0.1);
 
     // distance to flare is based on ground speed, adjusted as we
     // get closer. This takes into account the wind


### PR DESCRIPTION
if sink rate set to zero. Found during SITL testing
