### PR TITLE
Copter: 4.3.1 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.3.1-rc1 17-Nov-2022
+Copter 4.3.1 05-Dec-2022 / 4.3.1-rc1 17-Nov-2022
 Changes from 4.3.0
 1) Autopilot specific enhancements
    a) ARKV6X support

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.1-rc1"
+#define THISFIRMWARE "ArduCopter V4.3.1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,1,FIRMWARE_VERSION_TYPE_RC
+#define FIRMWARE_VERSION 4,3,1,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.3.1 official release which has been in beta testing for a couple of weeks.

The [beta discussion thread is here](https://discuss.ardupilot.org/t/copter-4-3-1-rc1-available-for-beta-testing/93378) and we received a couple of positive comments from beta testers.