### PR TITLE
opendroneid: add the push of arm message to gcs through MAV port

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -177,6 +177,13 @@ void AP_OpenDroneID::send_dynamic_out()
         _last_send_system_update_ms = now;
         send_system_update_message();
     }
+    // send arm status message to the GCS every 4000 ms and only when receive
+    // arm_status message from the transmitter.
+    if (now - _last_arm_status_ms >= 4000 && 5000 > now - last_arm_status_ms &&
+         ODID_HAVE_PAYLOAD_SPACE(OPEN_DRONE_ID_ARM_STATUS)) {
+        _last_arm_status_ms = now;
+        send_arm_status_message();
+    }
 }
 
 void AP_OpenDroneID::send_static_out()
@@ -429,6 +436,14 @@ void AP_OpenDroneID::send_operator_id_message()
     // note that packet is filled in by the GCS
     if (_chan != MAV_CHAN_INVALID) {
         mavlink_msg_open_drone_id_operator_id_send_struct(_chan, &pkt_operator_id);
+    }
+}
+
+void AP_OpenDroneID::send_arm_status_message()
+{
+    // note that packet is filled in by the GCS
+    if (_chan != MAV_CHAN_INVALID) {
+        mavlink_msg_open_drone_id_arm_status_send_struct(_chan, &arm_status);
     }
 }
 

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.h
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.h
@@ -122,6 +122,7 @@ private:
     uint32_t _last_send_location_ms;
     uint32_t _last_send_system_update_ms;
     uint32_t _last_send_static_messages_ms;
+    uint32_t _last_arm_status_ms;
     const uint32_t _mavlink_dynamic_period_ms = 1000; //how often are mavlink dynamic messages sent in ms. E.g. 1000 = 1 Hz
     const uint32_t _mavlink_static_period_ms = 5000; //how often are mavlink static messages sent in ms
 
@@ -161,6 +162,7 @@ private:
     void send_system_update_message();
     void send_self_id_message();
     void send_operator_id_message();
+    void send_arm_status_message();
     void send_location_message();
     enum next_msg : uint8_t {
         NEXT_MSG_BASIC_ID = 0,


### PR DESCRIPTION
Add the send of opendroneid arm status message to the GCS every 4000 ms and only when receive arm_status message from the transmitter.

Signed-off-by: IssamHamdi <ih@simonwunderlich.de>