### PR TITLE
Copter: Add MANUAL_CONTROL to telemetry

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -344,6 +344,11 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         send_wind();
         break;
 
+    case MSG_MANUAL_CONTROL:
+        CHECK_PAYLOAD_SIZE(MANUAL_CONTROL);
+        send_manual_control();
+        break;
+
     case MSG_SERVO_OUT:
     case MSG_AOA_SSA:
     case MSG_LANDING:
@@ -508,6 +513,7 @@ static const ap_message STREAM_RC_CHANNELS_msgs[] = {
     MSG_SERVO_OUTPUT_RAW,
     MSG_RC_CHANNELS,
     MSG_RC_CHANNELS_RAW, // only sent on a mavlink1 connection
+    MSG_MANUAL_CONTROL,
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,
@@ -1471,6 +1477,18 @@ void GCS_MAVLINK_Copter::send_wind() const
         degrees(atan2f(-wind.y, -wind.x)),
         wind.length(),
         wind.z);
+}
+
+void GCS_MAVLINK_Copter::send_manual_control() const
+{
+    mavlink_msg_manual_control_send(
+        chan,
+        1,
+        int16_t(copter.channel_pitch->norm_input()*1000.0f),
+        int16_t(copter.channel_roll->norm_input()*1000.0f),
+        int16_t(copter.channel_throttle->get_control_in()),
+        int16_t(copter.channel_yaw->norm_input()*1000.0f),
+        0);
 }
 
 #if HAL_HIGH_LATENCY2_ENABLED

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -76,6 +76,8 @@ private:
 
     void send_wind() const;
 
+    void send_manual_control() const;
+
 #if HAL_HIGH_LATENCY2_ENABLED
     int16_t high_latency_target_altitude() const override;
     uint8_t high_latency_tgt_heading() const override;

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -83,5 +83,6 @@ enum ap_message : uint8_t {
     MSG_ATTITUDE_TARGET,
     MSG_HYGROMETER,
     MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE,
+    MSG_MANUAL_CONTROL,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
I want to get the value of the propo as a joystick value.
I can operate the vehicle with MANUAL_CONTROL by getting this value.
The advantage is that the CC can operate the vehicle without being aware of the PWM value.

RC1-4: 1000 PWM
![Screenshot from 2022-12-06 02-44-30](https://user-images.githubusercontent.com/646194/205712127-76789553-d5ec-4d3f-b253-9452183f3a30.png)

RC1-4: 1500 PWM
![Screenshot from 2022-12-06 02-46-49](https://user-images.githubusercontent.com/646194/205712567-bad72625-f953-4a9b-b9df-522409af6ee3.png)


RC1-4: 2000 PWM
![Screenshot from 2022-12-06 02-47-34](https://user-images.githubusercontent.com/646194/205712610-2b0c5218-78e8-4d64-8d63-fd293a4125d8.png)
