### PR TITLE
.github: use older cygwin installer

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -13,9 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - uses: cygwin/cygwin-install-action@master
+      - uses: cygwin/cygwin-install-action@v2
         with:
           packages: install cygwin32-gcc-g++ python37 python37-future python37-lxml python37-pip python37-setuptools python37-wheel git libexpat procps gettext
+          site: http://mirrors.kernel.org/sourceware/cygwin-archive/20221123
       - name: Install cygwin
         env:
           HOME: ${{ runner.workspace }}/ardupilot


### PR DESCRIPTION
Try to fix this:
![image](https://user-images.githubusercontent.com/7077857/205757408-782b89c0-6f1a-4169-a338-568c357c81ab.png)
