### PR TITLE
Copter: pilot takeoff uses rangefinder if present and healthy

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -203,6 +203,8 @@ protected:
         bool _running;
         float take_off_start_alt;
         float take_off_complete_alt;
+        float take_off_complete_alt_terrain_cm;
+        bool use_terrain_alt;   // if true take_off_complete_alt_terrain_cm used as final target (in cm) above terrain
     };
 
     static _TakeOff takeoff;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -195,7 +195,7 @@ protected:
     public:
         void start(float alt_cm);
         void stop();
-        void do_pilot_takeoff(float& pilot_climb_rate);
+        void do_pilot_takeoff(float pilot_climb_rate);
         bool triggered(float target_climb_rate) const;
 
         bool running() const { return _running; }

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -78,7 +78,7 @@ void Mode::_TakeOff::stop()
 //  take off is complete when the vertical target reaches the take off altitude.
 //  climb is cancelled if pilot_climb_rate_cm becomes negative
 //  sets take off to complete when target altitude is within 1% of the take off altitude
-void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
+void Mode::_TakeOff::do_pilot_takeoff(float pilot_climb_rate_cm)
 {
     // return pilot_climb_rate if take-off inactive
     if (!_running) {

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -61,6 +61,15 @@ void Mode::_TakeOff::start(float alt_cm)
     _running = true;
     take_off_start_alt = copter.pos_control->get_pos_target_z_cm();
     take_off_complete_alt  = take_off_start_alt + alt_cm;
+
+    // if rangefinder if available "alt_cm" argument is interpreted as an alt above terrain
+    if ((alt_cm > 0) && copter.rangefinder_alt_ok() && (copter.rangefinder_state.glitch_count == 0)) {
+        use_terrain_alt = true;
+        take_off_complete_alt_terrain_cm = alt_cm;
+    } else {
+        use_terrain_alt = false;
+        take_off_complete_alt_terrain_cm = 0;
+    }
 }
 
 // stop takeoff
@@ -85,6 +94,22 @@ void Mode::_TakeOff::do_pilot_takeoff(float pilot_climb_rate_cm)
         return;
     }
 
+    // calculate takeoff alt correction using range finder
+    float terr_offset = 0.0f;
+    if (use_terrain_alt) {
+        if (copter.rangefinder_alt_ok()) {
+            terr_offset = copter.inertial_nav.get_position_z_up_cm() - copter.rangefinder_state.alt_cm_filt.get();
+        } else {
+            // turn off use of rangefinder if unhealthy
+            use_terrain_alt = false;
+            copter.gcs().send_text(MAV_SEVERITY_WARNING, "takeoff: stopped using rangefinder");
+        }
+    }
+
+    // total climb distance in cm
+    const float est_complete_alt_cm = use_terrain_alt ? take_off_complete_alt_terrain_cm + terr_offset : take_off_complete_alt;
+    const float total_climb_cm = est_complete_alt_cm - take_off_start_alt;
+
     if (copter.ap.land_complete) {
         // send throttle to attitude controller with angle boost
         float throttle = constrain_float(copter.attitude_control->get_throttle_in() + copter.G_Dt / copter.g2.takeoff_throttle_slew_time, 0.0, 1.0);
@@ -94,7 +119,7 @@ void Mode::_TakeOff::do_pilot_takeoff(float pilot_climb_rate_cm)
         if (throttle >= 0.9 || 
             (copter.pos_control->get_z_accel_cmss() >= 0.5 * copter.pos_control->get_max_accel_z_cmss()) ||
             (copter.pos_control->get_vel_desired_cms().z >= constrain_float(pilot_climb_rate_cm, copter.pos_control->get_max_speed_up_cms() * 0.1, copter.pos_control->get_max_speed_up_cms() * 0.5)) || 
-            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_target_z_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
+            (is_positive(total_climb_cm) && copter.pos_control->get_pos_target_z_cm() - take_off_start_alt > 0.5 * total_climb_cm)) {
             // throttle > 90%
             // acceleration > 50% maximum acceleration
             // velocity > 10% maximum velocity && commanded climb rate
@@ -103,16 +128,21 @@ void Mode::_TakeOff::do_pilot_takeoff(float pilot_climb_rate_cm)
             copter.set_land_complete(false);
         }
     } else {
-        float pos_z = take_off_complete_alt;
+        float pos_z = est_complete_alt_cm;
         float vel_z = pilot_climb_rate_cm;
 
         // command the aircraft to the take off altitude and current pilot climb rate
         copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
 
         // stop take off early and return if negative climb rate is commanded or we are within 0.1% of our take off altitude
-        if (is_negative(pilot_climb_rate_cm) ||
-            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_target_z_cm() - take_off_start_alt) {
+        const bool reached_target = total_climb_cm * 0.999f < copter.pos_control->get_pos_target_z_cm() - take_off_start_alt;
+        if (is_negative(pilot_climb_rate_cm) || reached_target) {
             stop();
+
+            // if using rangefinder pass target to surface tracking
+            if (use_terrain_alt && reached_target) {
+                copter.surface_tracking.set_target_alt_cm(take_off_complete_alt_terrain_cm);
+            }
         }
     }
 }

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -778,7 +778,7 @@ void AC_PosControl::init_z_controller()
     _last_update_z_us = AP_HAL::micros64();
 }
 
-/// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
+/// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
 ///     The vel is projected forwards in time based on a time step of dt and acceleration accel.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
 ///     The function alters the vel to be the kinematic path based on accel
@@ -793,7 +793,7 @@ void AC_PosControl::input_accel_z(float accel)
     shape_accel(accel, _accel_desired.z, jerk_max_z_cmsss, _dt);
 }
 
-/// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+/// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
 ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.


### PR DESCRIPTION
This is an updated version of PR https://github.com/ArduPilot/ardupilot/pull/14222.

This modifies the Takeoff class so that it uses the rangefinder if present and healthy when the takeoff starts so that when the takeoff completes the vehicle flying at PILOT_TKOFF_ALT above the terrain (or very close to it).  This only affects semi-manual modes (e.g. AltHold, Loiter, PosHold, ZigZag, etc) and only if the user has set the PILOT_TKOFF_ALT parameter to a non-zero value.

As a reminder, the PILOT_TKOFF_ALT feature causes the vehicle to climb the specified height as soon as the pilot raises the throttle.  This feature was originally added for the Solo because many new users who unfamiliar with drones were flipping their vehicles during overly cautious takeoffs.  These days another common use for this feature is to get agricultural copters up into the air at the specified alt before crop spraying begins.  Crop spraying (normally using ZigZag mode) is typically done at the same altitude each time so having the vehicle climb immediately to this alt saves the pilot some effort.

There are also two small drive-by changes to fixup some comments in AC_PosControl and remove an unnecessary reference on an argument.

Below are before and after shots of the altitudes in SITL where:
- param load [copter-rangefinder.parm](https://github.com/ArduPilot/ardupilot/blob/master/Tools/autotest/default_params/copter-rangefinder.parm) to setup the rangefinder
- PILOT_TKOFF_ALT = 800
- SIM_SONAR_SCALE = 10 (default is about 12.1, this causes the rangefinder to less accurately match the baro alt)
![before-after-rngfnd-scale](https://user-images.githubusercontent.com/1498098/206097019-ca3e34a7-731f-44ae-9118-64087f3ef43e.png)

