### PR TITLE
AP_Mount: fix Siyi A8 reporting of record on/off status

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -397,7 +397,7 @@ void AP_Mount_Siyi::process_packet()
         // update recording state and warn user of mismatch
         const bool recording = _msg_buff[_msg_buff_data_start+3] > 0;
         if (recording != _last_record_video) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Siyi: recording %s", recording ? "ON" : "OFF");
+            gcs().send_text(MAV_SEVERITY_INFO, "Siyi: recording %s", recording ? "ON" : "OFF");
         }
         _last_record_video = recording;
         debug("GimConf hdr:%u rec:%u foll:%u", (unsigned)_msg_buff[_msg_buff_data_start+1],

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -384,7 +384,8 @@ void AP_Mount_Siyi::process_packet()
         break;
 
     case SiyiCommandId::ACQUIRE_GIMBAL_CONFIG_INFO: {
-        if (_parsed_msg.data_bytes_received != 5) {
+        if (_parsed_msg.data_bytes_received != 5 &&     // ZR10 firmware version reply is 5 bytes
+            _parsed_msg.data_bytes_received != 7) {     // A8 firmware version reply is 7 bytes
 #if AP_MOUNT_SIYI_DEBUG
             unexpected_len = true;
 #endif


### PR DESCRIPTION
With the arrival of my Siyi A8 camera I've discovered a couple of issues that this PR fixes:

1. The Siyi A8 camera sends the Gimbal Configuration message with 7 fields (the ZR10 sends 5).  This caused the consumption of the message to fail and so the AP driver was never sure whether video recording was working or not.
2. Request the Gimbal Configuration at 1hz to be sure that we've got the latest status.  The previous method only requested this status if the pilot had actively changed the status but the camera recording can fail for other reasons (like the SD Card filling up) so it is more reliable to also request an update at 1hz
3. The "Recording ON/OFF" message was sent as an ERROR which is not correct.  Although we'd like the user to see this message, INFO is perhaps good enough.

This has been tested on a real vehicle and below is a screen shot of MP's message tab showing the reporting working as I turn on/off recording using MP's Aux Functions tab.
![image](https://user-images.githubusercontent.com/1498098/206632385-ba9dc32a-61de-4dfd-ac08-3c457574957e.png)
