### PR TITLE
AP_AHRS: use active EKF type for origin and crtl limits

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1904,6 +1904,11 @@ AP_AHRS::EKFType AP_AHRS::active_EKF_type(void) const
     if (ret != EKFType::NONE &&
         (_vehicle_class == VehicleClass::FIXED_WING ||
          _vehicle_class == VehicleClass::GROUND)) {
+        if (!dcm.yaw_source_available() && !fly_forward) {
+            // if we don't have a DCM yaw source available and we are
+            // in a non-fly-forward mode then we are best off using the EKF
+            return ret;
+        }
         bool should_use_gps = true;
         nav_filter_status filt_state;
 #if HAL_NAVEKF2_AVAILABLE

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -223,6 +223,14 @@ void AP_AHRS::init()
     }
 #endif
 
+#if HAL_NAVEKF2_AVAILABLE && HAL_NAVEKF3_AVAILABLE
+    // a special case to catch users who had AHRS_EKF_TYPE=2 saved and
+    // updated to a version where EK2_ENABLE=0
+    if (_ekf_type.get() == 2 && !EKF2.get_enable() && EKF3.get_enable()) {
+        _ekf_type.set(3);
+    }
+#endif
+
     last_active_ekf_type = (EKFType)_ekf_type.get();
 
     // init backends
@@ -2705,29 +2713,21 @@ void AP_AHRS::send_ekf_status_report(GCS_MAVLINK &link) const
     }
 }
 
-// passes a reference to the location of the inertial navigation origin
-// in WGS-84 coordinates
-// returns a boolean true when the inertial navigation origin has been set
-bool AP_AHRS::get_origin(Location &ret) const
+// return origin for a specified EKF type
+bool AP_AHRS::get_origin(EKFType type, Location &ret) const
 {
-    switch (ekf_type()) {
+    switch (type) {
     case EKFType::NONE:
         return dcm.get_origin(ret);
 
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
-        if (!EKF2.getOriginLLH(ret)) {
-            return false;
-        }
-        return true;
+        return EKF2.getOriginLLH(ret);
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        if (!EKF3.getOriginLLH(ret)) {
-            return false;
-        }
-        return true;
+        return EKF3.getOriginLLH(ret);
 #endif
 
 #if AP_AHRS_SIM_ENABLED
@@ -2745,7 +2745,25 @@ bool AP_AHRS::get_origin(Location &ret) const
         return AP::externalAHRS().get_origin(ret);
 #endif
     }
+    return false;
+}
 
+/*
+  return origin for the configured EKF type. If we are armed and the
+  configured EKF type cannot return an origin then return origin for
+  the active EKF type (if available)
+
+  This copes with users force arming a plane that is running on DCM as
+  the EKF has not fully initialised
+ */
+bool AP_AHRS::get_origin(Location &ret) const
+{
+    if (get_origin(ekf_type(), ret)) {
+        return true;
+    }
+    if (hal.util->get_soft_armed() && get_origin(active_EKF_type(), ret)) {
+        return true;
+    }
     return false;
 }
 
@@ -2754,7 +2772,7 @@ bool AP_AHRS::get_origin(Location &ret) const
 // it will return false when no limiting is required
 bool AP_AHRS::get_hgt_ctrl_limit(float& limit) const
 {
-    switch (ekf_type()) {
+    switch (active_EKF_type()) {
     case EKFType::NONE:
         // We are not using an EKF so no limiting applies
         return false;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -690,6 +690,9 @@ private:
     // update roll_sensor, pitch_sensor and yaw_sensor
     void update_cd_values(void);
 
+    // return origin for a specified EKF type
+    bool get_origin(EKFType type, Location &ret) const;
+
     // helper trig variables
     float _cos_roll{1.0f};
     float _cos_pitch{1.0f};

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1254,3 +1254,9 @@ bool AP_AHRS_DCM::get_relative_position_D_origin(float &posD) const
 void AP_AHRS_DCM::send_ekf_status_report(GCS_MAVLINK &link) const
 {
 }
+
+// return true if DCM has a yaw source available
+bool AP_AHRS_DCM::yaw_source_available(void) const
+{
+    return AP::compass().use_for_yaw();
+}

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -124,6 +124,9 @@ public:
 
     void send_ekf_status_report(class GCS_MAVLINK &link) const override;
 
+    // return true if DCM has a yaw source
+    bool yaw_source_available(void) const;
+
 private:
 
     // settable parameters

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -244,6 +244,9 @@ public:
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set_enable(enable); }
 
+    // get the enable parameter
+    bool get_enable(void) const { return bool(_enable.get()); }
+    
     /*
      * Write position and quaternion data from an external navigation system
      *

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -312,6 +312,9 @@ public:
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set_enable(enable); }
 
+    // get the enable parameter
+    bool get_enable(void) const { return bool(_enable.get()); }
+    
     /*
       check if switching lanes will reduce the normalised
       innovations. This is called when the vehicle code is about to


### PR DESCRIPTION
this fixes a "climb away" in quadplanes when AHRS_EKF_TYPE=2 and EK2_ENABLE=0. The user has ARMING_CHECK=5390 to disable key arming checks, and the plane flew on DCM as the configured EKF wasn't enabled.

This resulted in AHRS::get_origin() returning false as it couldn't ask EKF2 for the origin (as EKF2 was not enabled or instantiated)

The result was an incorrect calculation for target height during the descent stage of QRTL, resulting in a climb away until the user took over

The fix involves several changes:

 - if the configured EKF type cannot provide an origin then use the active EKF type if we are armed. We don't do this while disarmed as the vehicle code may use the boolean result of get_origin() to determine if the EKF is initialised or not (see for example set_home() in copter).

 - if DCM does not have a yaw source (only compass currently) then when not in fly forward don't do the fallback to DCM. This copes with quadplanes with no compass

 - for the update problem from 4.1.x and earlier, some vehicles may have AHRS_EKF_TYPE=2 but have EK2_ENABLE=0 and EK3_ENABLE=1. This can easily happen if the user has ever set AHRS_EKF_TYPE and then updates to 4.2.x or later. For this special case we auto-set AHSR_EKF_TYPE=3

test flown on a 4+1 quadplane, CubeOrange and on a Jumper-Xiake800
