### PR TITLE
AP_RangeFinder: skip GPIO arming check on analog backend

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -771,6 +771,11 @@ bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_le
                 hal.util->snprintf(failure_msg, failure_msg_len, "RNGFND%u_PIN not set", unsigned(i + 1));
                 return false;
             }
+            if (drivers[i]->allocated_type() == Type::ANALOG) {
+                // Analog backend does not use GPIO pin
+                break;
+            }
+
             // ensure that the pin we're configured to use is available
             if (!hal.gpio->valid_pin(params[i].pin)) {
                 uint8_t servo_ch;


### PR DESCRIPTION
The analog back end uses analog pins not GPIO pins, so its not correct to use `hal.gpio->valid_pin` this breaks out of the check before reaching that case. 

There is sometimes cross over between GPIO and analog, but as far as I am aware never analog and SERVO.

Resolves outstanding issue from 4.3 release, https://github.com/ArduPilot/ardupilot/issues/21711