### PR TITLE
Plane: Auto Landing Refinement

### DIFF
--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -154,6 +154,15 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FLARE_AIM", 17, AP_Landing, flare_effectivness_pct, 50),
 
+    // @Param: WIND_COMP
+    // @DisplayName: Headwind Compensation when Landing
+    // @Description: This param controls how much headwind compensation is used when landing.  Headwind speed component multiplied by this parameter is added to TECS_LAND_ARSPD command.  Set to Zero to disable.  Note:  The target landing airspeed command is still limited to ARSPD_FBW_MAX.
+    // @Range: 0 1
+    // @Units: %
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("WIND_COMP", 18, AP_Landing, wind_comp, 0.5),
+
     // @Param: TYPE
     // @DisplayName: Auto-landing type
     // @Description: Specifies the auto-landing type to use

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -157,11 +157,11 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: WIND_COMP
     // @DisplayName: Headwind Compensation when Landing
     // @Description: This param controls how much headwind compensation is used when landing.  Headwind speed component multiplied by this parameter is added to TECS_LAND_ARSPD command.  Set to Zero to disable.  Note:  The target landing airspeed command is still limited to ARSPD_FBW_MAX.
-    // @Range: 0 1
+    // @Range: 0 100
     // @Units: %
-    // @Increment: 0.1
+    // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("WIND_COMP", 18, AP_Landing, wind_comp, 0.5),
+    AP_GROUPINFO("WIND_COMP", 18, AP_Landing, wind_comp, 50),
 
     // @Param: TYPE
     // @DisplayName: Auto-landing type

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -141,7 +141,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Landing options bitmask
     // @Description: Bitmask of options to use with landing.
-    // @Bitmask: 0: honor min throttle during landing flare
+    // @Bitmask: 0: honor min throttle during landing flare,1: Increase Target landing airspeed constraint From Trim Airspeed to ARSPD_FBW_MAX
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 16, AP_Landing, _options, 0),
 
@@ -691,6 +691,12 @@ bool AP_Landing::is_throttle_suppressed(void) const
 bool AP_Landing::use_thr_min_during_flare(void) const
 {
     return (OptionsMask::ON_LANDING_FLARE_USE_THR_MIN & _options) != 0;
+}
+
+//defaults to false, but _options bit zero enables it.
+bool AP_Landing::allow_max_airspeed_on_land(void) const
+{
+    return (OptionsMask::ON_LANDING_USE_ARSPD_MAX & _options) != 0;
 }
 
 /*

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -166,6 +166,7 @@ private:
     AP_Int8 throttle_slewrate;
     AP_Int8 type;
     AP_Int8 flare_effectivness_pct;
+    AP_Float wind_comp;
 
     // Land Type STANDARD GLIDE SLOPE
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -61,6 +61,7 @@ public:
     // we support upto 32 boolean bits for users wanting to change landing behaviour.
     enum OptionsMask {
         ON_LANDING_FLARE_USE_THR_MIN                   = (1<<0),   // If set then set trottle to thr_min instead of zero on final flare
+        ON_LANDING_USE_ARSPD_MAX                       = (1<<1),   // If set then allow landing throttle constraint to be increased from trim airspeed to max airspeed (ARSPD_FBW_MAX)
     };
 
     void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
@@ -79,6 +80,7 @@ public:
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
     bool use_thr_min_during_flare(void) const; //defaults to false, but _options bit zero enables it.
+    bool allow_max_airspeed_on_land(void) const; //defaults to false, but _options bit one enables it.
     void handle_flight_stage_change(const bool _in_landing_stage);
     int32_t constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool get_target_altitude_location(Location &location);

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -365,8 +365,8 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     // when landing, add half of head-wind.
     const int32_t head_wind_compensation_cm = head_wind() * 0.5f * 100;
 
-    // Do not lower it or exceed cruise speed
-    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_cruise_cm);
+    // Do not lower it or exceed max airspeed `ARSPD_FBW_MAX`
+    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_max*100);
 }
 
 int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd)

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -363,7 +363,8 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     }
 
     // when landing, add half of head-wind.
-    const int32_t head_wind_compensation_cm = head_wind() * 0.5f * 100;
+    const float head_wind_comp = constrain_float((float)wind_comp, 0.0f, 1.0f);
+    const int32_t head_wind_compensation_cm = head_wind() * head_wind_comp * 100;
 
     // Do not lower it or exceed max airspeed `ARSPD_FBW_MAX`
     return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_max*100);

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -363,7 +363,7 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     }
 
     // when landing, add half of head-wind.
-    const float head_wind_comp = constrain_float((float)wind_comp, 0.0f, 1.0f);
+    const float head_wind_comp = constrain_float((float)wind_comp, 0.0f, 100.0f)*0.01;
     const int32_t head_wind_compensation_cm = head_wind() * head_wind_comp * 100;
 
     // Do not lower it or exceed max airspeed `ARSPD_FBW_MAX`

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -363,11 +363,13 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     }
 
     // when landing, add half of head-wind.
-    const float head_wind_comp = constrain_float((float)wind_comp, 0.0f, 100.0f)*0.01;
+    const float head_wind_comp = constrain_float(wind_comp, 0.0f, 100.0f)*0.01;
     const int32_t head_wind_compensation_cm = head_wind() * head_wind_comp * 100;
 
-    // Do not lower it or exceed max airspeed `ARSPD_FBW_MAX`
-    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_max*100);
+    const uint32_t max_airspeed_cm = AP_Landing::allow_max_airspeed_on_land() ? aparm.airspeed_max*100 : aparm.airspeed_cruise_cm;
+    
+    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, max_airspeed_cm);
+    
 }
 
 int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd)

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: LAND_ARSPD
     // @DisplayName: Airspeed during landing approach (m/s)
-    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
+    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is ARSPD_FBW_MAX.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
     // @Range: -1 127
     // @Increment: 1
     // @User: Standard

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: LAND_ARSPD
     // @DisplayName: Airspeed during landing approach (m/s)
-    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is ARSPD_FBW_MAX.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
+    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is Trim Airspeed or ARSPD_FBW_MAX as defined by LAND_OPTIONS bitmask.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
     // @Range: -1 127
     // @Increment: 1
     // @User: Standard


### PR DESCRIPTION
It was found that entry airspeed was critical to the pseudo open loop flare.  In this case, the `TECS_LAND_AIRSPEED` needed to be higher than `TRIM_ARSPD_CM`.  The aircraft flew safely at `ARSPD_FBW_MIN` and `TRIM_ARSPD_CM`, but in order to get predictable and safe flare behavior, the aircraft required slightly higher than trim airspeed on flare entry.  It was discovered that this configuration wasn't capable because the current master implementation constrains at `TRIM_ARSPD_CM`.  Test flights were flown with raising this constraint to `ARSPD_FBW_MAX` airspeed with successful results.  However, also unique to this aircraft, the headwind compensation was desired to be disabled.  As this was a static constant in the code, I've added a user defined parameter to allow user to pick their desired HeadWind component compensation.

* Raised Landing Airspeed max constraint to `ARSPD_FBW_MAX`
* Added `LAND_WIND_COMP` parameter to define how much headwind compensation the user wants

<img width="1111" alt="Screenshot 2022-12-11 at 12 36 59 AM" src="https://user-images.githubusercontent.com/7753691/206888479-e1896c9f-d5b1-4f68-88f8-9c4d4fc4a630.png">

