### PR TITLE
Plane: move adjust_altitude_target functionality to per mode functions

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -115,7 +115,7 @@ public:
     virtual bool does_auto_throttle() const { return false; }
 
     // method for mode specific target altitude profiles
-    virtual bool update_target_altitude() { return false; }
+    virtual void update_target_altitude();
 
     // handle a guided target request from GCS
     virtual bool handle_guided_request(Location target_loc) { return false; }
@@ -226,6 +226,8 @@ public:
 
     void set_radius_and_direction(const float radius, const bool direction_is_ccw);
 
+    void update_target_altitude() override;
+
 protected:
 
     bool _enter() override;
@@ -275,8 +277,10 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
-    
+
     bool allows_terrain_disable() const override { return true; }
+
+    void update_target_altitude() override;
 
 protected:
 
@@ -422,6 +426,8 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
+    void update_target_altitude() override {};
+
 protected:
 
     bool _enter() override;
@@ -447,6 +453,8 @@ public:
     bool get_target_heading_cd(int32_t &target_heading) const;
 
     bool does_auto_throttle() const override { return true; }
+
+    void update_target_altitude() override {};
 
 protected:
 
@@ -596,7 +604,7 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
-    bool update_target_altitude() override;
+    void update_target_altitude() override;
 
     bool allows_throttle_nudging() const override;
 

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -110,3 +110,10 @@ void ModeLoiter::navigate()
     plane.update_loiter(0);
 }
 
+void ModeLoiter::update_target_altitude()
+{
+    if (plane.stick_mixing_enabled() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
+        return;
+    }
+    Mode::update_target_altitude();
+}

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -132,13 +132,14 @@ void ModeQRTL::run()
 /*
   update target altitude for QRTL profile
  */
-bool ModeQRTL::update_target_altitude()
+void ModeQRTL::update_target_altitude()
 {
     /*
       update height target in approach
      */
     if ((submode != SubMode::RTL) || (plane.quadplane.poscontrol.get_state() != QuadPlane::QPOS_APPROACH)) {
-        return false;
+        Mode::update_target_altitude();
+        return;
     }
 
     /*
@@ -158,7 +159,7 @@ bool ModeQRTL::update_target_altitude()
     Location loc = plane.next_WP_loc;
     loc.alt += alt*100;
     plane.set_target_altitude_location(loc);
-    return true;
+    plane.altitude_error_cm = plane.calc_altitude_error_cm();
 }
 
 // only nudge during approach


### PR DESCRIPTION
A none functional re-work of the `adjust_altitude_target` function, moving functionality down into the existing per-mode `update_target_altitude` function. This simplifys code by keeping mode specific functionality in mode files.

The if's for fbwb, cruise, loiter and guided have been moved down. The remaining functionality is then moved to the base `Mode` class. Currently this is left in `altitude.cpp` to minimize the diff (just lots of `plane.` due to the namespace change), but it should be moved into `mode.cpp` in the future.