### PR TITLE
AP_TemperatureSensor: fix param count change when loading drivers

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
@@ -151,6 +151,11 @@ void AP_TemperatureSensor::init()
             _num_instances = instance + 1;
         }
     }
+    
+    if (_num_instances > 0) {
+        // param count could have changed
+        AP_Param::invalidate_count();
+    }
 }
 
 // update: - For all active instances update temperature and log TEMP


### PR DESCRIPTION
fix AP_TemperatureSensor param count change when loading drivers which was causing GCS spam. Closes  https://github.com/ArduPilot/ardupilot/issues/22357