### PR TITLE
AP_Arming: skip AHRS vs GPS location check if GPS is disabled

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -379,7 +379,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     }
 
     // warn about hdop separately - to prevent user confusion with no gps lock
-    if (copter.gps.get_hdop() > copter.g.gps_hdop_good) {
+    if ((copter.gps.num_sensors() > 0) && (copter.gps.get_hdop() > copter.g.gps_hdop_good)) {
         check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP");
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -549,12 +549,12 @@ bool AP_Arming::gps_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS)) {
 
         // Any failure messages from GPS backends
-            char failure_msg[50] = {};
-            if (!AP::gps().backends_healthy(failure_msg, ARRAY_SIZE(failure_msg))) {
-                if (failure_msg[0] != '\0') {
-                    check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
-                }
-                return false;
+        char failure_msg[50] = {};
+        if (!AP::gps().backends_healthy(failure_msg, ARRAY_SIZE(failure_msg))) {
+            if (failure_msg[0] != '\0') {
+                check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
+            }
+            return false;
         }
 
         for (uint8_t i = 0; i < gps.num_sensors(); i++) {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -602,13 +602,15 @@ bool AP_Arming::gps_checks(bool report)
         }
 
         // check AHRS and GPS are within 10m of each other
-        const Location gps_loc = gps.location();
-        Location ahrs_loc;
-        if (AP::ahrs().get_location(ahrs_loc)) {
-            const float distance = gps_loc.get_distance(ahrs_loc);
-            if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
-                check_failed(ARMING_CHECK_GPS, report, "GPS and AHRS differ by %4.1fm", (double)distance);
-                return false;
+        if (gps.num_sensors() > 0) {
+            const Location gps_loc = gps.location();
+            Location ahrs_loc;
+            if (AP::ahrs().get_location(ahrs_loc)) {
+                const float distance = gps_loc.get_distance(ahrs_loc);
+                if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
+                    check_failed(ARMING_CHECK_GPS, report, "GPS and AHRS differ by %4.1fm", (double)distance);
+                    return false;
+                }
             }
         }
     }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -585,7 +585,7 @@ bool AP_Arming::gps_checks(bool report)
         }
 
         if (!AP::ahrs().home_is_set()) {
-            check_failed(ARMING_CHECK_GPS, report, "GPS: waiting for home");
+            check_failed(ARMING_CHECK_GPS, report, "AHRS: waiting for home");
             return false;
         }
 


### PR DESCRIPTION
This PR clears up some false-positive arming failures when using Non-GPS navigation (e.g. the [ModalAI VOXL camera](https://ardupilot.org/copter/docs/common-modalai-voxl.html)).  The troublesome messages are:

- GPS and AHRS differ by 1.5e+07m
- High GPS HDOP (Copter only)

The changes are:

1. Skip the AP_Arming comparison of AHRS vs the primary GPS if no GPSs are enabled (e.g. AP_GPS::num_sensors() == 0)
2. Skip the Copter specific GPS HDOP arming check if no GPSs are enabled (e.g. AP_GPS::num_sensors() == 0)

BTW, I was concerned about the difference between "AP_GPS::num_sensors()" and the number configured (e.g. GPS_TYPE, GPS_TYPE2) but the existing AP_GPS::first_unconfigured_gps() check catches cases where the user has set GPS_TYPE, GPS_TYPE2 but the drivers haven't found the GPS.  It also should not be an issue if only the 2nd GPS is configured (e.g. GPS_TYPE = 0, GPS_TYPE2 = x).

This PR also includes two small formatting changes:

3. AP_Arming indentation fix (surely left over from a previous PR that wanted to keep the diff to a minimum)
4. Replaced "GPS: waiting for home" with "AHRS: waiting for home" which is more accurate.

This PR resolves issues https://github.com/ArduPilot/ardupilot/issues/22383, https://github.com/ArduPilot/ardupilot/issues/14661 and https://github.com/ArduPilot/ardupilot/issues/14841

Below are some screen shots of testing on a real vehicle.
![pr-ahrs-vs-gps-before-vs-after](https://user-images.githubusercontent.com/1498098/207314032-bb7739d6-e6d3-4211-ac3b-4e3448216a4c.png)

