### PR TITLE
Tools: extract_features.py: add Richenpower define

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -106,6 +106,7 @@ class ExtractFeatures(object):
             ('HAL_EFI_ENABLED', 'AP_RPM_EFI::AP_RPM_EFI',),
             ('HAL_EFI_NWPWU_ENABLED', r'AP_EFI_NWPMU::update\b',),
             ('HAL_GENERATOR_ENABLED', 'AP_Generator::AP_Generator',),
+            ('AP_GENERATOR_{type}_ENABLED', r'AP_Generator_(?P<type>.*)::update',),
 
             ('OSD_ENABLED', 'AP_OSD::AP_OSD',),
             ('HAL_PLUSCODE_ENABLE', 'AP_OSD_Screen::draw_pluscode',),


### PR DESCRIPTION
... well, for all backends, but this is the one that has backend-specific defines
