### PR TITLE
GCS_MAVLink: Ensure serial tunnel avoids nullptr

### DIFF
--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -80,9 +80,9 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
         stream = port = AP::serialmanager().get_serial_by_id(packet.device - SERIAL_CONTROL_SERIAL0);
 
         // see if we need to lock mavlink
-        for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+        for (uint8_t i=0; i<gcs().num_gcs(); i++) {
             GCS_MAVLINK *link = gcs().chan(i);
-            if (link == nullptr || link->get_uart() != port) {
+            if (link->get_uart() != port) {
                 continue;
             }
             link->lock(exclusive);


### PR DESCRIPTION
This solves an ``Internal errors 0x40000 l:15 gcs_offset`` caused by trying to access a nonexistent MAVLink channel.

Tested on a CubeOrange.