### PR TITLE
GCS_MAVLink_*: code-generate chan-fetching methods 

### DIFF
--- a/AntennaTracker/GCS_Tracker.h
+++ b/AntennaTracker/GCS_Tracker.h
@@ -10,21 +10,12 @@ class GCS_Tracker : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Tracker *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Tracker*)_chan[ofs];
-    }
-    const GCS_MAVLINK_Tracker *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Tracker*)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Tracker);
 
     void update_vehicle_sensor_status_flags() override;
 

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -9,21 +9,12 @@ class GCS_Copter : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Copter *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Copter *)_chan[ofs];
-    }
-    const GCS_MAVLINK_Copter *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Copter *)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Copter);
 
     void update_vehicle_sensor_status_flags(void) override;
 

--- a/ArduPlane/GCS_Plane.h
+++ b/ArduPlane/GCS_Plane.h
@@ -9,21 +9,12 @@ class GCS_Plane : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Plane *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Plane *)_chan[ofs];
-    }
-    const GCS_MAVLINK_Plane *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Plane *)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Plane);
 
 protected:
 

--- a/ArduSub/GCS_Sub.h
+++ b/ArduSub/GCS_Sub.h
@@ -9,21 +9,12 @@ class GCS_Sub : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Sub *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Sub*)_chan[ofs];
-    }
-    const GCS_MAVLINK_Sub *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Sub*)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Sub);
 
     void update_vehicle_sensor_status_flags() override;
 

--- a/Blimp/GCS_Blimp.h
+++ b/Blimp/GCS_Blimp.h
@@ -9,23 +9,12 @@ class GCS_Blimp : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Blimp *chan(const uint8_t ofs) override
-    {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Blimp *)_chan[ofs];
-    }
-    const GCS_MAVLINK_Blimp *chan(const uint8_t ofs) const override
-    {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Blimp *)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Blimp);
 
     void update_vehicle_sensor_status_flags(void) override;
 

--- a/Rover/GCS_Rover.h
+++ b/Rover/GCS_Rover.h
@@ -9,22 +9,12 @@ class GCS_Rover : public GCS
 
 public:
 
-    // return GCS link at offset ofs
-    GCS_MAVLINK_Rover *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Rover*)_chan[ofs];
-    }
-    // return GCS link at offset ofs
-    const GCS_MAVLINK_Rover *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Rover*)_chan[ofs];
-    }
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Rover);
 
     uint32_t custom_mode() const override;
     MAV_TYPE frame_type() const override;

--- a/Tools/AP_Periph/GCS_MAVLink.h
+++ b/Tools/AP_Periph/GCS_MAVLink.h
@@ -70,20 +70,12 @@ protected:
     }
 
 private:
-    GCS_MAVLINK_Periph *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Periph *)_chan[ofs];
-    };
-    const GCS_MAVLINK_Periph *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Periph *)_chan[ofs];
-    };
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Periph);
 
     MAV_TYPE frame_type() const override { return MAV_TYPE_GENERIC; }
     uint32_t custom_mode() const override { return 3; } // magic number

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -86,6 +86,28 @@ void gcs_out_of_space_to_send(mavlink_channel_t chan);
     }
 #define MAV_STREAM_TERMINATOR { (streams)0, nullptr, 0 }
 
+// code generation; avoid each subclass duplicating these two methods
+// and just changing the name.  These methods allow retrieval of
+// objects specific to the vehicle's subclass, which the vehicle can
+// then call its own specific methods on
+#define GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(subclass_name) \
+    subclass_name *chan(const uint8_t ofs) override {                   \
+        if (ofs > _num_gcs) {                                           \
+            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
+            return nullptr;                                             \
+        }                                                               \
+        return (subclass_name *)_chan[ofs];                        \
+    }                                                                   \
+                                                                        \
+    const subclass_name *chan(const uint8_t ofs) const override { \
+        if (ofs > _num_gcs) {                                           \
+            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
+            return nullptr;                                             \
+        }                                                               \
+        return (subclass_name *)_chan[ofs];                        \
+    }
+
+
 #define GCS_MAVLINK_NUM_STREAM_RATES 10
 class GCS_MAVLINK_Parameters
 {

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -61,20 +61,12 @@ protected:
     }
 
 private:
-    GCS_MAVLINK_Dummy *chan(const uint8_t ofs) override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Dummy *)_chan[ofs];
-    };
-    const GCS_MAVLINK_Dummy *chan(const uint8_t ofs) const override {
-        if (ofs > _num_gcs) {
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);
-            return nullptr;
-        }
-        return (GCS_MAVLINK_Dummy *)_chan[ofs];
-    };
+    // the following define expands to a pair of methods to retrieve a
+    // pointer to an object of the correct subclass for the link at
+    // offset ofs.  These are of the form:
+    // GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override;
+    // const GCS_MAVLINK_XXXX *chan(const uint8_t ofs) override const;
+    GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(GCS_MAVLINK_Dummy);
 
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, uint8_t dest_bitmask) override;
 


### PR DESCRIPTION
A recent PR had to change every single one of these methods, which was kind of unfortunate.

So generate the methods using a #define so the duplication happens at preprocessor-time.
