### PR TITLE
Correct gcs-channel-offset check

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -92,7 +92,7 @@ void gcs_out_of_space_to_send(mavlink_channel_t chan);
 // then call its own specific methods on
 #define GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(subclass_name) \
     subclass_name *chan(const uint8_t ofs) override {                   \
-        if (ofs > _num_gcs) {                                           \
+        if (ofs >= _num_gcs) {                                           \
             INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
             return nullptr;                                             \
         }                                                               \
@@ -100,7 +100,7 @@ void gcs_out_of_space_to_send(mavlink_channel_t chan);
     }                                                                   \
                                                                         \
     const subclass_name *chan(const uint8_t ofs) const override { \
-        if (ofs > _num_gcs) {                                           \
+        if (ofs >= _num_gcs) {                                           \
             INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
             return nullptr;                                             \
         }                                                               \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2717,11 +2717,11 @@ MAV_RESULT GCS::set_message_interval(uint8_t port_num, uint32_t msg_id, int32_t 
 {
     uint8_t channel = get_channel_from_port_number(port_num);
 
-    if ((channel < MAVLINK_COMM_NUM_BUFFERS) && (chan(channel) != nullptr)) {
-        return chan(channel)->set_message_interval(msg_id, interval_us);
+    if (channel >= num_gcs()) {
+        return MAV_RESULT_FAILED;
     }
 
-    return MAV_RESULT_FAILED;
+    return chan(channel)->set_message_interval(msg_id, interval_us);
 }
 
 uint8_t GCS::get_channel_from_port_number(uint8_t port_num)

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -87,12 +87,8 @@ void GCS_MAVLINK::handle_setup_signing(const mavlink_message_t &msg) const
     }
 
     // activate it immediately on all links:
-    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
-        GCS_MAVLINK *backend = gcs().chan(i);
-        if (backend == nullptr) {
-            return;
-        }
-        backend->load_signing_key();
+    for (uint8_t i=0; i<gcs().num_gcs(); i++) {
+        gcs().chan(i)->load_signing_key();
     }
 }
 

--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -80,9 +80,9 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
         stream = port = AP::serialmanager().get_serial_by_id(packet.device - SERIAL_CONTROL_SERIAL0);
 
         // see if we need to lock mavlink
-        for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+        for (uint8_t i=0; i<gcs().num_gcs(); i++) {
             GCS_MAVLINK *link = gcs().chan(i);
-            if (link == nullptr || link->get_uart() != port) {
+            if (link->get_uart() != port) {
                 continue;
             }
             link->lock(exclusive);


### PR DESCRIPTION
Off-by-one error.

The equivalent change was made by tridge at some stage, but it is not in master or Pl;ane-4.3.1 and I can't find a PR....

Corrected two places that were relying on being able to get a nullptr back from `chan(i)`.

Built on top of https://github.com/ArduPilot/ardupilot/pull/22398
