### PR TITLE
WIP: AP_CANManager: CAN Node Pre ARM Check 

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -99,6 +99,62 @@ const AP_Param::GroupInfo AP_CANManager::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("LOGLEVEL", 8, AP_CANManager, _loglevel, AP_CANManager::LOG_NONE),
 
+    // @Param: ID_1
+    // @DisplayName: ID_1
+    // @Description: CAN ID from 1 -16 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_1", 9, AP_CANManager, _can_id_check_1, 0),
+
+    // @Param: ID_2
+    // @DisplayName: ID_2
+    // @Description: CAN ID from 17 - 32 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_2", 10, AP_CANManager, _can_id_check_2, 0),
+
+    // @Param: ID_3
+    // @DisplayName: ID_3
+    // @Description: CAN ID from 33 - 48 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_3", 11, AP_CANManager, _can_id_check_3, 0),
+
+    // @Param: ID_4
+    // @DisplayName: ID_4
+    // @Description: CAN ID from 49 - 64 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_4", 12, AP_CANManager, _can_id_check_4, 0),
+
+    // @Param: ID_5
+    // @DisplayName: ID_5
+    // @Description: CAN ID from 65 - 80 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_5", 13, AP_CANManager, _can_id_check_5, 0),
+
+    // @Param: ID_6
+    // @DisplayName: ID_6
+    // @Description: CAN ID from 81 - 96 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_6", 14, AP_CANManager, _can_id_check_6, 0),
+
+    // @Param: ID_7
+    // @DisplayName: ID_7
+    // @Description: CAN ID from 97 - 112 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 16
+    // @User: Advanced
+    AP_GROUPINFO("ID_7", 15, AP_CANManager, _can_id_check_7, 0),
+
+    // @Param: ID_8
+    // @DisplayName: ID_8
+    // @Description: CAN ID from 113 - 125 could be checked if to have a pre arm condition  
+    // @Bitmask: 0 13
+    // @User: Advanced
+    AP_GROUPINFO("ID_8", 16, AP_CANManager, _can_id_check_8, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -110,6 +110,16 @@ public:
         return Driver_Type_None;
     }
 
+    // Can Id Pre arm check Param
+    AP_Int32 _can_id_check_1;
+    AP_Int32 _can_id_check_2;
+    AP_Int32 _can_id_check_3;
+    AP_Int32 _can_id_check_4;
+    AP_Int32 _can_id_check_5;
+    AP_Int32 _can_id_check_6;
+    AP_Int32 _can_id_check_7;
+    AP_Int32 _can_id_check_8;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 #if HAL_GCS_ENABLED

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -146,6 +146,18 @@ public:
     // Save parameters
     bool save_parameters_on_node(uint8_t node_id, ParamSaveCb *cb);
 
+    // returns can check node id param
+    void get_can_check_node_param(int32_t *temp_array) const {
+        temp_array[0] = AP::can()._can_id_check_1.get();
+        temp_array[1] = AP::can()._can_id_check_2.get();
+        temp_array[2] = AP::can()._can_id_check_3.get();
+        temp_array[3] = AP::can()._can_id_check_4.get();
+        temp_array[4] = AP::can()._can_id_check_5.get();
+        temp_array[5] = AP::can()._can_id_check_6.get();
+        temp_array[6] = AP::can()._can_id_check_7.get();
+        temp_array[7] = AP::can()._can_id_check_8.get();
+    }
+
     template <typename DataType_>
     class RegistryBinder {
     protected:

--- a/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN_DNA_Server.h
@@ -26,6 +26,7 @@ class AP_UAVCAN_DNA_Server
 
     enum ServerState {
         NODE_STATUS_UNHEALTHY = -5,
+        FAILED_TO_CHECK_NODE = -4,
         STORAGE_FAILURE = -3,
         DUPLICATE_NODES = -2,
         FAILED_TO_ADD_NODE = -1,
@@ -131,6 +132,8 @@ public:
 
     //Run through the list of seen node ids for verification
     void verify_nodes();
+
+    void handleNodesIDCheck();
 };
 
 #endif


### PR DESCRIPTION
The idea is to have a way of assuring flight controller is able to see all the CPN necessary for the system to safe.
Made 8 config param "CAN_ID_1" ... "CAN_ID_8" where each bit is ranging from 1 -125 node ID.
Currently, we are calling this code at a 5Hz frequency under verify_node() but can be done at a faster rate.

Tested it with SITL and our system and it  works. Not sure if we should also have a check during ARM and not just Pre ARM.
