### PR TITLE
AP_Logger: include PIDInfo header in place of PID header

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -8,7 +8,7 @@
 #include <AP_RSSI/AP_RSSI.h>
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
-#include <AC_PID/AC_PID.h>
+#include <AC_PID/AP_PIDInfo.h>
 
 #include "AP_Logger.h"
 #include "AP_Logger_File.h"


### PR DESCRIPTION
AC_PID.h includes a remarkable amount of stuff