### PR TITLE
GCS_MAVLink: provide and use iterator for mavlink backends (remove internal_error)

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -84,8 +84,7 @@ void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
     if (entry == nullptr) {
         return;
     }
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        GCS_MAVLINK &c = *chan(i);
+    for (auto &c : links) {
         if (c.is_private()) {
             continue;
         }
@@ -115,8 +114,7 @@ void GCS::send_named_float(const char *name, float value) const
 #if HAL_HIGH_LATENCY2_ENABLED
 void GCS::enable_high_latency_connections(bool enabled)
 {
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        GCS_MAVLINK &c = *chan(i);
+    for (auto &c : links) {
         c.high_latency_link_enabled = enabled && c.is_high_latency_link;
     } 
     gcs().send_text(MAV_SEVERITY_NOTICE, "High Latency %s", enabled ? "enabled" : "disabled");
@@ -130,15 +128,16 @@ void GCS::enable_high_latency_connections(bool enabled)
  */
 bool GCS::install_alternative_protocol(mavlink_channel_t c, GCS_MAVLINK::protocol_handler_fn_t handler)
 {
-    if (c >= num_gcs()) {
+    auto *link = chan(c);
+    if (link == nullptr) {
         return false;
     }
-    if (chan(c)->alternative.handler && handler) {
+    if (link->alternative.handler && handler) {
         // already have one installed - we may need to add support for
         // multiple alternative handlers
         return false;
     }
-    chan(c)->alternative.handler = handler;
+    link->alternative.handler = handler;
     return true;
 }
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -92,16 +92,14 @@ void gcs_out_of_space_to_send(mavlink_channel_t chan);
 // then call its own specific methods on
 #define GCS_MAVLINK_CHAN_METHOD_DEFINITIONS(subclass_name) \
     subclass_name *chan(const uint8_t ofs) override {                   \
-        if (ofs > _num_gcs) {                                           \
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
+        if (ofs >= _num_gcs) {                                           \
             return nullptr;                                             \
         }                                                               \
         return (subclass_name *)_chan[ofs];                        \
     }                                                                   \
                                                                         \
     const subclass_name *chan(const uint8_t ofs) const override { \
-        if (ofs > _num_gcs) {                                           \
-            INTERNAL_ERROR(AP_InternalError::error_t::gcs_offset);      \
+        if (ofs >= _num_gcs) {                                           \
             return nullptr;                                             \
         }                                                               \
         return (subclass_name *)_chan[ofs];                        \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2191,8 +2191,8 @@ void GCS_MAVLINK::service_statustext(void)
 
 void GCS::send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        chan(i)->send_message(id);
+    for (auto &l : links) {
+        l.send_message(id);
     }
 }
 
@@ -2250,8 +2250,8 @@ void GCS::update_send()
 
 void GCS::update_receive(void)
 {
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        chan(i)->update_receive();
+    for (auto &l : links) {
+        l.update_receive();
     }
     // also update UART pass-thru, if enabled
     update_passthru();
@@ -2259,9 +2259,9 @@ void GCS::update_receive(void)
 
 void GCS::send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        chan(i)->mission_item_reached_index = mission_index;
-        chan(i)->send_message(MSG_MISSION_ITEM_REACHED);
+    for (auto &l : links) {
+        l.mission_item_reached_index = mission_index;
+        l.send_message(MSG_MISSION_ITEM_REACHED);
     }
 }
 
@@ -2715,25 +2715,32 @@ MAV_RESULT GCS_MAVLINK::set_message_interval(uint32_t msg_id, int32_t interval_u
  */
 MAV_RESULT GCS::set_message_interval(uint8_t port_num, uint32_t msg_id, int32_t interval_us)
 {
-    uint8_t channel = get_channel_from_port_number(port_num);
-
-    if ((channel < MAVLINK_COMM_NUM_BUFFERS) && (chan(channel) != nullptr)) {
-        return chan(channel)->set_message_interval(msg_id, interval_us);
+    GCS_MAVLINK *l = get_link_from_port_number(port_num);
+    if (l == nullptr) {
+        return MAV_RESULT_FAILED;
     }
 
-    return MAV_RESULT_FAILED;
+    return l->set_message_interval(msg_id, interval_us);
+}
+
+GCS_MAVLINK *GCS::get_link_from_port_number(uint8_t port_num)
+{
+    const AP_HAL::UARTDriver *u = AP::serialmanager().get_serial_by_id(port_num);
+    for (auto &l : links) {
+        if (l.get_uart() == u) {
+            return &l;
+        }
+    }
+    return nullptr;
 }
 
 uint8_t GCS::get_channel_from_port_number(uint8_t port_num)
 {
-    const AP_HAL::UARTDriver *u = AP::serialmanager().get_serial_by_id(port_num);
-    for (uint8_t i=0; i<num_gcs(); i++) {
-        if (chan(i)->get_uart() == u) {
-            return i;
-        }
+    GCS_MAVLINK *l = get_link_from_port_number(port_num);
+    if (l == nullptr) {
+        return UINT8_MAX;
     }
-
-    return UINT8_MAX;
+    return l->get_chan();
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_long_t &packet)

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -87,12 +87,8 @@ void GCS_MAVLINK::handle_setup_signing(const mavlink_message_t &msg) const
     }
 
     // activate it immediately on all links:
-    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
-        GCS_MAVLINK *backend = gcs().chan(i);
-        if (backend == nullptr) {
-            return;
-        }
-        backend->load_signing_key();
+    for (auto &l : gcs().links) {
+        l.load_signing_key();
     }
 }
 

--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -80,9 +80,9 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
         stream = port = AP::serialmanager().get_serial_by_id(packet.device - SERIAL_CONTROL_SERIAL0);
 
         // see if we need to lock mavlink
-        for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+        for (uint8_t i=0; i<gcs().num_gcs(); i++) {
             GCS_MAVLINK *link = gcs().chan(i);
-            if (link == nullptr || link->get_uart() != port) {
+            if (link->get_uart() != port) {
                 continue;
             }
             link->lock(exclusive);

--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -80,12 +80,11 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
         stream = port = AP::serialmanager().get_serial_by_id(packet.device - SERIAL_CONTROL_SERIAL0);
 
         // see if we need to lock mavlink
-        for (uint8_t i=0; i<gcs().num_gcs(); i++) {
-            GCS_MAVLINK *link = gcs().chan(i);
-            if (link->get_uart() != port) {
+        for (auto &link : gcs().links) {
+            if (link.get_uart() != port) {
                 continue;
             }
-            link->lock(exclusive);
+            link.lock(exclusive);
             break;
         }
         break;


### PR DESCRIPTION
Creates an iterator which can be used to cross each of the backends without worrying about `num_gcs()` vs `MAVLINK_COMM_NUM_CHANNELS`

Each additional use of the iterator reduces the code size, which is kind of cool.
```
Board,AP_Periph,blimp,copter,heli,plane,rover,sub
Durandal,,-136,-136,-128,-120,-168,-200
Hitec-Airspeed,0,,,,,,
KakuteH7-bdshot,,-96,-128,-136,-88,-120,16
MatekF405,,-64,-72,-80,-112,-80,16
Pixhawk1-1M,,-32,-64,-80,-128,-56,-96
f103-QiotekPeriph,0,,,,,,
f303-Universal,0,,,,,,
revo-mini,,-56,-152,-144,-136,-80,-48
skyviper-v2450,,,-48,,,,
```
