### PR TITLE
AP_Arming: revert main loop rate check from Copter-4.3.2

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -50,7 +50,6 @@
 #include <AP_Mount/AP_Mount.h>
 #include <AP_OpenDroneID/AP_OpenDroneID.h>
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_Scheduler/AP_Scheduler.h>
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
   #include <AP_CANManager/AP_CANManager.h>
@@ -961,16 +960,6 @@ bool AP_Arming::system_checks(bool report)
             check_failed(ARMING_CHECK_SYSTEM, report, "Param storage failed");
             return false;
         }
-
-        // check main loop rate is at least 90% of expected value
-        const float actual_loop_rate = AP::scheduler().get_filtered_loop_rate_hz();
-        const uint16_t expected_loop_rate = AP::scheduler().get_loop_rate_hz();
-        const float loop_rate_pct =  actual_loop_rate / expected_loop_rate;
-        if (loop_rate_pct < 0.90) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "Main loop slow (%uHz < %uHz)", (unsigned)actual_loop_rate, (unsigned)expected_loop_rate);
-            return false;
-        }
-
 #if AP_TERRAIN_AVAILABLE
         const AP_Terrain *terrain = AP_Terrain::get_singleton();
         if ((terrain != nullptr) && terrain->init_failed()) {


### PR DESCRIPTION
This reverts the AP_Arming check that the main loop is running at 90% of the configured rate.  We are reverting this in the 4.3 branches because we think these can be triggered by the Motor Test and CompassMot features.

FYI @lthall 
