### PR TITLE
AP_HAL_Linux: Raspberry 64OS Address fix

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_RPI.h
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.h
@@ -71,7 +71,7 @@ public:
     void* get_page(void **pages, const uint32_t addr) const;
 
     // This function returns offset from the beginning of the buffer using (virtual) address in 'pages' and memory_table.
-    uint32_t get_offset(void **pages, const uint32_t addr) const;
+    uint32_t get_offset(void **pages, const uint64_t addr) const;
 
     //How many bytes are available for reading in circle buffer?
     uint32_t bytes_available(const uint32_t read_addr, const uint32_t write_addr) const;


### PR DESCRIPTION
Ardupilot running on RaspberryPi Bulleyes 64OS crashes in RCInput_RPI.cpp
This is due to enabling **CONFIG_STRICT_DEVMEM** in LinuxKernel.

Still after disabling this configuration item virtual memory address needs to be 64bit.

This PR works on RPI-Zero running (Raspberry OS 32-bit)
& RPI-Zero W2 64 bit running  (Raspberry Bulleyes 64)
