### PR TITLE
Position Control Limit Handling

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -736,7 +736,7 @@ void ModeGuided::accel_control_run()
             auto_yaw.set_mode(AutoYaw::Mode::HOLD);
         }
         pos_control->input_vel_accel_xy(guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
-        pos_control->input_vel_accel_z(guided_vel_target_cms.z, guided_accel_target_cmss.z, false, false);
+        pos_control->input_vel_accel_z(guided_vel_target_cms.z, guided_accel_target_cmss.z, false);
     } else {
         // update position controller with new target
         pos_control->input_accel_xy(guided_accel_target_cmss);
@@ -804,7 +804,7 @@ void ModeGuided::velaccel_control_run()
         // set position errors to zero
         pos_control->stop_pos_xy_stabilisation();
     }
-    pos_control->input_vel_accel_z(guided_vel_target_cms.z, guided_accel_target_cmss.z, false, false);
+    pos_control->input_vel_accel_z(guided_vel_target_cms.z, guided_accel_target_cmss.z, false);
 
     // call velocity controller which includes z axis controller
     pos_control->update_xy_controller();
@@ -834,7 +834,7 @@ void ModeGuided::pause_control_run()
 
     // set the vertical velocity and acceleration targets to zero
     float vel_z = 0.0;
-    pos_control->input_vel_accel_z(vel_z, 0.0, false, false);
+    pos_control->input_vel_accel_z(vel_z, 0.0, false);
 
     // call velocity controller which includes z axis controller
     pos_control->update_xy_controller();

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -8,7 +8,7 @@ bool ModeQHover::_enter()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_velocity_z_max_up, quadplane.pilot_accel_z);
     pos_control->set_correction_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_velocity_z_max_up, quadplane.pilot_accel_z);
-    quadplane.set_climb_rate_cms(0, false);
+    quadplane.set_climb_rate_cms(0);
 
     quadplane.init_throttle_wait();
     return true;

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -103,13 +103,13 @@ void ModeQLoiter::run()
             quadplane.ahrs.set_touchdown_expected(true);
         }
 
-        quadplane.set_climb_rate_cms(-descent_rate_cms, descent_rate_cms>0);
+        pos_control->land_at_climb_rate_cm(-descent_rate_cms, descent_rate_cms>0);
         quadplane.check_land_complete();
     } else if (plane.control_mode == &plane.mode_guided && quadplane.guided_takeoff) {
-        quadplane.set_climb_rate_cms(0, false);
+        quadplane.set_climb_rate_cms(0);
     } else {
         // update altitude target and call position controller
-        quadplane.set_climb_rate_cms(quadplane.get_pilot_desired_climb_rate_cms(), false);
+        quadplane.set_climb_rate_cms(quadplane.get_pilot_desired_climb_rate_cms());
     }
     quadplane.run_z_controller();
 }

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -88,7 +88,7 @@ void ModeQRTL::run()
                                                                           quadplane.get_weathervane_yaw_rate_cds());
 
             // climb at full WP nav speed
-            quadplane.set_climb_rate_cms(quadplane.wp_nav->get_default_speed_up(), false);
+            quadplane.set_climb_rate_cms(quadplane.wp_nav->get_default_speed_up());
             quadplane.run_z_controller();
 
             ftype alt_diff;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1003,9 +1003,9 @@ void QuadPlane::check_yaw_reset(void)
     }
 }
 
-void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms, bool force_descend)
+void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms)
 {
-    pos_control->land_at_climb_rate_cm(target_climb_rate_cms, force_descend);
+    pos_control->input_vel_accel_z(target_climb_rate_cms, 0, false);
 }
 
 /*
@@ -1023,7 +1023,7 @@ void QuadPlane::hold_hover(float target_climb_rate_cms)
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false));
 
     // call position controller
-    set_climb_rate_cms(target_climb_rate_cms, false);
+    set_climb_rate_cms(target_climb_rate_cms);
 
     run_z_controller();
 }
@@ -2790,7 +2790,7 @@ void QuadPlane::vtol_position_controller(void)
             float zero = 0;
             pos_control->input_pos_vel_accel_z(target_z, zero, 0);
         } else {
-            set_climb_rate_cms(0, false);
+            set_climb_rate_cms(0);
         }
         break;
     }
@@ -2804,7 +2804,7 @@ void QuadPlane::vtol_position_controller(void)
             }
         }
         const float descent_rate_cms = landing_descent_rate_cms(height_above_ground);
-        set_climb_rate_cms(-descent_rate_cms, descent_rate_cms>0);
+        pos_control->land_at_climb_rate_cm(-descent_rate_cms, descent_rate_cms>0);
         break;
     }
 
@@ -2952,10 +2952,10 @@ void QuadPlane::takeoff_controller(void)
             vel_z = 0;
             pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
         } else {
-            set_climb_rate_cms(vel_z, false);
+            set_climb_rate_cms(vel_z);
         }
     } else {
-        set_climb_rate_cms(vel_z, false);
+        set_climb_rate_cms(vel_z);
     }
 
     run_z_controller();
@@ -3000,7 +3000,7 @@ void QuadPlane::waypoint_controller(void)
                                                        true);
 
     // climb based on altitude error
-    set_climb_rate_cms(assist_climb_rate_cms(), false);
+    set_climb_rate_cms(assist_climb_rate_cms());
     run_z_controller();
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1005,7 +1005,7 @@ void QuadPlane::check_yaw_reset(void)
 
 void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms, bool force_descend)
 {
-    pos_control->input_vel_accel_z(target_climb_rate_cms, 0, force_descend);
+    pos_control->land_at_climb_rate_cm(target_climb_rate_cms, force_descend);
 }
 
 /*

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -228,7 +228,7 @@ private:
     void hold_stabilize(float throttle_in);
 
     // set climb rate in position controller
-    void set_climb_rate_cms(float target_climb_rate_cms, bool force_descend);
+    void set_climb_rate_cms(float target_climb_rate_cms);
 
     // get pilot desired yaw rate in cd/s
     float get_pilot_input_yaw_rate_cds(void) const;

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -798,13 +798,8 @@ void AC_PosControl::input_accel_z(float accel)
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
 ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool ignore_descent_limit, bool limit_output)
+void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool limit_output)
 {
-    if (ignore_descent_limit) {
-        // turn off limits in the negative z direction
-        _limit_vector.z = MAX(_limit_vector.z, 0.0f);
-    }
-
     // calculated increased maximum acceleration and jerk if over speed
     const float overspeed_gain = calculate_overspeed_gain();
     const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
@@ -832,7 +827,7 @@ void AC_PosControl::set_pos_target_z_from_climb_rate_cm(float vel)
     _accel_desired.z -= _accel_offset_z;
 
     float vel_temp = vel;
-    input_vel_accel_z(vel_temp, 0, false);
+    input_vel_accel_z(vel_temp, 0.0);
 
     // update the vertical position, velocity and acceleration offsets
     update_pos_offset_z(_pos_offset_target_z);
@@ -848,7 +843,12 @@ void AC_PosControl::set_pos_target_z_from_climb_rate_cm(float vel)
 ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be false unless landing.
 void AC_PosControl::land_at_climb_rate_cm(float vel, bool ignore_descent_limit)
 {
-    input_vel_accel_z(vel, 0, ignore_descent_limit);
+    if (ignore_descent_limit) {
+        // turn off limits in the negative z direction
+        _limit_vector.z = MAX(_limit_vector.z, 0.0f);
+    }
+
+    input_vel_accel_z(vel, 0.0);
 }
 
 /// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -344,8 +344,9 @@ void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_offset_z, float
     _accel_desired.z -= _accel_offset_z;
 
     // calculated increased maximum acceleration and jerk if over speed
-    float accel_max_z_cmss = _accel_max_z_cmss * calculate_overspeed_gain();
-    float jerk_max_z_cmsss = _jerk_max_z_cmsss * calculate_overspeed_gain();
+    const float overspeed_gain = calculate_overspeed_gain();
+    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
+    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
     update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
@@ -780,10 +781,8 @@ void AC_PosControl::init_z_controller()
     _last_update_z_us = AP::ins().get_last_update_usec();
 }
 
-/// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
-///     The vel is projected forwards in time based on a time step of dt and acceleration accel.
+/// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The function alters the vel to be the kinematic path based on accel
 void AC_PosControl::input_accel_z(float accel)
 {
     // calculated increased maximum jerk if over speed
@@ -807,8 +806,9 @@ void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool ignore_desce
     }
 
     // calculated increased maximum acceleration and jerk if over speed
-    float accel_max_z_cmss = _accel_max_z_cmss * calculate_overspeed_gain();
-    float jerk_max_z_cmsss = _jerk_max_z_cmsss * calculate_overspeed_gain();
+    const float overspeed_gain = calculate_overspeed_gain();
+    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
+    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
     // adjust desired alt if motors have not hit their limits
     update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
@@ -859,8 +859,9 @@ void AC_PosControl::land_at_climb_rate_cm(float vel, bool ignore_descent_limit)
 void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, bool limit_output)
 {
     // calculated increased maximum acceleration and jerk if over speed
-    float accel_max_z_cmss = _accel_max_z_cmss * calculate_overspeed_gain();
-    float jerk_max_z_cmsss = _jerk_max_z_cmsss * calculate_overspeed_gain();
+    const float overspeed_gain = calculate_overspeed_gain();
+    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
+    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
     // adjust desired altitude if motors have not hit their limits
     update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -201,7 +201,7 @@ public:
     ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
     ///     The function alters the vel to be the kinematic path based on accel
     ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-    virtual void input_vel_accel_z(float &vel, float accel, bool ignore_descent_limit, bool limit_output = true);
+    virtual void input_vel_accel_z(float &vel, float accel, bool limit_output = true);
 
     /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
     ///     using the default position control kinematic path.

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -299,7 +299,9 @@ void shape_pos_vel_accel(postype_t pos_input, float vel_input, float accel_input
     float vel_target = sqrt_controller(pos_error, KPv, accel_tc_max, dt);
 
     // limit velocity between vel_min and vel_max
-    vel_target = constrain_float(vel_target, vel_min, vel_max);
+    if (is_negative(vel_min) || is_positive(vel_max)) {
+        vel_target = constrain_float(vel_target, vel_min, vel_max);
+    }
 
     // velocity correction with input velocity
     vel_target += vel_input;
@@ -336,7 +338,9 @@ void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input
     Vector2f vel_target = sqrt_controller(pos_error, KPv, accel_tc_max, dt);
 
     // limit velocity to vel_max
-    vel_target.limit_length(vel_max);
+    if (is_positive(vel_max)) {
+        vel_target.limit_length(vel_max);
+    }
 
     // velocity correction with input velocity
     vel_target = vel_target + vel_input;

--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -1,0 +1,37 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/AP_Math.h>
+#include <AP_Math/vector2.h>
+#include <AP_Math/vector3.h>
+#include <AP_Math/control.h>
+
+TEST(Control, test_control)
+{
+    postype_t pos_start = 17;
+    float vel_start = 20;
+
+    float vel = vel_start;
+    postype_t pos = pos_start;
+    const float dt = 0.01;
+    const float accel = 1.0;
+
+    update_pos_vel_accel(pos, vel, accel, dt, 0, 0, 0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel*dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + 0.5*(vel+vel_start)*dt);
+
+    vel = vel_start;
+    pos = pos_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 1.0, 1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start);
+    EXPECT_FLOAT_EQ(pos, pos_start);
+
+    vel = vel_start;
+    pos = pos_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 1.0, 1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel*dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + 0.5*(vel+vel_start)*dt);
+}
+
+
+AP_GTEST_MAIN()
+int hal = 0;

--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -9,27 +9,460 @@ TEST(Control, test_control)
 {
     postype_t pos_start = 17;
     float vel_start = 20;
+    float accel_start = 1.0;
+    const float dt = 0.01;
 
+    // test for update_pos_vel_accel includes update_vel_accel.
+    // test unlimited behaviour
+    // 1
     float vel = vel_start;
     postype_t pos = pos_start;
-    const float dt = 0.01;
-    const float accel = 1.0;
+    float accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 0.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
 
-    update_pos_vel_accel(pos, vel, accel, dt, 0, 0, 0);
-    EXPECT_FLOAT_EQ(vel, vel_start + accel*dt);
-    EXPECT_FLOAT_EQ(pos, pos_start + 0.5*(vel+vel_start)*dt);
-
+    // 2
     vel = vel_start;
     pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 0.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // error has no impact when not limited
+    // 3
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 0.0, 1.0, 1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 4
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 0.0, -1.0, -1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // test unlimited behaviour
+    // zero error should result in normal behaviour
+    // 5
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 6
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 7
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 8
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 0.0, 0.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+    
+    // error sign opposite to limit sign should result in normal behaviour
+    // 9
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, -1.0, -1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 10
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, -1.0, -1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 11
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 1.0, 1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 12
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 1.0, 1.0);
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+    
+    // error sign same as limit sign should result various limited behaviours
+    // 13
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
     update_pos_vel_accel(pos, vel, accel, dt, 1.0, 1.0, 1.0);
+    // vel is not increased
     EXPECT_FLOAT_EQ(vel, vel_start);
+    // pos is not increased
     EXPECT_FLOAT_EQ(pos, pos_start);
 
+    // 14
     vel = vel_start;
     pos = pos_start;
-    update_pos_vel_accel(pos, vel, accel, dt, -1.0, 1.0, 1.0);
-    EXPECT_FLOAT_EQ(vel, vel_start + accel*dt);
-    EXPECT_FLOAT_EQ(pos, pos_start + 0.5*(vel+vel_start)*dt);
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 1.0, 1.0);
+    // vel is decreased
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    // pos is not increased
+    EXPECT_FLOAT_EQ(pos, pos_start);
+
+    // 15
+    vel = vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, -1.0, -1.0);
+    // vel is increased
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    // pos is increased
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 16
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, -1.0, -1.0);
+    // velocity is limited but limit is not applied because velocity is reducing
+    EXPECT_FLOAT_EQ(vel, vel_start + accel * dt);
+    // pos is increased
+    EXPECT_FLOAT_EQ(pos, pos_start + vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 17
+    vel = -vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 1.0, 1.0);
+    // velocity is limited but limit is not applied because velocity is reducing
+    EXPECT_FLOAT_EQ(vel, -vel_start + accel * dt);
+    // pos is decreased
+    EXPECT_FLOAT_EQ(pos, pos_start - vel_start * dt + 0.5 * accel * sq(dt));
+
+    // 18
+    vel_start = 0.1 * accel_start * dt;
+    vel = vel_start;
+    pos = pos_start;
+    accel = -accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, -1.0, -1.0, -1.0);
+    // velocity is limited but limit is not applied because velocity is reducing
+    // final result is zero because velocity would change sign during dt
+    EXPECT_FLOAT_EQ(vel, 0.0);
+    // pos is not changed because is_negative(vel_start * dt + 0.5 * accel * sq(t))
+    EXPECT_FLOAT_EQ(pos, pos_start);
+
+    // 19
+    vel = -vel_start;
+    pos = pos_start;
+    accel = accel_start;
+    update_pos_vel_accel(pos, vel, accel, dt, 1.0, 1.0, 1.0);
+    // velocity is limited but limit is not applied because velocity is reducing
+    // final result is zero because velocity would change sign during dt
+    EXPECT_FLOAT_EQ(vel, 0.0);
+    // pos is not changed because is_negative(vel_start * dt + 0.5 * accel * sq(t))
+    EXPECT_FLOAT_EQ(pos, pos_start);
+
+
+    // test for update_pos_vel_accel includes update_vel_accel.
+    // test unlimited behaviour
+    
+    // 1
+    pos_start = 17;
+    vel_start = 20;
+    accel_start = 1.0;
+    Vector2p posxy = Vector2p(pos_start, 0.0);
+    Vector2f velxy = Vector2f(vel_start, 0.0);
+    Vector2f accelxy = Vector2f(accel_start, 0.0);
+    Vector2f limit = Vector2f(0.0, 0.0);
+    Vector2f pos_error = Vector2f(0.0, 0.0);
+    Vector2f vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 2
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(0.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // error has no impact when not limited
+    // 3
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(0.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 4
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(0.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // test unlimited behaviour
+    // zero error should result in normal behaviour
+    // 5
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 6
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 7
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 8
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(0.0, 0.0);
+    vel_error = Vector2f(0.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    
+    // error sign opposite to limit sign should result in normal behaviour
+    // 9
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(-1.0, 0.0);
+    vel_error = Vector2f(-1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 10
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(-1.0, 0.0);
+    vel_error = Vector2f(-1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 11
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(-1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 12
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(-1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    
+    // error sign same as limit sign should result various limited behaviours
+    // 13
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // vel is not increased
+    EXPECT_FLOAT_EQ(velxy.x, vel_start);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is not increased
+    EXPECT_FLOAT_EQ(posxy.x, pos_start);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 14
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // vel is decreased
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is not increased
+    EXPECT_FLOAT_EQ(posxy.x, pos_start);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 15
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(-1.0, 0.0);
+    pos_error = Vector2f(-1.0, 0.0);
+    vel_error = Vector2f(-1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // vel is increased
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is increased
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 16
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(-1.0, 0.0);
+    pos_error = Vector2f(-1.0, 0.0);
+    vel_error = Vector2f(-1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // velocity is limited but limit is not applied because velocity is reducing
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is increased
+    EXPECT_FLOAT_EQ(posxy.x, pos_start + vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 17
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(-vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // velocity is limited but limit is not applied because velocity is reducing
+    EXPECT_FLOAT_EQ(velxy.x, -vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is decreased
+    EXPECT_FLOAT_EQ(posxy.x, pos_start - vel_start * dt + 0.5 * accelxy.x * sq(dt));
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 18
+    vel_start = 0.1 * accel_start * dt;
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(vel_start, 0.0);
+    accelxy = Vector2f(-accel_start, 0.0);
+    limit = Vector2f(-1.0, 0.0);
+    pos_error = Vector2f(-1.0, 0.0);
+    vel_error = Vector2f(-1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // velocity is limited but limit is not applied because velocity is reducing
+    // ideally this would be zero but code makes a simplification here
+    EXPECT_FLOAT_EQ(velxy.x, vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is not changed because is_negative(vel_start * dt + 0.5 * accel * sq(t))
+    EXPECT_FLOAT_EQ(posxy.x, pos_start);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+
+    // 19
+    posxy = Vector2p(pos_start, 0.0);
+    velxy = Vector2f(-vel_start, 0.0);
+    accelxy = Vector2f(accel_start, 0.0);
+    limit = Vector2f(1.0, 0.0);
+    pos_error = Vector2f(1.0, 0.0);
+    vel_error = Vector2f(1.0, 0.0);
+    update_pos_vel_accel_xy(posxy, velxy, accelxy, dt, limit, pos_error, vel_error);
+    // velocity is limited but limit is not applied because velocity is reducing
+    // ideally this would be zero but code makes a simplification here
+    EXPECT_FLOAT_EQ(velxy.x, -vel_start + accelxy.x * dt);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
+    // pos is not changed because is_negative(vel_start * dt + 0.5 * accel * sq(t))
+    EXPECT_FLOAT_EQ(posxy.x, pos_start);
+    EXPECT_FLOAT_EQ(velxy.y, 0.0);
 }
 
 


### PR DESCRIPTION
This PR improves the handling of limits in the position controller and clarifies some of the code.
1. Fixes problem where limits can result in the aircraft overshooting the stopping point. This was seen during a landing where the aircraft becomes limited during the early deceleration phase. This slides the stopping point past the intended altitude resulting in a possible "hard landing".
2. Moves the removal of ignore_descent_limit from input_vel_accel_z to land_at_climb_rate_cm (a better name would be nice). This simplifies the use of input_vel_accel_z  for the vast majority of use cases and clarifies the use of land_at_climb_rate_cm.
3. A few efficiency clean ups
4. Math library changes to support 1.
5. Math library changes to prevent limits from altering the velocity vector direction.