### PR TITLE
AP_GPS: use only when HDT heading is available

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -450,8 +450,6 @@ bool AP_GPS_NMEA::_term_complete()
             _sentence_type = _GPS_SENTENCE_GGA;
         } else if (strcmp(term_type, "HDT") == 0) {
             _sentence_type = _GPS_SENTENCE_HDT;
-            // HDT doesn't have a data qualifier
-            _gps_data_good = true;
         } else if (strcmp(term_type, "THS") == 0) {
             _sentence_type = _GPS_SENTENCE_THS;
         } else if (strcmp(term_type, "VTG") == 0) {
@@ -532,6 +530,8 @@ bool AP_GPS_NMEA::_term_complete()
             break;
         case _GPS_SENTENCE_HDT + 1: // Course (HDT)
             _new_gps_yaw = _parse_decimal_100(_term);
+            // HDT doesn't have a data qualifier
+            _gps_data_good = true;
             break;
         case _GPS_SENTENCE_THS + 1: // Course (THS)
             _new_gps_yaw = _parse_decimal_100(_term);


### PR DESCRIPTION
Septentrio modules send HDT empty messages before getting correct heading.
When AP receives it, EKF yaw is aligned.
This PR changes to discard empty HDTs and processes only those that contain values.

Before
![image](https://user-images.githubusercontent.com/16643069/208226232-b9e8c713-ce45-4a68-a901-35bc8e017e5e.png)
EKF3 yaw is aligned soon after EKF3 tilt alignment complete.

After
![image](https://user-images.githubusercontent.com/16643069/208226297-e171ed2e-4e3a-4170-adf1-75a1795aaad2.png)
EKF3 yaw is aligned after GPS yaw is set.

Tested with CubeBlack+mosaic-H.

Note:
When ARMING_REQUIRE=0 is set, EKF Failsafe is not cleared forever.
After this changes, the problem with EKF Failsafe has also been fixed.
If I use THS instead of HDT, it also fixed this problem.