### PR TITLE
SITL: change HDOP from 2.0 to 1.2

### DIFF
--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -538,7 +538,7 @@ void GPS::update_nmea(const struct gps_data *d)
                      lng_string,
                      d->have_lock?1:0,
                      d->have_lock?_sitl->gps_numsats[instance]:3,
-                     2.0,
+                     1.2,
                      d->altitude);
     const float speed_mps = norm(d->speedN, d->speedE);
     const float speed_knots = speed_mps * M_PER_SEC_TO_KNOTS;


### PR DESCRIPTION
I changed HDOP of SIM_GPS from 2.0 to 1.2 to prevent triggering arming check.
![image](https://user-images.githubusercontent.com/16643069/208229225-6a26754b-6089-48af-8df4-005522190577.png)

I tested this with these settings:
 SIM_GPS_TYPE 5
 GPS_TYPE 5
