### PR TITLE
Dockerfile: sim_vehicle.py can not found mavproxy.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ USER ${USER_NAME}
 ENV SKIP_AP_EXT_ENV=1 SKIP_AP_GRAPHIC_ENV=1 SKIP_AP_COV_ENV=1 SKIP_AP_GIT_CHECK=1
 RUN Tools/environment_install/install-prereqs-ubuntu.sh -y
 
-# add waf alias to ardupilot waf to .bashrc
-RUN echo "alias waf=\"/${USER_NAME}/waf\"" >> ~/ardupilot_entrypoint.sh
+# add waf alias to ardupilot waf to .ardupilot_env
+RUN echo "alias waf=\"/${USER_NAME}/waf\"" >> ~/.ardupilot_env
 
 # Check that local/bin are in PATH for pip --user installed package
-RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/ardupilot_entrypoint.sh
+RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/.ardupilot_env
 
 # Create entrypoint as docker cannot do shell substitution correctly
 RUN export ARDUPILOT_ENTRYPOINT="/home/${USER_NAME}/ardupilot_entrypoint.sh" \


### PR DESCRIPTION
Maybe this is a duplicate of this PR. https://github.com/ArduPilot/ardupilot/pull/20948

When I started a container from a Docker-built image and ran SITL, I got an error that mavproxy.py was not found. mavproxy.py was installed in $HOME/.local/bin but no path.

OS: Mac Big Sur 11.6
Docker Desktop 4.8.2
Engine: 20.10.14

Currently mavproxy not found
![mavproxy-not-found](https://user-images.githubusercontent.com/22985371/208245390-e3b0431c-cb4e-49c5-8dcc-3743a48ffe3c.png)

It should work properly with this PR.
![ardupilot-env](https://user-images.githubusercontent.com/22985371/208245706-9f3f315b-f683-4712-b05e-d76c1ef18b8d.png)

![sitl-copter](https://user-images.githubusercontent.com/22985371/208245720-322dfc1e-5874-4a81-9a81-0aabe3a60205.png)

firmware build test for CubeOrange
![cubeorange](https://user-images.githubusercontent.com/22985371/208248660-d5c07a9a-feff-4c18-844e-cef8179ee895.png)
