### PR TITLE
AP_DAL: call start_frame for all backends

### DIFF
--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -79,7 +79,7 @@ void AP_DAL_RangeFinder::start_frame()
     for (uint8_t i=0; i<_RRNH.num_sensors; i++) {
         auto *backend = rangefinder->get_backend(i);
         if (backend == nullptr) {
-            break;
+            continue;
         }
         _backend[i]->start_frame(backend);
     }


### PR DESCRIPTION
This fixes #18205.
If the first backend could not be obtained, subsequent ones were not checked.
This PR checks for the number of num_sensors, even if the first backend is nullptr.

I could reproduce the issue, and tested it in SITL.
![image](https://user-images.githubusercontent.com/16643069/208329135-482e8557-f213-4346-8d70-3a2de2fed6a2.png)

