### PR TITLE
Tools: correct autotest copter-gimbal .parm

### DIFF
--- a/Tools/autotest/default_params/copter-gimbal.parm
+++ b/Tools/autotest/default_params/copter-gimbal.parm
@@ -1,5 +1,5 @@
 # copter with simulated 3-axis servo gimbal
-MNT_TYPE 1
+MNT1_TYPE 1
 RC6_OPTION 213
 SERVO5_FUNCTION 8
 SERVO6_FUNCTION 7


### PR DESCRIPTION
This corrects a parameter name in the copter-gimbal.parm file which is used when testing a gimbal in SITL.  This is very low risk because it is only used by developers as a convenient way to get the virtual gimbal working in SITL.

I've tested this on my local machine.