### PR TITLE
set RemoteID status to Emergency if vehicle is lost

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -37,6 +37,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Notify/AP_Notify.h>
+#include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -257,7 +258,7 @@ void AP_OpenDroneID::send_location_message()
         return;
     }
     uint8_t uav_status = hal.util->get_soft_armed()? MAV_ODID_STATUS_AIRBORNE : MAV_ODID_STATUS_GROUND;
-    if (AP_Notify::flags.vehicle_lost == true) {
+    if (AP_Notify::flags.vehicle_lost == true || AP_Notify::flags.parachute_release == 1 || AP_AdvancedFailsafe::should_crash_vehicle == true) {
         uav_status = MAV_ODID_STATUS_EMERGENCY;
     }
 

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -36,6 +36,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Notify/AP_Notify.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -255,7 +256,10 @@ void AP_OpenDroneID::send_location_message()
     if (!ahrs.get_location(current_location)) {
         return;
     }
-    const uint8_t uav_status = hal.util->get_soft_armed()? MAV_ODID_STATUS_AIRBORNE : MAV_ODID_STATUS_GROUND;
+    uint8_t uav_status = hal.util->get_soft_armed()? MAV_ODID_STATUS_AIRBORNE : MAV_ODID_STATUS_GROUND;
+    if (AP_Notify::flags.vehicle_lost == true) {
+        uav_status = MAV_ODID_STATUS_EMERGENCY;
+    }
 
     float direction = ODID_INV_DIR;
     if (!got_bad_gps_fix) {

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -257,8 +257,9 @@ void AP_OpenDroneID::send_location_message()
     if (!ahrs.get_location(current_location)) {
         return;
     }
+        
     uint8_t uav_status = hal.util->get_soft_armed()? MAV_ODID_STATUS_AIRBORNE : MAV_ODID_STATUS_GROUND;
-    if (AP_Notify::flags.vehicle_lost == true || AP_Notify::flags.parachute_release == 1 || AP_AdvancedFailsafe::should_crash_vehicle == true) {
+    if (AP_Notify::flags.vehicle_lost == true || AP_Notify::flags.parachute_release == 1) {
         uav_status = MAV_ODID_STATUS_EMERGENCY;
     }
 


### PR DESCRIPTION
According to the FAA MoC, the drone should set the location status to emergency  in case of Uncontrolled descent or loss of control. See also https://github.com/ArduPilot/ArduRemoteID/issues/34

In this PR, the location status is set to emergency when the vehicle is set to vehicle_lost. Not sure if there are other emergency cases in which we also need to set the location status to emergency.

@tridge 