### PR TITLE
Improve collective to yaw compensation for traditional helicopters

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -29,7 +29,7 @@
 #define AP_MOTORS_HELI_SINGLE_EXT_GYRO_GAIN                    350
 
 // COLYAW parameter min and max values
-#define AP_MOTORS_HELI_SINGLE_COLYAW_RANGE                     10.0f
+#define AP_MOTORS_HELI_SINGLE_COLYAW_RANGE                     5.0f
 
 // maximum number of swashplate servos
 #define AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS            3
@@ -140,9 +140,9 @@ protected:
     AP_Int16        _tail_type;                 // Tail type used: Servo, Servo with external gyro, direct drive variable pitch or direct drive fixed pitch
     AP_Int16        _ext_gyro_gain_std;         // PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro
     AP_Int16        _ext_gyro_gain_acro;        // PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro in ACRO
-    AP_Float        _collective_yaw_effect;     // Feed-forward compensation to automatically add rudder input when collective pitch is increased. Can be positive or negative depending on mechanics.
     AP_Int8         _flybar_mode;               // Flybar present or not.  Affects attitude controller used during ACRO flight mode
     AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed (0 ~ 1000)
+    AP_Float        _collective_yaw_scale;      // Feed-forward compensation to automatically add rudder input when collective pitch is increased. Can be positive or negative depending on mechanics.
 
     bool            _acro_tail = false;
 };


### PR DESCRIPTION
This PR corrects a long time concern I had with how collective to yaw compensation was implemented in traditional heli code.  The feature is designed to compensate for collective inputs to keep the added torque from causing yaw  excursions by feeding in yaw inputs with the collective input.  The compensation is not only needed to help reduce yaw excursions when making collective changes in flight but also when changing gross weight.

It was originally designed as a linear relationship for feedforward from collective.  However theory for hover performance of full scale helicopters shows that the relationship between gross weight and hover power required is gross weight ^ 3/2.  This assumes that density altitude and rotor speed are not changed.  This theory can be applied to the collective to yaw compensation.  With the assumption that the rotor speed is not changing, power required is directly proportional to torque and subsequently tailrotor thrust.   Also gross weight is proportional to collective.  So the 3/2 power relationship can be applied to collective to tail rotor blade pitch feedforward compensation.

Future improvements would be to make this also dependent on rotor speed.

Testing had been conducted on a real helicopter at two different gross weights to demonstrate that the feature works.

There is a question as to how to handle transitioning the feature between versions.  I have made a new parameter H_COL2YAW for this feature rather than using the existing one (H_COLYAW).  I think this is necessary because I can't reasonably predict what the new parameter value would be based on the existing one.  So I just made a new parameter which will force users to determine the value for the new method.