### PR TITLE
Tools: macos-env: overwrite files when upgrading Python

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -97,6 +97,7 @@ function maybe_prompt_user() {
 }
 
 brew update
+brew install --overwrite python@3.10
 brew install gawk curl coreutils wget
 
 PIP=pip


### PR DESCRIPTION
the 3.10.8 to 3.10.9 upgrade is failing in CI