### PR TITLE
Add simulator for TMotor DataLink device

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -388,6 +388,19 @@ SITL::SerialDevice *SITL_State::create_serial_sim(const char *name, const char *
     } else if (streq(name, "fetteconewireesc")) {
         sitl_model->set_fetteconewireesc(&_sitl->fetteconewireesc_sim);
         return &_sitl->fetteconewireesc_sim;
+#if AP_SIM_TMOTOR_DATALINK_ENABLED
+    } else if (!strncmp(name, "tmotordatalink", sizeof("tmotordatalink"))) {
+        if (tmotordatalink != nullptr) {
+            AP_HAL::panic("Only one TMotorDataLink at a time");
+        }
+        tmotordatalink = new SITL::TMotorDataLink();
+        if (tmotordatalink == nullptr) {
+            AP_HAL::panic("Failed to create TMotorDataLink");
+        }
+        tmotordatalink->set_motors(arg);
+        sitl_model->set_tmotordatalink(tmotordatalink);
+        return tmotordatalink;
+#endif  // AP_SIM_TMOTOR_DATALINK_ENABLED
     } else if (streq(name, "ie24")) {
         sitl_model->set_ie24(&_sitl->ie24_sim);
         return &_sitl->ie24_sim;

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -44,6 +44,7 @@
 #include <SITL/SIM_RF_NMEA.h>
 #include <SITL/SIM_RF_MAVLink.h>
 #include <SITL/SIM_RF_GYUS42v2.h>
+#include <SITL/SIM_TMotorDataLink.h>
 #include <SITL/SIM_VectorNav.h>
 #include <SITL/SIM_LORD.h>
 #include <SITL/SIM_AIS.h>
@@ -282,6 +283,11 @@ private:
 #if HAL_SIM_AIS_ENABLED
     // simulated AIS stream
     SITL::AIS *ais;
+#endif
+
+#if AP_SIM_TMOTOR_DATALINK_ENABLED
+    // simulated TMotorDataLink
+    SITL::TMotorDataLink *tmotordatalink;
 #endif
 
     // simulated EFI MegaSquirt device:

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -169,6 +169,7 @@ public:
         SerialProtocol_MSP_DisplayPort = 42,
         SerialProtocol_MAVLinkHL = 43,
         SerialProtocol_Tramp = 44,
+        SerialProtocol_TMotorDataLink = 46,
         SerialProtocol_NumProtocols                    // must be the last value
     };
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -37,6 +37,7 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include "SIM_TMotorDataLink.h"
 
 using namespace SITL;
 
@@ -1003,6 +1004,12 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     if (fetteconewireesc) {
         fetteconewireesc->update(*this);
     }
+
+#if AP_SIM_TMOTOR_DATALINK_ENABLED
+    if (tmotordatalink != nullptr) {
+        tmotordatalink->update(*this, input);
+    }
+#endif
 
 #if AP_SIM_SHIP_ENABLED
     sitl->shipsim.update();

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -142,6 +142,7 @@ public:
     void set_gripper_servo(Gripper_Servo *_gripper) { gripper = _gripper; }
     void set_gripper_epm(Gripper_EPM *_gripper_epm) { gripper_epm = _gripper_epm; }
     void set_precland(SIM_Precland *_precland);
+    void set_tmotordatalink(class TMotorDataLink *_tmotordatalink) { tmotordatalink = _tmotordatalink; }
     void set_i2c(class I2C *_i2c) { i2c = _i2c; }
 
     float get_battery_voltage() const { return battery_voltage; }
@@ -331,6 +332,7 @@ private:
     IntelligentEnergy24 *ie24;
     SIM_Precland *precland;
     class I2C *i2c;
+    class TMotorDataLink *tmotordatalink;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_TMotorDataLink.cpp
+++ b/libraries/SITL/SIM_TMotorDataLink.cpp
@@ -1,0 +1,117 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the TMotorDataLink
+*/
+
+#include <AP_Math/AP_Math.h>
+#include "SIM_Aircraft.h"
+#include "SITL.h"
+#include "SITL_Input.h"
+
+#include "SIM_TMotorDataLink.h"
+
+#if AP_SIM_TMOTOR_DATALINK_ENABLED
+
+#include <AP_HAL/utility/sparse-endian.h>
+#include <GCS_MAVLink/GCS.h>
+
+#include <stdio.h>
+#include <errno.h>
+
+using namespace SITL;
+
+TMotorDataLink::TMotorDataLink() :
+    SerialDevice::SerialDevice()
+{
+}
+
+void TMotorDataLink::set_motors(const char *comma_separated_list_of_motors)
+{
+    char s[64];
+    strncpy(s, comma_separated_list_of_motors, sizeof(s));
+
+    uint8_t count = 0;
+    servo_channel_numbers[count++] = atoi(s);
+
+    char *saveptr = NULL;
+    for (char *p = strtok_r(s, ",", &saveptr);
+         p && count <ARRAY_SIZE(servo_channel_numbers);
+         p = strtok_r(nullptr, "\n", &saveptr)) {
+        servo_channel_numbers[count++] = atoi(p);
+    }
+}
+
+
+void TMotorDataLink::Packet::update_checksum()
+{
+    crc = crc_xmodem((uint8_t*)this, sizeof(*this)-2);
+}
+
+void TMotorDataLink::update(const Aircraft &aircraft, const sitl_input &input)
+{
+    for (uint8_t i=0; i<8; i++) {  // 8 being the number of motors in the packet...
+        update_motor(i, aircraft, input);
+    }
+    counter++;  // we share the counters for each ESC at the moment - i.e. every ESC is in every packet and everything has the same seqno
+}
+
+void TMotorDataLink::update_motor(uint8_t motor_number, const Aircraft &aircraft, const sitl_input &input)
+{
+    uint16_t pwm = 0;
+    if (motor_number > num_servo_channels || servo_channel_numbers[motor_number] == 0) {
+        // there's no servo associcated with this motor number; think
+        // of it as there being no motor plugged into the physical
+        // device.
+        memset(&packet.motor[motor_number], '\0', sizeof(packet.motor[motor_number]));  // hmmm.  Is this necessary?
+        return;
+    }
+
+    const uint8_t servo_channel_number = servo_channel_numbers[motor_number];
+    const uint16_t servo_channel_offset = servo_channel_number - 1;
+    if (servo_channel_offset < ARRAY_SIZE(input.servos)) {
+        pwm = input.servos[servo_channel_offset];
+    }
+
+
+    // FIXME: the vehicle models should be supplying this RPM!
+    const uint16_t Kv = 1000;
+    const float p = (pwm-1000)/1000.0;
+    int16_t rpm = aircraft.get_battery_voltage() * Kv * p;
+
+    ESCInfo &escinfo = packet.motor[motor_number];
+
+    // FIXME: a lot of stuff in here needs fixing.  Also note that this is essentially copied from HWing.cpp so it has the same problems.
+    escinfo.seq = htobe16(counter);
+    escinfo.throttle = htobe16(pwm - 1000);
+    escinfo.throttle_req = htobe16(pwm - 1000);
+    escinfo.rpm = htobe16(rpm * 7.0 / 5.0);  // scale from RPM to eRPM
+    escinfo.voltage = aircraft.get_battery_voltage() * 100;
+    escinfo.current = 0;
+    escinfo.phase_current = 0;
+
+    // FIXME: this may not be an entirely accurate model of the
+    // temperature profile of these ESCs.
+    escinfo.mos_temperature += pwm/100000;
+    escinfo.mos_temperature *= 0.95;
+
+    // FIXME: this may not be an entirely accurate model of the
+    // temperature profile of these ESCs.
+    escinfo.cap_temperature += pwm/100000;
+    escinfo.cap_temperature *= 0.95;
+    escinfo.status = 0;
+}
+
+#endif  // AP_SIM_TMOTOR_DATALINK_ENABLED

--- a/libraries/SITL/SIM_TMotorDataLink.h
+++ b/libraries/SITL/SIM_TMotorDataLink.h
@@ -1,0 +1,113 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the T-Motor DataLink protocol
+
+ Note that the data being packed in is very similar to the data handled in SIM_HWing.cpp
+
+See https://store.tmotor.com/goods.php?id=728
+
+# the following creates a tmotordatalink connection on SERIAL5 with
+#  the ESC connected to ArduPilot's servo3 output connected on the
+#  "M1" port on the device and the ESC connected to ArduPilot's servo8
+#  port connected on the DataLink's M3 port:
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v plane -f plane -A --uartF=sim:tmotordatalink:3,0,8 --speedup=1 --console
+
+param set SERIAL5_PROTOCOL 46
+
+reboot
+
+arm throttle
+mode takeoff
+
+param fetch
+
+./Tools/autotest/autotest.py --gdb --debug build.ArduCopter fly.ArduPlane.TMotorDataLink
+
+*/
+
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_SIM_TMOTOR_DATALINK_ENABLED
+#define AP_SIM_TMOTOR_DATALINK_ENABLED 1
+#endif
+
+#if AP_SIM_TMOTOR_DATALINK_ENABLED
+
+#include "SIM_SerialDevice.h"
+
+namespace SITL {
+
+class TMotorDataLink : public SerialDevice {
+public:
+
+    TMotorDataLink();
+
+    // set the motors which are connected to the simulated device.
+    // This is a comma-separated list, where 0 can be used as a
+    // placeholder for "nothing connected"
+    void set_motors(const char *comma_separated_list_of_motors);
+
+    // update state
+    void update(const class Aircraft &aircraft, const struct sitl_input &input);
+
+private:
+
+    struct PACKED ESCInfo {
+        uint8_t esc_channel_number;
+        uint16_t seq;
+        uint16_t throttle_req;
+        uint16_t throttle;
+        uint16_t rpm;
+        uint16_t voltage;
+        uint16_t current;
+        uint16_t phase_current;
+        uint8_t mos_temperature;
+        uint8_t cap_temperature;
+        uint16_t status;
+    };
+
+    struct PACKED Packet {
+        uint8_t header; // 0x9B
+        uint8_t pkt_len; // 160
+        uint8_t communications_protocol_version;
+        uint8_t command_word;
+        uint16_t seq;
+        ESCInfo motor[8];
+        uint16_t crc;
+
+        void update_checksum();
+
+    } packet {
+        0x9B,  // MAGIC!
+        160,   // length
+        1,     // protcol version number
+        0x02,  // command word
+    };
+
+    uint8_t servo_channel_numbers[8];
+    const uint8_t num_servo_channels = 8;  // length of servo_channel_number
+
+    uint32_t counter;
+
+    void update_motor(uint8_t motor_number, const Aircraft &aircraft, const sitl_input &input);
+
+};
+}
+
+#endif


### PR DESCRIPTION
This builds on top of another PR which creates `AP_HobbyWing` - which has a similar format for the ESCs.

This adds a simulator for this physical device which aggregates data from devices speaking the HobbyWing protcol (which looks to be identical to the TMotor individual-ESC protocol).

We don't currently have a driver for this piece of hardware, but @khancyr has a branch and @OXINARF has a branch here: https://github.com/ArduPilot/ardupilot/commit/e78d1bcecba32bfd76491eaef71f9561a148e81a
