### PR TITLE
AP_Terrain: only include GCS_MAVLink if terrain is enabled

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -14,11 +14,8 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Common/Location.h>
 #include <AP_Filesystem/AP_Filesystem_config.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef AP_TERRAIN_AVAILABLE
 #if HAVE_FILESYSTEM_SUPPORT && defined(HAL_BOARD_TERRAIN_DIRECTORY)
@@ -30,7 +27,10 @@
 
 #if AP_TERRAIN_AVAILABLE
 
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define TERRAIN_DEBUG 0
 


### PR DESCRIPTION
Avoid unnecessary deps if terrain is not compiled in, make things more likely to compile in non-actual-AP_Vehicle firmwares.
