### PR TITLE
Avoid compilation errors when building without GCS enabled

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -39,7 +39,9 @@ public:
 #include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT 1
+#ifndef AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT
+#define AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT AP_MAVLINK_ENABLED
+#endif
 
 class AC_PolyFence_loader
 {
@@ -129,7 +131,9 @@ public:
     /// mavlink
     ///
     /// handler for polygon fence messages with GCS
+#if AP_MAVLINK_ENABLED
     void handle_msg(class GCS_MAVLINK &link, const mavlink_message_t& msg);
+#endif
 
     //  breached() - returns true if the vehicle has breached any fence
     bool breached() const WARN_IF_UNUSED;
@@ -371,6 +375,7 @@ private:
      */
     void handle_msg_fetch_fence_point(GCS_MAVLINK &link, const mavlink_message_t& msg);
     void handle_msg_fence_point(GCS_MAVLINK &link, const mavlink_message_t& msg);
+
     // contains_compatible_fence - returns true if the permanent fence
     // storage contains fences that are compatible with the old
     // FENCE_POINT protocol.

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -11,7 +11,10 @@
 #endif
 #endif
 
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
+
 #include "AccelCalibrator.h"
 
 #define AP_ACCELCAL_MAX_NUM_CLIENTS 4

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -4,7 +4,10 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_TemperatureSensor/AP_TemperatureSensor_config.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 #include "AP_BattMonitor_Params.h"
 #include "AP_BattMonitor_config.h"
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -253,7 +253,9 @@ public:
     bool reset_remaining(uint8_t instance, float percentage) { return reset_remaining_mask(1U<<instance, percentage);}
 
     // Returns mavlink charge state
+#if HAL_GCS_ENABLED
     MAV_BATTERY_CHARGE_STATE get_mavlink_charge_state(const uint8_t instance) const;
+#endif
 
     // Returns mavlink fault state
     uint32_t get_mavlink_fault_bitmask(const uint8_t instance) const;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -411,7 +411,7 @@ void AP_BoardConfig::throw_error(const char *err_type, const char *fmt, va_list 
         uint32_t now = AP_HAL::millis();
         if (now - last_print_ms >= 5000) {
             last_print_ms = now;
-            char printfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+2];
+            char printfmt[52];  // MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+2
             hal.util->snprintf(printfmt, sizeof(printfmt), "%s: %s\n", err_type, fmt);
             {
                 va_list arg_copy;

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -192,10 +192,12 @@ public:
     /*
       handle an incoming MAG_CAL command
     */
+#if HAL_GCS_ENABLED
     MAV_RESULT handle_mag_cal_command(const mavlink_command_long_t &packet);
 
     bool send_mag_cal_progress(const class GCS_MAVLINK& link);
     bool send_mag_cal_report(const class GCS_MAVLINK& link);
+#endif
 
     // check if the compasses are pointing in the same direction
     bool consistent() const;
@@ -339,9 +341,11 @@ public:
     /*
       fast compass calibration given vehicle position and yaw
      */
+#if HAL_GCS_ENABLED
     MAV_RESULT mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
                                  float lat_deg, float lon_deg,
                                  bool force_use=false);
+#endif
 
 #if AP_COMPASS_MSP_ENABLED
     void handle_msp(const MSP::msp_compass_data_message_t &pkt);
@@ -389,8 +393,10 @@ private:
     bool _start_calibration(uint8_t i, bool retry=false, float delay_sec=0.0f);
     bool _start_calibration_mask(uint8_t mask, bool retry=false, bool autosave=false, float delay_sec=0.0f, bool autoreboot=false);
     bool _auto_reboot() const { return _compass_cal_autoreboot; }
+#if HAL_GCS_ENABLED
     Priority next_cal_progress_idx[MAVLINK_COMM_NUM_BUFFERS];
     Priority next_cal_report_idx[MAVLINK_COMM_NUM_BUFFERS];
+#endif
 
     // see if we already have probed a i2c driver by bus number and address
     bool _have_i2c_driver(uint8_t bus_num, uint8_t address) const;

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -9,7 +9,10 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -21,7 +21,10 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 
 #include "AP_EFI_Backend.h"
 #include "AP_EFI_State.h"

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -91,7 +91,9 @@ public:
     }
 
     // send EFI_STATUS
+#if HAL_GCS_ENABLED
     void send_mavlink_status(mavlink_channel_t chan);
+#endif
 
 #if AP_SCRIPTING_ENABLED
     AP_EFI_Backend* get_backend(uint8_t idx) { return idx==0?backend:nullptr; }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
@@ -47,7 +47,9 @@ public:
     }
 #endif
 
+#if HAL_GCS_ENABLED
     virtual void queue_text_message(MAV_SEVERITY severity, const char *text) { }
+#endif
 
 protected:
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
@@ -4,7 +4,10 @@
 
 #if AP_FRSKY_TELEM_ENABLED
 
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 
 class AP_Frsky_Backend
 {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -47,12 +47,14 @@ public:
     static bool set_telem_data(const uint8_t frame,const uint16_t appid, const uint32_t data);
 #endif
 
+#if HAL_GCS_ENABLED
     void queue_message(MAV_SEVERITY severity, const char *text) {
         if (_backend == nullptr) {
             return;
         }
         return _backend->queue_text_message(severity, text);
     }
+#endif
 
 private:
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -18,6 +18,7 @@
 
 #if AP_FRSKY_TELEM_ENABLED
 
+#include <GCS_MAVLink/GCS_config.h>
 #include "AP_Frsky_Backend.h"
 #include "AP_Frsky_SPort.h"
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1245,6 +1245,7 @@ void AP_GPS::update_primary(void)
 }
 #endif  // GPS_MAX_RECEIVERS > 1
 
+#if AP_MAVLINK_ENABLED
 void AP_GPS::handle_gps_inject(const mavlink_message_t &msg)
 {
     mavlink_gps_inject_data_t packet;
@@ -1257,6 +1258,7 @@ void AP_GPS::handle_gps_inject(const mavlink_message_t &msg)
 
     handle_gps_rtcm_fragment(0, packet.data, packet.len);
 }
+#endif
 
 /*
   pass along a mavlink message (for MAV type)

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -185,7 +185,7 @@ void AP_GPS_Backend::broadcast_gps_type() const
 void AP_GPS_Backend::Write_AP_Logger_Log_Startup_messages() const
 {
 #if HAL_LOGGING_ENABLED
-    char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char buffer[81];
     _detection_message(buffer, sizeof(buffer));
     AP::logger().Write_Message(buffer);
 #endif

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -57,11 +57,15 @@ public:
 
     //MAVLink methods
     virtual bool supports_mavlink_gps_rtk_message() const { return false; }
+#if AP_MAVLINK_ENABLED
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);
+#endif
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }
 
+#if AP_MAVLINK_ENABLED
     virtual void handle_msg(const mavlink_message_t &msg) { return ; }
+#endif
 #if HAL_MSP_GPS_ENABLED
     virtual void handle_msp(const MSP::msp_gps_data_message_t &pkt) { return; }
 #endif

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -252,7 +252,9 @@ public:
     void Write_Fence();
 #endif
     void Write_Power(void);
+#if AP_MAVLINK_ENABLED
     void Write_Radio(const mavlink_radio_t &packet);
+#endif
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
     void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct);
@@ -260,11 +262,13 @@ public:
     void Write_Mode(uint8_t mode, const ModeReason reason);
 
     void Write_EntireMission();
+#if AP_MAVLINK_ENABLED
     void Write_Command(const mavlink_command_int_t &packet,
                        uint8_t source_system,
                        uint8_t source_component,
                        MAV_RESULT result,
                        bool was_command_long=false);
+#endif
     void Write_Mission_Cmd(const AP_Mission &mission,
                                const AP_Mission::Mission_Command &cmd);
     void Write_RallyPoint(uint8_t total,
@@ -296,7 +300,9 @@ public:
     void flush(void);
 #endif
 
+#if AP_MAVLINK_ENABLED
     void handle_mavlink_msg(class GCS_MAVLINK &, const mavlink_message_t &msg);
+#endif
 
     void periodic_tasks(); // may want to split this into GCS/non-GCS duties
 
@@ -566,6 +572,7 @@ private:
     // can be used by other subsystems to detect if they should log data
     uint8_t _log_start_count;
 
+#if AP_MAVLINK_ENABLED
     void handle_log_message(class GCS_MAVLINK &, const mavlink_message_t &msg);
 
     void handle_log_request_list(class GCS_MAVLINK &, const mavlink_message_t &msg);
@@ -575,6 +582,7 @@ private:
     void handle_log_send_listing(); // handle LISTING state
     void handle_log_sending(); // handle SENDING state
     bool handle_log_send_data(); // send data chunk to client
+#endif
 
     void get_log_info(uint16_t log_num, uint32_t &size, uint32_t &time_utc);
 

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -101,10 +101,12 @@ public:
     virtual void flush(void) { }
 #endif
 
+#if AP_MAVLINK_ENABLED
      // for Logger_MAVlink
     virtual void remote_log_block_status_msg(const GCS_MAVLINK &link,
                                              const mavlink_message_t &msg) { }
     // end for Logger_MAVlink
+#endif
 
    virtual void periodic_tasks();
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -566,6 +566,7 @@ public:
     ///     home is taken directly from ahrs
     void write_home_to_storage();
 
+#if AP_MAVLINK_ENABLED
     static MAV_MISSION_RESULT convert_MISSION_ITEM_to_MISSION_ITEM_INT(const mavlink_mission_item_t &mission_item,
             mavlink_mission_item_int_t &mission_item_int) WARN_IF_UNUSED;
     static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_MISSION_ITEM(const mavlink_mission_item_int_t &mission_item_int,
@@ -582,6 +583,7 @@ public:
     // mission_cmd_to_mavlink_int - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
     //  return true on success, false on failure
     static bool mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_int_t& packet);
+#endif
 
     // return the last time the mission changed in milliseconds
     uint32_t last_change_time_ms(void) const
@@ -629,8 +631,10 @@ public:
         return _rsem;
     }
 
+#if AP_MAVLINK_ENABLED
     // returns true if the mission contains the requested items
     bool contains_item(MAV_CMD command) const;
+#endif
 
     // returns true if the mission has a terrain relative mission item
     bool contains_terrain_alt_items(void);
@@ -655,9 +659,11 @@ public:
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
+#if AP_MAVLINK_ENABLED
     // allow lua to get/set any WP items in any order in a mavlink-ish kinda way.
     bool get_item(uint16_t index, mavlink_mission_item_int_t& result) const ;
     bool set_item(uint16_t index, mavlink_mission_item_int_t& source) ;
+#endif
 
 private:
     static AP_Mission *_singleton;
@@ -744,8 +750,10 @@ private:
     // update progress made in mission to store last position in the event of mission exit
     void update_exit_position(void);
 
+#if AP_MAVLINK_ENABLED
     /// sanity checks that the masked fields are not NaN's or infinite
     static MAV_MISSION_RESULT sanity_check_params(const mavlink_mission_item_int_t& packet);
+#endif
 
     /// check if the next nav command is a takeoff, skipping delays
     bool is_takeoff_next(uint16_t start_index);

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.h
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.h
@@ -17,7 +17,10 @@
 #include <AP_HAL/Semaphores.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 
 #define TELEM_PAYLOAD_STATUS_CAPACITY          5 // size of the message buffer queue (max number of messages waiting to be sent)
 

--- a/libraries/AP_RCTelemetry/AP_RCTelemetry.h
+++ b/libraries/AP_RCTelemetry/AP_RCTelemetry.h
@@ -33,8 +33,10 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_RCTelemetry);
 
+#if HAL_GCS_ENABLED
     // add statustext message to message queue
     virtual void queue_message(MAV_SEVERITY severity, const char *text);
+#endif
 
     // scheduler entry helpers
     void enable_scheduler_entry(const uint8_t slot) {
@@ -115,12 +117,14 @@ protected:
 #endif
     } _scheduler;
 
+#if HAL_GCS_ENABLED
     struct {
         HAL_Semaphore sem;
         ObjectBuffer<mavlink_statustext_t> queue{TELEM_PAYLOAD_STATUS_CAPACITY};
         mavlink_statustext_t next;
         bool available;
     } _statustext;
+#endif
 
 private:
     uint32_t check_sensor_status_timer;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -18,7 +18,10 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_config.h>
+#if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#endif
 #include <AP_MSP/msp.h>
 #include "AP_RangeFinder_Params.h"
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -158,7 +158,9 @@ public:
     void update(void);
 
     // Handle an incoming DISTANCE_SENSOR message (from a MAVLink enabled range finder)
+#if HAL_GCS_ENABLED
     void handle_msg(const mavlink_message_t &msg);
+#endif
 
 #if HAL_MSP_RANGEFINDER_ENABLED
     // Handle an incoming DISTANCE_SENSOR message (from a MSP enabled range finder)
@@ -189,7 +191,9 @@ public:
     int16_t max_distance_cm_orient(enum Rotation orientation) const;
     int16_t min_distance_cm_orient(enum Rotation orientation) const;
     int16_t ground_clearance_cm_orient(enum Rotation orientation) const;
+#if HAL_GCS_ENABLED
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type_orient(enum Rotation orientation) const;
+#endif
     RangeFinder::Status status_orient(enum Rotation orientation) const;
     bool has_data_orient(enum Rotation orientation) const;
     uint8_t range_valid_count_orient(enum Rotation orientation) const;

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -4,6 +4,8 @@
 
 #include <AP_HAL/AP_HAL_Boards.h>
 
+#if AP_MAVLINK_ENABLED
+
 // we have separate helpers disabled to make it possible
 // to select MAVLink 1.0 in the arduino GUI build
 #define MAVLINK_SEPARATE_HELPERS
@@ -75,3 +77,5 @@ void comm_send_unlock(mavlink_channel_t chan);
 HAL_Semaphore &comm_chan_lock(mavlink_channel_t chan);
 
 #pragma GCC diagnostic pop
+
+#endif

--- a/wscript
+++ b/wscript
@@ -622,7 +622,7 @@ def _build_cmd_tweaks(bld):
         bld.options.clear_failed_tests = True
 
 def _build_dynamic_sources(bld):
-    if not bld.env.BOOTLOADER:
+    if bld.env.MAVLINK:
         bld(
             features='mavgen',
             source='modules/mavlink/message_definitions/v1.0/all.xml',


### PR DESCRIPTION
e.g. when crossing these headers when building bootloaders or IOMCU firmware.

Most AP_Periph firmware doesn't do mavlink, but we compile it anyway, which is why compilation works for AP_Periph...
