### PR TITLE
Scripting: use MultiHeap class for memory

### DIFF
--- a/libraries/AP_Common/MultiHeap.cpp
+++ b/libraries/AP_Common/MultiHeap.cpp
@@ -1,0 +1,143 @@
+/*
+  multiple heap interface, allowing for an allocator that uses
+  multiple underlying heaps to cope with multiple memory regions on
+  STM32 boards
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Util.h>
+#include <AP_Math/AP_Math.h>
+
+#include "MultiHeap.h"
+
+/*
+  on ChibiOS allow up to 4 heaps. On other HALs only allow a single
+  heap. This is needed as hal.util->heap_realloc() needs to have the
+  property that heap_realloc(heap, ptr, 0) must not care if ptr comes
+  from the given heap. This is true on ChibiOS, but is not true on
+  other HALs
+ */
+#ifndef MAX_HEAPS
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#define MAX_HEAPS 4
+#else
+#define MAX_HEAPS 1
+#endif
+#endif
+
+extern const AP_HAL::HAL &hal;
+
+/*
+  create heaps with a total memory size, splitting over at most
+  max_heaps
+ */
+bool MultiHeap::create(uint32_t total_size, uint8_t max_heaps)
+{
+    max_heaps = MIN(MAX_HEAPS, max_heaps);
+    if (heaps != nullptr) {
+        // don't allow double allocation
+        return false;
+    }
+    heaps = new void*[max_heaps];
+    if (heaps == nullptr) {
+        return false;
+    }
+    num_heaps = max_heaps;
+    for (uint8_t i=0; i<max_heaps; i++) {
+        uint32_t alloc_size = total_size;
+        while (alloc_size > 0) {
+            heaps[i] = hal.util->allocate_heap_memory(alloc_size);
+            if (heaps[i] != nullptr) {
+                total_size -= alloc_size;
+                break;
+            }
+            alloc_size *= 0.9;
+        }
+        if (total_size == 0) {
+            break;
+        }
+    }
+    if (total_size != 0) {
+        destroy();
+        return false;
+    }
+    return true;
+}
+
+// destroy heap
+void MultiHeap::destroy(void)
+{
+    if (!available()) {
+        return;
+    }
+    for (uint8_t i=0; i<num_heaps; i++) {
+        if (heaps[i] != nullptr) {
+            free(heaps[i]);
+            heaps[i] = nullptr;
+        }
+    }
+    delete[] heaps;
+    heaps = nullptr;
+    num_heaps = 0;
+}
+
+// return true if heap is available for operations
+bool MultiHeap::available(void) const
+{
+    return heaps != nullptr && heaps[0] != nullptr;
+}
+
+/*
+  allocate memory from a heap
+ */
+void *MultiHeap::allocate(uint32_t size)
+{
+    if (!available()) {
+        return nullptr;
+    }
+    for (uint8_t i=0; i<num_heaps; i++) {
+        if (heaps[i] == nullptr) {
+            break;
+        }
+        void *newptr = hal.util->heap_realloc(heaps[i], nullptr, 0, size);
+        if (newptr != nullptr) {
+            return newptr;
+        }
+    }
+    return nullptr;
+}
+
+/*
+  free memory from a heap
+ */
+void MultiHeap::deallocate(void *ptr)
+{
+    if (!available()) {
+        return;
+    }
+    // NOTE! this relies on either there being a single heap or heap_realloc()
+    // not using the first argument when size is zero.
+    hal.util->heap_realloc(heaps[0], ptr, 0, 0);
+}
+
+/*
+  change size of an allocation
+ */
+void *MultiHeap::change_size(void *ptr, uint32_t old_size, uint32_t new_size)
+{
+    if (new_size == 0) {
+        deallocate(ptr);
+        return nullptr;
+    }
+    if (old_size == 0 || ptr == nullptr) {
+        return allocate(new_size);
+    }
+    /*
+      we cannot know which heap this came from, so we rely on the fact
+      that on ChibiOS the underlying call doesn't use the heap
+      argument and on other HALs we only have one heap. We pass
+      through old_size and new_size so that we can validate the lua
+      old_size value
+    */
+    return hal.util->heap_realloc(heaps[0], ptr, old_size, new_size);
+}

--- a/libraries/AP_Common/MultiHeap.h
+++ b/libraries/AP_Common/MultiHeap.h
@@ -1,0 +1,29 @@
+/*
+  multiple heap interface, allowing for an allocator that uses
+  multiple underlying heaps to cope with multiple memory regions on
+  STM32 boards
+ */
+
+class MultiHeap {
+public:
+    /*
+      allocate/deallocate heaps
+     */
+    bool create(uint32_t total_size, uint8_t max_heaps);
+    void destroy(void);
+
+    // return true if the heap is available for operations
+    bool available(void) const;
+
+    // allocate memory within heaps
+    void *allocate(uint32_t size);
+    void deallocate(void *ptr);
+
+    // change allocated size of a pointer - this requires the old
+    // size, unlike realloc()
+    void *change_size(void *ptr, uint32_t old_size, uint32_t new_size);
+
+private:
+    uint8_t num_heaps;
+    void **heaps;
+};

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -153,7 +153,7 @@ public:
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) = 0;
-    virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) = 0;
+    virtual void *heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size) = 0;
 #if USE_LIBC_REALLOC
     virtual void *std_realloc(void *ptr, size_t new_size) { return realloc(ptr, new_size); }
 #else

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -118,7 +118,7 @@ void *Util::std_realloc(void *addr, size_t size)
     return new_mem;
 }
 
-void *Util::heap_realloc(void *heap, void *ptr, size_t new_size)
+void *Util::heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size)
 {
     if (heap == nullptr) {
         return nullptr;
@@ -134,7 +134,13 @@ void *Util::heap_realloc(void *heap, void *ptr, size_t new_size)
     }
     void *new_mem = chHeapAlloc((memory_heap_t *)heap, new_size);
     if (new_mem != nullptr) {
-        memcpy(new_mem, ptr, chHeapGetSize(ptr) > new_size ? new_size : chHeapGetSize(ptr));
+        const size_t old_size2 = chHeapGetSize(ptr);
+#ifdef HAL_DEBUG_BUILD
+        if (new_size != 0 && old_size2 != old_size) {
+            INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        }
+#endif
+        memcpy(new_mem, ptr, old_size2 > new_size ? new_size : old_size2);
         chHeapFree(ptr);
     }
     return new_mem;

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -46,7 +46,7 @@ public:
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) override;
-    virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) override;
+    virtual void *heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size) override;
     virtual void *std_realloc(void *ptr, size_t new_size) override;
 #endif // ENABLE_HEAP
 

--- a/libraries/AP_HAL_ESP32/Util.cpp
+++ b/libraries/AP_HAL_ESP32/Util.cpp
@@ -107,7 +107,7 @@ void *Util::allocate_heap_memory(size_t size)
     return heap;
 }
 
-void *Util::heap_realloc(void *heap, void *ptr, size_t new_size)
+void *Util::heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size)
 {
     if (heap == nullptr) {
         return nullptr;

--- a/libraries/AP_HAL_ESP32/Util.h
+++ b/libraries/AP_HAL_ESP32/Util.h
@@ -41,7 +41,7 @@ public:
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) override;
-    virtual void *heap_realloc(void *heap, void *ptr, size_t new_size) override;
+    virtual void *heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size) override;
     virtual void *std_realloc(void *ptr, size_t new_size) override;
 #endif // ENABLE_HEAP
 

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -253,7 +253,7 @@ void *Util::allocate_heap_memory(size_t size)
     return (void *)new_heap;
 }
 
-void *Util::heap_realloc(void *h, void *ptr, size_t new_size)
+void *Util::heap_realloc(void *h, void *ptr, size_t old_size, size_t new_size)
 {
     if (h == nullptr) {
         return nullptr;
@@ -261,8 +261,10 @@ void *Util::heap_realloc(void *h, void *ptr, size_t new_size)
 
     struct heap *heapp = (struct heap*)h;
 
-    // extract appropriate headers
-    size_t old_size = 0;
+    // extract appropriate headers. We use the old_size from the
+    // header not from the caller. We use SITL to catch cases they
+    // don't match (which would be a lua bug)
+    old_size = 0;
     heap_allocation_header *old_header = nullptr;
     if (ptr != nullptr) {
         old_header = ((heap_allocation_header *)ptr) - 1;

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -75,7 +75,7 @@ public:
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     virtual void *allocate_heap_memory(size_t size) override;
-    virtual void *heap_realloc(void *h, void *ptr, size_t new_size) override;
+    virtual void *heap_realloc(void *h, void *ptr, size_t old_size, size_t new_size) override;
 #endif // ENABLE_HEAP
     
     /*

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -49,7 +49,7 @@ public:
 #ifdef ENABLE_HEAP
     // heap functions, note that a heap once alloc'd cannot be dealloc'd
     void *allocate_heap_memory(size_t size) override;
-    void *heap_realloc(void *heap, void *ptr, size_t new_size) override;
+    void *heap_realloc(void *heap, void *ptr, size_t old_size, size_t new_size) override;
 #endif // ENABLE_HEAP
 
 #ifdef WITH_SITL_TONEALARM

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -34,12 +34,13 @@ uint32_t lua_scripts::last_print_ms;
 lua_scripts::lua_scripts(const AP_Int32 &vm_steps, const AP_Int32 &heap_size, const AP_Int8 &debug_options, struct AP_Scripting::terminal_s &_terminal)
     : _vm_steps(vm_steps),
       _debug_options(debug_options),
-     terminal(_terminal) {
-    _heap = hal.util->allocate_heap_memory(heap_size);
+     terminal(_terminal)
+{
+    _heap.create(heap_size, 4);
 }
 
 lua_scripts::~lua_scripts() {
-    free(_heap);
+    _heap.destroy();
 }
 
 void lua_scripts::hook(lua_State *L, lua_Debug *ar) {
@@ -69,7 +70,7 @@ void lua_scripts::set_and_print_new_error_message(MAV_SEVERITY severity, const c
     // reset buffer and print count
     print_error_count = 0;
     if (error_msg_buf) {
-        hal.util->heap_realloc(_heap, error_msg_buf, 0);
+        _heap.deallocate(error_msg_buf);
         error_msg_buf = nullptr;
     }
 
@@ -92,7 +93,7 @@ void lua_scripts::set_and_print_new_error_message(MAV_SEVERITY severity, const c
     }
 
     // allocate buffer on scripting heap
-    error_msg_buf = (char *)hal.util->heap_realloc(_heap, nullptr, len+1);
+    error_msg_buf = (char *)_heap.allocate(len+1);
     if (!error_msg_buf) {
         // allocation failed
         va_end(arg_list);
@@ -170,7 +171,7 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
     const int loadMem = lua_gc(L, LUA_GCCOUNT, 0) * 1024 + lua_gc(L, LUA_GCCOUNTB, 0);
     const uint32_t loadStart = AP_HAL::micros();
 
-    script_info *new_script = (script_info *)hal.util->heap_realloc(_heap, nullptr, sizeof(script_info));
+    script_info *new_script = (script_info *)_heap.allocate(sizeof(script_info));
     if (new_script == nullptr) {
         // No memory, shouldn't happen, we even attempted to do a GC
         set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Insufficent memory loading %s", filename);
@@ -242,7 +243,7 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
 
         // FIXME: because chunk name fetching is not working we are allocating and storing an extra string we shouldn't need to
         size_t size = strlen(dirname) + strlen(de->d_name) + 2;
-        char * filename = (char *) hal.util->heap_realloc(_heap, nullptr, size);
+        char * filename = (char *) _heap.allocate(size);
         if (filename == nullptr) {
             continue;
         }
@@ -251,7 +252,7 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
         // we have something that looks like a lua file, attempt to load it
         script_info * script = load_script(L, filename);
         if (script == nullptr) {
-            hal.util->heap_realloc(_heap, filename, 0);
+            _heap.deallocate(filename);
             continue;
         }
         reschedule_script(script);
@@ -371,8 +372,8 @@ void lua_scripts::remove_script(lua_State *L, script_info *script) {
         // state could be null if we are force killing all scripts
         luaL_unref(L, LUA_REGISTRYINDEX, script->lua_ref);
     }
-    hal.util->heap_realloc(_heap, script->name, 0);
-    hal.util->heap_realloc(_heap, script, 0);
+    _heap.deallocate(script->name);
+    _heap.deallocate(script);
 }
 
 void lua_scripts::reschedule_script(script_info *script) {
@@ -410,11 +411,11 @@ void lua_scripts::reschedule_script(script_info *script) {
     previous->next = script;
 }
 
-void *lua_scripts::_heap;
+MultiHeap lua_scripts::_heap;
 
 void *lua_scripts::alloc(void *ud, void *ptr, size_t osize, size_t nsize) {
-    (void)ud; (void)osize;  /* not used */
-    return hal.util->heap_realloc(_heap, ptr, nsize);
+    (void)ud; /* not used */
+    return _heap.change_size(ptr, osize, nsize);
 }
 
 void lua_scripts::repl_cleanup (void) {
@@ -433,7 +434,7 @@ void lua_scripts::repl_cleanup (void) {
 void lua_scripts::run(void) {
     bool succeeded_initial_load = false;
 
-    if (_heap == nullptr) {
+    if (!_heap.available()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Lua: Unable to allocate a heap");
         return;
     }
@@ -582,7 +583,7 @@ void lua_scripts::run(void) {
 
     error_msg_buf_sem.take_blocking();
     if (error_msg_buf != nullptr) {
-        hal.util->heap_realloc(_heap, error_msg_buf, 0);
+        _heap.deallocate(error_msg_buf);
         error_msg_buf = nullptr;
     }
     error_msg_buf_sem.give();

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -22,6 +22,7 @@
 #include <AP_Scripting/AP_Scripting.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_HAL/Semaphores.h>
+#include <AP_Common/MultiHeap.h>
 
 #include "lua/src/lua.hpp"
 
@@ -59,7 +60,7 @@ public:
     CLASS_NO_COPY(lua_scripts);
 
     // return true if initialisation failed
-    bool heap_allocated() const { return _heap != nullptr; }
+    bool heap_allocated() const { return _heap.available(); }
 
     // run scripts, does not return unless an error occured
     void run(void);
@@ -131,7 +132,7 @@ private:
 
     static void *alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
-    static void *_heap;
+    static MultiHeap _heap;
 
     // helper for print and log of runtime stats
     void update_stats(const char *name, uint32_t run_time, int total_mem, int run_mem);


### PR DESCRIPTION
This allows for the heap to be split across multiple underlying heaps on ChibiOS, which allows for large amount of memory in scripting on boards which don't have a large enough contiguous region of memory (common on many H7 and F7 boards)
Note the change to the API for heap_realloc() is to allow for the old_size parameter in lua alloc() call to be validated in SITL and on ChibiOS debug builds, which provides us with some level of checking against lua heap corruption
This was tested in SITL and with SIM-on-hw using #22474 using aerobatics scripting 

