### PR TITLE
Plane: glide slope switch to per mode method

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -40,40 +40,10 @@ void Plane::setup_glide_slope(void)
     TECS_controller.set_path_proportion(auto_state.wp_proportion);
     update_flight_stage();
 
-    /*
-      work out if we will gradually change altitude, or try to get to
-      the new altitude as quickly as possible.
-     */
-    switch (control_mode->mode_number()) {
-    case Mode::Number::RTL:
-    case Mode::Number::AVOID_ADSB:
-    case Mode::Number::GUIDED:
-        /* glide down slowly if above target altitude, but ascend more
-           rapidly if below it. See
-           https://github.com/ArduPilot/ardupilot/issues/39
-        */
-        if (above_location_current(next_WP_loc)) {
-            set_offset_altitude_location(prev_WP_loc, next_WP_loc);
-        } else {
-            reset_offset_altitude();
-        }
-        break;
-
-    case Mode::Number::AUTO:
-        // we only do glide slide handling in AUTO when above 20m or
-        // when descending. The 20 meter threshold is arbitrary, and
-        // is basically to prevent situations where we try to slowly
-        // gain height at low altitudes, potentially hitting
-        // obstacles.
-        if (adjusted_relative_altitude_cm() > 2000 || above_location_current(next_WP_loc)) {
-            set_offset_altitude_location(prev_WP_loc, next_WP_loc);
-        } else {
-            reset_offset_altitude();
-        }
-        break;
-    default:
+    if (control_mode->use_glide_slope()) {
+        set_offset_altitude_location(prev_WP_loc, next_WP_loc);
+    } else {
         reset_offset_altitude();
-        break;
     }
 }
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -120,6 +120,10 @@ public:
     // handle a guided target request from GCS
     virtual bool handle_guided_request(Location target_loc) { return false; }
 
+    // return true if vehicle should gradually change altitude, if false the vehicle
+    // will try to get to the new altitude as quickly as possible.
+    virtual bool use_glide_slope() const { return false; }
+
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -176,6 +180,8 @@ public:
 
     bool does_auto_throttle() const override;
 
+    bool use_glide_slope() const override;
+
 protected:
 
     bool _enter() override;
@@ -227,6 +233,8 @@ public:
     void set_radius_and_direction(const float radius, const bool direction_is_ccw);
 
     void update_target_altitude() override;
+
+    bool use_glide_slope() const override;
 
 protected:
 
@@ -341,6 +349,8 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    bool use_glide_slope() const override;
 
 protected:
 
@@ -482,6 +492,8 @@ public:
     virtual bool is_guided_mode() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    bool use_glide_slope() const override;
 
 protected:
 

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -139,3 +139,13 @@ bool ModeAuto::does_auto_throttle() const
 #endif
    return true;
 }
+
+bool ModeAuto::use_glide_slope() const
+{
+    // we only do glide slide handling in AUTO when above 20m or
+    // when descending. The 20 meter threshold is arbitrary, and
+    // is basically to prevent situations where we try to slowly
+    // gain height at low altitudes, potentially hitting
+    // obstacles.
+    return plane.adjusted_relative_altitude_cm() > 2000 || plane.above_location_current(plane.next_WP_loc);
+}

--- a/ArduPlane/mode_avoidADSB.cpp
+++ b/ArduPlane/mode_avoidADSB.cpp
@@ -19,5 +19,10 @@ void ModeAvoidADSB::navigate()
     plane.update_loiter(0);
 }
 
+bool ModeAvoidADSB::use_glide_slope() const
+{
+    return plane.above_location_current(plane.next_WP_loc);
+}
+
 #endif // HAL_ADSB_ENABLED
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -93,3 +93,8 @@ void ModeGuided::update_target_altitude()
         Mode::update_target_altitude();
     }
 }
+
+bool ModeGuided::use_glide_slope() const
+{
+    return plane.above_location_current(plane.next_WP_loc);
+}

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -158,3 +158,8 @@ bool ModeRTL::switch_QRTL()
 }
 
 #endif  // HAL_QUADPLANE_ENABLED
+
+bool ModeRTL::use_glide_slope() const
+{
+    return plane.above_location_current(plane.next_WP_loc);
+}


### PR DESCRIPTION
Some more plane tidy ups moving from a switch on mode number to a per mode function. Costs a little flash but structure is better. 