### PR TITLE
Plane: Quadplane: remove RTL navigate incorrect comment and unneeded…

### DIFF
--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -81,9 +81,7 @@ void ModeRTL::update()
 void ModeRTL::navigate()
 {
 #if HAL_QUADPLANE_ENABLED
-    if ((plane.control_mode->mode_number() != QRTL) && plane.quadplane.available()) {
-        // QRTL shares this navigate function with RTL
-
+    if (plane.quadplane.available()) {
         if (plane.quadplane.rtl_mode == QuadPlane::RTL_MODE::VTOL_APPROACH_QRTL) {
             // VTOL approach landing
             AP_Mission::Mission_Command cmd;


### PR DESCRIPTION
… check

This comment and check was added by me at some point in the past. I'm not sure if it was ever correct, it certainty is not now. Navigate is only called from the mode pointer here: https://github.com/ArduPilot/ardupilot/blob/ec0b51dadd1bbe3fd774723b3da3c88c73da3d8a/ArduPlane/navigation.cpp#L109

So it is not possible to call the RTL navigate from QRTL mode. Possibly in the past we were calling the RTL mode function directly.  Tested by adding a panic if in QRTL mode and running the quadplane autotest. 