### PR TITLE
github: macosx: remove github-installed Python symlinks in /usr/local/bin

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -96,8 +96,14 @@ function maybe_prompt_user() {
     fi
 }
 
+# delete links installed by github in /usr/local/bin; installing or
+# upgrading python via brew fails if these links are in place.  brew
+# auto-updates things when you install other packages which depend on
+# more recent versions.
+# see https://github.com/orgs/Homebrew/discussions/3895
+find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+
 brew update
-brew install --overwrite python@3.10
 brew install gawk curl coreutils wget
 
 PIP=pip


### PR DESCRIPTION
... this doesn't pin the Python package so later steps may still be installed - and they still haven't fixed the files-exist problem