### PR TITLE
Fix race condition in Copter TakeoffCheck test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1128,6 +1128,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode(mode)
         self.zero_throttle()
         self.wait_ready_to_arm()
+        self.context_push()
         self.context_collect('STATUSTEXT')
         self.send_mavlink_arm_command()
         self.mav.recv_match(blocking=True, timeout=1)
@@ -1137,6 +1138,7 @@ class AutoTestCopter(AutoTest):
             self.set_rc(3, 1700)
         # we may never see ourselves as armed in a heartbeat
         self.wait_statustext("Takeoff blocked: ESC RPM too low", check_context=True)
+        self.context_pop()
         self.zero_throttle()
         self.disarm_vehicle()
         self.wait_disarmed()

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1130,8 +1130,7 @@ class AutoTestCopter(AutoTest):
         self.wait_ready_to_arm()
         self.context_push()
         self.context_collect('STATUSTEXT')
-        self.send_mavlink_arm_command()
-        self.mav.recv_match(blocking=True, timeout=1)
+        self.arm_vehicle()
         if user_takeoff:
             self.run_cmd(mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 0, 0, 0, 0, 10)
         else:


### PR DESCRIPTION
    sending the arm command isn't sufficient if there are other arming problems.
    
    Caught a test failing when throttle was found to be high - I think the rc(3, 1700) was managing to have effect before we processed the arm command because of the way the input queues to ArduPilot SITL work
