### PR TITLE
AC_PosControl: Include FF in _pid_vel_xy integrator initialisation

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -448,8 +448,6 @@ void AC_PosControl::init_xy_controller_stopping_point()
     get_stopping_point_xy_cm(_pos_target.xy());
     _vel_desired.xy().zero();
     _accel_desired.xy().zero();
-
-    _pid_vel_xy.set_integrator(_accel_target);
 }
 
 // relax_velocity_controller_xy - initialise the position controller to the current position and velocity with decaying acceleration.
@@ -513,7 +511,7 @@ void AC_PosControl::init_xy_controller()
     _pid_vel_xy.reset_filter();
     // initialise the I term to _accel_target - _accel_desired
     // _accel_desired is zero and can be removed from the equation
-    _pid_vel_xy.set_integrator(_accel_target);
+    _pid_vel_xy.set_integrator(_accel_target.xy() - _vel_target.xy() * _pid_vel_xy.ff());
 
     // initialise ekf xy reset handler
     init_ekf_xy_reset();


### PR DESCRIPTION
This PR fixes a serious bug that can cause the aircraft to command an exponentially increasing pitch or roll rate during takeoff.

The problem is part of the initialisation of the xy position controller when the vel xy feed forward term PSC_VELXY_FF is non zero.

This meant that each loop the FF component would be moved into the I term, resulting in the exponential growth.

Before fix:
 
![image](https://user-images.githubusercontent.com/100896/209611187-748f4b48-5916-43dd-bf46-2f1cc68b369d.png)

1: Normal takeoff
2: WP_NAVALT_MIN = 1 m
3 WP_NAVALT_MIN = 1 m and PSC_VELXY_FF = 0.5

After fix, WP_NAVALT_MIN = 1 m and PSC_VELXY_FF = 0.5 :
![image](https://user-images.githubusercontent.com/100896/209611939-31af985d-84bc-4817-8e06-837a97bfc66b.png)




