### PR TITLE
Copter: Allow configurable landing delay time

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -454,6 +454,15 @@ const AP_Param::Info Copter::var_info[] = {
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     (uint8_t)ModeAcro::Trainer::LIMITED),
 #endif
 
+    // @Param: LAND_WITH_DELAY
+    // @DisplayName: Land with delay
+    // @Description: land-with-delay is triggered during a failsafe event
+    // @Units: ms
+    // @Range: 0 10000
+    // @Increment: 1
+    // @User: Standard
+    GSCALAR(land_with_delay,        "LAND_WITH_DELAY",   LAND_WITH_DELAY_MS),
+
     // variables not in the g class which contain EEPROM saved variables
 
 #if AP_CAMERA_ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -382,6 +382,8 @@ public:
 
         k_param_vehicle = 257, // vehicle common block of parameters
 
+        k_param_land_with_delay = 258,
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -475,6 +477,8 @@ public:
     // Acro parameters
     AP_Int8                 acro_trainer;
 #endif
+
+    AP_Int32                land_with_delay;
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -83,7 +83,7 @@ void ModeLand::gps_run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // pause before beginning land descent
-        if (land_pause && millis()-land_start_time >= LAND_WITH_DELAY_MS) {
+        if (land_pause && millis()-land_start_time >= uint32_t(copter.g.land_with_delay.get())) {
             land_pause = false;
         }
 


### PR DESCRIPTION
I allow the landing delay time to be set arbitrarily.
In case of fail-safe transition to landing mode, the vehicle will hover for 4 seconds before entering the landing operation.
I sometimes recover from a radio fail-safe by moving the radio to a different location.
It would be nice to be able to specify a delay of a few minutes for some operators.