### PR TITLE
AP_Terrain: only include GCS_MAVLink if terrain is enabled

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -13,17 +13,17 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Terrain.h"
+
+#if AP_TERRAIN_AVAILABLE
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
-#include "AP_Terrain.h"
 #include <AP_AHRS/AP_AHRS.h>
-
-#if AP_TERRAIN_AVAILABLE
-
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -14,11 +14,8 @@
  */
 #pragma once
 
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Common/Location.h>
 #include <AP_Filesystem/AP_Filesystem_config.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #ifndef AP_TERRAIN_AVAILABLE
 #if HAVE_FILESYSTEM_SUPPORT && defined(HAL_BOARD_TERRAIN_DIRECTORY)
@@ -30,7 +27,10 @@
 
 #if AP_TERRAIN_AVAILABLE
 
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #define TERRAIN_DEBUG 0
 

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -18,14 +18,14 @@
 
 #include "AP_Terrain.h"
 
+#if AP_TERRAIN_AVAILABLE
+
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
-
-#if AP_TERRAIN_AVAILABLE
 
 #include <assert.h>
 #include <stdio.h>

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -16,17 +16,15 @@
   handle disk IO for terrain code
  */
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Common/AP_Common.h>
-#include <AP_Math/AP_Math.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
-#include <stdio.h>
 #include "AP_Terrain.h"
 
 #if AP_TERRAIN_AVAILABLE
 
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Terrain/TerrainMission.cpp
+++ b/libraries/AP_Terrain/TerrainMission.cpp
@@ -16,17 +16,16 @@
   handle checking mission points for terrain data
  */
 
+#include "AP_Terrain.h"
+
+#if AP_TERRAIN_AVAILABLE
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Rally/AP_Rally.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
-#include "AP_Terrain.h"
 #include <AP_GPS/AP_GPS.h>
-
-#if AP_TERRAIN_AVAILABLE
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Terrain/TerrainUtil.cpp
+++ b/libraries/AP_Terrain/TerrainUtil.cpp
@@ -16,16 +16,13 @@
   handle disk IO for terrain code
  */
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Common/AP_Common.h>
-#include <AP_Math/AP_Math.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
 #include "AP_Terrain.h"
 
 #if AP_TERRAIN_AVAILABLE
 
-#include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
... many of our boards don't have a terrain directory (e.g. stm32 / no SD card)...

also prune some un-needed includes in cpp files.  These look like they were copy/pasted.

