### PR TITLE
AP_Arming: only require AP_RALLY_ENABLED if MIS_ITEM_CHECK_RALLY

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -789,15 +789,6 @@ bool AP_Arming::mission_checks(bool report)
             check_failed(ARMING_CHECK_MISSION, report, "No mission library present");
             return false;
         }
-#if HAL_RALLY_ENABLED
-        AP_Rally *rally = AP::rally();
-        if (rally == nullptr) {
-            check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
-            return false;
-        }
-#else
-        check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
-#endif
 
         const struct MisItemTable {
           MIS_ITEM_CHECK check;
@@ -819,8 +810,13 @@ bool AP_Arming::mission_checks(bool report)
                 }
             }
         }
-#if HAL_RALLY_ENABLED
         if (_required_mission_items & MIS_ITEM_CHECK_RALLY) {
+#if HAL_RALLY_ENABLED
+            AP_Rally *rally = AP::rally();
+            if (rally == nullptr) {
+                check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
+                return false;
+            }
             Location ahrs_loc;
             if (!AP::ahrs().get_location(ahrs_loc)) {
                 check_failed(ARMING_CHECK_MISSION, report, "Can't check rally without position");
@@ -831,8 +827,11 @@ bool AP_Arming::mission_checks(bool report)
                 check_failed(ARMING_CHECK_MISSION, report, "No sufficently close rally point located");
                 return false;
             }
-          }
+#else
+            check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
+            return false;
 #endif
+        }
     }
 
     return true;


### PR DESCRIPTION
It's OK to not have AP_RALLY_ENABLED if the user isn't requiring that a rally point be avaiable.  i.e. if the user is requesting that there be a landing point that doesn't infer rally must be compiled in!

Tested in SITL; before this PR we fail to arm if "require RTL" bit is set and rally is not present
