### PR TITLE
AP_FETtecOneWire: change comments to not use @param

### DIFF
--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -858,9 +858,9 @@ void AP_FETtecOneWire::beep(const uint8_t beep_frequency)
 #if HAL_AP_FETTEC_ESC_LIGHT
 /**
     sets the racewire color for all ESCs
-    @param r red brightness
-    @param g green brightness
-    @param b blue brightness
+    r = red brightness
+    g = green brightness
+    b = blue brightness
 */
 void AP_FETtecOneWire::led_color(const uint8_t r, const uint8_t g, const uint8_t b)
 {


### PR DESCRIPTION
these comments break the MissionPlanner param parser

see these errors in MissionPlanner.log

```
2022-12-30 08:28:42,641  INFO MissionPlanner.Utilities.ParameterMetaDataParser - using cache https://raw.oborne.me/ardupilot/ardupilot/master/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp (D:\a\MissionPlanner\MissionPlanner\ExtLibs\Utilities\ParameterMetaDataParser.cs:503) [65]
2022-12-30 08:28:42,641 ERROR MissionPlanner.Utilities.ParameterMetaDataParser - Invalid MetaFrame Blimp (D:\a\MissionPlanner\MissionPlanner\ExtLibs\Utilities\ParameterMetaDataParser.cs:390) [70]
2022-12-30 08:28:42,641  INFO MissionPlanner.Utilities.ParameterMetaDataParser - using cache https://raw.oborne.me/ardupilot/ardupilot/master/libraries/AP_Proximity/AP_Proximity_Params.cpp (D:\a\MissionPlanner\MissionPlanner\ExtLibs\Utilities\ParameterMetaDataParser.cs:503) [71]
2022-12-30 08:28:42,642 ERROR MissionPlanner.Utilities.ParameterMetaDataParser - Bad Key - Value @param b blue brightness
*/
void AP_FETtecOneWire::led_color(const uint8_t r, const uint8_t g, const uint8_t b)
{
    for (uint8_t i=0; i<_esc_count; i++) {
        auto &esc = _escs[i];
        if (esc.state != ESCState::RUNNING) {
            continue;
        }
        transmit_config_request(PackedMessage<LEDColour>{esc.id, LEDColour{r, g, b}});
    }
}
```