### PR TITLE
AP_Param: allow class specific defaults using pointer diff. 

### DIFF
--- a/libraries/AC_AttitudeControl/AC_CommandModel.cpp
+++ b/libraries/AC_AttitudeControl/AC_CommandModel.cpp
@@ -15,7 +15,7 @@ const AP_Param::GroupInfo AC_CommandModel::var_info[] = {
     // @Units: deg/s
     // @Range: 1 360
     // @User: Standard
-    AP_GROUPINFO("RATE", 1, AC_CommandModel, rate, 202.5),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("RATE", 1, AC_CommandModel, rate, default_rate),
 
     // @Param: EXPO
     // @DisplayName: Controlled Expo
@@ -23,7 +23,7 @@ const AP_Param::GroupInfo AC_CommandModel::var_info[] = {
     // @Values: 0:Disabled,0.1:Very Low,0.2:Low,0.3:Medium,0.4:High,0.5:Very High
     // @Range: -0.5 1.0
     // @User: Advanced
-    AP_GROUPINFO("EXPO", 2, AC_CommandModel, expo, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("EXPO", 2, AC_CommandModel, expo, default_expo),
 
     // @Param: RATE_TC
     // @DisplayName: Rate control input time constant
@@ -33,17 +33,17 @@ const AP_Param::GroupInfo AC_CommandModel::var_info[] = {
     // @Increment: 0.01
     // @Values: 0.5:Very Soft, 0.2:Soft, 0.15:Medium, 0.1:Crisp, 0.05:Very Crisp
     // @User: Standard
-    AP_GROUPINFO("RATE_TC", 3, AC_CommandModel, rate_tc, 0.05f),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("RATE_TC", 3, AC_CommandModel, rate_tc, default_rate_tc),
 
     AP_GROUPEND
 };
 
 // Constructor
-AC_CommandModel::AC_CommandModel(float initial_rate, float initial_expo, float initial_tc)
+AC_CommandModel::AC_CommandModel(float initial_rate, float initial_expo, float initial_tc) :
+    default_rate(initial_rate),
+    default_expo(initial_expo),
+    default_rate_tc(initial_tc)
 {
     AP_Param::setup_object_defaults(this, var_info);
-    rate.set_and_default(initial_rate);
-    expo.set_and_default(initial_expo);
-    rate_tc.set_and_default(initial_tc);
 }
 

--- a/libraries/AC_AttitudeControl/AC_CommandModel.h
+++ b/libraries/AC_AttitudeControl/AC_CommandModel.h
@@ -29,5 +29,9 @@ protected:
     AP_Float rate;          // maximum rate
     AP_Float expo;          // expo shaping
 
+private:
+    const float default_rate_tc;
+    const float default_rate;
+    const float default_expo;
 };
 

--- a/libraries/AC_PID/AC_P.cpp
+++ b/libraries/AC_PID/AC_P.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AC_P::var_info[] = {
     // @Param: P
     // @DisplayName: PI Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_P, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_P, _kp, default_kp),
     AP_GROUPEND
 };
 

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -20,10 +20,10 @@ public:
     ///
     /// @param  initial_p       Initial value for the P term.
     ///
-    AC_P(const float &initial_p = 0.0f)
+    AC_P(const float &initial_p = 0.0f) :
+        default_kp(initial_p)
     {
-		AP_Param::setup_object_defaults(this, var_info);
-        _kp.set_and_default(initial_p);
+        AP_Param::setup_object_defaults(this, var_info);
     }
 
     CLASS_NO_COPY(AC_P);
@@ -65,4 +65,6 @@ public:
 
 private:
     AP_Float        _kp;
+
+    const float default_kp;
 };

--- a/libraries/AC_PID/AC_PI.cpp
+++ b/libraries/AC_PID/AC_PI.cpp
@@ -25,14 +25,13 @@ const AP_Param::GroupInfo AC_PI::var_info[] = {
 };
 
 // Constructor
-AC_PI::AC_PI(float initial_p, float initial_i, float initial_imax)
+AC_PI::AC_PI(float initial_p, float initial_i, float initial_imax) :
+    default_kp(initial_p),
+    default_ki(initial_i),
+    default_imax(initial_imax)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
-
-    kP.set_and_default(initial_p);
-    kI.set_and_default(initial_i);
-    imax.set_and_default(initial_imax);
 }
 
 float AC_PI::update(float measurement, float target, float dt)

--- a/libraries/AC_PID/AC_PI.h
+++ b/libraries/AC_PID/AC_PI.h
@@ -33,4 +33,10 @@ protected:
     AP_Float        imax;
     float           integrator;
     float           output_P;
+
+private:
+    const float default_kp;
+    const float default_ki;
+    const float default_imax;
+
 };

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -8,29 +8,29 @@ const AP_Param::GroupInfo AC_PID::var_info[] = {
     // @Param: P
     // @DisplayName: PID Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P", 0, AC_PID, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P", 0, AC_PID, _kp, default_kp),
 
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I", 1, AC_PID, _ki, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I", 1, AC_PID, _ki, default_ki),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
-    AP_GROUPINFO("D", 2, AC_PID, _kd, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D", 2, AC_PID, _kd, default_kd),
 
     // 3 was for uint16 IMAX
 
     // @Param: FF
     // @DisplayName: FF FeedForward Gain
     // @Description: FF Gain which produces an output value that is proportional to the demanded input
-    AP_GROUPINFO("FF", 4, AC_PID, _kff, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FF", 4, AC_PID, _kff, default_kff),
 
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 5, AC_PID, _kimax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 5, AC_PID, _kimax, default_kimax),
 
     // 6 was for float FILT
 
@@ -42,19 +42,19 @@ const AP_Param::GroupInfo AC_PID::var_info[] = {
     // @DisplayName: PID Target filter frequency in Hz
     // @Description: Target filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTT", 9, AC_PID, _filt_T_hz, AC_PID_TFILT_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTT", 9, AC_PID, _filt_T_hz, default_filt_T_hz),
 
     // @Param: FLTE
     // @DisplayName: PID Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTE", 10, AC_PID, _filt_E_hz, AC_PID_EFILT_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTE", 10, AC_PID, _filt_E_hz, default_filt_E_hz),
 
     // @Param: FLTD
     // @DisplayName: PID Derivative term filter frequency in Hz
     // @Description: Derivative filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTD", 11, AC_PID, _filt_D_hz, AC_PID_DFILT_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTD", 11, AC_PID, _filt_D_hz, default_filt_D_hz),
 
     // @Param: SMAX
     // @DisplayName: Slew rate limit
@@ -62,28 +62,29 @@ const AP_Param::GroupInfo AC_PID::var_info[] = {
     // @Range: 0 200
     // @Increment: 0.5
     // @User: Advanced
-    AP_GROUPINFO("SMAX", 12, AC_PID, _slew_rate_max, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("SMAX", 12, AC_PID, _slew_rate_max, default_slew_rate_max),
 
     AP_GROUPEND
 };
 
 // Constructor
 AC_PID::AC_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz,
-               float initial_srmax, float initial_srtau)
+               float initial_srmax, float initial_srtau) :
+    default_kp(initial_p),
+    default_ki(initial_i),
+    default_kd(initial_d),
+    default_kff(initial_ff),
+    default_kimax(initial_imax),
+    default_filt_T_hz(initial_filt_T_hz),
+    default_filt_E_hz(initial_filt_E_hz),
+    default_filt_D_hz(initial_filt_D_hz),
+    default_slew_rate_max(initial_srmax)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
 
-    _kp.set_and_default(initial_p);
-    _ki.set_and_default(initial_i);
-    _kd.set_and_default(initial_d);
-    _kff.set_and_default(initial_ff);
-    _kimax.set_and_default(initial_imax);
-    _filt_T_hz.set_and_default(initial_filt_T_hz);
-    _filt_E_hz.set_and_default(initial_filt_E_hz);
-    _filt_D_hz.set_and_default(initial_filt_D_hz);
-    _slew_rate_max.set_and_default(initial_srmax);
-    _slew_rate_tau.set_and_default(initial_srtau);
+    // this param is not in the table, so its default is no loaded in the call above
+    _slew_rate_tau.set(initial_srtau);
 
     // reset input filter to first value received
     _flags._reset_filter = true;

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -152,4 +152,15 @@ protected:
     int8_t _slew_limit_scale;
 
     AP_PIDInfo _pid_info;
+
+private:
+    const float default_kp;
+    const float default_ki;
+    const float default_kd;
+    const float default_kff;
+    const float default_kimax;
+    const float default_filt_T_hz;
+    const float default_filt_E_hz;
+    const float default_filt_D_hz;
+    const float default_slew_rate_max;
 };

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -4,64 +4,61 @@
 #include <AP_Math/AP_Math.h>
 #include "AC_PID_2D.h"
 
-#define AC_PID_2D_FILT_E_HZ_DEFAULT  20.0f   // default input filter frequency
-#define AC_PID_2D_FILT_D_HZ_DEFAULT  10.0f   // default input filter frequency
 #define AC_PID_2D_FILT_D_HZ_MIN      0.005f   // minimum input filter frequency
 
 const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @Param: P
     // @DisplayName: PID Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_PID_2D, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_PID_2D, _kp, default_kp),
 
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I",    1, AC_PID_2D, _ki, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, AC_PID_2D, _ki, default_ki),
 
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 2, AC_PID_2D, _kimax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 2, AC_PID_2D, _kimax, default_kimax),
 
     // @Param: FLTE
     // @DisplayName: PID Input filter frequency in Hz
     // @Description: Input filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTE", 3, AC_PID_2D, _filt_E_hz, AC_PID_2D_FILT_E_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTE", 3, AC_PID_2D, _filt_E_hz, default_filt_E_hz),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
-    AP_GROUPINFO("D",    4, AC_PID_2D, _kd, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D",    4, AC_PID_2D, _kd, default_kd),
 
     // @Param: FLTD
     // @DisplayName: D term filter frequency in Hz
     // @Description: D term filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTD", 5, AC_PID_2D, _filt_D_hz, AC_PID_2D_FILT_D_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTD", 5, AC_PID_2D, _filt_D_hz, default_filt_D_hz),
 
     // @Param: FF
     // @DisplayName: PID Feed Forward Gain
     // @Description: FF Gain which produces an output that is proportional to the magnitude of the target
-    AP_GROUPINFO("FF",    6, AC_PID_2D, _kff, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FF",    6, AC_PID_2D, _kff, default_kff),
 
     AP_GROUPEND
 };
 
 // Constructor
-AC_PID_2D::AC_PID_2D(float initial_kP, float initial_kI, float initial_kD, float initial_kFF, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz)
+AC_PID_2D::AC_PID_2D(float initial_kP, float initial_kI, float initial_kD, float initial_kFF, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz) :
+    default_kp(initial_kP),
+    default_ki(initial_kI),
+    default_kd(initial_kD),
+    default_kff(initial_kFF),
+    default_kimax(initial_imax),
+    default_filt_E_hz(initial_filt_E_hz),
+    default_filt_D_hz(initial_filt_D_hz)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
-
-    _kp.set_and_default(initial_kP);
-    _ki.set_and_default(initial_kI);
-    _kd.set_and_default(initial_kD);
-    _kff.set_and_default(initial_kFF);
-    _kimax.set_and_default(initial_imax);
-    _filt_E_hz.set_and_default(initial_filt_E_hz);
-    _filt_D_hz.set_and_default(initial_filt_D_hz);
 
     // reset input filter to first value received
     _reset_filter = true;

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -98,4 +98,13 @@ protected:
 
     AP_PIDInfo _pid_info_x;
     AP_PIDInfo _pid_info_y;
+
+private:
+    const float default_kp;
+    const float default_ki;
+    const float default_kd;
+    const float default_kff;
+    const float default_kimax;
+    const float default_filt_E_hz;
+    const float default_filt_D_hz;
 };

--- a/libraries/AC_PID/AC_PID_Basic.cpp
+++ b/libraries/AC_PID/AC_PID_Basic.cpp
@@ -5,65 +5,62 @@
 #include <AP_InternalError/AP_InternalError.h>
 #include "AC_PID_Basic.h"
 
-#define AC_PID_Basic_FILT_E_HZ_DEFAULT 20.0f   // default input filter frequency
 #define AC_PID_Basic_FILT_E_HZ_MIN     0.01f   // minimum input filter frequency
-#define AC_PID_Basic_FILT_D_HZ_DEFAULT 10.0f   // default input filter frequency
 #define AC_PID_Basic_FILT_D_HZ_MIN     0.005f  // minimum input filter frequency
 
 const AP_Param::GroupInfo AC_PID_Basic::var_info[] = {
     // @Param: P
     // @DisplayName: PID Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_PID_Basic, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_PID_Basic, _kp, default_kp),
 
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I",    1, AC_PID_Basic, _ki, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, AC_PID_Basic, _ki, default_ki),
 
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 2, AC_PID_Basic, _kimax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 2, AC_PID_Basic, _kimax, default_kimax),
 
     // @Param: FLTE
     // @DisplayName: PID Error filter frequency in Hz
     // @Description: Error filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTE", 3, AC_PID_Basic, _filt_E_hz, AC_PID_Basic_FILT_E_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTE", 3, AC_PID_Basic, _filt_E_hz, default_filt_E_hz),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
-    AP_GROUPINFO("D",    4, AC_PID_Basic, _kd, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D",    4, AC_PID_Basic, _kd, default_kd),
 
     // @Param: FLTD
     // @DisplayName: D term filter frequency in Hz
     // @Description: D term filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FLTD", 5, AC_PID_Basic, _filt_D_hz, AC_PID_Basic_FILT_D_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTD", 5, AC_PID_Basic, _filt_D_hz, default_filt_D_hz),
 
     // @Param: FF
     // @DisplayName: PID Feed Forward Gain
     // @Description: FF Gain which produces an output that is proportional to the magnitude of the target
-    AP_GROUPINFO("FF",   6, AC_PID_Basic, _kff, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FF",   6, AC_PID_Basic, _kff, default_kff),
 
     AP_GROUPEND
 };
 
 // Constructor
-AC_PID_Basic::AC_PID_Basic(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz)
+AC_PID_Basic::AC_PID_Basic(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_E_hz, float initial_filt_D_hz) :
+    default_kp(initial_p),
+    default_ki(initial_i),
+    default_kd(initial_d),
+    default_kff(initial_ff),
+    default_kimax(initial_imax),
+    default_filt_E_hz(initial_filt_E_hz),
+    default_filt_D_hz(initial_filt_D_hz)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
-
-    _kp.set_and_default(initial_p);
-    _ki.set_and_default(initial_i);
-    _kd.set_and_default(initial_d);
-    _kff.set_and_default(initial_ff);
-    _kimax.set_and_default(initial_imax);
-    _filt_E_hz.set_and_default(initial_filt_E_hz);
-    _filt_D_hz.set_and_default(initial_filt_D_hz);
 
     // reset input filter to first value received
     _reset_filter = true;

--- a/libraries/AC_PID/AC_PID_Basic.h
+++ b/libraries/AC_PID/AC_PID_Basic.h
@@ -91,4 +91,13 @@ protected:
     bool _reset_filter; // true when input filter should be reset during next call to set_input
 
     AP_PIDInfo _pid_info;
+
+private:
+    const float default_kp;
+    const float default_ki;
+    const float default_kd;
+    const float default_kff;
+    const float default_kimax;
+    const float default_filt_E_hz;
+    const float default_filt_D_hz;
 };

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -8,38 +8,38 @@ const AP_Param::GroupInfo AC_PI_2D::var_info[] = {
     // @Param: P
     // @DisplayName: PI Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_PI_2D, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_PI_2D, _kp, default_kp),
 
     // @Param: I
     // @DisplayName: PI Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I",    1, AC_PI_2D, _ki, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, AC_PI_2D, _ki, default_ki),
 
     // @Param: IMAX
     // @DisplayName: PI Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 2, AC_PI_2D, _imax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 2, AC_PI_2D, _imax, default_imax),
 
     // @Param: FILT_HZ
     // @DisplayName: PI Input filter frequency in Hz
     // @Description: Input filter frequency in Hz
     // @Units: Hz
-    AP_GROUPINFO("FILT_HZ", 3, AC_PI_2D, _filt_hz, AC_PI_2D_FILT_HZ_DEFAULT),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FILT_HZ", 3, AC_PI_2D, _filt_hz, default_filt_hz),
 
     AP_GROUPEND
 };
 
 // Constructor
 AC_PI_2D::AC_PI_2D(float initial_p, float initial_i, float initial_imax, float initial_filt_hz, float dt) :
-    _dt(dt)
+    _dt(dt),
+    default_kp(initial_p),
+    default_ki(initial_i),
+    default_imax(initial_imax),
+    default_filt_hz(initial_filt_hz)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
 
-    _kp.set_and_default(initial_p);
-    _ki.set_and_default(initial_i);
-    _imax.set_and_default(initial_imax);
-    _filt_hz.set_and_default(initial_filt_hz);
     filt_hz(initial_filt_hz);
 
     // reset input filter to first value received

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <cmath>
 
-#define AC_PI_2D_FILT_HZ_DEFAULT  20.0f   // default input filter frequency
 #define AC_PI_2D_FILT_HZ_MIN      0.01f   // minimum input filter frequency
 
 /// @class	AC_PI_2D
@@ -92,4 +91,10 @@ private:
     Vector2f _integrator;   // integrator value
     Vector2f _input;        // last input for derivative
     float _filt_alpha;      // input filter alpha
+
+    const float default_kp;
+    const float default_ki;
+    const float default_imax;
+    const float default_filt_hz;
+
 };

--- a/libraries/AC_PID/AC_P_1D.cpp
+++ b/libraries/AC_PID/AC_P_1D.cpp
@@ -8,17 +8,16 @@ const AP_Param::GroupInfo AC_P_1D::var_info[] = {
     // @Param: P
     // @DisplayName: P Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_P_1D, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_P_1D, _kp, default_kp),
     AP_GROUPEND
 };
 
 // Constructor
-AC_P_1D::AC_P_1D(float initial_p)
+AC_P_1D::AC_P_1D(float initial_p) :
+    default_kp(initial_p)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
-
-    _kp.set_and_default(initial_p);
 }
 
 // update_all - set target and measured inputs to P controller and calculate outputs

--- a/libraries/AC_PID/AC_P_1D.h
+++ b/libraries/AC_PID/AC_P_1D.h
@@ -57,4 +57,6 @@ private:
     float _error_min; // error limit in negative direction
     float _error_max; // error limit in positive direction
     float _D1_max;      // maximum first derivative of output
+
+    const float default_kp;
 };

--- a/libraries/AC_PID/AC_P_2D.cpp
+++ b/libraries/AC_PID/AC_P_2D.cpp
@@ -8,17 +8,16 @@ const AP_Param::GroupInfo AC_P_2D::var_info[] = {
     // @Param: P
     // @DisplayName: Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, AC_P_2D, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_P_2D, _kp, default_kp),
     AP_GROUPEND
 };
 
 // Constructor
-AC_P_2D::AC_P_2D(float initial_p)
+AC_P_2D::AC_P_2D(float initial_p) :
+    default_kp(initial_p)
 {
     // load parameter values from eeprom
     AP_Param::setup_object_defaults(this, var_info);
-
-    _kp.set_and_default(initial_p);
 }
 
 // update_all - set target and measured inputs to P controller and calculate outputs

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -58,4 +58,6 @@ private:
     Vector2f _error;    // time step in seconds
     float _error_max;   // error limit in positive direction
     float _D1_max;      // maximum first derivative of output
+
+    const float default_kp;
 };

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -72,11 +72,15 @@ public:
     AP_Int8 xpos;
     AP_Int8 ypos;
 
-    AP_OSD_Setting();
-    AP_OSD_Setting(bool enabled, uint8_t x, uint8_t y);
+    AP_OSD_Setting(bool enabled = 0, uint8_t x = 0, uint8_t y = 0);
 
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
+
+private:
+    const float default_enabled;
+    const float default_xpos;
+    const float default_ypos;
 };
 
 class AP_OSD;
@@ -384,6 +388,13 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    float default_enabled;
+    float default_ypos;
+    float default_param_group;
+    float default_param_idx;
+    float default_param_key;
+    float default_type;
+
 };
 
 /*

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo AP_OSD_ParamSetting::var_info[] = {
     // @Description: Enable setting
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO("_EN", 1, AP_OSD_ParamSetting, enabled, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_EN", 1, AP_OSD_ParamSetting, enabled, default_enabled),
 
     // @Param: _X
     // @DisplayName: X position
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo AP_OSD_ParamSetting::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     // @User: Standard
-    AP_GROUPINFO("_Y", 3, AP_OSD_ParamSetting, ypos, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_Y", 3, AP_OSD_ParamSetting, ypos, default_ypos),
 
     // Parameter access keys. These default to -1 too allow user overrides
     // to work properly
@@ -58,19 +58,19 @@ const AP_Param::GroupInfo AP_OSD_ParamSetting::var_info[] = {
     // @DisplayName: Parameter key
     // @Description: Key of the parameter to be displayed and modified
     // @User: Standard
-    AP_GROUPINFO("_KEY", 4, AP_OSD_ParamSetting, _param_key, -1),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_KEY", 4, AP_OSD_ParamSetting, _param_key, default_param_key),
 
     // @Param: _IDX
     // @DisplayName: Parameter index
     // @Description: Index of the parameter to be displayed and modified
     // @User: Standard
-    AP_GROUPINFO("_IDX", 5, AP_OSD_ParamSetting, _param_idx, -1),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_IDX", 5, AP_OSD_ParamSetting, _param_idx, default_param_idx),
 
     // @Param: _GRP
     // @DisplayName: Parameter group
     // @Description: Group of the parameter to be displayed and modified
     // @User: Standard
-    AP_GROUPINFO("_GRP", 6, AP_OSD_ParamSetting, _param_group, -1),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_GRP", 6, AP_OSD_ParamSetting, _param_group, default_param_group),
 
     // @Param: _MIN
     // @DisplayName: Parameter minimum
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_OSD_ParamSetting::var_info[] = {
     // @DisplayName: Parameter type
     // @Description: Type of the parameter to be displayed and modified
     // @User: Standard
-    AP_GROUPINFO("_TYPE", 10, AP_OSD_ParamSetting, _type, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_TYPE", 10, AP_OSD_ParamSetting, _type, default_type),
 
     AP_GROUPEND
 };
@@ -237,26 +237,27 @@ const AP_OSD_ParamSetting::ParamMetadata AP_OSD_ParamSetting::_param_metadata[OS
 extern const AP_HAL::HAL& hal;
 
 // default constructor that just sets some sensible defaults that exist on all platforms
-AP_OSD_ParamSetting::AP_OSD_ParamSetting(uint8_t param_number)
-    : _param_number(param_number)
+AP_OSD_ParamSetting::AP_OSD_ParamSetting(uint8_t param_number) :
+    _param_number(param_number),
+    default_ypos(param_number + 1),
+    default_param_group(-1),
+    default_param_idx(-1),
+    default_param_key(-1)
 {
     AP_Param::setup_object_defaults(this, var_info);
-
-    ypos.set(param_number + 1);
 }
 
 // construct a setting from a compact static initializer structure
-AP_OSD_ParamSetting::AP_OSD_ParamSetting(const Initializer& initializer)
-    : _param_number(initializer.index)
+AP_OSD_ParamSetting::AP_OSD_ParamSetting(const Initializer& initializer) :
+    _param_number(initializer.index),
+    default_enabled(true),
+    default_ypos(initializer.index + 1),
+    default_param_group(initializer.token.group_element),
+    default_param_idx(initializer.token.idx),
+    default_param_key(initializer.token.key),
+    default_type(initializer.type)
 {
     AP_Param::setup_object_defaults(this, var_info);
-
-    enabled.set(true);
-    ypos.set(initializer.index + 1);
-    _param_group.set(initializer.token.group_element);
-    _param_idx.set(initializer.token.idx);
-    _param_key.set(initializer.token.key);
-    _type.set(initializer.type);
 }
 
 // update the contained parameter

--- a/libraries/AP_OSD/AP_OSD_Setting.cpp
+++ b/libraries/AP_OSD/AP_OSD_Setting.cpp
@@ -29,36 +29,30 @@ const AP_Param::GroupInfo AP_OSD_Setting::var_info[] = {
     // @Description: Enable setting
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO("_EN", 1, AP_OSD_Setting, enabled, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_EN", 1, AP_OSD_Setting, enabled, default_enabled),
 
     // @Param: _X
     // @DisplayName: X position
     // @Description: Horizontal position on screen
     // @Range: 0 29
     // @User: Standard
-    AP_GROUPINFO("_X", 2, AP_OSD_Setting, xpos, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_X", 2, AP_OSD_Setting, xpos, default_xpos),
 
     // @Param: _Y
     // @DisplayName: Y position
     // @Description: Vertical position on screen
     // @Range: 0 15
     // @User: Standard
-    AP_GROUPINFO("_Y", 3, AP_OSD_Setting, ypos, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("_Y", 3, AP_OSD_Setting, ypos, default_ypos),
 
     AP_GROUPEND
 };
 
-// constructors
-AP_OSD_Setting::AP_OSD_Setting()
+// constructor
+AP_OSD_Setting::AP_OSD_Setting(bool _enabled, uint8_t x, uint8_t y) :
+    default_enabled(_enabled),
+    default_xpos(x),
+    default_ypos(y)
 {
     AP_Param::setup_object_defaults(this, var_info);
-}
-
-
-AP_OSD_Setting::AP_OSD_Setting(bool _enabled, uint8_t x, uint8_t y) :
-    AP_OSD_Setting()
-{
-    enabled.set(_enabled);
-    xpos.set(x);
-    ypos.set(y);
 }

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2793,6 +2793,16 @@ void AP_Param::show_all(AP_HAL::BetterStream *port, bool showKeyValues)
         show(ap, token, type, port);
         hal.scheduler->delay(1);
     }
+
+#if AP_PARAM_DEFAULTS_ENABLED
+    uint16_t list_len = 0;
+    if (default_list != nullptr) {
+        for (defaults_list *item = default_list; item; item = item->next) {
+            list_len++;
+        }
+    }
+    ::printf("Defaults list containts %i params (%li bytes)\n", list_len, list_len*sizeof(defaults_list));
+#endif
 }
 #endif // AP_PARAM_KEY_DUMP
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -90,13 +90,16 @@
 // hide parameter from param download
 #define AP_PARAM_FLAG_HIDDEN (1<<6)
 
+// Default value is a "pointer" actually its a offest from the base value, but the idea is the same
+#define AP_PARAM_FLAG_DEFAULT_POINTER (1<<7)
+
 // keep all flags before the FRAME tags
 
 // vehicle and frame type flags, used to hide parameters when not
 // relevent to a vehicle type. Use AP_Param::set_frame_type_flags() to
 // enable parameters flagged in this way. frame type flags are stored
 // in flags field, shifted by AP_PARAM_FRAME_TYPE_SHIFT.
-#define AP_PARAM_FRAME_TYPE_SHIFT   7
+#define AP_PARAM_FRAME_TYPE_SHIFT   8
 
 // supported frame types for parameters
 #define AP_PARAM_FRAME_COPTER       (1<<0)
@@ -123,6 +126,9 @@
 
 // declare a group var_info line with both flags and frame type mask
 #define AP_GROUPINFO_FLAGS_FRAME(name, idx, clazz, element, def, flags, frame_flags) AP_GROUPINFO_FLAGS(name, idx, clazz, element, def, flags|((frame_flags)<<AP_PARAM_FRAME_TYPE_SHIFT) )
+
+// declare a group var_info line with a default "pointer"
+#define AP_GROUPINFO_FLAGS_DEFAULT_POINTER(name, idx, clazz, element, def) {  name, AP_VAROFFSET(clazz, element), {def_value_offset : AP_VAROFFSET(clazz, element) - AP_VAROFFSET(clazz, def)}, AP_PARAM_FLAG_DEFAULT_POINTER, idx, AP_CLASSTYPE(clazz, element) }
 
 // declare a group var_info line
 #define AP_GROUPINFO(name, idx, clazz, element, def) AP_GROUPINFO_FLAGS(name, idx, clazz, element, def, 0)
@@ -186,6 +192,7 @@ public:
             const struct GroupInfo *group_info;
             const struct GroupInfo **group_info_ptr; // when AP_PARAM_FLAG_INFO_POINTER is set in flags
             const float def_value;
+            ptrdiff_t def_value_offset; // Default value offset from param object, when AP_PARAM_FLAG_DEFAULT_POINTER is set in flags
         };
         uint16_t flags;
         uint8_t idx;  // identifier within the group
@@ -198,6 +205,7 @@ public:
             const struct GroupInfo *group_info;
             const struct GroupInfo **group_info_ptr; // when AP_PARAM_FLAG_INFO_POINTER is set in flags
             const float def_value;
+            ptrdiff_t def_value_offset; // Default value offset from param object, when AP_PARAM_FLAG_DEFAULT_POINTER is set in flags
         };
         uint16_t flags;
         uint16_t key; // k_param_*
@@ -706,7 +714,8 @@ private:
                                     float *default_val);
 
     // find a default value given a pointer to a default value in flash
-    static float get_default_value(const AP_Param *object_ptr, const float *def_value_ptr);
+    static float get_default_value(const AP_Param *object_ptr, const struct GroupInfo &info);
+    static float get_default_value(const AP_Param *object_ptr, const struct Info &info);
 
     static bool parse_param_line(char *line, char **vname, float &value, bool &read_only);
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -572,7 +572,7 @@ public:
 protected:
 
     // store default value in linked list
-    static void add_default(AP_Param *ap, float v) { add_default(ap, v, default_list); }
+    static void add_default(AP_Param *ap, float v);
 
 private:
     static AP_Param *_singleton;
@@ -801,11 +801,7 @@ private:
         float val;
         defaults_list *next;
     };
-#if AP_PARAM_MAX_EMBEDDED_PARAM > 0
-    static defaults_list *embedded_default_list;
-#endif
     static defaults_list *default_list;
-    static void add_default(AP_Param *ap, float v, defaults_list *&list);
     static void check_default(AP_Param *ap, float *default_value);
 };
 

--- a/libraries/PID/PID.cpp
+++ b/libraries/PID/PID.cpp
@@ -14,22 +14,22 @@ const AP_Param::GroupInfo PID::var_info[] = {
     // @Param: P
     // @DisplayName: PID Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    0, PID, _kp, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, PID, _kp, default_kp),
 
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I",    1, PID, _ki, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, PID, _ki, default_ki),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
-    AP_GROUPINFO("D",    2, PID, _kd, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D",    2, PID, _kd, default_kd),
 
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 3, PID, _imax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 3, PID, _imax, default_kimax),
 
     AP_GROUPEND
 };

--- a/libraries/PID/PID.h
+++ b/libraries/PID/PID.h
@@ -16,13 +16,13 @@ public:
     PID(const float &   initial_p = 0.0f,
         const float &   initial_i = 0.0f,
         const float &   initial_d = 0.0f,
-        const int16_t & initial_imax = 0)
+        const int16_t & initial_imax = 0):
+            default_kp(initial_p),
+            default_ki(initial_i),
+            default_kd(initial_d),
+            default_kimax(initial_imax)
     {
 		AP_Param::setup_object_defaults(this, var_info);
-        _kp.set_and_default(initial_p);
-        _ki.set_and_default(initial_i);
-        _kd.set_and_default(initial_d);
-        _imax.set_and_default(initial_imax);
 
 		// set _last_derivative as invalid when we startup
 		_last_derivative = NAN;
@@ -121,4 +121,9 @@ private:
     /// http://en.wikipedia.org/wiki/Low-pass_filter.
     ///
     static const uint8_t        _fCut = 20;
+
+    const float default_kp;
+    const float default_ki;
+    const float default_kd;
+    const float default_kimax;
 };


### PR DESCRIPTION
This allows defaults to be loaded via the param table in the same way as params are referenced. This means we don't have to add to the linked list of defaults changed at run-time saving memory (https://github.com/ArduPilot/ardupilot/issues/22529)

Also means we don't have to keep a second list for embedded defaults. 