### PR TITLE
Remove erratic logging of first home position into CMD log

### DIFF
--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -54,7 +54,6 @@ bool Copter::set_home_to_current_location(bool lock) {
 }
 
 // set_home - sets ahrs home (used for RTL) to specified location
-//  initialises inertial nav and compass on first call
 //  returns true if home location set successfully
 bool Copter::set_home(const Location& loc, bool lock)
 {
@@ -69,24 +68,9 @@ bool Copter::set_home(const Location& loc, bool lock)
         return false;
     }
 
-    const bool home_was_set = ahrs.home_is_set();
-
     // set ahrs home (used for RTL)
     if (!ahrs.set_home(loc)) {
         return false;
-    }
-
-    // init inav and compass declination
-    if (!home_was_set) {
-#if MODE_AUTO_ENABLED == ENABLED
-        // log new home position which mission library will pull from ahrs
-        if (should_log(MASK_LOG_CMD)) {
-            AP_Mission::Mission_Command temp_cmd;
-            if (mode_auto.mission.read_cmd_from_storage(0, temp_cmd)) {
-                logger.Write_Mission_Cmd(mode_auto.mission, temp_cmd);
-            }
-        }
-#endif
     }
 
     // lock home position

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -51,7 +51,6 @@ bool Sub::set_home_to_current_location(bool lock)
 }
 
 // set_home - sets ahrs home (used for RTL) to specified location
-//  initialises inertial nav and compass on first call
 //  returns true if home location set successfully
 bool Sub::set_home(const Location& loc, bool lock)
 {
@@ -61,22 +60,9 @@ bool Sub::set_home(const Location& loc, bool lock)
         return false;
     }
 
-    const bool home_was_set = ahrs.home_is_set();
-
     // set ahrs home (used for RTL)
     if (!ahrs.set_home(loc)) {
         return false;
-    }
-
-    // init inav and compass declination
-    if (!home_was_set) {
-        // log new home position which mission library will pull from ahrs
-        if (should_log(MASK_LOG_CMD)) {
-            AP_Mission::Mission_Command temp_cmd;
-            if (mission.read_cmd_from_storage(0, temp_cmd)) {
-                logger.Write_Mission_Cmd(mission, temp_cmd);
-            }
-        }
     }
 
     // lock home position

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -19,21 +19,9 @@ bool Rover::set_home_to_current_location(bool lock)
 // returns true if home location set successfully
 bool Rover::set_home(const Location& loc, bool lock)
 {
-    const bool home_was_set = ahrs.home_is_set();
-
     // set ahrs home
     if (!ahrs.set_home(loc)) {
         return false;
-    }
-
-    if (!home_was_set) {
-        // log new home position which mission library will pull from ahrs
-        if (should_log(MASK_LOG_CMD)) {
-            AP_Mission::Mission_Command temp_cmd;
-            if (mode_auto.mission.read_cmd_from_storage(0, temp_cmd)) {
-                logger.Write_Mission_Cmd(mode_auto.mission, temp_cmd);
-            }
-        }
     }
 
     // lock home position


### PR DESCRIPTION
Three of our vehicles log the first home position they see into a CMD message.  This adds confusion in the logs as CMD messages can already come from a mission upload, at log-open or actually executing the mission item in auto mode!

The message really adds no benefit as you will only ever get one, regardless of whether HOME is subsequently reset (e.g. by the GCS).  If you're not logging at the time it will be lost.  Compare and contrast vs the `ORGN` message which is logged when the home position is changed and at log open.

The following dump was taken on master.  The vehicle was armed after home was acquired (SITL), and the home was set by right-clicking on the map and choosing "Set Home".  You can see CMD is not logged but the new home *is* logged in ORGN.


```
pbarker@fx:~/rc/ardupilot/logs(master)$ mavlogdump.py 00000010.BIN | grep CMD
2023-01-01 11:35:41.08: FMT {Type : 75, Length : 46, Name : CMD, Format : QHHHffffLLfB, Columns : TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt,Frame}
pbarker@fx:~/rc/ardupilot/logs(master)$ mavlogdump.py 00000010.BIN | grep ORGN
2023-01-01 11:35:41.08: FMT {Type : 70, Length : 24, Name : ORGN, Format : QBLLe, Columns : TimeUS,Type,Lat,Lng,Alt}
2023-01-01 11:35:31.73: ORGN {TimeUS : 22923327, Type : 0, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2023-01-01 11:35:31.73: ORGN {TimeUS : 22923327, Type : 1, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2023-01-01 11:35:40.42: ORGN {TimeUS : 31609018, Type : 0, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2023-01-01 11:35:40.42: ORGN {TimeUS : 31609018, Type : 1, Lat : -35.3605728, Lng : 149.1689687, Alt : 584.09}
```

Contrast this with the scenario of arming in STABILIZE and getting home in flight.  In  this scenario you *do* get your CMD message - but it's kind of pointless as the data is also in `ORGN`:
```
pbarker@fx:~/rc/ardupilot/logs(master)$ mavlogdump.py 00000012.BIN --t CMD
2023-01-01 11:47:23.42: CMD {TimeUS : 18608387, CTot : 0, CNum : 0, CId : 16, Prm1 : 0.0, Prm2 : 0.0, Prm3 : 0.0, Prm4 : 0.0, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.0899658203125, Frame : 0}
pbarker@fx:~/rc/ardupilot/logs(master)$ mavlogdump.py 00000012.BIN --t ORGN
2023-01-01 11:47:23.42: ORGN {TimeUS : 18608387, Type : 0, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2023-01-01 11:47:23.42: ORGN {TimeUS : 18608387, Type : 1, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
pbarker@fx:~/rc/ardupilot/logs(master)$ 
```


After this PR, if home is acquired post-log-start we no longer get the confusing `CMD` message.
