### PR TITLE
MAVLink: send FTP replies from within the FTP thread

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -187,6 +187,11 @@ void AP_OADatabase::init_queue()
     }
 
     _queue.items = new ObjectBuffer<OA_DbItem>(_queue.size);
+    if (_queue.items != nullptr && _queue.items->get_size() == 0) {
+        // allocation failed
+        delete _queue.items;
+        _queue.items = nullptr;
+    }
 }
 
 void AP_OADatabase::init_database()

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -427,11 +427,13 @@ void AP_CANManager::handle_can_frame(const mavlink_message_t &msg)
         while (frame_buffer == nullptr && buffer_size > 0) {
             // we'd like 20 frames, but will live with less
             frame_buffer = new ObjectBuffer<BufferFrame>(buffer_size);
-            if (frame_buffer != nullptr) {
+            if (frame_buffer != nullptr && frame_buffer->get_size() != 0) {
                 // register a callback for when frames can't be sent immediately
                 hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&AP_CANManager::process_frame_buffer, void));
                 break;
             }
+            delete frame_buffer;
+            frame_buffer = nullptr;
             buffer_size /= 2;
         }
         if (frame_buffer == nullptr) {

--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -129,6 +129,9 @@ public:
 
     // return size of ringbuffer
     uint32_t get_size(void) const {
+        if (buffer == nullptr) {
+            return 0;
+        }
         uint32_t size = buffer->get_size() / sizeof(T);
         return size>0?size-1:0;
     }
@@ -291,6 +294,9 @@ public:
     // return size of ringbuffer
     uint32_t get_size(void) {
         WITH_SEMAPHORE(sem);
+        if (buffer == nullptr) {
+            return 0;
+        }
         uint32_t size = buffer->get_size() / sizeof(T);
         return size>0?size-1:0;
     }

--- a/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
+++ b/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
@@ -171,6 +171,11 @@ void OpticalFlow_Onboard::init()
     }
 
     _gyro_ring_buffer = new ObjectBuffer<GyroSample>(OPTICAL_FLOW_GYRO_BUFFER_LEN);
+    if (_gyro_ring_buffer != nullptr && _gyro_ring_buffer->get_size() == 0) {
+        // allocation failed
+        delete _gyro_ring_buffer;
+        _gyro_ring_buffer = nullptr;
+    }
 
     _initialized = true;
 }

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -274,6 +274,10 @@ void AP_Scripting::handle_mission_command(const AP_Mission::Mission_Command& cmd
     if (mission_data == nullptr) {
         // load buffer
         mission_data = new ObjectBuffer<struct AP_Scripting::scripting_mission_cmd>(mission_cmd_queue_size);
+        if (mission_data != nullptr && mission_data->get_size() == 0) {
+            delete mission_data;
+            mission_data = nullptr;
+        }
         if (mission_data == nullptr) {
             gcs().send_text(MAV_SEVERITY_INFO, "Scripting: %s", "unable to receive mission command");
             return;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -903,7 +903,6 @@ private:
 
     struct ftp_state {
         ObjectBuffer<pending_ftp> *requests;
-        ObjectBuffer<pending_ftp> *replies;
 
         // session specific info, currently only support a single session over all links
         int fd = -1;
@@ -920,7 +919,7 @@ private:
 
     bool ftp_init(void);
     void handle_file_transfer_protocol(const mavlink_message_t &msg);
-    void send_ftp_replies(void);
+    bool send_ftp_reply(const pending_ftp &reply);
     void ftp_worker(void);
     void ftp_push_replies(pending_ftp &reply);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1045,7 +1045,7 @@ uint16_t GCS_MAVLINK::get_reschedule_interval_ms(const deferred_message_bucket_t
         // we are sending requests for waypoints, penalize streams:
         interval_ms *= 4;
     }
-    if (ftp.replies && AP_HAL::millis() - ftp.last_send_ms < 500) {
+    if (AP_HAL::millis() - ftp.last_send_ms < 500) {
         // we are sending ftp replies
         interval_ms *= 4;
     }
@@ -1222,7 +1222,6 @@ void GCS_MAVLINK::update_send()
         AP::logger().handle_log_send();
     }
 #endif
-    send_ftp_replies();
 
     if (!deferred_messages_initialised) {
         initialise_message_intervals_from_streamrates();

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -44,7 +44,7 @@ bool GCS_MAVLINK::ftp_init(void) {
     }
 
     ftp.requests = new ObjectBuffer<pending_ftp>(5);
-    if (ftp.requests == nullptr) {
+    if (ftp.requests == nullptr || ftp.requests->get_size() == 0) {
         goto failed;
     }
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -47,10 +47,6 @@ bool GCS_MAVLINK::ftp_init(void) {
     if (ftp.requests == nullptr) {
         goto failed;
     }
-    ftp.replies = new ObjectBuffer<pending_ftp>(30);
-    if (ftp.replies == nullptr) {
-        goto failed;
-    }
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&GCS_MAVLINK::ftp_worker, void),
                                       "FTP", 2560, AP_HAL::Scheduler::PRIORITY_IO, 0)) {
@@ -62,8 +58,6 @@ bool GCS_MAVLINK::ftp_init(void) {
 failed:
     delete ftp.requests;
     ftp.requests = nullptr;
-    delete ftp.replies;
-    ftp.replies = nullptr;
     gcs().send_text(MAV_SEVERITY_WARNING, "failed to initialize MAVFTP");
 
     return false;
@@ -96,50 +90,34 @@ void GCS_MAVLINK::handle_file_transfer_protocol(const mavlink_message_t &msg) {
     }
 }
 
-void GCS_MAVLINK::send_ftp_replies(void)
+bool GCS_MAVLINK::send_ftp_reply(const pending_ftp &reply)
 {
     /*
       provide same banner we would give with old param download
     */
-    if (ftp.need_banner_send_mask & (1U<<chan)) {
-        ftp.need_banner_send_mask &= ~(1U<<chan);
+    if (ftp.need_banner_send_mask & (1U<<reply.chan)) {
+        ftp.need_banner_send_mask &= ~(1U<<reply.chan);
         send_banner();
     }
-    
-    if (ftp.replies == nullptr || ftp.replies->is_empty()) {
-        return;
+    WITH_SEMAPHORE(comm_chan_lock(reply.chan));
+    if (!HAVE_PAYLOAD_SPACE(chan, FILE_TRANSFER_PROTOCOL)) {
+        return false;
     }
-
-    for (uint8_t i = 0; i < 20; i++) {
-        if (!HAVE_PAYLOAD_SPACE(chan, FILE_TRANSFER_PROTOCOL)) {
-            return;
-        }
-        if ((i > 0) && comm_get_txspace(chan) < (2 * (packet_overhead() + MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN))) {
-            // if this isn't the first packet we have to leave deadspace for the next message
-            return;
-        }
-
-        struct pending_ftp reply;
-        uint8_t payload[251] = {};
-        if (ftp.replies->peek(reply) && (reply.chan == chan)) {
-            put_le16_ptr(payload, reply.seq_number);
-            payload[2] = reply.session;
-            payload[3] = static_cast<uint8_t>(reply.opcode);
-            payload[4] = reply.size;
-            payload[5] = static_cast<uint8_t>(reply.req_opcode);
-            payload[6] = reply.burst_complete ? 1 : 0;
-            put_le32_ptr(&payload[8], reply.offset);
-            memcpy(&payload[12], reply.data, sizeof(reply.data));
-            mavlink_msg_file_transfer_protocol_send(
-                reply.chan,
-                0, reply.sysid, reply.compid,
-                payload);
-            ftp.replies->pop();
-            ftp.last_send_ms = AP_HAL::millis();
-        } else {
-            return;
-        }
-    }
+    uint8_t payload[251] = {};
+    put_le16_ptr(payload, reply.seq_number);
+    payload[2] = reply.session;
+    payload[3] = static_cast<uint8_t>(reply.opcode);
+    payload[4] = reply.size;
+    payload[5] = static_cast<uint8_t>(reply.req_opcode);
+    payload[6] = reply.burst_complete ? 1 : 0;
+    put_le32_ptr(&payload[8], reply.offset);
+    memcpy(&payload[12], reply.data, sizeof(reply.data));
+    mavlink_msg_file_transfer_protocol_send(
+        reply.chan,
+        0, reply.sysid, reply.compid,
+        payload);
+    ftp.last_send_ms = AP_HAL::millis();
+    return true;
 }
 
 void GCS_MAVLINK::ftp_error(struct pending_ftp &response, FTP_ERROR error) {
@@ -168,7 +146,7 @@ void GCS_MAVLINK::ftp_error(struct pending_ftp &response, FTP_ERROR error) {
 // send our response back out to the system
 void GCS_MAVLINK::ftp_push_replies(pending_ftp &reply)
 {
-    while (!ftp.replies->push(reply)) { // we must fit the response, keep shoving it in
+    while (!send_ftp_reply(reply)) {
         hal.scheduler->delay(2);
     }
 }


### PR DESCRIPTION
This saves over 7k of ram and also makes FTP faster as replies can be sent without waiting for the next send window from the main thread
This PR also fixes a nasty bug in handling ObjectBuffer allocation which is what led me to look into the FTP send code. When you have:
```
    x = new ObjectBuffer<pending_ftp>(30);
```
then this actually does 3 allocations:
 - the ObjectBuffer object
 - the ByteBuffer object
 - the data buffer itself (the largest allocation)

The problem happens if the allocation of the ObjectBuffer succeeds but the allocation of the ByteBuffer or the data fails then the caller doesn't see it has failed without checking get_size(). The pattern of just checking the pointer returned from the new of ObjectBuffer is the problem. This affects several subsystems, though the one that caused the most issues was the ftp reply buffer due to its size of over 7k and late allocation

update: I've added an improvement to FTP bandwidth utilization that should help a lot for radios without hardware flow control. I tested with SiK radios with 57kbaud serial and both 64 or 128 kbaud air data rate. This PR greatly reduces the packet loss in parameter downloads (for most downloads the loss is zero)


