### PR TITLE
Move mavlink receive buffer into GCS_MAVLINK object

### DIFF
--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -52,6 +52,15 @@ void AP_Periph_FW::adsb_init(void)
     }
 }
 
+static mavlink_message_t chan_buffer;
+mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
+    return &chan_buffer;
+}
+
+static mavlink_status_t chan_status;
+mavlink_status_t* mavlink_get_channel_status(uint8_t chan) {
+    return &chan_status;
+}
 
 /*
   update ADSB subsystem

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -195,6 +195,10 @@ public:
     GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters, AP_HAL::UARTDriver &uart);
     virtual ~GCS_MAVLINK() {}
 
+    // accessors used to retrieve objects used for parsing incoming messages:
+    mavlink_message_t *channel_buffer() { return &_channel_buffer; }
+    mavlink_status_t *channel_status() { return &_channel_status; }
+
     void        update_receive(uint32_t max_time_us=1000);
     void        update_send();
     bool        init(uint8_t instance);
@@ -725,6 +729,10 @@ protected:
     bool location_from_command_t(const mavlink_command_int_t &in, Location &out);
 
 private:
+
+    // define the two objects used for parsing incoming messages:
+    mavlink_message_t _channel_buffer;
+    mavlink_status_t _channel_status;
 
     const AP_SerialManager::UARTState *uartstate;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -163,18 +163,14 @@ bool GCS_MAVLINK::init(uint8_t instance)
     mavlink_comm_port[chan] = _port;
 
     const auto mavlink_protocol = uartstate->get_protocol();
-    mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if (status == nullptr) {
-        return false;
-    }
-    
+
     if (mavlink_protocol == AP_SerialManager::SerialProtocol_MAVLink2 ||
         mavlink_protocol == AP_SerialManager::SerialProtocol_MAVLinkHL) {
         // load signing key
         load_signing_key();
     } else {
         // user has asked to only send MAVLink1
-        status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+        _channel_status.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
     }
 
 #if HAL_HIGH_LATENCY2_ENABLED
@@ -1511,11 +1507,8 @@ void GCS_MAVLINK::update_send()
     // update the number of packets transmitted base on seqno, making
     // the assumption that we don't send more than 256 messages
     // between the last pass through here
-    mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if (status != nullptr) {
-        send_packet_count += uint8_t(status->current_tx_seq - last_tx_seq);
-        last_tx_seq = status->current_tx_seq;
-    }
+    send_packet_count += uint8_t(_channel_status.current_tx_seq - last_tx_seq);
+    last_tx_seq = _channel_status.current_tx_seq;
 }
 
 void GCS_MAVLINK::remove_message_from_bucket(int8_t bucket, ap_message id)
@@ -1685,10 +1678,7 @@ void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
         // if we receive any MAVLink2 packets on a connection
         // currently sending MAVLink1 then switch to sending
         // MAVLink2
-        mavlink_status_t *cstatus = mavlink_get_channel_status(chan);
-        if (cstatus != nullptr) {
-            cstatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-        }
+        _channel_status.flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
     }
     if (!routing.check_and_forward(*this, msg)) {
         // the routing code has indicated we should not handle this packet locally
@@ -1877,11 +1867,6 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
 */
 void GCS_MAVLINK::log_mavlink_stats()
 {
-    mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if (status == nullptr) {
-        return;
-    }
-
     uint8_t flags = 0;
     if (signing_enabled()) {
         flags |= (uint8_t)Flags::USING_SIGNING;
@@ -1904,8 +1889,8 @@ void GCS_MAVLINK::log_mavlink_stats()
     time_us                : AP_HAL::micros64(),
     chan                   : (uint8_t)chan,
     packet_tx_count        : send_packet_count,
-    packet_rx_success_count: status->packet_rx_success_count,
-    packet_rx_drop_count   : status->packet_rx_drop_count,
+    packet_rx_success_count: _channel_status.packet_rx_success_count,
+    packet_rx_drop_count   : _channel_status.packet_rx_drop_count,
     flags                  : flags,
     stream_slowdown_ms     : stream_slowdown_ms,
     times_full             : out_of_space_to_send_count,
@@ -1964,12 +1949,7 @@ void GCS_MAVLINK::send_rc_channels() const
 
 bool GCS_MAVLINK::sending_mavlink1() const
 {
-    const mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if (status == nullptr) {
-        // should not happen
-        return true;
-    }
-    return ((status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0);
+    return ((_channel_status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0);
 }
 
 void GCS_MAVLINK::send_rc_channels_raw() const

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -56,6 +56,22 @@ GCS_MAVLINK *GCS_MAVLINK::find_by_mavtype_and_compid(uint8_t mav_type, uint8_t c
     return gcs().chan(channel);
 }
 
+mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
+    GCS_MAVLINK *link = gcs().chan(chan);
+    if (link == nullptr) {
+        return nullptr;
+    }
+    return link->channel_buffer();
+}
+
+mavlink_status_t* mavlink_get_channel_status(uint8_t chan) {
+    GCS_MAVLINK *link = gcs().chan(chan);
+    if (link == nullptr) {
+        return nullptr;
+    }
+    return link->channel_status();
+}
+
 // set a channel as private. Private channels get sent heartbeats, but
 // don't get broadcast packets or forwarded packets
 void GCS_MAVLINK::set_channel_private(mavlink_channel_t _chan)

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -17,6 +17,9 @@
 // allow five telemetry ports
 #define MAVLINK_COMM_NUM_BUFFERS 5
 
+#define MAVLINK_GET_CHANNEL_BUFFER 1
+#define MAVLINK_GET_CHANNEL_STATUS 1
+
 /*
   The MAVLink protocol code generator does its own alignment, so
   alignment cast warnings can be ignored
@@ -51,6 +54,9 @@ static inline bool valid_channel(mavlink_channel_t chan)
     return chan < MAVLINK_COMM_NUM_BUFFERS;
 #pragma clang diagnostic pop
 }
+
+mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan);
+mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
 
 void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len);
 

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -132,11 +132,6 @@ void GCS_MAVLINK::load_signing_key(void)
     if (!signing_key_load(key)) {
         return;
     }
-    mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if (status == nullptr) {
-        DEV_PRINTF("Failed to load signing key - no status");
-        return;        
-    }
     memcpy(signing.secret_key, key.secret_key, 32);
     signing.link_id = (uint8_t)chan;
     // use a timestamp 1 minute past the last recorded
@@ -156,11 +151,11 @@ void GCS_MAVLINK::load_signing_key(void)
     }
     if (all_zero) {
         // disable signing
-        status->signing = nullptr;
-        status->signing_streams = nullptr;
+        _channel_status.signing = nullptr;
+        _channel_status.signing_streams = nullptr;
     } else {
-        status->signing = &signing;
-        status->signing_streams = &signing_streams;
+        _channel_status.signing = &signing;
+        _channel_status.signing_streams = &signing_streams;
     }
 }
 


### PR DESCRIPTION
Currently we define `MAVLINK_COMM_NUM_BUFFERS` without defining MAVLINK_GET_CHANNEL_BUFFER

This makes the mavlink library statically allocate objects to hold data about messages being received.  Combined this comes to about 300 bytes per value in `MAVLINK_COMM_NUM_BUFFERS`

`MAVLINK_COMM_NUM_BUFFERS` is 5 on our embedded boards.  Our default parameters set mavlink on serials 0, 1 and 2.  So in the default configuration we burn ~900 bytes of RAM on static buffers that will never be used.

This change moves the buffer (and the status object) into the GCS_MAVLink objects, which are dynamically allocated at boot-time according to the user's parameters.  This will stop us burning that 900 bytes, and for each backend the user disables will free up an additional 300 bytes.

Drawbacks here include
 -  we size a lot of arrays on MAVLINK_COMM_NUM_BUFFERS - these *should* at least be based off a renamed variable, something like MAX_GCS_MAVLINK_BACKENDS or similar.
 - increased overheads when getting the buffer and status objects
  - severity yet to be assessed
 - possibly a few more bytes of flash used (yet to be assessed)

Some very, very badly extracted numbers from a CubeBlack:
```
master freemem/backends:
3: STABILIZE> 277: MEMINFO {brkval : 0, freemem : 50384, freemem32 : 50384}
2: STABILIZE> 522: MEMINFO {brkval : 0, freemem : 52864, freemem32 : 52864}
1: STABILIZE> 654: MEMINFO {brkval : 0, freemem : 55328, freemem32 : 55328}


new freemem/backends:
3: STABILIZE> 1493: MEMINFO {brkval : 0, freemem : 51160, freemem32 : 51160}
2: STABILIZE> 1102: MEMINFO {brkval : 0, freemem : 53960, freemem32 : 53960}
1: STABILIZE> 906: MEMINFO {brkval : 0, freemem : 56520, freemem32 : 56520}
```

... but at least there's rough correlation with the expected savings.

@Hwurzburg should we document disabling un-used `SERIALn_PROTOCOL==2`  backends as a way of saving memory on e.g. F405?
