### PR TITLE
hwdef: minimize features on VRBrain-v52 and VRCore-v10

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/VRBrain-v52/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRBrain-v52/hwdef.dat
@@ -165,3 +165,6 @@ define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
 
 define STM32_PWM_USE_ADVANCED TRUE
+
+# minimal drivers to reduce flash usage
+include ../include/minimal.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/VRCore-v10/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRCore-v10/hwdef.dat
@@ -165,3 +165,6 @@ define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
 
 define STM32_PWM_USE_ADVANCED TRUE
+
+# minimal drivers to reduce flash usage
+include ../include/minimal.inc


### PR DESCRIPTION
these are failing to build on the firmware server

![image](https://user-images.githubusercontent.com/7077857/210295142-3d9be46b-d368-43cb-b186-6cc34890d65e.png)
