### PR TITLE
AP_Scripting/AP_Mount: ViewPro gimbal driver

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -12,6 +12,7 @@
 #include "AP_Mount_SToRM32_serial.h"
 #include "AP_Mount_Gremsy.h"
 #include "AP_Mount_Siyi.h"
+#include "AP_Mount_Scripting.h"
 #include <stdio.h>
 #include <AP_Math/location.h>
 #include <SRV_Channel/SRV_Channel.h>
@@ -117,6 +118,13 @@ void AP_Mount::init()
             _backends[instance] = new AP_Mount_Siyi(*this, _params[instance], instance);
             _num_instances++;
 #endif // HAL_MOUNT_SIYI_ENABLED
+
+#if HAL_MOUNT_SCRIPTING_ENABLED
+        // check for Scripting gimbal
+        } else if (mount_type == Mount_Type_Scripting) {
+            _backends[instance] = new AP_Mount_Scripting(*this, _params[instance], instance);
+            _num_instances++;
+#endif // HAL_MOUNT_SCRIPTING_ENABLED
 
         }
 
@@ -426,6 +434,47 @@ bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
     }
 
     return true;
+}
+
+// accessors for scripting backends
+bool AP_Mount::get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
+{
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->get_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame);
+}
+
+bool AP_Mount::get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
+{
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->get_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
+}
+
+bool AP_Mount::get_location_target(uint8_t instance, Location& target_loc)
+{
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->get_location_target(target_loc);
+}
+
+void AP_Mount::set_attitude_euler(uint8_t instance, float roll_deg, float pitch_deg, float yaw_bf_deg)
+{
+    if (!check_instance(instance)) {
+        return;
+    }
+    _backends[instance]->set_attitude_euler(roll_deg, pitch_deg, yaw_bf_deg);
+}
+
+bool AP_Mount::get_camera_state(uint8_t instance, uint16_t& pic_count, bool& record_video, int8_t& zoom_step, int8_t& focus_step, bool& auto_focus)
+{
+    if (!check_instance(instance)) {
+        return false;
+    }
+    return _backends[instance]->get_camera_state(pic_count, record_video, zoom_step, focus_step, auto_focus);
 }
 
 // point at system ID sysid

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -49,6 +49,7 @@ class AP_Mount_SToRM32;
 class AP_Mount_SToRM32_serial;
 class AP_Mount_Gremsy;
 class AP_Mount_Siyi;
+class AP_Mount_Scripting;
 
 /*
   This is a workaround to allow the MAVLink backend access to the
@@ -66,6 +67,7 @@ class AP_Mount
     friend class AP_Mount_SToRM32_serial;
     friend class AP_Mount_Gremsy;
     friend class AP_Mount_Siyi;
+    friend class AP_Mount_Scripting;
 
 public:
     AP_Mount();
@@ -89,6 +91,7 @@ public:
         Mount_Type_Gremsy = 6,          /// Gremsy gimbal using MAVLink v2 Gimbal protocol
         Mount_Type_BrushlessPWM = 7,    /// Brushless (stabilized) gimbal using PWM protocol
         Mount_Type_Siyi = 8,            /// Siyi gimbal using custom serial protocol
+        Mount_Type_Scripting = 9,       /// Scripting gimbal driver
     };
 
     // init - detect and initialise all mounts
@@ -163,6 +166,13 @@ public:
     // run pre-arm check.  returns false on failure and fills in failure_msg
     // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
+
+    // accessors for scripting backends
+    bool get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame);
+    bool get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame);
+    bool get_location_target(uint8_t instance, Location& target_loc);
+    void set_attitude_euler(uint8_t instance, float roll_deg, float pitch_deg, float yaw_bf_deg);
+    bool get_camera_state(uint8_t instance, uint16_t& pic_count, bool& record_video, int8_t& zoom_step, int8_t& focus_step, bool& auto_focus);
 
     //
     // camera controls for gimbals that include a camera

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -104,6 +104,13 @@ public:
     // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
     virtual void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) {}
 
+    // accessors for scripting backends
+    virtual bool get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame) { return false; }
+    virtual bool get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame) { return false; }
+    virtual bool get_location_target(Location &target_loc) { return false; }
+    virtual void set_attitude_euler(float roll_deg, float pitch_deg, float yaw_bf_deg) {};
+    virtual bool get_camera_state(uint16_t& pic_count, bool& record_video, int8_t& zoom_step, int8_t& focus_step, bool& auto_focus) { return false; }
+
     //
     // camera controls for gimbals that include a camera
     //

--- a/libraries/AP_Mount/AP_Mount_Params.cpp
+++ b/libraries/AP_Mount/AP_Mount_Params.cpp
@@ -9,7 +9,7 @@ const AP_Param::GroupInfo AP_Mount_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Mount Type
     // @Description: Mount Type
-    // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial, 6:Gremsy, 7:BrushlessPWM, 8:Siyi
+    // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial, 6:Gremsy, 7:BrushlessPWM, 8:Siyi, 9:Scripting
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE", 1, AP_Mount_Params, type, 0, AP_PARAM_FLAG_ENABLE),

--- a/libraries/AP_Mount/AP_Mount_Scripting.cpp
+++ b/libraries/AP_Mount/AP_Mount_Scripting.cpp
@@ -1,0 +1,243 @@
+#include "AP_Mount_Scripting.h"
+
+#if HAL_MOUNT_SCRIPTING_ENABLED
+#include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define AP_MOUNT_SCRIPTING_TIMEOUT_MS    1000   // scripting mount becomes unhealthy after 1sec with no updates
+
+#define AP_MOUNT_SCRIPTING_DEBUG 0
+#define debug(fmt, args ...) do { if (AP_MOUNT_SCRIPTING_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Siyi: " fmt, ## args); } } while (0)
+
+// update mount position - should be called periodically
+void AP_Mount_Scripting::update()
+{
+    // update based on mount mode
+    switch (get_mode()) {
+        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
+        case MAV_MOUNT_MODE_RETRACT: {
+            const Vector3f &angle_bf_target = _params.retract_angles.get();
+            target_angle_rad.roll = ToRad(angle_bf_target.x);
+            target_angle_rad.pitch = ToRad(angle_bf_target.y);
+            target_angle_rad.yaw = ToRad(angle_bf_target.z);
+            target_angle_rad.yaw_is_ef = false;
+            target_angle_rad_valid = true;
+
+            // mark other targets as invalid
+            target_rate_rads_valid = false;
+            target_loc_valid = false;
+            break;
+        }
+
+        // move mount to a neutral position, typically pointing forward
+        case MAV_MOUNT_MODE_NEUTRAL: {
+            const Vector3f &angle_bf_target = _params.neutral_angles.get();
+            target_angle_rad.roll = ToRad(angle_bf_target.x);
+            target_angle_rad.pitch = ToRad(angle_bf_target.y);
+            target_angle_rad.yaw = ToRad(angle_bf_target.z);
+            target_angle_rad.yaw_is_ef = false;
+            target_angle_rad_valid = true;
+
+            // mark other targets as invalid
+            target_rate_rads_valid = false;
+            target_loc_valid = false;
+            break;
+        }
+
+        // point to the angles given by a mavlink message
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+            switch (mavt_target.target_type) {
+            case MountTargetType::ANGLE:
+                target_angle_rad = mavt_target.angle_rad;
+                target_angle_rad_valid = true;
+                target_rate_rads_valid = false;
+                target_loc_valid = false;
+                break;
+            case MountTargetType::RATE:
+                target_rate_rads = mavt_target.rate_rads;
+                target_rate_rads_valid = true;
+                target_angle_rad_valid = false;
+                target_loc_valid = false;
+                break;
+            }
+            break;
+
+        // RC radio manual angle control, but with stabilization from the AHRS
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's rc inputs
+            MountTarget rc_target {};
+            if (get_rc_rate_target(rc_target)) {
+                target_rate_rads = rc_target;
+                target_rate_rads_valid = true;
+                target_angle_rad_valid = false;
+                target_loc_valid = false;
+            } else if (get_rc_angle_target(rc_target)) {
+                target_angle_rad = rc_target;
+                target_angle_rad_valid = true;
+                target_rate_rads_valid = false;
+                target_loc_valid = false;
+            }
+            break;
+        }
+
+        // point mount towards a GPS point
+        case MAV_MOUNT_MODE_GPS_POINT: {
+            target_loc_valid = _roi_target_set;
+            if (target_loc_valid) {
+                target_loc = _roi_target;
+                target_angle_rad_valid = get_angle_target_to_location(target_loc, target_angle_rad);
+            } else {
+                target_angle_rad_valid = false;
+            }
+            target_rate_rads_valid = false;
+            break;
+        }
+
+        // point mount towards home
+        case MAV_MOUNT_MODE_HOME_LOCATION: {
+            target_loc_valid = AP::ahrs().home_is_set();
+            if (target_loc_valid) {
+                target_loc = AP::ahrs().get_home();
+                target_angle_rad_valid = get_angle_target_to_home(target_angle_rad);
+            } else {
+                target_angle_rad_valid = false;
+            }
+            target_rate_rads_valid = false;
+            break;
+        }
+
+        // point mount towards another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET: {
+            target_loc_valid = _target_sysid_location_set;
+            if (target_loc_valid) {
+                target_loc = _target_sysid_location;
+                target_angle_rad_valid = get_angle_target_to_location(target_loc, target_angle_rad);
+            } else {
+                target_angle_rad_valid = false;
+            }
+            target_rate_rads_valid = false;
+            break;
+        }
+
+        default:
+            // we do not know this mode so raise internal error
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            break;
+    }
+}
+
+// return true if healthy
+bool AP_Mount_Scripting::healthy() const
+{
+    // healthy if scripting backend has updated actual angles recently
+    return (AP_HAL::millis() - last_update_ms <= AP_MOUNT_SCRIPTING_TIMEOUT_MS);
+}
+
+// take a picture.  returns true on success
+bool AP_Mount_Scripting::take_picture()
+{
+    picture_count++;
+    recording_video = false;
+    return true;
+}
+
+// start or stop video recording.  returns true on success
+// set start_recording = true to start record, false to stop recording
+bool AP_Mount_Scripting::record_video(bool start_recording)
+{
+    recording_video = start_recording;
+    return true;
+}
+
+// set camera zoom step.  returns true on success
+// zoom out = -1, hold = 0, zoom in = 1
+bool AP_Mount_Scripting::set_zoom_step(int8_t zoom_step)
+{
+    manual_zoom_step = zoom_step;
+    return true;
+}
+
+// set focus in, out or hold.  returns true on success
+// focus in = -1, focus hold = 0, focus out = 1
+bool AP_Mount_Scripting::set_manual_focus_step(int8_t focus_step)
+{
+    manual_focus_step = focus_step;
+    auto_focus_active = false;
+    return true;
+}
+
+// auto focus.  returns true on success
+bool AP_Mount_Scripting::set_auto_focus()
+{
+    manual_focus_step = 0;
+    auto_focus_active = true;
+    return true;
+}
+
+// accessors for scripting backends
+bool AP_Mount_Scripting::get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
+{
+    if (target_rate_rads_valid) {
+        roll_degs = degrees(target_rate_rads.roll);
+        pitch_degs = degrees(target_rate_rads.pitch);
+        yaw_degs = degrees(target_rate_rads.yaw);
+        yaw_is_earth_frame = target_rate_rads.yaw_is_ef;
+        return true;
+    }
+    return false;
+}
+
+bool AP_Mount_Scripting::get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
+{
+    if (target_angle_rad_valid) {
+        roll_deg = degrees(target_angle_rad.roll);
+        pitch_deg = degrees(target_angle_rad.pitch);
+        yaw_deg = degrees(target_angle_rad.yaw);
+        yaw_is_earth_frame = target_angle_rad.yaw_is_ef;
+        return true;
+    }
+    return false;
+}
+
+// return target location if available
+// returns true if a target location is available and fills in target_loc argument
+bool AP_Mount_Scripting::get_location_target(Location &_target_loc)
+{
+    if (target_loc_valid) {
+        _target_loc = target_loc;
+        return true;
+    }
+    return false;
+}
+
+// update mount's actual angles (to be called by script communicating with mount)
+void AP_Mount_Scripting::set_attitude_euler(float roll_deg, float pitch_deg, float yaw_bf_deg)
+{
+    last_update_ms = AP_HAL::millis();
+    current_angle_deg.x = roll_deg;
+    current_angle_deg.y = pitch_deg;
+    current_angle_deg.z = yaw_bf_deg;
+}
+
+bool AP_Mount_Scripting::get_camera_state(uint16_t& pic_count, bool& record_video, int8_t& zoom_step, int8_t& focus_step, bool& auto_focus)
+{
+    pic_count = picture_count;
+    record_video = recording_video;
+    zoom_step = manual_zoom_step;
+    focus_step = manual_focus_step;
+    auto_focus = auto_focus_active;
+    return true;
+}
+
+// get attitude as a quaternion.  returns true on success
+bool AP_Mount_Scripting::get_attitude_quaternion(Quaternion& att_quat)
+{
+    // construct quaternion
+    att_quat.from_euler(radians(current_angle_deg.x), radians(current_angle_deg.y), radians(current_angle_deg.z));
+    return true;
+}
+
+#endif // HAL_MOUNT_SCRIPTING_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Scripting.h
+++ b/libraries/AP_Mount/AP_Mount_Scripting.h
@@ -1,0 +1,94 @@
+/*
+  Scripting mount/gimbal driver
+ */
+
+#pragma once
+
+#include "AP_Mount_Backend.h"
+
+#ifndef HAL_MOUNT_SCRIPTING_ENABLED
+#define HAL_MOUNT_SCRIPTING_ENABLED HAL_MOUNT_ENABLED && AP_SCRIPTING_ENABLED
+#endif
+
+#if HAL_MOUNT_SCRIPTING_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
+
+class AP_Mount_Scripting : public AP_Mount_Backend
+{
+
+public:
+    // Constructor
+    using AP_Mount_Backend::AP_Mount_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Mount_Scripting);
+
+    // init - performs any required initialisation for this instance
+    void init() override {};
+
+    // update mount position - should be called periodically
+    void update() override;
+
+    // return true if healthy
+    bool healthy() const override;
+
+    // has_pan_control - returns true if this mount can control its pan (required for multicopters)
+    bool has_pan_control() const override { return yaw_range_valid(); };
+
+    // take a picture.  returns true on success
+    bool take_picture() override;
+
+    // start or stop video recording.  returns true on success
+    // set start_recording = true to start record, false to stop recording
+    bool record_video(bool start_recording) override;
+
+    // set camera zoom step.  returns true on success
+    // zoom out = -1, hold = 0, zoom in = 1
+    bool set_zoom_step(int8_t zoom_step) override;
+
+    // set focus in, out or hold.  returns true on success
+    // focus in = -1, focus hold = 0, focus out = 1
+    bool set_manual_focus_step(int8_t focus_step) override;
+
+    // auto focus.  returns true on success
+    bool set_auto_focus() override;
+
+    // accessors for scripting backends
+    bool get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame) override;
+    bool get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame) override;
+    bool get_location_target(Location& _target_loc) override;
+    void set_attitude_euler(float roll_deg, float pitch_deg, float yaw_bf_deg) override;
+    bool get_camera_state(uint16_t& pic_count, bool& record_video, int8_t& zoom_step, int8_t& focus_step, bool& auto_focus) override;
+
+protected:
+
+    // get attitude as a quaternion.  returns true on success
+    bool get_attitude_quaternion(Quaternion& att_quat) override;
+
+private:
+
+    // internal variables
+    uint32_t last_update_ms;        // system time of last call to one of the get_ methods.  Used for health reporting
+    Vector3f current_angle_deg;     // current gimbal angles in degrees (x=roll, y=pitch, z=yaw)
+
+    MountTarget target_rate_rads;   // rate target in rad/s
+    bool target_rate_rads_valid;    // true if _target_rate_degs holds a valid rate target
+
+    MountTarget target_angle_rad;   // angle target in radians
+    bool target_angle_rad_valid;    // true if _target_rate_degs holds a valid rate target
+
+    Location target_loc;            // target location
+    bool target_loc_valid;          // true if target_loc holds a valid target location
+
+    // camera related internal variables
+    uint16_t picture_count;         // number of pictures that have been taken (or at least requested)
+    bool recording_video;           // true when record video has been requested
+    int8_t manual_zoom_step;        // manual zoom step.  zoom out = -1, hold = 0, zoom in = 1
+    int8_t manual_focus_step;       // manual focus step.  focus in = -1, focus hold = 0, focus out = 1
+    bool auto_focus_active;         // auto focus active
+};
+
+#endif // HAL_MOUNT_SIYISERIAL_ENABLED

--- a/libraries/AP_Scripting/applets/mount-viewpro-driver.lua
+++ b/libraries/AP_Scripting/applets/mount-viewpro-driver.lua
@@ -1,0 +1,373 @@
+-- mount-viewpro-driver.lua: Viewpro mount/gimbal driver
+--
+-- How to use
+--   Connect gimbal UART to one of the autopilot's serial ports
+--   Set SERIALx_PROTOCOL = 28 (Scripting) where "x" corresponds to the serial port connected to the gimbal
+--   Set SCR_ENABLE = 1 to enable scripting and reboot the autopilot
+--   Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
+--   Set CAM_TRIGG_TYPE = 3 (Mount) to enable the camera driver
+--   Copy this script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot
+--
+-- Packet format
+--    byte      description     notes
+--    0~3       header          FF 01 0F 10
+--    4         roll mode       00=no_control, 01=speed_mode, 02=angle_mode, 04= RC_mode, 05=mode_angle_rel_frame
+--    5         pitch mode      same as above
+--    6         yaw mode        same as above. should normally be 05
+--    7,8       roll speed      low byte, high byte.  units: 0.122 deg/sec
+--    9,10      roll angle      low byte, high byte.  units: 0.02197 deg
+--    11,12     pitch speed     low byte, high byte.  units: 0.122 deg/sec
+--    13,14     pitch angle     low byte, high byte.  units: 0.02197 deg
+--    15,16     yaw speed       low byte, high byte.  units: 0.122 deg/sec
+--    17,18     yaw angle       low byte, high byte.  units: 0.02197 deg
+--    19        checksum        body checksum, checksum is calculated as a sum of all data bytes (from "roll mode" to "yaw angle") modulo 256
+--
+
+-- global definitions
+local INIT_INTERVAL_MS = 3000           -- attempt to initialise the gimbal at this interval
+local UPDATE_INTERVAL_MS = 20           -- update at 50hz
+local MOUNT_INSTANCE = 0                -- always control the first mount/gimbal
+local VIEWPRO_HEADER1 = 0xFF            -- Viewpro protocol's 1st header byte
+local VIEWPRO_HEADER2 = 0x01            -- Viewpro protocol's 2nd header byte
+local VIEWPRO_HEADER3 = 0x0F            -- Viewpro protocol's 3rd header byte
+local VIEWPRO_HEADER4 = 0x10            -- Viewpro protocol's 4th header byte
+local VIEWPRO_NOCONTROL_MODE = 0        -- no control mode for an axis
+local VIEWPRO_SPEED_MODE = 1            -- speed mode for an axis
+local VIEWPRO_ANGLE_MODE = 2            -- earth-frame angle mode for any axis
+local VIEWPRO_ANGLE_REL_FRAME_MODE = 5  -- body-frame angle mode for yaw axis
+local ANGLE_DEG_TO_OUTPUT_SCALING = (8192.0 / 180.0)    -- scalar to convert angles (in deg) to output scaling
+
+-- incoming message definitions
+local HEADER1 = 0x3E
+local HEADER2 = 0x3D
+local HEADER3 = 0x36
+local HEADER4 = 0x73
+
+-- parsing state definitions
+local PARSE_STATE_WAITING_FOR_HEADER1   = 0
+local PARSE_STATE_WAITING_FOR_HEADER2   = 1
+local PARSE_STATE_WAITING_FOR_HEADER3   = 2
+local PARSE_STATE_WAITING_FOR_HEADER4   = 3
+local PARSE_STATE_WAITING_FOR_DATA      = 4
+
+-- hardcoded outgoing messages
+local REQUEST_ATTITUDE_MSG = {0x3E,0x3D,0x00,0x3D,0x00}
+local ZOOM_OUT_MSG = {0xFF,0x01,0x00,0x40,0x00,0x00,0x41}
+local ZOOM_IN_MSG = {0xFF,0x01,0x00,0x20,0x00,0x00,0x21}
+local ZOOM_STOP_MSG = {0xFF,0x01,0x00,0x00,0x00,0x00,0x01}
+local FOCUS_IN_MSG = {0xFF,0x01,0x01,0x00,0x00,0x00,0x02}
+local FOCUS_OUT_MSG = {0xFF,0x01,0x00,0x80,0x00,0x00,0x81}
+local FOCUS_STOP_MSG = {0xFF,0x01,0x00,0x00,0x00,0x00,0x01} -- same as ZOOM_STOP
+local RECORD_START = {0xFF,0x01,0x00,0x07,0x00,0x65,0x6d}
+local RECORD_STOP = {0xFF,0x01,0x00,0x07,0x00,0x64,0x6c}
+local TAKE_PICTURE = {0xFF,0x01,0x00,0x07,0x00,0x55,0x5D}
+
+-- local variables and definitions
+local uart                              -- uart object connected to mount
+local initialised = false               -- true once connection to gimbal has been initialised
+local parse_state = PARSE_STATE_WAITING_FOR_HEADER1 -- parse state
+local parse_expected_crc = 0            -- incoming messages expected crc.  this is checked against actual crc received
+local parse_data_buff = {}              -- data buffer holding roll, pitch and yaw angles from gimbal
+local parse_data_bytes_recv = 0         -- count of the number of bytes received in the message so far
+local cam_pic_count = 0                 -- last picture count.  used to detect trigger pic
+local cam_rec_video = false             -- last record video state.  used to detect record video
+local cam_zoom_step = 0                 -- last zoom step state.  zoom out = -1, hold = 0, zoom in = 1
+local cam_focus_step = 0                -- last focus step state.  focus in = -1, focus hold = 0, focus out = 1
+
+-- find and initialise serial port connected to gimbal
+function init()
+  uart = serial:find_serial(0)    -- 1st instance of SERIALx_PROTOCOL = 28 (Scripting)
+  if uart == nil then
+    gcs:send_text(3, "ViewPro: no SERIALx_PROTOCOL = 28") -- MAV_SEVERITY_ERR
+  else
+    uart:begin(115200)
+    uart:set_flow_control(0)
+    initialised = true
+  end
+end
+
+-- send hard coded message
+function send_msg(msg)
+  for i=1,#msg do
+    uart:write(msg[i])
+  end
+end
+
+-- reading incoming packets from gimbal
+function read_incoming_packets()
+  local n_bytes = uart:available()
+  while n_bytes > 0 do
+    n_bytes = n_bytes - 1
+    b = uart:read()
+
+    -- waiting for header1
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER1 and b == HEADER1 then
+      parse_state = PARSE_STATE_WAITING_FOR_HEADER2
+      parse_expected_crc = 0
+      parse_data_bytes_recv = 0
+      break
+    end
+
+    -- waiting for header2
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER2 then
+      if b == HEADER2 then
+        parse_state = PARSE_STATE_WAITING_FOR_HEADER3
+      else
+        -- unexpected byte so reset parsing state
+        parse_state = PARSE_STATE_WAITING_FOR_HEADER1
+      end
+      break
+    end
+
+    -- waiting for header3
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER3 then
+      if b == HEADER3 then
+        parse_state = PARSE_STATE_WAITING_FOR_HEADER4
+      else
+        -- unexpected byte so reset parsing state
+        parse_state = PARSE_STATE_WAITING_FOR_HEADER1
+      end
+      break
+    end
+
+    -- waiting for header4
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER4 then
+      if b == HEADER4 then
+        parse_state = PARSE_STATE_WAITING_FOR_DATA
+      else
+        -- unexpected byte so reset parsing state
+        parse_state = PARSE_STATE_WAITING_FOR_HEADER1
+      end
+      break
+    end
+
+    -- waiting for data
+    if parse_state == PARSE_STATE_WAITING_FOR_DATA then
+
+      -- check for crc
+      if parse_data_bytes_recv >= 54 then
+        if b == parse_expected_crc then
+          -- complete parsing
+          local roll_deg = bytearray_to_angle_deg(parse_data_buff[5], parse_data_buff[6], parse_data_buff[7], parse_data_buff[8])
+          local pitch_deg = bytearray_to_angle_deg(parse_data_buff[23], parse_data_buff[24], parse_data_buff[25], parse_data_buff[26])
+          local yaw_deg = bytearray_to_angle_deg(parse_data_buff[41], parse_data_buff[42], parse_data_buff[43], parse_data_buff[44])          
+          mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
+       end
+       parse_state = PARSE_STATE_WAITING_FOR_HEADER1
+       break
+      end
+
+      -- add latest byte to crc and buffer
+      parse_expected_crc = (parse_expected_crc + b) & 0xFF
+      parse_data_bytes_recv = parse_data_bytes_recv + 1
+      parse_data_buff[parse_data_bytes_recv] = b
+    end
+  end
+end
+
+-- write a byte to the uart and update the checksum
+function write_byte(b, checksum)
+  if b == nil or checksum == nil then
+    gcs:send_text(3, "ViewPro: failed to write byte") -- MAV_SEVERITY_ERR
+    return
+  end
+  local byte_to_write = b & 0xFF
+  uart:write(byte_to_write)
+
+  return (checksum + byte_to_write) & 0xFF
+end
+
+-- get lowbyte of a number
+function lowbyte(num)
+  return num & 0xFF
+end
+
+-- get highbyte of a number
+function highbyte(num)
+  return (num >> 8) & 0xFF
+end
+
+-- convert 4 byte array to angle in degrees1
+function bytearray_to_angle_deg(b0, b1, b2, b3)
+  return ((b3 << 24) + (b2 << 16) + (b1 << 8) + b0) / ANGLE_DEG_TO_OUTPUT_SCALING
+end
+
+-- write num to the uart and update the checksum
+function write_number(num, checksum)
+  if not num or not checksum then
+    gcs:send_text(3, "ViewPro: failed to write number") -- MAV_SEVERITY_ERR
+    return
+  end
+  checksum = write_byte(lowbyte(num), checksum)
+  checksum = write_byte(highbyte(num), checksum)
+  return checksum
+end
+
+-- convert angle (in degres) to output scaling
+function angle_to_output_scaling(angle_deg)
+  local scaled_angle = math.floor(angle_deg * ANGLE_DEG_TO_OUTPUT_SCALING + 0.5)
+  if scaled_angle > 8192 then
+    scaled_angle = 8192
+  end
+  if scaled_angle < -8192 then
+    scaled_angle = -8192
+  end
+  return scaled_angle
+end
+
+-- convert rate (in deg/sec) to output scaling
+function rate_to_output_scaling(rate_degs)
+  local scaled_rate = math.floor(rate_degs / 0.122 + 0.5)
+  if scaled_rate > 8192 then
+    scaled_rate = 8192
+  end
+  if scaled_rate < -8192 then
+    scaled_rate = -8192
+  end
+  return scaled_rate
+end
+
+-- send target angles (in degrees) to gimbal
+-- yaw_angle_deg is always a body-frame angle
+function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg)
+  local roll_angle_scaled = angle_to_output_scaling(roll_angle_deg)
+  local pitch_angle_scaled = angle_to_output_scaling(pitch_angle_deg)
+  local yaw_angle_scaled = angle_to_output_scaling(yaw_angle_deg)
+  local checksum = 0
+  write_byte(VIEWPRO_HEADER1, 0)
+  write_byte(VIEWPRO_HEADER2, 0)
+  write_byte(VIEWPRO_HEADER3, 0)
+  write_byte(VIEWPRO_HEADER4, 0)
+  checksum = write_byte(VIEWPRO_ANGLE_REL_FRAME_MODE, checksum) -- roll angle mode
+  checksum = write_byte(VIEWPRO_ANGLE_REL_FRAME_MODE, checksum) -- pitch angle mode
+  checksum = write_byte(VIEWPRO_ANGLE_REL_FRAME_MODE, checksum) -- yaw body-frame angle mode
+  checksum = write_number(0, checksum)                  -- roll speed low byte, high byte
+  checksum = write_number(roll_angle_scaled, checksum)  -- roll angle low byte, high byte
+  checksum = write_number(0, checksum)                  -- pitch speed low byte, high byte
+  checksum = write_number(pitch_angle_scaled, checksum) -- pitch angle low byte, high byte
+  checksum = write_number(0, checksum)                  -- yaw speed low byte, high byte
+  checksum = write_number(yaw_angle_scaled, checksum)   -- yaw angle low byte, high byte
+  write_byte(checksum, 0)                               -- checksum
+end
+
+-- send target rates (in deg/sec) to gimbal
+function send_target_rates(roll_rate_deg, pitch_rate_degs, yaw_rate_degs)
+  local roll_rate_scaled = rate_to_output_scaling(roll_rate_deg)
+  local pitch_rate_scaled = rate_to_output_scaling(pitch_rate_degs)
+  local yaw_rate_scaled = rate_to_output_scaling(yaw_rate_degs)
+  local checksum = 0
+  write_byte(VIEWPRO_HEADER1, 0)
+  write_byte(VIEWPRO_HEADER2, 0)
+  write_byte(VIEWPRO_HEADER3, 0)
+  write_byte(VIEWPRO_HEADER4, 0)
+  checksum = write_byte(VIEWPRO_SPEED_MODE, checksum)   -- roll rate mode
+  checksum = write_byte(VIEWPRO_SPEED_MODE, checksum)   -- pitch rate mode
+  checksum = write_byte(VIEWPRO_SPEED_MODE, checksum)   -- yaw rate mode
+  checksum = write_number(roll_rate_scaled, checksum)   -- roll speed low byte, high byte
+  checksum = write_number(0, checksum)                  -- roll angle low byte, high byte
+  checksum = write_number(pitch_rate_scaled, checksum)  -- pitch speed low byte, high byte
+  checksum = write_number(0, checksum)                  -- pitch angle low byte, high byte
+  checksum = write_number(yaw_rate_scaled, checksum)    -- yaw speed low byte, high byte
+  checksum = write_number(0, checksum)                  -- yaw angle low byte, high byte
+  write_byte(checksum, 0)                               -- checksum
+end
+
+-- check for changes in camera state and send messages to gimbal if required
+function check_camera_state()
+
+  -- get latest state from AP driver
+  -- auto focus is not supported
+  local pic_count, rec_video, zoom_step, focus_step, auto_focus = mount:get_camera_state(MOUNT_INSTANCE)
+
+  -- check for take picture
+  if pic_count and pic_count ~= cam_pic_count then
+    cam_pic_count = pic_count
+    send_msg(TAKE_PICTURE)
+    gcs:send_text(6, string.format("ViewPro: took pic %u", pic_count)) -- MAV_SEVERITY_INFO
+  end
+
+  -- check for start/stop recording video
+  if rec_video ~= cam_rec_video then
+    cam_rec_video = rec_video
+    if cam_rec_video == true then
+      send_msg(RECORD_START)
+    elseif cam_rec_video == false then
+      send_msg(RECORD_STOP)
+    end
+    gcs:send_text(6, "ViewPro: rec video:" .. tostring(cam_rec_video)) -- MAV_SEVERITY_INFO
+  end
+    
+  -- check manual zoom
+  -- zoom out = -1, hold = 0, zoom in = 1
+  if zoom_step ~= cam_zoom_step then
+    cam_zoom_step = zoom_step
+    if cam_zoom_step < 0 then
+      send_msg(ZOOM_OUT_MSG)
+    elseif cam_zoom_step == 0 then
+      send_msg(ZOOM_STOP_MSG)
+    elseif cam_zoom_step > 0 then
+      send_msg(ZOOM_IN_MSG)
+    end
+    gcs:send_text(6, "ViewPro: zoom:" .. tostring(cam_zoom_step)) -- MAV_SEVERITY_INFO
+  end
+
+  -- check manual focus
+  -- focus in = -1, focus hold = 0, focus out = 1
+  if focus_step ~= cam_focus_step then
+    cam_focus_step = focus_step
+    if cam_focus_step < 0 then
+      send_msg(FOCUS_IN_MSG)
+    elseif cam_focus_step == 0 then
+      send_msg(FOCUS_STOP_MSG)
+    elseif cam_focus_step > 0 then
+      send_msg(FOCUS_IN_MSG)
+    end
+    gcs:send_text(6, "ViewPro: focus:" .. tostring(cam_focus_step)) -- MAV_SEVERITY_INFO
+  end
+end
+
+-- the main update function that performs a simplified version of RTL
+function update()
+
+  -- get current system time
+  local now_ms = millis()
+
+  -- initialise connection to gimbal
+  if not initialised then
+    init()
+    return update, INIT_INTERVAL_MS
+  end
+
+  -- request gimbal attitude
+  send_msg(REQUEST_ATTITUDE_MSG)
+
+  -- check camera status
+  check_camera_state()
+
+  -- consume incoming bytes
+  read_incoming_packets()
+
+  -- get target location
+  -- local target_loc = mount:get_location_target(MOUNT_INSTANCE)
+  -- if target_loc then
+  --   gcs:send_text(6, string.format("ViewPro: lat:%.1f lon:%.1f alt:%.1f", target_loc:lat(), target_loc:lng(), target_loc:alt())) -- MAV_SEVERITY_INFO
+  -- end
+
+  -- get target angle
+  local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
+  if roll_deg and pitch_deg and yaw_deg then
+    send_target_angles(roll_deg, pitch_deg, yaw_deg)
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  -- get target rate
+  local roll_degs, pitch_degs, yaw_degs, yaw_is_ef = mount:get_rate_target(MOUNT_INSTANCE)
+  if roll_degs and pitch_degs and yaw_degs then
+    send_target_rates(roll_degs, pitch_degs, yaw_degs)
+    return update, UPDATE_INTERVAL_MS
+  end
+
+  return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/applets/mount-viewpro-driver.md
+++ b/libraries/AP_Scripting/applets/mount-viewpro-driver.md
@@ -1,0 +1,11 @@
+# Mount Viewpro Driver
+
+Viewpro gimbal driver lua script
+
+How to use
+  Connect gimbal UART to one of the autopilot's serial ports
+  Set SERIALx_PROTOCOL = 28 (Scripting) where "x" corresponds to the serial port connected to the gimbal
+  Set SCR_ENABLE = 1 to enable scripting and reboot the autopilot
+  Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
+  Set CAM_TRIGG_TYPE = 3 (Mount) to enable camera control using the mount driver
+  Copy the mount-viewpro-driver.lua script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -968,6 +968,43 @@ function winch:healthy() end
 mount = {}
 
 -- desc
+---@param param1 integer
+---@return integer|nil  -- pic_count
+---@return boolean|nil  -- record_video
+---@return integer|nil  -- zoom_step
+---@return integer|nil  -- focus_step
+---@return boolean|nil  -- auto_focus
+function mount:get_camera_state(param1) end
+
+-- desc
+---@param instance integer
+---@param roll_deg number
+---@param pitch_deg number
+---@param yaw_deg number
+function mount:set_attitude_euler(instance, roll_deg, pitch_deg, yaw_deg) end
+
+-- desc
+---@param instance integer
+---@return Location_ud|nil
+function mount:get_location_target(instance) end
+
+-- desc
+---@param instance integer
+---@return number|nil   -- roll_deg
+---@return number|nil   -- pitch_deg
+---@return number|nil   -- yaw_deg
+---@return boolean|nil  -- yaw_is_earth_frame
+function mount:get_angle_target(instance) end
+
+-- desc
+---@param instance integer
+---@return number|nil   -- roll_degs
+---@return number|nil   -- pitch_degs
+---@return number|nil   -- yaw_degs
+---@return boolean|nil  -- yaw_is_earth_frame
+function mount:get_rate_target(instance) end
+
+-- desc
 ---@param instance integer
 ---@param target_loc Location_ud
 function mount:set_roi_target(instance, target_loc) end

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -5,6 +5,7 @@
 --   Set CAN_D1_PROTOCOL = 10 (Scripting)
 --   Set CAN_P1_DRIVER = 1 (First driver)
 --   Set SCR_ENABLE = 1 to enable scripting
+--   Set SCR_HEAP_SIZE = 120000 (or higher)
 --   Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
 --   Reboot the autopilot
 --   Copy this script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -74,6 +74,7 @@ local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTI
 -- bind parameters to variables
 local CAN_P1_DRIVER = Parameter("CAN_P1_DRIVER")        -- should be 1:Enabled
 local CAN_D1_PROTOCOL = Parameter("CAN_D1_PROTOCOL")    -- should be 10:Scripting
+local MNT1_TYPE = Parameter("MNT1_TYPE")                -- should be 9:Scripting
 
 -- message definitions
 local HEADER = 0xAA
@@ -217,13 +218,6 @@ end
 
 -- perform any require initialisation
 function init()
-
-  -- check parameters exist
-  if not CAN_P1_DRIVER or not CAN_D1_PROTOCOL then
-    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: CAN disabled")   
-    do return end
-  end
-
   -- check parameter settings
   if CAN_P1_DRIVER:get() <= 0 then
     gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: set CAN_P1_DRIVER=1")   
@@ -231,6 +225,10 @@ function init()
   end
   if CAN_D1_PROTOCOL:get() ~= 10 then
     gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: set CAN_D1_PROTOCOL=10")   
+    do return end
+  end
+  if MNT1_TYPE:get() ~= 9 then
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: set MNT1_TYPE=9")   
     do return end
   end
 

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -661,6 +661,15 @@ function uint32_value(byte3, byte2, byte1, byte0)
   return (((byte3 & 0xFF) << 24) | ((byte2 & 0xFF) << 16) | ((byte1 & 0xFF) << 8) | (byte0 & 0xFF))
 end
 
+-- wrap yaw angle in degrees to value between -180 and +180
+function wrap_180(angle_deg)
+  local res = wrap_360(angle_deg)
+  if res > 180 then
+    res = res - 360
+  end
+  return res
+end
+
 -- the main update function that performs a simplified version of RTL
 function update()
 
@@ -758,7 +767,11 @@ function update()
 
     -- send angle target
     local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
-    if roll_deg and pitch_deg and yaw_deg then
+    if roll_deg and pitch_deg and yaw_deg and yaw_is_ef then
+      if yaw_is_ef then
+        -- convert to body-frame
+        yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw()))
+      end
       send_target_angles(roll_deg, pitch_deg, yaw_deg, 1)
       --send_target_rates(roll_deg * 0.1, pitch_deg * 0.1, yaw_deg * 0.1)
       return update, UPDATE_INTERVAL_MS

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -381,7 +381,7 @@ function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time
   time_sec = math.floor(time_sec + 0.5)
 
   -- debug
-  gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ang R:%f P:%f Y:%f t:%f", roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time_sec))
+  --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ang R:%f P:%f Y:%f t:%f", roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time_sec))
 
   --    0x0E, 0x00: Handheld Gimbal Position Control
   --      Command frame bytes
@@ -472,7 +472,7 @@ function send_target_rates(roll_rate_degs, pitch_rate_degs, yaw_rate_degs)
   end
 
   -- debug
-  gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: rate R:%x %x P:%x %x Y:%x %x", set_target_speed_msg[18], set_target_speed_msg[17], set_target_speed_msg[20], set_target_speed_msg[19], set_target_speed_msg[16], set_target_speed_msg[15]))
+  --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: rate R:%x %x P:%x %x Y:%x %x", set_target_speed_msg[18], set_target_speed_msg[17], set_target_speed_msg[20], set_target_speed_msg[19], set_target_speed_msg[16], set_target_speed_msg[15]))
 end
 
 -- consume incoming CAN packets
@@ -516,7 +516,7 @@ function parse_byte(b)
       else
         -- unexpected byte
         bytes_error = bytes_error + 1
-        gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexp byte:%x", b))
+        --gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexp byte:%x", b))
       end
     end
 
@@ -530,7 +530,7 @@ function parse_byte(b)
           parse_state = PARSE_STATE_WAITING_FOR_HEADER
           -- invalid length
           bytes_error = bytes_error + 1
-          gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexpected len:%u", parse_length))
+          --gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexpected len:%u", parse_length))
         else
           parse_state = PARSE_STATE_WAITING_FOR_DATA
           --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: good len:%d", parse_length))
@@ -578,16 +578,16 @@ function parse_byte(b)
           -- parse attitude reply message
           if (expected_reply == REPLY_TYPE.ATTITUDE) and (parse_length >= 20) then
             local ret_code = parse_buff[13]
-            gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
+            --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
             if ret_code == RETURN_CODE.SUCCESS then
               --local data_type = parse_buff[14]
               local yaw_deg = int16_value(parse_buff[16],parse_buff[15]) * 0.1
               local roll_deg = int16_value(parse_buff[18],parse_buff[17]) * 0.1 -- reversed with pitch below?
               local pitch_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
               mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
-              gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: roll:%4.1f pitch:%4.1f yaw:%4.1f", roll_deg, pitch_deg, yaw_deg))
+              --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: roll:%4.1f pitch:%4.1f yaw:%4.1f", roll_deg, pitch_deg, yaw_deg))
             else
-              gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: ret code failure")
+              --gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: ret code failure")
               execute_fails = execute_fails + 1
             end
           end
@@ -595,11 +595,12 @@ function parse_byte(b)
           -- parse position control reply message
           if (expected_reply == REPLY_TYPE.POSITION_CONTROL) and (parse_length >= 13) then
             local ret_code = parse_buff[13]
-            gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
-            if ret_code == RETURN_CODE.SUCCESS then
-              gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: poscon success")
-            else
-              gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: poscon fail")
+            --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
+            --if ret_code == RETURN_CODE.SUCCESS then
+            --  gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: poscon success")
+            --else
+            if ret_code ~= RETURN_CODE.SUCCESS then
+              --gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: poscon fail")
               execute_fails = execute_fails + 1
             end
           end
@@ -607,11 +608,12 @@ function parse_byte(b)
           -- parse speed control reply message
           if (expected_reply == REPLY_TYPE.SPEED_CONTROL) and (parse_length >= 13) then
             local ret_code = parse_buff[13]
-            gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
-            if ret_code == RETURN_CODE.SUCCESS then
-              gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: speedcon success")
-            else
-              gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: speedcon fail")
+            --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ret code:%x", ret_code))
+            --if ret_code == RETURN_CODE.SUCCESS then
+            --  gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: speedcon success")
+            --else
+            --  gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: speedcon fail")
+            if ret_code ~= RETURN_CODE.SUCCESS then
               execute_fails = execute_fails + 1
             end
           end

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -767,7 +767,7 @@ function update()
 
     -- send angle target
     local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
-    if roll_deg and pitch_deg and yaw_deg and yaw_is_ef then
+    if roll_deg and pitch_deg and yaw_deg then
       if yaw_is_ef then
         -- convert to body-frame
         yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw()))

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -358,6 +358,15 @@ function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time
   yaw_angle_deg = yaw_angle_deg or 0
   time_sec = time_sec or 2
 
+  -- ensure angles are integers
+  roll_angle_deg = math.floor(roll_angle_deg + 0.5)
+  pitch_angle_deg = math.floor(pitch_angle_deg + 0.5)
+  yaw_angle_deg = math.floor(yaw_angle_deg + 0.5)
+  time_sec = math.floor(time_sec + 0.5)
+
+  -- debug
+  gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: ang R:%f P:%f Y:%f t:%f", roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time_sec))
+
   --    0x0E, 0x00: Handheld Gimbal Position Control
   --      Command frame bytes
   --       0~1: yaw angle * 10, int16, -1800 to +1800
@@ -401,6 +410,11 @@ function send_target_rates(roll_rate_degs, pitch_rate_degs, yaw_rate_degs)
   pitch_rate_degs = pitch_rate_degs or 0
   yaw_rate_degs = yaw_rate_degs or 0
   time_sec = time_sec or 2
+
+  -- ensure rates are integers
+  roll_rate_degs = math.floor(roll_rate_degs + 0.5)
+  pitch_rate_degs = math.floor(pitch_rate_degs + 0.5)
+  yaw_rate_degs = math.floor(yaw_rate_degs + 0.5)
 
   --    0x0E, 0x01: Handheld Gimbal Speed Control
   --      Command frame bytes
@@ -493,7 +507,7 @@ function parse_byte(b)
           gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexpected len:%u", parse_length))
         else
           parse_state = PARSE_STATE_WAITING_FOR_DATA
-          gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: good len:%d", parse_length))
+          --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: good len:%d", parse_length))
         end
       end
       do return end
@@ -522,13 +536,13 @@ function parse_byte(b)
 
         -- check if reply
         local cmd_type_reply = (parse_buff[4] & 0x20) > 0
-        gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: reply:" .. tostring(cmd_type_reply))
+        --gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: reply:" .. tostring(cmd_type_reply))
 
         -- if message has at least 2 bytes of data, check cmdid and cmdset
         if cmd_type_reply and parse_length >= SERIAL_PACKET_LENGTH_MIN + 2 then
           local cmdset = parse_buff[13]
           local cmdid = parse_buff[14]
-          gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: cmdset:%x cmdid:%x", cmdset, cmdid))
+          gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: cmdset:%x cmdid:%x len:%d", cmdset, cmdid, parse_length))
   -- Field number                     1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19
   --                                SOF  LenL  LenH CmdTyp  Enc   RES   RES   RES  SeqL  SeqH  CrcL  CrcH CmdSet CmdId Data1 CRC32 CRC32 CRC32 CRC32
   -- local request_attitude_msg = {0xAA, 0x13, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x0E, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00}
@@ -574,6 +588,9 @@ function parse_byte(b)
             end
           end
 
+        else
+          -- not attempting to parse
+          gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: skipped reply:" .. tostring(cmd_type_reply) .. "len:" .. tostring(parse_length))
         end
 
        parse_state = PARSE_STATE_WAITING_FOR_HEADER
@@ -696,11 +713,11 @@ function update()
 
     -- send angle target
     --local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
-    --if roll_degs and pitch_degs and yaw_degs then
+    --if roll_deg and pitch_deg and yaw_deg then
     --  send_target_angles(roll_deg, pitch_deg, yaw_deg, 1)
     --  return update, UPDATE_INTERVAL_MS
     --end
-    send_target_angles(0, 10, 20, 1)
+    --send_target_angles(0, 10, 20, 1)
 
     -- send rate target
     --local roll_degs, pitch_degs, yaw_degs, yaw_is_ef = mount:get_rate_target(MOUNT_INSTANCE)

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -65,8 +65,8 @@
 -- global definitions
 local INIT_INTERVAL_MS = 3000           -- attempt to initialise the gimbal at this interval
 local UPDATE_INTERVAL_MS = 1            -- update interval in millis
-local REQUEST_ATTITUDE_INTERVAL_MS = 100   -- request attitude at this interval
-local SET_ATTITUDE_INTERVAL_MS = 100   -- set attitude at this interval
+local REQUEST_ATTITUDE_INTERVAL_MS = 5000   -- request attitude at this interval
+local SET_ATTITUDE_INTERVAL_MS = 5000   -- set attitude at this interval
 local MOUNT_INSTANCE = 0                -- always control the first mount/gimbal
 local SEND_FRAMEID = 0x223              -- send CAN messages with this frame id
 local RECEIVE_FRAMEID = 0x222           -- receive CAN messages with this frame id
@@ -643,9 +643,9 @@ function update()
   end
 
   -- do not send any messages until CAN traffic has been seen
-  --if msg_ignored == 0 and bytes_read == 0 then
-  --  return update, UPDATE_INTERVAL_MS
-  --end
+  if msg_ignored == 0 and bytes_read == 0 then
+    return update, UPDATE_INTERVAL_MS
+  end
 
   -- send test message
   if now_ms - last_test_msg_send_ms > 10000 then
@@ -685,26 +685,29 @@ function update()
   -- request gimbal attitude
   if now_ms - last_req_attitude_ms > REQUEST_ATTITUDE_INTERVAL_MS then
     last_req_attitude_ms = now_ms
-    --request_attitude()
+    request_attitude()
   end
 
-  -- set gimbal attitude
+  -- set gimbal attitude or rate
   if now_ms - last_set_attitude_ms > SET_ATTITUDE_INTERVAL_MS then
     last_set_attitude_ms = now_ms
+
+    -- send angle target
     --local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
     --if roll_degs and pitch_degs and yaw_degs then
     --  send_target_angles(roll_deg, pitch_deg, yaw_deg, 1)
+    --  return update, UPDATE_INTERVAL_MS
     --end
-    --send_target_angles(0, 10, 20, 1)
-    send_target_rates(0, 10, -30)
-  end
+    send_target_angles(0, 10, 20, 1)
 
-  -- get target rate
-  --local roll_degs, pitch_degs, yaw_degs, yaw_is_ef = mount:get_rate_target(MOUNT_INSTANCE)
-  --if roll_degs and pitch_degs and yaw_degs then
-    --send_target_rates(roll_degs, pitch_degs, yaw_degs)
-  --  return update, UPDATE_INTERVAL_MS
-  --end
+    -- send rate target
+    --local roll_degs, pitch_degs, yaw_degs, yaw_is_ef = mount:get_rate_target(MOUNT_INSTANCE)
+    --if roll_degs and pitch_degs and yaw_degs then
+    --  send_target_rates(roll_degs, pitch_degs, yaw_degs)
+    --  return update, UPDATE_INTERVAL_MS
+    --end
+    --send_target_rates(0, 10, -30)
+  end
 
   return update, UPDATE_INTERVAL_MS
 end

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -1,0 +1,560 @@
+-- mount-djir2-driver.lua: DJIR2 mount/gimbal driver
+--
+-- How to use
+--   Connect gimbal to autopilot's CAN1 port
+--   Set CAN_D1_PROTOCOL = 10 (Scripting)
+--   Set CAN_P1_DRIVER = 1 (First driver)
+--   Set SCR_ENABLE = 1 to enable scripting
+--   Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
+--   Reboot the autopilot
+--   Copy this script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot
+--
+-- CAN format
+--   packet's data segment holds up to 8 serial bytes.  These should be extracted and sent to the serial packet parser
+--   the CAN packets will never hold the contents of more than one serial packet
+--
+--   the external caller (e.g. this script) must send CAN frames with frameId = 0x223
+--   gimbal will reply with frameId = 0x222
+--
+-- Serial Packet format
+--    byte      description     notes
+--    0         header          AA
+--    1~2       Ver/Length      bits 0~9 are length of entire frame, LSB first. bits 10~15 are version number
+--    3         CmdType         bits 0~4 are Reply type, 0=No Reply required, 1=Can reply or not after data sent, 2~31=Reply is required after data sent
+--                              bit 5 is Frame type, 0=Command frame, 1=Reply Frame
+--                              bits 6~7 reserved (0 by default)
+--    4         ENC             bits 0~4 length of supplementary bytes when encrypting
+--                              bits 5~7 Encryption type, 0=Unencrypted, 1=AES256 encyrption
+--    5~7       RES             reserved
+--    8~9       SEQ             sequence number.  increments with each packet
+--    10~11     CRC-16          frame header check
+--    12~n      Data            Data segment Start
+--      12        CmdSet        Data segment Command set
+--      13        CmdID         Data segment Command code
+--      14~n      Data content  Data content
+--    n+1       CRC-32          frame check (the entire frame)
+--
+-- Used CmdSet and CmdId
+--    0x0E, 0x00: Handheld Gimbal Position Control
+--      Command frame bytes
+--       0~1: yaw angle * 10, int16, -1800 to +1800
+--       2~3: roll angle * 10, int16, -300 to +300
+--       4~5: pitch angle * 10, int16, -560 to +1460
+--       6: ctrl_byte, uint8
+--             bit0 = 0:relative control, 1:absolute control
+--             bit1 = 0:yaw axis valid, 1:invalid
+--             bit2 = 0:roll axis valid, 1:invalid
+--             bit3 = 0:pitch axis valid, 1:invalid
+--             bit4~7 = reserved, must be zero
+--       7: time for action, uint8_t, unit: 0.1s.  e.g. if 20, gimbal will rotate to the position desired within 2sec
+--     Reply frame bytes
+--       0: return code, uint8_t
+--
+--    0x0E, 0x02: Obtain the angle information of handheld gimbal, including joint angle and attitude angle
+--      Command frame bytes
+--       0: ctrl_byte, uint8_t, 0x00:No operation, 0x01:angle of handlheld gimbal, 0x02:joint angle of handheld gimbal
+--     Reply frame bytes
+--       0: return code, uint8_t
+--       1: data_type, uint8_t, 0x00:Data is not ready, 0x01:attitude angle, 0x02:joint angle
+--       2~3: yaw angle * 10, int16, -1800 to +1800
+--       4~5: roll angle * 10, int16, -300 to +300
+--       6~7: pitch angle * 10, int16, -560 to +1460
+--
+
+-- global definitions
+local INIT_INTERVAL_MS = 3000           -- attempt to initialise the gimbal at this interval
+local UPDATE_INTERVAL_MS = 1            -- update interval in millis
+local REQUEST_ATTITUDE_INTERVAL_MS = 100   -- request attitude at this interval
+local SET_ATTITUDE_INTERVAL_MS = 100   -- set attitude at this interval
+local MOUNT_INSTANCE = 0                -- always control the first mount/gimbal
+local SEND_FRAMEID = 0x223              -- send CAN messages with this frame id
+local RECEIVE_FRAMEID = 0x222           -- receive CAN messages with this frame id
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+-- message definitions
+local HEADER = 0xAA
+local REQUEST_ATTITUDE_CMDSET = 0x0E
+local REQUEST_ATTITUDE_CMDID = 0x02
+
+-- parsing state definitions
+local PARSE_STATE_WAITING_FOR_HEADER        = 0
+local PARSE_STATE_WAITING_FOR_VERLENGTH     = 1
+local PARSE_STATE_WAITING_FOR_DATA          = 3
+
+-- other parsing definitions
+local CAN_PACKET_LENGTH_MAX = 8         -- CAN packet maximum length
+local SERIAL_PACKET_LENGTH_MAX = 32     -- serial packet maximum length.  used to sanity check length of incoming messages
+local SERIAL_PACKET_LENGTH_MIN = 16     -- serial packet minimum length.  used to sanity check sends
+
+-- local variables and definitions
+local driver                            -- CAN bus
+local initialised = false               -- true once connection to gimbal has been initialised
+local parse_state = PARSE_STATE_WAITING_FOR_HEADER  -- parse state
+local parse_length = 0                  -- incoming message's packet length
+local parse_buff = {}                   -- message buffer holding roll, pitch and yaw angles from gimbal
+local parse_bytes_recv = 0              -- message buffer length.  count of the number of bytes received in the message so far
+local last_send_seq = 0                 -- last sequence number sent
+local last_req_attitude_ms = 0          -- system time of last request for attitude
+local last_set_attitude_ms = 0          -- system time of last set attitude call
+
+-- debug variables
+local last_print_ms = 0                 -- system time that debug output was last printed
+local bytes_read = 0                    -- number of bytes read from gimbal
+local bytes_written = 0                 -- number of bytes written to gimbal
+local bytes_error = 0                   -- number of bytes read that could not be parsed
+local msg_ignored = 0                   -- number of ignored messages (because frame id does not match)
+local write_fails = 0                   -- number of times write failed
+
+local crc16_lookup = {
+    0x0000, 0xc0c1, 0xc181, 0x0140, 0xc301, 0x03c0, 0x0280, 0xc241,
+    0xc601, 0x06c0, 0x0780, 0xc741, 0x0500, 0xc5c1, 0xc481, 0x0440,
+    0xcc01, 0x0cc0, 0x0d80, 0xcd41, 0x0f00, 0xcfc1, 0xce81, 0x0e40,
+    0x0a00, 0xcac1, 0xcb81, 0x0b40, 0xc901, 0x09c0, 0x0880, 0xc841,
+    0xd801, 0x18c0, 0x1980, 0xd941, 0x1b00, 0xdbc1, 0xda81, 0x1a40,
+    0x1e00, 0xdec1, 0xdf81, 0x1f40, 0xdd01, 0x1dc0, 0x1c80, 0xdc41,
+    0x1400, 0xd4c1, 0xd581, 0x1540, 0xd701, 0x17c0, 0x1680, 0xd641,
+    0xd201, 0x12c0, 0x1380, 0xd341, 0x1100, 0xd1c1, 0xd081, 0x1040,
+    0xf001, 0x30c0, 0x3180, 0xf141, 0x3300, 0xf3c1, 0xf281, 0x3240,
+    0x3600, 0xf6c1, 0xf781, 0x3740, 0xf501, 0x35c0, 0x3480, 0xf441,
+    0x3c00, 0xfcc1, 0xfd81, 0x3d40, 0xff01, 0x3fc0, 0x3e80, 0xfe41,
+    0xfa01, 0x3ac0, 0x3b80, 0xfb41, 0x3900, 0xf9c1, 0xf881, 0x3840,
+    0x2800, 0xe8c1, 0xe981, 0x2940, 0xeb01, 0x2bc0, 0x2a80, 0xea41,
+    0xee01, 0x2ec0, 0x2f80, 0xef41, 0x2d00, 0xedc1, 0xec81, 0x2c40,
+    0xe401, 0x24c0, 0x2580, 0xe541, 0x2700, 0xe7c1, 0xe681, 0x2640,
+    0x2200, 0xe2c1, 0xe381, 0x2340, 0xe101, 0x21c0, 0x2080, 0xe041,
+    0xa001, 0x60c0, 0x6180, 0xa141, 0x6300, 0xa3c1, 0xa281, 0x6240,
+    0x6600, 0xa6c1, 0xa781, 0x6740, 0xa501, 0x65c0, 0x6480, 0xa441,
+    0x6c00, 0xacc1, 0xad81, 0x6d40, 0xaf01, 0x6fc0, 0x6e80, 0xae41,
+    0xaa01, 0x6ac0, 0x6b80, 0xab41, 0x6900, 0xa9c1, 0xa881, 0x6840,
+    0x7800, 0xb8c1, 0xb981, 0x7940, 0xbb01, 0x7bc0, 0x7a80, 0xba41,
+    0xbe01, 0x7ec0, 0x7f80, 0xbf41, 0x7d00, 0xbdc1, 0xbc81, 0x7c40,
+    0xb401, 0x74c0, 0x7580, 0xb541, 0x7700, 0xb7c1, 0xb681, 0x7640,
+    0x7200, 0xb2c1, 0xb381, 0x7340, 0xb101, 0x71c0, 0x7080, 0xb041,
+    0x5000, 0x90c1, 0x9181, 0x5140, 0x9301, 0x53c0, 0x5280, 0x9241,
+    0x9601, 0x56c0, 0x5780, 0x9741, 0x5500, 0x95c1, 0x9481, 0x5440,
+    0x9c01, 0x5cc0, 0x5d80, 0x9d41, 0x5f00, 0x9fc1, 0x9e81, 0x5e40,
+    0x5a00, 0x9ac1, 0x9b81, 0x5b40, 0x9901, 0x59c0, 0x5880, 0x9841,
+    0x8801, 0x48c0, 0x4980, 0x8941, 0x4b00, 0x8bc1, 0x8a81, 0x4a40,
+    0x4e00, 0x8ec1, 0x8f81, 0x4f40, 0x8d01, 0x4dc0, 0x4c80, 0x8c41,
+    0x4400, 0x84c1, 0x8581, 0x4540, 0x8701, 0x47c0, 0x4680, 0x8641,
+    0x8201, 0x42c0, 0x4380, 0x8341, 0x4100, 0x81c1, 0x8081, 0x4040
+}
+
+local crc32_lookup = {
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+    0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+    0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+    0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172, 0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+    0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+    0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924, 0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+    0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+    0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e, 0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+    0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+    0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0, 0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+    0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+    0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a, 0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+    0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+    0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc, 0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+    0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+    0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236, 0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+    0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+    0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38, 0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+    0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+    0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2, 0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+    0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+    0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+}
+
+-- calculate crc16 for a series of bytes
+-- byte_array should be a table of uint8 values
+-- start_byte should be the first byte to start from (using 1 indexing) or left as nil to default to the first byte
+-- num_bytes should be the number of bytes to process or left as nil to use the entire message
+function calc_crc16(byte_array, start_byte, num_bytes)
+  start_byte = start_byte or 1
+  num_bytes = num_bytes or #byte_array - start_byte + 1
+  local crc = 0x3AA3
+  for i = start_byte, num_bytes do
+    local b = byte_array[i] & 0xFF
+    local crc16_lookup_index = ((crc ~ b) % 256) + 1
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: %u index:%u", i, crc16_lookup_index))
+    local lookup_val = crc16_lookup[crc16_lookup_index]
+    crc = ((crc >> 8) & 0xFF) ~ lookup_val
+  end
+  return crc
+end
+
+-- calculate crc32 for a series of bytes
+-- byte_array should be a table of uint8 values
+-- start_byte should be the first byte to start from (using 1 indexing) or left as nil to default to the first byte
+-- num_bytes should be the number of bytes to process or left as nil to use the entire message
+function calc_crc32(byte_array, start_byte, num_bytes)
+  start_byte = start_byte or 1
+  num_bytes = num_bytes or #byte_array - start_byte + 1
+  local crc = 0x3AA3
+  for i = start_byte, num_bytes do
+    local b = byte_array[i] & 0xFF
+    local crc32_lookup_index = (((crc ~ b) & 0xff) + 1)
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: %u index:%u", i, crc16_lookup_index))
+    local lookup_val = crc32_lookup[crc32_lookup_index]
+    crc = ((crc >> 8) & 0x00FFFFFF) ~ lookup_val
+  end
+  return crc
+end
+
+-- perform any require initialisation
+function init()
+  driver = CAN:get_device(25)
+  if driver then
+    initialised = true
+    gcs:send_text(MAV_SEVERITY.INFO, "DJIR2: mount driver started")   
+  else
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: failed to connect to CAN bus")   
+  end
+end
+
+-- send serial message over CAN bus
+function send_msg(serial_msg)
+
+  if not serial_msg then
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: cannot send invalid message")
+    do return end
+  end
+
+  -- debug
+  --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: sending %d bytes", #serial_msg))
+
+  -- calculate number of CAN frames required to send mesage
+  local num_frames = math.floor(#serial_msg / CAN_PACKET_LENGTH_MAX)
+  if #serial_msg % CAN_PACKET_LENGTH_MAX > 0 then
+    num_frames = num_frames + 1
+  end
+  --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: sending %d frames", num_frames))
+
+  -- create and send CAN messages
+  for i=0, num_frames-1 do
+    local start_byte = i * CAN_PACKET_LENGTH_MAX + 1
+    local finish_byte = math.min(start_byte + CAN_PACKET_LENGTH_MAX - 1 , #serial_msg)
+    local num_bytes = finish_byte - start_byte + 1
+
+    -- debug
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: start:%d end:%d num:%d", start_byte, finish_byte, num_bytes))
+
+    local canframe = CANFrame()
+    canframe:id(SEND_FRAMEID)
+    canframe:dlc(num_bytes)
+    for j = 0, num_bytes-1 do
+      canframe:data(j, serial_msg[start_byte+j])
+    end
+    if driver:write_frame(canframe, 10000) then
+      bytes_written = bytes_written + num_bytes
+    else
+      write_fails = write_fails + 1
+    end
+
+    -- debug
+    --gcs:send_text(MAV_SEVERITY.INFO,string.format("DJIR2: dlc:%u %x %x %x %x %x %x %x %x", canframe:dlc(), canframe:data(0), canframe:data(1), canframe:data(2), canframe:data(3), canframe:data(4), canframe:data(5), canframe:data(6), canframe:data(7)))
+  end
+end
+
+-- get next sequence number that should be used for send commands
+function get_next_sequence_number()
+  last_send_seq = last_send_seq + 1
+  if last_send_seq > 0xFFFF then
+    last_send_seq = 0
+  end
+  return last_send_seq
+end
+
+-- update serial message's sequence number, crc-16 and crc-32 fields
+function update_msg_seq_and_crc(serial_msg)
+  -- sanity checks
+  if not serial_msg then
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: update_msg_seq_and_crc null arg")
+    do return end
+  end
+  if #serial_msg < SERIAL_PACKET_LENGTH_MIN then
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "DJIR2: update_msg_seq_and_crc message too short")
+    do return end
+  end
+
+  -- update sequence
+  local seq = get_next_sequence_number()
+  serial_msg[9] = lowbyte(seq)
+  serial_msg[10] = highbyte(seq)
+  --gcs:send_text(MAV_SEVERITY.INFO,string.format("DJIR2: seq:%d l:%x h:%x", seq, serial_msg[9], serial_msg[10]))
+
+  -- update header crc16
+  local crc16 = calc_crc16(serial_msg, 1, 10)
+  serial_msg[11] = lowbyte(crc16)
+  serial_msg[12] = highbyte(crc16)
+
+  -- update entire frame's crc32
+  local crc32 = calc_crc32(serial_msg, 1, #serial_msg-4)
+  serial_msg[#serial_msg-3] = lowbyte(crc32)
+  serial_msg[#serial_msg-2] = lowbyte(crc32 >> 8)
+  serial_msg[#serial_msg-1] = lowbyte(crc32 >> 16)
+  serial_msg[#serial_msg] = lowbyte(crc32 >> 24)
+end
+
+-- request attitude from gimbal
+function request_attitude()
+  -- Field number                  1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19
+  --                             SOF  LenL  LenH CmdTyp  Enc   RES   RES   RES  SeqL  SeqH  CrcL  CrcH CmdSet CmdId Data1 CRC32 CRC32 CRC32 CRC32
+  local request_attitude_msg = {0xAA, 0x13, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x0E, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00}
+
+  -- update_msg_seq_and_crc
+  update_msg_seq_and_crc(request_attitude_msg)
+
+  -- send bytes
+  send_msg(request_attitude_msg)
+end
+
+-- send target angles (in degrees) to gimbal
+-- yaw_angle_deg is always a body-frame angle
+function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time_sec)
+  -- default argument values
+  roll_angle_deg = roll_angle_deg or 0
+  pitch_angle_deg = pitch_angle_deg or 0
+  yaw_angle_deg = yaw_angle_deg or 0
+  time_sec = time_sec or 2
+
+  --    0x0E, 0x00: Handheld Gimbal Position Control
+  --      Command frame bytes
+  --       0~1: yaw angle * 10, int16, -1800 to +1800
+  --       2~3: roll angle * 10, int16, -300 to +300
+  --       4~5: pitch angle * 10, int16, -560 to +1460
+  --       6: ctrl_byte, uint8
+  --             bit0 = 0:relative control, 1:absolute control
+  --             bit1 = 0:yaw axis valid, 1:invalid
+  --             bit2 = 0:roll axis valid, 1:invalid
+  --             bit3 = 0:pitch axis valid, 1:invalid
+  --             bit4~7 = reserved, must be zero
+  --       7: time for action, uint8_t, unit: 0.1s.  e.g. if 20, gimbal will rotate to the position desired within 2sec
+  --
+  -- Field number                1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19    20    21    22    23    24    25    26
+  -- Field name                SOF  LenL  LenH CmdTyp  Enc   RES   RES   RES  SeqL  SeqH  CrcL  CrcH CmdSet CmdId YawL  YawH  RollL RollH PitL  PitH  Ctrl Time  CRC32 CRC32 CRC32 CRC32
+  local set_target_att_msg = {0xAA, 0x1A, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0E, 0x00, 0x20, 0x00, 0x30, 0x00, 0x40, 0x00, 0x01, 0x14, 0x7B, 0x40, 0x97, 0xBE}
+  --                         {0xAA, 0x1A, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x22, 0x11, 0xA2, 0x42, 0x0E, 0x00, 0x20, 0x00, 0x30, 0x00, 0x40, 0x00, 0x01, 0x14, 0x7B, 0x40, 0x97, 0xBE}
+
+  -- set angles
+  set_target_att_msg[15] = lowbyte(yaw_angle_deg * 10)
+  set_target_att_msg[16] = highbyte(yaw_angle_deg * 10)
+  set_target_att_msg[17] = lowbyte(roll_angle_deg * 10)
+  set_target_att_msg[18] = highbyte(roll_angle_deg * 10)
+  set_target_att_msg[19] = lowbyte(pitch_angle_deg * 10)
+  set_target_att_msg[20] = highbyte(pitch_angle_deg * 10)
+
+  -- set time
+  set_target_att_msg[22] = lowbyte(time_sec * 10)
+
+  -- update_msg_seq_and_crc
+  update_msg_seq_and_crc(set_target_att_msg)
+
+  -- send bytes
+  send_msg(set_target_att_msg)
+end
+
+-- send target rates (in deg/sec) to gimbal
+function send_target_rates(roll_rate_deg, pitch_rate_degs, yaw_rate_degs)
+end
+
+-- consume incoming CAN packets
+function read_incoming_packets()
+  local canframe
+  repeat
+    canframe = driver:read_frame()
+    if canframe then
+      if uint32_t(canframe:id()) == uint32_t(RECEIVE_FRAMEID) then
+        for i = 0, canframe:dlc()-1 do
+          parse_byte(canframe:data(i))
+        end
+      else
+        msg_ignored = msg_ignored + 1
+      end
+    end
+  until not canframe
+end
+
+-- parse an byte from the gimbal
+function parse_byte(b)
+
+    -- debug
+    bytes_read = bytes_read + 1
+
+    -- clear buffer while waiting for header
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER then
+      parse_expected_crc = 0
+      parse_bytes_recv = 0
+    end
+
+    -- add byte to buffer
+    parse_bytes_recv = parse_bytes_recv + 1
+    parse_buff[parse_bytes_recv] = b
+
+    -- waiting for header1
+    if parse_state == PARSE_STATE_WAITING_FOR_HEADER and b == HEADER then
+      parse_state = PARSE_STATE_WAITING_FOR_VERLENGTH
+      do return end
+    else
+      -- unexpected byte
+      bytes_error = bytes_error + 1
+    end
+
+    -- waiting for version/length LSB
+    if parse_state == PARSE_STATE_WAITING_FOR_VERLENGTH then
+      if parse_bytes_recv == 2 then
+        parse_length = b
+      else
+        parse_length = uint16_value(b & 0x03, parse_length)
+        if (parse_length < SERIAL_PACKET_LENGTH_MIN) or (parse_length > SERIAL_PACKET_LENGTH_MAX) then
+          parse_state = PARSE_STATE_WAITING_FOR_HEADER
+          -- invalid length
+          bytes_error = bytes_error + 1
+          gcs:send_text(MAV_SEVERITY.CRITICAL, string.format("DJIR2: unexpected len:%u", parse_length))
+        else
+          parse_state = PARSE_STATE_WAITING_FOR_DATA
+        end
+      end
+      do return end
+    end
+
+    -- waiting for data
+    if (parse_state == PARSE_STATE_WAITING_FOR_DATA) and (parse_bytes_recv >= parse_length) then
+        -- check crc16
+        local expected_crc16 = calc_crc16(parse_buff, 1, 10)
+        local received_crc16 = uint16_value(parse_buff[12], parse_buff[11])
+        if (expected_crc16 ~= received_crc16) then
+          gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: crc16 exp:%x got:%x", expected_crc16, received_crc16))
+          gcs:send_text(MAV_SEVERITY.INFO,string.format("DJIR2: msg:%x %x %x %x %x %x %x %x %x %x", parse_buff[1], parse_buff[2], parse_buff[3], parse_buff[4], parse_buff[5], parse_buff[6], parse_buff[7], parse_buff[8], parse_buff[9], parse_buff[10]))
+        end
+
+        -- check crc32
+        local expected_crc32 = calc_crc32(parse_buff, 1, parse_length-4)
+        local received_crc32 = uint32_value(parse_buff[parse_length], parse_buff[parse_length-1], parse_buff[parse_length-2], parse_buff[parse_length-3])
+        if (expected_crc32 ~= received_crc32) then
+          gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: crc32 exp:%x got:%x", expected_crc32, received_crc32))
+        end
+
+        -- check if reply
+        local cmd_type_reply = (parse_buff[4] & 0x20) > 0
+
+        -- if message has at least 2 bytes of data, check cmdid and cmdset
+        if cmd_type_reply and parse_length >= SERIAL_PACKET_LENGTH_MIN + 2 then
+          local cmdset = parse_buff[13]
+          local cmdid = parse_buff[14]
+
+  -- Field number                     1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19
+  --                                SOF  LenL  LenH CmdTyp  Enc   RES   RES   RES  SeqL  SeqH  CrcL  CrcH CmdSet CmdId Data1 CRC32 CRC32 CRC32 CRC32
+  -- local request_attitude_msg = {0xAA, 0x13, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x0E, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00}
+
+          -- parse attitude message
+          if (cmdset == REQUEST_ATTITUDE_CMDSET) and (cmdid == REQUEST_ATTITUDE_CMDID) and (parse_length >= 22) then
+            --local return_code = parse_buff[15]
+            --local data_type = parse_buff[16]
+            local yaw_deg = uint16_value(parse_buff[18],parse_buff[17]) * 0.1
+            local roll_deg = uint16_value(parse_buff[20],parse_buff[19]) * 0.1
+            local pitch_deg = uint16_value(parse_buff[22],parse_buff[21]) * 0.1
+            mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
+          end
+        end
+
+       parse_state = PARSE_STATE_WAITING_FOR_HEADER
+       do return end
+    end
+
+end
+
+-- get lowbyte of a number
+function lowbyte(num)
+  return num & 0xFF
+end
+
+-- get highbyte of a number
+function highbyte(num)
+  return (num >> 8) & 0xFF
+end
+
+-- get uint16 from two bytes
+function uint16_value(hbyte, lbyte)
+  return ((hbyte & 0xFF) << 8) | (lbyte & 0xFF)
+end
+
+-- get uint32 from four bytes
+function uint32_value(byte3, byte2, byte1, byte0)
+  return (((byte3 & 0xFF) << 24) | ((byte2 & 0xFF) << 16) | ((byte1 & 0xFF) << 8) | (byte0 & 0xFF))
+end
+
+-- the main update function that performs a simplified version of RTL
+function update()
+
+  -- initialise connection to gimbal
+  if not initialised then
+    init()
+    return update, INIT_INTERVAL_MS
+  end
+
+  -- consume incoming bytes
+  read_incoming_packets()
+
+  -- get system time
+  local now_ms = millis()
+
+  -- debug  
+  if now_ms - last_print_ms > 5000 then
+    last_print_ms = now_ms
+    gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: read:%u write:%u fail:%u perr:%u ign:%u", bytes_read, bytes_written, write_fails, bytes_error, msg_ignored))
+
+    -- debug of crc16
+    --local test_msg1 = {0xAA,0x1A,0x00,0x03,0x00,0x00,0x00,0x00,0x22, 0x11}
+    --local crc_res = calc_crc16(test_msg1)
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: crc16 %x %x", lowbyte(crc_res), highbyte(crc_res)))
+
+    -- debug of crc32
+    --local test_msg = {0xAA,0x1A,0x00,0x03,0x00,0x00,0x00,0x00,0x22, 0x11, 0xA2, 0x42, 0x0E, 0x00, 0x20, 0x00, 0x30, 0x00, 0x40, 0x00, 0x01, 0x14}
+    --local crc_res = calc_crc32(test_msg)
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR2: crc32 %x %x %x %x", lowbyte(crc_res), lowbyte(crc_res>>8), lowbyte(crc_res>>16), lowbyte(crc_res>>24)))
+
+  end
+
+  -- do not send any messages until CAN traffic has been seen
+  --if msg_ignored == 0 and bytes_read == 0 then
+  --  return update, UPDATE_INTERVAL_MS
+  --end
+
+  -- request gimbal attitude
+  if now_ms - last_req_attitude_ms > REQUEST_ATTITUDE_INTERVAL_MS then
+    last_req_attitude_ms = now_ms
+    request_attitude()
+  end
+
+  -- set gimbal attitude
+  if now_ms - last_set_attitude_ms > SET_ATTITUDE_INTERVAL_MS then
+    last_set_attitude_ms = now_ms
+    --local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
+    --if roll_degs and pitch_degs and yaw_degs then
+    --  send_target_angles(roll_deg, pitch_deg, yaw_deg, 1)
+    --end
+    send_target_angles(0, 10, 20, 1)
+  end
+
+  -- get target rate
+  --local roll_degs, pitch_degs, yaw_degs, yaw_is_ef = mount:get_rate_target(MOUNT_INSTANCE)
+  --if roll_degs and pitch_degs and yaw_degs then
+    --send_target_rates(roll_degs, pitch_degs, yaw_degs)
+  --  return update, UPDATE_INTERVAL_MS
+  --end
+
+  return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -66,8 +66,8 @@
 local INIT_INTERVAL_MS = 3000           -- attempt to initialise the gimbal at this interval
 local UPDATE_INTERVAL_MS = 1            -- update interval in millis
 local REPLY_TIMEOUT_MS = 1000           -- timeout waiting for reply after 1 sec
-local REQUEST_ATTITUDE_INTERVAL_MS = 5000   -- request attitude at this interval
-local SET_ATTITUDE_INTERVAL_MS = 5000   -- set attitude at this interval
+local REQUEST_ATTITUDE_INTERVAL_MS = 1000   -- request attitude at this interval
+local SET_ATTITUDE_INTERVAL_MS = 1000   -- set attitude at this interval
 local MOUNT_INSTANCE = 0                -- always control the first mount/gimbal
 local SEND_FRAMEID = 0x223              -- send CAN messages with this frame id
 local RECEIVE_FRAMEID = 0x222           -- receive CAN messages with this frame id

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.lua
@@ -287,6 +287,8 @@ function send_msg(serial_msg)
       bytes_written = bytes_written + num_bytes
     else
       write_fails = write_fails + 1
+      -- on failure do not send rest of message
+      do return end
     end
 
     -- debug

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.md
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.md
@@ -7,6 +7,7 @@ How to use
   Set CAN_D1_PROTOCOL = 10 (Scripting)
   Set CAN_P1_DRIVER = 1 (First driver)
   Set SCR_ENABLE = 1 to enable scripting
+  Set SCR_HEAP_SIZE = 120000 (or higher)
   Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
   Reboot the autopilot
   Copy the mount-djir2-driver.lua script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot

--- a/libraries/AP_Scripting/drivers/mount-djir2-driver.md
+++ b/libraries/AP_Scripting/drivers/mount-djir2-driver.md
@@ -1,0 +1,12 @@
+# DJIR2 Mount Driver
+
+DJIR2 gimbal mount driver lua script
+
+How to use
+  Connect gimbal to autopilot's CAN1 port
+  Set CAN_D1_PROTOCOL = 10 (Scripting)
+  Set CAN_P1_DRIVER = 1 (First driver)
+  Set SCR_ENABLE = 1 to enable scripting
+  Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
+  Reboot the autopilot
+  Copy the mount-djir2-driver.lua script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -558,6 +558,11 @@ singleton AP_Mount method set_angle_target void uint8_t'skip_check float'skip_ch
 singleton AP_Mount method set_rate_target void uint8_t'skip_check float'skip_check float'skip_check float'skip_check boolean
 singleton AP_Mount method set_roi_target void uint8_t'skip_check Location
 singleton AP_Mount method get_attitude_euler boolean uint8_t'skip_check float'Null float'Null float'Null
+singleton AP_Mount method get_rate_target boolean uint8_t'skip_check float'Null float'Null float'Null boolean'Null
+singleton AP_Mount method get_angle_target boolean uint8_t'skip_check float'Null float'Null float'Null boolean'Null
+singleton AP_Mount method get_location_target boolean uint8_t'skip_check Location'Null
+singleton AP_Mount method set_attitude_euler void uint8_t'skip_check float'skip_check float'skip_check float'skip_check
+singleton AP_Mount method get_camera_state boolean uint8_t'skip_check uint16_t'Null boolean'Null int8_t'Null int8_t'Null boolean'Null
 
 include AP_Winch/AP_Winch.h depends APM_BUILD_COPTER_OR_HELI
 singleton AP_Winch depends APM_BUILD_COPTER_OR_HELI


### PR DESCRIPTION
This adds support for at least some of the [ViewPro gimbals](http://www.viewprotech.com/index.php?ac=article&at=list&tid=127) ([including the Q30TIRM](https://www.viewprouav.com/product/q30tirm-sony-30x-zoom-starlight-camera-3-axis-high-precise-foc-program-ireo-dual-sensors-object-tracking-gps-location-resolving.html)) using a Lua script based AP_Mount driver.

Changes include:

- AP_Mount gets new accessors and a scripting backend that allows a script to get the latest targets (rate, angle and location) and camera state (e.g. take picture, record video, zoom, focus) from the main flight code and also record the actual angles retrieved from the gimbal so they can be reported to the ground station
- AP_Scripting gets new bindings (including docs) for the new AP_Mount accesors mentioned above
- AP_Scripting mount-viewpro-driver.lua implements the low level serial communication

This has been bench tested using fake input messages copied from the "datasheet" but still needs to be tested on real hardware.

Wiring diagrams are below
![viewpro-cube-wiring](https://user-images.githubusercontent.com/1498098/210698636-5b6b6a3f-1067-40a7-8af5-d5497cbb0e0e.png)
![viewpro-viewport-cube-wiring](https://user-images.githubusercontent.com/1498098/210698637-6eab473d-2c4f-4a9d-9627-b7d4c51fcf4e.png)
