### PR TITLE
AP_AHRS: get_relative_position_D_home: don't use home until set

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1773,6 +1773,13 @@ bool AP_AHRS::get_relative_position_D_origin(float &posD) const
 // will use the barometer if the EKF isn't available
 void AP_AHRS::get_relative_position_D_home(float &posD) const
 {
+    if (!_home_is_set) {
+        // fall back to an altitude derived from barometric pressure
+        // differences vs a calibrated ground pressure:
+        posD = -AP::baro().get_altitude();
+        return;
+    }
+
     Location originLLH;
     float originD;
     if (!get_relative_position_D_origin(originD) ||


### PR DESCRIPTION
This problem was found by running Plane's rangefinder test like this:
```
./Tools/autotest/autotest.py --gdb --debug --force-ahrs-type=10  build.Plane test.Plane.RangeFinder
```

The test fails because we decide takeoff is complete because the vehicle's relative altitude becomes equal to its AMSL altitude (or its negative, one of the two....) until home is set.  It never takes off from the ground in this case, staying at its starting spot and failing to reach waypoint 5.  This *may* be because we never run the takeoff "do" code because the verify passes instantaenously, so we never unlock the throttle (I'm only theorising here, haven't stepped through it.

This debug code neatly shows the problem in the autotest output:
```
index e69f7abe2b..ee61b0338d 100644
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -22,6 +22,8 @@
 
 #include "Plane.h"
 
+#include "signal.h"
+
 #define SCHED_TASK(func, rate_hz, max_time_micros, priority) SCHED_TASK_CLASS(Plane, &plane, func, rate_hz, max_time_micros, priority)
 #define FAST_TASK(func) FAST_TASK_CLASS(Plane, &plane, func)
 
@@ -405,6 +407,10 @@ void Plane::update_GPS_50Hz(void)
     // get position from AHRS
     have_position = ahrs.get_location(current_loc);
     ahrs.get_relative_position_D_home(relative_altitude);
+    gcs().send_text(MAV_SEVERITY_INFO, "relalt=%f", relative_altitude);
+    if (fabs(relative_altitude) > 10) {
+        kill(0, 5);
+    }
     relative_altitude *= -1.0f;
 }
 ```

you can set a breakpoint on get_relative_position_D_home to see where we then use a home.alt of zero in a subtraction against the origin altitude.

Into the future, when we sort out the "One Vehicle Origin to rule them all", we may be able to avoid this by saying that if you have an origin you have a home.
