### PR TITLE
Param: fixed invalid param count issues

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -188,6 +188,11 @@ uint8_t AP_Filesystem_Param::pack_param(const struct rfile &r, struct cursor &c,
         ap = AP_Param::next_scalar(&c.token, &ptype, &default_val);
     }
     if (ap == nullptr || (r.count && c.idx >= r.count)) {
+        if (r.count == 0 && c.idx != AP_Param::count_parameters()) {
+            // the parameter count is incorrect, invalidate so a
+            // repeated param download avoids an error
+            AP_Param::invalidate_count();
+        }
         return 0;
     }
     ap->copy_name_token(c.token, name, AP_MAX_NAME_SIZE, true);

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -278,6 +278,10 @@ void AP_Vehicle::setup()
     }
 #endif
 
+    // invalidate count in case an enable parameter changed during
+    // initialisation
+    AP_Param::invalidate_count();
+
     gcs().send_text(MAV_SEVERITY_INFO, "ArduPilot Ready");
 }
 


### PR DESCRIPTION
The recent AP_Airspeed changes could lead to invalid parameter counts in param ftp. This fixes the issue plus protects against repeated failures of ftp due to this issue
This issue is most visible on real boards, because AP_InertialSensor::init() is called before AP_Airspeed::init(). The gyro init takes time and the parameters can start to download before the airspeed init has run, which means the default ARSPD_TYPE isn't set yet
