### PR TITLE
AP_Airspeed: move setting of first backend defualts to constructor to avoid race

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -186,6 +186,13 @@ AP_Airspeed::AP_Airspeed()
 {
     AP_Param::setup_object_defaults(this, var_info);
 
+    // Setup defaults that only apply to first sensor
+    param[0].type.set_default(ARSPD_DEFAULT_TYPE);
+    param[0].bus.set_default(HAL_AIRSPEED_BUS_DEFAULT);
+#ifndef HAL_BUILD_AP_PERIPH
+    param[0].pin.set_default(ARSPD_DEFAULT_PIN);
+#endif
+
     if (_singleton != nullptr) {
         AP_HAL::panic("AP_Airspeed must be singleton");
     }
@@ -297,13 +304,6 @@ void AP_Airspeed::convert_per_instance()
 
 void AP_Airspeed::init()
 {
-
-    // Setup defaults that only apply to first sensor
-    param[0].type.set_default(ARSPD_DEFAULT_TYPE);
-    param[0].bus.set_default(HAL_AIRSPEED_BUS_DEFAULT);
-#ifndef HAL_BUILD_AP_PERIPH
-    param[0].pin.set_default(ARSPD_DEFAULT_PIN);
-#endif
 
     convert_per_instance();
 


### PR DESCRIPTION
A delay in defaults being set can result in getting the wrong params initially if the user is very quick connecting, so moving to constructor. Doesn't help with param conversion, but that only happens once. 

Reported by @tridge: https://discord.com/channels/674039678562861068/800819275069390920/1060053746119352320

https://github.com/ArduPilot/ardupilot/pull/22573