### PR TITLE
Tools: fix wsl2 check in sim_vehicle to match uploader.py

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -196,8 +196,8 @@ def under_vagrant():
 
 
 def under_wsl2():
-    from platform import uname
-    return 'microsoft-standard-WSL2' in uname().release
+    import platform
+    return 'microsoft-standard-WSL2' in platform.release()
 
 
 def wsl2_host_ip():


### PR DESCRIPTION
Changes sim_vehicle.py's WSL2 method to match [uploader.py's method](https://github.com/ArduPilot/ardupilot/blob/master/Tools/scripts/uploader.py#L75)

This will likely close https://github.com/ArduPilot/ardupilot/issues/22577