### PR TITLE
AP_Scripting:Add mission to Script_Controller and improve

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1330,17 +1330,12 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT(const ma
       any commands which use the x and y fields not as
       latitude/longitude.
      */
-    switch (packet.command) {
-    case MAV_CMD_DO_DIGICAM_CONTROL:
-    case MAV_CMD_DO_DIGICAM_CONFIGURE:
-    case MAV_CMD_NAV_ATTITUDE_TIME:
-    case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
+    if (!cmd_has_location(packet.command)) {
         mav_cmd.x = packet.x;
         mav_cmd.y = packet.y;
-        break;
 
-    default:
-        // all other commands use x and y as lat/lon. We need to
+    } else {
+         //these commands use x and y as lat/lon. We need to
         // multiply by 1e7 to convert to int32_t
         if (!check_lat(packet.x)) {
             return MAV_MISSION_INVALID_PARAM5_X;
@@ -1350,7 +1345,6 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT(const ma
         }
         mav_cmd.x = packet.x * 1.0e7f;
         mav_cmd.y = packet.y * 1.0e7f;
-        break;
     }
 
     return MAV_MISSION_ACCEPTED;
@@ -1373,17 +1367,12 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(const ma
     item.autocontinue = item_int.autocontinue;
     item.mission_type = item_int.mission_type;
 
-    switch (item_int.command) {
-    case MAV_CMD_DO_DIGICAM_CONTROL:
-    case MAV_CMD_DO_DIGICAM_CONFIGURE:
-    case MAV_CMD_NAV_ATTITUDE_TIME:
-    case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
+    if (!cmd_has_location(item_int.command)) {
         item.x = item_int.x;
         item.y = item_int.y;
-        break;
 
-    default:
-        // all other commands use x and y as lat/lon. We need to
+    } else {
+        // These commands use x and y as lat/lon. We need to
         // multiply by 1e-7 to convert to float
         item.x = item_int.x * 1.0e-7f;
         item.y = item_int.y * 1.0e-7f;
@@ -1393,7 +1382,6 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(const ma
         if (!check_lng(item.y)) {
             return MAV_MISSION_INVALID_PARAM6_Y;
         }
-        break;
     }
 
     return MAV_MISSION_ACCEPTED;
@@ -2515,6 +2503,15 @@ bool AP_Mission::contains_item(MAV_CMD command) const
         }
     }
     return false;
+}
+
+/*
+  return true if the mission item has a location
+*/
+
+bool AP_Mission::cmd_has_location(const uint16_t command)
+{
+    return stored_in_location(command);
 }
 
 /*

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -634,6 +634,9 @@ public:
 
     // returns true if the mission has a terrain relative mission item
     bool contains_terrain_alt_items(void);
+    
+    // returns true if the mission cmd has a location
+    static bool cmd_has_location(const uint16_t command);
 
     // reset the mission history to prevent recalling previous mission histories when restarting missions.
     void reset_wp_history(void);

--- a/libraries/AP_Scripting/applets/Script_Controller.lua
+++ b/libraries/AP_Scripting/applets/Script_Controller.lua
@@ -179,36 +179,54 @@ function mission_load(n)
   -- read each line and write to mission
   local item = mavlink_mission_item_int_t()
   local index = 0
-  while true do
-    local data = {}
-    for i = 1, 12 do
-      data[i] = file:read('n')
-      if data[i] == nil then
-        if i == 1 then
-          gcs:send_text(6, 'loaded mission: ' .. file_name)
-          return -- got to the end of the file
-        else
-          mission:clear() -- clear part loaded mission
-          error('failed to read file')
-        end
-      end
-    end
-    item:seq(data[1])
-    item:frame(data[3])
-    item:command(data[4])
-    item:param1(data[5])
-    item:param2(data[6])
-    item:param3(data[7])
-    item:param4(data[8])
-    item:x(data[9]*10^7)
-    item:y(data[10]*10^7)
-    item:z(data[11])
-    if not mission:set_item(index,item) then
-      mission:clear() -- clear part loaded mission
-      error(string.format('failed to set mission item %i',index))
-    end
-    index = index + 1
+  local fail = false
+  while true and not fail do
+     local data = {}
+     local line = file:read()
+     if not line then
+        break
+     end
+     local ret, _, seq, curr, frame, cmd, p1, p2, p3, p4, x, y, z, autocont = string.find(line, "^(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+(%d+)")
+     if not ret then
+        fail = true
+        break
+     end
+     if tonumber(seq) ~= index then
+        fail = true
+        break
+     end
+     item:seq(tonumber(seq))
+     item:frame(tonumber(frame))
+     item:command(tonumber(cmd))
+     item:param1(tonumber(p1))
+     item:param2(tonumber(p2))
+     item:param3(tonumber(p3))
+     item:param4(tonumber(p4))
+     if mission:cmd_has_location(tonumber(cmd)) then
+        item:x(math.floor(tonumber(x)*10^7))
+        item:y(math.floor(tonumber(y)*10^7))
+     else
+        item:x(math.floor(tonumber(x)))
+        item:y(math.floor(tonumber(y)))
+     end
+     item:z(tonumber(z))
+     if not mission:set_item(index,item) then
+        mission:clear() -- clear part loaded mission
+        fail = true
+        break
+     end
+     index = index + 1
   end
+  if fail then
+     mission:clear()  --clear anything already loaded
+     error(string.format('failed to load mission at seq num %u', index))
+  end
+  gcs:send_text(0, string.format("Loaded %u mission items", index))
+end
+
+function update()
+  read_mission('mission1.txt')
+  return
 end
 
 --[[

--- a/libraries/AP_Scripting/applets/Script_Controller.lua
+++ b/libraries/AP_Scripting/applets/Script_Controller.lua
@@ -4,8 +4,13 @@
 --]]
 
 local THIS_SCRIPT = "Script_Controller.lua"
-local SEL_CH = 302
+local sel_ch = Parameter("SCR_USER6")
+SEL_CH = sel_ch:get()
+if SEL_CH == 0 then
+   SEL_CH = 302
+end
 
+MISSION_FILENAME = "mission.txt"
 --[[
    check that directory exists
 --]]
@@ -157,6 +162,55 @@ function copy_scripts(subdir)
    return ret
 end
 
+ --[[ 
+   load a mission from a MISSION_FILENAME file in subdirectory n
+ --]]
+function mission_load(n)
+  file_name = get_scripts_dir() .. "/" .. n .."/" .. MISSION_FILENAME
+  -- Open file
+  file = io.open(file_name)
+  if not file then
+     return
+  end
+  -- check header
+  assert(string.find(file:read('l'),'QGC WPL 110') == 1, file_name .. ': incorrect format')
+  -- clear any existing mission
+  assert(mission:clear(), 'Could not clear current mission')
+  -- read each line and write to mission
+  local item = mavlink_mission_item_int_t()
+  local index = 0
+  while true do
+    local data = {}
+    for i = 1, 12 do
+      data[i] = file:read('n')
+      if data[i] == nil then
+        if i == 1 then
+          gcs:send_text(6, 'loaded mission: ' .. file_name)
+          return -- got to the end of the file
+        else
+          mission:clear() -- clear part loaded mission
+          error('failed to read file')
+        end
+      end
+    end
+    item:seq(data[1])
+    item:frame(data[3])
+    item:command(data[4])
+    item:param1(data[5])
+    item:param2(data[6])
+    item:param3(data[7])
+    item:param4(data[8])
+    item:x(data[9]*10^7)
+    item:y(data[10]*10^7)
+    item:z(data[11])
+    if not mission:set_item(index,item) then
+      mission:clear() -- clear part loaded mission
+      error(string.format('failed to set mission item %i',index))
+    end
+    index = index + 1
+  end
+end
+
 --[[
    activate a scripting subdirectory
 --]]
@@ -171,31 +225,33 @@ end
 local sw_last = -1
 function update()
    local sw_current = rc:get_aux_cached(SEL_CH)
-   if sw_current == sw_last then
+   if sw_current == sw_last or sw_current == nil then
       return update, 500
    end
-   if sw_current == 0 then 
-        subdir = 1
+   if sw_current == 1  then 
+        subdir = 2
       elseif sw_current == 2 then
         subdir = 3
       else
-        subdir = 2
+        subdir = 1  --default if RC not established yet
    end
    sw_last = sw_current
    if not check_subdir_exists(subdir) then
       gcs:send_text(0,string.format("Scripts subdirectory /%s does not exist!",subdir))
       return update, 500
    end
+
    changes_made = activate_subdir(subdir)
    if changes_made then
       scripting:restart_all()
    else
-      gcs:send_text(0, string.format("Script subbdirectory %s active", subdir))
+      mission_load(subdir)
+      gcs:send_text(0, string.format("Scripts subbdirectory %s active", subdir))
    end
    return update, 500
 end
 
-gcs:send_text(5,"Loaded Script_Controller.lua")
+gcs:send_text(6,"Loaded Script_Controller.lua")
 return update, 500
 
 

--- a/libraries/AP_Scripting/applets/Script_Controller.md
+++ b/libraries/AP_Scripting/applets/Script_Controller.md
@@ -1,16 +1,22 @@
 # Script Control LUA Script
 
-This script allows the user to have groups of scripts in three subdirectories of the main scripting directory and copy them into the main directory, removing any files in that directory with the .lua extension (except itself) and issue a scripting restart based on the position of a switch with the auxiliary function of "302". This provides  means to have differing scripting depending on the mission or conditions, and use whichever set is desired without having them consume memory all the time and without requiring a GCS to manage the content of the scripts directory. 
+This script allows the user to have groups of scripts in three subdirectories of the main scripting directory and copy them into the main scripts directory, removing any files in that directory with the .lua extension (except itself) and issue a scripting restart based on the position of a switch with a programmable auxiliary function option (default is "302", but can be changed by user during setup) or using Mission Planner's AUX Function tab. This provides means to have differing scripts depending on the mission or conditions, and use whichever set is desired without having them consume memory all the time, and without requiring a GCS to manage the content of the scripts directory. It also allows a new mission to be loaded associated with those new scripts, if desired.
+
+If the designated RC switch auxiliary option is not assigned to a RC channel via an RCx_OPTION, or the selected subdirectory does not exist, no action is taken, so the script can reside in the scripts directory even if not being used.
 
 # Setup and Operation
 
-The user must setup an RCx_OPTION to function 302 to determine which of the three scripts subdirectories will be used: LOW:scripts/1, MIDDLE:scripts/2, or HIGH:scripts/3. If no RC has been established during ground start, it will behave as if subdirectory 1 is selected. Changing this switch position either prior to ground start or after, will remove ALL the *.lua files in the scripts directory (except itself), and copy any *.lua files (only) from the desginated subdirectory, and then issue a scripting restart. 
+The auxiliary function option (300 - 307) that can be assigned to an RC channel and/or used by Mission Planner is set by the scripting parameter SCR_USER6. If not set (this param's default is "0") then function "302" is assigned automatically. Setting an RC channel's option to this value allows RC control of the scripting subdirectory that will be used for scripts (and optionally to load a mission file from within that subdirectory). Mission Planner can control switching also, or in place of the RC channel, using its AUX Function tab.
+
+The auxiliary function (default "302") is used to determine which of the three scripts subdirectories will be used: LOW:scripts/1, MIDDLE:scripts/2, or HIGH:scripts/3. If an RC channel option has been set to this,but no RC has been established during ground start, it will behave as if subdirectory 1 is selected. Changing this switch position either prior to ground start or after (or using Mission Planner), if the selected subdirectory exists, will remove ALL the *.lua files in the scripts directory (except itself), and copy any *.lua files (only) from the desginated subdirectory, load a new mission if a mission file named "mission.txt" exists in the subdirectory, and then issue a scripting restart. If the subdirectory does not exist, then no action is taken and a GCS message issued.
 
 # CAUTIONS
 
-If parameters are being created and used be sure that different scripts do not use the same PARAMETER KEY to create their param tables, unless you desire to use the same parameter set in two different scripts. Otherwise, param values will be corrupt when you change scripts.
-Be sure to have unique parameter names for different parameter sets. Names are only visible and used by Ground Control Stations. While indentically named params in different scripts will operate fine, you will not be able to distinguish them in the GCS displays!
+If parameters are being created by scripts be sure that different scripts do not use the same PARAMETER KEY to create their param tables, unless you desire to use the same parameter set in two different scripts. Otherwise, param values will be corrupt when you change scripts.
+Be sure to have unique parameter names for different parameter sets. This script does not create any parameters for potential conflict.
 
-Any .lua script in the scripts directory will be ERASED! when this script is run. In order to keep another .lua script running when using this script, place it in every subdirectory so that it will be copied over when changing directories.
+Parameter names are only visible and used by Ground Control Stations. While indentically named params in different scripts will operate fine, you will not be able to distinguish them in the GCS displays!
+
+Any .lua script in the scripts directory will be ERASED! when this script is run. In order to keep another .lua script running when using this script, place it in every subdirectory so that it will be copied into the main scripts directory whenever changing directories.
 
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1304,6 +1304,11 @@ function mission:get_current_nav_index() end
 ---@return integer
 function mission:state() end
 
+-- desc
+---@param cmd integer
+---@return boolean
+function mission:cmd_has_location(cmd)end
+
 
 -- desc
 ---@class param

--- a/libraries/AP_Scripting/examples/mission-load.lua
+++ b/libraries/AP_Scripting/examples/mission-load.lua
@@ -1,10 +1,12 @@
 -- Example of loading a mission from the SD card using Scripting
 -- Would be trivial to select a mission based on scripting params or RC switch
 
+
+
 local function read_mission(file_name)
 
   -- Open file
-  file = assert(io.open(file_name), 'Could open :' .. file_name)
+  file = assert(io.open(file_name), 'Could not open :' .. file_name)
 
   -- check header
   assert(string.find(file:read('l'),'QGC WPL 110') == 1, file_name .. ': incorrect format')
@@ -15,44 +17,53 @@ local function read_mission(file_name)
   -- read each line and write to mission
   local item = mavlink_mission_item_int_t()
   local index = 0
-  while true do
-
-    local data = {}
-    for i = 1, 12 do
-      data[i] = file:read('n')
-      if data[i] == nil then
-        if i == 1 then
-          gcs:send_text(6, 'loaded mission: ' .. file_name)
-          return -- got to the end of the file
-        else
-          mission:clear() -- clear part loaded mission
-          error('failed to read file')
-        end
-      end
-    end
-
-    item:seq(data[1])
-    item:frame(data[3])
-    item:command(data[4])
-    item:param1(data[5])
-    item:param2(data[6])
-    item:param3(data[7])
-    item:param4(data[8])
-    item:x(data[9]*10^7)
-    item:y(data[10]*10^7)
-    item:z(data[11])
-
-    if not mission:set_item(index,item) then
-      mission:clear() -- clear part loaded mission
-      error(string.format('failed to set mission item %i',index))
-    end
-    index = index + 1
+  local fail = false
+  while true and not fail do
+     local data = {}
+     local line = file:read()
+     if not line then
+        break
+     end
+     local ret, _, seq, curr, frame, cmd, p1, p2, p3, p4, x, y, z, autocont = string.find(line, "^(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+([-.%d]+)%s+(%d+)")
+     if not ret then
+        fail = true
+        break
+     end
+     if tonumber(seq) ~= index then
+        fail = true
+        break
+     end
+     item:seq(tonumber(seq))
+     item:frame(tonumber(frame))
+     item:command(tonumber(cmd))
+     item:param1(tonumber(p1))
+     item:param2(tonumber(p2))
+     item:param3(tonumber(p3))
+     item:param4(tonumber(p4))
+     if mission:cmd_has_location(tonumber(cmd)) then
+        item:x(math.floor(tonumber(x)*10^7))
+        item:y(math.floor(tonumber(y)*10^7))
+     else
+        item:x(math.floor(tonumber(x)))
+        item:y(math.floor(tonumber(y)))
+     end
+     item:z(tonumber(z))
+     if not mission:set_item(index,item) then
+        mission:clear() -- clear part loaded mission
+        fail = true
+        break
+     end
+     index = index + 1
   end
-
+  if fail then
+     mission:clear()  --clear anything already loaded
+     error(string.format('failed to load mission at seq num %u', index))
+  end
+  gcs:send_text(0, string.format("Loaded %u mission items", index))
 end
 
 function update()
-  read_mission('Tools/autotest/Generic_Missions/CMAC-bigloop.txt')
+  read_mission('mission1.txt')
   return
 end
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -374,6 +374,7 @@ singleton AP_Mission method num_commands uint16_t
 singleton AP_Mission method get_item boolean uint16_t'skip_check mavlink_mission_item_int_t'Null
 singleton AP_Mission method set_item boolean uint16_t'skip_check mavlink_mission_item_int_t
 singleton AP_Mission method clear boolean
+singleton AP_Mission method cmd_has_location boolean uint16_t'skip_check
 
 userdata mavlink_mission_item_int_t field param1 float'skip_check read write
 userdata mavlink_mission_item_int_t field param2 float'skip_check read write


### PR DESCRIPTION
replaces #22582 

-adds optional mission file load on scripts switching..can also be used as a mission switcher by itself, if desired
-adds ability to select which aux function (301-307) is used for switching
-no RC channel need be set,ie use GCS only
-if no RC channel set, nothing occurs on restart or boot....script can be active always if desired with no impact if GCS switching is not used or subdirectories not setup
-minimally verbose

@timtuxworth you might be interested in this