### PR TITLE
Make AP_Param::check_var_info void (die-early, die-often)

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1316,11 +1316,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Copter::load_parameters(void)
 {
-    if (!AP_Param::check_var_info()) {
-        DEV_PRINTF("Bad var table\n");
-        AP_HAL::panic("Bad var table");
-    }
-
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1350,10 +1350,6 @@ static const RCConversionInfo rc_option_conversion[] = {
 
 void Plane::load_parameters(void)
 {
-    if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad parameter table\n");
-        AP_HAL::panic("Bad parameter table");
-    }
     if (!g.format_version.load() ||
         g.format_version != Parameters::k_format_version) {
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -674,11 +674,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Sub::load_parameters()
 {
-    if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad var table\n");
-        AP_HAL::panic("Bad var table");
-    }
-
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -832,11 +832,6 @@ ParametersG2::ParametersG2(void)
 
 void Blimp::load_parameters(void)
 {
-    if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad var table\n");
-        AP_HAL::panic("Bad var table");
-    }
-
     hal.util->set_soft_armed(false);
 
     if (!g.format_version.load() ||

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -803,11 +803,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Rover::load_parameters(void)
 {
-    if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad var table\n");
-        AP_HAL::panic("Bad var table");
-    }
-
     if (!g.format_version.load() ||
          g.format_version != Parameters::k_format_version) {
         // erase all parameters

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -532,10 +532,8 @@ void AP_Periph_FW::load_parameters(void)
 {
     AP_Param::setup_sketch_defaults();
 
-    if (!AP_Param::check_var_info()) {
-        hal.console->printf("Bad parameter table\n");
-        AP_HAL::panic("Bad parameter table");
-    }
+    AP_Param::check_var_info();
+
     if (!g.format_version.load() ||
         g.format_version != Parameters::k_format_version) {
         // erase all parameters

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -90,9 +90,8 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
 
 void ReplayVehicle::load_parameters(void)
 {
-    if (!AP_Param::check_var_info()) {
-        AP_HAL::panic("Bad parameter table");
-    }
+    AP_Param::check_var_info();
+
     StorageManager::erase();
     AP_Param::erase_all();
     // Load all auto-loaded EEPROM variables - also registers thread

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -493,7 +493,7 @@ public:
     float                   cast_to_float(enum ap_var_type type) const;
 
     // check var table for consistency
-    static bool             check_var_info(void);
+    static void             check_var_info(void);
 
     // return true if the parameter is configured
     bool configured(void) const;
@@ -617,7 +617,7 @@ private:
 #endif
 
 
-    static bool                 check_group_info(const struct GroupInfo *group_info, uint16_t *total_size, 
+    static void                 check_group_info(const struct GroupInfo *group_info, uint16_t *total_size, 
                                                  uint8_t max_bits, uint8_t prefix_length);
     static bool                 duplicate_key(uint16_t vindex, uint16_t key);
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -145,6 +145,9 @@ void AP_Vehicle::setup()
     check_firmware_print();
 #endif
 
+    // validate the static parameter table, then load persistent
+    // values from storage:
+    AP_Param::check_var_info();
     load_parameters();
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS


### PR DESCRIPTION
Every caller to this method dies if it returns false.  By that time we've lost a lot of information about what's going on, especially if you've got a debugger attached.

I created this PR in frustration after enabling debug caused the autopilot to hard-fault rather than panic!  The reason there was that the Debug statement was referencing a bad pointer value - that hasn't changed, but at least without debug your panic will be in the right place!

All this code does is makes it panic earlier rather than later.

Without debug enabled we save a small amount of flash.
```
Board              AP_Periph  blimp  copter  heli  plane  rover  sub
Durandal                      -16    -24     -16   -32    -24    -24
Hitec-Airspeed     -56                                           
KakuteH7-bdshot               -32    -40     -40   -64    -32    -40
MatekF405                     -32    -32     -40   -48    -32    -32
Pixhawk1-1M                   -32    -32     -32   -48    -40    -32
f103-QiotekPeriph  -56                                           
f303-Universal     -56                                           
revo-mini                     -32    -40     -32   -48    -32    -32
skyviper-v2450                       -40                         
```

Tested on CubeOrange.
