### PR TITLE
AP_Bootloader: sync ArduPilot and PX4 boards.txt

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -11,6 +11,7 @@ TARGET_HW_PX4_FMU_V5                   50
 TARGET_HW_PX4_FMU_V5X                  51
 TARGET_HW_PX4_FMU_V6                   52
 TARGET_HW_PX4_FMU_V6X                  53
+TARGET_HW_ARK_FMU_V6X                  57
 TARGET_HW_MINDPX_V2                    88
 TARGET_HW_PX4_FLOW_V1                   6
 TARGET_HW_PX4_DISCOVERY_V1             99
@@ -32,6 +33,7 @@ TARGET_HW_SMARTAP_AIRLINK              55
 TARGET_HW_SMARTAP_PRO                  32
 TARGET_HW_MODALAI_FC_V1             41775
 TARGET_HW_MODALAI_FC_V2             41776
+TARGET_HW_MODALAI_VOXL2_IO          41777
 TARGET_HW_HOLYBRO_PIX32_V5             78
 TARGET_HW_HOLYBRO_CAN_GPS              79
 TARGET_HW_FMUK66_V3                    28
@@ -41,9 +43,10 @@ TARGET_HW_FMURT1062-V1                 31
 TARGET_HW_ARK_CAN_FLOW                 80
 TARGET_HW_ARK_CAN_GPS                  81
 TARGET_HW_ARK_CAN_RTK_GPS              82
+TARGET_HW_ARK_CANNODE                  83
 TARGET_HW_FF_RTK_CAN_GPS               85
+TARGET_HW_PDW_MAS_MAIN-V1              86
 TARGET_HW_ATL_MANTIS_EDU               97
-TARGET_HW_ARK_FMU_V6X                  57
 TARGET_HW_THE_PEACH_K1                212
 TARGET_HW_THE_PEACH_R1                213
 
@@ -52,7 +55,9 @@ Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52
 Reserved "PX4 [BL] FMU v6X.x"          53
 Reserved "PX4 [BL] FMU v6C.x"          56
- 
+
+Reserved "ARK [BL] FMU v6X.x"          57
+
 Reserved "GUMSTIX [BL] FMU v6"         54
 Reserved "ARK CAN FLOW"                80
 Reserved "NXP ucans32k146"             34
@@ -71,6 +76,7 @@ EXT_HW_RADIOLINK_MINI_PIX               3
 # https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader
 # the values come from the APJ_BOARD_ID in the hwdef files here:
 # https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_ChibiOS/hwdef
+
 AP_HW_CUBEYELLOW                      120
 AP_HW_OMNIBUSF7V2                     121
 AP_HW_KAKUTEF4                        122
@@ -200,4 +206,3 @@ AP_HW_SWBOOMBOARD_PERIPH             1403
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140
 AP_HW_Pixhawk6_ODID                 10053
-


### PR DESCRIPTION
This PR aligns boards.txt between ArduPilot and PX4. A matching PR will be submitted to the other repo, so that the contexts of boards.txt matches exactly (at the time of drafting).
