### PR TITLE
param_parse.py: emit SIM_ parameters along with everthing else

### DIFF
--- a/Tools/autotest/param_metadata/emit.py
+++ b/Tools/autotest/param_metadata/emit.py
@@ -6,8 +6,8 @@ import re
 
 
 class Emit:
-    def __init__(self, sitl=False):
-        self.sitl = sitl
+    def __init__(self):
+        pass
 
     prog_values_field = re.compile(r"-?\d*\.?\d+: ?[\w ]+,?")
 

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -37,11 +37,6 @@ parser.add_argument("--format",
                     default='all',
                     choices=['all', 'html', 'rst', 'rstlatexpdf', 'wiki', 'xml', 'json', 'edn', 'md', 'xml_mp'],
                     help="what output format to use")
-parser.add_argument("--sitl",
-                    dest='emit_sitl',
-                    action='store_true',
-                    default=False,
-                    help="true to only emit sitl parameters, false to not emit sitl parameters")
 
 args = parser.parse_args()
 
@@ -163,8 +158,7 @@ def process_vehicle(vehicle):
             libraries.append(lib)
 
     param_matches = []
-    if not args.emit_sitl:
-        param_matches = prog_param.findall(p_text)
+    param_matches = prog_param.findall(p_text)
 
     for param_match in param_matches:
         (only_vehicles, param_name, field_text) = (param_match[0],
@@ -212,11 +206,6 @@ def process_vehicle(vehicle):
 process_vehicle(vehicle)
 
 debug("Found %u documented libraries" % len(libraries))
-
-if args.emit_sitl:
-    libraries = filter(lambda x : x.name == 'SIM_', libraries)
-else:
-    libraries = filter(lambda x : x.name != 'SIM_', libraries)
 
 libraries = list(libraries)
 
@@ -293,7 +282,7 @@ def process_library(vehicle, library, pathprefix=None):
             seen_values_or_bitmask_for_other_vehicle = False
             for field in fields:
                 only_for_vehicles = field[1].split(",")
-                only_for_vehicles = [x.rstrip().lstrip() for x in only_for_vehicles]
+                only_for_vehicles = [some_vehicle.rstrip().lstrip() for some_vehicle in only_for_vehicles]
                 delta = set(only_for_vehicles) - set(truename_map.values())
                 if len(delta):
                     error("Unknown vehicles (%s)" % delta)
@@ -593,16 +582,11 @@ for emitter_name in all_emitters.keys():
     if args.output_format == 'all' or args.output_format == emitter_name:
         emitters_to_use.append(emitter_name)
 
-if args.emit_sitl:
-    # only generate rst for SITL for now:
-    emitters_to_use = ['rst']
-
 # actually invoke each emitter:
 for emitter_name in emitters_to_use:
-    emit = all_emitters[emitter_name](sitl=args.emit_sitl)
+    emit = all_emitters[emitter_name]()
 
-    if not args.emit_sitl:
-        emit.emit(vehicle)
+    emit.emit(vehicle)
 
     emit.start_libraries()
 

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -28,6 +28,7 @@ This list is automatically generated from the latest ardupilot source code, and 
         self.f = open(self.output_fname(), mode='w')
         self.spacer = re.compile("^", re.MULTILINE)
         self.rstescape = re.compile("([^a-zA-Z0-9\n 	])")
+        self.emitted_sitl_heading = False
         parameterlisttype = "Complete Parameter List"
         parameterlisttype += "\n" + "=" * len(parameterlisttype)
         self.preamble = """.. Dynamically generated list of documented parameters
@@ -191,8 +192,17 @@ This list is automatically generated from the latest ardupilot source code, and 
         return ''
 
     def emit(self, g):
-        tag = '%s Parameters' % self.escape(g.reference)
-        reference = "parameters_" + g.reference
+        # make only a single group for SIM_ parameters
+        do_emit_heading = True
+        if g.reference.startswith("SIM_"):
+            if self.emitted_sitl_heading:
+                do_emit_heading = False
+            self.emitted_sitl_heading = True
+            tag = "Simulation Parameters"
+            reference = "parameters_sim"
+        else:
+            tag = '%s Parameters' % self.escape(g.reference)
+            reference = "parameters_" + g.reference
 
         field_table_info = {
             "Values": {
@@ -203,7 +213,9 @@ This list is automatically generated from the latest ardupilot source code, and 
             },
         }
 
-        ret = """
+        ret = ""
+        if do_emit_heading:
+            ret = """
 
 .. _{reference}:
 

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -12,8 +12,6 @@ except Exception:
 # Emit docs in a RST format
 class RSTEmit(Emit):
     def blurb(self):
-        if self.sitl:
-            return """SITL parameters"""
         return """This is a complete list of the parameters which can be set (e.g. via the MAVLink protocol) to control vehicle behaviour. They are stored in persistent storage on the vehicle.
 
 This list is automatically generated from the latest ardupilot source code, and so may contain parameters which are not yet in the stable released versions of the code.
@@ -30,10 +28,7 @@ This list is automatically generated from the latest ardupilot source code, and 
         self.f = open(self.output_fname(), mode='w')
         self.spacer = re.compile("^", re.MULTILINE)
         self.rstescape = re.compile("([^a-zA-Z0-9\n 	])")
-        if self.sitl:
-            parameterlisttype = "SITL Parameter List"
-        else:
-            parameterlisttype = "Complete Parameter List"
+        parameterlisttype = "Complete Parameter List"
         parameterlisttype += "\n" + "=" * len(parameterlisttype)
         self.preamble = """.. Dynamically generated list of documented parameters
 .. This page was generated using {toolname}


### PR DESCRIPTION
This starts to emit the `SIM_` parameters along with all of the other parameters.

We will need to make sure it's clear in the Wiki that these are simulation parameters (somehow...).

MissionPlanner should start to display these when the vehicle actually has the parameter (in its simulation), which will be cool.

Current XML diff:
```
--- apm.pdef.xml-master	2023-01-07 12:01:30.994715169 +1100
+++ apm.pdef.xml	2023-01-07 12:31:37.822057604 +1100
@@ -23078,6 +23078,154 @@
         <field name="UnitText">seconds</field>
       </param>
     </parameters>
+    <parameters name="SIM_">
+      <param humanName="Baro Noise" name="SIM_BARO_RND" documentation="Amount of (evenly-distributed) noise injected into the 1st baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Baro Glitch" name="SIM_BARO_GLITCH" documentation="Glitch for 1st baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Baro2 Noise" name="SIM_BAR2_RND" documentation="Amount of (evenly-distributed) noise injected into the 2nd baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Baro2 Glitch" name="SIM_BAR2_GLITCH" documentation="Glitch for 2nd baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Baro3 Noise" name="SIM_BAR3_RND" documentation="Amount of (evenly-distributed) noise injected into the 3rd baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Baro3 Glitch" name="SIM_BAR3_GLITCH" documentation="Glitch for 2nd baro" user="Advanced">
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Sailboat simulation sail type" name="SIM_SAIL_TYPE" documentation="0: mainsail with sheet, 1: directly actuated wing">
+</param>
+      <param humanName="JSON master instance" name="SIM_JSON_MASTER" documentation="the instance number to  take servos from">
+</param>
+      <param humanName="SIM-on_hardware Output Enable Mask" name="SIM_OH_MASK" documentation="channels which are passed through to actual hardware when running on actual hardware">
+</param>
+    </parameters>
+    <parameters name="SIM_GRPE_">
+      <param humanName="Gripper servo Sim enable/disable" name="SIM_GRPE_ENABLE" documentation="Allows you to enable (1) or disable (0) the gripper servo simulation" user="Advanced">
+        <values>
+          <value code="0">Disabled</value>
+          <value code="1">Enabled</value>
+        </values>
+      </param>
+      <param humanName="Gripper emp pin" name="SIM_GRPE_PIN" documentation="The pin number that the gripper emp is connected to. (start at 1)" user="Advanced">
+        <field name="Range">0 15</field>
+      </param>
+    </parameters>
+    <parameters name="SIM_GRPS_">
+      <param humanName="Gripper servo Sim enable/disable" name="SIM_GRPS_ENABLE" documentation="Allows you to enable (1) or disable (0) the gripper servo simulation" user="Advanced">
+        <values>
+          <value code="0">Disabled</value>
+          <value code="1">Enabled</value>
+        </values>
+      </param>
+      <param humanName="Gripper servo pin" name="SIM_GRPS_PIN" documentation="The pin number that the gripper servo is connected to. (start at 1)" user="Advanced">
+        <field name="Range">0 15</field>
+      </param>
+      <param humanName="Gripper Grab PWM" name="SIM_GRPS_GRAB" documentation="PWM value in microseconds sent to Gripper to initiate grabbing the cargo" user="Advanced">
+        <field name="Range">1000 2000</field>
+        <field name="Units">PWM</field>
+        <field name="UnitText">PWM in microseconds</field>
+      </param>
+      <param humanName="Gripper Release PWM" name="SIM_GRPS_RELEASE" documentation="PWM value in microseconds sent to Gripper to release the cargo" user="Advanced">
+        <field name="Range">1000 2000</field>
+        <field name="Units">PWM</field>
+        <field name="UnitText">PWM in microseconds</field>
+      </param>
+      <param humanName="Gripper close direction" name="SIM_GRPS_REVERSE" documentation="Reverse the closing direction." user="Advanced">
+        <values>
+          <value code="0">Normal</value>
+          <value code="1">Reverse</value>
+        </values>
+      </param>
+    </parameters>
+    <parameters name="SIM_PLD_">
+      <param humanName="Preland device Sim enable/disable" name="SIM_PLD_ENABLE" documentation="Allows you to enable (1) or disable (0) the Preland simulation" user="Advanced">
+        <values>
+          <value code="0">Disabled</value>
+          <value code="1">Enabled</value>
+        </values>
+      </param>
+      <param humanName="Precland device center's latitude" name="SIM_PLD_LAT" documentation="Precland device center's latitude" user="Advanced">
+        <field name="Range">-90 90</field>
+        <field name="Increment">0.000001</field>
+        <field name="Units">deg</field>
+        <field name="UnitText">degrees</field>
+      </param>
+      <param humanName="Precland device center's longitude" name="SIM_PLD_LON" documentation="Precland device center's longitude" user="Advanced">
+        <field name="Range">-180 180</field>
+        <field name="Increment">0.000001</field>
+        <field name="Units">deg</field>
+        <field name="UnitText">degrees</field>
+      </param>
+      <param humanName="Precland device center's height above sealevel" name="SIM_PLD_HEIGHT" documentation="Precland device center's height above sealevel assume a 2x2m square as station base" user="Advanced">
+        <field name="Range">0 10000</field>
+        <field name="Increment">1</field>
+        <field name="Units">cm</field>
+        <field name="UnitText">centimeters</field>
+      </param>
+      <param humanName="Precland device systems rotation from north" name="SIM_PLD_YAW" documentation="Precland device systems rotation from north" user="Advanced">
+        <field name="Range">-180 +180</field>
+        <field name="Increment">1</field>
+        <field name="Units">deg</field>
+        <field name="UnitText">degrees</field>
+      </param>
+      <param humanName="Precland device update rate" name="SIM_PLD_RATE" documentation="Precland device rate. e.g led patter refresh rate, RF message rate, etc." user="Advanced">
+        <field name="Range">0 200</field>
+        <field name="Units">Hz</field>
+        <field name="UnitText">hertz</field>
+      </param>
+      <param humanName="Precland device radiance type" name="SIM_PLD_TYPE" documentation="Precland device radiance type: it can be a cylinder, a cone, or a sphere." user="Advanced">
+        <values>
+          <value code="0">cylinder</value>
+          <value code="1">cone</value>
+          <value code="2">sphere</value>
+        </values>
+      </param>
+      <param humanName="Precland device alt range" name="SIM_PLD_ALT_LIMIT" documentation="Precland device maximum range altitude" user="Advanced">
+        <field name="Range">0 100</field>
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Precland device lateral range" name="SIM_PLD_DIST_LIMIT" documentation="Precland device maximum lateral range" user="Advanced">
+        <field name="Range">5 100</field>
+        <field name="Units">m</field>
+        <field name="UnitText">meters</field>
+      </param>
+      <param humanName="Precland device orientation" name="SIM_PLD_ORIENT" documentation="Precland device orientation vector" user="Advanced">
+        <values>
+          <value code="0">Front</value>
+          <value code="4">Back</value>
+          <value code="24">Up</value>
+        </values>
+      </param>
+      <param humanName="SIM_Precland extra options" name="SIM_PLD_OPTIONS" documentation="SIM_Precland extra options" user="Advanced">
+        <field name="Bitmask">0: Enable target distance</field>
+      </param>
+    </parameters>
+    <parameters name="SIM_SPR_">
+      <param humanName="Sprayer Sim enable/disable" name="SIM_SPR_ENABLE" documentation="Allows you to enable (1) or disable (0) the Sprayer simulation" user="Advanced">
+        <values>
+          <value code="0">Disabled</value>
+          <value code="1">Enabled</value>
+        </values>
+      </param>
+      <param humanName="Sprayer pump pin" name="SIM_SPR_PUMP" documentation="The pin number that the Sprayer pump is connected to. (start at 1)" user="Advanced">
+        <field name="Range">0 15</field>
+      </param>
+      <param humanName="Sprayer spinner servo pin" name="SIM_SPR_SPIN" documentation="The pin number that the Sprayer spinner servo is connected to. (start at 1)" user="Advanced">
+        <field name="Range">0 15</field>
+      </param>
+    </parameters>
     <parameters name="SPRAY_">
       <param humanName="Sprayer enable/disable" name="SPRAY_ENABLE" documentation="Allows you to enable (1) or disable (0) the sprayer" user="Standard">
         <values>
```
