### PR TITLE
Copter: fix yaw feed-forward rate sent to gimbal

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -761,10 +761,15 @@ bool Copter::get_wp_crosstrack_error_m(float &xtrack_error) const
     return true;
 }
 
-// get the target body-frame angular velocities in rad/s (Z-axis component used by some gimbals)
-bool Copter::get_rate_bf_targets(Vector3f& rate_bf_targets) const
+// get the target earth-frame angular velocities in rad/s (Z-axis component used by some gimbals)
+bool Copter::get_rate_ef_targets(Vector3f& rate_ef_targets) const
 {
-    rate_bf_targets = attitude_control->rate_bf_targets();
+    // always returns zero vector if landed or disarmed
+    if (copter.ap.land_complete) {
+        rate_ef_targets.zero();
+    } else {
+        rate_ef_targets = attitude_control->get_rate_ef_targets();
+    }
     return true;
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -691,7 +691,7 @@ private:
     bool get_wp_distance_m(float &distance) const override;
     bool get_wp_bearing_deg(float &bearing) const override;
     bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
-    bool get_rate_bf_targets(Vector3f& rate_bf_targets) const override;
+    bool get_rate_ef_targets(Vector3f& rate_ef_targets) const override;
 
     // Attitude.cpp
     void update_throttle_hover();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -272,6 +272,9 @@ public:
     // Return angular velocity in radians used in the angular velocity controller
     Vector3f rate_bf_targets() const { return _ang_vel_body + _sysid_ang_vel_body; }
 
+    // return the angular velocity of the target (setpoint) attitude rad/s
+    const Vector3f& get_rate_ef_targets() const { return _euler_rate_target; }
+
     // Enable or disable body-frame feed forward
     void bf_feedforward(bool enable_or_disable) { _rate_bf_ff_enabled.set(enable_or_disable); }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -244,9 +244,9 @@ public:
     virtual void get_osd_roll_pitch_rad(float &roll, float &pitch) const;
 
     /*
-     get the target body-frame angular velocities in rad/s (Z-axis component used by some gimbals)
+     get the target earth-frame angular velocities in rad/s (Z-axis component used by some gimbals)
      */
-    virtual bool get_rate_bf_targets(Vector3f& rate_bf_targets) const { return false; }
+    virtual bool get_rate_ef_targets(Vector3f& rate_ef_targets) const { return false; }
 
 protected:
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5359,11 +5359,11 @@ void GCS_MAVLINK::send_autopilot_state_for_gimbal_device() const
         vel.zero();
     }
 
-    // get vehicle body-frame rotation rate targets
-    Vector3f rate_bf_targets;
+    // get vehicle earth-frame rotation rate targets
+    Vector3f rate_ef_targets;
     const AP_Vehicle *vehicle = AP::vehicle();
     if (vehicle != nullptr) {
-        vehicle->get_rate_bf_targets(rate_bf_targets);
+        vehicle->get_rate_ef_targets(rate_ef_targets);
     }
 
     // get estimator flags
@@ -5384,7 +5384,7 @@ void GCS_MAVLINK::send_autopilot_state_for_gimbal_device() const
         vel.y,  // y speed in NED (m/s)
         vel.z,  // z speed in NED (m/s)
         0,      // velocity estimated delay in micros
-        rate_bf_targets.z,// feed forward angular velocity z
+        rate_ef_targets.z,  // feed forward angular velocity z
         est_status_flags,   // estimator status
         0);     // landed_state (see MAV_LANDED_STATE)
 }


### PR DESCRIPTION
This corrects two issues reported with the AUTOPILOT_STATE_FOR_GIMBAL_DEVICE messages sent to our mavlink enabled gimbals (e.g. Gremsy, SToRM32)

- Earth frame rate targets sent instead of the actual body-frame rate (see https://github.com/ArduPilot/ardupilot/issues/22564)
- Zero (0) is sent when the vehicle is landed or disarmed (when disarmed the landed state is always true)

This only affects Copter because it is the only vehicle to override the state sent.  We should eventually extend this to Plane, Rover, etc but this is an existing issue that need not be handled in this PR.

This has been tested in SITL and below are before vs after screens shots of the rates sent.  These rates were generated using a custom debug logging message.
![gimbal-rate-ff-before](https://user-images.githubusercontent.com/1498098/211130466-9e31344a-25d9-49f3-8dc4-bb85d3af4ad9.png)
![gimbal-rate-ff-after](https://user-images.githubusercontent.com/1498098/211130469-d9a9324f-e705-4537-a943-676895813f18.png)
