### PR TITLE
Tools: Update ardupilot_gazebo install script

### DIFF
--- a/Tools/environment_install/install-ROS-ubuntu.sh
+++ b/Tools/environment_install/install-ROS-ubuntu.sh
@@ -4,7 +4,7 @@ set -e
 # set -x
 
 ROS_WS_ROOT=$HOME/ardupilot-ws
-AP_GZ_ROOT=$HOME/ardupilot_gazebo
+AP_GZ_ROOT=$HOME/ardupilot_gz_ws
 
 red=`tput setaf 1`
 green=`tput setaf 2`
@@ -231,6 +231,7 @@ if maybe_prompt_user "Add ardupilot-ws to your home folder [N/y]?" ; then
     if [ ! -d $ROS_WS_ROOT ]; then
         mkdir -p $ROS_WS_ROOT/src
         pushd $ROS_WS_ROOT
+        source /opt/ros/${ROS_VERSION}/setup.bash
         catkin init
         pushd src
         git clone https://github.com/ArduPilot/ardupilot_ros.git
@@ -250,16 +251,19 @@ fi
 
 if maybe_prompt_user "Add ardupilot_gazebo to your home folder [N/y]?" ; then
     if [ ! -d $AP_GZ_ROOT ]; then
-        sudo apt install libgz-sim7-dev rapidjson-dev
+        sudo apt install gz-garden rapidjson-dev
+        mkdir -p $AP_GZ_ROOT/src
+        pushd $AP_GZ_ROOT/src
         git clone https://github.com/ArduPilot/ardupilot_gazebo
-        pushd $AP_GZ_ROOT
+        pushd ardupilot_gazebo
         mkdir build && pushd build
         cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
         make -j4
         popd
         popd
-        echo 'export GZ_SIM_SYSTEM_PLUGIN_PATH=$AP_GZ_ROOT/build:${GZ_SIM_SYSTEM_PLUGIN_PATH}' >> ~/.bashrc
-        echo 'export GZ_SIM_RESOURCE_PATH=$AP_GZ_ROOT/models:$AP_GZ_ROOT/worlds:${GZ_SIM_RESOURCE_PATH}' >> ~/.bashrc
+        popd
+        echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=${AP_GZ_ROOT}/src/ardupilot_gazebo/build:${GZ_SIM_SYSTEM_PLUGIN_PATH}" >> ~/.bashrc
+        echo "export GZ_SIM_RESOURCE_PATH=${AP_GZ_ROOT}/src/ardupilot_gazebo/models:${AP_GZ_ROOT}/src/ardupilot_gazebo/worlds:${GZ_SIM_RESOURCE_PATH}" >> ~/.bashrc
     else
         heading "${red}ardupilot_gazebo already exists, skipping...${reset}"
     fi


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/22598

- Update prerequisites
- Update workspace and build order.
- Update GZ envs.

**Host**: macOS Monterey 12.6, Intel Mac Pro
**System**: Ubuntu Focal 20.04.5 LTS on VMware Fusion 13.0


### Testing

1. Run script for package `ros-base`

```bash
./install-ROS-ubuntu.sh -p ros-base
```

2. Check env variables correctly set in .bashrc

```bash
$tail ~/.bashrc

#---------------------------------------------------------
# ArduPilot
export  PATH=$PATH:$HOME/Code/ardupilot/ardupilot/Tools/autotest

source /home/rhys/ardupilot-ws/devel/setup.bash
export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/rhys/ardupilot_gz_ws/src/ardupilot_gazebo/build:
export GZ_SIM_RESOURCE_PATH=/home/rhys/ardupilot_gz_ws/src/ardupilot_gazebo/models:/home/rhys/ardupilot_gz_ws/src/ardupilot_gazebo/worlds:
```

3. Run the Iris example (in new terminal)

```bash
gz sim -v4 -r --render-engine=ogre iris_runway.sdf
```

(need to use ogre rather than ogre2 if rendering on a 20.04 VM).

