### PR TITLE
waf: add -fcheck-new to g++ build

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -249,6 +249,9 @@ class Board:
                 env.CXXFLAGS += [
                     '-Werror=implicit-fallthrough',
                 ]
+            env.CXXFLAGS += [
+                '-fcheck-new',
+            ]
 
         if cfg.env.DEBUG:
             env.CFLAGS += [


### PR DESCRIPTION
this ensures the compiler doesn't assume that new always returns a non-NULL value. Without this the compiler may remove the error path in code like this:

```
MyObject *x = new MyObject;
if (x == nullptr) {
  ::printf("Alloc failed\n");
}
```

the reason it can do this is the new operator is marked as throwing an exception on failure, which means the error path is unreachable. As we don't have C++ exceptions in ArduPilot could (and does!) have code that ends up losing protection against allocation failures

@andyp1per I believe this is possible the cause of your PixracerPro errors

an example of the impact of this is here:
```
void AP_RollController::autotune_start(void)
{
    if (autotune == nullptr) {
        autotune = new AP_AutoTune(gains, AP_AutoTune::AUTOTUNE_ROLL, aparm, rate_pid);
        if (autotune == nullptr) {
            if (!failed_autotune_alloc) {
                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AutoTune: failed roll allocation");
            }
            failed_autotune_alloc = true;
        }
    }
    if (autotune != nullptr) {
        autotune->start();
    }
}
```
the compiler was removing the nullptr check, and would run autotune->start() on a nullptr if we ran out of memory. The "AutoTune: failed roll allocation" string does not appear anywhere in the binary without this PR. The compiler thought it could remove the nullptr check as it assumed that if new failed then an exception would be raised, so it wouldn't get to that line.
A test on a H7 that has been deliberately run low on memory was done, then fixed wing auto-tune was started. The board did a null ptr dereference

