### PR TITLE
AP_NavEKF3: remove mag_state state

### DIFF
--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -171,6 +171,6 @@ public:
         }
     }
 
-private:
+protected:
     T _v[N];
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -341,7 +341,6 @@ void NavEKF2_core::FuseMagnetometer()
     Vector6 SK_MY;
     Vector6 SK_MZ;
 
-    // copy required states to local variable names
     q0       = stateStruct.quat[0];
     q1       = stateStruct.quat[1];
     q2       = stateStruct.quat[2];

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -689,8 +689,8 @@ void NavEKF3_core::checkGyroCalStatus(void)
         (yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV)) {
         // rotate the variances into earth frame and evaluate horizontal terms only as yaw component is poorly observable without a yaw reference
         // which can make this check fail
-        Vector3F delAngBiasVarVec = Vector3F(P[10][10],P[11][11],P[12][12]);
-        Vector3F temp = prevTnb * delAngBiasVarVec;
+        const Vector3F delAngBiasVarVec { P[10][10], P[11][11], P[12][12] };
+        const Vector3F temp = prevTnb * delAngBiasVarVec;
         delAngBiasLearned = (fabsF(temp.x) < delAngBiasVarMax) &&
                             (fabsF(temp.y) < delAngBiasVarMax);
     } else {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -443,11 +443,6 @@ void NavEKF3_core::SelectMagFusion()
 */
 void NavEKF3_core::FuseMagnetometer()
 {
-    Vector24 H_MAG;
-    Vector5 SK_MX;
-    Vector5 SK_MY;
-    Vector5 SK_MZ;
-
     // perform sequential fusion of magnetometer measurements.
     // this assumes that the errors in the different components are
     // uncorrelated which is not true, however in the absence of covariance
@@ -470,41 +465,42 @@ void NavEKF3_core::FuseMagnetometer()
 
     // rotate predicted earth components into body axes and calculate
     // predicted measurements
-    Matrix3F DCM;
-    DCM[0][0] = q0*q0 + q1*q1 - q2*q2 - q3*q3;
-    DCM[0][1] = 2.0f*(q1*q2 + q0*q3);
-    DCM[0][2] = 2.0f*(q1*q3-q0*q2);
-    DCM[1][0] = 2.0f*(q1*q2 - q0*q3);
-    DCM[1][1] = q0*q0 - q1*q1 + q2*q2 - q3*q3;
-    DCM[1][2] = 2.0f*(q2*q3 + q0*q1);
-    DCM[2][0] = 2.0f*(q1*q3 + q0*q2);
-    DCM[2][1] = 2.0f*(q2*q3 - q0*q1);
-    DCM[2][2] = q0*q0 - q1*q1 - q2*q2 + q3*q3;
+    const Matrix3F DCM {
+        q0*q0 + q1*q1 - q2*q2 - q3*q3,
+        2.0f*(q1*q2 + q0*q3),
+        2.0f*(q1*q3-q0*q2),
+        2.0f*(q1*q2 - q0*q3),
+        q0*q0 - q1*q1 + q2*q2 - q3*q3,
+        2.0f*(q2*q3 + q0*q1),
+        2.0f*(q1*q3 + q0*q2),
+        2.0f*(q2*q3 - q0*q1),
+        q0*q0 - q1*q1 - q2*q2 + q3*q3
+    };
 
-    Vector3F MagPred;
-    MagPred[0] = DCM[0][0]*magN + DCM[0][1]*magE  + DCM[0][2]*magD + magXbias;
-    MagPred[1] = DCM[1][0]*magN + DCM[1][1]*magE  + DCM[1][2]*magD + magYbias;
-    MagPred[2] = DCM[2][0]*magN + DCM[2][1]*magE  + DCM[2][2]*magD + magZbias;
+    const Vector3F MagPred {
+        DCM[0][0]*magN + DCM[0][1]*magE  + DCM[0][2]*magD + magXbias,
+        DCM[1][0]*magN + DCM[1][1]*magE  + DCM[1][2]*magD + magYbias,
+        DCM[2][0]*magN + DCM[2][1]*magE  + DCM[2][2]*magD + magZbias
+    };
 
     // calculate the measurement innovation for each axis
-    for (uint8_t i = 0; i<=2; i++) {
-        innovMag[i] = MagPred[i] - magDataDelayed.mag[i];
-    }
+    innovMag = MagPred - magDataDelayed.mag;
 
     // scale magnetometer observation error with total angular rate to allow for timing errors
     const ftype R_MAG = sq(constrain_ftype(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / imuDataDelayed.delAngDT);
 
     // calculate common expressions used to calculate observation jacobians an innovation variance for each component
-    Vector9 SH_MAG;
-    SH_MAG[0] = 2.0f*magD*q3 + 2.0f*magE*q2 + 2.0f*magN*q1;
-    SH_MAG[1] = 2.0f*magD*q0 - 2.0f*magE*q1 + 2.0f*magN*q2;
-    SH_MAG[2] = 2.0f*magD*q1 + 2.0f*magE*q0 - 2.0f*magN*q3;
-    SH_MAG[3] = sq(q3);
-    SH_MAG[4] = sq(q2);
-    SH_MAG[5] = sq(q1);
-    SH_MAG[6] = sq(q0);
-    SH_MAG[7] = 2.0f*magN*q0;
-    SH_MAG[8] = 2.0f*magE*q3;
+    const Vector9 SH_MAG {
+        2.0f*magD*q3 + 2.0f*magE*q2 + 2.0f*magN*q1,
+        2.0f*magD*q0 - 2.0f*magE*q1 + 2.0f*magN*q2,
+        2.0f*magD*q1 + 2.0f*magE*q0 - 2.0f*magN*q3,
+        sq(q3),
+        sq(q2),
+        sq(q1),
+        sq(q0),
+        2.0f*magN*q0,
+        2.0f*magE*q3
+    };
 
     // Calculate the innovation variance for each axis
     // X axis
@@ -556,6 +552,7 @@ void NavEKF3_core::FuseMagnetometer()
         return;
     }
 
+    Vector24 H_MAG;
     for (uint8_t obsIndex = 0; obsIndex <= 2; obsIndex++) {
 
         if (obsIndex == 0) {
@@ -573,11 +570,13 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[21] = 0.0f;
 
             // calculate Kalman gain
-            SK_MX[0] = 1.0f / varInnovMag[0];
-            SK_MX[1] = SH_MAG[3] + SH_MAG[4] - SH_MAG[5] - SH_MAG[6];
-            SK_MX[2] = SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2;
-            SK_MX[3] = 2.0f*q0*q2 - 2.0f*q1*q3;
-            SK_MX[4] = 2.0f*q0*q3 + 2.0f*q1*q2;
+            const Vector5 SK_MX {
+                1.0f / varInnovMag[0],
+                SH_MAG[3] + SH_MAG[4] - SH_MAG[5] - SH_MAG[6],
+                SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2,
+                2.0f*q0*q2 - 2.0f*q1*q3,
+                2.0f*q0*q3 + 2.0f*q1*q2
+            };
 
             Kfusion[0] = SK_MX[0]*(P[0][19] + P[0][1]*SH_MAG[0] - P[0][2]*SH_MAG[1] + P[0][3]*SH_MAG[2] + P[0][0]*SK_MX[2] - P[0][16]*SK_MX[1] + P[0][17]*SK_MX[4] - P[0][18]*SK_MX[3]);
             Kfusion[1] = SK_MX[0]*(P[1][19] + P[1][1]*SH_MAG[0] - P[1][2]*SH_MAG[1] + P[1][3]*SH_MAG[2] + P[1][0]*SK_MX[2] - P[1][16]*SK_MX[1] + P[1][17]*SK_MX[4] - P[1][18]*SK_MX[3]);
@@ -653,11 +652,13 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[21] = 0.0f;
 
             // calculate Kalman gain
-            SK_MY[0] = 1.0f / varInnovMag[1];
-            SK_MY[1] = SH_MAG[3] - SH_MAG[4] + SH_MAG[5] - SH_MAG[6];
-            SK_MY[2] = SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2;
-            SK_MY[3] = 2.0f*q0*q3 - 2.0f*q1*q2;
-            SK_MY[4] = 2.0f*q0*q1 + 2.0f*q2*q3;
+            const Vector5 SK_MY {
+                1.0f / varInnovMag[1],
+                SH_MAG[3] - SH_MAG[4] + SH_MAG[5] - SH_MAG[6],
+                SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2,
+                2.0f*q0*q3 - 2.0f*q1*q2,
+                2.0f*q0*q1 + 2.0f*q2*q3
+            };
 
             Kfusion[0] = SK_MY[0]*(P[0][20] + P[0][0]*SH_MAG[2] + P[0][1]*SH_MAG[1] + P[0][2]*SH_MAG[0] - P[0][3]*SK_MY[2] - P[0][17]*SK_MY[1] - P[0][16]*SK_MY[3] + P[0][18]*SK_MY[4]);
             Kfusion[1] = SK_MY[0]*(P[1][20] + P[1][0]*SH_MAG[2] + P[1][1]*SH_MAG[1] + P[1][2]*SH_MAG[0] - P[1][3]*SK_MY[2] - P[1][17]*SK_MY[1] - P[1][16]*SK_MY[3] + P[1][18]*SK_MY[4]);
@@ -735,11 +736,13 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[21] = 1.0f;
 
             // calculate Kalman gain
-            SK_MZ[0] = 1.0f / varInnovMag[2];
-            SK_MZ[1] = SH_MAG[3] - SH_MAG[4] - SH_MAG[5] + SH_MAG[6];
-            SK_MZ[2] = SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2;
-            SK_MZ[3] = 2.0f*q0*q1 - 2.0f*q2*q3;
-            SK_MZ[4] = 2.0f*q0*q2 + 2.0f*q1*q3;
+            const Vector5 SK_MZ {
+                1.0f / varInnovMag[2],
+                SH_MAG[3] - SH_MAG[4] - SH_MAG[5] + SH_MAG[6],
+                SH_MAG[7] + SH_MAG[8] - 2.0f*magD*q2,
+                2.0f*q0*q1 - 2.0f*q2*q3,
+                2.0f*q0*q2 + 2.0f*q1*q3
+            };
 
             Kfusion[0] = SK_MZ[0]*(P[0][21] + P[0][0]*SH_MAG[1] - P[0][1]*SH_MAG[2] + P[0][3]*SH_MAG[0] + P[0][2]*SK_MZ[2] + P[0][18]*SK_MZ[1] + P[0][16]*SK_MZ[4] - P[0][17]*SK_MZ[3]);
             Kfusion[1] = SK_MZ[0]*(P[1][21] + P[1][0]*SH_MAG[1] - P[1][1]*SH_MAG[2] + P[1][3]*SH_MAG[0] + P[1][2]*SK_MZ[2] + P[1][18]*SK_MZ[1] + P[1][16]*SK_MZ[4] - P[1][17]*SK_MZ[3]);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -443,21 +443,6 @@ void NavEKF3_core::SelectMagFusion()
 */
 void NavEKF3_core::FuseMagnetometer()
 {
-    // declarations
-    ftype &q0 = mag_state.q0;
-    ftype &q1 = mag_state.q1;
-    ftype &q2 = mag_state.q2;
-    ftype &q3 = mag_state.q3;
-    ftype &magN = mag_state.magN;
-    ftype &magE = mag_state.magE;
-    ftype &magD = mag_state.magD;
-    ftype &magXbias = mag_state.magXbias;
-    ftype &magYbias = mag_state.magYbias;
-    ftype &magZbias = mag_state.magZbias;
-    Matrix3F &DCM = mag_state.DCM;
-    Vector3F &MagPred = mag_state.MagPred;
-    ftype &R_MAG = mag_state.R_MAG;
-    ftype *SH_MAG = &mag_state.SH_MAG[0];
     Vector24 H_MAG;
     Vector5 SK_MX;
     Vector5 SK_MY;
@@ -471,20 +456,21 @@ void NavEKF3_core::FuseMagnetometer()
     // associated with sequential fusion
     // calculate observation jacobians and Kalman gains
 
-    // copy required states to local variable names
-    q0       = stateStruct.quat[0];
-    q1       = stateStruct.quat[1];
-    q2       = stateStruct.quat[2];
-    q3       = stateStruct.quat[3];
-    magN     = stateStruct.earth_magfield[0];
-    magE     = stateStruct.earth_magfield[1];
-    magD     = stateStruct.earth_magfield[2];
-    magXbias = stateStruct.body_magfield[0];
-    magYbias = stateStruct.body_magfield[1];
-    magZbias = stateStruct.body_magfield[2];
+    // create aliases for state to make code easier to read:
+    const ftype q0       = stateStruct.quat[0];
+    const ftype q1       = stateStruct.quat[1];
+    const ftype q2       = stateStruct.quat[2];
+    const ftype q3       = stateStruct.quat[3];
+    const ftype magN     = stateStruct.earth_magfield[0];
+    const ftype magE     = stateStruct.earth_magfield[1];
+    const ftype magD     = stateStruct.earth_magfield[2];
+    const ftype magXbias = stateStruct.body_magfield[0];
+    const ftype magYbias = stateStruct.body_magfield[1];
+    const ftype magZbias = stateStruct.body_magfield[2];
 
     // rotate predicted earth components into body axes and calculate
     // predicted measurements
+    Matrix3F DCM;
     DCM[0][0] = q0*q0 + q1*q1 - q2*q2 - q3*q3;
     DCM[0][1] = 2.0f*(q1*q2 + q0*q3);
     DCM[0][2] = 2.0f*(q1*q3-q0*q2);
@@ -494,6 +480,8 @@ void NavEKF3_core::FuseMagnetometer()
     DCM[2][0] = 2.0f*(q1*q3 + q0*q2);
     DCM[2][1] = 2.0f*(q2*q3 - q0*q1);
     DCM[2][2] = q0*q0 - q1*q1 - q2*q2 + q3*q3;
+
+    Vector3F MagPred;
     MagPred[0] = DCM[0][0]*magN + DCM[0][1]*magE  + DCM[0][2]*magD + magXbias;
     MagPred[1] = DCM[1][0]*magN + DCM[1][1]*magE  + DCM[1][2]*magD + magYbias;
     MagPred[2] = DCM[2][0]*magN + DCM[2][1]*magE  + DCM[2][2]*magD + magZbias;
@@ -504,9 +492,10 @@ void NavEKF3_core::FuseMagnetometer()
     }
 
     // scale magnetometer observation error with total angular rate to allow for timing errors
-    R_MAG = sq(constrain_ftype(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / imuDataDelayed.delAngDT);
+    const ftype R_MAG = sq(constrain_ftype(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / imuDataDelayed.delAngDT);
 
     // calculate common expressions used to calculate observation jacobians an innovation variance for each component
+    Vector9 SH_MAG;
     SH_MAG[0] = 2.0f*magD*q3 + 2.0f*magE*q2 + 2.0f*magN*q1;
     SH_MAG[1] = 2.0f*magD*q0 - 2.0f*magE*q1 + 2.0f*magN*q2;
     SH_MAG[2] = 2.0f*magD*q1 + 2.0f*magE*q0 - 2.0f*magN*q3;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -460,8 +460,6 @@ void NavEKF3_core::InitialiseVariablesMag()
     magTimeout = false;
     allMagSensorsFailed = false;
     finalInflightMagInit = false;
-    mag_state.q0 = 1;
-    mag_state.DCM.identity();
     inhibitMagStates = true;
     magSelectIndex = dal.compass().get_first_usable();
     lastMagOffsetsValid = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1449,26 +1449,6 @@ private:
         uint16_t value;
     } gpsCheckStatus;
 
-    // states held by magnetometer fusion across time steps
-    // magnetometer X,Y,Z measurements are fused across three time steps
-    // to level computational load as this is an expensive operation
-    struct {
-        ftype q0;
-        ftype q1;
-        ftype q2;
-        ftype q3;
-        ftype magN;
-        ftype magE;
-        ftype magD;
-        ftype magXbias;
-        ftype magYbias;
-        ftype magZbias;
-        Matrix3F DCM;
-        Vector3F MagPred;
-        ftype R_MAG;
-        Vector9 SH_MAG;
-    } mag_state;
-
     // string representing last reason for prearm failure
     char prearm_fail_string[40];
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -454,14 +454,31 @@ private:
     uint8_t obs_buffer_length;
 
 #if MATH_CHECK_INDEXES
+    class Vector9 : public VectorN<ftype, 9> {
+    public:
+        Vector9(ftype p0, ftype p1, ftype p2,
+                ftype p3, ftype p4, ftype p5,
+                ftype p6, ftype p7, ftype p8) {
+            _v[0] = p0;   _v[1] = p1;  _v[2] = p2;
+            _v[3] = p3;   _v[4] = p4;  _v[5] = p5;
+            _v[6] = p6;   _v[7] = p7;  _v[8] = p8;
+        }
+    };
+    class Vector5 : public VectorN<ftype, 5> {
+    public:
+        Vector5(ftype p0, ftype p1, ftype p2,
+                ftype p3, ftype p4) {
+            _v[0] = p0;   _v[1] = p1;  _v[2] = p2;
+            _v[3] = p3;   _v[4] = p4;
+        }
+    };
+
     typedef VectorN<ftype,2> Vector2;
     typedef VectorN<ftype,3> Vector3;
     typedef VectorN<ftype,4> Vector4;
-    typedef VectorN<ftype,5> Vector5;
     typedef VectorN<ftype,6> Vector6;
     typedef VectorN<ftype,7> Vector7;
     typedef VectorN<ftype,8> Vector8;
-    typedef VectorN<ftype,9> Vector9;
     typedef VectorN<ftype,10> Vector10;
     typedef VectorN<ftype,11> Vector11;
     typedef VectorN<ftype,13> Vector13;


### PR DESCRIPTION
```
we don't need to persist this across multiple calls as we now fuse all axes on the one step.

I've moved the defintion of these variables to where they are initialised to make it clear they're not used uninitialised.
```

Some of the initialisations could probably be tidied up to `const` the variables at definition, but that would have made this patch look pretty complicated.

Memory saved as expected on CubeBlack:
```
master:  RTL> 96: MEMINFO {brkval : 0, freemem : 59944, freemem32 : 59944}
   new: RTL> 163: MEMINFO {brkval : 0, freemem : 60224, freemem32 : 60224}
222
```
(delta is 280)
