### PR TITLE
Move warning of core changes into AP_AHRS

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -233,12 +233,10 @@ void Copter::check_ekf_reset()
         AP::logger().Write_Event(LogEvent::EKF_YAW_RESET);
     }
 
-    // check for change in primary EKF, reset attitude target and log.  AC_PosControl handles position target adjustment
+    // check for change in primary EKF, reset attitude target.  AC_PosControl handles position target adjustment
     if ((ahrs.get_primary_core_index() != ekf_primary_core) && (ahrs.get_primary_core_index() != -1)) {
         attitude_control->inertial_frame_reset();
         ekf_primary_core = ahrs.get_primary_core_index();
-        AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }
 }
 

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -185,11 +185,10 @@ void Blimp::check_ekf_reset()
         AP::logger().Write_Event(LogEvent::EKF_YAW_RESET);
     }
 
-    // check for change in primary EKF, reset attitude target and log.  AC_PosControl handles position target adjustment
+    // check for change in primary EKF.  AC_PosControl handles position target adjustment
     if ((ahrs.get_primary_core_index() != ekf_primary_core) && (ahrs.get_primary_core_index() != -1)) {
+        // consider resetting attitude target
         ekf_primary_core = ahrs.get_primary_core_index();
-        AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -780,6 +780,8 @@ void NavEKF2::UpdateFilter(void)
         }
         runCoreSelection = (imuSampleTime_us - lastUnhealthyTime_us) > 1E7;
     }
+
+    const uint8_t original_primary = primary;
     float primaryErrorScore = core[primary].errorScore();
     if ((primaryErrorScore > 1.0f || !core[primary].healthy()) && runCoreSelection) {
         float lowestErrorScore = 0.67f * primaryErrorScore;
@@ -820,6 +822,13 @@ void NavEKF2::UpdateFilter(void)
         // noise characteristics this leads to inconsistent
         // performance
         primary = 0;
+    }
+
+    if (primary != original_primary) {
+#if !APM_BUILD_TYPE(APM_BUILD_Replay)
+        AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary));
+#endif
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)primary);
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -929,6 +929,7 @@ void NavEKF3::UpdateFilter(void)
     }
 
     const bool armed  = AP::dal().get_armed();
+    const uint8_t original_primary = primary;
 
     // core selection is only available after the vehicle is armed, else forced to lane 0 if its healthy
     if (runCoreSelection && armed) {
@@ -997,6 +998,13 @@ void NavEKF3::UpdateFilter(void)
         // have quite different noise characteristics this leads to
         // inconsistent performance
         primary = user_primary;
+    }
+
+    if (primary != original_primary) {
+#if !APM_BUILD_TYPE(APM_BUILD_Replay)
+            AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary));
+#endif
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)primary);
     }
 
     // align position of inactive sources to ahrs


### PR DESCRIPTION
On master we get this warning when your ` EK3_PRIMARY` is not 0:
![image](https://user-images.githubusercontent.com/7077857/211468402-88c5bf9b-8d57-4109-92a8-3edd3b50a8c3.png)

... but no warning if it is zero.  We send that message as a warning - but if the user has configured their vehicle to use a different primary it shouldn't be commented on at all at boot.

.... frankly I think the entire check in Copter is bogus and should be based on an `AP::ahrs().last_attitude_reset_ms()` - which would change if you changed EKF cores or backend estimators (e.g. changing `AHRS_EKF_TYPE`, but also via callback onto the active EKF type).

... the check should probably also be in AC_AttitudeControl, rather than requiring the vehicle to mediate.  Why a QuadPlane in `QLOITER` shouldn't reset the attitude targets as Copter does is a bit of a mystery to me.
