### PR TITLE
AP_Scripting:add error check to mission_load.lua

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -376,6 +376,7 @@ singleton AP_Mission method set_item boolean uint16_t'skip_check mavlink_mission
 singleton AP_Mission method clear boolean
 singleton AP_Mission method cmd_has_location boolean uint16_t'skip_check
 
+
 userdata mavlink_mission_item_int_t field param1 float'skip_check read write
 userdata mavlink_mission_item_int_t field param2 float'skip_check read write
 userdata mavlink_mission_item_int_t field param3 float'skip_check read write


### PR DESCRIPTION
figured I would fix Buz's example first since I used that in the Scripting_Controller PR...when its okay, will use it in that

rather than changing his file reading code, I added a data integrity check...minimal changes approach

this checks : 
that each seq number increments and matches the input matrix index (no out of sequence numbers), the first fields are integers, and the lat and long ranges are correct....

tested in SITL