### PR TITLE
AP_BattMoniter: don't allow equal low and critical FS thresholds

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -171,10 +171,10 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
                                  ((_params._pack_capacity - _state.consumed_mah) < _params._arming_minimum_capacity);
     bool fs_capacity_inversion = is_positive(_params._critical_capacity) &&
                                  is_positive(_params._low_capacity) &&
-                                 (_params._low_capacity < _params._critical_capacity);
+                                 !(_params._low_capacity > _params._critical_capacity);
     bool fs_voltage_inversion = is_positive(_params._critical_voltage) &&
                                 is_positive(_params._low_voltage) &&
-                                (_params._low_voltage < _params._critical_voltage);
+                                !(_params._low_voltage > _params._critical_voltage);
 
     bool result = update_check(buflen, buffer, !_state.healthy, "unhealthy");
     result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
@@ -183,8 +183,8 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
     result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
     result = result && update_check(buflen, buffer, critical_voltage, "critical voltage failsafe");
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
-    result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical > low");
-    result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical > low");
+    result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical >= low");
+    result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical >= low");
 
     return result;
 }


### PR DESCRIPTION
Fix for the issues from: https://discuss.ardupilot.org/t/no-rtl-engagement-after-a-fail-safe-battery/95312

In that case both low and critical voltage thresholds were the same so the low action of RTL was skipped for the critical action of none.

This is one way to fix of course, if the voltages are not the same but very close the same thing might happen if the battery is dropping fast. Maybe we should enforce some minimum split? Maybe low must be 1v above critical. Not really sure what threshold for capacity should be. We could use a percentage....

The other fix would be to take the low battery action if not in low failsafe and critical action is none, but that makes the failfafe behavior less clear for users. 