### PR TITLE
Plane: QRTL: use cone for QRTL climb close to home

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -827,6 +827,7 @@ private:
     void setup_glide_slope(void);
     int32_t get_RTL_altitude_cm() const;
     float relative_ground_altitude(bool use_rangefinder_if_available);
+    float relative_ground_altitude(bool use_rangefinder_if_available, bool use_terrain_if_available);
     void set_target_altitude_current(void);
     void set_target_altitude_current_adjusted(void);
     void set_target_altitude_location(const Location &loc);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -92,7 +92,7 @@ int32_t Plane::get_RTL_altitude_cm() const
   return relative altitude in meters (relative to terrain, if available,
   or home otherwise)
  */
-float Plane::relative_ground_altitude(bool use_rangefinder_if_available)
+float Plane::relative_ground_altitude(bool use_rangefinder_if_available, bool use_terrain_if_available)
 {
    if (use_rangefinder_if_available && rangefinder_state.in_range) {
         return rangefinder_state.height_estimate;
@@ -109,7 +109,7 @@ float Plane::relative_ground_altitude(bool use_rangefinder_if_available)
 
 #if AP_TERRAIN_AVAILABLE
     float altitude;
-    if (target_altitude.terrain_following &&
+    if (use_terrain_if_available &&
         terrain.status() == AP_Terrain::TerrainStatusOK &&
         terrain.height_above_terrain(altitude, true)) {
         return altitude;
@@ -129,6 +129,17 @@ float Plane::relative_ground_altitude(bool use_rangefinder_if_available)
 
     return relative_altitude;
 }
+
+// Helper for above method using terrain if the vehicle is currently terrain following
+float Plane::relative_ground_altitude(bool use_rangefinder_if_available)
+{
+#if AP_TERRAIN_AVAILABLE
+    return relative_ground_altitude(use_rangefinder_if_available, target_altitude.terrain_following);
+#else
+    return relative_ground_altitude(use_rangefinder_if_available, false);
+#endif
+}
+
 
 /*
   set the target altitude to the current altitude. This is used when 

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -23,8 +23,9 @@ bool ModeQRTL::_enter()
         const float radius = MAX(fabsf(plane.aparm.loiter_radius), fabsf(plane.g.rtl_radius));
 
         // Climb at least to a cone around home of hight of QRTL alt and radius of 1.5*radius
-        // Always climb up to at least land final alt
-        const float target_alt = MAX(quadplane.qrtl_alt * (dist / MAX(1.5*radius, dist)), quadplane.land_final_alt);
+        // Always climb up to at least Q_RTL_ALT_MIN, constrain Q_RTL_ALT_MIN between Q_LAND_FINAL_ALT and Q_RTL_ALT
+        const float min_climb = constrain_float(quadplane.qrtl_alt_min, quadplane.land_final_alt, quadplane.qrtl_alt);
+        const float target_alt = MAX(quadplane.qrtl_alt * (dist / MAX(1.5*radius, dist)), min_climb);
 
 
 #if AP_TERRAIN_AVAILABLE

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -495,6 +495,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Standard
     AP_SUBGROUPINFO(command_model_pilot, "PLT_Y_", 33, QuadPlane, AC_CommandModel),
 
+    // @Param: RTL_ALT_MIN
+    // @DisplayName: QRTL minimum altitude
+    // @Description: If VTOL motors are active QRTL mode will VTOL climb to at least this altitude before returning home. If outside 150% the larger of WP_LOITER_RAD and RTL_RADIUS the vehicle will VTOL climb to Q_RTL_ALT. This parameter has no effect if the vehicle is in forward flight. Should be between Q_LAND_FINAL_ALT and Q_RTL_ALT
+    // @Units: m
+    // @Range: 1 200
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RTL_ALT_MIN", 34, QuadPlane, qrtl_alt_min, 10),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -337,6 +337,7 @@ private:
 
     // QRTL start altitude, meters
     AP_Int16 qrtl_alt;
+    AP_Int16 qrtl_alt_min;
     
     // alt to switch to QLAND_FINAL
     AP_Float land_final_alt;


### PR DESCRIPTION
This applies a cone logic similar to copters for QRTL close to home.

This is only a change in behavior in VTOL inside 1.5 radius and under QRTL altitude. The vehicle will always climb up to at least `Q_LAND_FINAL`. It will climb higher if it is further from home as defined by the cone. Once the climb is done, or if already above the cone it will then return at the current altitude. 

![image](https://user-images.githubusercontent.com/33176108/211951827-b1837c73-80e8-4453-ae6b-88537b005c31.png)

Currently close in QRTL's start returning home and climbing up to QRTL altitude. Then start descending again before getting home due to the cone type logic in the VTOL position controller. 

I have not tested extensively and not with ship landing.

edit: maybe I should add that the brown, blue, red and green locations all result in pure VTOL flight. Yellow fly's FW home and transitions for a VTOL landing. Green does a VTOL climb and transitions to FW to return home and then does a VTOL landing. 