### PR TITLE
AC_PID: don't change pid info I in reset calls, report actual value used.

### DIFF
--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -93,6 +93,5 @@ void AC_HELI_PID::update_leaky_i(float leak_rate)
             _integrator -= (float)(_integrator + _leak_min) * leak_rate;
         }
 
-        _pid_info.I = _integrator;
     }
 }

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -268,7 +268,6 @@ float AC_PID::get_ff()
 void AC_PID::reset_I()
 {
     _integrator = 0.0;
-    _pid_info.I = 0.0;
 }
 
 void AC_PID::load_gains()
@@ -336,13 +335,11 @@ void AC_PID::set_integrator(float target, float measurement, float integrator)
 void AC_PID::set_integrator(float error, float integrator)
 {
     _integrator = constrain_float(integrator - error * _kp, -_kimax, _kimax);
-    _pid_info.I = _integrator;
 }
 
 void AC_PID::set_integrator(float integrator)
 {
     _integrator = constrain_float(integrator, -_kimax, _kimax);
-    _pid_info.I = _integrator;
 }
 
 void AC_PID::relax_integrator(float integrator, float dt, float time_constant)
@@ -351,5 +348,4 @@ void AC_PID::relax_integrator(float integrator, float dt, float time_constant)
     if (is_positive(dt)) {
         _integrator = _integrator + (integrator - _integrator) * (dt / (dt + time_constant));
     }
-    _pid_info.I = _integrator;
 }

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -168,8 +168,6 @@ Vector2f AC_PID_2D::get_ff()
 void AC_PID_2D::reset_I()
 {
     _integrator.zero(); 
-    _pid_info_x.I = 0.0;
-    _pid_info_y.I = 0.0;
 }
 
 // save_gains - save gains to eeprom

--- a/libraries/AC_PID/AC_PID_Basic.cpp
+++ b/libraries/AC_PID/AC_PID_Basic.cpp
@@ -141,7 +141,6 @@ void AC_PID_Basic::update_i(float dt, bool limit_neg, bool limit_pos)
 void AC_PID_Basic::reset_I()
 {
     _integrator = 0.0; 
-    _pid_info.I = 0.0;
 }
 
 // save_gains - save gains to eeprom
@@ -181,5 +180,4 @@ void AC_PID_Basic::set_integrator(float error, float i)
 void AC_PID_Basic::set_integrator(float i)
 {
     _integrator = constrain_float(i, -_kimax, _kimax);
-    _pid_info.I = _integrator;
 }

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -345,7 +345,6 @@ float AP_PitchController::get_servo_out(int32_t angle_err, float scaler, bool di
 
 void AP_PitchController::reset_I()
 {
-    _pid_info.I = 0;
     rate_pid.reset_I();
 }
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -247,7 +247,6 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
 
 void AP_RollController::reset_I()
 {
-    _pid_info.I = 0;
     rate_pid.reset_I();
 }
 


### PR DESCRIPTION
This stops setting `_pid_info.I` in a set integrator call, that means that the PID value logged is always the one actually used. This means that after a I reset to 0 the 0 I is never actually logged because it increases in the loop.

The goal is simply to report the actual value used, this is already filled in the various update calls.

It also removes a race where the I value changes depending if you grab it before or after the set integrator calls.
