### PR TITLE
SITL: add option to read Saleae Logic Async serial data into UART

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -660,6 +660,7 @@ class sitl(Board):
 
         env.AP_LIBRARIES += [
             'AP_HAL_SITL',
+            'AP_CSVReader',
         ]
 
         if not cfg.env.AP_PERIPH:

--- a/libraries/AP_CSVReader/AP_CSVReader.cpp
+++ b/libraries/AP_CSVReader/AP_CSVReader.cpp
@@ -1,0 +1,102 @@
+#include "AP_CSVReader.h"
+
+#include <AP_Common/AP_Common.h>
+
+#include <stdio.h>
+
+AP_CSVReader::RetCode AP_CSVReader::handle_unquoted_term(uint8_t c)
+{
+    if (c == separator) {
+        set_state(State::START_OF_START_OF_TERM);
+        return RetCode::TERM_DONE;
+    }
+    switch (c) {
+    case '\r':
+        set_state(State::END_OF_VECTOR_CR);
+        return RetCode::VECTOR_DONE;
+    case '\n':
+        set_state(State::START_OF_START_OF_TERM);
+        return RetCode::VECTOR_DONE;
+    default:
+        if (term_ofs >= term_len-1) { // -1 for null termination
+            return RetCode::ERROR;
+        }
+        term[term_ofs++] = c;
+        term[term_ofs] = '\0';
+        return RetCode::OK;
+    }
+}
+
+AP_CSVReader::RetCode AP_CSVReader::handle_quoted_term(uint8_t c)
+{
+    if (c == '"') {
+        set_state(State::END_OF_QUOTED_TERM);
+        return RetCode::OK;
+    }
+    if (state == State::END_OF_QUOTED_TERM) {
+        if (c == separator) {
+            set_state(State::START_OF_START_OF_TERM);
+            return RetCode::TERM_DONE;
+        }
+
+        switch (c) {
+        case '\r':
+            set_state(State::END_OF_VECTOR_CR);
+            return RetCode::VECTOR_DONE;
+        case '\n':
+            set_state(State::START_OF_START_OF_TERM);
+            return RetCode::VECTOR_DONE;
+        }
+        return RetCode::ERROR;
+    }
+
+    // still within the quoted term, append to current value
+    if (term_ofs >= term_len-1) { // -1 for null termination
+        return RetCode::ERROR;
+    }
+    term[term_ofs++] = c;
+    term[term_ofs] = '\0';
+    return RetCode::OK;
+}
+
+AP_CSVReader::RetCode AP_CSVReader::feed(uint8_t c)
+{
+    if (term_len == 0) {
+        return RetCode::ERROR;
+    }
+
+again:
+    switch (state) {
+    case State::START_OF_START_OF_TERM:
+        term_ofs = 0;
+        term[term_ofs] = '\0';
+        state = State::START_OF_TERM;
+        FALLTHROUGH;
+    case State::START_OF_TERM:
+        // if (c == '"') {
+        //     set_state(State::START_OF_QUOTED_TERM);
+        //     return RetCode::OK;
+        // }
+        if (c == '"') {
+            set_state(State::IN_QUOTED_TERM);
+            return RetCode::OK;
+        } else {
+            set_state(State::IN_UNQUOTED_TERM);
+            return handle_unquoted_term(c);
+        }
+    case State::END_OF_VECTOR_CR:
+        if (c == '\n') {
+            set_state(State::START_OF_START_OF_TERM);
+            return RetCode::OK;
+        }
+        set_state(State::START_OF_START_OF_TERM);
+        goto again;
+    case State::IN_UNQUOTED_TERM:
+        return handle_unquoted_term(c);
+    case State::IN_QUOTED_TERM:
+    case State::END_OF_QUOTED_TERM:
+        return handle_quoted_term(c);
+    }
+
+    return RetCode::ERROR;
+}

--- a/libraries/AP_CSVReader/AP_CSVReader.h
+++ b/libraries/AP_CSVReader/AP_CSVReader.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Note: term is always null-terminated so a final line with no cr/lf
+// on it can still be fetched by the caller
+
+#include <stdint.h>
+
+class AP_CSVReader
+{
+
+public:
+
+    AP_CSVReader(uint8_t *_term, uint8_t _term_len, uint8_t _separator=',') :
+        separator{_separator},
+        term{_term},
+        term_len{_term_len}
+        {}
+
+    enum class RetCode : uint8_t {
+        OK,
+        ERROR,
+        TERM_DONE,
+        VECTOR_DONE,
+    };
+
+    RetCode feed(uint8_t c);
+//    RetCode feed(const uint8_t *buffer, uint8_t len);
+
+private:
+
+    enum class State : uint8_t {
+        START_OF_START_OF_TERM = 46,
+        START_OF_TERM = 47,
+        END_OF_VECTOR_CR = 48,
+        IN_UNQUOTED_TERM = 49,
+        IN_QUOTED_TERM = 50,
+        END_OF_QUOTED_TERM = 51,
+    } state = State::START_OF_START_OF_TERM;
+
+    // term separator
+    const uint8_t separator;
+
+    // pointer to memory where term will be assembled
+    uint8_t *term;
+
+    // amount of memory term points to
+    const uint8_t term_len;
+
+    // offset into term for next character
+    uint8_t term_ofs;
+
+    void set_state(State newstate) {
+        state = newstate;
+    }
+
+    AP_CSVReader::RetCode handle_unquoted_term(uint8_t c);
+    AP_CSVReader::RetCode handle_quoted_term(uint8_t c);
+};

--- a/libraries/AP_CSVReader/tests/test_csvreader.cpp
+++ b/libraries/AP_CSVReader/tests/test_csvreader.cpp
@@ -1,0 +1,142 @@
+#include <AP_gtest.h>
+#include <AP_Common/AP_Common.h>
+
+#include <AP_Math/AP_Math.h>
+
+#include <AP_CSVReader/AP_CSVReader.h>
+
+TEST(AP_CSVReader, basic)
+{
+    static const char *basic_csv =
+        "A 1\n"
+        "B 2\n"
+        "C 3\n"
+        "Fred 31\n"
+        ;
+    static const char *basic_csv_crlf =
+        "A 1\r\n"
+        "B 2\r\n"
+        "C 3\r\n"
+        "Fred 31\r\n"
+        ;
+    static const char *basic_csv_results[][2] = {
+        {"A", "1"},
+        {"B", "2"},
+        {"C", "3"},
+        {"Fred", "31"}
+    };
+
+    uint8_t term[16];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ' '};
+
+    const char *csvs[] {
+        basic_csv,
+        basic_csv_crlf
+    };
+
+    for (const char *csv : csvs) {
+        uint8_t termcount = 0;
+        uint8_t linecount = 0;
+        for (uint8_t i=0; i<strlen(csv); i++) {
+            switch (csvreader.feed(csv[i])) {
+            case AP_CSVReader::RetCode::ERROR:
+                abort();
+            case AP_CSVReader::RetCode::OK:
+                continue;
+            case AP_CSVReader::RetCode::TERM_DONE:
+                EXPECT_STREQ(basic_csv_results[linecount][termcount], (char*)term);
+                termcount++;
+                continue;
+            case AP_CSVReader::RetCode::VECTOR_DONE:
+                EXPECT_STREQ(basic_csv_results[linecount][termcount], (char*)term);
+                termcount++;
+                EXPECT_EQ(termcount, 2);
+                termcount = 0;
+                linecount++;
+                continue;
+            }
+        }
+
+        EXPECT_EQ(linecount, 4);
+        EXPECT_EQ(termcount, 0);
+    }
+}
+
+TEST(AP_CSVReader, commabasic)
+{
+    static const char *basic_csv =
+        "A,1\n"
+        "B,2\n"
+        "C,3\n"
+        "Fred,31\n"
+        ;
+    static const char *basic_csv_results[][2] = {
+        {"A", "1"},
+        {"B", "2"},
+        {"C", "3"},
+        {"Fred", "31"}
+    };
+
+    uint8_t term[16];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    uint8_t termcount = 0;
+    uint8_t linecount = 0;
+    for (uint8_t i=0; i<strlen(basic_csv); i++) {
+        switch (csvreader.feed(basic_csv[i])) {
+        case AP_CSVReader::RetCode::ERROR:
+            abort();
+        case AP_CSVReader::RetCode::OK:
+            continue;
+        case AP_CSVReader::RetCode::TERM_DONE:
+            EXPECT_STREQ(basic_csv_results[linecount][termcount], (char*)term);
+            termcount++;
+            continue;
+        case AP_CSVReader::RetCode::VECTOR_DONE:
+            EXPECT_STREQ(basic_csv_results[linecount][termcount], (char*)term);
+            termcount++;
+            EXPECT_EQ(termcount, 2);
+            termcount = 0;
+            linecount++;
+            continue;
+        }
+    }
+
+    EXPECT_EQ(linecount, 4);
+    EXPECT_EQ(termcount, 0);
+}
+
+TEST(AP_CSVReader, missinglastcr)
+{
+    static const char *basic_csv =
+        "A,1"
+        ;
+    uint8_t term[16];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    uint8_t termcount = 0;
+    uint8_t linecount = 0;
+    for (uint8_t i=0; i<strlen(basic_csv); i++) {
+        switch (csvreader.feed(basic_csv[i])) {
+        case AP_CSVReader::RetCode::ERROR:
+            abort();
+        case AP_CSVReader::RetCode::OK:
+            continue;
+        case AP_CSVReader::RetCode::TERM_DONE:
+            if (linecount == 0 && termcount == 0) {
+                EXPECT_STREQ((char*)term, "A");
+            }
+            termcount++;
+            continue;
+        case AP_CSVReader::RetCode::VECTOR_DONE:
+            abort();
+        }
+    }
+
+    EXPECT_STREQ((char*)term, "1");
+}
+
+AP_GTEST_MAIN()
+
+
+int hal = 0; // bizarrely, this fixes an undefined-symbol error but doesn't raise a type exception.  Yay.

--- a/libraries/AP_CSVReader/tests/wscript
+++ b/libraries/AP_CSVReader/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -87,6 +87,7 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
              uart:/dev/ttyUSB0:57600
              sim:ParticleSensor_SDS021:
              file:/tmp/my-device-capture.BIN
+             logic_async_csv:/tmp/logic_async.csv:
          */
         char *saveptr = nullptr;
         char *s = strdup(path);
@@ -165,6 +166,17 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
                 AP_HAL::panic("Failed to open (%s): %m", args1);
             }
             _connected = true;
+        } else if (strcmp(devtype, "logic_async_csv") == 0) {
+            if (_connected) {
+                AP::FS().close(_fd);
+            }
+            ::printf("logic_async_csv connection %s\n", args1);
+            _fd = AP::FS().open(args1, O_RDONLY);
+            if (_fd == -1) {
+                AP_HAL::panic("Failed to open (%s): %m", args1);
+            }
+            _connected = true;
+            logic_async_csv.active = true;
         } else {
             AP_HAL::panic("Invalid device path: %s", path);
         }
@@ -696,6 +708,98 @@ void UARTDriver::_check_reconnect(void)
     _uart_start_connection();
 }
 
+uint16_t UARTDriver::read_from_async_csv(uint8_t *buffer, uint16_t space)
+{
+    if (_fd == -1) {
+        return 0;
+    }
+    const uint32_t micros = AP_HAL::micros();
+    if (micros < 5000000) {
+        // don't inject for the first several seconds
+        return 0;
+    }
+
+    static uint32_t frame_number;
+    frame_number++;
+
+    uint8_t i;
+    for (i=0; i<space; i++) {
+        static uint32_t count;
+        if (logic_async_csv.loaded) {
+            const uint32_t emit_timestamp_us = micros - logic_async_csv.first_emit_micros_us;
+            const uint32_t data_timestamp_us = logic_async_csv.loaded_data.timestamp_us - logic_async_csv.first_timestamp_us;
+            if (data_timestamp_us > emit_timestamp_us) {
+                return i;
+            }
+            buffer[i] = logic_async_csv.loaded_data.b;
+            count++;
+            logic_async_csv.loaded = false;
+        }
+
+        while (!logic_async_csv.loaded) {
+            uint8_t c;
+            const ssize_t nread = ::read(_fd, &c, 1);
+            if (nread == 0) {
+                // EOF
+                close(_fd);
+                _fd = -1;
+                return i;
+            }
+
+            // feed data into CSV Reader, handle new state:
+            const auto retcode = logic_async_csv.csvreader.feed(c);
+            switch (retcode) {
+            case AP_CSVReader::RetCode::OK:
+                continue;
+            case AP_CSVReader::RetCode::ERROR:
+                AP_HAL::panic("Malformed CSV?");
+            case AP_CSVReader::RetCode::TERM_DONE:
+            case AP_CSVReader::RetCode::VECTOR_DONE:
+                switch (logic_async_csv.terms_seen) {
+                case 0:  // start_time
+                    if (!logic_async_csv.done_first_line) {
+                        break;
+                    }
+                    logic_async_csv.loaded_data.timestamp_us = atof((char*)logic_async_csv.term) * 1000000;  // seconds to microseconds
+                    break;
+                case 1:  // data
+                    if (!logic_async_csv.done_first_line) {
+                        break;
+                    }
+                    logic_async_csv.loaded_data.b = (char_to_hex(logic_async_csv.term[2]) << 4) | char_to_hex(logic_async_csv.term[3]);
+                    break;
+                case 2:  // error
+                case 3:  // framing error
+                    break;
+                case 4:
+                    AP_HAL::panic("Too many terms in CSV, want (name,type,start_time,duration,data");
+                }
+                logic_async_csv.terms_seen++;
+                if (retcode != AP_CSVReader::RetCode::VECTOR_DONE) {
+                    break;
+                }
+
+                // we've handled the last term, now handle the vector:
+                if (logic_async_csv.terms_seen != 4) {
+                    AP_HAL::panic("Incorrect number off terms in CSV, want (Time [s],Value,Parity Error,Framing Error)");
+                }
+                logic_async_csv.terms_seen = 0;
+                if (!logic_async_csv.done_first_line) {
+                    // skip the headers
+                    logic_async_csv.done_first_line = true;
+                    break;
+                }
+                if (logic_async_csv.first_timestamp_us == 0) {
+                    logic_async_csv.first_timestamp_us = logic_async_csv.loaded_data.timestamp_us;
+                    logic_async_csv.first_emit_micros_us = micros;
+                }
+                logic_async_csv.loaded = true;
+            }
+        }
+    }
+    return i;
+}
+
 void UARTDriver::_timer_tick(void)
 {
     if (!_connected) {
@@ -790,6 +894,8 @@ void UARTDriver::_timer_tick(void)
         }
     } else if (_sim_serial_device != nullptr) {
         nread = _sim_serial_device->read_from_device(buf, space);
+    } else if (logic_async_csv.active) {
+        nread = read_from_async_csv((uint8_t*)buf, space);
     } else if (!_use_send_recv) {
         if (!_select_check(_fd)) {
             return;

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -8,6 +8,7 @@
 #include "AP_HAL_SITL_Namespace.h"
 #include <AP_HAL/utility/Socket.h>
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_CSVReader/AP_CSVReader.h>
 
 #include <SITL/SIM_SerialDevice.h>
 
@@ -130,6 +131,22 @@ private:
     uint32_t last_tick_us;
 
     SITL::SerialDevice *_sim_serial_device;
+
+    struct {
+        bool active;
+        uint8_t term[20];
+        AP_CSVReader csvreader{term, sizeof(term), ','};
+        struct {
+            uint32_t timestamp_us;
+            uint8_t b;  // the byte
+        } loaded_data;
+        bool loaded;  // true if data is all valid
+        bool done_first_line = false;
+        uint8_t terms_seen;
+        uint32_t first_timestamp_us;
+        uint32_t first_emit_micros_us;
+    } logic_async_csv;
+    uint16_t read_from_async_csv(uint8_t *buffer, uint16_t space);
 };
 
 #endif


### PR DESCRIPTION
From the accompanying wiki PR:

```
Replaying serial data from Saleae Logic data captures
=====================================================

Saleae Logic is often used when decoding and debugging protocols for the first time.  The "async serial" analyzers can export the data to a CSV, and this data can then be replayed through ArduPilot's simulated UARTDriver to test parsing of that data.

Serial data is replayed into the simulation at the same rate it appeared on the wire when taking the trace, preserving frame-gaps and the like.

After you have Logic decoding the serial stream, export the data using this interface element:

.. figure:: ../images/saleae-async-save.png
   :target: ../_images/saleae-async-save.png
   :width: 450px

That data should be in this format:

::

   Time [s],Value,Parity Error,Framing Error
   109.557104960000004,0x9B,,
   109.590780800000005,0x00,,
   109.609869119999999,0x00,,
   109.610386399999996,0x00,,
   109.613748799999996,0x00,,
   109.614266079999993,0x6B,,
   109.616231679999999,0x00,,
   109.744313439999999,0x0A,,
   109.744830719999996,0x89,,

Place this capture file into the root directory of your ArduPilot repository checkout.

Specify the schema and filename on the ``sim_vehicle.py`` command-line.  The following example inserts a breakpoint where the data is being read into the parser:

::

   ./Tools/autotest/sim_vehicle.py  --gdb --debug -v plane -A --uartF=logic_async_csv:hobbywing-platinum-pro-v3.csv --speedup=1 -B AP_HobbyWing_Platinum_PRO_v3::update

.. note::

   Your ``SERIAL5_PROTOCOL`` must be set appropriately for this data to be read.

.. note::

   There is a 5s simulated-time delay before data is fed into the simulation from the file.
```
