### PR TITLE
Add proper printf macros for stdints in a few locations

### DIFF
--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -165,7 +165,7 @@ bool AP_Compass_IST8308::init()
     }
     set_dev_id(_instance, _dev->get_bus_id());
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    printf("%s found on bus %" PRIu8 " id %" PRIu32 " address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -159,7 +159,7 @@ bool AP_Compass_IST8310::init()
     }
     set_dev_id(_instance, _dev->get_bus_id());
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    printf("%s found on bus %" PRIu8 " id %" PRIu32 " address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -111,7 +111,7 @@ bool AP_Compass_LIS3MDL::init()
     }
     set_dev_id(compass_instance, dev->get_bus_id());
 
-    printf("Found a LIS3MDL on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
+    printf("Found a LIS3MDL on 0x%" PRIx32 " as compass %" PRIu8 "\n", dev->get_bus_id(), compass_instance);
     
     set_rotation(compass_instance, rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -97,7 +97,7 @@ bool AP_Compass_MMC3416::init()
     
     set_dev_id(compass_instance, dev->get_bus_id());
 
-    printf("Found a MMC3416 on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
+    printf("Found a MMC3416 on 0x%" PRIx32 " as compass %" PRIu8 "\n", dev->get_bus_id(), compass_instance);
     
     set_rotation(compass_instance, rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -112,7 +112,7 @@ bool AP_Compass_MMC5XX3::init()
 
     set_dev_id(compass_instance, dev->get_bus_id());
 
-    printf("Found a MMC5983 on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
+    printf("Found a MMC5983 on 0x%" PRIx32 " as compass %" PRIu8 "\n", dev->get_bus_id(), compass_instance);
 
     set_rotation(compass_instance, rotation);
 

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -120,7 +120,7 @@ bool AP_Compass_QMC5883L::init()
     }
     set_dev_id(_instance, _dev->get_bus_id());
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    printf("%s found on bus %" PRIu8 " id %" PRIu32 " address 0x%02x\n", name,
            _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
 
     set_rotation(_instance, _rotation);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -76,7 +76,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
             struct i2c_integral_frame frame;
             success = tdev->read_registers(REG_INTEGRAL_FRAME, (uint8_t *)&frame, sizeof(frame));
             if (success) {
-                printf("Found PX4Flow on bus %u\n", bus);
+                printf("Found PX4Flow on bus %" PRIu32 "\n", bus);
                 dev = std::move(tdev);
                 break;
             }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -207,7 +207,7 @@ bool AP_RangeFinder_PulsedLightLRF::init(void)
         }
     }
 
-    printf("Found LidarLite device=0x%x v2=%d v3hp=%d\n", _dev->get_bus_id(), (int)v2_hardware, (int)v3hp_hardware);
+    printf("Found LidarLite device=0x%" PRIx32 " v2=%d v3hp=%d\n", _dev->get_bus_id(), (int)v2_hardware, (int)v3hp_hardware);
     
     _dev->get_semaphore()->give();
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -259,7 +259,7 @@ bool AP_RangeFinder_VL53L0X::check_id(void)
         v2 != 0xAA) {
         return false;
     }
-    printf("Detected VL53L0X on bus 0x%x\n", dev->get_bus_id());
+    printf("Detected VL53L0X on bus 0x%" PRIx32 "\n", dev->get_bus_id());
     return true;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
@@ -81,7 +81,7 @@ bool AP_RangeFinder_VL53L1X::check_id(void)
         (v2 != 0xCC)) {
         return false;
     }
-    printf("Detected VL53L1X on bus 0x%x\n", dev->get_bus_id());
+    printf("Detected VL53L1X on bus 0x%" PRIx32 "\n", dev->get_bus_id());
     return true;
 }
 


### PR DESCRIPTION
Libraries: Add proper printf macros for stdints in a few locations.

Compiling Ardupilot against different targets complaints about the mismatching stdint types and the corresponding wrong printf format specifiers. This small PR intends to fix this by using the proper printf macros at these locations.