### PR TITLE
GCS_MAVLink: fixed FTP terminate session error

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -116,7 +116,11 @@ bool GCS_MAVLINK::send_ftp_reply(const pending_ftp &reply)
         reply.chan,
         0, reply.sysid, reply.compid,
         payload);
-    ftp.last_send_ms = AP_HAL::millis();
+    if (reply.req_opcode == FTP_OP::TerminateSession) {
+        ftp.last_send_ms = 0;
+    } else {
+        ftp.last_send_ms = AP_HAL::millis();
+    }
     return true;
 }
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -325,6 +325,13 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 
     AP_GROUPINFO("ESC_ARM_RPM", 41, SIM,  esc_rpm_armed, 0.0f),
 
+    // @Param: UART_LOSS
+    // @DisplayName: UART byte loss percentage
+    // @Description: Sets percentage of outgoing byte loss on UARTs
+    // @Units: %
+    // @User: Advanced
+    AP_GROUPINFO("UART_LOSS", 42, SIM,  uart_byte_loss_pct, 0),
+
     AP_SUBGROUPINFO(airspeed[0], "ARSPD_", 50, SIM, SIM::AirspeedParm),
 #if AIRSPEED_MAX_SENSORS > 1
     AP_SUBGROUPINFO(airspeed[1], "ARSPD2_", 51, SIM, SIM::AirspeedParm),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -236,6 +236,8 @@ public:
     AP_Int16 loop_time_jitter_us;
     AP_Int32 on_hardware_output_enable_mask;  // mask of output channels passed through to actual hardware
 
+    AP_Float uart_byte_loss_pct;
+
 #ifdef SFML_JOYSTICK
     AP_Int8 sfml_joystick_id;
     AP_Int8 sfml_joystick_axis[8];


### PR DESCRIPTION
this caused ftp downloads to intermittently fail. The cause is the FTP client may ask for a session terminate and then immediately afterwards a ftp open. The open would fail as the ftp session was considered active

this also adds SIM_UART_LOSS to make it easier for us to test lossy links