### PR TITLE
AP_MotorsHeli: add thrust linearization for ddfp tail rotors

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -142,28 +142,24 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Description: Tail rotor DDFP motor thrust curve exponent (0.0 for linear to 1.0 for second order curve)
     // @Range: -1 1
     // @User: Standard
-    AP_GROUPINFO("DDFP_THST_EXPO", 22, AP_MotorsHeli_Single,  thr_lin.curve_expo, 0.55),
 
     // @Param: DDFP_SPIN_MIN
     // @DisplayName: DDFP Tail Rotor Motor Spin minimum
     // @Description: Point at which the thrust starts expressed as a number from 0 to 1 in the entire output range.  Should be higher than MOT_SPIN_ARM.
     // @Values: 0.0:Low, 0.15:Default, 0.3:High
     // @User: Standard
-    AP_GROUPINFO("DDFP_SPIN_MIN", 23, AP_MotorsHeli_Single,  thr_lin.spin_min, 0.15),
 
     // @Param: DDFP_SPIN_MAX
     // @DisplayName: DDFP Tail Rotor Motor Spin maximum
     // @Description: Point at which the thrust saturates expressed as a number from 0 to 1 in the entire output range
     // @Values: 0.9:Low, 0.95:Default, 1.0:High
     // @User: Standard
-    AP_GROUPINFO("DDFP_SPIN_MAX", 24, AP_MotorsHeli_Single,  thr_lin.spin_max, 0.95),
 
     // @Param: DDFP_BAT_IDX
     // @DisplayName: DDFP Tail Rotor Battery compensation index
     // @Description: Which battery monitor should be used for doing compensation
     // @Values: 0:First battery, 1:Second battery
     // @User: Standard
-    AP_GROUPINFO("DDFP_BAT_IDX", 25, AP_MotorsHeli_Single, thr_lin.batt_idx, 0),
 
     // @Param: DDFP_BAT_V_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
@@ -171,7 +167,6 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Range: 6 53
     // @Units: V
     // @User: Standard
-    AP_GROUPINFO("DDFP_BAT_V_MAX", 26, AP_MotorsHeli_Single, thr_lin.batt_voltage_max, AP_MOTORS_HELI_SINGLE_BAT_VOLT_MAX_DEFAULT),
 
     // @Param: DDFP_BAT_V_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
@@ -179,7 +174,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Range: 6 42
     // @Units: V
     // @User: Standard
-    AP_GROUPINFO("DDFP_BAT_V_MIN", 27, AP_MotorsHeli_Single, thr_lin.batt_voltage_min, AP_MOTORS_HELI_SINGLE_BAT_VOLT_MIN_DEFAULT),
+    AP_SUBGROUPINFO(thr_lin, "DDFP_", 22, AP_MotorsHeli_Single, Thrust_Linearization),
 
     AP_GROUPEND
 };
@@ -608,6 +603,8 @@ void AP_MotorsHeli_Single::output_to_motors()
                 } else {
                     // if servo pwm min and max are bad, convert servo4_out from -1 to 1 to 0 to 1
                     servo_out = 0.5f * (_servo4_out + 1.0f);
+                    // this should never happen
+                    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                 }
                 // output yaw servo to tail rsc
                 rc_write(AP_MOTORS_MOT_4, calculate_ddfp_output(thr_lin.thrust_to_actuator(constrain_float(servo_out, 0.0f, 1.0f))));

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -35,9 +35,6 @@
 // maximum number of swashplate servos
 #define AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS            3
 
-#define AP_MOTORS_HELI_SINGLE_BAT_VOLT_MAX_DEFAULT             0.0f    // voltage limiting max default
-#define AP_MOTORS_HELI_SINGLE_BAT_VOLT_MIN_DEFAULT             0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
-
 /// @class      AP_MotorsHeli_Single
 class AP_MotorsHeli_Single : public AP_MotorsHeli {
 public:

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -8,6 +8,7 @@
 #include "AP_MotorsHeli.h"
 #include "AP_MotorsHeli_RSC.h"
 #include "AP_MotorsHeli_Swash.h"
+#include "AP_Motors_Thrust_Linearization.h"
 
 // rsc and extgyro function output channels.
 #define AP_MOTORS_HELI_SINGLE_EXTGYRO                          CH_7
@@ -33,6 +34,9 @@
 
 // maximum number of swashplate servos
 #define AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS            3
+
+#define AP_MOTORS_HELI_SINGLE_BAT_VOLT_MAX_DEFAULT             0.0f    // voltage limiting max default
+#define AP_MOTORS_HELI_SINGLE_BAT_VOLT_MIN_DEFAULT             0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
 
 /// @class      AP_MotorsHeli_Single
 class AP_MotorsHeli_Single : public AP_MotorsHeli {
@@ -79,6 +83,9 @@ public:
     // parameter_check - returns true if helicopter specific parameters are sensible, used for pre-arm check
     bool parameter_check(bool display_msg) const override;
 
+    // Thrust Linearization handling
+    Thrust_Linearization thr_lin {*this};
+
     // var_info
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -95,6 +102,9 @@ protected:
 
     // move_yaw - moves the yaw servo
     void move_yaw(float yaw_out);
+
+    // calculate the motor output for DDFP tails from yaw_out
+    uint16_t calculate_ddfp_output(float yaw_out);
 
     // servo_test - move servos through full range of movement
     void servo_test() override;
@@ -120,6 +130,9 @@ protected:
     float _servo3_out = 0.0f;                   // output value sent to motor
     float _servo4_out = 0.0f;                   // output value sent to motor
     float _servo5_out = 0.0f;                   // output value sent to motor
+    uint16_t _ddfp_pwm_min = 0;                 // minimum ddfp servo min
+    uint16_t _ddfp_pwm_max = 0;                 // minimum ddfp servo max
+    uint16_t _ddfp_pwm_trim = 0;                // minimum ddfp servo trim
 
     // parameters
     AP_Int16        _tail_type;                 // Tail type used: Servo, Servo with external gyro, direct drive variable pitch or direct drive fixed pitch

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -16,6 +16,56 @@
     #endif
 #endif
 
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo Thrust_Linearization::var_info[] = {
+
+    // @Param: THST_EXPO
+    // @DisplayName: Thrust Curve Expo
+    // @Description: motor thrust curve exponent (0.0 for linear to 1.0 for second order curve)
+    // @Range: -1 1
+    // @User: Standard
+    AP_GROUPINFO("THST_EXPO", 1, Thrust_Linearization,  curve_expo, THRST_LIN_THST_EXPO_DEFAULT),
+
+    // @Param: SPIN_MIN
+    // @DisplayName: Motor Spin minimum
+    // @Description: Point at which the thrust starts expressed as a number from 0 to 1 in the entire output range.  Should be higher than MOT_SPIN_ARM.
+    // @Values: 0.0:Low, 0.15:Default, 0.3:High
+    // @User: Standard
+    AP_GROUPINFO("SPIN_MIN", 2, Thrust_Linearization,  spin_min, THRST_LIN_SPIN_MIN_DEFAULT),
+
+    // @Param: SPIN_MAX
+    // @DisplayName: Motor Spin maximum
+    // @Description: Point at which the thrust saturates expressed as a number from 0 to 1 in the entire output range
+    // @Values: 0.9:Low, 0.95:Default, 1.0:High
+    // @User: Standard
+    AP_GROUPINFO("SPIN_MAX", 3, Thrust_Linearization,  spin_max, THRST_LIN_SPIN_MAX_DEFAULT),
+
+    // @Param: BAT_IDX
+    // @DisplayName: Battery compensation index
+    // @Description: Which battery monitor should be used for doing compensation
+    // @Values: 0:First battery, 1:Second battery
+    // @User: Standard
+    AP_GROUPINFO("BAT_IDX", 4, Thrust_Linearization, batt_idx, 0),
+
+    // @Param: BAT_V_MAX
+    // @DisplayName: Battery voltage compensation maximum voltage
+    // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.2 * cell count, 0 = Disabled
+    // @Range: 6 53
+    // @Units: V
+    // @User: Standard
+    AP_GROUPINFO("BAT_V_MAX", 5, Thrust_Linearization, batt_voltage_max, THRST_LIN_BAT_VOLT_MAX_DEFAULT),
+
+    // @Param: BAT_V_MIN
+    // @DisplayName: Battery voltage compensation minimum voltage
+    // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.3 * cell count, 0 = Disabled
+    // @Range: 6 42
+    // @Units: V
+    // @User: Standard
+    AP_GROUPINFO("BAT_V_MIN", 6, Thrust_Linearization, batt_voltage_min, THRST_LIN_BAT_VOLT_MIN_DEFAULT),
+
+    AP_GROUPEND
+};
 
 Thrust_Linearization::Thrust_Linearization(AP_Motors& _motors) :
     motors(_motors),
@@ -24,6 +74,8 @@ Thrust_Linearization::Thrust_Linearization(AP_Motors& _motors) :
     // setup battery voltage filtering
     batt_voltage_filt.set_cutoff_frequency(AP_MOTORS_BATT_VOLT_FILT_HZ);
     batt_voltage_filt.reset(1.0);
+
+    AP_Param::setup_object_defaults(this, var_info);
 }
 
 // converts desired thrust to linearized actuator output in a range of 0~1

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -16,6 +16,21 @@
     #endif
 #endif
 
+#if APM_BUILD_TYPE(APM_BUILD_Heli)
+    #define THRST_LIN_THST_EXPO_DEFAULT     0.55f   // set to 0 for linear and 1 for second order approximation
+    #define THRST_LIN_SPIN_MIN_DEFAULT      0.15f   // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    #define THRST_LIN_SPIN_MAX_DEFAULT      0.95f   // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    #define THRST_LIN_BAT_VOLT_MAX_DEFAULT  0.0f    // voltage limiting max default
+    #define THRST_LIN_BAT_VOLT_MIN_DEFAULT  0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
+#else
+    #define THRST_LIN_THST_EXPO_DEFAULT     0.65f   // set to 0 for linear and 1 for second order approximation
+    #define THRST_LIN_SPIN_MIN_DEFAULT      0.15f   // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    #define THRST_LIN_SPIN_MAX_DEFAULT      0.95f   // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    #define THRST_LIN_BAT_VOLT_MAX_DEFAULT  0.0f    // voltage limiting max default
+    #define THRST_LIN_BAT_VOLT_MIN_DEFAULT  0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
+#endif
+
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo Thrust_Linearization::var_info[] = {
@@ -75,7 +90,9 @@ Thrust_Linearization::Thrust_Linearization(AP_Motors& _motors) :
     batt_voltage_filt.set_cutoff_frequency(AP_MOTORS_BATT_VOLT_FILT_HZ);
     batt_voltage_filt.reset(1.0);
 
+#if APM_BUILD_TYPE(APM_BUILD_Heli)
     AP_Param::setup_object_defaults(this, var_info);
+#endif
 }
 
 // converts desired thrust to linearized actuator output in a range of 0~1

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
@@ -7,6 +7,7 @@ class AP_Motors;
 class Thrust_Linearization {
 friend class AP_MotorsMulticopter;
 friend class AP_MotorsMulticopter_test;
+friend class AP_MotorsHeli_Single;
 public:
     Thrust_Linearization(AP_Motors& _motors);
 

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
@@ -3,6 +3,12 @@
 #include <AP_Param/AP_Param.h>
 #include <Filter/LowPassFilter.h>
 
+#define THRST_LIN_THST_EXPO_DEFAULT     0.55f   // set to 0 for linear and 1 for second order approximation
+#define THRST_LIN_SPIN_MIN_DEFAULT      0.15f   // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+#define THRST_LIN_SPIN_MAX_DEFAULT      0.95f   // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+#define THRST_LIN_BAT_VOLT_MAX_DEFAULT  0.0f    // voltage limiting max default
+#define THRST_LIN_BAT_VOLT_MIN_DEFAULT  0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
+
 class AP_Motors;
 class Thrust_Linearization {
 friend class AP_MotorsMulticopter;
@@ -43,6 +49,9 @@ public:
 
     // Get lift max
     float get_lift_max() const { return lift_max; }
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
     AP_Float curve_expo;       // curve used to linearize pwm to thrust conversion.  set to 0 for linear and 1 for second order approximation

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
@@ -3,12 +3,6 @@
 #include <AP_Param/AP_Param.h>
 #include <Filter/LowPassFilter.h>
 
-#define THRST_LIN_THST_EXPO_DEFAULT     0.55f   // set to 0 for linear and 1 for second order approximation
-#define THRST_LIN_SPIN_MIN_DEFAULT      0.15f   // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
-#define THRST_LIN_SPIN_MAX_DEFAULT      0.95f   // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
-#define THRST_LIN_BAT_VOLT_MAX_DEFAULT  0.0f    // voltage limiting max default
-#define THRST_LIN_BAT_VOLT_MIN_DEFAULT  0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
-
 class AP_Motors;
 class Thrust_Linearization {
 friend class AP_MotorsMulticopter;


### PR DESCRIPTION
This PR includes code from the multicopter motors library that linearizes the DDFP tail rotor thrust and adjusts for battery voltage.  This was tested on an actual heli.  