### PR TITLE
Cope with sensor alignment not being set in betaflight

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
@@ -2,6 +2,9 @@
 '''
 convert a betaflight unified configuration file into a hwdef.dat
 currently very approximate, file requires cleanup afterwards
+must be run from within a source tree as it relies on other other python files
+
+code by Andy Piper <github@andypiper.com>
 '''
 
 import sys, re

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
@@ -91,7 +91,11 @@ def write_imu_config(f, n):
     global dma_noshare
     global dma_pri
     bus = settings['gyro_' + n + '_spibus']
-    align = settings['gyro_' + n + '_sensor_align']
+    sensor_align = 'gyro_' + n + '_sensor_align'
+    if sensor_align in settings:
+        align = settings[sensor_align]
+    else:
+        align = 'CW0'
     f.write('''
 # IMU setup
 SPIDEV imu%s   SPI%s DEVID1 GYRO%s_CS   MODE3   1*MHZ   8*MHZ


### PR DESCRIPTION
Address some small issues with the betaflight converter script working on other boards:
- if IMU orientation is not set, use a default