### PR TITLE
Plane: Quadplane: limit manual throttle tilt angle to Q_TILT_MAX

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -292,9 +292,9 @@ void Tiltrotor::continuous_update(void)
             // no manual throttle control, set angle to zero
             slew(0);
         } else {
-            // manual control of forward throttle
+            // manual control of forward throttle up to max VTOL angle
             float settilt = .01f * quadplane.forward_throttle_pct();
-            slew(settilt);
+            slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt())); 
         }
         return;
     }


### PR DESCRIPTION
Fixes a exciting issue where it was possible to manually move the tilts past tilt max thus the `tilt_over_max_angle` check returns true and control of the vectored tilts is handed over to the FW controller while still in a VTOL mode:

https://github.com/ArduPilot/ardupilot/blob/12c24df47653f769b35bce7ba756499c98209f46/ArduPlane/tiltrotor.cpp#L548
 
Now uses the same constraint as when in position control VTOL modes:

https://github.com/ArduPilot/ardupilot/blob/12c24df47653f769b35bce7ba756499c98209f46/ArduPlane/tiltrotor.cpp#L313