### PR TITLE
Plane: support NAV_PAYLOAD_PLACE mission item for quadplanes

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -413,7 +413,7 @@ bool AP_Arming_Plane::mission_checks(bool report)
             if (!plane.mission.read_cmd_from_storage(i, cmd)) {
                 break;
             }
-            if ((cmd.id == MAV_CMD_NAV_VTOL_LAND || cmd.id == MAV_CMD_NAV_LAND) &&
+            if (plane.is_land_command(cmd.id) &&
                 prev_cmd.id == MAV_CMD_NAV_WAYPOINT) {
                 const float dist = cmd.content.location.get_distance(prev_cmd.content.location);
                 const float tecs_land_speed = plane.TECS_controller.get_land_airspeed();

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -801,6 +801,19 @@ bool Plane::set_velocity_match(const Vector2f &velocity)
     return false;
 }
 
+// allow for override of land descent rate
+bool Plane::set_land_descent_rate(float descent_rate)
+{
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.in_vtol_land_descent()) {
+        quadplane.poscontrol.override_descent_rate = descent_rate;
+        quadplane.poscontrol.last_override_descent_ms = AP_HAL::millis();
+        return true;
+    }
+#endif
+    return false;
+}
+
 #endif // AP_SCRIPTING_ENABLED
 
 // correct AHRS pitch for TRIM_PITCH_CD in non-VTOL modes, and return VTOL view in VTOL

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1039,8 +1039,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         {
             uint16_t mission_id = plane.mission.get_current_nav_cmd().id;
             bool is_in_landing = (plane.flight_stage == AP_FixedWing::FlightStage::LAND) ||
-                                 (mission_id == MAV_CMD_NAV_LAND) ||
-                                 (mission_id == MAV_CMD_NAV_VTOL_LAND);
+                plane.is_land_command(mission_id);
             if (is_in_landing) {
                 // fly a user planned abort pattern if available
                 if (plane.mission.jump_to_abort_landing_sequence()) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -936,6 +936,13 @@ private:
     void do_nav_delay(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
+    bool is_land_command(uint16_t cmd) const;
+
+    /*
+      return true if in a specific AUTO mission command
+    */
+    bool in_auto_mission_id(uint16_t command) const;
+    
     // Delay the next navigation command
     struct {
         uint32_t time_max_ms;
@@ -953,12 +960,6 @@ private:
     void update_home();
     // set home location and store it persistently:
     bool set_home_persistently(const Location &loc) WARN_IF_UNUSED;
-
-    // quadplane.cpp
-#if HAL_QUADPLANE_ENABLED
-    bool verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd);
-    bool verify_vtol_land(const AP_Mission::Mission_Command &cmd);
-#endif
 
     // control_modes.cpp
     void read_control_switch();
@@ -1226,6 +1227,9 @@ public:
     bool get_target_location(Location& target_loc) override;
     bool update_target_location(const Location &old_loc, const Location &new_loc) override;
     bool set_velocity_match(const Vector2f &velocity) override;
+
+    // allow for landing descent rate to be overridden by a script, may be -ve to climb
+    bool set_land_descent_rate(float descent_rate) override;
 #endif // AP_SCRIPTING_ENABLED
 
 };

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -98,6 +98,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         return quadplane.do_vtol_takeoff(cmd);
 
     case MAV_CMD_NAV_VTOL_LAND:
+    case MAV_CMD_NAV_PAYLOAD_PLACE:
         if (quadplane.landing_with_fixed_wing_spiral_approach()) {
             // the user wants to approach the landing in a fixed wing flight mode
             // the waypoint will be used as a loiter_to_alt
@@ -243,7 +244,7 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
     case MAV_CMD_NAV_LAND:
 #if HAL_QUADPLANE_ENABLED
         if (quadplane.is_vtol_land(cmd.id)) {
-            return quadplane.verify_vtol_land();            
+            return quadplane.verify_vtol_land();
         }
 #endif
         if (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
@@ -286,6 +287,7 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
     case MAV_CMD_NAV_VTOL_TAKEOFF:
         return quadplane.verify_vtol_takeoff(cmd);
     case MAV_CMD_NAV_VTOL_LAND:
+    case MAV_CMD_NAV_PAYLOAD_PLACE:
         if (quadplane.landing_with_fixed_wing_spiral_approach() && !verify_landing_vtol_approach(cmd)) {
             // verify_landing_vtol_approach will return true once we have completed the approach,
             // in which case we fall over to normal vtol landing code
@@ -1265,3 +1267,24 @@ bool Plane::nav_scripting_enable(uint8_t mode)
    return nav_scripting.enabled;
 }
 #endif // AP_SCRIPTING_ENABLED
+
+/*
+  return true if this is a LAND command
+  note that we consider a PAYLOAD_PLACE to be a land command as it
+  follows the landing logic for quadplanes
+ */
+bool Plane::is_land_command(uint16_t command) const
+{
+    return
+        command == MAV_CMD_NAV_VTOL_LAND ||
+        command == MAV_CMD_NAV_LAND ||
+        command == MAV_CMD_NAV_PAYLOAD_PLACE;
+}
+
+/*
+  return true if in a specific AUTO mission command
+ */
+bool Plane::in_auto_mission_id(uint16_t command) const
+{
+    return control_mode == &mode_auto && mission.get_current_nav_id() == command;
+}

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -97,6 +97,9 @@ public:
         return available() && assisted_flight;
     }
 
+    // abort landing, only valid when in a VTOL landing descent
+    bool abort_landing(void);
+
     /*
       return true if we are in a transition to fwd flight from hover
     */
@@ -171,6 +174,11 @@ public:
 
     // Check if servo auto trim is allowed
     bool allow_servo_auto_trim();
+
+    /*
+      are we in the descent phase of a VTOL landing?
+     */
+    bool in_vtol_land_descent(void) const;
 
 private:
     AP_AHRS &ahrs;
@@ -461,6 +469,7 @@ private:
         QPOS_POSITION1,
         QPOS_POSITION2,
         QPOS_LAND_DESCEND,
+        QPOS_LAND_ABORT,
         QPOS_LAND_FINAL,
         QPOS_LAND_COMPLETE
     };
@@ -491,6 +500,9 @@ private:
         float target_accel;
         uint32_t last_pos_reset_ms;
         bool overshoot;
+
+        float override_descent_rate;
+        uint32_t last_override_descent_ms;
     private:
         uint32_t last_state_change_ms;
         enum position_control_state state;
@@ -574,6 +586,9 @@ private:
 
     float last_land_final_agl;
 
+    // AHRS alt for land abort and package place, meters
+    float land_descend_start_alt;
+
     // min alt for navigation in takeoff
     AP_Float takeoff_navalt_min;
     uint32_t takeoff_last_run_ms;
@@ -602,11 +617,6 @@ private:
       are we in the approach phase of a VTOL landing?
      */
     bool in_vtol_land_approach(void) const;
-
-    /*
-      are we in the descent phase of a VTOL landing?
-     */
-    bool in_vtol_land_descent(void) const;
 
     /*
       are we in the final landing phase of a VTOL landing?

--- a/libraries/AP_Scripting/applets/plane_package_place.lua
+++ b/libraries/AP_Scripting/applets/plane_package_place.lua
@@ -1,0 +1,186 @@
+--[[
+ support package place for quadplanes
+--]]
+
+local PARAM_TABLE_KEY = 9
+local PARAM_TABLE_PREFIX = "PKG_"
+
+local MODE_AUTO = 10
+
+local NAV_TAKEOFF = 22
+local NAV_VTOL_PAYLOAD_PLACE = 94
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+   assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+   return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+-- setup package place specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 5), 'could not add param table')
+local PKG_ENABLE        = bind_add_param('ENABLE', 1, 0)
+local PKG_RELEASE_FUNC  = bind_add_param('RELEASE_FUNC', 2, 94)
+local PKG_RELEASE_HGT   = bind_add_param('RELEASE_HGT',  3, 10)
+local PKG_RELEASE_HOLD  = bind_add_param('RELEASE_HOLD', 4, 1)
+
+local Q_LAND_SPEED = Parameter("Q_LAND_SPEED")
+local Q_LAND_FINAL_ALT = Parameter("Q_LAND_FINAL_ALT")
+
+local MAV_SEVERITY_INFO = 6
+local MAV_SEVERITY_NOTICE = 5
+local MAV_SEVERITY_EMERGENCY = 0
+
+local RNG_ORIENT_DOWN = 25
+
+-- motors state
+local MOTORS_SHUT_DOWN = 0
+
+-- release state
+local RELEASE_NONE    = 0
+local RELEASE_DESCENT = 1
+local RELEASE_HOLD1   = 2
+local RELEASE_HOLD2   = 3
+local RELEASE_DONE    = 4
+local release_state = RELEASE_NONE
+
+local release_start_t = 0
+
+if PKG_ENABLE:get() ~= 1 then
+   -- not enabled
+   return
+end
+
+SRV_Channels:set_range(PKG_RELEASE_FUNC:get(), 1000)
+SRV_Channels:set_output_scaled(PKG_RELEASE_FUNC:get(), 0)
+
+-- get time in seconds
+function get_time()
+   return millis():tofloat() * 0.001
+end
+
+-- reset state
+function reset()
+   release_state = RELEASE_NONE
+   SRV_Channels:set_output_scaled(PKG_RELEASE_FUNC:get(), 0)
+end
+
+--[[
+   main update function, called at 20Hz
+--]]
+function update()
+   if PKG_ENABLE:get() ~= 1 then
+      -- not enabled
+      return
+   end
+
+   -- only do something if in AUTO and in a PACKAGE_PLACE waypoint
+   if vehicle:get_mode() ~= MODE_AUTO or mission:get_current_nav_id() ~= NAV_VTOL_PAYLOAD_PLACE then
+      reset()
+      return
+   end
+
+   if not arming:is_armed() then
+      -- nothing to do when disarmed
+      reset()
+      return
+   end
+
+   -- check spool state for if we are landed
+   local landed = false
+   if motors:get_desired_spool_state() == MOTORS_SHUT_DOWN and release_state >= RELEASE_DESCENT then
+      landed = true
+   end
+
+   -- wait till we are in the descent
+   if not quadplane:in_vtol_land_descent() and release_state == RELEASE_NONE then
+      reset()
+      return
+   end
+
+   if release_state == RELEASE_NONE then
+      -- we have started the descent
+      release_state = RELEASE_DESCENT
+   end
+
+   -- see if we have valid rangefinder data
+   if not landed and not rangefinder:has_data_orient(RNG_ORIENT_DOWN) then
+      return
+   end
+
+   -- check the distance, if less than RNG_ORIENT_DOWN then release
+   local dist_m
+   if not landed then
+      dist_m = rangefinder:distance_cm_orient(RNG_ORIENT_DOWN) * 0.01
+   else
+      dist_m = 0.0
+   end
+
+   -- slow down when within Q_LAND_FINAL_ALT of target
+   local remaining_m = dist_m - PKG_RELEASE_HGT:get()
+   if remaining_m > 0 and remaining_m < Q_LAND_FINAL_ALT:get() then
+      vehicle:set_land_descent_rate(Q_LAND_SPEED:get()*0.01)
+   end
+
+   if remaining_m <= 0 then
+      if PKG_RELEASE_HGT:get() <= 0 and not landed then
+         -- wait for landing
+         return
+      end
+
+      local now = get_time()
+      -- we are at the target altitude
+      if release_state == RELEASE_DESCENT then
+         -- start timer
+         release_start_t = now
+         release_state = RELEASE_HOLD1
+         vehicle:set_land_descent_rate(0)
+      elseif release_state == RELEASE_HOLD1 then
+         -- start waiting for the hold time for vehicle to settle
+         vehicle:set_land_descent_rate(0)
+         if now - release_start_t > PKG_RELEASE_HOLD:get() then
+            gcs:send_text(MAV_SEVERITY_INFO, string.format("Package released at %.1fm", dist_m))
+            SRV_Channels:set_output_scaled(PKG_RELEASE_FUNC:get(), 1000)
+            release_state = RELEASE_HOLD2
+         end
+      elseif release_state == RELEASE_HOLD2 then
+         -- do the release and wait for hold time again to ensure clean release
+         vehicle:set_land_descent_rate(0)
+         if now - release_start_t > PKG_RELEASE_HOLD:get()*2 then
+            release_state = RELEASE_DONE
+            -- aborting the landing causes us to climb back up and continue the mission
+            if quadplane:abort_landing() then
+               gcs:send_text(MAV_SEVERITY_INFO, string.format("Climbing"))
+            else
+               gcs:send_text(MAV_SEVERITY_NOTICE, string.format("land abort failed"))
+            end
+         end
+      end
+   end
+
+end
+
+function loop()
+   update()
+   -- run at 20Hz
+   return loop, 50
+end
+
+-- wrapper around update(). This calls update() at 20Hz,
+-- and if update faults then an error is displayed, but the script is not
+-- stopped
+function protected_wrapper()
+  local success, err = pcall(update)
+  if not success then
+     gcs:send_text(0, "Internal Error: " .. err)
+     -- when we fault we run the update function again after 1s, slowing it
+     -- down a bit so we don't flood the console with errors
+     return protected_wrapper, 1000
+  end
+  return protected_wrapper, 50
+end
+
+gcs:send_text(MAV_SEVERITY_INFO, "Loaded package place script")
+
+-- start running update loop
+return protected_wrapper()
+

--- a/libraries/AP_Scripting/applets/plane_package_place.md
+++ b/libraries/AP_Scripting/applets/plane_package_place.md
@@ -1,0 +1,65 @@
+# Quadplane Package Place Support
+
+This script implements support for package place in quadplanes.
+
+To use this script you need to install it in the APM/scripts folder on
+your microSD card (or build it into the firmware in ROMFS). Then
+enable scripting with SCR_ENABLE=1 and reboot.
+
+# Parameters
+
+The script adds the following parameters:
+
+## PKG_ENABLE
+
+You need to set PKG_ENABLE=1 to enable this script
+
+## PKG_RELEASE_FUNC
+
+This needs to be set to the SERVOn_FUNCTION of the release servo. It
+is recommended that you leave it at the default of 94 and set
+SERVOn_FUNCTION to 94 for the servo you want to use for package
+release.
+
+## PKG_RELEASE_HGT
+
+The parameter PKG_RELEASE_HGT controls the rangefinder height at which
+the package will be released. This can be zero if you want to release
+the package after you land.
+
+## PKG_RELEASE_HOLD
+
+This controls the time that the vehicle will stop the descent before
+it releases the package. This defaults to 1 second and is used to let
+the vehicle get into a steady hover.
+
+After package release the vehicle will hold for another
+PKG_RELEASE_HOLD seconds to let the package cleanly release before the
+vehicle climbs.
+
+# Operation
+
+To setup a mission for package place you should setup your vehicle for
+rangefinder landings. Setup a good lidar or radar and test that it
+works. Then set RNGFND_LANDING=1 to enable use of rangefinder for VTOL
+landing.
+
+In the mission you should add a PAYLOAD_PLACE waypoint at the desired
+location of the payload placement. The altitude of the PAYLOAD_PLACE
+command should be set to zero as a relative height.
+
+The PAYLOAD_PLACE command has a parametere "max descent" (parameter 1
+of the command). If this is non-zero then this is the maximum amount
+of height that the aircraft will descend from the start of the
+descent. If the aircraft tries to descend more than this height then
+the payload place will abort and the aircraft will climb back up to
+the initial descent height then continue the mission.
+
+# Landing Then Release
+
+You can also do payload place where you wait till the vehicle fully
+lands before doing the release. To do that set PGK_RELEASE_HGT to 0
+and the aircraft will land fully and shutdown the motors for
+PKG_RELEASE_HOLD seconds before releasing the servo. It will then hold
+for another PKG_RELEASE_HOLD seconds, then will climb back up to the
+original descent start height before continuing with the mission.

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1047,6 +1047,9 @@ function motors:get_interlock() end
 ---@param param1 string
 function motors:set_frame_string(param1) end
 
+-- desc
+---@return integer
+function motors:get_desired_spool_state() end
 
 -- desc
 ---@class FWVersion
@@ -1254,6 +1257,14 @@ function quadplane:in_assisted_flight() end
 -- desc
 ---@return boolean
 function quadplane:in_vtol_mode() end
+
+-- true in descent phase of VTOL landing
+---@return boolean
+function quadplane:in_vtol_land_descent() end
+
+-- abort a VTOL landing, climbing back up
+---@return boolean
+function quadplane:abort_landing() end
 
 
 -- desc
@@ -1620,6 +1631,11 @@ function serialLED:set_num_neopixel(chan, num_leds) end
 -- desc
 ---@class vehicle
 vehicle = {}
+
+-- override landing descent rate, times out in 1s
+---@param rate number
+---@return boolean
+function vehicle:set_land_descent_rate(rate) end
 
 -- desc
 ---@return boolean

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -258,6 +258,7 @@ singleton AP_Vehicle method set_desired_turn_rate_and_speed boolean float'skip_c
 singleton AP_Vehicle method set_desired_speed boolean float'skip_check
 singleton AP_Vehicle method nav_scripting_enable boolean uint8_t'skip_check
 singleton AP_Vehicle method set_velocity_match boolean Vector2f
+singleton AP_Vehicle method set_land_descent_rate boolean float'skip_check
 singleton AP_Vehicle method has_ekf_failsafed boolean
 
 include AP_SerialLED/AP_SerialLED.h
@@ -414,6 +415,8 @@ singleton QuadPlane rename quadplane
 singleton QuadPlane depends APM_BUILD_TYPE(APM_BUILD_ArduPlane) && HAL_QUADPLANE_ENABLED
 singleton QuadPlane method in_vtol_mode boolean
 singleton QuadPlane method in_assisted_flight boolean
+singleton QuadPlane method abort_landing boolean
+singleton QuadPlane method in_vtol_land_descent boolean
 
 include AP_Motors/AP_MotorsMatrix.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
@@ -524,6 +527,7 @@ singleton AP::motors() literal
 singleton AP::motors() rename motors
 singleton AP::motors() method set_frame_string void string
 singleton AP::motors() method get_interlock boolean
+singleton AP::motors() method get_desired_spool_state uint8_t
 
 include AP_Common/AP_FWVersion.h
 singleton AP::fwversion() literal

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -188,6 +188,9 @@ public:
     // returns true if the EKF failsafe has triggered
     virtual bool has_ekf_failsafed() const { return false; }
 
+    // allow for landing descent rate to be overridden by a script, may be -ve to climb
+    virtual bool set_land_descent_rate(float descent_rate) { return false; }
+    
     // control outputs enumeration
     enum class ControlOutput {
         Roll = 1,


### PR DESCRIPTION
This allows quadplanes to do package delivery using a lua script. Documentation is provided in the applets directory

This is a typical mission:
![image](https://user-images.githubusercontent.com/831867/212832427-f35fd847-7b33-4115-86ae-6f9013bd56d9.png)

The script adds some PKG_ parameters to control the release height and hold time. It supports both payload place with hover, and waiting for a full landing before releasing the package

Testing has only been done in SITL so far

MissionPlanner needs the following change: https://github.com/ArduPilot/MissionPlanner/pull/3045

Demo video: https://www.youtube.com/watch?v=A8Romq6wiek
