### PR TITLE
AP_Scripting:examples - rangefinder_test.lua : Minor Spelling Correction

### DIFF
--- a/libraries/AP_Scripting/examples/rangefinder_test.lua
+++ b/libraries/AP_Scripting/examples/rangefinder_test.lua
@@ -25,7 +25,7 @@ function info(rotation)
   local offset = rangefinder:get_pos_offset_orient(rotation)
   local distance_cm = rangefinder:distance_cm_orient(rotation)
 
-  gcs:send_text(0, string.format("Ratation %d %.0f cm range %d - %d offset %.0f %.0f %.0f ground clearance %.0f", rotation, distance_cm, distance_min, distance_max, offset:x(), offset:y(), offset:z(), ground_clearance))
+  gcs:send_text(0, string.format("Rotation %d %.0f cm range %d - %d offset %.0f %.0f %.0f ground clearance %.0f", rotation, distance_cm, distance_min, distance_max, offset:x(), offset:y(), offset:z(), ground_clearance))
 end
 
 return update(), 1000 -- first message may be displayed 1 seconds after start-up


### PR DESCRIPTION
found while reviewing lua examples..

Ratation -> Rotation