### PR TITLE
Correct use of SIM_ESC_TELEM parameter

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9223,6 +9223,7 @@ class AutoTestCopter(AutoTest):
             "SERVO6_FUNCTION": 34,
             "SERVO7_FUNCTION": 35,
             "SERVO8_FUNCTION": 36,
+            "SIM_ESC_TELEM": 0,
         })
         self.customise_SITL_commandline(["--uartF=sim:fetteconewireesc"])
         self.FETtecESC_safety_switch()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2209,7 +2209,6 @@ class AutoTest(ABC):
             "SIM_ENGINE_FAIL",
             "SIM_ENGINE_MUL",
             "SIM_ESC_ARM_RPM",
-            "SIM_ESC_TELEM",
             "SIM_FLOAT_EXCEPT",
             "SIM_FLOW_DELAY",
             "SIM_FLOW_ENABLE",

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -88,18 +88,14 @@ void RCOutput::push(void)
         _corked = false;
     }
 
-    // do not overwrite FETTec simulation's ESC telemetry data:
     SITL::SIM *sitl = AP::sitl();
-    if (sitl != nullptr &&
-        sitl->fetteconewireesc_sim.enabled()) {
-        return;
-    }
-
-    if (esc_telem == nullptr) {
-        esc_telem = new AP_ESC_Telem_SITL;
-    }
-    if (esc_telem != nullptr) {
-        esc_telem->update();
+    if (sitl && sitl->esc_telem) {
+        if (esc_telem == nullptr) {
+            esc_telem = new AP_ESC_Telem_SITL;
+        }
+        if (esc_telem != nullptr) {
+            esc_telem->update();
+        }
     }
 }
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -339,6 +339,10 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Units: m
     // @User: Advanced
 
+    // @Param: ESC_TELEM
+    // @DisplayName: Simulated ESC Telemetry
+    // @Description: enable perfect simulated ESC telemetry
+    // @User: Advanced
     AP_GROUPINFO("ESC_TELEM", 40, SIM, esc_telem, 1),
 
     AP_GROUPINFO("ESC_ARM_RPM", 41, SIM,  esc_rpm_armed, 0.0f),


### PR DESCRIPTION
This was otherwise unused.  Looks like it might have been meant to be used at some stage...
