### PR TITLE
MAVFtp: possible division by zero, and another correction

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -132,8 +132,8 @@ public:
      */
     virtual uint64_t receive_time_constraint_us(uint16_t nbytes) { return 0; }
 
-    virtual uint32_t bw_in_kilobytes_per_second() const {
-        return 57;
+    virtual uint32_t bw_in_bytes_per_second() const {
+        return 5760;
     }
 
     virtual uint32_t get_baud_rate() const { return 0; }

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -133,11 +133,11 @@ public:
      */
     uint64_t receive_time_constraint_us(uint16_t nbytes) override;
 
-    uint32_t bw_in_kilobytes_per_second() const override {
+    uint32_t bw_in_bytes_per_second() const override {
         if (sdef.is_usb) {
-            return 200;
+            return 200*1024;
         }
-        return _baudrate/(9*1024);
+        return _baudrate/10;
     }
 
     uint32_t get_baud_rate() const override { return _baudrate; }

--- a/libraries/AP_HAL_ESP32/UARTDriver.h
+++ b/libraries/AP_HAL_ESP32/UARTDriver.h
@@ -71,9 +71,9 @@ public:
     size_t write(const uint8_t *buffer, size_t size) override;
 
     bool discard_input() override; // discard all bytes available for reading
-    uint32_t bw_in_kilobytes_per_second() const override
+    uint32_t bw_in_bytes_per_second() const override
     {
-        return 10;
+        return 10*1024;
     }
 
     //bool lock_port(uint32_t write_key, uint32_t read_key) override;

--- a/libraries/AP_HAL_ESP32/WiFiDriver.h
+++ b/libraries/AP_HAL_ESP32/WiFiDriver.h
@@ -44,9 +44,9 @@ public:
     size_t write(uint8_t c) override;
     size_t write(const uint8_t *buffer, size_t size) override;
 
-    uint32_t bw_in_kilobytes_per_second() const override
+    uint32_t bw_in_bytes_per_second() const override
     {
-        return 1000;
+        return 1000*1024;
     }
 
 

--- a/libraries/AP_HAL_ESP32/WiFiUdpDriver.h
+++ b/libraries/AP_HAL_ESP32/WiFiUdpDriver.h
@@ -43,9 +43,9 @@ public:
     size_t write(uint8_t c) override;
     size_t write(const uint8_t *buffer, size_t size) override;
 
-    uint32_t bw_in_kilobytes_per_second() const override
+    uint32_t bw_in_bytes_per_second() const override
     {
-        return 1000;
+        return 1000*1024;
     }
 
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -499,12 +499,11 @@ void GCS_MAVLINK::ftp_worker(void) {
                         if (valid_channel(request.chan)) {
                             auto *port = mavlink_comm_port[request.chan];
                             if (port != nullptr && port->get_flow_control() != AP_HAL::UARTDriver::FLOW_CONTROL_ENABLE) {
-                                const uint32_t bw = port->bw_in_kilobytes_per_second();
+                                const uint32_t bw = port->bw_in_bytes_per_second();
                                 const uint16_t pkt_size = PAYLOAD_SIZE(request.chan, FILE_TRANSFER_PROTOCOL) - (sizeof(reply.data) - max_read);
-                                burst_delay_ms = 3 * pkt_size / bw;
+                                burst_delay_ms = 3000 * pkt_size / bw;
                             }
                         }
-
 
                         // this transfer size is enough for a full parameter file with max parameters
                         const uint32_t transfer_size = 500;

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -47,11 +47,10 @@ GCS_MAVLINK::queued_param_send()
     const uint32_t tnow = AP_HAL::millis();
     const uint32_t tstart = AP_HAL::micros();
 
-    // use at most 30% of bandwidth on parameters. The constant 26 is
-    // 1/(1000 * 1/8 * 0.001 * 0.3)
-    const uint32_t link_bw = _port->bw_in_kilobytes_per_second();
+    // use at most 30% of bandwidth on parameters
+    const uint32_t link_bw = _port->bw_in_bytes_per_second();
 
-    uint32_t bytes_allowed = link_bw * (tnow - _queued_parameter_send_time_ms) * 26;
+    uint32_t bytes_allowed = link_bw * (tnow - _queued_parameter_send_time_ms) / 3333;
     const uint16_t size_for_one_param_value_msg = MAVLINK_MSG_ID_PARAM_VALUE_LEN + packet_overhead();
     if (bytes_allowed < size_for_one_param_value_msg) {
         bytes_allowed = size_for_one_param_value_msg;


### PR DESCRIPTION
The function bw_in_kilobytes_per_second() does return a value of zero for baudrates of 4800 and lower, which in https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_FTP.cpp#L504 would result in a division by zero.

This is corrected here by changing the function to return bytes/sec and not kBytes/sec.

Note: While I'm not using such small baudrates myself, I have seen that some folks do.

The division by zero should probably be considered serious.

The occasion is grabbed to correct also a long standing bug in the calculation for the parameter upload here https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Param.cpp#L50-L54. A value of zero doesn't cause a real issue here thx to the following if's, but the factor 26 is wrong, i.e., too large by a factor of 80 with the obvious effect that the whole mechanism is ineffective.

This change needs probably larger testing (besides by myself) since it's changing behavior.

As a side note, I would wish the FTP slowing down would also consider get_last_txbuf(). I am experimenting with inserting something like 
```
if (burst_delay_ms) {
   for (uint8_t n = 0; n < 20; n++) {
      if (get_last_txbuf() > 50) break;
      hal.scheduler->delay(burst_delay_ms);
   }
}
```
at this line https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_FTP.cpp#L512, which skips up to 20 "slots", but I don't feel comfortable to pr anything at the time being.
