### PR TITLE
AP_InertialSensor: fixed flood of log with fast fifo reset

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -453,14 +453,11 @@ bool AP_InertialSensor_Invensense::update() /* front end */
         // check if we have reported in the last 1 seconds or
         // fast_reset_count changed
 #if HAL_GCS_ENABLED && BOARD_FLASH_SIZE > 1024
-        if (AP_HAL::millis() - last_fast_reset_count_report_ms > 1000) {
-            last_fast_reset_count_report_ms = AP_HAL::millis();
-            char param_name[sizeof("IMUx_RST")];
-            if (_gyro_instance <= 9) {
-                snprintf(param_name, sizeof(param_name), "IMU%u_RST", _gyro_instance);
-            } else {
-                snprintf(param_name, sizeof(param_name), "IMUx_RST");
-            }
+        const uint32_t now = AP_HAL::millis();
+        if (now - last_fast_reset_count_report_ms > 5000U) {
+            last_fast_reset_count_report_ms = now;
+            char param_name[sizeof("IMUxx_RST")];
+            snprintf(param_name, sizeof(param_name), "IMU%u_RST", MIN(_gyro_instance,9));
             gcs().send_named_float(param_name, fast_reset_count);
         }
 #endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -467,6 +467,7 @@ bool AP_InertialSensor_Invensense::update() /* front end */
 #if HAL_LOGGING_ENABLED
         if (last_fast_reset_count != fast_reset_count) {
             AP::logger().Write_MessageF("IMU%u fast fifo reset %u", _gyro_instance, fast_reset_count);
+            last_fast_reset_count = fast_reset_count;
         }
 #endif
     }


### PR DESCRIPTION
log was flooded with resets:
```
2023-01-19 00:17:23.537 IMU0 fast fifo reset 6
2023-01-19 00:17:23.540 IMU0 fast fifo reset 6
2023-01-19 00:17:23.544 IMU0 fast fifo reset 6
2023-01-19 00:17:23.547 IMU0 fast fifo reset 6
2023-01-19 00:17:23.550 IMU0 fast fifo reset 6
2023-01-19 00:17:23.554 IMU0 fast fifo reset 6
2023-01-19 00:17:23.557 IMU0 fast fifo reset 6
2023-01-19 00:17:23.560 IMU0 fast fifo reset 6
2023-01-19 00:17:23.564 IMU0 fast fifo reset 6
2023-01-19 00:17:23.567 IMU0 fast fifo reset 6
2023-01-19 00:17:23.570 IMU0 fast fifo reset 6
2023-01-19 00:17:23.574 IMU0 fast fifo reset 6
2023-01-19 00:17:23.577 IMU0 fast fifo reset 6
2023-01-19 00:17:23.580 IMU0 fast fifo reset 6
2023-01-19 00:17:23.584 IMU0 fast fifo reset 6
2023-01-19 00:17:23.587 IMU0 fast fifo reset 6
2023-01-19 00:17:23.590 IMU0 fast fifo reset 6
```

this is with the fix:
![image](https://user-images.githubusercontent.com/831867/213316721-4c45dc49-13b1-4b99-9938-e43629d6f22c.png)

