### PR TITLE
Correct FFT Tune notch calculation

### DIFF
--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo AP_GyroFFT::var_info[] = {
     // @Range: 20 400
     // @Units: Hz
     // @User: Advanced
-    AP_GROUPINFO("MINHZ", 2, AP_GyroFFT, _fft_min_hz, 80),
+    AP_GROUPINFO("MINHZ", 2, AP_GyroFFT, _fft_min_hz, 50),
 
     // @Param: MAXHZ
     // @DisplayName: Maximum Frequency
@@ -83,7 +83,7 @@ const AP_Param::GroupInfo AP_GyroFFT::var_info[] = {
     // @Range: 20 495
     // @Units: Hz
     // @User: Advanced
-    AP_GROUPINFO("MAXHZ", 3, AP_GyroFFT, _fft_max_hz, 200),
+    AP_GROUPINFO("MAXHZ", 3, AP_GyroFFT, _fft_max_hz, 450),
 
     // @Param: SAMPLE_MODE
     // @DisplayName: Sample Mode

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -701,7 +701,40 @@ void AP_GyroFFT::start_notch_tune()
     if (!hal.dsp->fft_start_average(_state)) {
         gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to start FFT averaging");
     }
+    // throttle averaging for average fft calculation
     _avg_throttle_out = 0.0f;
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+    AP_Motors* motors = AP::motors();
+    if (motors != nullptr) {
+        _avg_throttle_out = motors->get_throttle_hover();
+    }
+#endif
+}
+
+// calculate the frequency to be used for the harmonic notch
+float AP_GyroFFT::calculate_notch_frequency(float* freqs, uint16_t numpeaks, float harmonic_fit, uint8_t& harmonics)
+{
+    float harmonic = freqs[0];
+    harmonics = 1;
+
+    for (uint8_t i = 1; i < numpeaks; i++) {
+        if (freqs[i] < harmonic) {
+            for (uint8_t x = 2; x <=HNF_MAX_HARMONICS; x++) {
+                if (is_harmonic_of(harmonic, freqs[i], x, harmonic_fit)) {
+                    harmonic = freqs[i];
+                }
+            }
+        }
+    }
+    // select the harmonics that were matched
+    for (uint8_t i = 0; i < numpeaks; i++) {
+        for (uint8_t x = 1; x <=HNF_MAX_HARMONICS; x++) {
+            if (is_harmonic_of(freqs[i], harmonic, x, harmonic_fit)) {
+                harmonics |= 1<<(x - 1);
+            }
+        }
+    }
+    return harmonic;
 }
 
 void AP_GyroFFT::stop_notch_tune()
@@ -718,21 +751,11 @@ void AP_GyroFFT::stop_notch_tune()
         return;
     }
 
-    float harmonic = freqs[0];
-    float harmonic_fit = 100.0f;
-
-    for (uint8_t i = 1; i < numpeaks; i++) {
-        if (freqs[i] < harmonic) {
-            const float fit = 100.0f * fabsf(harmonic - freqs[i] * _harmonic_multiplier) / harmonic;
-            if (isfinite(fit) && fit < _harmonic_fit && fit < harmonic_fit) {
-                harmonic = freqs[i];
-                harmonic_fit = fit;
-            }
-        }
-    }
+    uint8_t harmonics;
+    float harmonic = calculate_notch_frequency(freqs, numpeaks, _harmonic_fit, harmonics);
 
     gcs().send_text(MAV_SEVERITY_INFO, "FFT: Found peaks at %.1f/%.1f/%.1fHz", freqs[0], freqs[1], freqs[2]);
-    gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Selected %.1fHz with fit %.1f%%\n", harmonic, is_equal(harmonic_fit, 100.0f) ? 100.0f : 100.0f - harmonic_fit);
+    gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Selected %.1fHz\n", harmonic);
 
     // if we don't have a throttle value then all bets are off
     if (is_zero(_avg_throttle_out) || is_zero(harmonic)) {
@@ -740,17 +763,14 @@ void AP_GyroFFT::stop_notch_tune()
         return;
     }
 
-    // pick a ref which means the notch covers all the way down to FFT_MINHZ
-    const float thr_ref = _avg_throttle_out * sq((float)_fft_min_hz.get() / harmonic);
-
-    if (!_ins->setup_throttle_gyro_harmonic_notch((float)_fft_min_hz.get(), thr_ref)) {
+    if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics)) {
         gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
-            (float)_fft_min_hz.get(), thr_ref);
+            harmonic, _avg_throttle_out);
         // save results to FFT slots
-        _throttle_ref.set(thr_ref);
+        _throttle_ref.set(_avg_throttle_out);
         _freq_hover_hz.set(harmonic);
     } else {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", (float)_fft_min_hz.get(), thr_ref);
+        gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
     }
 }
 

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -760,17 +760,20 @@ void AP_GyroFFT::stop_notch_tune()
     // if we don't have a throttle value then all bets are off
     if (is_zero(_avg_throttle_out) || is_zero(harmonic)) {
         gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to calculate notch: need stable hover");
+        AP_Notify::events.autotune_failed = true;
         return;
     }
 
     if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics)) {
         gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
             harmonic, _avg_throttle_out);
+        AP_Notify::events.autotune_failed = true;
         // save results to FFT slots
         _throttle_ref.set(_avg_throttle_out);
         _freq_hover_hz.set(harmonic);
     } else {
         gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
+        AP_Notify::events.autotune_complete = true;
     }
 }
 

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -113,6 +113,11 @@ public:
     bool check_esc_noise() const { return (_options & uint32_t(Options::ESCNoiseCheck)) != 0; }
     // look for a frequency in the detected noise
     float has_noise_at_frequency_hz(float freq) const;
+    static float calculate_notch_frequency(float* freqs, uint16_t numpeaks, float harmonic_fit, uint8_t& harmonics);
+    static bool is_harmonic_of(float harmonic, float fundamental, uint8_t mult, float _fit) {
+        const float fit = 100.0f * fabsf(harmonic - fundamental * mult) / harmonic;
+        return (isfinite(fit) && fit < _fit);
+    }
 
     static const struct AP_Param::GroupInfo var_info[];
     static AP_GyroFFT *get_singleton() { return _singleton; }

--- a/libraries/AP_GyroFFT/tests/test_harmonic_fit.cpp
+++ b/libraries/AP_GyroFFT/tests/test_harmonic_fit.cpp
@@ -1,0 +1,23 @@
+#include <AP_gtest.h>
+#include <AP_HAL/HAL.h>
+#include <AP_HAL/Util.h>
+#include <AP_GyroFFT/AP_GyroFFT.h>
+#include <stdio.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+TEST(harmonic_fit_Test, Basic)
+{
+#if HAL_GYROFFT_ENABLED
+    float freqs[] { 176.9, 57.2, 228.7 };
+    uint8_t harmonics;
+    float harmonic = AP_GyroFFT::calculate_notch_frequency(freqs, 3, 10, harmonics);
+
+    printf("FFT: Found peaks at %.1f/%.1f/%.1fHz\n", freqs[0], freqs[1], freqs[2]);
+    printf("FFT: Selected %.1fHz %d\n", harmonic, harmonics);
+
+    EXPECT_TRUE(is_equal(harmonic, 57.2f));
+#endif
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_GyroFFT/tests/wscript
+++ b/libraries/AP_GyroFFT/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_HAL/DSP.cpp
+++ b/libraries/AP_HAL/DSP.cpp
@@ -358,6 +358,8 @@ uint16_t DSP::fft_stop_average(FFTWindowState* fft, uint16_t start_bin, uint16_t
         scratch_space, peaks, MAX_TRACKED_PEAKS, 0.0f, -1.0f, smoothwidth, 2);
     hal.util->free_type(scratch_space, sizeof(float) * fft->_num_stored_freqs, DSP_MEM_REGION);
 
+    numpeaks = MIN(numpeaks, uint16_t(MAX_TRACKED_PEAKS));
+
     // now try and find the lowest harmonic
     for (uint16_t i = 0; i < numpeaks; i++) {
         const uint16_t bin = peaks[i] + start_bin;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2135,7 +2135,7 @@ void AP_InertialSensor::HarmonicNotch::update_frequencies_hz(uint8_t num_freqs, 
 }
 
 // setup the notch for throttle based tracking, called from FFT based tuning
-bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float ref)
+bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics)
 {
     for (auto &notch : harmonic_notches) {
         if (notch.params.tracking_mode() != HarmonicNotchDynamicMode::UpdateThrottle) {
@@ -2145,6 +2145,8 @@ bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz,
         notch.params.set_center_freq_hz(center_freq_hz);
         notch.params.set_reference(ref);
         notch.params.set_bandwidth_hz(center_freq_hz / 2.0f);
+        notch.params.set_freq_min_ratio(lower_freq_hz / center_freq_hz);
+        notch.params.set_harmonics(harmonics);
         notch.params.save_params();
         // only enable the first notch
         return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -257,7 +257,7 @@ public:
     uint16_t get_accel_filter_hz(void) const { return _accel_filter_cutoff; }
 
     // setup the notch for throttle based tracking
-    bool setup_throttle_gyro_harmonic_notch(float center_freq_hz, float ref);
+    bool setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics);
 
     // write out harmonic notch log messages
     void write_notch_log_messages() const;

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -101,6 +101,8 @@ public:
     void set_bandwidth_hz(float bandwidth_hz) { _bandwidth_hz.set(bandwidth_hz); }
     // harmonics enabled on the harmonic notch
     uint8_t harmonics(void) const { return _harmonics; }
+    // set the harmonics value
+    void set_harmonics(uint8_t hmncs) { _harmonics.set(hmncs); }
     // has the user set the harmonics value
     void set_default_harmonics(uint8_t hmncs) { _harmonics.set_default(hmncs); }
     // reference value of the harmonic notch
@@ -116,6 +118,7 @@ public:
     float freq_min_ratio(void) const {
         return _freq_min_ratio;
     }
+    void set_freq_min_ratio(float ratio) { _freq_min_ratio.set(ratio); }
 
     // save parameters
     void save_params();


### PR DESCRIPTION
This fixes a bug whereby we would select the wrong harmonic and set the wrong throttle reference when tuning a copter with a higher energy higher frequency harmonic. This occurred for me tuning the Hexsoon 650.

Also fixes a bug where a stack overflow can occur when more than one frequency peak is detected during tuning

Adds better notification of FFT tune success or failure

Changes FFT default frequency range to 50->450Hz to better cover a reasonable range of setups. The old defaults were really only suitable for smaller copters at low revs.

Tested on a Hexsoon 650