### PR TITLE
AP_Periph: separate ESC_TELEM from RC_OUT

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -167,6 +167,12 @@ void AP_Periph_FW::init()
     rcout_init();
 #endif
 
+#if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
+    if (g.esc_telem_port >= 0) {
+        serial_manager.set_protocol_and_baud(g.esc_telem_port, AP_SerialManager::SerialProtocol_ESCTelemetry, 115200);
+    }
+#endif
+
 #ifdef HAL_PERIPH_ENABLE_ADSB
     adsb_init();
 #endif
@@ -374,6 +380,11 @@ void AP_Periph_FW::update()
 #endif
         hal.scheduler->delay(1);
 #endif
+
+#if HAL_WITH_ESC_TELEM
+        esc_telem_update_period_ms = 1000 / constrain_int32(g.esc_telem_rate.get(), 1, 1000);
+#endif
+
 #ifdef HAL_PERIPH_NEOPIXEL_COUNT_WITHOUT_NOTIFY
         hal.rcout->set_serial_led_num_LEDs(HAL_PERIPH_NEOPIXEL_CHAN_WITHOUT_NOTIFY, HAL_PERIPH_NEOPIXEL_COUNT_WITHOUT_NOTIFY, AP_HAL::RCOutput::MODE_NEOPIXEL);
 #endif

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -217,7 +217,6 @@ public:
     uint32_t efi_update_ms;
 #endif
     
-#ifdef HAL_PERIPH_ENABLE_RC_OUT
 #if HAL_WITH_ESC_TELEM
     AP_ESC_Telem esc_telem;
     uint32_t last_esc_telem_update_ms;
@@ -225,6 +224,7 @@ public:
     uint32_t esc_telem_update_period_ms;
 #endif
 
+#ifdef HAL_PERIPH_ENABLE_RC_OUT
     SRV_Channels servo_channels;
     bool rcout_has_new_data_to_update;
 

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -373,8 +373,10 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Units: ms
     // @User: Advanced
     GSCALAR(esc_command_timeout_ms, "ESC_CMD_TIMO",     200),
+#endif
 
-#if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
+#if HAL_WITH_ESC_TELEM
+#if !HAL_GCS_ENABLED
     // @Param: ESC_TELEM_PORT
     // @DisplayName: ESC Telemetry Serial Port
     // @Description: This is the serial port number where SERIALx_PROTOCOL will be set to ESC Telemetry
@@ -383,9 +385,8 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     GSCALAR(esc_telem_port, "ESC_TELEM_PORT", AP_PERIPH_ESC_TELEM_PORT_DEFAULT),
-#endif
+#endif // HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
 
-#if HAL_WITH_ESC_TELEM
     // @Param: ESC_TELEM_RATE
     // @DisplayName: ESC Telemetry update rate
     // @Description: This is the rate at which ESC Telemetry will be sent across the CAN bus
@@ -394,8 +395,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     GSCALAR(esc_telem_rate, "ESC_TELEM_RATE", AP_PERIPH_ESC_TELEM_RATE_DEFAULT),
-#endif
-#endif
+#endif // HAL_WITH_ESC_TELEM
 
 #if AP_TEMPERATURE_SENSOR_ENABLED
     // @Group: TEMP

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -137,11 +137,12 @@ public:
 #ifdef HAL_PERIPH_ENABLE_RC_OUT
     AP_Int8 esc_pwm_type;
     AP_Int16 esc_command_timeout_ms;
-#if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
-    AP_Int8 esc_telem_port;
 #endif
+
 #if HAL_WITH_ESC_TELEM
     AP_Int32 esc_telem_rate;
+#if !HAL_GCS_ENABLED
+    AP_Int8 esc_telem_port;
 #endif
 #endif
 

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -31,12 +31,6 @@ void AP_Periph_FW::rcout_init()
     // start up with safety enabled. This disables the pwm output until we receive an packet from the rempte system
     hal.rcout->force_safety_on();
 
-#if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
-    if (g.esc_telem_port >= 0) {
-        serial_manager.set_protocol_and_baud(g.esc_telem_port, AP_SerialManager::SerialProtocol_ESCTelemetry, 115200);
-    }
-#endif
-
 #if HAL_PWM_COUNT > 0
     for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
         servo_channels.set_default_function(i, SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i));
@@ -64,9 +58,6 @@ void AP_Periph_FW::rcout_init()
 
     // run DShot at 1kHz
     hal.rcout->set_dshot_rate(SRV_Channels::get_dshot_rate(), 400);
-#if HAL_WITH_ESC_TELEM
-    esc_telem_update_period_ms = 1000 / constrain_int32(g.esc_telem_rate.get(), 1, 1000);
-#endif
 }
 
 void AP_Periph_FW::rcout_init_1Hz()
@@ -148,12 +139,6 @@ void AP_Periph_FW::rcout_update()
     SRV_Channels::cork();
     SRV_Channels::output_ch_all();
     SRV_Channels::push();
-#if HAL_WITH_ESC_TELEM
-    if (now_ms - last_esc_telem_update_ms >= esc_telem_update_period_ms) {
-        last_esc_telem_update_ms = now_ms;
-        esc_telem_update();
-    }
-#endif
 }
 
 #endif // HAL_PERIPH_ENABLE_RC_OUT


### PR DESCRIPTION
This (almost) allows ESC_TELEM to function without any PWM RC_OUT channels. It solves the problem in AP_Periph but just separating the # ifdef's but it's still tied together up in the library [here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_ESC_Telem/AP_ESC_Telem.h#L12) which we can figure out how to de-couple later. For now, this is a refactor and almost non-functional change.

The one change this does end up doing is allowing ESC_TELEM to send it's CAN packet at it's arbitrary user-defined interval without any PWM. Existing code did not respect that timer very well because it required a Servos update as well.

Key purpose of this is to have an AP_Periph as a temp sensor on not require the PWM stuff