### PR TITLE
AP_RCTelemetry: Change GCC12.2 warning

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -820,12 +820,11 @@ void AP_CRSF_Telem::update_vtx_params()
         }
         _telem_pending = true;
         // calculate command crc
-        uint8_t* crcptr = &_telem.ext.command.destination;
         uint8_t crc = crc8_dvb(0, AP_RCProtocol_CRSF::CRSF_FRAMETYPE_COMMAND, 0xBA);
         for (uint8_t i = 0; i < len; i++) {
-            crc = crc8_dvb(crc, crcptr[i], 0xBA);
+            crc = crc8_dvb(crc, _telem.ext.byte[i], 0xBA);
         }
-        crcptr[len] = crc;
+        _telem.ext.byte[len] = crc;
         _telem_size = len + 1;
     }
 }

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -224,6 +224,7 @@ public:
         ParameterSettingsEntry param_entry;
         ParameterSettingsReadFrame param_read;
         ParameterSettingsWriteFrame param_write;
+        uint8_t byte[sizeof(command)];
     };
 
     union PACKED TelemetryPayload {


### PR DESCRIPTION
I tried to build with GCC 12.2.
I found the warning.
I changed the warning.
I could free up 9K bytes by going to GCC 12.2.

GCC 12.2
Waf: Leaving directory `/home/muramura/work2/ardupilot/build/CubeOrangePlus'

BUILD SUMMARY
Build directory: /home/muramura/work2/ardupilot/build/CubeOrangePlus
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)
---------------------------------------------------------------------------------
bin/arducopter   1791313      3472   258900               1794785          171276


GCC 11.3
Waf: Leaving directory `/home/muramura/work2/ardupilot/build/CubeOrangePlus'

BUILD SUMMARY
Build directory: /home/muramura/work2/ardupilot/build/CubeOrangePlus
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)
---------------------------------------------------------------------------------
bin/arducopter   1799649      3472   258900               1803121          162940