### PR TITLE
AP_VisualOdom: handle ModalAi VOXL resets

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -218,8 +218,8 @@ void AP_VisualOdom::handle_vision_speed_estimate(uint64_t remote_time_us, uint32
     }
 }
 
-// calibrate camera attitude to align with vehicle's AHRS/EKF attitude
-void AP_VisualOdom::align_sensor_to_vehicle()
+// request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+void AP_VisualOdom::request_align_yaw_to_ahrs()
 {
     // exit immediately if not enabled
     if (!enabled()) {
@@ -228,7 +228,7 @@ void AP_VisualOdom::align_sensor_to_vehicle()
 
     // call backend
     if (_driver != nullptr) {
-        _driver->align_sensor_to_vehicle();
+        _driver->request_align_yaw_to_ahrs();
     }
 }
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -93,8 +93,8 @@ public:
     // velocity in NED meters per second
     void handle_vision_speed_estimate(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter);
 
-    // calibrate camera attitude to align with vehicle's AHRS/EKF attitude
-    void align_sensor_to_vehicle();
+    // request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+    void request_align_yaw_to_ahrs();
 
     // update position offsets to align to AHRS position
     // should only be called when this library is not being used as the position source

--- a/libraries/AP_VisualOdom/AP_VisualOdom_Backend.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_Backend.h
@@ -36,8 +36,8 @@ public:
     // consume vision velocity estimate data and send to EKF, velocity in NED meters per second
     virtual void handle_vision_speed_estimate(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter) = 0;
 
-    // handle request to align camera's attitude with vehicle's AHRS/EKF attitude
-    virtual void align_sensor_to_vehicle() {}
+    // request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+    virtual void request_align_yaw_to_ahrs() {}
 
     // handle request to align position with AHRS
     virtual void align_position_to_ahrs(bool align_xy, bool align_z) {}

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -33,10 +33,10 @@ void AP_VisualOdom_IntelT265::handle_vision_position_estimate(uint64_t remote_ti
     Vector3f pos{x * scale_factor, y * scale_factor, z * scale_factor};
     Quaternion att = attitude;
 
-    // handle user request to align camera
-    if (_align_camera) {
-        if (align_sensor_to_vehicle(pos, attitude)) {
-            _align_camera = false;
+    // handle request to align sensor's yaw with vehicle's AHRS/EKF attitude
+    if (_align_yaw) {
+        if (align_yaw_to_ahrs(pos, attitude)) {
+            _align_yaw = false;
         }
     }
     if (_align_posxy || _align_posz) {
@@ -128,7 +128,7 @@ void AP_VisualOdom_IntelT265::rotate_attitude(Quaternion &attitude) const
 }
 
 // use sensor provided attitude to calculate rotation to align sensor with AHRS/EKF attitude
-bool AP_VisualOdom_IntelT265::align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude)
+bool AP_VisualOdom_IntelT265::align_yaw_to_ahrs(const Vector3f &position, const Quaternion &attitude)
 {
     // do not align to ahrs if we are its yaw source
     if (AP::ahrs().using_extnav_for_yaw()) {

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
@@ -59,6 +59,15 @@ protected:
     // new_pos should be a NED position offset from the EKF origin
     void align_position(const Vector3f &sensor_pos, const Vector3f &new_pos, bool align_xy, bool align_z);
 
+    // record voxl camera's position and reset counter for reset jump handling
+    // position is post scaling, offset and orientation corrections
+    void record_voxl_position_and_reset_count(const Vector3f &position, uint8_t reset_counter);
+
+    // handle voxl camera reset jumps in attitude and position
+    // sensor_pos should be the position directly from the sensor with only scaling applied (i.e. no yaw or position corrections)
+    // sensor_att is similarly the attitude directly from the sensor
+    void handle_voxl_camera_reset_jump(const Vector3f &sensor_pos, const Quaternion &sensor_att, uint8_t reset_counter);
+
     float _yaw_trim;                            // yaw angle trim (in radians) to align camera's yaw to ahrs/EKF's
     Quaternion _yaw_rotation;                   // earth-frame yaw rotation to align heading of sensor with vehicle.  use when _yaw_trim is non-zero
     Quaternion _att_rotation;                   // body-frame rotation corresponding to ORIENT parameter.  use when get_orientation != NONE
@@ -73,6 +82,10 @@ protected:
     Quaternion _attitude_last;                  // last attitude received from camera (used for arming checks)
     uint8_t _pos_reset_counter_last;            // last vision-position-estimate reset counter value
     uint32_t _pos_reset_ignore_start_ms;        // system time we start ignoring sensor information, 0 if sensor data is not being ignored
+
+    // voxl reset jump handling variables
+    uint8_t _voxl_reset_counter_last;           // last reset counter from voxl camera (only used for origin jump handling)
+    Vector3f _voxl_position_last;               // last recorded position (post scaling, offset and orientation corrections)
 };
 
 #endif

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
@@ -39,7 +39,11 @@ protected:
     void rotate_attitude(Quaternion &attitude) const;
 
     // use sensor provided position and attitude to calculate rotation to align sensor yaw with AHRS/EKF attitude
+    // calls align_yaw (see below)
     bool align_yaw_to_ahrs(const Vector3f &position, const Quaternion &attitude);
+
+    // align sensor yaw with any new yaw (in radians)
+    void align_yaw(const Vector3f &position, const Quaternion &attitude, float yaw_rad);
 
     // returns true if sensor data should be consumed, false if it should be ignored
     // set vision_position_estimate to true if reset_counter is from the VISION_POSITION_ESTIMATE source, false otherwise
@@ -49,6 +53,11 @@ protected:
     // align position with ahrs position by updating _pos_correction
     // sensor_pos should be the position directly from the sensor with only scaling applied (i.e. no yaw or position corrections)
     bool align_position_to_ahrs(const Vector3f &sensor_pos, bool align_xy, bool align_z);
+
+    // align position with a new position by updating _pos_correction
+    // sensor_pos should be the position directly from the sensor with only scaling applied (i.e. no yaw or position corrections)
+    // new_pos should be a NED position offset from the EKF origin
+    void align_position(const Vector3f &sensor_pos, const Vector3f &new_pos, bool align_xy, bool align_z);
 
     float _yaw_trim;                            // yaw angle trim (in radians) to align camera's yaw to ahrs/EKF's
     Quaternion _yaw_rotation;                   // earth-frame yaw rotation to align heading of sensor with vehicle.  use when _yaw_trim is non-zero

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.h
@@ -17,8 +17,8 @@ public:
     // consume vision velocity estimate data and send to EKF, velocity in NED meters per second
     void handle_vision_speed_estimate(uint64_t remote_time_us, uint32_t time_ms, const Vector3f &vel, uint8_t reset_counter) override;
 
-    // handle request to align camera's attitude with vehicle's AHRS/EKF attitude
-    void align_sensor_to_vehicle() override { _align_camera = true; }
+    // request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+    void request_align_yaw_to_ahrs() override { _align_yaw = true; }
 
     // update position offsets to align to AHRS position
     // should only be called when this library is not being used as the position source
@@ -38,8 +38,8 @@ protected:
     // rotate attitude using _yaw_trim
     void rotate_attitude(Quaternion &attitude) const;
 
-    // use sensor provided position and attitude to calculate rotation to align sensor with AHRS/EKF attitude
-    bool align_sensor_to_vehicle(const Vector3f &position, const Quaternion &attitude);
+    // use sensor provided position and attitude to calculate rotation to align sensor yaw with AHRS/EKF attitude
+    bool align_yaw_to_ahrs(const Vector3f &position, const Quaternion &attitude);
 
     // returns true if sensor data should be consumed, false if it should be ignored
     // set vision_position_estimate to true if reset_counter is from the VISION_POSITION_ESTIMATE source, false otherwise
@@ -57,7 +57,7 @@ protected:
     Vector3f _pos_correction;                   // position correction that should be added to position reported from sensor
     bool _use_att_rotation;                     // true if _att_rotation should be applied to sensor's attitude data
     bool _use_posvel_rotation;                  // true if _posvel_rotation should be applied to sensor's position and/or velocity data
-    bool _align_camera = true;                  // true if camera should be aligned to AHRS/EKF
+    bool _align_yaw = true;                     // true if sensor yaw should be aligned to AHRS/EKF
     bool _align_posxy;                          // true if sensor xy position should be aligned to AHRS
     bool _align_posz;                           // true if sensor z position should be aligned to AHRS
     bool _error_orientation;                    // true if the orientation is not supported

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1218,7 +1218,7 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
         if (ch_flag == AuxSwitchPos::HIGH) {
             AP_VisualOdom *visual_odom = AP::visualodom();
             if (visual_odom != nullptr) {
-                visual_odom->align_sensor_to_vehicle();
+                visual_odom->request_align_yaw_to_ahrs();
             }
         }
         break;


### PR DESCRIPTION
This PR improves the AP_VisualOdometry library's handling of [ModalAI VOXL camera](https://ardupilot.org/copter/docs/common-modalai-voxl.html) resets which are different than the IntelT265 camera with which it shares a driver.

When the T265 "resets" it increments the reset_counter and the position jumps (often to a location many meters away).  The yaw normally does not jump.  Resets often occur many times in a row.  The camera continues providing position, velocity and yaw estimates although they unreliable for about 1sec.  These resets normally occur due to high vibration or sunlight hitting the camera.

When the ModalAI "resets" it stops providing position, velocity and yaw estimates for a few seconds.  When it recovers increments the reset_counter and resets the position and yaw back to zero.  From the user's point of view, this means the vehicle jumps back close to the EKF origin and the heading resets to North.  Note: the jump will not be exactly to the origin or North because the camera may have been "aligned" to the compass and/or GPS based position. These resets are much more rare than on the T265 and they occur when the camera's view is blocked or there are not enough features.

This PR improves the reset handling (for the VOXL camera) by "aligning" the position back to what it was before the reset occurred and "aligns" the yaw so it matches the current AHRS/EKF yaw.  The detailed changes are:

- renamed align_sensor_to_vehicle() to align_yaw_to_ahrs() which is more precise
- split align_yaw_to_ahrs() and align_position_to_ahrs() to create more general purpose align_yaw() and align_position() methods
- added record_voxl_position_and_reset_count() to record the last good position from the camera.  Note these are not raw positions from the camera but instead scaled and rotated positions that are fed into the EKF
- when a reset occurs, use align_position() to shift the position to the last good camera position.  align_yaw_to_ahrs() is used to rotate the yaw to the current AHRS/EKF yaw

This has been bench tested on a real vehicle and I've confirmed the position and yaw do not jump after a reset.  Below are some screenshots from those tests.  I've also looked in the VISP logs and confirmed that there are no jumps.
![pr-before-screenshot](https://user-images.githubusercontent.com/1498098/213844737-94e27ff4-1800-47a0-a25b-3a1d63f26eae.png)
![pr-after-screenshot](https://user-images.githubusercontent.com/1498098/213844739-7870b5b0-e00e-4335-9f83-8780976dccfb.png)
