### PR TITLE
AP_Arming: Use arming helper to always check if all bit is set.

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -69,8 +69,7 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
 
 bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
 {
-    if ((checks_to_perform != ARMING_CHECK_ALL) &&
-        (checks_to_perform & ARMING_CHECK_RC) == 0) {
+    if (!check_enabled(ARMING_CHECK_RC)) {
         // this check has been disabled
         return true;
     }
@@ -114,7 +113,7 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
 
     bool ret = true;
     // check Baro
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_BARO)) {
+    if (check_enabled(ARMING_CHECK_BARO)) {
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.
@@ -134,7 +133,7 @@ bool AP_Arming_Copter::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);
 
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_INS)) {
+    if (check_enabled(ARMING_CHECK_INS)) {
 
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
@@ -153,7 +152,7 @@ bool AP_Arming_Copter::board_voltage_checks(bool display_failure)
     }
 
     // check battery voltage
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_VOLTAGE)) {
+    if (check_enabled(ARMING_CHECK_VOLTAGE)) {
         if (copter.battery.has_failsafed()) {
             check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
             return false;
@@ -183,7 +182,7 @@ bool AP_Arming_Copter::terrain_database_required() const
 bool AP_Arming_Copter::parameter_checks(bool display_failure)
 {
     // check various parameter values
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
 
         // failsafe parameter checks
         if (copter.g.failsafe_throttle) {
@@ -379,7 +378,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     }
 
     // return true immediately if gps check is disabled
-    if (!(checks_to_perform == ARMING_CHECK_ALL || checks_to_perform & ARMING_CHECK_GPS)) {
+    if (!check_enabled(ARMING_CHECK_GPS)) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }
@@ -414,7 +413,7 @@ bool AP_Arming_Copter::proximity_checks(bool display_failure) const
         return false;
     }
 
-    if (!((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS))) {
+    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
         // check is disabled
         return true;
     }
@@ -605,7 +604,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     }
 
     // check lean angle
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_INS)) {
+    if (check_enabled(ARMING_CHECK_INS)) {
         if (degrees(acosf(ahrs.cos_roll()*ahrs.cos_pitch()))*100.0f > copter.aparm.angle_max) {
             check_failed(ARMING_CHECK_INS, true, "Leaning");
             return false;
@@ -614,7 +613,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     // check adsb
 #if HAL_ADSB_ENABLED
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
         if (copter.failsafe.adsb) {
             check_failed(ARMING_CHECK_PARAMETERS, true, "ADSB threat detected");
             return false;
@@ -623,7 +622,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 #endif
 
     // check throttle
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
+    if (check_enabled(ARMING_CHECK_RC)) {
          #if FRAME_CONFIG == HELI_FRAME
         const char *rc_item = "Collective";
         #else

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -45,7 +45,7 @@ bool AP_Arming_Blimp::barometer_checks(bool display_failure)
 
     bool ret = true;
     // check Baro
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_BARO)) {
+    if (check_enabled(ARMING_CHECK_BARO)) {
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.
@@ -65,7 +65,7 @@ bool AP_Arming_Blimp::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);
 
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_INS)) {
+    if (check_enabled(ARMING_CHECK_INS)) {
 
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
@@ -84,7 +84,7 @@ bool AP_Arming_Blimp::board_voltage_checks(bool display_failure)
     }
 
     // check battery voltage
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_VOLTAGE)) {
+    if (check_enabled(ARMING_CHECK_VOLTAGE)) {
         if (blimp.battery.has_failsafed()) {
             check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
             return false;
@@ -102,7 +102,7 @@ bool AP_Arming_Blimp::board_voltage_checks(bool display_failure)
 bool AP_Arming_Blimp::parameter_checks(bool display_failure)
 {
     // check various parameter values
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
 
         // failsafe parameter checks
         if (blimp.g.failsafe_throttle) {
@@ -159,7 +159,7 @@ bool AP_Arming_Blimp::gps_checks(bool display_failure)
     }
 
     // return true immediately if gps check is disabled
-    if (!(checks_to_perform == ARMING_CHECK_ALL || checks_to_perform & ARMING_CHECK_GPS)) {
+    if (!check_enabled(ARMING_CHECK_GPS)) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -5,7 +5,7 @@
 bool AP_Arming_Rover::rc_calibration_checks(const bool display_failure)
 {
     // set rc-checks to success if RC checks are disabled
-    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_RC)) {
+    if (!check_enabled(ARMING_CHECK_RC)) {
         return true;
     }
 
@@ -180,7 +180,7 @@ bool AP_Arming_Rover::oa_check(bool report)
 bool AP_Arming_Rover::parameter_checks(bool report)
 {
     // success if parameter checks are disabled
-    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
         return true;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1632,7 +1632,7 @@ AP_Arming::Required AP_Arming::arming_required()
 bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channel *channels[4]) const
 {
     // set rc-checks to success if RC checks are disabled
-    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_RC)) {
+    if (!check_enabled(ARMING_CHECK_RC)) {
         return true;
     }
 
@@ -1676,7 +1676,7 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
 // check visual odometry is working
 bool AP_Arming::visodom_checks(bool display_failure) const
 {
-    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_VISION)) {
+    if (!check_enabled(ARMING_CHECK_VISION)) {
         return true;
     }
 


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/22706, this one is a change in behavior. 

Currently these call are checking `checks_to_perform == ARMING_CHECK_ALL` rather than `checks_to_perform & ARMING_CHECK_ALL`. This means you will skip all checks except the ones in your arming mask even if the all bit is set. This changes to run all checks whenever the bit is set.

For example if I had `ARMING_CHECK` set to 3 for "ALL" and "Barometer". The current pattern would only check "Barometer". The new pattern checks "ALL" and "Barometer". Of course its not as bad as that because not all the methods follow the bad pattern. 