### PR TITLE
AP_InertialSensor: cope with 0xff from BMI088 gyro

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -400,6 +400,7 @@ void AP_InertialSensor_BMI088::read_fifo_gyro(void)
     }
     const float scale = radians(2000.0f) / 32767.0f;
     const uint8_t max_frames = 8;
+    const Vector3i bad_frame{int16_t(0xffff), int16_t(0xffff), int16_t(0xffff)};
     Vector3i data[max_frames];
 
     if (num_frames & 0x80) {
@@ -427,6 +428,10 @@ void AP_InertialSensor_BMI088::read_fifo_gyro(void)
 
     // data is 16 bits with 2000dps range
     for (uint8_t i = 0; i < num_frames; i++) {
+        if (data[i] == bad_frame) {
+            _inc_gyro_error_count(gyro_instance);
+            continue;
+        }
         Vector3f gyro(data[i].x, data[i].y, data[i].z);
         gyro *= scale;
 

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -632,5 +632,6 @@ bool Vector3<T>::segment_plane_intersect(const Vector3<T>& seg_start, const Vect
 template class Vector3<float>;
 template class Vector3<double>;
 
-// define needed ops for Vector3l
+// define needed ops for Vector3l, Vector3i as needed
 template Vector3<int32_t> &Vector3<int32_t>::operator +=(const Vector3<int32_t> &v);
+template bool Vector3<int16_t>::operator ==(const Vector3<int16_t> &v) const;


### PR DESCRIPTION
A log on a mRoControlZeroH7 seems to show a transfer giving 0xff data from a BMI088:

![image](https://user-images.githubusercontent.com/831867/213891697-53ce864d-5ca2-40fc-b320-2c5bce3b8341.png)

tested on a CUAV-X7
