### PR TITLE
AP_Periph: Allow user to change serial port for HW Telem

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -31,6 +31,10 @@
 #include <AP_HAL_ChibiOS/I2CDevice.h>
 #endif
 
+#ifndef HAL_PERIPH_HWESC_SERIAL_PORT
+#define HAL_PERIPH_HWESC_SERIAL_PORT 3
+#endif
+
 extern const AP_HAL::HAL &hal;
 
 AP_Periph_FW periph;
@@ -228,7 +232,7 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_HWESC
-    hwesc_telem.init(hal.serial(3));
+    hwesc_telem.init(hal.serial(HAL_PERIPH_HWESC_SERIAL_PORT));
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MSP

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-HWTelem/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-HWTelem/hwdef-bl.dat
@@ -1,0 +1,3 @@
+include ../MatekL431/hwdef-bl.inc
+
+define CAN_APP_NODE_NAME "org.ardupilot.MatekL431-HWtelem"

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-HWTelem/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-HWTelem/hwdef.dat
@@ -1,0 +1,11 @@
+include ../MatekL431/hwdef.inc
+
+define CAN_APP_NODE_NAME "org.ardupilot.MatekL431-HWtelem"
+
+define HAL_USE_ADC FALSE
+define STM32_ADC_USE_ADC1 FALSE
+define HAL_DISABLE_ADC_DRIVER TRUE
+
+define HAL_PERIPH_ENABLE_HWESC
+define HAL_PERIPH_HWESC_SERIAL_PORT 2
+


### PR DESCRIPTION
It's not possible to change the serial port to be used for accessing telemetry from HW ESC. This PR makes it possible without adding a parameter. 