### PR TITLE
Implement manual autorotation feature for Tradheli

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -117,15 +117,15 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if AC_CUSTOMCONTROL_MULTI_ENABLED == ENABLED
     FAST_TASK(run_custom_controller),
 #endif
+#if FRAME_CONFIG == HELI_FRAME
+    FAST_TASK(heli_update_autorotation),
+#endif //HELI_FRAME
     // send outputs to the motors library immediately
     FAST_TASK(motors_output),
      // run EKF state estimator (expensive)
     FAST_TASK(read_AHRS),
 #if FRAME_CONFIG == HELI_FRAME
     FAST_TASK(update_heli_control_dynamics),
-    #if MODE_AUTOROTATE_ENABLED == ENABLED
-    FAST_TASK(heli_update_autorotation),
-    #endif
 #endif //HELI_FRAME
     // Inertial Nav
     FAST_TASK(read_inertia),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -796,10 +796,8 @@ private:
     float get_pilot_desired_rotor_speed() const;
     void heli_update_rotor_speed_targets();
     void heli_update_autorotation();
-#if MODE_AUTOROTATE_ENABLED == ENABLED
-    void heli_set_autorotation(bool autotrotation);
-#endif
     void update_collective_low_flag(int16_t throttle_control);
+
     // inertia.cpp
     void read_inertia();
 

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -288,17 +288,14 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Autorotate - autonomous auto-rotation - helicopters only
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    #if FRAME_CONFIG == HELI_FRAME
+#if FRAME_CONFIG == HELI_FRAME
         #ifndef MODE_AUTOROTATE_ENABLED
         # define MODE_AUTOROTATE_ENABLED !HAL_MINIMIZE_FEATURES
         #endif
     #else
         # define MODE_AUTOROTATE_ENABLED DISABLED
-    #endif
-#else
-    # define MODE_AUTOROTATE_ENABLED DISABLED
 #endif
+
 //////////////////////////////////////////////////////////////////////////////
 
 // Beacon support - support for local positioning systems

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -288,12 +288,16 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Autorotate - autonomous auto-rotation - helicopters only
-#if FRAME_CONFIG == HELI_FRAME
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    #if FRAME_CONFIG == HELI_FRAME
         #ifndef MODE_AUTOROTATE_ENABLED
         # define MODE_AUTOROTATE_ENABLED !HAL_MINIMIZE_FEATURES
         #endif
     #else
         # define MODE_AUTOROTATE_ENABLED DISABLED
+    #endif
+#else
+    # define MODE_AUTOROTATE_ENABLED DISABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -5,7 +5,7 @@
 #if FRAME_CONFIG == HELI_FRAME
 
 #ifndef HELI_DYNAMIC_FLIGHT_SPEED_MIN
- #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      250     // we are in "dynamic flight" when the speed is over 2.5m/s for 2 seconds
+#define HELI_DYNAMIC_FLIGHT_SPEED_MIN      250     // we are in "dynamic flight" when the speed is over 2.5m/s for 2 seconds
 #endif
 
 // counter to control dynamic flight profile
@@ -37,7 +37,7 @@ void Copter::check_dynamic_flight(void)
         // get horizontal speed
         const float speed = inertial_nav.get_speed_xy_cms();
         moving = (speed >= HELI_DYNAMIC_FLIGHT_SPEED_MIN);
-    }else{
+    } else {
         // with no GPS lock base it on throttle and forward lean angle
         moving = (motors->get_throttle() > 0.8f || ahrs.pitch_sensor < -1500);
     }
@@ -47,7 +47,7 @@ void Copter::check_dynamic_flight(void)
         // rangefinder lock consider it to be dynamic flight
         moving = (rangefinder.distance_cm_orient(ROTATION_PITCH_270) > 200);
     }
-    
+
     if (moving) {
         // if moving for 2 seconds, set the dynamic flight flag
         if (!heli_flags.dynamic_flight) {
@@ -57,12 +57,12 @@ void Copter::check_dynamic_flight(void)
                 heli_dynamic_flight_counter = 100;
             }
         }
-    }else{
+    } else {
         // if not moving for 2 seconds, clear the dynamic flight flag
         if (heli_flags.dynamic_flight) {
             if (heli_dynamic_flight_counter > 0) {
                 heli_dynamic_flight_counter--;
-            }else{
+            } else {
                 heli_flags.dynamic_flight = false;
             }
         }
@@ -88,9 +88,9 @@ void Copter::update_heli_control_dynamics(void)
         motors->set_land_complete(false);
     }
 
-    if (ap.land_complete || (is_zero(motors->get_desired_rotor_speed()))){
+    if (ap.land_complete || (is_zero(motors->get_desired_rotor_speed()))) {
         // if we are landed or there is no rotor power demanded, decrement slew scalar
-        hover_roll_trim_scalar_slew--;        
+        hover_roll_trim_scalar_slew--;
     } else {
         // if we are not landed and motor power is demanded, increment slew scalar
         hover_roll_trim_scalar_slew++;
@@ -161,31 +161,31 @@ void Copter::heli_update_rotor_speed_targets()
     uint8_t rsc_control_mode = motors->get_rsc_mode();
 
     switch (rsc_control_mode) {
-        case ROTOR_CONTROL_MODE_PASSTHROUGH:
-            // pass through pilot desired rotor speed from the RC
-            if (get_pilot_desired_rotor_speed() > 0.01) {
-                ap.motor_interlock_switch = true;
-                motors->set_desired_rotor_speed(get_pilot_desired_rotor_speed());
-            } else {
-                ap.motor_interlock_switch = false;
-                motors->set_desired_rotor_speed(0.0f);
-            }
-            break;
-        case ROTOR_CONTROL_MODE_SETPOINT:
-        case ROTOR_CONTROL_MODE_THROTTLECURVE:
-        case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
-            if (motors->get_interlock()) {
-                motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
-            }else{
-                motors->set_desired_rotor_speed(0.0f);
-            }
-            break;
+    case ROTOR_CONTROL_MODE_PASSTHROUGH:
+        // pass through pilot desired rotor speed from the RC
+        if (get_pilot_desired_rotor_speed() > 0.01) {
+            ap.motor_interlock_switch = true;
+            motors->set_desired_rotor_speed(get_pilot_desired_rotor_speed());
+        } else {
+            ap.motor_interlock_switch = false;
+            motors->set_desired_rotor_speed(0.0f);
+        }
+        break;
+    case ROTOR_CONTROL_MODE_SETPOINT:
+    case ROTOR_CONTROL_MODE_THROTTLECURVE:
+    case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
+        if (motors->get_interlock()) {
+            motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
+        } else {
+            motors->set_desired_rotor_speed(0.0f);
+        }
+        break;
     }
 
     // when rotor_runup_complete changes to true, log event
-    if (!rotor_runup_complete_last && motors->rotor_runup_complete()){
+    if (!rotor_runup_complete_last && motors->rotor_runup_complete()) {
         AP::logger().Write_Event(LogEvent::ROTOR_RUNUP_COMPLETE);
-    } else if (rotor_runup_complete_last && !motors->rotor_runup_complete() && !heli_flags.in_autorotation){
+    } else if (rotor_runup_complete_last && !motors->rotor_runup_complete() && !heli_flags.in_autorotation) {
         AP::logger().Write_Event(LogEvent::ROTOR_SPEED_BELOW_CRITICAL);
     }
     rotor_runup_complete_last = motors->rotor_runup_complete();

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -73,6 +73,9 @@ void Copter::update_land_detector()
         // check if landing
         const bool landing = flightmode->is_landing();
         bool motor_at_lower_limit = (flightmode->has_manual_throttle() && (motors->get_below_land_min_coll() || heli_flags.coll_stk_low) && fabsf(ahrs.get_roll()) < M_PI/2.0f)
+#if MODE_AUTOROTATE_ENABLED == ENABLED
+                                    || (flightmode->mode_number() == Mode::Number::AUTOROTATE && motors->get_below_land_min_coll())
+#endif
                                     || ((!force_flying || landing) && motors->limit.throttle_lower && pos_control->get_vel_desired_cms().z < 0.0f);
         bool throttle_mix_at_min = true;
 #else

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -87,6 +87,9 @@ public:
     // get_rsc_setpoint - gets contents of _rsc_setpoint parameter (0~1)
     float get_rsc_setpoint() const { return _main_rotor._rsc_setpoint.get() * 0.01f; }
 
+    // arot_man_enabled - gets contents of manual_autorotation_enabled parameter
+    bool arot_man_enabled() const { return (_main_rotor._rsc_arot_man_enable.get() == 1) ? true : false; }
+
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     virtual void set_desired_rotor_speed(float desired_speed) = 0;
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -144,6 +144,9 @@ public:
 
     // set land complete flag
     void set_land_complete(bool landed) { _heliflags.land_complete = landed; }
+	
+	//return zero lift collective position
+    float get_coll_mid() const { return _collective_zero_thrust_pct; }
 
     // enum for heli optional features
     enum class HeliOption {

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -251,7 +251,7 @@ bool AP_MotorsHeli_Dual::init_outputs()
 
     // set signal value for main rotor external governor to know when to use autorotation bailout ramp up
     if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH) {
-        _main_rotor.set_ext_gov_arot_bail(_main_rotor._ext_gov_arot_pct.get());
+        _main_rotor.set_ext_gov_arot_bail(_main_rotor._arot_idle_output.get());
     } else {
         _main_rotor.set_ext_gov_arot_bail(0);
     }
@@ -342,7 +342,7 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     _main_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
 
     // allow use of external governor autorotation bailout window on main rotor
-    if (_main_rotor._ext_gov_arot_pct.get() > 0  &&  (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH)){
+    if (_main_rotor._arot_idle_output.get() > 0  &&  (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH)){
         // RSC only needs to know that the vehicle is in an autorotation if using the bailout window on an external governor
         _main_rotor.set_autorotation_flag(_heliflags.in_autorotation);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -62,7 +62,7 @@ bool AP_MotorsHeli_Quad::init_outputs()
 
     // set signal value for main rotor external governor to know when to use autorotation bailout ramp up
     if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH) {
-        _main_rotor.set_ext_gov_arot_bail(_main_rotor._ext_gov_arot_pct.get());
+        _main_rotor.set_ext_gov_arot_bail(_main_rotor._arot_idle_output.get());
     } else {
         _main_rotor.set_ext_gov_arot_bail(0);
     }
@@ -121,7 +121,7 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     _main_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
 
     // allow use of external governor autorotation bailout window on main rotor
-    if (_main_rotor._ext_gov_arot_pct.get() > 0  &&  (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH)){
+    if (_main_rotor._arot_idle_output.get() > 0  &&  (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH)){
         // RSC only needs to know that the vehicle is in an autorotation if using the bailout window on an external governor
         _main_rotor.set_autorotation_flag(_heliflags.in_autorotation);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -166,6 +166,7 @@ private:
     bool            _autorotating;                // flag that holds the status of autorotation
     bool            _bailing_out;                 // flag that holds the status of bail out(power engagement)
     float           _idle_throttle;               // current idle throttle setting
+    bool            _gov_bailing_out;             // flag that holds the status of governor bail out
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -17,7 +17,7 @@
 // default main rotor ramp up time in seconds
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to setpoint
 #define AP_MOTORS_HELI_RSC_RUNUP_TIME           10      // 10 seconds for rotor to reach full speed
-#define AP_MOTORS_HELI_RSC_BAILOUT_TIME         1       // time in seconds to ramp motors when bailing out of autorotation
+#define AP_MOTORS_HELI_RSC_AROT_ENGAGE_TIME     1       // time in seconds to ramp motors when bailing out of autorotation
 #define AP_MOTORS_HELI_RSC_AROT_PCT             0
 
 // Throttle Curve Defaults
@@ -130,7 +130,8 @@ public:
     AP_Int16        _critical_speed;          // Rotor speed below which flight is not possible
     AP_Int16        _idle_output;             // Rotor control output while at idle
     AP_Int16        _ext_gov_arot_pct;        // Percent value sent to external governor when in autorotation
-    AP_Int8         _rsc_bailout_time;        // time in seconds for power recovery
+    AP_Int8         _rsc_arot_engage_time;    // time in seconds for in-flight power re-engagement
+    AP_Int8         _rsc_arot_man_enable;     // enables manual autorotation
 
 private:
     uint64_t        _last_update_us;
@@ -164,6 +165,7 @@ private:
     float           _governor_torque_reference;   // governor reference for load calculations
     bool            _autorotating;
     bool            _bailing_out;
+    float           _idle_throttle;
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -163,9 +163,9 @@ private:
     float           _fast_idle_timer;             // cooldown timer variable
     uint8_t         _governor_fault_count;        // variable for tracking governor speed sensor faults
     float           _governor_torque_reference;   // governor reference for load calculations
-    bool            _autorotating;
-    bool            _bailing_out;
-    float           _idle_throttle;
+    bool            _autorotating;                // flag that holds the status of autorotation
+    bool            _bailing_out;                 // flag that holds the status of bail out(power engagement)
+    float           _idle_throttle;               // current idle throttle setting
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -18,6 +18,7 @@
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to setpoint
 #define AP_MOTORS_HELI_RSC_RUNUP_TIME           10      // 10 seconds for rotor to reach full speed
 #define AP_MOTORS_HELI_RSC_BAILOUT_TIME         1       // time in seconds to ramp motors when bailing out of autorotation
+#define AP_MOTORS_HELI_RSC_AROT_PCT             0
 
 // Throttle Curve Defaults
 #define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     25
@@ -129,6 +130,7 @@ public:
     AP_Int16        _critical_speed;          // Rotor speed below which flight is not possible
     AP_Int16        _idle_output;             // Rotor control output while at idle
     AP_Int16        _ext_gov_arot_pct;        // Percent value sent to external governor when in autorotation
+    AP_Int8         _rsc_bailout_time;        // time in seconds for power recovery
 
 private:
     uint64_t        _last_update_us;
@@ -160,6 +162,8 @@ private:
     float           _fast_idle_timer;             // cooldown timer variable
     uint8_t         _governor_fault_count;        // variable for tracking governor speed sensor faults
     float           _governor_torque_reference;   // governor reference for load calculations
+    bool            _autorotating;
+    bool            _bailing_out;
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -18,7 +18,7 @@
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to setpoint
 #define AP_MOTORS_HELI_RSC_RUNUP_TIME           10      // 10 seconds for rotor to reach full speed
 #define AP_MOTORS_HELI_RSC_AROT_ENGAGE_TIME     1       // time in seconds to ramp motors when bailing out of autorotation
-#define AP_MOTORS_HELI_RSC_AROT_PCT             0
+#define AP_MOTORS_HELI_RSC_AROT_IDLE            0
 
 // Throttle Curve Defaults
 #define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     25
@@ -129,7 +129,7 @@ public:
     AP_Int8         _runup_time;              // Time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
     AP_Int16        _critical_speed;          // Rotor speed below which flight is not possible
     AP_Int16        _idle_output;             // Rotor control output while at idle
-    AP_Int16        _ext_gov_arot_pct;        // Percent value sent to external governor when in autorotation
+    AP_Int16        _arot_idle_output;           // Percent value used when in autorotation
     AP_Int8         _rsc_arot_engage_time;    // time in seconds for in-flight power re-engagement
     AP_Int8         _rsc_arot_man_enable;     // enables manual autorotation
 
@@ -195,4 +195,5 @@ private:
     float       get_idle_output() const { return _idle_output * 0.01; }
     float       get_governor_torque() const { return _governor_torque * 0.01; }
     float       get_governor_compensator() const { return _governor_compensator * 0.000001; }
+    float       get_arot_idle_output() const { return _arot_idle_output * 0.01; }
 };

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -188,7 +188,7 @@ bool AP_MotorsHeli_Single::init_outputs()
 
     // set signal value for main rotor external governor to know when to use autorotation bailout ramp up
     if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH) {
-        _main_rotor.set_ext_gov_arot_bail(_main_rotor._ext_gov_arot_pct.get());
+        _main_rotor.set_ext_gov_arot_bail(_main_rotor._arot_idle_output.get());
     } else {
         _main_rotor.set_ext_gov_arot_bail(0);
     }
@@ -196,7 +196,7 @@ bool AP_MotorsHeli_Single::init_outputs()
     // set signal value for tail rotor external governor to know when to use autorotation bailout ramp up
     if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPIT_EXT_GOV) {
         // set point for tail rsc is the same as for main rotor to save on parameters
-        _tail_rotor.set_ext_gov_arot_bail(_main_rotor._ext_gov_arot_pct.get());
+        _tail_rotor.set_ext_gov_arot_bail(_main_rotor._arot_idle_output.get());
     } else {
         _tail_rotor.set_ext_gov_arot_bail(0);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -289,22 +289,26 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
         _main_rotor._rsc_mode.save();
         _heliflags.save_rsc_mode = false;
     }
-
-    // set bailout ramp time
-    _main_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
-    _tail_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
-
-    // allow use of external governor autorotation bailout
-    if (_main_rotor._ext_gov_arot_pct.get() > 0) {
-        // RSC only needs to know that the vehicle is in an autorotation if using the bailout window on an external governor
-        if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_SETPOINT  ||  _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_PASSTHROUGH) {
-            _main_rotor.set_autorotation_flag(_heliflags.in_autorotation);
-        }
-        if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPIT_EXT_GOV) {
-            _tail_rotor.set_autorotation_flag(_heliflags.in_autorotation);
-        }
+	
+    if (_heliflags.start_engine) {
+        _main_rotor.set_turbine_start(true);
+    } else {
+        _main_rotor.set_turbine_start(false);
     }
 
+    // allow use of external governor autorotation bailout
+    if (_heliflags.in_autorotation) {        
+        _main_rotor.set_autorotation_flag(_heliflags.in_autorotation);
+        // set bailout ramp time
+        _main_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
+        _tail_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
+        if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPIT_EXT_GOV) {
+            _tail_rotor.set_autorotation_flag(_heliflags.in_autorotation);
+            _tail_rotor.use_bailout_ramp_time(_heliflags.enable_bailout);
+        }
+    }else { 
+        _main_rotor.set_autorotation_flag(false);
+    }
 }
 
 // calculate_scalars - recalculates various scalers used.


### PR DESCRIPTION
This PR implements a manual autorotation capability for tradheli frames.  This is the first step toward incorporating autonomous autorotations.  Currently it is only implemented for the Single heli.  After it goes through review, it will be pretty quick to extend it to the dual and quad heli frames as they all use the same RSC class.

This takes manual autorotation out of the SITL only capability and brings it into the actual flight capability.  Manual autorotation has an enable setting that is disabled by default.   There is a feature that allows users that employ ESCs with an autorotation feature (it enables fast spool up) to set the throttle output to enable that feature in the ESC.  This works in conjunction with the bailout feature (in-flight power recovery) that ramps the throttle back to the throttle curve or the setpoint at a faster time than normal spool up on the ground.  Logic was added to ensure that it exits properly from the autorotation depending on whether it landed or bailed out.  

This was tested in SITL with Realflight but I hope to have @Ferruccio1984 test this in an actual heli