### PR TITLE
Copter: AC_WPNav: circle_rate param description added

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
 
     // @Param: RATE
     // @DisplayName: Circle rate
-    // @Description: Circle mode's turn rate in deg/sec.  Positive to turn clockwise, negative for counter clockwise
+    // @Description: Circle mode's turn rate in deg/sec.  Positive to turn clockwise, negative for counter clockwise. Circle rate must be less than ATC_SLEW_YAW parameter.
     // @Units: deg/s
     // @Range: -90 90
     // @Increment: 1


### PR DESCRIPTION
closes #21098 
added parameter description in Circle_rate that it must be smaller than Slew_yaw. Open for feedback.
thanks to @rmackay9 and @IamPete1 for the help. I found what I was doing wrong and will avoid it in future.