### PR TITLE
AP_ExternalAHRS: added EAHRS_SENSORS parameter

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -618,7 +618,7 @@ void AP_Baro::init(void)
 #endif
 
 #if AP_BARO_EXTERNALAHRS_ENABLED
-    const int8_t serial_port = AP::externalAHRS().get_port();
+    const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::BARO);
     if (serial_port >= 0) {
         ADD_BACKEND(new AP_Baro_ExternalAHRS(*this, serial_port));
     }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1268,7 +1268,7 @@ void Compass::_probe_external_i2c_compasses(void)
 void Compass::_detect_backends(void)
 {
 #if AP_COMPASS_EXTERNALAHRS_ENABLED
-    const int8_t serial_port = AP::externalAHRS().get_port();
+    const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::COMPASS);
     if (serial_port >= 0) {
         ADD_BACKEND(DRIVER_SERIAL, new AP_Compass_ExternalAHRS(serial_port));
     }

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -68,6 +68,13 @@ const AP_Param::GroupInfo AP_ExternalAHRS::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 3, AP_ExternalAHRS, options, 0),
 
+    // @Param: _SENSORS
+    // @DisplayName: External AHRS sensors
+    // @Description: External AHRS sensors bitmask
+    // @Bitmask: 0:GPS,1:IMU,2:Baro,3:Compass
+    // @User: Advanced
+    AP_GROUPINFO("_SENSORS", 4, AP_ExternalAHRS, sensors, 0xF),
+    
     AP_GROUPEND
 };
 
@@ -101,9 +108,9 @@ bool AP_ExternalAHRS::enabled() const
 }
 
 // get serial port number for the uart, or -1 if not applicable
-int8_t AP_ExternalAHRS::get_port(void) const
+int8_t AP_ExternalAHRS::get_port(AvailableSensor sensor) const
 {
-    if (!backend) {
+    if (!backend || !has_sensor(sensor)) {
         return -1;
     }
     return backend->get_port();

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -59,8 +59,15 @@ public:
     // Get model/type name
     const char* get_name() const;
 
+    enum class AvailableSensor {
+        GPS = (1U<<0),
+        IMU = (1U<<1),
+        BARO = (1U<<2),
+        COMPASS = (1U<<3),
+    };
+
     // get serial port number, -1 for not enabled
-    int8_t get_port(void) const;
+    int8_t get_port(AvailableSensor sensor) const;
 
     struct state_t {
         HAL_Semaphore sem;
@@ -147,8 +154,14 @@ private:
     AP_Enum<DevType> devtype;
     AP_Int16         rate;
     AP_Int16         options;
+    AP_Int16         sensors;
 
     static AP_ExternalAHRS *_singleton;
+
+    // check if a sensor type is enabled
+    bool has_sensor(AvailableSensor sensor) const {
+        return (uint16_t(sensors.get()) & uint16_t(sensor)) != 0;
+    }
 };
 
 namespace AP {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1072,7 +1072,7 @@ AP_InertialSensor::detect_backends(void)
 
 #if HAL_EXTERNAL_AHRS_ENABLED
     // if enabled, make the first IMU the external AHRS
-    const int8_t serial_port = AP::externalAHRS().get_port();
+    const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::IMU);
     if (serial_port >= 0) {
         ADD_BACKEND(new AP_InertialSensor_ExternalAHRS(*this, serial_port));
     }


### PR DESCRIPTION
This enables each sensor type to be disabled, both for backends that can't provide it and for when you just don't want to use that sensor
tested in SITL with VectorNav backend