### PR TITLE
AP_HAL_ChibiOS: move all defaults to end of hwdef.h

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2366,10 +2366,6 @@ def write_hwdef_header(outfilename):
     write_BARO_config(f)
     write_AIRSPEED_config(f)
     write_board_validate_macro(f)
-    add_apperiph_defaults(f)
-    add_bootloader_defaults(f)
-    add_iomcu_firmware_defaults(f)
-    add_normal_firmware_defaults(f)
     write_check_firmware(f)
 
     write_peripheral_enable(f)
@@ -2490,6 +2486,11 @@ def write_hwdef_header(outfilename):
             for r in dma_required:
                 if fnmatch.fnmatch(d, r):
                     error("Missing required DMA for %s" % d)
+
+    add_apperiph_defaults(f)
+    add_bootloader_defaults(f)
+    add_iomcu_firmware_defaults(f)
+    add_normal_firmware_defaults(f)
 
     f.close()
     # see if we ended up with the same file, on an unnecessary reconfigure


### PR DESCRIPTION
this allows the defaults to be based on other things set in the hwdef - for example, NUM_SERVO_CHANNELS to be dependent on HAL_PWM_COUNT


```
Board              AP_Periph  blimp  bootloader  copter  heli  plane  rover  sub
Durandal                      0      0           0       0     0      0      0
Hitec-Airspeed     0                                                         
KakuteH7-bdshot               0      0           0       0     0      0      0
MatekF405                     0      0           0       0     0      0      0
Pixhawk1-1M                   0      0           0       0     0      0      0
f103-QiotekPeriph  0                                                         
f303-Universal     0                                                         
revo-mini                     0      0           0       0     0      0      0
skyviper-v2450                                   0                           
```
