### PR TITLE
AP_RCProtocol: use using for constructor to save bytes

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
@@ -24,7 +24,8 @@
 
 class AP_RCProtocol_DSM : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_DSM(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void start_bind(void) override;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
@@ -16,11 +16,6 @@
 
 #include "AP_RCProtocol_IBUS.h"
 
-// constructor
-AP_RCProtocol_IBUS::AP_RCProtocol_IBUS(AP_RCProtocol &_frontend) :
-    AP_RCProtocol_Backend(_frontend)
-{}
-
 // decode a full IBUS frame
 bool AP_RCProtocol_IBUS::ibus_decode(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe)
 {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
@@ -25,7 +25,8 @@
 class AP_RCProtocol_IBUS : public AP_RCProtocol_Backend
 {
 public:
-    AP_RCProtocol_IBUS(AP_RCProtocol &_frontend);
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_PPMSum.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_PPMSum.h
@@ -20,7 +20,8 @@
 
 class AP_RCProtocol_PPMSum : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_PPMSum(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
 private:
     // state of ppm decoder

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
@@ -38,7 +38,8 @@
 
 class AP_RCProtocol_SRXL : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SRXL(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
@@ -38,7 +38,8 @@
 
 class AP_RCProtocol_ST24 : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_ST24(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
@@ -24,7 +24,8 @@
 #define SUMD_FRAME_MAXLEN   40
 class AP_RCProtocol_SUMD : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SUMD(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 


### PR DESCRIPTION
```
Board              AP_Periph  blimp  bootloader  copter  heli  plane  rover  sub
Durandal                      -8     0           -16     -16   -16    -16    -16
Hitec-Airspeed     0                                                         
KakuteH7-bdshot               -8     0           -8      -8    -8     -8     -16
MatekF405                     -16    0           -16     -16   -16    -16    -16
Pixhawk1-1M                   -8     0           -8      -16   -8     -8     -8
f103-QiotekPeriph  0                                                         
f303-Universal     0                                                         
revo-mini                     -8     0           -8      -16   -8     -8     -8
skyviper-v2450                                   -16                         
```

... and slightly less code
