### PR TITLE
Remove more code based on AP_VIDEOTX_ENABLED

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -88,8 +88,9 @@ BUILD_OPTIONS = [
     Feature('OSD', 'OSD_PARAM', 'OSD_PARAM_ENABLED', 'Enable OSD param', 0, 'OSD'),
     Feature('OSD', 'OSD_SIDEBARS', 'HAL_OSD_SIDEBAR_ENABLE', 'Enable Scrolling Sidebars', 0, 'OSD'),
 
-    Feature('VTX', 'SMARTAUDIO', 'AP_SMARTAUDIO_ENABLED', 'Enable SmartAudio VTX Contol', 0, None),
-    Feature('VTX', 'TRAMP', 'AP_TRAMP_ENABLED', 'Enable IRC Tramp VTX Control', 0, None),
+    Feature('VTX', 'VIDEO_TX', 'AP_VIDEOTX_ENABLED', 'Enable VideoTX control', 0, None),
+    Feature('VTX', 'SMARTAUDIO', 'AP_SMARTAUDIO_ENABLED', 'Enable SmartAudio VTX Contol', 0, "VIDEO_TX"),
+    Feature('VTX', 'TRAMP', 'AP_TRAMP_ENABLED', 'Enable IRC Tramp VTX Control', 0, "VIDEO_TX"),
 
     Feature('ESC', 'PICCOLOCAN', 'HAL_PICCOLO_CAN_ENABLE', 'Enable PiccoloCAN', 0, None),
     Feature('ESC', 'TORQEEDO', 'HAL_TORQEEDO_ENABLED', 'Enable Torqeedo Motors', 0, None),

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -901,6 +901,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(current2, "CURRENT2", 54, AP_OSD_Screen, AP_OSD_Setting),
 
+#if AP_VIDEOTX_ENABLED
     // @Param: VTX_PWR_EN
     // @DisplayName: VTX_PWR_EN
     // @Description: Displays VTX Power
@@ -916,6 +917,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Vertical position on screen
     // @Range: 0 15
     AP_SUBGROUPINFO(vtx_power, "VTX_PWR", 55, AP_OSD_Screen, AP_OSD_Setting),
+#endif  // AP_VIDEOTX_ENABLED
 
 #if AP_TERRAIN_AVAILABLE
     // @Param: TER_HGT_EN
@@ -2111,9 +2113,9 @@ void AP_OSD_Screen::draw_current2(uint8_t x, uint8_t y)
     draw_current(1, x, y);
 }
 
+#if AP_VIDEOTX_ENABLED
 void AP_OSD_Screen::draw_vtx_power(uint8_t x, uint8_t y)
 {
-#if AP_VIDEOTX_ENABLED
     AP_VideoTX *vtx = AP_VideoTX::get_singleton();
     if (!vtx) {
         return;
@@ -2124,8 +2126,9 @@ void AP_OSD_Screen::draw_vtx_power(uint8_t x, uint8_t y)
         powr = vtx->get_power_mw();
     }
     backend->write(x, y, !vtx->is_configuration_finished(), "%4hu%c", powr, SYMBOL(SYM_MW));
-#endif  // AP_VIDEOTX_ENABLED
 }
+#endif  // AP_VIDEOTX_ENABLED
+
 #if AP_TERRAIN_AVAILABLE
 void AP_OSD_Screen::draw_hgt_abvterr(uint8_t x, uint8_t y)
 {
@@ -2231,7 +2234,9 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(hdop);
     DRAW_SETTING(flightime);
     DRAW_SETTING(clk);
+#if AP_VIDEOTX_ENABLED
     DRAW_SETTING(vtx_power);
+#endif
 
 #if HAL_WITH_ESC_TELEM
     DRAW_SETTING(esc_temp);

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -389,7 +389,11 @@ bool AP_CRSF_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
     case PARAMETERS:
         return _pending_request.frame_type > 0;
     case VTX_PARAMETERS:
+#if AP_VIDEOTX_ENABLED
         return AP::vtx().have_params_changed() ||_vtx_power_change_pending || _vtx_freq_change_pending || _vtx_options_change_pending;
+#else
+        return false;
+#endif
     case PASSTHROUGH:
         return rc().crsf_custom_telemetry();
     case STATUS_TEXT:
@@ -421,9 +425,11 @@ void AP_CRSF_Telem::process_packet(uint8_t idx)
         case ATTITUDE:
             calc_attitude();
             break;
+#if AP_VIDEOTX_ENABLED
         case VTX_PARAMETERS: // update various VTX parameters
             update_vtx_params();
             break;
+#endif
         case BATTERY: // BATTERY
             calc_battery();
             break;
@@ -482,6 +488,7 @@ bool AP_CRSF_Telem::_process_frame(AP_RCProtocol_CRSF::FrameType frame_type, voi
         _enable_telemetry = true;
         break;
 
+#if AP_VIDEOTX_ENABLED
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_VTX:
         process_vtx_frame((VTXFrame*)data);
         break;
@@ -489,6 +496,7 @@ bool AP_CRSF_Telem::_process_frame(AP_RCProtocol_CRSF::FrameType frame_type, voi
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_VTX_TELEM:
         process_vtx_telem_frame((VTXTelemetryFrame*)data);
         break;
+#endif
 
     case AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAM_DEVICE_PING:
         process_ping_frame((ParameterPingFrame*)data);
@@ -516,6 +524,7 @@ bool AP_CRSF_Telem::_process_frame(AP_RCProtocol_CRSF::FrameType frame_type, voi
     return true;
 }
 
+#if AP_VIDEOTX_ENABLED
 void AP_CRSF_Telem::process_vtx_frame(VTXFrame* vtx) {
     vtx->user_frequency = be16toh(vtx->user_frequency);
 
@@ -600,6 +609,7 @@ void AP_CRSF_Telem::process_vtx_telem_frame(VTXTelemetryFrame* vtx)
 
     _vtx_power_change_pending = _vtx_freq_change_pending = _vtx_options_change_pending = false;
 }
+#endif  // AP_VIDEOTX_ENABLED
 
 // request for device info
 void AP_CRSF_Telem::process_ping_frame(ParameterPingFrame* ping)
@@ -737,6 +747,7 @@ void AP_CRSF_Telem::process_pending_requests()
     _pending_request.frame_type = 0;
 }
 
+#if AP_VIDEOTX_ENABLED
 void AP_CRSF_Telem::update_vtx_params()
 {
     AP_VideoTX& vtx = AP::vtx();
@@ -829,6 +840,7 @@ void AP_CRSF_Telem::update_vtx_params()
         _telem_size = len + 1;
     }
 }
+#endif  // AP_VIDEOTX_ENABLED
 
 // prepare parameter ping data
 void AP_CRSF_Telem::calc_parameter_ping()

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -503,7 +503,9 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::SCRIPTING_6:
     case AUX_FUNC::SCRIPTING_7:
     case AUX_FUNC::SCRIPTING_8:
+#if AP_VIDEOTX_ENABLED
     case AUX_FUNC::VTX_POWER:
+#endif
     case AUX_FUNC::OPTFLOW_CAL:
     case AUX_FUNC::TURBINE_START:
     case AUX_FUNC::MOUNT1_ROLL:


### PR DESCRIPTION
I've run this through the script which disables all build options in turn; the tramp dependency seems to work.

```
Board              AP_Periph  blimp  bootloader  copter  heli  plane  rover  sub
Durandal                      0      0           0       0     0      0      0
Hitec-Airspeed     0                                                         
KakuteH7-bdshot               0      0           0       0     0      0      0
MatekF405                     0      0           0       0     0      0      0
Pixhawk1-1M                   0      0           0       0     0      0      0
f103-QiotekPeriph  0                                                         
f303-Universal     0                                                         
revo-mini                     0      0           0       0     0      0      0
skyviper-v2450                                   -24                         
```
