### PR TITLE
AP_RCProtocol: use a pointer to active backend rather than derefefencing array using enum value

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -43,44 +43,44 @@ extern const AP_HAL::HAL& hal;
 void AP_RCProtocol::init()
 {
 #if AP_RCPROTOCOL_PPMSUM_ENABLED
-    backend[AP_RCProtocol::PPMSUM] = new AP_RCProtocol_PPMSum(*this);
+    backend[AP_RCProtocol::PPMSUM] = new AP_RCProtocol_PPMSum(*this, AP_RCProtocol::PPMSUM);
 #endif
 #if AP_RCPROTOCOL_IBUS_ENABLED
-    backend[AP_RCProtocol::IBUS] = new AP_RCProtocol_IBUS(*this);
+    backend[AP_RCProtocol::IBUS] = new AP_RCProtocol_IBUS(*this, AP_RCProtocol::IBUS);
 #endif
 #if AP_RCPROTOCOL_SBUS_ENABLED
-    backend[AP_RCProtocol::SBUS] = new AP_RCProtocol_SBUS(*this, true, 100000);
+    backend[AP_RCProtocol::SBUS] = new AP_RCProtocol_SBUS(*this, AP_RCProtocol::SBUS, true, 100000);
 #endif
 #if AP_RCPROTOCOL_FASTSBUS_ENABLED
-    backend[AP_RCProtocol::FASTSBUS] = new AP_RCProtocol_SBUS(*this, true, 200000);
+    backend[AP_RCProtocol::FASTSBUS] = new AP_RCProtocol_SBUS(*this, AP_RCProtocol::FASTSBUS, true, 200000);
 #endif
-    backend[AP_RCProtocol::DSM] = new AP_RCProtocol_DSM(*this);
+    backend[AP_RCProtocol::DSM] = new AP_RCProtocol_DSM(*this, AP_RCProtocol::DSM);
 #if AP_RCPROTOCOL_SUMD_ENABLED
-    backend[AP_RCProtocol::SUMD] = new AP_RCProtocol_SUMD(*this);
+    backend[AP_RCProtocol::SUMD] = new AP_RCProtocol_SUMD(*this, AP_RCProtocol::SUMD);
 #endif
 #if AP_RCPROTOCOL_SRXL_ENABLED
-    backend[AP_RCProtocol::SRXL] = new AP_RCProtocol_SRXL(*this);
+    backend[AP_RCProtocol::SRXL] = new AP_RCProtocol_SRXL(*this, AP_RCProtocol::SRXL);
 #endif
 #if AP_RCPROTOCOL_SBUS_NI_ENABLED
-    backend[AP_RCProtocol::SBUS_NI] = new AP_RCProtocol_SBUS(*this, false, 100000);
+    backend[AP_RCProtocol::SBUS_NI] = new AP_RCProtocol_SBUS(*this, AP_RCProtocol::SBUS_NI, false, 100000);
 #endif
 #if AP_RCPROTOCOL_SRXL2_ENABLED
-    backend[AP_RCProtocol::SRXL2] = new AP_RCProtocol_SRXL2(*this);
+    backend[AP_RCProtocol::SRXL2] = new AP_RCProtocol_SRXL2(*this, AP_RCProtocol::SRXL2);
 #endif
 #if AP_RCPROTOCOL_CRSF_ENABLED
-    backend[AP_RCProtocol::CRSF] = new AP_RCProtocol_CRSF(*this);
+    backend[AP_RCProtocol::CRSF] = new AP_RCProtocol_CRSF(*this, AP_RCProtocol::CRSF);
 #endif
 #if AP_RCPROTOCOL_FPORT2_ENABLED
-    backend[AP_RCProtocol::FPORT2] = new AP_RCProtocol_FPort2(*this, true);
+    backend[AP_RCProtocol::FPORT2] = new AP_RCProtocol_FPort2(*this, AP_RCProtocol::FPORT2, true);
 #endif
 #if AP_RCPROTOCOL_ST24_ENABLED
-    backend[AP_RCProtocol::ST24] = new AP_RCProtocol_ST24(*this);
+    backend[AP_RCProtocol::ST24] = new AP_RCProtocol_ST24(*this, AP_RCProtocol::ST24);
 #endif
 #if AP_RCPROTOCOL_FPORT_ENABLED
-    backend[AP_RCProtocol::FPORT] = new AP_RCProtocol_FPort(*this, true);
+    backend[AP_RCProtocol::FPORT] = new AP_RCProtocol_FPort(*this, AP_RCProtocol::FPORT, true);
 #endif
 #if AP_RCPROTOCOL_DRONECAN_ENABLED
-    backend[AP_RCProtocol::DRONECAN] = new AP_RCProtocol_DroneCAN(*this);
+    backend[AP_RCProtocol::DRONECAN] = new AP_RCProtocol_DroneCAN(*this, AP_RCProtocol::DRONECAN);
 #endif
 }
 
@@ -97,12 +97,13 @@ AP_RCProtocol::~AP_RCProtocol()
 bool AP_RCProtocol::should_search(uint32_t now_ms) const
 {
 #if AP_RC_CHANNEL_ENABLED && !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
-    if (_detected_protocol != AP_RCProtocol::NONE && !rc().option_is_enabled(RC_Channels::Option::MULTI_RECEIVER_SUPPORT)) {
+    if (_active_backend != nullptr &&
+        !rc().option_is_enabled(RC_Channels::Option::MULTI_RECEIVER_SUPPORT)) {
         return false;
     }
 #else
     // on IOMCU don't allow protocol to change once detected
-    if (_detected_protocol != AP_RCProtocol::NONE) {
+    if (_active_backend != nullptr) {
         return false;
     }
 #endif
@@ -118,19 +119,20 @@ void AP_RCProtocol::process_pulse(uint32_t width_s0, uint32_t width_s1)
     rc_protocols_mask = rc().enabled_protocols();
 #endif
 
-    if (_detected_protocol != AP_RCProtocol::NONE &&
-        !protocol_enabled(_detected_protocol)) {
-        _detected_protocol = AP_RCProtocol::NONE;
+    if (_active_backend != nullptr &&
+        !protocol_enabled(_active_backend->protocol())) {
+        // backend was disabled at runtime
+        _active_backend = nullptr;
     }
-    
-    if (_detected_protocol != AP_RCProtocol::NONE && _detected_with_bytes && !searching) {
+
+    if (_active_backend != nullptr && _detected_with_bytes && !searching) {
         // we're using byte inputs, discard pulses
         return;
     }
     // first try current protocol
-    if (_detected_protocol != AP_RCProtocol::NONE && !searching) {
-        backend[_detected_protocol]->process_pulse(width_s0, width_s1);
-        if (backend[_detected_protocol]->new_input()) {
+    if (_active_backend != nullptr && !searching) {
+        _active_backend->process_pulse(width_s0, width_s1);
+        if (_active_backend->new_input()) {
             _new_input = true;
             _last_input_ms = now;
         }
@@ -156,7 +158,7 @@ void AP_RCProtocol::process_pulse(uint32_t width_s0, uint32_t width_s1)
                     continue;
                 }
                 _new_input = (input_count != backend[i]->get_rc_input_count());
-                _detected_protocol = (enum AP_RCProtocol::rcprotocol_t)i;
+                _active_backend = backend[i];
                 for (uint8_t j = 0; j < ARRAY_SIZE(backend); j++) {
                     if (backend[j]) {
                         backend[j]->reset_rc_frame_count();
@@ -202,20 +204,21 @@ bool AP_RCProtocol::process_byte(uint8_t byte, uint32_t baudrate)
     rc_protocols_mask = rc().enabled_protocols();
 #endif
 
-    if (_detected_protocol != AP_RCProtocol::NONE &&
-        !protocol_enabled(_detected_protocol)) {
-        _detected_protocol = AP_RCProtocol::NONE;
+    if (_active_backend != nullptr &&
+        !protocol_enabled(_active_backend->protocol())) {
+        // backend was disabled at runtime
+        _active_backend = nullptr;
     }
 
-    if (_detected_protocol != AP_RCProtocol::NONE && !_detected_with_bytes && !searching) {
+    if (_active_backend != nullptr && !_detected_with_bytes && !searching) {
         // we're using pulse inputs, discard bytes
         return false;
     }
 
     // first try current protocol
-    if (_detected_protocol != AP_RCProtocol::NONE && !searching) {
-        backend[_detected_protocol]->process_byte(byte, baudrate);
-        if (backend[_detected_protocol]->new_input()) {
+    if (_active_backend != nullptr && !searching) {
+        _active_backend->process_byte(byte, baudrate);
+        if (_active_backend->new_input()) {
             _new_input = true;
             _last_input_ms = now;
         }
@@ -236,8 +239,8 @@ bool AP_RCProtocol::process_byte(uint8_t byte, uint32_t baudrate)
                 if (requires_3_frames((rcprotocol_t)i) && frame_count2 < 3) {
                     continue;
                 }
-                _new_input = (input_count != backend[i]->get_rc_input_count());
-                _detected_protocol = (enum AP_RCProtocol::rcprotocol_t)i;
+                _active_backend = backend[i];
+                _new_input = (input_count != _active_backend->get_rc_input_count());
                 _last_input_ms = now;
                 _detected_with_bytes = true;
                 for (uint8_t j = 0; j < ARRAY_SIZE(backend); j++) {
@@ -258,7 +261,7 @@ bool AP_RCProtocol::process_byte(uint8_t byte, uint32_t baudrate)
 void AP_RCProtocol::process_handshake( uint32_t baudrate)
 {
     // if we ever succeeded before then do not handshake
-    if (_detected_protocol != AP_RCProtocol::NONE || _last_input_ms > 0) {
+    if (_active_backend != nullptr || _last_input_ms > 0) {
         return;
     }
 
@@ -348,9 +351,9 @@ void AP_RCProtocol::check_added_uart(void)
         }
     // power loss on CRSF requires re-bootstrap because the baudrate is reset to the default. The CRSF side will
     // drop back down to 416k if it has received 200 incorrect characters (or none at all)
-    } else if (_detected_protocol != AP_RCProtocol::NONE
+    } else if (_active_backend != nullptr
         // protocols that want to be able to renegotiate should return false in is_rx_active()
-        && !backend[_detected_protocol]->is_rx_active()
+        && !_active_backend->is_rx_active()
         && now - added.last_config_change_ms > 1000) {
         added.opened = false;
     }
@@ -378,11 +381,11 @@ bool AP_RCProtocol::new_input()
     if (should_search(now)) {
         if (backend[AP_RCProtocol::DRONECAN] != nullptr &&
             backend[AP_RCProtocol::DRONECAN]->new_input()) {
-            _detected_protocol = AP_RCProtocol::DRONECAN;
+            _active_backend = backend[AP_RCProtocol::DRONECAN];
             _last_input_ms = now;
         }
-    } else if (_detected_protocol == AP_RCProtocol::DRONECAN) {
-        _new_input = backend[AP_RCProtocol::DRONECAN]->new_input();
+    } else if (_active_backend == backend[AP_RCProtocol::DRONECAN]) {
+        _new_input = _active_backend->new_input();
         if (_new_input) {
             _last_input_ms = now;
         }
@@ -396,38 +399,38 @@ bool AP_RCProtocol::new_input()
 
 uint8_t AP_RCProtocol::num_channels()
 {
-    if (_detected_protocol != AP_RCProtocol::NONE) {
-        return backend[_detected_protocol]->num_channels();
+    if (_active_backend != nullptr) {
+        return _active_backend->num_channels();
     }
     return 0;
 }
 
 uint16_t AP_RCProtocol::read(uint8_t chan)
 {
-    if (_detected_protocol != AP_RCProtocol::NONE) {
-        return backend[_detected_protocol]->read(chan);
+    if (_active_backend != nullptr) {
+        return _active_backend->read(chan);
     }
     return 0;
 }
 
 void AP_RCProtocol::read(uint16_t *pwm, uint8_t n)
 {
-    if (_detected_protocol != AP_RCProtocol::NONE) {
-        backend[_detected_protocol]->read(pwm, n);
+    if (_active_backend != nullptr) {
+        _active_backend->read(pwm, n);
     }
 }
 
 int16_t AP_RCProtocol::get_RSSI(void) const
 {
-    if (_detected_protocol != AP_RCProtocol::NONE) {
-        return backend[_detected_protocol]->get_RSSI();
+    if (_active_backend != nullptr) {
+        return _active_backend->get_RSSI();
     }
     return -1;
 }
 int16_t AP_RCProtocol::get_rx_link_quality(void) const
 {
-    if (_detected_protocol != AP_RCProtocol::NONE) {
-        return backend[_detected_protocol]->get_rx_link_quality();
+    if (_active_backend != nullptr) {
+        return _active_backend->get_rx_link_quality();
     }
     return -1;
 }
@@ -517,7 +520,10 @@ const char *AP_RCProtocol::protocol_name_from_protocol(rcprotocol_t protocol)
  */
 const char *AP_RCProtocol::protocol_name(void) const
 {
-    return protocol_name_from_protocol(_detected_protocol);
+    if (_active_backend == nullptr) {
+        return nullptr;
+    }
+    return protocol_name_from_protocol(_active_backend->protocol());
 }
 
 /*
@@ -537,6 +543,14 @@ bool AP_RCProtocol::protocol_enabled(rcprotocol_t protocol) const
         return true;
     }
     return ((1U<<(uint8_t(protocol)+1)) & rc_protocols_mask) != 0;
+}
+
+// return detected protocol
+enum AP_RCProtocol::rcprotocol_t AP_RCProtocol::protocol_detected(void) const {
+    if (_active_backend == nullptr) {
+        return rcprotocol_t::NONE;
+    }
+    return _active_backend->protocol();
 }
 
 namespace AP {

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -167,9 +167,7 @@ public:
     const char *protocol_name(void) const;
 
     // return detected protocol
-    enum rcprotocol_t protocol_detected(void) const {
-        return _detected_protocol;
-    }
+    enum rcprotocol_t protocol_detected(void) const;
 
     // add a UART for RCIN
     void add_uart(AP_HAL::UARTDriver* uart);
@@ -201,7 +199,8 @@ private:
     // return true if a specific protocol is enabled
     bool protocol_enabled(enum rcprotocol_t protocol) const;
 
-    enum rcprotocol_t _detected_protocol = NONE;
+    AP_RCProtocol_Backend *_active_backend;
+
     uint16_t _disabled_for_pulses;
     bool _detected_with_bytes;
     AP_RCProtocol_Backend *backend[NONE];

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -34,8 +34,9 @@
 
 
 
-AP_RCProtocol_Backend::AP_RCProtocol_Backend(AP_RCProtocol &_frontend) :
+AP_RCProtocol_Backend::AP_RCProtocol_Backend(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) :
     frontend(_frontend),
+    _protocol{protocol},
     rc_input_count(0),
     last_rc_input_count(0),
     _num_channels(0)

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -28,8 +28,11 @@ class AP_RCProtocol_Backend {
     friend class AP_RCProtcol;
 
 public:
-    AP_RCProtocol_Backend(AP_RCProtocol &_frontend);
+    AP_RCProtocol_Backend(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t);
     virtual ~AP_RCProtocol_Backend() {}
+
+    AP_RCProtocol::rcprotocol_t protocol() const { return _protocol; }
+
     virtual void process_pulse(uint32_t width_s0, uint32_t width_s1) {}
     virtual void process_byte(uint8_t byte, uint32_t baudrate) {}
     virtual void process_handshake(uint32_t baudrate) {}
@@ -133,6 +136,8 @@ private:
     uint8_t  _num_channels;
     int16_t rssi = -1;
     int16_t rx_link_quality = -1;
+
+    AP_RCProtocol::rcprotocol_t _protocol;
 };
 
 #endif  // AP_RCPROTOCOL_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -165,7 +165,7 @@ const uint16_t AP_RCProtocol_CRSF::RF_MODE_RATES[RFMode::RF_MODE_MAX_MODES] = {
 
 AP_RCProtocol_CRSF* AP_RCProtocol_CRSF::_singleton;
 
-AP_RCProtocol_CRSF::AP_RCProtocol_CRSF(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend)
+AP_RCProtocol_CRSF::AP_RCProtocol_CRSF(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
     if (_singleton != nullptr) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -38,8 +38,9 @@
 
 class AP_RCProtocol_CRSF : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_CRSF(AP_RCProtocol &_frontend);
+    AP_RCProtocol_CRSF(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol);
     virtual ~AP_RCProtocol_CRSF();
+
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void process_handshake(uint32_t baudrate) override;
     void update(void) override;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
@@ -29,7 +29,7 @@
 
 class AP_RCProtocol_DSM : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_DSM(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    AP_RCProtocol_DSM(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void start_bind(void) override;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DroneCAN.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DroneCAN.h
@@ -13,8 +13,8 @@
 class AP_RCProtocol_DroneCAN : public AP_RCProtocol_Backend {
 public:
 
-    AP_RCProtocol_DroneCAN(AP_RCProtocol &_frontend) :
-        AP_RCProtocol_Backend(_frontend) {
+    AP_RCProtocol_DroneCAN(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) :
+        AP_RCProtocol_Backend(_frontend, protocol) {
         _singleton = this;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -78,8 +78,8 @@ struct PACKED FPort_Frame {
 static_assert(sizeof(FPort_Frame) == FPORT_CONTROL_FRAME_SIZE, "FPort_Frame incorrect size");
 
 // constructor
-AP_RCProtocol_FPort::AP_RCProtocol_FPort(AP_RCProtocol &_frontend, bool _inverted) :
-    AP_RCProtocol_Backend(_frontend),
+AP_RCProtocol_FPort::AP_RCProtocol_FPort(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool _inverted) :
+    AP_RCProtocol_Backend(_frontend, protocol),
     inverted(_inverted)
 {}
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.h
@@ -31,7 +31,8 @@ struct FPort_Frame;
 
 class AP_RCProtocol_FPort : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_FPort(AP_RCProtocol &_frontend, bool inverted);
+    AP_RCProtocol_FPort(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool inverted);
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -68,8 +68,8 @@ struct PACKED FPort2_Frame {
 static_assert(sizeof(FPort2_Frame) == FPORT2_CONTROL_FRAME_SIZE, "FPort2_Frame incorrect size");
 
 // constructor
-AP_RCProtocol_FPort2::AP_RCProtocol_FPort2(AP_RCProtocol &_frontend, bool _inverted) :
-    AP_RCProtocol_Backend(_frontend),
+AP_RCProtocol_FPort2::AP_RCProtocol_FPort2(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool _inverted) :
+    AP_RCProtocol_Backend(_frontend, protocol),
     inverted(_inverted)
 {}
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.h
@@ -31,7 +31,8 @@ struct FPort2_Frame;
 
 class AP_RCProtocol_FPort2 : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_FPort2(AP_RCProtocol &_frontend, bool inverted);
+    AP_RCProtocol_FPort2(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool inverted);
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
@@ -20,11 +20,6 @@
 
 #include "AP_RCProtocol_IBUS.h"
 
-// constructor
-AP_RCProtocol_IBUS::AP_RCProtocol_IBUS(AP_RCProtocol &_frontend) :
-    AP_RCProtocol_Backend(_frontend)
-{}
-
 // decode a full IBUS frame
 bool AP_RCProtocol_IBUS::ibus_decode(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe)
 {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
@@ -30,7 +30,9 @@
 class AP_RCProtocol_IBUS : public AP_RCProtocol_Backend
 {
 public:
-    AP_RCProtocol_IBUS(AP_RCProtocol &_frontend);
+    AP_RCProtocol_IBUS(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) :
+        AP_RCProtocol_Backend(_frontend, protocol) { }
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_PPMSum.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_PPMSum.h
@@ -24,7 +24,7 @@
 
 class AP_RCProtocol_PPMSum : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_PPMSum(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    AP_RCProtocol_PPMSum(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
 private:
     // state of ppm decoder

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
@@ -80,8 +80,8 @@
 #endif
 
 // constructor
-AP_RCProtocol_SBUS::AP_RCProtocol_SBUS(AP_RCProtocol &_frontend, bool _inverted, uint32_t configured_baud) :
-    AP_RCProtocol_Backend(_frontend),
+AP_RCProtocol_SBUS::AP_RCProtocol_SBUS(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool _inverted, uint32_t configured_baud) :
+    AP_RCProtocol_Backend(_frontend, protocol),
     inverted(_inverted),
     ss{configured_baud, SoftSerial::SERIAL_CONFIG_8E2I}
 {}

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.h
@@ -26,7 +26,8 @@
 
 class AP_RCProtocol_SBUS : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SBUS(AP_RCProtocol &_frontend, bool inverted, uint32_t configured_baud);
+    AP_RCProtocol_SBUS(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol, bool inverted, uint32_t configured_baud);
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
@@ -42,7 +42,7 @@
 
 class AP_RCProtocol_SRXL : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SRXL(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    AP_RCProtocol_SRXL(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -41,7 +41,7 @@ extern const AP_HAL::HAL& hal;
 
 AP_RCProtocol_SRXL2* AP_RCProtocol_SRXL2::_singleton;
 
-AP_RCProtocol_SRXL2::AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend)
+AP_RCProtocol_SRXL2::AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
     if (_singleton != nullptr) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -28,8 +28,9 @@
 
 class AP_RCProtocol_SRXL2 : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend);
+    AP_RCProtocol_SRXL2(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t);
     virtual ~AP_RCProtocol_SRXL2();
+
     void process_byte(uint8_t byte, uint32_t baudrate) override;
     void process_handshake(uint32_t baudrate) override;
     void start_bind(void) override;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_ST24.h
@@ -42,7 +42,7 @@
 
 class AP_RCProtocol_ST24 : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_ST24(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    AP_RCProtocol_ST24(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
@@ -28,7 +28,7 @@
 #define SUMD_FRAME_MAXLEN   40
 class AP_RCProtocol_SUMD : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SUMD(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    AP_RCProtocol_SUMD(AP_RCProtocol &_frontend, AP_RCProtocol::rcprotocol_t protocol) : AP_RCProtocol_Backend(_frontend, protocol) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 


### PR DESCRIPTION
This helps properly decouple the number of allocated backends from the length of the array.  This should allow us to not allocate backends depending on what backends are enabled (care will need to be taken with the iomcu firmware there).

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -40    *           -40     -48               -48    -40    -40
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -32    *           -32     -32               -32    -24    -24
MatekF405                      -40    *           -40     -40               -40    -40    -40
Pixhawk1-1M-bdshot             -16                -24     -16               -16    -24    -16
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           -40                       
revo-mini                      -40    *           -40     -40               -40    -40    -40
skyviper-v2450                                    *                                       
```
