### PR TITLE
AP_ADSB: bug fix send mavlink status for only two types

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -680,7 +680,7 @@ void AP_ADSB::handle_transceiver_report(const mavlink_channel_t chan, const mavl
 void AP_ADSB::send_adsb_out_status(const mavlink_channel_t chan) const
 {
     for (uint8_t i=0; i < ADSB_MAX_INSTANCES; i++) {
-        if (_type[i] == (int8_t)(AP_ADSB::Type::uAvionix_UCP) || (int8_t)(AP_ADSB::Type::Sagetech_MXS)) {
+        if (_type[i] == (int8_t)(AP_ADSB::Type::uAvionix_UCP) || _type[i] == (int8_t)(AP_ADSB::Type::Sagetech_MXS)) {
             mavlink_msg_uavionix_adsb_out_status_send_struct(chan, &out_state.tx_status);
             return;
         }


### PR DESCRIPTION
AP_ADSB: bug fix send mavlink status for only two types