### PR TITLE
Plane: QRTL: combine threshold radius for QRTL and RTL

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -608,6 +608,8 @@ public:
 
     bool allows_throttle_nudging() const override;
 
+    float get_VTOL_return_radius() const;
+
 protected:
 
     bool _enter() override;

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -27,12 +27,8 @@ bool ModeRTL::_enter()
         // if VTOL landing is expected and quadplane motors are active and within QRTL radius and under QRTL altitude then switch to QRTL
         const bool vtol_landing = (plane.quadplane.rtl_mode == QuadPlane::RTL_MODE::SWITCH_QRTL) || (plane.quadplane.rtl_mode == QuadPlane::RTL_MODE::VTOL_APPROACH_QRTL);
         if (vtol_landing && (quadplane.motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED)) {
-            uint16_t qrtl_radius = abs(plane.g.rtl_radius);
-            if (qrtl_radius == 0) {
-                qrtl_radius = abs(plane.aparm.loiter_radius);
-            }
             int32_t alt_cm;
-            if ((plane.current_loc.get_distance(plane.next_WP_loc) < qrtl_radius) &&
+            if ((plane.current_loc.get_distance(plane.next_WP_loc) < plane.mode_qrtl.get_VTOL_return_radius()) &&
                 plane.current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_cm) && (alt_cm < plane.quadplane.qrtl_alt*100)) {
                 plane.set_mode(plane.mode_qrtl, ModeReason::QRTL_INSTEAD_OF_RTL);
                 return true;


### PR DESCRIPTION
This moves to a shared mode QRTL method for getting the distance at which we just VTOL home. The main change in behavior is for RTL mode with `Q_RTL_MODE` 1 or 2, this moves from RTL radius else waypoint radius to using 1.5 times the larger. The key thing is to make the two modes behave the same. Now no matter RTL or QRTL it will VTOL home at the same radius.

These two poscontrol prints also now report the full radius. Previously they would omit the 1.5 multiplyer.

https://github.com/ArduPilot/ardupilot/blob/8a312d4f342deb327928ee1a6ef9bed4490eab6b/ArduPlane/mode_qrtl.cpp#L60