### PR TITLE
size_compare_branches.py: add test for identicality

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -112,6 +112,7 @@ class SizeCompareBranches(object):
         # TODO: find a way to get this information from board_list:
         self.bootloader_blacklist = frozenset([
             'skyviper-v2450',
+            'iomcu',
         ])
 
     def find_bin_dir(self):


### PR DESCRIPTION
Previously binaries which haven't changed between branches would come out as zero bytes.

After this, if the files are byte-for-byte then we will get a `*` indicating no change in place of the `0`

Interestingly, identical branches don't give identical results for AP_Periph on master.  In fact, we don't get a stable build at all, with it sometimes being identical, sometimes not.  elf_diff shows no changes, because it doesn't care about symbol ordering.

```
-out-branch-f303-Universal/f303-Universal/bin/AP_Periph:     file format elf32-littlearm
+out-master-f303-Universal/f303-Universal/bin/AP_Periph:     file format elf32-littlearm
 
 
 Disassembly of section startup:
@@ -6973,110 +6973,110 @@
  800b218:	e7a8      	b.n	800b16c <uavcan_protocol_param_GetSetRequest_decode+0x70>
 	...
 
-0800b21c <_uavcan_protocol_param_Value_encode.constprop.0>:
- 800b21c:	b5f7      	push	{r0, r1, r2, r4, r5, r6, r7, lr}
+0800b21c <_uavcan_protocol_param_NumericValue_encode.constprop.0>:
+ 800b21c:	b573      	push	{r0, r1, r4, r5, r6, lr}
  800b21e:	460c      	mov	r4, r1
  800b220:	7813      	ldrb	r3, [r2, #0]
  800b222:	6809      	ldr	r1, [r1, #0]
  800b224:	f88d 3007 	strb.w	r3, [sp, #7]
  800b228:	4615      	mov	r5, r2
  800b22a:	f10d 0307 	add.w	r3, sp, #7
- 800b22e:	2203      	movs	r2, #3
+ 800b22e:	2202      	movs	r2, #2
  800b230:	4606      	mov	r6, r0
  800b232:	f01a fcbd 	bl	8025bb0 <canardEncodeScalar>
  800b236:	6821      	ldr	r1, [r4, #0]
- 800b238:	3103      	adds	r1, #3
+ 800b238:	3102      	adds	r1, #2
  800b23a:	6021      	str	r1, [r4, #0]
  800b23c:	782b      	ldrb	r3, [r5, #0]
- 800b23e:	3b01      	subs	r3, #1
- 800b240:	2b03      	cmp	r3, #3
- 800b242:	d80c      	bhi.n	800b25e <_uavcan_protocol_param_Value_encode.constprop.0+0x42>
- 800b244:	e8df f003 	tbb	[pc, r3]
- 800b248:	1f160d02 	svcne	0x00160d02
- 800b24c:	f105 0308 	add.w	r3, r5, #8
- 800b250:	2240      	movs	r2, #64	; 0x40
```

... interestingly, even with only preprocessor pragma additions to the code the output of the compiler will change, as our `WITH_SEMAPHORE` call records line numbers!
