### PR TITLE
Save freq_min_ratio when saving parameters

### DIFF
--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -338,6 +338,7 @@ void HarmonicNotchFilterParams::save_params()
     _attenuation_dB.save();
     _harmonics.save();
     _reference.save();
+    _freq_min_ratio.save();
 }
 
 /* 


### PR DESCRIPTION
Fixes a bug which affect throttle notch FFT tunining