### PR TITLE
AP_Camera: add support for Runcam 2 4k

### DIFF
--- a/libraries/AP_Camera/AP_RunCam.h
+++ b/libraries/AP_Camera/AP_RunCam.h
@@ -62,6 +62,7 @@ public:
         Split = 2, // camera and video support
         Split4k = 3, // video support only + 5key OSD
         Hybrid = 4, // video support + QR mode switch
+		Run24k = 5, // camera and video support like Split but recording command like Split4k
     };
 
     // operation of camera button simulation
@@ -107,7 +108,7 @@ public:
 private:
     // definitions prefixed with RCDEVICE taken from https://support.runcam.com/hc/en-us/articles/360014537794-RunCam-Device-Protocol
     // possible supported features
-    // RunCam Split 3S micro reports 0x77 (POWER, WIFI, MODE, SETTING, DPORT, START)
+    // RunCam 2 4k and Split 3S micro reports 0x77 (POWER, WIFI, MODE, SETTING, DPORT, START)
     // RunCam Split 2S reports 0x57 (POWER, WIFI, MODE, SETTING, START)
     // RunCam Racer 3 reports 0x08 (OSD)
     enum class Feature {
@@ -216,7 +217,7 @@ private:
     static const uint8_t  RUNCAM_NUM_EXPECTED_RESPONSES = 4;
     static const uint8_t  RUNCAM_MAX_MENUS =              1;
     static const uint8_t  RUNCAM_MAX_MENU_LENGTH =        6;
-    static const uint8_t  RUNCAM_MAX_DEVICE_TYPES =       4;
+    static const uint8_t  RUNCAM_MAX_DEVICE_TYPES =       5;
 
     // supported features, usually probed from the device
     AP_Int16 _features;


### PR DESCRIPTION
Adaptation of AP_Runcam for the Runcam 2 4k version : 
- new camera type (Run24k = 5),
- OSD menu modification for use with no "Save and Exit" option,
- Use same command than Split 2 4k and Hybrid for remote recording.

AP_Runcam.h and AP_Runcam.cpp modified.