### PR TITLE
AP_InternalSensor: fix imu temprature

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -598,6 +598,7 @@ private:
     
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];
+    uint8_t _min_internal_imu_index = INS_MAX_INSTANCES;
 
     // filtering frequency (0 means default)
     AP_Int16    _accel_filter_cutoff;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -731,7 +731,9 @@ void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float tem
 
 #if HAL_HAVE_IMU_HEATER
     /* give the temperature to the control loop in order to keep it constant*/
-    if (instance == 0) {
+    if ((instance <= _min_internal_imu_index) && (is_internal_imu())) {
+        //use the least index number
+        _min_internal_imu_index = instance;
         AP_BoardConfig *bc = AP::boardConfig();
         if (bc) {
             bc->set_imu_temp(temperature);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -310,6 +310,12 @@ protected:
     // function which instantiates an instance of the backend sensor
     // driver if the sensor is available
 
+    bool is_internal_imu () {
+        return _internal_imu;
+    }
+
+    bool _internal_imu = true;
+
 private:
 
     bool should_log_imu_raw() const ;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ExternalAHRS.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ExternalAHRS.cpp
@@ -11,6 +11,7 @@ AP_InertialSensor_ExternalAHRS::AP_InertialSensor_ExternalAHRS(AP_InertialSensor
     AP_InertialSensor_Backend(imu),
     serial_port(_serial_port)
 {
+    _internal_imu = false;
 }
 
 void AP_InertialSensor_ExternalAHRS::handle_external(const AP_ExternalAHRS::ins_data_message_t &pkt)


### PR DESCRIPTION
This is a proposed solution for this [issue](https://github.com/ArduPilot/ardupilot/issues/22731)

adding **is_internal_imu** to know if imu is internal or not.
**_min_internal_imu_index** is initialized with max instance and later is updated by least index of an internal imu.
