### PR TITLE
AP_Motors: Single and coaxcopter fins not centered.

### DIFF
--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -82,7 +82,7 @@ void AP_MotorsSingle::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _spin_up_ratio * _actuator_out[i] * AP_MOTORS_SINGLE_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[P_MOTORS_MOT_5], actuator_spin_up_to_ground_idle());
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], actuator_spin_up_to_ground_idle());
             set_actuator_with_slew(_actuator[P_MOTORS_MOT_6], actuator_spin_up_to_ground_idle());
             rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[P_MOTORS_MOT_5]));
             rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[P_MOTORS_MOT_6]));

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -82,10 +82,10 @@ void AP_MotorsSingle::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _spin_up_ratio * _actuator_out[i] * AP_MOTORS_SINGLE_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[5], actuator_spin_up_to_ground_idle());
-            set_actuator_with_slew(_actuator[6], actuator_spin_up_to_ground_idle());
-            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[5]));
-            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[6]));
+            set_actuator_with_slew(_actuator[P_MOTORS_MOT_5], actuator_spin_up_to_ground_idle());
+            set_actuator_with_slew(_actuator[P_MOTORS_MOT_6], actuator_spin_up_to_ground_idle());
+            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[P_MOTORS_MOT_5]));
+            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[P_MOTORS_MOT_6]));
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
@@ -94,10 +94,10 @@ void AP_MotorsSingle::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _actuator_out[i] * AP_MOTORS_SINGLE_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[5], thrust_to_actuator(_thrust_out));
-            set_actuator_with_slew(_actuator[6], thrust_to_actuator(_thrust_out));
-            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[5]));
-            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[6]));
+            set_actuator_with_slew(_actuator[P_MOTORS_MOT_5], thrust_to_actuator(_thrust_out));
+            set_actuator_with_slew(_actuator[P_MOTORS_MOT_6], thrust_to_actuator(_thrust_out));
+            rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[P_MOTORS_MOT_5]));
+            rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[P_MOTORS_MOT_6]));
             break;
     }
 }


### PR DESCRIPTION
This pull request addresses an issue with the single and coaxcopter fins not centered if using DShot #18201.