### PR TITLE
AC_WPNav: Fix Bug to use WPNAV_ACCEL_C

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -87,7 +87,7 @@ public:
     float get_wp_acceleration() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss : WPNAV_ACCELERATION; }
 
     /// get_wp_acceleration - returns acceleration in cm/s/s during missions
-    float get_corner_acceleration() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_cmss : get_wp_acceleration(); }
+    float get_corner_acceleration() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss : get_wp_acceleration(); }
 
     /// get_wp_destination waypoint using position vector
     /// x,y are distance from ekf origin in cm


### PR DESCRIPTION
This PR fixes a simple bug where we use _wp_accel_cmss instead of _wp_accel_c_cmss during a sanity check.