### PR TITLE
Plane: rework stickmixing to use per mode functions

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -860,7 +860,6 @@ private:
     void calc_nav_pitch();
     float calc_speed_scaler(void);
     float get_speed_scaler(void) const { return surface_speed_scaler; }
-    bool stick_mixing_enabled(void);
     void stabilize_roll();
     float stabilize_roll_get_roll_out();
     void stabilize_pitch();

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -169,3 +169,21 @@ void Mode::update_target_altitude()
 
     plane.altitude_error_cm = plane.calc_altitude_error_cm();
 }
+
+// Return true if roll/pitch stick mixing is enabled
+bool Mode::allows_roll_pitch_stick_mixing() const
+{
+    // Direct stick mixing functionality has been removed, so as not to remove all stick mixing from the user completely
+    // the old direct option is now used to enable fbw mixing, this is easier than doing a param conversion.
+    if ((plane.g.stick_mixing != StickMixing::FBW) && (plane.g.stick_mixing != StickMixing::DIRECT_REMOVED)) {
+        return false;
+    }
+
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.available() && !quadplane.transition->allow_stick_mixing()) {
+        return false;
+    }
+#endif
+
+    return allows_stick_mixing();
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -6,6 +6,7 @@
 #include <AP_Soaring/AP_Soaring.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_Vehicle/ModeReason.h>
+#include "defines.h"
 #include "quadplane.h"
 
 class AC_PosControl;
@@ -124,6 +125,12 @@ public:
     // handle a guided target request from GCS
     virtual bool handle_guided_request(Location target_loc) { return false; }
 
+    // Return true if stick mixing of any type is enabled
+    virtual bool allows_stick_mixing() const;
+
+    // Return true if roll/pitch stick mixing is enabled
+    virtual bool allows_roll_pitch_stick_mixing() const;
+
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -154,6 +161,8 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 protected:
 
     bool _enter() override;
@@ -182,6 +191,8 @@ public:
     
     bool mode_allows_autotuning() const override { return true; }
 
+    bool allows_stick_mixing() const override;
+
 protected:
 
     bool _enter() override;
@@ -201,6 +212,8 @@ public:
     void update() override;
     
     bool mode_allows_autotuning() const override { return true; }
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
 
 protected:
 
@@ -383,6 +396,9 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 };
 
 class ModeInitializing : public Mode
@@ -418,6 +434,10 @@ public:
     
     bool mode_allows_autotuning() const override { return true; }
 
+    bool allows_stick_mixing() const override;
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 };
 
 class ModeFBWB : public Mode
@@ -440,6 +460,8 @@ public:
     bool mode_allows_autotuning() const override { return true; }
 
     void update_target_altitude() override {};
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
 
 protected:
 
@@ -468,6 +490,8 @@ public:
     bool does_auto_throttle() const override { return true; }
 
     void update_target_altitude() override {};
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
 
 protected:
 
@@ -524,6 +548,8 @@ public:
 
     void run() override;
 
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 protected:
 private:
 
@@ -548,6 +574,8 @@ public:
 
     void run() override;
 
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 protected:
 
     bool _enter() override;
@@ -571,6 +599,8 @@ public:
 
     void run() override;
 
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 protected:
 
     bool _enter() override;
@@ -592,6 +622,8 @@ public:
     void run() override;
 
     bool allows_arming() const override { return false; }
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
 
 protected:
 
@@ -623,6 +655,8 @@ public:
 
     float get_VTOL_return_radius() const;
 
+    bool allows_stick_mixing() const override;
+
 protected:
 
     bool _enter() override;
@@ -652,6 +686,8 @@ public:
 
     void run() override;
 
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
+
 protected:
 
     bool _enter() override;
@@ -673,6 +709,8 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    bool allows_roll_pitch_stick_mixing() const override { return false; }
 
 protected:
 

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -139,3 +139,16 @@ bool ModeAuto::does_auto_throttle() const
 #endif
    return true;
 }
+
+// Return true if stick mixing of any type is enabled
+bool ModeAuto::allows_stick_mixing() const
+{
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.in_vtol_land_poscontrol()) {
+        // user may be repositioning
+        return false;
+    }
+#endif
+
+    return Mode::allows_stick_mixing();
+}

--- a/ArduPlane/mode_fbwa.cpp
+++ b/ArduPlane/mode_fbwa.cpp
@@ -35,3 +35,14 @@ void ModeFBWA::update()
         }
     }
 }
+
+// Return true if stick mixing of any type is enabled
+bool ModeFBWA::allows_stick_mixing() const
+{
+    if (plane.failsafe.rc_failsafe && plane.g.fs_action_short == FS_ACTION_SHORT_FBWA) {
+        // don't do stick mixing in FBWA glide mode
+        return false;
+    }
+
+    return Mode::allows_stick_mixing();
+}

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -9,7 +9,7 @@ bool ModeLoiter::_enter()
     // make sure the local target altitude is the same as the nav target used for loiter nav
     // this allows us to do FBWB style stick control
     /*IGNORE_RETURN(plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, plane.target_altitude.amsl_cm));*/
-    if (plane.stick_mixing_enabled() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
+    if (allows_stick_mixing() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
         plane.set_target_altitude_current();
     }
 
@@ -21,7 +21,7 @@ bool ModeLoiter::_enter()
 void ModeLoiter::update()
 {
     plane.calc_nav_roll();
-    if (plane.stick_mixing_enabled() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
+    if (allows_stick_mixing() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
         plane.update_fbwb_speed_height();
     } else {
         plane.calc_nav_pitch();
@@ -112,7 +112,7 @@ void ModeLoiter::navigate()
 
 void ModeLoiter::update_target_altitude()
 {
-    if (plane.stick_mixing_enabled() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
+    if (allows_stick_mixing() && (plane.g2.flight_options & FlightOptions::ENABLE_LOITER_ALT_CONTROL)) {
         return;
     }
     Mode::update_target_altitude();

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -213,4 +213,15 @@ float ModeQRTL::get_VTOL_return_radius() const
     return MAX(fabsf(plane.aparm.loiter_radius), fabsf(plane.g.rtl_radius)) * 1.5;
 }
 
+// Return true if stick mixing of any type is enabled
+bool ModeQRTL::allows_stick_mixing() const
+{
+    if (quadplane.poscontrol.get_state() >= QuadPlane::QPOS_POSITION1) {
+        // user may be repositioning
+        return false;
+    }
+
+    return Mode::allows_stick_mixing();
+}
+
 #endif

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4344,7 +4344,7 @@ MAV_VTOL_STATE SLT_Transition::get_mav_vtol_state() const
 }
 
 // Set FW roll and pitch limits and keep TECS informed
-void SLT_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing)
+void SLT_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd)
 {
     if (quadplane.in_vtol_mode() || quadplane.in_vtol_airbrake()) {
         // not in FW flight

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -227,7 +227,7 @@ int16_t Plane::rudder_input(void)
         return 0;
     }
 
-    if (stick_mixing_enabled()) {
+    if (control_mode->allows_stick_mixing()) {
         return channel_rudder->get_control_in();
     }
 

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -880,7 +880,7 @@ bool Tailsitter_Transition::show_vtol_view() const
     return show_vtol;
 }
 
-void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing)
+void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd)
 {
     uint32_t now = AP_HAL::millis();
     if (tailsitter.in_vtol_transition(now)) {
@@ -892,7 +892,6 @@ void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& na
         // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
         nav_pitch_cd = constrain_float(vtol_transition_initial_pitch + (tailsitter.transition_rate_vtol * dt) * 0.1f, -8500, 8500);
         nav_roll_cd = 0;
-        allow_stick_mixing = false;
 
     } else if (transition_state == TRANSITION_DONE) {
         // still in FW, reset transition starting point
@@ -908,10 +907,14 @@ void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& na
             } else {
                 nav_pitch_cd = pitch_limit_cd;
                 nav_roll_cd = 0;
-                allow_stick_mixing = false;
             }
         }
     }
+}
+
+bool Tailsitter_Transition::allow_stick_mixing() const
+{
+    return tailsitter.in_vtol_transition(AP_HAL::millis()) || ((transition_state == TRANSITION_DONE) && (fw_limit_start_ms != 0));
 }
 
 bool Tailsitter_Transition::set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd)

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -159,7 +159,9 @@ public:
 
     bool show_vtol_view() const override;
 
-    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) override;
+    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) override;
+
+    bool allow_stick_mixing() const override;
 
     MAV_VTOL_STATE get_mav_vtol_state() const override;
 

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -40,7 +40,9 @@ public:
 
     virtual bool show_vtol_view() const = 0;
 
-    virtual void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) {};
+    virtual void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) {};
+
+    virtual bool allow_stick_mixing() const { return true; }
 
     virtual bool set_FW_roll_limit(int32_t& roll_limit_cd) { return false; }
 
@@ -87,7 +89,7 @@ public:
 
     bool show_vtol_view() const override;
 
-    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) override;
+    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) override;
 
     bool set_FW_roll_limit(int32_t& roll_limit_cd) override;
 


### PR DESCRIPTION
Moves stick mixing to be a per mode method. 