### PR TITLE
AP_Motors: single: removed fins from motor mask

### DIFF
--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -107,10 +107,6 @@ void AP_MotorsSingle::output_to_motors()
 uint32_t AP_MotorsSingle::get_motor_mask()
 {
     uint32_t motor_mask =
-        1U << AP_MOTORS_MOT_1 |
-        1U << AP_MOTORS_MOT_2 |
-        1U << AP_MOTORS_MOT_3 |
-        1U << AP_MOTORS_MOT_4 |
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
 


### PR DESCRIPTION
closes #18201
I have tried removing the fins from the motor mask. Please let me know if the array indexing should also be changed as in PR #19202