### PR TITLE
Copter: Add option to resume precland after reposiiton

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -668,6 +668,13 @@ void Mode::land_run_horizontal_control()
                     AP::logger().Write_Event(LogEvent::LAND_REPO_ACTIVE);
                 }
                 copter.ap.land_repo_active = true;
+#if PRECISION_LANDING == ENABLED
+            } else {
+                // no override right now, check if we should allow precland
+                if (copter.precland.allow_precland_after_reposition()) {
+                    copter.ap.land_repo_active = false;
+                }
+#endif
             }
         }
     }

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -173,7 +173,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Precision Landing Extra Options
     // @Description: Precision Landing Extra Options
-    // @Bitmask: 0: Moving Landing Target
+    // @Bitmask: 0: Moving Landing Target, 1: Allow Precision Landing after manual reposition 
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 17, AC_PrecLand, _options, 0),
 

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -109,6 +109,8 @@ public:
     float get_min_retry_time_sec() const { return _retry_timeout_sec; }
     AC_PrecLand_StateMachine::RetryAction get_retry_behaviour() const { return static_cast<AC_PrecLand_StateMachine::RetryAction>(_retry_behave.get()); }
 
+    bool allow_precland_after_reposition() const { return _options & PLND_OPTION_PRECLAND_AFTER_REPOSITION; }
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -130,6 +132,7 @@ private:
     enum PLndOptions {
         PLND_OPTION_DISABLED = 0,
         PLND_OPTION_MOVING_TARGET = (1 << 0),
+        PLND_OPTION_PRECLAND_AFTER_REPOSITION = (1 << 1),
     };
 
     // check the status of the target


### PR DESCRIPTION
Currently, if the user were to reposition the vehicle during a Prec Land manually, it would cancel Prec Land and not resume it even if the target was in view (i.e Copter just does a normal land). 
By using PLND_OPTIONS parameter, one can now allow resuming prec land even after a manual reposition. 

This has been tested on SITL 