### PR TITLE
Move THR_G_BOOST to Multicopter only

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -150,13 +150,6 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("INPUT_TC", 20, AC_AttitudeControl, _input_tc, AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT),
 
-    // @Param: THR_G_BOOST
-    // @DisplayName: Throttle-gain boost
-    // @Description: Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.
-    // @Range: 0 1
-    // @User: Advanced
-    AP_GROUPINFO("THR_G_BOOST", 21, AC_AttitudeControl, _throttle_gain_boost, 0.0f),
-
     AP_GROUPEND
 };
 
@@ -1015,12 +1008,6 @@ bool AC_AttitudeControl::ang_vel_to_euler_rate(const Vector3f& euler_rad, const 
 Vector3f AC_AttitudeControl::update_ang_vel_target_from_att_error(const Vector3f &attitude_error_rot_vec_rad)
 {
     Vector3f rate_target_ang_vel;
-
-    // Boost Angle P one very rapid throttle changes
-    if (_motors.get_throttle_slew_rate() > AC_ATTITUDE_CONTROL_THR_G_BOOST_THRESH) {
-        float angle_p_boost = constrain_float((_throttle_gain_boost + 1.0f) * (_throttle_gain_boost + 1.0f), 1.0, 4.0);
-        set_angle_P_scale_mult(Vector3f(angle_p_boost, angle_p_boost, 1.0f));
-    }
 
     // Compute the roll angular velocity demand from the roll angle error
     const float angleP_roll = _p_angle_roll.kP() * _angle_P_scale.x;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -457,9 +457,6 @@ protected:
     // rate controller input smoothing time constant
     AP_Float            _input_tc;
 
-    // angle_p/pd boost multiplier
-    AP_Float            _throttle_gain_boost;
-
     // Intersampling period in seconds
     float               _dt;
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -83,6 +83,9 @@ public:
 
 protected:
 
+    // boost angle_p/pd each cycle on high throttle slew
+    void update_throttle_gain_boost();
+
     // update_throttle_rpy_mix - updates thr_low_comp value towards the target
     void update_throttle_rpy_mix();
 
@@ -97,4 +100,7 @@ protected:
     AP_Float              _thr_mix_man;     // throttle vs attitude control prioritisation used when using manual throttle (higher values mean we prioritise attitude control over throttle)
     AP_Float              _thr_mix_min;     // throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)
     AP_Float              _thr_mix_max;     // throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)
+
+    // angle_p/pd boost multiplier
+    AP_Float              _throttle_gain_boost;
 };


### PR DESCRIPTION
As requested by @bnsgeyer to prevent Heli users seeing the parameter. @rmackay9 needs to go in 4.4 before it goes to beta