### PR TITLE
AP_Dal: populate missing fields `learn_offsets_enabled` and `ekf_type`

### DIFF
--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -70,6 +70,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.opticalflow_enabled = AP::opticalflow() && AP::opticalflow()->enabled();
 #endif
     _RFRN.wheelencoder_enabled = AP::wheelencoder() && (AP::wheelencoder()->num_sensors() > 0);
+    _RFRN.ekf_type = ahrs.get_ekf_type();
     WRITE_REPLAY_BLOCK_IFCHANGED(RFRN, _RFRN, old);
 
     // update body conversion

--- a/libraries/AP_DAL/AP_DAL_Compass.cpp
+++ b/libraries/AP_DAL/AP_DAL_Compass.cpp
@@ -24,6 +24,7 @@ void AP_DAL_Compass::start_frame()
     _RMGH.num_enabled = compass.get_num_enabled();
     _RMGH.consistent = compass.consistent();
     _RMGH.first_usable = compass.get_first_usable();
+    _RMGH.learn_offsets_enabled = compass.learn_offsets_enabled();
 
     WRITE_REPLAY_BLOCK_IFCHANGED(RMGH, _RMGH, old);
 


### PR DESCRIPTION
Was poking about trying to diagnose EKF compass stuff, turns out we never actually fill in `learn_offsets_enabled` so its always false.

It is used here in EKF3:
https://github.com/ArduPilot/ardupilot/blob/bb05f405600c5bf4244ded8df859c67c91b34176/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L297-L307

And here in EKF2:
https://github.com/ArduPilot/ardupilot/blob/bb05f405600c5bf4244ded8df859c67c91b34176/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp#L242-L252

So this will change behavior with `COMPASS_LEARN` 3.

After finding that I did a sweep of all the structures, the rest are all filled in correctly except the EKF type. Its only used in one place for a init message so its not nearly as nasty. We might just want to remove the variable. 

https://github.com/ArduPilot/ardupilot/blob/bb05f405600c5bf4244ded8df859c67c91b34176/libraries/AP_NavEKF2/AP_NavEKF2.cpp#L623-L625

