### PR TITLE
AP_Scripting:fix duplicate function in Script_Controller

### DIFF
--- a/libraries/AP_Scripting/applets/Script_Controller.lua
+++ b/libraries/AP_Scripting/applets/Script_Controller.lua
@@ -224,11 +224,6 @@ function mission_load(n)
   gcs:send_text(0, string.format("Loaded %u mission items", index))
 end
 
-function update()
-  read_mission('mission1.txt')
-  return
-end
-
 --[[
    activate a scripting subdirectory
 --]]


### PR DESCRIPTION
interesting that this extreme copy/paste error would only show up once in a while when running the script...95% of the time it ran perfectly...