### PR TITLE
AP_Motors: move Thrust Linearization functions and variables to own class

### DIFF
--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -163,7 +163,7 @@ void ModeTurtle::run()
     Vector2f input{sign_roll, sign_pitch};
     motors_input = input.normalized() * 0.5;
     // we bypass spin min and friends in the deadzone because we only want spin up when the sticks are moved
-    motors_output = !is_zero(flip_power) ? motors->thrust_to_actuator(flip_power) : 0.0f;
+    motors_output = !is_zero(flip_power) ? motors->thr_lin.thrust_to_actuator(flip_power) : 0.0f;
 }
 
 // actually write values to the motors

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -6,8 +6,6 @@ void Copter::read_barometer(void)
     barometer.update();
 
     baro_alt = barometer.get_altitude() * 100.0f;
-
-    motors->set_air_density_ratio(barometer.get_air_density_ratio());
 }
 
 void Copter::init_rangefinder(void)

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -511,12 +511,6 @@ void Plane::update_alt()
 {
     barometer.update();
 
-#if HAL_QUADPLANE_ENABLED
-    if (quadplane.available()) {
-        quadplane.motors->set_air_density_ratio(barometer.get_air_density_ratio());
-    }
-#endif
-
     // calculate the sink rate.
     float sink_rate;
     Vector3f vel;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -302,11 +302,11 @@ void Tailsitter::output(void)
             */
             if (!is_negative(transition_throttle_vtol)) { 
                 // Q_TAILSIT_THR_VT is positive use it until transition is complete
-                throttle = motors->actuator_to_thrust(MIN(transition_throttle_vtol*0.01,1.0));
+                throttle = motors->thr_lin.actuator_to_thrust(MIN(transition_throttle_vtol*0.01,1.0));
             } else {
                 throttle = motors->get_throttle_hover();
                 // work out equivelent motors throttle level for cruise
-                throttle = MAX(throttle,motors->actuator_to_thrust(plane.aparm.throttle_cruise.get() * 0.01));
+                throttle = MAX(throttle,motors->thr_lin.actuator_to_thrust(plane.aparm.throttle_cruise.get() * 0.01));
             }
 
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0.0);
@@ -321,7 +321,7 @@ void Tailsitter::output(void)
 
                 // convert the hover throttle to the same output that would result if used via AP_Motors
                 // apply expo, battery scaling and SPIN min/max.
-                throttle = motors->thrust_to_actuator(throttle);
+                throttle = motors->thr_lin.thrust_to_actuator(throttle);
 
                 // override AP_MotorsTailsitter throttles during back transition
 

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -91,8 +91,8 @@ void AP_MotorsCoax::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _actuator_out[i] * AP_MOTORS_COAX_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], thrust_to_actuator(_thrust_yt_ccw));
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], thrust_to_actuator(_thrust_yt_cw));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], thr_lin.thrust_to_actuator(_thrust_yt_ccw));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], thr_lin.thrust_to_actuator(_thrust_yt_cw));
             rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[AP_MOTORS_MOT_5]));
             rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[AP_MOTORS_MOT_6]));
             break;
@@ -129,7 +129,7 @@ void AP_MotorsCoax::output_armed_stabilizing()
     float   actuator_allowed = 0.0f;    // amount of yaw we can fit in
 
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain();
+    const float compensation_gain = thr_lin.get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
     yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -168,7 +168,7 @@ void AP_MotorsMatrix::output_to_motors()
             // set motor output based on thrust requests
             for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled[i]) {
-                    set_actuator_with_slew(_actuator[i], thrust_to_actuator(_thrust_rpyt_out[i]));
+                    set_actuator_with_slew(_actuator[i], thr_lin.thrust_to_actuator(_thrust_rpyt_out[i]));
                 }
             }
             break;
@@ -213,7 +213,7 @@ float AP_MotorsMatrix::boost_ratio(float boost_value, float normal_value) const
 void AP_MotorsMatrix::output_armed_stabilizing()
 {
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
+    const float compensation_gain = thr_lin.get_compensation_gain(); // compensation for battery voltage and altitude
 
     // pitch thrust input value, +/- 1.0
     const float roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
@@ -454,7 +454,7 @@ void AP_MotorsMatrix::check_for_failed_motor(float throttle_thrust_best_plus_adj
     }
 
     // check to see if thrust boost is using more throttle than _throttle_thrust_max
-    if ((_throttle_thrust_max * get_compensation_gain() > throttle_thrust_best_plus_adj) && (rpyt_high < 0.9f) && _thrust_balanced) {
+    if ((_throttle_thrust_max * thr_lin.get_compensation_gain() > throttle_thrust_best_plus_adj) && (rpyt_high < 0.9f) && _thrust_balanced) {
         _thrust_boost = false;
     }
 }

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -46,17 +46,17 @@ void AP_MotorsMatrix_6DoF_Scripting::output_to_motors()
                     if (_reversible[i]) {
                         // revesible motor can provide both positive and negative thrust, +- spin max, spin min does not apply
                         if (is_positive(_thrust_rpyt_out[i])) { 
-                            _actuator[i] = apply_thrust_curve_and_volt_scaling(_thrust_rpyt_out[i]) * _spin_max;
+                            _actuator[i] = thr_lin.apply_thrust_curve_and_volt_scaling(_thrust_rpyt_out[i]) * thr_lin.get_spin_max();
 
                         } else if (is_negative(_thrust_rpyt_out[i])) {
-                            _actuator[i] = -apply_thrust_curve_and_volt_scaling(-_thrust_rpyt_out[i]) * _spin_max;
+                            _actuator[i] = -thr_lin.apply_thrust_curve_and_volt_scaling(-_thrust_rpyt_out[i]) * thr_lin.get_spin_max();
 
                         } else {
                             _actuator[i] = 0.0f;
                         }
                     } else {
                         // motor can only provide trust in a single direction, spin min to spin max as 'normal' copter
-                         _actuator[i] = thrust_to_actuator(_thrust_rpyt_out[i]);
+                         _actuator[i] = thr_lin.thrust_to_actuator(_thrust_rpyt_out[i]);
                     }
                 }
             }
@@ -85,7 +85,7 @@ void AP_MotorsMatrix_6DoF_Scripting::output_armed_stabilizing()
     // note that the throttle, forwards and right inputs are not in bodyframe, they are in the frame of the 'normal' 4DoF copter were pretending to be
 
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
+    const float compensation_gain = thr_lin.get_compensation_gain(); // compensation for battery voltage and altitude
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
     yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -94,8 +94,8 @@ void AP_MotorsSingle::output_to_motors()
             for (uint8_t i = 0; i < NUM_ACTUATORS; i++) {
                 rc_write_angle(AP_MOTORS_MOT_1 + i, _actuator_out[i] * AP_MOTORS_SINGLE_SERVO_INPUT_RANGE);
             }
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], thrust_to_actuator(_thrust_out));
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], thrust_to_actuator(_thrust_out));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_5], thr_lin.thrust_to_actuator(_thrust_out));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_6], thr_lin.thrust_to_actuator(_thrust_out));
             rc_write(AP_MOTORS_MOT_5, output_to_pwm(_actuator[AP_MOTORS_MOT_5]));
             rc_write(AP_MOTORS_MOT_6, output_to_pwm(_actuator[AP_MOTORS_MOT_6]));
             break;
@@ -134,7 +134,7 @@ void AP_MotorsSingle::output_armed_stabilizing()
     float   actuator_max = 0.0f;        // maximum actuator value
 
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain();
+    const float compensation_gain = thr_lin.get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
     yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -95,9 +95,9 @@ void AP_MotorsTailsitter::output_to_motors()
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
         case SpoolState::SPOOLING_DOWN:
-            set_actuator_with_slew(_actuator[0], thrust_to_actuator(_thrust_left));
-            set_actuator_with_slew(_actuator[1], thrust_to_actuator(_thrust_right));
-            set_actuator_with_slew(_actuator[2], thrust_to_actuator(_throttle));
+            set_actuator_with_slew(_actuator[0], thr_lin.thrust_to_actuator(_thrust_left));
+            set_actuator_with_slew(_actuator[1], thr_lin.thrust_to_actuator(_thrust_right));
+            set_actuator_with_slew(_actuator[2], thr_lin.thrust_to_actuator(_throttle));
             break;
     }
 
@@ -143,7 +143,7 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
     float   thr_adj = 0.0f;             // the difference between the pilot's desired throttle and throttle_thrust_best_rpy
 
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain();
+    const float compensation_gain = thr_lin.get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = _pitch_in + _pitch_in_ff;
     yaw_thrust = _yaw_in + _yaw_in_ff;

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -109,9 +109,9 @@ void AP_MotorsTri::output_to_motors()
         case SpoolState::THROTTLE_UNLIMITED:
         case SpoolState::SPOOLING_DOWN:
             // set motor output based on thrust requests
-            set_actuator_with_slew(_actuator[1], thrust_to_actuator(_thrust_right));
-            set_actuator_with_slew(_actuator[2], thrust_to_actuator(_thrust_left));
-            set_actuator_with_slew(_actuator[4], thrust_to_actuator(_thrust_rear));
+            set_actuator_with_slew(_actuator[1], thr_lin.thrust_to_actuator(_thrust_right));
+            set_actuator_with_slew(_actuator[2], thr_lin.thrust_to_actuator(_thrust_left));
+            set_actuator_with_slew(_actuator[4], thr_lin.thrust_to_actuator(_thrust_rear));
             rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[1]));
             rc_write(AP_MOTORS_MOT_2, output_to_pwm(_actuator[2]));
             rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[4]));
@@ -157,7 +157,7 @@ void AP_MotorsTri::output_armed_stabilizing()
     _yaw_servo_angle_max_deg.set(constrain_float(_yaw_servo_angle_max_deg, AP_MOTORS_TRI_SERVO_RANGE_DEG_MIN, AP_MOTORS_TRI_SERVO_RANGE_DEG_MAX));
 
     // apply voltage and air pressure compensation
-    const float compensation_gain = get_compensation_gain();
+    const float compensation_gain = thr_lin.get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
     yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain * sinf(radians(_yaw_servo_angle_max_deg)); // we scale this so a thrust request of 1.0f will ask for full servo deflection at full rear throttle

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -33,8 +33,7 @@ AP_Motors::AP_Motors(uint16_t speed_hz) :
     _throttle_slew(),
     _throttle_slew_filter(),
     _spool_desired(DesiredSpoolState::SHUT_DOWN),
-    _spool_state(SpoolState::SHUT_DOWN),
-    _air_density_ratio(1.0f)
+    _spool_state(SpoolState::SHUT_DOWN)
 {
     _singleton = this;
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -188,9 +188,6 @@ public:
     // get_spool_state - get current spool state
     enum SpoolState  get_spool_state(void) const { return _spool_state; }
 
-    // set_density_ratio - sets air density as a proportion of sea level density
-    void                set_air_density_ratio(float ratio) { _air_density_ratio = ratio; }
-
     // set_dt / get_dt - dt is the time since the last time the motor mixers were updated
     //   _dt should be set based on the time of the last IMU read used by these controllers
     //   the motor mixers should run on each loop to ensure normal operation
@@ -323,9 +320,6 @@ protected:
     LowPassFilterFloat  _throttle_slew_filter;      // filter for the output of the throttle slew
     DesiredSpoolState   _spool_desired;             // desired spool state
     SpoolState          _spool_state;               // current spool mode
-
-    // air pressure compensation variables
-    float               _air_density_ratio;     // air density / sea level density - decreases in altitude
 
     // mask of what channels need fast output
     uint32_t            _motor_fast_mask;

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -1,0 +1,118 @@
+
+#include "AP_Motors_Thrust_Linearization.h"
+#include "AP_Motors_Class.h"
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Baro/AP_Baro.h>
+
+#define AP_MOTORS_BATT_VOLT_FILT_HZ 0.5 // battery voltage filtered at 0.5hz
+
+#ifndef AP_MOTORS_DENSITY_COMP
+#define AP_MOTORS_DENSITY_COMP 1
+#endif
+
+
+Thrust_Linearization::Thrust_Linearization(AP_Motors& _motors) :
+    motors(_motors),
+    lift_max(1.0)
+{
+    // setup battery voltage filtering
+    batt_voltage_filt.set_cutoff_frequency(AP_MOTORS_BATT_VOLT_FILT_HZ);
+    batt_voltage_filt.reset(1.0);
+}
+
+// converts desired thrust to linearized actuator output in a range of 0~1
+float Thrust_Linearization::thrust_to_actuator(float thrust_in) const
+{
+    thrust_in = constrain_float(thrust_in, 0.0, 1.0);
+    return spin_min + (spin_max - spin_min) * apply_thrust_curve_and_volt_scaling(thrust_in);
+}
+
+// inverse of above, tested with AP_Motors/examples/expo_inverse_test
+// used to calculate equivelent motor throttle level to direct ouput, used in tailsitter transtions
+float Thrust_Linearization::actuator_to_thrust(float actuator) const
+{
+    actuator = (actuator - spin_min) /  (spin_max - spin_min);
+    return constrain_float(remove_thrust_curve_and_volt_scaling(actuator), 0.0, 1.0);
+}
+
+// apply_thrust_curve_and_volt_scaling - returns throttle in the range 0 ~ 1
+float Thrust_Linearization::apply_thrust_curve_and_volt_scaling(float thrust) const
+{
+    float battery_scale = 1.0;
+    if (is_positive(batt_voltage_filt.get())) {
+        battery_scale = 1.0 / batt_voltage_filt.get();
+    }
+    // apply thrust curve - domain -1.0 to 1.0, range -1.0 to 1.0
+    float thrust_curve_expo = constrain_float(curve_expo, -1.0, 1.0);
+    if (is_zero(thrust_curve_expo)) {
+        // zero expo means linear, avoid floating point exception for small values
+        return lift_max * thrust * battery_scale;
+    }
+    float throttle_ratio = ((thrust_curve_expo - 1.0) + safe_sqrt((1.0 - thrust_curve_expo) * (1.0 - thrust_curve_expo) + 4.0 * thrust_curve_expo * lift_max * thrust)) / (2.0 * thrust_curve_expo);
+    return constrain_float(throttle_ratio * battery_scale, 0.0, 1.0);
+}
+
+// inverse of above, tested with AP_Motors/examples/expo_inverse_test
+// used to calculate equivelent motor throttle level to direct ouput, used in tailsitter transtions
+float Thrust_Linearization::remove_thrust_curve_and_volt_scaling(float throttle) const
+{
+    float battery_scale = 1.0;
+    if (is_positive(batt_voltage_filt.get())) {
+        battery_scale = 1.0 / batt_voltage_filt.get();
+    }
+    // apply thrust curve - domain -1.0 to 1.0, range -1.0 to 1.0
+    float thrust_curve_expo = constrain_float(curve_expo, -1.0, 1.0);
+    if (is_zero(thrust_curve_expo)) {
+        // zero expo means linear, avoid floating point exception for small values
+        return  throttle / (lift_max * battery_scale);
+    }
+    float thrust = ((throttle / battery_scale) * (2.0 * thrust_curve_expo)) - (thrust_curve_expo - 1.0);
+    thrust = (thrust * thrust) - ((1.0 - thrust_curve_expo) * (1.0 - thrust_curve_expo));
+    thrust /=  4.0 * thrust_curve_expo * lift_max;
+    return constrain_float(thrust, 0.0, 1.0);
+}
+
+// update_lift_max from battery voltage - used for voltage compensation
+void Thrust_Linearization::update_lift_max_from_batt_voltage()
+{
+    // sanity check battery_voltage_min is not too small
+    // if disabled or misconfigured exit immediately
+    float _batt_voltage_resting_estimate = AP::battery().voltage_resting_estimate(batt_idx);
+    if ((batt_voltage_max <= 0) || (batt_voltage_min >= batt_voltage_max) || (_batt_voltage_resting_estimate < 0.25 * batt_voltage_min)) {
+        batt_voltage_filt.reset(1.0);
+        lift_max = 1.0;
+        return;
+    }
+
+    batt_voltage_min.set(MAX(batt_voltage_min, batt_voltage_max * 0.6));
+
+    // contrain resting voltage estimate (resting voltage is actual voltage with sag removed based on current draw and resistance)
+    _batt_voltage_resting_estimate = constrain_float(_batt_voltage_resting_estimate, batt_voltage_min, batt_voltage_max);
+
+    // filter at 0.5 Hz
+    float batt_voltage_flittered = batt_voltage_filt.apply(_batt_voltage_resting_estimate / batt_voltage_max, motors.get_dt());
+
+    // calculate lift max
+    float thrust_curve_expo = constrain_float(curve_expo, -1.0, 1.0);
+    lift_max = batt_voltage_flittered * (1 - thrust_curve_expo) + thrust_curve_expo * batt_voltage_flittered * batt_voltage_flittered;
+}
+
+// return gain scheduling gain based on voltage and air density
+float Thrust_Linearization::get_compensation_gain() const
+{
+    // avoid divide by zero
+    if (get_lift_max() <= 0.0) {
+        return 1.0;
+    }
+
+    float ret = 1.0 / get_lift_max();
+
+#if AP_MOTORS_DENSITY_COMP == 1
+    // air density ratio is increasing in density / decreasing in altitude
+    const float air_density_ratio = AP::baro().get_air_density_ratio();
+    if (air_density_ratio > 0.3 && air_density_ratio < 1.5) {
+        ret *= 1.0 / constrain_float(air_density_ratio, 0.5, 1.25);
+    }
+#endif
+    return ret;
+}

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -3,11 +3,17 @@
 #include "AP_Motors_Class.h"
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define AP_MOTORS_BATT_VOLT_FILT_HZ 0.5 // battery voltage filtered at 0.5hz
 
-#ifndef AP_MOTORS_DENSITY_COMP
-#define AP_MOTORS_DENSITY_COMP 1
+#if APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+    // Example does not instantiate baro so cannot do density compensation
+    #define AP_MOTORS_DENSITY_COMP 0
+#else
+    #ifndef AP_MOTORS_DENSITY_COMP
+        #define AP_MOTORS_DENSITY_COMP 1
+    #endif
 #endif
 
 

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+#include <Filter/LowPassFilter.h>
+
+class AP_Motors;
+class Thrust_Linearization {
+friend class AP_MotorsMulticopter;
+friend class AP_MotorsMulticopter_test;
+public:
+    Thrust_Linearization(AP_Motors& _motors);
+
+    // Apply_thrust_curve_and_volt_scaling - returns throttle in the range 0 ~ 1
+    float apply_thrust_curve_and_volt_scaling(float thrust) const;
+
+    // Inverse of above
+    float remove_thrust_curve_and_volt_scaling(float throttle) const;
+
+    // Converts desired thrust to linearized actuator output in a range of 0~1
+    float thrust_to_actuator(float thrust_in) const;
+
+    // Inverse of above
+    float actuator_to_thrust(float actuator) const;
+
+    // Update_lift_max_from_batt_voltage - used for voltage compensation
+    void update_lift_max_from_batt_voltage();
+
+    // return gain scheduling gain based on voltage and air density
+    float get_compensation_gain() const;
+
+    // Get spin min parameter value
+    float get_spin_min() const { return spin_min.get(); }
+
+    // Get spin max parameter value
+    float get_spin_max() const { return spin_max.get(); }
+
+    // Get spin max parameter value
+    int8_t get_battery_index() const { return batt_idx.get(); }
+
+    // Get min battery voltage
+    float get_battery_min_voltage() const { return batt_voltage_min.get(); }
+
+    // Get lift max
+    float get_lift_max() const { return lift_max; }
+
+protected:
+    AP_Float curve_expo;       // curve used to linearize pwm to thrust conversion.  set to 0 for linear and 1 for second order approximation
+    AP_Float spin_min;         // throttle out ratio which produces the minimum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    AP_Float spin_max;         // throttle out ratio which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+    AP_Int8  batt_idx;         // battery index used for compensation
+    AP_Float batt_voltage_max; // maximum voltage used to scale lift
+    AP_Float batt_voltage_min; // minimum voltage used to scale lift
+
+private:
+    float               lift_max;          // maximum lift ratio from battery voltage
+    float               throttle_limit;    // ratio of throttle limit between hover and maximum
+    LowPassFilterFloat  batt_voltage_filt; // filtered battery voltage expressed as a percentage (0 ~ 1.0) of batt_voltage_max
+
+    AP_Motors& motors;
+};

--- a/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
+++ b/libraries/AP_Motors/examples/expo_inverse_test/expo_inverse_test.cpp
@@ -44,7 +44,7 @@ public:
     void output_to_motors() override {};
 
     // helper function to allow setting of expo
-    void set_expo(float v) { _thrust_curve_expo.set(v); }
+    void set_expo(float v) { thr_lin.curve_expo.set(v); }
 
 };
 
@@ -74,7 +74,7 @@ void setup(void)
         float throttle = 0.0;
         while (throttle < 1.0+throttle_step*0.5) {
 
-            const float throttle_out = motors.actuator_to_thrust(motors.thrust_to_actuator(throttle));
+            const float throttle_out = motors.thr_lin.actuator_to_thrust(motors.thr_lin.thrust_to_actuator(throttle));
             const double diff = fabsf(throttle_out - throttle);
             if (diff > max_diff) {
                 max_diff_throttle = throttle;


### PR DESCRIPTION
Moves functions and code to new class for easier use by others in the future. https://github.com/ArduPilot/ardupilot/pull/22661

Since I was moving the code I also took the opportunity for motors ask baro for air density ratio directly rather than having the vehicles set it into motors.
