### PR TITLE
Clean up use of HAL_GCS_ENABLED

### DIFF
--- a/libraries/AP_HAL/GPIO.cpp
+++ b/libraries/AP_HAL/GPIO.cpp
@@ -2,13 +2,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#ifndef HAL_BOOTLOADER_BUILD
 #include <GCS_MAVLink/GCS.h>
-#endif
-
-#ifndef GCS_SEND_TEXT
-#define GCS_SEND_TEXT(severity, format, args...)
-#endif
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_HAL/utility/packetise.cpp
+++ b/libraries/AP_HAL/utility/packetise.cpp
@@ -2,13 +2,11 @@
   support for sending UDP packets on MAVLink packet boundaries.
  */
 
-#include <AP_HAL/AP_HAL.h>
-
-#ifndef HAL_BOOTLOADER_BUILD
 #include <GCS_MAVLink/GCS.h>
-#include "packetise.h"
 
 #if HAL_GCS_ENABLED
+
+#include "packetise.h"
 
 /*
   return the number of bytes to send for a packetised connection
@@ -69,6 +67,5 @@ uint16_t mavlink_packetise(ByteBuffer &writebuf, uint16_t n)
     }
     return n;
 }
-#endif // HAL_BOOTLOADER_BUILD
 
 #endif // HAL_GCS_ENABLED

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -255,12 +255,10 @@ uint64_t Util::get_hw_rtc() const
 
 #if !defined(HAL_NO_FLASH_SUPPORT) && !defined(HAL_NO_ROMFS_SUPPORT)
 
-#ifndef HAL_BOOTLOADER_BUILD
 #include <GCS_MAVLink/GCS.h>
 #if HAL_GCS_ENABLED
 #define Debug(fmt, args ...)  do { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
 #endif // HAL_GCS_ENABLED
-#endif // ifndef HAL_BOOT_LOADER_BUILD
 
 #ifndef Debug
 #define Debug(fmt, args ...)  do { hal.console->printf(fmt, ## args); } while (0)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -3028,6 +3028,10 @@ def add_bootloader_defaults(f):
 #ifndef HAL_ENABLE_SAVE_PERSISTENT_PARAMS
 #define HAL_ENABLE_SAVE_PERSISTENT_PARAMS 0
 #endif
+
+#ifndef HAL_GCS_ENABLED
+#define HAL_GCS_ENABLED 0
+#endif
 ''')
 
 def add_iomcu_firmware_defaults(f):


### PR DESCRIPTION
previous cleanups made it easy to make it benign to include `GCS_MAVLink/GCS.h` on the bootloader build.  Use it instead of explicit bootloader check.

```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           *       *                 *      *      *
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               *      *           *       *                 *      *      *
MatekF405                     *      *           *       *                 *      *      *
Pixhawk1-1M                   *      *           *       *                 *      *      *
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     *      *           *       *                 *      *      *
skyviper-v2450                                   *                                       
```
