### PR TITLE
Tools: Add Sierra True series periphs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -199,6 +199,12 @@ AP_HW_Sierra_F1                      1087
 AP_HW_HolybroCompass                 1088
 AP_HW_FOXEERH743_V1                  1089
 
+AP_HW_Sierra-TrueNav Pro             1091
+AP_HW_Sierra-TrueNav                 1092
+AP_HW_Sierra-TrueNorth               1093
+AP_HW_Sierra-TrueSpeed               1094
+AP_HW_Sierra-PrecisionPoint          1095
+
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402


### PR DESCRIPTION
Allocate board IDs from 1091 to 1095 for Sierra True series of DroneCAN peripherals.
@peterbarker can you check this?
Thank you!