### PR TITLE
AP_HAL_ChibiOS: disable watchdog in hwdef.h not in-line in code

### DIFF
--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -261,7 +261,7 @@ static void main_loop()
 #if !defined(DISABLE_WATCHDOG)
 #ifdef IOMCU_FW
     stm32_watchdog_init();
-#elif !defined(HAL_BOOTLOADER_BUILD)
+#else
     // setup watchdog to reset if main loop stops
     if (AP_BoardConfig::watchdog_enabled()) {
         stm32_watchdog_init();

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1113,6 +1113,7 @@ def write_mcu_config(f):
 #define HAL_USE_EMPTY_STORAGE 1
 #ifndef HAL_STORAGE_SIZE
 #define HAL_STORAGE_SIZE 16384
+#define DISABLE_WATCHDOG 1
 #endif
 ''')
         else:
@@ -1149,6 +1150,7 @@ def write_mcu_config(f):
 #define HAL_USE_RTC FALSE
 #define DISABLE_SERIAL_ESC_COMM TRUE
 #define CH_CFG_USE_DYNAMIC FALSE
+#define DISABLE_WATCHDOG 1
 ''')
         if not env_vars['EXT_FLASH_SIZE_MB'] and not args.signed_fw:
             f.write('''


### PR DESCRIPTION
This just adds defines in `chibios_hwdef.py`, re-using the existing variable uses to control the watchdog, rather than explicitly checking for being a bootloader build.
