### PR TITLE
Tools:board_types.txt - reserve ids for esp32 and esp32s3 ap_periph

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -205,6 +205,9 @@ AP_HW_Sierra-TrueNorth               1093
 AP_HW_Sierra-TrueSpeed               1094
 AP_HW_Sierra-PrecisionPoint          1095
 
+AP_HW_ESP32_PERIPH                   1205
+AP_HW_ESP32S3_PERIPH                 1206
+
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402


### PR DESCRIPTION
Adds 2 boards to board_types.txt