### PR TITLE
RC_Channel: allocate channel option for loweheiser manual control

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -512,6 +512,11 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::MOUNT2_ROLL:
     case AUX_FUNC::MOUNT2_PITCH:
     case AUX_FUNC::MOUNT2_YAW:
+    case AUX_FUNC::LOWEHEISER_STARTER:
+        break;
+
+    // not really aux functions:
+    case AUX_FUNC::LOWEHEISER_THROTTLE:
         break;
     case AUX_FUNC::AVOID_ADSB:
     case AUX_FUNC::AVOID_PROXIMITY:
@@ -1418,6 +1423,11 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
     case AUX_FUNC::SCRIPTING_6:
     case AUX_FUNC::SCRIPTING_7:
     case AUX_FUNC::SCRIPTING_8:
+        break;
+
+    case AUX_FUNC::LOWEHEISER_THROTTLE:
+    case AUX_FUNC::LOWEHEISER_STARTER:
+        // monitored by the library itself
         break;
 
     default:

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -216,6 +216,8 @@ public:
         QRTL =               108, // QRTL mode
         CUSTOM_CONTROLLER =  109,
         KILL_IMU3 =          110, // disable third IMU (for IMU failure testing)
+        LOWEHEISER_STARTER = 111,  // allows for manually running starter
+
         // if you add something here, make sure to update the documentation of the parameter in RC_Channel.cpp!
         // also, if you add an option >255, you will need to fix duplicate_options_exist
 
@@ -258,6 +260,7 @@ public:
         MOUNT2_ROLL =        215, // mount2 roll input
         MOUNT2_PITCH =       216, // mount3 pitch input
         MOUNT2_YAW =         217, // mount4 yaw input
+        LOWEHEISER_THROTTLE= 218,  // allows for throttle on slider
 
         // inputs 248-249 are reserved for the Skybrush fork at
         // https://github.com/skybrush-io/ardupilot


### PR DESCRIPTION
I should've done this a long time ago; units are being shipped by multiple partners using channel options which have different meanings in my old PR branch and the PR against master.

At least this means they'll only have to fix things once.
