### PR TITLE
Copter: Clarify the exclusion determination in the ENUM definition

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1338,7 +1338,7 @@ public:
     void restart_without_terrain();
 
     // enum for RTL_ALT_TYPE parameter
-    enum class RTLAltType {
+    enum class RTLAltType : int8_t {
         RTL_ALTTYPE_RELATIVE = 0,
         RTL_ALTTYPE_TERRAIN = 1
     };

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -49,7 +49,7 @@ void ModeRTL::restart_without_terrain()
 ModeRTL::RTLAltType ModeRTL::get_alt_type() const
 {
     // sanity check parameter
-    if (g.rtl_alt_type < 0 || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
+    if (g.rtl_alt_type < (int8_t)RTLAltType::RTL_ALTTYPE_RELATIVE || g.rtl_alt_type > (int8_t)RTLAltType::RTL_ALTTYPE_TERRAIN) {
         return RTLAltType::RTL_ALTTYPE_RELATIVE;
     }
     return (RTLAltType)g.rtl_alt_type.get();


### PR DESCRIPTION
slight update on https://github.com/ArduPilot/ardupilot/pull/21198 (close https://github.com/ArduPilot/ardupilot/pull/21198)

restrinct rtl_alt_type to RTLAltType values range and make RTLAltType an int8_t enum.

This is NFC as compiler was already guessing this. Tested on CubeOrange build and SITL.
No change in build size.
This is a small improvement in readility (relatively) as we get ride a magic number. The 0 check is usefull there but we can restrinct to the RTLAltType values safely in this case. If a change is made to RTLAltType values then it is still be easy to modify the check.