### PR TITLE
Plane: stop passing speed_scaler all over the place

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -856,17 +856,17 @@ private:
     float calc_speed_scaler(void);
     float get_speed_scaler(void) const { return surface_speed_scaler; }
     bool stick_mixing_enabled(void);
-    void stabilize_roll(float speed_scaler);
-    float stabilize_roll_get_roll_out(float speed_scaler);
-    void stabilize_pitch(float speed_scaler);
-    float stabilize_pitch_get_pitch_out(float speed_scaler);
+    void stabilize_roll();
+    float stabilize_roll_get_roll_out();
+    void stabilize_pitch();
+    float stabilize_pitch_get_pitch_out();
     void stabilize_stick_mixing_direct();
     void stabilize_stick_mixing_fbw();
-    void stabilize_yaw(float speed_scaler);
-    void stabilize_training(float speed_scaler);
-    void stabilize_acro(float speed_scaler);
-    void stabilize_acro_quaternion(float speed_scaler);
-    void calc_nav_yaw_coordinated(float speed_scaler);
+    void stabilize_yaw();
+    void stabilize_training();
+    void stabilize_acro();
+    void stabilize_acro_quaternion();
+    void calc_nav_yaw_coordinated();
     void calc_nav_yaw_course(void);
     void calc_nav_yaw_ground(void);
 


### PR DESCRIPTION
`get_speed_scaler()` just returns a plane variable, there is no calculation so passing it through all these functions has no advantage and is confusing.

https://github.com/ArduPilot/ardupilot/blob/c13eada89857e2d3faf0c1129952abc2fc0bd6d9/ArduPlane/Plane.h#L857