### PR TITLE
Copter: Clarify the exclusion determination in the ENUM definition

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -407,7 +407,7 @@ public:
     AP_Int16        rtl_alt_final;
     AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
     AP_Int32        rtl_loiter_time;
-    AP_Int8         rtl_alt_type;
+    AP_Enum<ModeRTL::RTLAltType> rtl_alt_type;
 #endif
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1338,7 +1338,7 @@ public:
     void restart_without_terrain();
 
     // enum for RTL_ALT_TYPE parameter
-    enum class RTLAltType {
+    enum class RTLAltType : int8_t {
         RTL_ALTTYPE_RELATIVE = 0,
         RTL_ALTTYPE_TERRAIN = 1
     };

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -49,10 +49,12 @@ void ModeRTL::restart_without_terrain()
 ModeRTL::RTLAltType ModeRTL::get_alt_type() const
 {
     // sanity check parameter
-    if (g.rtl_alt_type < 0 || g.rtl_alt_type > (int)RTLAltType::RTL_ALTTYPE_TERRAIN) {
-        return RTLAltType::RTL_ALTTYPE_RELATIVE;
+    switch ((ModeRTL::RTLAltType)g.rtl_alt_type) {
+    case RTLAltType::RTL_ALTTYPE_RELATIVE ... RTLAltType::RTL_ALTTYPE_TERRAIN:
+        return g.rtl_alt_type;
     }
-    return (RTLAltType)g.rtl_alt_type.get();
+    // user has an invalid value
+    return RTLAltType::RTL_ALTTYPE_RELATIVE;
 }
 
 // rtl_run - runs the return-to-launch controller


### PR DESCRIPTION
Co-authored-by: Pierre Kancir <pierre.kancir.emn@gmail.com>
Co-authored-by: Peter Barker<pbarker@barker.dropbear.id.au>

Alternative to https://github.com/ArduPilot/ardupilot/pull/22803/files - but gives type-safety and if another altitude type gets added this there will be a compilation error instead of a silent squashing to relative alt.

Compiles to the exact same code, interestingly.

```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           *       *                 *      *      *
Hitec-Airspeed     0                                                                     
KakuteH7-bdshot               *      *           *       *                 *      *      *
MatekF405                     *      *           *       *                 *      *      *
Pixhawk1-1M                   *      *           *       *                 *      *      *
f103-QiotekPeriph  0                                                                     
f303-Universal     0                                                                     
iomcu                                                          *                         
revo-mini                     *      *           *       *                 *      *      *
skyviper-v2450                                   *                                       
```
