### PR TITLE
Plane: mode allows arming return string allowing quadplane mode checks tidy

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -169,3 +169,30 @@ void Mode::update_target_altitude()
 
     plane.altitude_error_cm = plane.calc_altitude_error_cm();
 }
+
+// returns true if the vehicle can be armed in this mode
+bool Mode::pre_arm_checks(size_t buflen, char *buffer) const
+{
+    if (!_pre_arm_checks(buflen, buffer)) {
+        if (strlen(buffer) == 0) {
+            // If no message is provided add a generic one
+            hal.util->snprintf(buffer, buflen, "mode not armable");
+        }
+        return false;
+    }
+
+    return true;
+}
+
+// Auto and Guided do not call this to bypass the q-mode check.
+bool Mode::_pre_arm_checks(size_t buflen, char *buffer) const
+{
+#if HAL_QUADPLANE_ENABLED
+    if (plane.quadplane.enabled() && !is_vtol_mode() &&
+            plane.quadplane.option_is_set(QuadPlane::OPTION::ONLY_ARM_IN_QMODE_OR_AUTO)) {
+        hal.util->snprintf(buffer, buflen, "not Q mode");
+        return false;
+    }
+#endif
+    return true;
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -76,7 +76,7 @@ public:
     virtual const char *name4() const = 0;
 
     // returns true if the vehicle can be armed in this mode
-    virtual bool allows_arming() const { return true; }
+    bool pre_arm_checks(size_t buflen, char *buffer) const;
 
     //
     // methods that sub classes should override to affect movement of the vehicle in this mode
@@ -132,6 +132,9 @@ protected:
     // subclasses override this to perform any required cleanup when exiting the mode
     virtual void _exit() { return; }
 
+    // mode specific pre-arm checks
+    virtual bool _pre_arm_checks(size_t buflen, char *buffer) const;
+
 #if HAL_QUADPLANE_ENABLED
     // References for convenience, used by QModes
     AC_PosControl*& pos_control;
@@ -186,6 +189,7 @@ protected:
 
     bool _enter() override;
     void _exit() override;
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override;
 };
 
 
@@ -238,6 +242,7 @@ public:
 protected:
 
     bool _enter() override;
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override { return true; }
 
 private:
     float active_radius_m;
@@ -354,6 +359,7 @@ public:
 protected:
 
     bool _enter() override;
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
 
 private:
 
@@ -398,11 +404,13 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override { }
 
-    bool allows_arming() const override { return false; }
-
     bool allows_throttle_nudging() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+protected:
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
+
 };
 
 class ModeFBWA : public Mode
@@ -591,11 +599,11 @@ public:
 
     void run() override;
 
-    bool allows_arming() const override { return false; }
-
 protected:
 
     bool _enter() override;
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
+
 };
 
 class ModeQRTL : public Mode
@@ -613,8 +621,6 @@ public:
 
     void run() override;
 
-    bool allows_arming() const override { return false; }
-
     bool does_auto_throttle() const override { return true; }
 
     void update_target_altitude() override;
@@ -626,6 +632,7 @@ public:
 protected:
 
     bool _enter() override;
+    bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
 
 private:
 

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -139,3 +139,23 @@ bool ModeAuto::does_auto_throttle() const
 #endif
    return true;
 }
+
+// returns true if the vehicle can be armed in this mode
+bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
+{
+#if HAL_QUADPLANE_ENABLED
+    if (plane.quadplane.enabled()) {
+        if (plane.quadplane.option_is_set(QuadPlane::OPTION::ONLY_ARM_IN_QMODE_OR_AUTO) &&
+                !plane.quadplane.is_vtol_takeoff(plane.mission.get_current_nav_cmd().id)) {
+            hal.util->snprintf(buffer, buflen, "not in VTOL takeoff");
+            return false;
+        }
+        if (!plane.mission.starts_with_takeoff_cmd()) {
+            hal.util->snprintf(buffer, buflen, "missing takeoff waypoint");
+            return false;
+        }
+    }
+#endif
+    // Note that this bypasses the base class checks
+    return true;
+}


### PR DESCRIPTION
Moves mode based arming checks to be in one place. It does mean that the Quadplane checks move from pre-arm to arm, so you will not be shouted at until you try and arm, but they can all be resolved by a mode change so I think thats OK. 

RTL is now never armable, currently none quadplanes are allowed to arm in RTL. If there is a good reason for this we can preserve that behavior, I couldn't think of one. 

We move to the same arming fail message as copter. Currently its just `"Mode does not allow arming" now we get for example "RTL mode not armable". 