### PR TITLE
.github: remove Disco from size builds

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -19,7 +19,6 @@ jobs:
             base,  # GCC
         ]
         config: [
-            disco,
             Durandal,
             MatekF405,
             Pixhawk1-1M,
@@ -38,7 +37,6 @@ jobs:
         run: |
           NOW=$(date -u +"%F-%T")
           echo "{timestamp}=${NOW}" >> $GITHUB_OUTPUT
-          apt install -y arm-linux-gnueabihf
       - name: ccache cache files
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Unable to install compiler package on server for unknown reason

Replaces https://github.com/ArduPilot/ardupilot/pull/22816
