### PR TITLE
Tools: Update pyenv for new MacOS Clang13

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -118,7 +118,7 @@ if maybe_prompt_user "Install python using pyenv [N/y]?" ; then
 
         pushd $HOME/.pyenv
         git fetch --tags
-        git checkout v2.3.9
+        git checkout v2.3.12
         popd
         exportline="export PYENV_ROOT=\$HOME/.pyenv"
         echo $exportline >> ~/$SHELL_LOGIN


### PR DESCRIPTION
https://bugs.python.org/issue45405

Version of pyenv 2.3.12 has patched most versions of python to properly compile with Mac clang 13.  This version is required to properly install python on new machine.