### PR TITLE
DevEnv: add-brackets in astylerc set to true

### DIFF
--- a/Tools/CodeStyle/astylerc
+++ b/Tools/CodeStyle/astylerc
@@ -1,6 +1,6 @@
 style=linux
 keep-one-line-statements
-add-brackets
+add-brackets=true
 indent=spaces=4
 indent-col1-comments
 min-conditional-indent=0


### PR DESCRIPTION
As per the style guide https://ardupilot.org/dev/docs/style-guide.html , control statements (if, while, do, else) should always use braces around the statements. This can be implemented by setting add-brackets option to true.