### PR TITLE
Tools: autotest: logger_metadata: parse `@FieldBits` to new bitmask format and ouput bitmask in xml

### DIFF
--- a/Tools/autotest/logger_metadata/emit_html.py
+++ b/Tools/autotest/logger_metadata/emit_html.py
@@ -46,9 +46,6 @@ DO NOT EDIT
                     fdesc = ""
                 print('        <tr><td>%s</td><td>%s</td></tr>' % (f, fdesc),
                       file=self.fh)
-#                if "bits" in docco.fields[f]:
-#                    print('                <bits>%s</bits>' %
-#                          docco.fields[f]["bits"], file=self.fh)
             print('        </table>', file=self.fh)
 
             print("", file=self.fh)

--- a/Tools/autotest/logger_metadata/emit_xml.py
+++ b/Tools/autotest/logger_metadata/emit_xml.py
@@ -35,9 +35,20 @@ class XMLEmitter(emitter.Emitter):
                 if "description" in docco.fields[f]:
                     xml_description2 = etree.SubElement(xml_field, 'description')
                     xml_description2.text = docco.fields[f]["description"]
-                if "bits" in docco.fields[f]:
-                    xml_bits = etree.SubElement(xml_field, 'bits')
-                    xml_bits.text = docco.fields[f]["bits"]
+                if "bitmaskenum" in docco.fields[f]:
+                    enum_name = docco.fields[f]["bitmaskenum"]
+                    if enum_name not in enumerations:
+                        raise Exception("Unknown enum (%s) (have %s)" %
+                                        (enum_name, "\n".join(sorted(enumerations.keys()))))
+                    bit_mask = enumerations[enum_name]
+                    xml_bitmask = etree.SubElement(xml_field, 'bitmask')
+                    for bit in bit_mask.entries:
+                        xml_bitmask_bit = etree.SubElement(xml_bitmask, 'bit', name=bit.name)
+                        xml_bitmask_bit_value = etree.SubElement(xml_bitmask_bit, 'value')
+                        xml_bitmask_bit_value.text =  str(bit.value)
+                        if bit.comment is not None:
+                            xml_bitmask_bit_comment = etree.SubElement(xml_bitmask_bit, 'description')
+                            xml_bitmask_bit_comment.text = bit.comment
             if xml_fields.text is None and not len(xml_fields):
                 xml_fields.text = '\n'  # add </param> on next line in case of empty element.
         self.stop()

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -13,6 +13,7 @@ import emit_rst
 import emit_xml
 
 import enum_parse
+from enum_parse import EnumDocco
 
 topdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../')
 topdir = os.path.realpath(topdir)
@@ -22,7 +23,6 @@ re_commentline = re.compile(r"\s*//")
 re_description = re.compile(r"\s*//\s*@Description\s*:\s*(.*)")
 re_url = re.compile(r"\s*//\s*@URL\s*:\s*(.*)")
 re_field = re.compile(r"\s*//\s*@Field\s*:\s*(\w+):\s*(.*)")
-re_fieldbits = re.compile(r"\s*//\s*@FieldBits\s*:\s*(\w+):\s*(.*)")
 re_fieldbits = re.compile(r"\s*//\s*@FieldBits\s*:\s*(\w+):\s*(.*)")
 re_fieldbitmaskenum = re.compile(r"\s*//\s*@FieldBitmaskEnum\s*:\s*(\w+):\s*(.*)")
 re_fieldvalueenum = re.compile(r"\s*//\s*@FieldValueEnum\s*:\s*(\w+):\s*(.*)")
@@ -61,6 +61,7 @@ class LoggerDocco(object):
             self.fields = {}
             self.fields_order = []
             self.vehicles = None
+            self.bits_enums = []
 
         def set_description(self, desc):
             self.description = desc
@@ -81,8 +82,16 @@ class LoggerDocco(object):
             self.fields[field]["description"] = description
 
         def set_field_bits(self, field, bits):
+            bits = bits.split(",")
+            count = 0
+            entries = []
+            for bit in bits:
+                entries.append(EnumDocco.EnumEntry(bit, 1<<count, None))
+                count += 1
+            bitmask_name = self.name + field
+            self.bits_enums.append(EnumDocco.Enumeration(bitmask_name, entries))
             self.ensure_field(field)
-            self.fields[field]["bits"] = bits
+            self.fields[field]["bitmaskenum"] = bitmask_name
 
         def set_fieldbitmaskenum(self, field, bits):
             self.ensure_field(field)
@@ -199,6 +208,7 @@ class LoggerDocco(object):
 
     def finalise_docco(self, docco):
         self.doccos.append(docco)
+        self.enumerations += docco.bits_enums
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow up from https://github.com/ArduPilot/ardupilot/pull/13858 to allow mission planner to use the new fields which are not currently output for the xml format.  https://github.com/ArduPilot/MissionPlanner/pull/3046

 `@FieldBits` gets the converted to the new format, previously it was only parsed in the `xml`. Now it works for `rst` too. This then updates the `xml` parser to output the new bitmask format. `TECS` is the only log using  `@FieldBits` so we could change it, but there is no rush.

Some example xml:
```
      <field name="ArmState">
        <description>true if vehicle is now armed</description>
      </field>
      <field name="ArmChecks">
        <description>arming bitmask at time of arming</description>
        <bitmask>
          <bit name="ARMING_CHECK_ALL">
            <value>1</value>
          </bit>
          <bit name="ARMING_CHECK_BARO">
            <value>2</value>
          </bit>
          <bit name="ARMING_CHECK_COMPASS">
            <value>4</value>
          </bit>
          <bit name="ARMING_CHECK_GPS">
            <value>8</value>
          </bit>
          <bit name="ARMING_CHECK_INS">
            <value>16</value>
          </bit>
          <bit name="ARMING_CHECK_PARAMETERS">
            <value>32</value>
          </bit>
          <bit name="ARMING_CHECK_RC">
            <value>64</value>
          </bit>
          <bit name="ARMING_CHECK_VOLTAGE">
            <value>128</value>
          </bit>
          <bit name="ARMING_CHECK_BATTERY">
            <value>256</value>
          </bit>
          <bit name="ARMING_CHECK_AIRSPEED">
            <value>512</value>
          </bit>
          <bit name="ARMING_CHECK_LOGGING">
            <value>1024</value>
          </bit>
          <bit name="ARMING_CHECK_SWITCH">
            <value>2048</value>
          </bit>
          <bit name="ARMING_CHECK_GPS_CONFIG">
            <value>4096</value>
          </bit>
          <bit name="ARMING_CHECK_SYSTEM">
            <value>8192</value>
          </bit>
          <bit name="ARMING_CHECK_MISSION">
            <value>16384</value>
          </bit>
          <bit name="ARMING_CHECK_RANGEFINDER">
            <value>32768</value>
          </bit>
          <bit name="ARMING_CHECK_CAMERA">
            <value>65536</value>
          </bit>
          <bit name="ARMING_CHECK_AUX_AUTH">
            <value>131072</value>
          </bit>
          <bit name="ARMING_CHECK_VISION">
            <value>262144</value>
          </bit>
          <bit name="ARMING_CHECK_FFT">
            <value>524288</value>
          </bit>
        </bitmask>
      </field>
      <field name="Forced">
        <description>true if arm/disarm was forced</description>
      </field>
```