### PR TITLE
Tools/environment_install: add net-tools for WSL2

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -280,6 +280,11 @@ if [ -n "$RP" ]; then
     BASE_PKGS+=" realpath"
 fi
 
+# WSL2 needs route to detect the host to auto-forward mavlink to it
+if [[ $(grep -i Microsoft /proc/version) ]]; then
+    SITL_PKGS+=" net-tools"
+fi
+
 # Check if we need to manually install libtool-bin
 LBTBIN=$(apt-cache search -n '^libtool-bin')
 if [ -n "$LBTBIN" ]; then


### PR DESCRIPTION
add net-tools to apt install for WSL2 which it needs to detect the host via method in PR (https://github.com/ArduPilot/ardupilot/pull/22588). I came across a fresh install of WSL2 that didn't have route so I guess it's not installed by default like we thought.