### PR TITLE
AC_PID: AC_PI: fix param defaulting

### DIFF
--- a/libraries/AC_PID/AC_PI.cpp
+++ b/libraries/AC_PID/AC_PI.cpp
@@ -9,17 +9,17 @@ const AP_Param::GroupInfo AC_PI::var_info[] = {
     // @Param: P
     // @DisplayName: PID Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
-    AP_GROUPINFO("P",    1, AC_PI, kP, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    1, AC_PI, kP, default_kp),
 
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
-    AP_GROUPINFO("I",    2, AC_PI, kI, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    2, AC_PI, kI, default_ki),
 
     // @Param: IMAX
     // @DisplayName: PID Integral Maximum
     // @Description: The maximum/minimum value that the I term can output
-    AP_GROUPINFO("IMAX", 3, AC_PI, imax, 0),
+    AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 3, AC_PI, imax, default_imax),
 
     AP_GROUPEND
 };


### PR DESCRIPTION
This fixes a bug caused by me in https://github.com/ArduPilot/ardupilot/pull/22531

I forgot to change to the new define in the param table for the PI controller. I did not spot when comparing defaults in SITL because board heater is the only user, which we don't have in SITL.

Thanks to @pompecukor for the report.