### PR TITLE
ChibioOS: hwdef: CUAV-X7: correct 6.6v ADC scale factor

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X7/hwdef.dat
@@ -191,6 +191,9 @@ PA1 BATT_CURRENT_SENS ADC1 SCALE(1)
 
 # ADC3.3/ADC6.6
 PC4 SPARE1_ADC1 ADC1 SCALE(1)
+
+# Note that this should be SCALE(2), but we don't want to break existing setups
+# See: https://github.com/ArduPilot/ardupilot/pull/22831
 PA4 SPARE2_ADC1 ADC1 SCALE(1)
 
 PF12 RSSI_IN ADC1 SCALE(1)


### PR DESCRIPTION
Corrects the 6.6v pin scale factor, bug reported on discord. https://discord.com/channels/674039678562861068/780728024756781056/1071757983937216522

Of course there is the usual dilemma about whether or not its safe to correct the bug and mess up peoples parameters.....  I suspect this pin is very rarely used.
