### PR TITLE
AP_RangeFinder: Add minimum distance to the effective distance determination for VL53L1X

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
@@ -556,7 +556,8 @@ bool AP_RangeFinder_VL53L1X::write_register32(uint16_t reg, uint32_t value)
 void AP_RangeFinder_VL53L1X::timer(void)
 {
     uint16_t range_mm;
-    if ((get_reading(range_mm)) && (range_mm <= 4000)) {
+    // MIN: 4cm MAX: 4m
+    if ((get_reading(range_mm)) && (range_mm <= 4000) && (range_mm >= 40)) {
         WITH_SEMAPHORE(_sem);
         sum_mm += range_mm;
         counter++;


### PR DESCRIPTION
#22769 Related.

Make it so that distances less than the manufacturer's warranty distance do not accumulate.
The manufacturer sets the minimum distance at 4 cm.
In this process, the value is not 1cm.

Datasheet:
https://www.pololu.com/file/0J1506/VL53L1X.pdf
