### PR TITLE
AP_HAL_Linux: Raspberry more initialization checks

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -163,12 +163,15 @@ void GPIO_RPI::init()
     const int rpi_version = UtilRPI::from(hal.util)->get_rpi_version();
 
     GPIO_RPI::Address peripheral_base;
-    if(rpi_version == 1) {
+    if(rpi_version == 0) {
         peripheral_base = Address::BCM2708_PERIPHERAL_BASE;
-    } else if (rpi_version == 2) {
+    } else if (rpi_version == 1 || rpi_version == 2) {
         peripheral_base = Address::BCM2709_PERIPHERAL_BASE;
-    } else {
+    } else if (rpi_version == 3) {
         peripheral_base = Address::BCM2711_PERIPHERAL_BASE;
+    } else {
+        AP_HAL::panic("Unknown rpi_version, cannot locate peripheral base address");
+        return;
     }
 
     if (!openMemoryDevice()) {


### PR DESCRIPTION
Check more mmap() call sites for failure and exit. Also exit when starting on an unknown board.

I'm having some problems bringing up ardupilot on a new Pi4. Since mmap failures will prevent the RCInput driver from working, print and exit().