### PR TITLE
AP_Camera: make trigger dist a float

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -373,7 +373,7 @@ void AP_Camera::update()
         return;
     }
 
-    if (is_zero(_trigg_dist)) {
+    if (!is_positive(_trigg_dist)) {
         _last_location.lat = 0;
         _last_location.lng = 0;
         return;

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -50,7 +50,7 @@ public:
     void            control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
 
     // set camera trigger distance in a mission
-    void            set_trigger_distance(uint32_t distance_m)
+    void            set_trigger_distance(float distance_m)
     {
         _trigg_dist.set(distance_m);
     }


### PR DESCRIPTION
the parameters and the callers all use float, we unnecessarily lose precision here

thanks to D Przybysz for finding the issue