### PR TITLE
AP_Scripting: fix uint32 bitwise not

### DIFF
--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -88,7 +88,7 @@ UINT32_T_BOX_OP_BOOL(le, <=)
 
 #define UINT32_T_BOX_OP_UNARY(name, sym) \
     int uint32_t___##name(lua_State *L) { \
-        binding_argcheck(L, 1); \
+        binding_argcheck(L, 2); \
           \
         uint32_t v1 = coerce_to_uint32_t(L, 1); \
           \


### PR DESCRIPTION
It seems unary operators have a second fake argument for some reason. This seems to fix. I can't find any documentation but did find this in our lua source.

https://github.com/ArduPilot/ardupilot/blob/8d1a362db7156aacd402e572a767b71383b1109b/libraries/AP_Scripting/lua/src/lapi.c#L306-L309

