### PR TITLE
Tools: change WSL2 host IP detection method from route to ip

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -204,7 +204,7 @@ def wsl2_host_ip():
     if not under_wsl2():
         return None
 
-    pipe = subprocess.Popen("route -n | grep eth0 | grep '^0[.]0[.]0[.]0'  | tr -s ' ' | cut -f 2 -d ' '",
+    pipe = subprocess.Popen("ip route show default | awk '{print $3}'",
                             shell=True,
                             stdout=subprocess.PIPE)
     output_lines = pipe.stdout.read().decode('utf-8').strip(' \r\n')


### PR DESCRIPTION
Change the WSL2 hostname detection method app from ```route``` to ```ip``` because:
- ```route``` is deprecated, no longer installed in modem Ubuntu builds. Would require installing ```net-tools```.
- ```ip``` is now installed by default on Ubuntu 20+. 

This is a better solution than the original one done in PR https://github.com/ArduPilot/ardupilot/pull/22588/. This is also better than having to install net-tools which was proposed in PR https://github.com/ArduPilot/ardupilot/pull/22824