### PR TITLE
AP_Motors: Matrix: mixer simplification

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -597,7 +597,7 @@ bool AP_MotorsMatrix::setup_quad_matrix(motor_frame_type frame_type)
         add_motors(motors, ARRAY_SIZE(motors));
         break;
     }
-#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
     case MOTOR_FRAME_TYPE_NYT_PLUS: {
         _frame_type_string = "NYT_PLUS";
         static const AP_MotorsMatrix::MotorDef motors[] {
@@ -620,7 +620,7 @@ bool AP_MotorsMatrix::setup_quad_matrix(motor_frame_type frame_type)
         add_motors(motors, ARRAY_SIZE(motors));
         break;
     }
-#endif //APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+#endif //APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
     case MOTOR_FRAME_TYPE_BF_X: {
         // betaflight quad X order
         // see: https://fpvfrenzy.com/betaflight-motor-order/
@@ -1364,6 +1364,30 @@ void AP_MotorsMatrix::disable_yaw_torque(void)
         _yaw_factor[i] = 0;
     }
 }
+
+#if APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+// examples can pull values direct
+float AP_MotorsMatrix::get_thrust_rpyt_out(uint8_t i) const
+{
+    if (i < AP_MOTORS_MAX_NUM_MOTORS) {
+        return _thrust_rpyt_out[i];
+    }
+    return 0.0;
+}
+
+bool AP_MotorsMatrix::get_factors(uint8_t i, float &roll, float &pitch, float &yaw, float &throttle, uint8_t &testing_order) const
+{
+    if ((i < AP_MOTORS_MAX_NUM_MOTORS) && motor_enabled[i]) {
+        roll = _roll_factor[i];
+        pitch = _pitch_factor[i];
+        yaw = _yaw_factor[i];
+        throttle = _throttle_factor[i];
+        testing_order = _test_order[i];
+        return true;
+    }
+    return false;
+}
+#endif
 
 // singleton instance
 AP_MotorsMatrix *AP_MotorsMatrix::_singleton;

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -200,32 +200,38 @@ uint32_t AP_MotorsMatrix::get_motor_mask()
     return mask;
 }
 
+// helper to return value scaled between boost and normal based on the value of _thrust_boost_ratio
+// _thrust_boost_ratio of 1 -> return = boost_value
+// _thrust_boost_ratio of 0 -> return = normal_value
+float AP_MotorsMatrix::boost_ratio(float boost_value, float normal_value) const
+{
+    return _thrust_boost_ratio * boost_value + (1.0 - _thrust_boost_ratio) * normal_value;
+}
+
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
 void AP_MotorsMatrix::output_armed_stabilizing()
 {
-    uint8_t i;                          // general purpose counter
-    float   roll_thrust;                // roll thrust input value, +/- 1.0
-    float   pitch_thrust;               // pitch thrust input value, +/- 1.0
-    float   yaw_thrust;                 // yaw thrust input value, +/- 1.0
-    float   throttle_thrust;            // throttle thrust input value, 0.0 - 1.0
-    float   throttle_avg_max;           // throttle thrust average maximum value, 0.0 - 1.0
-    float   throttle_thrust_max;        // throttle thrust maximum value, 0.0 - 1.0
-    float   throttle_thrust_best_rpy;   // throttle providing maximum roll, pitch and yaw range without climbing
-    float   rpy_scale = 1.0f;           // this is used to scale the roll, pitch and yaw to fit within the motor limits
-    float   yaw_allowed = 1.0f;         // amount of yaw we can fit in
-    float   thr_adj;                    // the difference between the pilot's desired throttle and throttle_thrust_best_rpy
-
     // apply voltage and air pressure compensation
     const float compensation_gain = get_compensation_gain(); // compensation for battery voltage and altitude
-    roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
-    pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
-    yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
-    throttle_thrust = get_throttle() * compensation_gain;
-    throttle_avg_max = _throttle_avg_max * compensation_gain;
 
-    // If thrust boost is active then do not limit maximum thrust
-    throttle_thrust_max = _thrust_boost_ratio + (1.0f - _thrust_boost_ratio) * _throttle_thrust_max * compensation_gain;
+    // pitch thrust input value, +/- 1.0
+    const float roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
+
+    // pitch thrust input value, +/- 1.0
+    const float pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
+
+    // yaw thrust input value, +/- 1.0
+    float yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
+
+    // throttle thrust input value, 0.0 - 1.0
+    float throttle_thrust = get_throttle() * compensation_gain;
+
+    // throttle thrust average maximum value, 0.0 - 1.0
+    float throttle_avg_max = _throttle_avg_max * compensation_gain;
+
+    // throttle thrust maximum value, 0.0 - 1.0, If thrust boost is active then do not limit maximum thrust
+    const float throttle_thrust_max = boost_ratio(1.0, _throttle_thrust_max * compensation_gain);
 
     // sanity check throttle is above zero and below current limited throttle
     if (throttle_thrust <= 0.0f) {
@@ -240,8 +246,9 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // ensure that throttle_avg_max is between the input throttle and the maximum throttle
     throttle_avg_max = constrain_float(throttle_avg_max, throttle_thrust, throttle_thrust_max);
 
+    // throttle providing maximum roll, pitch and yaw range
     // calculate the highest allowed average thrust that will provide maximum control range
-    throttle_thrust_best_rpy = MIN(0.5f, throttle_avg_max);
+    float throttle_thrust_best_rpy = MIN(0.5f, throttle_avg_max);
 
     // calculate throttle that gives most possible room for yaw which is the lower of:
     //      1. 0.5f - (rpy_low+rpy_high)/2.0 - this would give the maximum possible margin above the highest motor and below the lowest
@@ -266,29 +273,26 @@ void AP_MotorsMatrix::output_armed_stabilizing()
 
     // calculate amount of yaw we can fit into the throttle range
     // this is always equal to or less than the requested yaw from the pilot or rate controller
-    float rp_low = 1.0f;    // lowest thrust value
-    float rp_high = -1.0f;  // highest thrust value
-    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+    float yaw_allowed = 1.0f; // amount of yaw we can fit in
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             // calculate the thrust outputs for roll and pitch
             _thrust_rpyt_out[i] = roll_thrust * _roll_factor[i] + pitch_thrust * _pitch_factor[i];
-            // record lowest roll + pitch command
-            if (_thrust_rpyt_out[i] < rp_low) {
-                rp_low = _thrust_rpyt_out[i];
-            }
-            // record highest roll + pitch command
-            if (_thrust_rpyt_out[i] > rp_high && (!_thrust_boost || i != _motor_lost_index)) {
-                rp_high = _thrust_rpyt_out[i];
-            }
 
             // Check the maximum yaw control that can be used on this channel
             // Exclude any lost motors if thrust boost is enabled
-            if (!is_zero(_yaw_factor[i]) && (!_thrust_boost || i != _motor_lost_index)){
+            if (!is_zero(_yaw_factor[i]) && (!_thrust_boost || i != _motor_lost_index)) {
+                const float thrust_rp_best_throttle = throttle_thrust_best_rpy + _thrust_rpyt_out[i];
+                float motor_room;
                 if (is_positive(yaw_thrust * _yaw_factor[i])) {
-                    yaw_allowed = MIN(yaw_allowed, fabsf(MAX(1.0f - (throttle_thrust_best_rpy + _thrust_rpyt_out[i]), 0.0f)/_yaw_factor[i]));
+                    // room to upper limit
+                    motor_room = 1.0 - thrust_rp_best_throttle;
                 } else {
-                    yaw_allowed = MIN(yaw_allowed, fabsf(MAX(throttle_thrust_best_rpy + _thrust_rpyt_out[i], 0.0f)/_yaw_factor[i]));
+                    // room to lower limit
+                    motor_room = thrust_rp_best_throttle;
                 }
+                const float motor_yaw_allowed = MAX(motor_room, 0.0)/fabsf(_yaw_factor[i]);
+                yaw_allowed = MIN(yaw_allowed, motor_yaw_allowed);
             }
         }
     }
@@ -298,26 +302,25 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     float yaw_allowed_min = (float)_yaw_headroom * 0.001f;
 
     // increase yaw headroom to 50% if thrust boost enabled
-    yaw_allowed_min = _thrust_boost_ratio * 0.5f + (1.0f - _thrust_boost_ratio) * yaw_allowed_min;
+    yaw_allowed_min = boost_ratio(0.5, yaw_allowed_min);
 
     // Let yaw access minimum amount of head room
     yaw_allowed = MAX(yaw_allowed, yaw_allowed_min);
 
     // Include the lost motor scaled by _thrust_boost_ratio to smoothly transition this motor in and out of the calculation
     if (_thrust_boost && motor_enabled[_motor_lost_index]) {
-        // record highest roll + pitch command
-        if (_thrust_rpyt_out[_motor_lost_index] > rp_high) {
-            rp_high = _thrust_boost_ratio * rp_high + (1.0f - _thrust_boost_ratio) * _thrust_rpyt_out[_motor_lost_index];
-        }
-
         // Check the maximum yaw control that can be used on this channel
         // Exclude any lost motors if thrust boost is enabled
         if (!is_zero(_yaw_factor[_motor_lost_index])){
+            const float thrust_rp_best_throttle = throttle_thrust_best_rpy + _thrust_rpyt_out[_motor_lost_index];
+            float motor_room;
             if (is_positive(yaw_thrust * _yaw_factor[_motor_lost_index])) {
-                yaw_allowed = _thrust_boost_ratio * yaw_allowed + (1.0f - _thrust_boost_ratio) * MIN(yaw_allowed, fabsf(MAX(1.0f - (throttle_thrust_best_rpy + _thrust_rpyt_out[_motor_lost_index]), 0.0f)/_yaw_factor[_motor_lost_index]));
+                motor_room = 1.0 - thrust_rp_best_throttle;
             } else {
-                yaw_allowed = _thrust_boost_ratio * yaw_allowed + (1.0f - _thrust_boost_ratio) * MIN(yaw_allowed, fabsf(MAX(throttle_thrust_best_rpy + _thrust_rpyt_out[_motor_lost_index], 0.0f)/_yaw_factor[_motor_lost_index]));
+                motor_room = thrust_rp_best_throttle;
             }
+            const float motor_yaw_allowed = MAX(motor_room, 0.0)/fabsf(_yaw_factor[_motor_lost_index]);
+            yaw_allowed = boost_ratio(yaw_allowed, MIN(yaw_allowed, motor_yaw_allowed));
         }
     }
 
@@ -330,7 +333,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // add yaw control to thrust outputs
     float rpy_low = 1.0f;   // lowest thrust value
     float rpy_high = -1.0f; // highest thrust value
-    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             _thrust_rpyt_out[i] = _thrust_rpyt_out[i] + yaw_thrust * _yaw_factor[i];
 
@@ -349,11 +352,12 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     if (_thrust_boost) {
         // record highest roll + pitch + yaw command
         if (_thrust_rpyt_out[_motor_lost_index] > rpy_high && motor_enabled[_motor_lost_index]) {
-            rpy_high = _thrust_boost_ratio * rpy_high + (1.0f - _thrust_boost_ratio) * _thrust_rpyt_out[_motor_lost_index];
+            rpy_high = boost_ratio(rpy_high, _thrust_rpyt_out[_motor_lost_index]);
         }
     }
 
     // calculate any scaling needed to make the combined thrust outputs fit within the output range
+    float rpy_scale = 1.0f;
     if (rpy_high - rpy_low > 1.0f) {
         rpy_scale = 1.0f / (rpy_high - rpy_low);
     }
@@ -365,7 +369,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     rpy_high *= rpy_scale;
     rpy_low *= rpy_scale;
     throttle_thrust_best_rpy = -rpy_low;
-    thr_adj = throttle_thrust - throttle_thrust_best_rpy;
+    float thr_adj = throttle_thrust - throttle_thrust_best_rpy;
     if (rpy_scale < 1.0f) {
         // Full range is being used by roll, pitch, and yaw.
         limit.roll = true;
@@ -375,21 +379,19 @@ void AP_MotorsMatrix::output_armed_stabilizing()
             limit.throttle_upper = true;
         }
         thr_adj = 0.0f;
-    } else {
-        if (thr_adj < 0.0f) {
-            // Throttle can't be reduced to desired value
-            // todo: add lower limit flag and ensure it is handled correctly in altitude controller
-            thr_adj = 0.0f;
-        } else if (thr_adj > 1.0f - (throttle_thrust_best_rpy + rpy_high)) {
-            // Throttle can't be increased to desired value
-            thr_adj = 1.0f - (throttle_thrust_best_rpy + rpy_high);
-            limit.throttle_upper = true;
-        }
+    } else if (thr_adj < 0.0f) {
+        // Throttle can't be reduced to desired value
+        // todo: add lower limit flag and ensure it is handled correctly in altitude controller
+        thr_adj = 0.0f;
+    } else if (thr_adj > 1.0f - (throttle_thrust_best_rpy + rpy_high)) {
+        // Throttle can't be increased to desired value
+        thr_adj = 1.0f - (throttle_thrust_best_rpy + rpy_high);
+        limit.throttle_upper = true;
     }
 
     // add scaled roll, pitch, constrained yaw and throttle for each motor
     const float throttle_thrust_best_plus_adj = throttle_thrust_best_rpy + thr_adj;
-    for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+    for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             _thrust_rpyt_out[i] = (throttle_thrust_best_plus_adj * _throttle_factor[i]) + (rpy_scale * _thrust_rpyt_out[i]);
         }

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -156,6 +156,10 @@ protected:
     const char*         _frame_type_string = "";  //  string representation of frame type
 
 private:
+
+    // helper to return value scaled between boost and normal based on the value of _thrust_boost_ratio
+    float boost_ratio(float boost_value, float normal_value) const;
+
     // setup motors matrix
     bool setup_quad_matrix(motor_frame_type frame_type);
     bool setup_hexa_matrix(motor_frame_type frame_type);

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -101,6 +101,10 @@ public:
     };
     void add_motors_raw(const struct MotorDefRaw *motors, uint8_t num_motors);
 
+    // pull values direct, (examples only)
+    float get_thrust_rpyt_out(uint8_t i) const;
+    bool get_factors(uint8_t i, float &roll, float &pitch, float &yaw, float &throttle, uint8_t &testing_order) const;
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -857,3 +857,16 @@ bool AP_MotorsMulticopter::arming_checks(size_t buflen, char *buffer) const
 
     return true;
 }
+
+#if APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+// Getters for AP_Motors example, not used by vehicles
+float AP_MotorsMulticopter::get_throttle_avg_max() const
+{
+    return _throttle_avg_max;
+}
+
+int16_t AP_MotorsMulticopter::get_yaw_headroom() const
+{
+    return _yaw_headroom;
+}
+#endif

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -105,6 +105,10 @@ public:
     // Run arming checks
     bool arming_checks(size_t buflen, char *buffer) const override;
 
+    // Getters for AP_Motors example, not used by vehicles
+    float get_throttle_avg_max() const;
+    int16_t get_yaw_headroom() const;
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -42,6 +42,8 @@ AP_MotorsMatrix   motors(400);
 
 AP_BattMonitor _battmonitor{0, nullptr, nullptr};
 
+bool thrust_boost = false;
+
 // setup
 void setup()
 {
@@ -90,6 +92,9 @@ void setup()
 
             } else if (strcmp(cmd,"throttle_avg_max") == 0) {
                 motors.set_throttle_avg_max(value);
+
+            } else if (strcmp(cmd,"thrust_boost") == 0) {
+                thrust_boost = value > 0.0;
 
             } else {
                 ::printf("Expected \"yaw_headroom\" or \"throttle_avg_max\"\n");
@@ -162,6 +167,7 @@ void stability_test()
 {
     hal.console->printf("Throttle average max: %0.4f\n",  motors.get_throttle_avg_max());
     hal.console->printf("Yaw headroom: %i\n", motors.get_yaw_headroom());
+    hal.console->printf("Thrust boost: %s\n", thrust_boost?"True":"False");
 
     const float throttle_tests[] = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
     const uint8_t throttle_tests_num = ARRAY_SIZE(throttle_tests);
@@ -229,6 +235,7 @@ void update_motors()
 {
     // call update motors 1000 times to get any ramp limiting complete
     for (uint16_t i=0; i<1000; i++) {
+        motors.set_thrust_boost(thrust_boost);
         motors.output();
     }
 }

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -3,6 +3,12 @@
  *  Code by Randy Mackay. DIYDrones.com
  */
 
+/* on Linux run with
+    ./waf configure --board linux
+    ./waf --targets examples/AP_Motors_test
+    ./build/linux/examples/AP_Motors_test
+*/
+
 // Libraries
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -11,6 +17,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <stdio.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -41,13 +48,68 @@ void setup()
     hal.console->printf("AP_Motors library test ver 1.0\n");
 
     // motor initialisation
+    motors.set_dt(1.0/400.0);
     motors.set_update_rate(490);
+
+#if NUM_OUTPUTS == 8
+    motors.init(AP_Motors::MOTOR_FRAME_OCTA, AP_Motors::MOTOR_FRAME_TYPE_X);
+#elif NUM_OUTPUTS == 6
+    motors.init(AP_Motors::MOTOR_FRAME_HEXA, AP_Motors::MOTOR_FRAME_TYPE_X);
+#else
     motors.init(AP_Motors::MOTOR_FRAME_QUAD, AP_Motors::MOTOR_FRAME_TYPE_X);
+#endif
+
+    char frame_and_type_string[30];
+    motors.get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
+    hal.console->printf("%s\n", frame_and_type_string);
+
 #if HELI_TEST == 0
     motors.update_throttle_range();
     motors.set_throttle_avg_max(0.5f);
 #endif
     motors.output_min();
+
+    // allow command line args for single run
+    uint8_t argc;
+    char * const *argv;
+    hal.util->commandline_arguments(argc, argv);
+    if (argc > 1) {
+        for (uint8_t i = 2; i < argc; i++) {
+            const char* arg = argv[i];
+
+            const char *eq = strchr(arg, '=');
+            if (eq == NULL) {
+                ::printf("Expected argument with \"=\"\n");
+                exit(1);
+            }
+            char cmd[20] {};
+            strncpy(cmd, arg, eq-arg);
+            const float value = atof(eq+1);
+            if (strcmp(cmd,"yaw_headroom") == 0) {
+                motors.set_yaw_headroom(value);
+
+            } else if (strcmp(cmd,"throttle_avg_max") == 0) {
+                motors.set_throttle_avg_max(value);
+
+            } else {
+                ::printf("Expected \"yaw_headroom\" or \"throttle_avg_max\"\n");
+                exit(1);
+            }
+
+        }
+        if (strcmp(argv[1],"t") == 0) {
+            motor_order_test();
+
+        } else if (strcmp(argv[1],"s") == 0) {
+            stability_test();
+
+        } else {
+            ::printf("Expected first argument, 't' or 's'\n");
+
+        }
+        hal.scheduler->delay(1000);
+        exit(0);
+    }
 
     hal.scheduler->delay(1000);
 }
@@ -71,9 +133,11 @@ void loop()
     // test motors
     if (value == 't' || value == 'T') {
         motor_order_test();
+        hal.console->printf("finished test.\n");
     }
     if (value == 's' || value == 'S') {
         stability_test();
+        hal.console->printf("finished test.\n");
     }
 }
 
@@ -90,75 +154,58 @@ void motor_order_test()
         hal.scheduler->delay(2000);
     }
     motors.armed(false);
-    hal.console->printf("finished test.\n");
 
 }
 
 // stability_test
 void stability_test()
 {
-    int16_t roll_in, pitch_in, yaw_in, avg_out;
-    float throttle_in;
+    hal.console->printf("Throttle average max: %0.4f\n",  motors.get_throttle_avg_max());
+    hal.console->printf("Yaw headroom: %i\n", motors.get_yaw_headroom());
 
-    int16_t throttle_tests[] = {0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000};
-    uint8_t throttle_tests_num = sizeof(throttle_tests) / sizeof(int16_t);
-    int16_t rpy_tests[] = {0, 1000, 2000, 3000, 4500, -1000, -2000, -3000, -4500};
-    uint8_t rpy_tests_num = sizeof(rpy_tests) / sizeof(int16_t);
+    const float throttle_tests[] = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    const uint8_t throttle_tests_num = ARRAY_SIZE(throttle_tests);
+    const float rpy_tests[] = {-1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    const uint8_t rpy_tests_num = ARRAY_SIZE(rpy_tests);
 
     // arm motors
     motors.armed(true);
     motors.set_interlock(true);
     SRV_Channels::enable_aux_servos();
 
-#if NUM_OUTPUTS <= 4
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,AvgOut,LimRP,LimY,LimThD,LimThU\n");                       // quad
-#elif NUM_OUTPUTS <= 6
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,AvgOut,LimRP,LimY,LimThD,LimThU\n");             // hexa
-#else
-    hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,Mot5,Mot6,Mot7,Mot8,AvgOut,LimRP,LimY,LimThD,LimThU\n");   // octa
-#endif
+    hal.console->printf("Roll,Pitch,Yaw,Thr,");
+    for (uint8_t i=0; i<NUM_OUTPUTS; i++) {
+        hal.console->printf("Mot%i,",i+1);
+    }
+    for (uint8_t i=0; i<NUM_OUTPUTS; i++) {
+        hal.console->printf("Mot%i_norm,",i+1);
+    }
+    hal.console->printf("LimR,LimP,LimY,LimThD,LimThU\n");
 
     // run stability test
     for (uint8_t y=0; y<rpy_tests_num; y++) {
         for (uint8_t p=0; p<rpy_tests_num; p++) {
             for (uint8_t r=0; r<rpy_tests_num; r++) {
                 for (uint8_t t=0; t<throttle_tests_num; t++) {
-                    roll_in = rpy_tests[r];
-                    pitch_in = rpy_tests[p];
-                    yaw_in = rpy_tests[y];
-                    throttle_in = throttle_tests[t]/1000.0f;
-                    motors.set_roll(roll_in/4500.0f);
-                    motors.set_pitch(pitch_in/4500.0f);
-                    motors.set_yaw(yaw_in/4500.0f);
+                    const float roll_in = rpy_tests[r];
+                    const float pitch_in = rpy_tests[p];
+                    const float yaw_in = rpy_tests[y];
+                    const float throttle_in = throttle_tests[t];
+                    motors.set_roll(roll_in);
+                    motors.set_pitch(pitch_in);
+                    motors.set_yaw(yaw_in);
                     motors.set_throttle(throttle_in);
                     motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
                     update_motors();
-                    avg_out = ((hal.rcout->read(0) + hal.rcout->read(1) + hal.rcout->read(2) + hal.rcout->read(3))/4);
                     // display input and output
-#if NUM_OUTPUTS <= 4
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",                // quad
-#elif NUM_OUTPUTS <= 6
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",          // hexa
-#else
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",    // octa
-#endif
-                            (int)roll_in,
-                            (int)pitch_in,
-                            (int)yaw_in,
-                            (double)throttle_in,
-                            (int)hal.rcout->read(0),
-                            (int)hal.rcout->read(1),
-                            (int)hal.rcout->read(2),
-                            (int)hal.rcout->read(3),
-#if NUM_OUTPUTS >= 6
-                            (int)hal.rcout->read(4),
-                            (int)hal.rcout->read(5),
-#endif
-#if NUM_OUTPUTS >= 8
-                            (int)hal.rcout->read(6),
-                            (int)hal.rcout->read(7),
-#endif
-                            (int)avg_out,
+                    hal.console->printf("%0.2f,%0.2f,%0.2f,%0.2f,", roll_in, pitch_in, yaw_in, throttle_in);
+                    for (uint8_t i=0; i<NUM_OUTPUTS; i++) {
+                        hal.console->printf("%d,",(int)hal.rcout->read(i));
+                    }
+                    for (uint8_t i=0; i<NUM_OUTPUTS; i++) {
+                        hal.console->printf("%0.4f,", motors.get_thrust_rpyt_out(i));
+                    }
+                    hal.console->printf("%d,%d,%d,%d,%d\n",
                             (int)motors.limit.roll,
                             (int)motors.limit.pitch,
                             (int)motors.limit.yaw,
@@ -176,7 +223,6 @@ void stability_test()
     motors.set_throttle(0);
     motors.armed(false);
 
-    hal.console->printf("finished test.\n");
 }
 
 void update_motors()

--- a/libraries/AP_Motors/examples/AP_Motors_test/MotorTestSweep.sh
+++ b/libraries/AP_Motors/examples/AP_Motors_test/MotorTestSweep.sh
@@ -18,7 +18,10 @@ for headroom in $YAW_HEADROOM; do
     echo "Yaw Headroom: $headroom"
     for Thr in $THR_AVERAGE_MAX; do
         echo "    Throttle average max: $Thr"
-        ./build/linux/examples/AP_Motors_test s yaw_headroom=$headroom throttle_avg_max=$Thr > MotorTestSweep/$COUNTER.csv
+        # Test with and without boost
+        ./build/linux/examples/AP_Motors_test s yaw_headroom=$headroom throttle_avg_max=$Thr thrust_boost=0 > MotorTestSweep/$COUNTER.csv
+        let COUNTER++
+        ./build/linux/examples/AP_Motors_test s yaw_headroom=$headroom throttle_avg_max=$Thr thrust_boost=1 > MotorTestSweep/$COUNTER.csv
         let COUNTER++
     done
     echo

--- a/libraries/AP_Motors/examples/AP_Motors_test/MotorTestSweep.sh
+++ b/libraries/AP_Motors/examples/AP_Motors_test/MotorTestSweep.sh
@@ -1,0 +1,26 @@
+# Build and run the motors example stability test at a range of yaw headroom and throttle average max values
+# Output results to files for comparison
+
+cd "$(dirname "$0")"
+cd ../../../..
+
+mkdir -p MotorTestSweep
+
+./waf configure --board linux
+./waf build --target examples/AP_Motors_test
+echo
+
+YAW_HEADROOM="0 100 200 300 400 500 600 700 800 900 1000"
+THR_AVERAGE_MAX="0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0"
+
+COUNTER=0
+for headroom in $YAW_HEADROOM; do
+    echo "Yaw Headroom: $headroom"
+    for Thr in $THR_AVERAGE_MAX; do
+        echo "    Throttle average max: $Thr"
+        ./build/linux/examples/AP_Motors_test s yaw_headroom=$headroom throttle_avg_max=$Thr > MotorTestSweep/$COUNTER.csv
+        let COUNTER++
+    done
+    echo
+done
+


### PR DESCRIPTION
This is simplification for the main motor mixer, the goal is to make the mixer easier to understand while being mathematically identical. This is more of a what it might look like than a tested suggestion. If this seems like a good idea we can test it is functionally the same using the motors example script. 

- moves the variables declared at the top down to where there used, this means that the handy comment that explains what they do is in the same place the variable is used. This also means a couple can become const.
- ~moves to `if (!motor_enabled[i]) { continue; }` pattern. This means code is not a for and a if loop.~
- removes the unused variable `rp_low` and `rp_high`
- adds a `boost_ratio` helper to simplify the code.
- adds a `const float` intermediate step in the yaw headroom calc
- un-nests two if statements in the `thr_adj` calculation. 
- moves `fabsf` to the denominator in the yaw headroom calc.

