### PR TITLE
StorageManager: add compile define to favor more mission points

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -219,6 +219,7 @@ BUILD_OPTIONS = [
     Feature('Other', 'NMEA_OUTPUT', 'HAL_NMEA_OUTPUT_ENABLED', 'Enable NMEA Output', 0, None),
     Feature('Other', 'BARO_WIND_COMP', 'HAL_BARO_WIND_COMP_ENABLED', 'Enable Baro Wind Compensation', 0, None),
     Feature('Other', 'ADVANCED_FAILSAFE', 'AP_ADVANCEDFAILSAFE_ENABLED', 'Enable Advanced Failsafe features', 0, None),
+    Feature('Other', 'Mission', 'STORAGE_ALLOCATION_FAVOR_MISSION', 'Partition storage to favor more Mission points', 0, None),
 
     Feature('GPS Drivers', 'UBLOX', 'AP_GPS_UBLOX_ENABLED', 'Enable u-blox GPS', 1, None),
     Feature('GPS Drivers', 'SBP2', 'AP_GPS_SBP2_ENABLED', 'Enable SBP2 GPS', 0, 'SBP'),

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -43,6 +43,39 @@ const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
     { StorageParam,   0,     HAL_STORAGE_SIZE}
 };
 
+#elif STORAGE_ALLOCATION_FAVOR_MISSION && STORAGE_NUM_AREAS >= 15
+#if !APM_BUILD_COPTER_OR_HELI
+    { StorageParam,   0,     1280}, // 0x500 parameter bytes
+    { StorageMission, 1280,  2506},
+    { StorageRally,   3786,   150}, // 10 rally points
+    { StorageFence,   3936,   160}, // 20 fence points
+#else
+    { StorageParam,   0,     1536}, // 0x600 param bytes
+    { StorageMission, 1536,  2422},
+    { StorageRally,   3958,    90}, // 6 rally points
+    { StorageFence,   4048,    48}, // 6 fence points
+#endif
+
+    { StorageParam,   4096,  1280},
+    { StorageMission, 5376,   300},
+    { StorageMission, 5676,   256},
+    { StorageMission, 5932,  2132},
+    { StorageKeys,    8064,    64}, 
+    { StorageBindInfo,8128,    56},
+    { StorageMission, 8192,  1280},
+    { StorageMission, 9472,   300},
+    { StorageMission, 9772,   256},
+    { StorageMission, 10028,  5204}, // leave 128 byte gap for expansion
+    { StorageCANDNA,  15232,  1024},
+    // 128 byte gap at end of first 16k
+
+#if STORAGE_NUM_AREAS >= 18
+    { StorageMission, 16384,  1280},
+    { StorageMission, 17664,  9842},
+    { StorageMission, 27506,  5262},
+#endif
+};
+
 #else
 /*
   layout for fixed wing and rovers

--- a/libraries/StorageManager/StorageManager.h
+++ b/libraries/StorageManager/StorageManager.h
@@ -44,8 +44,12 @@
 #error "Unsupported storage size"
 #endif
 
+#ifndef STORAGE_ALLOCATION_FAVOR_MISSION
+#define STORAGE_ALLOCATION_FAVOR_MISSION 0
+#endif
+
 /*
-  The StorageManager holds the layout of non-volatile storeage
+  The StorageManager holds the layout of non-volatile storage
  */
 class StorageManager {
     friend class StorageAccess;


### PR DESCRIPTION
This introduces build option STORAGE_ALLOCATION_FAVOR_MISSION which increases Storage space allocates for Mission items and reduces allocation of Params, Fence and Rally points. This is an opt-in feature and only effects targets with 16k+ space.

Zero code size change.

For platforms with HAL_STORAGE_SIZE 32768, AP_Mission::num_commands_max() roughly triples from 600ish to 1800ish.

A nice follow-on PR would wrap all the StorageManager::StorageTypes so that if that feature is removed then it wouldn't allocate memory to it. Examples:
```StorageFence``` needs AP_FENCE_ENABLED
```StorageRally``` needs HAL_RALLY_ENABLED
```StorageBindInfo``` needs HAL_RCINPUT_WITH_AP_RADIO
```StorageCANDNA``` needs HAL_ENABLE_LIBUAVCAN_DRIVERS
```StorageParamBak``` is only allocated on targets with 32k and is otherwise wasting program flash space, needs disable compile option