### PR TITLE
AP_HAL_ChibiOS: exclude more code based on HAL_WITH_IO_MCU

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -176,11 +176,15 @@ void RCInput::_timer_tick(void)
     }
 #endif
 
+#if HAL_WITH_IO_MCU
     uint32_t now = AP_HAL::millis();
     const bool have_iocmu_rc = (_rcin_last_iomcu_ms != 0 && now - _rcin_last_iomcu_ms < 400);
     if (!have_iocmu_rc) {
         _rcin_last_iomcu_ms = 0;
     }
+#else
+    const bool have_iocmu_rc = false;
+#endif
 
     if (rcprot.new_input() && !have_iocmu_rc) {
         WITH_SEMAPHORE(rcin_mutex);

--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -69,7 +69,9 @@ private:
     int16_t _rssi = -1;
     int16_t _rx_link_quality = -1;
     uint32_t _rcin_timestamp_last_signal;
+#if HAL_WITH_IO_MCU
     uint32_t _rcin_last_iomcu_ms;
+#endif
     bool _init;
     const char *last_protocol;
 


### PR DESCRIPTION
The patch reasonably clearly shows that the variable being manipulated here wasn't ever used.

```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      0      *           0       0                 0      0      0
Hitec-Airspeed     0                                                                     
KakuteH7-bdshot               -24    *           -24     -24               -24    -24    -24
MatekF405                     -24    *           -24     -24               -32    -32    -32
Pixhawk1-1M                   0      *           0       0                 0      0      0
f103-QiotekPeriph  0                                                                     
f303-Universal     0                                                                     
iomcu                                                          -24                       
revo-mini                     -24    *           -24     -32               -24    -24    -24
skyviper-v2450                                   -48                                     
```
