### PR TITLE
AP_Bootloader: add board id for PixFlamingo L4R5 v1

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -198,6 +198,7 @@ AP_HW_JUMPER_XIAKE800                1086
 AP_HW_Sierra_F1                      1087
 AP_HW_HolybroCompass                 1088
 AP_HW_FOXEERH743_V1                  1089
+AP_HW_PixFlamingoL4R5_V1             1090
 
 AP_HW_Sierra-TrueNav Pro             1091
 AP_HW_Sierra-TrueNav                 1092


### PR DESCRIPTION
Add new board id for custom board PixFlamingo L4R5 v1