### PR TITLE
Add back roll-pitch-yawrate control in GUIDED(NO-GPS) mode

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -375,7 +375,7 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     Quaternion q;
     q.from_euler(radians(roll_deg),radians(pitch_deg),radians(yaw_deg));
 
-    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false);
+    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false, false);
     return true;
 }
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1184,8 +1184,8 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
             ang_vel.z = packet.body_yaw_rate;
         }
 
-        copter.mode_guided.set_angle(attitude_quat, ang_vel,
-                climb_rate_or_thrust, use_thrust);
+        bool use_yawrate = !yaw_rate_ignore && pitch_rate_ignore && roll_rate_ignore;
+        copter.mode_guided.set_angle(attitude_quat, ang_vel, climb_rate_or_thrust, use_thrust, use_yawrate);
 
         break;
     }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -949,8 +949,7 @@ public:
     // climb_rate_cms_or_thrust: represents either the climb_rate (cm/s) or thrust scaled from [0, 1], unitless
     // use_thrust: IF true: climb_rate_cms_or_thrust represents thrust
     //             IF false: climb_rate_cms_or_thrust represents climb_rate (cm/s)
-    void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust);
-
+    void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust, bool use_yaw_rate);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool terrain_alt = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool get_wp(Location &loc) const override;

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -635,7 +635,7 @@ bool ModeGuided::use_wpnav_for_position_control() const
 // climb_rate_cms_or_thrust: represents either the climb_rate (cm/s) or thrust scaled from [0, 1], unitless
 // use_thrust: IF true: climb_rate_cms_or_thrust represents thrust
 //             IF false: climb_rate_cms_or_thrust represents climb_rate (cm/s)
-void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust)
+void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust, bool use_yaw_rate)
 {
     // check we are in velocity control mode
     if (guided_mode != SubMode::Angle) {
@@ -644,6 +644,7 @@ void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_
 
     guided_angle_state.attitude_quat = attitude_quat;
     guided_angle_state.ang_vel = ang_vel;
+    guided_angle_state.use_yaw_rate = use_yaw_rate;
 
     guided_angle_state.use_thrust = use_thrust;
     if (use_thrust) {
@@ -1053,6 +1054,12 @@ void ModeGuided::angle_control_run()
     // call attitude controller
     if (guided_angle_state.attitude_quat.is_zero()) {
         attitude_control->input_rate_bf_roll_pitch_yaw(ToDeg(guided_angle_state.ang_vel.x) * 100.0f, ToDeg(guided_angle_state.ang_vel.y) * 100.0f, ToDeg(guided_angle_state.ang_vel.z) * 100.0f);
+    } else if (guided_angle_state.use_yaw_rate) {
+        // convert quaternion to euler angles
+        float roll_rad, pitch_rad, yaw_rad;
+        guided_angle_state.attitude_quat.to_euler(roll_rad, pitch_rad, yaw_rad);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(
+            ToDeg(roll_rad) * 100.0f, ToDeg(pitch_rad) * 100.0f, ToDeg(guided_angle_state.ang_vel.z) * 100.0f);
     } else {
         attitude_control->input_quaternion(guided_angle_state.attitude_quat, guided_angle_state.ang_vel);
     }


### PR DESCRIPTION
This PR adds back the ability to send body frame roll-pitch and yawrate commands with SET_ATTITUDE_TARGET message bitmask  set to 3 (IGNORE_PITCH_RATE + IGNORE_ROLL_RATE). 

Relevant issue https://github.com/ArduPilot/ardupilot/issues/20444.