### PR TITLE
AP_BattMonitor: Allow manual control of MPPT power on/off state via new param

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -47,6 +47,7 @@ BUILD_OPTIONS = [
     Feature('Battery', 'BATTMON_SMBUS', 'AP_BATTMON_SMBUS_ENABLE', 'Enable SMBUS BatteryMonitor', 0, None),
     Feature('Battery', 'BATTMON_INA2XX', 'HAL_BATTMON_INA2XX_ENABLED', 'Enable INA2XX BatteryMonitor', 0, None),
     Feature('Battery', 'BATTMON_SYNTHETIC_CURRENT', 'AP_BATTMON_SYNTHETIC_CURRENT_ENABLED', 'Enable Synthetic Current Monitor', 0, None), # noqa: E501
+    Feature('Battery', 'BATTMON_MPPT_EN_PARAM', 'AP_BATTMONITOR_UAVCAN_MPPT_USE_STATUS_AND_OVERRIDE_PARAM', 'Enable param BATTn_MPPT_EN to manually set the ON/Off power state', 0, None), # noqa: E501
 
     Feature('Ident', 'ADSB', 'HAL_ADSB_ENABLED', 'Enable ADSB', 0, None),
     Feature('Ident', 'ADSB_SAGETECH', 'HAL_ADSB_SAGETECH_ENABLED', 'Enable SageTech ADSB', 0, 'ADSB'),

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -12,6 +12,10 @@
 #define AP_BATTMONITOR_UAVCAN_MPPT_DEBUG 0
 #endif
 
+#ifndef AP_BATTMONITOR_UAVCAN_MPPT_USE_STATUS_AND_OVERRIDE_PARAM
+#define AP_BATTMONITOR_UAVCAN_MPPT_USE_STATUS_AND_OVERRIDE_PARAM (BOARD_FLASH_SIZE > 1024)
+#endif
+
 class BattInfoCb;
 class BattInfoAuxCb;
 class MpptStreamCb;
@@ -106,6 +110,9 @@ private:
     AP_Float _curr_mult;                 // scaling multiplier applied to current reports for adjustment
     // MPPT variables
     struct {
+#if AP_BATTMONITOR_UAVCAN_MPPT_USE_STATUS_AND_OVERRIDE_PARAM
+        AP_Int8 powered_state_param;
+#endif
         bool is_detected;               // true if this UAVCAN device is a Packet Digital MPPT
         bool powered_state;             // true if the mppt is powered on, false if powered off
         bool powered_state_changed;     // true if _mppt_powered_state has changed and should be sent to MPPT board


### PR DESCRIPTION
Current DroneCAN MPPT driver power ONN/OFF state is entirely event driven (boot on arm/disarm events). There is no way to manually set it on or off, for example, during flight. The PR adds a new param BATTx_MPPT_EN which shows the state of the mppt and if you change that then it sets the MPPT's state to that.

Disabled on <=1 MB boards. Uses 80 bytes flash on CubeOrange.

This is a follow on to PR https://github.com/ArduPilot/ardupilot/pull/22868 .