### PR TITLE
SIM: Log FlightAxis glitches and related data

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1220,6 +1220,14 @@ struct PACKED log_VER {
 // @Field: Total_mem: total memory usage of all scripts
 // @Field: Run_mem: run memory usage
 
+// @LoggerMessage: SIMF
+// @Description: Simulator Flight Axis Framerate/communications 
+// @Field: TimeUS: Time since system startup
+// @Field: FrameDT: Frames per Time Delta
+// @Field: DT: Time Delta
+// @Field: FPSAvg: Average Frames per second
+// @Field: Glitches: running count of glitches (>200ms)
+
 // @LoggerMessage: MOTB
 // @Description: Motor mixer information
 // @Field: TimeUS: Time since system startup


### PR DESCRIPTION
This is pretty much 'draft for comment', not ready to be merged for sure, but I think there are some good ideas here:
1. Adds logging for "SIMF" (Sim FlightAxis) including FPS and some other helpful values which can then be used to graph along with other params. 
2. Reduces the spamming of the console with FPS messages, only displays them if there have been network glitches.
3. Changes the threshold for "glitch" to 150ms which based on my own analysis (limited I guess), seems to be where logging can start to impact EKF.
4. makes the "glitch" message a bit more informative. Most importantly includes the word "network" because otherwise it could be anything.