### PR TITLE
Missions: Enhanced JUMP_TAG

### DIFF
--- a/ROMFS/scripts/jump_tags_into_wind_landing.lua
+++ b/ROMFS/scripts/jump_tags_into_wind_landing.lua
@@ -1,0 +1,84 @@
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+local MAV_CMD_NAV_LAND = 21
+
+
+local MISSION_TAG_DETERMINE_LAND_DIRECTION  = 200
+local MISSION_TAG_LAND1_DIRECTION_NORMAL    = 300
+local MISSION_TAG_LAND1_DIRECTION_REVERSE   = 301
+
+function get_bearing_of_first_land_after_tag(tag)
+
+    local index_start = mission:get_index_of_jump_tag(tag)
+    mitem_prev = mission:get_item(index_start)
+    if (not mitem_prev) then
+        return nil
+    end
+
+    for index = index_start+1, mission:num_commands()-1 do
+        mitem = mission:get_item(index)
+        if (not mitem) then
+            return nil
+        end
+        if (mitem:command() == MAV_CMD_NAV_LAND) then
+            local wp1 = Location()
+            wp1:lat(mitem_prev:x())
+            wp1:lng(mitem_prev:y())
+        
+            local wp2 = Location()
+            wp2:lat(mitem:x())
+            wp2:lng(mitem:y())
+        
+            return wp1:get_bearing(wp2)
+        end
+        mitem_prev = mitem;
+    end
+    return nil
+end
+
+function check_wind_and_jump_to_INTO_wind_landing()
+    if ((mission:get_last_jump_tag() ~= MISSION_TAG_DETERMINE_LAND_DIRECTION) or (mission:get_last_jump_tag_age() > 3)) then
+        -- we're not at the decision point yet or we saw it a while ago and we dont' care any more
+        return
+    end
+
+    local reverse_land_bearing = get_bearing_of_first_land_after_tag(MISSION_TAG_LAND1_DIRECTION_REVERSE)
+    if (not reverse_land_bearing) then
+        return
+    end
+
+    local wind = ahrs:wind_estimate()
+    local tail_wind = (math.sin(reverse_land_bearing) * wind:y()) + (math.cos(reverse_land_bearing) * wind:x())
+
+    -- we need at least 10 cm/s of tailwind. With very little wind (or a noisy 0 value) we don't want to flip around.
+    local tail_wind_threshold = 0.1
+
+    local tag
+    if (tail_wind > tail_wind_threshold) then
+        gcs:send_text(MAV_SEVERITY.INFO, "LUA: continuing with normal landing direction")
+        tag = MISSION_TAG_LAND1_DIRECTION_NORMAL
+    else
+        gcs:send_text(MAV_SEVERITY.INFO, "LUA: jump mission to other into-wind landing direction")
+        tag = MISSION_TAG_LAND1_DIRECTION_REVERSE
+    end
+
+    if (not mission:jump_to_tag(tag)) then
+        gcs:send_text(MAV_SEVERITY.WARNING, string.format("LUA: jump_to_tag %u failed", tag))
+    end
+end
+
+function update()
+    if (mission:state() ~= mission.MISSION_RUNNING) or (not arming:is_armed()) or (not vehicle:get_likely_flying()) then
+        -- only run landing mission checks if in auto with a valid mission and armed and flying.
+        return update, 5000
+    end
+
+    check_wind_and_jump_to_INTO_wind_landing()
+
+    return update, 1000
+end
+
+gcs:send_text(MAV_SEVERITY.INFO, string.format("LUA: SCRIPT START: Jump_Tag into wind landing"))
+return update() -- run immediately before starting to reschedule
+

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4148,6 +4148,7 @@ class AutoTest(ABC):
             mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH,
             mavutil.mavlink.MAV_CMD_NAV_LOITER_TIME,
             mavutil.mavlink.MAV_CMD_DO_JUMP,
+            mavutil.mavlink.MAV_CMD_DO_JUMP_TAG,
             mavutil.mavlink.MAV_CMD_DO_DIGICAM_CONTROL,
             mavutil.mavlink.MAV_CMD_DO_SET_SERVO,
             mavutil.mavlink.MAV_CMD_DO_PAUSE_CONTINUE,

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -280,6 +280,12 @@ void AP_Mission::update()
 
     update_exit_position();
 
+    // mission_change events
+    if (_last_change_time_prev_ms != _last_change_time_ms) {
+        _last_change_time_prev_ms = _last_change_time_ms;
+        on_mission_timestamp_change();
+    }
+
     // save persistent waypoint_num for watchdog restore
     hal.util->persistent_data.waypoint_num = _nav_cmd.index;
 
@@ -317,6 +323,12 @@ void AP_Mission::update()
     }
 }
 
+// handle events for when the mission has been updated (but maybe not changed)
+void AP_Mission::on_mission_timestamp_change()
+{
+    _jump_tag.age = 0;
+}
+
 bool AP_Mission::verify_command(const Mission_Command& cmd)
 {
     switch (cmd.id) {
@@ -337,6 +349,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_AUX_FUNCTION:
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
+    case MAV_CMD_JUMP_TAG:
         return true;
     default:
         return _cmd_verify_fn(cmd);
@@ -350,6 +363,11 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         set_in_landing_sequence_flag(true);
     } else if (is_takeoff_type_cmd(cmd.id)) {
         set_in_landing_sequence_flag(false);
+    }
+
+    if (_jump_tag.age > 0 && _jump_tag.age < UINT16_MAX) {
+        // we're tracking a tag so increase it's age as we execute more commands
+        _jump_tag.age++;
     }
 
     gcs().send_text(MAV_SEVERITY_INFO, "Mission: %u %s", cmd.index, cmd.type());
@@ -382,6 +400,10 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         return command_do_set_repeat_dist(cmd);
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         return start_command_do_gimbal_manager_pitchyaw(cmd);
+    case MAV_CMD_JUMP_TAG:
+        _jump_tag.tag = cmd.content.jump.target;
+        _jump_tag.age = 1;
+        FALLTHROUGH; // fall through in case the vehicle handles tag events
     default:
         return _cmd_start_fn(cmd);
     }
@@ -1044,8 +1066,13 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_DO_JUMP:                               // MAV ID: 177
-        cmd.content.jump.target = packet.param1;        // jump-to command number
+    case MAV_CMD_DO_JUMP_TAG:                           // MAV ID: 601
+        cmd.content.jump.target = packet.param1;        // jump-to command/tag number
         cmd.content.jump.num_times = packet.param2;     // repeat count
+        break;
+
+    case MAV_CMD_JUMP_TAG:                              // MAV ID: 600
+        cmd.content.jump.target = packet.param1;        // jump-to tag number
         break;
 
     case MAV_CMD_DO_CHANGE_SPEED:                       // MAV ID: 178
@@ -1528,8 +1555,13 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         break;
 
     case MAV_CMD_DO_JUMP:                               // MAV ID: 177
-        packet.param1 = cmd.content.jump.target;        // jump-to command number
+    case MAV_CMD_DO_JUMP_TAG:                           // MAV ID: 601
+        packet.param1 = cmd.content.jump.target;        // jump-to command/tag number
         packet.param2 = cmd.content.jump.num_times;     // repeat count
+        break;
+
+    case MAV_CMD_JUMP_TAG:                              // MAV ID: 600
+        packet.param1 = cmd.content.jump.target;        // jump-to tag number
         break;
 
     case MAV_CMD_DO_CHANGE_SPEED:                       // MAV ID: 178
@@ -1939,6 +1971,13 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
             return false;
         }
 
+        // check for do-jump-tag command and convert target tag to do-jump target index and do-jump to it
+        if (temp_cmd.id == MAV_CMD_DO_JUMP_TAG) {
+            // convert tmp_cmd target from a target tag to a target index
+            temp_cmd.content.jump.target = get_index_of_jump_tag(temp_cmd.content.jump.target);
+            temp_cmd.id = MAV_CMD_DO_JUMP;
+        }
+
         // check for do-jump command
         if (temp_cmd.id == MAV_CMD_DO_JUMP) {
 
@@ -2024,6 +2063,33 @@ bool AP_Mission::get_next_do_cmd(uint16_t start_index, Mission_Command& cmd)
 ///
 /// jump handling methods
 ///
+
+// Set the mission index to the first JUMP_TAG with this tag.
+// Returns true on success, else false if no appropriate JUMP_TAG match can be found or if setting the index failed
+bool AP_Mission::jump_to_tag(const uint16_t tag)
+{
+    const uint16_t index = get_index_of_jump_tag(tag);
+    if (index == 0) {
+        return false;
+    }
+    return set_current_cmd(index);
+}
+
+// find the first JUMP_TAG with this tag and return its index.
+// Returns 0 if no appropriate JUMP_TAG match can be found.
+uint16_t AP_Mission::get_index_of_jump_tag(const uint16_t tag) const
+{
+    for (uint16_t i = 1; i < (unsigned)_cmd_total; i++) {
+        Mission_Command tmp;
+        if (!read_cmd_from_storage(i, tmp)) {
+            continue;
+        }
+        if (tmp.id == MAV_CMD_JUMP_TAG && tmp.content.jump.target == tag) {
+            return i;
+        }
+    }
+    return 0;
+}
 
 // init_jump_tracking - initialise jump_tracking variables
 void AP_Mission::init_jump_tracking()
@@ -2467,6 +2533,10 @@ const char *AP_Mission::Mission_Command::type() const
         return "Scripting";
     case MAV_CMD_DO_JUMP:
         return "Jump";
+    case MAV_CMD_DO_JUMP_TAG:
+        return "JumpToTag";
+    case MAV_CMD_JUMP_TAG:
+        return "Tag";
     case MAV_CMD_DO_GO_AROUND:
         return "Go Around";
 #if AP_SCRIPTING_ENABLED

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -659,12 +659,34 @@ public:
     bool get_item(uint16_t index, mavlink_mission_item_int_t& result) const ;
     bool set_item(uint16_t index, mavlink_mission_item_int_t& source) ;
 
+    // Jump Tags. When a JUMP_TAG is run in the mission, either via DO_JUMP_TAG or
+    // by just being the next item, the tag is remembered and the age is set to 1.
+    // Only the last tag is remembered. It's age is how many times the mission
+    // index has progressed since the tag was seen. While executing the tag, the
+    // age will be 1. The command after it will tick the age to 2, and so on.
+    // The tag value is only valid if its is age > 0
+    uint16_t get_last_jump_tag() const { return _jump_tag.tag; }
+    uint16_t get_last_jump_tag_age() const { return _jump_tag.age; }
+
+    // Set the mission index to the first JUMP_TAG with this tag.
+    // Returns true on success, else false if no appropriate JUMP_TAG match can be found or if setting the index failed
+    bool jump_to_tag(const uint16_t tag);
+
+    // find the first JUMP_TAG with this tag and return its index.
+    // Returns 0 if no appropriate JUMP_TAG match can be found.
+    uint16_t get_index_of_jump_tag(const uint16_t tag) const;
+
 private:
     static AP_Mission *_singleton;
 
     static StorageAccess _storage;
 
     static bool stored_in_location(uint16_t id);
+
+    struct {
+        uint16_t age;   // a value of 0 means we have never seen a tag. Once a tag is seen, age will increment every time the mission index changes.
+        uint16_t tag;   // most recent tag that was successfully jumped to. Only valid if age > 0
+    } _jump_tag;
 
     struct Mission_Flags {
         mission_state state;
@@ -744,6 +766,8 @@ private:
     // update progress made in mission to store last position in the event of mission exit
     void update_exit_position(void);
 
+    void on_mission_timestamp_change();
+
     /// sanity checks that the masked fields are not NaN's or infinite
     static MAV_MISSION_RESULT sanity_check_params(const mavlink_mission_item_int_t& packet);
 
@@ -779,6 +803,7 @@ private:
 
     // last time that mission changed
     uint32_t _last_change_time_ms;
+    uint32_t _last_change_time_prev_ms;
 
     // memoisation of contains-relative:
     bool _contains_terrain_alt_items;  // true if the mission has terrain-relative items

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1354,6 +1354,24 @@ function mission:state() end
 ---@return boolean
 function mission:cmd_has_location(cmd)end
 
+-- desc
+---@param tag integer
+---@return boolean
+function mission:jump_to_tag(tag) end
+
+-- desc
+---@param tag integer
+---@return integer
+function mission:get_index_of_jump_tag(tag) end
+
+-- desc
+---@return integer
+function mission:get_last_jump_tag() end
+
+-- desc
+---@return integer
+function mission:get_last_jump_tag_age() end
+
 
 -- desc
 ---@class param

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -379,6 +379,10 @@ singleton AP_Mission method get_item boolean uint16_t'skip_check mavlink_mission
 singleton AP_Mission method set_item boolean uint16_t'skip_check mavlink_mission_item_int_t
 singleton AP_Mission method clear boolean
 singleton AP_Mission method cmd_has_location boolean uint16_t'skip_check
+singleton AP_Mission method jump_to_tag boolean uint16_t 0 UINT16_MAX
+singleton AP_Mission method get_index_of_jump_tag uint16_t uint16_t 0 UINT16_MAX
+singleton AP_Mission method get_last_jump_tag uint16_t
+singleton AP_Mission method get_last_jump_tag_age uint16_t
 
 
 userdata mavlink_mission_item_int_t field param1 float'skip_check read write

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4313,6 +4313,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_can(const mavlink_command_long_
 // the current waypoint, rather than this DO command.  It is hoped we
 // can move to this command in the future to avoid acknowledgement
 // issues with MISSION_SET_CURRENT
+// This also handles DO_JUMP_TAG by converting the tag to an index
+// and setting the index as if it was a normal do_set_mission_current
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_command_long_t &packet)
 {
     AP_Mission *mission = AP::mission();
@@ -4321,7 +4323,11 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
     }
 
     const uint32_t seq = (uint32_t)packet.param1;
-    if (!mission->set_current_cmd(seq)) {
+    if (packet.command == MAV_CMD_DO_JUMP_TAG) {
+        if (!mission->jump_to_tag(seq)) {
+            return MAV_RESULT_FAILED;
+        }
+    } else if (!mission->set_current_cmd(seq)) {
         return MAV_RESULT_FAILED;
     }
 
@@ -4634,6 +4640,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
         break;
 
 
+    case MAV_CMD_DO_JUMP_TAG:
     case MAV_CMD_DO_SET_MISSION_CURRENT:
         result = handle_command_do_set_mission_current(packet);
         break;


### PR DESCRIPTION
This extends PR https://github.com/ArduPilot/ardupilot/pull/22421 to give it a concept of an active jump tag for scripting.

Logic:
- we execute a DO_JUMP_TAG and jump to that tag's mission index (which completes immediately like a DO_JUMP)
- Set active flag to true
- start executing next NAV command, flag stays true
- start executing next NAV command, flag set to false


Basically, if you do a DO_JUMP_TAG then while executing the NAV you can know that you've started or triggered some sort of event.

See included lua script that uses a few tags to:
- know when we're starting to fly over the runway to start sampling lidar distance data
- know when we're done to get an avg 'true' altitude compared to baro
- offset baro altitude by that averaged alt
- check the wind and decide to continue with current landing pattern or jump to the alternate/reversed pattern/direction
