### PR TITLE
AP_PiccoloCAN: Fix ESC voltage and current telem scaling

### DIFF
--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -743,8 +743,8 @@ bool AP_PiccoloCAN::handle_esc_message(AP_HAL::CANFrame &frame)
         
         AP_ESC_Telem_Backend::TelemetryData telem {};
 
-        telem.voltage = float(esc.voltage) * 0.01f;
-        telem.current = float(esc.current) * 0.01f;
+        telem.voltage = float(esc.voltage) * 0.1f;
+        telem.current = float(esc.current) * 0.1f;
         telem.motor_temp_cdeg = int16_t(esc.motorTemperature * 100);
 
         update_telem_data(addr, telem,


### PR DESCRIPTION
ESC voltage and current were (*somehow*) both being scaled incorrectly and reporting at *0.1 the actual value. e.g. ESC at 30V, reported 3V.

Now actually follows what is defined in the protocol spec at https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_PiccoloCAN/piccolo_protocol/ESCVelocity_source.xml:

```
<Data comment="ESC Rail Voltage" inMemoryType="unsigned16" name="voltage" units="0.1V per bit" />
<Data comment="ESC Current. Current IN to the ESC is positive. Current OUT of the ESC is negative" inMemoryType="signed16" name="current" units="0.1A per bit" />
```