### PR TITLE
Scripting: added ability to generate param docs for lua applets and drivers

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -16,11 +16,12 @@ class Vehicle(object):
 
 
 class Library(object):
-    def __init__(self, name, reference=None):
+    def __init__(self, name, reference=None, not_rst=False):
         self.set_name(name)
         self.params = []
         if reference is not None:
             self.reference = reference
+        self.not_rst = not_rst
 
     def set_name(self, name):
         self.name = name

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -16,9 +16,11 @@ class Vehicle(object):
 
 
 class Library(object):
-    def __init__(self, name):
+    def __init__(self, name, reference=None):
         self.set_name(name)
         self.params = []
+        if reference is not None:
+            self.reference = reference
 
     def set_name(self, name):
         self.name = name

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -12,6 +12,7 @@ import copy
 import os
 import re
 import sys
+import glob
 from argparse import ArgumentParser
 
 from param import (Library, Parameter, Vehicle, known_group_fields,
@@ -44,7 +45,7 @@ args = parser.parse_args()
 
 # Regular expressions for parsing the parameter metadata
 
-prog_param = re.compile(r"@Param(?:{([^}]+)})?: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: ?(.*))+)(?:\n[ \t\r]*\n|\n[ \t]+[A-Z])", re.MULTILINE)  # noqa
+prog_param = re.compile(r"@Param(?:{([^}]+)})?: (\w+).*((?:\n[ \t]*// @(\w+)(?:{([^}]+)})?: ?(.*))+)(?:\n[ \t\r]*\n|\n[ \t]+[A-Z]|\n\-\-\]\])", re.MULTILINE)  # noqa
 
 # match e.g @Value: 0=Unity, 1=Koala, 17=Liability
 prog_param_fields = re.compile(r"[ \t]*// @(\w+): ?([^\r\n]*)")
@@ -80,6 +81,25 @@ def find_vehicle_parameter_filepath(vehicle_name):
 
     raise ValueError("Unable to find parameters file for (%s)" % vehicle_name)
 
+def debug(str_to_print):
+    """Debug output if verbose is set."""
+    if args.verbose:
+        print(str_to_print)
+
+def lua_applets():
+    '''return list of Library objects for lua applets and drivers'''
+    lua_lib = Library("", reference="Lua Script")
+    patterns=["libraries/AP_Scripting/applets/*.lua", "libraries/AP_Scripting/drivers/*.lua"]
+    paths = []
+    for p in patterns:
+        debug("Adding lua paths %s" % p)
+        luafiles = glob.glob(p)
+        for f in luafiles:
+            f = f.replace("libraries/", "")
+            paths.append(f)
+    setattr(lua_lib, "Path", ','.join(paths))
+    return lua_lib
+
 
 libraries = []
 
@@ -89,15 +109,11 @@ ap_vehicle_lib = Library("") # the "" is tacked onto the front of param name
 setattr(ap_vehicle_lib, "Path", os.path.join('..', 'libraries', 'AP_Vehicle', 'AP_Vehicle.cpp'))
 libraries.append(ap_vehicle_lib)
 
+libraries.append(lua_applets())
+
 error_count = 0
 current_param = None
 current_file = None
-
-
-def debug(str_to_print):
-    """Debug output if verbose is set."""
-    if args.verbose:
-        print(str_to_print)
 
 
 def error(str_to_print):

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -81,15 +81,17 @@ def find_vehicle_parameter_filepath(vehicle_name):
 
     raise ValueError("Unable to find parameters file for (%s)" % vehicle_name)
 
+
 def debug(str_to_print):
     """Debug output if verbose is set."""
     if args.verbose:
         print(str_to_print)
 
+
 def lua_applets():
     '''return list of Library objects for lua applets and drivers'''
-    lua_lib = Library("", reference="Lua Script")
-    patterns=["libraries/AP_Scripting/applets/*.lua", "libraries/AP_Scripting/drivers/*.lua"]
+    lua_lib = Library("", reference="Lua Script", not_rst=True)
+    patterns = ["libraries/AP_Scripting/applets/*.lua", "libraries/AP_Scripting/drivers/*.lua"]
     paths = []
     for p in patterns:
         debug("Adding lua paths %s" % p)
@@ -620,6 +622,8 @@ for emitter_name in emitters_to_use:
             # rename, and on the assumption that an asciibetical sort
             # gives a good layout:
             if emitter_name == 'rst':
+                if library.not_rst:
+                    continue
                 if library.name == 'SIM_':
                     library = copy.deepcopy(library)
                     library.params = sim_params

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -95,9 +95,11 @@ def lua_applets():
     paths = []
     for p in patterns:
         debug("Adding lua paths %s" % p)
-        luafiles = glob.glob(p)
+        luafiles = glob.glob(os.path.join(apm_path, p))
         for f in luafiles:
-            f = f.replace("libraries/", "")
+            # the library is expected to have the path as a relative path from within
+            # a vehicle directory
+            f = f.replace(apm_path, "../")
             paths.append(f)
     setattr(lua_lib, "Path", ','.join(paths))
     return lua_lib

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -39,17 +39,113 @@ end
 -- setup quicktune specific parameters
 assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 12), 'could not add param table')
 
+--[[
+  // @Param: QUIK_ENABLE
+  // @DisplayName: Quicktune enable
+  // @Description: Enable quicktune system
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
 local QUIK_ENABLE      = bind_add_param('ENABLE',         1, 0) 
+
+--[[
+  // @Param: QUIK_AXES
+  // @DisplayName: Quicktune axes
+  // @Description: axes to tune
+  // @Bitmask: 0:Roll,1:Pitch,2:Yaw
+  // @User: Standard
+--]]
 local QUIK_AXES        = bind_add_param('AXES',           2, 7)
+
+--[[
+  // @Param: QUIK_DOUBLE_TIME
+  // @DisplayName: Quicktune doubling time
+  // @Description: Time to double a tuning parameter. Raise this for a slower tune.
+  // @Range: 5 20
+  // @Units: s
+  // @User: Standard
+--]]
 local QUIK_DOUBLE_TIME = bind_add_param('DOUBLE_TIME',    3, 10)
+
+--[[
+  // @Param: QUIK_GAIN_MARGIN
+  // @DisplayName: Quicktune gain margin
+  // @Description: Reduction in gain after oscillation detected. Raise this number to get a more conservative tune
+  // @Range: 20 80
+  // @Units: %
+  // @User: Standard
+--]]
 local QUIK_GAIN_MARGIN = bind_add_param('GAIN_MARGIN',    4, 60)
+
+--[[
+  // @Param: QUIK_OSC_SMAX
+  // @DisplayName: Quicktune oscillation rate threshold
+  // @Description: Threshold for oscillation detection. A lower value will lead to a more conservative tune.
+  // @Range: 1 10
+  // @User: Standard
+--]]
 local QUIK_OSC_SMAX    = bind_add_param('OSC_SMAX',       5, 5)
+
+--[[
+  // @Param: QUIK_YAW_P_MAX
+  // @DisplayName: Quicktune Yaw P max
+  // @Description: Maximum value for yaw P gain
+  // @Range: 0.1 3
+  // @User: Standard
+--]]
 local QUIK_YAW_P_MAX   = bind_add_param('YAW_P_MAX',      6, 0.5)
+
+--[[
+  // @Param: QUIK_YAW_D_MAX
+  // @DisplayName: Quicktune Yaw D max
+  // @Description: Maximum value for yaw D gain
+  // @Range: 0.001 1
+  // @User: Standard
+--]]
 local QUIK_YAW_D_MAX   = bind_add_param('YAW_D_MAX',      7, 0.01)
+
+--[[
+  // @Param: QUIK_RP_PI_RATIO
+  // @DisplayName: Quicktune roll/pitch PI ratio
+  // @Description: Ratio between P and I gains for roll and pitch. Raise this to get a lower I gain
+  // @Range: 0.5 1.0
+  // @User: Standard
+--]]
 local QUIK_RP_PI_RATIO = bind_add_param('RP_PI_RATIO',    8, 1.0)
+
+--[[
+  // @Param: QUIK_Y_PI_RATIO
+  // @DisplayName: Quicktune Yaw PI ratio
+  // @Description: Ratio between P and I gains for yaw. Raise this to get a lower I gain
+  // @Range: 0.5 20
+  // @User: Standard
+--]]
 local QUIK_Y_PI_RATIO  = bind_add_param('Y_PI_RATIO',     9, 10)
+
+--[[
+  // @Param: QUIK_AUTO_FILTER
+  // @DisplayName: Quicktune auto filter enable
+  // @Description: When enabled the PID filter settings are automatically set based on INS_GYRO_FILTER
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
 local QUIK_AUTO_FILTER = bind_add_param('AUTO_FILTER',   10, 1)
+
+--[[
+  // @Param: QUIK_AUTO_SAVE
+  // @DisplayName: Quicktune auto save
+  // @Description: Number of seconds after completion of tune to auto-save. This is useful when using a 2 position switch for quicktune
+  // @Units: s
+  // @User: Standard
+--]]
 local QUIK_AUTO_SAVE   = bind_add_param('AUTO_SAVE',     11, 0)
+
+--[[
+  // @Param: QUIK_RC_FUNC
+  // @DisplayName: Quicktune RC function
+  // @Description: RCn_OPTION number to use to control tuning stop/start/save
+  // @User: Standard
+--]]
 local QUIK_RC_FUNC     = bind_add_param('RC_FUNC',       12, 300)
 
 local INS_GYRO_FILTER  = bind_param("INS_GYRO_FILTER")


### PR DESCRIPTION
This allows for parameter docs in lua applets and drivers. This will make using the applets a lot easier for users
we could get rid of the need for // in the lua docs with a bit more regex work
parameter docs added for one script (VTOL-quicktune.lua) as a test

Example output: http://uav.tridgell.net/tmp/Parameters.rst