### PR TITLE
Tools: fix show_output bug in run_program methods

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -113,7 +113,7 @@ class build_binaries(object):
                 raise Exception("BB-WAF: Missing compiler %s" % gcc_path)
         self.run_program("BB-WAF", cmd_list, env=env)
 
-    def run_program(self, prefix, cmd_list, show_output=True, env=None):
+    def run_program(self, prefix, cmd_list, show_output=True, env=None, force_success=False):
         if show_output:
             self.progress("Running (%s)" % " ".join(cmd_list))
         p = subprocess.Popen(cmd_list, bufsize=1, stdin=None,
@@ -138,7 +138,7 @@ class build_binaries(object):
             if show_output:
                 print("%s: %s" % (prefix, x))
         (_, status) = returncode
-        if status != 0 and show_output:
+        if status != 0 and not force_success:
             self.progress("Process failed (%s)" %
                           str(returncode))
             raise subprocess.CalledProcessError(
@@ -211,7 +211,12 @@ is bob we will attempt to checkout bob-AVR'''
         '''
 
         try:
-            out = self.run_program('waf', ['./waf', 'configure', '--board=BOARDTEST'], False)
+            out = self.run_program(
+                'waf',
+                ['./waf', 'configure', '--board=BOARDTEST'],
+                show_output=False,
+                force_success=True
+            )
             lines = out.split('\n')
             needles = ["BOARDTEST' (choose from", "BOARDTEST': choices are"]
             for line in lines:

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -157,7 +157,7 @@ class SizeCompareBranches(object):
             if show_output:
                 print("%s: %s" % (prefix, x))
         (_, status) = returncode
-        if status != 0 and show_output:
+        if status != 0:
             self.progress("Process failed (%s)" %
                           str(returncode))
             raise subprocess.CalledProcessError(


### PR DESCRIPTION
just because we're not showing output doesn't mean we shouldn't raise exceptions on failure!