### PR TITLE
.github: only run test on related files change

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -1,6 +1,24 @@
 name: Cygwin Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore: # ignore autotest, chibios, esp32 stuffs, .sh/md/txt files
+      - 'Tools/autotest/**'
+      - 'libraries/AP_HAL_ChibiOS/**'
+      - 'libraries/AP_HAL_ESP32/**'
+      - '**/*.sh'
+      - '**/*.md'
+      - '**/*.txt'
+  pull_request:
+    paths-ignore:
+      - 'Tools/autotest/**'
+      - 'libraries/AP_HAL_ChibiOS/**'
+      - 'libraries/AP_HAL_ESP32/**'
+      - '**/*.sh'
+      - '**/*.md'
+      - '**/*.txt'
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -1,6 +1,30 @@
 name: ESP32 Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - '.github/workflows/esp32_build.yml'
+      - 'Tools/scripts/esp32_get_idf.sh'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  pull_request:
+    paths:
+      - '.github/workflows/esp32_build.yml'
+      - 'Tools/scripts/esp32_get_idf.sh'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -1,6 +1,38 @@
 name: Macos Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - '.github/workflows/macos_build.yml'
+      - 'Tools/environment_install/install-prereqs-mac.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  pull_request:
+    paths:
+      - '.github/workflows/macos_build.yml'
+      - 'Tools/environment_install/install-prereqs-mac.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -1,9 +1,28 @@
 name: test ccache
 
-on: [push, pull_request, workflow_dispatch]
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+on:
+  push:
+    paths:
+      - '.github/workflows/test_ccache.yml'
+      - 'Tools/scripts/build_tests/test_ccache.py'
+      - 'ArduCopter/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  pull_request:
+    paths:
+      - '.github/workflows/test_ccache.yml'
+      - 'Tools/scripts/build_tests/test_ccache.py'
+      - 'ArduCopter/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -1,10 +1,54 @@
 name: test chibios
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - '.github/workflows/test_chibios.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'Tools/AP_Bootloader/**'
+      - 'Tools/AP_Periph/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/autotest/param_metadata/param_parse.py'
+      - 'Tools/scripts/configure_all.py'
+      - 'Tools/autotest/test_build_options.py'
+      - 'Tools/scripts/signing/generate_keys.py'
+      - 'Tools/scripts/build_bootloaders.py'
+      - 'Tools/scripts/signing/**'
 
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+  pull_request:
+    paths:
+      - '.github/workflows/test_chibios.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'Tools/AP_Bootloader/**'
+      - 'Tools/AP_Periph/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/autotest/param_metadata/param_parse.py'
+      - 'Tools/scripts/configure_all.py'
+      - 'Tools/autotest/test_build_options.py'
+      - 'Tools/scripts/signing/generate_keys.py'
+      - 'Tools/scripts/build_bootloaders.py'
+      - 'Tools/scripts/signing/**'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -1,9 +1,42 @@
 name: test dds
 
-on: [push, pull_request, workflow_dispatch]
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+on:
+  push:
+    paths:
+      - '.github/workflows/test_dds.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'Tools/AP_Bootloader/**'
+      - 'Tools/AP_Periph/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/autotest/param_metadata/param_parse.py'
+      - 'Tools/scripts/configure_all.py'
+      - 'Tools/autotest/test_build_options.py'
+      - 'Tools/scripts/signing/generate_keys.py'
+      - 'Tools/scripts/build_bootloaders.py'
+      - 'Tools/scripts/signing/**'
+
+  pull_request:
+    paths:
+      - '.github/workflows/test_chibios.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -3,6 +3,15 @@ on:
   schedule:
     - cron: '0 0 * * 6'  # every saturday at midnight
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/test_environment.yml'
+      - 'Tools/scripts/environment_install/**'
+
+  pull_request:
+    paths:
+      - '.github/workflows/test_environment.yml'
+      - 'Tools/scripts/environment_install/**'
 
 
 concurrency:

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -1,9 +1,40 @@
 name: test Linux SBC
 
-on: [push, pull_request, workflow_dispatch]
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+on:
+  push:
+    paths:
+      - '.github/workflows/test_linux_sbc.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/Linux_HAL_Essentials/**'
+
+  pull_request:
+    paths:
+      - '.github/workflows/test_linux_sbc.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'AntennaTracker/**'
+      - 'ArduCopter/**'
+      - 'ArduPlane/**'
+      - 'ArduSub/**'
+      - 'Rover/**'
+      - 'Blimp/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/Linux_HAL_Essentials/**'
+
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -1,26 +1,27 @@
 name: test replay
 
-on: 
+on:
   push:
-    paths-ignore: # ignore vehicle only changes
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_replay.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/Replay/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_replay.yml'
+      - 'Tools/scripts/build_ci.sh'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - 'Tools/Replay/**'
 
   workflow_dispatch:
-
 
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -2,20 +2,43 @@ name: test copter
 
 on:
   push:
-    paths-ignore: # ignore vehicle only changes not for copter
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
+    paths:
+      - '.github/workflows/test_sitl_copter.yml'
+      - 'ArduCopter/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/arducopter.py'
+      - 'Tools/autotest/helicopter.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes not for copter
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
+    paths:
+      - '.github/workflows/test_sitl_copter.yml'
+      - 'ArduCopter/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/arducopter.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -2,22 +2,28 @@ name: test ap_periph
 
 on: 
   push:
-    paths-ignore: # ignore vehicle only changes
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_periph.yml'
+      - 'Tools/AP_Periph/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/autotest/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_periph.yml'
+      - 'Tools/AP_Periph/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/autotest/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'wscript'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -1,21 +1,45 @@
 name: test plane
 
-on: 
+on:
   push:
-    paths-ignore: # ignore vehicle only changes not for plane
-      - 'AntennaTracker/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_plane.yml'
+      - 'ArduPlane/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/arduplane.py'
+      - 'Tools/autotest/quadplane.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes not for plane
-      - 'AntennaTracker/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_plane.yml'
+      - 'ArduPlane/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/arduplane.py'
+      - 'Tools/autotest/quadplane.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -1,21 +1,47 @@
 name: test rover
 
-on: 
+on:
   push:
-    paths-ignore: # ignore vehicle only changes not for rover
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_rover.yml'
+      - 'Rover/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/rover.py'
+      - 'Tools/autotest/sailboat.py'
+      - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes not for rover
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_rover.yml'
+      - 'Rover/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/rover.py'
+      - 'Tools/autotest/sailboat.py'
+      - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -2,20 +2,42 @@ name: test sub
 
 on:
   push:
-    paths-ignore: # ignore vehicle only changes not for sub
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_sub.yml'
+      - 'ArduSub/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/ardusub.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes not for sub
-      - 'AntennaTracker/**'
-      - 'ArduPlane/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_sub.yml'
+      - 'ArduSub/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/ardusub.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -2,20 +2,42 @@ name: test tracker
 
 on: 
   push:
-    paths-ignore: # ignore vehicle only changes
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_tracker.yml'
+      - 'AntennaTracker/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/antennatracker.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   pull_request:
-    paths-ignore: # ignore vehicle only changes
-      - 'ArduPlane/**'
-      - 'ArduSub/**'
-      - 'Rover/**'
-      - 'Blimp/**'
-      - 'ArduCopter/**'
+    paths:
+      - '.github/workflows/test_sitl_tracker.yml'
+      - 'AntennaTracker/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'Tools/ardupilotwaf/**'
+      - 'Tools/autotest/**/*.py'
+      - '!Tools/autotest/*.py'
+      - 'Tools/autotest/antennatracker.py'
+      - 'Tools/autotest/autotest.py'
+      - 'Tools/autotest/common.py'
+      - 'Tools/autotest/**/*.txt'
+      - 'wscript'
+      - '!Tools/autotest/location.txt'
+      - '!Tools/autotest/swarminit.txt'
+      - '!libraries/AP_HAL_ChibiOS/**'
+      - '!libraries/AP_HAL_ESP32/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -1,9 +1,12 @@
 name: test size
 
-on: [pull_request]
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+on:
+  pull_request:
+    paths-ignore:  # ignore autotest stuffs
+      - 'Tools/autotest/**'
+  workflow_dispatch:
+
+
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This run CI test only when the file in the selected path are modified. That will speed up CI greatly by not launching all test each time we got a PR.
For example a readme change won't run any test.
Change in autotest/arducopter.py, will just run the copter test and not chibios build

This need carefull review and testing. I have already done some testing and it working but I could have forget some path to check on the differents workfow.