### PR TITLE
AP_Scripting: add luacheck lua linter CI, and fix all current warnings

### DIFF
--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -1,15 +1,17 @@
-name: test scripting docs
+name: test scripting
 
 on:
   push:
     paths: # only run for scripting changes
       - 'libraries/AP_Scripting/tests/docs_check.py'
       - 'libraries/AP_Scripting/generator/**'
+      - '**.lua'
 
   pull_request:
     paths: # only run for scripting changes
       - 'libraries/AP_Scripting/tests/docs_check.py'
       - 'libraries/AP_Scripting/generator/**'
+      - '**.lua'
 
   workflow_dispatch:
 
@@ -18,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-scripting-docs:
+  test-scripting:
     runs-on: ubuntu-20.04
     container: ardupilot/ardupilot-dev-base:latest
     steps:
@@ -26,6 +28,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+
+      - name: Lua Linter
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install lua-check
+          ./Tools/scripts/run_luacheck.sh
 
       - name: copy docs
         run: |

--- a/Tools/scripts/run_luacheck.sh
+++ b/Tools/scripts/run_luacheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run lua check for all lua files passing AP specific config
+
+cd "$(dirname "$0")"
+cd ../..
+
+luacheck */ --config libraries/AP_Scripting/tests/luacheck.lua

--- a/libraries/AP_HAL_ChibiOS/hwdef/HerePro/scripts/hereproled.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HerePro/scripts/hereproled.lua
@@ -1,4 +1,5 @@
 -- This script is a test of led override
+-- luacheck: only 0
 
 local count = 0
 local num_leds = 16

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
@@ -5,6 +5,7 @@ cmd = 3: rolling circle, arg1 = yaw rate, arg2 = roll rate
 cmd = 4: knife edge at any angle, arg1 = roll angle to hold, arg2 = duration
 cmd = 5: pause, holding heading and alt to allow stabilization after a move, arg1 = duration in seconds
 ]]--
+-- luacheck: only 0
 
 DO_JUMP = 177
 k_throttle = 70

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -4,6 +4,7 @@
    Written by Matthew Hampsey, Andy Palmer and Andrew Tridgell, with controller
    assistance from Paul Riseborough, testing by Henry Wurzburg
 ]]--
+-- luacheck: only 0
 
 -- setup param block for aerobatics, reserving 30 params beginning with AERO_
 local PARAM_TABLE_KEY = 70

--- a/libraries/AP_Scripting/applets/Heli_IM_COL_Tune.lua
+++ b/libraries/AP_Scripting/applets/Heli_IM_COL_Tune.lua
@@ -4,6 +4,7 @@
 -- this pot to adjust the sensitivity of the collective about the collective midstick.  The 2nd Pot then controls
 -- the value of the 50% point on the curve.  This can be used to set the collective position to aid with hovering 
 -- at the midstick.
+-- luacheck: only 0
 
 -- Tested and working as of 25th Aug 2020 (Copter Dev)
 

--- a/libraries/AP_Scripting/applets/Hexsoon LEDs.lua
+++ b/libraries/AP_Scripting/applets/Hexsoon LEDs.lua
@@ -25,6 +25,7 @@ LEDs should now work!, if not try swapping AUX 5 and 6, either by physically swa
 To get colours to match either change the ordering in "local led_map ="  below or swap headers round on the LED distribution board
 If using 6 les add two extra colours to "local led_map =" e.g:  "local led_map = {red, red, red, green, green, green}"
 --]]
+-- luacheck: only 0
 
 -- helper colours, red, green, blue values from 0 to 255
 local red   = {255, 0,   0}

--- a/libraries/AP_Scripting/applets/MissionSelector.lua
+++ b/libraries/AP_Scripting/applets/MissionSelector.lua
@@ -2,6 +2,7 @@
 -- Must have Mission Reset switch assigned, it will function normally when armed or disarmed
 -- but also on the disarm to arm transition, it will load (if file exists) a file in the root named
 -- missionH.txt, missionM.txt, or missionH.txt corresponding to the the Mission Reset switch position of High/Mid/Low
+-- luacheck: only 0
 
 local mission_loaded = false
 local rc_switch = rc:find_channel_for_option(24)  --AUX FUNC sw for mission restart

--- a/libraries/AP_Scripting/applets/Script_Controller.lua
+++ b/libraries/AP_Scripting/applets/Script_Controller.lua
@@ -2,6 +2,7 @@
    a script to select other lua scripts using an auxillary switch from
     /1 /2 or /3 subdirectories of the scripts directory
 --]]
+-- luacheck: only 0
 
 local THIS_SCRIPT = "Script_Controller.lua"
 local sel_ch = Parameter("SCR_USER6")

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -5,6 +5,8 @@
  for copters, although it will work in other VTOL modes
 
 --]]
+-- luacheck: only 0
+
 
 --[[
  - TODO:

--- a/libraries/AP_Scripting/applets/forward_flight_motor_shutdown.lua
+++ b/libraries/AP_Scripting/applets/forward_flight_motor_shutdown.lua
@@ -4,6 +4,8 @@
 -- Throttle thresholds also allow automatic enable and disable of stop motors
 -- slew up and down times allow to configure how fast the motors are disabled and re-enabled
 
+-- luacheck: only 0
+
 -- Config
 
 -- Motors numbers to stop

--- a/libraries/AP_Scripting/applets/plane_package_place.lua
+++ b/libraries/AP_Scripting/applets/plane_package_place.lua
@@ -1,6 +1,8 @@
 --[[
  support package place for quadplanes
 --]]
+-- luacheck: only 0
+
 
 local PARAM_TABLE_KEY = 9
 local PARAM_TABLE_PREFIX = "PKG_"

--- a/libraries/AP_Scripting/applets/plane_ship_landing.lua
+++ b/libraries/AP_Scripting/applets/plane_ship_landing.lua
@@ -1,4 +1,5 @@
 -- support takeoff and landing on moving platforms for VTOL planes
+-- luacheck: only 0
 
 local PARAM_TABLE_KEY = 7
 local PARAM_TABLE_PREFIX = "SHIP_"

--- a/libraries/AP_Scripting/applets/runcam_on_arm.lua
+++ b/libraries/AP_Scripting/applets/runcam_on_arm.lua
@@ -19,6 +19,8 @@
 -- presses, I want the script to be responsive and start recording as
 -- soon as the vehicle arms, so there I use a shorter delay.
 
+-- luacheck: only 0
+
 
 -- constants
 local RC_OPTION = {RunCamControl=78}

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2,6 +2,8 @@
 -- This file should be auto generated and then manual edited
 -- generate with --scripting-docs, eg  ./waf copter --scripting-docs
 -- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations
+-- luacheck: ignore 212 (Unused argument)
+-- luacheck: ignore 241 (Local variable is mutated but never accessed)
 
 -- set and get for field types share function names
 ---@diagnostic disable: duplicate-set-field

--- a/libraries/AP_Scripting/drivers/EFI_HFE.lua
+++ b/libraries/AP_Scripting/drivers/EFI_HFE.lua
@@ -1,6 +1,8 @@
 --[[ 
   EFI Scripting backend driver for HFE based on HFEDCN0191 Rev E
 --]]
+-- luacheck: only 0
+
 
 -- Check Script uses a miniumum firmware version
 local SCRIPT_AP_VERSION = 4.3

--- a/libraries/AP_Scripting/drivers/EFI_SkyPower.lua
+++ b/libraries/AP_Scripting/drivers/EFI_SkyPower.lua
@@ -11,6 +11,7 @@ CAN_P1_DRIVER 1 (First driver)
 CAN_D1_BITRATE 500000 (500 kbit/s)
 
 --]]
+-- luacheck: only 0
 
 -- Check Script uses a miniumum firmware version
 local SCRIPT_AP_VERSION = 4.3

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -1,4 +1,5 @@
 -- mount-djirs2-driver.lua: DJIRS2 mount/gimbal driver
+-- luacheck: only 0
 
 --[[
   How to use

--- a/libraries/AP_Scripting/examples/LED_matrix_image.lua
+++ b/libraries/AP_Scripting/examples/LED_matrix_image.lua
@@ -2,6 +2,7 @@
 Script to control LED strips based on the roll of the aircraft. This is an example to demonstrate
 the LED interface for WS2812 LEDs
 --]]
+-- luacheck: only 0
 
 --[[
 for this demo we will use a single strip with 30 LEDs

--- a/libraries/AP_Scripting/examples/LED_matrix_text.lua
+++ b/libraries/AP_Scripting/examples/LED_matrix_text.lua
@@ -2,6 +2,7 @@
 Script to control LED strips based on the roll of the aircraft. This is an example to demonstrate
 the LED interface for WS2812 LEDs
 --]]
+-- luacheck: only 0
 
 --[[
 for this demo we will use a single strip with 30 LEDs

--- a/libraries/AP_Scripting/examples/LED_roll.lua
+++ b/libraries/AP_Scripting/examples/LED_roll.lua
@@ -2,6 +2,8 @@
 Script to control LED strips based on the roll of the aircraft. This is an example to demonstrate
 the LED interface for WS2812 LEDs
 --]]
+-- luacheck: only 0
+
 
 --[[
 for this demo we will use a single strip with 30 LEDs

--- a/libraries/AP_Scripting/examples/NMEA-decode.lua
+++ b/libraries/AP_Scripting/examples/NMEA-decode.lua
@@ -1,4 +1,5 @@
 -- Script decodes, checks and prints NMEA messages
+-- luacheck: only 0
 
 -- find the serial first (0) scripting serial port instance
 local port = serial:find_serial(0)

--- a/libraries/AP_Scripting/examples/OOP_example.lua
+++ b/libraries/AP_Scripting/examples/OOP_example.lua
@@ -1,4 +1,5 @@
 -- this is an example of how to do object oriented programming in Lua
+-- luacheck: only 0
 
 function constrain(v, minv, maxv)
    -- constrain a value between two limits

--- a/libraries/AP_Scripting/examples/Serial_Dump.lua
+++ b/libraries/AP_Scripting/examples/Serial_Dump.lua
@@ -1,4 +1,6 @@
 -- this script reads data from a serial port and dumps it to a file
+-- luacheck: only 0
+
 local file_name = 'raw serial dump.txt'
 local file_name_plain = 'serial dump.txt'
 local baud_rate = 9600

--- a/libraries/AP_Scripting/examples/ahrs-source-gps-optflow.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source-gps-optflow.lua
@@ -26,6 +26,7 @@
 -- SCR_USER4 holds the threshold for optical flow innovations (about 0.15 is a good choice)
 --
 -- When the 2nd auxiliary switch (300/Scripting1) is pulled high automatic source selection uses these thresholds:
+-- luacheck: only 0
 
 local rangefinder_rotation = 25     -- check downward (25) facing lidar
 local source_prev = 0               -- previous source, defaults to primary source

--- a/libraries/AP_Scripting/examples/ahrs-source-gps-wheelencoders.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source-gps-wheelencoders.lua
@@ -9,6 +9,7 @@
 -- SCR_USER3 holds the threshold for GPS innovations (around 0.3 is a good choice)
 --     if GPS speed accuracy <= SCR_USER2 and GPS innovations <= SRC_USER3 then the GPS (primary source set) will be used
 --     otherwise wheel encoders (secondary source set) will be used
+-- luacheck: only 0
 
 local source_prev = 0               -- previous source, defaults to primary source
 local sw_source_prev = -1           -- previous source switch position

--- a/libraries/AP_Scripting/examples/ahrs-source.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source.lua
@@ -14,6 +14,7 @@
 -- SCR_USER3 holds the threshold for Non-GPS vertical speed innovation (about 0.3 is a good choice)
 --     if both GPS speed accuracy <= SCR_USER2 and ExternalNav speed variance >= SCR_USER3, source1 will be used
 --     otherwise source2 (T265) or source3 (optical flow) will be used based on rangefinder distance
+-- luacheck: only 0
 
 local rangefinder_rotation = 25     -- check downward (25) facing lidar
 local source_prev = 0               -- previous source, defaults to primary source

--- a/libraries/AP_Scripting/examples/aux_cached.lua
+++ b/libraries/AP_Scripting/examples/aux_cached.lua
@@ -1,6 +1,8 @@
 --[[ 
    example for getting cached aux function value
 --]]
+-- luacheck: only 0
+
 
 local RATE_HZ = 10
 

--- a/libraries/AP_Scripting/examples/copter-deadreckon-home.lua
+++ b/libraries/AP_Scripting/examples/copter-deadreckon-home.lua
@@ -55,6 +55,8 @@
 --   a. SIM_WIND_DIR <-- sets direction wind is coming from
 --   b. SIM_WIND_SPD <-- sets wind speed in m/s
 --
+-- luacheck: only 0
+
 
 -- create and initialise parameters
 local PARAM_TABLE_KEY = 86  -- parameter table key must be used by only one script on a particular flight controller

--- a/libraries/AP_Scripting/examples/copy_userdata.lua
+++ b/libraries/AP_Scripting/examples/copy_userdata.lua
@@ -1,6 +1,7 @@
 --[[
  An example of using the copy() method on userdata
 --]]
+-- luacheck: only 0
 
 
 local loc1 = Location()

--- a/libraries/AP_Scripting/examples/frsky_wp.lua
+++ b/libraries/AP_Scripting/examples/frsky_wp.lua
@@ -17,6 +17,7 @@
   For this test we'll use sensor ID 17 (0x71),
   Note: 17 is the index, 0x71 is the actual ID
 --]]
+-- luacheck: only 0
 
 local loop_time = 1000 -- number of ms between runs
 

--- a/libraries/AP_Scripting/examples/gen_control.lua
+++ b/libraries/AP_Scripting/examples/gen_control.lua
@@ -5,6 +5,8 @@
    generators. It monitors battery voltage and controls the throttle
    of the generator to maintain a target voltage using a PI controller
 --]]
+-- luacheck: only 0
+
 
 UPDATE_RATE_HZ = 10
 

--- a/libraries/AP_Scripting/examples/mission-edit-demo.lua
+++ b/libraries/AP_Scripting/examples/mission-edit-demo.lua
@@ -1,5 +1,7 @@
 -- mission editing demo lua script.
 -- by Buzz 2020
+-- luacheck: only 0
+
 current_pos = nil
 home = 0
 a = {}

--- a/libraries/AP_Scripting/examples/mission-load.lua
+++ b/libraries/AP_Scripting/examples/mission-load.lua
@@ -1,5 +1,6 @@
 -- Example of loading a mission from the SD card using Scripting
 -- Would be trivial to select a mission based on scripting params or RC switch
+-- luacheck: only 0
 
 
 

--- a/libraries/AP_Scripting/examples/mount-poi.lua
+++ b/libraries/AP_Scripting/examples/mount-poi.lua
@@ -18,6 +18,7 @@
 --   9. repeat step 6, 7 and 8 until the test_loc's altitude falls below the terrain altitude
 --  10. interpolate between test_loc and prev_test_loc to find the lat, lon, alt (above sea-level) where alt-above-terrain is zero
 --  11. display the POI to the user
+-- luacheck: only 0
 
 -- global definitions
 local ALT_FRAME_ABSOLUTE = 0

--- a/libraries/AP_Scripting/examples/opendog_demo.lua
+++ b/libraries/AP_Scripting/examples/opendog_demo.lua
@@ -1,5 +1,6 @@
 -- demo of waving paw of opendog
---
+-- luacheck: only 0
+
 local flipflop = true
 
 pwm = { 1500, 1500, 2000,

--- a/libraries/AP_Scripting/examples/param_get_set_test.lua
+++ b/libraries/AP_Scripting/examples/param_get_set_test.lua
@@ -1,4 +1,6 @@
 -- This script is a test of param set and get
+-- luacheck: only 0
+
 local count = 0
 
 -- for fast param acess it is better to get a param object,

--- a/libraries/AP_Scripting/examples/plane-doublets.lua
+++ b/libraries/AP_Scripting/examples/plane-doublets.lua
@@ -7,6 +7,7 @@
 -- It is suggested to allow the aircraft to trim for straight, level, unaccelerated flight (SLUF) in FBWB mode before
 -- starting a doublet
 -- Charlie Johnson, Oklahoma State University 2020
+-- luacheck: only 0
 
 local DOUBLET_ACTION_CHANNEL = 6 -- RCIN channel to start a doublet when high (>1700)
 local DOUBLET_CHOICE_CHANNEL = 7 -- RCIN channel to choose elevator (low) or rudder (high)

--- a/libraries/AP_Scripting/examples/plane-wind-failsafe.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-failsafe.lua
@@ -1,6 +1,7 @@
 -- warn the user if wind speed exceeds a threshold, failsafe if a second threshold is exceeded
 
 -- note that this script is only intended to be run on ArduPlane
+-- luacheck: only 0
 
 -- tuning parameters
 local warn_speed = 10 -- metres/second

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -2,6 +2,7 @@
 -- the average battery consumption, and the wind to decide when to failsafe
 --
 -- CAUTION: This script only works for Plane
+-- luacheck: only 0
 
 -- store the batt info as { instance, filtered, capacity, margin_mah }
 -- instance: the battery monitor instance (zero indexed)

--- a/libraries/AP_Scripting/examples/plane_guided_follow.lua
+++ b/libraries/AP_Scripting/examples/plane_guided_follow.lua
@@ -1,4 +1,5 @@
 -- support follow in GUIDED mode in plane
+-- luacheck: only 0
 
 local PARAM_TABLE_KEY = 11
 local PARAM_TABLE_PREFIX = "GFOLL_"

--- a/libraries/AP_Scripting/examples/protected_call.lua
+++ b/libraries/AP_Scripting/examples/protected_call.lua
@@ -1,6 +1,7 @@
 -- this shows how to protect against faults in your scripts
 -- you can wrap your update() call (or any other call) in a pcall()
 -- which catches errors, allowing you to take an appropriate action
+-- luacheck: only 0
 
 
 -- example main loop function

--- a/libraries/AP_Scripting/examples/quadruped.lua
+++ b/libraries/AP_Scripting/examples/quadruped.lua
@@ -18,6 +18,7 @@
 -- Output12: back right tibia (shin) servo
 --
 -- CAUTION: This script should only be used with ArduPilot Rover's firmware
+-- luacheck: only 0
 
 
 local FRAME_LEN = 80    -- frame length in mm

--- a/libraries/AP_Scripting/examples/rangefinder_test.lua
+++ b/libraries/AP_Scripting/examples/rangefinder_test.lua
@@ -1,4 +1,5 @@
 -- This script checks RangeFinder
+-- luacheck: only 0
 
 local rotation_downward = 25
 local rotation_forward = 0

--- a/libraries/AP_Scripting/examples/rover-SaveTurns.lua
+++ b/libraries/AP_Scripting/examples/rover-SaveTurns.lua
@@ -11,6 +11,7 @@ of a vehicle.  Use this script AT YOUR OWN RISK.
 
 LICENSE - GNU GPLv3 https://www.gnu.org/licenses/gpl-3.0.en.html
 ------------------------------------------------------------------------------]]
+-- luacheck: only 0
 
 local SCRIPT_NAME = 'SaveTurns'
 

--- a/libraries/AP_Scripting/examples/set-target-location.lua
+++ b/libraries/AP_Scripting/examples/set-target-location.lua
@@ -5,6 +5,7 @@
 --    a) switches to Guided mode
 --    b) sets the target location to be 10m above home
 --    c) switches the vehicle to land once it is within a couple of meters of home
+-- luacheck: only 0
 
 local wp_radius = 2
 local target_alt_above_home = 10

--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -7,6 +7,7 @@
 --      2) switch to GUIDED mode 
 --      3) the vehilce will follow a circle in clockwise direction with increasing speed until ramp_up_time_s time has passed.
 --      4) switch out of and into the GUIDED mode any time to restart the trajectory from the start.
+-- luacheck: only 0
 
 -- Edit these variables
 local rad_xy_m = 10.0   -- circle radius in xy plane in m

--- a/libraries/AP_Scripting/examples/terrain_warning.lua
+++ b/libraries/AP_Scripting/examples/terrain_warning.lua
@@ -1,4 +1,5 @@
 -- height above terrain warning script
+-- luacheck: only 0
 
 -- min altitude above terrain, script will warn if lower than this
 local terrain_min_alt = 20

--- a/libraries/AP_Scripting/examples/test_load.lua
+++ b/libraries/AP_Scripting/examples/test_load.lua
@@ -7,6 +7,8 @@ gcs:send_text(0,"Testing load() method")
 -- a function written as a string. This could come from a file
 -- or any other source (eg. mavlink)
 -- Note that the [[ xxx ]] syntax is just a multi-line string
+-- luacheck: only 0
+
 local func_str = [[
 function TestFunc(x,y)
   return math.sin(x) + math.cos(y)

--- a/libraries/AP_Scripting/examples/wp_test.lua
+++ b/libraries/AP_Scripting/examples/wp_test.lua
@@ -1,4 +1,5 @@
 -- Example script for accessing waypoint info
+-- luacheck: only 0
 
 local wp_index
 local wp_distance

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2898,7 +2898,9 @@ int main(int argc, char **argv) {
   fprintf(docs, "-- ArduPilot lua scripting documentation in EmmyLua Annotations\n");
   fprintf(docs, "-- This file should be auto generated and then manual edited\n");
   fprintf(docs, "-- generate with --scripting-docs, eg  ./waf copter --scripting-docs\n");
-  fprintf(docs, "-- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations\n\n");
+  fprintf(docs, "-- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations\n");
+  fprintf(docs, "-- luacheck: ignore 212 (Unused argument)\n");
+  fprintf(docs, "-- luacheck: ignore 241 (Local variable is mutated but never accessed)\n\n");
 
   emit_docs(parsed_userdata, TRUE, TRUE);
 

--- a/libraries/AP_Scripting/tests/luacheck.lua
+++ b/libraries/AP_Scripting/tests/luacheck.lua
@@ -1,0 +1,12 @@
+
+-- Don't check globals yet. This requires us to add a list of all the AP bindings
+global = false
+
+-- https://luacheck.readthedocs.io/en/stable/warnings.html
+ignore = {"631", -- Line is too long
+          "611", -- A line consists of nothing but whitespace.
+          "612", -- A line contains trailing whitespace.
+          "614"} -- Trailing whitespace in a comment.
+
+-- These lua scripts are not for running on AP
+exclude_files = {"Tools/CHDK-Scripts/*", "modules/*"}

--- a/libraries/AP_Scripting/tests/math.lua
+++ b/libraries/AP_Scripting/tests/math.lua
@@ -27,6 +27,12 @@
 
 -- This code is copied from https://github.com/lua/tests and slightly modified to work within ArduPilot
 
+-- luacheck: ignore 211 (Unused local variable)
+-- luacheck: ignore 213 (Unused loop variable)
+-- luacheck: ignore 411 (Redefining a local variable)
+-- luacheck: ignore 421 (Shadowing a local variable)
+-- luacheck: ignore 581 (Negation of a relational operator - operator can be flipped)
+
 gcs:send_text(6, "testing numbers and math lib")
 
 local minint = math.mininteger

--- a/libraries/AP_Scripting/tests/strings.lua
+++ b/libraries/AP_Scripting/tests/strings.lua
@@ -27,6 +27,8 @@
 
 -- This code is copied from https://github.com/lua/tests and slightly modified to work within ArduPilot
 
+-- luacheck: ignore 581 (Negation of a relational operator - operator can be flipped)
+
 gcs:send_text(6, 'testing strings and string library')
 
 local maxi, mini = math.maxinteger, math.mininteger


### PR DESCRIPTION
Adds a luacheck config and then uses that as part of CI meaning CI will fail for bad lua. EG these are all the warnings on current master [Total: 1105 warnings / 0 errors in 127 files](https://github.com/IamPete1/ardupilot/actions/runs/4137833751/jobs/7153492319)

Not a complete check yet as this currently ignores globals, some extra config is needed to tell luacheck about the extra bindings we have. https://github.com/ArduPilot/ardupilot/issues/15014

I have fixed all the warnings in our current scripts. Mostly by just fixing them but in some-cases adding `-- luacheck: ignore`. I have globally turned off some white space checks, and a line length check. I have not tested any of the fixes, if there is a desire for significant testing I would prefer that we just add ignores everywhere and then fix them one at a time as we update scripts.

Luacheck docs: https://luacheck.readthedocs.io/en/stable/index.html

You can run locally with `luacheck */ --config libraries/AP_Scripting/tests/luacheck.lua` to check everything. Or for example `luacheck libraries/AP_Scripting/examples/simple_loop.lua --config libraries/AP_Scripting/tests/luacheck.lua` to check a particular file.