### PR TITLE
[Backport] AP_HAL_ChibiOS: add HAL_WITH_MCU_MONITORING define for H757

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
@@ -69,6 +69,7 @@ mcu = {
 
     'DEFINES' : {
         'HAL_HAVE_HARDWARE_DOUBLE' : '1',
+        'HAL_WITH_MCU_MONITORING' : '1',
         'STM32H7' : '1',
     }
 }


### PR DESCRIPTION
* Did bench test to see if MCU Voltage for H757 show up on CubeOrangePlus