### PR TITLE
Add and use waf argument to get consistent builds 

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -456,6 +456,16 @@ class Board:
         if cfg.options.ekf_single:
             env.CXXFLAGS += ['-DHAL_WITH_EKF_DOUBLE=0']
 
+        if cfg.options.consistent_builds:
+            # squash all line numbers to be the number 17
+            env.CXXFLAGS += [
+                "-D__AP_LINE__=17",
+            ]
+        else:
+            env.CXXFLAGS += [
+                "-D__AP_LINE__=__LINE__",
+            ]
+
         # add files from ROMFS_custom
         custom_dir = 'ROMFS_custom'
         if os.path.exists(custom_dir):

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -56,6 +56,7 @@ class SizeCompareBranches(object):
                  all_vehicles=False,
                  all_boards=False,
                  use_merge_base=True,
+                 waf_consistent_builds=True,
                  extra_hwdef=[],
                  extra_hwdef_branch=[],
                  extra_hwdef_master=[]):
@@ -74,6 +75,7 @@ class SizeCompareBranches(object):
         self.all_vehicles = all_vehicles
         self.all_boards = all_boards
         self.use_merge_base = use_merge_base
+        self.waf_consistent_builds = waf_consistent_builds
 
         if self.bin_dir is None:
             self.bin_dir = self.find_bin_dir()
@@ -220,6 +222,8 @@ class SizeCompareBranches(object):
         self.run_git(["submodule", "update", "--recursive"])
         shutil.rmtree("build", ignore_errors=True)
         waf_configure_args = ["configure", "--board", board]
+        if self.waf_consistent_builds:
+            waf_configure_args.append("--consistent-builds")
 
         if extra_hwdef is not None:
             waf_configure_args.extend(["--extra-hwdef", extra_hwdef])
@@ -426,6 +430,11 @@ if __name__ == '__main__':
                       default=False,
                       help="do not use the merge-base for testing, do a direct comparison between branches")
     parser.add_option("",
+                      "--no-waf-consistent-builds",
+                      action="store_true",
+                      default=False,
+                      help="do not use the --consistent-builds waf command-line option (for older branches)")
+    parser.add_option("",
                       "--branch",
                       type="string",
                       default=None,
@@ -491,5 +500,6 @@ if __name__ == '__main__':
         all_vehicles=cmd_opts.all_vehicles,
         all_boards=cmd_opts.all_boards,
         use_merge_base=not cmd_opts.no_merge_base,
+        waf_consistent_builds=not cmd_opts.no_waf_consistent_builds,
     )
     x.run()

--- a/libraries/AP_HAL/Semaphores.h
+++ b/libraries/AP_HAL/Semaphores.h
@@ -51,6 +51,7 @@ private:
 };
 
 // From: https://stackoverflow.com/questions/19666142/why-is-a-level-of-indirection-needed-for-this-concatenation-macro
-#define WITH_SEMAPHORE( sem ) JOIN( sem, __LINE__, __COUNTER__ )
+#define WITH_SEMAPHORE( sem ) JOIN( sem, __AP_LINE__, __COUNTER__ )
+
 #define JOIN( sem, line, counter ) _DO_JOIN( sem, line, counter )
 #define _DO_JOIN( sem, line, counter ) WithSemaphore _getsem ## counter(sem, line)

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -112,4 +112,4 @@ extern "C" {
 }
 
 #define INTERNAL_ERROR(error_number) \
-    AP::internalerror().error(error_number, __LINE__);
+    AP::internalerror().error(error_number, __AP_LINE__);

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -171,8 +171,8 @@ T constrain_value(const T amt, const T low, const T high);
 template <typename T>
 T constrain_value_line(const T amt, const T low, const T high, uint32_t line);
 
-#define constrain_float(amt, low, high) constrain_value_line(float(amt), float(low), float(high), uint32_t(__LINE__))
-#define constrain_ftype(amt, low, high) constrain_value_line(ftype(amt), ftype(low), ftype(high), uint32_t(__LINE__))
+#define constrain_float(amt, low, high) constrain_value_line(float(amt), float(low), float(high), uint32_t(__AP_LINE__))
+#define constrain_ftype(amt, low, high) constrain_value_line(ftype(amt), ftype(low), ftype(high), uint32_t(__AP_LINE__))
 
 inline int16_t constrain_int16(const int16_t amt, const int16_t low, const int16_t high)
 {

--- a/wscript
+++ b/wscript
@@ -362,7 +362,12 @@ configuration in order to save typing.
         action='store_true',
         default=False,
         help='force single precision postype_t')
-    
+
+    g.add_option('--consistent-builds',
+        action='store_true',
+        default=False,
+        help='force consistent build outputs for things like __LINE__')
+
     g.add_option('--extra-hwdef',
 	    action='store',
 	    default=None,


### PR DESCRIPTION
This stops us using `__LINE__` in three places when building, which means vertical whitespace and ineffective pragma changes don't modify the build output.

Used to create output on https://github.com/ArduPilot/ardupilot/pull/22893

(edited to make this less confusing, @andyp1per )
