### PR TITLE
AP_IOMCU: fixed an issue with double reset of IOMCU

### DIFF
--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -161,6 +161,7 @@ private:
     uint32_t last_rc_read_ms;
     uint32_t last_servo_read_ms;
     uint32_t last_safety_option_check_ms;
+    uint32_t last_reg_read_ms;
 
     // last value of safety options
     uint16_t last_safety_options = 0xFFFF;

--- a/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
+++ b/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
@@ -41,8 +41,13 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-// enable testing of IOMCU watchdog using safety switch
-#define IOMCU_ENABLE_WATCHDOG_TEST 0
+/*
+ enable testing of IOMCU reset using safety switch
+ a value of 0 means normal operation
+ a value of 1 means test with watchdog
+ a value of 2 means test with reboot
+*/
+#define IOMCU_ENABLE_RESET_TEST 0
 
 // pending events on the main thread
 enum ioevents {
@@ -707,21 +712,40 @@ void AP_IOMCU_FW::safety_update(void)
         }
     }
 
-#if IOMCU_ENABLE_WATCHDOG_TEST
-    if (safety_button_counter == 50) {
+#if IOMCU_ENABLE_RESET_TEST
+    {
         // deliberate lockup of IOMCU on 5s button press, for testing
         // watchdog
-        while (true) {
-            hal.scheduler->delay(50);
-            palToggleLine(HAL_GPIO_PIN_SAFETY_LED);
-            if (palReadLine(HAL_GPIO_PIN_SAFETY_INPUT)) {
-                // only trigger watchdog on button release, so we
-                // don't end up stuck in the bootloader
-                stm32_watchdog_pat();
+        static uint32_t safety_test_counter;
+        static bool should_lockup;
+        if (palReadLine(HAL_GPIO_PIN_SAFETY_INPUT)) {
+            safety_test_counter++;
+        } else {
+            safety_test_counter = 0;
+        }
+        if (safety_test_counter == 50) {
+            should_lockup = true;
+        }
+        // wait for lockup for safety to be released so we don't end
+        // up in the bootloader
+        if (should_lockup && palReadLine(HAL_GPIO_PIN_SAFETY_INPUT) == 0) {
+#if IOMCU_ENABLE_RESET_TEST == 1
+            // lockup with watchdog
+            while (true) {
+                hal.scheduler->delay(50);
+                palToggleLine(HAL_GPIO_PIN_SAFETY_LED);
             }
+#else
+            // hard fault to simulate power reset or software fault
+            void *foo = (void*)0xE000ED38;
+            typedef void (*fptr)();
+            fptr gptr = (fptr) (void *) foo;
+            gptr();
+            while (true) {}
+#endif
         }
     }
-#endif
+#endif // IOMCU_ENABLE_RESET_TEST
 
     led_counter = (led_counter+1) % 16;
     const uint16_t led_pattern = reg_status.flag_safety_off?0xFFFF:0x5500;


### PR DESCRIPTION
if the IOMCU resets twice in quick succession then the code that restores the safety state while flying can fail, leading to the aircraft trying to continue flying with safety on

This results from two issues:

- a race in handling the last_safety_off variable
- the fact that plane sets the soft_armed state based on safety state

issue reported here: https://discuss.ardupilot.org/t/plane-4-3-stable-release/91727/107

we could change the behaviour of plane so it doesn't set soft armed based on safety by removing this line of code:

https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/AP_Arming.cpp#L383

we would then need to carefully check the consequences of that for takeoff delays etc when safety is on

tested on CubeOrange quadplane and in bench testing
