### PR TITLE
AP_OSD:add aspect ratio correction for DisplayPort

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -26,7 +26,7 @@ class AP_OSD_Backend
 
 public:
     //constructor
-    AP_OSD_Backend(AP_OSD &osd): _osd(osd) {};
+    AP_OSD_Backend(AP_OSD &osd): _osd(osd) {}
 
     //destructor
     virtual ~AP_OSD_Backend(void) {}
@@ -51,7 +51,7 @@ public:
     virtual void clear()
     {
         blink_phase = (blink_phase+1)%4;
-    };
+    }
 
     // copy the backend specific symbol set to the OSD lookup table
     virtual void init_symbol_set(uint8_t *symbols, const uint8_t size);

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -133,4 +133,12 @@ AP_OSD_Backend *AP_OSD_MSP_DisplayPort::probe(AP_OSD &osd)
     }
     return backend;
 }
+ 
+// return a correction factor used to display angles correctly
+float AP_OSD_MSP_DisplayPort::get_aspect_ratio_correction() const
+{
+    return 12.0/18.0;
+}
+
+
 #endif

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -28,6 +28,8 @@ public:
     // used to initialize the uart in the correct thread
     void osd_thread_run_once() override;
 
+    // return a correction factor used to display angles correctly
+    float get_aspect_ratio_correction() const override;
 
 protected:
     uint8_t format_string_for_osd(char* dst, uint8_t size, bool decimal_packed, const char *fmt, va_list ap) override;


### PR DESCRIPTION
makes DisplayPort OSD output of artificial horizon match actual horizon..
tested with DJI goggles running DIsplayPort OSD and Walksnail/Avatar system

and a minor unrelated drive by that @tridge noticed as we were discussing this