### PR TITLE
AP_Logger: add @FieldValueEnum for rangefinder status

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1084,6 +1084,7 @@ struct PACKED log_VER {
 // @Field: Instance: rangefinder instance number this data is from
 // @Field: Dist: Reported distance from sensor
 // @Field: Stat: Sensor state
+// @FieldValueEnum: Stat: RangeFinder::Status
 // @Field: Orient: Sensor orientation
 
 // @LoggerMessage: RSSI


### PR DESCRIPTION
will add meaning to Wiki and log analysis tools

```
--- LogMessages.rst-master	2023-02-11 14:03:51.204650105 +1100
+++ LogMessages.rst	2023-02-11 14:04:32.297022568 +1100
@@ -4764,6 +4764,20 @@
 | Dist     | Reported distance from sensor                 |
 +----------+-----------------------------------------------+
 | Stat     | Sensor state                                  |
+|          | Values:                                       |
+|          |                                               |
+|          | +----------------+---+--+                     |
+|          | | NotConnected   | 0 |  |                     |
+|          | +----------------+---+--+                     |
+|          | | NoData         | 1 |  |                     |
+|          | +----------------+---+--+                     |
+|          | | OutOfRangeLow  | 2 |  |                     |
+|          | +----------------+---+--+                     |
+|          | | OutOfRangeHigh | 3 |  |                     |
+|          | +----------------+---+--+                     |
+|          | | Good           | 4 |  |                     |
+|          | +----------------+---+--+                     |
+|          |                                               |
 +----------+-----------------------------------------------+
 | Orient   | Sensor orientation                            |
 +----------+-----------------------------------------------+
```
