### PR TITLE
Rover: add circle mode

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -171,7 +171,7 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: MODE1
     // @DisplayName: Mode1
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,6:Follow,7:Simple,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,6:Follow,7:Simple,10:Auto,11:RTL,12:SmartRTL,15:Guided, 17:Circle
     // @User: Standard
     // @Description: Driving mode for switch position 1 (910 to 1230 and above 2049)
     GSCALAR(mode1,           "MODE1",         Mode::Number::MANUAL),

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -81,6 +81,7 @@ public:
     friend class GCS_Rover;
     friend class Mode;
     friend class ModeAcro;
+    friend class ModeCircle;
     friend class ModeAuto;
     friend class ModeGuided;
     friend class ModeHold;
@@ -228,6 +229,7 @@ private:
     ModeHold mode_hold;
     ModeManual mode_manual;
     ModeAcro mode_acro;
+    ModeCircle mode_circle;
     ModeGuided mode_guided;
     ModeAuto mode_auto;
     ModeLoiter mode_loiter;

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -522,6 +522,9 @@ Mode *Rover::mode_from_mode_num(const enum Mode::Number num)
     case Mode::Number::ACRO:
         ret = &mode_acro;
         break;
+    case Mode::Number::CIRCLE:
+        ret = &mode_circle;
+        break;
     case Mode::Number::STEERING:
         ret = &mode_steering;
         break;

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -27,6 +27,7 @@ public:
         SMART_RTL    = 12,
         GUIDED       = 15,
         INITIALISING = 16,
+        CIRCLE       = 17
     };
 
     // Constructor
@@ -383,6 +384,31 @@ private:
 
     // Mission change detector
     AP_Mission_ChangeDetector mis_change_detector;
+};
+
+
+class ModeCircle : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return CIRCLE; }
+    const char *name4() const override { return "CIRCLE"; }
+
+    void update() override;
+
+protected:
+
+    bool _enter() override;
+    void _exit() override;
+
+private:
+    Location center;
+    double radius = 50.0f; // in meters
+    const int K = 400;     // maximum steering
+    const int M = 50;      // parameter for how much to change the steering
+    double last_dist = radius;
+    double throttle;
+    double steering;
 };
 
 

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -1,0 +1,41 @@
+#include "Rover.h"
+
+bool ModeCircle::_enter()
+{
+    ahrs.get_location(center);
+
+    steering = 200.0f;
+    throttle = 20.0f;
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Entering Mode Circle");
+
+    return true;
+}
+
+void ModeCircle::update()
+{
+    Location current_location;
+    ahrs.get_location(current_location);
+
+    float dist = center.get_distance(current_location);
+    float offset = (last_dist - dist) / radius;
+    last_dist = dist;
+    float val = abs(dist/radius);
+
+    if (offset > 0) {
+        // inside the circle -> decrease the steering
+        steering = MAX(steering - val * M, 0);
+        g2.motors.set_steering(steering);
+        g2.motors.set_throttle(throttle);
+    } else {
+        // outside the circle -> increase the steering
+        steering = MIN(steering + val * M, K);
+        g2.motors.set_steering(steering);
+        g2.motors.set_throttle(throttle);
+    }
+}
+
+void ModeCircle::_exit()
+{
+    gcs().send_text(MAV_SEVERITY_INFO, "Exiting Mode Circle");
+}


### PR DESCRIPTION
Fix #13466

Details: when entering the mode, the current position is set as center, clockwise. The steering is updated according to the distance from the center (using gps). Any advice or criticism is welcome.
Tested on: SITL Rover
How to reproduce: using command `mode 17`.