### PR TITLE
AP_InertialSensor: the accel fast-sampling rate of MPU6500 is 4k,not 1k

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -902,7 +902,7 @@ void AP_InertialSensor_Invensense::_set_filter_register(void)
             _gyro_backend_rate_hz *= fast_sampling_rate;
 
             // calculate rate we will be giving accel samples to the backend
-            if (_mpu_type >= Invensense_MPU9250) {
+            if (_mpu_type >= Invensense_MPU6500) {
                 _accel_fifo_downsample_rate = MAX(4 / fast_sampling_rate, 1);
                 _accel_backend_rate_hz *= MIN(fast_sampling_rate, 4);
             } else {


### PR DESCRIPTION
[Althold mode is abnormal](https://discuss.ardupilot.org/t/why-ctun-crt-does-not-follow-the-derivate-of-ctun-alt/96357)
The above is my link in the forum.
I am using Copter4.2.2 to fly to the althold mode on my 210 copter.but the effect of the althold is abnormal.
When i change the INS_FAST_SAMPLE parameter from the default value of 1 to 0,the althold is normal.
At the same time,after I modified the code in the submission,the althold is also normal.