### PR TITLE
Rangefinder: add param OPTIONS to apply Earth frame rotation to sensor

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_RangeFinder.h"
 #include "AP_RangeFinder_Backend.h"
+#include <AP_AHRS/AP_AHRS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -80,3 +81,13 @@ void AP_RangeFinder_Backend::set_status(RangeFinder::Status _status)
     }
 }
 
+float AP_RangeFinder_Backend::gcs_distance() const
+{
+#ifndef HAL_BUILD_AP_PERIPH
+    if (option_is_set(AP_RangeFinder_Params::Options::GCS_USES_EARTH_FRAME) && state.status == RangeFinder::Status::Good) {
+        // only apply rotations to good data that is in range
+        return state.distance_m * AP::ahrs().get_rotation_body_to_ned().c.z;
+    }
+#endif
+    return state.distance_m;
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -39,6 +39,7 @@ public:
 #endif
 
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
+    float gcs_distance() const;
     float distance() const { return state.distance_m; }
     uint16_t distance_cm() const { return state.distance_m*100.0f; }
     uint16_t voltage_mv() const { return state.voltage_mv; }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -73,6 +73,11 @@ public:
     // parameter value which may be changed at runtime.
     RangeFinder::Type allocated_type() const { return _backend_type; }
 
+    // check if a option is set
+    bool option_is_set(AP_RangeFinder_Params::Options option) const {
+        return (uint16_t(params.options.get()) & uint16_t(option)) != 0;
+    }
+
 protected:
 
     // update status based on distance measurement

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -138,6 +138,13 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, AP_RANGEFINDER_DEFAULT_ORIENTATION),
 
+    // @Param: OPTIONS
+    // @DisplayName: Rangefinder options
+    // @Description: Rangefinder options
+    // @Bitmask: 0:Send Earth-Frame compensated distance to GCS
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 54, AP_RangeFinder_Params, options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -12,6 +12,12 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_RangeFinder_Params);
 
+    // bitmask of options
+    enum class Options : uint8_t {
+        GCS_USES_EARTH_FRAME            = (1U<<0),
+    };
+    AP_Int16 options;
+
     AP_Vector3f pos_offset; // position offset in body frame
     AP_Float scaling;
     AP_Float offset;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -401,7 +401,7 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         AP_HAL::millis(),                        // time since system boot TODO: take time of measurement
         sensor->min_distance_cm(),               // minimum distance the sensor can measure in centimeters
         sensor->max_distance_cm(),               // maximum distance the sensor can measure in centimeters
-        sensor->distance_cm(),                   // current distance reading
+        sensor->gcs_distance()*100,              // current distance reading
         sensor->get_mav_distance_sensor_type(),  // type from MAV_DISTANCE_SENSOR enum
         instance,                                // onboard ID of the sensor == instance
         sensor->orientation(),                   // direction the sensor faces from MAV_SENSOR_ORIENTATION enum
@@ -469,7 +469,7 @@ void GCS_MAVLINK::send_rangefinder() const
     }
     mavlink_msg_rangefinder_send(
             chan,
-            s->distance(),
+            s->gcs_distance(),
             s->voltage_mv() * 0.001f);
 }
 


### PR DESCRIPTION
As-is, there is no change in behavior. If RNGFNDx_OPTIONS = 1 then the data from your sensor will be rotated to earth frame via ```AP::ahrs().get_rotation_body_to_ned().c.z```. It's possible that this should only be done if orient is ROTATION_PITCH_270 but for now it applies that rotation on any rangefinder sensor with that option bit set.

This should allow better copter hover/follow-terrain and more useful GCS data which in many cases is assuming down-facing is earth-frame anyways.