### PR TITLE
AP_InertialSensor: the accel fast-sampling rate of MPU6500 is 4k Hz,not 1k Hz(master branch)

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -894,7 +894,7 @@ void AP_InertialSensor_Invensense::_set_filter_register(void)
             _gyro_backend_rate_hz *= fast_sampling_rate;
 
             // calculate rate we will be giving accel samples to the backend
-            if (_mpu_type >= Invensense_MPU9250) {
+            if (_mpu_type >= Invensense_MPU6500) {
                 _accel_fifo_downsample_rate = MAX(4 / fast_sampling_rate, 1);
                 _accel_backend_rate_hz *= MIN(fast_sampling_rate, 4);
             } else {


### PR DESCRIPTION
This PR was previously on the Copter-4.3 branch and now on the master branch.
The PR link of Copter-4.3 is as follows:
[the accel fast-sampling rate of MPU6500 is 4k,not 1k](https://github.com/ArduPilot/ardupilot/pull/22915)