### PR TITLE
AP_Proximity/AP_Airspeed: corrected return type of uart::read()

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -73,8 +73,11 @@ bool AP_Airspeed_NMEA::get_airspeed(float &airspeed)
     uint16_t count = 0;
     int16_t nbytes = _uart->available();
     while (nbytes-- > 0) {
-        char c = _uart->read();
-        if (decode(c)) {
+        int16_t c = _uart->read();
+        if (c==-1) {
+            return false;
+        }
+        if (decode(char(c))) {
             _last_update_ms = now;
             if (_sentence_type == TYPE_VHW) {
                 sum += _speed;

--- a/libraries/AP_Proximity/AP_Proximity_Cygbot_D1.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Cygbot_D1.cpp
@@ -43,7 +43,7 @@ void AP_Proximity_Cygbot_D1::read_sensor_data()
 {
     uint32_t nbytes = _uart->available();
     while (nbytes-- > 0) {
-        uint8_t byte = _uart->read();
+        int16_t byte = _uart->read();
         if (!parse_byte(byte)) {
             // reset
             reset();

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -163,7 +163,7 @@ void AP_Proximity_RPLidarA2::get_readings()
 
     while (nbytes-- > 0) {
 
-        uint8_t c = _uart->read();
+        int16_t c = _uart->read();
         Debug(2, "UART READ %x <%c>", c, c); //show HEX values
 
         STATE:

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -62,8 +62,11 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
     int16_t nbytes = _uart->available();
 
     while (nbytes-- > 0) {
-        char c = _uart->read();
-        if (c == 'T' ) {
+        int16_t c = _uart->read();
+        if (c==-1) {
+            return false;
+        }
+        if (char(c) == 'T' ) {
             buffer_count = 0;
         }
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -116,8 +116,11 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
     }
 
     while (nbytes-- > 0) {
-        char c = _uart->read();
-        if (c == 'T' ) {
+        int16_t c = _uart->read();
+        if (c==-1) {
+            return false;
+        }
+        if (char(c) == 'T' ) {
             buffer_count = 0;
         }
         buffer[buffer_count++] = c;


### PR DESCRIPTION
Fixes #21836.
The actual return type is int16_t.
Thank you.