### PR TITLE
AP_Scripting: luacheck: check globals

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2,6 +2,8 @@
 -- This file should be auto generated and then manual edited
 -- generate with --scripting-docs, eg  ./waf copter --scripting-docs
 -- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations
+-- luacheck: ignore 121 (Setting a read-only global variable)
+-- luacheck: ignore 122 (Setting a read-only field of a global variable)
 -- luacheck: ignore 212 (Unused argument)
 -- luacheck: ignore 241 (Local variable is mutated but never accessed)
 

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2899,6 +2899,8 @@ int main(int argc, char **argv) {
   fprintf(docs, "-- This file should be auto generated and then manual edited\n");
   fprintf(docs, "-- generate with --scripting-docs, eg  ./waf copter --scripting-docs\n");
   fprintf(docs, "-- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations\n");
+  fprintf(docs, "-- luacheck: ignore 121 (Setting a read-only global variable)\n");
+  fprintf(docs, "-- luacheck: ignore 122 (Setting a read-only field of a global variable)\n");
   fprintf(docs, "-- luacheck: ignore 212 (Unused argument)\n");
   fprintf(docs, "-- luacheck: ignore 241 (Local variable is mutated but never accessed)\n\n");
 

--- a/libraries/AP_Scripting/tests/luacheck.lua
+++ b/libraries/AP_Scripting/tests/luacheck.lua
@@ -1,12 +1,57 @@
 
--- Don't check globals yet. This requires us to add a list of all the AP bindings
-global = false
-
 -- https://luacheck.readthedocs.io/en/stable/warnings.html
-ignore = {"631", -- Line is too long
+ignore = {"111", -- Setting an undefined global variable.
+          "113", -- Accessing an undefined global variable.
+          "631", -- Line is too long.
           "611", -- A line consists of nothing but whitespace.
           "612", -- A line contains trailing whitespace.
           "614"} -- Trailing whitespace in a comment.
 
 -- These lua scripts are not for running on AP
-exclude_files = {"Tools/CHDK-Scripts/*", "modules/*"}
+exclude_files = {"Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua"}
+
+-- Grab AP globals from docs file
+stds.ArduPilot = {}
+stds.ArduPilot.read_globals = {}
+
+local env = setmetatable({}, {__index = _G})
+assert(pcall(setfenv(assert(loadfile("libraries/AP_Scripting/docs/docs.lua")), env)))
+
+for key, value in pairs(env) do
+    local singleton = { other_fields = false }
+
+    -- add sub-functions
+    if type(value) == 'table' then
+        singleton['fields'] = {}
+        for s_key, _ in pairs(value) do
+            singleton['fields'][s_key] = { other_fields = false }
+        end
+    end
+
+    stds.ArduPilot.read_globals[key] = singleton
+end
+
+-- We cannot add enums to the docs without giving a value, we don't know the value until compile time
+-- There are only a few, so I have added them manually here.
+local function add_enum(singleton, enum)
+    stds.ArduPilot.read_globals[singleton].fields[enum] = { other_fields = false }
+end
+
+add_enum('mission', 'MISSION_COMPLETE')
+add_enum('mission', 'MISSION_RUNNING')
+add_enum('mission', 'MISSION_STOPPED')
+
+add_enum('terrain', 'TerrainStatusOK')
+add_enum('terrain', 'TerrainStatusUnhealthy')
+add_enum('terrain', 'TerrainStatusDisabled')
+
+add_enum('gps', 'GPS_OK_FIX_3D_RTK_FIXED')
+add_enum('gps', 'GPS_OK_FIX_3D_RTK_FLOAT')
+add_enum('gps', 'GPS_OK_FIX_3D_DGPS')
+add_enum('gps', 'GPS_OK_FIX_3D')
+add_enum('gps', 'GPS_OK_FIX_2D')
+add_enum('gps', 'NO_FIX')
+add_enum('gps', 'NO_GPS')
+
+std = "lua53+ArduPilot"
+


### PR DESCRIPTION
Adds checking of globals, everything passes already. Was able to do it by parsing the existing docs.

Prevents stuff like this:
```
gcs:not_a_method()
gcs = 10
```
I wasn't able to get parsing of emus from the docs to work, so I have just added them manually, there are only 13. 

This still has all the built in methods. So for example `print('foo')` is not a error.

Luacheck is not return type aware, so we don't get any checking of userdata or ap-objects. So I can still:
```
foo = uint32_t(0)
foo:bar()
```

The VS-Code extension that uses the current docs actually is return type aware and catches stuff like the above. I might poke about and see if we can use what ever it does in CI. 