### PR TITLE
Fix flash overflow building DrotekP3Pro bootloader

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -62,9 +62,11 @@ AP_FlashIface_JEDEC ext_flash;
 
 int main(void)
 {
+#ifdef STM32F427xx
     if (BOARD_FLASH_SIZE > 1024 && check_limit_flash_1M()) {
         board_info.fw_size = (1024 - (FLASH_BOOTLOADER_LOAD_KB + APP_START_OFFSET_KB))*1024;
     }
+#endif
 
     bool try_boot = false;
     uint32_t timeout = HAL_BOOTLOADER_TIMEOUT;

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -243,16 +243,16 @@ uint32_t get_mcu_desc(uint32_t max, uint8_t *revstr)
 
     mcu_des_t des = mcu_descriptions[STM32_UNKNOWN];
 
-    for (int i = 0; i < ARRAY_SIZE(mcu_descriptions); i++) {
-        if (mcuid == mcu_descriptions[i].mcuid) {
-            des = mcu_descriptions[i];
+    for (const auto &desc : mcu_descriptions) {
+        if (mcuid == desc.mcuid) {
+            des = desc;
             break;
         }
     }
 
-    for (int i = 0; i < ARRAY_SIZE(silicon_revs); i++) {
-        if (silicon_revs[i].revid == revid) {
-            des.rev = silicon_revs[i].rev;
+    for (const auto &rev : silicon_revs) {
+        if (rev.revid == revid) {
+            des.rev = rev.rev;
         }
     }
 
@@ -433,14 +433,14 @@ void init_uarts(void)
 
 #if HAL_USE_SERIAL == TRUE
     sercfg.speed = BOOTLOADER_BAUDRATE;
-    
-    for (uint8_t i=0; i<ARRAY_SIZE(uarts); i++) {
+
+    for (const auto &uart : uarts) {
 #if HAL_USE_SERIAL_USB == TRUE
-        if (uarts[i] == (BaseChannel *)&SDU1) {
+        if (uart == (BaseChannel *)&SDU1) {
             continue;
         }
 #endif
-        sdStart((SerialDriver *)uarts[i], &sercfg);
+        sdStart((SerialDriver *)uart, &sercfg);
     }
 #endif
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.c
@@ -565,9 +565,9 @@ unsigned int stm32_rand_generate_nonblocking(unsigned char* output, unsigned int
 /*
   see if we should limit flash to 1M on devices with older revisions of STM32F427
  */
+#ifdef STM32F427xx
 bool check_limit_flash_1M(void)
 {
-#ifdef STM32F427xx
     const uint16_t revid = (*(uint32_t *)DBGMCU_BASE) >> 16;
     static const uint16_t badrevs[4] = { 0x1000, 0x1001, 0x1003, 0x1007 };
     for (uint8_t i=0; i<4; i++) {
@@ -575,6 +575,6 @@ bool check_limit_flash_1M(void)
             return true;
         }
     }
-#endif
     return false;
 }
+#endif


### PR DESCRIPTION
 - entirely remove a method rather than just its body using `#if`s
 - use iterators rather than normal for loops

It wasn't *far* over....
