### PR TITLE
Tools: size_compare_branches.py: blacklist linux and esp32 boards for…

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -116,10 +116,51 @@ class SizeCompareBranches(object):
 
         # some boards we don't have a -bl.dat for, so skip them.
         # TODO: find a way to get this information from board_list:
-        self.bootloader_blacklist = frozenset([
+        self.bootloader_blacklist = set([
             'skyviper-v2450',
             'iomcu',
+            'CubeOrange-SimOnHardWare',
         ])
+
+        # blacklist all linux boards for bootloader build:
+        self.bootloader_blacklist.update(self.linux_board_names())
+        # ... and esp32 boards:
+        self.bootloader_blacklist.update(self.esp32_board_names())
+
+    def linux_board_names(self):
+        '''return a list of all Linux board names; FIXME: get this dynamically'''
+        # grep 'class.*[(]linux' Tools/ardupilotwaf/boards.py  | perl -pe "s/class (.*)\(linux\).*/            '\\1',/"
+        return [
+            'navigator',
+            'erleboard',
+            'navio',
+            'navio2',
+            'edge',
+            'zynq',
+            'ocpoc_zynq',
+            'bbbmini',
+            'blue',
+            'pocket',
+            'pxf',
+            'bebop',
+            'vnav',
+            'disco',
+            'erlebrain2',
+            'bhat',
+            'dark',
+            'pxfmini',
+            'aero',
+            'rst_zynq',
+            'obal',
+        ]
+
+    def esp32_board_names(self):
+        return [
+            'esp32buzz',
+            'esp32empty',
+            'esp32icarous',
+            'esp32diy',
+        ]
 
     def find_bin_dir(self):
         '''attempt to find where the arm-none-eabi tools are'''

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -118,8 +118,18 @@ class SizeCompareBranches(object):
         # TODO: find a way to get this information from board_list:
         self.bootloader_blacklist = set([
             'skyviper-v2450',
+            'skyviper-f412-rev1',
+            'skyviper-journey',
             'iomcu',
             'CubeOrange-SimOnHardWare',
+            'fmuv2',  # the fmuv3 bootloader auto-detects
+            'fmuv3-bdshot',
+            'luminousbee4',
+            'Pixhawk1-1M-bdshot',
+            'SITL_arm_linux_gnueabihf',
+            'SITL_x86_64_linux_gnu',
+            'iomcu',
+            'iomcu_f103_8MHz',
         ])
 
         # blacklist all linux boards for bootloader build:

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -379,7 +379,9 @@ class SizeCompareBranches(object):
                 if not board_info.is_ap_periph:
                     continue
             else:
-                if board_info.is_ap_periph:
+                # bootloaders for periph devices are *also* AP_Periphs
+                # (or we build uavcan rather than libcanard!)
+                if board_info.is_ap_periph and not vehicle == 'bootloader':
                     continue
                 # the bootloader target isn't an autobuild target, so
                 # it gets special treatment here:


### PR DESCRIPTION
… bootloader build

we already blacklist some things we can't (or don't) build bootloaders for; we need to include esp32 and linux boards in that list.
