### PR TITLE
AP_Motors: add throttle output logging.

### DIFF
--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -213,14 +213,6 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
 // @Field: DCRt: desired climb rate
 // @Field: CRt: climb rate
 
-// @LoggerMessage: MOTB
-// @Description: Battery information
-// @Field: TimeUS: Time since system startup
-// @Field: LiftMax: Maximum motor compensation gain
-// @Field: BatVolt: Ratio betwen detected battery voltage and maximum battery voltage
-// @Field: BatRes: Estimated battery resistance
-// @Field: ThLimit: Throttle limit set due to battery current limitations
-
 // @LoggerMessage: D16
 // @Description: Generic 16-bit-signed-integer storage
 // @Field: TimeUS: Time since system startup

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -690,6 +690,7 @@ struct PACKED log_MotBatt {
     float   bat_volt;
     float   th_limit;
     float th_average_max;
+    float th_out;
     uint8_t mot_fail_flags;
 };
 
@@ -1228,6 +1229,7 @@ struct PACKED log_VER {
 // @Field: BatVolt: Ratio between detected battery voltage and maximum battery voltage
 // @Field: ThLimit: Throttle limit set due to battery current limitations
 // @Field: ThrAvMx: Maximum average throttle that can be used to maintain attitude control, derived from throttle mix params
+// @Field: ThrOut: Throttle output
 // @Field: FailFlags: bit 0 motor failed, bit 1 motors balanced, should be 2 in normal flight
 
 // messages for all boards
@@ -1356,7 +1358,7 @@ LOG_STRUCTURE_FROM_AIS \
     { LOG_VER_MSG, sizeof(log_VER), \
       "VER",   "QBHBBBBIZH", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ", "s---------", "F---------", false }, \
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt), \
-      "MOTB", "QffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,FailFlags", "s-----", "F-----" , true }
+      "MOTB", "QfffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,ThrOut,FailFlags", "s------", "F------" , true }
 
 // message types 0 to 63 reserved for vehicle specific use
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -424,6 +424,7 @@ void AP_MotorsMulticopter::Log_Write()
         bat_volt        : _batt_voltage_filt.get(),
         th_limit        : _throttle_limit,
         th_average_max  : _throttle_avg_max,
+        th_out          : _throttle_out,
         mot_fail_flags  : (uint8_t)(_thrust_boost | (_thrust_balanced << 1U)),
     };
     AP::logger().WriteBlock(&pkt_mot, sizeof(pkt_mot));


### PR DESCRIPTION
We don't actually log the motors output throttle anywhere. This can be different to input throttle in CTUN in cases of motor saturation where throttle mix params allow boosting of throttle.

This also removes duplicate log documentation that was in SUB.