### PR TITLE
AP_Camera: frontend/backend split and support for 2 cameras

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -444,9 +444,9 @@ const AP_Param::Info Copter::var_info[] = {
     // variables not in the g class which contain EEPROM saved variables
 
 #if AP_CAMERA_ENABLED
-    // @Group: CAM_
+    // @Group: CAM
     // @Path: ../libraries/AP_Camera/AP_Camera.cpp
-    GOBJECT(camera,           "CAM_", AP_Camera),
+    GOBJECT(camera, "CAM", AP_Camera),
 #endif
 
     // @Group: RELAY_

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -127,6 +127,11 @@ void Copter::init_ardupilot()
     camera_mount.init();
 #endif
 
+#if AP_CAMERA_ENABLED
+    // initialise camera
+    camera.init();
+#endif
+
 #if PRECISION_LANDING == ENABLED
     // initialise precision landing
     init_precland();

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -745,9 +745,9 @@ const AP_Param::Info Plane::var_info[] = {
     GOBJECT(gps, "GPS", AP_GPS),
 
 #if AP_CAMERA_ENABLED
-    // @Group: CAM_
+    // @Group: CAM
     // @Path: ../libraries/AP_Camera/AP_Camera.cpp
-    GOBJECT(camera,                  "CAM_", AP_Camera),
+    GOBJECT(camera, "CAM", AP_Camera),
 #endif
 
     // @Group: ARMING_

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -101,6 +101,11 @@ void Plane::init_ardupilot()
     camera_mount.init();
 #endif
 
+#if AP_CAMERA_ENABLED
+    // initialise camera
+    camera.init();
+#endif
+
 #if AP_LANDINGGEAR_ENABLED
     // initialise landing gear position
     g2.landing_gear.init();

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -404,9 +404,9 @@ const AP_Param::Info Sub::var_info[] = {
     // variables not in the g class which contain EEPROM saved variables
 
 #if AP_CAMERA_ENABLED
-    // @Group: CAM_
+    // @Group: CAM
     // @Path: ../libraries/AP_Camera/AP_Camera.cpp
-    GOBJECT(camera,           "CAM_", AP_Camera),
+    GOBJECT(camera, "CAM", AP_Camera),
 #endif
 
     // @Group: RELAY_

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -103,6 +103,11 @@ void Sub::init_ardupilot()
     camera_mount.set_mode(MAV_MOUNT_MODE_RC_TARGETING);
 #endif
 
+#if AP_CAMERA_ENABLED
+    // initialise camera
+    camera.init();
+#endif
+
 #ifdef USERHOOK_INIT
     USERHOOK_INIT
 #endif

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -292,9 +292,9 @@ const AP_Param::Info Rover::var_info[] = {
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),
 
 #if AP_CAMERA_ENABLED
-    // @Group: CAM_
+    // @Group: CAM
     // @Path: ../libraries/AP_Camera/AP_Camera.cpp
-    GOBJECT(camera,                  "CAM_", AP_Camera),
+    GOBJECT(camera, "CAM", AP_Camera),
 #endif
 
 #if PRECISION_LANDING == ENABLED

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -112,6 +112,11 @@ void Rover::init_ardupilot()
     camera_mount.init();
 #endif
 
+#if AP_CAMERA_ENABLED
+    // initialise camera
+    camera.init();
+#endif
+
 #if PRECISION_LANDING == ENABLED
     // initialise precision landing
     init_precland();

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -938,6 +938,7 @@ class AutoTestPlane(AutoTest):
     def TestRCCamera(self):
         '''Test RC Option - Camera Trigger'''
         self.set_parameter("RC12_OPTION", 9) # CameraTrigger
+        self.set_parameter("CAM1_TYPE", 1)   # Camera with servo trigger
         self.reboot_sitl() # needed for RC12_OPTION to take effect
 
         x = self.mav.messages.get("CAMERA_FEEDBACK", None)

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9725,6 +9725,8 @@ Also, ignores heartbeats not from our target system'''
 
     def SET_MESSAGE_INTERVAL(self):
         '''Test MAV_CMD_SET_MESSAGE_INTERVAL'''
+        self.set_parameter("CAM1_TYPE", 1) # Camera with servo trigger
+        self.reboot_sitl() # needed for CAM1_TYPE to take effect
         self.start_subtest('Basic tests')
         self.test_set_message_interval_basic()
         self.start_subtest('Many-message tests')
@@ -9890,6 +9892,8 @@ Also, ignores heartbeats not from our target system'''
 
     def REQUEST_MESSAGE(self, timeout=60):
         '''Test MAV_CMD_REQUEST_MESSAGE'''
+        self.set_parameter("CAM1_TYPE", 1) # Camera with servo trigger
+        self.reboot_sitl() # needed for CAM1_TYPE to take effect
         rate = round(self.get_message_rate("CAMERA_FEEDBACK", 10))
         if rate != 0:
             raise PreconditionFailedException("Receiving camera feedback")

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1151,6 +1151,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def CameraMission(self):
         '''Test Camera Mission Items'''
+        self.set_parameter("CAM1_TYPE", 1) # Camera with servo trigger
+        self.reboot_sitl() # needed for CAM1_TYPE to take effect
         self.load_mission("rover-camera-mission.txt")
         self.wait_ready_to_arm()
         self.change_mode("AUTO")
@@ -5407,6 +5409,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def SendToComponents(self):
         '''Test ArduPilot send_to_components function'''
+        self.set_parameter("CAM1_TYPE", 5) # Camera with MAVlink trigger
+        self.reboot_sitl() # needed for CAM1_TYPE to take effect
         self.progress("Introducing ourselves to the autopilot as a component")
         old_srcSystem = self.mav.mav.srcSystem
         self.mav.mav.srcSystem = 1
@@ -5424,7 +5428,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             1, # zoom_pos
             0, # zoom_step
             0, # focus_lock
-            1, # 1 shot or start filming
+            0, # 1 shot or start filming
             17, # command id (de-dupe field)
             0, # extra_param
             0.0, # extra_value

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -13,319 +13,190 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Mount/AP_Mount.h>
+#include "AP_Camera_Backend.h"
+#include "AP_Camera_Servo.h"
+#include "AP_Camera_Relay.h"
+#include "AP_Camera_Mount.h"
+#include "AP_Camera_MAVLink.h"
 #include "AP_Camera_SoloGimbal.h"
 
-// ------------------------------
-#define CAM_DEBUG DISABLED
-
 const AP_Param::GroupInfo AP_Camera::var_info[] = {
-    // @Param: TRIGG_TYPE
-    // @DisplayName: Camera shutter (trigger) type
-    // @Description: how to trigger the camera to take a picture
-    // @Values: 0:Servo,1:Relay, 2:GoPro in Solo Gimbal, 3:Mount (Siyi)
-    // @User: Standard
-    AP_GROUPINFO("TRIGG_TYPE",  0, AP_Camera, _trigger_type, 0),
 
-    // @Param: DURATION
-    // @DisplayName: Duration that shutter is held open
-    // @Description: How long the shutter will be held open in 10ths of a second (i.e. enter 10 for 1second, 50 for 5seconds)
-    // @Units: ds
-    // @Range: 0 50
-    // @User: Standard
-    AP_GROUPINFO("DURATION",    1, AP_Camera, _trigger_duration, AP_CAMERA_TRIGGER_DEFAULT_DURATION),
-
-    // @Param: SERVO_ON
-    // @DisplayName: Servo ON PWM value
-    // @Description: PWM value in microseconds to move servo to when shutter is activated
-    // @Units: PWM
-    // @Range: 1000 2000
-    // @User: Standard
-    AP_GROUPINFO("SERVO_ON",    2, AP_Camera, _servo_on_pwm, AP_CAMERA_SERVO_ON_PWM),
-
-    // @Param: SERVO_OFF
-    // @DisplayName: Servo OFF PWM value
-    // @Description: PWM value in microseconds to move servo to when shutter is deactivated
-    // @Units: PWM
-    // @Range: 1000 2000
-    // @User: Standard
-    AP_GROUPINFO("SERVO_OFF",   3, AP_Camera, _servo_off_pwm, AP_CAMERA_SERVO_OFF_PWM),
-
-    // @Param: TRIGG_DIST
-    // @DisplayName: Camera trigger distance
-    // @Description: Distance in meters between camera triggers. If this value is non-zero then the camera will trigger whenever the position changes by this number of meters regardless of what mode the APM is in. Note that this parameter can also be set in an auto mission using the DO_SET_CAM_TRIGG_DIST command, allowing you to enable/disable the triggering of the camera during the flight.
-    // @User: Standard
-    // @Units: m
-    // @Range: 0 1000
-    AP_GROUPINFO("TRIGG_DIST",  4, AP_Camera, _trigg_dist, 0),
-
-    // @Param: RELAY_ON
-    // @DisplayName: Relay ON value
-    // @Description: This sets whether the relay goes high or low when it triggers. Note that you should also set RELAY_DEFAULT appropriately for your camera
-    // @Values: 0:Low,1:High
-    // @User: Standard
-    AP_GROUPINFO("RELAY_ON",    5, AP_Camera, _relay_on, 1),
-
-    // @Param: MIN_INTERVAL
-    // @DisplayName: Minimum time between photos
-    // @Description: Postpone shooting if previous picture was taken less than preset time(ms) ago.
-    // @User: Standard
-    // @Units: ms
-    // @Range: 0 10000
-    AP_GROUPINFO("MIN_INTERVAL",  6, AP_Camera, _min_interval, 0),
-
-    // @Param: MAX_ROLL
+    // @Param: _MAX_ROLL
     // @DisplayName: Maximum photo roll angle.
     // @Description: Postpone shooting if roll is greater than limit. (0=Disable, will shoot regardless of roll).
     // @User: Standard
     // @Units: deg
     // @Range: 0 180
-    AP_GROUPINFO("MAX_ROLL",  7, AP_Camera, _max_roll, 0),
+    AP_GROUPINFO("_MAX_ROLL",  7, AP_Camera, _max_roll, 0),
 
-    // @Param: FEEDBACK_PIN
-    // @DisplayName: Camera feedback pin
-    // @Description: pin number to use for save accurate camera feedback messages. If set to -1 then don't use a pin flag for this, otherwise this is a pin number which if held high after a picture trigger order, will save camera messages when camera really takes a picture. A universal camera hot shoe is needed. The pin should be held high for at least 2 milliseconds for reliable trigger detection.  Some common values are given, but see the Wiki's "GPIOs" page for how to determine the pin number for a given autopilot. See also the CAM_FEEDBACK_POL option.
-    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
-    // @User: Standard
-    // @RebootRequired: True
-    AP_GROUPINFO("FEEDBACK_PIN",  8, AP_Camera, _feedback_pin, AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN),
-
-    // @Param: FEEDBACK_POL
-    // @DisplayName: Camera feedback pin polarity
-    // @Description: Polarity for feedback pin. If this is 1 then the feedback pin should go high on trigger. If set to 0 then it should go low
-    // @Values: 0:TriggerLow,1:TriggerHigh
-    // @User: Standard
-    AP_GROUPINFO("FEEDBACK_POL",  9, AP_Camera, _feedback_polarity, 1),
-
-    // @Param: AUTO_ONLY
+    // @Param: _AUTO_ONLY
     // @DisplayName: Distance-trigging in AUTO mode only
     // @Description: When enabled, trigging by distance is done in AUTO mode only.
     // @Values: 0:Always,1:Only when in AUTO
     // @User: Standard
-    AP_GROUPINFO("AUTO_ONLY",  10, AP_Camera, _auto_mode_only, 0),
+    AP_GROUPINFO("_AUTO_ONLY",  10, AP_Camera, _auto_mode_only, 0),
 
-    // @Param: TYPE
-    // @DisplayName: Type of camera (0: None, 1: BMMCC)
-    // @Description: Set the camera type that is being used, certain cameras have custom functions that need further configuration, this enables that.
-    // @Values: 0:Default,1:BMMCC
-    // @User: Standard
-    AP_GROUPINFO("TYPE",  11, AP_Camera, _type, 0),
+    // @Group: 1
+    // @Path: AP_Camera_Params.cpp
+    AP_SUBGROUPINFO(_params[0], "1", 12, AP_Camera, AP_Camera_Params),
+
+#if AP_CAMERA_MAX_INSTANCES > 1
+    // @Group: 2
+    // @Path: AP_Camera_Params.cpp
+    AP_SUBGROUPINFO(_params[1], "2", 13, AP_Camera, AP_Camera_Params),
+#endif
 
     AP_GROUPEND
 };
 
 extern const AP_HAL::HAL& hal;
 
-/// Servo operated camera
-void
-AP_Camera::servo_pic()
+AP_Camera::AP_Camera(uint32_t _log_camera_bit) :
+    log_camera_bit(_log_camera_bit)
 {
-    SRV_Channels::set_output_pwm(SRV_Channel::k_cam_trigger, _servo_on_pwm);
-
-    // leave a message that it should be active for this many loops (assumes 50hz loops)
-    _trigger_counter = constrain_int16(_trigger_duration*5,0,255);
+    AP_Param::setup_object_defaults(this, var_info);
+    _singleton = this;
 }
 
-/// basic relay activation
-void
-AP_Camera::relay_pic()
+// returns camera type of the given instance
+AP_Camera::CameraType AP_Camera::get_type(uint8_t instance) const
 {
-    AP_Relay *_apm_relay = AP::relay();
-    if (_apm_relay == nullptr) {
+    if (instance >= AP_CAMERA_MAX_INSTANCES) {
+        return CameraType::NONE;
+    }
+
+    return (CameraType)_params[instance].type.get();
+}
+
+// detect and initialise backends
+void AP_Camera::init()
+{
+    // check init has not been called before
+    if (_num_instances != 0) {
         return;
     }
-    if (_relay_on) {
-        _apm_relay->on(0);
-    } else {
-        _apm_relay->off(0);
-    }
 
-    // leave a message that it should be active for this many loops (assumes 50hz loops)
-    _trigger_counter = constrain_int16(_trigger_duration*5,0,255);
-}
+    // perform any required parameter conversion
+    convert_params();
 
-/// single entry point to take pictures
-void AP_Camera::trigger_pic()
-{
-    setup_feedback_callback();
+    // create each instance
+    bool primary_set = false;
+    for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
+        CameraType camera_type = get_type(instance);
 
-    _image_index++;
-    switch (get_trigger_type()) {
-    case CamTrigType::servo:
-        servo_pic();            // Servo operated camera
-        break;
-    case CamTrigType::relay:
-        relay_pic();            // basic relay activation
-        break;
+        // check for servo camera
+        if (camera_type == CameraType::SERVO) {
+            _backends[instance] = new AP_Camera_Servo(*this, _params[instance], instance);
+            _num_instances++;
+
+        // check for relay camera
+        } else if (camera_type == CameraType::RELAY) {
+            _backends[instance] = new AP_Camera_Relay(*this, _params[instance], instance);
+            _num_instances++;
+
 #if HAL_SOLO_GIMBAL_ENABLED
-    case CamTrigType::gopro:  // gopro in Solo Gimbal
-        AP_Camera_SoloGimbal::gopro_shutter_toggle();
-        break;
+        // check for GoPro in Solo camera
+        } else if (camera_type == CameraType::SOLOGIMBAL) {
+            _backends[instance] = new AP_Camera_SoloGimbal(*this, _params[instance], instance);
+            _num_instances++;
 #endif
-#if HAL_MOUNT_ENABLED
-    case CamTrigType::mount: {
-        AP_Mount* mount = AP::mount();
-        if (mount != nullptr) {
-            mount->take_picture(0);
-        }
-        break;
-    }
-#endif
-    default:
-        break;
-    }
 
-    log_picture();
-}
+        // check for Mount camera
+        } else if (camera_type == CameraType::MOUNT) {
+            _backends[instance] = new AP_Camera_Mount(*this, _params[instance], instance);
+            _num_instances++;
 
-/// de-activate the trigger after some delay, but without using a delay() function
-/// should be called at 50hz
-void
-AP_Camera::trigger_pic_cleanup()
-{
-    if (_trigger_counter) {
-        _trigger_counter--;
-    } else {
-        switch (get_trigger_type()) {
-        case CamTrigType::servo:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_trigger, _servo_off_pwm);
-            break;
-        case CamTrigType::relay: {
-            AP_Relay *_apm_relay = AP::relay();
-            if (_apm_relay == nullptr) {
-                break;
-            }
-            if (_relay_on) {
-                _apm_relay->off(0);
-            } else {
-                _apm_relay->on(0);
-            }
-            break;
+        // check for MAVLink enabled camera driver
+        } else if (camera_type == CameraType::MAVLINK) {
+            _backends[instance] = new AP_Camera_MAVLink(*this, _params[instance], instance);
+            _num_instances++;
         }
-        case CamTrigType::gopro:
-        case CamTrigType::mount:
-            // nothing to do
-            break;
+
+        // set primary to first non-null index
+        if (!primary_set && (_backends[instance] != nullptr)) {
+            primary = instance;
+            primary_set = true;
         }
     }
 
-    if (_trigger_counter_cam_function) {
-        _trigger_counter_cam_function--;
-    } else {
-        switch (_type) {
-        case AP_Camera::CAMERA_TYPE_BMMCC:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_iso, _servo_off_pwm);
-            break;
+    // init each instance, do it after all instances were created, so that they all know things
+    for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->init();
         }
     }
 }
 
+// handle incoming mavlink messages
 void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &msg)
 {
-    switch (msg.msgid) {
-    case MAVLINK_MSG_ID_DIGICAM_CONTROL:
-        control_msg(msg);
-        break;
-#if HAL_SOLO_GIMBAL_ENABLED
-    case MAVLINK_MSG_ID_GOPRO_HEARTBEAT:
-        // heartbeat from the Solo gimbal with a GoPro
-        if (get_trigger_type() == CamTrigType::gopro) {
-            AP_Camera_SoloGimbal::handle_gopro_heartbeat(chan, msg);
-            break;
+    if (msg.msgid == MAVLINK_MSG_ID_DIGICAM_CONTROL) {
+        // decode deprecated MavLink message that controls camera.
+        __mavlink_digicam_control_t packet;
+        mavlink_msg_digicam_control_decode(&msg, &packet);
+        control(packet.session, packet.zoom_pos, packet.zoom_step, packet.focus_lock, packet.shot, packet.command_id);
+        return;
+    }
+
+    // call each instance
+    for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->handle_message(chan, msg);
         }
-        break;
-#endif
     }
 }
 
-/// momentary switch to cycle camera modes
-void AP_Camera::cam_mode_toggle()
+// set camera trigger distance in a mission
+void AP_Camera::set_trigger_distance(uint8_t instance, float distance_m)
 {
-    switch (get_trigger_type()) {
-#if HAL_SOLO_GIMBAL_ENABLED
-    case CamTrigType::gopro:
-        AP_Camera_SoloGimbal::gopro_capture_mode_toggle();
-        break;
-#endif
-    default:
-        // no other cameras use this yet
-        break;
+    if (!is_valid_instance(instance)) {
+        return;
     }
+
+    // call backend
+    _backends[instance]->set_trigger_distance(distance_m);
 }
 
-/// decode deprecated MavLink message that controls camera.
-void
-AP_Camera::control_msg(const mavlink_message_t &msg)
+// momentary switch to change camera between picture and video modes
+void AP_Camera::cam_mode_toggle(uint8_t instance)
 {
-    __mavlink_digicam_control_t packet;
-    mavlink_msg_digicam_control_decode(&msg, &packet);
+    if (!is_valid_instance(instance)) {
+        return;
+    }
 
-    control(packet.session, packet.zoom_pos, packet.zoom_step, packet.focus_lock, packet.shot, packet.command_id);
+    // call backend
+    _backends[instance]->cam_mode_toggle();
 }
 
 void AP_Camera::configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time)
 {
-    // we cannot process the configure command so convert to mavlink message
-    // and send to all components in case they and process it
+    configure(primary, shooting_mode, shutter_speed, aperture, ISO, exposure_type, cmd_id, engine_cutoff_time);
+}
 
-    mavlink_command_long_t mav_cmd_long = {};
-
-    // convert mission command to mavlink command_long
-    mav_cmd_long.command = MAV_CMD_DO_DIGICAM_CONFIGURE;
-    mav_cmd_long.param1 = shooting_mode;
-    mav_cmd_long.param2 = shutter_speed;
-    mav_cmd_long.param3 = aperture;
-    mav_cmd_long.param4 = ISO;
-    mav_cmd_long.param5 = exposure_type;
-    mav_cmd_long.param6 = cmd_id;
-    mav_cmd_long.param7 = engine_cutoff_time;
-
-    // send to all components
-    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
-
-    if (_type == AP_Camera::CAMERA_TYPE_BMMCC) {
-        // Set a trigger for the additional functions that are flip controlled (so far just ISO and Record Start / Stop use this method, will add others if required)
-        _trigger_counter_cam_function = constrain_int16(_trigger_duration*5,0,255);
-
-        // If the message contains non zero values then use them for the below functions
-        if (ISO > 0) {
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_iso, _servo_on_pwm);
-        }
-
-        if (aperture > 0) {
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_aperture, (int)aperture);
-        }
-
-        if (shutter_speed > 0) {
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_shutter_speed, (int)shutter_speed);
-        }
-
-        // Use the shooting mode PWM value for the BMMCC as the focus control - no need to modify or create a new MAVlink message type.
-        if (shooting_mode > 0) {
-            SRV_Channels::set_output_pwm(SRV_Channel::k_cam_focus, (int)shooting_mode);
-        }
+void AP_Camera::configure(uint8_t instance, float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time)
+{
+    if (!is_valid_instance(instance)) {
+        return;
     }
+
+    // call backend
+    _backends[instance]->configure(shooting_mode, shutter_speed, aperture, ISO, exposure_type, cmd_id, engine_cutoff_time);
 }
 
 void AP_Camera::control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id)
 {
-    // take picture
-    if (is_equal(shooting_cmd,1.0f)) {
-        trigger_pic();
+    control(primary, session, zoom_pos, zoom_step, focus_lock, shooting_cmd, cmd_id);
+}
+
+void AP_Camera::control(uint8_t instance, float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id)
+{
+    if (!is_valid_instance(instance)) {
+        return;
     }
 
-    mavlink_command_long_t mav_cmd_long = {};
-
-    // convert command to mavlink command long
-    mav_cmd_long.command = MAV_CMD_DO_DIGICAM_CONTROL;
-    mav_cmd_long.param1 = session;
-    mav_cmd_long.param2 = zoom_pos;
-    mav_cmd_long.param3 = zoom_step;
-    mav_cmd_long.param4 = focus_lock;
-    mav_cmd_long.param5 = shooting_cmd;
-    mav_cmd_long.param6 = cmd_id;
-
-    // send to all components
-    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
+    // call backend
+    _backends[instance]->control(session, zoom_pos, zoom_step, focus_lock, shooting_cmd, cmd_id);
 }
 
 /*
@@ -333,306 +204,145 @@ void AP_Camera::control(float session, float zoom_pos, float zoom_step, float fo
  */
 void AP_Camera::send_feedback(mavlink_channel_t chan) const
 {
-
-    int32_t altitude = 0;
-    if (feedback.location.initialised() && !feedback.location.get_alt_cm(Location::AltFrame::ABSOLUTE, altitude)) {
-        // completely ignore this failure!  this is a shouldn't-happen
-        // as current_loc should never be in an altitude we can't
-        // convert.
+    // call each instance
+    for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->send_camera_feedback(chan);
+        }
     }
-    int32_t altitude_rel = 0;
-    if (feedback.location.initialised() && !feedback.location.get_alt_cm(Location::AltFrame::ABOVE_HOME, altitude_rel)) {
-        // completely ignore this failure!  this is a shouldn't-happen
-        // as current_loc should never be in an altitude we can't
-        // convert.
-    }
-
-    mavlink_msg_camera_feedback_send(
-        chan,
-        feedback.timestamp_us,
-        0, 0, _image_index,
-        feedback.location.lat,
-        feedback.location.lng,
-        altitude*1e-2f, altitude_rel*1e-2f,
-        feedback.roll_sensor*1e-2f,
-        feedback.pitch_sensor*1e-2f,
-        feedback.yaw_sensor*1e-2f,
-        0.0f, CAMERA_FEEDBACK_PHOTO,
-        feedback.camera_trigger_logged);
 }
-
 
 /*
   update; triggers by distance moved and camera trigger
 */
 void AP_Camera::update()
 {
-    update_trigger();
-
-    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
-        return;
-    }
-
-    if (!is_positive(_trigg_dist)) {
-        _last_location.lat = 0;
-        _last_location.lng = 0;
-        return;
-    }
-
-    const AP_AHRS &ahrs = AP::ahrs();
-    Location current_loc;
-
-    // ignore failure - AHRS will provide its best guess
-    IGNORE_RETURN(ahrs.get_location(current_loc));
-
-    if (_last_location.lat == 0 && _last_location.lng == 0) {
-        _last_location = current_loc;
-        return;
-    }
-    if (_last_location.lat == current_loc.lat && _last_location.lng == current_loc.lng) {
-        // we haven't moved - this can happen as update() may
-        // be called without a new GPS fix
-        return;
-    }
-
-    if (current_loc.get_distance(_last_location) < _trigg_dist) {
-        return;
-    }
-
-    if (_max_roll > 0 && fabsf(AP::ahrs().roll_sensor*1e-2f) > _max_roll) {
-        return;
-    }
-
-    if (_is_in_auto_mode != true && _auto_mode_only != 0) {
-        return;
-    }
-
-    take_picture();
-}
-
-/*
-  interrupt handler for interrupt based feedback trigger
- */
-void AP_Camera::feedback_pin_isr(uint8_t pin, bool high, uint32_t timestamp_us)
-{
-    _feedback_trigger_timestamp_us = timestamp_us;
-    _camera_trigger_count++;
-}
-
-/*
-  check if feedback pin is high for timer based feedback trigger, when
-  attach_interrupt fails
- */
-void AP_Camera::feedback_pin_timer(void)
-{
-    uint8_t pin_state = hal.gpio->read(_feedback_pin);
-    uint8_t trigger_polarity = _feedback_polarity==0?0:1;
-    if (pin_state == trigger_polarity &&
-        _last_pin_state != trigger_polarity) {
-        _feedback_trigger_timestamp_us = AP_HAL::micros();
-        _camera_trigger_count++;
-    }
-    _last_pin_state = pin_state;
-}
-
-/*
-  setup a callback for a feedback pin. When on PX4 with the right FMU
-  mode we can use the microsecond timer.
- */
-void AP_Camera::setup_feedback_callback(void)
-{
-    if (_feedback_pin <= 0 || _timer_installed || _isr_installed) {
-        // invalid or already installed
-        return;
-    }
-
-    // ensure we are in input mode
-    hal.gpio->pinMode(_feedback_pin, HAL_GPIO_INPUT);
-
-    // enable pullup/pulldown
-    uint8_t trigger_polarity = _feedback_polarity==0?0:1;
-    hal.gpio->write(_feedback_pin, !trigger_polarity);
-
-    if (hal.gpio->attach_interrupt(_feedback_pin, FUNCTOR_BIND_MEMBER(&AP_Camera::feedback_pin_isr, void, uint8_t, bool, uint32_t),
-                                   trigger_polarity?AP_HAL::GPIO::INTERRUPT_RISING:AP_HAL::GPIO::INTERRUPT_FALLING)) {
-        _isr_installed = true;
-    } else {
-        // install a 1kHz timer to check feedback pin
-        hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Camera::feedback_pin_timer, void));
-
-        _timer_installed = true;
-    }
-}
-
-// log_picture - log picture taken and send feedback to GCS
-void AP_Camera::log_picture()
-{
-    if (!using_feedback_pin()) {
-        // if we're using a feedback pin then when the event occurs we
-        // stash the feedback data.  Since we're not using a feedback
-        // pin, we just use "now".
-        prep_mavlink_msg_camera_feedback(AP::gps().time_epoch_usec());
-    }
-
-    AP_Logger *logger = AP_Logger::get_singleton();
-    if (logger == nullptr) {
-        return;
-    }
-    if (!logger->should_log(log_camera_bit)) {
-        return;
-    }
-
-    if (!using_feedback_pin()) {
-        Write_Camera();
-    } else {
-        Write_Trigger();
+    // call each instance
+    for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->update();
+        }
     }
 }
 
 // take_picture - take a picture
-void AP_Camera::take_picture()
+void AP_Camera::take_picture(uint8_t instance)
 {
-    uint32_t tnow = AP_HAL::millis();
-    if (tnow - _last_photo_time < (unsigned) _min_interval) {
-        _trigger_pending = true;
+    if (!is_valid_instance(instance)) {
         return;
     }
-    _trigger_pending = false;
 
-    IGNORE_RETURN(AP::ahrs().get_location(_last_location));
-
-    _last_photo_time = tnow;
-    
-    // take a local picture:
-    trigger_pic();
-
-    // tell all of our components to take a picture:
-    mavlink_command_long_t cmd_msg {};
-    cmd_msg.command = MAV_CMD_DO_DIGICAM_CONTROL;
-    cmd_msg.param5 = 1;
-
-    // forward to all components
-    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
+    // call backend
+    _backends[instance]->take_picture();
 }
 
 // start/stop recording video.  returns true on success
 // start_recording should be true to start recording, false to stop recording
-bool AP_Camera::record_video(bool start_recording)
+bool AP_Camera::record_video(uint8_t instance, bool start_recording)
 {
-#if HAL_MOUNT_ENABLED
-    // only mount implements recording video
-    if (get_trigger_type() == CamTrigType::mount) {
-        AP_Mount* mount = AP::mount();
-        if (mount != nullptr) {
-            return mount->record_video(0, start_recording);
-        }
+    if (!is_valid_instance(instance)) {
+        return false;
     }
-#endif
-    return false;
+
+    // call backend
+    return _backends[instance]->record_video(start_recording);
 }
 
 // zoom in, out or hold.  returns true on success
 // zoom out = -1, hold = 0, zoom in = 1
-bool AP_Camera::set_zoom_step(int8_t zoom_step)
+bool AP_Camera::set_zoom_step(uint8_t instance, int8_t zoom_step)
 {
-#if HAL_MOUNT_ENABLED
-    // only mount implements set_zoom_step
-    if (get_trigger_type() == CamTrigType::mount) {
-        AP_Mount* mount = AP::mount();
-        if (mount != nullptr) {
-            return mount->set_zoom_step(0, zoom_step);
-        }
+    if (!is_valid_instance(instance)) {
+        return false;
     }
-#endif
-    return false;
+
+    // call each instance
+    return _backends[instance]->set_zoom_step(zoom_step);
 }
 
 // focus in, out or hold.  returns true on success
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera::set_manual_focus_step(int8_t focus_step)
+bool AP_Camera::set_manual_focus_step(uint8_t instance, int8_t focus_step)
 {
-#if HAL_MOUNT_ENABLED
-    // only mount implements set_manual_focus_step
-    if (get_trigger_type() == CamTrigType::mount) {
-        AP_Mount* mount = AP::mount();
-        if (mount != nullptr) {
-            return mount->set_manual_focus_step(0, focus_step);
-        }
+    if (!is_valid_instance(instance)) {
+        return false;
     }
-#endif
-    return false;
+
+    // call backend
+    return _backends[instance]->set_manual_focus_step(focus_step);
 }
 
 // auto focus.  returns true on success
-bool AP_Camera::set_auto_focus()
+bool AP_Camera::set_auto_focus(uint8_t instance)
 {
-#if HAL_MOUNT_ENABLED
-    // only mount implements set_auto_focus
-    if (get_trigger_type() == CamTrigType::mount) {
-        AP_Mount* mount = AP::mount();
-        if (mount != nullptr) {
-            return mount->set_auto_focus(0);
-        }
+    if (!is_valid_instance(instance)) {
+        return false;
     }
-#endif
-    return false;
+
+    // call backend
+    return _backends[instance]->set_auto_focus();
 }
 
-void AP_Camera::prep_mavlink_msg_camera_feedback(uint64_t timestamp_us)
+// check instance number is valid
+bool AP_Camera::is_valid_instance(uint8_t instance) const
 {
-    const AP_AHRS &ahrs = AP::ahrs();
-    if (!ahrs.get_location(feedback.location)) {
-        // completely ignore this failure!  AHRS will provide its best guess.
-    }
-    feedback.timestamp_us = timestamp_us;
-    feedback.roll_sensor = ahrs.roll_sensor;
-    feedback.pitch_sensor = ahrs.pitch_sensor;
-    feedback.yaw_sensor = ahrs.yaw_sensor;
-    feedback.camera_trigger_logged = _camera_trigger_logged;
-
-    gcs().send_message(MSG_CAMERA_FEEDBACK);
+    return ((instance < AP_CAMERA_MAX_INSTANCES) && (_backends[instance] != nullptr));
 }
 
-/*
-  update camera trigger - 50Hz
- */
-void AP_Camera::update_trigger()
+// perform any required parameter conversion
+void AP_Camera::convert_params()
 {
-    if (_trigger_pending) {
-        take_picture();
+    // exit immediately if CAM1_TYPE has already been configured
+    if (_params[0].type.configured()) {
+        return;
     }
-    trigger_pic_cleanup();
-    
-    if (_camera_trigger_logged != _camera_trigger_count) {
-        uint32_t timestamp32 = _feedback_trigger_timestamp_us;
-        _camera_trigger_logged = _camera_trigger_count;
 
-        // we should consider doing this inside the ISR and pin_timer
-        prep_mavlink_msg_camera_feedback(_feedback_trigger_timestamp_us);
+    // below conversions added Feb 2023 ahead of 4.4 release
 
-        AP_Logger *logger = AP_Logger::get_singleton();
-        if (logger != nullptr) {
-            if (logger->should_log(log_camera_bit)) {
-                uint32_t tdiff = AP_HAL::micros() - timestamp32;
-                uint64_t timestamp = AP_HAL::micros64();
-                Write_Camera(timestamp - tdiff);
-            }
-        }
+    // convert CAM_TRIGG_TYPE to CAM1_TYPE
+    int8_t cam_trigg_type = 0;
+    int8_t cam1_type = 0;
+    IGNORE_RETURN(AP_Param::get_param_by_index(this, 0, AP_PARAM_INT8, &cam_trigg_type));
+    if ((cam_trigg_type == 0) && SRV_Channels::function_assigned(SRV_Channel::k_cam_trigger)) {
+        // CAM_TRIGG_TYPE was 0 (Servo) and camera trigger servo function was assigned so set CAM1_TYPE = 1 (Servo)
+        cam1_type = 1;
     }
-}
+    if ((cam_trigg_type >= 1) && (cam_trigg_type <= 3)) {
+        // CAM_TRIGG_TYPE was set to Relay, GoPro or Mount
+        cam1_type = cam_trigg_type + 1;
+    }
+    _params[0].type.set_and_save(cam1_type);
 
-AP_Camera::CamTrigType AP_Camera::get_trigger_type(void)
-{
-    uint8_t type = _trigger_type.get();
+    // convert CAM_DURATION (in deci-seconds) to CAM1_DURATION (in seconds)
+    int8_t cam_duration = 0;
+    if (AP_Param::get_param_by_index(this, 1, AP_PARAM_INT8, &cam_duration) && (cam_duration > 0)) {
+        _params[0].trigger_duration.set_and_save(cam_duration * 0.1);
+    }
 
-    switch ((CamTrigType)type) {
-        case CamTrigType::servo:
-        case CamTrigType::relay:
-        case CamTrigType::gopro:
-        case CamTrigType::mount:
-            return (CamTrigType)type;
-        default:
-            return CamTrigType::servo;
+    // convert CAM_MIN_INTERVAL (in milliseconds) to CAM1__INTRVAL_MIN (in seconds)
+    int16_t cam_min_interval = 0;
+    if (AP_Param::get_param_by_index(this, 6, AP_PARAM_INT16, &cam_min_interval) && (cam_min_interval > 0)) {
+        _params[0].interval_min.set_and_save(cam_min_interval * 0.001f);
+    }
+
+    // find Camera's top level key
+    uint16_t k_param_camera_key;
+    if (!AP_Param::find_top_level_key_by_pointer(this, k_param_camera_key)) {
+        return;
+    }
+
+    // table parameters to convert without scaling
+    static const AP_Param::ConversionInfo camera_param_conversion_info[] {
+        { k_param_camera_key, 2, AP_PARAM_INT16, "CAM1_SERVO_ON" },
+        { k_param_camera_key, 3, AP_PARAM_INT16, "CAM1_SERVO_OFF" },
+        { k_param_camera_key, 4, AP_PARAM_FLOAT, "CAM1_TRIGG_DIST" },
+        { k_param_camera_key, 5, AP_PARAM_INT8, "CAM1_RELAY_ON" },
+        { k_param_camera_key, 8, AP_PARAM_INT8, "CAM1_FEEDBAK_PIN" },
+        { k_param_camera_key, 9, AP_PARAM_INT8, "CAM1_FEEDBAK_POL" },
+    };
+    uint8_t table_size = ARRAY_SIZE(camera_param_conversion_info);
+    for (uint8_t i=0; i<table_size; i++) {
+        AP_Param::convert_old_parameter(&camera_param_conversion_info[i], 1.0f);
     }
 }
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -10,173 +10,141 @@
 #include <AP_Logger/LogStructure.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include "AP_Camera_Params.h"
 
-#define AP_CAMERA_TRIGGER_DEFAULT_DURATION  10      // default duration servo or relay is held open in 10ths of a second (i.e. 10 = 1 second)
+#define AP_CAMERA_MAX_INSTANCES             2       // maximum number of camera backends
 
-#define AP_CAMERA_SERVO_ON_PWM              1300    // default PWM value to move servo to when shutter is activated
-#define AP_CAMERA_SERVO_OFF_PWM             1100    // default PWM value to move servo to when shutter is deactivated
-
-#define AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN -1  // default is to not use camera feedback pin
+// declare backend classes
+class AP_Camera_Backend;
+class AP_Camera_Servo;
+class AP_Camera_Relay;
+class AP_Camera_SoloGimbal;
+class AP_Camera_Mount;
 
 /// @class	Camera
 /// @brief	Object managing a Photo or video camera
 class AP_Camera {
 
+    // declare backends as friends
+    friend class AP_Camera_Backend;
+    friend class AP_Camera_Servo;
+    friend class AP_Camera_Relay;
+    friend class AP_Camera_SoloGimbal;
+    friend class AP_Camera_Mount;
+    friend class AP_Camera_MAVLink;
+
 public:
-    AP_Camera(uint32_t _log_camera_bit)
-        : log_camera_bit(_log_camera_bit)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-        _singleton = this;
-    }
+
+    // constructor
+    AP_Camera(uint32_t _log_camera_bit);
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_Camera);
 
     // get singleton instance
-    static AP_Camera *get_singleton()
-    {
-        return _singleton;
-    }
+    static AP_Camera *get_singleton() { return _singleton; }
+
+    // enums
+    enum class CameraType {
+        NONE = 0,           // None
+        SERVO = 1,          // Servo/PWM controlled camera
+        RELAY = 2,          // Relay controlled camera
+        SOLOGIMBAL = 3,     // GoPro in Solo gimbal
+        MOUNT = 4,          // Mount library implements camera
+        MAVLINK = 5,        // MAVLink enabled camera
+    };
+
+    // returns camera type of the given instance
+    CameraType get_type(uint8_t instance) const;
+
+    // detect and initialise backends
+    void init();
+
+    // update - to be called periodically at 50Hz
+    void update();
 
     // MAVLink methods
-    void            handle_message(mavlink_channel_t chan,
-                                   const mavlink_message_t &msg);
-    void            send_feedback(mavlink_channel_t chan) const;
+    void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg);
+    void send_feedback(mavlink_channel_t chan) const;
 
-    // Command processing
-    void            configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time);
+    // configure camera
+    void configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time);
+    void configure(uint8_t instance, float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time);
+
     // handle camera control
-    void            control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
+    void control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
+    void control(uint8_t instance, float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
 
     // set camera trigger distance in a mission
-    void            set_trigger_distance(float distance_m)
-    {
-        _trigg_dist.set(distance_m);
-    }
+    void set_trigger_distance(float distance_m) { set_trigger_distance(primary, distance_m); }
+    void set_trigger_distance(uint8_t instance, float distance_m);
 
-    // momentary switch to change camera modes
-    void cam_mode_toggle();
+    // momentary switch to change camera between picture and video modes
+    void cam_mode_toggle() { cam_mode_toggle(primary); }
+    void cam_mode_toggle(uint8_t instance);
 
-    void take_picture();
+    // take a picture
+    void take_picture() { take_picture(primary); }
+    void take_picture(uint8_t instance);
 
     // start/stop recording video
     // start_recording should be true to start recording, false to stop recording
-    bool record_video(bool start_recording);
+    bool record_video(bool start_recording) { return record_video(primary, start_recording); }
+    bool record_video(uint8_t instance, bool start_recording);
 
     // zoom in, out or hold
     // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step);
+    bool set_zoom_step(int8_t zoom_step) { return set_zoom_step(primary, zoom_step); }
+    bool set_zoom_step(uint8_t instance, int8_t zoom_step);
 
     // focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step);
+    bool set_manual_focus_step(int8_t focus_step) { return set_manual_focus_step(primary, focus_step); }
+    bool set_manual_focus_step(uint8_t instance, int8_t focus_step);
 
     // auto focus
-    bool set_auto_focus();
-
-    // Update - to be called periodically @at least 50Hz
-    void update();
-
-    static const struct AP_Param::GroupInfo        var_info[];
+    bool set_auto_focus() { return set_auto_focus(primary); }
+    bool set_auto_focus(uint8_t instance);
 
     // set if vehicle is in AUTO mode
-    void set_is_auto_mode(bool enable)
-    {
-        _is_in_auto_mode = enable;
-    }
+    void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 
-    enum camera_types {
-        CAMERA_TYPE_STD,
-        CAMERA_TYPE_BMMCC
-    };
+    // parameter var table
+    static const struct AP_Param::GroupInfo var_info[];
 
-    enum class CamTrigType {
-        servo   = 0,
-        relay   = 1,
-        gopro   = 2,
-        mount   = 3,
-    };
+protected:
 
-    AP_Camera::CamTrigType get_trigger_type(void);
+    // return true if vehicle mode allows trigg dist
+    bool vehicle_mode_ok_for_trigg_dist() const { return (_auto_mode_only == 0) || _is_in_auto_mode; }
+
+    // return maximum acceptable vehicle roll angle (in degrees)
+    int16_t get_roll_max() const { return _max_roll; }
+
+    // return log bit
+    uint32_t get_log_camera_bit() const { return log_camera_bit; }
+
+    // parameters for backends
+    AP_Camera_Params _params[AP_CAMERA_MAX_INSTANCES];
 
 private:
 
     static AP_Camera *_singleton;
 
-    void            control_msg(const mavlink_message_t &msg);
+    // parameters
+    AP_Int8 _auto_mode_only;    // if 1: trigger by distance only if in AUTO mode.
+    AP_Int16 _max_roll;         // Maximum acceptable roll angle when trigging camera
 
-    AP_Int8         _trigger_type;      // 0:Servo,1:Relay, 2:GoPro in Solo Gimbal
-    AP_Int8         _trigger_duration;  // duration in 10ths of a second that the camera shutter is held open
-    AP_Int8         _relay_on;          // relay value to trigger camera
-    AP_Int16        _servo_on_pwm;      // PWM value to move servo to when shutter is activated
-    AP_Int16        _servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
-    uint8_t         _trigger_counter;   // count of number of cycles shutter has been held open
-    uint8_t         _trigger_counter_cam_function;   // count of number of cycles alternative camera function has been held open
-    AP_Int8         _auto_mode_only;    // if 1: trigger by distance only if in AUTO mode.
-    AP_Int8         _type;              // Set the type of camera in use, will open additional parameters if set
-    bool            _is_in_auto_mode;   // true if in AUTO mode
+    // check instance number is valid
+    bool is_valid_instance(uint8_t instance) const;
 
-    void            servo_pic();        // Servo operated camera
-    void            relay_pic();        // basic relay activation
-    void            feedback_pin_timer();
-    void            feedback_pin_isr(uint8_t, bool, uint32_t);
-    void            setup_feedback_callback(void);
+    // perform any required parameter conversion
+    void convert_params();
 
-    AP_Float        _trigg_dist;        // distance between trigger points (meters)
-    AP_Int16        _min_interval;      // Minimum time between shots required by camera
-    AP_Int16        _max_roll;          // Maximum acceptable roll angle when trigging camera
-    uint32_t        _last_photo_time;   // last time a photo was taken
-    bool            _trigger_pending;   // true when we have delayed take_picture
-    Location        _last_location;
-    uint16_t        _image_index;       // number of pictures taken since boot
-
-    // pin number for accurate camera feedback messages
-    AP_Int8         _feedback_pin;
-    AP_Int8         _feedback_polarity;
-
-    uint32_t        _camera_trigger_count;
-    uint32_t        _camera_trigger_logged;
-    uint32_t        _feedback_trigger_timestamp_us;
-    struct {
-        uint64_t        timestamp_us;
-        Location        location; // place where most recent image was taken
-        int32_t         roll_sensor;
-        int32_t         pitch_sensor;
-        int32_t         yaw_sensor;
-        uint32_t        camera_trigger_logged;  // ID sequence number
-    } feedback;
-    void prep_mavlink_msg_camera_feedback(uint64_t timestamp_us);
-
-    bool            _timer_installed;
-    bool            _isr_installed;
-    uint8_t         _last_pin_state;
-
-    void log_picture();
-
-    // Logging Function
-    void Write_Camera(uint64_t timestamp_us=0);
-    void Write_Trigger(void);
-    void Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us=0);
-
-    uint32_t log_camera_bit;
-
-    // update camera trigger - 50Hz
-    void update_trigger();
-
-    // entry point to trip local shutter (e.g. by relay or servo)
-    void trigger_pic();
-
-    // de-activate the trigger after some delay, but without using a delay() function
-    // should be called at 50hz from main program
-    void trigger_pic_cleanup();
-
-    // return true if we are using a feedback pin
-    bool using_feedback_pin(void) const
-    {
-        return _feedback_pin > 0;
-    }
-
+    uint8_t primary;                    // index of primary backend (normally the first one)
+    bool _is_in_auto_mode;              // true if in AUTO mode
+    uint32_t log_camera_bit;            // logging bit (from LOG_BITMASK) to enable camera logging
+    uint8_t _num_instances;             // number of camera backends instantiated
+    AP_Camera_Backend *_backends[AP_CAMERA_MAX_INSTANCES];  // pointers to instantiated backends
 };
 
 namespace AP {

--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -1,0 +1,243 @@
+#include "AP_Camera_Backend.h"
+
+#if AP_CAMERA_ENABLED
+#include <GCS_MAVLink/GCS.h>
+#include <AP_GPS/AP_GPS.h>
+
+extern const AP_HAL::HAL& hal;
+
+// Constructor
+AP_Camera_Backend::AP_Camera_Backend(AP_Camera &frontend, AP_Camera_Params &params, uint8_t instance) :
+    _frontend(frontend),
+    _params(params),
+    _instance(instance)
+{}
+
+// update - should be called at 50hz
+void AP_Camera_Backend::update()
+{
+    // try to take picture if pending
+    if (trigger_pending) {
+        take_picture();
+    }
+
+    // check feedback pin
+    check_feedback();
+
+    // implement trigger distance
+    if (!is_positive(_params.trigg_dist)) {
+        last_location.lat = 0;
+        last_location.lng = 0;
+        return;
+    }
+
+    // check GPS status
+    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+        return;
+    }
+
+    // check vehicle flight mode supports trigg dist
+    if (!_frontend.vehicle_mode_ok_for_trigg_dist()) {
+        return;
+    }
+
+    // check vehicle roll angle is less than configured maximum
+    const AP_AHRS &ahrs = AP::ahrs();
+    if ((_frontend.get_roll_max() > 0) && (fabsf(AP::ahrs().roll_sensor * 1e-2f) > _frontend.get_roll_max())) {
+        return;
+    }
+
+    // get current location. ignore failure because AHRS will provide its best guess
+    Location current_loc;
+    IGNORE_RETURN(ahrs.get_location(current_loc));
+
+    // initialise last location to current location
+    if (last_location.lat == 0 && last_location.lng == 0) {
+        last_location = current_loc;
+        return;
+    }
+    if (last_location.lat == current_loc.lat && last_location.lng == current_loc.lng) {
+        // we haven't moved - this can happen as update() may
+        // be called without a new GPS fix
+        return;
+    }
+
+    // check vehicle has moved at least trigg_dist meters
+    if (current_loc.get_distance(last_location) < _params.trigg_dist) {
+        return;
+    }
+
+    take_picture();
+}
+
+// take a picture.  returns true on success
+bool AP_Camera_Backend::take_picture()
+{
+    // setup feedback pin interrupt or timer
+    setup_feedback_callback();
+
+    // check minimum time interval since last picture taken
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_photo_time_ms < (uint32_t)(_params.interval_min * 1000)) {
+        trigger_pending = true;
+        return false;
+    }
+
+    trigger_pending = false;
+
+    // trigger actually taking picture and update image count
+    if (trigger_pic()) {
+        image_index++;
+        last_photo_time_ms = now_ms;
+        IGNORE_RETURN(AP::ahrs().get_location(last_location));
+        log_picture();
+        return true;
+    }
+
+    return false;
+}
+
+// handle camera control
+void AP_Camera_Backend::control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id)
+{
+    // take picture
+    if (is_equal(shooting_cmd, 1.0f)) {
+        take_picture();
+    }
+}
+
+// send camera feedback message to GCS
+void AP_Camera_Backend::send_camera_feedback(mavlink_channel_t chan) const
+{
+    int32_t altitude = 0;
+    if (camera_feedback.location.initialised() && !camera_feedback.location.get_alt_cm(Location::AltFrame::ABSOLUTE, altitude)) {
+        // completely ignore this failure!  this is a shouldn't-happen
+        // as current_loc should never be in an altitude we can't
+        // convert.
+    }
+    int32_t altitude_rel = 0;
+    if (camera_feedback.location.initialised() && !camera_feedback.location.get_alt_cm(Location::AltFrame::ABOVE_HOME, altitude_rel)) {
+        // completely ignore this failure!  this is a shouldn't-happen
+        // as current_loc should never be in an altitude we can't
+        // convert.
+    }
+
+    // send camera feedback message
+    mavlink_msg_camera_feedback_send(
+        chan,
+        camera_feedback.timestamp_us,       // image timestamp
+        0,                                  // target system id
+        _instance,                          // camera id
+        image_index,                        // image index
+        camera_feedback.location.lat,       // latitude
+        camera_feedback.location.lng,       // longitude
+        altitude*1e-2f,                     // alt MSL
+        altitude_rel*1e-2f,                 // alt relative to home
+        camera_feedback.roll_sensor*1e-2f,  // roll angle (deg)
+        camera_feedback.pitch_sensor*1e-2f, // pitch angle (deg)
+        camera_feedback.yaw_sensor*1e-2f,   // yaw angle (deg)
+        0.0f,                               // focal length
+        CAMERA_FEEDBACK_PHOTO,              // flags
+        camera_feedback.feedback_trigger_logged_count); // completed image captures
+}
+
+// setup a callback for a feedback pin. When on PX4 with the right FMU
+// mode we can use the microsecond timer.
+void AP_Camera_Backend::setup_feedback_callback()
+{
+    if (_params.feedback_pin <= 0 || timer_installed || isr_installed) {
+        // invalid or already installed
+        return;
+    }
+
+    // ensure we are in input mode
+    hal.gpio->pinMode(_params.feedback_pin, HAL_GPIO_INPUT);
+
+    // enable pullup/pulldown
+    uint8_t trigger_polarity = _params.feedback_polarity == 0 ? 0 : 1;
+    hal.gpio->write(_params.feedback_pin, !trigger_polarity);
+
+    if (hal.gpio->attach_interrupt(_params.feedback_pin, FUNCTOR_BIND_MEMBER(&AP_Camera_Backend::feedback_pin_isr, void, uint8_t, bool, uint32_t),
+                                   trigger_polarity?AP_HAL::GPIO::INTERRUPT_RISING:AP_HAL::GPIO::INTERRUPT_FALLING)) {
+        isr_installed = true;
+    } else {
+        // install a 1kHz timer to check feedback pin
+        hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Camera_Backend::feedback_pin_timer, void));
+
+        timer_installed = true;
+    }
+}
+
+// interrupt handler for interrupt based feedback trigger
+void AP_Camera_Backend::feedback_pin_isr(uint8_t pin, bool high, uint32_t timestamp_us)
+{
+    feedback_trigger_timestamp_us = timestamp_us;
+    feedback_trigger_count++;
+}
+
+// check if feedback pin is high for timer based feedback trigger, when
+// attach_interrupt fails
+void AP_Camera_Backend::feedback_pin_timer()
+{
+    uint8_t pin_state = hal.gpio->read(_params.feedback_pin);
+    uint8_t trigger_polarity = _params.feedback_polarity == 0 ? 0 : 1;
+    if (pin_state == trigger_polarity &&
+        last_pin_state != trigger_polarity) {
+        feedback_trigger_timestamp_us = AP_HAL::micros();
+        feedback_trigger_count++;
+    }
+    last_pin_state = pin_state;
+}
+
+// check for feedback pin update and log if necessary
+void AP_Camera_Backend::check_feedback()
+{
+    if (feedback_trigger_logged_count != feedback_trigger_count) {
+        const uint32_t timestamp32 = feedback_trigger_timestamp_us;
+        feedback_trigger_logged_count = feedback_trigger_count;
+
+        // we should consider doing this inside the ISR and pin_timer
+        prep_mavlink_msg_camera_feedback(feedback_trigger_timestamp_us);
+
+        // log camera message
+        uint32_t tdiff = AP_HAL::micros() - timestamp32;
+        uint64_t timestamp = AP_HAL::micros64();
+        Write_Camera(timestamp - tdiff);
+    }
+}
+
+void AP_Camera_Backend::prep_mavlink_msg_camera_feedback(uint64_t timestamp_us)
+{
+    const AP_AHRS &ahrs = AP::ahrs();
+    if (!ahrs.get_location(camera_feedback.location)) {
+        // completely ignore this failure!  AHRS will provide its best guess.
+    }
+    camera_feedback.timestamp_us = timestamp_us;
+    camera_feedback.roll_sensor = ahrs.roll_sensor;
+    camera_feedback.pitch_sensor = ahrs.pitch_sensor;
+    camera_feedback.yaw_sensor = ahrs.yaw_sensor;
+    camera_feedback.feedback_trigger_logged_count = feedback_trigger_logged_count;
+
+    gcs().send_message(MSG_CAMERA_FEEDBACK);
+}
+
+// log picture
+void AP_Camera_Backend::log_picture()
+{
+    const bool using_feedback_pin = _params.feedback_pin > 0;
+
+    if (!using_feedback_pin) {
+        // if we're using a feedback pin then when the event occurs we
+        // stash the feedback data.  Since we're not using a feedback
+        // pin, we just use "now".
+        prep_mavlink_msg_camera_feedback(AP::gps().time_epoch_usec());
+    }
+
+    if (!using_feedback_pin) {
+        Write_Camera();
+    } else {
+        Write_Trigger();
+    }
+}
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -1,0 +1,128 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Camera driver backend class. Each supported camera type
+  needs to have an object derived from this class.
+ */
+#pragma once
+
+#include "AP_Camera_config.h"
+
+#if AP_CAMERA_ENABLED
+#include "AP_Camera.h"
+
+class AP_Camera_Backend
+{
+public:
+
+    // Constructor
+    AP_Camera_Backend(AP_Camera &frontend, AP_Camera_Params &params, uint8_t instance);
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_Backend);
+
+    // init - performs any required initialisation
+    virtual void init() {};
+
+    // update - should be called at 50hz
+    virtual void update();
+
+    // return true if healthy
+    virtual bool healthy() const { return true; }
+
+    // momentary switch to change camera between picture and video modes
+    virtual void cam_mode_toggle() {}
+
+    // take a picture.  returns true on success
+    bool take_picture();
+
+    // entry point to actually take a picture.  returns true on success
+    virtual bool trigger_pic() = 0;
+
+    // start or stop video recording.  returns true on success
+    // set start_recording = true to start record, false to stop recording
+    virtual bool record_video(bool start_recording) { return false; }
+
+    // set camera zoom step.  returns true on success
+    // zoom out = -1, hold = 0, zoom in = 1
+    virtual bool set_zoom_step(int8_t zoom_step) { return false; }
+
+    // set focus in, out or hold.  returns true on success
+    // focus in = -1, focus hold = 0, focus out = 1
+    virtual bool set_manual_focus_step(int8_t focus_step) { return false; }
+
+    // auto focus.  returns true on success
+    virtual bool set_auto_focus() { return false; }
+
+    // handle incoming mavlink message
+    virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}
+
+    // configure camera
+    virtual void configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time) {}
+
+    // handle camera control
+    virtual void control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
+
+    // set camera trigger distance in meters
+    void set_trigger_distance(float distance_m) { _params.trigg_dist.set(distance_m); }
+
+    // send camera feedback message to GCS
+    void send_camera_feedback(mavlink_channel_t chan) const;
+
+protected:
+
+    // references
+    AP_Camera &_frontend;       // reference to the front end which holds parameters
+    AP_Camera_Params &_params;  // parameters for this backend
+
+    // feedback pin related methods
+    void setup_feedback_callback();
+    void feedback_pin_isr(uint8_t pin, bool high, uint32_t timestamp_us);
+    void feedback_pin_timer();
+    void check_feedback();
+
+    // store vehicle location and attitude for use in camera_feedback message to GCS
+    void prep_mavlink_msg_camera_feedback(uint64_t timestamp_us);
+    struct {
+        uint64_t timestamp_us;      // system time of most recent image
+        Location location;          // location where most recent image was taken
+        int32_t roll_sensor;        // vehicle roll in centi-degrees
+        int32_t pitch_sensor;       // vehicle pitch in centi-degrees
+        int32_t yaw_sensor;         // vehicle yaw in centi-degrees
+        uint32_t feedback_trigger_logged_count; // ID sequence number
+    } camera_feedback;
+
+    // Logging Function
+    void log_picture();
+    void Write_Camera(uint64_t timestamp_us=0);
+    void Write_Trigger();
+    void Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us=0);
+
+    // internal members
+    uint8_t _instance;      // this instance's number
+    bool timer_installed;   // true if feedback pin change detected using timer
+    bool isr_installed;     // true if feedback pin change is detected with an interrupt
+    uint8_t last_pin_state; // last pin state.  used by timer based detection
+    uint32_t feedback_trigger_count;        // number of times the interrupt detected the feedback pin changed
+    uint32_t feedback_trigger_timestamp_us; // system time (in microseconds) that timer detected the feedback pin changed
+    uint32_t feedback_trigger_logged_count; // number of times the feedback has been logged
+    bool trigger_pending;           // true if a call to take_pic() was delayed due to the minimum time interval time
+    uint32_t last_photo_time_ms;    // system time that photo was last taken
+    Location last_location;         // Location that last picture was taken at (used for trigg_dist calculation)
+    uint16_t image_index;           // number of pictures taken since boot
+};
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -1,4 +1,4 @@
-#include "AP_Camera.h"
+#include "AP_Camera_Backend.h"
 
 #if AP_CAMERA_ENABLED
 
@@ -6,8 +6,19 @@
 #include <AP_GPS/AP_GPS.h>
 
 // Write a Camera packet
-void AP_Camera::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
+void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
 {
+    // exit immediately if no logger
+    AP_Logger *logger = AP_Logger::get_singleton();
+    if (logger == nullptr) {
+        return;
+    }
+
+    // exit immediately if should not log camera messages
+    if (!logger->should_log(_frontend.get_log_camera_bit())) {
+        return;
+    }
+
     const AP_AHRS &ahrs = AP::ahrs();
 
     Location current_loc;
@@ -32,7 +43,8 @@ void AP_Camera::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
 
     const struct log_Camera pkt{
         LOG_PACKET_HEADER_INIT(static_cast<uint8_t>(msg)),
-        time_us     : timestamp_us?timestamp_us:AP_HAL::micros64(),
+        time_us     : timestamp_us ? timestamp_us : AP_HAL::micros64(),
+        instance    : _instance,
         gps_time    : gps.time_week_ms(),
         gps_week    : gps.time_week(),
         latitude    : current_loc.lat,
@@ -48,13 +60,13 @@ void AP_Camera::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
 }
 
 // Write a Camera packet
-void AP_Camera::Write_Camera(uint64_t timestamp_us)
+void AP_Camera_Backend::Write_Camera(uint64_t timestamp_us)
 {
     Write_CameraInfo(LOG_CAMERA_MSG, timestamp_us);
 }
 
 // Write a Trigger packet
-void AP_Camera::Write_Trigger(void)
+void AP_Camera_Backend::Write_Trigger()
 {
     Write_CameraInfo(LOG_TRIGGER_MSG, 0);
 }

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -45,6 +45,7 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
         LOG_PACKET_HEADER_INIT(static_cast<uint8_t>(msg)),
         time_us     : timestamp_us ? timestamp_us : AP_HAL::micros64(),
         instance    : _instance,
+        image_number: image_index,
         gps_time    : gps.time_week_ms(),
         gps_week    : gps.time_week(),
         latitude    : current_loc.lat,

--- a/libraries/AP_Camera/AP_Camera_MAVLink.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLink.cpp
@@ -1,0 +1,64 @@
+#include "AP_Camera_MAVLink.h"
+
+#if AP_CAMERA_ENABLED
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+// entry point to actually take a picture.  returns true on success
+bool AP_Camera_MAVLink::trigger_pic()
+{
+    // tell all of our components to take a picture:
+    mavlink_command_long_t cmd_msg {};
+    cmd_msg.command = MAV_CMD_DO_DIGICAM_CONTROL;
+    cmd_msg.param5 = 1;
+
+    // forward to all components
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
+    return true;
+}
+
+// configure camera
+void AP_Camera_MAVLink::configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time)
+{
+    // convert to mavlink message and send to all components
+    mavlink_command_long_t mav_cmd_long = {};
+
+    // convert mission command to mavlink command_long
+    mav_cmd_long.command = MAV_CMD_DO_DIGICAM_CONFIGURE;
+    mav_cmd_long.param1 = shooting_mode;
+    mav_cmd_long.param2 = shutter_speed;
+    mav_cmd_long.param3 = aperture;
+    mav_cmd_long.param4 = ISO;
+    mav_cmd_long.param5 = exposure_type;
+    mav_cmd_long.param6 = cmd_id;
+    mav_cmd_long.param7 = engine_cutoff_time;
+
+    // send to all components
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
+}
+
+// handle camera control message
+void AP_Camera_MAVLink::control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id)
+{
+    // take picture and ignore other arguments
+    if (is_equal(shooting_cmd, 1.0f)) {
+        take_picture();
+        return;
+    }
+
+    // convert command to mavlink command long
+    mavlink_command_long_t mav_cmd_long = {};
+    mav_cmd_long.command = MAV_CMD_DO_DIGICAM_CONTROL;
+    mav_cmd_long.param1 = session;
+    mav_cmd_long.param2 = zoom_pos;
+    mav_cmd_long.param3 = zoom_step;
+    mav_cmd_long.param4 = focus_lock;
+    mav_cmd_long.param5 = shooting_cmd;
+    mav_cmd_long.param6 = cmd_id;
+
+    // send to all components
+    GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&mav_cmd_long, sizeof(mav_cmd_long));
+}
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_MAVLink.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLink.h
@@ -1,0 +1,45 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Camera driver for cameras included in Mount
+ */
+#pragma once
+
+#include "AP_Camera_Backend.h"
+
+#if AP_CAMERA_ENABLED
+
+class AP_Camera_MAVLink : public AP_Camera_Backend
+{
+public:
+
+    // Constructor
+    using AP_Camera_Backend::AP_Camera_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_MAVLink);
+
+    // entry point to actually take a picture
+    bool trigger_pic() override;
+
+    // configure camera
+    void configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time) override;
+
+    // handle camera control message
+    void control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id) override;
+};
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -1,0 +1,72 @@
+#include "AP_Camera_Mount.h"
+
+#if AP_CAMERA_ENABLED
+#include <AP_Mount/AP_Mount.h>
+
+extern const AP_HAL::HAL& hal;
+
+// entry point to actually take a picture.  returns true on success
+bool AP_Camera_Mount::trigger_pic()
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        mount->take_picture(0);
+        return true;
+    }
+#endif
+    return false;
+}
+
+// start/stop recording video.  returns true on success
+// start_recording should be true to start recording, false to stop recording
+bool AP_Camera_Mount::record_video(bool start_recording)
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->record_video(0, start_recording);
+    }
+#endif
+    return false;
+}
+
+// zoom in, out or hold.  returns true on success
+// zoom out = -1, hold = 0, zoom in = 1
+bool AP_Camera_Mount::set_zoom_step(int8_t zoom_step)
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->set_zoom_step(0, zoom_step);
+    }
+#endif
+    return false;
+}
+
+// focus in, out or hold.  returns true on success
+// focus in = -1, focus hold = 0, focus out = 1
+bool AP_Camera_Mount::set_manual_focus_step(int8_t focus_step)
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->set_manual_focus_step(0, focus_step);
+    }
+#endif
+    return false;
+}
+
+// auto focus.  returns true on success
+bool AP_Camera_Mount::set_auto_focus()
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->set_auto_focus(0);
+    }
+#endif
+    return false;
+}
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -1,0 +1,54 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Camera driver for cameras included in Mount
+ */
+#pragma once
+
+#include "AP_Camera_Backend.h"
+
+#if AP_CAMERA_ENABLED
+
+class AP_Camera_Mount : public AP_Camera_Backend
+{
+public:
+
+    // Constructor
+    using AP_Camera_Backend::AP_Camera_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_Mount);
+
+    // entry point to actually take a picture.  returns true on success
+    bool trigger_pic() override;
+
+    // start or stop video recording.  returns true on success
+    // set start_recording = true to start record, false to stop recording
+    bool record_video(bool start_recording) override;
+
+    // set camera zoom step.  returns true on success
+    // zoom out = -1, hold = 0, zoom in = 1
+    bool set_zoom_step(int8_t zoom_step) override;
+
+    // set focus in, out or hold.  returns true on success
+    // focus in = -1, focus hold = 0, focus out = 1
+    bool set_manual_focus_step(int8_t focus_step) override;
+
+    // auto focus.  returns true on success
+    bool set_auto_focus() override;
+};
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -1,0 +1,83 @@
+#include "AP_Camera_Params.h"
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
+
+    // 0 should not be used
+
+    // @Param: _TYPE
+    // @DisplayName: Camera shutter (trigger) type
+    // @Description: how to trigger the camera to take a picture
+    // @Values: 1:Servo,2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi), 5:MAVLink
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_TYPE",  1, AP_Camera_Params, type, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: _DURATION
+    // @DisplayName: Camera shutter duration held open
+    // @Description: Duration in seconds that the camera shutter is held open
+    // @Units: s
+    // @Range: 0 5
+    // @User: Standard
+    AP_GROUPINFO("_DURATION", 2, AP_Camera_Params, trigger_duration, 0.1),
+
+    // @Param: _SERVO_ON
+    // @DisplayName: Camera servo ON PWM value
+    // @Description: PWM value in microseconds to move servo to when shutter is activated
+    // @Units: PWM
+    // @Range: 1000 2000
+    // @User: Standard
+    AP_GROUPINFO("_SERVO_ON", 3, AP_Camera_Params, servo_on_pwm, 1300),
+
+    // @Param: _SERVO_OFF
+    // @DisplayName: Camera servo OFF PWM value
+    // @Description: PWM value in microseconds to move servo to when shutter is deactivated
+    // @Units: PWM
+    // @Range: 1000 2000
+    // @User: Standard
+    AP_GROUPINFO("_SERVO_OFF", 4, AP_Camera_Params, servo_off_pwm, 1100),
+
+    // @Param: _TRIGG_DIST
+    // @DisplayName: Camera trigger distance
+    // @Description: Distance in meters between camera triggers. If this value is non-zero then the camera will trigger whenever the position changes by this number of meters regardless of what mode the APM is in. Note that this parameter can also be set in an auto mission using the DO_SET_CAM_TRIGG_DIST command, allowing you to enable/disable the triggering of the camera during the flight.
+    // @User: Standard
+    // @Units: m
+    // @Range: 0 1000
+    AP_GROUPINFO("_TRIGG_DIST", 5, AP_Camera_Params, trigg_dist, 0),
+
+    // @Param: _RELAY_ON
+    // @DisplayName: Camera relay ON value
+    // @Description: This sets whether the relay goes high or low when it triggers. Note that you should also set RELAY_DEFAULT appropriately for your camera
+    // @Values: 0:Low,1:High
+    // @User: Standard
+    AP_GROUPINFO("_RELAY_ON", 6, AP_Camera_Params, relay_on, 1),
+
+    // @Param: _INTRVAL_MIN
+    // @DisplayName: Camera minimum time interval between photos
+    // @Description: Postpone shooting if previous picture was taken less than this many seconds ago
+    // @Units: s
+    // @Range: 0 10
+    // @User: Standard
+    AP_GROUPINFO("_INTRVAL_MIN", 7, AP_Camera_Params, interval_min, 0),
+
+    // @Param: _FEEDBAK_PIN
+    // @DisplayName: Camera feedback pin
+    // @Description: pin number to use for save accurate camera feedback messages. If set to -1 then don't use a pin flag for this, otherwise this is a pin number which if held high after a picture trigger order, will save camera messages when camera really takes a picture. A universal camera hot shoe is needed. The pin should be held high for at least 2 milliseconds for reliable trigger detection.  Some common values are given, but see the Wiki's "GPIOs" page for how to determine the pin number for a given autopilot. See also the CAMx_FEEDBCK_POL option.
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("_FEEDBAK_PIN", 8, AP_Camera_Params, feedback_pin, -1),
+
+    // @Param: _FEEDBAK_POL
+    // @DisplayName: Camera feedback pin polarity
+    // @Description: Polarity for feedback pin. If this is 1 then the feedback pin should go high on trigger. If set to 0 then it should go low
+    // @Values: 0:TriggerLow,1:TriggerHigh
+    // @User: Standard
+    AP_GROUPINFO("_FEEDBAK_POL", 9, AP_Camera_Params, feedback_polarity, 1),
+
+    AP_GROUPEND
+
+};
+
+AP_Camera_Params::AP_Camera_Params(void) {
+    AP_Param::setup_object_defaults(this, var_info);
+}

--- a/libraries/AP_Camera/AP_Camera_Params.h
+++ b/libraries/AP_Camera/AP_Camera_Params.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+
+class AP_Camera_Params {
+
+public:
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    AP_Camera_Params(void);
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_Params);
+
+    AP_Int8 type;               // camera type (see CameraType enum)
+    AP_Float trigger_duration;  // duration in seconds that the camera shutter is held open
+    AP_Int16 servo_on_pwm;      // PWM value to move servo to when shutter is activated
+    AP_Int16 servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
+    AP_Float trigg_dist;        // distance between trigger points (meters)
+    AP_Int8 relay_on;           // relay value to trigger camera
+    AP_Float interval_min;      // minimum time (in seconds) between shots required by camera
+
+    // pin number for accurate camera feedback messages
+    AP_Int8 feedback_pin;
+    AP_Int8 feedback_polarity;
+};

--- a/libraries/AP_Camera/AP_Camera_Relay.cpp
+++ b/libraries/AP_Camera/AP_Camera_Relay.cpp
@@ -1,0 +1,57 @@
+#include "AP_Camera_Relay.h"
+
+#if AP_CAMERA_ENABLED
+
+#include <AP_Relay/AP_Relay.h>
+
+extern const AP_HAL::HAL& hal;
+
+// update - should be called at 50hz
+void AP_Camera_Relay::update()
+{
+    if (trigger_counter > 0) {
+        trigger_counter--;
+    } else {
+        AP_Relay *ap_relay = AP::relay();
+        if (ap_relay == nullptr) {
+            return;
+        }
+        if (_params.relay_on) {
+            ap_relay->off(0);
+        } else {
+            ap_relay->on(0);
+        }
+    }
+
+    // call parent update
+    AP_Camera_Backend::update();
+}
+
+// entry point to actually take a picture.  returns true on success
+bool AP_Camera_Relay::trigger_pic()
+{
+    // fail if have not completed previous picture
+    if (trigger_counter > 0) {
+        return false;
+    }
+
+    // exit immediately if no relay is setup
+    AP_Relay *ap_relay = AP::relay();
+    if (ap_relay == nullptr) {
+        return false;
+    }
+
+    if (_params.relay_on) {
+        ap_relay->on(0);
+    } else {
+        ap_relay->off(0);
+    }
+
+    // set counter to move servo to off position after this many iterations of update (assumes 50hz update rate)
+    trigger_counter = constrain_float(_params.trigger_duration * 50, 0, UINT16_MAX);
+
+    return true;
+}
+
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Relay.h
+++ b/libraries/AP_Camera/AP_Camera_Relay.h
@@ -1,0 +1,46 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Camera servo driver backend class
+ */
+#pragma once
+
+#include "AP_Camera_Backend.h"
+
+#if AP_CAMERA_ENABLED
+
+class AP_Camera_Relay : public AP_Camera_Backend
+{
+public:
+
+    // Constructor
+    using AP_Camera_Backend::AP_Camera_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_Relay);
+
+    // update - should be called at 50hz
+    void update() override;
+
+    // entry point to actually take a picture.  returns true on success
+    bool trigger_pic() override;
+
+private:
+
+    uint16_t trigger_counter;   // count of number of cycles shutter should be held open
+};
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Servo.cpp
+++ b/libraries/AP_Camera/AP_Camera_Servo.cpp
@@ -1,0 +1,71 @@
+#include "AP_Camera_Servo.h"
+
+#if AP_CAMERA_ENABLED
+
+#include <SRV_Channel/SRV_Channel.h>
+
+extern const AP_HAL::HAL& hal;
+
+// update - should be called at 50hz
+void AP_Camera_Servo::update()
+{
+    // shutter counter
+    if (trigger_counter > 0) {
+        trigger_counter--;
+    } else {
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_trigger, _params.servo_off_pwm);
+    }
+
+    // iso counter
+    if (iso_counter > 0) {
+        iso_counter--;
+    } else {
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_iso, _params.servo_off_pwm);
+    }
+
+    // call parent update
+    AP_Camera_Backend::update();
+}
+
+// entry point to actually take a picture.  returns true on success
+bool AP_Camera_Servo::trigger_pic()
+{
+    // fail if have not completed previous picture
+    if (trigger_counter > 0) {
+        return false;
+    }
+
+    SRV_Channels::set_output_pwm(SRV_Channel::k_cam_trigger, _params.servo_on_pwm);
+
+    // set counter to move servo to off position after this many iterations of update (assumes 50hz update rate)
+    trigger_counter = constrain_float(_params.trigger_duration * 50, 0, UINT16_MAX);
+
+    return true;
+}
+
+// configure camera
+void AP_Camera_Servo::configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time)
+{
+    // designed to control Blackmagic Micro Cinema Camera (BMMCC) cameras
+    // if the message contains non zero values then use them for the below functions
+    if (ISO > 0) {
+        // set a trigger for the iso function that is flip controlled
+        iso_counter = constrain_float(_params.trigger_duration * 50, 0, UINT16_MAX);
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_iso, _params.servo_on_pwm);
+    }
+
+    if (aperture > 0) {
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_aperture, (uint16_t)aperture);
+    }
+
+    if (shutter_speed > 0) {
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_shutter_speed, (uint16_t)shutter_speed);
+    }
+
+    // Use the shooting mode PWM value for the BMMCC as the focus control - no need to modify or create a new MAVlink message type.
+    if (shooting_mode > 0) {
+        SRV_Channels::set_output_pwm(SRV_Channel::k_cam_focus, (uint16_t)shooting_mode);
+    }
+}
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Servo.h
+++ b/libraries/AP_Camera/AP_Camera_Servo.h
@@ -1,0 +1,50 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Camera servo driver backend class
+ */
+#pragma once
+
+#include "AP_Camera_Backend.h"
+
+#if AP_CAMERA_ENABLED
+
+class AP_Camera_Servo : public AP_Camera_Backend
+{
+public:
+
+    // Constructor
+    using AP_Camera_Backend::AP_Camera_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_Servo);
+
+    // update - should be called at 50hz
+    void update() override;
+
+    // entry point to actually take a picture.  returns true on success
+    bool trigger_pic() override;
+
+    // configure camera
+    void configure(float shooting_mode, float shutter_speed, float aperture, float ISO, float exposure_type, float cmd_id, float engine_cutoff_time) override;
+
+private:
+
+    uint16_t trigger_counter;   // count of number of cycles shutter should be held open
+    uint16_t iso_counter;       // count of number of cycles iso output should be held open
+};
+
+#endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
@@ -1,22 +1,19 @@
 #include "AP_Camera_SoloGimbal.h"
+
+#if AP_CAMERA_ENABLED && HAL_SOLO_GIMBAL_ENABLED
+
 #include <GCS_MAVLink/GCS.h>
-
-#if HAL_SOLO_GIMBAL_ENABLED
-
-GOPRO_CAPTURE_MODE AP_Camera_SoloGimbal::gopro_capture_mode;
-GOPRO_HEARTBEAT_STATUS AP_Camera_SoloGimbal::gopro_status;
-bool AP_Camera_SoloGimbal::gopro_is_recording;
-mavlink_channel_t AP_Camera_SoloGimbal::heartbeat_channel;
 
 // Toggle the shutter on the GoPro
 // This is so ArduPilot can toggle the shutter directly, either for mission/GCS commands, or when the
 // Solo's gimbal is installed on a vehicle other than a Solo.  The usual GoPro controls thorugh the 
 // Solo app and Solo controller do not use this, as it is done offboard on the companion computer.
-void AP_Camera_SoloGimbal::gopro_shutter_toggle()
+// entry point to actually take a picture.  returns true on success
+bool AP_Camera_SoloGimbal::trigger_pic()
 {
     if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
         gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
-        return;
+        return false;
     }
 
     const uint8_t gopro_shutter_start[4] = { 1, 0, 0, 0};
@@ -38,18 +35,22 @@ void AP_Camera_SoloGimbal::gopro_shutter_toggle()
             mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_start);
         }
     } else {
-        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Unsupported Capture Mode");    
+        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Unsupported Capture Mode");
+        return false;
     }
+
+    return true;
 }
 
 // Cycle the GoPro capture mode
 // This is so ArduPilot can cycle through the capture modes of the GoPro directly, probably with an RC Aux function.
 // This is primarily for Solo's gimbal being installed on a vehicle other than a Solo. The usual GoPro controls 
 // through the Solo app and Solo controller do not use this, as it is done offboard on the companion computer.
-void AP_Camera_SoloGimbal::gopro_capture_mode_toggle()
+// momentary switch to change camera between picture and video modes
+void AP_Camera_SoloGimbal::cam_mode_toggle()
 {
     uint8_t gopro_capture_mode_values[4] = { };
-    
+
     if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
         gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
         return;
@@ -67,7 +68,7 @@ void AP_Camera_SoloGimbal::gopro_capture_mode_toggle()
                 gcs().send_text(MAV_SEVERITY_INFO, "GoPro changing to mode photo");
             }
             break;
-        
+
         case GOPRO_CAPTURE_MODE_PHOTO:
         default:
             // Change to video mode
@@ -78,8 +79,8 @@ void AP_Camera_SoloGimbal::gopro_capture_mode_toggle()
     }
 }
 
-// heartbeat from the Solo gimbal GoPro
-void AP_Camera_SoloGimbal::handle_gopro_heartbeat(mavlink_channel_t chan, const mavlink_message_t &msg)
+// handle incoming heartbeat from the Solo gimbal GoPro
+void AP_Camera_SoloGimbal::handle_message(mavlink_channel_t chan, const mavlink_message_t &msg)
 {
     mavlink_gopro_heartbeat_t report_msg;
     mavlink_msg_gopro_heartbeat_decode(&msg, &report_msg);
@@ -113,4 +114,4 @@ void AP_Camera_SoloGimbal::handle_gopro_heartbeat(mavlink_channel_t chan, const 
     }
 }
 
-#endif // HAL_SOLO_GIMBAL_ENABLED
+#endif // AP_CAMERA_ENABLED && HAL_SOLO_GIMBAL_ENABLED

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.h
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.h
@@ -1,23 +1,37 @@
 #pragma once
 
-#include <GCS_MAVLink/GCS_MAVLink.h>
+#include "AP_Camera_Backend.h"
 #include <AP_Mount/AP_Mount.h>
 
-#if HAL_SOLO_GIMBAL_ENABLED
+#if AP_CAMERA_ENABLED && HAL_SOLO_GIMBAL_ENABLED
 
-class AP_Camera_SoloGimbal {
+#include <GCS_MAVLink/GCS_MAVLink.h>
+
+class AP_Camera_SoloGimbal : public AP_Camera_Backend
+{
 public:
 
-    static void gopro_shutter_toggle();
-    static void gopro_capture_mode_toggle();
-    static void handle_gopro_heartbeat(mavlink_channel_t chan, const mavlink_message_t &msg);
+    // Constructor
+    using AP_Camera_Backend::AP_Camera_Backend;
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Camera_SoloGimbal);
+
+    // entry point to actually take a picture.  returns true on success
+    bool trigger_pic() override;
+
+    // momentary switch to change camera between picture and video modes
+    void cam_mode_toggle() override;
+
+    // handle incoming mavlink message
+    void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) override;
 
 private:
 
-    static GOPRO_CAPTURE_MODE gopro_capture_mode;
-    static GOPRO_HEARTBEAT_STATUS gopro_status;
-    static bool gopro_is_recording;
-    static mavlink_channel_t heartbeat_channel;
+    GOPRO_CAPTURE_MODE gopro_capture_mode;
+    GOPRO_HEARTBEAT_STATUS gopro_status;
+    bool gopro_is_recording;
+    mavlink_channel_t heartbeat_channel;
 };
 
-#endif // HAL_SOLO_GIMBAL_ENABLED
+#endif // AP_CAMERA_ENABLED && HAL_SOLO_GIMBAL_ENABLED

--- a/libraries/AP_Camera/LogStructure.h
+++ b/libraries/AP_Camera/LogStructure.h
@@ -10,6 +10,7 @@
 // @Description: Camera shutter information
 // @Field: TimeUS: Time since system startup
 // @Field: I: Instance number
+// @Field: Img: Image number
 // @Field: GPSTime: milliseconds since start of GPS week
 // @Field: GPSWeek: weeks since 5 Jan 1980
 // @Field: Lat: current latitude
@@ -17,13 +18,14 @@
 // @Field: Alt: current altitude
 // @Field: RelAlt: current altitude relative to home
 // @Field: GPSAlt: altitude as reported by GPS
-// @Field: Roll: current vehicle roll
-// @Field: Pit: current vehicle pitch
-// @Field: Yaw: current vehicle yaw
+// @Field: R: current vehicle roll
+// @Field: P: current vehicle pitch
+// @Field: Y: current vehicle yaw
 struct PACKED log_Camera {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint8_t  instance;
+    uint16_t image_number;
     uint32_t gps_time;
     uint16_t gps_week;
     int32_t  latitude;
@@ -38,6 +40,6 @@ struct PACKED log_Camera {
 
 #define LOG_STRUCTURE_FROM_CAMERA \
     { LOG_CAMERA_MSG, sizeof(log_Camera), \
-      "CAM", "QBIHLLeeeccC","TimeUS,I,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pit,Yaw", "s#--DUmmmddd", "F---GGBBBBBB" }, \
+      "CAM", "QBHIHLLeeeccC","TimeUS,I,Img,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,R,P,Y", "s#---DUmmmddd", "F----GGBBBBBB" }, \
     { LOG_TRIGGER_MSG, sizeof(log_Camera), \
-      "TRIG", "QBIHLLeeeccC","TimeUS,I,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pit,Yaw", "s#--DUmmmddd", "F---GGBBBBBB" },
+      "TRIG", "QBHIHLLeeeccC","TimeUS,I,Img,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,R,P,Y", "s#---DUmmmddd", "F----GGBBBBBB" },

--- a/libraries/AP_Camera/LogStructure.h
+++ b/libraries/AP_Camera/LogStructure.h
@@ -9,6 +9,7 @@
 // @LoggerMessage: CAM,TRIG
 // @Description: Camera shutter information
 // @Field: TimeUS: Time since system startup
+// @Field: I: Instance number
 // @Field: GPSTime: milliseconds since start of GPS week
 // @Field: GPSWeek: weeks since 5 Jan 1980
 // @Field: Lat: current latitude
@@ -17,11 +18,12 @@
 // @Field: RelAlt: current altitude relative to home
 // @Field: GPSAlt: altitude as reported by GPS
 // @Field: Roll: current vehicle roll
-// @Field: Pitch: current vehicle pitch
+// @Field: Pit: current vehicle pitch
 // @Field: Yaw: current vehicle yaw
 struct PACKED log_Camera {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t  instance;
     uint32_t gps_time;
     uint16_t gps_week;
     int32_t  latitude;
@@ -36,6 +38,6 @@ struct PACKED log_Camera {
 
 #define LOG_STRUCTURE_FROM_CAMERA \
     { LOG_CAMERA_MSG, sizeof(log_Camera), \
-      "CAM", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
+      "CAM", "QBIHLLeeeccC","TimeUS,I,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pit,Yaw", "s#--DUmmmddd", "F---GGBBBBBB" }, \
     { LOG_TRIGGER_MSG, sizeof(log_Camera), \
-      "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" },
+      "TRIG", "QBIHLLeeeccC","TimeUS,I,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pit,Yaw", "s#--DUmmmddd", "F---GGBBBBBB" },


### PR DESCRIPTION
This restructures the AP_Camera library into our regular frontend/backend split which provides these advantages:

1. easier to add support for new cameras
2. easier support of multiple cameras (this PR adds support for a 2nd camera but adding even more is trivial)

The changes include:

- New backend classes created for Servo, Relay, SoloGimbal, Mount and MAVLink
- Most parameters are moved into a new AP_Camera_Params class.  parameter conversion is done for these params
  - CAM_TRIGG_TYPE becomes CAM1_TYPE
  - CAM_DURATION becomes CAM1_DURATION.  Note change of scale from deci-seconds to seconds
  - CAM_MIN_**INTERVAL** becomes CAM1_**INTRVAL**_MIN.  Note change of scale from milliseconds to seconds.  Also missing "E"
  - CAM_**FEEDBACK**\_PIN and POL become CAM1_**FEEDBAK**_PIN and POL (Note missing "C")
  - CAM_SERVO_ON, CAM_SERVO_OFF, CAM_RELAY_ON become CAM**1**_SERVO_ON, CAM**1**_SERVO_OFF, CAM**1**_RELAY_ON
  - CAM_TYPE is removed because the "BMMCC" support is included in the Servo backend
- AP_Camera becomes the frontend with new accessors that accept the instance.  In practice these are not fully utilised because the existing vehicle code still calls the original methods (which then calls the new methods but passes in the primary instance)
- Small autotest changes to set the CAM1_TYPE because it is no longer set by default

There are some known issues:

- The Relay backend always uses the 1st Relay meaning if both CAM1 and CAM2 are Relay they will conflict
- [do-digicam-control messages](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1143) with shutter_cmd > 0 should not have other args (e.g. zoom, focus, etc) because these args will be set to zero before being forwarded on by the MAVLink backend to all components.

This has been fairly extensively tested in SITL and lightly tested on a desktop CubeOrange.  Tests included:

1. ensuring parameter conversion worked correctly for all parameters
2. servo and relay stayed open for the correct amount of time
3. feedback pin worked correctly
4. auto-only and roll-max features worked correctly
5. logging and feedback to GCS worked correctly
6. do-set-cam-trigg-dist mission command worked correctly

Here's a screen pic of SITL setup with two cameras, one with trigger distance of 10m, the other 20m.  If you look closely you can see every other camera icon is actually two overlapping icons.
![image](https://user-images.githubusercontent.com/1498098/219576764-ce4960c1-d8ad-435e-a1b1-1e0e11a760a7.png)

Here's a screen shot of the param conversion testing
![mp-param-conversion](https://user-images.githubusercontent.com/1498098/219577464-e17369c4-70d1-488d-8620-32523a61e439.png)

This has not been flown on a real vehicle.  Some additional testing still remains:

- [x] test the Mount backend can control a camera in a gimbal (e.g. Siyi A8, ViewPro)
- [x] check MP and QGC correctly handle the CAM format change

MP does not seem able to consume the CAM log message even before this PR (see below)
![mp-with-latest](https://user-images.githubusercontent.com/1498098/220216024-8f6c98fc-1a63-4dfc-a209-b8763bad0693.png)
![mp-with-new](https://user-images.githubusercontent.com/1498098/220216032-db502ab2-8ca7-49c6-8d59-f461bd9f1c8e.png)
