### PR TITLE
AP_BattMonitor: refactor Option param usage

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -506,7 +506,7 @@ float AP_BattMonitor::voltage_resting_estimate(uint8_t instance) const
 /// voltage - returns battery voltage in volts for GCS, may be resting voltage if option enabled
 float AP_BattMonitor::gcs_voltage(uint8_t instance) const
 {
-    if ((_params[instance]._options.get() & uint32_t(AP_BattMonitor_Params::Options::GCS_Resting_Voltage)) != 0) {
+    if (_params[instance].option_is_set(AP_BattMonitor_Params::Options::GCS_Resting_Voltage)) {
         return voltage_resting_estimate(instance);
     }
     if (instance < _num_instances) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -26,6 +26,11 @@ public:
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
     };
 
+    // check if a option is set
+    bool option_is_set(const Options option) const {
+        return (uint16_t(_options.get()) & uint16_t(option)) != 0;
+    }
+
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
 
     AP_Int32 _pack_capacity;            /// battery pack capacity less reserve in mAh

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -202,7 +202,7 @@ void AP_BattMonitor_UAVCAN::handle_battery_info_aux(const BattInfoAuxCb &cb)
 
 void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
 {
-    const bool use_input_value = (uint32_t(_params._options.get()) & uint32_t(AP_BattMonitor_Params::Options::MPPT_Use_Input_Value)) != 0;
+    const bool use_input_value = _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Use_Input_Value);
     const float voltage = use_input_value ? cb.msg->input_voltage : cb.msg->output_voltage;
     const float current = use_input_value ? cb.msg->input_current : cb.msg->output_current;
 
@@ -218,7 +218,13 @@ void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
         // this is the first time the mppt message has been received
         // so set powered up state
         _mppt.is_detected = true;
-        mppt_set_bootup_powered_state();
+
+        // Boot/Power-up event
+        if (_params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Boot)) {
+            mppt_set_powered_state(true);
+        } else if (_params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Boot)) {
+            mppt_set_powered_state(false);
+        }
     }
 
 #if AP_BATTMONITOR_UAVCAN_MPPT_DEBUG
@@ -319,62 +325,36 @@ bool AP_BattMonitor_UAVCAN::get_cycle_count(uint16_t &cycles) const
     return false;
 }
 
-// request MPPT board to power on/off at boot as specified by BATT_OPTIONS
-void AP_BattMonitor_UAVCAN::mppt_set_bootup_powered_state()
-{
-    const uint32_t options = uint32_t(_params._options.get());
-    const bool on_at_boot = (options & uint32_t(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Boot)) != 0;
-    const bool off_at_boot = (options & uint32_t(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Boot)) != 0;
-
-    if (on_at_boot) {
-        mppt_set_powered_state(true, true);
-    } else if (off_at_boot) {
-        mppt_set_powered_state(false, true);
-    }
-}
-
 // request MPPT board to power on/off depending upon vehicle arming state as specified by BATT_OPTIONS
 void AP_BattMonitor_UAVCAN::mppt_check_powered_state()
 {
     if ((_mppt.powered_state_remote_ms != 0) && (AP_HAL::millis() - _mppt.powered_state_remote_ms >= 1000)) {
         // there's already a set attempt that didnt' respond. Retry at 1Hz
-        mppt_set_powered_state(_mppt.powered_state, true);
+        mppt_set_powered_state(_mppt.powered_state);
     }
 
     // check if vehicle armed state has changed
     const bool vehicle_armed = hal.util->get_soft_armed();
-    if (vehicle_armed == _mppt.vehicle_armed_last) {
-        return;
+    if ((!_mppt.vehicle_armed_last && vehicle_armed) && _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Arm)) {
+        // arm event
+        mppt_set_powered_state(true);
+    }else if ((_mppt.vehicle_armed_last && !vehicle_armed) && _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Disarm)) {
+        // disarm event
+        mppt_set_powered_state(false);
     }
     _mppt.vehicle_armed_last = vehicle_armed;
-
-    // check options for arming state change events
-    const uint32_t options = uint32_t(_params._options.get());
-    const bool power_on_at_arm = (options & uint32_t(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Arm)) != 0;
-    const bool power_off_at_disarm = (options & uint32_t(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Disarm)) != 0;
-
-    if (vehicle_armed && power_on_at_arm) {
-        mppt_set_powered_state(true, false);
-    } else if (!vehicle_armed && power_off_at_disarm) {
-        mppt_set_powered_state(false, false);
-    }
 }
 
 // request MPPT board to power on or off
 // power_on should be true to power on the MPPT, false to power off
 // force should be true to force sending the state change request to the MPPT
-void AP_BattMonitor_UAVCAN::mppt_set_powered_state(bool power_on, bool force)
+void AP_BattMonitor_UAVCAN::mppt_set_powered_state(bool power_on)
 {
     if (_ap_uavcan == nullptr || _node == nullptr || !_mppt.is_detected) {
         return;
     }
 
-    // return immediately if already desired state and not forced
-    if ((_mppt.powered_state == power_on) && !force) {
-        return;
-    }
     _mppt.powered_state = power_on;
-    _mppt.powered_state_changed = true;
 
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Battery %u: powering %s%s", (unsigned)_instance+1, _mppt.powered_state ? "ON" : "OFF",
         (_mppt.powered_state_remote_ms == 0) ? "" : " Retry");

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -76,9 +76,8 @@ private:
         OVER_TEMPERATURE    = (1U<<3),
     };
     void handle_mppt_stream(const MpptStreamCb &cb);
-    void mppt_set_bootup_powered_state();
     void mppt_check_powered_state();
-    void mppt_set_powered_state(bool power_on, bool force);
+    void mppt_set_powered_state(bool power_on);
 
 #if AP_BATTMONITOR_UAVCAN_MPPT_DEBUG
     static void mppt_report_faults(const uint8_t instance, const uint8_t fault_flags);
@@ -108,7 +107,6 @@ private:
     struct {
         bool is_detected;               // true if this UAVCAN device is a Packet Digital MPPT
         bool powered_state;             // true if the mppt is powered on, false if powered off
-        bool powered_state_changed;     // true if _mppt_powered_state has changed and should be sent to MPPT board
         bool vehicle_armed_last;        // latest vehicle armed state. used to detect changes and power on/off MPPT board
         uint8_t fault_flags;            // bits holding fault flags
         uint32_t powered_state_remote_ms; // timestamp of when request was sent, zeroed on response. Used to retry


### PR DESCRIPTION
Refactors battery param OPTIONS to use a member function. Then using that I cleaned up some MPPT code using the new options and just considered all enable/disable attempts to be treated as force because all except two places were forcing and the one that didn't wasn't a big deal to just do it. Just saves a single GCS message from going out if you're trying to set it to a state it already was. 