### PR TITLE
Plane: arming: modes: don't always display

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -127,7 +127,7 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 
     char failure_msg[50] {};
     if (!plane.control_mode->pre_arm_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
-        check_failed(true, "%s %s", plane.control_mode->name(), failure_msg);
+        check_failed(display_failure, "%s %s", plane.control_mode->name(), failure_msg);
         return false;
     }
 


### PR DESCRIPTION
Fixes a bug introduced by me in https://github.com/ArduPilot/ardupilot/pull/22812

The old plane arm check used to always display failure however now there pre-arm that makes them extremely spammy. They now honor the `display_failure` flag.