### PR TITLE
AP_Scripting: DJIRS2 gimbal driver upside down support

### DIFF
--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -88,6 +88,24 @@ assert(param:add_table(PARAM_TABLE_KEY, "DJIR_", 2), "could not add param table"
 assert(param:add_param(PARAM_TABLE_KEY, 1, "DEBUG", 0), "could not add DJIR_DEBUG param")
 assert(param:add_param(PARAM_TABLE_KEY, 2, "UPSIDEDOWN", 0), "could not add DJIR_UPSIDEDOWN param")
 
+--[[
+  // @Param: DJIR_DEBUG
+  // @DisplayName: DJIRS2 debug
+  // @Description: Enable DJIRS2 debug
+  // @Values: 0:Disabled,1:Enabled,2:Enabled with attitude reporting
+  // @User: Advanced
+--]]
+local DJIR_DEBUG = Parameter("DJIR_DEBUG")              -- debug level. 0:disabled 1:enabled 2:enabled with attitude reporting
+
+--[[
+  // @Param: DJIR_UPSIDEDOWN
+  // @DisplayName: DJIRS2 upside down
+  // @Description: DJIRS2 upside down
+  // @Values: 0:Right side up,1:Upside down
+  // @User: Standard
+--]]
+local DJIR_UPSIDEDOWN = Parameter("DJIR_UPSIDEDOWN")    -- 0:rightsideup, 1:upsidedown
+
 -- bind parameters to variables
 local CAN_P1_DRIVER = Parameter("CAN_P1_DRIVER")        -- If using CAN1, should be 1:First driver
 local CAN_P1_BITRATE = Parameter("CAN_P1_BITRATE")      -- If using CAN1, should be 1000000
@@ -96,8 +114,6 @@ local CAN_P2_DRIVER = Parameter("CAN_P2_DRIVER")        -- If using CAN2, should
 local CAN_P2_BITRATE = Parameter("CAN_P2_BITRATE")      -- If using CAN2, should be 1000000
 local CAN_D2_PROTOCOL = Parameter("CAN_D2_PROTOCOL")    -- If using CAN2, should be 10:Scripting
 local MNT1_TYPE = Parameter("MNT1_TYPE")                -- should be 9:Scripting
-local DJIR_DEBUG = Parameter("DJIR_DEBUG")              -- debug level. 0:disabled 1:enabled 2:enabled with attitude reporting
-local DJIR_UPSIDEDOWN = Parameter("DJIR_UPSIDEDOWN")    -- 0:rightsideup, 1:upsidedown
 
 -- message definitions
 local HEADER = 0xAA

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -84,8 +84,9 @@ local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTI
 
 -- parameters
 local PARAM_TABLE_KEY = 38
-assert(param:add_table(PARAM_TABLE_KEY, "DJIR_", 1), "could not add param table")
+assert(param:add_table(PARAM_TABLE_KEY, "DJIR_", 2), "could not add param table")
 assert(param:add_param(PARAM_TABLE_KEY, 1, "DEBUG", 0), "could not add DJIR_DEBUG param")
+assert(param:add_param(PARAM_TABLE_KEY, 2, "UPSIDEDOWN", 0), "could not add DJIR_UPSIDEDOWN param")
 
 -- bind parameters to variables
 local CAN_P1_DRIVER = Parameter("CAN_P1_DRIVER")        -- If using CAN1, should be 1:First driver
@@ -96,6 +97,7 @@ local CAN_P2_BITRATE = Parameter("CAN_P2_BITRATE")      -- If using CAN2, should
 local CAN_D2_PROTOCOL = Parameter("CAN_D2_PROTOCOL")    -- If using CAN2, should be 10:Scripting
 local MNT1_TYPE = Parameter("MNT1_TYPE")                -- should be 9:Scripting
 local DJIR_DEBUG = Parameter("DJIR_DEBUG")              -- debug level. 0:disabled 1:enabled 2:enabled with attitude reporting
+local DJIR_UPSIDEDOWN = Parameter("DJIR_UPSIDEDOWN")    -- 0:rightsideup, 1:upsidedown
 
 -- message definitions
 local HEADER = 0xAA
@@ -437,6 +439,11 @@ function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time
   pitch_angle_deg = pitch_angle_deg or 0
   yaw_angle_deg = yaw_angle_deg or 0
   time_sec = time_sec or 2
+
+  -- if upsidedown, add 180deg to yaw
+  if DJIR_UPSIDEDOWN:get() > 0 then
+    yaw_angle_deg = wrap_180(yaw_angle_deg + 180)
+  end
 
   -- ensure angles are integers
   roll_angle_deg = -math.floor(roll_angle_deg + 0.5)

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -438,7 +438,7 @@ function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time
   yaw_angle_deg = yaw_angle_deg or 0
   time_sec = time_sec or 2
 
-  -- ensure angles are integers. invert roll direction
+  -- ensure angles are integers
   roll_angle_deg = -math.floor(roll_angle_deg + 0.5)
   pitch_angle_deg = math.floor(pitch_angle_deg + 0.5)
   yaw_angle_deg = math.floor(yaw_angle_deg + 0.5)


### PR DESCRIPTION
This adds support to orient the DJIRS2 gimbals upside down.  It also adds parameter descriptions.

This has been lightly tested on a real gimbal.
