### PR TITLE
AP_Scripting: fix PWMSource deletion crash

### DIFF
--- a/libraries/AP_HAL/GPIO.cpp
+++ b/libraries/AP_HAL/GPIO.cpp
@@ -6,6 +6,15 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_HAL::PWMSource::~PWMSource()
+{
+    if (interrupt_attached) {
+        // Assume this is always successful
+        hal.gpio->detach_interrupt(_pin);
+        interrupt_attached = false;
+    }
+}
+
 bool AP_HAL::PWMSource::set_pin(int16_t new_pin, const char *subsystem)
 {
     if (new_pin == _pin) {

--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -19,6 +19,9 @@ public:
 class AP_HAL::PWMSource {
 public:
 
+    // Destructor detaches interrupt
+    ~PWMSource();
+
     bool set_pin(int16_t new_pin, const char *subsystem);
     int16_t pin() const { return _pin; }  // returns pin this is attached to
 

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -244,6 +244,15 @@ void AP_Scripting::thread(void) {
         }
         num_i2c_devices = 0;
 
+        // clear allocated PWM sources
+        for (uint8_t i=0; i<SCRIPTING_MAX_NUM_PWM_SOURCE; i++) {
+            if (_pwm_source[i] != nullptr) {
+                delete _pwm_source[i];
+                _pwm_source[i] = nullptr;
+            }
+        }
+        num_pwm_source = 0;
+
         bool cleared = false;
         while(true) {
             // 1hz check if we should restart

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -28,6 +28,8 @@
   #define SCRIPTING_MAX_NUM_I2C_DEVICE 4
 #endif
 
+#define SCRIPTING_MAX_NUM_PWM_SOURCE 4
+
 class AP_Scripting
 {
 public:
@@ -88,6 +90,10 @@ public:
         uint32_t time_ms;
     };
     ObjectBuffer<struct scripting_mission_cmd> * mission_data;
+
+    // PWMSource storage
+    uint8_t num_pwm_source;
+    AP_HAL::PWMSource *_pwm_source[SCRIPTING_MAX_NUM_PWM_SOURCE];
 
 private:
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -309,24 +309,24 @@ function motor_factor_table_ud:roll(index, value) end
 
 
 -- desc
----@class PWMSource_ud
-local PWMSource_ud = {}
+---@class AP_HAL__PWMSource_ud
+local AP_HAL__PWMSource_ud = {}
 
----@return PWMSource_ud
+---@return AP_HAL__PWMSource_ud
 function PWMSource() end
 
 -- desc
 ---@return integer
-function PWMSource_ud:get_pwm_avg_us() end
+function AP_HAL__PWMSource_ud:get_pwm_avg_us() end
 
 -- desc
 ---@return integer
-function PWMSource_ud:get_pwm_us() end
+function AP_HAL__PWMSource_ud:get_pwm_us() end
 
 -- desc
 ---@param pin_number integer
 ---@return boolean
-function PWMSource_ud:set_pin(pin_number) end
+function AP_HAL__PWMSource_ud:set_pin(pin_number) end
 
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -478,10 +478,11 @@ ap_object AP_HAL::AnalogSource method voltage_average float
 ap_object AP_HAL::AnalogSource method voltage_latest float
 ap_object AP_HAL::AnalogSource method voltage_average_ratiometric float
 
-userdata AP_HAL::PWMSource rename PWMSource
-userdata AP_HAL::PWMSource method set_pin boolean uint8_t'skip_check "Scripting"'literal
-userdata AP_HAL::PWMSource method get_pwm_us uint16_t
-userdata AP_HAL::PWMSource method get_pwm_avg_us uint16_t
+global manual PWMSource lua_get_PWMSource 0
+
+ap_object AP_HAL::PWMSource method set_pin boolean uint8_t'skip_check "Scripting"'literal
+ap_object AP_HAL::PWMSource method get_pwm_us uint16_t
+ap_object AP_HAL::PWMSource method get_pwm_avg_us uint16_t
 
 singleton hal.gpio rename gpio
 singleton hal.gpio literal

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -382,26 +382,28 @@ int lua_get_i2c_device(lua_State *L) {
         }
     }
 
+    auto *scripting = AP::scripting();
+
     static_assert(SCRIPTING_MAX_NUM_I2C_DEVICE >= 0, "There cannot be a negative number of I2C devices");
-    if (AP::scripting()->num_i2c_devices >= SCRIPTING_MAX_NUM_I2C_DEVICE) {
+    if (scripting->num_i2c_devices >= SCRIPTING_MAX_NUM_I2C_DEVICE) {
         return luaL_argerror(L, 1, "no i2c devices available");
     }
 
-    AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] = new AP_HAL::OwnPtr<AP_HAL::I2CDevice>;
-    if (AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] == nullptr) {
+    scripting->_i2c_dev[scripting->num_i2c_devices] = new AP_HAL::OwnPtr<AP_HAL::I2CDevice>;
+    if (scripting->_i2c_dev[scripting->num_i2c_devices] == nullptr) {
         return luaL_argerror(L, 1, "i2c device nullptr");
     }
 
-    *AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] = std::move(hal.i2c_mgr->get_device(bus, address, bus_clock, use_smbus));
+    *scripting->_i2c_dev[scripting->num_i2c_devices] = std::move(hal.i2c_mgr->get_device(bus, address, bus_clock, use_smbus));
 
-    if (AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices] == nullptr || AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices]->get() == nullptr) {
+    if (scripting->_i2c_dev[scripting->num_i2c_devices] == nullptr || scripting->_i2c_dev[scripting->num_i2c_devices]->get() == nullptr) {
         return luaL_argerror(L, 1, "i2c device nullptr");
     }
 
     new_AP_HAL__I2CDevice(L);
-    *((AP_HAL::I2CDevice**)luaL_checkudata(L, -1, "AP_HAL::I2CDevice")) = AP::scripting()->_i2c_dev[AP::scripting()->num_i2c_devices]->get();
+    *((AP_HAL::I2CDevice**)luaL_checkudata(L, -1, "AP_HAL::I2CDevice")) = scripting->_i2c_dev[scripting->num_i2c_devices]->get();
 
-    AP::scripting()->num_i2c_devices++;
+    scripting->num_i2c_devices++;
 
     return 1;
 }
@@ -459,15 +461,17 @@ int lua_get_CAN_device(lua_State *L) {
     const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25);
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
-    if (AP::scripting()->_CAN_dev == nullptr) {
-        AP::scripting()->_CAN_dev = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting);
-        if (AP::scripting()->_CAN_dev == nullptr) {
+    auto *scripting = AP::scripting();
+
+    if (scripting->_CAN_dev == nullptr) {
+        scripting->_CAN_dev = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting);
+        if (scripting->_CAN_dev == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }
     }
 
     new_ScriptingCANBuffer(L);
-    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = AP::scripting()->_CAN_dev->add_buffer(buffer_len);
+    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = scripting->_CAN_dev->add_buffer(buffer_len);
 
     return 1;
 }
@@ -482,15 +486,17 @@ int lua_get_CAN_device2(lua_State *L) {
     const uint32_t raw_buffer_len = get_uint32(L, 1 + arg_offset, 1, 25);
     const uint32_t buffer_len = static_cast<uint32_t>(raw_buffer_len);
 
-    if (AP::scripting()->_CAN_dev2 == nullptr) {
-        AP::scripting()->_CAN_dev2 = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting2);
-        if (AP::scripting()->_CAN_dev2 == nullptr) {
+    auto *scripting = AP::scripting();
+
+    if (scripting->_CAN_dev2 == nullptr) {
+        scripting->_CAN_dev2 = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting2);
+        if (scripting->_CAN_dev2 == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }
     }
 
     new_ScriptingCANBuffer(L);
-    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = AP::scripting()->_CAN_dev2->add_buffer(buffer_len);
+    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = scripting->_CAN_dev2->add_buffer(buffer_len);
 
     return 1;
 }
@@ -547,20 +553,22 @@ int SRV_Channels_get_safety_state(lua_State *L) {
 int lua_get_PWMSource(lua_State *L) {
     binding_argcheck(L, 0);
 
+    auto *scripting = AP::scripting();
+
     static_assert(SCRIPTING_MAX_NUM_PWM_SOURCE >= 0, "There cannot be a negative number of PWMSources");
-    if (AP::scripting()->num_pwm_source >= SCRIPTING_MAX_NUM_PWM_SOURCE) {
+    if (scripting->num_pwm_source >= SCRIPTING_MAX_NUM_PWM_SOURCE) {
         return luaL_argerror(L, 1, "no PWMSources available");
     }
 
-    AP::scripting()->_pwm_source[AP::scripting()->num_pwm_source] = new AP_HAL::PWMSource;
-    if (AP::scripting()->_pwm_source[AP::scripting()->num_pwm_source] == nullptr) {
+    scripting->_pwm_source[scripting->num_pwm_source] = new AP_HAL::PWMSource;
+    if (scripting->_pwm_source[scripting->num_pwm_source] == nullptr) {
         return luaL_argerror(L, 1, "PWMSources device nullptr");
     }
 
     new_AP_HAL__PWMSource(L);
-    *((AP_HAL::PWMSource**)luaL_checkudata(L, -1, "AP_HAL::PWMSource")) = AP::scripting()->_pwm_source[AP::scripting()->num_pwm_source];
+    *((AP_HAL::PWMSource**)luaL_checkudata(L, -1, "AP_HAL::PWMSource")) = scripting->_pwm_source[scripting->num_pwm_source];
 
-    AP::scripting()->num_pwm_source++;
+    scripting->num_pwm_source++;
 
     return 1;
 }

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -13,3 +13,4 @@ int lua_get_CAN_device2(lua_State *L);
 int lua_dirlist(lua_State *L);
 int lua_removefile(lua_State *L);
 int SRV_Channels_get_safety_state(lua_State *L);
+int lua_get_PWMSource(lua_State *L);


### PR DESCRIPTION
This fixes a crash caused by deleting the scripting `PWMSource` object. The object registers a interrupt callback, so when its deleted the callback points to nothing and we crash. 

This moves to handle in a similar way to `i2c` Scripting not the script keeps the object and give the script a pointer to it. This means we can delete it properly if we need to. This does limit the number of `PWMSource` objects to 4, but I think that OK (we can change to more is we need to).