### PR TITLE
Copter: made changes to make DO_CHANGE_SPEED work

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -216,6 +216,7 @@ void AC_WPNav::set_speed_xy(float speed_cms)
 
         // initialize the desired wp speed
         _wp_desired_speed_xy_cms = speed_cms;
+        _wp_speed_cms.set_and_save_ifchanged(speed_cms);
 
         // update position controller speed and acceleration
         _pos_control.set_max_speed_accel_xy(_wp_desired_speed_xy_cms, get_wp_acceleration());


### PR DESCRIPTION
closes #21080.
@rmackay9 sir, I have done one modification. Please let me know if it's correct. 
I have one doubt, as the init() method of WPNav is called only when the destination is to be set either through the set_spline_destination() method or set_wp_destination() method, why is the stopping point set to default vector(Vector3f{}) and not the destination vector which we have while calling init() method?
