### PR TITLE
AP_UAVCAN: refactor init to use less stack RAM

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -251,6 +251,12 @@ private:
     // periodic logging
     void logging();
     
+    // init all the DroneCAN message callbacks and handlers
+    void init_ap_library_msgs();
+    void init_service_client_msgs(const uint8_t driver_index);
+    void init_listen_msgs(const uint8_t driver_index);
+    void init_publish_msgs(const uint8_t driver_index);
+
     // set parameter on a node
     ParamGetSetIntCb *param_int_cb;
     ParamGetSetFloatCb *param_float_cb;


### PR DESCRIPTION
Non-Functional change of refactoring various AP_UAVCAN:init() tasks into a few chunks to reduce stack RAM usage. This removes the need of having the pragma ram warning/bump

The diff is a little messy but this is a copy/paste of each chunk.