### PR TITLE
AP_OpenDroneID: use static period as last msg threshold

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -184,8 +184,8 @@ void AP_OpenDroneID::send_static_out()
     const uint32_t now_ms = AP_HAL::millis();
 
     // we need to notify user if we lost the transmitter
-    if (now_ms - last_arm_status_ms > 5000) {
-        if (now_ms - last_lost_tx_ms > 5000) {
+    if (now_ms - last_arm_status_ms > _mavlink_static_period_ms) {
+        if (now_ms - last_lost_tx_ms > _mavlink_static_period_ms) {
             last_lost_tx_ms = now_ms;
             GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "ODID: lost transmitter");
         }
@@ -196,7 +196,7 @@ void AP_OpenDroneID::send_static_out()
     }
 
     // we need to notify user if we lost system msg with operator location
-    if (now_ms - last_system_ms > 5000 && now_ms - last_lost_operator_msg_ms > 5000) {
+    if (now_ms - last_system_ms > _mavlink_static_period_ms && now_ms - last_lost_operator_msg_ms > _mavlink_static_period_ms) {
         last_lost_operator_msg_ms = now_ms;
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "ODID: lost operator location");
     }


### PR DESCRIPTION
Use the static period as the threshold for updating last arm status msg (from transmitter) and last system msg for updating operator location (which is required to be transmitted at least once every three seconds and no older than one second.)