### PR TITLE
AP_HAL_ChibiOS: Fix half-duplex serial on L431 periph nodes

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1154,7 +1154,6 @@ void UARTDriver::write_pending_bytes(void)
  */
 void UARTDriver::half_duplex_setup_tx(void)
 {
-#ifdef HAVE_USB_SERIAL
     if (!hd_tx_active) {
         chEvtGetAndClearFlags(&hd_listener);
         // half-duplex transmission is done when both the output is empty and the transmission is ended
@@ -1165,7 +1164,6 @@ void UARTDriver::half_duplex_setup_tx(void)
         sercfg.cr3 &= ~USART_CR3_HDSEL;
         sdStart(sd, &sercfg);
     }
-#endif
 }
 
 /*


### PR DESCRIPTION
This changeset intends to fix Half Duplex communications on Peripherals.
Tested on a MatekL431, with external device connected to `TX2`.

Without this changeset, the periph is unable to read the returned bytes from the devices on the far end.

![2023-02-22-bad-periph-halfduplex](https://user-images.githubusercontent.com/12959316/220535998-7a0a4d27-608e-4fa2-b38a-cebc740dfbe6.png)

With this changeset, the periph is able to read the returned bytes from the devices on the far end.
![2023-02-22-good-periph-halfduplex](https://user-images.githubusercontent.com/12959316/220535941-eac10dfa-109c-4a82-936c-60120c1ce8fb.png)
