### PR TITLE
AP_BattMonitor: refactor Option param usage v2

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -506,14 +506,13 @@ float AP_BattMonitor::voltage_resting_estimate(uint8_t instance) const
 /// voltage - returns battery voltage in volts for GCS, may be resting voltage if option enabled
 float AP_BattMonitor::gcs_voltage(uint8_t instance) const
 {
+    if (instance >= _num_instances || drivers[instance] == nullptr) {
+        return 0.0f;
+    }
     if (drivers[instance]->option_is_set(AP_BattMonitor_Params::Options::GCS_Resting_Voltage)) {
         return voltage_resting_estimate(instance);
     }
-    if (instance < _num_instances) {
-        return state[instance].voltage;
-    } else {
-        return 0.0f;
-    }
+    return state[instance].voltage;
 }
 
 /// current_amps - returns the instantaneous current draw in amperes
@@ -678,7 +677,7 @@ const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t in
 // returns true if there is a temperature reading
 bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance) const
 {
-    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES || drivers[instance] == nullptr) {
+    if (instance >= _num_instances || drivers[instance] == nullptr) {
         return false;
     } 
     
@@ -698,7 +697,7 @@ bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance)
 // return true when successfully setting a battery temperature from an external source by instance
 bool AP_BattMonitor::set_temperature(const float temperature, const uint8_t instance)
 {
-    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES || drivers[instance] == nullptr) {
+    if (instance >= _num_instances || drivers[instance] == nullptr) {
         return false;
     }
     state[instance].temperature_external = temperature;
@@ -722,7 +721,7 @@ bool AP_BattMonitor::set_temperature_by_serial_number(const float temperature, c
 // return true if cycle count can be provided and fills in cycles argument
 bool AP_BattMonitor::get_cycle_count(uint8_t instance, uint16_t &cycles) const
 {
-    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES || (drivers[instance] == nullptr)) {
+    if (instance >= _num_instances || (drivers[instance] == nullptr)) {
         return false;
     }
     return drivers[instance]->get_cycle_count(cycles);
@@ -732,7 +731,7 @@ bool AP_BattMonitor::arming_checks(size_t buflen, char *buffer) const
 {
     char temp_buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
 
-    for (uint8_t i = 0; i < AP_BATT_MONITOR_MAX_INSTANCES; i++) {
+    for (uint8_t i = 0; i < _num_instances; i++) {
         if (drivers[i] != nullptr && !(drivers[i]->arming_checks(temp_buffer, sizeof(temp_buffer)))) {
             hal.util->snprintf(buffer, buflen, "Battery %d %s", i + 1, temp_buffer);
             return false;
@@ -830,7 +829,7 @@ MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t 
 // Returns mavlink fault state
 uint32_t AP_BattMonitor::get_mavlink_fault_bitmask(const uint8_t instance) const
 {
-    if (drivers[instance] == nullptr) {
+    if (instance >= _num_instances || drivers[instance] == nullptr) {
         return 0;
     }
     return drivers[instance]->get_mavlink_fault_bitmask();

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -506,7 +506,7 @@ float AP_BattMonitor::voltage_resting_estimate(uint8_t instance) const
 /// voltage - returns battery voltage in volts for GCS, may be resting voltage if option enabled
 float AP_BattMonitor::gcs_voltage(uint8_t instance) const
 {
-    if (_params[instance].option_is_set(AP_BattMonitor_Params::Options::GCS_Resting_Voltage)) {
+    if (drivers[instance]->option_is_set(AP_BattMonitor_Params::Options::GCS_Resting_Voltage)) {
         return voltage_resting_estimate(instance);
     }
     if (instance < _num_instances) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -82,6 +82,11 @@ public:
     // dt_us: time between samples (micro-seconds)
     static float calculate_mah(float amps, float dt_us) { return (float) (amps * dt_us * AUS_TO_MAH); }
 
+    // check if a option is set
+    bool option_is_set(const AP_BattMonitor_Params::Options option) const {
+        return (uint16_t(_params._options.get()) & uint16_t(option)) != 0;
+    }
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -26,11 +26,6 @@ public:
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
     };
 
-    // check if a option is set
-    bool option_is_set(const Options option) const {
-        return (uint16_t(_options.get()) & uint16_t(option)) != 0;
-    }
-
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
 
     AP_Int32 _pack_capacity;            /// battery pack capacity less reserve in mAh

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -202,7 +202,7 @@ void AP_BattMonitor_UAVCAN::handle_battery_info_aux(const BattInfoAuxCb &cb)
 
 void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
 {
-    const bool use_input_value = _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Use_Input_Value);
+    const bool use_input_value = option_is_set(AP_BattMonitor_Params::Options::MPPT_Use_Input_Value);
     const float voltage = use_input_value ? cb.msg->input_voltage : cb.msg->output_voltage;
     const float current = use_input_value ? cb.msg->input_current : cb.msg->output_current;
 
@@ -220,9 +220,9 @@ void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
         _mppt.is_detected = true;
 
         // Boot/Power-up event
-        if (_params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Boot)) {
+        if (option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Boot)) {
             mppt_set_powered_state(true);
-        } else if (_params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Boot)) {
+        } else if (option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Boot)) {
             mppt_set_powered_state(false);
         }
     }
@@ -335,10 +335,10 @@ void AP_BattMonitor_UAVCAN::mppt_check_powered_state()
 
     // check if vehicle armed state has changed
     const bool vehicle_armed = hal.util->get_soft_armed();
-    if ((!_mppt.vehicle_armed_last && vehicle_armed) && _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Arm)) {
+    if ((!_mppt.vehicle_armed_last && vehicle_armed) && option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_On_At_Arm)) {
         // arm event
         mppt_set_powered_state(true);
-    }else if ((_mppt.vehicle_armed_last && !vehicle_armed) && _params.option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Disarm)) {
+    } else if ((_mppt.vehicle_armed_last && !vehicle_armed) && option_is_set(AP_BattMonitor_Params::Options::MPPT_Power_Off_At_Disarm)) {
         // disarm event
         mppt_set_powered_state(false);
     }


### PR DESCRIPTION
This fixes my PR-foo mixup on https://github.com/ArduPilot/ardupilot/pull/22964 (aka v1)

PR https://github.com/ArduPilot/ardupilot/pull/22965 (mppt enable) was on top of this v1 version and in that PR it was suggested to move option_is_set() from _Param to _Backend. I did but since it was a different branch, the v1 branch PR didn't change so when @khancyr reviewed and approved it I had thought I had updated it before I merged. My mistake, I should have double-checked before merging :(

Sorry about the commit churn.