### PR TITLE
AP_Scripting: fix doc warnings

### DIFF
--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -112,13 +112,13 @@ local function MAVLinkProcessor()
     local _txseqid = 0
 
     -- AUTOGEN from MAVLink generator
-    _crc_extra = {}
+    local _crc_extra = {}
     _crc_extra[75] = 0x9e
     _crc_extra[76] = 0x98
     _crc_extra[235] = 0xb3
     _crc_extra[73] = 0x26
     
-    _messages = {}
+    local _messages = {}
     _messages[75] = { -- COMMAND_INT
         {"param1", "<f"}, {"param2", "<f"}, {"param3", "<f"}, {"param4", "<f"},
         {"x", "<i4"}, {"y", "<i4"}, {"z", "<f"}, {"command", "<I2"},

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -55,13 +55,13 @@ local function MAVLinkProcessor()
     local _txseqid = 0
 
     -- AUTOGEN from MAVLink generator
-    _crc_extra = {}
+    local _crc_extra = {}
     _crc_extra[75] = 0x9e
     _crc_extra[76] = 0x98
     _crc_extra[235] = 0xb3
     _crc_extra[73] = 0x26
 
-    _messages = {}
+    local _messages = {}
     _messages[75] = { -- COMMAND_INT
         {"param1", "<f"}, {"param2", "<f"}, {"param3", "<f"}, {"param4", "<f"},
         {"x", "<i4"}, {"y", "<i4"}, {"z", "<f"}, {"command", "<I2"},


### PR DESCRIPTION
Fixed warnings in a lua script that had local variables that mirrored globals because they weren't declared local. These warnings are new and all new PRs that touch the scripts will fail until this is fixed.

```
Checking libraries/AP_Scripting/applets/RockBlock.lua 8 warnings
    libraries/AP_Scripting/applets/RockBlock.lua:116:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/applets/RockBlock.lua:117:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/applets/RockBlock.lua:118:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/applets/RockBlock.lua:119:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/applets/RockBlock.lua:122:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/applets/RockBlock.lua:128:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/applets/RockBlock.lua:134:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/applets/RockBlock.lua:146:5: mutating non-standard global variable _messages

Checking libraries/AP_Scripting/examples/MAVLinkHL.lua 8 warnings
    libraries/AP_Scripting/examples/MAVLinkHL.lua:59:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/examples/MAVLinkHL.lua:60:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/examples/MAVLinkHL.lua:61:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/examples/MAVLinkHL.lua:62:5: mutating non-standard global variable _crc_extra
    libraries/AP_Scripting/examples/MAVLinkHL.lua:65:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/examples/MAVLinkHL.lua:71:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/examples/MAVLinkHL.lua:77:5: mutating non-standard global variable _messages
    libraries/AP_Scripting/examples/MAVLinkHL.lua:89:5: mutating non-standard global variable _messages
```