### PR TITLE
RC_Channel: Delete unnecessary judgments

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1552,10 +1552,8 @@ bool RC_Channels::duplicate_options_exist()
         auxsw_option_counts[option]++;
     }
 
-    for (uint16_t i=0; i<sizeof(auxsw_option_counts); i++) {
-        if (i == 0) { // MAGIC VALUE! This is AUXSW_DO_NOTHING
-            continue;
-        }
+    // Do not check RC_Channel::aux_func_t::DO_NOTHING
+    for (uint16_t i=1; i<sizeof(auxsw_option_counts); i++) {
         if (auxsw_option_counts[i] > 1) {
             return true;
         }


### PR DESCRIPTION
The value of 0 is commented as a magic number.
If the initial value of the loop is set to 1, this determination is unnecessary.