### PR TITLE
Add support for handling Named Values in Scripting

### DIFF
--- a/libraries/AP_Scripting/examples/handle_named_value.lua
+++ b/libraries/AP_Scripting/examples/handle_named_value.lua
@@ -1,0 +1,15 @@
+nv:register("HEAD_ANGLE")
+
+function update()
+    val = nv:get("HEAD_ANGLE") -- just get the value
+    val, ts = nv:get("HEAD_ANGLE") -- get the value and the timestamp
+    val, ts, sysid, compid = nv:get("HEAD_ANGLE") -- get the value, the timestamp, the sysid and the compid
+    if val ~= nil then
+        gcs:send_text(0, "Time:" .. tostring(ts) .. " HEAD_ANGLE: " .. tostring(val) .. " sysid: " .. tostring(sysid) .. " compid: " .. tostring(compid))
+    else
+        gcs:send_text(0, "HEAD_ANGLE: nil")
+    end
+    return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -670,3 +670,6 @@ userdata uint32_t manual tofloat uint32_t_tofloat 0
 
 global manual dirlist lua_dirlist 1
 global manual remove lua_removefile 1
+
+singleton nv manual register lua_register_named_value string
+singleton nv manual get lua_get_named_value string

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -13,3 +13,5 @@ int lua_get_CAN_device2(lua_State *L);
 int lua_dirlist(lua_State *L);
 int lua_removefile(lua_State *L);
 int SRV_Channels_get_safety_state(lua_State *L);
+int lua_register_named_value(lua_State *L);
+int lua_get_named_value(lua_State *L);

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -19,6 +19,7 @@
 #include <AP_Logger/AP_Logger.h>
 
 #include <AP_Scripting/lua_generated_bindings.h>
+#include "lua_bindings.h"
 
 #define DISABLE_INTERRUPTS_FOR_SCRIPT_RUN 0
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -598,6 +598,7 @@ protected:
 
     void handle_statustext(const mavlink_message_t &msg) const;
     void handle_named_value(const mavlink_message_t &msg) const;
+    void handle_named_value_int(const mavlink_message_t &msg) const;
 
     bool telemetry_delayed() const;
     virtual uint32_t telem_delay() const = 0;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3336,6 +3336,32 @@ void GCS_MAVLINK::handle_named_value(const mavlink_message_t &msg) const
     mavlink_msg_named_value_float_decode(&msg, &p);
     char s[11] {};
     strncpy(s, p.name, sizeof(s)-1);
+    AP::scripting()->set_named_value(s, p.value, p.time_boot_ms, msg.sysid, msg.compid);
+
+    logger->Write("NVAL", "TimeUS,TimeBootMS,Name,Value,SSys,SCom", "ss#---", "FC----", "QINfBB",
+                  AP_HAL::micros64(),
+                  p.time_boot_ms,
+                  s,
+                  p.value,
+                  msg.sysid,
+                  msg.compid);
+}
+
+/*
+  handle logging of named values from mavlink.
+ */
+void GCS_MAVLINK::handle_named_value_int(const mavlink_message_t &msg) const
+{
+    auto *logger = AP_Logger::get_singleton();
+    if (logger == nullptr) {
+        return;
+    }
+    mavlink_named_value_int_t p;
+    mavlink_msg_named_value_int_decode(&msg, &p);
+    char s[11] {};
+    strncpy(s, p.name, sizeof(s)-1);
+    AP::scripting()->set_named_value(s, p.value, p.time_boot_ms, msg.sysid, msg.compid);
+
     logger->Write("NVAL", "TimeUS,TimeBootMS,Name,Value,SSys,SCom", "ss#---", "FC----", "QINfBB",
                   AP_HAL::micros64(),
                   p.time_boot_ms,
@@ -4034,6 +4060,10 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_NAMED_VALUE_FLOAT:
         handle_named_value(msg);
+        break;
+    
+    case MAVLINK_MSG_ID_NAMED_VALUE_INT:
+        handle_named_value_int(msg);
         break;
 
     case MAVLINK_MSG_ID_CAN_FRAME:


### PR DESCRIPTION
This adds support for accessing Named value int and float inside lua scripting.
`nv:register(<name>)` to add listener for named value.
`<value>,<timestamp>,<sysid>,<compid> = nv:get(<name>)` to get value information