### PR TITLE
AP_Mount: correct double-mapping of port to channel number

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -100,7 +100,7 @@ void AP_Mount_Gremsy::update()
 bool AP_Mount_Gremsy::healthy() const
 {
     // unhealthy until gimbal has been found and replied with device info
-    if (!_found_gimbal || !_got_device_info) {
+    if (_link == nullptr || !_got_device_info) {
         return false;
     }
 
@@ -152,17 +152,16 @@ void AP_Mount_Gremsy::find_gimbal()
     }
 
     // search for a mavlink enabled gimbal
-    if (!_found_gimbal) {
+    if (_link == nullptr) {
         // we expect that instance 0 has compid = MAV_COMP_ID_GIMBAL, instance 1 has compid = MAV_COMP_ID_GIMBAL2, etc
         uint8_t compid = (_instance == 0) ? MAV_COMP_ID_GIMBAL : MAV_COMP_ID_GIMBAL2 + (_instance - 1);
-        if (GCS_MAVLINK::find_by_mavtype_and_compid(MAV_TYPE_GIMBAL, compid, _sysid, _chan)) {
-            _compid = compid;
-            _found_gimbal = true;
-            return;
-        } else {
+        _link = GCS_MAVLINK::find_by_mavtype_and_compid(MAV_TYPE_GIMBAL, compid, _sysid);
+        if (_link == nullptr) {
             // have not yet found a gimbal so return
             return;
         }
+
+        _compid = compid;
     }
 
     // request GIMBAL_DEVICE_INFORMATION
@@ -232,6 +231,11 @@ void AP_Mount_Gremsy::handle_gimbal_device_attitude_status(const mavlink_message
 // request GIMBAL_DEVICE_INFORMATION message
 void AP_Mount_Gremsy::request_gimbal_device_information() const
 {
+    if (_link == nullptr) {
+        return;
+    }
+    const mavlink_channel_t _chan = _link->get_chan();
+
     // check we have space for the message
     if (!HAVE_PAYLOAD_SPACE(_chan, COMMAND_LONG)) {
         return;
@@ -248,8 +252,12 @@ void AP_Mount_Gremsy::request_gimbal_device_information() const
 // start sending ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE to gimbal
 bool AP_Mount_Gremsy::start_sending_attitude_to_gimbal()
 {
+    // better safe than sorry:
+    if (_link == nullptr) {
+        return false;
+    }
     // send AUTOPILOT_STATE_FOR_GIMBAL_DEVICE
-    const MAV_RESULT res = gcs().set_message_interval(_chan, MAVLINK_MSG_ID_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE, AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US);
+    const MAV_RESULT res = _link->set_message_interval(MAVLINK_MSG_ID_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE, AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US);
 
     // return true on success
     return (res == MAV_RESULT_ACCEPTED);
@@ -258,6 +266,11 @@ bool AP_Mount_Gremsy::start_sending_attitude_to_gimbal()
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)
 void AP_Mount_Gremsy::send_gimbal_device_retract() const
 {
+    if (_link == nullptr) {
+        return;
+    }
+    const mavlink_channel_t _chan = _link->get_chan();
+
     // check we have space for the message
     if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
         return;
@@ -277,6 +290,11 @@ void AP_Mount_Gremsy::send_gimbal_device_retract() const
 // earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
 void AP_Mount_Gremsy::send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const
 {
+    if (_link == nullptr) {
+        return;
+    }
+    const mavlink_channel_t _chan = _link->get_chan();
+
     // check we have space for the message
     if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
         return;
@@ -303,6 +321,11 @@ void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitc
     if (!_initialised) {
         return;
     }
+
+    if (_link == nullptr) {
+        return;
+    }
+    const mavlink_channel_t _chan = _link->get_chan();
 
     // check we have space for the message
     if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -234,15 +234,15 @@ void AP_Mount_Gremsy::request_gimbal_device_information() const
     if (_link == nullptr) {
         return;
     }
-    const mavlink_channel_t _chan = _link->get_chan();
+    const mavlink_channel_t chan = _link->get_chan();
 
     // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(_chan, COMMAND_LONG)) {
+    if (!HAVE_PAYLOAD_SPACE(chan, COMMAND_LONG)) {
         return;
     }
 
     mavlink_msg_command_long_send(
-        _chan,
+        chan,
         _sysid,
         _compid,
         MAV_CMD_REQUEST_MESSAGE,
@@ -269,16 +269,16 @@ void AP_Mount_Gremsy::send_gimbal_device_retract() const
     if (_link == nullptr) {
         return;
     }
-    const mavlink_channel_t _chan = _link->get_chan();
+    const mavlink_channel_t chan = _link->get_chan();
 
     // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
+    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
         return;
     }
 
     // send command_long command containing a do_mount_control command
     const float quat_array[4] = {NAN, NAN, NAN, NAN};
-    mavlink_msg_gimbal_device_set_attitude_send(_chan,
+    mavlink_msg_gimbal_device_set_attitude_send(chan,
                                                 _sysid,     // target system
                                                 _compid,    // target component
                                                 GIMBAL_DEVICE_FLAGS_RETRACT,    // gimbal device flags
@@ -293,10 +293,10 @@ void AP_Mount_Gremsy::send_gimbal_device_set_rate(float roll_rads, float pitch_r
     if (_link == nullptr) {
         return;
     }
-    const mavlink_channel_t _chan = _link->get_chan();
+    const mavlink_channel_t chan = _link->get_chan();
 
     // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
+    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
         return;
     }
 
@@ -305,7 +305,7 @@ void AP_Mount_Gremsy::send_gimbal_device_set_rate(float roll_rads, float pitch_r
     const float quat_array[4] = {NAN, NAN, NAN, NAN};
 
     // send command_long command containing a do_mount_control command
-    mavlink_msg_gimbal_device_set_attitude_send(_chan,
+    mavlink_msg_gimbal_device_set_attitude_send(chan,
                                                 _sysid,     // target system
                                                 _compid,    // target component
                                                 flags,      // gimbal device flags
@@ -325,10 +325,10 @@ void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitc
     if (_link == nullptr) {
         return;
     }
-    const mavlink_channel_t _chan = _link->get_chan();
+    const mavlink_channel_t chan = _link->get_chan();
 
     // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(_chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
+    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
         return;
     }
 
@@ -341,7 +341,7 @@ void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitc
     const float quat_array[4] = {q.q1, q.q2, q.q3, q.q4};
 
     // send command_long command containing a do_mount_control command
-    mavlink_msg_gimbal_device_set_attitude_send(_chan,
+    mavlink_msg_gimbal_device_set_attitude_send(chan,
                                                 _sysid,     // target system
                                                 _compid,    // target component
                                                 flags,      // gimbal device flags

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -69,11 +69,10 @@ private:
     void send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const;
 
     // internal variables
-    bool _found_gimbal;             // true once a MAVLink enabled gimbal has been found
     bool _got_device_info;          // true once gimbal has provided device info
     bool _initialised;              // true once the gimbal has provided a GIMBAL_DEVICE_INFORMATION
     uint32_t _last_devinfo_req_ms;  // system time that GIMBAL_DEVICE_INFORMATION was last requested (used to throttle requests)
-    mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
+    class GCS_MAVLINK *_link;       // link we have found gimbal on; nullptr if not seen yet
     uint8_t _sysid;                 // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
     mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -444,6 +444,9 @@ public:
       returns true if a match is found
      */
     static bool find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) { return routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel); }
+    // same as above, but returns a pointer to the GCS_MAVLINK object
+    // corresponding to the channel
+    static GCS_MAVLINK *find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid);
 
     // update signing timestamp on GPS lock
     static void update_signing_timestamp(uint64_t timestamp_usec);

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -48,6 +48,14 @@ mavlink_system_t mavlink_system = {7,1};
 // routing table
 MAVLink_routing GCS_MAVLINK::routing;
 
+GCS_MAVLINK *GCS_MAVLINK::find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid) {
+    mavlink_channel_t channel;
+    if (!routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel)) {
+        return nullptr;
+    }
+    return gcs().chan(channel);
+}
+
 // set a channel as private. Private channels get sent heartbeats, but
 // don't get broadcast packets or forwarded packets
 void GCS_MAVLINK::set_channel_private(mavlink_channel_t _chan)


### PR DESCRIPTION
Tested on a PixyU connected to SITL.

Note that most of the nullptr checks are can't-happens due to checks elsewhere.

Note also that we can save some bytes in the send-message methods in future by using `link->set_message(type, pkt)`.   Not done here to make backport easier.

This work sponsored by Harris Aerial.
