### PR TITLE
Neutral Pitch Translation for tilt rotors feature addition

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3533,10 +3533,10 @@ float QuadPlane::forward_throttle_pct()
             return 0;
         } else {
             // calculate fwd throttle demand from manual input
-            float fwd_thr = rc_fwd_thr_ch->percent_input();
+            float fwd_thr = rc_fwd_thr_ch->norm_input() * 100.0f;
 
-            // set forward throttle to fwd_thr_max * (manual input + mix): range [0,100]
-            fwd_thr *= .01f * constrain_float(fwd_thr_max, 0, 100);
+            // set forward throttle to fwd_thr_max * (manual input + mix): range [-100,100]
+            fwd_thr *= .01f * constrain_float(fwd_thr_max, -100, 100);
             return fwd_thr;
         }
     }
@@ -3603,8 +3603,8 @@ float QuadPlane::forward_throttle_pct()
     // integrator as throttle percentage (-100 to 100)
     vel_forward.integrator += fwd_vel_error * deltat * vel_forward.gain * 100;
 
-    // inhibit reverse throttle and allow petrol engines with min > 0
-    int8_t fwd_throttle_min = plane.have_reverse_thrust() ? 0 : plane.aparm.throttle_min;
+    // inhibit to minimum throttle
+    int8_t fwd_throttle_min = plane.aparm.throttle_min;
     vel_forward.integrator = constrain_float(vel_forward.integrator, fwd_throttle_min, plane.aparm.throttle_cruise);
 
     if (in_vtol_land_approach()) {

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -309,7 +309,7 @@ void Tiltrotor::continuous_update(void)
         // Q_TILT_MAX. Anything above 50% throttle gets
         // Q_TILT_MAX. Below 50% throttle we decrease linearly. This
         // relies heavily on Q_VFWD_GAIN being set appropriately.
-       float settilt = constrain_float((SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)-MAX(plane.aparm.throttle_min.get(),0)) * 0.02, 0, 1);
+       float settilt = .01f * quadplane.forward_throttle_pct();
        slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt())); 
     }
 }


### PR DESCRIPTION
In quadplanes with tilt rotors and vectored yaw, allow for pitch neutral fore/aft translation in VTOL modes.  Essentially just forward manual throttle and forward velocity hold, but allows for aft translation using the available Q_TILT_YAW_ANGLE.

Testing in RealFlight on the Convergence and Griffin vehicles shown below. 

https://youtu.be/tIIfGUtbbV4