### PR TITLE
Have send_message(id, buffer) check size, use it in Gremsy

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -234,19 +234,22 @@ void AP_Mount_Gremsy::request_gimbal_device_information() const
     if (_link == nullptr) {
         return;
     }
-    const mavlink_channel_t chan = _link->get_chan();
 
-    // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(chan, COMMAND_LONG)) {
-        return;
-    }
-
-    mavlink_msg_command_long_send(
-        chan,
+    const mavlink_command_long_t pkt {
+        MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION,  // param1
+        0,  // param2
+        0,  // param3
+        0,  // param4
+        0,  // param5
+        0,  // param6
+        0,  // param7
+        MAV_CMD_REQUEST_MESSAGE,
         _sysid,
         _compid,
-        MAV_CMD_REQUEST_MESSAGE,
-        0, MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION, 0, 0, 0, 0, 0, 0);
+        0  // confirmation
+    };
+
+    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
 }
 
 // start sending ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE to gimbal
@@ -266,51 +269,37 @@ bool AP_Mount_Gremsy::start_sending_attitude_to_gimbal()
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)
 void AP_Mount_Gremsy::send_gimbal_device_retract() const
 {
-    if (_link == nullptr) {
-        return;
-    }
-    const mavlink_channel_t chan = _link->get_chan();
+    const mavlink_gimbal_device_set_attitude_t pkt {
+        {NAN, NAN, NAN, NAN},  // attitude
+        0,   // angular velocity x
+        0,  // angular velocity y
+        0,    // angular velocity z
+        GIMBAL_DEVICE_FLAGS_RETRACT,  // flags
+        _sysid,
+        _compid
+    };
 
-    // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
-        return;
-    }
-
-    // send command_long command containing a do_mount_control command
-    const float quat_array[4] = {NAN, NAN, NAN, NAN};
-    mavlink_msg_gimbal_device_set_attitude_send(chan,
-                                                _sysid,     // target system
-                                                _compid,    // target component
-                                                GIMBAL_DEVICE_FLAGS_RETRACT,    // gimbal device flags
-                                                quat_array, // attitude as a quaternion
-                                                0, 0, 0);   // angular velocities
+    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
 // earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
 void AP_Mount_Gremsy::send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const
 {
-    if (_link == nullptr) {
-        return;
-    }
-    const mavlink_channel_t chan = _link->get_chan();
-
-    // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
-        return;
-    }
-
     // prepare flags
     const uint16_t flags = earth_frame ? (GIMBAL_DEVICE_FLAGS_ROLL_LOCK | GIMBAL_DEVICE_FLAGS_PITCH_LOCK | GIMBAL_DEVICE_FLAGS_YAW_LOCK) : 0;
-    const float quat_array[4] = {NAN, NAN, NAN, NAN};
 
-    // send command_long command containing a do_mount_control command
-    mavlink_msg_gimbal_device_set_attitude_send(chan,
-                                                _sysid,     // target system
-                                                _compid,    // target component
-                                                flags,      // gimbal device flags
-                                                quat_array, // attitude as a quaternion
-                                                roll_rads, pitch_rads, yaw_rads);   // angular velocities
+    const mavlink_gimbal_device_set_attitude_t pkt {
+        {NAN, NAN, NAN, NAN},  // attitude
+        roll_rads,   // angular velocity x
+        pitch_rads,  // angular velocity y
+        yaw_rads,    // angular velocity z
+        flags,
+        _sysid,
+        _compid
+    };
+
+    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
@@ -322,31 +311,24 @@ void AP_Mount_Gremsy::send_gimbal_device_set_attitude(float roll_rad, float pitc
         return;
     }
 
-    if (_link == nullptr) {
-        return;
-    }
-    const mavlink_channel_t chan = _link->get_chan();
-
-    // check we have space for the message
-    if (!HAVE_PAYLOAD_SPACE(chan, GIMBAL_DEVICE_SET_ATTITUDE)) {
-        return;
-    }
-
     // prepare flags
     const uint16_t flags = earth_frame ? (GIMBAL_DEVICE_FLAGS_ROLL_LOCK | GIMBAL_DEVICE_FLAGS_PITCH_LOCK | GIMBAL_DEVICE_FLAGS_YAW_LOCK) : 0;
 
     // convert euler angles to quaternion
     Quaternion q;
     q.from_euler(roll_rad, pitch_rad, yaw_rad);
-    const float quat_array[4] = {q.q1, q.q2, q.q3, q.q4};
 
-    // send command_long command containing a do_mount_control command
-    mavlink_msg_gimbal_device_set_attitude_send(chan,
-                                                _sysid,     // target system
-                                                _compid,    // target component
-                                                flags,      // gimbal device flags
-                                                quat_array, // attitude as a quaternion
-                                                NAN, NAN, NAN);   // angular velocities
+    const mavlink_gimbal_device_set_attitude_t pkt {
+        {q.q1, q.q2, q.q3, q.q4},
+        NAN,  // angular velocity x
+        NAN,  // angular velocity y
+        NAN,  // angular velocity z
+        flags,
+        _sysid,
+        _compid
+    };
+
+    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
 }
 
 #endif // HAL_MOUNT_GREMSY_ENABLED

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -93,10 +93,7 @@ void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
         if (!c.is_active()) {
             continue;
         }
-        if (entry->max_msg_len + c.packet_overhead() > c.txspace()) {
-            // no room on this channel
-            continue;
-        }
+        // size checks done by this method:
         c.send_message(pkt, entry);
     }
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -244,15 +244,17 @@ public:
                                 const mavlink_message_t &msg);
 
     // send a mavlink_message_t out this GCS_MAVLINK connection.
-    // Caller is responsible for ensuring space.
-    void send_message(uint32_t msgid, const char *pkt) const {
+    void send_message(uint32_t msgid, const char *pkt) {
         const mavlink_msg_entry_t *entry = mavlink_get_msg_entry(msgid);
         if (entry == nullptr) {
             return;
         }
         send_message(pkt, entry);
     }
-    void send_message(const char *pkt, const mavlink_msg_entry_t *entry) const {
+    void send_message(const char *pkt, const mavlink_msg_entry_t *entry) {
+        if (!check_payload_size(entry->max_msg_len)) {
+            return;
+        }
         _mav_finalize_message_chan_send(chan,
                                         entry->msgid,
                                         pkt,
@@ -519,9 +521,9 @@ protected:
     MAV_RESULT handle_command_do_aux_function(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
     void handle_mission_request_list(const mavlink_message_t &msg);
-    void handle_mission_request(const mavlink_message_t &msg) const;
-    void handle_mission_request_int(const mavlink_message_t &msg) const;
-    void handle_mission_clear_all(const mavlink_message_t &msg) const;
+    void handle_mission_request(const mavlink_message_t &msg);
+    void handle_mission_request_int(const mavlink_message_t &msg);
+    void handle_mission_clear_all(const mavlink_message_t &msg);
 
     // Note that there exists a relatively new mavlink DO command,
     // MAV_CMD_DO_SET_MISSION_CURRENT which provides an acknowledgement

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -589,7 +589,7 @@ void GCS_MAVLINK::handle_mission_request_list(const mavlink_message_t &msg)
 /*
   handle a MISSION_REQUEST mavlink packet
  */
-void GCS_MAVLINK::handle_mission_request_int(const mavlink_message_t &msg) const
+void GCS_MAVLINK::handle_mission_request_int(const mavlink_message_t &msg)
 {
         // decode
         mavlink_mission_request_int_t packet;
@@ -602,7 +602,7 @@ void GCS_MAVLINK::handle_mission_request_int(const mavlink_message_t &msg) const
         prot->handle_mission_request_int(*this, packet, msg);
 }
 
-void GCS_MAVLINK::handle_mission_request(const mavlink_message_t &msg) const
+void GCS_MAVLINK::handle_mission_request(const mavlink_message_t &msg)
 {
         // decode
         mavlink_mission_request_t packet;
@@ -674,7 +674,7 @@ void GCS_MAVLINK::handle_mission_count(const mavlink_message_t &msg)
 /*
   handle a MISSION_CLEAR_ALL mavlink packet
  */
-void GCS_MAVLINK::handle_mission_clear_all(const mavlink_message_t &msg) const
+void GCS_MAVLINK::handle_mission_clear_all(const mavlink_message_t &msg)
 {
     // decode
     mavlink_mission_clear_all_t packet;

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -122,7 +122,7 @@ void MissionItemProtocol::handle_mission_request_list(
                                    mission_type());
 }
 
-void MissionItemProtocol::handle_mission_request_int(const GCS_MAVLINK &_link,
+void MissionItemProtocol::handle_mission_request_int(GCS_MAVLINK &_link,
                                                      const mavlink_mission_request_int_t &packet,
                                                      const mavlink_message_t &msg)
 {
@@ -152,11 +152,10 @@ void MissionItemProtocol::handle_mission_request_int(const GCS_MAVLINK &_link,
         return;
     }
 
-    CHECK_PAYLOAD_SIZE2_VOID(_link.get_chan(), MISSION_ITEM_INT);
     _link.send_message(MAVLINK_MSG_ID_MISSION_ITEM_INT, (const char*)&ret_packet);
 }
 
-void MissionItemProtocol::handle_mission_request(const GCS_MAVLINK &_link,
+void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
                                                  const mavlink_mission_request_t &packet,
                                                  const mavlink_message_t &msg
 )
@@ -191,13 +190,12 @@ void MissionItemProtocol::handle_mission_request(const GCS_MAVLINK &_link,
         return;
     }
 
-    CHECK_PAYLOAD_SIZE2_VOID(_link.get_chan(), MISSION_ITEM_INT);
-
     if (!mission_request_warning_sent) {
         mission_request_warning_sent = true;
         gcs().send_text(MAV_SEVERITY_WARNING, "got MISSION_REQUEST; use MISSION_REQUEST_INT!");
     }
 
+    // buffer space is checked by send_message
     _link.send_message(MAVLINK_MSG_ID_MISSION_ITEM, (const char*)&ret_packet);
 }
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.h
@@ -30,10 +30,10 @@ public:
     void handle_mission_request_list(const class GCS_MAVLINK &link,
                                      const mavlink_mission_request_list_t &packet,
                                      const mavlink_message_t &msg);
-    void handle_mission_request_int(const GCS_MAVLINK &link,
+    void handle_mission_request_int(GCS_MAVLINK &link,
                                     const mavlink_mission_request_int_t &packet,
                                     const mavlink_message_t &msg);
-    void handle_mission_request(const GCS_MAVLINK &link,
+    void handle_mission_request(GCS_MAVLINK &link,
                                 const mavlink_mission_request_t &packet,
                                 const mavlink_message_t &msg);
 


### PR DESCRIPTION
This removes a lot of boiler-plate around sending messages on a mavlink channel.  Now you just create a `static const` message and ask the link to send it.

I believe this may also fix a problem where downloading fence points using the old protocol may not be checking for buffer space before sending.

Needs testing on a Gremsy, which I will do.
