### PR TITLE
Plane: constrain tilt range for vectored yaw

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -581,7 +581,14 @@ void Tiltrotor::vectoring(void)
         // we need to use the same factor here to keep the same roll
         // gains when tilted as we have when not tilted
         const float avg_roll_factor = 0.5;
-        const float tilt_offset = (throttle_scaler * yaw_out * cos_tilt + avg_roll_factor * roll_out * sin_tilt) * yaw_range;
+        float tilt_scale = throttle_scaler * yaw_out * cos_tilt + avg_roll_factor * roll_out * sin_tilt;
+
+        if (fabsf(tilt_scale) > 1.0) {
+            tilt_scale = constrain_float(tilt_scale, -1.0, 1.0);
+            motors->limit.yaw = true;
+        }
+
+        const float tilt_offset = tilt_scale * yaw_range;
 
         float left_tilt = base_output + tilt_offset;
         float right_tilt = base_output - tilt_offset;


### PR DESCRIPTION
this prevents a case where we can demand unlimited vectored yaw, leading to loss of control

this was particularly noticible before the fix in #23023 - if you armed for a 2nd time in QHOVER after moving the throttle above 10% so throttle_wait was cleared then the motors would try to tilt fully so one motor is in fwd flight position. This would cause a prop strike while on the ground

Bug was introduced in https://github.com/ArduPilot/ardupilot/pull/22376 - bug not present in 4.3.x
