### PR TITLE
Copter DCM fallback

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -398,6 +398,9 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 // check ekf attitude is acceptable
 bool AP_Arming_Copter::pre_arm_ekf_attitude_check()
 {
+    if (!copter.ahrs.always_use_EKF()) {
+        return true;
+    }
     // get ekf filter status
     nav_filter_status filt_status = copter.inertial_nav.get_filter_status();
 
@@ -485,7 +488,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     }
 
     // check EKF's compass, position, height and velocity variances are below failsafe threshold
-    if (copter.g.fs_ekf_thresh > 0.0f) {
+    if (ahrs.always_use_EKF() && copter.g.fs_ekf_thresh > 0.0f) {
         float vel_variance, pos_variance, hgt_variance, tas_variance;
         Vector3f mag_variance;
         ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -398,7 +398,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 // check ekf attitude is acceptable
 bool AP_Arming_Copter::pre_arm_ekf_attitude_check()
 {
-    if (!copter.ahrs.always_use_EKF()) {
+    if (!AP::ahrs().always_use_EKF() && !AP::ahrs().have_inertial_nav()) {
         return true;
     }
     // get ekf filter status
@@ -488,7 +488,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     }
 
     // check EKF's compass, position, height and velocity variances are below failsafe threshold
-    if (ahrs.always_use_EKF() && copter.g.fs_ekf_thresh > 0.0f) {
+    if ((ahrs.always_use_EKF() || ahrs.have_inertial_nav()) && copter.g.fs_ekf_thresh > 0.0f) {
         float vel_variance, pos_variance, hgt_variance, tas_variance;
         Vector3f mag_variance;
         ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -741,6 +741,7 @@ private:
     // ekf_check.cpp
     void ekf_check();
     bool ekf_over_threshold();
+    bool ekf_check_failsafe();
     void failsafe_ekf_event();
     void failsafe_ekf_off_event(void);
     void failsafe_ekf_recheck();

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -59,7 +59,7 @@ bool Copter::set_home(const Location& loc, bool lock)
 {
     // check EKF origin has been set
     Location ekf_origin;
-    if (ahrs.always_use_EKF() && !ahrs.get_origin(ekf_origin)) {
+    if ((ahrs.always_use_EKF() || ahrs.have_inertial_nav()) && !ahrs.get_origin(ekf_origin)) {
         return false;
     }
     // check home is close to EKF origin
@@ -87,7 +87,7 @@ bool Copter::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
     Location ekf_origin;
-    if (ahrs.always_use_EKF() && ahrs.get_origin(ekf_origin)) {
+    if ((ahrs.always_use_EKF() || ahrs.have_inertial_nav()) && ahrs.get_origin(ekf_origin)) {
         if (labs(ekf_origin.alt - loc.alt)*0.01 > EKF_ORIGIN_MAX_ALT_KM*1000.0) {
             return true;
         }

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -59,10 +59,9 @@ bool Copter::set_home(const Location& loc, bool lock)
 {
     // check EKF origin has been set
     Location ekf_origin;
-    if (!ahrs.get_origin(ekf_origin)) {
+    if (ahrs.always_use_EKF() && !ahrs.get_origin(ekf_origin)) {
         return false;
     }
-
     // check home is close to EKF origin
     if (far_from_EKF_origin(loc)) {
         return false;
@@ -88,7 +87,7 @@ bool Copter::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
     Location ekf_origin;
-    if (ahrs.get_origin(ekf_origin)) {
+    if (ahrs.always_use_EKF() && ahrs.get_origin(ekf_origin)) {
         if (labs(ekf_origin.alt - loc.alt)*0.01 > EKF_ORIGIN_MAX_ALT_KM*1000.0) {
             return true;
         }

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -38,8 +38,8 @@ void Copter::ekf_check()
         return;
     }
 
-    // return immediately if ekf check is disabled
-    if (g.fs_ekf_thresh <= 0.0f) {
+    // return immediately if ekf check is disabled or we have fallen back to DCM
+    if ((!ahrs.always_use_EKF() && !ahrs.have_inertial_nav()) || g.fs_ekf_thresh <= 0.0f) {
         ekf_check_state.fail_count = 0;
         ekf_check_state.bad_variance = false;
         AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
@@ -108,6 +108,12 @@ void Copter::ekf_check()
     AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
 
     // To-Do: add ekf variances to extended status
+}
+
+// ekf_check_failsafe - returns true if the ekf's failsafe checks are over the tolerance
+bool Copter::ekf_check_failsafe()
+{
+    return ekf_check_state.fail_count >= (EKF_CHECK_ITERATIONS_MAX-1);
 }
 
 // ekf_over_threshold - returns true if the ekf's variance are over the tolerance

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -223,7 +223,7 @@ void Copter::init_ardupilot()
 void Copter::startup_INS_ground()
 {
     // initialise ahrs (may push imu calibration into the mpu6000 if using that device).
-    ahrs.init();
+    ahrs.init(FUNCTOR_BIND(&copter, &Copter::ekf_check_failsafe, bool));
     ahrs.set_vehicle_class(AP_AHRS::VehicleClass::COPTER);
 
     // Warm up and calibrate gyro offsets

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -250,7 +250,7 @@ bool Copter::ekf_has_absolute_position() const
 {
     if (!ahrs.have_inertial_nav()) {
         // do not allow navigation with dcm position
-        return false;
+        return !ahrs.always_use_EKF();
     }
 
     // with EKF use filter status and ekf check
@@ -269,7 +269,7 @@ bool Copter::ekf_has_absolute_position() const
 bool Copter::ekf_has_relative_position() const
 {
     // return immediately if EKF not used
-    if (!ahrs.have_inertial_nav()) {
+    if (ahrs.always_use_EKF() && !ahrs.have_inertial_nav()) {
         return false;
     }
 
@@ -307,8 +307,7 @@ bool Copter::ekf_has_relative_position() const
 bool Copter::ekf_alt_ok() const
 {
     if (!ahrs.have_inertial_nav()) {
-        // do not allow alt control with only dcm
-        return false;
+        return !ahrs.always_use_EKF();
     }
 
     // with EKF use filter status and ekf check

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -50,7 +50,7 @@ public:
     };
 
     // Constructor
-    AP_AHRS(uint8_t flags = 0);
+    AP_AHRS();
 
     // initialise
     void init(void);
@@ -365,6 +365,11 @@ public:
         return _ekf_type;
     }
 
+    // set the ekf flags
+    void set_ekf_flags(int8_t flags) {
+        _ekf_flags.set(flags);
+    }
+
     // these are only out here so vehicles can reference them for parameters
 #if HAL_NAVEKF2_AVAILABLE
     NavEKF2 EKF2;
@@ -595,6 +600,10 @@ public:
     // get access to an EKFGSF_yaw estimator
     const EKFGSF_yaw *get_yaw_estimator(void) const;
 
+    bool always_use_EKF() const {
+        return _ekf_flags & FLAG_ALWAYS_USE_EKF;
+    }
+
 private:
 
     // optional view class
@@ -630,6 +639,7 @@ private:
 
     AP_Enum<GPSUse> _gps_use;
     AP_Int8 _gps_minsats;
+    AP_Int8 _ekf_flags; // bitmask from Flags enumeration
 
     enum class EKFType {
         NONE = 0,
@@ -651,10 +661,6 @@ private:
     // if successful returns true and sets secondary_ekf_type to None (for DCM), EKF3 or EKF3
     // returns false if no secondary (i.e. only using DCM)
     bool get_secondary_EKF_type(EKFType &secondary_ekf_type) const;
-
-    bool always_use_EKF() const {
-        return _ekf_flags & FLAG_ALWAYS_USE_EKF;
-    }
 
     // check all cores providing consistent attitudes for prearm checks
     bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const;
@@ -704,7 +710,6 @@ private:
 
     const uint16_t startup_delay_ms = 1000;
     uint32_t start_time_ms;
-    uint8_t _ekf_flags; // bitmask from Flags enumeration
 
     EKFType ekf_type(void) const;
     void update_DCM();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -32,6 +32,8 @@
 #include "AP_AHRS_DCM.h"
 #include "AP_AHRS_SIM.h"
 
+#include <AP_HAL/utility/functor.h>
+
 // forward declare view class
 class AP_AHRS_View;
 
@@ -49,11 +51,14 @@ public:
         FLAG_ALWAYS_USE_EKF = 0x1,
     };
 
+
+    FUNCTOR_TYPEDEF(ekf_failsafe_check_t, bool);
+
     // Constructor
     AP_AHRS();
 
     // initialise
-    void init(void);
+    void init(ekf_failsafe_check_t failsafe_check_cb = ekf_failsafe_check_t());
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_AHRS);
@@ -608,6 +613,9 @@ private:
 
     // optional view class
     AP_AHRS_View *_view;
+
+    // optional failsafe check callback
+    ekf_failsafe_check_t _failsafe_check_cb;
 
     static AP_AHRS *_singleton;
 

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -25,7 +25,7 @@ static AP_Logger logger{logger_bitmask};
 
 class DummyVehicle : public AP_Vehicle {
 public:
-    AP_AHRS ahrs{AP_AHRS::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS ahrs;
     bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; };
     uint8_t get_mode() const override { return 1; };
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks, uint8_t &task_count, uint32_t &log_bit) override {};
@@ -34,6 +34,7 @@ public:
     void init() {
         BoardConfig.init();
         ins.init(100);
+        ahrs.set_ekf_flags(AP_AHRS::FLAG_ALWAYS_USE_EKF);
         ahrs.init();
     }
 

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -12,7 +12,7 @@ public:
     bool start_cmd(const AP_Mission::Mission_Command& cmd) { return true; };
     bool verify_cmd(const AP_Mission::Mission_Command& cmd) { return true; };
     void mission_complete() { };
-    AP_AHRS ahrs{AP_AHRS::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS ahrs;
 
     AP_Mission mission{
         FUNCTOR_BIND_MEMBER(&DummyVehicle::start_cmd, bool, const AP_Mission::Mission_Command &),

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
@@ -46,7 +46,7 @@ static AP_Logger logger{logger_bitmask};
 
 class DummyVehicle : public AP_Vehicle {
 public:
-    AP_AHRS ahrs{AP_AHRS::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS ahrs;
     bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; };
     uint8_t get_mode() const override { return 1; };
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks, uint8_t &task_count, uint32_t &log_bit) override {};

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -28,7 +28,7 @@ public:
     AP_InertialSensor ins;
     AP_SerialManager serial_manager;
     RangeFinder sonar;
-    AP_AHRS ahrs{AP_AHRS::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS ahrs;
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -20,7 +20,7 @@ static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    AP_AHRS ahrs{AP_AHRS::FLAG_ALWAYS_USE_EKF};
+    AP_AHRS ahrs;
 };
 
 static DummyVehicle vehicle;


### PR DESCRIPTION
In fast copters with high lean angles the EKF can get corrupted quite easily by GPS innovations leading to flyaways. In these cases DCM appears to be much more reliable. This PR allows copter to fallback to DCM in the same way that plane currently does.