### PR TITLE
Plane: titrotor: is_motor_tilting: dont cast to uint8

### DIFF
--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -45,7 +45,7 @@ public:
     bool tilt_over_max_angle(void) const;
 
     bool is_motor_tilting(uint8_t motor) const {
-        return (((uint8_t)tilt_mask.get()) & (1U<<motor));
+        return tilt_mask.get() & (1U<<motor);
     }
 
     bool fully_fwd() const;


### PR DESCRIPTION
Cast means that we can't tilt more than 8 motors. I mostly fixed this in https://github.com/ArduPilot/ardupilot/pull/22290 but missed this one in the header. 