### PR TITLE
Remove isnanf

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -157,7 +157,7 @@ void AP_BattMonitor_UAVCAN::update_interim_state(const float voltage, const floa
     _interim_state.current_amps = _curr_mult * current;
     _soc = soc;
 
-    if (!isnanf(temperature_K) && temperature_K > 0) {
+    if (!isnan(temperature_K) && temperature_K > 0) {
         // Temperature reported from battery in kelvin and stored internally in Celsius.
         _interim_state.temperature = KELVIN_TO_C(temperature_K);
         _interim_state.temperature_time = AP_HAL::millis();
@@ -210,7 +210,7 @@ void AP_BattMonitor_UAVCAN::handle_mppt_stream(const MpptStreamCb &cb)
     const uint8_t soc = 127;
 
     // convert C to Kelvin
-    const float temperature_K = isnanf(cb.msg->temperature) ? 0 : C_TO_KELVIN(cb.msg->temperature);
+    const float temperature_K = isnan(cb.msg->temperature) ? 0 : C_TO_KELVIN(cb.msg->temperature);
 
     update_interim_state(voltage, current, temperature_K, soc); 
 

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -379,7 +379,7 @@ void AP_GPS_UAVCAN::handle_velocity(const float vx, const float vy, const float 
         interim_state.velocity = vel;
         velocity_to_speed_course(interim_state);
         // assume we have vertical velocity if we ever get a non-zero Z velocity
-        if (!isnanf(vel.z) && !is_zero(vel.z)) {
+        if (!isnan(vel.z) && !is_zero(vel.z)) {
             interim_state.have_vertical_velocity = true;
         } else {
             interim_state.have_vertical_velocity = state.have_vertical_velocity;

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -1054,9 +1054,9 @@ void AP_UAVCAN::handle_ESC_status(AP_UAVCAN* ap_uavcan, uint8_t node_id, const E
 
     ap_uavcan->update_rpm(esc_index, cb.msg->rpm, cb.msg->error_count);
     ap_uavcan->update_telem_data(esc_index, t,
-        (isnanf(cb.msg->current) ? 0 : AP_ESC_Telem_Backend::TelemetryType::CURRENT)
-            | (isnanf(cb.msg->voltage) ? 0 : AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)
-            | (isnanf(cb.msg->temperature) ? 0 : AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE));
+        (isnan(cb.msg->current) ? 0 : AP_ESC_Telem_Backend::TelemetryType::CURRENT)
+            | (isnan(cb.msg->voltage) ? 0 : AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)
+            | (isnan(cb.msg->temperature) ? 0 : AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE));
 #endif
 }
 


### PR DESCRIPTION
Under Alpine linux, with g++11 and g++12

```
#0 33.08 ../../libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp:160:10: error: 'isnanf' was not declared in this scope; did you mean 'isnan'?
#0 33.08   160 |     if (!isnanf(temperature_K) && temperature_K > 0) {
#0 33.08       |          ^~~~~~
#0 33.08       |          isnan
#0 33.08 compilation terminated due to -Wfatal-errors.
#0 33.08 
#0 34.47 Waf: Leaving directory `/ardupilot/src/build/sitl'
#0 34.47 Build failed
#0 34.47  -> task in 'objs/AP_BattMonitor' failed (exit status 1): 
#0 34.47 	{task 140300009668304: cxx AP_BattMonitor_UAVCAN.cpp -> AP_BattMonitor_UAVCAN.cpp.0.o}
#0 34.47  (run with -v to display more information)
------

```

those are the only place we are using isnanf that need math.h