### PR TITLE
AC_Attitude:Add TKOFF/LAND Only Weathervaning option

### DIFF
--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AC_WeatherVane::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Weathervaning options
     // @Description: Options impacting weathervaning behaviour
-    // @Bitmask: 0:Use pitch when nose or tail-in for faster weathervaning
+    // @Bitmask: 0:Use pitch when nose or tail-in for faster weathervaning, 1:Only Weathervane in landings or takeoffs
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 9, AC_WeatherVane, _options, 0),
     
@@ -107,10 +107,11 @@ AC_WeatherVane::AC_WeatherVane(void)
 bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, const float hgt, const float roll_cdeg, const float pitch_cdeg, const bool is_takeoff, const bool is_landing)
 {
     Direction dir = (Direction)_direction.get();
-    if ((dir == Direction::OFF) || !allowed || (pilot_yaw != 0) || !is_positive(_gain)) {
+    if ((dir == Direction::OFF) || !allowed || (pilot_yaw != 0) || !is_positive(_gain)|| (!(is_takeoff || is_landing) && (bool(uint8_t(_options.get()) & uint8_t(Options::TAKEOFF_OR_LAND_ONLY))))) {
         // parameter disabled, or 0 gain
         // disabled temporarily
         // dont't override pilot
+        // not in takeoff and landing when option for only those cases is set
         reset();
         return false;
     }

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -33,6 +33,7 @@ class AC_WeatherVane {
 
         enum class Options {
             PITCH_ENABLE = (1<<0),
+            TAKEOFF_OR_LAND_ONLY = (1<<1),
         };
     
         // Paramaters


### PR DESCRIPTION
fixes a issue in Copter where you cant have weathervaning in landings or takeoffs without also having it during waypoint travel...messes up ROI, WP YAW, etc.