### PR TITLE
AP_Notify: fix SerialLED simulation

### DIFF
--- a/libraries/AP_Notify/SITL_SFML_LED.cpp
+++ b/libraries/AP_Notify/SITL_SFML_LED.cpp
@@ -141,6 +141,18 @@ void SITL_SFML_LED::update_serial_LEDs()
         w->clear(sf::Color(0, 0, 0, 255));
     }
 
+    WITH_SEMAPHORE(AP::notify().sf_window_mutex);
+    sf::Event event;
+    while (w->pollEvent(event)) {
+        if (event.type == sf::Event::Closed) {
+            w->close();
+            break;
+        }
+    }
+    if (!w->isOpen()) {
+        return;
+    }
+
     for (uint8_t chan=0; chan<16; chan++) {
         for (uint8_t led=0; led<sitl->led.num_leds[chan]; led++) {
             uint8_t *rgb = &sitl->led.rgb[chan][led].rgb[0];

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -16,6 +16,16 @@
 */
 #pragma once
 
+/*
+  cp libraries/AP_Scripting/examples/LED_roll.lua scripts/
+  param set SCR_ENABLE 1
+  param set SIM_LED_LAYOUT 1
+  param set SERVO10_FUNCTION 94  # script1
+  param set SERVO11_FUNCTION 132  # profiled clock
+  param set NTF_LED_TYPES 1024
+  reboot
+ */
+
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <SITL/SITL.h>
 


### PR DESCRIPTION
Not checking for events makes window managers annoyed

Also added instructions on how to test in SITL. 