### PR TITLE
Use simulated i2c-connected ToshibaLED for graphical LED display

### DIFF
--- a/libraries/AP_Notify/SITL_SFML_LED.cpp
+++ b/libraries/AP_Notify/SITL_SFML_LED.cpp
@@ -25,14 +25,6 @@
 
 #include "SITL_SFML_LED.h"
 
-SITL_SFML_LED::SITL_SFML_LED():
-    RGBLed((uint8_t)brightness::LED_OFF,
-           (uint8_t)brightness::LED_HIGH,
-           (uint8_t)brightness::LED_MEDIUM,
-           (uint8_t)brightness::LED_LOW)
-{
-}
-
 /*
   return layout size for a LED layout scheme
  */
@@ -176,37 +168,9 @@ void SITL_SFML_LED::update_serial_LEDs()
 
 void SITL_SFML_LED::update_thread(void)
 {
-    sf::RenderWindow *w = nullptr;
-    {
-        WITH_SEMAPHORE(AP::notify().sf_window_mutex);
-        w = new sf::RenderWindow(sf::VideoMode(width, height), "LED");
-    }
-
-    if (!w) {
-        AP_HAL::panic("Unable to create RGBLed window");
-    }
-
     while (true) {
         {
             WITH_SEMAPHORE(AP::notify().sf_window_mutex);
-            sf::Event event;
-            while (w->pollEvent(event)) {
-                if (event.type == sf::Event::Closed) {
-                    w->close();
-                    break;
-                }
-            }
-            if (!w->isOpen()) {
-                break;
-            }
-            const uint32_t colour = red<<16 | green<<8 | blue;
-            if (colour != last_colour) {
-                last_colour = colour;
-
-                w->clear(sf::Color(red, green, blue, 255));
-                w->display();
-            }
-
             update_serial_LEDs();
         }
         usleep(10000);
@@ -227,12 +191,9 @@ bool SITL_SFML_LED::init()
     return true;
 }
 
-bool SITL_SFML_LED::hw_set_rgb(uint8_t _red, uint8_t _green, uint8_t _blue)
+void SITL_SFML_LED::update()
 {
-    red = _red;
-    green = _green;
-    blue = _blue;
-
-    return true;
+    // all updates are done in the thread
 }
+
 #endif

--- a/libraries/AP_Notify/SITL_SFML_LED.cpp
+++ b/libraries/AP_Notify/SITL_SFML_LED.cpp
@@ -141,6 +141,18 @@ void SITL_SFML_LED::update_serial_LEDs()
         w->clear(sf::Color(0, 0, 0, 255));
     }
 
+    WITH_SEMAPHORE(AP::notify().sf_window_mutex);
+    sf::Event event;
+    while (w->pollEvent(event)) {
+        if (event.type == sf::Event::Closed) {
+            w->close();
+            break;
+        }
+    }
+    if (!w->isOpen()) {
+        return;
+    }
+
     for (uint8_t chan=0; chan<16; chan++) {
         for (uint8_t led=0; led<sitl->led.num_leds[chan]; led++) {
             uint8_t *rgb = &sitl->led.rgb[chan][led].rgb[0];

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -31,22 +31,18 @@
 
 #ifdef WITH_SITL_RGBLED
 
-#include "RGBLed.h"
-
 #ifdef HAVE_SFML_GRAPHICS_H
 #include <SFML/Graphics.h>
 #else
 #include <SFML/Graphics.hpp>
 #endif
 
-class SITL_SFML_LED: public RGBLed
+class SITL_SFML_LED : public NotifyDevice
 {
 public:
-    SITL_SFML_LED();
+    SITL_SFML_LED() {}
     bool init(void) override;
-
-protected:
-    bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
+    void update() override;
 
 private:
 
@@ -55,23 +51,7 @@ private:
     void update_serial_LEDs(void);
     static void *update_thread_start(void *obj);
 
-    static constexpr uint8_t height = 50;
-    static constexpr uint8_t width = height;
-
     static constexpr uint8_t serialLED_size = 16;
-
-    enum class brightness {
-        LED_LOW    = 0x33,
-        LED_MEDIUM = 0x7F,
-        LED_HIGH   = 0xFF,
-        LED_OFF    = 0x00
-    };
-
-    uint32_t last_colour;
-
-    uint8_t red;
-    uint8_t green;
-    uint8_t blue;
 
     static const uint8_t MAX_LEDS = 64;
 

--- a/libraries/AP_Notify/SITL_SFML_LED.h
+++ b/libraries/AP_Notify/SITL_SFML_LED.h
@@ -16,6 +16,16 @@
 */
 #pragma once
 
+/*
+  cp libraries/AP_Scripting/examples/LED_roll.lua scripts/
+  param set SCR_ENABLE 1
+  param set SIM_LED_LAYOUT 1
+  param set SERVO10_FUNCTION 94  # script1
+  param set SERVO11_FUNCTION 132  # profiled clock
+  param set NTF_LED_TYPES 1024
+  reboot
+ */
+
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <SITL/SITL.h>
 

--- a/libraries/SITL/SIM_RGBLED.cpp
+++ b/libraries/SITL/SIM_RGBLED.cpp
@@ -1,0 +1,65 @@
+#include "SIM_RGBLED.h"
+
+#ifdef WITH_SITL_RGBLED
+
+#include <AP_HAL/HAL.h>
+
+#ifdef HAVE_SFML_GRAPHICS_H
+#include <SFML/Graphics.h>
+#else
+#include <SFML/Graphics.hpp>
+#endif
+
+#include <AP_Notify/AP_Notify.h>
+
+void SIM_RGBLED::update_thread(void)
+{
+    sf::RenderWindow *w = nullptr;
+    {
+        WITH_SEMAPHORE(AP::notify().sf_window_mutex);
+        w = new sf::RenderWindow(sf::VideoMode(width, height), name);
+    }
+
+    if (w == nullptr) {
+        AP_HAL::panic("Unable to create SIM_RGBLED window");
+    }
+
+    while (true) {
+        {
+            WITH_SEMAPHORE(AP::notify().sf_window_mutex);
+            sf::Event event;
+            while (w->pollEvent(event)) {
+                if (event.type == sf::Event::Closed) {
+                    w->close();
+                    break;
+                }
+            }
+            if (!w->isOpen()) {
+                break;
+            }
+            const uint32_t colour = red<<16 | green<<8 | blue;
+            if (colour != last_colour) {
+                last_colour = colour;
+                w->clear(sf::Color(red, green, blue, 255));
+                w->display();
+            }
+        }
+        usleep(10000);
+    }
+}
+
+// trampoline for update thread
+void *SIM_RGBLED::update_thread_start(void *obj)
+{
+    ((SIM_RGBLED *)obj)->update_thread();
+    return nullptr;
+}
+
+#endif  // WITH_SITL_RGBLED
+
+void SIM_RGBLED::init()
+{
+#ifdef WITH_SITL_RGBLED
+    pthread_create(&thread, NULL, update_thread_start, this);
+#endif
+}

--- a/libraries/SITL/SIM_RGBLED.h
+++ b/libraries/SITL/SIM_RGBLED.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdint.h>
+#include <pthread.h>
+
+/*
+  A class to create output of some description or another for RGB LEDs.
+
+  Hopefully something visual, but perhaps just text
+*/
+
+class SIM_RGBLED
+{
+public:
+    SIM_RGBLED(const char *_name) :
+        name{_name}
+        { }
+
+    void init();
+
+    void set_colours(uint8_t _red, uint8_t _green, uint8_t _blue) {
+        red = _red;
+        green = _green;
+        blue = _blue;
+    }
+
+private:
+
+    const char *name;
+
+    uint8_t red;
+    uint8_t green;
+    uint8_t blue;
+
+    static constexpr uint8_t height = 50;
+    static constexpr uint8_t width = height;
+
+    pthread_t thread;
+    static void *update_thread_start(void *obj);
+    void update_thread(void);
+
+    uint32_t last_colour;
+};

--- a/libraries/SITL/SIM_ToshibaLED.cpp
+++ b/libraries/SITL/SIM_ToshibaLED.cpp
@@ -18,6 +18,18 @@ void SITL::ToshibaLED::update(const class Aircraft &aircraft)
     last_print_pwm2 = get_register(ToshibaLEDDevReg::PWM2);
     last_print_enable = get_register(ToshibaLEDDevReg::ENABLE);
     // gcs().send_text(MAV_SEVERITY_INFO, "SIM_ToshibaLED: PWM0=%u PWM1=%u PWM2=%u ENABLE=%u", last_print_pwm0, last_print_pwm1, last_print_pwm2, last_print_enable);
+
+    if (get_register(ToshibaLEDDevReg::ENABLE)) {
+        // here we convert from 0-15 BGR (the PWM values from the i2c bus)
+        // to 0-255 RGB (what SIM_RGBLED wants):
+        rgbled.set_colours(
+            get_register(ToshibaLEDDevReg::PWM2) * 17,
+            get_register(ToshibaLEDDevReg::PWM1) * 17,
+            get_register(ToshibaLEDDevReg::PWM0) * 17
+            );
+    } else {
+        rgbled.set_colours(0, 0, 0);
+    }
 }
 
 #endif

--- a/libraries/SITL/SIM_ToshibaLED.h
+++ b/libraries/SITL/SIM_ToshibaLED.h
@@ -8,6 +8,8 @@
 
 #if AP_SIM_TOSHIBALED_ENABLED
 
+#include "SIM_RGBLED.h"
+
 namespace SITL {
 
 class ToshibaLEDDevReg : public I2CRegEnum {
@@ -22,6 +24,8 @@ class ToshibaLED : public I2CDevice, protected I2CRegisters_8Bit
 {
 public:
     void init() override {
+        rgbled.init();
+
         add_register("PWM0", ToshibaLEDDevReg::PWM0, I2CRegisters::RegMode::WRONLY);
         add_register("PWM1", ToshibaLEDDevReg::PWM1, I2CRegisters::RegMode::WRONLY);
         add_register("PWM2", ToshibaLEDDevReg::PWM2, I2CRegisters::RegMode::WRONLY);
@@ -39,6 +43,8 @@ private:
     uint8_t last_print_pwm1;
     uint8_t last_print_pwm2;
     uint8_t last_print_enable;
+
+    SIM_RGBLED rgbled{"ToshibaLED"};
 };
 
 } // namespace SITL


### PR DESCRIPTION
This incorporates the bugfix from https://github.com/ArduPilot/ardupilot/pull/23044 which leds simulated SerialLEDs work.

This change means the SITL layer does the displaying of the ToshibaLED state, rather than a special backend in `libraries/AP_Notify`.  This means the data must travel over the simulated serial bus and then be displayed by the simualted ToshibaLED.

This new structure will allow for graphical simulation of i2c-connected LEDs other than ToshibaLED, which should aid development.

All tested in SITL, including the SerialLED stuff which works post-afore-mentioned bugfix.  The SerialLED stuff should also probably move down to the SITL directory at some stage - but that would require creation of a `SITL::SIM_ProfiLED` class.
