### PR TITLE
Rover: Go to hold mode when MIS_DONE_BEHAVE is 0

### DIFF
--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -526,6 +526,10 @@ void ModeAuto::exit_mission()
         return;
     }
 
+    if (g2.mis_done_behave == MIS_DONE_BEHAVE_HOLD && rover.set_mode(rover.mode_hold, ModeReason::MISSION_END)) {
+        return;
+    }
+
     start_stop();
 }
 


### PR DESCRIPTION
Documentation says that when MIS_DONE_BEHAVE is 0, Rover will go to hold mode on completion of mission.

Currently, Rover doesn't do this.

This PR fixes Rover is it _does_ go to hold mode on completion of mission.

I have a sneaking suspicion that Rover did previously do this - some custom GCS code I'm working on seemed to expect it. Also, given the documentation explicitly mentions it ....