### PR TITLE
AP_Proximity: SF45b mode filter reduced to detect narrower obstacles

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6728,12 +6728,12 @@ class AutoTestCopter(AutoTest):
         })
         sensors = [  # tuples of name, prx_type
             ('sf45b', 8, {
-                mavutil.mavlink.MAV_SENSOR_ROTATION_NONE: 292,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_45: 257,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_90: 1130,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_NONE: 285,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_45: 256,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_90: 1131,
                 mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_135: 1283,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_180: 627,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_225: 967,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_180: 625,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_225: 968,
                 mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_270: 760,
                 mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_315: 762,
             }),

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF45B.h
@@ -81,7 +81,7 @@ private:
     uint32_t _last_init_ms;                 // system time of last re-initialisation
     uint32_t _last_distance_received_ms;    // system time of last distance measurement received from sensor
     bool _init_complete;                    // true once sensor initialisation is complete
-    ModeFilterInt16_Size5 _distance_filt{2};// mode filter to reduce glitches
+    ModeFilterInt16_Size3 _distance_filt{1};// mode filter to reduce glitches
 
     // 3D boundary face and distance for latest readings
     AP_Proximity_Boundary_3D::Face _face;   // face of most recently received distance

--- a/libraries/Filter/ModeFilter.cpp
+++ b/libraries/Filter/ModeFilter.cpp
@@ -97,4 +97,5 @@ void ModeFilter<T,FILTER_SIZE>::isort(T new_sample, bool drop_high)
 
 // instantiate required implementations
 template class ModeFilter<float,5>;
+template class ModeFilter<int16_t,3>;
 template class ModeFilter<int16_t,5>;


### PR DESCRIPTION
During testing with the SF45b I found that it was unable to detect a person standing in front of the drone.  The reason was that the SF45b uses a 5 element mode filter and the person was only 2 elements wide (approximately 6 degrees).  This PR reduces the mode filter to 3 elements so that narrower objects can be detected.

This has been tested on real hardware.