### PR TITLE
Tidy the BMM150-on-f103 compass oddity into hwdef files

### DIFF
--- a/libraries/AP_Compass/AP_Compass_config.h
+++ b/libraries/AP_Compass/AP_Compass_config.h
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef AP_COMPASS_BMM150_ENABLED
-#define AP_COMPASS_BMM150_ENABLED AP_COMPASS_I2C_BACKEND_DEFAULT_ENABLED && !defined(STM32F1)
+#define AP_COMPASS_BMM150_ENABLED AP_COMPASS_I2C_BACKEND_DEFAULT_ENABLED
 #endif
 
 // this define dictates whether we iterate over the external i2c

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
@@ -5,6 +5,8 @@ define CAN_APP_NODE_NAME "org.ardupilot.ap_periph_gps"
 
 # and support all external compass types
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+# .... except BMM150:
+define AP_COMPASS_BMM150_ENABLED 0
 
 # increase TX size for RTCM
 undef HAL_UART_MIN_TX_SIZE


### PR DESCRIPTION
We noted this oddity on the DevCall and I said I'd make a future PR to move this definition around.  This is that - if you don't want a compass on an AP_Periph you should put that in the hwdef.

I built all of the periphs and none change - particularly the f103s:

```
VRUBrain-v51,
ZubaxGNSS,0
airbotf4,
bbbmini,
blue,
crazyflie2,
edge,
erlebrain2,
f103-ADSB,*
f103-Airspeed,0
f103-GPS,0
f103-HWESC,0
f103-QiotekPeriph,*
f103-RangeFinder,*
f103-Trigger,0
f303-GPS,*
f303-HWESC,*
f303-M10025,*
f303-M10070,0
f303-MatekGPS,*
f303-PWM,*
f303-TempSensor,*
f303-Universal,0
f405-MatekAirspeed,0
f405-MatekGPS,0
fmuv2,
fmuv3,
fmuv3-bdshot,
fmuv5,
iomcu,
iomcu_f103_8MHz,
luminousbee4,
luminousbee5,
mRo-M10095,0
```