### PR TITLE
GCS_MAVLink: constrain battery % to 0-100

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -350,7 +350,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
                                     current,      // current in centiampere
                                     consumed_mah, // total consumed current in milliampere.hour
                                     consumed_wh,  // consumed energy in hJ (hecto-Joules)
-                                    percentage,
+                                    constrain_int16(percentage, -1, 100),
                                     time_remaining, // time remaining, seconds
                                     battery.get_mavlink_charge_state(instance), // battery charge state
                                     cell_mvolts_ext, // Cell 11..14 voltages


### PR DESCRIPTION
When using a battery under 100% charged that has a generator or MPPT available to charge during flight, it's possible to calculate and report a capacity_remaining_pct() greater than 100%. [MAVLink spec for BATTERY_STATUS](https://github.com/ArduPilot/mavlink/blob/734d04188897f70c8b19e119543a395d4f61d6de/message_definitions/v1.0/common.xml#L5141) specifies a valid range as 0-100. Mission Planner is correctly-ish treating 101% as 0%. MAVProxy is not effected (it correctly-ish shows >100% values).

The other battery % packets such as HIGH_LATENCY and SYS_STATUS do not specify an out-of-range high value.
