### PR TITLE
Copter: pause resume reporting

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2236,26 +2236,18 @@ bool ModeAuto::verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd)
 bool ModeAuto::pause()
 {
     // do not pause if not in the WP sub mode or already reached to the destination
-    if(_mode != SubMode::WP || wp_nav->reached_wp_destination()) {
+    if (_mode != SubMode::WP || wp_nav->reached_wp_destination()) {
         return false;
     }
 
-    // do not pause if already paused
-    if (!wp_nav->paused()) {
-        wp_nav->set_pause();
-    }
-
+    wp_nav->set_pause();
     return true;
 }
 
 // resume - Allow aircraft to progress along the track
 bool ModeAuto::resume()
 {
-    // do not resume if not paused before
-    if(wp_nav->paused()) {
-        wp_nav->set_resume();
-    }
-
+    wp_nav->set_resume();
     return true;
 }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2235,12 +2235,16 @@ bool ModeAuto::verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd)
 // pause - Prevent aircraft from progressing along the track
 bool ModeAuto::pause()
 {
-    // do not pause if already paused or not in the WP sub mode or already reached to the destination
-    if(wp_nav->paused() || _mode != SubMode::WP || wp_nav->reached_wp_destination()) {
+    // do not pause if not in the WP sub mode or already reached to the destination
+    if(_mode != SubMode::WP || wp_nav->reached_wp_destination()) {
         return false;
     }
 
-    wp_nav->set_pause();
+    // do not pause if already paused
+    if (!wp_nav->paused()) {
+        wp_nav->set_pause();
+    }
+
     return true;
 }
 
@@ -2248,11 +2252,10 @@ bool ModeAuto::pause()
 bool ModeAuto::resume()
 {
     // do not resume if not paused before
-    if(!wp_nav->paused()) {
-        return false;
+    if(wp_nav->paused()) {
+        wp_nav->set_resume();
     }
 
-    wp_nav->set_resume();
     return true;
 }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8851,6 +8851,14 @@ class AutoTestCopter(AutoTest):
         self.send_pause_command()
         self.wait_groundspeed(speed_min=0, speed_max=1, minimum_duration=5)
         self.send_resume_command()
+        
+        # sending a pause, or resume, to the aircraft twice, doesn't result in reporting a failure
+        self.wait_current_waypoint(wpnum=5, timeout=500)
+        self.send_pause_command()
+        self.send_pause_command()
+        self.wait_groundspeed(speed_min=0, speed_max=1, minimum_duration=5)
+        self.send_resume_command()
+        self.send_resume_command()
 
         self.wait_disarmed(timeout=500)
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8851,7 +8851,7 @@ class AutoTestCopter(AutoTest):
         self.send_pause_command()
         self.wait_groundspeed(speed_min=0, speed_max=1, minimum_duration=5)
         self.send_resume_command()
-        
+
         # sending a pause, or resume, to the aircraft twice, doesn't result in reporting a failure
         self.wait_current_waypoint(wpnum=5, timeout=500)
         self.send_pause_command()


### PR DESCRIPTION
I think the reporting can be a little confusing for pause and resume in AUTO. If either the GCS or companion computer get out of sync with AP's paused sate, then the GCS will receive reports for the command failing. This isn't the case for GUIDED mode where the command is always accepted.

If the aircraft is already paused, rather than reporting a failure to pause, and sending the GCS a status text message, we can just return success as the aircraft has already paused. Similarly for resume.