### PR TITLE
AP_Mount: allow gimbals other than primary to be retracted/neutralised

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -279,22 +279,6 @@ MAV_RESULT AP_Mount::handle_command_do_mount_control(const mavlink_command_long_
 
 MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet)
 {
-    if (!check_primary()) {
-        return MAV_RESULT_FAILED;
-    }
-
-    // check flags for change to RETRACT
-    uint32_t flags = (uint32_t)packet.param5;
-    if ((flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
-        _backends[_primary]->set_mode(MAV_MOUNT_MODE_RETRACT);
-        return MAV_RESULT_ACCEPTED;
-    }
-    // check flags for change to NEUTRAL
-    if ((flags & GIMBAL_MANAGER_FLAGS_NEUTRAL) > 0) {
-        _backends[_primary]->set_mode(MAV_MOUNT_MODE_NEUTRAL);
-        return MAV_RESULT_ACCEPTED;
-    }
-
     // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is 2nd gimbal, etc
     if ((packet.param7 < 0) || (packet.param7 > AP_MOUNT_MAX_INSTANCES)) {
         return MAV_RESULT_FAILED;
@@ -302,6 +286,18 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
     const uint8_t gimbal_instance = (packet.param7 < 1) ? get_primary() : (uint8_t)packet.param7 - 1;
     if (!check_instance(gimbal_instance)) {
         return MAV_RESULT_FAILED;
+    }
+
+    // check flags for change to RETRACT
+    uint32_t flags = (uint32_t)packet.param5;
+    if ((flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
+        _backends[gimbal_instance]->set_mode(MAV_MOUNT_MODE_RETRACT);
+        return MAV_RESULT_ACCEPTED;
+    }
+    // check flags for change to NEUTRAL
+    if ((flags & GIMBAL_MANAGER_FLAGS_NEUTRAL) > 0) {
+        _backends[gimbal_instance]->set_mode(MAV_MOUNT_MODE_NEUTRAL);
+        return MAV_RESULT_ACCEPTED;
     }
 
     // param1 : pitch_angle (in degrees)

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -205,6 +205,9 @@ MAV_MOUNT_MODE AP_Mount::get_mode(uint8_t instance) const
 //      this operation requires 60us on a Pixhawk/PX4
 void AP_Mount::set_mode_to_default(uint8_t instance)
 {
+    if (instance > ARRAY_SIZE(_params)) {
+        return;
+    }
     set_mode(instance, (enum MAV_MOUNT_MODE)_params[instance].default_mode.get());
 }
 


### PR DESCRIPTION
Also adds a sanity check on a public method

I've tested this on a Gremsy T3v3 by setting the gimbal's component ID to GIMBAL2 and executing a retract command.

```
STABILIZE> long DO_GIMBAL_MANAGER_PITCHYAW 0 0 0 0 1 0 0

STABILIZE> Got COMMAND_ACK: DO_GIMBAL_MANAGER_PITCHYAW: ACCEPTED

STABILIZE> 
STABILIZE> long DO_GIMBAL_MANAGER_PITCHYAW 0 0 0 0 1 0 1
STABILIZE> Got COMMAND_ACK: DO_GIMBAL_MANAGER_PITCHYAW: FAILED
long DO_GIMBAL_MANAGER_PITCHYAW 0 0 0 0 1 0 2
STABILIZE> Got COMMAND_ACK: DO_GIMBAL_MANAGER_PITCHYAW: ACCEPTED
```

The gimbal retracted appropriately.

This work sponsored by Harris Aerial
