### PR TITLE
AP_BatteryMonitor: add max of type

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -307,6 +307,7 @@ AP_BattMonitor::init()
 #endif
                 break;
             case Type::Sum:
+            case Type::Max_of:
                 drivers[instance] = new AP_BattMonitor_Sum(*this, state[instance], _params[instance], instance);
                 break;
 #if AP_BATTMON_FUELFLOW_ENABLE

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -107,6 +107,7 @@ public:
         Analog_Volt_Synthetic_Current  = 25,
         INA239_SPI                     = 26,
         EFI                            = 27,
+        Max_of                         = 28,
     };
 
     FUNCTOR_TYPEDEF(battery_failsafe_handler_fn_t, void, const char *, const int8_t);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -13,7 +13,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: MONITOR
     // @DisplayName: Battery monitoring
     // @Description: Controls enabling monitoring of the battery's voltage and current
-    // @Values: 0:Disabled,3:Analog Voltage Only,4:Analog Voltage and Current,5:Solo,6:Bebop,7:SMBus-Generic,8:DroneCAN-BatteryInfo,9:ESC,10:Sum Of Selected Monitors,11:FuelFlow,12:FuelLevelPWM,13:SMBUS-SUI3,14:SMBUS-SUI6,15:NeoDesign,16:SMBus-Maxell,17:Generator-Elec,18:Generator-Fuel,19:Rotoye,20:MPPT,21:INA2XX,22:LTC2946,23:Torqeedo,24:FuelLevelAnalog,25:Synthetic Current and Analog Voltage,26:INA239_SPI,27:EFI
+    // @Values: 0:Disabled,3:Analog Voltage Only,4:Analog Voltage and Current,5:Solo,6:Bebop,7:SMBus-Generic,8:DroneCAN-BatteryInfo,9:ESC,10:Sum Of Selected Monitors,11:FuelFlow,12:FuelLevelPWM,13:SMBUS-SUI3,14:SMBUS-SUI6,15:NeoDesign,16:SMBus-Maxell,17:Generator-Elec,18:Generator-Fuel,19:Rotoye,20:MPPT,21:INA2XX,22:LTC2946,23:Torqeedo,24:FuelLevelAnalog,25:Synthetic Current and Analog Voltage,26:INA239_SPI,27:EFI,28:Max voltage of selected
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("MONITOR", 1, AP_BattMonitor_Params, _type, int8_t(AP_BattMonitor::Type::NONE), AP_PARAM_FLAG_ENABLE),

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -41,8 +41,38 @@ AP_BattMonitor_Sum::AP_BattMonitor_Sum(AP_BattMonitor &mon,
 }
 
 // read - read the voltage and current
-void
-AP_BattMonitor_Sum::read()
+void AP_BattMonitor_Sum::read()
+{
+    if (_mon.get_type(_instance) == AP_BattMonitor::Type::Max_of) {
+        read_max();
+    } else {
+        read_sum();
+    }
+}
+
+// Return true if this instance should be included in calculation
+bool AP_BattMonitor_Sum::include_instance(uint8_t i) const
+{
+    if (i == _instance) {
+        // never include self
+        return false;
+    }
+    if ((_sum_mask == 0) && (i <= _instance)) {
+        // sum of remaining, skip lower instances
+        return false;
+    }
+    if ((_sum_mask != 0) && ((_sum_mask & 1U<<i) == 0)) {
+        // mask param, skip if mask bit not set
+        return false;
+    }
+    if (!_mon.healthy(i)) {
+        // Not healthy
+        return false;
+    }
+    return true;
+}
+
+void AP_BattMonitor_Sum::read_sum()
 {
     float voltage_sum = 0;
     uint8_t voltage_count = 0;
@@ -50,19 +80,7 @@ AP_BattMonitor_Sum::read()
     uint8_t current_count = 0;
 
     for (uint8_t i=0; i<_mon.num_instances(); i++) {
-        if (i == _instance) {
-            // never include self
-            continue;
-        }
-        if ((_sum_mask == 0) && (i <= _instance)) {
-            // sum of remaining, skip lower instances
-            continue;
-        }
-        if ((_sum_mask != 0) && ((_sum_mask & 1U<<i) == 0)) {
-            // mask param, skip if mask bit not set
-            continue;
-        }
-        if (!_mon.healthy(i)) {
+        if (!include_instance(i)) {
             continue;
         }
         voltage_sum += _mon.voltage(i);
@@ -90,5 +108,26 @@ AP_BattMonitor_Sum::read()
 
     if (_state.healthy) {
         _state.last_time_micros = tnow_us;
+    }
+}
+
+void AP_BattMonitor_Sum::read_max()
+{
+    _has_current = false;
+    bool got_voltage = false;
+    float voltage = 0.0;
+
+    for (uint8_t i=0; i<_mon.num_instances(); i++) {
+        if (!include_instance(i)) {
+            continue;
+        }
+        voltage = MAX(voltage, _mon.voltage(i));
+        got_voltage = true;
+    }
+
+    _state.healthy = got_voltage;
+    if (got_voltage) {
+        _state.voltage = voltage;
+        _state.last_time_micros = AP_HAL::micros();
     }
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.h
@@ -25,6 +25,15 @@ public:
 
 private:
 
+    // Return true if this instance should be included in calculation
+    bool include_instance(uint8_t i) const;
+
+    // Read sum of monitors
+    void read_sum();
+
+    // Read max of monitors
+    void read_max();
+
     AP_Int16  _sum_mask;
     uint8_t _instance;
     bool _has_current;


### PR DESCRIPTION
Adds a battery monitor that takes the max voltage from the remaining/mask of other monitors. 

Useful for diode or ideal diode setups where the max voltage is needed for voltage scaling of motors. 