### PR TITLE
Correcting the baud rate in AP_Winch_Daiwa.cpp

### DIFF
--- a/libraries/AP_Winch/AP_Winch_Daiwa.cpp
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.cpp
@@ -22,8 +22,8 @@ void AP_Winch_Daiwa::init()
     const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Winch, 0);
     if (uart != nullptr) {
-        // always use baudrate of 115200
-        uart->begin(115200);
+        // always use baudrate of 38400
+        uart->begin(38400);
     }
 }
 


### PR DESCRIPTION
The baud rate of 115200 does not work with the newer Daiwa Winches. with this baud rate, the winch is not detected by arducopter, and no messages are transmitted over "winch_status". We confirmed with the manufacturer that the correct baud rate was 38400. This was tested with a daiwa winch at version 1.02. We also confirmed with the manufacturer that the baud rate of 38400 was correct with the newest versions of the winch at v1.04 as well.

I'm not very good at coding so i can't be exactly certain but I believe this block of code overrides anything from "Serialx_baud". If this is intentional, i propose removing the override to be consistent with the documentation that has you change "serialx_baud", and also in case the manufacturer changes the baud rate again in the future, so the user can set the correct baud rate through "serialx_baud"