### PR TITLE
AP_Winch: Fix baud rate handling in AP_Winch_Daiwa

### DIFF
--- a/libraries/AP_Winch/AP_Winch_Daiwa.cpp
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.cpp
@@ -21,10 +21,6 @@ void AP_Winch_Daiwa::init()
     // initialise serial connection to winch
     const AP_SerialManager &serial_manager = AP::serialmanager();
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Winch, 0);
-    if (uart != nullptr) {
-        // always use baudrate of 115200
-        uart->begin(115200);
-    }
 }
 
 void AP_Winch_Daiwa::update()


### PR DESCRIPTION
Removed if statement forcing baud rate of 115200 to be consistent with documentation, and to avoid issues in future if manufacturer changes baud rate again. Correct baud rate is 38400. Documentation needs to be updated as well. 

Confirmed with manufacturer, and with a winch on v1.02. Also confirmed w/ manufacturer that newest winches on v1.04 also use 38400. 

From issue: https://discuss.ardupilot.org/t/daiwa-winch-not-working-prearm-winch-unhealthy-documentation-drivers-outdated-for-current-units/97532