### PR TITLE
AP_Arming: add INS batch sampling initialized check 

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -464,6 +464,15 @@ bool AP_Arming::ins_checks(bool report)
             check_failed(ARMING_CHECK_INS, report, "temperature cal running");
             return false;
         }
+
+#if AP_INERTIALSENSOR_BATCHSAMPLER_ENABLED
+        // If Batch sampling enabled it must be initialized
+        if (ins.batchsampler.enabled() && !ins.batchsampler.is_initialised()) {
+            check_failed(ARMING_CHECK_INS, report, "Batch sampling requires reboot");
+            return false;
+        }
+#endif
+
     }
 
 #if HAL_GYROFFT_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -351,6 +351,10 @@ public:
                 || (_doing_pre_post_filter_logging && post_filter);
         }
 
+        // Getters for arming check
+        bool is_initialised() const { return initialised; }
+        bool enabled() const { return _sensor_mask > 0; }
+
         // class level parameters
         static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
I forgot to reboot and got no batch logging, not for the first time.....

Of course, runtime init would be better, but would be a significantly more complex patch....