### PR TITLE
RangeFinder: Add FOV

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -51,6 +51,8 @@ public:
     uint16_t voltage_mv() const { return state.voltage_mv; }
     virtual int16_t max_distance_cm() const { return params.max_distance_cm; }
     virtual int16_t min_distance_cm() const { return params.min_distance_cm; }
+    virtual float horizontal_fov() const { return params.horizontal_fov; }
+    virtual float vertical_fov() const { return params.vertical_fov; }
     int16_t ground_clearance_cm() const { return params.ground_clearance_cm; }
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -138,6 +138,24 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, AP_RANGEFINDER_DEFAULT_ORIENTATION),
 
+    // @Param: H_FOV
+    // @DisplayName: horizontal FOV
+    // @Description: At different horizontal distances, the size of the spot, namely the edge length of the detection range, is different.
+    // @Units: deg
+    // @Range: 0.0 359.9
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("H_FOV", 54, AP_RangeFinder_Params, horizontal_fov, 0),
+
+    // @Param: V_FOV
+    // @DisplayName: vertical FOV
+    // @Description: At different vertical distances, the size of the spot, namely the edge length of the detection range, is different.
+    // @Units: deg
+    // @Range: 0.0 359.9
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("V_FOV", 55, AP_RangeFinder_Params, vertical_fov, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -18,6 +18,8 @@ public:
     AP_Int16 powersave_range;
     AP_Int16 min_distance_cm;
     AP_Int16 max_distance_cm;
+    AP_Float horizontal_fov;
+    AP_Float vertical_fov;
     AP_Int8  type;
     AP_Int8  pin;
     AP_Int8  ratiometric;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -409,8 +409,8 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         instance,                                // onboard ID of the sensor == instance
         sensor->orientation(),                   // direction the sensor faces from MAV_SENSOR_ORIENTATION enum
         0,                                       // Measurement covariance in centimeters, 0 for unknown / invalid readings
-        0,                                       // horizontal FOV
-        0,                                       // vertical FOV
+        sensor->horizontal_fov(),                // horizontal FOV
+        sensor->vertical_fov(),                  // vertical FOV
         (const float *)nullptr,                  // quaternion of sensor orientation for MAV_SENSOR_ROTATION_CUSTOM
         quality);                                // Signal quality of the sensor. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.
 }


### PR DESCRIPTION
I am using BENEWAKE's TF02 PRO.
I have a lot of FOV defined in the BENEWAKE rangefinder.
I can know the measurement range by this FOV value.
I can get this FOV value from the FC to allow LUA, CC, and GCS to process using FOV.

![Screenshot from 2023-03-04 09-10-16](https://user-images.githubusercontent.com/646194/222859669-627bef1a-fdea-42ec-b05d-2003a313c8b3.png)
![Screenshot from 2023-03-04 09-10-00](https://user-images.githubusercontent.com/646194/222859671-eebb2ebd-dc7e-4d47-a2e7-1919d33018af.png)
