### PR TITLE
Check configured AHRS type last in order to provide a more meaningful error to the user

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -173,7 +173,7 @@ class AutoTestPlane(AutoTest):
                 raise NotAchievedException("Did not get correct failure reason")
             self.run_cmd_run_prearms()
             try:
-                self.wait_statustext(".*AHRS: not using configured AHRS type.*", timeout=1, check_context=True, regex=True)
+                self.wait_statustext(".*AHRS: (EKF3 not started|Not healthy).*", timeout=1, check_context=True, regex=True)
                 success = True
                 continue
             except AutoTestTimeoutException:

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1992,12 +1992,6 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         return false;
     }
 
-    // ensure we're using the configured backend, but bypass in compass-less cases:
-    if (ekf_type() != active_EKF_type() && AP::compass().use_for_yaw()) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "not using configured AHRS type");
-        return false;
-    }
-
     switch (ekf_type()) {
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
@@ -2032,6 +2026,13 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
 
     // if we get here then ekf type is invalid
     hal.util->snprintf(failure_msg, failure_msg_len, "invalid EKF type");
+
+    // ensure we're using the configured backend, but bypass in compass-less cases:
+    if (ekf_type() != active_EKF_type() && AP::compass().use_for_yaw()) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "not using configured AHRS type");
+        return false;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Currently EKF issues before arming result in the message:
```
PreArm: AHRS: not using configured AHRS type
```
Because DCM fallback causes the configured type not to match the actual type. This PR moves the check so that the EKF check is hit first and results in 
```
AHRS: Not healthy
```
Which is slightly more meaningful