### PR TITLE
AP_Periph: improved probing of rangefinders

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -206,13 +206,16 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_RANGEFINDER
-    if (rangefinder.get_type(0) != RangeFinder::Type::NONE && g.rangefinder_port >= 0) {
-        auto *uart = hal.serial(g.rangefinder_port);
-        if (uart != nullptr) {
-            uart->begin(g.rangefinder_baud);
-            serial_manager.set_protocol_and_baud(g.rangefinder_port, AP_SerialManager::SerialProtocol_Rangefinder, g.rangefinder_baud);
-            rangefinder.init(ROTATION_NONE);
+    if (rangefinder.get_type(0) != RangeFinder::Type::NONE) {
+        if (g.rangefinder_port >= 0) {
+            // init uart for serial rangefinders
+            auto *uart = hal.serial(g.rangefinder_port);
+            if (uart != nullptr) {
+                uart->begin(g.rangefinder_baud);
+                serial_manager.set_protocol_and_baud(g.rangefinder_port, AP_SerialManager::SerialProtocol_Rangefinder, g.rangefinder_baud);
+            }
         }
+        rangefinder.init(ROTATION_NONE);
     }
 #endif
 

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -154,8 +154,8 @@ uint8_t PreferredNodeID = HAL_CAN_DEFAULT_NODE_ID;
 #define AP_PERIPH_BATTERY_MODEL_NAME CAN_APP_NODE_NAME
 #endif
 
-#ifndef CAN_PROBE_CONTINUOUS
-#define CAN_PROBE_CONTINUOUS 0
+#ifndef AP_PERIPH_PROBE_CONTINUOUS
+#define AP_PERIPH_PROBE_CONTINUOUS 0
 #endif
 
 #ifndef AP_PERIPH_ENFORCE_AT_LEAST_ONE_PORT_IS_UAVCAN_1MHz
@@ -1778,7 +1778,7 @@ void AP_Periph_FW::can_mag_update(void)
         return;
     }
     compass.read();
-#if CAN_PROBE_CONTINUOUS
+#if AP_PERIPH_PROBE_CONTINUOUS
     if (compass.get_count() == 0) {
         static uint32_t last_probe_ms;
         uint32_t now = AP_HAL::native_millis();
@@ -2219,7 +2219,7 @@ void AP_Periph_FW::can_airspeed_update(void)
     if (!airspeed.enabled()) {
         return;
     }
-#if CAN_PROBE_CONTINUOUS
+#if AP_PERIPH_PROBE_CONTINUOUS
     if (!airspeed.healthy()) {
         uint32_t now = AP_HAL::native_millis();
         static uint32_t last_probe_ms;
@@ -2279,7 +2279,7 @@ void AP_Periph_FW::can_rangefinder_update(void)
     if (rangefinder.get_type(0) == RangeFinder::Type::NONE) {
         return;
     }
-#if CAN_PROBE_CONTINUOUS
+#if AP_PERIPH_PROBE_CONTINUOUS
     if (rangefinder.num_sensors() == 0) {
         uint32_t now = AP_HAL::native_millis();
         static uint32_t last_probe_ms;

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Rangefinder/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Rangefinder/hwdef.dat
@@ -13,3 +13,6 @@ define AP_PERIPH_RANGEFINDER_PORT_DEFAULT 2
 
 # setup for MSP
 define HAL_MSP_ENABLED 1
+
+# some lidars take a long time to init, keep probing till we find it
+define AP_PERIPH_PROBE_CONTINUOUS 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
@@ -15,3 +15,6 @@ define HAL_NO_ROMFS_SUPPORT
 
 # setup for MSP
 define HAL_MSP_ENABLED 1
+
+# some lidars take a long time to init, keep probing till we find it
+define AP_PERIPH_PROBE_CONTINUOUS 1

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -185,11 +185,10 @@ RangeFinder::RangeFinder()
  */
 void RangeFinder::init(enum Rotation orientation_default)
 {
-    if (init_done) {
-        // init called a 2nd time?
+    if (num_instances != 0) {
+        // don't re-init if we've found some sensors already
         return;
     }
-    init_done = true;
 
     // set orientation defaults
     for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
@@ -298,9 +297,11 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #if AP_RANGEFINDER_LWI2C_ENABLED
         if (params[instance].address) {
             // the LW20 needs a long time to boot up, so we delay 1.5s here
+#ifndef HAL_BUILD_AP_PERIPH
             if (!hal.util->was_watchdog_armed()) {
                 hal.scheduler->delay(1500);
             }
+#endif
 #ifdef HAL_RANGEFINDER_LIGHTWARE_I2C_BUS
             _add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance], params[instance],
                                                              hal.i2c_mgr->get_device(HAL_RANGEFINDER_LIGHTWARE_I2C_BUS, params[instance].address)),

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -219,7 +219,6 @@ private:
     RangeFinder_State state[RANGEFINDER_MAX_INSTANCES];
     AP_RangeFinder_Backend *drivers[RANGEFINDER_MAX_INSTANCES];
     uint8_t num_instances;
-    bool init_done;
     HAL_Semaphore detect_sem;
     float estimated_terrain_height;
     Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests


### PR DESCRIPTION
This fixes a few issues with peripheral rangefinder init
 - cope with sensors that take a long time to startup (eg. LW20)
 - cope with sensors that are powered on separately to the periph CAN node
 - cope with boards without a uart and only i2c sensors

issue reported here: https://discuss.ardupilot.org/t/ap-periph-not-working-with-lightwarei2c/95913