### PR TITLE
AP_Mount: remove redundant constructors

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -68,9 +68,7 @@ class AP_Mount_Alexmos : public AP_Mount_Backend
 {
 public:
     //constructor
-    AP_Mount_Alexmos(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance):
-        AP_Mount_Backend(frontend, params, instance)
-    {}
+    using AP_Mount_Backend::AP_Mount_Backend;
 
     // init - performs any required initialisation for this instance
     void init() override;

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -11,10 +11,6 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_GREMSY_SEARCH_MS  60000    // search for gimbal for 1 minute after startup
 #define AP_MOUNT_GREMSY_ATTITUDE_INTERVAL_US    20000  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 50hz
 
-AP_Mount_Gremsy::AP_Mount_Gremsy(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
-    AP_Mount_Backend(frontend, params, instance)
-{}
-
 // update mount position
 void AP_Mount_Gremsy::update()
 {

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -20,7 +20,7 @@ class AP_Mount_Gremsy : public AP_Mount_Backend
 
 public:
     // Constructor
-    AP_Mount_Gremsy(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance);
+    using AP_Mount_Backend::AP_Mount_Backend;
 
     // init
     void init() override {}

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -9,11 +9,6 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_STORM32_RESEND_MS  1000    // resend angle targets to gimbal once per second
 #define AP_MOUNT_STORM32_SEARCH_MS  60000   // search for gimbal for 1 minute after startup
 
-AP_Mount_SToRM32::AP_Mount_SToRM32(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
-    AP_Mount_Backend(frontend, params, instance),
-    _chan(MAVLINK_COMM_0)
-{}
-
 // update mount position - should be called periodically
 void AP_Mount_SToRM32::update()
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -19,7 +19,7 @@ class AP_Mount_SToRM32 : public AP_Mount_Backend
 
 public:
     // Constructor
-    AP_Mount_SToRM32(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance);
+    using AP_Mount_Backend::AP_Mount_Backend;
 
     // init - performs any required initialisation for this instance
     void init() override {}
@@ -47,7 +47,7 @@ private:
     bool _initialised;              // true once the driver has been initialised
     uint8_t _sysid;                 // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
-    mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal
+    mavlink_channel_t _chan = MAVLINK_COMM_0;        // mavlink channel used to communicate with gimbal
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
     MountTarget _angle_rad;         // latest angle target
 };

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -6,11 +6,6 @@
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
-AP_Mount_SToRM32_serial::AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
-    AP_Mount_Backend(frontend, params, instance),
-    _reply_type(ReplyType_UNKNOWN)
-{}
-
 // init - performs any required initialisation for this instance
 void AP_Mount_SToRM32_serial::init()
 {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -22,7 +22,7 @@ class AP_Mount_SToRM32_serial : public AP_Mount_Backend
 
 public:
     // Constructor
-    AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance);
+    using AP_Mount_Backend::AP_Mount_Backend;
 
     // init - performs any required initialisation for this instance
     void init() override;
@@ -139,7 +139,7 @@ private:
 
     uint8_t _reply_length;
     uint8_t _reply_counter;
-    ReplyType _reply_type;
+    ReplyType _reply_type = ReplyType_UNKNOWN;
 
 
     union PACKED SToRM32_reply {


### PR DESCRIPTION
just copy in the one from the parent class

```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           -72     -72               -72    -72    -72
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               *      *           -72     -72               -72    -72    -72
MatekF405                     *      *           -8      -16               -16    -16    -16
Pixhawk1-1M                   *      *           *       *                 *      *      *
f103-QiotekPeriph  0                                                                     
f303-Universal     0                                                                     
iomcu                                                          *                         
revo-mini                     *      *           -8      -16               -16    -8     -8
skyviper-v2450                                   *                                       
```
