### PR TITLE
AP_Periph: limit peripheral mag to 25Hz by default

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -73,6 +73,10 @@ extern AP_Periph_FW periph;
 #endif
 #endif
 
+#ifndef AP_PERIPH_MAG_MAX_RATE
+#define AP_PERIPH_MAG_MAX_RATE 25U
+#endif
+
 #define DEBUG_PRINTS 0
 #define DEBUG_PKTS 0
 #if DEBUG_PRINTS
@@ -1777,6 +1781,15 @@ void AP_Periph_FW::can_mag_update(void)
     if (!compass.available()) {
         return;
     }
+
+#if AP_PERIPH_MAG_MAX_RATE > 0
+    // don't flood the bus with very high rate magnetometers
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_mag_update_ms < (1000U / AP_PERIPH_MAG_MAX_RATE)) {
+        return;
+    }
+#endif
+
     compass.read();
 #if AP_PERIPH_PROBE_CONTINUOUS
     if (compass.get_count() == 0) {

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -101,9 +101,10 @@ bool AP_Compass_MMC5XX3::init()
     // 10ms minimum startup time
     hal.scheduler->delay(15);
 
-    if (!dev->write_register(REG_CONTROL1, REG_CONTROL1_BW0 | REG_CONTROL1_BW1)) {
+    // setup for 100Hz output
+    if (!dev->write_register(REG_CONTROL1, 0)) {
         return false;
-    } //  // This BW config sets the sensor measurement time to 0.5ms and filter bandwidth to 800Hz
+    }
 
 
     /* register the compass instance in the frontend */
@@ -124,8 +125,8 @@ bool AP_Compass_MMC5XX3::init()
 
     dev->set_retries(1);
 
-    // call timer() at 1kHz
-    dev->register_periodic_callback(1000,
+    // call timer() at 100Hz
+    dev->register_periodic_callback(10000U,
                                     FUNCTOR_BIND_MEMBER(&AP_Compass_MMC5XX3::timer, void));
 
     return true;
@@ -134,10 +135,10 @@ bool AP_Compass_MMC5XX3::init()
 void AP_Compass_MMC5XX3::timer()
 {
     // recalculate the offset with set/reset operation every measure_count_limit measurements
-    // sensor is read at about 500Hz, so about every 10 seconds
-    const uint16_t measure_count_limit = 5000;
-    const uint16_t zero_offset = 32768; // 16 bit mode
-    const uint16_t sensitivity = 4096; // counts per Gauss, 16 bit mode
+    // sensor is read at about 100Hz, so about every 10 seconds
+    const uint16_t measure_count_limit = 1000U;
+    const uint16_t zero_offset = 32768U; // 16 bit mode
+    const uint16_t sensitivity = 4096U; // counts per Gauss, 16 bit mode
     constexpr float counts_to_milliGauss = 1.0e3f / sensitivity;
 
     /*


### PR DESCRIPTION
we only read mag on the vehicles at 10Hz. Some magnetometers were reporting data at 500Hz (see MMC5xx3 driver)

by sampling more slowly the data is accumulated and averaged on the node which saves a lot of bandwidth

this also drops the MMC5xx3 driver to 100Hz, from current I2C read at 1kHz. That used too much I2C bandwidth