### PR TITLE
Copter: Re-enable PID logging in SystemID mode

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -517,7 +517,7 @@ void Copter::ten_hz_logging_loop()
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
         Log_Write_Attitude();
     }
-    if (!should_log(MASK_LOG_ATTITUDE_FAST)) {
+    if (!should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
     // log at 10Hz if PIDS bitmask is selected, even if no ATT bitmask is selected; logs at looprate if ATT_FAST and PIDS bitmask set
         Log_Write_PIDS();
     }

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -299,6 +299,7 @@ void ModeSystemId::log_data() const
 
     // Full rate logging of attitude, rate and pid loops
     copter.Log_Write_Attitude();
+    copter.Log_Write_PIDS();
 }
 
 #endif


### PR DESCRIPTION
This is a simple fix to re-enable the writing of PID log messages when a copter enters system identification mode. This issue currently occurs on all versions of Copter-4.3.

Explanation:
I noticed that the PID log messages are disabled when entering the SystemID mode while I was experimenting with the ArduCopter Simulink model. These messages are required when feeding part of the flight using SystemID to the Matlab scripts.

The missing PID messages seem to be caused by #21372 which separated the writing of PIDs from the attitude messages. However, since the SystemID mode records both attitude and PIDs at its own rate and not at the full loop rate, it is necessary to write the PIDs from this mode as well.

I also added the `logs_attitude` condition mask to the PID writing in the `ten_hz_logging_loop` since the writing will already be done from SystemID and because (to my knowledge) only SystemID has the `logs_attitude` mask set to `true`.