### PR TITLE
AP_MOUNT: add GIMBAL_MANAGER_SET_PITCHYAW message support

### DIFF
--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -223,6 +223,7 @@ private:
     MAV_RESULT handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_gimbal_manager_configure(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
     void handle_gimbal_manager_set_attitude(const mavlink_message_t &msg);
+    void handle_command_gimbal_manager_set_pitchyaw(const mavlink_message_t &msg);
     void handle_global_position_int(const mavlink_message_t &msg);
     void handle_gimbal_device_information(const mavlink_message_t &msg);
     void handle_gimbal_device_attitude_status(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3915,6 +3915,7 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION:
     case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
     case MAVLINK_MSG_ID_GIMBAL_MANAGER_SET_ATTITUDE:
+    case MAVLINK_MSG_ID_GIMBAL_MANAGER_SET_PITCHYAW:
         handle_mount_message(msg);
         break;
 #endif


### PR DESCRIPTION
In reference to #20985. Adds support for GIMBAL_MANAGER_SET_PITCHYAW message listed [here](https://github.com/ArduPilot/ardupilot/issues/20985#:~:text=add%20GIMBAL_MANAGER_SET_PITCHYAW%20message%20support%20(not%20to%20be%20confused%20with%20MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW))

These other pulls needs merging before it:
#https://github.com/ArduPilot/mavlink/pull/305