### PR TITLE
Feature/fix rover sitl rate

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6348,12 +6348,12 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.PrivateChannel,
             self.GCSFailsafe,
             self.InitialMode,
+            self.DriveMaxRCIN,
         ])
         return ret
 
     def disabled_tests(self):
         return {
-            "DriveMaxRCIN": "currently triggers Arithmetic Exception",
             "SlewRate": "got timing report failure on CI",
         }
 

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -63,10 +63,10 @@ float SimRover::turn_circle(float steering) const
 float SimRover::calc_yaw_rate(float steering, float speed)
 {
     if (skid_steering) {
-        return steering * skid_turn_rate;
+        return constrain_float(steering * skid_turn_rate, -MAX_YAW_RATE, MAX_YAW_RATE);
     }
     if (vectored_thrust) {
-        return steering * vectored_turn_rate_max;
+        return constrain_float(steering * vectored_turn_rate_max, -MAX_YAW_RATE, MAX_YAW_RATE);
     }
     if (fabsf(steering) < 1.0e-6 or fabsf(speed) < 1.0e-6) {
         return 0;
@@ -74,7 +74,7 @@ float SimRover::calc_yaw_rate(float steering, float speed)
     float d = turn_circle(steering);
     float c = M_PI * d;
     float t = c / speed;
-    float rate = 360.0f / t;
+    float rate = constrain_float(360.0f / t, -MAX_YAW_RATE, MAX_YAW_RATE);
     return rate;
 }
 

--- a/libraries/SITL/SIM_Rover.h
+++ b/libraries/SITL/SIM_Rover.h
@@ -38,6 +38,7 @@ public:
     }
 
 private:
+    static constexpr float MAX_YAW_RATE = 360.0;  // MAX 360 deg/s yaw rate speed to not nuke the ekf gsf
     float max_speed = 20.0f;            // vehicle's maximum forward speed in m/s
     float max_accel = 10.0f;            // vehicle's maximum forward acceleration in m/s/s
     float max_wheel_turn = 35.0f;       // ackermann steering vehicle's maximum steering angle


### PR DESCRIPTION
fix Rover SITL insane yaw rate and GSF FPE that occure.

On master branch, it is quite simple to trigger, with default rover : 
arm throttle
rc 3 2000
rc 1 2000

yaw rate reach 1042 deg/s and GSF crash

This cap the yaw rate speed
It also bring back a test that was disabled because of the FPE