### PR TITLE
board_types.txt: move rFCU and rGNSS to different IDs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -212,8 +212,8 @@ AP_HW_FlywooF405S_AIO                1099
 AP_HW_mRoCANPower                    1100
 AP_HW_mRoControlOne                  1101
 
-AP_HW_rFCU                           1096
-AP_HW_rGNSS                          1097
+AP_HW_rFCU                           1102
+AP_HW_rGNSS                          1103
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
these are clashing with board IDs already in-tree