### PR TITLE
Yaw D Autotune

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2325,6 +2325,45 @@ class AutoTestCopter(AutoTest):
         raise NotAchievedException("AUTOTUNE failed (%u seconds)" %
                                    (self.get_sim_time() - tstart))
 
+    def AutoTuneYawD(self):
+        """Test autotune mode"""
+
+        rlld = self.get_parameter("ATC_RAT_RLL_D")
+        rlli = self.get_parameter("ATC_RAT_RLL_I")
+        rllp = self.get_parameter("ATC_RAT_RLL_P")
+        self.set_parameter("ATC_RAT_RLL_SMAX", 1)
+        self.set_parameter("AUTOTUNE_AXES", 15)
+        self.takeoff(10)
+
+        # hold position in loiter
+        self.change_mode('AUTOTUNE')
+
+        tstart = self.get_sim_time()
+        sim_time_expected = 5000
+        deadline = tstart + sim_time_expected
+        while self.get_sim_time_cached() < deadline:
+            now = self.get_sim_time_cached()
+            m = self.mav.recv_match(type='STATUSTEXT',
+                                    blocking=True,
+                                    timeout=1)
+            if m is None:
+                continue
+            self.progress("STATUSTEXT (%u<%u): %s" % (now, deadline, m.text))
+            if "AutoTune: Success" in m.text:
+                self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
+                # near enough for now:
+                self.change_mode('LAND')
+                self.wait_landed_and_disarmed()
+                # check the original gains have been re-instated
+                if (rlld != self.get_parameter("ATC_RAT_RLL_D") or
+                        rlli != self.get_parameter("ATC_RAT_RLL_I") or
+                        rllp != self.get_parameter("ATC_RAT_RLL_P")):
+                    raise NotAchievedException("AUTOTUNE gains still present")
+                return
+
+        raise NotAchievedException("AUTOTUNE failed (%u seconds)" %
+                                   (self.get_sim_time() - tstart))
+
     def AutoTuneSwitch(self):
         """Test autotune on a switch with gains being saved"""
 
@@ -9523,6 +9562,7 @@ class AutoTestCopter(AutoTest):
              self.AuxSwitchOptions,
              self.AuxFunctionsInMission,
              self.AutoTune,
+             self.AutoTuneYawD,
              self.NoRCOnBootPreArmFailure,
         ])
         return ret

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -172,7 +172,9 @@ const char *AC_AutoTune::axis_string() const
     case PITCH:
         return "Pitch";
     case YAW:
-        return "Yaw";
+        return "Yaw(E)";
+    case YAW_D:
+        return "Yaw(D)";
     }
     return "";
 }
@@ -363,6 +365,7 @@ void AC_AutoTune::control_attitude()
             start_angle = ahrs_view->pitch_sensor;
             break;
         case YAW:
+        case YAW_D:
             abort_angle = AUTOTUNE_TARGET_ANGLE_YAW_CD;
             start_rate = ToDeg(ahrs_view->get_gyro().z) * 100.0f;
             start_angle = ahrs_view->yaw_sensor;
@@ -477,6 +480,8 @@ void AC_AutoTune::control_attitude()
                         axis = PITCH;
                     } else if (yaw_enabled()) {
                         axis = YAW;
+                    } else if (yaw_d_enabled()) {
+                        axis = YAW_D;
                     } else {
                         complete = true;
                     }
@@ -485,12 +490,22 @@ void AC_AutoTune::control_attitude()
                     axes_completed |= AUTOTUNE_AXIS_BITMASK_PITCH;
                     if (yaw_enabled()) {
                         axis = YAW;
+                    } else if (yaw_d_enabled()) {
+                        axis = YAW_D;
                     } else {
                         complete = true;
                     }
                     break;
                 case YAW:
                     axes_completed |= AUTOTUNE_AXIS_BITMASK_YAW;
+                    if (yaw_d_enabled()) {
+                        axis = YAW_D;
+                    } else {
+                        complete = true;
+                    }
+                    break;
+                case YAW_D:
+                    axes_completed |= AUTOTUNE_AXIS_BITMASK_YAW_D;
                     complete = true;
                     break;
                 }
@@ -512,7 +527,7 @@ void AC_AutoTune::control_attitude()
         // reverse direction for multicopter twitch test
         positive_direction = twitch_reverse_direction();
 
-        if (axis == YAW) {
+        if (axis == YAW || axis == YAW_D) {
             attitude_control->input_euler_angle_roll_pitch_yaw(0.0f, 0.0f, ahrs_view->yaw_sensor, false);
         }
 
@@ -539,6 +554,8 @@ void AC_AutoTune::backup_gains_and_initialise()
         axis = PITCH;
     } else if (yaw_enabled()) {
         axis = YAW;
+    } else if (yaw_d_enabled()) {
+        axis = YAW_D;
     }
     // no axes are complete
     axes_completed = 0;
@@ -599,10 +616,11 @@ void AC_AutoTune::update_gcs(uint8_t message_id) const
         gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Pilot Testing");
         break;
     case AUTOTUNE_MESSAGE_SAVED_GAINS:
-        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Saved gains for %s%s%s",
+        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Saved gains for %s%s%s%s",
                         (axes_completed&AUTOTUNE_AXIS_BITMASK_ROLL)?"Roll ":"",
                         (axes_completed&AUTOTUNE_AXIS_BITMASK_PITCH)?"Pitch ":"",
-                        (axes_completed&AUTOTUNE_AXIS_BITMASK_YAW)?"Yaw":"");
+                        (axes_completed&AUTOTUNE_AXIS_BITMASK_YAW)?"Yaw(E)":"",
+                        (axes_completed&AUTOTUNE_AXIS_BITMASK_YAW_D)?"Yaw(D)":"");
         break;
     }
 }
@@ -621,6 +639,15 @@ bool AC_AutoTune::pitch_enabled() const
 bool AC_AutoTune::yaw_enabled() const
 {
     return get_axis_bitmask() & AUTOTUNE_AXIS_BITMASK_YAW;
+}
+
+bool AC_AutoTune::yaw_d_enabled() const
+{
+#if APM_BUILD_TYPE(APM_BUILD_Heli)
+    return false;
+#else
+    return get_axis_bitmask() & AUTOTUNE_AXIS_BITMASK_YAW_D;
+#endif
 }
 
 /*

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -26,6 +26,7 @@
 #define AUTOTUNE_AXIS_BITMASK_ROLL            1
 #define AUTOTUNE_AXIS_BITMASK_PITCH           2
 #define AUTOTUNE_AXIS_BITMASK_YAW             4
+#define AUTOTUNE_AXIS_BITMASK_YAW_D           8
 
 #define AUTOTUNE_SUCCESS_COUNT                4     // The number of successful iterations we need to freeze at current gains
 
@@ -69,7 +70,8 @@ protected:
     enum AxisType {
         ROLL = 0,                 // roll axis is being tuned (either angle or rate)
         PITCH = 1,                // pitch axis is being tuned (either angle or rate)
-        YAW = 2,                  // pitch axis is being tuned (either angle or rate)
+        YAW = 2,                  // yaw axis is being tuned using FLTE (either angle or rate)
+        YAW_D = 3,                // yaw axis is being tuned using D (either angle or rate)
     };
 
     //
@@ -122,6 +124,7 @@ protected:
     bool roll_enabled() const;
     bool pitch_enabled() const;
     bool yaw_enabled() const;
+    bool yaw_d_enabled() const;
 
     // update gains for the rate p up tune type
     virtual void updating_rate_p_up_all(AxisType test_axis)=0;


### PR DESCRIPTION
This patch allows one to tune ATC_RAT_YAW_D rather than ATC_RAT_YAW_FLTE in autotune. This is particularly necessary for quadplanes using vectored yaw which have no momentum-based D component. This can also be used as a mechanism for tightening a copter yaw tune once a standard FLTE tune has been completed.

Enabled by setting:
```
AUTOTUNE_AXES = 8
````
Tested on a Heewing T-1 Ranger tri-tilt