### PR TITLE
AC_PrecLand: converted yaw_align param to orient

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -209,6 +209,9 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
         return;
     }
 
+    // perform any required parameter conversion
+    convert_params();
+
     // init as target TARGET_NEVER_SEEN, we will update this later
     _current_target_state = TargetState::TARGET_NEVER_SEEN;
 
@@ -260,6 +263,25 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
 
     _approach_vector_body.x = 1;
     _approach_vector_body.rotate(_orient);
+}
+
+void AC_PrecLand::convert_params()
+{
+    //convert _yaw_align to _orient
+    if (_orient.configured()) {
+        // exit immediately if _orient has already been configured
+        return;
+    }
+    int orient = 0;
+    if (AP_Param::get_param_by_index(this, 2, AP_FLOAT, &orient)) {
+        if (orient>22) {
+        orient = (int((orient*0.01)/22.5) -1)/2 + 1;
+        }
+        else {
+            orient=0;
+        }
+        _orient.set_and_save(orient);
+    }
 }
 
 // update - give chance to driver to get updates from sensor

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -135,6 +135,9 @@ private:
         PLND_OPTION_PRECLAND_AFTER_REPOSITION = (1 << 1),
     };
 
+    // converts old parameters to new ones
+    void convert_params();
+
     // check the status of the target
     void check_target_status(float rangefinder_alt_m, bool rangefinder_alt_valid);
 


### PR DESCRIPTION
@rishabsingh3003 sir, is it safe now to remove the yaw_align parameter? And I would be happy if you could guide me on making the parameter available to the copter.
I converted yaw_align into degrees and then rounded it to an int from 0 to 8.
closes #21572