### PR TITLE
AP_Scripting: add some docs

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1145,8 +1145,16 @@ function FWVersion:minor() end
 ---@return integer
 function FWVersion:major() end
 
--- get field
+--get APM_BUILD_? value from AP_Vehicle/AP_Vehicle_Type.h that is checked against APM_BUILD_TYPE()
 ---@return integer
+---| '1' # Rover
+---| '2' # ArduCopter
+---| '3' # ArduPlane
+---| '4' # AntennaTracker
+---| '7' # ArduSub
+---| '9' # AP_Periph
+---| '12' # Blimp
+---| '13' # Heli
 function FWVersion:type() end
 
 -- get field


### PR DESCRIPTION
Added scripting hooks `FWVersion:hal_board()` and `FWVersion:hal_board_subtype()`. I've also added suitable documentation to make the function calls more useful.

My inspiration was to check for
```
local HAL_BOARD_SITL = 3
if FWVersion:hal_board() == HAL_BOARD_SITL then
  -- do SITL specific handling
end
```