### PR TITLE
CI: allow test_size to work on private repos

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -151,9 +151,9 @@ jobs:
           cd pr/
           git config user.email "ardupilot-ci@ardupilot.org"
           git config user.name "ArduPilot CI"
-          git remote add ardupilot https://github.com/ArduPilot/ardupilot.git
-          git fetch --no-tags --prune --progress ardupilot ${{ github.event.pull_request.base.ref }}
-          git rebase ardupilot/${{ github.event.pull_request.base.ref }}
+          git remote add target_repo https://github.com/${{github.event.pull_request.base.repo.full_name}}
+          git fetch --no-tags --prune --progress target_repo ${{ github.event.pull_request.base.ref }}
+          git rebase target_repo/${{ github.event.pull_request.base.ref }}
           git submodule update --init --recursive --depth=1
           # configure
           if [ $BOOTLOADER -eq 1 ]; then


### PR DESCRIPTION
If the target repo is a private repo then CI fails when checking out the various branches to test size them against

This is the current failure msg in CI:
```
git config user.email ardupilot-ci@ardupilot.org
+ git config user.name 'ArduPilot CI'
+ git remote add ardupilot https://github.com/ArduPilot/ardupilot.git
+ git fetch --no-tags --prune --progress ardupilot some-branch-on-a-private-repo
fatal: couldn't find remote ref some-branch-on-a-private-repo
Error: Process completed with exit code 128.
```

