### PR TITLE
AP_Airspeed: save some bytes by making conversion structure static

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -246,7 +246,7 @@ void AP_Airspeed::convert_per_instance()
         return;
     }
 
-    const struct convert_table {
+    static const struct convert_table {
         uint32_t element[2];
         ap_var_type type;
         const char* name;


### PR DESCRIPTION
```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           8       8                 8      16     16
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               *      *           -8      -8                -8     -8     -8
MatekF405                     *      *           *       *                 -8     -8     -8
Pixhawk1-1M                   *      *           *       *                 -8     -8     -8
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     *      *           *       *                 -8     -8     -8
skyviper-v2450                                   *                                       
```

... only noticed this because it was appearing in the `nm` output
