### PR TITLE
AP_Mission/AP_Camera: improve camera controls

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -217,6 +217,54 @@ MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
             take_picture();
         }
         return MAV_RESULT_ACCEPTED;
+    case MAV_CMD_SET_CAMERA_ZOOM:
+        if (is_equal(packet.param1, (float)ZOOM_TYPE_CONTINUOUS)) {
+            set_zoom_step((int8_t)packet.param2);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_UNSUPPORTED;
+    case MAV_CMD_SET_CAMERA_FOCUS:
+        // accept any of the auto focus types
+        if (is_equal(packet.param1, (float)FOCUS_TYPE_AUTO) ||
+            is_equal(packet.param1, (float)FOCUS_TYPE_AUTO_SINGLE) ||
+            is_equal(packet.param1, (float)FOCUS_TYPE_AUTO_CONTINUOUS)) {
+            set_auto_focus();
+            return MAV_RESULT_ACCEPTED;
+        }
+        // accept step or continuous manual focus
+        if (is_equal(packet.param1, (float)FOCUS_TYPE_CONTINUOUS)) {
+            set_manual_focus_step((int8_t)packet.param2);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_UNSUPPORTED;
+    case MAV_CMD_IMAGE_START_CAPTURE:
+        if (!is_zero(packet.param2) || !is_equal(packet.param3, 1.0f) || !is_zero(packet.param4)) {
+            // time interval is not supported
+            // multiple image capture is not supported
+            // capture sequence number is not supported
+            return MAV_RESULT_UNSUPPORTED;
+        }
+        take_picture();
+        return MAV_RESULT_ACCEPTED;
+    case MAV_CMD_VIDEO_START_CAPTURE:
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
+    {
+        bool success = false;
+        const bool start_recording = (packet.command == MAV_CMD_VIDEO_START_CAPTURE);
+        const uint8_t stream_id = packet.param1;  // Stream ID
+        if (stream_id == 0) {
+            // stream id of 0 interpreted as primary camera
+            success = record_video(start_recording);
+        } else {
+            // convert stream id to instance id
+            success = record_video(stream_id - 1, start_recording);
+        }
+        if (success) {
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            return MAV_RESULT_FAILED;
+        }
+    }
     default:
         return MAV_RESULT_UNSUPPORTED;
     }

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -2,10 +2,7 @@
 
 #if AP_CAMERA_ENABLED
 
-#include <AP_AHRS/AP_AHRS.h>
-#include <AP_Relay/AP_Relay.h>
 #include <AP_Math/AP_Math.h>
-#include <RC_Channel/RC_Channel.h>
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -204,6 +204,27 @@ void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &
     }
 }
 
+// handle command_long mavlink messages
+MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
+{
+    switch (packet.command) {
+    case MAV_CMD_DO_DIGICAM_CONFIGURE:
+        configure(packet.param1, packet.param2, packet.param3, packet.param4, packet.param5, packet.param6, packet.param7);
+        return MAV_RESULT_ACCEPTED;
+    case MAV_CMD_DO_DIGICAM_CONTROL:
+        control(packet.param1, packet.param2, packet.param3, packet.param4, packet.param5, packet.param6);
+        return MAV_RESULT_ACCEPTED;
+    case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+        set_trigger_distance(packet.param1);
+        if (is_equal(packet.param3, 1.0f)) {
+            take_picture();
+        }
+        return MAV_RESULT_ACCEPTED;
+    default:
+        return MAV_RESULT_UNSUPPORTED;
+    }
+}
+
 // set camera trigger distance in a mission
 void AP_Camera::set_trigger_distance(uint8_t instance, float distance_m)
 {

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -73,6 +73,7 @@ public:
 
     // MAVLink methods
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg);
+    MAV_RESULT handle_command_long(const mavlink_command_long_t &packet);
     void send_feedback(mavlink_channel_t chan) const;
 
     // configure camera

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -375,6 +375,11 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
     case MAV_CMD_JUMP_TAG:
+    case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_SET_CAMERA_ZOOM:
+    case MAV_CMD_SET_CAMERA_FOCUS:
+    case MAV_CMD_VIDEO_START_CAPTURE:
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
         return true;
     default:
         return _cmd_verify_fn(cmd);
@@ -407,6 +412,11 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     case MAV_CMD_DO_DIGICAM_CONFIGURE:
     case MAV_CMD_DO_DIGICAM_CONTROL:
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+    case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_SET_CAMERA_ZOOM:
+    case MAV_CMD_SET_CAMERA_FOCUS:
+    case MAV_CMD_VIDEO_START_CAPTURE:
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
         return start_command_camera(cmd);
 #endif
     case MAV_CMD_DO_PARACHUTE:
@@ -1292,6 +1302,30 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.gimbal_manager_pitchyaw.gimbal_id = packet.z;
         break;
 
+    case MAV_CMD_IMAGE_START_CAPTURE:
+        cmd.content.image_start_capture.interval_s = packet.param2;
+        cmd.content.image_start_capture.total_num_images = packet.param3;
+        cmd.content.image_start_capture.start_seq_number = packet.param4;
+        break;
+
+    case MAV_CMD_SET_CAMERA_ZOOM:
+        cmd.content.set_camera_zoom.zoom_type = packet.param1;
+        cmd.content.set_camera_zoom.zoom_value = packet.param2;
+        break;
+
+    case MAV_CMD_SET_CAMERA_FOCUS:
+        cmd.content.set_camera_focus.focus_type = packet.param1;
+        cmd.content.set_camera_focus.focus_value = packet.param2;
+        break;
+
+    case MAV_CMD_VIDEO_START_CAPTURE:
+        cmd.content.video_start_capture.video_stream_id = packet.param1;
+        break;
+
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
+        cmd.content.video_stop_capture.video_stream_id = packet.param1;
+        break;
+
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1779,6 +1813,30 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param4 = cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs;
         packet.x = cmd.content.gimbal_manager_pitchyaw.flags;
         packet.z = cmd.content.gimbal_manager_pitchyaw.gimbal_id;
+        break;
+
+    case MAV_CMD_IMAGE_START_CAPTURE:
+        packet.param2 = cmd.content.image_start_capture.interval_s;
+        packet.param3 = cmd.content.image_start_capture.total_num_images;
+        packet.param4 = cmd.content.image_start_capture.start_seq_number;
+        break;
+
+    case MAV_CMD_SET_CAMERA_ZOOM:
+        packet.param1 = cmd.content.set_camera_zoom.zoom_type;
+        packet.param2 = cmd.content.set_camera_zoom.zoom_value;
+        break;
+
+    case MAV_CMD_SET_CAMERA_FOCUS:
+        packet.param1 = cmd.content.set_camera_focus.focus_type;
+        packet.param2 = cmd.content.set_camera_focus.focus_value;
+        break;
+
+    case MAV_CMD_VIDEO_START_CAPTURE:
+        packet.param1 = cmd.content.video_start_capture.video_stream_id;
+        break;
+
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
+        packet.param1 = cmd.content.video_stop_capture.video_stream_id;
         break;
 
     default:
@@ -2584,6 +2642,16 @@ const char *AP_Mission::Mission_Command::type() const
         return "PauseContinue";
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         return "GimbalPitchYaw";
+    case MAV_CMD_IMAGE_START_CAPTURE:
+        return "ImageStartCapture";
+    case MAV_CMD_SET_CAMERA_ZOOM:
+        return "SetCameraZoom";
+    case MAV_CMD_SET_CAMERA_FOCUS:
+        return "SetCameraFocus";
+    case MAV_CMD_VIDEO_START_CAPTURE:
+        return "VideoStartCapture";
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
+        return "VideoStopCapture";
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Mission command with ID %u has no string", id);

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -267,6 +267,35 @@ public:
         uint8_t gimbal_id;
     };
 
+    // MAV_CMD_IMAGE_START_CAPTURE support
+    struct PACKED image_start_capture_Command {
+        float interval_s;
+        uint16_t total_num_images;
+        uint16_t start_seq_number;
+    };
+
+    // MAV_CMD_SET_CAMERA_ZOOM support
+    struct PACKED set_camera_zoom_Command {
+        uint8_t zoom_type;
+        float zoom_value;
+    };
+
+    // MAV_CMD_SET_CAMERA_FOCUS support
+    struct PACKED set_camera_focus_Command {
+        uint8_t focus_type;
+        float focus_value;
+    };
+
+    // MAV_CMD_VIDEO_START_CAPTURE support
+    struct PACKED video_start_capture_Command {
+        uint8_t video_stream_id;
+    };
+
+    // MAV_CMD_VIDEO_STOP_CAPTURE support
+    struct PACKED video_stop_capture_Command {
+        uint8_t video_stream_id;
+    };
+
     union Content {
         // jump structure
         Jump_Command jump;
@@ -347,6 +376,21 @@ public:
 
         // MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW
         gimbal_manager_pitchyaw_Command gimbal_manager_pitchyaw;
+
+        // MAV_CMD_IMAGE_START_CAPTURE support
+        image_start_capture_Command image_start_capture;
+
+        // MAV_CMD_SET_CAMERA_ZOOM support
+        set_camera_zoom_Command set_camera_zoom;
+
+        // MAV_CMD_SET_CAMERA_FOCUS support
+        set_camera_focus_Command set_camera_focus;
+
+        // MAV_CMD_VIDEO_START_CAPTURE support
+        video_start_capture_Command video_start_capture;
+
+        // MAV_CMD_VIDEO_STOP_CAPTURE support
+        video_stop_capture_Command video_stop_capture;
 
         // location
         Location location{};      // Waypoint location

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3361,39 +3361,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_camera(const mavlink_command_long_t &pack
         return MAV_RESULT_UNSUPPORTED;
     }
 
-    MAV_RESULT result = MAV_RESULT_FAILED;
-    switch (packet.command) {
-    case MAV_CMD_DO_DIGICAM_CONFIGURE:
-        camera->configure(packet.param1,
-                          packet.param2,
-                          packet.param3,
-                          packet.param4,
-                          packet.param5,
-                          packet.param6,
-                          packet.param7);
-        result = MAV_RESULT_ACCEPTED;
-        break;
-    case MAV_CMD_DO_DIGICAM_CONTROL:
-        camera->control(packet.param1,
-                        packet.param2,
-                        packet.param3,
-                        packet.param4,
-                        packet.param5,
-                        packet.param6);
-        result = MAV_RESULT_ACCEPTED;
-        break;
-    case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
-        camera->set_trigger_distance(packet.param1);
-        if (is_equal(packet.param3, 1.0f)) {
-            camera->take_picture();
-        }
-        result = MAV_RESULT_ACCEPTED;
-        break;
-    default:
-        result = MAV_RESULT_UNSUPPORTED;
-        break;
-    }
-    return result;
+    return camera->handle_command_long(packet);
 }
 #endif
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4701,6 +4701,11 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_DO_DIGICAM_CONFIGURE:
     case MAV_CMD_DO_DIGICAM_CONTROL:
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+    case MAV_CMD_SET_CAMERA_ZOOM:
+    case MAV_CMD_SET_CAMERA_FOCUS:
+    case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_VIDEO_START_CAPTURE:
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
         result = handle_command_camera(packet);
         break;
 #endif


### PR DESCRIPTION
This improves support for controlling the camera both using real-time commands from the GCS and using mission commands in Auto mode.  The newly supported commands are:

- [MAV_CMD_SET_CAMERA_ZOOM](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1507) <-- only continuous type (not step or position yet)
- [MAV_CMD_SET_CAMERA_FOCUS](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1515) <-- only continuous type (not step or distance yet)
- [MAV_CMD_IMAGE_START_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1544) <-- only takes 1 picture
- [MAV_CMD_VIDEO_START_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1584)
- [MAV_CMD_VIDEO_STOP_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1594)

This has been tested in SITL and on a real autopilot and appears to work although mission commands for zoom and focus could not be tested completely.

The corresponding [developer mavlink interface wiki PR is here](https://github.com/ArduPilot/ardupilot_wiki/pull/5002).
The corresponding MP PR is here https://github.com/ArduPilot/MissionPlanner/pull/3071

Here's a picture from testing the video start/stop recording commands.
![image](https://user-images.githubusercontent.com/1498098/225228631-fc99dcbf-c3fa-47e7-baac-c5df913de04c.png)



