### PR TITLE
Various small CI / autotest fixes

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
         config: [
-            check_autotest_options
+            check_autotest_options,
+            param_parse,
         ]
     steps:
       # git checkout the PR

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -16,7 +16,9 @@ jobs:
         config: [
             check_autotest_options,
             param_parse,
-        ]
+            python-cleanliness,
+            validate_board_list,
+       ]
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -1,0 +1,29 @@
+name: test scripts
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container: ardupilot/ardupilot-dev-base:latest
+    strategy:
+      fail-fast: false  # don't cancel if a job from the matrix fails
+      matrix:
+        config: [
+            check_autotest_options
+        ]
+    steps:
+      # git checkout the PR
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: test ${{matrix.config}}
+        env:
+          CI_BUILD_TARGET: ${{matrix.config}}
+        shell: bash
+        run: |
+          Tools/scripts/build_ci.sh

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -1,4 +1,4 @@
-name: test unit tests and Python cleanliness
+name: test unit tests and sitl building
 
 on: [push, pull_request, workflow_dispatch]
 # paths:
@@ -23,17 +23,9 @@ jobs:
         ]
         config: [
             unit-tests,
-            python-cleanliness,
-            validate_board_list,
             sitl
             # examples,
         ]
-        exclude:
-          - config: [
-                python-cleanliness,
-                validate_board_list
-            ]
-            toolchain: clang
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -415,7 +415,7 @@ def run_specific_test(step, *args, **kwargs):
     global tester
     tester = tester_class(*args, **kwargs)
 
-    print("Got %s" % str(tester))
+    # print("Got %s" % str(tester))
     for a in tester.tests():
         if type(a) != Test:
             a = Test(a)

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -810,11 +810,9 @@ def list_subtests():
         subtests = tester.tests()
         sorted_list = []
         for subtest in subtests:
-            if type(subtest) is tuple:
-                (name, description, function) = subtest
-                sorted_list.append([name, description])
-            else:
-                sorted_list.append([subtest.name, subtest.description])
+            if str(type(subtest)) == "<class 'method'>":
+                subtest = Test(subtest)
+            sorted_list.append([subtest.name, subtest.description])
         sorted_list.sort()
 
         print("%s:" % vehicle)

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -406,6 +406,13 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "param_parse" ]; then
+        for v in Rover AntennaTracker ArduCopter ArduPlane ArduSub Blimp; do
+            python Tools/autotest/param_metadata/param_parse.py --vehicle $v
+        done
+        continue
+    fi
+
     if [[ -z ${CI_CRON_JOB+1} ]]; then
         echo "Starting waf build for board ${t}..."
         $waf configure --board "$t" \
@@ -423,13 +430,6 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 done
-
-python Tools/autotest/param_metadata/param_parse.py --vehicle Rover
-python Tools/autotest/param_metadata/param_parse.py --vehicle AntennaTracker
-python Tools/autotest/param_metadata/param_parse.py --vehicle ArduCopter
-python Tools/autotest/param_metadata/param_parse.py --vehicle ArduPlane
-python Tools/autotest/param_metadata/param_parse.py --vehicle ArduSub
-python Tools/autotest/param_metadata/param_parse.py --vehicle Blimp
 
 echo build OK
 exit 0

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -45,14 +45,7 @@ function install_pymavlink() {
     fi
 }
 
-function run_autotest() {
-    NAME="$1"
-    BVEHICLE="$2"
-    RVEHICLE="$3"
-
-    # report on what cpu's we have for later log review if needed
-    cat /proc/cpuinfo
-
+function install_mavproxy() {
     if [ $mavproxy_installed -eq 0 ]; then
         echo "Installing MAVProxy"
         pushd /tmp
@@ -65,6 +58,17 @@ function run_autotest() {
         # now uninstall the version of pymavlink pulled in by MAVProxy deps:
         python -m pip uninstall -y pymavlink
     fi
+}
+
+function run_autotest() {
+    NAME="$1"
+    BVEHICLE="$2"
+    RVEHICLE="$3"
+
+    # report on what cpu's we have for later log review if needed
+    cat /proc/cpuinfo
+
+    install_mavproxy
     install_pymavlink
     unset BUILDROOT
     echo "Running SITL $NAME test"
@@ -342,6 +346,16 @@ for t in $CI_BUILD_TARGET; do
     if [ "$t" == "validate_board_list" ]; then
         echo "Validating board list"
         ./Tools/autotest/validate_board_list.py
+        continue
+    fi
+
+    if [ "$t" == "check_autotest_options" ]; then
+        echo "Checking autotest options"
+        install_mavproxy
+        install_pymavlink
+        ./Tools/autotest/autotest.py --help
+        ./Tools/autotest/autotest.py --list
+        ./Tools/autotest/autotest.py --list-subtests
         continue
     fi
 


### PR DESCRIPTION
 - fix autotest.py --list-subtests
 - add test so we don't break --list-subtests again
 - stop running param parse step every time we invoke build_ci.sh
 - stop printing test names out when we run autotest.py - it's just noise, usually
