### PR TITLE
hwdef: stop minimizing Nucleo-L496 - it's an AP_Periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Nucleo-L496/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Nucleo-L496/hwdef.dat
@@ -99,9 +99,6 @@ PA4 VSENSE ADC1 SCALE(2)
 
 define HAL_NO_MONITOR_THREAD
 
-include ../include/minimize_features.inc
-
-
 define AP_PARAM_MAX_EMBEDDED_PARAM 512
 
 


### PR DESCRIPTION
minimized builds and AP_Periph don't make sense together