### PR TITLE
AP_Terrain: terrain offset max default to 30m

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Units: m
     // @Range: 0 50
     // @User: Advanced
-    AP_GROUPINFO("OFS_MAX",  4, AP_Terrain, offset_max, 15),
+    AP_GROUPINFO("OFS_MAX",  4, AP_Terrain, offset_max, 30),
     
     AP_GROUPEND
 };


### PR DESCRIPTION
This increases the default terrain altitude's offset (aka TERRAIN_OFS_MAX) to 30m (from 15m).

To provide background, this is the maximum altitude that the terrain database will be shifted up or down to match the vehicle's altitude at takeoff.  This shift happens at takeoff and is built on the assumption that the vehicle is taking off from the ground (e.g. not the top of a building).

The current 15m default is too strict (e.g. triggers too often under normal use) resulting in two problems:

1. unnecessary user confusion and fear and support calls due to the "Terrain: clamping xxx" message appearing
2. a real risk of terrain based missions flying at the wrong altitude.  Normally this results in the vehicle flying too high but too low is also possible.

I personally have seen the clamping message numerous times in Japan which has perfectly good GPS coverage and quality and using up-to-date vehicles with very commonly used, good quality GPSs.  During a demo to a large number of people, the payload place demonstration failed because the vehicle flew 10m higher than it should have.
