### PR TITLE
AP_Notify: remove pointless zeroing of memory

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -412,10 +412,6 @@ void AP_Notify::add_backends(void)
 // initialisation
 void AP_Notify::init(void)
 {
-    // clear all flags and events
-    memset(&AP_Notify::flags, 0, sizeof(AP_Notify::flags));
-    memset(&AP_Notify::events, 0, sizeof(AP_Notify::events));
-
     // add all the backends
     add_backends();
 }


### PR DESCRIPTION
this is static memory
```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      -40    *           -40     -40               -40    -40    -40
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               -32    *           -32     -32               -40    -32    -40
MatekF405                     -32    *           -40     -32               -32    -40    -40
Pixhawk1-1M                   -32    *           -40     -40               -32    -40    -32
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     -40    *           -40     -32               -32    -40    -32
skyviper-v2450                                   -32                                     
```
