### PR TITLE
StorageManager: fixed startup crash

### DIFF
--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -121,6 +121,9 @@ StorageAccess::StorageAccess(StorageManager::StorageType _type) :
 {
     // calculate available bytes
     total_size = 0;
+#if AP_SDCARD_STORAGE_ENABLED
+    file = nullptr;
+#endif
     for (uint8_t i=0; i<STORAGE_NUM_AREAS; i++) {
         const StorageManager::StorageArea &area = StorageManager::layout[i];
         if (area.type == type) {

--- a/libraries/StorageManager/StorageManager.h
+++ b/libraries/StorageManager/StorageManager.h
@@ -84,6 +84,9 @@ private:
 
 /*
   A StorageAccess object allows access to one type of storage
+
+  NOTE: this object may be declared on the stack, so it will not be
+  zero initialised
  */
 class StorageAccess {
 public:


### PR DESCRIPTION
this crash was caused by AP_UAVCAN_DNA_Server declaring a storage object on the stack, which meant file was not initialised to nullptr.

thanks to @rmackay9 for reporting
