### PR TITLE
Tools: Reserve ID for CBUnmanned CM405 Flight Controller

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -290,6 +290,8 @@ AP_HW_FlywooF405HD_AIOv2             1180
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206
 
+AP_HW_CBUnmanned-CM405-FC            1301
+
 AP_HW_KHA_ETH                        1315
 
 AP_HW_CUBEORANGE_PERIPH              1400


### PR DESCRIPTION
This PR Adds CBUnmanned-CM405-FC to the board ID list with ID 1301