### PR TITLE
AP_Notify: Use the number of arrays

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -473,7 +473,7 @@ void AP_Notify::play_tune(const char *tune)
 // set flight mode string
 void AP_Notify::set_flight_mode_str(const char *str)
 {
-    strncpy(_flight_mode_str, str, 4);
+    strncpy(_flight_mode_str, str, sizeof(_flight_mode_str));
     _flight_mode_str[sizeof(_flight_mode_str)-1] = 0;
 }
 


### PR DESCRIPTION
I would change the direct value to an array number.
The following process sets NULL at the end of the array.
I saw a similar process in the send_text method.
By using the number of arrays, there is no code change.