### PR TITLE
Plane:prevent in landing prearm fails if booting without rc

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1041,6 +1041,7 @@ private:
     void trim_radio();
     bool rc_throttle_value_ok(void) const;
     bool rc_failsafe_active(void) const;
+    bool seen_valid_rc ;
 
     // sensors.cpp
     void read_rangefinder(void);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -184,6 +184,14 @@ void Plane::read_radio()
 
     control_failsafe();
 
+    // if disarmed and seeing rc for the first time, reset mission so in landing prearm does not occur
+    if (!arming.is_armed() && seen_valid_rc == false)
+    {
+           mission.reset();
+    }
+
+    seen_valid_rc = true;
+
 #if AP_FENCE_ENABLED
     const bool stickmixing = fence_stickmixing();
 #else


### PR DESCRIPTION
addresses #23180
SITL tested....only issue is that if the mission starts with a DO_LAND_START resetting the mission on the first valid RC does not solve the issue.....an acceptable limitation in my opinion