### PR TITLE
StrageManager: Returns FLASE if NULLPTR

### DIFF
--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -351,6 +351,7 @@ bool StorageAccess::attach_file(const char *filename, uint16_t size_kbyte)
     auto *newfile = new FileStorage;
     if (newfile == nullptr) {
         AP_BoardConfig::allocation_error("StorageFile");
+        return false;
     }
     ssize_t nread;
 


### PR DESCRIPTION
In the case of NULLPTR, the message is output and the process is executed.
Essentially, in the case of NULLPTR, no further processing can be executed.
Therefore, the result of FLASE processing should be returned.