### PR TITLE
Plane:rudder arm in AUTO/TAKEOFF only after stick returns

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1092,6 +1092,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 10: Adjust mid-throttle to be TRIM_THROTTLE in non-auto throttle modes except MANUAL
     // @Bitmask: 11: Disable suppression of fixed wing rate gains in ground mode
     // @Bitmask: 12: Enable FBWB style loiter altitude control
+    // @Bitmask: 13: Indicate takeoff waiting for neutral rudder with flight control surfaces
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -401,11 +401,13 @@ private:
     struct {
         uint32_t last_tkoff_arm_time;
         uint32_t last_check_ms;
+        uint32_t rudder_takeoff_warn_ms;
         uint32_t last_report_ms;
         bool launchTimerStarted;
         uint8_t accel_event_counter;
         uint32_t accel_event_ms;
         uint32_t start_time_ms;
+        bool waiting_for_rudder_neutral;
     } takeoff_state;
 
     // ground steering controller state
@@ -1099,6 +1101,7 @@ private:
     void channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
                                 SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out) const;
     void flaperon_update();
+    void indicate_waiting_for_rud_neutral_to_takeoff(void);
 
     // is_flying.cpp
     void update_is_flying_5Hz(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -8,6 +8,8 @@
 
 #define MIN_AIRSPEED_MIN 5 // m/s, used for arming check and speed scaling
 
+#define TAKEOFF_RUDDER_WARNING_TIMEOUT 3000 //ms that GCS warning about not returning arming rudder to neutral repeats
+
 // failsafe
 // ----------------------
 enum failsafe_state {
@@ -161,7 +163,7 @@ enum FlightOptions {
     CENTER_THROTTLE_TRIM = (1<<10),
     DISABLE_GROUND_PID_SUPPRESSION = (1<<11),
     ENABLE_LOITER_ALT_CONTROL = (1<<12),
-
+    INDICATE_WAITING_FOR_RUDDER_NEUTRAL = (1<<13),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -32,6 +32,9 @@ bool Mode::enter()
 
     // cancel inverted flight
     plane.auto_state.inverted_flight = false;
+    
+    // cancel waiting for rudder neutral
+    plane.takeoff_state.waiting_for_rudder_neutral = false;
 
     // don't cross-track when starting a mission
     plane.auto_state.next_wp_crosstrack = false;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2955,9 +2955,9 @@ void QuadPlane::takeoff_controller(void)
         // start motor spinning if not spinning already so user sees it is armed
         set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         takeoff_start_time_ms = now;
-        if (now - rudder_takeoff_warn_ms > 3000) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "takeoff wait rudder release");
-            rudder_takeoff_warn_ms = now;
+        if (now - plane.takeoff_state.rudder_takeoff_warn_ms > TAKEOFF_RUDDER_WARNING_TIMEOUT) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Takeoff waiting for rudder release");
+            plane.takeoff_state.rudder_takeoff_warn_ms = now;
         }
         return;
     }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -583,7 +583,6 @@ private:
     AP_Float maximum_takeoff_airspeed;
     uint32_t takeoff_start_time_ms;
     uint32_t takeoff_time_limit_ms;
-    uint32_t rudder_takeoff_warn_ms;
 
     float last_land_final_agl;
 

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -139,6 +139,7 @@ void Plane::rudder_arm_disarm_check()
 				arming.arm(AP_Arming::Method::RUDDER);
                 rudder_arm_timer = 0;
                 seen_neutral_rudder = false;
+                takeoff_state.rudder_takeoff_warn_ms = now;
             }
 		} else {
 			// not at full right rudder


### PR DESCRIPTION
prevents throttle up while stick is still hard right...spectator saver
similar to VTOL takeoff prevention when rudder armed
tested in SITL
addresses #23181