### PR TITLE
Plane: don't trigger RC failsafe until RC has been received for the first time

### DIFF
--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -29,12 +29,18 @@ public:
     void update_soft_armed();
     bool get_delay_arming() const { return delay_arming; };
 
+    // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced
+    bool mandatory_checks(bool display_failure) override;
+
 protected:
     bool ins_checks(bool report) override;
     bool terrain_database_required() const override;
 
     bool quadplane_checks(bool display_failure);
     bool mission_checks(bool report) override;
+
+    // Checks rc has been received if it is configured to be used
+    bool rc_received_if_enabled_check(bool display_failure);
 
 private:
     void change_arm_state(void);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -278,7 +278,10 @@ void Plane::control_failsafe()
         }
     }
 
-    if (ThrFailsafe(g.throttle_fs_enabled.get()) != ThrFailsafe::Enabled) {
+    const bool allow_failsafe_bypass = !arming.is_armed() && !is_flying() && (rc().enabled_protocols() != 0);
+    const bool has_had_input = rc().has_had_rc_receiver() || rc().has_had_rc_override();
+    if ((ThrFailsafe(g.throttle_fs_enabled.get()) != ThrFailsafe::Enabled) || (allow_failsafe_bypass && !has_had_input)) {
+        // If not flying and disarmed don't trigger failsafe until RC has been received for the fist time
         return;
     }
 


### PR DESCRIPTION
This brings plane in line with copter. Currently if you boot with no RC the vehicle will sit in initial mode for a bit and then take failsafe actions. This can be quite annoying because control surfaces will all start moving.

Because the failsafe action of switching to RTL, or starting landing sequence (https://github.com/ArduPilot/ardupilot/issues/23180) currently causes arming to fail this adds a new arming check that RC is present if the failsafe has been skipped by the new path. 