### PR TITLE
Copter-4.1: PosController: Slow relax behaviour bug 

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -472,14 +472,13 @@ void AC_PosControl::init_xy_controller_stopping_point()
 ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
 void AC_PosControl::relax_velocity_controller_xy()
 {
-    init_xy();
-
     // decay resultant acceleration and therefore current attitude target to zero
     float decay = 1.0 - _dt / (_dt + POSCONTROL_RELAX_TC);
 
     _accel_target.x *= decay;
     _accel_target.y *= decay;
-    _pid_vel_xy.set_integrator(_accel_target - _accel_desired);
+
+    init_xy();
 }
 
 /// init_xy - initialise the position controller to the current position, velocity and acceleration.
@@ -507,7 +506,9 @@ void AC_PosControl::init_xy()
     // Set desired accel to zero because raw acceleration is prone to noise
     _accel_desired.xy().zero();
 
-    lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    if (!is_active_xy()) {
+        lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    }
 
     // initialise I terms from lean angles
     _pid_vel_xy.reset_filter();
@@ -1061,9 +1062,9 @@ Vector3f AC_PosControl::lean_angles_to_accel(const Vector3f& att_target_euler) c
     const float cos_yaw = cosf(att_target_euler.z);
 
     return Vector3f{
-        (GRAVITY_MSS * 100) * (-cos_yaw * sin_pitch * cos_roll - sin_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
-        (GRAVITY_MSS * 100) * (-sin_yaw * sin_pitch * cos_roll + cos_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
-        (GRAVITY_MSS * 100)
+        (GRAVITY_MSS * 100.0f) * (-cos_yaw * sin_pitch * cos_roll - sin_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
+        (GRAVITY_MSS * 100.0f) * (-sin_yaw * sin_pitch * cos_roll + cos_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
+        (GRAVITY_MSS * 100.0f)
     };
 }
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -116,8 +116,8 @@ void AC_Loiter::init_target()
     _pos_control.set_correction_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
     _pos_control.set_pos_error_max_xy_cm(LOITER_POS_CORRECTION_MAX);
 
-    // initialise position controller
-    _pos_control.init_xy_controller();
+    // initialise position controller and move target accelerations smoothly towards zero
+    _pos_control.relax_velocity_controller_xy();
 
     // initialise predicted acceleration and angles from the position controller
     _predicted_accel.x = _pos_control.get_accel_target_cmss().x;


### PR DESCRIPTION
This is a backport of PR https://github.com/ArduPilot/ardupilot/pull/21605 to the Copter-4.1 branch.

This bug can cause the vehicle to flip on takeoff in Loiter mode and is sadly quite easy to reproduce.  The two known ways it can happen are:

1. Pilot switch to RTL and the Loiter (while on the ground) and then takes off in Loiter.  This is the worst situation and can lead to very large desired roll and pitch angles (>ANGLE_MAX in unlucky cases where the autopilot is mounted upside-down and the vehicle enters RTL and then Loiter as the EKF is correcting itself to be right side up).
2. Pilot provide RC input while switching into Loiter (while on the ground) and then takes off in Loiter

This has been tested in SITL and resolves the problem.

This is serious enough that we probably need to warn users and release Copter-4.1.6 with this fix.  The issue also occurs in 4.2 but does not occur in 4.0 or 4.3.

Thanks very much to @tatsuy for discovering this problem and working with me on the fix.

Below are some before-vs-after screenshots of the nav roll and pitch when testing case 2 (see above).
![415-before-vs-after](https://user-images.githubusercontent.com/1498098/224990158-d0c9b551-c75a-4155-b196-51599a903512.png)

