### PR TITLE
Copter-4.2: PosController: Slow relax behaviour bug 

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -454,12 +454,12 @@ void AC_PosControl::init_xy_controller_stopping_point()
 ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
 void AC_PosControl::relax_velocity_controller_xy()
 {
-    init_xy_controller();
-
-    // decay resultant acceleration and therefore current attitude target to zero
+    // decay acceleration and therefore current attitude target to zero
+    // this will be reset by init_xy_controller() if !is_active_xy()
     float decay = 1.0 - _dt / (_dt + POSCONTROL_RELAX_TC);
     _accel_target.xy() *= decay;
-    _pid_vel_xy.set_integrator(_accel_target - _accel_desired);
+
+    init_xy_controller();
 }
 
 /// reduce response for landing
@@ -494,7 +494,9 @@ void AC_PosControl::init_xy_controller()
     // Set desired accel to zero because raw acceleration is prone to noise
     _accel_desired.xy().zero();
 
-    lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    if (!is_active_xy()) {
+        lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    }
 
     // limit acceleration using maximum lean angles
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max_cd(), get_lean_angle_max_cd());
@@ -1024,9 +1026,9 @@ Vector3f AC_PosControl::lean_angles_to_accel(const Vector3f& att_target_euler) c
     const float cos_yaw = cosf(att_target_euler.z);
 
     return Vector3f{
-        (GRAVITY_MSS * 100) * (-cos_yaw * sin_pitch * cos_roll - sin_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
-        (GRAVITY_MSS * 100) * (-sin_yaw * sin_pitch * cos_roll + cos_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
-        (GRAVITY_MSS * 100)
+        (GRAVITY_MSS * 100.0f) * (-cos_yaw * sin_pitch * cos_roll - sin_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
+        (GRAVITY_MSS * 100.0f) * (-sin_yaw * sin_pitch * cos_roll + cos_yaw * sin_roll) / MAX(cos_roll * cos_pitch, 0.1f),
+        (GRAVITY_MSS * 100.0f)
     };
 }
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -118,8 +118,8 @@ void AC_Loiter::init_target()
     _pos_control.set_correction_speed_accel_xy(LOITER_VEL_CORRECTION_MAX, _accel_cmss);
     _pos_control.set_pos_error_max_xy_cm(LOITER_POS_CORRECTION_MAX);
 
-    // initialise position controller
-    _pos_control.init_xy_controller();
+    // initialise position controller and move target accelerations smoothly towards zero
+    _pos_control.relax_velocity_controller_xy();
 
     // initialise predicted acceleration and angles from the position controller
     _predicted_accel.x = _pos_control.get_accel_target_cmss().x;


### PR DESCRIPTION
This is a backport of PR https://github.com/ArduPilot/ardupilot/pull/21605 to the Copter-4.2 branch.

This bug can cause the vehicle to flip on takeoff in Loiter mode and is quite easy to reproduce.  The two known ways it can happen are:

1. Pilot switch to RTL and the Loiter (while on the ground) and then takes off in Loiter.  This is the worst situation and can lead to very large desired roll and pitch angles (>ANGLE_MAX in some cases)
2. Pilot provide RC input while switching into Loiter (while on the ground) and then takes off in Loiter

This is serious enough that we probably need to warn users and release Copter-4.2.4 with this fix.  The issue also occurs in 4.1 but does not occur in 4.0 or 4.3.

Thanks very much to @tatsuy for discovering this problem and working with me on the fix.

Here are some screen shots of tests on real hardware of the 2nd case (which is easier to reproduce).  In the "After" we can see that the target roll and pitch angles correctly return to zero after the pilot moves the pitch and roll sticks back to the neutral position.
![423-before-vs-after](https://user-images.githubusercontent.com/1498098/224992080-a296dadd-def2-4ec5-bae6-524baafb1c08.png)
