### PR TITLE
AP_WindVane: use body frame when setting apparent wind in SITL

### DIFF
--- a/libraries/AP_WindVane/AP_WindVane_SITL.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_SITL.cpp
@@ -42,8 +42,8 @@ void AP_WindVane_SITL::update_direction()
         _frontend._direction_apparent_raw =  wrap_PI(atan2f(wind_vector_ef.y, wind_vector_ef.x) - AP::ahrs().yaw);
 
     } else { // WINDVANE_SITL_APARRENT
-        // directly read the apparent wind from as set by physics backend
-        _frontend._direction_apparent_raw =  wrap_PI(AP::sitl()->get_apparent_wind_dir() - AP::ahrs().yaw);
+        // directly read the body frame apparent wind set by physics backend
+        _frontend._direction_apparent_raw =  wrap_PI(AP::sitl()->get_apparent_wind_dir());
     }
 
 }


### PR DESCRIPTION
The simulated wind vane AP_WindVane_SITL currently expects the apparent wind from the SITL state `state.wind_vane_apparent.direction` to be measured in the NED frame. This requires an adjustment using  `AP::ahrs().yaw` to convert the apparent wind back to the body frame when it is used in calculations.

This isn't consistent with the documentation here: https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/examples/JSON/readme.md which suggests the physics backend should supply the apparent wind direction in the body frame. 

The documented behaviour is preferable. Using the yaw estimate introduces additional noise into the apparent wind measurement.
