### PR TITLE
AP_RCProtocol: correct SRXL max-channels usage

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
@@ -19,15 +19,13 @@
 
 #include "AP_RCProtocol_config.h"
 
-// this define is out here because SRXL2 uses it - probably incorrectly
-#define SRXL_MAX_CHANNELS 20U           /* Maximum number of channels from srxl datastream  */
-
 #if AP_RCPROTOCOL_SRXL_ENABLED
 
 #include "AP_RCProtocol.h"
 #include "SoftSerial.h"
 
 #define SRXL_MIN_FRAMESPACE_US 8000U    /* Minumum space between srxl frames in us (applies to all variants)  */
+#define SRXL_MAX_CHANNELS 20U           /* Maximum number of channels from srxl datastream  */
 
 /* Variant specific SRXL datastream characteristics */
 /* Framelength in byte */

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -146,7 +146,7 @@ void AP_RCProtocol_SRXL2::_process_byte(uint32_t timestamp_us, uint8_t byte)
             }
             // Try to parse SRXL packet -- this internally calls srxlRun() after packet is parsed and resets timeout
             if (srxlParsePacket(0, _buffer, _frame_len_full)) {
-                add_input(MAX_CHANNELS, _channels, _in_failsafe, _new_rssi);
+                add_input(ARRAY_SIZE(_channels), _channels, _in_failsafe, _new_rssi);
             }
             _last_run_ms = AP_HAL::millis();
 
@@ -200,7 +200,7 @@ void AP_RCProtocol_SRXL2::_capture_scaled_input(const uint8_t *values_p, bool in
         _new_rssi = new_rssi * 255 / 100;
     }
 
-    for (uint8_t i = 0; i < MAX_CHANNELS; i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(_channels); i++) {
         /*
          * Store the decoded channel into the R/C input buffer, taking into
          * account the different ideas about channel assignement that we have.

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -46,8 +46,6 @@ public:
 
 private:
 
-    const uint8_t MAX_CHANNELS = MIN((uint8_t)SRXL2_MAX_CHANNELS, (uint8_t)MAX_RCIN_CHANNELS);
-
     static AP_RCProtocol_SRXL2* _singleton;
 
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
@@ -60,7 +58,7 @@ private:
     uint8_t _buffer[SRXL2_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */
     uint8_t _buflen;                          /* length in number of bytes of received srxl dataframe in buffer  */
     uint32_t _last_run_ms;                    // last time the state machine was run
-    uint16_t _channels[SRXL2_MAX_CHANNELS];    /* buffer for extracted RC channel data as pulsewidth in microseconds */
+    uint16_t _channels[SRXL2_MAX_CHANNELS < MAX_RCIN_CHANNELS ? SRXL2_MAX_CHANNELS : MAX_RCIN_CHANNELS];    /* buffer for extracted RC channel data as pulsewidth in microseconds */
     bool _in_bootstrap_or_failsafe;         // controls whether we allow UART sends outside a receive time constraint
     uint8_t _device_id;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -46,7 +46,7 @@ public:
 
 private:
 
-    const uint8_t MAX_CHANNELS = MIN((uint8_t)SRXL_MAX_CHANNELS, (uint8_t)MAX_RCIN_CHANNELS);
+    const uint8_t MAX_CHANNELS = MIN((uint8_t)SRXL2_MAX_CHANNELS, (uint8_t)MAX_RCIN_CHANNELS);
 
     static AP_RCProtocol_SRXL2* _singleton;
 


### PR DESCRIPTION
This started with SRXL2 just using its own define.

There's another fix in here now, right-sizing an array and using ARRAY_SIZE to make sure everything is passed correctly.
