### PR TITLE
Copter: 4.1.6 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.1.6 16-Mar-2023
+Changes from 4.1.5
+1) Loiter fix to avoid potential wobble or flip on takeoff
+------------------------------------------------------------------
 Copter 4.1.5 19-Feb-2022 / 4.1.5-rc1 10-Feb-2022
 Changes from 4.1.4
 1) Bug fixes

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.1.5"
+#define THISFIRMWARE "ArduCopter V4.1.6"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,1,5,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,1,6,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 1
-#define FW_PATCH 5
+#define FW_PATCH 6
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.1.6 release which is just 4.1.5 with the single "[Loiter level bug](https://github.com/ArduPilot/ardupilot/pull/23203)" fixed.  I think I might rename this issue "Loiter's wonky takeoff"

This is equivalent to the 4.2.4 release (see https://github.com/ArduPilot/ardupilot/pull/23227)