### PR TITLE
Copter: 4.2.4 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,8 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.2.4 16-Aug-2023
+1) Loiter fix to avoid potential wobble or flip on takeoff
+------------------------------------------------------------------
 Copter 4.2.3 30-Aug-2022
 Changes from 4.2.3-rc3
 1) OpenDroneId bug fix to consume open-drone-id-system-update message

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.2.3"
+#define THISFIRMWARE "ArduCopter V4.2.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,2,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,2,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 2
-#define FW_PATCH 3
+#define FW_PATCH 4
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.2.4 release which is just the 4.2.3 release with the single fix to Loiter's wonky takeoff ([see PR](https://github.com/ArduPilot/ardupilot/pull/23206))

This is the equivalent of the [4.1.6 release](https://github.com/ArduPilot/ardupilot/pull/23226).