### PR TITLE
Add support for new fields in MISSION_CURRENT message

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -579,6 +579,14 @@ const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] = {
     MAV_STREAM_TERMINATOR // must have this at end of stream_entries
 };
 
+MISSION_STATE GCS_MAVLINK_Copter::mission_state(const class AP_Mission &mission) const
+{
+    if (copter.mode_auto.paused()) {
+        return MISSION_STATE_PAUSED;
+    }
+    return GCS_MAVLINK::mission_state(mission);
+}
+
 bool GCS_MAVLINK_Copter::handle_guided_request(AP_Mission::Mission_Command &cmd)
 {
 #if MODE_AUTO_ENABLED == ENABLED

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -55,6 +55,8 @@ protected:
 
 private:
 
+    MISSION_STATE mission_state(const class AP_Mission &mission) const override;
+
     void handleMessage(const mavlink_message_t &msg) override;
     void handle_command_ack(const mavlink_message_t &msg) override;
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -462,6 +462,7 @@ public:
     // pause continue in auto mode
     bool pause() override;
     bool resume() override;
+    bool paused() const;
 
     bool loiter_start();
     void rtl_start();

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2251,4 +2251,9 @@ bool ModeAuto::resume()
     return true;
 }
 
+bool ModeAuto::paused() const
+{
+    return wp_nav->paused();
+}
+
 #endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -323,6 +323,12 @@ public:
     // mission item index to be sent on queued msg, delayed or not
     uint16_t mission_item_reached_index = AP_MISSION_CMD_INDEX_NONE;
 
+    // generate a MISSION_STATE enumeration value for where the
+    // mission is up to:
+    MISSION_STATE mission_state(const class AP_Mission &mission) const;
+    // send a mission_current message for the supplied waypoint
+    void send_mission_current(const class AP_Mission &mission, uint16_t seq);
+
     // common send functions
     void send_heartbeat(void) const;
     void send_meminfo(void);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -325,7 +325,7 @@ public:
 
     // generate a MISSION_STATE enumeration value for where the
     // mission is up to:
-    MISSION_STATE mission_state(const class AP_Mission &mission) const;
+    virtual MISSION_STATE mission_state(const class AP_Mission &mission) const;
     // send a mission_current message for the supplied waypoint
     void send_mission_current(const class AP_Mission &mission, uint16_t seq);
 


### PR DESCRIPTION
 - mission state (useful for "complete")
 - number of commands
 

@auturgy this might be problematic in that I've implemented the spec as-written which is the number of commands - but we consider the home location a command, so your current squence number is never going to equal this new "total" field.
