### PR TITLE
Correct compilation when camera not compiled in on CustomBuild server

### DIFF
--- a/libraries/AP_Camera/AP_Camera_config.h
+++ b/libraries/AP_Camera/AP_Camera_config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Mount/AP_Mount_config.h>
 
 #ifndef AP_CAMERA_ENABLED

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
 #ifndef AP_GPS_BACKEND_DEFAULT_ENABLED
 #define AP_GPS_BACKEND_DEFAULT_ENABLED 1
 #endif

--- a/libraries/AP_Generator/AP_Generator_config.h
+++ b/libraries/AP_Generator/AP_Generator_config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef HAL_GENERATOR_ENABLED
 #define HAL_GENERATOR_ENABLED !HAL_MINIMIZE_FEATURES

--- a/libraries/AP_Gripper/AP_Gripper_config.h
+++ b/libraries/AP_Gripper/AP_Gripper_config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef AP_GRIPPER_ENABLED
 #define AP_GRIPPER_ENABLED 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_features.inc
@@ -55,8 +55,8 @@ define AP_WINCH_ENABLED 0
 
 # prune out some odd camera backends:
 define AP_CAMERA_BACKEND_DEFAULT_ENABLED 0
-define AP_CAMERA_RELAY_ENABLED 1
-define AP_CAMERA_SERVO_ENABLED 1
+define AP_CAMERA_RELAY_ENABLED AP_CAMERA_ENABLED
+define AP_CAMERA_SERVO_ENABLED AP_CAMERA_ENABLED
 
 # no SLCAN on these boards (use can-over-mavlink if required)
 define AP_CAN_SLCAN_ENABLED 0

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -8,6 +8,7 @@
 #include <AP_Camera/AP_Camera.h>
 #include <AP_Gripper/AP_Gripper_config.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 const AP_Param::GroupInfo AP_Mission::var_info[] = {
 

--- a/libraries/AP_Notify/AP_Notify_config.h
+++ b/libraries/AP_Notify/AP_Notify_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
 #include <GCS_MAVLink/GCS_config.h>
 #if HAL_GCS_ENABLED
 #include <GCS_MAVLink/GCS_MAVLink.h>


### PR DESCRIPTION
```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           *       *                 *      *      *
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               *      *           *       *                 *      *      *
MatekF405                     *      *           *       *                 *      *      *
Pixhawk1-1M                   0      *           8       0                 8      0      8
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     *      *           *       *                 *      *      *
skyviper-v2450                                   *                                       
```
