### PR TITLE
GCS_MAVLink: deprecate use of MISSION_SET_CURRENT message

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1316,6 +1316,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlin
     return result;
 }
 
+#if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
 void GCS_MAVLINK_Plane::handle_mission_set_current(AP_Mission &mission, const mavlink_message_t &msg)
 {
     // if you change this you must change handle_command_do_set_mission_current
@@ -1325,6 +1326,7 @@ void GCS_MAVLINK_Plane::handle_mission_set_current(AP_Mission &mission, const ma
         plane.mission.resume();
     }
 }
+#endif
 
 uint64_t GCS_MAVLINK_Plane::capabilities() const
 {

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -15,7 +15,9 @@ protected:
 
     uint32_t telem_delay() const override;
 
+#if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
     void handle_mission_set_current(AP_Mission &mission, const mavlink_message_t &msg) override;
+#endif
 
     uint8_t sysid_my_gcs() const override;
     bool sysid_enforce() const override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -525,12 +525,15 @@ protected:
     void handle_mission_request_int(const mavlink_message_t &msg);
     void handle_mission_clear_all(const mavlink_message_t &msg);
 
+#if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
     // Note that there exists a relatively new mavlink DO command,
     // MAV_CMD_DO_SET_MISSION_CURRENT which provides an acknowledgement
     // that the command has been received, rather than the GCS having to
     // rely on getting back an identical sequence number as some currently
     // do.
     virtual void handle_mission_set_current(AP_Mission &mission, const mavlink_message_t &msg);
+#endif
+
     void handle_mission_count(const mavlink_message_t &msg);
     void handle_mission_write_partial_list(const mavlink_message_t &msg);
     void handle_mission_item(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -615,6 +615,7 @@ void GCS_MAVLINK::handle_mission_request(const mavlink_message_t &msg)
         prot->handle_mission_request(*this, packet, msg);
 }
 
+#if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
 /*
   handle a MISSION_SET_CURRENT mavlink packet
 
@@ -626,6 +627,8 @@ void GCS_MAVLINK::handle_mission_request(const mavlink_message_t &msg)
  */
 void GCS_MAVLINK::handle_mission_set_current(AP_Mission &mission, const mavlink_message_t &msg)
 {
+    // send_received_message_deprecation_warning("MISSION_SET_CURRENT");
+
     // decode
     mavlink_mission_set_current_t packet;
     mavlink_msg_mission_set_current_decode(&msg, &packet);
@@ -648,6 +651,7 @@ void GCS_MAVLINK::handle_mission_set_current(AP_Mission &mission, const mavlink_
         }
     }
 }
+#endif  // AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
 
 /*
   handle a MISSION_COUNT mavlink packet
@@ -4059,6 +4063,7 @@ void GCS_MAVLINK::handle_common_mission_message(const mavlink_message_t &msg)
         handle_mission_request(msg);
         break;
 
+#if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
     case MAVLINK_MSG_ID_MISSION_SET_CURRENT:    // MAV ID: 41
     {
         AP_Mission *_mission = AP::mission();
@@ -4067,6 +4072,7 @@ void GCS_MAVLINK::handle_common_mission_message(const mavlink_message_t &msg)
         }
         break;
     }
+#endif
 
     // GCS request the full list of commands, we return just the number and leave the GCS to then request each command individually
     case MAVLINK_MSG_ID_MISSION_REQUEST_LIST:       // MAV ID: 43

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -10,3 +10,11 @@
 #ifndef AP_MAVLINK_BATTERY2_ENABLED
 #define AP_MAVLINK_BATTERY2_ENABLED 1
 #endif
+
+// handling of MISSION_SET_CURRENT (the message) is slated to be
+// removed.  It has signficant deficiencies vs MAV_CMD_DO_SET_CURRENT.
+// The command was added to the spec in January 2019 and to MAVLink in
+// ArduPilot in 4.1.x
+#ifndef AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
+#define AP_MAVLINK_MISSION_SET_CURRENT_ENABLED 1
+#endif


### PR DESCRIPTION
The mavlink command MAV_CMD_DO_SET_MISSION_CURRENT has been in place since January 2019 and is superior to this.

ArduPilot has had support since 2021 (4.1.x but not 4.0.x)

We have to get GCSs to move forward!  Before we can do that PX4 has to support the command.

A GCS could try the command and if it gets back an UNSUPPORTED try the message instead.

I'm not intending tthe message to be technically deprecated any time soon - raising for discussion on DevCall to make sure people are OK with me putting out an announcement on ArduPilot's GCS maintainers list suggesting people move to the command in their GCSs rather than the message.

Eventually this will save ~240 bytes on MatekF405-Wing when we can remove support for this message.
