### PR TITLE
hwdef: fixed polarity of VDD_5V_PERIPH_EN on several boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -172,7 +172,7 @@ PA7 SPI1_MOSI SPI1
 # this defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # this is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3-bdshot/hwdef.dat
@@ -210,7 +210,7 @@ PA7 SPI1_MOSI SPI1
 # This defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board.
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # This is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN.

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -210,7 +210,7 @@ PA7 SPI1_MOSI SPI1
 # This defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board.
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # This is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN.

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRoX21-777/hwdef.dat
@@ -172,7 +172,7 @@ PA7 SPI1_MOSI SPI1
 # this defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # this is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/hwdef.dat
@@ -85,7 +85,7 @@ PA7 SPI1_MOSI SPI1
 # This defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board.
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # This is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN.

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/hwdef.dat
@@ -85,7 +85,7 @@ PA7 SPI1_MOSI SPI1
 # This defines an output pin which will default to output LOW. It is a
 # pin that enables peripheral power on this board.
 
-PA8 VDD_5V_PERIPH_EN OUTPUT LOW
+PA8 nVDD_5V_PERIPH_EN OUTPUT LOW
 
 # This is the pin that senses USB being connected. It is an input pin
 # setup as OPENDRAIN.


### PR DESCRIPTION
we can tell these are incorrect as they init to LOW, and previously we didn't have handling of VDD_5V_PERIPH_EN, so we know that LOW is enabled or the boards would not have worked

this fixes GPS on Pixhawk1

fix needed since #22882 
