### PR TITLE
AP_Motors: use raw voltage for battery compensation

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -215,6 +215,13 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SAFE_TIME", 42, AP_MotorsMulticopter, _safe_time, AP_MOTORS_SAFE_TIME_DEFAULT),
 
+    // @Param: OPTIONS
+    // @DisplayName: Motor options
+    // @Description: Motor options
+    // @Bitmask: 0:Voltage compensation uses raw voltage
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 43, AP_MotorsMulticopter, _options, 0),
+
     AP_GROUPEND
 };
 
@@ -361,7 +368,6 @@ float AP_MotorsMulticopter::get_current_limit_max_throttle()
     // limit max throttle
     return get_throttle_hover() + ((1.0 - get_throttle_hover()) * _throttle_limit);
 }
-
 
 // 10hz logging of voltage scaling and max trust
 void AP_MotorsMulticopter::Log_Write()

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -277,6 +277,11 @@ public:
     // write log, to be called at 10hz
     virtual void Log_Write() {};
 
+    enum MotorOptions : uint8_t {
+        BATT_RAW_VOLTAGE = (1 << 0U)
+    };
+    bool has_option(MotorOptions option) { return _options.get() & uint8_t(option); }
+
 protected:
     // output functions that should be overloaded by child classes
     virtual void        output_armed_stabilizing() = 0;
@@ -339,6 +344,9 @@ protected:
     bool                _thrust_boost;          // true if thrust boost is enabled to handle motor failure
     bool                _thrust_balanced;       // true when output thrust is well balanced
     float               _thrust_boost_ratio;    // choice between highest and second highest motor output for output mixing (0 ~ 1). Zero is normal operation
+
+    // motor options
+    AP_Int16            _options;
 
     MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
 


### PR DESCRIPTION
@lthall believes this might cope better with the big temporary sags small copters get on punch out