### PR TITLE
GCS_MAVLink: routing: do not process our own packets locally

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -94,7 +94,7 @@ bool MAVLink_routing::check_and_forward(GCS_MAVLINK &in_link, const mavlink_mess
     // incorrect serial configuration.
     if (msg.sysid == mavlink_system.sysid &&
         msg.compid == mavlink_system.compid) {
-        return true;
+        return false;
     }
 
     // learn new routes including private channels


### PR DESCRIPTION
returning true from this method means we will process the packets locally.

If that message changes the vehicle state that could be bad.

This work sponsored by Harris Aerial.
