### PR TITLE
RC_Channel:rename 173 option more appropriately

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -231,7 +231,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Plane}: 170:Mode QStabilize
     // @Values{Copter, Rover, Plane, Blimp}: 171:Calibrate Compasses
     // @Values{Copter, Rover, Plane, Blimp}: 172:Battery MPPT Enable
-    // @Values{Plane}: 173:Plane landing abort for VTOL Payload Place or glide-slope go-around
+    // @Values{Plane}: 173:Plane AUTO Mode Landing Abort
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail


### PR DESCRIPTION
As I was documenting, the switch name felt very clumsy....It does abort all landings while in AUTO mode...hence the name change