### PR TITLE
Remove coupling between AP_RCProtocols SRXL2 and DSM

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -23,9 +23,7 @@
 #include "AP_RCProtocol_SBUS.h"
 #include "AP_RCProtocol_SUMD.h"
 #include "AP_RCProtocol_SRXL.h"
-#ifndef IOMCU_FW
 #include "AP_RCProtocol_SRXL2.h"
-#endif
 #include "AP_RCProtocol_CRSF.h"
 #include "AP_RCProtocol_ST24.h"
 #include "AP_RCProtocol_FPort.h"

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -19,6 +19,7 @@
 
 #include "AP_RCProtocol.h"
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_VideoTX/AP_VideoTX_config.h>
 
 class AP_RCProtocol_Backend {
     friend class AP_RCProtcol;
@@ -91,8 +92,10 @@ public:
         return true;
     }
 
+#if AP_VIDEOTX_ENABLED
     // called by static methods to confiig video transmitters:
     static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
+#endif
 
 protected:
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -90,8 +90,12 @@ public:
     virtual bool is_rx_active() const {
         return true;
     }
-    
+
+    // called by static methods to confiig video transmitters:
+    static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
+
 protected:
+
     struct Channels11Bit_8Chan {
 #if __BYTE_ORDER != __LITTLE_ENDIAN
 #error "Only supported on little-endian architectures"

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
@@ -19,10 +19,6 @@
  */
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "AP_RCProtocol_DSM.h"
-#if !APM_BUILD_TYPE(APM_BUILD_iofirmware)
-#include "AP_RCProtocol_SRXL2.h"
-#endif
-
 #include <AP_VideoTX/AP_VideoTX_config.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
@@ -239,7 +239,7 @@ bool AP_RCProtocol_DSM::dsm_decode(uint32_t frame_time_ms, const uint8_t dsm_fra
     // Handle VTX control frame.
 #if AP_VIDEOTX_ENABLED
     if (haveVtxControl) {
-        AP_RCProtocol_SRXL2::configure_vtx(
+        configure_vtx(
             (vtxControl & SPEKTRUM_VTX_BAND_MASK)     >> SPEKTRUM_VTX_BAND_SHIFT,
             (vtxControl & SPEKTRUM_VTX_CHANNEL_MASK)  >> SPEKTRUM_VTX_CHANNEL_SHIFT,
             (vtxControl & SPEKTRUM_VTX_POWER_MASK)    >> SPEKTRUM_VTX_POWER_SHIFT,

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -301,7 +301,7 @@ void AP_RCProtocol_SRXL2::send_on_uart(uint8_t* pBuffer, uint8_t length)
 
 #if AP_VIDEOTX_ENABLED
 // configure the video transmitter, the input values are Spektrum-oriented
-void AP_RCProtocol_SRXL2::configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode)
+void AP_RCProtocol_Backend::configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode)
 {
     AP_VideoTX& vtx = AP::vtx();
     // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A)
@@ -458,6 +458,6 @@ bool srxlOnBind(SrxlFullID device, SrxlBindData info)
 void srxlOnVtx(SrxlVtxData* pVtxData)
 {
 #if AP_VIDEOTX_ENABLED
-    AP_RCProtocol_SRXL2::configure_vtx(pVtxData->band, pVtxData->channel, pVtxData->power, pVtxData->pit);
+    AP_RCProtocol_Backend::configure_vtx(pVtxData->band, pVtxData->channel, pVtxData->power, pVtxData->pit);
 #endif
 }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.cpp
@@ -299,61 +299,6 @@ void AP_RCProtocol_SRXL2::send_on_uart(uint8_t* pBuffer, uint8_t length)
     }
 }
 
-#if AP_VIDEOTX_ENABLED
-// configure the video transmitter, the input values are Spektrum-oriented
-void AP_RCProtocol_Backend::configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode)
-{
-    AP_VideoTX& vtx = AP::vtx();
-    // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A)
-    // map to TBS band A, B, E, Race, Airwave, LoRace
-    switch (band) {
-    case VTX_BAND_FATSHARK:
-        vtx.set_configured_band(AP_VideoTX::VideoBand::FATSHARK);
-        break;
-    case VTX_BAND_RACEBAND:
-        vtx.set_configured_band(AP_VideoTX::VideoBand::RACEBAND);
-        break;
-    case VTX_BAND_E_BAND:
-        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_E);
-        break;
-    case VTX_BAND_B_BAND:
-        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_B);
-        break;
-    case VTX_BAND_A_BAND:
-        vtx.set_configured_band(AP_VideoTX::VideoBand::BAND_A);
-        break;
-    default:
-        break;
-    }
-    // VTX Channel (0-7)
-    vtx.set_configured_channel(channel);
-    if (pitmode) {
-        vtx.set_configured_options(vtx.get_options() | uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
-    } else {
-        vtx.set_configured_options(vtx.get_options() & ~uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
-    }
-
-    switch (power) {
-    case VTX_POWER_1MW_14MW:
-    case VTX_POWER_15MW_25MW:
-        vtx.set_configured_power_mw(25);
-        break;
-    case VTX_POWER_26MW_99MW:
-    case VTX_POWER_100MW_299MW:
-        vtx.set_configured_power_mw(100);
-        break;
-    case VTX_POWER_300MW_600MW:
-        vtx.set_configured_power_mw(400);
-        break;
-    case VTX_POWER_601_PLUS:
-        vtx.set_configured_power_mw(800);
-        break;
-    default:
-        break;
-    }
-}
-#endif  // AP_VIDEOTX_ENABLED
-
 // send data to the uart
 void AP_RCProtocol_SRXL2::_send_on_uart(uint8_t* pBuffer, uint8_t length)
 {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL2.h
@@ -42,7 +42,6 @@ public:
     static void send_on_uart(uint8_t* pBuffer, uint8_t length);
     static void change_baud_rate(uint32_t baudrate);
     // configure the VTX from Spektrum data
-    static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
 
 private:
 


### PR DESCRIPTION
Having the DSM backend calling into the SRXL2 backend isn't nice, so this fixes that.

Two commits, one changing namespaces the other moving the code into the correct files.


```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      0      *           0       0                 0      0      0
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               0      *           0       0                 0      0      0
MatekF405                     0      *           0       0                 0      0      0
Pixhawk1-1M                   0      *           0       0                 0      0      0
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     0      *           0       0                 0      0      0
skyviper-v2450                                   *                                       
```