### PR TITLE
Rover: bugfix PRECISION_LANDING needing AP_GRIPPER_ENABLED

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -97,9 +97,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_ServoRelayEvents, &rover.ServoRelayEvents, update_events,  50,  200,  66),
 #if AP_GRIPPER_ENABLED
     SCHED_TASK_CLASS(AP_Gripper,          &rover.g2.gripper,       update,         10,   75,  69),
+#endif
 #if PRECISION_LANDING == ENABLED
     SCHED_TASK(update_precland,      400,     50,  70),
-#endif
 #endif
 #if AP_RPM_ENABLED
     SCHED_TASK_CLASS(AP_RPM,              &rover.rpm_sensor,       update,         10,  100,  72),


### PR DESCRIPTION
This looks like a goof of endif's that happened to work out so far. Before this PR update_precland() was only scheduled if AP_GRIPPER_ENABLED and PRECISION_LANDING were both enabled. Now only PRECISION_LANDING is needed.