### PR TITLE
AP_Common: Add same_loc_as() function to Location

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -821,12 +821,7 @@ bool Plane::get_target_location(Location& target_loc)
  */
 bool Plane::update_target_location(const Location &old_loc, const Location &new_loc)
 {
-    if (!old_loc.same_latlon_as(next_WP_loc)) {
-        return false;
-    }
-    ftype alt_diff;
-    if (!old_loc.get_alt_distance(next_WP_loc, alt_diff) ||
-        !is_zero(alt_diff)) {
+    if (!old_loc.same_loc_as(next_WP_loc)) {
         return false;
     }
     next_WP_loc = new_loc;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3044,8 +3044,7 @@ void QuadPlane::waypoint_controller(void)
 
     const Location &loc = plane.next_WP_loc;
     const uint32_t now = AP_HAL::millis();
-    if (!loc.same_latlon_as(last_auto_target) ||
-        plane.next_WP_loc.alt != last_auto_target.alt ||
+    if (!loc.same_loc_as(last_auto_target) ||
         now - last_loiter_ms > 500) {
         wp_nav->set_wp_destination(poscontrol.target_cm.tofloat());
         last_auto_target = loc;

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -393,6 +393,20 @@ bool Location::same_latlon_as(const Location &loc2) const
     return (lat == loc2.lat) && (lng == loc2.lng);
 }
 
+bool Location::same_alt_as(const Location &loc2) const
+{
+    // fast path if the altitude frame is the same
+    if (this->get_alt_frame() == loc2.get_alt_frame()) {
+        return this->alt == loc2.alt;
+    }
+
+    ftype alt_diff;
+    bool have_diff = this->get_alt_distance(loc2, alt_diff);
+
+    const ftype tolerance = FLT_EPSILON;
+    return have_diff && (fabsF(alt_diff) < tolerance);
+}
+
 // return true when lat and lng are within range
 bool Location::check_latlng() const
 {

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -107,6 +107,9 @@ public:
     // check if lat and lng match. Ignore altitude and options
     bool same_latlon_as(const Location &loc2) const;
 
+    // check if altitude matches.
+    bool same_alt_as(const Location &loc2) const;
+
     /*
      * convert invalid waypoint with useful data. return true if location changed
      */

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -110,6 +110,11 @@ public:
     // check if altitude matches.
     bool same_alt_as(const Location &loc2) const;
 
+    // check if lat, lng, and alt match.
+    bool same_loc_as(const Location &loc2) const {
+        return same_latlon_as(loc2) && same_alt_as(loc2);
+    }
+
     /*
      * convert invalid waypoint with useful data. return true if location changed
      */


### PR DESCRIPTION
There is currently a 2D comparison (`Location::same_latlon_as()`), but there is no 3D comparison.

This also adds a `Location::same_alt_as()` function.