### PR TITLE
AP_Mount: Add clear_roi_target() function

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -528,6 +528,16 @@ void AP_Mount::set_roi_target(uint8_t instance, const Location &target_loc)
     backend->set_roi_target(target_loc);
 }
 
+// clear_roi_target - clears target location that mount should attempt to point towards
+void AP_Mount::clear_roi_target(uint8_t instance)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return;
+    }
+    backend->clear_roi_target();
+}
+
 //
 // camera controls for gimbals that include a camera
 //

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -139,6 +139,10 @@ public:
     void set_roi_target(const Location &target_loc) { set_roi_target(_primary,target_loc); }
     void set_roi_target(uint8_t instance, const Location &target_loc);
 
+    // clear_roi_target - clears target location that mount should attempt to point towards
+    void clear_roi_target() { clear_roi_target(_primary); }
+    void clear_roi_target(uint8_t instance);
+
     // point at system ID sysid
     void set_target_sysid(uint8_t sysid) { set_target_sysid(_primary, sysid); }
     void set_target_sysid(uint8_t instance, uint8_t sysid);

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -48,6 +48,19 @@ void AP_Mount_Backend::set_roi_target(const Location &target_loc)
     set_mode(MAV_MOUNT_MODE_GPS_POINT);
 }
 
+// clear_roi_target - clears target location that mount should attempt to point towards
+void AP_Mount_Backend::clear_roi_target()
+{
+    // clear the target GPS location
+    _roi_target_set = false;
+
+    // reset the mode if in GPS tracking mode
+    if (_mode == MAV_MOUNT_MODE_GPS_POINT) {
+        MAV_MOUNT_MODE default_mode = (MAV_MOUNT_MODE)_params.default_mode.get();
+        set_mode(default_mode);
+    }
+}
+
 // set_sys_target - sets system that mount should attempt to point towards
 void AP_Mount_Backend::set_target_sysid(uint8_t sysid)
 {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -72,6 +72,8 @@ public:
 
     // set_roi_target - sets target location that mount should attempt to point towards
     void set_roi_target(const Location &target_loc);
+    // clear_roi_target - clears target location that mount should attempt to point towards
+    void clear_roi_target();
 
     // set_sys_target - sets system that mount should attempt to point towards
     void set_target_sysid(uint8_t sysid);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4969,12 +4969,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const Location &roi_loc)
     }
 
     if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
-        // switch off the camera tracking if enabled
-        if (mount->get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-            mount->set_mode_to_default();
-        }
+        mount->clear_roi_target();
     } else {
-        // send the command to the camera mount
         mount->set_roi_target(roi_loc);
     }
     return MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
Moves the handling of exiting ROI Targetting out of `GCS_MAVLink` and into `AP_Mount`. More importantly, ensures the internal `_roi_target_set` flag is cleared in the Mount backend.