### PR TITLE
GCS_MAVLink: Use MAV_FRAME_GLOBAL when converting ROI location

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5085,7 +5085,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const mavlink_command_long_t &
     // off support for MAV_CMD_DO_SET_ROI_LOCATION (which doesn't
     // support the extra fields).
     Location roi_loc;
-    if (!location_from_command_t(packet, MAV_FRAME_GLOBAL_RELATIVE_ALT, roi_loc)) {
+    if (!location_from_command_t(packet, MAV_FRAME_GLOBAL, roi_loc)) {
         return MAV_RESULT_DENIED;
     }
     return handle_command_do_set_roi(roi_loc);


### PR DESCRIPTION
This matches how MAVProxy behaves, and matches the way the [Home location is converted](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp#L4617).