### PR TITLE
Plane:allow airbrakes to be used

### DIFF
--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -154,6 +154,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
     case AUX_FUNC::RTL:
     case AUX_FUNC::TAKEOFF:
     case AUX_FUNC::FBWA:
+    case AUX_FUNC::AIRBRAKE:
 #if HAL_QUADPLANE_ENABLED
     case AUX_FUNC::QRTL:
     case AUX_FUNC::QSTABILIZE:


### PR DESCRIPTION
What a tangled web......
A user complained that RC failsafe was activating his flaps....simple SITL testing showed that indeed flaps went to servo_min during RC failure....reported and Tridge suggested a fix....it did not work....then I realized that the code was forcing manual FLAPS=0 until RC is restored which is indeed supposed to be no flaps, and is the correct behavior ..the user had setup his flaps servo as a manual spoiler AND flap which the FLAP function will not do correctly...so it was operating correctly...taking his input of 1500 and forcing the output to 1100 (should be no flaps)....BUT....

as I was checking every other flap or similar function, I discovered that AIRBRAKE was not being initialized....#20370 supposedly fixed, but did not actually...boot gives a nag message about the function as being not initialized....this PR addresses that...and manual AIRBRAKEs are indeed zero'd correctly during RC loss

other than that DSPOILER  and FLAPERON operation gives a glitch to full flaps for the first cycle after an RC fail but returns to 0 flaps on the next cycle..I doubt it causes issues...

PS...since this has been broken for a very long time...pretty sure no one is using manually controlled airbrakes!