### PR TITLE
[Backport Plane 4.4] AP_InertialSensor: fix duplicate sensor detection for CubeOrangePlus

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/hwdef.dat
@@ -45,7 +45,7 @@ PG1 ICM45686_CS CS
 SPIDEV icm42688_ext   SPI4 DEVID4  ACCEL_EXT_CS  MODE3  2*MHZ  8*MHZ
 
 #IMU 1
-SPIDEV icm42688_ext2  SPI4 DEVID4  GYRO_EXT_CS   MODE3  2*MHZ  8*MHZ
+SPIDEV icm42688_ext2  SPI4 DEVID5  GYRO_EXT_CS   MODE3  2*MHZ  8*MHZ
 
 #IMU 2
 SPIDEV icm45686       SPI1 DEVID4  ICM45686_CS   MODE1  2*MHZ  8*MHZ
@@ -69,9 +69,15 @@ IMU Invensensev3 SPI:icm45686 ROTATION_ROLL_180_YAW_135 INSTANCE:2
 
 define ICM45686_CLKIN 1
 
-IMU Invensensev2 SPI:icm20948_aux ROTATION_PITCH_180
+# AUX:<devid> keyword is used to check for the presence of the sensor
+# in the detected IMUs list. If the IMU with the given devid is found
+# then we skip the probe for the sensor the second time. This is useful
+# if you have multiple choices for IMU over same instance number, and still 
+# want to instantiate the sensor after main IMUs are detected.
 
-IMU Invensensev3 SPI:icm45686_aux ROTATION_ROLL_180_YAW_135
+IMU Invensensev2 SPI:icm20948_aux ROTATION_PITCH_180 AUX:2883874
+
+IMU Invensensev3 SPI:icm45686_aux ROTATION_ROLL_180_YAW_135 AUX:3867658
 
 define INS_AUX_INSTANCES 2
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1524,8 +1524,12 @@ def write_IMU_config(f):
         driver = dev[0]
         # get instance number if mentioned
         instance = -1
+        aux_devid = -1
         if dev[-1].startswith("INSTANCE:"):
             instance = int(dev[-1][9:])
+            dev = dev[:-1]
+        if dev[-1].startswith("AUX:"):
+            aux_devid = int(dev[-1][4:])
             dev = dev[:-1]
         for i in range(1, len(dev)):
             if dev[i].startswith("SPI:"):
@@ -1534,7 +1538,11 @@ def write_IMU_config(f):
                 (wrapper, dev[i]) = parse_i2c_device(dev[i])
         n = len(devlist)+1
         devlist.append('HAL_INS_PROBE%u' % n)
-        if instance != -1:
+        if aux_devid != -1:
+            f.write(
+            '#define HAL_INS_PROBE%u %s ADD_BACKEND_AUX(AP_InertialSensor_%s::probe(*this,%s),%d)\n'
+            % (n, wrapper, driver, ','.join(dev[1:]), aux_devid))
+        elif instance != -1:
             f.write(
             '#define HAL_INS_PROBE%u %s ADD_BACKEND_INSTANCE(AP_InertialSensor_%s::probe(*this,%s),%d)\n'
             % (n, wrapper, driver, ','.join(dev[1:]), instance))


### PR DESCRIPTION
Stops detection of same sensor type multiple times. Impacts CubeOrangePlus where ICM20948 ends up appearing twice in Initial version of CubeOrangePlus.