### PR TITLE
AP_DDS: Use python3 shebang

### DIFF
--- a/libraries/AP_DDS/gen_config_h.py
+++ b/libraries/AP_DDS/gen_config_h.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
  process a *.h.in file to produce a *.h file
 '''

--- a/libraries/AP_DDS/wscript
+++ b/libraries/AP_DDS/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 
 import os
 


### PR DESCRIPTION
Use python3 shebang since python3 is required

removed utf-8 encoding since that's only needed in python2