### PR TITLE
.pre-commit: Add xmllint for AP_DDS xml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
         -   id: check-xml
         -   id: check-yaml
 
+  -   repo: https://github.com/lsst-ts/pre-commit-xmllint
+      rev: v1.0.0
+      hooks:
+        - id: format-xmllint
+          files: libraries/AP_DDS/dds_xrce_profile.xml
 # Disable isort and mypy temporarily due to config conflicts
 # # Use to sort python imports by name and put system import first.
 #   -   repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This adds an XML linter for AP_DDS. 

Note. This tool can't run on Windows. Perhaps we shouldn't adopt it (or fix it) if we expect windows developers to want to use the hook? 

Solves #23282 