### PR TITLE
.github: replace testing of Hirsute by Jammy

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu
             name: focal
           - os: ubuntu
-            name: hirsute
+            name: jammy
           - os: archlinux
             name: latest
           - os: debian


### PR DESCRIPTION
Hirsute is OEL and don't work for long time
Jammy is 22.04 and should be properly tested

close https://github.com/ArduPilot/ardupilot/issues/23202