### PR TITLE
AP_Baro: LPS2XH SPI/I2C bug during setup

### DIFF
--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -146,7 +146,9 @@ bool AP_Baro_LPS2XH::_init()
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     // top bit is for read on SPI
-    _dev->set_read_flag(0x80);
+    if (_dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
+        _dev->set_read_flag(0x80);
+    }
 
     if (!_check_whoami()) {
         _dev->get_semaphore()->give();


### PR DESCRIPTION
I guess the driver only was tested for SPI.
When used with I2C top bit of register address should not be set.