### PR TITLE
AP_Airspeed: fixed airspeed peripherals

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -188,8 +188,8 @@ AP_Airspeed::AP_Airspeed()
 
     // Setup defaults that only apply to first sensor
     param[0].type.set_default(ARSPD_DEFAULT_TYPE);
-    param[0].bus.set_default(HAL_AIRSPEED_BUS_DEFAULT);
 #ifndef HAL_BUILD_AP_PERIPH
+    param[0].bus.set_default(HAL_AIRSPEED_BUS_DEFAULT);
     param[0].pin.set_default(ARSPD_DEFAULT_PIN);
 #endif
 


### PR DESCRIPTION
AP_Periph does not have the ARSPD_BUS parameter, and setting this default sets the bus to one that doesn't exist, plus it can't be fixed using user parameters
Thanks to Robert from Pegasus for finding this
