### PR TITLE
AP_DDS: Bump to using latest MicroXRCEDDSGen

### DIFF
--- a/libraries/AP_DDS/Idl/NavSatFix.idl
+++ b/libraries/AP_DDS/Idl/NavSatFix.idl
@@ -1,4 +1,4 @@
-// generated from rosidl_adapter/resource/msg.idl.em
+/// generated from rosidl_adapter/resource/msg.idl.em
 // with input from sensor_msgs/msg/NavSatFix.msg
 // generated code does not contain a copyright notice
 
@@ -11,10 +11,10 @@ module sensor_msgs {
     module NavSatFix_Constants {
       @verbatim (language="comment", text=
         "If the covariance of the fix is known, fill it in completely. If the" "\n"        "GPS receiver provides the variance of each measurement, put them" "\n"        "along the diagonal. If only Dilution of Precision is available," "\n"        "estimate an approximate covariance from that.")
-      const octet COVARIANCE_TYPE_UNKNOWN = 0;
-      const octet COVARIANCE_TYPE_APPROXIMATED = 1;
-      const octet COVARIANCE_TYPE_DIAGONAL_KNOWN = 2;
-      const octet COVARIANCE_TYPE_KNOWN = 3;
+      const uint8 COVARIANCE_TYPE_UNKNOWN = 0;
+      const uint8 COVARIANCE_TYPE_APPROXIMATED = 1;
+      const uint8 COVARIANCE_TYPE_DIAGONAL_KNOWN = 2;
+      const uint8 COVARIANCE_TYPE_KNOWN = 3;
     };
     @verbatim (language="comment", text=
       "Navigation Satellite fix for any Global Navigation Satellite System" "\n"
@@ -59,9 +59,9 @@ module sensor_msgs {
         "" "\n"
         "Beware: this coordinate system exhibits singularities at the poles.")
       @unit (value="m^2")
-      double position_covariance[9];
+      double__9 position_covariance;
 
-      octet position_covariance_type;
+      uint8 position_covariance_type;
     };
   };
 };

--- a/libraries/AP_DDS/Idl/NavSatStatus.idl
+++ b/libraries/AP_DDS/Idl/NavSatStatus.idl
@@ -8,16 +8,16 @@ module sensor_msgs {
     module NavSatStatus_Constants {
       @verbatim (language="comment", text=
         "unable to fix position")
-      const char STATUS_NO_FIX = -1;
+      const int8 STATUS_NO_FIX = -1;
       @verbatim (language="comment", text=
         "unaugmented fix")
-      const char STATUS_FIX = 0;
+      const int8 STATUS_FIX = 0;
       @verbatim (language="comment", text=
         "with satellite-based augmentation")
-      const char STATUS_SBAS_FIX = 1;
+      const int8 STATUS_SBAS_FIX = 1;
       @verbatim (language="comment", text=
         "with ground-based augmentation")
-      const char STATUS_GBAS_FIX = 2;
+      const int8 STATUS_GBAS_FIX = 2;
       @verbatim (language="comment", text=
         "Bits defining which Global Navigation Satellite System signals were" "\n"        "used by the receiver.")
       const uint16 SERVICE_GPS = 1;
@@ -34,7 +34,7 @@ module sensor_msgs {
       "type and the last time differential corrections were received.  A" "\n"
       "fix is valid when status >= STATUS_FIX.")
     struct NavSatStatus {
-      char status;
+      int8 status;
 
       uint16 service;
     };

--- a/libraries/AP_DDS/Idl/PoseStamped.idl
+++ b/libraries/AP_DDS/Idl/PoseStamped.idl
@@ -2,14 +2,9 @@
 // with input from geometry_msgs/msg/PoseStamped.msg
 // generated code does not contain a copyright notice
 
-#include "Point.idl"
-#include "Quaternion.idl"
+#include "Pose.idl"
 #include "Header.idl"
-struct Pose {
-  geometry_msgs::msg::Point position;
 
-  geometry_msgs::msg::Quaternion orientation;
-};
 module geometry_msgs {
   module msg {
     @verbatim (language="comment", text=
@@ -17,7 +12,7 @@ module geometry_msgs {
     struct PoseStamped {
       std_msgs::msg::Header header;
 
-      Pose pose;
+      geometry_msgs::msg::Pose pose;
     };
   };
 };

--- a/libraries/AP_DDS/wscript
+++ b/libraries/AP_DDS/wscript
@@ -103,7 +103,7 @@ def build(bld):
             # build IDL file
             source=idl,
             target=gen,
-            rule=f"{bld.env.MICROXRCEDDSGEN[0]} -replace -d {os.path.join(gen_path, 'generated')} {idl}",
+            rule=f"{bld.env.MICROXRCEDDSGEN[0]} -cs -replace -d {os.path.join(gen_path, 'generated')} {idl}",
             group='dynamic_sources',
         )
         bld.env.AP_LIB_EXTRA_SOURCES['AP_DDS'] += [os.path.join('generated', gen_c)]


### PR DESCRIPTION
* Adds -cs argument to fix case sensitive issue with PoseStamped
* Adds support for uint8_t type alias
* Updated the copies of IDL to remove these mods, matching upstream
* Solves #23302

If the PR fails, it's likely because the docker image with MicroXRCEDDSGen needs to be rebuilt using latest develop hash `20bbbd0ed8fcb3284e25fe1fa257a08537cfb5fa`. See https://github.com/ArduPilot/ardupilot_dev_docker/pull/16