### PR TITLE
ChibiOS: fixed bug in bdshot causing failure on 32 bit microsecond wrap

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -496,6 +496,8 @@ def load_env_vars(env):
         env.CHIBIOS_BUILD_FLAGS += ' ENABLE_STATS=yes'
     if env.ENABLE_DFU_BOOT and env.BOOTLOADER:
         env.CHIBIOS_BUILD_FLAGS += ' USE_ASXOPT=-DCRT0_ENTRY_HOOK=TRUE'
+    if env.AP_BOARD_START_TIME:
+        env.CHIBIOS_BUILD_FLAGS += ' AP_BOARD_START_TIME=0x%x' % env.AP_BOARD_START_TIME
 
 
 def setup_optimization(env):

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -150,8 +150,8 @@ void RCOutput::init()
  */
 void RCOutput::rcout_thread()
 {
-    uint32_t last_thread_run_us = 0; // last time we did a 1kHz run of rcout
-    uint32_t last_cycle_run_us = 0;
+    uint64_t last_thread_run_us = 0; // last time we did a 1kHz run of rcout
+    uint64_t last_cycle_run_us = 0;
 
     rcout_thread_ctx = chThdGetSelfX();
 
@@ -166,11 +166,11 @@ void RCOutput::rcout_thread()
         const auto mask = chEvtWaitOne(EVT_PWM_SEND | EVT_PWM_SYNTHETIC_SEND | EVT_LED_SEND);
         const bool have_pwm_event = (mask & (EVT_PWM_SEND | EVT_PWM_SYNTHETIC_SEND)) != 0;
         // start the clock
-        last_thread_run_us = AP_HAL::micros();
+        last_thread_run_us = AP_HAL::micros64();
 
         // this is when the cycle is supposed to start
         if (_dshot_cycle == 0 && have_pwm_event) {
-            last_cycle_run_us = AP_HAL::micros();
+            last_cycle_run_us = AP_HAL::micros64();
             // register a timer for the next tick if push() will not be providing it
             if (_dshot_rate != 1) {
                 chVTSet(&_dshot_rate_timer, chTimeUS2I(_dshot_period_us), dshot_update_tick, this);
@@ -179,7 +179,7 @@ void RCOutput::rcout_thread()
 
         // if DMA sharing is in effect there can be quite a delay between the request to begin the cycle and
         // actually sending out data - thus we need to work out how much time we have left to collect the locks
-        uint32_t time_out_us = (_dshot_cycle + 1) * _dshot_period_us + last_cycle_run_us;
+        uint64_t time_out_us = (_dshot_cycle + 1) * _dshot_period_us + last_cycle_run_us;
         if (!_dshot_rate) {
             time_out_us = last_thread_run_us + _dshot_period_us;
         }
@@ -226,7 +226,7 @@ __RAMFUNC__ void RCOutput::dshot_update_tick(void* p)
 
 #if AP_HAL_SHARED_DMA_ENABLED
 // release locks on the groups that are pending in reverse order
-void RCOutput::dshot_collect_dma_locks(uint32_t time_out_us)
+void RCOutput::dshot_collect_dma_locks(uint64_t time_out_us)
 {
     if (NUM_GROUPS == 0) {
         return;
@@ -235,10 +235,10 @@ void RCOutput::dshot_collect_dma_locks(uint32_t time_out_us)
         pwm_group &group = pwm_group_list[i];
         if (group.dma_handle != nullptr && group.dma_handle->is_locked()) {
             // calculate how long we have left
-            uint32_t now = AP_HAL::micros();
+            uint64_t now = AP_HAL::micros64();
             // if we have time left wait for the event
             eventmask_t mask = 0;
-            const uint32_t pulse_elapsed_us = now - group.last_dmar_send_us;
+            const uint64_t pulse_elapsed_us = now - group.last_dmar_send_us;
             uint32_t wait_us = 0;
             if (now < time_out_us) {
                 wait_us = time_out_us - now;
@@ -1220,14 +1220,14 @@ void RCOutput::trigger_groups(void)
   periodic timer. This is used for oneshot and dshot modes, plus for
   safety switch update. Runs every 1000us.
  */
-void RCOutput::timer_tick(uint32_t time_out_us)
+void RCOutput::timer_tick(uint64_t time_out_us)
 {
     if (serial_group) {
         return;
     }
 
     // if we have enough time left send out LED data
-    if (serial_led_pending && (time_out_us > (AP_HAL::micros() + (_dshot_period_us >> 1)))) {
+    if (serial_led_pending && (time_out_us > (AP_HAL::micros64() + (_dshot_period_us >> 1)))) {
         serial_led_pending = false;
         for (auto &group : pwm_group_list) {
             serial_led_pending |= !serial_led_send(group);
@@ -1241,7 +1241,7 @@ void RCOutput::timer_tick(uint32_t time_out_us)
         return;
     }
 
-    uint32_t now = AP_HAL::micros();
+    uint64_t now = AP_HAL::micros64();
 
     if (now > min_pulse_trigger_us &&
         now - min_pulse_trigger_us > 4000) {
@@ -1251,7 +1251,7 @@ void RCOutput::timer_tick(uint32_t time_out_us)
 }
 
 // send dshot for all groups that support it
-void RCOutput::dshot_send_groups(uint32_t time_out_us)
+void RCOutput::dshot_send_groups(uint64_t time_out_us)
 {
 #ifndef DISABLE_DSHOT
     if (serial_group) {
@@ -1380,7 +1380,7 @@ void RCOutput::fill_DMA_buffer_dshot(uint32_t *buffer, uint8_t stride, uint16_t 
   This call be called in blocking mode from the timer, in which case it waits for the DMA lock.
   In normal operation it doesn't wait for the DMA lock.
  */
-void RCOutput::dshot_send(pwm_group &group, uint32_t time_out_us)
+void RCOutput::dshot_send(pwm_group &group, uint64_t time_out_us)
 {
 #ifndef DISABLE_DSHOT
     if (irq.waiter || (group.dshot_state != DshotState::IDLE && group.dshot_state != DshotState::RECV_COMPLETE)) {
@@ -1394,7 +1394,8 @@ void RCOutput::dshot_send(pwm_group &group, uint32_t time_out_us)
 
     // if we are sharing UP channels then it might have taken a long time to get here,
     // if there's not enough time to actually send a pulse then cancel
-    if (AP_HAL::micros() + group.dshot_pulse_time_us > time_out_us) {
+
+    if (AP_HAL::micros64() + group.dshot_pulse_time_us > time_out_us) {
         group.dma_handle->unlock();
         return;
     }
@@ -1604,7 +1605,7 @@ void RCOutput::send_pulses_DMAR(pwm_group &group, uint32_t buffer_length)
 
     dmaStreamEnable(group.dma);
     // record when the transaction was started
-    group.last_dmar_send_us = AP_HAL::micros();
+    group.last_dmar_send_us = AP_HAL::micros64();
 #endif //#ifndef DISABLE_DSHOT
 }
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -102,7 +102,7 @@ public:
     /*
       timer push (for oneshot min rate)
      */
-    void timer_tick(uint32_t last_run_us);
+    void timer_tick(uint64_t last_run_us);
 
     /*
       setup for serial output to a set of ESCs, using the given
@@ -320,9 +320,9 @@ private:
         uint32_t bit_width_mul;
         uint32_t rc_frequency;
         bool in_serial_dma;
-        uint32_t last_dmar_send_us;
-        uint32_t dshot_pulse_time_us;
-        uint32_t dshot_pulse_send_time_us;
+        uint64_t last_dmar_send_us;
+        uint64_t dshot_pulse_time_us;
+        uint64_t dshot_pulse_send_time_us;
         virtual_timer_t dma_timeout;
 
         // serial LED support
@@ -599,13 +599,13 @@ private:
     uint16_t create_dshot_packet(const uint16_t value, bool telem_request, bool bidir_telem);
     void fill_DMA_buffer_dshot(uint32_t *buffer, uint8_t stride, uint16_t packet, uint16_t clockmul);
 
-    void dshot_send_groups(uint32_t time_out_us);
-    void dshot_send(pwm_group &group, uint32_t time_out_us);
+    void dshot_send_groups(uint64_t time_out_us);
+    void dshot_send(pwm_group &group, uint64_t time_out_us);
     bool dshot_send_command(pwm_group &group, uint8_t command, uint8_t chan);
     static void dshot_update_tick(void* p);
     static void dshot_send_next_group(void* p);
     // release locks on the groups that are pending in reverse order
-    void dshot_collect_dma_locks(uint32_t last_run_us);
+    void dshot_collect_dma_locks(uint64_t last_run_us);
     static void dma_up_irq_callback(void *p, uint32_t flags);
     static void dma_unlock(void *p);
     void dma_cancel(pwm_group& group);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
@@ -243,6 +243,10 @@ ifeq ($(ENABLE_STATS),yes)
  ASXFLAGS += -DHAL_ENABLE_THREAD_STATISTICS
 endif
 
+ifneq ($(AP_BOARD_START_TIME),)
+ UDEFS += -DAP_BOARD_START_TIME=$(AP_BOARD_START_TIME)
+endif
+
 # Define ASM defines here
 UADEFS =
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
@@ -75,6 +75,9 @@ static uint32_t get_systime_us32(void)
 {
     static uint32_t last_us32;
     uint32_t now = system_time_u32_us();
+#ifdef AP_BOARD_START_TIME
+    now += AP_BOARD_START_TIME;
+#endif
     if (now < last_us32) {
         const uint64_t dt_us = 0x100000000ULL;
         timer_base_us64 += dt_us;

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -319,7 +319,11 @@ __FASTRAMFUNC__ uint32_t micros()
 {
 #if CH_CFG_ST_RESOLUTION == 32 && CH_CFG_ST_FREQUENCY==1000000U
     // special case optimisation for 32 bit timers
+#ifdef AP_BOARD_START_TIME
+    return st_lld_get_counter() + AP_BOARD_START_TIME;
+#else
     return st_lld_get_counter();
+#endif
 #else
     return hrt_micros32();
 #endif

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1939,6 +1939,10 @@ function vehicle:nav_script_time_done(param1) end
 function vehicle:nav_script_time() end
 
 -- desc
+---@param hold_in_bootloader boolean
+function vehicle:reboot(hold_in_bootloader) end
+
+-- desc
 ---@class onvif
 onvif = {}
 

--- a/libraries/AP_Scripting/examples/wrap32_test.lua
+++ b/libraries/AP_Scripting/examples/wrap32_test.lua
@@ -1,0 +1,113 @@
+--[[
+a script to test handling of 32 bit micros timer wrap with BDShot
+
+- Requires bdshot output on SERVO9 to 12
+- Requires a wire from one of SERVO9 to 12 to SERVO14 (AUX6, pin 55)
+- needs SERVO13_FUNCTION and SERVO14_FUNCTION set to -1
+- needs firmware with change for time to start 30s before 32 bit usec wrap and to allow lua reboot
+- BRD_SAFETY_DFLT must be 0
+- BDShot must be enabled on outputs 9-12
+--]]
+
+local PARAM_TABLE_KEY = 138
+local PARAM_TABLE_PREFIX = "WRAP32_"
+
+-- setup quicktune specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 10), 'could not add param table')
+
+-- bind a parameter to a variable
+function bind_param(name)
+   local p = Parameter()
+   assert(p:init(name), string.format('could not find %s parameter', name))
+   return p
+end
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+   assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+   return bind_param(PARAM_TABLE_PREFIX .. name)
+end
+
+local WRAP32_COUNT = bind_add_param('COUNT', 1, 0)
+local WRAP32_FAIL = bind_add_param('FAIL', 2, 0)
+local WRAP32_ERR = bind_add_param('ERR', 3, 0)
+local WRAP32_PIN = bind_add_param('PIN', 4, 55)
+local WRAP32_PASS = bind_add_param('PASS', 5, 0)
+
+local wrap_time_ms = uint32_t(0x418937)
+
+--[[
+   return number of seconds until we wrap. This will be negative after the wrap
+--]]
+function time_to_wrap()
+   local tnow = millis()
+   if tnow < wrap_time_ms then
+      return (wrap_time_ms - tnow):tofloat()*0.001
+   else
+      return -(tnow - wrap_time_ms):tofloat()*0.001
+   end
+end
+
+function count_changes(wait_ms)
+   local start_ms = millis()
+   local last_pin_value = 0
+   local change_count = 0
+   local pin = math.floor(WRAP32_PIN:get())
+   local pin_check = pin-1
+   gpio:pinMode(pin,0)
+   gpio:pinMode(pin_check,1)
+   gpio:write(pin-1, 0)
+   while millis() - start_ms < wait_ms do
+      gpio:toggle(pin_check)
+      local v = gpio:read(pin)
+      if v ~= last_pin_value then
+         change_count = change_count + 1
+      end
+      last_pin_value = v
+   end
+   return change_count
+end
+
+local done_pre_wrap = false
+local done_post_wrap = false
+
+function check_failure()
+   local changes = count_changes(100)
+   local to_wrap = time_to_wrap()
+   gcs:send_text(0,string.format("changes: %u ttw: %.1f", changes, to_wrap))
+   if not done_pre_wrap and to_wrap > 5 and to_wrap < 10 then
+      -- pre-wrap, should have dshot
+      if changes < 4 then
+         WRAP32_ERR:set_and_save(WRAP32_ERR:get()+1)
+      end
+      done_pre_wrap = true
+   end
+   if not done_post_wrap and to_wrap < -2 and to_wrap > -4 then
+      -- post-wrap, should have dshot
+      if changes < 4 then
+         WRAP32_FAIL:set_and_save(WRAP32_FAIL:get()+1)
+      else
+         WRAP32_PASS:set_and_save(WRAP32_PASS:get()+1)
+      end
+      done_post_wrap = true
+   end
+end
+
+function update()
+   check_failure()
+   gcs:send_text(0,string.format("Boots:%.0f fail:%.0f err:%.0f pass:%.0f",
+                                 WRAP32_COUNT:get(),
+                                 WRAP32_FAIL:get(),
+                                 WRAP32_ERR:get(),
+                                 WRAP32_PASS:get()))
+   if done_post_wrap and time_to_wrap() < -6 then
+      gcs:send_text(0,string.format("REBOOTING"))
+      vehicle:reboot(false)
+   end
+   return update, 1000
+end
+
+-- incremement on boot
+WRAP32_COUNT:set_and_save(WRAP32_COUNT:get()+1)
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -276,6 +276,7 @@ singleton AP_Vehicle method nav_scripting_enable boolean uint8_t'skip_check
 singleton AP_Vehicle method set_velocity_match boolean Vector2f
 singleton AP_Vehicle method set_land_descent_rate boolean float'skip_check
 singleton AP_Vehicle method has_ekf_failsafed boolean
+singleton AP_Vehicle method reboot void boolean
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/wscript
+++ b/wscript
@@ -386,6 +386,11 @@ configuration in order to save typing.
                  default=0,
                  help='number of auxiliary IMUs')
 
+    g.add_option('--board-start-time',
+                 type='int',
+                 default=0,
+                 help='zero time on boot in microseconds')
+    
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []
@@ -455,6 +460,11 @@ def configure(cfg):
 
     if cfg.options.num_aux_imus > 0:
         cfg.define('INS_AUX_INSTANCES', cfg.options.num_aux_imus)
+
+    if cfg.options.board_start_time != 0:
+        cfg.define('AP_BOARD_START_TIME', cfg.options.board_start_time)
+        # also in env for hrt.c
+        cfg.env.AP_BOARD_START_TIME = cfg.options.board_start_time
 
     cfg.load('ap_library')
 


### PR DESCRIPTION
This fixes a bug that happens about 1/3 times with BDShot-150 on STM32 boards when micros() wraps at 71 minutes after boot
It also adds a lua script that can be used to test the fix, and a configure option to allow us to boot with a non-zero boot time
for the test script this was used:
```
./waf configure --board CubeOrange-bdshot --board-start-time=0xFE363C7F
```
that boots at 30s before the 32 bit micros wrap
this bug affects 4.2, 4.3 and 4.4
