### PR TITLE
Copter: Remove misleading enable_motor_output method

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -206,10 +206,7 @@ void Copter::init_ardupilot()
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
-    // enable output to motors
-    if (arming.rc_calibration_checks(true)) {
-        motors->output_min();  // output lowest possible value to motors
-    }
+    motors->output_min();  // output lowest possible value to motors
 
     // attempt to set the intial_mode, else set to STABILIZE
     if (!set_mode((enum Mode::Number)g.initial_mode.get(), ModeReason::INITIALISED)) {


### PR DESCRIPTION
This doesn't actually enable the motors output.  It's a trivial method which sets the motor output level.

Not all places which set the motors as armed actually call this, so we can't roll it in there without a bit of thought.

This also removes the setting of the motor output levels at boot, based on your calibration at boot.  Leaving the motor outputs unconfigured based off rc configuration doesn't help.  We do these checks explicitly in the motor test routines where it is important.
