### PR TITLE
AP_Arming: remove redundant trim checks in Copter/Sub

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1689,23 +1689,6 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
             check_failed(ARMING_CHECK_RC, display_failure, "%s radio max too low", channel_name);
             ret = false;
         }
-        bool fail = true;
-        if (i == 2) {
-            // skip checking trim for throttle as older code did not check it
-            fail = false;
-        }
-        if (channel->get_radio_trim() < channel->get_radio_min()) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio trim below min", channel_name);
-            if (fail) {
-                ret = false;
-            }
-        }
-        if (channel->get_radio_trim() > channel->get_radio_max()) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio trim above max", channel_name);
-            if (fail) {
-                ret = false;
-            }
-        }
     }
     return ret;
 }


### PR DESCRIPTION
The main rc_calibration_checks method checks all channels, not just the subset being tested explicitly on Copter/Sub.

The code making this redundant was added in 1b18a78d1d6f5473559dcfffafa3dbc85e5273c6 with a comment "Add a RC check that (<=min trim max) for all channels.

You can see the redundancy in the prearms if you cause it to trigger on master:
![image](https://user-images.githubusercontent.com/7077857/227405531-aa614321-ae8f-4463-a2e9-28e142603943.png)

After this patch:
![image](https://user-images.githubusercontent.com/7077857/227405655-6994941b-4ff0-438b-974b-2723cd6c047c.png)

We do lose the word "throttle", but the indirection is probably not actually useful!
