### PR TITLE
AP_Arming: add and use a define for AP_ARMING_AUX_AUTH_ENABLED

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1306,6 +1306,7 @@ bool AP_Arming::fettec_checks(bool display_failure) const
     return true;
 }
 
+#if AP_ARMING_AUX_AUTH_ENABLED
 // request an auxiliary authorisation id.  This id should be used in subsequent calls to set_aux_auth_passed/failed
 // returns true on success
 bool AP_Arming::get_aux_auth_id(uint8_t& auth_id)
@@ -1422,6 +1423,7 @@ bool AP_Arming::aux_auth_checks(bool display_failure)
     // if we got this far all auxiliary checks must have passed
     return true;
 }
+#endif  // AP_ARMING_AUX_AUTH_ENABLED
 
 bool AP_Arming::generator_checks(bool display_failure) const
 {
@@ -1499,7 +1501,9 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  mount_checks(report)
         &  fettec_checks(report)
         &  visodom_checks(report)
+#if AP_ARMING_AUX_AUTH_ENABLED
         &  aux_auth_checks(report)
+#endif
         &  disarm_switch_checks(report)
         &  fence_checks(report)
         &  opendroneid_checks(report)

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -4,6 +4,8 @@
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
 
+#include "AP_Arming_config.h"
+
 class AP_Arming {
 public:
 
@@ -114,10 +116,12 @@ public:
 
     RudderArming get_rudder_arming_type() const { return (RudderArming)_rudder_arming.get(); }
 
+#if AP_ARMING_AUX_AUTH_ENABLED
     // auxiliary authorisation methods
     bool get_aux_auth_id(uint8_t& auth_id);
     void set_aux_auth_passed(uint8_t auth_id);
     void set_aux_auth_failed(uint8_t auth_id, const char* fail_msg);
+#endif
 
     static const struct AP_Param::GroupInfo        var_info[];
 
@@ -200,7 +204,9 @@ protected:
 
     bool mount_checks(bool display_failure) const;
 
+#if AP_ARMING_AUX_AUTH_ENABLED
     bool aux_auth_checks(bool display_failure);
+#endif
 
     bool generator_checks(bool report) const;
 
@@ -255,6 +261,7 @@ private:
         MIS_ITEM_CHECK_MAX
     };
 
+#if AP_ARMING_AUX_AUTH_ENABLED
     // auxiliary authorisation
     static const uint8_t aux_auth_count_max = 3;    // maximum number of auxiliary authorisers
     static const uint8_t aux_auth_str_len = 42;     // maximum length of failure message (50-8 for "PreArm: ")
@@ -268,6 +275,7 @@ private:
     char* aux_auth_fail_msg;    // buffer for holding failure messages
     bool aux_auth_error;        // true if too many auxiliary authorisers
     HAL_Semaphore aux_auth_sem; // semaphore for accessing the aux_auth_state and aux_auth_fail_msg
+#endif
 
     // method that was last used for arm/disarm; invalid unless the
     // vehicle has been disarmed at least once.

--- a/libraries/AP_Arming/AP_Arming_config.h
+++ b/libraries/AP_Arming/AP_Arming_config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_ARMING_AUX_AUTH_ENABLED
+#define AP_ARMING_AUX_AUTH_ENABLED AP_SCRIPTING_ENABLED
+#endif


### PR DESCRIPTION
only the LUA bindings can actually activate this... so exclude it on builds that don't have scripting:

```
Board              AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                      *      *           *       *                 *      *      *
HerePro            *                                                                     
Hitec-Airspeed     *                                                                     
KakuteH7-bdshot               *      *           *       *                 *      *      *
MatekF405                     -392   *           -416    -416              -408   -400   -416
Pixhawk1-1M                   -384   *           -400    -408              -400   -384   -400
f103-QiotekPeriph  *                                                                     
f303-Universal     *                                                                     
iomcu                                                          *                         
revo-mini                     -384   *           -672    -656              -384   -408   -440
skyviper-v2450                                   -384                                    
```
