### PR TITLE
AP_Compass: use new vector methods to make for more compact code

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -12903,6 +12903,27 @@ switch value'''
         if ex is not None:
             raise ex
 
+    def CompassPrearms(self):
+        '''test compass prearm checks'''
+        self.wait_ready_to_arm()
+        # XY are checked specially:
+        for axis in 'X', 'Y':  # ArduPilot only checks these two axes
+            self.context_push()
+            self.set_parameter(f"COMPASS_OFS2_{axis}", 1000)
+            self.assert_prearm_failure("Compasses inconsistent")
+            self.context_pop()
+            self.wait_ready_to_arm()
+
+        # now test the total anglular difference:
+        self.context_push()
+        self.set_parameters({
+            "COMPASS_OFS2_X": 1000,
+            "COMPASS_OFS2_Y": -1000,
+            "COMPASS_OFS2_Z": -10000,
+        })
+        self.assert_prearm_failure("Compasses inconsistent")
+        self.context_pop()
+
     def AHRS_ORIENTATION(self):
         '''test AHRS_ORIENTATION parameter works'''
         self.context_push()

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6355,6 +6355,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.InitialMode,
             self.DriveMaxRCIN,
             self.NoArmWithoutMissionItems,
+            self.CompassPrearms,
         ])
         return ret
 


### PR DESCRIPTION
The check for zero-length magnetic field on the primary is redundant given the one on the loop

I tested this by printing the values calculated by the new method with those by the old and making sure they matched.

Builds are a little larger on the smaller boards as this now includes the se angle methods:
![image](https://user-images.githubusercontent.com/7077857/227527899-acf4165f-d6db-4f6b-af3f-0d4e7688b559.png)

A few more uses of those will make this a net win on those boards.  Plane already uses one of those methods so it's already a saving on that vehicle.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -96    *           -72     -72               -200   -72    -80
HerePro             -104                                                                  
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -64    *           -40     -48               -168   -40    -48
MatekF405                      40     *           56      56                -72    56     56
Pixhawk1-1M-bdshot             32                 56      56                -72    56     56
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      40     *           56      56                -64    56     56
skyviper-v2450                                    56                                      

```