### PR TITLE
Copter: Add an element of NAV_CONTROLLER_OUTPUT to ZIGZAG mode

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1794,6 +1794,9 @@ protected:
 
     const char *name() const override { return "ZIGZAG"; }
     const char *name4() const override { return "ZIGZ"; }
+    uint32_t wp_distance() const override;
+    int32_t wp_bearing() const override;
+    float crosstrack_error() const override;
 
 private:
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -583,4 +583,29 @@ void ModeZigZag::spray(bool b)
 #endif
 }
 
+uint32_t ModeZigZag::wp_distance() const
+{
+    if (is_auto) {
+        return wp_nav->get_wp_distance_to_destination();
+    } else {
+        return 0;
+    }
+}
+int32_t ModeZigZag::wp_bearing() const
+{
+    if (is_auto) {
+        return wp_nav->get_wp_bearing_to_destination();
+    } else {
+        return 0;
+    }
+}
+float ModeZigZag::crosstrack_error() const
+{
+    if (is_auto) {
+        return wp_nav->crosstrack_error();
+    } else {
+        return 0;
+    }
+}
+
 #endif // MODE_ZIGZAG_ENABLED == ENABLED


### PR DESCRIPTION
rework from https://github.com/ArduPilot/ardupilot/pull/17456

use NAV_CONTROLLER_OUTPUT to display zigzag target when on auto zigzag mode. Otherwise don't send anything.

Tested with SITL.