### PR TITLE
Tools: add rover alias to sim_vehicle.py

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -974,6 +974,7 @@ vehicle_choices.append("copter")  # should change to ArduCopter at some stage
 vehicle_choices.append("plane")  # should change to ArduPlane at some stage
 vehicle_choices.append("sub")  # should change to Sub at some stage
 vehicle_choices.append("blimp")  # should change to Blimp at some stage
+vehicle_choices.append("rover")
 
 parser.add_option("-v", "--vehicle",
                   type='choice',
@@ -1405,7 +1406,8 @@ vehicle_map = {
     "copter": "ArduCopter",  # will switch eventually
     "plane": "ArduPlane",  # will switch eventually
     "sub": "ArduSub",  # will switch eventually
-    "blimp" : "Blimp", # will switch eventually
+    "blimp": "Blimp", # will switch eventually
+    "rover": "Rover",
 }
 if cmd_opts.vehicle in vehicle_map:
     progress("%s is now known as %s" %


### PR DESCRIPTION
allows using -v rover in addition to -v Rover as option like other vehicles which have both upper and lower case option names