### PR TITLE
Ensure the rcout TIM_UP DMA request source is re-instated after cancellation

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1582,7 +1582,9 @@ void RCOutput::send_pulses_DMAR(pwm_group &group, uint32_t buffer_length)
       up with this great method.
      */
     TOGGLE_PIN_DEBUG(54);
-
+#if STM32_DMA_SUPPORTS_DMAMUX
+    dmaSetRequestSource(group.dma, group.dma_up_channel);
+#endif
     dmaStreamSetPeripheral(group.dma, &(group.pwm_drv->tim->DMAR));
     stm32_cacheBufferFlush(group.dma_buffer, buffer_length);
     dmaStreamSetMemory0(group.dma, group.dma_buffer);


### PR DESCRIPTION
This fixes a bug in bdshot whereby dma cancellation could result in the wrong DMA channel being used for dshot output and hence motors stopping.

This only affects boards with DMA channels shared between UP and IC - which generally means all H7 boards but no others.

DMA cancellation is almost always triggered by time wrapping