### PR TITLE
Copter: 4.3.6-beta2 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.3.6-beta1 25-Mar-2023
+Copter 4.3.6-beta1/beta2 27-Mar-2023
 Changes from 4.3.5
 1) Bi-directional DShot fix for possible motor stop approx 72min after startup 
 ------------------------------------------------------------------

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.6-beta1"
+#define THISFIRMWARE "ArduCopter V4.3.6-beta2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,6,FIRMWARE_VERSION_TYPE_BETA+1
+#define FIRMWARE_VERSION 4,3,6,FIRMWARE_VERSION_TYPE_BETA+2
 
 #define FW_MAJOR 4
 #define FW_MINOR 3

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,5 @@
-Release 4.3.5beta1 24th March  2023
------------------------------------
+Release 4.3.5 26th March  2023
+------------------------------
 
 - fixed 32 bit microsecond wrap in BDShot code
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.3.5beta1"
+#define THISFIRMWARE "ArduPlane V4.3.5"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,5,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,3,5,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,6 +1,6 @@
 Rover Release Notes:
 ------------------------------------------------------------------
-Rover 4.3.0-beta11 25-Mar-2023
+Rover 4.3.0-beta11/beta12 27-Mar-2023
 Changes from 4.3.0-beta10
 1) Bi-directional DShot fix for possible motor stop approx 72min after startup 
 ------------------------------------------------------------------

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.3.0-beta11"
+#define THISFIRMWARE "ArduRover V4.3.0-beta12"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+11
+#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+12
 
 #define FW_MAJOR 4
 #define FW_MINOR 3

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1582,7 +1582,9 @@ void RCOutput::send_pulses_DMAR(pwm_group &group, uint32_t buffer_length)
       up with this great method.
      */
     TOGGLE_PIN_DEBUG(54);
-
+#if STM32_DMA_SUPPORTS_DMAMUX
+    dmaSetRequestSource(group.dma, group.dma_up_channel);
+#endif
     dmaStreamSetPeripheral(group.dma, &(group.pwm_drv->tim->DMAR));
     stm32_cacheBufferFlush(group.dma_buffer, buffer_length);
     dmaStreamSetMemory0(group.dma, group.dma_buffer);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1658,9 +1658,15 @@ void RCOutput::dma_cancel(pwm_group& group)
     chSysLock();
     dmaStreamDisable(group.dma);
 #ifdef HAL_WITH_BIDIR_DSHOT
-    if (group.ic_dma_enabled()) {
+    if (group.ic_dma_enabled() && !group.has_shared_ic_up_dma()) {
         dmaStreamDisable(group.bdshot.ic_dma[group.bdshot.curr_telem_chan]);
     }
+#if STM32_DMA_SUPPORTS_DMAMUX
+    // the DMA request source has been switched by the receive path, so reinstate the correct one
+    if (group.dshot_state == DshotState::RECV_START && group.has_shared_ic_up_dma()) {
+        dmaSetRequestSource(group.dma, group.dma_up_channel);
+    }
+#endif
 #endif
     // normally the CCR registers are reset by the final 0 in the DMA buffer
     // since we are cancelling early they need to be reset to avoid infinite pulses


### PR DESCRIPTION
This is the Copter-4.3.6-beta2 release.  This is hot on the heels of the -beta1 release because there are two more commits that @tridge and @andyp1per came up with to more completely resolve the bi-directional dshot issue.

This will also become the Rover-4.3.0-beta12 release.