### PR TITLE
Add support for require method in lua

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -196,6 +196,7 @@ class Context(object):
         self.heartbeat_interval_ms = 1000
         self.original_heartbeat_interval_ms = None
         self.installed_scripts = []
+        self.installed_modules = []
 
 
 # https://stackoverflow.com/questions/616645/how-do-i-duplicate-sys-stdout-to-a-log-file-in-python
@@ -4215,6 +4216,12 @@ class AutoTest(ABC):
         self.install_test_script(scriptname)
         self.context_get().installed_scripts.append(scriptname)
 
+    def install_test_modules_context(self):
+        '''installs test modules which will be removed when the context goes
+        away'''
+        self.install_test_modules()
+        self.context_get().installed_modules.append("test")
+
     def install_applet_script_context(self, scriptname):
         '''installs an applet script which will be removed when the context goes
         away'''
@@ -5654,6 +5661,9 @@ class AutoTest(ABC):
             self.remove_message_hook(hook)
         for script in dead.installed_scripts:
             self.remove_installed_script(script)
+        for module in dead.installed_modules:
+            print("Removing module (%s)" % module)
+            self.remove_installed_modules(module)
         if dead.sitl_commandline_customised and len(self.contexts):
             self.contexts[-1].sitl_commandline_customised = True
 
@@ -7629,6 +7639,12 @@ Also, ignores heartbeats not from our target system'''
         self.progress("Copying (%s) to (%s)" % (source, dest))
         shutil.copy(source, dest)
 
+    def install_test_modules(self):
+        source = os.path.join(self.rootdir(), "libraries", "AP_Scripting", "tests", "modules", "test")
+        dest = os.path.join("scripts", "modules", "test")
+        self.progress("Copying (%s) to (%s)" % (source, dest))
+        shutil.copytree(source, dest)
+
     def install_example_script(self, scriptname):
         source = self.script_example_source_path(scriptname)
         self.install_script(source, scriptname)
@@ -7645,6 +7661,15 @@ Also, ignores heartbeats not from our target system'''
         dest = self.installed_script_path(os.path.basename(scriptname))
         try:
             os.unlink(dest)
+        except IOError:
+            pass
+        except OSError:
+            pass
+
+    def remove_installed_modules(self, modulename):
+        dest = os.path.join("scripts", "modules", modulename)
+        try:
+            shutil.rmtree(dest)
         except IOError:
             pass
         except OSError:

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5236,6 +5236,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "SCR_HEAP_SIZE": 1024000,
             "SCR_VM_I_COUNT": 1000000,
         })
+        self.install_test_modules_context()
         for script in test_scripts:
             self.install_test_script_context(script)
         self.reboot_sitl()

--- a/libraries/AP_HAL/board/chibios.h
+++ b/libraries/AP_HAL/board/chibios.h
@@ -59,12 +59,14 @@
 #define HAL_WITH_EKF_DOUBLE HAL_HAVE_HARDWARE_DOUBLE
 #endif
 
+#ifdef __cplusplus
 // allow for static semaphores
 #include <AP_HAL_ChibiOS/Semaphores.h>
 #define HAL_Semaphore ChibiOS::Semaphore
 
 #include <AP_HAL/EventHandle.h>
 #define HAL_EventHandle AP_HAL::EventHandle
+#endif
 
 /* string names for well known SPI devices */
 #define HAL_BARO_MS5611_NAME "ms5611"

--- a/libraries/AP_HAL/board/esp32.h
+++ b/libraries/AP_HAL/board/esp32.h
@@ -23,9 +23,11 @@
 #define O_CLOEXEC 0
 #define HAL_STORAGE_SIZE (16384)
 
+#ifdef __cplusplus
 // allow for static semaphores
 #include <AP_HAL_ESP32/Semaphores.h>
 #define HAL_Semaphore ESP32::Semaphore
+#endif
 
 #define HAL_NUM_CAN_IFACES 0
 #define HAL_MEM_CLASS HAL_MEM_CLASS_192

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -380,10 +380,13 @@
     #define HAL_LINUX_I2C_EXTERNAL_BUS_MASK 0xFFFF
 #endif
 
+// only include if compiling C++ code
+#ifdef __cplusplus
 #include <AP_HAL_Linux/Semaphores.h>
 #define HAL_Semaphore Linux::Semaphore
 #include <AP_HAL/EventHandle.h>
 #define HAL_EventHandle AP_HAL::EventHandle
+#endif
 
 #ifndef HAL_HAVE_HARDWARE_DOUBLE
 #define HAL_HAVE_HARDWARE_DOUBLE 1

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -50,12 +50,15 @@
 #define HAL_HAVE_SERVO_VOLTAGE 1
 #define HAL_HAVE_SAFETY_SWITCH 0
 
+// only include if compiling C++ code
+#ifdef __cplusplus
 // allow for static semaphores
 #include <AP_HAL_SITL/Semaphores.h>
 #define HAL_Semaphore HALSITL::Semaphore
 
 #include <AP_HAL/EventHandle.h>
 #define HAL_EventHandle AP_HAL::EventHandle
+#endif
 
 #ifndef HAL_NUM_CAN_IFACES
 #define HAL_NUM_CAN_IFACES 0

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -94,6 +94,8 @@ public:
     // PWMSource storage
     uint8_t num_pwm_source;
     AP_HAL::PWMSource *_pwm_source[SCRIPTING_MAX_NUM_PWM_SOURCE];
+    int get_current_ref() { return current_ref; }
+    void set_current_ref(int ref) { current_ref = ref; }
 
 private:
 
@@ -116,7 +118,7 @@ private:
     bool _stop; // true if scripts should be stopped
 
     static AP_Scripting *_singleton;
-
+    int current_ref;
 };
 
 namespace AP {

--- a/libraries/AP_Scripting/lua/src/lbaselib.c
+++ b/libraries/AP_Scripting/lua/src/lbaselib.c
@@ -501,6 +501,13 @@ LUAMOD_API int luaopen_base (lua_State *L) {
 
 LUAMOD_API int luaopen_base_sandbox(lua_State *L) {
   luaL_setfuncs(L, base_funcs, 0);
+  // for debugging what has been loaded
+  // lua_pushvalue(L, -1);
+  // lua_setfield(L, -2, "_Sandbox");
+  // lua_pushglobaltable(L);
+  // lua_pushvalue(L, -1);
+  // lua_setfield(L, -3, "_G");
+  // lua_pop(L, 1);
+
   return 1;
 }
-

--- a/libraries/AP_Scripting/lua/src/luaconf.h
+++ b/libraries/AP_Scripting/lua/src/luaconf.h
@@ -17,6 +17,7 @@
 #ifndef LUA_SUPPORT_LOAD_BINARY
 #define LUA_SUPPORT_LOAD_BINARY 0
 #endif
+#include <AP_Scripting/lua_common_defs.h>
 
 /*
 ** ===================================================================
@@ -207,11 +208,10 @@
 #else			/* }{ */
 
 #define LUA_ROOT	"/usr/local/"
-#define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+#define LUA_LDIR	SCRIPTING_DIRECTORY "/modules/"
 #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
 #define LUA_PATH_DEFAULT  \
 		LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua;" \
-		LUA_CDIR"?.lua;"  LUA_CDIR"?/init.lua;" \
 		"./?.lua;" "./?/init.lua"
 #define LUA_CPATH_DEFAULT \
 		LUA_CDIR"?.so;" LUA_CDIR"loadall.so;" "./?.so"

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -572,3 +572,9 @@ int lua_get_PWMSource(lua_State *L) {
 
     return 1;
 }
+
+int lua_get_current_ref()
+{
+    auto *scripting = AP::scripting();
+    return scripting->get_current_ref();
+}

--- a/libraries/AP_Scripting/lua_common_defs.h
+++ b/libraries/AP_Scripting/lua_common_defs.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef REPL_DIRECTORY
+  #if HAL_OS_FATFS_IO
+    #define REPL_DIRECTORY "/APM/repl"
+  #else
+    #define REPL_DIRECTORY "./repl"
+  #endif //HAL_OS_FATFS_IO
+#endif // REPL_DIRECTORY
+
+#ifndef SCRIPTING_DIRECTORY
+  #if HAL_OS_FATFS_IO
+    #define SCRIPTING_DIRECTORY "/APM/scripts"
+  #else
+    #define SCRIPTING_DIRECTORY "./scripts"
+  #endif //HAL_OS_FATFS_IO
+#endif // SCRIPTING_DIRECTORY
+
+#ifndef REPL_IN
+  #define REPL_IN REPL_DIRECTORY "/in"
+#endif // REPL_IN
+
+#ifndef REPL_OUT
+  #define REPL_OUT REPL_DIRECTORY "/out"
+#endif // REPL_OUT
+
+int lua_get_current_ref();

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -23,32 +23,9 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Common/MultiHeap.h>
+#include "lua_common_defs.h"
 
 #include "lua/src/lua.hpp"
-
-#ifndef REPL_DIRECTORY
-  #if HAL_OS_FATFS_IO
-    #define REPL_DIRECTORY "/APM/repl"
-  #else
-    #define REPL_DIRECTORY "./repl"
-  #endif //HAL_OS_FATFS_IO
-#endif // REPL_DIRECTORY
-
-#ifndef SCRIPTING_DIRECTORY
-  #if HAL_OS_FATFS_IO
-    #define SCRIPTING_DIRECTORY "/APM/scripts"
-  #else
-    #define SCRIPTING_DIRECTORY "./scripts"
-  #endif //HAL_OS_FATFS_IO
-#endif // SCRIPTING_DIRECTORY
-
-#ifndef REPL_IN
-  #define REPL_IN REPL_DIRECTORY "/in"
-#endif // REPL_IN
-
-#ifndef REPL_OUT
-  #define REPL_OUT REPL_DIRECTORY "/out"
-#endif // REPL_OUT
 
 class lua_scripts
 {
@@ -78,7 +55,6 @@ public:
 private:
 
     void create_sandbox(lua_State *L);
-
     void repl_cleanup(void);
 
     typedef struct script_info {
@@ -143,6 +119,7 @@ private:
     static HAL_Semaphore error_msg_buf_sem;
     static uint8_t print_error_count;
     static uint32_t last_print_ms;
+    int current_ref;
 
 public:
     // must be static for use in atpanic, public to allow bindings to issue none fatal warnings

--- a/libraries/AP_Scripting/tests/modules/test/nested.lua
+++ b/libraries/AP_Scripting/tests/modules/test/nested.lua
@@ -1,0 +1,10 @@
+-- Description: Test require()ing another script
+local nested = {}
+nested.top = require('test/top')
+
+-- create some test functions to call
+function nested.call_fn()
+    return "nested"
+end
+
+return nested

--- a/libraries/AP_Scripting/tests/modules/test/top.lua
+++ b/libraries/AP_Scripting/tests/modules/test/top.lua
@@ -1,0 +1,9 @@
+-- Description: Test require()ing another script
+local top = {}
+
+-- create some test functions to call
+function top.call_fn()
+    return "top"
+end
+
+return top

--- a/libraries/AP_Scripting/tests/scripting_test.lua
+++ b/libraries/AP_Scripting/tests/scripting_test.lua
@@ -3,6 +3,7 @@
 -- heavily commented, and may require quite a bit more RAM to run in
 
 local loop_time = 500 -- number of ms between runs
+local require_test_global = require('test/nested')
 
 function is_equal(v1, v2, tolerance)
   return math.abs(v1 - v2) < (tolerance or 0.0001)
@@ -36,6 +37,20 @@ end
 
 function update()
   local all_tests_passed = true
+  local require_test_local = require('test/nested')
+  -- test require()ing a script
+  if require_test_local.call_fn() ~= 'nested' then
+    gcs:send_text(0, "Failed to require() the same script multiple times")
+    all_tests_passed = false
+  end
+  if require_test_global.call_fn() ~= 'nested' then
+    gcs:send_text(0, "Failed to require() the script once")
+    all_tests_passed = false
+  end
+  if require_test_global.top.call_fn() ~= 'top' then
+    gcs:send_text(0, "Failed to call a function nested in a required script")
+    all_tests_passed = false
+  end
   -- each test should run then and it's result with the previous ones
   all_tests_passed = test_offset(500, 200) and all_tests_passed
 


### PR DESCRIPTION
Also move the global library initialisation out of sandbox method. This way we initialise the lua libs once and then set the reference inside the sandbox, this is similar to what we do with our generated lua bindings.

Split from following PR as requested:

https://github.com/ArduPilot/ardupilot/pull/13660

Current master
```
AP: Lua: Running ./scripts/ahrs-print-home-and-origin.lua
AP: Home - Lat:-353632608.0 Long:1491652352.0 Alt:58409.0
AP: Origin - Lat:-353632608.0 Long:1491652352.0 Alt:58409.0
AP: Lua: Time: 0 Mem: 50777 + 886
AP: Lua: Running ./scripts/ahrs-print-angle-and-rates.lua
AP: Ang R:0.1 P:0.1 Y:-5.9 Rate R:0.0 P:0.0 Y:0.1
AP: Lua: Time: 0 Mem: 50629 + 738
```

With package module loaded
```
AP: Lua: Running ./scripts/ahrs-print-home-and-origin.lua
AP: Home - Lat:-353632608.0 Long:1491652352.0 Alt:58409.0
AP: Origin - Lat:-353632608.0 Long:1491652352.0 Alt:58409.0
AP: Lua: Time: 0 Mem: 52301 + 886
AP: Lua: Running ./scripts/ahrs-print-angle-and-rates.lua
AP: Ang R:0.1 P:0.0 Y:-4.2 Rate R:0.0 P:0.0 Y:0.4
AP: Lua: Time: 0 Mem: 52153 + 738
```