### PR TITLE
AP_Motors: Tricopter: rework yaw servo defaulting, remove yaw from mix if no servo is setup

### DIFF
--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -48,6 +48,9 @@ public:
     // using copter motors for forward flight
     float               get_roll_factor(uint8_t i) override;
 
+    // Run arming checks
+    bool arming_checks(size_t buflen, char *buffer) const override;
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
@@ -71,4 +74,5 @@ protected:
 
     // reverse pitch
     bool _pitch_reversed;
+    bool _have_tail_servo;
 };

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -481,7 +481,7 @@ public:
     static bool find_channel(SRV_Channel::Aux_servo_function_t function, uint8_t &chan);
 
     // find first channel that a function is assigned to, returning SRV_Channel object
-    static SRV_Channel *get_channel_for(SRV_Channel::Aux_servo_function_t function, int8_t default_chan=-1);
+    static SRV_Channel *get_channel_for(SRV_Channel::Aux_servo_function_t function);
 
     // call set_angle() on matching channels
     static void set_angle(SRV_Channel::Aux_servo_function_t function, uint16_t angle);

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -559,12 +559,9 @@ bool SRV_Channels::find_channel(SRV_Channel::Aux_servo_function_t function, uint
 /*
   get a pointer to first auxiliary channel for a channel function
 */
-SRV_Channel *SRV_Channels::get_channel_for(SRV_Channel::Aux_servo_function_t function, int8_t default_chan)
+SRV_Channel *SRV_Channels::get_channel_for(SRV_Channel::Aux_servo_function_t function)
 {
     uint8_t chan;
-    if (default_chan >= 0) {
-        set_aux_channel_default(function, default_chan);
-    }
     if (!find_channel(function, chan)) {
         return nullptr;
     }


### PR DESCRIPTION
Moves checking of yaw servo setup to arming check.

This also removes the last user of the default channel variable in the `get_channel_for` function, tricopter was the last user. 

Adds a `_have_tail_servo` bool plane does not try to use the tail servo if none is setup. 