### PR TITLE
Tools: blacklist build of CubeOrangePlus-SimOnHardware bootloader

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -120,6 +120,7 @@ class SizeCompareBranches(object):
         # TODO: find a way to get this information from board_list:
         self.bootloader_blacklist = set([
             'CubeOrange-SimOnHardWare',
+            'CubeOrangePlus-SimOnHardWare',
             'fmuv2',
             'fmuv3-bdshot',
             'iomcu',


### PR DESCRIPTION
Just as we do the CubeOrange equivalent; this uses the CubeOrangePlus bootloader