### PR TITLE
Add notify noises to Buzzer

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1675,6 +1675,7 @@ AP_InertialSensor::_init_gyro()
 
     // stop flashing leds
     AP_Notify::flags.initialising = false;
+    AP_Notify::flags.gyro_calibrated = true;
 }
 
 // save parameters to eeprom

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -123,6 +123,7 @@ public:
         bool powering_off;        // true when the vehicle is powering off
         bool video_recording;     // true when the vehicle is recording video
         bool temp_cal_running;    // true if a temperature calibration is running
+        bool gyro_calibrated;     // true if calibrated gyro/acc
     };
 
     /// notify_events_type - bitmask of active events.

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -66,6 +66,18 @@ void Buzzer::update_pattern_to_play()
         return;
     }
 
+    // initializing?
+    if (_flags.gyro_calibrated != AP_Notify::flags.gyro_calibrated) {
+        _flags.gyro_calibrated = AP_Notify::flags.gyro_calibrated;
+        play_pattern(INIT_GYRO);
+    }
+
+    // check if prearm check are good
+    if (AP_Notify::flags.pre_arm_check  && !_flags.pre_arm_check) {
+        _flags.pre_arm_check = true;
+        play_pattern(PRE_ARM_GOOD);
+    }
+
     // check if armed status has changed
     if (_flags.armed != AP_Notify::flags.armed) {
         _flags.armed = AP_Notify::flags.armed;

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -43,6 +43,8 @@ private:
     static const uint32_t    ARMING_BUZZ = 0b11111111111111111111111111111100UL; // 3s
     static const uint32_t      BARO_BUZZ = 0b10101010100000000000000000000000UL;
     static const uint32_t        EKF_BAD = 0b11101101010000000000000000000000UL;
+    static const uint32_t      INIT_GYRO = 0b10010010010010010010000000000000UL;
+    static const uint32_t   PRE_ARM_GOOD = 0b10101011111111110000000000000000UL;
 
     /// play_pattern - plays the defined buzzer pattern
     void play_pattern(const uint32_t pattern);
@@ -54,6 +56,8 @@ private:
         uint8_t armed               : 1;    // 0 = disarmed, 1 = armed
         uint8_t failsafe_battery    : 1;    // 1 if battery failsafe has triggered
         uint8_t ekf_bad             : 1;    // 1 if ekf position has gone bad
+        uint8_t gyro_calibrated     : 1;    // 1 if calibrating gyro
+        uint8_t pre_arm_check       : 1;    // 1 if pre-arm check has passed
     } _flags;
 
     uint32_t _pattern;           // current pattern


### PR DESCRIPTION
More and more autopilots are including the simple buzzer on their USB remotes....the only useful sounds currently for someone standing next to the plane are armed and disarmed....this adds a noise when the plane must not be moved and when it first becomes arm ready....could be more complex and have it notify if pre-arm checks return before arm, but I don't think that it really needed in 99.9% of the cases where this would be used.


flight tested