### PR TITLE
AP_GPS: Add covariance output to AP_GPS matching ROS NavSatFix

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -5,6 +5,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_RTC/AP_RTC.h>
 #include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
 
 #include "AP_DDS_Client.h"
@@ -78,17 +79,13 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t i
     case AP_GPS::GPS_OK_FIX_2D:
     case AP_GPS::GPS_OK_FIX_3D:
         msg.status.status = 0; // STATUS_FIX
-        msg.position_covariance_type = 1; // COVARIANCE_TYPE_APPROXIMATED
         break;
     case AP_GPS::GPS_OK_FIX_3D_DGPS:
         msg.status.status = 1; // STATUS_SBAS_FIX
-        msg.position_covariance_type = 1; // COVARIANCE_TYPE_APPROXIMATED
         break;
     case AP_GPS::GPS_OK_FIX_3D_RTK_FLOAT:
     case AP_GPS::GPS_OK_FIX_3D_RTK_FIXED:
         msg.status.status = 2; // STATUS_SBAS_FIX
-        msg.position_covariance_type = 1; // COVARIANCE_TYPE_APPROXIMATED
-        // RTK provides "rtk_accuracy" member, should it be used for the covariance?
         break;
     default:
         //! @todo Can we not just use an enum class and not worry about this condition?
@@ -107,17 +104,18 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t i
     }
     msg.altitude = alt_cm / 100.0;
 
-    // Calculate covariance: https://answers.ros.org/question/10310/calculate-navsatfix-covariance/
-    // https://github.com/ros-drivers/nmea_navsat_driver/blob/indigo-devel/src/libnmea_navsat_driver/driver.py#L110-L114
-    //! @todo This calculation will be moved to AP::gps and fixed in #23259
-    //! It is a placeholder for now matching the ROS1 nmea_navsat_driver behavior
-    const auto hdop = gps.get_hdop(instance);
-    const auto hdopSq = hdop * hdop;
-    const auto vdop = gps.get_vdop(instance);
-    const auto vdopSq = vdop * vdop;
-    msg.position_covariance[0] = hdopSq;
-    msg.position_covariance[4] = hdopSq;
-    msg.position_covariance[8] = vdopSq;
+    // ROS allows double precision, ArduPilot exposes float precision today
+    Matrix3f cov;
+    msg.position_covariance_type = (uint8_t)gps.position_covariance(instance, cov);
+    msg.position_covariance[0] = cov[0][0];
+    msg.position_covariance[1] = cov[0][1];
+    msg.position_covariance[2] = cov[0][2];
+    msg.position_covariance[3] = cov[1][0];
+    msg.position_covariance[4] = cov[1][1];
+    msg.position_covariance[5] = cov[1][2];
+    msg.position_covariance[6] = cov[2][0];
+    msg.position_covariance[7] = cov[2][1];
+    msg.position_covariance[8] = cov[2][2];
 }
 
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -525,6 +525,25 @@ bool AP_GPS::vertical_accuracy(uint8_t instance, float &vacc) const
     return false;
 }
 
+AP_GPS::CovarianceType AP_GPS::position_covariance(const uint8_t instance, Matrix3f& cov) const
+{
+    AP_GPS::CovarianceType cov_type = AP_GPS::CovarianceType::UNKNOWN;
+    cov.zero();
+    float hacc, vacc;
+    if (horizontal_accuracy(instance, hacc) && vertical_accuracy(instance, vacc))
+    {
+        cov_type = AP_GPS::CovarianceType::DIAGONAL_KNOWN;
+        const auto hacc_variance = hacc * hacc;
+        cov[0][0] = hacc_variance;
+        cov[1][1] = hacc_variance;
+        cov[2][2] = vacc * vacc;
+    }
+    // There may be a receiver that implements hdop+vdop but not accuracy
+    // If so, there could be a condition here to attempt to calculate it
+
+    return cov_type;
+}
+
 
 /**
    convert GPS week and milliseconds to unix epoch in milliseconds

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -20,6 +20,7 @@
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
 #include "GPS_detect_state.h"
+#include <AP_Math/AP_Math.h>
 #include <AP_MSP/msp.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <SITL/SIM_GPS.h>
@@ -166,6 +167,14 @@ public:
         GPS_ROLE_NORMAL,
         GPS_ROLE_MB_BASE,
         GPS_ROLE_MB_ROVER,
+    };
+
+    // GPS Covariance Types matching ROS2 sensor_msgs/msg/NavSatFix
+    enum class CovarianceType : uint8_t {
+        UNKNOWN = 0,  ///< The GPS does not support any accuracy metrics
+        APPROXIMATED = 1,  ///< The accuracy is approximated through metrics such as HDOP/VDOP
+        DIAGONAL_KNOWN = 2, ///< The diagonal (east, north, up) components of covariance are reported by the GPS
+        KNOWN = 3, ///< The full covariance array is reported by the GPS
     };
 
     /*
@@ -326,6 +335,8 @@ public:
     bool vertical_accuracy(float &vacc) const {
         return vertical_accuracy(primary_instance, vacc);
     }
+
+    CovarianceType position_covariance(const uint8_t instance, Matrix3f& cov) const WARN_IF_UNUSED;
 
     // 3D velocity in NED format
     const Vector3f &velocity(uint8_t instance) const {


### PR DESCRIPTION
This PR adds support for populated the double matrix of covariance, which will be consumed in ROS2 in a follow up PR. 

The covariance units are m^2 (it's a variance).

It's only computed when requested. 

Note, I did clarify this is the position covariance, since it seems the GPS receivers can also report velocity covariance. Currently, the velocity covariance is not part of the NavSatFix(yet), but we can expect a future with a `velocity_covariance` method when that is true.

Closes #23259