### PR TITLE
Tools: remove dsdl_generated before building bootloader

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -298,6 +298,11 @@ class SizeCompareBranches(object):
             # need special configuration directive
             bootloader_waf_configure_args = copy.copy(waf_configure_args)
             bootloader_waf_configure_args.append('--bootloader')
+            # hopefully temporary hack so you can build bootloader
+            # after building other vehicles without a clean:
+            dsdl_generated_path = os.path.join('build', board, "modules", "DroneCAN", "libcanard", "dsdlc_generated")
+            self.progress("HACK: Removing (%s)" % dsdl_generated_path)
+            shutil.rmtree(dsdl_generated_path, ignore_errors=True)
             self.run_waf(bootloader_waf_configure_args)
             self.run_waf([v])
         self.run_program("rsync", ["rsync", "-aP", "build/", outdir])


### PR DESCRIPTION
waf doesn't take care of this for us

hopefully temporary.  it would be nice to correct the generation of these.
