### PR TITLE
Copter: 4.3.6 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.3.6-beta1/beta2 27-Mar-2023
+Copter 4.3.6 05-Apr-2023 / 4.3.6-beta1, 4.3.6--beta2 27-Mar-2023
 Changes from 4.3.5
 1) Bi-directional DShot fix for possible motor stop approx 72min after startup 
 ------------------------------------------------------------------

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.6-beta2"
+#define THISFIRMWARE "ArduCopter V4.3.6"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,6,FIRMWARE_VERSION_TYPE_BETA+2
+#define FIRMWARE_VERSION 4,3,6,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 6
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.3.6 official release which is exactly the same as the last beta.