### PR TITLE
Fix spelling of receiver in ArduPilot repo

### DIFF
--- a/libraries/AP_GPS/MovingBase.h
+++ b/libraries/AP_GPS/MovingBase.h
@@ -18,6 +18,6 @@ public:
     };
 
     AP_Int8 type;            // an option from MovingBaseType
-    AP_Vector3f base_offset; // base position offset from the selected GPS reciever
+    AP_Vector3f base_offset; // base position offset from the selected GPS receiver
 
 };

--- a/libraries/AP_HAL_ESP32/README.md
+++ b/libraries/AP_HAL_ESP32/README.md
@@ -169,13 +169,13 @@ After flashing the esp32 , u can connect with a terminal app of your preference 
 | GND         |      GND  |
 | 5v          |      Pwr  |
 
-### RC reciever connection:
+### RC receiver connection:
 
-|ESP32| RCRECIEVER |
-| --- |    ---     |
-| D4  |  CPPM-out  |
-| GND |       GND  |
-| 5v  |       Pwr  |
+|ESP32| RC Receiver |
+| --- |    ---      |
+| D4  |  CPPM-out   |
+| GND |       GND   |
+| 5v  |       Pwr   |
 
 
 ###  I2C connection ( for gps with leds/compass-es/etc onboard, or digital airspeed sensorrs, etc):

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -582,7 +582,7 @@ public:
     // get mask of enabled protocols
     uint32_t enabled_protocols() const;
 
-    // returns true if we have had a direct detach RC reciever, does not include overrides
+    // returns true if we have had a direct detach RC receiver, does not include overrides
     bool has_had_rc_receiver() const { return _has_had_rc_receiver; }
 
     // returns true if we have had an override on any channel
@@ -653,7 +653,7 @@ private:
 
     uint32_t last_update_ms;
     bool has_new_overrides;
-    bool _has_had_rc_receiver; // true if we have had a direct detach RC reciever, does not include overrides
+    bool _has_had_rc_receiver; // true if we have had a direct detach RC receiver, does not include overrides
     bool _has_had_override; // true if we have had an override on any channel
 
     AP_Float _override_timeout;


### PR DESCRIPTION
I spelled it wrong earlier and found a few other places others did the same. It's all just comments, so a low risk PR