### PR TITLE
AP_BattMonitor: Add get_semaphore() member function

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -464,6 +464,8 @@ void AP_BattMonitor::convert_dynamic_param_groups(uint8_t instance)
 // read - For all active instances read voltage & current; log BAT, BCL, POWR
 void AP_BattMonitor::read()
 {
+    WITH_SEMAPHORE(rsem);
+    
 #if HAL_LOGGING_ENABLED
     AP_Logger *logger = AP_Logger::get_singleton();
     if (logger != nullptr && logger->should_log(_log_battery_bit)) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
@@ -118,6 +119,11 @@ public:
 
     static AP_BattMonitor *get_singleton() {
         return _singleton;
+    }
+
+    // allow threads to lock against Battery updates
+    HAL_Semaphore &get_semaphore(void) {
+        return rsem;
     }
 
     // cell voltages in millivolts
@@ -275,6 +281,7 @@ protected:
 
 private:
     static AP_BattMonitor *_singleton;
+    HAL_Semaphore rsem;
 
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];
     AP_BattMonitor_Backend *drivers[AP_BATT_MONITOR_MAX_INSTANCES];


### PR DESCRIPTION
Allow threads to lock against Battery updates, as requested in #23370 