### PR TITLE
Move Estop prearm up into Arming and add exception

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -33,12 +33,6 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         return false;
     }
 
-    // if we are using motor Estop switch, it must not be in Estop position
-    if (SRV_Channels::get_emergency_stop()){
-        check_failed(display_failure, "Motor Emergency Stopped");
-        return false;
-    }
-
     if (!disarm_switch_checks(display_failure)) {
         return false;
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -106,11 +106,6 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         ret = false;
     }
 
-    if (SRV_Channels::get_emergency_stop()) {
-        check_failed(display_failure,"Motors Emergency Stopped");
-        ret = false;
-    }
-
     if (plane.g2.flight_options & FlightOptions::CENTER_THROTTLE_TRIM){
        int16_t trim = plane.channel_throttle->get_radio_trim();
        if (trim < 1250 || trim > 1750) {

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -80,10 +80,6 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
     if (checks_to_perform == 0) {
         return true;
     }
-    if (SRV_Channels::get_emergency_stop()) {
-        check_failed(report, "Motors Emergency Stopped");
-        return false;
-    }
 
     if (rover.g2.sailboat.sail_enabled() && !rover.g2.windvane.enabled()) {
         check_failed(report, "Sailing enabled with no WindVane");

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -213,6 +213,8 @@ protected:
     bool opendroneid_checks(bool display_failure);
     
     bool serial_protocol_checks(bool display_failure);
+    
+    bool estop_checks(bool display_failure);
 
     virtual bool system_checks(bool report);
 


### PR DESCRIPTION
This PR has two parts:
1. move the individual estop prearm checks from each vehicles arming into top level AP_Arming
2. add the exclusion for the ARM_EMERGENCY_STOP switch in estop position

tested in SITL for plane,copter., and rover using sw 31(ESTOP) and sw 165(ARM_EMERGENCY_STOP)

Rover autotest needs rework since the flow of prearms has changed
