### PR TITLE
AP_Camera: Support for a maximum of 50 characters

### DIFF
--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -142,9 +142,11 @@ void AP_Camera_MAVLinkCamV2::handle_message(mavlink_channel_t chan, const mavlin
         const uint8_t fw_ver_build = (cam_info.firmware_version & 0xFF000000) >> 24;
 
         // display camera info to user
-        gcs().send_text(MAV_SEVERITY_INFO, "Camera: %s.32 %s.32 fw:%u.%u.%u.%u",
-                cam_info.vendor_name,
-                cam_info.model_name,
+        gcs().send_text(MAV_SEVERITY_INFO, "Camera: vendor:%s.32",    // string length max 47
+                cam_info.vendor_name);
+        gcs().send_text(MAV_SEVERITY_INFO, "Camera: model:%s.32",     // string length max 46
+                cam_info.model_name);
+        gcs().send_text(MAV_SEVERITY_INFO, "Camera: fw:%u.%u.%u.%u",  // string length max 26
                 (unsigned)fw_ver_major,
                 (unsigned)fw_ver_minor,
                 (unsigned)fw_ver_revision,


### PR DESCRIPTION
SEND_TEXT can only send 50 characters at a time.
If it exceeds 50 characters, it will be divided by 50 characters.
Change it so that it is sent item by item, being aware of the division.