### PR TITLE
AP_Camera: Remove NULLPTR judgment for priority variable values

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -176,9 +176,7 @@ void AP_Camera::init()
         }
 
         // set primary to first non-null instance
-        if (primary == nullptr) {
-            primary = _backends[instance];
-        }
+        primary = _backends[instance];
     }
 
     // init each instance, do it after all instances were created, so that they all know things


### PR DESCRIPTION
The priority variable NULLPTR is determined at the beginning of the method.
I think this judgment is unnecessary.