### PR TITLE
autotest: allow other prearm failures while waiting for estop prearm

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -11665,10 +11665,12 @@ switch value'''
                 0,
                 want_result=mavutil.mavlink.MAV_RESULT_FAILED
             )
-            self.wait_statustext("PreArm: Motors Emergency Stopped", check_context=True)
+            self.assert_prearm_failure("Motors Emergency Stopped",
+                                       other_prearm_failures_fatal=False)
             self.reboot_sitl()
-            self.delay_sim_time(10)
-            self.assert_prearm_failure("Motors Emergency Stopped")
+            self.assert_prearm_failure(
+                "Motors Emergency Stopped",
+                other_prearm_failures_fatal=False)
             self.context_pop()
             self.reboot_sitl()
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6071,8 +6071,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         })
         self.set_rc(9, 2000)
         self.reboot_sitl()
-        self.delay_sim_time(10)
-        self.assert_prearm_failure("Motors Emergency Stopped")
+        self.assert_prearm_failure(
+            "Motors Emergency Stopped",
+            other_prearm_failures_fatal=False)
         self.context_pop()
         self.reboot_sitl()
 


### PR DESCRIPTION
accels inconsistent was popping up in here.

We can ignore that - we only care we won't arm because of the estop being active.  This will also save a bit of time with the removal of the raw delay-for-10-seconds