### PR TITLE
Add Notch Filter to Rate Controller Feed Forward

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -5,6 +5,7 @@
 
 #include "AC_AttitudeControl.h"
 #include <AP_Motors/AP_MotorsMulticopter.h>
+#include <Filter/NotchFilterIncParams.h>
 
 // default rate controller PID gains
 #ifndef AC_ATC_MULTI_RATE_RP_P
@@ -91,6 +92,8 @@ protected:
 
     // get maximum value throttle can be raised to based on throttle vs attitude prioritisation
     float get_throttle_avg_max(float throttle_in);
+
+    NotchFilterIncParamVectors3f _input_notch;
 
     AP_MotorsMulticopter& _motors_multi;
     AC_PID                _pid_rate_roll;

--- a/libraries/Filter/NotchFilterIncParams.cpp
+++ b/libraries/Filter/NotchFilterIncParams.cpp
@@ -1,0 +1,66 @@
+
+#include "NotchFilter.h"
+#include "NotchFilterIncParams.h"
+
+// table of user settable parameters
+template <class T>
+const AP_Param::GroupInfo NotchFilterIncParams<T>::var_info[] = {
+
+    // @Param: ENAB
+    // @DisplayName: Enable filter
+    // @Description: Enable static notch filter
+    // @Values: 0:Disabled, 1:Enabled
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO_FLAGS("ENAB", 1, NotchFilterIncParams, _enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: ATT
+    // @DisplayName: Notch filter attenuation
+    // @Description: Notch filter attenuation
+    // @Range: 35 60
+    // @User: Advanced
+    AP_GROUPINFO("ATT", 2, NotchFilterIncParams, _attenuation_dB, 40),
+
+    // @Param: BW
+    // @DisplayName: Notch filter bandwidth
+    // @Description: Notch filter bandwidth
+    // @Range: 2 50
+    // @User: Advanced
+    AP_GROUPINFO("BW", 3, NotchFilterIncParams, _bandwidth_hz, 2),
+
+    // @Param: FREQ
+    // @DisplayName: Notch filter centre frequency
+    // @Description: Notch filter centre frequency
+    // @Range: 35 60
+    // @User: Advanced
+    AP_GROUPINFO("FREQ", 4, NotchFilterIncParams, _center_freq_hz, 8),
+
+    AP_GROUPEND
+};
+
+
+template <class T>
+NotchFilterIncParams<T>::NotchFilterIncParams(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+
+template <class T>
+void NotchFilterIncParams<T>::init(float sample_freq_hz)
+{
+    // sanity check the input
+    if (is_zero(sample_freq_hz) || isnan(sample_freq_hz)) {
+        return;
+    }
+
+    NotchFilter<T>::init(sample_freq_hz, _center_freq_hz.get(), _bandwidth_hz.get(), _attenuation_dB.get());
+}
+
+
+/*
+   instantiate template classes
+ */
+template class NotchFilterIncParams<float>;
+template class NotchFilterIncParams<Vector2f>;
+template class NotchFilterIncParams<Vector3f>;

--- a/libraries/Filter/NotchFilterIncParams.h
+++ b/libraries/Filter/NotchFilterIncParams.h
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "NotchFilter.h"
+
+template <class T>
+class NotchFilterIncParams : public NotchFilter<T>{
+
+public:
+    
+    // Inherit constructor
+    // using NotchFilter<T>::NotchFilter<T>;
+    NotchFilterIncParams(void);
+
+    void init(float sample_freq_hz);
+
+    // user settable parameters
+    static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+    AP_Int8 _enable;
+    AP_Float _center_freq_hz;
+    AP_Float _bandwidth_hz;
+    AP_Float _attenuation_dB;
+
+};
+
+typedef NotchFilterIncParams<float> NotchFilterIncParamsFloat;
+typedef NotchFilterIncParams<Vector2f> NotchFilterIncParamVectors2f;
+typedef NotchFilterIncParams<Vector3f> NotchFilterIncParamVectors3f;

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -79,7 +79,7 @@ Aircraft::Aircraft(const char *frame_str) :
     }
 
     // Negative attenuation gives us a gain
-    landing_gear_structure.init(rate_hz, sitl->gnd_res_freq.get(), 2.0, -40.0);
+    landing_gear_structure.init(rate_hz, sitl->gnd_res_freq.get(), 1.0, -10.0);
 }
 
 void Aircraft::set_start_location(const Location &start_loc, const float start_yaw)
@@ -685,10 +685,10 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 
             // Add a ground resonance component to yaw
             float gnd_res_angle = 0.0;
-            if (on_ground()) {
-               gnd_res_angle = 0.05*landing_gear_structure.apply(rot_accel.z);
+            if (on_ground() && (sitl->gnd_res_freq.get() >= 1.0)) {
+                gnd_res_angle = 0.1*landing_gear_structure.apply(rot_accel.z);
             }
-            
+
             y = y + yaw_rate * delta_time + gnd_res_angle;
             dcm.from_euler(0.0f, 0.0f, y);
             // X, Y movement tracks ground movement

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -335,6 +335,9 @@ private:
     IntelligentEnergy24 *ie24;
     SIM_Precland *precland;
     class I2C *i2c;
+
+    // Notch filter used to approximate the dynamic behaviour of landing gear when on ground
+    NotchFilterFloat landing_gear_structure;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -379,6 +379,12 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     AP_SUBGROUPINFO(airspeed[1], "ARSPD2_", 51, SIM, SIM::AirspeedParm),
 #endif
 
+    // @Param: GND_RES_F
+    // @DisplayName: Ground Resonance Frequency
+    // @Description: Enables a ground resonance model in yaw
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("GND_RES_F",       52, SIM,  gnd_res_freq,  0),
 
 #ifdef SFML_JOYSTICK
     AP_SUBGROUPEXTENSION("",      63, SIM,  var_sfml_joystick),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -238,6 +238,8 @@ public:
 
     AP_Float uart_byte_loss_pct;
 
+    AP_Float gnd_res_freq;  // natural frequency of fundamental mode for yaw structural oscillation on ground
+
 #ifdef SFML_JOYSTICK
     AP_Int8 sfml_joystick_id;
     AP_Int8 sfml_joystick_axis[8];


### PR DESCRIPTION
This is very much WIP and still full of hacky implementation/debugging.  Opening PR purely to socialise the idea.

Credit to Ryan Beall as this is his idea.

The purpose of this filter is to prevent the flight controller from exciting structural resonances.  This video covers the motivation behind why this should be of benefit: https://youtu.be/b_8v8scghh8?t=935

I am hoping this will be of use to multi-rotors that have long flexible landing gear and tend to hit a resonance excited by the yaw rate controller when sat on ground and slowly advancing the throttle to take off.  I am also hoping this will be useful to VTOL planes that excite a vibration mode in the wings and/or tail when in the hover.

This is just a basic implementation to begin with whilst I am still experimenting and testing.

I have added a simple ground resonance model into copter SITL.

Thus far, based on SITL testing this implementation does not appear to be doing much to prevent ground resonance.  This could either be due to my bad SITL model, the way I have implemented in AP, or it just may not be an effective method to prevent this coupling.  Currently working on IRL testing to understand what is going on.

Stuff that I am still planning to do:
- [ ] Make the params updatable at run time
- [ ] Add a Lua script example to be able to switch off the notch when in flight as an example for the ground resonance use case.
- [ ] Define out for 1MB boards

Comments and ideas welcome.