### PR TITLE
AP_SerialManager: allow SERIAL1 protocol to be hwdef defined

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -28,6 +28,12 @@
 
 extern const AP_HAL::HAL& hal;
 
+#ifdef HAL_SERIAL1_PROTOCOL
+#define SERIAL1_PROTOCOL HAL_SERIAL1_PROTOCOL
+#else
+#define SERIAL1_PROTOCOL SerialProtocol_MAVLink2
+#endif
+
 #ifdef HAL_SERIAL2_PROTOCOL
 #define SERIAL2_PROTOCOL HAL_SERIAL2_PROTOCOL
 #else
@@ -139,7 +145,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink2),
+    AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SERIAL1_PROTOCOL),
 
     // @Param: 1_BAUD
     // @DisplayName: Telem1 Baud Rate


### PR DESCRIPTION
Many boards rely on setting the SERIAL1 port protocol in the hwdef....but it doesn't...ran into this checking my SpeedyBeeF405WING hwdef.....this fixes that for

FlywooF405S-AIO/hwdef.dat:define HAL_SERIAL1_PROTOCOL SerialProtocol_RCIN
FoxeerH743v1/hwdef.dat:define HAL_SERIAL1_PROTOCOL SerialProtocol_RCIN
JHEMCU-GSF405A/hwdef.dat:define HAL_SERIAL1_PROTOCOL 23
SPRacingH7/hwdef.dat:define HAL_SERIAL1_PROTOCOL SerialProtocol_RCIN
SkystarsH7HD-bdshot/hwdef.dat:define HAL_SERIAL1_PROTOCOL SerialProtocol_RCIN
speedybeef4v3/hwdef.dat:define HAL_SERIAL1_PROTOCOL SerialProtocol_DJI_FPV