### PR TITLE
Tools: validate features are removed when we compile them out

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -319,9 +319,8 @@ class ExtractFeatures(object):
 
         return ret
 
-    def create_string(self):
-
-        ret = ""
+    def extract(self):
+        '''returns two sets - compiled_in and not_compiled_in'''
 
         build_options_defines = set([x.define for x in build_options.BUILD_OPTIONS])
 
@@ -350,10 +349,18 @@ class ExtractFeatures(object):
                     continue
                 compiled_in_feature_defines.append(some_define)
                 remaining_build_options_defines.discard(some_define)
+        return (compiled_in_feature_defines, remaining_build_options_defines)
+
+    def create_string(self):
+        '''returns a string with compiled in and not compiled-in features'''
+
+        (compiled_in_feature_defines, not_compiled_in_feature_defines) = self.extract()
+
+        ret = ""
 
         for compiled_in_feature_define in sorted(compiled_in_feature_defines):
             ret += compiled_in_feature_define + "\n"
-        for remaining in sorted(remaining_build_options_defines):
+        for remaining in sorted(not_compiled_in_feature_defines):
             ret += "!" + remaining + "\n"
 
         return ret

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -46,6 +46,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_LandingGear/AP_LandingGear.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
+#include <SRV_Channel/SRV_Channel.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_GPS/AP_GPS.h>


### PR DESCRIPTION
I noticed that our OSD detection isn't right.

This doesn't pick that problem up (not compiled into our test boards by default), but this did catch several others.
