### PR TITLE
AP_Airspeed: reuse airspeed backend contructor in more backends

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
@@ -13,11 +13,6 @@ extern const AP_HAL::HAL& hal;
 AP_Airspeed_DroneCAN::DetectedModules AP_Airspeed_DroneCAN::_detected_modules[];
 HAL_Semaphore AP_Airspeed_DroneCAN::_sem_registry;
 
-// constructor
-AP_Airspeed_DroneCAN::AP_Airspeed_DroneCAN(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
-{}
-
 void AP_Airspeed_DroneCAN::subscribe_msgs(AP_DroneCAN* ap_dronecan)
 {
     if (ap_dronecan == nullptr) {

--- a/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.h
@@ -14,7 +14,8 @@
 
 class AP_Airspeed_DroneCAN : public AP_Airspeed_Backend {
 public:
-    AP_Airspeed_DroneCAN(AP_Airspeed &_frontend, uint8_t _instance);
+
+    using AP_Airspeed_Backend::AP_Airspeed_Backend;
 
     bool init(void) override;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
@@ -27,7 +27,6 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Param/AP_Param.h>
 #include <AP_HAL/utility/OwnPtr.h>
 #include <AP_HAL/I2CDevice.h>
 #include <utility>

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
@@ -27,7 +27,6 @@
 #if AP_AIRSPEED_MS5525_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Param/AP_Param.h>
 #include <AP_HAL/utility/OwnPtr.h>
 #include <AP_HAL/I2CDevice.h>
 #include <utility>

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -30,13 +30,6 @@
 
 #define TIMEOUT_MS 2000
 
-extern const AP_HAL::HAL &hal;
-
-AP_Airspeed_NMEA::AP_Airspeed_NMEA(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
-{
-}
-
 bool AP_Airspeed_NMEA::init()
 {
     const AP_SerialManager& serial_manager = AP::serialmanager();

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.h
@@ -15,7 +15,8 @@
 class AP_Airspeed_NMEA : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_NMEA(AP_Airspeed &frontend, uint8_t _instance);
+
+    using AP_Airspeed_Backend::AP_Airspeed_Backend;
 
     // probe and initialise the sensor
     bool init(void) override;

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -42,11 +42,6 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Airspeed_SDP3X::AP_Airspeed_SDP3X(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
-{
-}
-
 /*
   send a 16 bit command code
  */

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
@@ -27,7 +27,6 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Param/AP_Param.h>
 #include <AP_HAL/utility/OwnPtr.h>
 #include <AP_HAL/I2CDevice.h>
 #include <utility>
@@ -42,8 +41,8 @@
 class AP_Airspeed_SDP3X : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_SDP3X(AP_Airspeed &frontend, uint8_t _instance);
-    ~AP_Airspeed_SDP3X(void) {}
+
+    using AP_Airspeed_Backend::AP_Airspeed_Backend;
 
     // probe and initialise the sensor
     bool init() override;

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.h
@@ -9,7 +9,6 @@
 #if AP_AIRSPEED_ANALOG_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Param/AP_Param.h>
 
 #include "AP_Airspeed_Backend.h"
 


### PR DESCRIPTION
... and clean out some unused includes

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           -8      -16               -16    -24    -24
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           -16     -16               -16    -24    -32
MatekF405                      *      *           *       *                 -16    -32    -32
Pixhawk1-1M-bdshot             *                  *       *                 -24    -24    -24
f103-QiotekPeriph   -24                                                                   
f303-Universal      -16                                                                   
iomcu                                                           *                         
revo-mini                      *      *           *       *                 -16    -32    -32
skyviper-v2450                                    *                                       

````
