### PR TITLE
AP_BattMonitor: move defines around battery types for consistency

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -174,7 +174,7 @@ class ExtractFeatures(object):
 
             ('AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED', r'RC_Channel::lookuptable',),
 
-            ('AP_NOTIFY_MAVLINK_PLAY_TUNE_SUPPORT_ENABLED', r'AP_Notify::play_tune'),
+            ('AP_NOTIFY_MAVLINK_PLAY_TUNE_SUPPORT_ENABLED', r'AP_Notify::handle_play_tune'),
             ('AP_NOTIFY_MAVLINK_LED_CONTROL_SUPPORT_ENABLED', r'AP_Notify::handle_led_control'),
             ('AP_NOTIFY_NCP5623_ENABLED', r'NCP5623::write'),
             ('AP_NOTIFY_PROFILED_ENABLED', r'ProfiLED::init_ports'),

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -305,21 +305,21 @@ AP_BattMonitor::init()
                 drivers[instance] = new AP_BattMonitor_SMBus_NeoDesign(*this, state[instance], _params[instance]);
                 break;
 #endif
-            case Type::BEBOP:
 #if AP_BATTERY_BEBOP_ENABLED
+            case Type::BEBOP:
                 drivers[instance] = new AP_BattMonitor_Bebop(*this, state[instance], _params[instance]);
-#endif
                 break;
-            case Type::UAVCAN_BatteryInfo:
+#endif
 #if AP_BATTERY_UAVCAN_BATTERYINFO_ENABLED
+            case Type::UAVCAN_BatteryInfo:
                 drivers[instance] = new AP_BattMonitor_DroneCAN(*this, state[instance], AP_BattMonitor_DroneCAN::UAVCAN_BATTERY_INFO, _params[instance]);
-#endif
                 break;
-            case Type::BLHeliESC:
+#endif
 #if AP_BATTERY_ESC_ENABLED
+            case Type::BLHeliESC:
                 drivers[instance] = new AP_BattMonitor_ESC(*this, state[instance], _params[instance]);
-#endif
                 break;
+#endif
 #if AP_BATTERY_SUM_ENABLED
             case Type::Sum:
                 drivers[instance] = new AP_BattMonitor_Sum(*this, state[instance], _params[instance], instance);


### PR DESCRIPTION
Makes all of the clauses in this switch look the same.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
