### PR TITLE
Logging: implement LOG_DISARMED=3 and LOG_DARM_RATEMAX

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -90,8 +90,8 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
 
     // @Param: _DISARMED
     // @DisplayName: Enable logging while disarmed
-    // @Description: If LOG_DISARMED is set to 1 then logging will be enabled at all times including when disarmed. Logging before arming can make for very large logfiles but can help a lot when tracking down startup issues and is necessary if logging of EKF replay data is selected via the LOG_REPLAY parameter. If LOG_DISARMED is set to 2, then logging will be enabled when disarmed, but not if a USB connection is detected. This can be used to prevent unwanted data logs being generated when the vehicle is connected via USB for log downloading or parameter changes.
-    // @Values: 0:Disabled,1:Enabled,2:Disabled on USB connection
+    // @Description: If LOG_DISARMED is set to 1 then logging will be enabled at all times including when disarmed. Logging before arming can make for very large logfiles but can help a lot when tracking down startup issues and is necessary if logging of EKF replay data is selected via the LOG_REPLAY parameter. If LOG_DISARMED is set to 2, then logging will be enabled when disarmed, but not if a USB connection is detected. This can be used to prevent unwanted data logs being generated when the vehicle is connected via USB for log downloading or parameter changes. If LOG_DISARMED is set to 3 then logging will happen while disarmed, but if the vehicle never arms then the logs using the filesystem backend will be discarded on the next boot.
+    // @Values: 0:Disabled,1:Enabled,2:Disabled on USB connection,3:Discard log on reboot if never armed
     // @User: Standard
     AP_GROUPINFO("_DISARMED",  2, AP_Logger, _params.log_disarmed,       0),
 
@@ -1469,6 +1469,7 @@ bool AP_Logger::log_while_disarmed(void) const
         return true;
     }
     if (_params.log_disarmed == LogDisarmed::LOG_WHILE_DISARMED ||
+        _params.log_disarmed == LogDisarmed::LOG_WHILE_DISARMED_DISCARD ||
         (_params.log_disarmed == LogDisarmed::LOG_WHILE_DISARMED_NOT_USB && !hal.gpio->usb_connected())) {
         return true;
     }

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -187,7 +187,7 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
 
     if (hal.util->was_watchdog_armed()) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Forcing logging for watchdog reset");
-        _params.log_disarmed.set(1);
+        _params.log_disarmed.set(LogDisarmed::LOG_WHILE_DISARMED);
     }
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     validate_structures(structures, num_types);
@@ -1468,7 +1468,8 @@ bool AP_Logger::log_while_disarmed(void) const
     if (_force_log_disarmed) {
         return true;
     }
-    if (_params.log_disarmed == 1 || (_params.log_disarmed == 2 && !hal.gpio->usb_connected())) {
+    if (_params.log_disarmed == LogDisarmed::LOG_WHILE_DISARMED ||
+        (_params.log_disarmed == LogDisarmed::LOG_WHILE_DISARMED_NOT_USB && !hal.gpio->usb_connected())) {
         return true;
     }
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -315,13 +315,19 @@ public:
 
     vehicle_startup_message_Writer _vehicle_messages;
 
+    enum class LogDisarmed : uint8_t {
+        NONE = 0,
+        LOG_WHILE_DISARMED = 1,
+        LOG_WHILE_DISARMED_NOT_USB = 2,
+    };
+
     // parameter support
     static const struct AP_Param::GroupInfo        var_info[];
     struct {
         AP_Int8 backend_types;
         AP_Int16 file_bufsize; // in kilobytes
         AP_Int8 file_disarm_rot;
-        AP_Int8 log_disarmed;
+        AP_Enum<LogDisarmed> log_disarmed;
         AP_Int8 log_replay;
         AP_Int8 mav_bufsize; // in kilobytes
         AP_Int16 file_timeout; // in seconds

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -319,6 +319,7 @@ public:
         NONE = 0,
         LOG_WHILE_DISARMED = 1,
         LOG_WHILE_DISARMED_NOT_USB = 2,
+        LOG_WHILE_DISARMED_DISCARD = 3,
     };
 
     // parameter support

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -311,6 +311,7 @@ public:
     void set_force_log_disarmed(bool force_logging) { _force_log_disarmed = force_logging; }
     void set_long_log_persist(bool b) { _force_long_log_persist = b; }
     bool log_while_disarmed(void) const;
+    bool in_log_persistance(void) const;
     uint8_t log_replay(void) const { return _params.log_replay; }
 
     vehicle_startup_message_Writer _vehicle_messages;
@@ -336,6 +337,7 @@ public:
         AP_Float file_ratemax;
         AP_Float mav_ratemax;
         AP_Float blk_ratemax;
+        AP_Float disarm_ratemax;
     } _params;
 
     const struct LogStructure *structure(uint16_t num) const;

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -671,22 +671,24 @@ void AP_Logger_Backend::df_stats_log() {
 
 
 // class to handle rate limiting of log messages
-AP_Logger_RateLimiter::AP_Logger_RateLimiter(const AP_Logger &_front, const AP_Float &_limit_hz)
-    : front(_front), rate_limit_hz(_limit_hz)
+AP_Logger_RateLimiter::AP_Logger_RateLimiter(const AP_Logger &_front, const AP_Float &_limit_hz, const AP_Float &_disarm_limit_hz)
+    : front(_front),
+      rate_limit_hz(_limit_hz),
+      disarm_rate_limit_hz(_disarm_limit_hz)
 {
 }
 
 /*
   return false if a streaming message should not be sent yet
  */
-bool AP_Logger_RateLimiter::should_log_streaming(uint8_t msgid)
+bool AP_Logger_RateLimiter::should_log_streaming(uint8_t msgid, float rate_hz)
 {
     if (front._log_pause) {
         return false;
     }
     const uint16_t now = AP_HAL::millis16();
     uint16_t delta_ms = now - last_send_ms[msgid];
-    if (delta_ms < 1000.0 / rate_limit_hz.get()) {
+    if (is_positive(rate_hz) && delta_ms < 1000.0 / rate_hz) {
         // too soon
         return false;
     }
@@ -700,7 +702,13 @@ bool AP_Logger_RateLimiter::should_log_streaming(uint8_t msgid)
  */
 bool AP_Logger_RateLimiter::should_log(uint8_t msgid, bool writev_streaming)
 {
-    if (rate_limit_hz <= 0 && !front._log_pause) {
+    float rate_hz = rate_limit_hz;
+    if (!hal.util->get_soft_armed() &&
+        !AP::logger().in_log_persistance() &&
+        !is_zero(disarm_rate_limit_hz)) {
+        rate_hz = disarm_rate_limit_hz;
+    }
+    if (!is_positive(rate_hz) && !front._log_pause) {
         // no rate limiting if not paused and rate is zero(user changed the parameter)
         return true;
     }
@@ -728,7 +736,7 @@ bool AP_Logger_RateLimiter::should_log(uint8_t msgid, bool writev_streaming)
     last_sched_count[msgid] = sched_ticks;
 #endif
 
-    bool ret = should_log_streaming(msgid);
+    bool ret = should_log_streaming(msgid, rate_hz);
     if (ret) {
         last_return.set(msgid);
     } else {

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -12,15 +12,16 @@ class LoggerMessageWriter_DFLogStart;
 class AP_Logger_RateLimiter
 {
 public:
-    AP_Logger_RateLimiter(const AP_Logger &_front, const AP_Float &_limit_hz);
+    AP_Logger_RateLimiter(const AP_Logger &_front, const AP_Float &_limit_hz, const AP_Float &_disarm_limit_hz);
 
     // return true if message passes the rate limit test
     bool should_log(uint8_t msgid, bool writev_streaming);
-    bool should_log_streaming(uint8_t msgid);
+    bool should_log_streaming(uint8_t msgid, float rate_hz);
 
 private:
     const AP_Logger &front;
     const AP_Float &rate_limit_hz;
+    const AP_Float &disarm_rate_limit_hz;
 
     // time in ms we last sent this message
     uint16_t last_send_ms[256];

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -307,9 +307,12 @@ void AP_Logger_Block::periodic_1Hz()
 {
     AP_Logger_Backend::periodic_1Hz();
 
-    if (rate_limiter == nullptr && (_front._params.blk_ratemax > 0 || _front._log_pause)) {
+    if (rate_limiter == nullptr &&
+        (_front._params.blk_ratemax > 0 ||
+         _front._params.disarm_ratemax > 0 ||
+         _front._log_pause)) {
         // setup rate limiting if log rate max > 0Hz or log pause of streaming entries is requested
-        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.blk_ratemax);
+        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.blk_ratemax, _front._params.disarm_ratemax);
     }
     
     if (!io_thread_alive()) {

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -94,6 +94,16 @@ void AP_Logger_File::Init()
         _log_directory = custom_dir;
     }
 
+    uint16_t last_log_num = find_last_log();
+    if (last_log_is_marked_discard) {
+        // delete the last log leftover from LOG_DISARMED=3
+        char *filename = _log_file_name(last_log_num);
+        if (filename != nullptr) {
+            AP::FS().unlink(filename);
+            free(filename);
+        }
+    }
+
     Prep_MinSpace();
 }
 
@@ -518,8 +528,13 @@ uint16_t AP_Logger_File::find_last_log()
     EXPECT_DELAY_MS(3000);
     FileData *fd = AP::FS().load_file(fname);
     free(fname);
+    last_log_is_marked_discard = false;
     if (fd != nullptr) {
-        ret = strtol((const char *)fd->data, nullptr, 10);
+        char *endptr = nullptr;
+        ret = strtol((const char *)fd->data, &endptr, 10);
+        if (endptr != nullptr) {
+            last_log_is_marked_discard = *endptr == 'D';
+        }
         delete fd;
     }
     return ret;
@@ -847,30 +862,34 @@ void AP_Logger_File::start_new_log(void)
     write_fd_semaphore.give();
 
     // now update lastlog.txt with the new log number
+    last_log_is_marked_discard = _front._params.log_disarmed == AP_Logger::LogDisarmed::LOG_WHILE_DISARMED_DISCARD;
+    if (!write_lastlog_file(log_num)) {
+        _open_error_ms = AP_HAL::millis();
+    }
+}
+
+/*
+  write LASTLOG.TXT, possibly with a discard marker
+ */
+bool AP_Logger_File::write_lastlog_file(uint16_t log_num)
+{
+    // now update lastlog.txt with the new log number
     char *fname = _lastlog_file_name();
 
     EXPECT_DELAY_MS(3000);
     int fd = AP::FS().open(fname, O_WRONLY|O_CREAT);
     free(fname);
     if (fd == -1) {
-        _open_error_ms = AP_HAL::millis();
-        return;
+        return false;
     }
 
     char buf[30];
-    snprintf(buf, sizeof(buf), "%u\r\n", (unsigned)log_num);
+    snprintf(buf, sizeof(buf), "%u%s\r\n", (unsigned)log_num, last_log_is_marked_discard?"D":"");
     const ssize_t to_write = strlen(buf);
     const ssize_t written = AP::FS().write(fd, buf, to_write);
     AP::FS().close(fd);
-
-    if (written < to_write) {
-        _open_error_ms = AP_HAL::millis();
-        return;
-    }
-
-    return;
+    return written == to_write;
 }
-
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 void AP_Logger_File::flush(void)
@@ -919,6 +938,13 @@ void AP_Logger_File::io_timer(void)
 
     if (_write_fd == -1 || !_initialised || recent_open_error()) {
         return;
+    }
+
+    if (last_log_is_marked_discard && hal.util->get_soft_armed()) {
+        // time to make the log permanent
+        const auto log_num = find_last_log();
+        last_log_is_marked_discard = false;
+        write_lastlog_file(log_num);
     }
 
     uint32_t nbytes = _writebuf.available();

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -164,9 +164,12 @@ void AP_Logger_File::periodic_1Hz()
         }
     }
 
-    if (rate_limiter == nullptr && (_front._params.file_ratemax > 0 || _front._log_pause)) {
+    if (rate_limiter == nullptr &&
+        (_front._params.file_ratemax > 0 ||
+         _front._params.disarm_ratemax > 0 ||
+         _front._log_pause)) {
         // setup rate limiting if log rate max > 0Hz or log pause of streaming entries is requested
-        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.file_ratemax);
+        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.file_ratemax, _front._params.disarm_ratemax);
     }
 }
 

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -70,6 +70,7 @@ protected:
 private:
     int _write_fd = -1;
     char *_write_filename;
+    bool last_log_is_marked_discard;
     uint32_t _last_write_ms;
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     bool _need_rtc_update;
@@ -101,6 +102,7 @@ private:
     bool log_exists(const uint16_t lognum) const;
 
     bool dirent_to_log_num(const dirent *de, uint16_t &log_num) const;
+    bool write_lastlog_file(uint16_t log_num);
 
     // write buffer
     ByteBuffer _writebuf{0};

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -530,9 +530,12 @@ void AP_Logger_MAVLink::periodic_10Hz(const uint32_t now)
 }
 void AP_Logger_MAVLink::periodic_1Hz()
 {
-    if (rate_limiter == nullptr && (_front._params.mav_ratemax > 0 || _front._log_pause)) {
+    if (rate_limiter == nullptr &&
+        (_front._params.mav_ratemax > 0 ||
+         _front._params.disarm_ratemax > 0 ||
+         _front._log_pause)) {
         // setup rate limiting if log rate max > 0Hz or log pause of streaming entries is requested
-        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.mav_ratemax);
+        rate_limiter = new AP_Logger_RateLimiter(_front, _front._params.mav_ratemax, _front._params.disarm_ratemax);
     }
 
     if (_sending_to_client &&

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -1018,6 +1018,9 @@ public:
     operator const eclass () const {
         return (eclass)_value;
     }
+    void set(eclass v) {
+        AP_Int8::set(int8_t(v));
+    }
 };
 
 template<typename eclass>
@@ -1026,5 +1029,8 @@ class AP_Enum16 : public AP_Int16
 public:
     operator const eclass () const {
         return (eclass)_value;
+    }
+    void set(eclass v) {
+        AP_Int16::set(int16_t(v));
     }
 };


### PR DESCRIPTION
This adds a nice option for disarmed logging without taking up a lot of space on the microSD.

Setting LOG_DISARMED=3 will log while disarmed, but the file is marked to be discarded on reboot. The marker is removed when we arm. 

The LOG_DARM_RATEMAX parameter allows to set the max logging rate while disarmed. In combination with LOG_DISARMED=3 you can get logging while disarmed with very little increase in log file size.

For replay logging we would use:
 - LOG_DISARMED=3
 - LOG_REPLAY=1
 - LOG_DARM_RATEMAX=1

this will give very nice replay logging while minimising log sizes. 
