### PR TITLE
.pre-commit: Enfore code style for AP_DDS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,12 @@ repos:
       hooks:
         - id: format-xmllint
           files: libraries/AP_DDS/dds_xrce_profile.xml
-# Disable isort and mypy temporarily due to config conflicts
+  -   repo: https://github.com/psf/black
+      rev: 23.1.0
+      hooks:
+        - id: black
+          files: libraries\/AP_DDS\/(wscript|.*\.py)$
+
 # # Use to sort python imports by name and put system import first.
 #   -   repo: https://github.com/pycqa/isort
 #       rev: 5.12.0


### PR DESCRIPTION
This enforces black code style in AP_DDS.

Black is nice because it can run in CI, as well as run in editor, without a user manually modifying their code to satisfy the linter. 

Since black is cross-platform, and the version is specified as 23.1.0, everyone edits with the same version. 

The next step would be to enforce the same rules in CI because pre-commit hooks are not mandatory. 

Question for maintainers - is there going to be any conflict by formatting AP_DDS to this code style with the other tooling in the repo?

