### PR TITLE
Fix SDIO PWRSAV on F4/F7 and MMC SPI reads

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
@@ -466,6 +466,7 @@
 #define STM32_SDC_READ_TIMEOUT_MS           1000
 #define STM32_SDC_CLOCK_ACTIVATION_DELAY    10
 #define STM32_SDC_SDIO_UNALIGNED_SUPPORT    TRUE
+#define STM32_SDC_SDIO_PWRSAV               TRUE
 
 /*
  * SERIAL driver system settings.


### PR DESCRIPTION
This fixes ChibiOS so that https://github.com/ArduPilot/ardupilot/pull/23455 is unnecessary