### PR TITLE
Plane: fix bug in RTL_AUTOLAND with rally points

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -348,6 +348,7 @@ void Plane::do_RTL(int32_t rtl_altitude_AMSL_cm)
     next_WP_loc = calc_best_rally_or_home_location(current_loc, rtl_altitude_AMSL_cm);
     setup_terrain_target_alt(next_WP_loc);
     set_target_altitude_location(next_WP_loc);
+    plane.altitude_error_cm = calc_altitude_error_cm();
 
     if (aparm.loiter_radius < 0) {
         loiter.direction = -1;


### PR DESCRIPTION
After loading the rally point, `ModeRTL:navigate` checks if rally altitude has been reached before `altitude_error_cm` gets updated:

What this means is that with `RTL_AUTOLAND = 1`, if RTL is entered near a rally point, it will skip straight to the landing sequence instead of climbing to the rally point's altitude first.

Instead of the fix in this PR, is there a reason we don't update this variable inside of `Plane::set_target_altitude_location`? That would seem to be the better place to do it, but I wasn't 100% sure. There are multiple places where we set the altitude error variable immediately after this function:
https://github.com/ArduPilot/ardupilot/blob/50eaa1cc549cfbaa877d165255f68037459f3c3e/ArduPlane/mode_guided.cpp#L88-L89
https://github.com/ArduPilot/ardupilot/blob/5c3d464754c1be40fdaffed355a59a27e033cdc2/ArduPlane/mode_qrtl.cpp#L199-L200