### PR TITLE
AP_Camera: add zoom percent control

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -233,11 +233,11 @@ MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
         return MAV_RESULT_ACCEPTED;
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (is_equal(packet.param1, (float)ZOOM_TYPE_CONTINUOUS) &&
-            set_zoom(AP_Camera::ZoomType::RATE, packet.param2)) {
+            set_zoom(ZoomType::RATE, packet.param2)) {
             return MAV_RESULT_ACCEPTED;
         }
         if (is_equal(packet.param1, (float)ZOOM_TYPE_RANGE) &&
-            set_zoom(AP_Camera::ZoomType::PCT, packet.param2)) {
+            set_zoom(ZoomType::PCT, packet.param2)) {
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_UNSUPPORTED;

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -4,12 +4,8 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
-#include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
-#include <AP_Mount/AP_Mount.h>
 #include "AP_Camera_Backend.h"
 #include "AP_Camera_Servo.h"
 #include "AP_Camera_Relay.h"

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -13,18 +13,6 @@
 #include "AP_Camera_Params.h"
 #include "AP_Mount/AP_Mount_config.h"
 
-#if AP_CAMERA_SCRIPTING_ENABLED
-    // structure and accessors for use by scripting backends
-    typedef struct {
-        uint16_t take_pic_incr; // incremented each time camera is requested to take a picture
-        bool recording_video;   // true when recording video
-        uint8_t zoom_type;      // zoom AP_Camera::ZoomType enum (1:Rate or 2:Pct)
-        float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
-        int8_t focus_step;      // focus in = -1, focus hold = 0, focus out = 1
-        bool auto_focus;        // true when auto focusing
-    } camera_state_t;
-#endif
-
 #define AP_CAMERA_MAX_INSTANCES             2       // maximum number of camera backends
 
 // declare backend classes
@@ -146,6 +134,16 @@ public:
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 
 #if AP_CAMERA_SCRIPTING_ENABLED
+    // structure and accessors for use by scripting backends
+    typedef struct {
+        uint16_t take_pic_incr; // incremented each time camera is requested to take a picture
+        bool recording_video;   // true when recording video
+        uint8_t zoom_type;      // see AP_Camera::ZoomType enum (1:Rate or 2:Pct)
+        float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
+        int8_t focus_step;      // focus in = -1, focus hold = 0, focus out = 1
+        bool auto_focus;        // true when auto focusing
+    } camera_state_t;
+
     // accessor to allow scripting backend to retrieve state
     // returns true on success and cam_state is filled in
     bool get_state(uint8_t instance, camera_state_t& cam_state);

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -6,12 +6,9 @@
 
 #if AP_CAMERA_ENABLED
 
-#include <AP_Common/Location.h>
-#include <AP_Logger/LogStructure.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AP_Camera_Params.h"
-#include "AP_Mount/AP_Mount_config.h"
 
 #define AP_CAMERA_MAX_INSTANCES             2       // maximum number of camera backends
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -18,7 +18,8 @@
     typedef struct {
         uint16_t take_pic_incr; // incremented each time camera is requested to take a picture
         bool recording_video;   // true when recording video
-        int8_t zoom_step;       // zoom out = -1, hold = 0, zoom in = 1
+        uint8_t zoom_type;      // zoom AP_Camera::ZoomType enum (1:Rate or 2:Pct)
+        float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
         int8_t focus_step;      // focus in = -1, focus hold = 0, focus out = 1
         bool auto_focus;        // true when auto focusing
     } camera_state_t;
@@ -123,10 +124,14 @@ public:
     bool record_video(bool start_recording);
     bool record_video(uint8_t instance, bool start_recording);
 
-    // zoom in, out or hold
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step);
-    bool set_zoom_step(uint8_t instance, int8_t zoom_step);
+    // set zoom specified as a rate or percentage
+    // enumerators match MAVLink CAMERA_ZOOM_TYPE
+    enum class ZoomType : uint8_t {
+        RATE = 1,   // zoom in, out or hold (zoom out = -1, hold = 0, zoom in = 1). Same as ZOOM_TYPE_CONTINUOUS
+        PCT = 2     // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
+    };
+    bool set_zoom(ZoomType zoom_type, float zoom_value);
+    bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
 
     // focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -9,6 +9,7 @@
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AP_Camera_Params.h"
+#include "AP_Camera_shareddefs.h"
 
 #define AP_CAMERA_MAX_INSTANCES             2       // maximum number of camera backends
 
@@ -110,11 +111,6 @@ public:
     bool record_video(uint8_t instance, bool start_recording);
 
     // set zoom specified as a rate or percentage
-    // enumerators match MAVLink CAMERA_ZOOM_TYPE
-    enum class ZoomType : uint8_t {
-        RATE = 1,   // zoom in, out or hold (zoom out = -1, hold = 0, zoom in = 1). Same as ZOOM_TYPE_CONTINUOUS
-        PCT = 2     // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
-    };
     bool set_zoom(ZoomType zoom_type, float zoom_value);
     bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
 
@@ -135,7 +131,7 @@ public:
     typedef struct {
         uint16_t take_pic_incr; // incremented each time camera is requested to take a picture
         bool recording_video;   // true when recording video
-        uint8_t zoom_type;      // see AP_Camera::ZoomType enum (1:Rate or 2:Pct)
+        uint8_t zoom_type;      // see ZoomType enum (1:Rate or 2:Pct)
         float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
         int8_t focus_step;      // focus in = -1, focus hold = 0, focus out = 1
         bool auto_focus;        // true when auto focusing

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -84,7 +84,7 @@ public:
 #if AP_CAMERA_SCRIPTING_ENABLED
     // accessor to allow scripting backend to retrieve state
     // returns true on success and cam_state is filled in
-    virtual bool get_state(camera_state_t& cam_state) { return false; }
+    virtual bool get_state(AP_Camera::camera_state_t& cam_state) { return false; }
 #endif
 
 protected:

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -23,6 +23,8 @@
 
 #if AP_CAMERA_ENABLED
 #include "AP_Camera.h"
+#include <AP_Common/Location.h>
+#include <AP_Logger/LogStructure.h>
 
 class AP_Camera_Backend
 {

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -56,9 +56,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     virtual bool record_video(bool start_recording) { return false; }
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    virtual bool set_zoom_step(int8_t zoom_step) { return false; }
+    // set zoom specified as a rate or percentage
+    virtual bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) { return false; }
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -59,7 +59,7 @@ public:
     virtual bool record_video(bool start_recording) { return false; }
 
     // set zoom specified as a rate or percentage
-    virtual bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) { return false; }
+    virtual bool set_zoom(ZoomType zoom_type, float zoom_value) { return false; }
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -65,7 +65,7 @@ bool AP_Camera_MAVLinkCamV2::record_video(bool start_recording)
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Camera_MAVLinkCamV2::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
+bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
 {
     // exit immediately if have not found camera or does not support zoom
     if (_link == nullptr || !(_cap_flags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM)) {
@@ -76,10 +76,10 @@ bool AP_Camera_MAVLinkCamV2::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_
     mavlink_command_long_t pkt {};
     pkt.command = MAV_CMD_SET_CAMERA_ZOOM;
     switch (zoom_type) {
-    case AP_Camera::ZoomType::RATE:
+    case ZoomType::RATE:
         pkt.param1 = ZOOM_TYPE_CONTINUOUS;
         break;
-    case AP_Camera::ZoomType::PCT:
+    case ZoomType::PCT:
         pkt.param1 = ZOOM_TYPE_RANGE;
         break;
     }

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -64,9 +64,8 @@ bool AP_Camera_MAVLinkCamV2::record_video(bool start_recording)
     return true;
 }
 
-// set camera zoom step.  returns true on success
-// zoom out = -1, hold = 0, zoom in = 1
-bool AP_Camera_MAVLinkCamV2::set_zoom_step(int8_t zoom_step)
+// set zoom specified as a rate or percentage
+bool AP_Camera_MAVLinkCamV2::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
 {
     // exit immediately if have not found camera or does not support zoom
     if (_link == nullptr || !(_cap_flags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM)) {
@@ -76,8 +75,15 @@ bool AP_Camera_MAVLinkCamV2::set_zoom_step(int8_t zoom_step)
     // prepare and send message
     mavlink_command_long_t pkt {};
     pkt.command = MAV_CMD_SET_CAMERA_ZOOM;
-    pkt.param1 = ZOOM_TYPE_CONTINUOUS;  // Zoom Type, 0:ZOOM_TYPE_STEP, 1:ZOOM_TYPE_CONTINUOUS, 2:ZOOM_TYPE_RANGE, 3:ZOOM_TYPE_FOCAL_LENGTH
-    pkt.param2 = zoom_step;             // Zoom Value
+    switch (zoom_type) {
+    case AP_Camera::ZoomType::RATE:
+        pkt.param1 = ZOOM_TYPE_CONTINUOUS;
+        break;
+    case AP_Camera::ZoomType::PCT:
+        pkt.param1 = ZOOM_TYPE_RANGE;
+        break;
+    }
+    pkt.param2 = zoom_value;            // Zoom Value
 
     _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
 

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -43,9 +43,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(bool start_recording) override;
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step) override;
+    // set zoom specified as a rate or percentage
+    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -44,7 +44,7 @@ public:
     bool record_video(bool start_recording) override;
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
+    bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -27,13 +27,12 @@ bool AP_Camera_Mount::record_video(bool start_recording)
     return false;
 }
 
-// zoom in, out or hold.  returns true on success
-// zoom out = -1, hold = 0, zoom in = 1
-bool AP_Camera_Mount::set_zoom_step(int8_t zoom_step)
+// set zoom specified as a rate or percentage
+bool AP_Camera_Mount::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_zoom_step(0, zoom_step);
+        return mount->set_zoom(0, zoom_type, zoom_value);
     }
     return false;
 }

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -28,7 +28,7 @@ bool AP_Camera_Mount::record_video(bool start_recording)
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Camera_Mount::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
+bool AP_Camera_Mount::set_zoom(ZoomType zoom_type, float zoom_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -40,7 +40,7 @@ public:
     bool record_video(bool start_recording) override;
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
+    bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -39,9 +39,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(bool start_recording) override;
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step) override;
+    // set zoom specified as a rate or percentage
+    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -47,7 +47,7 @@ bool AP_Camera_Scripting::set_auto_focus()
 
 // access for scripting backend to retrieve state
 // returns true on success and cam_state is filled in
-bool AP_Camera_Scripting::get_state(camera_state_t& cam_state)
+bool AP_Camera_Scripting::get_state(AP_Camera::camera_state_t& cam_state)
 {
     cam_state = _cam_state;
     return true;

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -21,7 +21,7 @@ bool AP_Camera_Scripting::record_video(bool start_recording)
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Camera_Scripting::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
+bool AP_Camera_Scripting::set_zoom(ZoomType zoom_type, float zoom_value)
 {
     _cam_state.zoom_type = (uint8_t)zoom_type;
     _cam_state.zoom_value = zoom_value;

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -20,11 +20,11 @@ bool AP_Camera_Scripting::record_video(bool start_recording)
     return true;
 }
 
-// set camera zoom step.  returns true on success
-// zoom out = -1, hold = 0, zoom in = 1
-bool AP_Camera_Scripting::set_zoom_step(int8_t zoom_step)
+// set zoom specified as a rate or percentage
+bool AP_Camera_Scripting::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
 {
-    _cam_state.zoom_step = zoom_step;
+    _cam_state.zoom_type = (uint8_t)zoom_type;
+    _cam_state.zoom_value = zoom_value;
     return true;
 }
 

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -40,7 +40,7 @@ public:
     bool record_video(bool start_recording) override;
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
+    bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -39,9 +39,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(bool start_recording) override;
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step) override;
+    // set zoom specified as a rate or percentage
+    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -50,12 +50,12 @@ public:
     bool set_auto_focus() override;
 
     // returns true on success and cam_state is filled in
-    bool get_state(camera_state_t& cam_state) override;
+    bool get_state(AP_Camera::camera_state_t& cam_state) override;
 
 private:
 
     // current state
-    camera_state_t _cam_state;
+    AP_Camera::camera_state_t _cam_state;
 };
 
 #endif // AP_CAMERA_SCRIPTING_ENABLED

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Camera related definitions required by both AP_Camera and AP_Mount are here
+// this avoids issues that would occur if AP_Mount and AP_Camera included each other
+
+#include <AP_Math/AP_Math.h>
+
+// set zoom specified as a rate or percentage
+// enumerators match MAVLink CAMERA_ZOOM_TYPE
+enum class ZoomType : uint8_t {
+    RATE = 1,   // zoom in, out or hold (zoom out = -1, hold = 0, zoom in = 1). Same as ZOOM_TYPE_CONTINUOUS
+    PCT = 2     // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
+};
+

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -131,8 +131,10 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_CONTINUOUS) {
-            camera->set_zoom_step(cmd.content.set_camera_zoom.zoom_value);
-            return true;
+            return camera->set_zoom(AP_Camera::ZoomType::RATE, cmd.content.set_camera_zoom.zoom_value);
+        }
+        if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_RANGE) {
+            return camera->set_zoom(AP_Camera::ZoomType::PCT, cmd.content.set_camera_zoom.zoom_value);
         }
         return false;
 

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -131,10 +131,10 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_CONTINUOUS) {
-            return camera->set_zoom(AP_Camera::ZoomType::RATE, cmd.content.set_camera_zoom.zoom_value);
+            return camera->set_zoom(ZoomType::RATE, cmd.content.set_camera_zoom.zoom_value);
         }
         if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_RANGE) {
-            return camera->set_zoom(AP_Camera::ZoomType::PCT, cmd.content.set_camera_zoom.zoom_value);
+            return camera->set_zoom(ZoomType::PCT, cmd.content.set_camera_zoom.zoom_value);
         }
         return false;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -621,15 +621,14 @@ bool AP_Mount::record_video(uint8_t instance, bool start_recording)
     return backend->record_video(start_recording);
 }
 
-// set camera zoom step.  returns true on success
-// zoom out = -1, hold = 0, zoom in = 1
-bool AP_Mount::set_zoom_step(uint8_t instance, int8_t zoom_step)
+// set zoom specified as a rate or percentage
+bool AP_Mount::set_zoom(uint8_t instance, AP_Camera::ZoomType zoom_type, float zoom_value)
 {
     auto *backend = get_instance(instance);
     if (backend == nullptr) {
         return false;
     }
-    return backend->set_zoom_step(zoom_step);
+    return backend->set_zoom(zoom_type, zoom_value);
 }
 
 // set focus in, out or hold.  returns true on success

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -622,7 +622,7 @@ bool AP_Mount::record_video(uint8_t instance, bool start_recording)
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Mount::set_zoom(uint8_t instance, AP_Camera::ZoomType zoom_type, float zoom_value)
+bool AP_Mount::set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value)
 {
     auto *backend = get_instance(instance);
     if (backend == nullptr) {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -27,7 +27,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <AP_Camera/AP_Camera.h>
+#include <AP_Camera/AP_Camera_shareddefs.h>
 #include "AP_Mount_Params.h"
 
 // maximum number of mounts
@@ -182,7 +182,7 @@ public:
     bool record_video(uint8_t instance, bool start_recording);
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(uint8_t instance, AP_Camera::ZoomType zoom_type, float zoom_value);
+    bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
 
     // set focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -27,6 +27,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Camera/AP_Camera.h>
 #include "AP_Mount_Params.h"
 
 // maximum number of mounts
@@ -180,9 +181,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(uint8_t instance, bool start_recording);
 
-    // set camera zoom step
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(uint8_t instance, int8_t zoom_step);
+    // set zoom specified as a rate or percentage
+    bool set_zoom(uint8_t instance, AP_Camera::ZoomType zoom_type, float zoom_value);
 
     // set focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -125,7 +125,7 @@ public:
     virtual bool record_video(bool start_recording) { return false; }
 
     // set zoom specified as a rate or percentage
-    virtual bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) { return false; }
+    virtual bool set_zoom(ZoomType zoom_type, float zoom_value) { return false; }
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -124,9 +124,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     virtual bool record_video(bool start_recording) { return false; }
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    virtual bool set_zoom_step(int8_t zoom_step) { return false; }
+    // set zoom specified as a rate or percentage
+    virtual bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) { return false; }
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -634,6 +634,7 @@ bool AP_Mount_Siyi::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
             zoom_step = 1;
         }
         if (zoom_value < 0) {
+            // Siyi API specifies -1 should be sent as 255
             zoom_step = UINT8_MAX;
         }
         return send_1byte_packet(SiyiCommandId::MANUAL_ZOOM_AND_AUTO_FOCUS, zoom_step);

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -626,9 +626,9 @@ bool AP_Mount_Siyi::record_video(bool start_recording)
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Mount_Siyi::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
+bool AP_Mount_Siyi::set_zoom(ZoomType zoom_type, float zoom_value)
 {
-    if (zoom_type == AP_Camera::ZoomType::RATE) {
+    if (zoom_type == ZoomType::RATE) {
         uint8_t zoom_step = 0;
         if (zoom_value > 0) {
             zoom_step = 1;

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -625,11 +625,22 @@ bool AP_Mount_Siyi::record_video(bool start_recording)
     return ret;
 }
 
-// set camera zoom step.  returns true on success
-// zoom out = -1, hold = 0, zoom in = 1
-bool AP_Mount_Siyi::set_zoom_step(int8_t zoom_step)
+// set zoom specified as a rate or percentage
+bool AP_Mount_Siyi::set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value)
 {
-    return send_1byte_packet(SiyiCommandId::MANUAL_ZOOM_AND_AUTO_FOCUS, (uint8_t)zoom_step);
+    if (zoom_type == AP_Camera::ZoomType::RATE) {
+        uint8_t zoom_step = 0;
+        if (zoom_value > 0) {
+            zoom_step = 1;
+        }
+        if (zoom_value < 0) {
+            zoom_step = UINT8_MAX;
+        }
+        return send_1byte_packet(SiyiCommandId::MANUAL_ZOOM_AND_AUTO_FOCUS, zoom_step);
+    }
+
+    // unsupported zoom type
+    return false;
 }
 
 // set focus in, out or hold.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -63,7 +63,7 @@ public:
     bool record_video(bool start_recording) override;
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
+    bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -62,9 +62,8 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(bool start_recording) override;
 
-    // set camera zoom step.  returns true on success
-    // zoom out = -1, hold = 0, zoom in = 1
-    bool set_zoom_step(int8_t zoom_step) override;
+    // set zoom specified as a rate or percentage
+    bool set_zoom(AP_Camera::ZoomType zoom_type, float zoom_value) override;
 
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1111,7 +1111,11 @@ function camera_state_t_ud:focus_step() end
 
 -- get field
 ---@return integer
-function camera_state_t_ud:zoom_step() end
+function camera_state_t_ud:zoom_type() end
+
+-- get field
+---@return number
+function camera_state_t_ud:zoom_value() end
 
 -- get field
 ---@return boolean

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1095,39 +1095,39 @@ function camera:record_video(instance, start_recording) end
 function camera:take_picture(instance) end
 
 -- desc
----@class camera_state_t_ud
-local camera_state_t_ud = {}
+---@class AP_Camera__camera_state_t_ud
+local AP_Camera__camera_state_t_ud = {}
 
----@return camera_state_t_ud
-function camera_state_t() end
+---@return AP_Camera__camera_state_t_ud
+function AP_Camera__camera_state_t() end
 
 -- get field
 ---@return boolean
-function camera_state_t_ud:auto_focus() end
+function AP_Camera__camera_state_t_ud:auto_focus() end
 
 -- get field
 ---@return integer
-function camera_state_t_ud:focus_step() end
-
--- get field
----@return integer
-function camera_state_t_ud:zoom_type() end
+function AP_Camera__camera_state_t_ud:focus_step() end
 
 -- get field
 ---@return number
-function camera_state_t_ud:zoom_value() end
-
--- get field
----@return boolean
-function camera_state_t_ud:recording_video() end
+function AP_Camera__camera_state_t_ud:zoom_value() end
 
 -- get field
 ---@return integer
-function camera_state_t_ud:take_pic_incr() end
+function AP_Camera__camera_state_t_ud:zoom_type() end
+
+-- get field
+---@return boolean
+function AP_Camera__camera_state_t_ud:recording_video() end
+
+-- get field
+---@return integer
+function AP_Camera__camera_state_t_ud:take_pic_incr() end
 
 -- desc
 ---@param instance integer
----@return camera_state_t_ud|nil
+---@return AP_Camera__camera_state_t_ud|nil
 function camera:get_state(instance) end
 
 -- desc

--- a/libraries/AP_Scripting/drivers/mount-viewpro-driver.md
+++ b/libraries/AP_Scripting/drivers/mount-viewpro-driver.md
@@ -21,4 +21,5 @@ Viewpro gimbal driver lua script
       6: IR1 13mm
       7: IR2 52mm
   Set VIEP_ZOOM_SPEED to control speed of zoom (value between 0 and 7)
-  Set VIEP_DEBUG = 1 or 2 to increase level of debug output to the GCS
+  Set VIEP_ZOOM_MAX to the maximum zoom.  E.g. for a camera with 20x zoom, set to 20
+  Optionally set VIEP_DEBUG = 1 or 2 to increase level of debug output to the GCS

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -613,7 +613,8 @@ singleton AP_Camera method set_trigger_distance void uint8_t'skip_check float'sk
 userdata camera_state_t depends (AP_CAMERA_SCRIPTING_ENABLED == 1)
 userdata camera_state_t field take_pic_incr uint16_t'skip_check read
 userdata camera_state_t field recording_video boolean read
-userdata camera_state_t field zoom_step int8_t'skip_check read
+userdata camera_state_t field zoom_type uint8_t'skip_check read
+userdata camera_state_t field zoom_value float'skip_check read
 userdata camera_state_t field focus_step int8_t'skip_check read
 userdata camera_state_t field auto_focus boolean read
 singleton AP_Camera method get_state boolean uint8_t'skip_check camera_state_t'Null

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -610,14 +610,14 @@ singleton AP_Camera semaphore
 singleton AP_Camera method take_picture void uint8_t'skip_check
 singleton AP_Camera method record_video boolean uint8_t'skip_check boolean
 singleton AP_Camera method set_trigger_distance void uint8_t'skip_check float'skip_check
-userdata camera_state_t depends (AP_CAMERA_SCRIPTING_ENABLED == 1)
-userdata camera_state_t field take_pic_incr uint16_t'skip_check read
-userdata camera_state_t field recording_video boolean read
-userdata camera_state_t field zoom_type uint8_t'skip_check read
-userdata camera_state_t field zoom_value float'skip_check read
-userdata camera_state_t field focus_step int8_t'skip_check read
-userdata camera_state_t field auto_focus boolean read
-singleton AP_Camera method get_state boolean uint8_t'skip_check camera_state_t'Null
+userdata AP_Camera::camera_state_t depends (AP_CAMERA_SCRIPTING_ENABLED == 1)
+userdata AP_Camera::camera_state_t field take_pic_incr uint16_t'skip_check read
+userdata AP_Camera::camera_state_t field recording_video boolean read
+userdata AP_Camera::camera_state_t field zoom_type uint8_t'skip_check read
+userdata AP_Camera::camera_state_t field zoom_value float'skip_check read
+userdata AP_Camera::camera_state_t field focus_step int8_t'skip_check read
+userdata AP_Camera::camera_state_t field auto_focus boolean read
+singleton AP_Camera method get_state boolean uint8_t'skip_check AP_Camera::camera_state_t'Null
 
 include AP_Winch/AP_Winch.h
 singleton AP_Winch depends AP_WINCH_ENABLED && APM_BUILD_COPTER_OR_HELI

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -945,7 +945,7 @@ bool RC_Channel::do_aux_function_camera_zoom(const AuxSwitchPos ch_flag)
         zoom_step = -1; // zoom out
         break;
     }
-    return camera->set_zoom_step(zoom_step);
+    return camera->set_zoom(AP_Camera::ZoomType::RATE, zoom_step);
 }
 
 bool RC_Channel::do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag)

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -945,7 +945,7 @@ bool RC_Channel::do_aux_function_camera_zoom(const AuxSwitchPos ch_flag)
         zoom_step = -1; // zoom out
         break;
     }
-    return camera->set_zoom(AP_Camera::ZoomType::RATE, zoom_step);
+    return camera->set_zoom(ZoomType::RATE, zoom_step);
 }
 
 bool RC_Channel::do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag)


### PR DESCRIPTION
This enhances AP_Camera to support a new "percentage" zoom type.  E.g. the user can specify they would like the camera to zoom to a percentage (expressed as a value from 0 to 100%) of its maximum.

For now only the MAVLinkCamV2 and Scripting backends (e.g. ViewPro) make use of this feature.  The Siyi ZR10 can apparently also support this feature but I haven't done this yet because it shares a driver with the Siyi A8 which doesn't have this ability.

There are two questionable parts to this PR:

- [x] The AP_Camera::ZoomType enum is separate from MAVLink's ZOOM_TYPE enum to reduce dependency on MAVLink (a hopeless cause?) but for whatever reason I kept the enumerator values the same between the two
- [x] The AP_Camera camera_state_t structure is currently declared outside the AP_Camera class because I ran into some issues with Scripting bindings.  This means I needed to declare its zoom_type field as a uint8_t instead of as a AP_Camera::ZoomType.  I think I can fix this though.

Below is an screenshot from a test in which the SET_CAMERA_ZOOM command was used to zoom a ViewPro camera to 25% of its maximum.
![image](https://user-images.githubusercontent.com/1498098/231618149-fdbdc79a-58e6-4efe-90f2-da35ed64b5d2.png)

The command can also be sent as a real-time command from a GCS so that a user can be presented with a slider from 0% to 100% instead of (or in addition to) "zoom in", "zoom out" buttons.

This has been tested on a ViewPro and a Siyi A8.  I will ask the Gremsy engineers to confirm this works with the ZIO camera as well.
