### PR TITLE
AP_Logger: do not rotate logs when disarming if we are replay-logging

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -612,7 +612,8 @@ uint16_t AP_Logger_Backend::find_oldest_log()
 
 void AP_Logger_Backend::vehicle_was_disarmed()
 {
-    if (_front._params.file_disarm_rot) {
+    if (_front._params.file_disarm_rot &&
+        !_front._params.log_replay) {
         // rotate our log.  Closing the current one and letting the
         // logging restart naturally based on log_disarmed should do
         // the trick:


### PR DESCRIPTION
You really don't want your nice replay log having holes in the middle.  So ignore the request to rotate on disarm if we are doing replay logging.
