### PR TITLE
AP_GPS_NMEA: fix stringop truncation failure on g++ 9

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -776,7 +776,7 @@ void AP_GPS_NMEA::parse_versiona_field(uint16_t term_number, const char *term)
     // ::printf("VERSIONA[%u]='%s'\n", term_number, term);
     auto &v = _versiona;
 #pragma GCC diagnostic push
-#if defined(__GNUC__) &&  __GNUC__ >= 10
+#if defined(__GNUC__) &&  __GNUC__ >= 9
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
     switch (term_number) {


### PR DESCRIPTION
```../../libraries/AP_GPS/AP_GPS_NMEA.cpp: In member function 'void AP_GPS_NMEA::parse_versiona_field(uint16_t, const char*)':
../../libraries/AP_GPS/AP_GPS_NMEA.cpp:787:16: error: 'char* strncpy(char*, const char*, size_t)' output may be truncated copying 19 bytes from a string of length 29 [-Werror=stringop-truncation]
  787 |         strncpy(v.version, _term, sizeof(v.version)-1);
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
```

```
pbarker@fx:~/rc/ardupilot(pr/AP_RANGEFINDER_ENABLED)$ arm-none-eabi-g++ --version
arm-none-eabi-g++ (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
```
