### PR TITLE
AP_Periph: use CopyFieldsFrom in CAN parameters

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -105,37 +105,23 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     GARRAY(can_protocol,     0, "CAN_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
     
     // @Param: CAN2_BAUDRATE
+    // @CopyFieldsFrom: CAN_BAUDRATE
     // @DisplayName: Bitrate of CAN2 interface
-    // @Description: Bit rate can be set up to from 10000 to 1000000
-    // @Range: 10000 1000000
-    // @User: Advanced
-    // @RebootRequired: True
     GARRAY(can_baudrate,     1, "CAN2_BAUDRATE", 1000000),
 
     // @Param: CAN2_PROTOCOL
-    // @DisplayName: Enable use of specific protocol to be used on this port
-    // @Description: Enabling this option starts selected protocol that will use this virtual driver. At least one CAN port must be UAVCAN or else CAN1 gets set to UAVCAN
-    // @Values: 0:Disabled,1:UAVCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN
-    // @User: Advanced
-    // @RebootRequired: True
+    // @CopyFieldsFrom: CAN_PROTOCOL
     GARRAY(can_protocol,     1, "CAN2_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
 #endif
 
 #if HAL_NUM_CAN_IFACES >= 3
     // @Param: CAN3_BAUDRATE
     // @DisplayName: Bitrate of CAN3 interface
-    // @Description: Bit rate can be set up to from 10000 to 1000000
-    // @Range: 10000 1000000
-    // @User: Advanced
-    // @RebootRequired: True
+    // @CopyFieldsFrom: CAN_BAUDRATE
     GARRAY(can_baudrate,    2, "CAN3_BAUDRATE", 1000000),
 
     // @Param: CAN3_PROTOCOL
-    // @DisplayName: Enable use of specific protocol to be used on this port
-    // @Description: Enabling this option starts selected protocol that will use this virtual driver. At least one CAN port must be UAVCAN or else CAN1 gets set to UAVCAN
-    // @Values: 0:Disabled,1:UAVCAN,4:PiccoloCAN,5:CANTester,6:EFI_NWPMU,7:USD1,8:KDECAN
-    // @User: Advanced
-    // @RebootRequired: True
+    // @CopyFieldsFrom: CAN_PROTOCOL
     GARRAY(can_protocol,    2, "CAN3_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
 #endif
 
@@ -158,11 +144,9 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
 #if HAL_NUM_CAN_IFACES >= 2
     // @Param: CAN2_FDBAUDRATE
+    // @CopyFieldsFrom: CAN_FDBAUDRATE
     // @DisplayName: Set up bitrate for data section on CAN2
     // @Description: This sets the bitrate for the data section of CAN2.
-    // @Values: 1:1M, 2:2M, 4:4M, 5:5M, 8:8M
-    // @User: Advanced
-    // @RebootRequired: True
     GARRAY(can_fdbaudrate,    1, "CAN2_FDBAUDRATE", HAL_CANFD_SUPPORTED),
 #endif
 #endif


### PR DESCRIPTION
Just some field reordering in the output:

```
pbarker@fx:~/rc/ardupilot(master)$ diff -u apm.pdef.xml apm.pdef.xml-new
--- apm.pdef.xml	2023-04-14 10:19:50.930351254 +1000
+++ apm.pdef.xml-new	2023-04-14 10:19:37.934244084 +1000
@@ -38,6 +38,7 @@
         <field name="RebootRequired">True</field>
       </param>
       <param humanName="Enable use of specific protocol to be used on this port" name="AP_Periph:CAN2_PROTOCOL" documentation="Enabling this option starts selected protocol that will use this virtual driver. At least one CAN port must be UAVCAN or else CAN1 gets set to UAVCAN" user="Advanced">
+        <field name="RebootRequired">True</field>
         <values>
           <value code="0">Disabled</value>
           <value code="1">UAVCAN</value>
@@ -47,13 +48,13 @@
           <value code="7">USD1</value>
           <value code="8">KDECAN</value>
         </values>
-        <field name="RebootRequired">True</field>
       </param>
       <param humanName="Bitrate of CAN3 interface" name="AP_Periph:CAN3_BAUDRATE" documentation="Bit rate can be set up to from 10000 to 1000000" user="Advanced">
         <field name="Range">10000 1000000</field>
         <field name="RebootRequired">True</field>
       </param>
       <param humanName="Enable use of specific protocol to be used on this port" name="AP_Periph:CAN3_PROTOCOL" documentation="Enabling this option starts selected protocol that will use this virtual driver. At least one CAN port must be UAVCAN or else CAN1 gets set to UAVCAN" user="Advanced">
+        <field name="RebootRequired">True</field>
         <values>
           <value code="0">Disabled</value>
           <value code="1">UAVCAN</value>
@@ -63,7 +64,6 @@
           <value code="7">USD1</value>
           <value code="8">KDECAN</value>
         </values>
-        <field name="RebootRequired">True</field>
       </param>
       <param humanName="Enable CANFD mode" name="AP_Periph:CAN_FDMODE" documentation="Enabling this option sets the CAN bus to be in CANFD mode with BRS." user="Advanced">
         <values>
@@ -83,6 +83,7 @@
         <field name="RebootRequired">True</field>
       </param>
       <param humanName="Set up bitrate for data section on CAN2" name="AP_Periph:CAN2_FDBAUDRATE" documentation="This sets the bitrate for the data section of CAN2." user="Advanced">
+        <field name="RebootRequired">True</field>
         <values>
           <value code="1">1M</value>
           <value code="2">2M</value>
@@ -90,7 +91,6 @@
           <value code="5">5M</value>
           <value code="8">8M</value>
         </values>
-        <field name="RebootRequired">True</field>
       </param>
       <param humanName="Trigger bootloader update" name="AP_Periph:FLASH_BOOTLOADER" documentation="DANGER! When enabled, the App will perform a bootloader update by copying the embedded bootloader over the existing bootloader. This may take a few seconds to perform and should only be done if you know what you're doing." user="Advanced">
         <field name="Range">0 1</field>
```