### PR TITLE
AP_DDS: Local Pose Publisher

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -10,6 +10,7 @@
 #include "sensor_msgs/msg/NavSatFix.h"
 #include "tf2_msgs/msg/TFMessage.h"
 #include "sensor_msgs/msg/BatteryState.h"
+#include "geometry_msgs/msg/PoseStamped.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Scheduler.h>
@@ -46,6 +47,7 @@ private:
     sensor_msgs_msg_NavSatFix nav_sat_fix_topic;
     tf2_msgs_msg_TFMessage static_transforms_topic;
     sensor_msgs_msg_BatteryState battery_state_topic;
+    geometry_msgs_msg_PoseStamped local_pose_topic;
 
     HAL_Semaphore csem;
 
@@ -56,6 +58,7 @@ private:
     bool update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance) WARN_IF_UNUSED;
     static void populate_static_transforms(tf2_msgs_msg_TFMessage& msg);
     static void update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_t instance);
+    static void update_topic(geometry_msgs_msg_PoseStamped& msg);
 
     // The last ms timestamp AP_DDS wrote a Time message
     uint64_t last_time_time_ms;
@@ -63,6 +66,8 @@ private:
     uint64_t last_nav_sat_fix_time_ms;
     // The last ms timestamp AP_DDS wrote a BatteryState message
     uint64_t last_battery_state_time_ms;
+    // The last ms timestamp AP_DDS wrote a Local Pose message
+    uint64_t last_local_pose_time_ms;
 
 
 public:
@@ -88,6 +93,8 @@ public:
     void write_static_transforms();
     //! @brief Serialize the current nav_sat_fix state and publish it to the IO stream(s)
     void write_battery_state_topic();
+    //! @brief Serialize the current local pose and publish to the IO stream(s)
+    void write_local_pose_topic();
     //! @brief Update the internally stored DDS messages with latest data
     void update();
 

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -52,4 +52,14 @@ const struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .deserialize = Generic_deserialize_topic_fn_t(&sensor_msgs_msg_BatteryState_deserialize_topic),
         .size_of = Generic_size_of_topic_fn_t(&sensor_msgs_msg_BatteryState_size_of_topic),
     },
+    {
+        .topic_id = 0x05,
+        .pub_id = 0x05,
+        .dw_id = uxrObjectId{.id=0x05, .type=UXR_DATAWRITER_ID},
+        .topic_profile_label = "localpose__t",
+        .dw_profile_label = "localpose__dw",
+        .serialize = Generic_serialize_topic_fn_t(&geometry_msgs_msg_PoseStamped_serialize_topic),
+        .deserialize = Generic_deserialize_topic_fn_t(&geometry_msgs_msg_PoseStamped_deserialize_topic),
+        .size_of = Generic_size_of_topic_fn_t(&geometry_msgs_msg_PoseStamped_size_of_topic),
+    },
 };

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -114,4 +114,32 @@
       </historyQos>
     </topic>
   </data_writer>
+  <topic profile_name="localpose__t">
+    <name>rt/ROS2_LocalPose</name>
+    <dataType>geometry_msgs::msg::dds_::PoseStamped_</dataType>
+    <historyQos>
+      <kind>KEEP_LAST</kind>
+      <depth>5</depth>
+    </historyQos>
+  </topic>
+  <data_writer profile_name="localpose__dw">
+    <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
+    <qos>
+      <reliability>
+        <kind>BEST_EFFORT</kind>
+      </reliability>
+      <durability>
+        <kind>VOLATILE</kind>
+      </durability>
+    </qos>
+    <topic>
+      <kind>NO_KEY</kind>
+      <name>rt/ROS2_LocalPose</name>
+      <dataType>geometry_msgs::msg::dds_::PoseStamped_</dataType>
+      <historyQos>
+        <kind>KEEP_LAST</kind>
+        <depth>5</depth>
+      </historyQos>
+    </topic>
+  </data_writer>
 </profiles>


### PR DESCRIPTION
Resolves #23278, here is the PR working on SITL:
![Screenshot from 2023-04-14 00-08-55](https://user-images.githubusercontent.com/62964137/231931691-8fe8a6ec-f366-4c22-8ccd-e6c6eba1d385.png)
The NED to ENU conversion seemed fine when I analysed the position coordinates of a plane flying in SITL. As you can see in the screenshot the plane went North-West after takeoff which resulted in a negative X axis (points towards east in ENU) and a positive Y axis (points towards north in ENU). Z is positive after takeoff.