### PR TITLE
Rover: Arming: still run mandatory checks if ARMING_CHECK 0

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -78,7 +78,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
 
     //are arming checks disabled?
     if (checks_to_perform == 0) {
-        return true;
+        return mandatory_checks(report);
     }
 
     if (rover.g2.sailboat.sail_enabled() && !rover.g2.windvane.enabled()) {


### PR DESCRIPTION
Currently arming check 0 on Rover skips all checks, whereas if you force arm from the GCS you still get the mandatory checks. This bring them both inline, and inline with copter and soon plane https://github.com/ArduPilot/ardupilot/pull/23189

Rover does not have have any extra mandatory checks, so its just the base method.

https://github.com/ArduPilot/ardupilot/blob/9cc8622ccc59cd2a64f06d79af53f91d8e4f36b1/libraries/AP_Arming/AP_Arming.cpp#L1589-L1598
