### PR TITLE
AP_DDS: Switch to master instead of develop tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,8 +34,8 @@
 [submodule "modules/Micro-XRCE-DDS-Client"]
 	path = modules/Micro-XRCE-DDS-Client
 	url = https://github.com/ardupilot/Micro-XRCE-DDS-Client.git
-	branch = develop
+	branch = master
 [submodule "modules/Micro-CDR"]
 	path = modules/Micro-CDR
 	url = https://github.com/ardupilot/Micro-CDR.git
-	branch = develop
+	branch = master


### PR DESCRIPTION
* No new features added, just switching to the tag on master
* Develop tags expire