### PR TITLE
AP_DroneCAN: add length specifier to format print to keep  g++ 7.5.0 happy

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -194,7 +194,7 @@ void AP_DroneCAN::init(uint8_t driver_index, bool enable_filters)
         return;
     }
 
-    node_info_rsp.name.len = snprintf((char*)node_info_rsp.name.data, sizeof(node_info_rsp.name.data), "org.ardupilot:%u", driver_index);
+    node_info_rsp.name.len = hal.util->snprintf((char*)node_info_rsp.name.data, sizeof(node_info_rsp.name.data), "org.ardupilot:%u", driver_index);
 
     node_info_rsp.software_version.major = AP_DRONECAN_SW_VERS_MAJOR;
     node_info_rsp.software_version.minor = AP_DRONECAN_SW_VERS_MINOR;
@@ -317,7 +317,7 @@ void AP_DroneCAN::init(uint8_t driver_index, bool enable_filters)
         canard_iface.process(1000);
     }
 
-    snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);
+    hal.util->snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);
 
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_DroneCAN::loop, void), _thread_name, DRONECAN_STACK_SIZE, AP_HAL::Scheduler::PRIORITY_CAN, 0)) {
         debug_dronecan(AP_CANManager::LOG_ERROR, "DroneCAN: couldn't create thread\n\r");


### PR DESCRIPTION
Fixes:
```
../../libraries/AP_DroneCAN/AP_DroneCAN.cpp:190:6: error: ‘%u’ directive output may be truncated writing between 1 and 10 bytes into a region of size 4 [-Werror=format-truncation=]
```
Related to:
```
snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);
```

Problem seems semi genuine, `_thread_name` is only 13 characters long `dronecan_` takes up 9 so the warning is that were trying to print a uint32 with `u` but only have 4 characters left. The fix is to add the length specifier `hh` so the compiler knows its a uint8 not a uint32. 

I guess newer compilers are clever enough to know its a uint8 from inspection of the variable rather than only the format string. 

In any case this means I don't have to update my compiler to build SITL.