### PR TITLE
AP_Proximity: include AP_Proximity_Backend.h in AP_Proximity.cpp

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -16,6 +16,7 @@
 #include "AP_Proximity.h"
 
 #if HAL_PROXIMITY_ENABLED
+#include "AP_Proximity_Backend.h"
 #include "AP_Proximity_RPLidarA2.h"
 #include "AP_Proximity_TeraRangerTower.h"
 #include "AP_Proximity_TeraRangerTowerEvo.h"


### PR DESCRIPTION
fixes a compilation problem if all of the backends are compiled out!