### PR TITLE
Use 3d velocity for airspeed health

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -135,8 +135,8 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     AP_GROUPINFO("_WIND_MAX", 22, AP_Airspeed, _wind_max, 0),
 
     // @Param: _WIND_WARN
-    // @DisplayName: Airspeed and ground speed difference that gives a warning
-    // @Description: If the difference between airspeed and ground speed is greater than this value the sensor will issue a warning. If 0 ARSPD_WIND_MAX is used.
+    // @DisplayName: Airspeed and GPS speed difference that gives a warning
+    // @Description: If the difference between airspeed and GPS speed is greater than this value the sensor will issue a warning. If 0 ARSPD_WIND_MAX is used.
     // @Description{Copter, Blimp, Rover, Sub}: This parameter and function is not used by this vehicle. Always set to 0.
     // @Units: m/s
     // @User: Advanced

--- a/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Health.cpp
@@ -64,8 +64,9 @@ void AP_Airspeed::check_sensor_ahrs_wind_max_failures(uint8_t i)
         }
         data_is_inconsistent = state[i].failures.test_ratio > gate_size;
     }
-
-    const float speed_diff = fabsf(state[i].airspeed-gps.ground_speed());
+    
+    const auto gps_speed = gps.velocity().length();
+    const float speed_diff = fabsf(state[i].airspeed-gps_speed);
     const bool data_is_implausible = is_positive(_wind_max) && speed_diff > _wind_max;
     // update health_probability with LowPassFilter
     if (data_is_implausible || data_is_inconsistent) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -189,7 +189,7 @@ public:
         uint32_t time_week_ms;              ///< GPS time (milliseconds from start of GPS week)
         uint16_t time_week;                 ///< GPS week number
         Location location;                  ///< last fix location
-        float ground_speed;                 ///< ground speed in m/sec
+        float ground_speed;                 ///< ground speed in m/s
         float ground_course;                ///< ground course in degrees
         float gps_yaw;                      ///< GPS derived yaw information, if available (degrees)
         uint32_t gps_yaw_time_ms;           ///< timestamp of last GPS yaw reading


### PR DESCRIPTION
This adds support in the airspeed checks for checking 3D speed instead of just using 2D. 

 Redacted: I did lower the necessary quality of GPS to FIX_2D which would expand the time that GPS is used to validate against.

The purpose of this is to allow users to increase the value of `AHRS_WIND_MAX` without the risk that the airspeed sensor is removed from EKF when vertical velocity is a non-trivial part of the airspeed vector. 

## Validation in SITL

Needs validation in SITL with the original changes, however PR scope was reduced and testing was no longer needed before this PR. Will be sure to test this in the plane release. 

### Airspeed params
Airspeed SIM params:
```
SIM_ARSPD2_FAIL  0.0
SIM_ARSPD2_FAILP 0.0
SIM_ARSPD2_OFS   2013.0
SIM_ARSPD2_PITOT 0.0
SIM_ARSPD2_RATIO 1.9900000095367432
SIM_ARSPD2_RND   2.0
SIM_ARSPD2_SIGN  0
SIM_ARSPD_FAIL   0.0
SIM_ARSPD_FAILP  0.0
SIM_ARSPD_OFS    2013.0
SIM_ARSPD_PITOT  0.0
SIM_ARSPD_RATIO  1.9900000095367432
SIM_ARSPD_RND    2.0
SIM_ARSPD_SIGN   0
```

### GPS params
GPS Sim params:
```
param show SIM_GPS*
MANUAL> SIM_GPS2_ACC     0.30000001192092896
SIM_GPS2_ALT_OFS 0
SIM_GPS2_BYTELOS 0.0
SIM_GPS2_DISABLE 1
SIM_GPS2_DRFTALT 0.0
SIM_GPS2_GLTCH_X 0.0
SIM_GPS2_GLTCH_Y 0.0
SIM_GPS2_GLTCH_Z 0.0
SIM_GPS2_HDG     0
SIM_GPS2_HZ      5
SIM_GPS2_LAG_MS  100
SIM_GPS2_LCKTIME 0
SIM_GPS2_NOISE   0.0
SIM_GPS2_NUMSATS 10
SIM_GPS2_POS_X   0.0
SIM_GPS2_POS_Y   0.0
SIM_GPS2_POS_Z   0.0
SIM_GPS2_TYPE    1
SIM_GPS2_VERR_X  0.0
SIM_GPS2_VERR_Y  0.0
SIM_GPS2_VERR_Z  0.0
SIM_GPS_ACC      0.30000001192092896
SIM_GPS_ALT_OFS  0
SIM_GPS_BYTELOSS 0.0
SIM_GPS_DISABLE  0
SIM_GPS_DRIFTALT 0.0
SIM_GPS_GLITCH_X 0.0
SIM_GPS_GLITCH_Y 0.0
SIM_GPS_GLITCH_Z 0.0
SIM_GPS_HDG      0
SIM_GPS_HZ       5
SIM_GPS_LAG_MS   100
SIM_GPS_LOCKTIME 0
SIM_GPS_LOG_NUM  0
SIM_GPS_NOISE    0.0
SIM_GPS_NUMSATS  10
SIM_GPS_POS_X    0.0
SIM_GPS_POS_Y    0.0
SIM_GPS_POS_Z    0.0
SIM_GPS_TYPE     1
SIM_GPS_VERR_X   0.0
SIM_GPS_VERR_Y   0.0
SIM_GPS_VERR_Z   0.0
```

### Tests

1.  Enable 1 GPS, 1 Airspeed sensor with 3D fix. Set params necessary to trigger loss of GPS below 2D fix and verify correct reliance on airspeed.
2. Enable 1 GPS, 1 Airspeed sensor with 3D fix. Do a steep dive at speeds greater than the threshold then kill the airspeed sensor. Ensure it's removed from EKF.
3. Enable 1 GPS, 1 airspeed sensor with 2D fix. Fly faster than the threshold then kill the airspeed sensor. Ensure it's removed from EKF. 
4. Anything for copter? 

## Validation in real life

1. Set AHRS_WIND_MAX to ~30% of the cruising speed, as a very tight number. Fly steep dives, and see if you can trigger loss of airspeed sensor before and after this PR. 