### PR TITLE
AP_MotorsMatrix: prevent altitude loss when thrust-to-weight is less than 2

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -252,11 +252,8 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // throttle facilitating physically maximum roll, pitch or yaw output.
     constexpr float THROTTLE_FOR_MAX_RPY{0.5f};
 
-    // Set a sensible throttle in case hover throttle was not set.
-    desired_altitude_output = MAX(THROTTLE_FOR_MAX_RPY, desired_altitude_output);
-
-    // calculate the highest allowed average thrust that will provide maximum control range without losing desired altitude output.
-    float throttle_thrust_best_rpy = MIN(desired_altitude_output, throttle_avg_max);
+    // Constraint on the low end is to set a sensible throttle in case hover throttle was not set.
+    float throttle_thrust_best_rpy = constrain_float(desired_altitude_output, THROTTLE_FOR_MAX_RPY, throttle_avg_max);
 
     // calculate throttle that gives most possible room for yaw which is the lower of:
     //      1. 0.5f - (rpy_low+rpy_high)/2.0 - this would give the maximum possible margin above the highest motor and below the lowest

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -247,7 +247,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     throttle_avg_max = constrain_float(throttle_avg_max, throttle_thrust, throttle_thrust_max);
 
     // Ensure desired altitude output is not sacrificed for attitude output, but allow sacrifice of climb rate.
-    float desired_altitude_output = MIN(throttle_thrust, get_throttle_hover() * compensation_gain);
+    const float desired_altitude_output = MIN(throttle_thrust, get_throttle_hover() * compensation_gain);
 
     // throttle facilitating physically maximum roll, pitch or yaw output.
     constexpr float THROTTLE_FOR_MAX_RPY{0.5f};


### PR DESCRIPTION
This change prevents the Copter flight controller from sacrificing altitude for attitude output when the thrust-to-weight ratio of the aircraft is below 2. In other words, this change prevents the Copter from suddenly dropping under certain conditions. Instead of a hard-coded minimum throttle of `0.5f` reserved for keeping altitude, this introduces a dynamic minimum throttle that preserves desired altitude output. This dynamic minimum throttle utilizes the parameter `MOT_THST_HOVER`. In the cases that this parameter is not set or hover throttle is otherwise not known, this implementation tries to revert to the previous implementation (`0.5f` minimum throttle for altitude preservation).

Tests

SITL tests were performed using a mission that saturated yaw outputs, demonstrating the problem and solution. [This branch](https://github.com/117-MasterChief/ardupilot/tree/prevent-altitude-loss-SITL-test) (which modifies the default T/W from 2.56 to 1.8) can be used to repeat these tests. The following results are from the aforementioned branch (without this PR), and drop in altitude is observed (note that the timescales may be shifted, due to having to press "Pause" on each graph):

![bug-with-yaw](https://user-images.githubusercontent.com/130329104/232251848-738ceb6e-67d8-4033-b8d5-c8ae8e0304ce.png)

With this PR, no drop in altitude is observed:

![fix-with-yaw](https://user-images.githubusercontent.com/130329104/232251862-31afaf01-0b58-49ae-9542-1d99d85bc9da.png)

The instructions for reproducing the test are included in a text file in [the test branch](https://github.com/117-MasterChief/ardupilot/tree/prevent-altitude-loss-SITL-test), but repeated here:

```
Go to ardupilot/ArduCopter/

../Tools/autotest/sim_vehicle.py --wipe-eeprom --frame=quad --vehicle=ArduCopter --map --console --osd

Load yaw-saturation-test-3.txt mission using Mission Editor GUI.

param set ATC_SLEW_YAW 18000
param set ATC_ACCEL_Y_MAX 72000
param set ATC_RAT_YAW_P 2.5
param set MOT_THST_HOVER 0.556

module load graph
graph SERVO_OUTPUT_RAW.servo1_raw SERVO_OUTPUT_RAW.servo2_raw SERVO_OUTPUT_RAW.servo3_raw SERVO_OUTPUT_RAW.servo4_raw
graph AHRS2.altitude
graph ATTITUDE.yaw

rc 3 1000
mode stabilize
arm throttle
mode auto
rc 3 1500
```