### PR TITLE
Plane: use dedicated quadplane function for stick mixing enable

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4349,7 +4349,7 @@ MAV_VTOL_STATE SLT_Transition::get_mav_vtol_state() const
 }
 
 // Set FW roll and pitch limits and keep TECS informed
-void SLT_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing)
+void SLT_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd)
 {
     if (quadplane.in_vtol_mode() || quadplane.in_vtol_airbrake()) {
         // not in FW flight
@@ -4526,6 +4526,17 @@ bool QuadPlane::abort_landing(void)
     }
     poscontrol.set_state(QuadPlane::QPOS_LAND_ABORT);
     return true;
+}
+
+// Should we allow stick mixing from the pilot
+bool QuadPlane::allow_stick_mixing() const
+{
+    if (!available()) {
+        // Quadplane not enabled
+        return true;
+    }
+    // Ask transition logic
+    return transition->allow_stick_mixing();
 }
 
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -180,6 +180,9 @@ public:
      */
     bool in_vtol_land_descent(void) const;
 
+    // Should we allow stick mixing from the pilot
+    bool allow_stick_mixing() const;
+
 private:
     AP_AHRS &ahrs;
 

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -880,7 +880,7 @@ bool Tailsitter_Transition::show_vtol_view() const
     return show_vtol;
 }
 
-void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing)
+void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd)
 {
     uint32_t now = AP_HAL::millis();
     if (tailsitter.in_vtol_transition(now)) {
@@ -892,7 +892,6 @@ void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& na
         // multiply by 0.1 to convert (degrees/second * milliseconds) to centi degrees
         nav_pitch_cd = constrain_float(vtol_transition_initial_pitch + (tailsitter.transition_rate_vtol * dt) * 0.1f, -8500, 8500);
         nav_roll_cd = 0;
-        allow_stick_mixing = false;
 
     } else if (transition_state == TRANSITION_DONE) {
         // still in FW, reset transition starting point
@@ -908,10 +907,22 @@ void Tailsitter_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& na
             } else {
                 nav_pitch_cd = pitch_limit_cd;
                 nav_roll_cd = 0;
-                allow_stick_mixing = false;
             }
         }
     }
+}
+
+bool Tailsitter_Transition::allow_stick_mixing() const
+{
+    // Transitioning into VTOL flight, inital pitch up
+    if (tailsitter.in_vtol_transition()) {
+        return false;
+    }
+    // Transitioning into fixed wing flight, leveling off
+    if ((transition_state == TRANSITION_DONE) && (fw_limit_start_ms != 0)) {
+        return false;
+    }
+    return true;
 }
 
 bool Tailsitter_Transition::set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd)

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -159,7 +159,9 @@ public:
 
     bool show_vtol_view() const override;
 
-    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) override;
+    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) override;
+
+    bool allow_stick_mixing() const override;
 
     MAV_VTOL_STATE get_mav_vtol_state() const override;
 

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -40,7 +40,7 @@ public:
 
     virtual bool show_vtol_view() const = 0;
 
-    virtual void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) {};
+    virtual void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) {};
 
     virtual bool set_FW_roll_limit(int32_t& roll_limit_cd) { return false; }
 
@@ -55,6 +55,8 @@ public:
     virtual bool allow_weathervane() { return true; }
 
     virtual void set_last_fw_pitch(void) {}
+
+    virtual bool allow_stick_mixing() const { return true; }
 
 protected:
 
@@ -87,7 +89,7 @@ public:
 
     bool show_vtol_view() const override;
 
-    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd, bool& allow_stick_mixing) override;
+    void set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_cd) override;
 
     bool set_FW_roll_limit(int32_t& roll_limit_cd) override;
 


### PR DESCRIPTION
This moves the quadplane allows stick mixing bool out of the `set_FW_roll_pitch` function. This removes the use of a local variable in the per-mode if allowing future clean ups. After this the `mode_stabilize` case can be moved into the mode.