### PR TITLE
Provide alternative to use of GSF for initial yaw alignment for fixed wing and rovers

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -231,6 +231,7 @@ void NavEKF3_core::setAidingMode()
     {
         PV_AidingMode = AID_NONE;
         yawAlignComplete = false;
+        yawAlignGpsValidCount = 0;
         finalInflightYawInit = false;
         ResetVelocity(resetDataSource::DEFAULT);
         ResetPosition(resetDataSource::DEFAULT);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -128,13 +128,13 @@ void NavEKF3_core::controlMagYawReset()
 
 // this function is used to do a forced re-alignment of the yaw angle to align with the horizontal velocity
 // vector from GPS. It is used to align the yaw angle after launch or takeoff.
-void NavEKF3_core::realignYawGPS()
+void NavEKF3_core::realignYawGPS(bool emergency_reset)
 {
     // get quaternion from existing filter states and calculate roll, pitch and yaw angles
     Vector3F eulerAngles;
     stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
 
-    if ((sq(gpsDataDelayed.vel.x) + sq(gpsDataDelayed.vel.y)) > 25.0f) {
+    if (gpsDataDelayed.vel.xy().length_squared() > 25.0f) {
         // calculate course yaw angle
         ftype velYaw = atan2F(stateStruct.velocity.y,stateStruct.velocity.x);
 
@@ -150,14 +150,20 @@ void NavEKF3_core::realignYawGPS()
         // correct yaw angle using GPS ground course if compass yaw bad
         if (badMagYaw) {
             // attempt to use EKF-GSF estimate if available as it is more robust to GPS glitches
-            if (EKFGSF_resetMainFilterYaw(true)) {
+            // by default fly forward vehicles use ground course for initial yaw unless the GSF is explicitly selected as the yaw source
+            const bool useGSF = !assume_zero_sideslip() || (frontend->sources.getYawSource() == AP_NavEKF_Source::SourceYaw::GSF);
+            if (useGSF && EKFGSF_resetMainFilterYaw(emergency_reset)) {
                 return;
             }
+
+            // get yaw variance from GPS speed uncertainty
+            const ftype gpsVelAcc = fmaxF(gpsSpdAccuracy, ftype(frontend->_gpsHorizVelNoise));
+            const ftype gps_yaw_variance = sq(asinF(constrain_float(gpsVelAcc/gpsDataDelayed.vel.xy().length(), -1.0F, 1.0F)));
 
             // keep roll and pitch and reset yaw
             rotationOrder order;
             bestRotationOrder(order);
-            resetQuatStateYawOnly(gpsYaw, sq(radians(45.0f)), order);
+            resetQuatStateYawOnly(gpsYaw, gps_yaw_variance, order);
 
             // reset the velocity and position states as they will be inaccurate due to bad yaw
             ResetVelocity(resetDataSource::GPS);
@@ -220,17 +226,17 @@ void NavEKF3_core::SelectMagFusion()
     }
 
     // Handle case where we are not using a yaw sensor of any type and attempt to reset the yaw in
-    // flight using the output from the GSF yaw estimator.
+    // flight using the output from the GSF yaw estimator or GPS ground course.
     if ((yaw_source == AP_NavEKF_Source::SourceYaw::GSF) ||
         (!use_compass() &&
          yaw_source != AP_NavEKF_Source::SourceYaw::GPS &&
          yaw_source != AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK &&
          yaw_source != AP_NavEKF_Source::SourceYaw::EXTNAV)) {
 
-        // because this type of reset event is not as time critical, require a continuous history of valid estimates
-        if ((!yawAlignComplete || yaw_source_reset) && EKFGSF_yaw_valid_count >= GSF_YAW_VALID_HISTORY_THRESHOLD) {
-            const bool emergency_reset = (yaw_source != AP_NavEKF_Source::SourceYaw::GSF);
-            yawAlignComplete = EKFGSF_resetMainFilterYaw(emergency_reset);
+        if ((!yawAlignComplete || yaw_source_reset) && ((yaw_source != AP_NavEKF_Source::SourceYaw::GSF) || (EKFGSF_yaw_valid_count >= GSF_YAW_VALID_HISTORY_THRESHOLD))) {
+            realignYawGPS(false);
+            yaw_source_reset = false;
+        } else {
             yaw_source_reset = false;
         }
 
@@ -238,7 +244,7 @@ void NavEKF3_core::SelectMagFusion()
             // use the EKF-GSF yaw estimator output as this is more robust than the EKF can achieve without a yaw measurement
             // for non fixed wing platform types
             ftype gsfYaw, gsfYawVariance;
-            const bool didUseEKFGSF = yawAlignComplete && EKFGSF_getYaw(gsfYaw, gsfYawVariance) && !assume_zero_sideslip() && fuseEulerYaw(yawFusionMethod::GSF);
+            const bool didUseEKFGSF = yawAlignComplete && (yaw_source == AP_NavEKF_Source::SourceYaw::GSF) && EKFGSF_getYaw(gsfYaw, gsfYawVariance) && !assume_zero_sideslip() && fuseEulerYaw(yawFusionMethod::GSF);
 
             // fallback methods
             if (!didUseEKFGSF) {
@@ -278,7 +284,7 @@ void NavEKF3_core::SelectMagFusion()
         } else if (tiltAlignComplete && !yawAlignComplete) {
             // External yaw sources can take significant time to start providing yaw data so
             // wuile waiting, fuse a 'fake' yaw observation at 7Hz to keeop the filter stable
-            if(imuSampleTime_ms - lastSynthYawTime_ms > 140) {
+            if (imuSampleTime_ms - lastSynthYawTime_ms > 140) {
                 yawAngDataDelayed.yawAngErr = MAX(frontend->_yawNoise, 0.05f);
                 // update the yaw angle using the last estimate which will be used as a static yaw reference when movement stops
                 if (!onGroundNotMoving) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -134,7 +134,7 @@ void NavEKF3_core::realignYawGPS(bool emergency_reset)
     Vector3F eulerAngles;
     stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
 
-    if (gpsDataDelayed.vel.xy().length_squared() > 25.0f) {
+    if (gpsDataDelayed.vel.xy().length_squared() > sq(GPS_VEL_YAW_ALIGN_MIN_SPD)) {
         // calculate course yaw angle
         ftype velYaw = atan2F(stateStruct.velocity.y,stateStruct.velocity.x);
 
@@ -160,25 +160,36 @@ void NavEKF3_core::realignYawGPS(bool emergency_reset)
             const ftype gpsVelAcc = fmaxF(gpsSpdAccuracy, ftype(frontend->_gpsHorizVelNoise));
             const ftype gps_yaw_variance = sq(asinF(constrain_float(gpsVelAcc/gpsDataDelayed.vel.xy().length(), -1.0F, 1.0F)));
 
-            // keep roll and pitch and reset yaw
-            rotationOrder order;
-            bestRotationOrder(order);
-            resetQuatStateYawOnly(gpsYaw, gps_yaw_variance, order);
+            if (gps_yaw_variance < sq(radians(GPS_VEL_YAW_ALIGN_MAX_ANG_ERR))) {
+                yawAlignGpsValidCount++;
+            } else {
+                yawAlignGpsValidCount = 0;
+            }
 
-            // reset the velocity and position states as they will be inaccurate due to bad yaw
-            ResetVelocity(resetDataSource::GPS);
-            ResetPosition(resetDataSource::GPS);
+            if (yawAlignGpsValidCount >= GPS_VEL_YAW_ALIGN_COUNT_THRESHOLD) {
+                yawAlignGpsValidCount = 0;
+                // keep roll and pitch and reset yaw
+                rotationOrder order;
+                bestRotationOrder(order);
+                resetQuatStateYawOnly(gpsYaw, gps_yaw_variance, order);
 
-            // send yaw alignment information to console
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u yaw aligned to GPS velocity",(unsigned)imu_index);
+                // reset the velocity and position states as they will be inaccurate due to bad yaw
+                ResetVelocity(resetDataSource::GPS);
+                ResetPosition(resetDataSource::GPS);
 
-            if (use_compass()) {
-                // request a mag field reset which may enable us to use the magnetometer if the previous fault was due to bad initialisation
-                magStateResetRequest = true;
-                // clear the all sensors failed status so that the magnetometers sensors get a second chance now that we are flying
-                allMagSensorsFailed = false;
+                // send yaw alignment information to console
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u yaw aligned to GPS velocity",(unsigned)imu_index);
+
+                if (use_compass()) {
+                    // request a mag field reset which may enable us to use the magnetometer if the previous fault was due to bad initialisation
+                    magStateResetRequest = true;
+                    // clear the all sensors failed status so that the magnetometers sensors get a second chance now that we are flying
+                    allMagSensorsFailed = false;
+                }
             }
         }
+    } else {
+        yawAlignGpsValidCount = 0;
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -303,6 +303,7 @@ void NavEKF3_core::readMagData()
         // force a new yaw alignment 1s after learning completes. The
         // delay is to ensure any buffered mag samples are discarded
         yawAlignComplete = false;
+        yawAlignGpsValidCount = 0;
         InitialiseVariablesMag();
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -516,7 +516,7 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // we have GPS data to fuse and a request to align the yaw using the GPS course
     if (gpsYawResetRequest) {
-        realignYawGPS();
+        realignYawGPS(false);
     }
 
     // Select height data to be fused from the available baro, range finder and GPS sources

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -281,6 +281,7 @@ void NavEKF3_core::InitialiseVariables()
     tiltErrorVariance = sq(M_2PI);
     tiltAlignComplete = false;
     yawAlignComplete = false;
+    yawAlignGpsValidCount = 0;
     have_table_earth_field = false;
     stateIndexLim = 23;
     last_gps_idx = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -795,7 +795,7 @@ private:
     void SelectBetaDragFusion();
 
     // force alignment of the yaw angle using GPS velocity data
-    void realignYawGPS();
+    void realignYawGPS(bool emergency_reset);
 
     // initialise the earth magnetic field states using declination and current attitude and magnetometer measurements
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -115,6 +115,15 @@
 #define DOWNWARD_RANGEFINDER_MAX_INSTANCES 1
 #endif
 
+// number of continuous valid GPS velocity samples required to reset yaw
+#define GPS_VEL_YAW_ALIGN_COUNT_THRESHOLD 5
+
+// minimum GPS horizontal speed required to use GPS ground course for yaw alignment (m/s)
+#define GPS_VEL_YAW_ALIGN_MIN_SPD 5.0F
+
+// maximum GPs ground course uncertainty allowed for yaw alignment (deg)
+#define GPS_VEL_YAW_ALIGN_MAX_ANG_ERR 15.0F
+
 class NavEKF3_core : public NavEKF_core_common
 {
 public:
@@ -1116,6 +1125,7 @@ private:
     uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
     bool tiltAlignComplete;         // true when tilt alignment is complete
     bool yawAlignComplete;          // true when yaw alignment is complete
+    uint8_t yawAlignGpsValidCount;  // number of continuous good GPS velocity samples used for in flight yaw alignment
     bool magStateInitComplete;      // true when the magnetic field states have been initialised
     uint8_t stateIndexLim;          // Max state index used during matrix and array operations
     imu_elements imuDataDelayed;    // IMU data at the fusion time horizon


### PR DESCRIPTION
This provides a work around for the problems with incorrect yaw alignment that some planes with no compass have encountered which have been reported here https://github.com/ArduPilot/ardupilot/issues/23224

By default the first yaw alignment after launch will be performed using the GPS ground course. Some additional protection against accidental yaw alignment during shake to arm and due to GPs glitches has been added.

This has been tested on replay of a log from a Matek F765-Wing flight controller fitted to a Strix Nano Goblin airframe, however this setup has not previously encountered the issue reported. The following figure shows the yaw alignment to GPS ground course after launch which is the behaviour with EK3_SRC1_YAW set to 1 (compass) or 0 (none) with no compass enabled. GPS ground course will only be used for vehicle operating in a 'fly forward' mode which is planes in fixed wing flight and rovers that are unambiguously driving forward.

<img width="1042" alt="Screen Shot 2023-04-16 at 10 55 12 am" src="https://user-images.githubusercontent.com/3596952/232260439-16ecbda9-03b4-4e55-9e81-a0e31e26d71f.png">

Alternatively if the Plane or Rover user wants to use the GSF to do the initial yaw alignment, they still have the option, but will  have to set EK3_SRC1_YAW to 8 (GSF). This option has also been tested on replay.

<img width="1037" alt="Screen Shot 2023-04-16 at 11 04 22 am" src="https://user-images.githubusercontent.com/3596952/232260634-db19c119-d213-4d5f-b04b-47981568d8d7.png">

There are some further refinements I would like to do which include:

1)  Checking GPS velocity innovations after alignment and a change in ground course of at least 30 degrees to check if the yaw alignment was valid before declaring the EKF nav solution valid
2) Retuning the GSF for fly-forward vehicles so that it takes longer to align, but is less susceptible to sensor errors
3) Pulling in the changes from https://github.com/priseborough/ardupilot/commits/pr-ekf3-gps-velpos-igate-mod and modifying them to be active for a period after an in flight yaw alignment so that the EKF gets a chance to fix it's yaw during the first turn without rejecting GPS.

The likelihood that the GSF yaw estimator will develop a bad estimate later in flight for planes can also be reduced by

4) Adding a resampling step for the GSF component yaw states so that they are spread out as yaw uncertainty increases
5) Turning of GSF updates when the assumption of mainly horizontal motion inherent in the 3-state formulation is invalidated, eg turn off if aircraft pitches outside +-60 degrees or pulls significant vertical g

However these will take longer and the patches submitted in this PR should be regarded as a 'hot fix.

Replayable logs from other non-compass planes are requested.