### PR TITLE
Add support for absolute zoom in AP_Camera:

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -115,6 +115,14 @@ bool AP_Camera::set_zoom_step(int8_t zoom_step)
     return primary->set_zoom_step(zoom_step);
 }
 
+bool AP_Camera::set_zoom_absolute(float zoom_absolute)
+{
+    if (primary == nullptr) {
+        return false;
+    }
+    return primary->set_zoom_absolute(zoom_absolute);
+}
+
 // focus in, out or hold
 // focus in = -1, focus hold = 0, focus out = 1
 bool AP_Camera::set_manual_focus_step(int8_t focus_step)
@@ -250,6 +258,10 @@ MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (is_equal(packet.param1, (float)ZOOM_TYPE_CONTINUOUS)) {
             set_zoom_step((int8_t)packet.param2);
+            return MAV_RESULT_ACCEPTED;
+        } else if (is_equal(packet.param1, (float)ZOOM_TYPE_RANGE)) {
+            // We need to check here if this is possible 100% of the times
+            set_zoom_absolute(packet.param2);
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_UNSUPPORTED;
@@ -448,6 +460,17 @@ bool AP_Camera::set_zoom_step(uint8_t instance, int8_t zoom_step)
 
     // call each instance
     return backend->set_zoom_step(zoom_step);
+}
+
+bool AP_Camera::set_zoom_absolute(uint8_t instance, float zoom_absolute)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+
+    // call each instance
+    return backend->set_zoom_absolute(zoom_absolute);
 }
 
 // focus in, out or hold.  returns true on success

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -127,6 +127,9 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     bool set_zoom_step(int8_t zoom_step);
     bool set_zoom_step(uint8_t instance, int8_t zoom_step);
+    
+    bool set_zoom_absolute(uint8_t instance, float zoom_absolute);
+    bool set_zoom_absolute(float zoom_absolute);
 
     // focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -60,6 +60,8 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     virtual bool set_zoom_step(int8_t zoom_step) { return false; }
 
+    virtual bool set_zoom_absolute(float zoom_absolute) { return false; }
+
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1
     virtual bool set_manual_focus_step(int8_t focus_step) { return false; }

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -38,6 +38,15 @@ bool AP_Camera_Mount::set_zoom_step(int8_t zoom_step)
     return false;
 }
 
+bool AP_Camera_Mount::set_zoom_absolute(float zoom_absolute)
+{
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->set_zoom_absolute(0, zoom_absolute);
+    }
+    return false;
+}
+
 // focus in, out or hold.  returns true on success
 // focus in = -1, focus hold = 0, focus out = 1
 bool AP_Camera_Mount::set_manual_focus_step(int8_t focus_step)

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -43,6 +43,8 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     bool set_zoom_step(int8_t zoom_step) override;
 
+    bool set_zoom_absolute(float zoom_absolute) override;
+
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1
     bool set_manual_focus_step(int8_t focus_step) override;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -632,6 +632,15 @@ bool AP_Mount::set_zoom_step(uint8_t instance, int8_t zoom_step)
     return backend->set_zoom_step(zoom_step);
 }
 
+bool AP_Mount::set_zoom_absolute(uint8_t instance, float zoom_absolute)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->set_zoom_absolute(zoom_absolute);
+}
+
 // set focus in, out or hold.  returns true on success
 // focus in = -1, focus hold = 0, focus out = 1
 bool AP_Mount::set_manual_focus_step(uint8_t instance, int8_t focus_step)

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -184,6 +184,8 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     bool set_zoom_step(uint8_t instance, int8_t zoom_step);
 
+    bool set_zoom_absolute(uint8_t instance, float zoom_absolute);
+
     // set focus in, out or hold
     // focus in = -1, focus hold = 0, focus out = 1
     bool set_manual_focus_step(uint8_t instance, int8_t focus_step);

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -128,6 +128,8 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     virtual bool set_zoom_step(int8_t zoom_step) { return false; }
 
+    virtual bool set_zoom_absolute(float zoom_absolute) { return false; }
+
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1
     virtual bool set_manual_focus_step(int8_t focus_step) { return false; }

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -66,6 +66,8 @@ public:
     // zoom out = -1, hold = 0, zoom in = 1
     bool set_zoom_step(int8_t zoom_step) override;
 
+    bool set_zoom_absolute(float zoom_absolute) override;
+
     // set focus in, out or hold.  returns true on success
     // focus in = -1, focus hold = 0, focus out = 1
     bool set_manual_focus_step(int8_t focus_step) override;
@@ -168,6 +170,8 @@ private:
     // yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
     void send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
 
+    void absolute_zoom_control();
+
     // internal variables
     AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
     bool _initialised;                              // true once the driver has been initialised
@@ -200,6 +204,10 @@ private:
 
     // variables for camera state
     bool _last_record_video;                        // last record_video state sent to gimbal
+
+    float _zoom_absolute_target = 0.0f;
+    float _zoom_absolute;
+    uint32_t _last_zoom_sent_ms;
 };
 
 #endif // HAL_MOUNT_SIYISERIAL_ENABLED


### PR DESCRIPTION
We already have support for mavlink control of continuous zoom, like continuous zoom in and continuous zoom out. This PR adds support to set an absolute zoom, so we can set by mavlink the precise desired zoom level.

It implements it in AP_Camera, AP_Camera mount type, AP_Mount and AP_Mount_Siyi, so Siyi's mounts are the only ones this PR adds support for, but other backends should be straightforward to add, when they support it.

PLEASE, BEFORE MERGING I NEED TO CLARIFY:

This has been tested and verified on a Siyi A8. This gimbal expects to receive the zoom value within its range, up to 5.5x, it is not standarized like 0-100. This will only be scalable if we have some way from Ardupilot ( or from the mavlink camera ), to report the supported zoom levels. This has been tested on a modified version of QGC, tailored for this Siyi A8, but ideally we should have a mechanism so the GCS knows the available zoom range. 

I would love to hear the thoughts on this last point from @rmackay9 . Thanks!