### PR TITLE
AP_DroneCAN: fixed timeout for 16 bit timers in events

### DIFF
--- a/libraries/AP_DroneCAN/AP_Canard_iface.cpp
+++ b/libraries/AP_DroneCAN/AP_Canard_iface.cpp
@@ -4,6 +4,8 @@
 #if HAL_ENABLE_DRONECAN_DRIVERS
 #include <canard/handler_list.h>
 #include <canard/transfer_object.h>
+#include <AP_Math/AP_Math.h>
+
 extern const AP_HAL::HAL& hal;
 #define LOG_TAG "DroneCANIface"
 
@@ -274,7 +276,7 @@ void CanardInterface::process(uint32_t duration_ms) {
         processTx();
         uint64_t now = AP_HAL::native_micros64();
         if (now < deadline) {
-            _event_handle.wait(deadline - now);
+            _event_handle.wait(MIN(UINT16_MAX - 2U, deadline - now));
         } else {
             break;
         }

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -312,9 +312,15 @@ void AP_DroneCAN::init(uint8_t driver_index, bool enable_filters)
     node_status_msg.sub_mode = 0;
 
     // Spin node for device discovery
-    for (uint8_t i = 0; i < 5; i++) {
-        send_node_status();
-        canard_iface.process(1000);
+    uint32_t start_loop_ms = AP_HAL::millis();
+    uint32_t last_send_ms = 0;
+    while (AP_HAL::millis() - start_loop_ms < 5000) {
+        uint32_t now = AP_HAL::millis();
+        if (now - last_send_ms >= 1000) {
+            send_node_status();
+            last_send_ms = now;
+        }
+        canard_iface.process(50);
     }
 
     snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -312,15 +312,9 @@ void AP_DroneCAN::init(uint8_t driver_index, bool enable_filters)
     node_status_msg.sub_mode = 0;
 
     // Spin node for device discovery
-    uint32_t start_loop_ms = AP_HAL::millis();
-    uint32_t last_send_ms = 0;
-    while (AP_HAL::millis() - start_loop_ms < 5000) {
-        uint32_t now = AP_HAL::millis();
-        if (now - last_send_ms >= 1000) {
-            send_node_status();
-            last_send_ms = now;
-        }
-        canard_iface.process(50);
+    for (uint8_t i = 0; i < 5; i++) {
+        send_node_status();
+        canard_iface.process(1000);
     }
 
     snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);

--- a/libraries/AP_HAL/EventHandle.cpp
+++ b/libraries/AP_HAL/EventHandle.cpp
@@ -16,12 +16,12 @@ bool AP_HAL::EventHandle::unregister_event(uint32_t evt_mask)
     return true;
 }
 
-bool AP_HAL::EventHandle::wait(uint64_t duration)
+bool AP_HAL::EventHandle::wait(uint16_t duration_us)
 {
     if (evt_src_ == nullptr) {
         return false;
     }
-    return evt_src_->wait(duration, this);
+    return evt_src_->wait(duration_us, this);
 }
 
 bool AP_HAL::EventHandle::set_source(AP_HAL::EventSource* src)

--- a/libraries/AP_HAL/EventHandle.h
+++ b/libraries/AP_HAL/EventHandle.h
@@ -14,7 +14,7 @@ public:
 
 
     // Wait on an Event handle, method for internal use by EventHandle
-    virtual bool wait(uint64_t duration, AP_HAL::EventHandle* evt_handle) = 0;
+    virtual bool wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle) = 0;
 };
 
 class AP_HAL::EventHandle {
@@ -31,7 +31,7 @@ public:
     virtual bool unregister_event(uint32_t evt_mask);
 
     // return true if event was triggered within the duration
-    virtual bool wait(uint64_t duration);
+    virtual bool wait(uint16_t duration_us);
 
     virtual uint32_t get_evt_mask() const { return evt_mask_; }
 

--- a/libraries/AP_HAL_ChibiOS/EventSource.cpp
+++ b/libraries/AP_HAL_ChibiOS/EventSource.cpp
@@ -5,16 +5,17 @@ using namespace ChibiOS;
 
 #if CH_CFG_USE_EVENTS == TRUE
 
-bool EventSource::wait(uint64_t duration, AP_HAL::EventHandle *evt_handle)
+bool EventSource::wait(uint16_t duration_us, AP_HAL::EventHandle *evt_handle)
 {
     chibios_rt::EventListener evt_listener;
     eventmask_t evt_mask = evt_handle->get_evt_mask();
     msg_t ret = msg_t();
     ch_evt_src_.registerMask(&evt_listener, evt_mask);
-    if (duration == 0) {
+    if (duration_us == 0) {
         ret = chEvtWaitAnyTimeout(evt_mask, TIME_IMMEDIATE);
     } else {
-        ret = chEvtWaitAnyTimeout(evt_mask, MAX(CH_CFG_ST_TIMEDELTA, chTimeUS2I(duration)));
+        const sysinterval_t wait_us = MIN(TIME_MAX_INTERVAL, MAX(CH_CFG_ST_TIMEDELTA, chTimeUS2I(duration_us)));
+        ret = chEvtWaitAnyTimeout(evt_mask, wait_us);
     }
     ch_evt_src_.unregister(&evt_listener);
     return ret == MSG_OK;

--- a/libraries/AP_HAL_ChibiOS/EventSource.h
+++ b/libraries/AP_HAL_ChibiOS/EventSource.h
@@ -21,6 +21,6 @@ public:
     void signalI(uint32_t evt_mask) override;
 
     // Wait on an Event handle, method for internal use by EventHandle
-    bool wait(uint64_t duration, AP_HAL::EventHandle* evt_handle) override;
+    bool wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle) override;
 };
 #endif //#if CH_CFG_USE_EVENTS == TRUE

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -255,7 +255,7 @@ void RCOutput::dshot_collect_dma_locks(uint64_t time_out_us)
             const uint32_t max_delay_us = _dshot_period_us;
             const uint32_t min_delay_us = 10; // matches our CH_CFG_ST_TIMEDELTA
             wait_us = constrain_uint32(wait_us, min_delay_us, max_delay_us);
-            mask = chEvtWaitOneTimeout(group.dshot_event_mask, chTimeUS2I(wait_us));
+            mask = chEvtWaitOneTimeout(group.dshot_event_mask, MIN(TIME_MAX_INTERVAL, chTimeUS2I(wait_us)));
 
             // no time left cancel and restart
             if (!mask) {

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -153,6 +153,7 @@ void Scheduler::delay_microseconds(uint16_t usec)
         // calling with ticks == 0 causes a hard fault on ChibiOS
         ticks = 1;
     }
+    ticks = MIN(TIME_MAX_INTERVAL, ticks);
     chThdSleep(MAX(ticks,CH_CFG_ST_TIMEDELTA)); //Suspends Thread for desired microseconds
 }
 

--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -535,7 +535,7 @@ bool CANIface::set_event_handle(AP_HAL::EventHandle* handle) {
 }
 
 
-bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle* evt_handle)
+bool CANIface::CANSocketEventSource::wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle)
 {
     if (evt_handle == nullptr) {
         return false;
@@ -564,8 +564,8 @@ bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle
 
     // Timeout conversion
     auto ts = timespec();
-    ts.tv_sec = duration / 1000000LL;
-    ts.tv_nsec = (duration % 1000000LL) * 1000;
+    ts.tv_sec = 0;
+    ts.tv_nsec = duration_us * 1000UL;
 
     // Blocking here
     const int res = ppoll(pollfds, num_pollfds, &ts, nullptr);

--- a/libraries/AP_HAL_Linux/CANSocketIface.h
+++ b/libraries/AP_HAL_Linux/CANSocketIface.h
@@ -122,7 +122,7 @@ public:
     public:
         // we just poll fd, no signaling is done
         void signal(uint32_t evt_mask) override { return; }
-        bool wait(uint64_t duration, AP_HAL::EventHandle* evt_handle) override;
+        bool wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle) override;
     };
 
 private:

--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -587,7 +587,7 @@ bool CANIface::set_event_handle(AP_HAL::EventHandle* handle) {
 }
 
 
-bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle* evt_handle)
+bool CANIface::CANSocketEventSource::wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle)
 {
     if (evt_handle == nullptr) {
         return false;
@@ -616,8 +616,8 @@ bool CANIface::CANSocketEventSource::wait(uint64_t duration, AP_HAL::EventHandle
 
     // Timeout conversion
     auto ts = timespec();
-    ts.tv_sec = duration / 1000000LL;
-    ts.tv_nsec = (duration % 1000000LL) * 1000;
+    ts.tv_sec = 0;
+    ts.tv_nsec = duration_us * 1000UL;
 
     // Blocking here
     const int res = ppoll(pollfds, num_pollfds, &ts, nullptr);

--- a/libraries/AP_HAL_SITL/CANSocketIface.h
+++ b/libraries/AP_HAL_SITL/CANSocketIface.h
@@ -132,7 +132,7 @@ public:
     public:
         // we just poll fd, no signaling is done
         void signal(uint32_t evt_mask) override { return; }
-        bool wait(uint64_t duration, AP_HAL::EventHandle* evt_handle) override;
+        bool wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle) override;
     };
 
 private:


### PR DESCRIPTION
this fixes an issue that prevents boot on some boards with a single CAN interface and no CAN devices attached. Reproduced by henry and me on a MatekH743-Wing. Without this change the loop sending 5 status messages in AP_DroneCAN::init() won't complete. Unfortunately gdb debug interface is pretty badly broken at the moment to try to work out the underlying issue
even a 1 microsecond delay is enough to avoid the issue