### PR TITLE
make default FW approach land speed the same as Qplane

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4114,23 +4114,16 @@ float QuadPlane::get_land_airspeed(void)
     if (qstate == QPOS_APPROACH ||
         plane.control_mode == &plane.mode_rtl) {
         const float cruise_speed = plane.aparm.airspeed_cruise_cm * 0.01;
-        float approach_speed = cruise_speed;
-        float tecs_land_airspeed = plane.TECS_controller.get_land_airspeed();
-        if (is_positive(tecs_land_airspeed)) {
-            approach_speed = tecs_land_airspeed;
-        } else {
-            if (qstate == QPOS_APPROACH) {
-                // default to half way between min airspeed and cruise
-                // airspeed when on the approach
-                approach_speed = 0.5*(cruise_speed+plane.aparm.airspeed_min);
-            } else {
-                // otherwise cruise
+        float approach_speed = plane.TECS_controller.get_land_airspeed();    
+        if (qstate != QPOS_APPROACH) {
+           // if not in approach yet then in RTL, use trim cruise airspeed, otherwise approach speed is
+           // landing airspeed
                 approach_speed = cruise_speed;
-            }
         }
         const float time_to_pos1 = (plane.auto_state.wp_distance - stopping_distance(sq(approach_speed))) / MAX(approach_speed, 5);
         /*
-          slow down to landing approach speed as we get closer to landing
+          slow down to landing approach speed as we get closer to POS1 while in APPROACH,
+          if in RTL the speed interpolation does nothing
         */
         approach_speed = linear_interpolate(approach_speed, cruise_speed,
                                             time_to_pos1,

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: LAND_ARSPD
     // @DisplayName: Airspeed during landing approach (m/s)
-    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is Trim Airspeed or ARSPD_FBW_MAX as defined by LAND_OPTIONS bitmask.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
+    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is Trim Airspeed or ARSPD_FBW_MAX as defined by LAND_OPTIONS bitmask.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is halfway between ARSPD_FBW_MIN and TRIM_CRUISE_CM speed.
     // @Range: -1 127
     // @Increment: 1
     // @User: Standard
@@ -1145,6 +1145,14 @@ void AP_TECS::_update_STE_rate_lim(void)
     _STEdot_min = - _minSinkRate * GRAVITY_MSS;
 }
 
+float AP_TECS::get_land_airspeed(void) const 
+{
+    if (_landAirspeed > 0.0) {
+        return _landAirspeed;
+    } else {
+        return 0.5 * (aparm.airspeed_cruise_cm * 0.01 + aparm.airspeed_min);
+    }
+}
 
 void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     int32_t EAS_dem_cm,

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -103,9 +103,7 @@ public:
     }
 
     // return landing airspeed
-    float get_land_airspeed(void) const {
-        return _landAirspeed;
-    }
+    float get_land_airspeed(void) const;
 
     // return height rate demand, in m/s
     float get_height_rate_demand(void) const {


### PR DESCRIPTION
if TECS_LAND_ARSPD = -1 make it use halfway between trim airspeed and airspeed min, like Qplane does for its fixed wing approach

this also makes sure that RTLs are at trim cruise in Qplane until approach begins....this is a minor change in behaviour...(actually back to older behaviour )but I think a good one