### PR TITLE
AP_DDS: Publish NavSatFix as soon as its available

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -53,7 +53,7 @@ private:
     bool connected = true;
 
     static void update_topic(builtin_interfaces_msg_Time& msg);
-    static void update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance);
+    bool update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance) WARN_IF_UNUSED;
     static void populate_static_transforms(tf2_msgs_msg_TFMessage& msg);
     static void update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_t instance);
 


### PR DESCRIPTION
* Removes the hard coded timing, now it's driven by the GPS update times
* Changed the function signature to return true if the data topic has been changed
* Tested on SITL, got ~4.5Hz
* Relates to #23277 
* This is the recommended way of doing it, by @tridge 