### PR TITLE
Move and rename AP_CANManager::Driver_Type to AP_CAN::Protocol

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -20,7 +20,8 @@
 #include "../AP_Bootloader/app_comms.h"
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 #include "hwing_esc.h"
-#include <AP_CANManager/AP_CANManager.h>
+#include <AP_CANManager/AP_CAN.h>
+#include <AP_CANManager/AP_SLCANIface.h>
 #include <AP_Scripting/AP_Scripting.h>
 #include <AP_HAL/CANIface.h>
 #include <AP_Stats/AP_Stats.h>
@@ -162,7 +163,7 @@ public:
     // This allows you to change the protocol and it continues to use the one at boot.
     // Without this, changing away from UAVCAN causes loss of comms and you can't
     // change the rest of your params or verify it succeeded.
-    AP_CANManager::Driver_Type can_protocol_cached[HAL_NUM_CAN_IFACES];
+    AP_CAN::Protocol can_protocol_cached[HAL_NUM_CAN_IFACES];
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MSP

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -102,7 +102,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Values: 0:Disabled,1:UAVCAN,4:PiccoloCAN,6:EFI_NWPMU,7:USD1,8:KDECAN
     // @User: Advanced
     // @RebootRequired: True
-    GARRAY(can_protocol,     0, "CAN_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
+    GARRAY(can_protocol,     0, "CAN_PROTOCOL", float(AP_CAN::Protocol::DroneCAN)),
     
     // @Param: CAN2_BAUDRATE
     // @CopyFieldsFrom: CAN_BAUDRATE
@@ -111,7 +111,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
     // @Param: CAN2_PROTOCOL
     // @CopyFieldsFrom: CAN_PROTOCOL
-    GARRAY(can_protocol,     1, "CAN2_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
+    GARRAY(can_protocol,     1, "CAN2_PROTOCOL", float(AP_CAN::Protocol::DroneCAN)),
 #endif
 
 #if HAL_NUM_CAN_IFACES >= 3
@@ -122,7 +122,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
     // @Param: CAN3_PROTOCOL
     // @CopyFieldsFrom: CAN_PROTOCOL
-    GARRAY(can_protocol,    2, "CAN3_PROTOCOL", AP_CANManager::Driver_Type_DroneCAN),
+    GARRAY(can_protocol,    2, "CAN3_PROTOCOL", float(AP_CAN::Protocol::DroneCAN)),
 #endif
 
 #if HAL_CANFD_SUPPORTED

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -78,7 +78,7 @@ public:
     
     AP_Int32 can_baudrate[HAL_NUM_CAN_IFACES];
 #if HAL_NUM_CAN_IFACES >= 2
-    AP_Enum<AP_CANManager::Driver_Type> can_protocol[HAL_NUM_CAN_IFACES];
+    AP_Enum<AP_CAN::Protocol> can_protocol[HAL_NUM_CAN_IFACES];
 #endif
 
 #if AP_CAN_SLCAN_ENABLED

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1197,7 +1197,7 @@ static void processTx(void)
             }
     #endif
     #if HAL_NUM_CAN_IFACES >= 2
-            if (periph.can_protocol_cached[ins.index] != AP_CANManager::Driver_Type_DroneCAN) {
+            if (periph.can_protocol_cached[ins.index] != AP_CAN::Protocol::DroneCAN) {
                 continue;
             }
     #endif
@@ -1229,7 +1229,7 @@ static void processRx(void)
             continue;
         }
 #if HAL_NUM_CAN_IFACES >= 2
-        if (periph.can_protocol_cached[ins.index] != AP_CANManager::Driver_Type_DroneCAN) {
+        if (periph.can_protocol_cached[ins.index] != AP_CAN::Protocol::DroneCAN) {
             continue;
         }
 #endif
@@ -1485,12 +1485,12 @@ void AP_Periph_FW::can_start()
 #if AP_PERIPH_ENFORCE_AT_LEAST_ONE_PORT_IS_UAVCAN_1MHz && HAL_NUM_CAN_IFACES >= 2
     bool has_uavcan_at_1MHz = false;
     for (uint8_t i=0; i<HAL_NUM_CAN_IFACES; i++) {
-        if (g.can_protocol[i] == AP_CANManager::Driver_Type_DroneCAN && g.can_baudrate[i] == 1000000) {
+        if (g.can_protocol[i] == AP_CAN::Protocol::DroneCAN && g.can_baudrate[i] == 1000000) {
             has_uavcan_at_1MHz = true;
         }
     }
     if (!has_uavcan_at_1MHz) {
-        g.can_protocol[0].set_and_save(AP_CANManager::Driver_Type_DroneCAN);
+        g.can_protocol[0].set_and_save(uint8_t(AP_CAN::Protocol::DroneCAN));
         g.can_baudrate[0].set_and_save(1000000);
     }
 #endif // HAL_PERIPH_ENFORCE_AT_LEAST_ONE_PORT_IS_UAVCAN_1MHz

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1153,7 +1153,7 @@ bool AP_Arming::can_checks(bool report)
 
         for (uint8_t i = 0; i < num_drivers; i++) {
             switch (AP::can().get_driver_type(i)) {
-                case AP_CANManager::Driver_Type_PiccoloCAN: {
+                case AP_CAN::Protocol::PiccoloCAN: {
 #if HAL_PICCOLO_CAN_ENABLE
                     AP_PiccoloCAN *ap_pcan = AP_PiccoloCAN::get_pcan(i);
 
@@ -1168,7 +1168,7 @@ bool AP_Arming::can_checks(bool report)
 #endif
                     break;
                 }
-                case AP_CANManager::Driver_Type_DroneCAN:
+                case AP_CAN::Protocol::DroneCAN:
                 {
 #if HAL_ENABLE_DRONECAN_DRIVERS
                     AP_DroneCAN *ap_dronecan = AP_DroneCAN::get_dronecan(i);
@@ -1179,13 +1179,13 @@ bool AP_Arming::can_checks(bool report)
 #endif
                     break;
                 }
-                case AP_CANManager::Driver_Type_EFI_NWPMU:
-                case AP_CANManager::Driver_Type_USD1:
-                case AP_CANManager::Driver_Type_None:
-                case AP_CANManager::Driver_Type_Scripting:
-                case AP_CANManager::Driver_Type_Scripting2:
-                case AP_CANManager::Driver_Type_Benewake:
-                case AP_CANManager::Driver_Type_KDECAN:
+                case AP_CAN::Protocol::EFI_NWPMU:
+                case AP_CAN::Protocol::USD1:
+                case AP_CAN::Protocol::None:
+                case AP_CAN::Protocol::Scripting:
+                case AP_CAN::Protocol::Scripting2:
+                case AP_CAN::Protocol::Benewake:
+                case AP_CAN::Protocol::KDECAN:
                     break;
             }
         }

--- a/libraries/AP_CANManager/AP_CAN.h
+++ b/libraries/AP_CANManager/AP_CAN.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/*
+ * this header contains data common to ArduPilot CAN, rather than to a
+ * specific implementation of the protocols.  So we try to share
+ * enumeration values where possible to make parameters similar across
+ * Periph and main firmwares, for example.
+ *
+ * this is *not* to be a one-stop-shop for including all things CAN...
+ */
+
+#include <stdint.h>
+
+class AP_CAN {
+public:
+    enum class Protocol : uint8_t {
+        None = 0,
+        DroneCAN = 1,
+        // 2 was KDECAN -- do not re-use
+        // 3 was ToshibaCAN -- do not re-use
+        PiccoloCAN = 4,
+        // 5 was CANTester
+        EFI_NWPMU = 6,
+        USD1 = 7,
+        KDECAN = 8,
+        // 9 was MPPT_PacketDigital
+        Scripting = 10,
+        Benewake = 11,
+        Scripting2 = 12,
+    };
+};

--- a/libraries/AP_CANManager/AP_CANDriver.cpp
+++ b/libraries/AP_CANManager/AP_CANDriver.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake,12:Scripting2
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, AP_CANManager::Driver_Type_DroneCAN),
+    AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, float(AP_CAN::Protocol::DroneCAN)),
 
 #if HAL_ENABLE_DRONECAN_DRIVERS
     // @Group: UC_

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -141,7 +141,7 @@ void AP_CANManager::init()
     _slcan_interface.reset_params();
 #endif
 
-    Driver_Type drv_type[HAL_MAX_CAN_PROTOCOL_DRIVERS] = {};
+    AP_CAN::Protocol drv_type[HAL_MAX_CAN_PROTOCOL_DRIVERS] = {};
     // loop through interfaces and allocate and initialise Iface,
     // Also allocate Driver objects, and add interfaces to them
     for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
@@ -165,7 +165,7 @@ void AP_CANManager::init()
         AP_HAL::CANIface* iface = hal.can[i];
 
         // Find the driver type that we need to allocate and register this interface with
-        drv_type[drv_num] = (Driver_Type) _drv_param[drv_num]._driver_type.get();
+        drv_type[drv_num] = (AP_CAN::Protocol) _drv_param[drv_num]._driver_type.get();
         bool can_initialised = false;
         // Check if this interface need hooking up to slcan passthrough
         // instead of a driver
@@ -203,7 +203,7 @@ void AP_CANManager::init()
 
         // Allocate the set type of Driver
 #if HAL_ENABLE_DRONECAN_DRIVERS
-        if (drv_type[drv_num] == Driver_Type_DroneCAN) {
+        if (drv_type[drv_num] == AP_CAN::Protocol::DroneCAN) {
             _drivers[drv_num] = _drv_param[drv_num]._uavcan = new AP_DroneCAN(drv_num);
 
             if (_drivers[drv_num] == nullptr) {
@@ -215,7 +215,7 @@ void AP_CANManager::init()
         } else
 #endif
 #if HAL_PICCOLO_CAN_ENABLE
-         if (drv_type[drv_num] == Driver_Type_PiccoloCAN) {
+         if (drv_type[drv_num] == AP_CAN::Protocol::PiccoloCAN) {
             _drivers[drv_num] = _drv_param[drv_num]._piccolocan = new AP_PiccoloCAN;
 
             if (_drivers[drv_num] == nullptr) {
@@ -268,7 +268,7 @@ void AP_CANManager::init()
 {
     WITH_SEMAPHORE(_sem);
     for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
-        if ((Driver_Type) _drv_param[i]._driver_type.get() == Driver_Type_DroneCAN) {
+        if ((AP_CAN::Protocol) _drv_param[i]._driver_type.get() == AP_CAN::Protocol::DroneCAN) {
             _drivers[i] = _drv_param[i]._uavcan = new AP_DroneCAN(i);
 
             if (_drivers[i] == nullptr) {
@@ -278,7 +278,7 @@ void AP_CANManager::init()
 
             AP_Param::load_object_from_eeprom((AP_DroneCAN*)_drivers[i], AP_DroneCAN::var_info);
             _drivers[i]->init(i, true);
-            _driver_type_cache[i] = (Driver_Type) _drv_param[i]._driver_type.get();
+            _driver_type_cache[i] = (AP_CAN::Protocol) _drv_param[i]._driver_type.get();
         }
     }
 }
@@ -286,7 +286,7 @@ void AP_CANManager::init()
 /*
   register a new CAN driver
  */
-bool AP_CANManager::register_driver(Driver_Type dtype, AP_CANDriver *driver)
+bool AP_CANManager::register_driver(AP_CAN::Protocol dtype, AP_CANDriver *driver)
 {
     WITH_SEMAPHORE(_sem);
 
@@ -298,7 +298,7 @@ bool AP_CANManager::register_driver(Driver_Type dtype, AP_CANDriver *driver)
         // from 1 based to 0 based
         drv_num--;
 
-        if (dtype != (Driver_Type)_drv_param[drv_num]._driver_type.get()) {
+        if (dtype != (AP_CAN::Protocol)_drv_param[drv_num]._driver_type.get()) {
             continue;
         }
         if (_drivers[drv_num] != nullptr) {

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -19,9 +19,9 @@
 
 #include "AP_CANManager_config.h"
 
-#include <AP_HAL/AP_HAL.h>
+#if HAL_CANMANAGER_ENABLED
 
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+#include <AP_HAL/AP_HAL.h>
 
 #include <AP_Param/AP_Param.h>
 #include "AP_SLCANIface.h"
@@ -198,4 +198,4 @@ namespace AP
 AP_CANManager& can();
 }
 
-#endif
+#endif  // HAL_CANMANAGER_ENABLED

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -32,6 +32,8 @@
 #include <AP_HAL/utility/RingBuffer.h>
 #endif
 
+#include "AP_CAN.h"
+
 class AP_CANManager
 {
 public:
@@ -56,26 +58,10 @@ public:
         LOG_DEBUG,
     };
 
-    enum Driver_Type : uint8_t {
-        Driver_Type_None = 0,
-        Driver_Type_DroneCAN = 1,
-        // 2 was KDECAN -- do not re-use
-        // 3 was ToshibaCAN -- do not re-use
-        Driver_Type_PiccoloCAN = 4,
-        // 5 was CANTester
-        Driver_Type_EFI_NWPMU = 6,
-        Driver_Type_USD1 = 7,
-        Driver_Type_KDECAN = 8,
-        // 9 was Driver_Type_MPPT_PacketDigital
-        Driver_Type_Scripting = 10,
-        Driver_Type_Benewake = 11,
-        Driver_Type_Scripting2 = 12,
-    };
-
     void init(void);
 
     // register a new driver
-    bool register_driver(Driver_Type dtype, AP_CANDriver *driver);
+    bool register_driver(AP_CAN::Protocol dtype, AP_CANDriver *driver);
 
     // returns number of active CAN Drivers
     uint8_t get_num_drivers(void) const
@@ -104,12 +90,12 @@ public:
     void log_retrieve(ExpandingString &str) const;
 
     // return driver type index i
-    Driver_Type get_driver_type(uint8_t i) const
+    AP_CAN::Protocol get_driver_type(uint8_t i) const
     {
         if (i < HAL_NUM_CAN_IFACES) {
             return _driver_type_cache[i];
         }
-        return Driver_Type_None;
+        return AP_CAN::Protocol::None;
     }
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -163,7 +149,7 @@ private:
     CANIface_Params _interfaces[HAL_NUM_CAN_IFACES];
     AP_CANDriver* _drivers[HAL_MAX_CAN_PROTOCOL_DRIVERS];
     CANDriver_Params _drv_param[HAL_MAX_CAN_PROTOCOL_DRIVERS];
-    Driver_Type _driver_type_cache[HAL_MAX_CAN_PROTOCOL_DRIVERS];
+    AP_CAN::Protocol _driver_type_cache[HAL_MAX_CAN_PROTOCOL_DRIVERS];
 
     AP_Int8 _loglevel;
     uint8_t _num_drivers;

--- a/libraries/AP_CANManager/AP_CANSensor.cpp
+++ b/libraries/AP_CANManager/AP_CANSensor.cpp
@@ -36,7 +36,7 @@ CANSensor::CANSensor(const char *driver_name, uint16_t stack_size) :
 {}
 
 
-void CANSensor::register_driver(AP_CANManager::Driver_Type dtype)
+void CANSensor::register_driver(AP_CAN::Protocol dtype)
 {
 #if HAL_CANMANAGER_ENABLED
     if (!AP::can().register_driver(dtype, this)) {
@@ -53,7 +53,7 @@ void CANSensor::register_driver(AP_CANManager::Driver_Type dtype)
 #ifdef HAL_BUILD_AP_PERIPH
 CANSensor::CANSensor_Periph CANSensor::_periph[HAL_NUM_CAN_IFACES];
 
-void CANSensor::register_driver_periph(const AP_CANManager::Driver_Type dtype)
+void CANSensor::register_driver_periph(const AP_CAN::Protocol dtype)
 {
     for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
         if (_periph[i].protocol != dtype) {

--- a/libraries/AP_CANManager/AP_CANSensor.h
+++ b/libraries/AP_CANManager/AP_CANSensor.h
@@ -18,7 +18,11 @@
  
 #pragma once
 
+#include "AP_CAN.h"
+#include "AP_CANDriver.h"
+#ifndef HAL_BUILD_AP_PERIPH
 #include "AP_CANManager.h"
+#endif
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
 
@@ -39,7 +43,7 @@ public:
     bool write_frame(AP_HAL::CANFrame &out_frame, const uint64_t timeout_us);
 
 #ifdef HAL_BUILD_AP_PERIPH
-    static void set_periph(const uint8_t i, const AP_CANManager::Driver_Type protocol, AP_HAL::CANIface* iface) {
+    static void set_periph(const uint8_t i, const AP_CAN::Protocol protocol, AP_HAL::CANIface* iface) {
         if (i < ARRAY_SIZE(_periph)) {
             _periph[i].protocol = protocol;
             _periph[i].iface = iface;
@@ -47,19 +51,19 @@ public:
     }
 
     // return driver type index i
-    static AP_CANManager::Driver_Type get_driver_type(const uint8_t i)
+    static AP_CAN::Protocol get_driver_type(const uint8_t i)
     {
         if (i < ARRAY_SIZE(_periph)) {
             return _periph[i].protocol;
         }
-        return AP_CANManager::Driver_Type_None;
+        return AP_CAN::Protocol::None;
     }
 #else
-    static AP_CANManager::Driver_Type get_driver_type(const uint8_t i) { return AP::can().get_driver_type(i); }
+    static AP_CAN::Protocol get_driver_type(const uint8_t i) { return AP::can().get_driver_type(i); }
 #endif
 
 protected:
-    void register_driver(AP_CANManager::Driver_Type dtype);
+    void register_driver(AP_CAN::Protocol dtype);
 
 private:
     void loop();
@@ -73,11 +77,11 @@ private:
     AP_HAL::CANIface* _can_iface;
 
 #ifdef HAL_BUILD_AP_PERIPH
-    void register_driver_periph(const AP_CANManager::Driver_Type dtype);
+    void register_driver_periph(const AP_CAN::Protocol dtype);
     
     struct CANSensor_Periph {
         AP_HAL::CANIface* iface;
-        AP_CANManager::Driver_Type protocol;
+        AP_CAN::Protocol protocol;
     } static _periph[HAL_NUM_CAN_IFACES];
 #endif
 };

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -168,7 +168,7 @@ AP_DroneCAN::~AP_DroneCAN()
 AP_DroneCAN *AP_DroneCAN::get_dronecan(uint8_t driver_index)
 {
     if (driver_index >= AP::can().get_num_drivers() ||
-        AP::can().get_driver_type(driver_index) != AP_CANManager::Driver_Type_DroneCAN) {
+        AP::can().get_driver_type(driver_index) != AP_CAN::Protocol::DroneCAN) {
         return nullptr;
     }
     return static_cast<AP_DroneCAN*>(AP::can().get_driver(driver_index));

--- a/libraries/AP_EFI/AP_EFI_NWPMU.cpp
+++ b/libraries/AP_EFI/AP_EFI_NWPMU.cpp
@@ -32,7 +32,7 @@ AP_EFI_NWPMU::AP_EFI_NWPMU(AP_EFI &_frontend) :
     CANSensor("NWPMU"),
     AP_EFI_Backend(_frontend)
 {
-    register_driver(AP_CANManager::Driver_Type_EFI_NWPMU);
+    register_driver(AP_CAN::Protocol::EFI_NWPMU);
 }
 
 void AP_EFI_NWPMU::handle_frame(AP_HAL::CANFrame &frame)

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -62,7 +62,7 @@ void AP_KDECAN::init()
     }
 
     for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
-        if (CANSensor::get_driver_type(i) == AP_CANManager::Driver_Type_KDECAN) {
+        if (CANSensor::get_driver_type(i) == AP_CAN::Protocol::KDECAN) {
             _driver = new AP_KDECAN_Driver();
             return;
         }
@@ -79,7 +79,7 @@ void AP_KDECAN::update()
 
 AP_KDECAN_Driver::AP_KDECAN_Driver() : CANSensor("KDECAN")
 {
-    register_driver(AP_CANManager::Driver_Type_KDECAN);
+    register_driver(AP_CAN::Protocol::KDECAN);
 
     // start thread for receiving and sending CAN frames. Tests show we use about 640 bytes of stack
     hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_KDECAN_Driver::loop, void), "kdecan", 2048, AP_HAL::Scheduler::PRIORITY_CAN, 0);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -118,7 +118,7 @@ AP_PiccoloCAN::AP_PiccoloCAN()
 AP_PiccoloCAN *AP_PiccoloCAN::get_pcan(uint8_t driver_index)
 {
     if (driver_index >= AP::can().get_num_drivers() ||
-        AP::can().get_driver_type(driver_index) != AP_CANManager::Driver_Type_PiccoloCAN) {
+        AP::can().get_driver_type(driver_index) != AP_CAN::Protocol::PiccoloCAN) {
         return nullptr;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
@@ -48,7 +48,7 @@ private:
 class Benewake_MultiCAN : public CANSensor {
 public:
     Benewake_MultiCAN() : CANSensor("Benewake") {
-        register_driver(AP_CANManager::Driver_Type_Benewake);
+        register_driver(AP_CAN::Protocol::Benewake);
     }
 
     // handler for incoming frames

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
@@ -45,7 +45,7 @@ private:
 class USD1_MultiCAN : public CANSensor {
 public:
     USD1_MultiCAN() : CANSensor("USD1") {
-        register_driver(AP_CANManager::Driver_Type_USD1);
+        register_driver(AP_CAN::Protocol::USD1);
     }
 
     // handler for incoming frames

--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.h
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.h
@@ -25,7 +25,7 @@ class ScriptingCANBuffer;
 class ScriptingCANSensor : public CANSensor {
 public:
 
-    ScriptingCANSensor(AP_CANManager::Driver_Type dtype)
+    ScriptingCANSensor(AP_CAN::Protocol dtype)
         : CANSensor("Script") {
         register_driver(dtype);
     }

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -464,7 +464,7 @@ int lua_get_CAN_device(lua_State *L) {
     auto *scripting = AP::scripting();
 
     if (scripting->_CAN_dev == nullptr) {
-        scripting->_CAN_dev = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting);
+        scripting->_CAN_dev = new ScriptingCANSensor(AP_CAN::Protocol::Scripting);
         if (scripting->_CAN_dev == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }
@@ -489,7 +489,7 @@ int lua_get_CAN_device2(lua_State *L) {
     auto *scripting = AP::scripting();
 
     if (scripting->_CAN_dev2 == nullptr) {
-        scripting->_CAN_dev2 = new ScriptingCANSensor(AP_CANManager::Driver_Type::Driver_Type_Scripting2);
+        scripting->_CAN_dev2 = new ScriptingCANSensor(AP_CAN::Protocol::Scripting2);
         if (scripting->_CAN_dev2 == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -267,7 +267,7 @@ protected:
     // board specific config
     AP_BoardConfig BoardConfig;
 
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
+#if HAL_CANMANAGER_ENABLED
     // board specific config for CAN bus
     AP_CANManager can_mgr;
 #endif

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -541,7 +541,7 @@ void SRV_Channels::push()
     uint8_t can_num_drivers = AP::can().get_num_drivers();
     for (uint8_t i = 0; i < can_num_drivers; i++) {
         switch (AP::can().get_driver_type(i)) {
-            case AP_CANManager::Driver_Type_DroneCAN: {
+            case AP_CAN::Protocol::DroneCAN: {
                 AP_DroneCAN *ap_dronecan = AP_DroneCAN::get_dronecan(i);
                 if (ap_dronecan == nullptr) {
                     continue;
@@ -550,7 +550,7 @@ void SRV_Channels::push()
                 break;
             }
 #if HAL_PICCOLO_CAN_ENABLE
-            case AP_CANManager::Driver_Type_PiccoloCAN: {
+            case AP_CAN::Protocol::PiccoloCAN: {
                 AP_PiccoloCAN *ap_pcan = AP_PiccoloCAN::get_pcan(i);
                 if (ap_pcan == nullptr) {
                     continue;
@@ -559,7 +559,7 @@ void SRV_Channels::push()
                 break;
             }
 #endif
-            case AP_CANManager::Driver_Type_None:
+            case AP_CAN::Protocol::None:
             default:
                 break;
         }


### PR DESCRIPTION
Stop AP_Periph including AP_CANManager class definition.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             -8                                                                    
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
