### PR TITLE
AP_DDS: Local Velocity Publisher

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -11,6 +11,7 @@
 #include "tf2_msgs/msg/TFMessage.h"
 #include "sensor_msgs/msg/BatteryState.h"
 #include "geometry_msgs/msg/PoseStamped.h"
+#include "geometry_msgs/msg/TwistStamped.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Scheduler.h>
@@ -48,6 +49,7 @@ private:
     tf2_msgs_msg_TFMessage static_transforms_topic;
     sensor_msgs_msg_BatteryState battery_state_topic;
     geometry_msgs_msg_PoseStamped local_pose_topic;
+    geometry_msgs_msg_TwistStamped local_velocity_topic;
 
     HAL_Semaphore csem;
 
@@ -59,6 +61,7 @@ private:
     static void populate_static_transforms(tf2_msgs_msg_TFMessage& msg);
     static void update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_t instance);
     static void update_topic(geometry_msgs_msg_PoseStamped& msg);
+    static void update_topic(geometry_msgs_msg_TwistStamped& msg);
 
     // The last ms timestamp AP_DDS wrote a Time message
     uint64_t last_time_time_ms;
@@ -68,6 +71,8 @@ private:
     uint64_t last_battery_state_time_ms;
     // The last ms timestamp AP_DDS wrote a Local Pose message
     uint64_t last_local_pose_time_ms;
+    // The last ms timestamp AP_DDS wrote a Local Velocity message
+    uint64_t last_local_velocity_time_ms;
 
 
 public:
@@ -95,6 +100,8 @@ public:
     void write_battery_state_topic();
     //! @brief Serialize the current local pose and publish to the IO stream(s)
     void write_local_pose_topic();
+    //! @brief Serialize the current local velocity and publish to the IO stream(s)
+    void write_local_velocity_topic();
     //! @brief Update the internally stored DDS messages with latest data
     void update();
 

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -62,4 +62,14 @@ const struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .deserialize = Generic_deserialize_topic_fn_t(&geometry_msgs_msg_PoseStamped_deserialize_topic),
         .size_of = Generic_size_of_topic_fn_t(&geometry_msgs_msg_PoseStamped_size_of_topic),
     },
+    {
+        .topic_id = 0x06,
+        .pub_id = 0x06,
+        .dw_id = uxrObjectId{.id=0x06, .type=UXR_DATAWRITER_ID},
+        .topic_profile_label = "localvelocity__t",
+        .dw_profile_label = "localvelocity__dw",
+        .serialize = Generic_serialize_topic_fn_t(&geometry_msgs_msg_TwistStamped_serialize_topic),
+        .deserialize = Generic_deserialize_topic_fn_t(&geometry_msgs_msg_TwistStamped_deserialize_topic),
+        .size_of = Generic_size_of_topic_fn_t(&geometry_msgs_msg_TwistStamped_size_of_topic),
+    }
 };

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -142,4 +142,32 @@
       </historyQos>
     </topic>
   </data_writer>
+  <topic profile_name="localvelocity__t">
+    <name>rt/ROS2_LocalVelocity</name>
+    <dataType>geometry_msgs::msg::dds_::TwistStamped_</dataType>
+    <historyQos>
+      <kind>KEEP_LAST</kind>
+      <depth>5</depth>
+    </historyQos>
+  </topic>
+  <data_writer profile_name="localvelocity__dw">
+    <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
+    <qos>
+      <reliability>
+        <kind>BEST_EFFORT</kind>
+      </reliability>
+      <durability>
+        <kind>VOLATILE</kind>
+      </durability>
+    </qos>
+    <topic>
+      <kind>NO_KEY</kind>
+      <name>rt/ROS2_LocalVelocity</name>
+      <dataType>geometry_msgs::msg::dds_::TwistStamped_</dataType>
+      <historyQos>
+        <kind>KEEP_LAST</kind>
+        <depth>5</depth>
+      </historyQos>
+    </topic>
+  </data_writer>
 </profiles>

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -143,7 +143,7 @@
     </topic>
   </data_writer>
   <topic profile_name="localvelocity__t">
-    <name>rt/ROS2_LocalVelocity</name>
+    <name>rt/ap/twist/filtered</name>
     <dataType>geometry_msgs::msg::dds_::TwistStamped_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -162,7 +162,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ROS2_LocalVelocity</name>
+      <name>rt/ap/twist/filtered</name>
       <dataType>geometry_msgs::msg::dds_::TwistStamped_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>


### PR DESCRIPTION
Resolves #23279 
Here is the PR working in its current state in SITL:
![Screenshot from 2023-04-18 18-21-45](https://user-images.githubusercontent.com/62964137/232908031-e33d9f40-53d0-47dd-a450-39de60de7c65.png)
It is currently following:
```
// In ROS REP 103, it follows this convention
// X - Forward
// Y - Left
// Z - Up
// https://www.ros.org/reps/rep-0103.html#axis-orientation
```
For linear velocity, the data is earth-fixed but starts alligned with the robot body (x-forward)
For angular velocity, the gyro data is body-fixed.
