### PR TITLE
AC_WPNav: wpnav speed param check fixed

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -165,7 +165,8 @@ void AC_WPNav::wp_and_spline_init(float speed_cms, Vector3f stopping_point)
     _pos_control.init_z_controller_stopping_point();
     _pos_control.init_xy_controller_stopping_point();
 
-    // initialize the desired wp speed if not already done
+    // initialize the desired wp speed
+    _check_wp_speed_change = !is_positive(speed_cms);
     _wp_desired_speed_xy_cms = is_positive(speed_cms) ? speed_cms : _wp_speed_cms;
     _wp_desired_speed_xy_cms = MAX(_wp_desired_speed_xy_cms, WPNAV_WP_SPEED_MIN);
 
@@ -588,9 +589,12 @@ bool AC_WPNav::update_wpnav()
 {
     bool ret = true;
 
-    if (!is_equal(_wp_speed_cms.get(), _last_wp_speed_cms)) {
-        set_speed_xy(_wp_speed_cms);
-        _last_wp_speed_cms = _wp_speed_cms;
+    // check for changes in speed parameter values
+    if (_check_wp_speed_change) {
+        if (!is_equal(_wp_speed_cms.get(), _last_wp_speed_cms)) {
+            set_speed_xy(_wp_speed_cms);
+            _last_wp_speed_cms = _wp_speed_cms;
+        }
     }
     if (!is_equal(_wp_speed_up_cms.get(), _last_wp_speed_up_cms)) {
         set_speed_up(_wp_speed_up_cms);

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -247,6 +247,8 @@ protected:
     AP_Float    _wp_jerk;               // maximum jerk used to generate scurve trajectories in m/s/s/s
     AP_Float    _terrain_margin;        // terrain following altitude margin. vehicle will stop if distance from target altitude is larger than this margin
 
+    // WPNAV_SPEED param change checker
+    bool _check_wp_speed_change;        // if true WPNAV_SPEED param should be checked for changes in-flight
     float _last_wp_speed_cms;  // last recorded WPNAV_SPEED, used for changing speed in-flight
     float _last_wp_speed_up_cms;  // last recorded WPNAV_SPEED_UP, used for changing speed in-flight
     float _last_wp_speed_down_cms;  // last recorded WPNAV_SPEED_DN, used for changing speed in-flight


### PR DESCRIPTION
This is an alternative to https://github.com/ArduPilot/ardupilot/pull/23220

This PR fixes an issue where RTL_SPEED = 400 but if users changed the WPNAV_SPEED parameter the vehicle would immediately change to this new speed.

This has been tested in SITL to confirm that user changes to WPNAV_SPEED will only take effect if the WPNAV_SPEED parameter value was used to initialise the vehicle's speed in the current mode.  The results are slightly unintuitive in some situations though so I'm happy to discuss if people think the behaviour is odd.

1. Fly in Auto mode, waypoint command, changes to WPNAV_SPEED take effect immediately
2. Fly in Auto mode, RTL command, if RTL_SPEED was zero when command started meaning WPNAV_SPEED was used, changes to WPNAV_SPEED will take effect immediately.  If RTL_SPEED was non-zero when command started, WPNAV_SPEED will not take effect.  Changes to RTL_SPEED while vehicle is executing RTL never take effect immediately
3. Fly in RTL mode acts just like 2 above

Below are some screenshots of SITL testing because PRs with pictures are nicer to look at.
![image](https://user-images.githubusercontent.com/1498098/233074074-a4dfb807-28bc-471b-9a2c-f152fcc821fb.png)
