### PR TITLE
waf: added -g for debug symbols to all builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -267,9 +267,13 @@ class Board:
                 '-fcheck-new',
             ]
 
+        # always enable -g to give debug symbols in elf files on firmware server, making for easier debug
+        # of crash dumps.
+        env.CFLAGS += [
+            '-g',
+        ]
         if cfg.env.DEBUG:
             env.CFLAGS += [
-                '-g',
                 '-O0',
             ]
             env.DEFINES.update(


### PR DESCRIPTION
with the 10.2.1 gcc compiler this seems to make no difference to flash usage, and makes the elf files on the firmware server a lot more useful for analysis of crash dumps

darn, this drops the ccache hit rate massively