### PR TITLE
Copter: RTL accepts do-change-speed commands

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1318,6 +1318,10 @@ public:
 
     bool use_pilot_yaw() const override;
 
+    bool set_speed_xy(float speed_xy_cms) override;
+    bool set_speed_up(float speed_up_cms) override;
+    bool set_speed_down(float speed_down_cms) override;
+
     // RTL states
     enum class SubMode : uint8_t {
         STARTING,

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -554,4 +554,22 @@ bool ModeRTL::use_pilot_yaw(void) const
     return allow_yaw_option || land_repositioning || final_landing;
 }
 
+bool ModeRTL::set_speed_xy(float speed_xy_cms)
+{
+    copter.wp_nav->set_speed_xy(speed_xy_cms);
+    return true;
+}
+
+bool ModeRTL::set_speed_up(float speed_up_cms)
+{
+    copter.wp_nav->set_speed_up(speed_up_cms);
+    return true;
+}
+
+bool ModeRTL::set_speed_down(float speed_down_cms)
+{
+    copter.wp_nav->set_speed_down(speed_down_cms);
+    return true;
+}
+
 #endif


### PR DESCRIPTION
This allows the vehicle's speed to be changed during RTL (either the flight mode or mission command) using a DO_CHANGE_SPEED command.

This has been tested in SITL (both the mode and the mission) and works as expected.

![rtl-do-change-speed-test](https://user-images.githubusercontent.com/1498098/233225491-28f46a19-5e8a-4cba-ad0c-bdb4a072df9d.png)
