### PR TITLE
AP_Notify: fix incorrect buzzer pin type to stop always instantiating

### DIFF
--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -195,7 +195,7 @@ public:
     uint32_t get_text_updated_millis() const {return _send_text_updated_millis; }
 
     static const struct AP_Param::GroupInfo var_info[];
-    uint8_t get_buzz_pin() const  { return _buzzer_pin; }
+    int8_t get_buzz_pin() const  { return _buzzer_pin; }
     uint8_t get_buzz_level() const  { return _buzzer_level; }
     uint8_t get_buzz_volume() const  { return _buzzer_volume; }
     uint8_t get_led_len() const { return _led_len; }

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -29,7 +29,7 @@ bool Buzzer::init()
         return false;
     }
     _pin = pNotify->get_buzz_pin();
-    if (_pin == 0u) {
+    if (_pin <= 0) {
         // no buzzer
         return false;
     }

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -61,7 +61,7 @@ private:
     } _flags;
 
     uint32_t _pattern;           // current pattern
-    uint8_t _pin;
+    int8_t _pin;
     uint32_t _pattern_start_time;
 
     // enforce minumum 100ms interval between patterns:


### PR DESCRIPTION
type and compare is wrong....it always instantiates (unless pin =0 which is not default)