### PR TITLE
build: require gcc 10.2.x or later for ChibiOS builds

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -35,27 +35,13 @@ jobs:
             signing
         ]
         toolchain: [
-            chibios,  # GCC-6
+            chibios,
             #chibios-clang,
         ]
-        gcc: [6, 10]
+        gcc: [10]
         exclude:
           - gcc: 10
             toolchain: chibios-clang
-          - gcc: 6
-            config: fmuv2-plane
-          - gcc: 6
-            config: revo-mini
-          - gcc: 6
-            config: MatekF405-Wing
-          - gcc: 6
-            config: periph-build
-          - gcc: 6
-            config: CubeOrange-ODID
-          - gcc: 6
-            config: signing
-          - gcc: 6
-            config: fmuv3-bootloader
         include:
           - config: stm32h7
             toolchain: chibios-py2

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1001,6 +1001,11 @@ class chibios(Board):
                 '-g3',
             ]
 
+        if cfg.env.COMPILER_CXX == "g++":
+            if not self.cc_version_gte(cfg, 10, 2):
+                # require at least 10.2 compiler
+                cfg.fatal("ChibiOS build requires g++ version 10.2.1 or later, found %s" % '.'.join(cfg.env.CC_VERSION))
+            
         if cfg.env.ENABLE_ASSERTS:
             cfg.msg("Enabling ChibiOS asserts", "yes")
             env.CFLAGS += [ '-DHAL_CHIBIOS_ENABLE_ASSERTS' ]


### PR DESCRIPTION
We are doing all production builds with 10.2.1. We should push all devs to use at least that version. That will allow us to use new C++ features and also ensures users are using a compiler that we do real testing with
