### PR TITLE
Copter: parameterize rotation rate for flip mode

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1169,6 +1169,17 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @Increment: 0.1
     AP_GROUPINFO("PILOT_TKO_ALT_M", 20, ParametersG2, pilot_takeoff_alt_m, PILOT_TKO_ALT_M_DEFAULT),
 
+#if MODE_FLIP_ENABLED
+    // @Param: FLIP_RATE
+    // @DisplayName: Flip Mode Rotational Rate
+    // @Description: Rotational Rate for Flip Mode in Deg/s.  Be sure to set a rotational rate that the aircraft can acheive.
+    // @Units: deg/s
+    // @Range: 60 1000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("FLIP_RATE", 21, ParametersG2, flip_rate_dps, 400),
+#endif
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1185,6 +1185,17 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     AP_GROUPINFO("SURFTRAK_GLSAM", 22, ParametersG2, surf_dist_parameters.glitch_num_samples, AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT),
 #endif
 
+#if MODE_FLIP_ENABLED
+    // @Param: FLIP_RATE
+    // @DisplayName: Flip Mode Rotational Rate
+    // @Description: Rotational Rate for Flip Mode in Deg/s.  Be sure to set a rotational rate that the aircraft can achieve.
+    // @Units: deg/s
+    // @Range: 60 1000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("FLIP_RATE", 23, ParametersG2, flip_rate_dps, 400),
+#endif
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1186,14 +1186,9 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
 #endif
 
 #if MODE_FLIP_ENABLED
-    // @Param: FLIP_RATE
-    // @DisplayName: Flip Mode Rotational Rate
-    // @Description: Rotational Rate for Flip Mode in Deg/s.  Be sure to set a rotational rate that the aircraft can achieve.
-    // @Units: deg/s
-    // @Range: 60 1000
-    // @Increment: 1
-    // @User: Standard
-    AP_GROUPINFO("FLIP_RATE", 23, ParametersG2, flip_rate_dps, 400),
+    // @Group: FLIP_
+    // @Path: mode_flip.cpp
+    AP_SUBGROUPPTR(mode_flip_ptr, "FLIP_", 23, ParametersG2, ModeFlip),
 #endif
 
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
@@ -1262,6 +1257,11 @@ ParametersG2::ParametersG2(void) :
 #if MODE_POSHOLD_ENABLED
     ,mode_poshold_ptr(&copter.mode_poshold)
 #endif
+
+#if MODE_FLIP_ENABLED
+    ,mode_flip_ptr(&copter.mode_flip)
+#endif
+
 {
     AP_Param::setup_object_defaults(this, var_info);
     AP_Param::setup_object_defaults(this, var_info2);

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -739,6 +739,9 @@ public:
     void *mode_poshold_ptr;
 #endif
 
+#if MODE_FLIP_ENABLED
+    AP_Int16 flip_rate_dps;
+#endif
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -737,8 +737,9 @@ public:
 #endif
 
 #if MODE_FLIP_ENABLED
-    AP_Int16 flip_rate_dps;
+    void *mode_flip_ptr;
 #endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -736,6 +736,9 @@ public:
     void *mode_poshold_ptr;
 #endif
 
+#if MODE_FLIP_ENABLED
+    AP_Int16 flip_rate_dps;
+#endif
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -958,8 +958,8 @@ private:
 class ModeFlip : public Mode {
 
 public:
-    // inherit constructor
-    using Mode::Mode;
+    // need a constructor
+    ModeFlip(void);
     Number mode_number() const override { return Number::FLIP; }
 
     bool init(bool ignore_checks) override;
@@ -972,6 +972,8 @@ public:
     bool crash_check_enabled() const override { return false; }
 
     void abandon_flip();
+
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
 
@@ -996,6 +998,7 @@ private:
     uint32_t start_time_ms;
     int8_t roll_dir;                    // roll direction (-1 = roll left, 1 = roll right)
     int8_t pitch_dir;                   // pitch direction (-1 = pitch forward, 1 = pitch back)
+    AP_Float flip_rate_dps;              // rotational rate during flip
 
     bool input_is_high_magnitude(RC_Channel &input) const;
 };

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -91,8 +91,12 @@ bool ModeFlip::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeFlip::run()
 {
+    // determine flip rotation rate
+    float flip_rate_rads = radians(g2.flip_rate_dps.get());
+    float flip_time_out_ms = 1000.0f * (360.0f / MAX(flip_rate_rads, radians(60.0)) + 1.0);
+
     // if pilot inputs roll > 40deg or timeout occurs abandon flip
-    if (!motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
+    if (!motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > flip_time_out_ms)) {
         _state = FlipState::Abandon;
     }
 
@@ -105,11 +109,14 @@ void ModeFlip::run()
     // get corrected angle based on direction and axis of rotation
     // we flip the sign of flip_angle to minimize the code repetition
     float flip_angle_rad;
+    float flip_angle_error_rad;
 
     if (roll_dir != 0) {
         flip_angle_rad = ahrs.get_roll_rad() * roll_dir;
+        flip_angle_error_rad = attitude_control->get_att_target_euler_rad().x - ahrs.get_roll_rad();
     } else {
         flip_angle_rad = ahrs.get_pitch_rad() * pitch_dir;
+        flip_angle_error_rad = attitude_control->get_att_target_euler_rad().y - ahrs.get_pitch_rad();
     }
 
     // state machine
@@ -117,7 +124,7 @@ void ModeFlip::run()
 
     case FlipState::Start:
         // under 45 degrees request 400deg/sec roll or pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(flip_rate_rads * roll_dir, flip_rate_rads * pitch_dir, 0.0);
 
         // increase throttle
         throttle_out += FLIP_THR_INC;
@@ -126,17 +133,24 @@ void ModeFlip::run()
         if (flip_angle_rad >= radians(45.0)) {
             if (roll_dir != 0) {
                 // we are rolling
-            _state = FlipState::Roll;
+                _state = FlipState::Roll;
             } else {
                 // we are pitching
                 _state = FlipState::Pitch_A;
-        }
+            }
         }
         break;
 
     case FlipState::Roll:
-        // between 45deg ~ -90deg request 400deg/sec roll
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, 0.0, 0.0);
+        // keep target aircraft from getting too far away from actual aircraft
+        if (flip_angle_error_rad > radians(15.0) && flip_angle_error_rad <= radians(45.0)) {
+            float knock_down = 1.0f - (flip_angle_error_rad - radians(15.0f)) / radians(30.0f);
+            flip_rate_rads = (ahrs.get_gyro().x + knock_down * (flip_rate_rads - ahrs.get_gyro().x)) * roll_dir;
+        } else if (flip_angle_error_rad > radians(45.0)) {
+            flip_rate_rads = ahrs.get_gyro().x * roll_dir;
+        }
+        // between 45deg ~ -90deg request user specified roll rate
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(flip_rate_rads * roll_dir, 0.0, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
@@ -148,7 +162,7 @@ void ModeFlip::run()
 
     case FlipState::Pitch_A:
         // between 45deg ~ -90deg request 400deg/sec pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0f, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0f, flip_rate_rads * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
@@ -160,7 +174,7 @@ void ModeFlip::run()
 
     case FlipState::Pitch_B:
         // between 45deg ~ -90deg request 400deg/sec pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0, flip_rate_rads * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -28,6 +28,29 @@
 #define FLIP_PITCH_BACK      1      // used to set flip_dir
 #define FLIP_PITCH_FORWARD  -1      // used to set flip_dir
 
+#define FLIP_RATE_DEFAULT_DPS 400.0f  // default flip rate in deg/s
+
+const AP_Param::GroupInfo ModeFlip::var_info[] = {
+
+    // @Param: RATE
+    // @DisplayName: Flip Mode Rotational Rate
+    // @Description: Rotational Rate for Flip Mode in Deg/s.  Be sure to set a rotational rate that the aircraft can achieve.
+    // @Units: deg/s
+    // @Range: 60 1000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RATE", 1, ModeFlip, flip_rate_dps, FLIP_RATE_DEFAULT_DPS),
+
+    AP_GROUPEND
+};
+
+// constructor
+ModeFlip::ModeFlip(void) : Mode()
+{
+    // load parameter defaults
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
 // flip_init - initialise flip controller
 bool ModeFlip::init(bool ignore_checks)
 {
@@ -88,7 +111,7 @@ bool ModeFlip::init(bool ignore_checks)
 void ModeFlip::run()
 {
     // get flip rotation rate parameter and constrain to range from 60 to 1000 deg/s.
-    const float flip_rate_rads = radians(constrain_float(g2.flip_rate_dps.get(), 60.0f, 1000.0f));
+    const float flip_rate_rads = radians(constrain_float(flip_rate_dps.get(), 60.0f, 1000.0f));
     // determine timeout for flip based on rotation rate.  Time is doubled to allow for poorly tuned vehicles.
     const float flip_time_out_ms = 1000.0f * (2.0f * radians(360.0f) / flip_rate_rads);
 

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -20,8 +20,6 @@
 
 #define FLIP_THR_INC            0.20f           // throttle increase during FlipState::Start stage (under 45deg lean angle)
 #define FLIP_THR_DEC            0.24f           // throttle decrease during FlipState::Roll stage (between 45deg ~ -90deg roll)
-#define FLIP_ROTATION_RATE_RADS radians(400.0)  // rotation rate request in radians / sec (i.e. 400 deg/sec)
-#define FLIP_TIMEOUT_MS         2500            // timeout after 2.5sec.  Vehicle will switch back to original flight mode
 #define FLIP_RECOVERY_ANGLE_RAD radians(5.0)    // consider successful recovery when roll is back within 5 degrees of original
 
 #define FLIP_ROLL_RIGHT      1      // used to set flip_dir
@@ -89,7 +87,13 @@ bool ModeFlip::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeFlip::run()
 {
-    if (abandon_requested || !motors->armed() || input_is_high_magnitude(*channel_roll) || input_is_high_magnitude(*channel_pitch) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
+    // get flip rotation rate parameter and constrain to range from 60 to 1000 deg/s.
+    const float flip_rate_rads = radians(constrain_float(g2.flip_rate_dps.get(), 60.0f, 1000.0f));
+    // determine timeout for flip based on rotation rate.  Time is doubled to allow for poorly tuned vehicles.
+    const float flip_time_out_ms = 1000.0f * (2.0f * radians(360.0f) / flip_rate_rads);
+
+    // if pilot inputs roll > 40deg or timeout occurs abandon flip
+    if (abandon_requested || !motors->armed() || input_is_high_magnitude(*channel_roll) || input_is_high_magnitude(*channel_pitch) || ((millis() - start_time_ms) > flip_time_out_ms)) {
         _state = FlipState::Abandon;
         abandon_requested = false;
     }
@@ -114,8 +118,8 @@ void ModeFlip::run()
     switch (_state) {
 
     case FlipState::Start:
-        // request FLIP_ROTATION_RATE_RADS in the nonzero dir
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        // request flip_rate_rads in the nonzero direction
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(flip_rate_rads * roll_dir, flip_rate_rads * pitch_dir, 0.0);
 
         // increase throttle
         throttle_out += FLIP_THR_INC;
@@ -124,7 +128,7 @@ void ModeFlip::run()
         if (flip_angle_rad >= radians(45.0)) {
             if (roll_dir != 0) {
                 // we are rolling
-            _state = FlipState::Roll;
+                _state = FlipState::Roll;
             } else {
                 // we are pitching
                 _state = FlipState::Pitch_A;
@@ -133,8 +137,8 @@ void ModeFlip::run()
         break;
 
     case FlipState::Roll:
-        // request FLIP_ROTATION_RATE_RADS roll
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, 0.0, 0.0);
+        // request flip_rate_rads roll
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(flip_rate_rads * roll_dir, 0.0, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
@@ -145,8 +149,8 @@ void ModeFlip::run()
         break;
 
     case FlipState::Pitch_A:
-        // request FLIP_ROTATION_RATE_RADS pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0f, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        // request flip_rate_rads pitch
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0f, flip_rate_rads * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
@@ -157,8 +161,8 @@ void ModeFlip::run()
         break;
 
     case FlipState::Pitch_B:
-        // request FLIP_ROTATION_RATE_RADS pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
+        // request flip_rate_rads pitch
+        attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0, flip_rate_rads * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 


### PR DESCRIPTION
This PR adds a parameter for the user to be able to specify the flip rotation rate for flip mode.  The timeout is calculated based on the flip rate by dividing the flip rate into 360 deg and adding 1 second.  This was tested in SITL with a tradheli frame to ensure it functionally works.  The parameter default rate was set to the rate hard coded which was 400 deg/s.