### PR TITLE
Tools: sim_vehicle to only launch one 1455x UDP port

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -857,7 +857,7 @@ def start_mavproxy(opts, stuff):
 
     for i in instances:
         if not opts.no_extra_ports:
-            ports = [p + 10 * i for p in [14550, 14551]]
+            ports = [14550 + 10 * i]
             for port in ports:
                 if under_vagrant():
                     # We're running inside of a vagrant guest; forward our


### PR DESCRIPTION
instead of sim_vehicle.py launching both a 14550 and a 14551 UDP fwd stream by default, use only 14550.

- This decreases cpu work on MAVProx and Mission Planner and SITL by not generating and parsing two streams when only 1 is being looked at by the user.
- reduces confusion of GCSs seeing two vehicles with the same SSID (times however many vehicles you have)
- doesn't cause Mission Planner to fetch params twice, at the same time from the same vehicle, at the moment it boots which is both not realistic in most cases and is also likely the reason Mission Planner often gets bogged down trying to fetch params at SITL boot as it's booting up.

Multiple streams can still be launch, of course, using the other argus such as --out.