### PR TITLE
AP_Scripting: Check for battery in MAVLinkHL and Rockblock

### DIFF
--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -777,7 +777,12 @@ function HLSatcom()
                                        ahrs:groundspeed_vector():length() * 5))
 
         hl2.temperature_air = math.floor(baro:get_external_temperature())
-        hl2.battery = battery:capacity_remaining_pct(0)
+        
+        if battery:num_instances() > 0 then
+            hl2.battery = battery:capacity_remaining_pct(0)
+        else
+            hl2.battery = 0
+        end
 
         -- just sending armed state here for simplicity. Flight mode is in the custom_mode field
         if arming:is_armed() then
@@ -802,7 +807,7 @@ end
 function protected_wrapper()
     local success, err = pcall(HLSatcom)
     if not success then
-        gcs:send_text(MAV_SEVERITY_ERROR, "Internal Error: " .. err)
+        gcs:send_text(3, "Internal Error: " .. err)
         -- when we fault we run the HLSatcom function again after 1s, slowing it
         -- down a bit so we don't flood the console with errors
         return protected_wrapper, 1000

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -433,8 +433,13 @@ function HLSatcom()
                                        ahrs:groundspeed_vector():length() * 5))
 
         hl2.temperature_air = math.floor(baro:get_external_temperature())
-        hl2.battery = battery:capacity_remaining_pct(0)
 
+        if battery:num_instances() > 0 then
+            hl2.battery = battery:capacity_remaining_pct(0)
+        else
+            hl2.battery = 0
+        end
+        
         -- just sending armed state here for simplicity. Flight mode is in the custom_mode field
         if arming:is_armed() then
             hl2.custom0 = 129 -- MAV_MODE_FLAG_SAFETY_ARMED + MAV_MODE_FLAG_CUSTOM_MODE_ENABLED


### PR DESCRIPTION
Check if the user has a configured battery monitor before getting battery voltage.

Also fix an undefined variable that crept in (``MAV_SEVERITY_ERROR``)