### PR TITLE
Copter, Plane, Rover, Tracker, Blimp: version to 4.5.0-dev

### DIFF
--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.3.0-dev"
+#define THISFIRMWARE "AntennaTracker V4.5.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,5,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 3
+#define FW_MINOR 5
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.4.0-dev"
+#define THISFIRMWARE "ArduCopter V4.5.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,5,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 4
+#define FW_MINOR 5
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.4.0-dev"
+#define THISFIRMWARE "ArduPlane V4.5.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,5,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 4
+#define FW_MINOR 5
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/Blimp/version.h
+++ b/Blimp/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Blimp V4.3.0-dev"
+#define THISFIRMWARE "Blimp V4.5.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,5,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 3
+#define FW_MINOR 5
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,13 +6,13 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.4.0-dev"
+#define THISFIRMWARE "ArduRover V4.5.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_DEV
+#define FIRMWARE_VERSION 4,5,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
-#define FW_MINOR 4
+#define FW_MINOR 5
 #define FW_PATCH 0
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 


### PR DESCRIPTION
This updates the versions for "latest" to 4.5.0 for Copter, Plane, Rover, Tracker and Blimp.

I think we've decided that we should try and keep each vehicle's major version number consistent.

Blimp's version file also gets an EOL character (this is on purpose).
