### PR TITLE
AP_Motors: remove unused function: rotor_speed_above_critical

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -461,7 +461,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
     // if in autorotation, don't let rotor_runup_output go less than critical speed to keep
     // runup complete flag from being set to false
-    if (_autorotating && _rotor_runup_output < get_critical_speed()) {
+    if (_autorotating && !rotor_speed_above_critical()) {
         _rotor_runup_output = get_critical_speed();
     }
 
@@ -479,7 +479,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
     // if rotor speed is less than critical speed, then run-up is not complete
     // this will prevent the case where the target rotor speed is less than critical speed
-    if (_runup_complete && (get_rotor_speed() < get_critical_speed())) {
+    if (_runup_complete && !rotor_speed_above_critical()) {
         _runup_complete = false;
     }
     // if rotor estimated speed is zero, then spooldown has been completed


### PR DESCRIPTION
Helper functions appear to be left over and not used.

This logic is used in the code but the helper is not called.  We can either add the helper to places in the code that the logic is duplicated or we should remove the helper.

IMHO the logic is not complicated enough that the helper actually improves readbility, hence this PR to delete.  