### PR TITLE
Use RPM Measurement in Run Up and Down

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -56,13 +56,13 @@ public:
     void set_desired_rotor_speed(float desired_speed) override;
 
     // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
+    float get_main_rotor_speed() const  override { return _main_rotor.get_norm_rotor_speed(); }
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
-    float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
+    float get_desired_rotor_speed() const  override { return _main_rotor.get_norm_rotor_speed(); }
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
+    bool rotor_speed_above_critical() const  override { return _main_rotor.get_norm_rotor_speed() > _main_rotor.get_critical_speed(); }
 
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -35,13 +35,13 @@ public:
     void set_desired_rotor_speed(float desired_speed) override;
 
     // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
+    float get_main_rotor_speed() const  override { return _main_rotor.get_norm_rotor_speed(); }
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
-    float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
+    float get_desired_rotor_speed() const  override { return _main_rotor.get_norm_rotor_speed(); }
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
+    bool rotor_speed_above_critical() const  override { return _main_rotor.get_norm_rotor_speed() > _main_rotor.get_critical_speed(); }
 
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -81,8 +81,8 @@ public:
     // set_desired_speed - this requires input to be 0-1
     void        set_desired_speed(float desired_speed) { _desired_speed = desired_speed; }
 
-    // get_rotor_speed - estimated rotor speed when no governor or rpm sensor is used
-    float       get_rotor_speed() const;
+    // get_norm_rotor_speed - estimated rotor speed when no governor or rpm sensor is used
+    float       get_norm_rotor_speed() const;
 
     // functions for autothrottle, throttle curve, governor, idle speed, output to servo
     void        set_governor_output(float governor_output) {_governor_output = governor_output; }
@@ -185,6 +185,9 @@ private:
     // calculate_throttlecurve - uses throttle curve and collective input to determine throttle setting
     float           calculate_throttlecurve(float collective_in);
 
+    // update_rotor_speed_measurement - gets measured rpm from desired rpm instance if available
+    void            update_rotor_speed_measurement(void);
+
     // parameters
     AP_Int16        _power_slewrate;            // throttle slew rate (percentage per second)
     AP_Int16        _thrcrv[5];                 // throttle value sent to throttle servo at 0, 25, 50, 75 and 100 percent collective
@@ -195,6 +198,7 @@ private:
     AP_Float        _governor_ff;               // governor feedforward variable
     AP_Float        _governor_range;            // RPM range +/- governor rpm reference setting where governor is operational
     AP_Int16        _cooldown_time;             // cooldown time to provide a fast idle
+    AP_Int8         _rpm_idx;                   // index to get rotor rpm measurement from
 
     // parameter accessors to allow conversions
     float       get_critical_speed() const { return _critical_speed * 0.01; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -56,13 +56,13 @@ public:
     void set_desired_rotor_speed(float desired_speed) override;
 
     // get_main_rotor_speed - estimated rotor speed when no speed sensor or governor is used
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
+    float get_main_rotor_speed() const  override { return _main_rotor.get_norm_rotor_speed(); }
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
     float get_desired_rotor_speed() const  override { return _main_rotor.get_desired_speed(); }
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
+    bool rotor_speed_above_critical() const  override { return _main_rotor.get_norm_rotor_speed() > _main_rotor.get_critical_speed(); }
 
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }


### PR DESCRIPTION
This PR looks to add in the RPM measurement for checking if we have completed run-up

To do this I have:
- Renamed the governer rpm param to make it more generic.  Name change is not breaking so current users not effected.
- Moved rpm measurement update to helper function.
- Allowed users to select which RPM instance to use for a given RCS.  Defaults to first instance to avoid braking param setups for  those that use the inbuilt governer.
- Renamed get_rotor_speed() to get_norm_rotor_speed to avoid confusion when reading the code.

TODO:
- [ ]  Handle failures to attain target head speed. (use a timeout?)
- [ ]  Check runup complete on numerous outputs (dual heli and heli-quad).
- [ ]  Change get_desired_rotor_speed() to not just always get the measured.
- [ ]  Update governer wiki with change of param name.
- [ ]  We may want more instances of AP_RPM for better handling of heli quad?