### PR TITLE
Plane: move to more mode run functions

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -213,23 +213,24 @@ float Plane::stabilize_pitch_get_pitch_out()
 
 /*
   this gives the user control of the aircraft in stabilization modes, only used in Stabilize Mode
+  to be moved to mode_stabilize.cpp in future
  */
-void Plane::stabilize_stick_mixing_direct()
+void ModeStabilize::stabilize_stick_mixing_direct()
 {
-    if (!stick_mixing_enabled()) {
+    if (!plane.stick_mixing_enabled()) {
         return;
     }
 #if HAL_QUADPLANE_ENABLED
-    if (!quadplane.allow_stick_mixing()) {
+    if (!plane.quadplane.allow_stick_mixing()) {
         return;
     }
 #endif
     float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
-    aileron = channel_roll->stick_mixing(aileron);
+    aileron = plane.channel_roll->stick_mixing(aileron);
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, aileron);
 
     float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
-    elevator = channel_pitch->stick_mixing(elevator);
+    elevator = plane.channel_pitch->stick_mixing(elevator);
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, elevator);
 }
 
@@ -392,13 +393,9 @@ void Plane::stabilize()
             steering_control.rudder = rudder;
         }
 #endif
-    } else if (control_mode == &mode_acro) {
+    } else if (control_mode == &mode_acro ||
+                control_mode == &mode_stabilize) {
         plane.control_mode->run();
-    } else if (control_mode == &mode_stabilize) {
-        stabilize_roll();
-        stabilize_pitch();
-        stabilize_stick_mixing_direct();
-        stabilize_yaw();
 #if HAL_QUADPLANE_ENABLED
     } else if (control_mode->is_vtol_mode() && !quadplane.tailsitter.in_vtol_transition(now)) {
         // run controlers specific to this mode

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -410,14 +410,7 @@ void Plane::stabilize()
         }
 #endif
     } else {
-        // Direct stick mixing functionality has been removed, so as not to remove all stick mixing from the user completely
-        // the old direct option is now used to enable fbw mixing, this is easier than doing a param conversion.
-        if ((g.stick_mixing == StickMixing::FBW) || (g.stick_mixing == StickMixing::DIRECT_REMOVED)) {
-            stabilize_stick_mixing_fbw();
-        }
-        stabilize_roll();
-        stabilize_pitch();
-        stabilize_yaw();
+        plane.control_mode->run();
     }
 
     /*

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -862,7 +862,6 @@ private:
     float stabilize_roll_get_roll_out();
     void stabilize_pitch();
     float stabilize_pitch_get_pitch_out();
-    void stabilize_stick_mixing_direct();
     void stabilize_stick_mixing_fbw();
     void stabilize_yaw();
     void calc_nav_yaw_coordinated();

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -200,3 +200,15 @@ bool Mode::_pre_arm_checks(size_t buflen, char *buffer) const
 #endif
     return true;
 }
+
+void Mode::run()
+{
+    // Direct stick mixing functionality has been removed, so as not to remove all stick mixing from the user completely
+    // the old direct option is now used to enable fbw mixing, this is easier than doing a param conversion.
+    if ((plane.g.stick_mixing == StickMixing::FBW) || (plane.g.stick_mixing == StickMixing::DIRECT_REMOVED)) {
+        plane.stabilize_stick_mixing_fbw();
+    }
+    plane.stabilize_roll();
+    plane.stabilize_pitch();
+    plane.stabilize_yaw();
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -65,7 +65,7 @@ public:
     void exit();
 
     // run controllers specific to this mode
-    virtual void run() {};
+    virtual void run();
 
     // returns a unique number specific to this mode
     virtual Number mode_number() const = 0;

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -398,6 +398,12 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    void run() override;
+
+private:
+    void stabilize_stick_mixing_direct();
+
 };
 
 class ModeTraining : public Mode

--- a/ArduPlane/mode_stabilize.cpp
+++ b/ArduPlane/mode_stabilize.cpp
@@ -7,3 +7,10 @@ void ModeStabilize::update()
     plane.nav_pitch_cd = 0;
 }
 
+void ModeStabilize::run()
+{
+    plane.stabilize_roll();
+    plane.stabilize_pitch();
+    stabilize_stick_mixing_direct();
+    plane.stabilize_yaw();
+}


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/23513. Now we can move the default and stabilize mode cases down into the mode classes.