### PR TITLE
Filter: SlewLimiter: always caculate slew limit

### DIFF
--- a/libraries/AP_Math/chirp.cpp
+++ b/libraries/AP_Math/chirp.cpp
@@ -46,6 +46,8 @@ void Chirp::init(float time_record, float frequency_start_hz, float frequency_st
 
     B = logf(wMax / wMin);
 
+    // Mark as incomplete
+    complete = false;
 }
 
 // determine chirp signal output at the specified time and amplitude
@@ -83,5 +85,8 @@ float Chirp::update(float time, float waveform_magnitude)
         waveform_freq_rads = wMax;
         output = 0.0f;
     }
+
+    complete = time > record;
+
     return output;
 }

--- a/libraries/AP_Math/chirp.h
+++ b/libraries/AP_Math/chirp.h
@@ -16,6 +16,9 @@ public:
     // accessor for the current waveform frequency
     float get_frequency_rads() {return waveform_freq_rads; }
 
+    // Return true if chirp is completed
+    bool completed() const { return complete; }
+
 private:
     // Total chirp length in seconds
     float record;
@@ -49,5 +52,8 @@ private:
 
     // output of chirp signal at the requested time
     float output;
+
+    // True if chirp is complete, reset to false on init
+    bool complete;
 
 };

--- a/libraries/Filter/SlewLimiter.cpp
+++ b/libraries/Filter/SlewLimiter.cpp
@@ -43,18 +43,45 @@ float SlewLimiter::modifier(float sample, float dt)
     if (!is_positive(dt)) {
         return 1.0;
     }
-    
-    if (slew_rate_max <= 0) {
-        _output_slew_rate = 0.0;
-        return 1.0;
-    }
 
     // Calculate a low pass filtered slew rate
     const float slew_rate = slew_filter.apply((sample - last_sample) / dt, dt);
     last_sample = sample;
 
     uint32_t now_ms = AP_HAL::millis();
+
+    // Apply a filter to decay maximum seen slew rate once the value had left the window period
     const float decay_alpha = fminf(dt, slew_rate_tau) / slew_rate_tau;
+
+    // Apply a filter to increases in slew rate only to reduce the effect of gusts and large controller setpoint changes
+    const float attack_alpha = fminf(2.0f * decay_alpha, 1.0f);
+
+    // Decay the peak positive and negative slew rate if they are outside the window
+    // Never drop PID gains below 10% of configured value
+    if (slew_rate > _max_pos_slew_rate) {
+        _max_pos_slew_rate = slew_rate;
+        _max_pos_slew_event_ms = now_ms;
+    } else if (now_ms - _max_pos_slew_event_ms > WINDOW_MS) {
+        _max_pos_slew_rate *= (1.0f - decay_alpha);
+    }
+
+    if (-slew_rate > _max_neg_slew_rate) {
+        _max_neg_slew_rate = -slew_rate;
+        _max_neg_slew_event_ms = now_ms;
+    } else if (now_ms - _max_neg_slew_event_ms > WINDOW_MS) {
+        _max_neg_slew_rate *= (1.0f - decay_alpha);
+    }
+
+    const float raw_slew_rate = 0.5f*(_max_pos_slew_rate + _max_neg_slew_rate);
+    _output_slew_rate = (1.0f - attack_alpha) * _output_slew_rate + attack_alpha * raw_slew_rate;
+    _output_slew_rate = fminf(_output_slew_rate, raw_slew_rate);
+
+    if (slew_rate_max <= 0) {
+        return 1.0;
+    }
+
+    // Constrain slew rate used for calculation
+    const float limited_raw_slew_rate = 0.5f*(fminf(_max_pos_slew_rate, 10.0f * slew_rate_max) + fminf(_max_neg_slew_rate, 10.0f * slew_rate_max));
 
     // Store a series of positive slew rate exceedance events
     if (!_pos_event_stored && slew_rate > slew_rate_max) {
@@ -68,7 +95,7 @@ float SlewLimiter::modifier(float sample, float dt)
     }
 
     // Store a series of negative slew rate exceedance events
-    if (!_neg_event_stored && slew_rate < - slew_rate_max) {
+    if (!_neg_event_stored && -slew_rate > slew_rate_max) {
         if (_neg_event_index >= N_EVENTS) {
             _neg_event_index = 0;
         }
@@ -81,57 +108,26 @@ float SlewLimiter::modifier(float sample, float dt)
     // Find the oldest event time
     uint32_t oldest_ms = now_ms;
     for (uint8_t index = 0; index < N_EVENTS; index++) {
-        if (_pos_event_ms[index] < oldest_ms) {
-            oldest_ms = _pos_event_ms[index];
-        }
-        if (_neg_event_ms[index] < oldest_ms) {
-            oldest_ms = _neg_event_ms[index];
-        }
+        oldest_ms = MIN(oldest_ms, _pos_event_ms[index]);
+        oldest_ms = MIN(oldest_ms, _neg_event_ms[index]);
     }
-
-    // Decay the peak positive and negative slew rate if they are outside the window
-    // Never drop PID gains below 10% of configured value
-    if (slew_rate > _max_pos_slew_rate) {
-        _max_pos_slew_rate = fminf(slew_rate, 10.0f * slew_rate_max);
-        _max_pos_slew_event_ms = now_ms;
-    } else if (now_ms - _max_pos_slew_event_ms > WINDOW_MS) {
-        _max_pos_slew_rate *= (1.0f - decay_alpha);
-    }
-
-    if (slew_rate < -_max_neg_slew_rate) {
-        _max_neg_slew_rate = fminf(-slew_rate, 10.0f * slew_rate_max);
-        _max_neg_slew_event_ms = now_ms;
-    } else if (now_ms - _max_neg_slew_event_ms > WINDOW_MS) {
-        _max_neg_slew_rate *= (1.0f - decay_alpha);
-    }
-
-    const float raw_slew_rate = 0.5f*(_max_pos_slew_rate + _max_neg_slew_rate);
 
     // Apply a further reduction when the oldest exceedance event falls outside the window required for the
     // specified number of exceedance events. This prevents spikes due to control mode changed, etc causing
     // unwanted gain reduction and is only applied to the slew rate used for gain reduction
-    float modifier_input = raw_slew_rate;
+    float modifier_input = limited_raw_slew_rate;
     if (now_ms - oldest_ms > (N_EVENTS + 1) * WINDOW_MS) {
         const float oldest_time_from_window = 0.001f*(float)(now_ms - oldest_ms - (N_EVENTS + 1) * WINDOW_MS);
         modifier_input *= expf(-oldest_time_from_window / slew_rate_tau);
     }
 
-    // Apply a filter to increases in slew rate only to reduce the effect of gusts and large controller
-    // setpoint changes
-    const float attack_alpha = fminf(2.0f * decay_alpha, 1.0f);
-
     _modifier_slew_rate = (1.0f - attack_alpha) * _modifier_slew_rate + attack_alpha * modifier_input;
     _modifier_slew_rate = fminf(_modifier_slew_rate, modifier_input);
 
-    _output_slew_rate = (1.0f - attack_alpha) * _output_slew_rate + attack_alpha * raw_slew_rate;
-    _output_slew_rate = fminf(_output_slew_rate, raw_slew_rate);
-
     // Calculate the gain adjustment
-    float mod;
+    float mod = 1.0f;
     if (_modifier_slew_rate > slew_rate_max) {
         mod = slew_rate_max / (slew_rate_max + MODIFIER_GAIN * (_modifier_slew_rate - slew_rate_max));
-    } else {
-        mod = 1.0f;
     }
 
     return mod;

--- a/libraries/Filter/examples/SlewLimiter/SlewLimiter.cpp
+++ b/libraries/Filter/examples/SlewLimiter/SlewLimiter.cpp
@@ -1,0 +1,75 @@
+// Example to test functionality of SlewLimiter
+
+#include <AP_HAL/AP_HAL.h>
+#include <Filter/SlewLimiter.h>
+#include <AP_Math/chirp.h>
+
+/* on Linux run with
+    ./waf configure --board linux
+    ./waf --targets examples/SlewLimiter
+    ./build/linux/examples/SlewLimiter
+*/
+
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+const float slew_rate_max = 50.0;
+const float slew_rate_tau = 1.0;
+
+// 400 hz loop
+const uint16_t dt_us = 2500;
+const float dt_s = dt_us * 1.0e-6;
+
+// Slew limiter object to be tested
+SlewLimiter slew_limiter{slew_rate_max, slew_rate_tau};
+
+// Chirp object to generate test signal
+Chirp chirp;
+
+// Chirp setup params
+const float magnitude = 5.0;
+const float duration = 60.0;
+const float frequency_start = 5.0;
+const float frequency_stop = 100;
+const float time_fade_in = 15;
+const float time_fade_out = 10;
+const float time_const_freq = 2.0 / frequency_start;
+
+uint64_t waveform_time_us = 0;
+
+static void setup()
+{
+    hal.console->printf("SlewLimiter - rate max: %f, tau: %f, loop rate: %fHz\n", slew_rate_max, slew_rate_tau, 1 / dt_s);
+
+    chirp.init(duration, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
+    hal.console->printf("Chirp - duration: %fs, magnitude: %f, start: %fHz, stop: %fHz, fade in: %fs, fade out:%fs, hold: %fs\n", duration, magnitude, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
+
+    hal.console->printf("Time (s), input, slew rate, mod\n");
+
+    hal.scheduler->stop_clock(waveform_time_us);
+
+}
+
+void loop()
+{
+    const float waveform_time_s = waveform_time_us * 1.0e-6;
+
+    const float input = chirp.update(waveform_time_s, magnitude);
+
+    const float mod = slew_limiter.modifier(input, dt_s);
+
+    const float slew_rate = slew_limiter.get_slew_rate();
+
+    hal.console->printf("%f, %f, %f, %f\n", waveform_time_s, input, slew_rate, mod);
+
+    if (chirp.completed()) {
+        exit(1);
+    }
+
+    // Force clock times so we can run faster than real time
+    waveform_time_us += dt_us;
+    hal.scheduler->stop_clock(waveform_time_us);
+}
+
+AP_HAL_MAIN();

--- a/libraries/Filter/examples/SlewLimiter/SlewLimiterPlot.m
+++ b/libraries/Filter/examples/SlewLimiter/SlewLimiterPlot.m
@@ -1,0 +1,43 @@
+close all
+clear
+clc
+
+% Script for plotting outputs of SlewLimiter examples
+
+files = dir('*.csv');
+for i = numel(files):-1:1
+    data = readmatrix(files(i).name);
+
+    run{i}.time = data(:,1);
+    run{i}.input = data(:,2);
+    run{i}.slew = data(:,3);
+    run{i}.mod = data(:,4);
+
+    legend_val{i} = strrep(files(i).name, '_' ,'\_');
+end
+
+figure
+tiledlayout(3,1)
+
+nexttile
+hold all
+for i = 1:numel(run)
+    plot(run{i}.time, run{i}.input)
+end
+ylabel('Input')
+
+nexttile
+hold all
+for i = 1:numel(run)
+    plot(run{i}.time, run{i}.slew)
+end
+legend(legend_val,'Location','eastoutside')
+ylabel('Slew rate')
+
+nexttile
+hold all
+for i = 1:numel(run)
+    plot(run{i}.time, run{i}.mod)
+end
+xlabel('Time (s)')
+ylabel('mod')

--- a/libraries/Filter/examples/SlewLimiter/wscript
+++ b/libraries/Filter/examples/SlewLimiter/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )


### PR DESCRIPTION
Should always calculate slew limit so it will be logged without having to set large values. Just a re-ordering within the function. Not yet tested. 