### PR TITLE
Add MCU monitoring through ADC3 for H750 and H730 based boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -80,9 +80,15 @@ const AnalogIn::pin_info AnalogIn::pin_config[] = { HAL_ANALOG_PINS };
 #if defined(HAL_ANALOG3_PINS) || HAL_WITH_MCU_MONITORING
 #if HAL_WITH_MCU_MONITORING
     // internal ADC channels (from H7 reference manual)
-    #define ADC3_VSENSE_CHAN 18
-    #define ADC3_VREFINT_CHAN 19
-    #define ADC3_VBAT4_CHAN 17
+    #ifndef ADC3_VSENSE_CHAN
+        #define ADC3_VSENSE_CHAN 18
+    #endif
+    #ifndef ADC3_VREFINT_CHAN
+        #define ADC3_VREFINT_CHAN 19
+    #endif
+    #ifndef ADC3_VBAT4_CHAN
+        #define ADC3_VBAT4_CHAN 17
+    #endif
     #define HAL_MCU_MONITORING_PINS {ADC3_VBAT4_CHAN, 252, 3.30/4096}, {ADC3_VSENSE_CHAN, 253, 3.30/4096}, {ADC3_VREFINT_CHAN, 254, 3.30/4096}
 #else
     #define HAL_MCU_MONITORING_PINS

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
@@ -328,6 +328,9 @@
 #ifndef STM32_ADC_SAMPLES_SIZE
 #define STM32_ADC_SAMPLES_SIZE              16
 #endif
+#ifndef STM32_ADC_USE_ADC3
+#define STM32_ADC_USE_ADC3                  TRUE
+#endif
 #define STM32_ADC_COMPACT_SAMPLES           FALSE
 #define STM32_ADC_USE_ADC12                 TRUE
 #define STM32_ADC_ADC12_DMA_PRIORITY        2

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
@@ -81,6 +81,10 @@ mcu = {
 
     'DEFINES' : {
         'HAL_HAVE_HARDWARE_DOUBLE' : '1',
+        'HAL_WITH_MCU_MONITORING' : '1',
+        'ADC3_VSENSE_CHAN' : 17,
+        'ADC3_VREFINT_CHAN' : 18,
+        'ADC3_VBAT4_CHAN' : 16,
         'STM32H7' : '1',
     },
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -77,9 +77,6 @@ mcu = {
     'DEFINES' : {
         'HAL_HAVE_HARDWARE_DOUBLE' : '1',
         'HAL_WITH_MCU_MONITORING' : '1',
-        'ADC3_VSENSE_CHAN' : 17,
-        'ADC3_VREFINT_CHAN' : 18,
-        'ADC3_VBAT4_CHAN' : 16,
         'STM32H7' : '1',
     },
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -76,6 +76,10 @@ mcu = {
 
     'DEFINES' : {
         'HAL_HAVE_HARDWARE_DOUBLE' : '1',
+        'HAL_WITH_MCU_MONITORING' : '1',
+        'ADC3_VSENSE_CHAN' : 17,
+        'ADC3_VREFINT_CHAN' : 18,
+        'ADC3_VBAT4_CHAN' : 16,
         'STM32H7' : '1',
     },
 


### PR DESCRIPTION
As promised here https://github.com/ArduPilot/ardupilot/pull/22671 , requires that PR to be merged in first.