### PR TITLE
AP_Camera: set_focus replaces set_manual_focus_step and set_auto_focus

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -114,14 +114,10 @@ public:
     bool set_zoom(ZoomType zoom_type, float zoom_value);
     bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
 
-    // focus in, out or hold
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step);
-    bool set_manual_focus_step(uint8_t instance, int8_t focus_step);
-
-    // auto focus
-    bool set_auto_focus();
-    bool set_auto_focus(uint8_t instance);
+    bool set_focus(FocusType focus_type, float focus_value);
+    bool set_focus(uint8_t instance, FocusType focus_type, float focus_value);
 
     // set if vehicle is in AUTO mode
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
@@ -133,7 +129,8 @@ public:
         bool recording_video;   // true when recording video
         uint8_t zoom_type;      // see ZoomType enum (1:Rate or 2:Pct)
         float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
-        int8_t focus_step;      // focus in = -1, focus hold = 0, focus out = 1
+        uint8_t focus_type;     // see FocusType enum (1:Rate, 2:Pct, 4:Auto)
+        float focus_value;      // If Rate, focus in = -1, focus hold = 0, focus out = 1.  If PCT 0 to 100
         bool auto_focus;        // true when auto focusing
     } camera_state_t;
 

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -61,12 +61,9 @@ public:
     // set zoom specified as a rate or percentage
     virtual bool set_zoom(ZoomType zoom_type, float zoom_value) { return false; }
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    virtual bool set_manual_focus_step(int8_t focus_step) { return false; }
-
-    // auto focus.  returns true on success
-    virtual bool set_auto_focus() { return false; }
+    virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
 
     // handle incoming mavlink message
     virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -46,12 +46,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step) override;
-
-    // auto focus.  returns true on success
-    bool set_auto_focus() override;
+    bool set_focus(FocusType focus_type, float focus_value) override;
 
     // handle incoming mavlink message
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) override;

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -37,23 +37,13 @@ bool AP_Camera_Mount::set_zoom(ZoomType zoom_type, float zoom_value)
     return false;
 }
 
-// focus in, out or hold.  returns true on success
+// set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera_Mount::set_manual_focus_step(int8_t focus_step)
+bool AP_Camera_Mount::set_focus(FocusType focus_type, float focus_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_manual_focus_step(0, focus_step);
-    }
-    return false;
-}
-
-// auto focus.  returns true on success
-bool AP_Camera_Mount::set_auto_focus()
-{
-    AP_Mount* mount = AP::mount();
-    if (mount != nullptr) {
-        return mount->set_auto_focus(0);
+        return mount->set_focus(0, focus_type, focus_value);
     }
     return false;
 }

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -42,12 +42,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step) override;
-
-    // auto focus.  returns true on success
-    bool set_auto_focus() override;
+    bool set_focus(FocusType focus_type, float focus_value) override;
 };
 
 #endif // AP_CAMERA_MOUNT_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -28,20 +28,12 @@ bool AP_Camera_Scripting::set_zoom(ZoomType zoom_type, float zoom_value)
     return true;
 }
 
-// set focus in, out or hold.  returns true on success
+// set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera_Scripting::set_manual_focus_step(int8_t focus_step)
+bool AP_Camera_Scripting::set_focus(FocusType focus_type, float focus_value)
 {
-    _cam_state.focus_step = focus_step;
-    _cam_state.auto_focus = false;
-    return true;
-}
-
-// auto focus.  returns true on success
-bool AP_Camera_Scripting::set_auto_focus()
-{
-    _cam_state.auto_focus = true;
-    _cam_state.focus_step = 0;
+    _cam_state.focus_type = (uint8_t)focus_type;
+    _cam_state.focus_value = focus_value;
     return true;
 }
 

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -42,12 +42,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step) override;
-
-    // auto focus.  returns true on success
-    bool set_auto_focus() override;
+    bool set_focus(FocusType focus_type, float focus_value) override;
 
     // returns true on success and cam_state is filled in
     bool get_state(AP_Camera::camera_state_t& cam_state) override;

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -3,7 +3,7 @@
 // Camera related definitions required by both AP_Camera and AP_Mount are here
 // this avoids issues that would occur if AP_Mount and AP_Camera included each other
 
-#include <AP_Math/AP_Math.h>
+#include <stdint.h>
 
 // set zoom specified as a rate or percentage
 // enumerators match MAVLink CAMERA_ZOOM_TYPE
@@ -12,3 +12,10 @@ enum class ZoomType : uint8_t {
     PCT = 2     // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
 };
 
+// set focus specified as a rate or percentage
+// enumerators match MAVLink CAMERA_FOCUS_TYPE
+enum class FocusType : uint8_t {
+    RATE = 1,   // focus in, out or hold (focus in = -1, hold = 0, focus out = 1). Same as FOCUS_TYPE_CONTINUOUS
+    PCT = 2,    // focus to a percentage (from 0 to 100) of the full range. Same as FOCUS_TYPE_RANGE
+    AUTO = 4    // focus automatically. Same as FOCUS_TYPE_AUTO
+};

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -143,13 +143,15 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         if ((cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO) ||
             (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_SINGLE) ||
             (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_CONTINUOUS)) {
-            camera->set_auto_focus();
-            return true;
+            return camera->set_focus(FocusType::AUTO, 0);
         }
-        // accept step or continuous manual focus
+        // accept continuous manual focus
         if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_CONTINUOUS) {
-            camera->set_manual_focus_step(cmd.content.set_camera_focus.focus_value);
-            return true;
+            return camera->set_focus(FocusType::RATE, cmd.content.set_camera_focus.focus_value);
+        }
+        // accept range manual focus
+        if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_RANGE) {
+            return camera->set_focus(FocusType::PCT, cmd.content.set_camera_focus.focus_value);
         }
         return false;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -639,27 +639,16 @@ bool AP_Mount::set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value)
     return backend->set_zoom(zoom_type, zoom_value);
 }
 
-// set focus in, out or hold.  returns true on success
+// set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Mount::set_manual_focus_step(uint8_t instance, int8_t focus_step)
+bool AP_Mount::set_focus(uint8_t instance, FocusType focus_type, float focus_value)
 {
     auto *backend = get_instance(instance);
     if (backend == nullptr) {
         return false;
     }
-    return backend->set_manual_focus_step(focus_step);
+    return backend->set_focus(focus_type, focus_value);
 }
-
-// auto focus.  returns true on success
-bool AP_Mount::set_auto_focus(uint8_t instance)
-{
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
-        return false;
-    }
-    return backend->set_auto_focus();
-}
-
 
 AP_Mount_Backend *AP_Mount::get_primary() const
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -187,12 +187,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
 
-    // set focus in, out or hold
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(uint8_t instance, int8_t focus_step);
-
-    // auto focus
-    bool set_auto_focus(uint8_t instance);
+    bool set_focus(uint8_t instance, FocusType focus_type, float focus_value);
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -137,12 +137,9 @@ public:
     // set zoom specified as a rate or percentage
     virtual bool set_zoom(ZoomType zoom_type, float zoom_value) { return false; }
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    virtual bool set_manual_focus_step(int8_t focus_step) { return false; }
-
-    // auto focus.  returns true on success
-    virtual bool set_auto_focus() { return false; }
+    virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
 
 protected:
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -644,17 +644,30 @@ bool AP_Mount_Siyi::set_zoom(ZoomType zoom_type, float zoom_value)
     return false;
 }
 
-// set focus in, out or hold.  returns true on success
+// set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Mount_Siyi::set_manual_focus_step(int8_t focus_step)
+bool AP_Mount_Siyi::set_focus(FocusType focus_type, float focus_value)
 {
-    return send_1byte_packet(SiyiCommandId::MANUAL_FOCUS, (uint8_t)focus_step);
-}
+    switch (focus_type) {
+    case FocusType::RATE: {
+        uint8_t focus_step = 0;
+        if (focus_value > 0) {
+            focus_step = 1;
+        } else if (focus_value < 0) {
+            // Siyi API specifies -1 should be sent as 255
+            focus_step = UINT8_MAX;
+        }
+        return send_1byte_packet(SiyiCommandId::MANUAL_FOCUS, (uint8_t)focus_step);
+    }
+    case FocusType::PCT:
+        // not supported
+        return false;
+    case FocusType::AUTO:
+        return send_1byte_packet(SiyiCommandId::AUTO_FOCUS, 1);
+    }
 
-// auto focus.  returns true on success
-bool AP_Mount_Siyi::set_auto_focus()
-{
-    return send_1byte_packet(SiyiCommandId::AUTO_FOCUS, 1);
+    // unsupported focus type
+    return false;
 }
 
 #endif // HAL_MOUNT_SIYI_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -68,12 +68,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
-    // set focus in, out or hold.  returns true on success
+    // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_manual_focus_step(int8_t focus_step) override;
-
-    // auto focus.  returns true on success
-    bool set_auto_focus() override;
+    bool set_focus(FocusType focus_type, float focus_value) override;
 
 protected:
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1102,12 +1102,12 @@ local AP_Camera__camera_state_t_ud = {}
 function AP_Camera__camera_state_t() end
 
 -- get field
----@return boolean
-function AP_Camera__camera_state_t_ud:auto_focus() end
+---@return number
+function AP_Camera__camera_state_t_ud:focus_value() end
 
 -- get field
 ---@return integer
-function AP_Camera__camera_state_t_ud:focus_step() end
+function AP_Camera__camera_state_t_ud:focus_type() end
 
 -- get field
 ---@return number

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -615,8 +615,8 @@ userdata AP_Camera::camera_state_t field take_pic_incr uint16_t'skip_check read
 userdata AP_Camera::camera_state_t field recording_video boolean read
 userdata AP_Camera::camera_state_t field zoom_type uint8_t'skip_check read
 userdata AP_Camera::camera_state_t field zoom_value float'skip_check read
-userdata AP_Camera::camera_state_t field focus_step int8_t'skip_check read
-userdata AP_Camera::camera_state_t field auto_focus boolean read
+userdata AP_Camera::camera_state_t field focus_type uint8_t'skip_check read
+userdata AP_Camera::camera_state_t field focus_value float'skip_check read
 singleton AP_Camera method get_state boolean uint8_t'skip_check AP_Camera::camera_state_t'Null
 
 include AP_Winch/AP_Winch.h

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -968,7 +968,7 @@ bool RC_Channel::do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag)
         focus_step = -1;
         break;
     }
-    return camera->set_manual_focus_step(focus_step);
+    return camera->set_focus(FocusType::RATE, focus_step);
 }
 
 bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
@@ -978,7 +978,7 @@ bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
         if (camera == nullptr) {
             return false;
         }
-        return camera->set_auto_focus();
+        return camera->set_focus(FocusType::AUTO, 0);
     }
     return false;
 }


### PR DESCRIPTION
This PR replaces AP_Camera's set_manual_focus_step() and set_auto_focus() methods with a single, set_focus() method that accepts a "focus type" and a "focus value".  This is very similar to the recent set_focus change https://github.com/ArduPilot/ardupilot/pull/23465

As-is this PR is an NFC but this paves the way for supporting more focus types including the percentage type (aka "PCT" or "Range") which could be useful for missions and other situations where we know the distance to the subject in the frame.  This would allow operators to avoid situations where the camera auto focuses on the fuselage.  Actually when I started on this PR I hoped to implement the PCT type on the ViewPro but sadly while it appears in the ViewPro API it is not yet implemented (at least not on the camera I have).

This has been tested on real hardware (a CubeOrange connected to a ViewPro) to confirm the existing focus types (manual, auto) still work.

