### PR TITLE
Make default for land airspeed halfway between min and cruise and make it apply to both FW and QPlane approaches

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -397,8 +397,7 @@ bool AP_Arming_Plane::mission_checks(bool report)
             if (plane.is_land_command(cmd.id) &&
                 prev_cmd.id == MAV_CMD_NAV_WAYPOINT) {
                 const float dist = cmd.content.location.get_distance(prev_cmd.content.location);
-                const float tecs_land_speed = plane.TECS_controller.get_land_airspeed();
-                const float landing_speed = is_positive(tecs_land_speed)?tecs_land_speed:plane.aparm.airspeed_cruise_cm*0.01;
+                const float landing_speed = plane.TECS_controller.get_land_airspeed();
                 const float min_dist = 0.75 * plane.quadplane.stopping_distance(sq(landing_speed));
                 if (dist < min_dist) {
                     ret = false;

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -116,13 +116,8 @@ float Plane::mode_auto_target_airspeed_cm()
     if (quadplane.landing_with_fixed_wing_spiral_approach() &&
         ((vtol_approach_s.approach_stage == Landing_ApproachStage::APPROACH_LINE) ||
          (vtol_approach_s.approach_stage == Landing_ApproachStage::VTOL_LANDING))) {
-        const float land_airspeed = TECS_controller.get_land_airspeed();
-        if (is_positive(land_airspeed)) {
-            return land_airspeed * 100;
+        return TECS_controller.get_land_airspeed() * 100;
         }
-        // fallover to normal airspeed
-        return aparm.airspeed_cruise_cm;
-    }
     if (quadplane.in_vtol_land_approach()) {
         return quadplane.get_land_airspeed() * 100;
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4112,22 +4112,13 @@ float QuadPlane::get_land_airspeed(void)
 {
     const auto qstate = poscontrol.get_state();
     if (qstate == QPOS_APPROACH ||
-        plane.control_mode == &plane.mode_rtl) {
+        plane.control_mode == &plane.mode_qrtl) {
         const float cruise_speed = plane.aparm.airspeed_cruise_cm * 0.01;
-        float approach_speed = cruise_speed;
-        float tecs_land_airspeed = plane.TECS_controller.get_land_airspeed();
-        if (is_positive(tecs_land_airspeed)) {
-            approach_speed = tecs_land_airspeed;
-        } else {
-            if (qstate == QPOS_APPROACH) {
-                // default to half way between min airspeed and cruise
-                // airspeed when on the approach
-                approach_speed = 0.5*(cruise_speed+plane.aparm.airspeed_min);
-            } else {
-                // otherwise cruise
+        float approach_speed = plane.TECS_controller.get_land_airspeed();
+            if (qstate != QPOS_APPROACH) {
+                // if not in QRTL or later phases of approach then use cruise speed
                 approach_speed = cruise_speed;
             }
-        }
         const float time_to_pos1 = (plane.auto_state.wp_distance - stopping_distance(sq(approach_speed))) / MAX(approach_speed, 5);
         /*
           slow down to landing approach speed as we get closer to landing

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -349,9 +349,7 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
 
     switch (type_slope_stage) {
     case SlopeStage::APPROACH:
-        if (land_airspeed >= 0) {
-            target_airspeed_cm = land_airspeed * 100;
-        }
+        target_airspeed_cm = land_airspeed * 100;
         break;
 
     case SlopeStage::PREFLARE:

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: LAND_ARSPD
     // @DisplayName: Airspeed during landing approach (m/s)
-    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is Trim Airspeed or ARSPD_FBW_MAX as defined by LAND_OPTIONS bitmask.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is not used during landing.
+    // @Description: When performing an autonomus landing, this value is used as the goal airspeed during approach.  Max airspeed allowed is Trim Airspeed or ARSPD_FBW_MAX as defined by LAND_OPTIONS bitmask.  Note that this parameter is not useful if your platform does not have an airspeed sensor (use TECS_LAND_THR instead).  If negative then this value is halfway between ARSPD_FBW_MIN and TRIM_CRUISE_CM speed.
     // @Range: -1 127
     // @Increment: 1
     // @User: Standard
@@ -1145,6 +1145,14 @@ void AP_TECS::_update_STE_rate_lim(void)
     _STEdot_min = - _minSinkRate * GRAVITY_MSS;
 }
 
+float AP_TECS::get_land_airspeed(void) const 
+{
+    if (_landAirspeed > 0.0) {
+        return _landAirspeed;
+    } else {
+        return 0.5 * (aparm.airspeed_cruise_cm * 0.01 + aparm.airspeed_min);
+    }
+}
 
 void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     int32_t EAS_dem_cm,

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -103,9 +103,7 @@ public:
     }
 
     // return landing airspeed
-    float get_land_airspeed(void) const {
-        return _landAirspeed;
-    }
+    float get_land_airspeed(void) const;
 
     // return height rate demand, in m/s
     float get_height_rate_demand(void) const {


### PR DESCRIPTION
The intent is to make the default for landing speed to be halfway between min and cruise and apply to both quadplane (which it currently implements) and fixed wing (which it currently does not).
This replaces #23531 since it had so many revs. I also realized that a lot of the code could be cleaned up.

First, the TECS get_land_airspeed function is modified to return the new default. It will always return positive now so all code that changes the return from negative to cruise can be removed.
