### PR TITLE
AP_DDS: update topic names

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/time_listener.py
+++ b/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/time_listener.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Subscribe to Time messages on topic /ROS2_Time."""
+"""Subscribe to Time messages on topic /ap/clock."""
 import rclpy
 import time
 
@@ -22,14 +22,14 @@ from builtin_interfaces.msg import Time
 
 
 class TimeListener(Node):
-    """Subscribe to Time messages on topic /ROS2_Time."""
+    """Subscribe to Time messages on topic /ap/clock."""
 
     def __init__(self):
         """Initialise the node."""
         super().__init__("time_listener")
 
         # Declare and acquire `topic` parameter.
-        self.declare_parameter("topic", "ROS2_Time")
+        self.declare_parameter("topic", "ap/clock")
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
         # Subscriptions.

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -39,7 +39,7 @@ def launch_description(sitl_dds):
 
 
 class NavSatFixListener(rclpy.node.Node):
-    """Subscribe to NavSatFix messages on /ROS2_NavSatFix0."""
+    """Subscribe to NavSatFix messages on /ap/navsat/navsat0."""
 
     def __init__(self):
         """Initialise the node."""
@@ -47,7 +47,7 @@ class NavSatFixListener(rclpy.node.Node):
         self.msg_event_object = threading.Event()
 
         # Declare and acquire `topic` parameter
-        self.declare_parameter("topic", "ROS2_NavSatFix0")
+        self.declare_parameter("topic", "ap/navsat/navsat0")
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
     def start_subscriber(self):
@@ -88,7 +88,7 @@ def test_navsat_msgs_received(sitl_dds, launch_context):
         node = NavSatFixListener()
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
-        assert msgs_received_flag, "Did not receive 'ROS2_NavSatFix0' msgs."
+        assert msgs_received_flag, "Did not receive 'ap/navsat/navsat0' msgs."
     finally:
         rclpy.shutdown()
 

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -37,7 +37,7 @@ def launch_description(sitl_dds):
 
 
 class TimeListener(rclpy.node.Node):
-    """Subscribe to Time messages on /ROS2_Time."""
+    """Subscribe to Time messages on /ap/clock."""
 
     def __init__(self):
         """Initialise the node."""
@@ -45,7 +45,7 @@ class TimeListener(rclpy.node.Node):
         self.msg_event_object = threading.Event()
 
         # Declare and acquire `topic` parameter.
-        self.declare_parameter("topic", "ROS2_Time")
+        self.declare_parameter("topic", "ap/clock")
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
     def start_subscriber(self):

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -146,19 +146,22 @@ After your setups are complete, do the following:
 
   $ ros2 topic list  -v
   Published topics:
-   * /ROS2_NavSatFix0 [sensor_msgs/msg/NavSatFix] 1 publisher
-   * /ROS2_Time [builtin_interfaces/msg/Time] 1 publisher
-   * /parameter_events [rcl_interfaces/msg/ParameterEvent] 1 publisher
-   * /rosout [rcl_interfaces/msg/Log] 1 publisher
-   * /tf [tf2_msgs/msg/TFMessage] 1 publisher
+  * /ap/battery/battery0 [sensor_msgs/msg/BatteryState] 1 publisher
+  * /ap/clock [builtin_interfaces/msg/Time] 1 publisher
+  * /ap/navsat/navsat0 [sensor_msgs/msg/NavSatFix] 1 publisher
+  * /ap/pose/filtered [geometry_msgs/msg/PoseStamped] 1 publisher
+  * /ap/tf_static [tf2_msgs/msg/TFMessage] 1 publisher
+  * /parameter_events [rcl_interfaces/msg/ParameterEvent] 1 publisher
+  * /rosout [rcl_interfaces/msg/Log] 1 publisher
 
   Subscribed topics:
 
-  $ ros2 topic hz /ROS2_Time
+
+  $ ros2 topic hz /ap/clock
   average rate: 50.115
           min: 0.012s max: 0.024s std dev: 0.00328s window: 52
 
-  $ ros2 topic echo /ROS2_Time 
+  $ ros2 topic echo /ap/clock 
   sec: 1678668735
   nanosec: 729410000
   ---
@@ -166,7 +169,7 @@ After your setups are complete, do the following:
 
   The static transforms for enabled sensors are also published, and can be recieved like so:
   ```console
-  ros2 topic echo /tf --qos-depth 1 --qos-history keep_last --qos-reliability reliable --qos-durability transient_local --once
+  ros2 topic echo /ap/tf_static --qos-depth 1 --qos-history keep_last --qos-reliability reliable --qos-durability transient_local --once
   ```
   In order to consume the transforms, it's highly recommended to [create and run a transform broadcaster in ROS 2](https://docs.ros.org/en/humble/Concepts/About-Tf2.html#tutorials). 
 

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -6,7 +6,7 @@
     </rtps>
   </participant>
   <topic profile_name="time__t">
-    <name>rt/ROS2_Time</name>
+    <name>rt/ap/clock</name>
     <dataType>builtin_interfaces::msg::dds_::Time_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -22,7 +22,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ROS2_Time</name>
+      <name>rt/ap/clock</name>
       <dataType>builtin_interfaces::msg::dds_::Time_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>
@@ -31,7 +31,7 @@
     </topic>
   </data_writer>
   <topic profile_name="navsatfix0__t">
-    <name>rt/ROS2_NavSatFix0</name>
+    <name>rt/ap/navsat/navsat0</name>
     <dataType>sensor_msgs::msg::dds_::NavSatFix_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -50,7 +50,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ROS2_NavSatFix0</name>
+      <name>rt/ap/navsat/navsat0</name>
       <dataType>sensor_msgs::msg::dds_::NavSatFix_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>
@@ -59,7 +59,7 @@
     </topic>
   </data_writer>
   <topic profile_name="statictransforms__t">
-    <name>rt/tf</name>
+    <name>rt/ap/tf_static</name>
     <dataType>tf2_msgs::msg::dds_::TFMessage_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -78,7 +78,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/tf</name>
+      <name>rt/ap/tf_static</name>
       <dataType>tf2_msgs::msg::dds_::TFMessage_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>
@@ -87,7 +87,7 @@
     </topic>
   </data_writer>
   <topic profile_name="batterystate0__t">
-    <name>rt/ROS2_BatteryState0</name>
+    <name>rt/ap/battery/battery0</name>
     <dataType>sensor_msgs::msg::dds_::BatteryState_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -106,7 +106,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ROS2_BatteryState0</name>
+      <name>rt/ap/battery/battery0</name>
       <dataType>sensor_msgs::msg::dds_::BatteryState_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>
@@ -115,7 +115,7 @@
     </topic>
   </data_writer>
   <topic profile_name="localpose__t">
-    <name>rt/ROS2_LocalPose</name>
+    <name>rt/ap/pose/filtered</name>
     <dataType>geometry_msgs::msg::dds_::PoseStamped_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -134,7 +134,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ROS2_LocalPose</name>
+      <name>rt/ap/pose/filtered</name>
       <dataType>geometry_msgs::msg::dds_::PoseStamped_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>


### PR DESCRIPTION
Update published topic names to use lower case underscore, and add a prefix `/ap` to prevent conflicts as the `micro_ros_agent` does not currently implement namespaces.

@Ryanf55, [this section](http://docs.ros.org/en/noetic/api/robot_localization/html/integrating_gps.html) of the `robot_localization` manual discusses pose estimates that include GPS and further distinguishes `local` and `global` odom estimates. So we could have: 

- `/pose/filtered/local` - when GPS data excluded from EKF.
- `/pose/filtered/global` - when GPS data is included in EKF.
- (see diagram for remaining topics and frames).

There are also alternate suggestions for naming other sensor topics (e.g. `navsat`). Unfortunately there does not seem to be a standard for topic naming that is consistently applied between various ROS packages.