### PR TITLE
AP_VisualOdom: allow for visual odom position without yaw

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -190,7 +190,12 @@ void AP_VisualOdom::handle_vision_position_estimate(uint64_t remote_time_us, uin
     if (_driver != nullptr) {
         // convert attitude to quaternion and call backend
         Quaternion attitude;
-        attitude.from_euler(roll, pitch, yaw);
+        if (isnan(roll) || isnan(pitch) || isnan(yaw)) {
+            // use nan quaternion, not attitude available
+            attitude.q1 = attitude.q2 = attitude.q3 = attitude.q4 = nanf("");
+        } else {
+            attitude.from_euler(roll, pitch, yaw);
+        }
         _driver->handle_vision_position_estimate(remote_time_us, time_ms, x, y, z, attitude, posErr, angErr, reset_counter);
     }
 }


### PR DESCRIPTION
the quaternion passed in via handle_vision_position_estimate is only used by EKF3 for yaw, and the EKF code handles the case that the quaternion is NaN. We need to accept NaN attitude to allow for external navigation systems that only provide a position. This requires that users setup the yaw source as compass