### PR TITLE
APBoardConfig: Add skip validate board

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -287,7 +287,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Board options
     // @Description: Board specific option flags
-    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters, 3:Enable Debug Pins, 4:Unlock flash on reboot, 5:Write protect firmware flash on reboot, 6:Write protect bootloader flash on reboot
+    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters, 3:Enable Debug Pins, 4:Unlock flash on reboot, 5:Write protect firmware flash on reboot, 6:Write protect bootloader flash on reboot, 7:Skip board validation
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -142,6 +142,7 @@ public:
         UNLOCK_FLASH = (1<<4),
         WRITE_PROTECT_FLASH = (1<<5),
         WRITE_PROTECT_BOOTLOADER = (1<<6),
+        SKIP_BOARD_VALIDATION = (1<<7)
     };
 
     // return true if ftp is disabled

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -301,12 +301,14 @@ void AP_BoardConfig::validate_board_type(void)
 void AP_BoardConfig::board_autodetect(void)
 {
 #if defined(HAL_VALIDATE_BOARD)
-    const char* errored_check = HAL_VALIDATE_BOARD;
-    if (errored_check == nullptr) {
-        return;
-    } else {
-        config_error("Board Validation %s Failed", errored_check);
-        return;
+    if((_options & SKIP_BOARD_VALIDATION) == 0) {
+        const char* errored_check = HAL_VALIDATE_BOARD;
+        if (errored_check == nullptr) {
+            return;
+        } else {
+            config_error("Board Validation %s Failed", errored_check);
+            return;
+        }
     }
 #endif
 


### PR DESCRIPTION
Added the ability to skip board validation to the BRD_OPTIONS param. This will allow the board to continue on board errors.