### PR TITLE
AP_HAL: default CAN_Px_DRIVER to 0 on SITL

### DIFF
--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -74,5 +74,5 @@
 #endif
 
 #ifndef HAL_CAN_DRIVER_DEFAULT
-#define HAL_CAN_DRIVER_DEFAULT 1
+#define HAL_CAN_DRIVER_DEFAULT 0
 #endif


### PR DESCRIPTION
having this default to 1 slows down SITL startup for a lot of people due to the CAN wait for sensor delays. It is easy to enable it when CAN is needed in SITL