### PR TITLE
AP_BattMonitor: Fixes the setting of a default parameter for battery 2 defined in hwdef

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -81,7 +81,7 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
         _volt_multiplier.set_default(HAL_BATT2_VOLT_SCALE);
 #endif
 #ifdef HAL_BATT2_CURR_SCALE
-        _curr_amp_per_volt.set_default(HAL_BATT2_VOLT_SCALE);
+        _curr_amp_per_volt.set_default(HAL_BATT2_CURR_SCALE);
 #endif
     }
 #endif


### PR DESCRIPTION
This fixes what appears to be a copy/paste error.

The hwdef erroneously sets the second battery monitor instance up for volt divider and amp_per_volt to use the same definition, it should however use `HAL_BATT2_CURR_SCALE`