### PR TITLE
AP_STATS: allow writing to param STAT_RESET

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -35,7 +35,6 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @DisplayName: Statistics Reset Time
     // @Description: Seconds since January 1st 2016 (Unix epoch+1451606400) since statistics reset (set to 0 to reset statistics)
     // @Units: s
-    // @ReadOnly: True
     // @User: Standard
     AP_GROUPINFO("_RESET",    3, AP_Stats, params.reset, 1),
 


### PR DESCRIPTION
bugfix: param STAT_RESET should not be read-only. A [fair chunk of code](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Stats/AP_Stats.cpp#L105-L120) depends on it being able to change. Even the param description says ```(set to 0 to reset statistics)```
