### PR TITLE
AP_Camera: support image tracking

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -142,10 +142,8 @@ public:
         uint8_t focus_type;     // see FocusType enum (1:Rate, 2:Pct, 4:Auto)
         float focus_value;      // If Rate, focus in = -1, focus hold = 0, focus out = 1.  If PCT 0 to 100
         uint8_t tracking_type;  // see TrackingType enum (0:NONE, 1:POINT, 2:RECTANGLE)
-        float tracking_p1x;     // center or top-left tracking point's x-axis value (0 is left, 1 is right)
-        float tracking_p1y;     // center or top-left tracking point's y-axis value (0 is top, 1 is bottom)
-        float tracking_p2x;     // bottom-right tracking point's x-axis value (0 is left, 1 is right)
-        float tracking_p2y;     // bottom-right tracking point's y-axis value (0 is top, 1 is bottom)
+        Vector2f tracking_p1;   // center or top-left tracking point. x left-right, y is top-bottom. range is 0 to 1
+        Vector2f tracking_p2;   // bottom-right tracking point. x left-right, y is top-bottom. range is 0 to 1
     } camera_state_t;
 
     // accessor to allow scripting backend to retrieve state

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -146,7 +146,6 @@ public:
         float tracking_p1y;     // center or top-left tracking point's y-axis value (0 is top, 1 is bottom)
         float tracking_p2x;     // bottom-right tracking point's x-axis value (0 is left, 1 is right)
         float tracking_p2y;     // bottom-right tracking point's y-axis value (0 is top, 1 is bottom)
-        Vector2f tracking_p2;   // bottom-right tracking point (0 is left or top, 1 is right or bottom)
     } camera_state_t;
 
     // accessor to allow scripting backend to retrieve state

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -80,9 +80,13 @@ public:
     // update - to be called periodically at 50Hz
     void update();
 
-    // MAVLink methods
+    // handle MAVLink messages from the camera
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg);
+
+    // handle MAVLink command from GCS to control the camera
     MAV_RESULT handle_command_long(const mavlink_command_long_t &packet);
+
+    // send camera feedback message to GCS
     void send_feedback(mavlink_channel_t chan);
 
     // configure camera

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -123,6 +123,12 @@ public:
     bool set_focus(FocusType focus_type, float focus_value);
     bool set_focus(uint8_t instance, FocusType focus_type, float focus_value);
 
+    // set tracking to none, point or rectangle (see TrackingType enum)
+    // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
+    // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
+    bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
+    bool set_tracking(uint8_t instance, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
+
     // set if vehicle is in AUTO mode
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 
@@ -135,6 +141,12 @@ public:
         float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
         uint8_t focus_type;     // see FocusType enum (1:Rate, 2:Pct, 4:Auto)
         float focus_value;      // If Rate, focus in = -1, focus hold = 0, focus out = 1.  If PCT 0 to 100
+        uint8_t tracking_type;  // see TrackingType enum (0:NONE, 1:POINT, 2:RECTANGLE)
+        float tracking_p1x;     // center or top-left tracking point's x-axis value (0 is left, 1 is right)
+        float tracking_p1y;     // center or top-left tracking point's y-axis value (0 is top, 1 is bottom)
+        float tracking_p2x;     // bottom-right tracking point's x-axis value (0 is left, 1 is right)
+        float tracking_p2y;     // bottom-right tracking point's y-axis value (0 is top, 1 is bottom)
+        Vector2f tracking_p2;   // bottom-right tracking point (0 is left or top, 1 is right or bottom)
     } camera_state_t;
 
     // accessor to allow scripting backend to retrieve state

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -135,7 +135,6 @@ public:
         float zoom_value;       // percentage or zoom out = -1, hold = 0, zoom in = 1
         uint8_t focus_type;     // see FocusType enum (1:Rate, 2:Pct, 4:Auto)
         float focus_value;      // If Rate, focus in = -1, focus hold = 0, focus out = 1.  If PCT 0 to 100
-        bool auto_focus;        // true when auto focusing
     } camera_state_t;
 
     // accessor to allow scripting backend to retrieve state

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -65,7 +65,7 @@ public:
     // focus in = -1, focus hold = 0, focus out = 1
     virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
 
-    // handle incoming mavlink message
+    // handle MAVLink messages from the camera
     virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}
 
     // configure camera

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -65,6 +65,11 @@ public:
     // focus in = -1, focus hold = 0, focus out = 1
     virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
 
+    // set tracking to none, point or rectangle (see TrackingType enum)
+    // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
+    // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
+    virtual bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2) { return false; }
+
     // handle MAVLink messages from the camera
     virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}
 

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -50,7 +50,7 @@ public:
     // focus in = -1, focus hold = 0, focus out = 1
     bool set_focus(FocusType focus_type, float focus_value) override;
 
-    // handle incoming mavlink message
+    // handle MAVLink messages from the camera
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) override;
 
 private:

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -43,10 +43,8 @@ bool AP_Camera_Scripting::set_focus(FocusType focus_type, float focus_value)
 bool AP_Camera_Scripting::set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2)
 {
     _cam_state.tracking_type = (uint8_t)tracking_type;
-    _cam_state.tracking_p1x = p1.x;
-    _cam_state.tracking_p1y = p1.y;
-    _cam_state.tracking_p2x = p2.x;
-    _cam_state.tracking_p2y = p2.y;
+    _cam_state.tracking_p1 = p1;
+    _cam_state.tracking_p2 = p2;
     return true;
 }
 

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -37,6 +37,19 @@ bool AP_Camera_Scripting::set_focus(FocusType focus_type, float focus_value)
     return true;
 }
 
+// set tracking to none, point or rectangle (see TrackingType enum)
+// if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
+// p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
+bool AP_Camera_Scripting::set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2)
+{
+    _cam_state.tracking_type = (uint8_t)tracking_type;
+    _cam_state.tracking_p1x = p1.x;
+    _cam_state.tracking_p1y = p1.y;
+    _cam_state.tracking_p2x = p2.x;
+    _cam_state.tracking_p2y = p2.y;
+    return true;
+}
+
 // access for scripting backend to retrieve state
 // returns true on success and cam_state is filled in
 bool AP_Camera_Scripting::get_state(AP_Camera::camera_state_t& cam_state)

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -46,6 +46,11 @@ public:
     // focus in = -1, focus hold = 0, focus out = 1
     bool set_focus(FocusType focus_type, float focus_value) override;
 
+    // set tracking to none, point or rectangle (see TrackingType enum)
+    // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
+    // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
+    bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2) override;
+
     // returns true on success and cam_state is filled in
     bool get_state(AP_Camera::camera_state_t& cam_state) override;
 

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.h
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.h
@@ -23,7 +23,7 @@ public:
     // momentary switch to change camera between picture and video modes
     void cam_mode_toggle() override;
 
-    // handle incoming mavlink message
+    // handle MAVLink messages from the camera
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) override;
 
 private:

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -19,3 +19,10 @@ enum class FocusType : uint8_t {
     PCT = 2,    // focus to a percentage (from 0 to 100) of the full range. Same as FOCUS_TYPE_RANGE
     AUTO = 4    // focus automatically. Same as FOCUS_TYPE_AUTO
 };
+
+// tracking types when tracking an object in the video stream
+enum class TrackingType : uint8_t {
+    NONE = 0,       // tracking is inactive
+    POINT = 1,      // tracking a point
+    RECTANGLE = 2   // tracking a rectangle
+};

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -102,6 +102,10 @@ function EFI_State_ud:ignition_voltage() end
 ---@param value number
 function EFI_State_ud:ignition_voltage(value) end
 
+-- get field
+---@return Cylinder_Status_ud
+function EFI_State_ud:cylinder_status() end
+
 -- set field
 ---@param value Cylinder_Status_ud
 function EFI_State_ud:cylinder_status(value) end
@@ -145,6 +149,14 @@ function EFI_State_ud:fuel_pressure() end
 -- set field
 ---@param value number
 function EFI_State_ud:fuel_pressure(value) end
+
+-- get field
+---@return integer
+---| '0' # Not supported
+---| '1' # Ok
+---| '2' # Below nominal
+---| '3' # Above nominal
+function EFI_State_ud:fuel_pressure_status() end
 
 -- set field
 ---@param status integer

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1114,20 +1114,12 @@ local AP_Camera__camera_state_t_ud = {}
 function AP_Camera__camera_state_t() end
 
 -- get field
----@return number
-function AP_Camera__camera_state_t_ud:tracking_p1x() end
+---@return Vector2f_ud
+function AP_Camera__camera_state_t_ud:tracking_p1() end
 
 -- get field
----@return number
-function AP_Camera__camera_state_t_ud:tracking_p1y() end
-
--- get field
----@return number
-function AP_Camera__camera_state_t_ud:tracking_p2x() end
-
--- get field
----@return number
-function AP_Camera__camera_state_t_ud:tracking_p2y() end
+---@return Vector2f_ud
+function AP_Camera__camera_state_t_ud:tracking_p2() end
 
 -- get field
 ---@return integer

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1115,6 +1115,26 @@ function AP_Camera__camera_state_t() end
 
 -- get field
 ---@return number
+function AP_Camera__camera_state_t_ud:tracking_p1x() end
+
+-- get field
+---@return number
+function AP_Camera__camera_state_t_ud:tracking_p1y() end
+
+-- get field
+---@return number
+function AP_Camera__camera_state_t_ud:tracking_p2x() end
+
+-- get field
+---@return number
+function AP_Camera__camera_state_t_ud:tracking_p2y() end
+
+-- get field
+---@return integer
+function AP_Camera__camera_state_t_ud:tracking_type() end
+
+-- get field
+---@return number
 function AP_Camera__camera_state_t_ud:focus_value() end
 
 -- get field

--- a/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
@@ -734,13 +734,13 @@ function check_tracking_state()
 
   -- check for change in tracking state
   local tracking_type_changed = cam_state:tracking_type() ~= last_tracking_type
-  local tracking_type_p1_changed = (cam_state:tracking_p1x() ~= last_tracking_p1x) or (cam_state:tracking_p1y() ~= last_tracking_p1y)
-  local tracking_type_p2_changed = (cam_state:tracking_p2x() ~= last_tracking_p2x) or (cam_state:tracking_p2y() ~= last_tracking_p2y)
+  local tracking_type_p1_changed = (cam_state:tracking_p1():x() ~= last_tracking_p1x) or (cam_state:tracking_p1():y() ~= last_tracking_p1y)
+  local tracking_type_p2_changed = (cam_state:tracking_p2():x() ~= last_tracking_p2x) or (cam_state:tracking_p2():y() ~= last_tracking_p2y)
   last_tracking_type = cam_state:tracking_type()
-  last_tracking_p1x = cam_state:tracking_p1x()
-  last_tracking_p1y = cam_state:tracking_p1y()
-  last_tracking_p2x = cam_state:tracking_p2x()
-  last_tracking_p2y = cam_state:tracking_p2y()
+  last_tracking_p1x = cam_state:tracking_p1():x()
+  last_tracking_p1y = cam_state:tracking_p1():y()
+  last_tracking_p2x = cam_state:tracking_p2():x()
+  last_tracking_p2y = cam_state:tracking_p2():y()
 
   if (last_tracking_type == 0) and tracking_type_changed then
     -- turn off tracking

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -617,6 +617,11 @@ userdata AP_Camera::camera_state_t field zoom_type uint8_t'skip_check read
 userdata AP_Camera::camera_state_t field zoom_value float'skip_check read
 userdata AP_Camera::camera_state_t field focus_type uint8_t'skip_check read
 userdata AP_Camera::camera_state_t field focus_value float'skip_check read
+userdata AP_Camera::camera_state_t field tracking_type uint8_t'skip_check read
+userdata AP_Camera::camera_state_t field tracking_p1x float'skip_check read
+userdata AP_Camera::camera_state_t field tracking_p1y float'skip_check read
+userdata AP_Camera::camera_state_t field tracking_p2x float'skip_check read
+userdata AP_Camera::camera_state_t field tracking_p2y float'skip_check read
 singleton AP_Camera method get_state boolean uint8_t'skip_check AP_Camera::camera_state_t'Null
 
 include AP_Winch/AP_Winch.h

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -618,10 +618,8 @@ userdata AP_Camera::camera_state_t field zoom_value float'skip_check read
 userdata AP_Camera::camera_state_t field focus_type uint8_t'skip_check read
 userdata AP_Camera::camera_state_t field focus_value float'skip_check read
 userdata AP_Camera::camera_state_t field tracking_type uint8_t'skip_check read
-userdata AP_Camera::camera_state_t field tracking_p1x float'skip_check read
-userdata AP_Camera::camera_state_t field tracking_p1y float'skip_check read
-userdata AP_Camera::camera_state_t field tracking_p2x float'skip_check read
-userdata AP_Camera::camera_state_t field tracking_p2y float'skip_check read
+userdata AP_Camera::camera_state_t field tracking_p1 Vector2f read
+userdata AP_Camera::camera_state_t field tracking_p2 Vector2f read
 singleton AP_Camera method get_state boolean uint8_t'skip_check AP_Camera::camera_state_t'Null
 
 include AP_Winch/AP_Winch.h

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -653,12 +653,12 @@ userdata EFI_State field coolant_temperature float'skip_check read write
 userdata EFI_State field oil_pressure float'skip_check read write
 userdata EFI_State field oil_temperature float'skip_check read write
 userdata EFI_State field fuel_pressure float'skip_check read write
-userdata EFI_State field fuel_pressure_status Fuel_Pressure_Status'enum write Fuel_Pressure_Status::NOT_SUPPORTED Fuel_Pressure_Status::ABOVE_NOMINAL
+userdata EFI_State field fuel_pressure_status Fuel_Pressure_Status'enum read write Fuel_Pressure_Status::NOT_SUPPORTED Fuel_Pressure_Status::ABOVE_NOMINAL
 userdata EFI_State field fuel_consumption_rate_cm3pm float'skip_check read write
 userdata EFI_State field estimated_consumed_fuel_volume_cm3 float'skip_check read write
 userdata EFI_State field throttle_position_percent uint8_t'skip_check read write
 userdata EFI_State field ecu_index uint8_t'skip_check read write
-userdata EFI_State field cylinder_status Cylinder_Status write
+userdata EFI_State field cylinder_status Cylinder_Status read write
 userdata EFI_State field ignition_voltage float'skip_check read write
 userdata EFI_State field throttle_out float'skip_check read write
 userdata EFI_State field pt_compensation float'skip_check read write

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1642,8 +1642,10 @@ void emit_field(const struct userdata_field *field, const char* object_name, con
       case TYPE_INT32_T:
       case TYPE_UINT8_T:
       case TYPE_UINT16_T:
-      case TYPE_ENUM:
         fprintf(source, "%slua_pushinteger(L, %s%s%s%s);\n", indent, object_name, object_access, field->name, index_string);
+        break;
+      case TYPE_ENUM:
+        fprintf(source, "%slua_pushinteger(L, static_cast<int32_t>(%s%s%s%s));\n", indent, object_name, object_access, field->name, index_string);
         break;
       case TYPE_UINT32_T:
         fprintf(source, "%snew_uint32_t(L);\n", indent);
@@ -1659,7 +1661,9 @@ void emit_field(const struct userdata_field *field, const char* object_name, con
         fprintf(source, "%slua_pushstring(L, %s%s%s%s);\n", indent, object_name, object_access, field->name, index_string);
         break;
       case TYPE_USERDATA:
-        error(ERROR_USERDATA, "Userdata does not currently support access to userdata field's");
+          // userdatas must allocate a new container to return
+          fprintf(source, "%snew_%s(L);\n", indent, field->type.data.ud.sanatized_name);
+          fprintf(source, "%s*check_%s(L, -1) = %s%s%s%s;\n", indent, field->type.data.ud.sanatized_name, object_name, object_access, field->name, index_string);
         break;
       case TYPE_AP_OBJECT: // FIXME: collapse the identical cases here, and use the type string function
         error(ERROR_USERDATA, "AP_Object does not currently support access to userdata field's");

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4659,6 +4659,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_CAMERA_TRACK_POINT:
+    case MAV_CMD_CAMERA_TRACK_RECTANGLE:
+    case MAV_CMD_CAMERA_STOP_TRACKING:
     case MAV_CMD_VIDEO_START_CAPTURE:
     case MAV_CMD_VIDEO_STOP_CAPTURE:
         result = handle_command_camera(packet);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -237,6 +237,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Blimp}: 171:Calibrate Compasses
     // @Values{Copter, Rover, Plane, Blimp}: 172:Battery MPPT Enable
     // @Values{Plane}: 173:Plane AUTO Mode Landing Abort
+    // @Values{Copter, Rover, Plane, Blimp}: 174:Camera Image Tracking
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail
@@ -765,6 +766,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::CAMERA_ZOOM, "Camera Zoom"},
     { AUX_FUNC::CAMERA_MANUAL_FOCUS, "Camera Manual Focus"},
     { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
+    { AUX_FUNC::CAMERA_IMAGE_TRACKING, "Camera Image Tracking"},
 };
 
 /* lookup the announcement for switch change */
@@ -981,6 +983,17 @@ bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
         return camera->set_focus(FocusType::AUTO, 0);
     }
     return false;
+}
+
+bool RC_Channel::do_aux_function_camera_image_tracking(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    // High position enables tracking a POINT in middle of image
+    // Low or Mediums disables tracking.  (0.5,0.5) is still passed in but ignored
+    return camera->set_tracking(ch_flag == AuxSwitchPos::HIGH ? TrackingType::POINT : TrackingType::NONE, Vector2f{0.5, 0.5}, Vector2f{});
 }
 #endif
 
@@ -1477,6 +1490,8 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
     case AUX_FUNC::CAMERA_AUTO_FOCUS:
         return do_aux_function_camera_auto_focus(ch_flag);
 
+    case AUX_FUNC::CAMERA_IMAGE_TRACKING:
+        return do_aux_function_camera_image_tracking(ch_flag);
 #endif
 
 #if HAL_MOUNT_ENABLED

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -246,6 +246,7 @@ public:
         MAG_CAL =            171, // Calibrate compasses (disarmed only)
         BATTERY_MPPT_ENABLE = 172,// Battery MPPT Power enable. high = ON, mid = auto (controlled by mppt/batt driver), low = OFF. This effects all MPPTs.
         PLANE_AUTO_LANDING_ABORT = 173, // Abort Glide-slope or VTOL landing during payload place or do_land type mission items
+        CAMERA_IMAGE_TRACKING = 174, // camera image tracking
 
 
         // inputs from 200 will eventually used to replace RCMAP
@@ -344,6 +345,7 @@ protected:
     bool do_aux_function_camera_zoom(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_image_tracking(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_control(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_osd_control(const AuxSwitchPos ch_flag);
     void do_aux_function_fence(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
This adds support for a camera gimbal to track an image on the video feed.

- GCS_MAVLink sends [CAMERA_TRACK_POINT](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1649), [CAMERA_TRACK_RECTANGLE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1655) and [CAMERA_STOP_TRACKING](MAV_CMD_CAMERA_STOP_TRACKING) commands to AP_Camera
- AP_Camera gets a new set_tracking() method allowing callers to start tracking a point, a rectangle or stop tracking
- AP_Camera::camera_state and corresponding AP_Scripting's bindings are extended to hold the tracking state
- AP_Scripting's mount-viewpro-driver.lua is enhanced to send the appropriate commands to the ViewPro gimbal
- RC_Channel gets a get auxiliary function, CAMERA_IMAGE_TRACKING, that allows a user to start tracking the point in the middle of the video image

Note1: that this does not support sending tracking feedback to the GCS using the [CAMERA_TRACKING_IMAGE_STATUS](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5842) message but this will come in a future PR.

Note2: In the future we will likely need to add AP_Mount::set_tracking() for combined camera+gimbal units where AP_Mount is the main driver used to interface to the gimbal.  At the moment though, the ViewPro camera gimbals are the only ones with tracking features and the lua script driver already has access to AP_Camera so it can get the state it needs.

This has been tested on real hardware (a CubeOrange and [ViewPro Q30TIRM camera gimbal](https://ardupilot.org/copter/docs/common-viewpro-gimbal.html#common-viewpro-gimbal)).

This is part of the ongoing project to improve AP's [camera](https://github.com/ArduPilot/ardupilot/issues/23151) and [gimbal support](https://github.com/ArduPilot/ardupilot/issues/20985).