### PR TITLE
GCS_MAVLink: Match the number of override channels to MAVLINK specifi…

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3661,7 +3661,9 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
         packet.chan13_raw,
         packet.chan14_raw,
         packet.chan15_raw,
-        packet.chan16_raw
+        packet.chan16_raw,
+        packet.chan17_raw,
+        packet.chan18_raw,
     };
 
     for (uint8_t i=0; i<8; i++) {


### PR DESCRIPTION
ISSUE: #23635

MAVLINK message reception processing should receive all data in accordance with MAVLINK specifications.
The maximum channel is determined by the method that sets the channel.
