### PR TITLE
AP_HAL_SITL: Fix divide by zero

### DIFF
--- a/libraries/AP_HAL_SITL/Synth.hpp
+++ b/libraries/AP_HAL_SITL/Synth.hpp
@@ -101,7 +101,7 @@ double amplitude(double dTime, sEnvelope env)
     else if (dTime > env.dAttackTime && dTime <= (env.dAttackTime + env.dDecayTime))                                                       // Decay phase
         dAmplitude = ((dTime - env.dAttackTime) / env.dDecayTime) * (env.dSustainAmplitude - env.dStartAmplitude) + env.dStartAmplitude;
 
-    else if (dTime <= env.dAttackTime)                                                                                                     // Attack phase
+    else if (!iszero(env.dAttackTime) && dTime <= env.dAttackTime)                                                                                                     // Attack phase
         dAmplitude = (dTime / env.dAttackTime) * env.dStartAmplitude;
 
     // Amplitude should not be negative, check just in case


### PR DESCRIPTION
I get an exception with SITL.
I add a 0 determination.

BEFORE
![Screenshot from 2023-04-30 12-16-00](https://user-images.githubusercontent.com/646194/235333855-b3f2b9ee-4b6d-4ac8-976d-9ad9cb7a7833.png)