### PR TITLE
hwdef: airbotf4: minimize this board

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
@@ -102,3 +102,6 @@ define HAL_GPIO_A_LED_PIN 57
 
 #To complementary channels work we define this
 define STM32_PWM_USE_ADVANCED TRUE
+
+# 64kB FLASH_RESERVE_START_KB means we're lacking a lot of space:
+include ../include/minimize_features.inc


### PR DESCRIPTION
not currently building.

The FLASH_RESERVE_START_KB at 64 means we're short on space on this board