### PR TITLE
waf: added -g option to configure

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -275,6 +275,10 @@ class Board:
             env.DEFINES.update(
                 HAL_DEBUG_BUILD = 1,
             )
+        elif cfg.options.g:
+            env.CFLAGS += [
+                '-g',
+            ]
         if cfg.env.COVERAGE:
             env.CFLAGS += [
                 '-fprofile-arcs',

--- a/wscript
+++ b/wscript
@@ -126,6 +126,11 @@ def options(opt):
         default=False,
         help='Configure as debug variant.')
 
+    g.add_option('-g',
+        action='store_true',
+        default=False,
+        help='Add debug symbolds to build.')
+    
     g.add_option('--disable-watchdog',
         action='store_true',
         default=False,


### PR DESCRIPTION
this adds debug symbolds to the build without enabling other debug code. This is needed for analysing watchdog crash dumps