### PR TITLE
Add logging to swashplate and Begin Heli Motor Restructuring

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -160,6 +160,13 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
     _frame_type = frame_type;
     _frame_class = frame_class;
 
+    // initialise servo/PWM ranges and endpoints
+    // we need to call this before set_update_rate() to ensure motor masks for swashplates will be correctly set
+    if (!init_outputs()) {
+        // don't set initialised_ok
+        return;
+    }
+
     // set update rate
     set_update_rate(_speed_hz);
 
@@ -171,12 +178,6 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
 
     // initialise radio passthrough for collective to middle
     _throttle_radio_passthrough = 0.5f;
-
-    // initialise Servo/PWM ranges and endpoints
-    if (!init_outputs()) {
-        // don't set initialised_ok
-        return;
-    }
 
     // calculate all scalars
     calculate_scalars();

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -183,7 +183,7 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
     calculate_scalars();
 
     // record successful initialisation if what we setup was the desired frame_class
-    set_initialised_ok(frame_class == MOTOR_FRAME_HELI);
+    set_initialised_ok(frame_class == MOTOR_FRAME_HELI || frame_class == MOTOR_FRAME_HELI_DUAL);
 
     // set flag to true so targets are initialized once aircraft is armed for first time
     _heliflags.init_targets_on_arming = true;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -250,8 +250,8 @@ bool AP_MotorsHeli_Dual::init_outputs()
 }
 
 // output_test_seq - spin a motor at the pwm value specified
-//  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
-//  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
+// motor_seq is the motor's sequence number from 1 to the number of motors on the frame
+// pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
 void AP_MotorsHeli_Dual::_output_test_seq(uint8_t motor_seq, int16_t pwm)
 {
     // output to motors and servos
@@ -445,7 +445,7 @@ float AP_MotorsHeli_Dual::get_swashplate (int8_t swash_num, int8_t swash_axis, f
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
-//  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+// this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint32_t AP_MotorsHeli_Dual::get_motor_mask()
 {
     // dual heli uses channels 1,2,3,4,5,6 and 8
@@ -711,7 +711,6 @@ void AP_MotorsHeli_Dual::servo_test()
     }
 
     // over-ride servo commands to move servos through defined ranges
-
     _throttle_filter.reset(constrain_float(_collective_test, 0.0f, 1.0f));
     _roll_in = constrain_float(_roll_test, -1.0f, 1.0f);
     _pitch_in = constrain_float(_pitch_test, -1.0f, 1.0f);

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -669,6 +669,11 @@ void AP_MotorsHeli_Dual::output_to_motors()
             update_motor_control(ROTOR_CONTROL_IDLE);
             break;
     }
+
+    // run swashplate logging
+    for (uint8_t s=0; s<AP_MOTORS_HELI_N_SWASH; s++) {
+        _swashplate[s].log_write(s);
+    }
 }
 
 // servo_test - move servos through full range of movement

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -17,7 +17,7 @@
 #define AP_MOTORS_HELI_DUAL_MODE_TRANSVERSE            1 // transverse mode (rotors side by side)
 #define AP_MOTORS_HELI_DUAL_MODE_INTERMESHING          2 // intermeshing mode (rotors side by side)
 
-// tandem modes
+// axis labels
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_PITCH           0 // swashplate pitch tilt axis
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_ROLL            1 // swashplate roll tilt axis
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_COLL            2 // swashplate collective axis
@@ -44,7 +44,6 @@ public:
     {
         AP_Param::setup_object_defaults(this, var_info);
     };
-
 
     // set_update_rate - set update rate to motors
     void set_update_rate( uint16_t speed_hz ) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -22,11 +22,14 @@
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_ROLL            1 // swashplate roll tilt axis
 #define AP_MOTORS_HELI_DUAL_SWASH_AXIS_COLL            2 // swashplate collective axis
 
+// number of swashplates
+#define AP_MOTORS_HELI_N_SWASH                         2
+
 // default differential-collective-pitch scaler
 #define AP_MOTORS_HELI_DUAL_DCP_SCALER             0.25f
 
 // maximum number of swashplate servos
-#define AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS    6
+#define AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS    8
 
 // default collective min, max and midpoints for the rear swashplate
 #define AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN 1250
@@ -79,6 +82,9 @@ public:
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     uint32_t get_motor_mask() override;
 
+    // get_swashplate_servo_mask - returns a bitmask of which outputs are being used for swashplate servos only
+    uint32_t get_swashplate_servo_mask();
+
     // has_flybar - returns true if we have a mechical flybar
     bool has_flybar() const  override { return AP_MOTORS_HELI_NOFLYBAR; }
 
@@ -110,9 +116,8 @@ protected:
 
     const char* _get_frame_string() const override { return "HELI_DUAL"; }
 
-    //  objects we depend upon
-    AP_MotorsHeli_Swash        _swashplate1;        // swashplate1
-    AP_MotorsHeli_Swash        _swashplate2;        // swashplate2
+    //  Setup both swashplates in an array
+    AP_MotorsHeli_Swash        _swashplate[AP_MOTORS_HELI_N_SWASH];
 
     // internal variables
     float _oscillate_angle = 0.0f;                  // cyclic oscillation angle, used by servo_test function

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -92,7 +92,6 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
 // configure - configure the swashplate settings for any updated parameters
 void AP_MotorsHeli_Swash::configure()
 {
-
     _swash_type = static_cast<SwashPlateType>(_swashplate_type.get());
     _collective_direction = static_cast<CollectiveDirection>(_swash_coll_dir.get());
     _make_servo_linear = _linear_swash_servo;
@@ -218,11 +217,8 @@ float AP_MotorsHeli_Swash::get_servo_out(int8_t ch_num, float pitch, float roll,
 // set_linear_servo_out - sets swashplate servo output to be linear
 float AP_MotorsHeli_Swash::get_linear_servo_output(float input) const
 {
-
     input = constrain_float(input, -1.0f, 1.0f);
 
     //servo output is calculated by normalizing input to 50 deg arm rotation as full input for a linear throw
     return safe_asin(0.766044f * input) * 1.145916;
-
 }
-

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -27,6 +27,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Description: H3 is generic, three-servo only. H3_120/H3_140 plates have Motor1 left side, Motor2 right side, Motor3 elevator in rear. HR3_120/HR3_140 have Motor1 right side, Motor2 left side, Motor3 elevator in front - use H3_120/H3_140 and reverse servo and collective directions as necessary. For all H3_90 swashplates use H4_90 and don't use servo output for the missing servo. For H4-90 Motors1&2 are left/right respectively, Motors3&4 are rear/front respectively. For H4-45 Motors1&2 are LF/RF, Motors3&4 are LR/RR 
     // @Values: 0:H3 Generic,1:H1 non-CPPM,2:H3_140,3:H3_120,4:H4_90,5:H4_45
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("TYPE", 1, AP_MotorsHeli_Swash, _swashplate_type, SWASHPLATE_TYPE_H3_120),
 
     // @Param: COL_DIR
@@ -34,6 +35,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
     // @Values: 0:Normal,1:Reversed
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("COL_DIR", 2, AP_MotorsHeli_Swash, _swash_coll_dir, COLLECTIVE_DIRECTION_NORMAL),
 
     // @Param: LIN_SVO
@@ -41,6 +43,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
     // @Description: This linearizes the swashplate servo's mechanical output to account for nonlinear output due to arm rotation.  This requires a specific setup procedure to work properly.  The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. Leveling the swashplate can only be done through the pitch links.  See the ardupilot wiki for more details on setup.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("LIN_SVO", 3, AP_MotorsHeli_Swash, _linear_swash_servo, 0),
 
     // @Param: H3_ENABLE

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -40,13 +40,16 @@ public:
     SwashPlateType get_swash_type() const { return _swash_type; }
 
     // get_servo_out - calculates servo output
-    float get_servo_out(int8_t servo_num, float pitch, float roll, float collective) const;
+    float get_servo_out(int8_t servo_num, float pitch, float roll, float collective);
 
     // linearize mechanical output of swashplate servo
     float get_linear_servo_output(float input) const;
 
     // get_phase_angle - returns the rotor phase angle
     int16_t get_phase_angle() const { return _phase_angle; }
+
+    // logging for each swashplate
+    void log_write(uint8_t instance) const;
 
     // var_info
     static const struct AP_Param::GroupInfo var_info[];
@@ -59,6 +62,7 @@ private:
     float                _pitchFactor[4];             // Pitch axis scaling of servo output based on servo position
     float                _collectiveFactor[4];        // Collective axis scaling of servo output based on servo position
     int8_t               _make_servo_linear;          // Sets servo output to be linearized
+    float                _collective;                 // collective value, stored for logging
 
     // parameters
     AP_Int8  _swashplate_type;                   // Swash Type Setting


### PR DESCRIPTION
The primary goal of this PR is add logging to swashplate.

Secondary:  I would like to begin restructuring Heli motors.  The way it is currently layout is difficult to read and has lead to a number of minor issues/inefficiencies.  I would like to do this in smaller bitesize chunks to make it easier to review.
The restructure here is to put the swashplate instances in dual heli into an array.  Doing this and making better use of bitmasks has meant I have been able to cut out duplicate blocks of code.

Apologies that these two things are comming in the same PR, but putting the swashplate instances into an array makes the logging cleaner and easier.

Only collective has been added so far.  As we have two collectives in dual, that may have differeing values (e.g. collective differential for yaw) it makes sense to have collective specifc loging.  Additionally, I hope that it will be a little more user friendly to find the collective value (instead of needing to know that CTUN.ThO is actually collective).

I have only done Dual heli so far, but the changes I have made can easily be integrated into single and quad.  I am just trying to keep this PR size down and I will go in and adjust those as we get agreement on this approach.

As there are a few things going on this PR I have broken out the features into commits, which should hopefully make it easier to review.