### PR TITLE
Make many more commands available as COMMAND_INT

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -412,7 +412,7 @@ MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro(const
     return ret;
 }
 
-MAV_RESULT GCS_MAVLINK_Tracker::handle_command_component_arm_disarm(const mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK_Tracker::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
     if (is_equal(packet.param1,1.0f)) {
         tracker.arm_servos();

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -19,7 +19,7 @@ protected:
     uint32_t telem_delay() const override { return 0; }
 
 
-    MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_int_t &packet) override;
     MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5154,6 +5154,32 @@ class AutoTestCopter(AutoTest):
                          roi_alt,
                          )
             self.test_mount_pitch(-52, 5, mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT)
+            self.progress("Using MAV_CMD_DO_SET_ROI_LOCATION")
+            # start by pointing the gimbal elsewhere with a
+            # known-working command:
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
+                0,
+                0,
+                0,
+                0,
+                roi_lat + 1,
+                roi_lon + 1,
+                roi_alt,
+            )
+            # now point it with command_int:
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
+                0,
+                0,
+                0,
+                0,
+                int(roi_lat * 1e7),
+                int(roi_lon * 1e7),
+                roi_alt,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            )
+            self.test_mount_pitch(-52, 5, mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT)
 
             self.progress("Using MAV_CMD_DO_SET_ROI_NONE")
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE,

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9296,11 +9296,23 @@ Also, ignores heartbeats not from our target system'''
                          0, # param2
                          0, # param3
                          0, # param4
-
                          0, # param5
                          0, # param6
                          0 # param7
                          )
+            self.verify_parameter_values(wanted)
+
+            # run same command but as command_int:
+            self.zero_mag_offset_parameters()
+            self.run_cmd_int(mavutil.mavlink.MAV_CMD_FIXED_MAG_CAL_YAW,
+                             math.degrees(ss.yaw), # param1
+                             0, # param2
+                             0, # param3
+                             0, # param4
+                             0, # param5
+                             0, # param6
+                             0 # param7
+                             )
             self.verify_parameter_values(wanted)
 
             self.progress("Rebooting and making sure we could arm with these values")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -9599,6 +9599,28 @@ Also, ignores heartbeats not from our target system'''
         self.progress("default disarm_vehicle() call")
         self.disarm_vehicle()
 
+        self.start_subtest("Arm/disarm vehicle with COMMAND_INT")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+            1,  # ARM
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+            0,  # DISARM
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+
         self.progress("arm with mavproxy")
         mavproxy = self.start_mavproxy()
         if not self.mavproxy_arm_vehicle(mavproxy):

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -728,6 +728,8 @@ protected:
     // converts a COMMAND_LONG packet to a COMMAND_INT packet, where
     // the command-long packet is assumed to be in the supplied frame.
     // If location is not present in the command then just omit frame.
+    // this method ensures the passed-in structure is entirely
+    // initialised.
     static void convert_COMMAND_LONG_to_COMMAND_INT(const mavlink_command_long_t &in, mavlink_command_int_t &out, MAV_FRAME frame = MAV_FRAME_GLOBAL_RELATIVE_ALT);
 
     // methods to extract a Location object from a command_long or command_int

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -525,7 +525,7 @@ protected:
     virtual bool set_home_to_current_location(bool lock) = 0;
     virtual bool set_home(const Location& loc, bool lock) = 0;
 
-    virtual MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_set_home(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_aux_function(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
@@ -651,11 +651,11 @@ protected:
 
     virtual MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
     MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
+    MAV_RESULT try_command_long_as_command_int(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_send_banner(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_set_roi(const mavlink_command_int_t &packet);
-    MAV_RESULT handle_command_do_set_roi(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_do_set_roi(const Location &roi_loc);
     MAV_RESULT handle_command_do_gripper(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_sprayer(const mavlink_command_long_t &packet);
@@ -675,7 +675,7 @@ protected:
 
     void handle_optical_flow(const mavlink_message_t &msg);
 
-    MAV_RESULT handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_fixed_mag_cal_yaw(const mavlink_command_int_t &packet);
 
     void handle_manual_control(const mavlink_message_t &msg);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4924,6 +4924,7 @@ bool GCS_MAVLINK::command_long_stores_location(const MAV_CMD command)
 
 void GCS_MAVLINK::convert_COMMAND_LONG_to_COMMAND_INT(const mavlink_command_long_t &in, mavlink_command_int_t &out, MAV_FRAME frame)
 {
+    out = {};
     out.target_system = in.target_system;
     out.target_component = in.target_component;
     out.frame = frame;


### PR DESCRIPTION
An alternative to https://github.com/mavlink/mavlink/pull/1982

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -24    *           128     120               120    -24    -24
HerePro             24                                                                    
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                40     *           40      32                40     32     40
MatekF405                      48     *           40      48                48     48     40
Pixhawk1-1M-bdshot             72                 72      72                72     72     72
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      40     *           64      56                56     40     48
skyviper-v2450                                    56                                      
```

~Still need to test ROI works~
