### PR TITLE
AP_Scripting: allow getting enum and userdata fields for userdata

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -102,6 +102,10 @@ function EFI_State_ud:ignition_voltage() end
 ---@param value number
 function EFI_State_ud:ignition_voltage(value) end
 
+-- get field
+---@return Cylinder_Status_ud
+function EFI_State_ud:cylinder_status() end
+
 -- set field
 ---@param value Cylinder_Status_ud
 function EFI_State_ud:cylinder_status(value) end
@@ -145,6 +149,14 @@ function EFI_State_ud:fuel_pressure() end
 -- set field
 ---@param value number
 function EFI_State_ud:fuel_pressure(value) end
+
+-- get field
+---@return integer
+---| '0' # Not supported
+---| '1' # Ok
+---| '2' # Below nominal
+---| '3' # Above nominal
+function EFI_State_ud:fuel_pressure_status() end
 
 -- set field
 ---@param status integer

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -653,12 +653,12 @@ userdata EFI_State field coolant_temperature float'skip_check read write
 userdata EFI_State field oil_pressure float'skip_check read write
 userdata EFI_State field oil_temperature float'skip_check read write
 userdata EFI_State field fuel_pressure float'skip_check read write
-userdata EFI_State field fuel_pressure_status Fuel_Pressure_Status'enum write Fuel_Pressure_Status::NOT_SUPPORTED Fuel_Pressure_Status::ABOVE_NOMINAL
+userdata EFI_State field fuel_pressure_status Fuel_Pressure_Status'enum read write Fuel_Pressure_Status::NOT_SUPPORTED Fuel_Pressure_Status::ABOVE_NOMINAL
 userdata EFI_State field fuel_consumption_rate_cm3pm float'skip_check read write
 userdata EFI_State field estimated_consumed_fuel_volume_cm3 float'skip_check read write
 userdata EFI_State field throttle_position_percent uint8_t'skip_check read write
 userdata EFI_State field ecu_index uint8_t'skip_check read write
-userdata EFI_State field cylinder_status Cylinder_Status write
+userdata EFI_State field cylinder_status Cylinder_Status read write
 userdata EFI_State field ignition_voltage float'skip_check read write
 userdata EFI_State field throttle_out float'skip_check read write
 userdata EFI_State field pt_compensation float'skip_check read write

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1642,8 +1642,10 @@ void emit_field(const struct userdata_field *field, const char* object_name, con
       case TYPE_INT32_T:
       case TYPE_UINT8_T:
       case TYPE_UINT16_T:
-      case TYPE_ENUM:
         fprintf(source, "%slua_pushinteger(L, %s%s%s%s);\n", indent, object_name, object_access, field->name, index_string);
+        break;
+      case TYPE_ENUM:
+        fprintf(source, "%slua_pushinteger(L, static_cast<int32_t>(%s%s%s%s));\n", indent, object_name, object_access, field->name, index_string);
         break;
       case TYPE_UINT32_T:
         fprintf(source, "%snew_uint32_t(L);\n", indent);
@@ -1659,7 +1661,9 @@ void emit_field(const struct userdata_field *field, const char* object_name, con
         fprintf(source, "%slua_pushstring(L, %s%s%s%s);\n", indent, object_name, object_access, field->name, index_string);
         break;
       case TYPE_USERDATA:
-        error(ERROR_USERDATA, "Userdata does not currently support access to userdata field's");
+          // userdatas must allocate a new container to return
+          fprintf(source, "%snew_%s(L);\n", indent, field->type.data.ud.sanatized_name);
+          fprintf(source, "%s*check_%s(L, -1) = %s%s%s%s;\n", indent, field->type.data.ud.sanatized_name, object_name, object_access, field->name, index_string);
         break;
       case TYPE_AP_OBJECT: // FIXME: collapse the identical cases here, and use the type string function
         error(ERROR_USERDATA, "AP_Object does not currently support access to userdata field's");


### PR DESCRIPTION
This allows reading enums and userdata fields from userdata. This allows the two outstanding `EFI_State` fields to become read and write. This should also allow https://github.com/ArduPilot/ardupilot/pull/23640.

This also stops adding a creation function for userdata that is all read only. This remove only the `camera_state_t` creation function. Currently that would not be useable in any case as the creation function is currently `AP_Camera::camera_state_t` which is invalid in lua. If we were to add some writable fields we would have to add a rename so it could be called. fixes https://github.com/ArduPilot/ardupilot/issues/23445