### PR TITLE
AP Motors Heli: Remove/Simplify Unneeded Virtuals

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -624,3 +624,9 @@ uint32_t AP_MotorsHeli::get_motor_mask()
 {
     return _main_rotor.get_output_mask();
 }
+
+// set_desired_rotor_speed
+void AP_MotorsHeli::set_desired_rotor_speed(float desired_speed)
+{
+    _main_rotor.set_desired_speed(desired_speed);
+}

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -68,7 +68,7 @@ public:
 
     // parameter_check - returns true if helicopter specific parameters are sensible, used for pre-arm check
     virtual bool parameter_check(bool display_msg) const;
-	
+
     //set turbine start flag on to initiaize starting sequence
     void set_turb_start(bool turb_start) { _heliflags.start_engine = turb_start; }
 
@@ -91,22 +91,22 @@ public:
     bool arot_man_enabled() const { return (_main_rotor._rsc_arot_man_enable.get() == 1) ? true : false; }
 
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
-    virtual void set_desired_rotor_speed(float desired_speed) = 0;
+    virtual void set_desired_rotor_speed(float desired_speed);
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
-    virtual float get_desired_rotor_speed() const = 0;
+    float get_desired_rotor_speed() const { return _main_rotor.get_desired_speed(); }
 
     // get_main_rotor_speed - estimated rotor speed when no governor or speed sensor used
-    virtual float get_main_rotor_speed() const = 0;
+    float get_main_rotor_speed() const { return _main_rotor.get_rotor_speed(); }
 
     // return true if the main rotor is up to speed
     bool rotor_runup_complete() const { return _heliflags.rotor_runup_complete; }
 
     //get rotor governor output
-    virtual float get_governor_output() const = 0;
+    float get_governor_output() const { return _main_rotor.get_governor_output(); }
 
     //get engine throttle output
-    virtual float get_control_output() const = 0;
+    float get_control_output() const { return _main_rotor.get_control_output(); }
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -102,9 +102,6 @@ public:
     // return true if the main rotor is up to speed
     bool rotor_runup_complete() const { return _heliflags.rotor_runup_complete; }
 
-    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    virtual bool rotor_speed_above_critical() const = 0;
-
     //get rotor governor output
     virtual float get_governor_output() const = 0;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -306,12 +306,6 @@ void AP_MotorsHeli_Dual::_output_test_seq(uint8_t motor_seq, int16_t pwm)
     }
 }
 
-// set_desired_rotor_speed
-void AP_MotorsHeli_Dual::set_desired_rotor_speed(float desired_speed)
-{
-    _main_rotor.set_desired_speed(desired_speed);
-}
-
 // calculate_armed_scalars
 void AP_MotorsHeli_Dual::calculate_armed_scalars()
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -52,21 +52,6 @@ public:
     // output_to_motors - sends values out to the motors
     void output_to_motors() override;
 
-    // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
-    void set_desired_rotor_speed(float desired_speed) override;
-
-    // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
-
-    // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
-    float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
-
-    // get_governor_output
-    float get_governor_output() const override { return _main_rotor.get_governor_output(); }
-
-    // get_control_output
-    float get_control_output() const override { return _main_rotor.get_control_output(); }
-
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -61,9 +61,6 @@ public:
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
     float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
 
-    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
-
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -85,12 +85,6 @@ void AP_MotorsHeli_Quad::_output_test_seq(uint8_t motor_seq, int16_t pwm)
     }
 }
 
-// set_desired_rotor_speed
-void AP_MotorsHeli_Quad::set_desired_rotor_speed(float desired_speed)
-{
-    _main_rotor.set_desired_speed(desired_speed);
-}
-
 // calculate_armed_scalars
 void AP_MotorsHeli_Quad::calculate_armed_scalars()
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -31,21 +31,6 @@ public:
     // output_to_motors - sends values out to the motors
     void output_to_motors() override;
 
-    // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
-    void set_desired_rotor_speed(float desired_speed) override;
-
-    // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
-
-    // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
-    float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
-
-    // get_governor_output
-    float get_governor_output() const override { return _main_rotor.get_governor_output(); }
-
-    // get_control_output
-    float get_control_output() const override { return _main_rotor.get_control_output(); }
-
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -40,9 +40,6 @@ public:
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
     float get_desired_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
 
-    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
-
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -461,7 +461,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
     // if in autorotation, don't let rotor_runup_output go less than critical speed to keep
     // runup complete flag from being set to false
-    if (_autorotating && _rotor_runup_output < get_critical_speed()) {
+    if (_autorotating && !rotor_speed_above_critical()) {
         _rotor_runup_output = get_critical_speed();
     }
 
@@ -479,7 +479,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
     // if rotor speed is less than critical speed, then run-up is not complete
     // this will prevent the case where the target rotor speed is less than critical speed
-    if (_runup_complete && (get_rotor_speed() < get_critical_speed())) {
+    if (_runup_complete && !rotor_speed_above_critical()) {
         _runup_complete = false;
     }
     // if rotor estimated speed is zero, then spooldown has been completed

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -128,6 +128,9 @@ public:
     // Return mask of output channels which the RSC is outputting on
     uint32_t    get_output_mask() const;
 
+    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
+    bool        rotor_speed_above_critical(void) const { return get_rotor_speed() > get_critical_speed(); }
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -442,7 +442,7 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
         // rudder feed forward based on collective
         // the feed-forward is not required when the motor is stopped or at idle, and thus not creating torque
         // also not required if we are using external gyro
-        if ((_main_rotor.get_control_output() > _main_rotor.get_idle_output()) && _tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
+        if ((get_control_output() > _main_rotor.get_idle_output()) && _tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
             // sanity check collective_yaw_scale
             _collective_yaw_scale.set(constrain_float(_collective_yaw_scale, -AP_MOTORS_HELI_SINGLE_COLYAW_RANGE, AP_MOTORS_HELI_SINGLE_COLYAW_RANGE));
             // This feedforward compensation follows the hover performance theory that hover power required

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -61,9 +61,6 @@ public:
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
     float get_desired_rotor_speed() const  override { return _main_rotor.get_desired_speed(); }
 
-    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
-
     // get_governor_output
     float get_governor_output() const override { return _main_rotor.get_governor_output(); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -55,18 +55,6 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     void set_desired_rotor_speed(float desired_speed) override;
 
-    // get_main_rotor_speed - estimated rotor speed when no speed sensor or governor is used
-    float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
-
-    // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
-    float get_desired_rotor_speed() const  override { return _main_rotor.get_desired_speed(); }
-
-    // get_governor_output
-    float get_governor_output() const override { return _main_rotor.get_governor_output(); }
-
-    // get_control_output
-    float get_control_output() const override{ return _main_rotor.get_control_output(); }
-
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
 


### PR DESCRIPTION
This is an extension to this PR: #23591 (that I have now closed).

This is a basic rework that removes unnecessary virtual functions.  There is no functional change.  Main benefit is to start making the library simpler.  We get the added benefit of approx. 100 b of flash saved.