### PR TITLE
AP_OSD: fix format of RF panel and check for out of range

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2201,12 +2201,11 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
     if (rangefinder == nullptr) {
        return;
     }
-    if (rangefinder->status_orient(ROTATION_PITCH_270) <= RangeFinder::Status::NoData) {
-        backend->write(x, y, false, "%c----%c", SYMBOL(SYM_RNGFD), u_icon(DISTANCE));
+    if (rangefinder->status_orient(ROTATION_PITCH_270) < RangeFinder::Status::Good) {
+        backend->write(x, y, false, "%c---%c", SYMBOL(SYM_RNGFD), u_icon(DISTANCE));
     } else {
         const float distance = rangefinder->distance_orient(ROTATION_PITCH_270);
-        const char *format = distance < 9.995 ? "%c %1.2f%c" : "%c%2.2f%c";
-        backend->write(x, y, false, format, SYMBOL(SYM_RNGFD), u_scale(DISTANCE, distance), u_icon(DISTANCE));
+        backend->write(x, y, false, "%c%4.1f%c", SYMBOL(SYM_RNGFD), u_scale(DISTANCE, distance), u_icon(DISTANCE));
     }
 }
 


### PR DESCRIPTION
SITL tested...and discovered a bug in the analog RF backend and in the SITL emulation of it ( #23669 )....flight tested