### PR TITLE
AP_RangeFinder: fix analog backend out of range max return value

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
@@ -106,11 +106,13 @@ void AP_RangeFinder_analog::update(void)
         } else {
             dist_m = scaling / (v - offset);
         }
-        if (dist_m > _max_distance_cm * 0.01f) {
-            dist_m = _max_distance_cm * 0.01f;
-        }
         break;
     }
+    if (dist_m > _max_distance_cm * 0.01f) {
+        // return a distance that will set the out of range check in status_update()
+        dist_m = 1 + _max_distance_cm * 0.01f;        
+    }
+    
     if (dist_m < 0) {
         dist_m = 0;
     }


### PR DESCRIPTION
out of range max status was never being set on analog rangefinder backend...discovered this when SITL testing my changes in the OSD RF panel to correctly display when out of range....

in addition, the SITL emulation of this function is broken in that it will never return a voltage value to the backend which would result in a measurement > max_cm since it scales its max voltage to that value, but this can be circumvented by setting an offset...