### PR TITLE
autotest: stop vehicle from entering RTL instantly when it enters auto

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7333,7 +7333,7 @@ class AutoTest(ABC):
         '''ensure we can't arm in auto mode without mission items present'''
         # load a trivial mission
         items = []
-        items.append((mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 20000),)
+        items.append((mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 1000, 0, 20000),)
         items.append((mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0))
         self.upload_simple_relhome_mission(items)
 


### PR DESCRIPTION
Test failure because we instantly reached the waypoint and did the RTL - so the change-mode-to-auto never saw us in auto mode