### PR TITLE
Tools: logger_metadata: add emit_md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ parameters.edn
 LogMessages.html
 LogMessages.rst
 LogMessages.xml
+LogMessages.md
 # JetBrains IDE files
 .idea/*
 # CMake

--- a/Tools/autotest/logger_metadata/emit_md.py
+++ b/Tools/autotest/logger_metadata/emit_md.py
@@ -1,0 +1,82 @@
+import os
+import time
+import emitter
+
+class MDEmitter(emitter.Emitter):
+    def preface(self):
+        if os.getenv('BRDOC') is not None:
+            now = time.strftime('%Y-%m-%dT%H:%M:%S%z')
+            now = now[:-2] + ':' + now[-2:]
+            return '\n'.join((
+                '+++',
+                'title = "Onboard Log Messages"',
+                'description = "Message listing for DataFlash autopilot logs."',
+                f'date = {now}',
+                'template = "docs/page.html"',
+                'sort_by = "weight"',
+                'weight = 30',
+                'draft = false',
+                '[extra]',
+                'toc = true',
+                'top = false',
+                '+++\n',
+                '<!-- Dynamically generated using Tools/autotest/logger_metadata/parse.py',
+                'DO NOT EDIT -->',
+                'This is a list of log messages which may be present in DataFlash (`.bin`) '
+                'logs produced and stored onboard ArduSub vehicles (see [Log Parameters]'
+                '(../parameters/#log-parameters) for creation details). '
+                'It is possible to [add a new message]'
+                '(https://ardupilot.org/dev/docs/code-overview-adding-a-new-log-message.html) '
+                'by modifying the firmware.\n',
+                'DataFlash logs can be downloaded and analysed '
+                '[from a computer](http://www.ardusub.com/reference/data-logging.html#downloading) '
+                'or [through BlueOS]'
+                '(@/software/onboard/BlueOS-1.1/advanced-usage/index.md#log-browser).\n'
+            ))
+
+        return """<!-- Dynamically generated list of Logger Messages
+This page was generated using Tools/autotest/logger_metdata/parse.py
+
+DO NOT EDIT
+-->
+
+
+<h3 style="text-align: center">Onboard Message Log Messages</h3>
+<hr />
+
+<p>This is a list of log messages which may be present in logs produced and stored onboard ArduPilot vehicles.</p>
+
+<!-- add auto-generated table of contents with "Table of Contents Plus" plugin -->
+[toc exclude="Onboard Message Log Messages"]
+
+"""
+    def postface(self):
+        return ""
+
+    def start(self):
+        self.fh = open("LogMessages.md", mode='w')
+        print(self.preface(), file=self.fh)
+
+    def emit(self, doccos, enumerations=None):
+        self.start()
+        for docco in doccos:
+            print(f'## {docco.name}', file=self.fh)
+            desc = ''
+            if docco.description is not None:
+                desc += docco.description
+            if docco.url is not None:
+                desc += f' ([Read more...]({docco.url}))'
+            print(desc, file=self.fh)
+            print("\n|FieldName|Description|\n|---|---|", file=self.fh)
+            for f in docco.fields_order:
+                if "description" in docco.fields[f]:
+                    fdesc = docco.fields[f]["description"]
+                else:
+                    fdesc = ""
+                print(f'|{f}|{fdesc}|', file=self.fh)
+            print("", file=self.fh)
+        self.stop()
+
+    def stop(self):
+        print(self.postface(), file=self.fh)
+        self.fh.close()

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -11,6 +11,7 @@ import sys
 import emit_html
 import emit_rst
 import emit_xml
+import emit_md
 
 import enum_parse
 from enum_parse import EnumDocco
@@ -50,6 +51,7 @@ class LoggerDocco(object):
             emit_html.HTMLEmitter(),
             emit_rst.RSTEmitter(),
             emit_xml.XMLEmitter(),
+            emit_md.MDEmitter(),
         ]
 
     class Docco(object):


### PR DESCRIPTION
Add markdown output option for DataFlash log messages, so it can be [used in ArduSub docs](https://docs.bluerobotics.com/ardusub-zola/software/autopilot/ArduSub-4.1/developers/log-messages/).

@Williangalvani 