### PR TITLE
Plane: move long failsafe action into mode. Allow postponed actions and use in takeoff mode

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -427,7 +427,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: The action to take on a long (FS_LONG_TIMEOUT seconds) failsafe event. If the aircraft was in a stabilization or manual mode when failsafe started and a long failsafe occurs then it will change to RTL mode if FS_LONG_ACTN is 0 or 1, and will change to FBWA if FS_LONG_ACTN is set to 2. If the aircraft was in an auto mode (such as AUTO or GUIDED) when the failsafe started then it will continue in the auto mode if FS_LONG_ACTN is set to 0, will change to RTL mode if FS_LONG_ACTN is set to 1 and will change to FBWA mode if FS_LONG_ACTN is set to 2. If FS_LONG_ACTN is set to 3, the parachute will be deployed (make sure the chute is configured and enabled). If FS_LONG_ACTN is set to 4 the aircraft will switch to mode AUTO with the current waypoint if it is not already in mode AUTO, unless it is in the middle of a landing sequence.
     // @Values: 0:Continue,1:ReturnToLaunch,2:Glide,3:Deploy Parachute,4:Auto
     // @User: Standard
-    GSCALAR(fs_action_long,         "FS_LONG_ACTN",   FS_ACTION_LONG_CONTINUE),
+    GSCALAR(fs_action_long,         "FS_LONG_ACTN",   (float)failsafe_action_long::CONTINUE),
 
     // @Param: FS_LONG_TIMEOUT
     // @DisplayName: Long failsafe timeout

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -324,7 +324,7 @@ private:
 
         // A tracking variable for type of failsafe active
         // Used for failsafe based on loss of RC signal or GCS signal
-        int16_t state;
+        failsafe_state state;
 
         // number of low throttle values
         uint8_t throttle_counter;
@@ -357,7 +357,7 @@ private:
 #endif
 
     bool any_failsafe_triggered() {
-        return failsafe.state != FAILSAFE_NONE || battery.has_failsafed() || failsafe.adsb;
+        return failsafe.state != failsafe_state::NONE || battery.has_failsafed() || failsafe.adsb;
     }
 
     // A counter used to count down valid gps fixes to allow the gps estimate to settle
@@ -982,8 +982,8 @@ private:
     bool autotuning;
 
     // events.cpp
-    void failsafe_short_on_event(enum failsafe_state fstype, ModeReason reason);
-    void failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason);
+    void failsafe_short_on_event(failsafe_state fstype, ModeReason reason);
+    void failsafe_long_on_event(failsafe_state fstype, ModeReason reason);
     void failsafe_short_off_event(ModeReason reason);
     void failsafe_long_off_event(ModeReason reason);
     void handle_battery_failsafe(const char* type_str, const int8_t action);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -983,7 +983,7 @@ private:
 
     // events.cpp
     void failsafe_short_on_event(failsafe_state fstype, ModeReason reason);
-    void failsafe_long_on_event(failsafe_state fstype, ModeReason reason);
+    void failsafe_long_on_event(failsafe_state fstype);
     void failsafe_short_off_event(ModeReason reason);
     void failsafe_long_off_event(ModeReason reason);
     void handle_battery_failsafe(const char* type_str, const int8_t action);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -45,6 +45,8 @@ enum class failsafe_action_long {
     GLIDE = 2,
     DEPLOY_PARACHUTE = 3,
     AUTO = 4,
+    QRTL = 5,
+    QLAND = 6,
 };
 
 // type of stick mixing enabled

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -12,11 +12,11 @@
 
 // failsafe
 // ----------------------
-enum failsafe_state {
-    FAILSAFE_NONE=0,
-    FAILSAFE_SHORT=1,
-    FAILSAFE_LONG=2,
-    FAILSAFE_GCS=3
+enum class failsafe_state {
+    NONE=0,
+    RC_SHORT=1,
+    RC_LONG=2,
+    GCS=3
 };
 
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -16,7 +16,9 @@ enum class failsafe_state {
     NONE=0,
     RC_SHORT=1,
     RC_LONG=2,
-    GCS=3
+    GCS=3,
+    RC_LONG_POSTPONED=4,
+    GCS_POSTPONED=5,
 };
 
 
@@ -47,6 +49,7 @@ enum class failsafe_action_long {
     AUTO = 4,
     QRTL = 5,
     QLAND = 6,
+    POSTPONED = 7,
 };
 
 // type of stick mixing enabled

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -39,12 +39,12 @@ enum failsafe_action_short {
     FS_ACTION_SHORT_FBWB = 4,
 };
 
-enum failsafe_action_long {
-    FS_ACTION_LONG_CONTINUE = 0,
-    FS_ACTION_LONG_RTL = 1,
-    FS_ACTION_LONG_GLIDE = 2,
-    FS_ACTION_LONG_PARACHUTE = 3,
-    FS_ACTION_LONG_AUTO = 4,
+enum class failsafe_action_long {
+    CONTINUE = 0,
+    RTL = 1,
+    GLIDE = 2,
+    DEPLOY_PARACHUTE = 3,
+    AUTO = 4,
 };
 
 // type of stick mixing enabled

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -130,13 +130,13 @@ void Plane::failsafe_long_on_event(failsafe_state fstype)
             set_mode(mode_fbwa, reason); // emergency landing switch overrides normal action to allow out of range landing
             break;
         }
-        if(g.fs_action_long == FS_ACTION_LONG_PARACHUTE) {
+        if(g.fs_action_long == (int8_t)failsafe_action_long::DEPLOY_PARACHUTE) {
 #if PARACHUTE == ENABLED
             parachute_release();
 #endif
-        } else if (g.fs_action_long == FS_ACTION_LONG_GLIDE) {
+        } else if (g.fs_action_long == (int8_t)failsafe_action_long::GLIDE) {
             set_mode(mode_fbwa, reason);
-        } else if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
+        } else if (g.fs_action_long == (int8_t)failsafe_action_long::AUTO) {
             set_mode(mode_auto, reason);
         } else {
             set_mode(mode_rtl, reason);
@@ -170,21 +170,21 @@ void Plane::failsafe_long_on_event(failsafe_state fstype)
 
     case Mode::Number::AVOID_ADSB:
     case Mode::Number::GUIDED:
-        if(g.fs_action_long == FS_ACTION_LONG_PARACHUTE) {
+        if(g.fs_action_long == (int8_t)failsafe_action_long::DEPLOY_PARACHUTE) {
 #if PARACHUTE == ENABLED
             parachute_release();
 #endif
-        } else if (g.fs_action_long == FS_ACTION_LONG_GLIDE) {
+        } else if (g.fs_action_long == (int8_t)failsafe_action_long::GLIDE) {
             set_mode(mode_fbwa, reason);
-        } else if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
+        } else if (g.fs_action_long == (int8_t)failsafe_action_long::AUTO) {
             set_mode(mode_auto, reason);
-        } else if (g.fs_action_long == FS_ACTION_LONG_RTL) {
+        } else if (g.fs_action_long == (int8_t)failsafe_action_long::RTL) {
             set_mode(mode_rtl, reason);
         }
         break;
 
     case Mode::Number::RTL:
-        if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
+        if (g.fs_action_long == (int8_t)failsafe_action_long::AUTO) {
             set_mode(mode_auto, reason);
         }
         break;

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -18,7 +18,7 @@ bool Plane::failsafe_in_landing_sequence() const
     return false;
 }
 
-void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reason)
+void Plane::failsafe_short_on_event(failsafe_state fstype, ModeReason reason)
 {
     // This is how to handle a short loss of control signal failsafe.
     failsafe.state = fstype;
@@ -105,7 +105,7 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
     }
 }
 
-void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason)
+void Plane::failsafe_long_on_event(failsafe_state fstype, ModeReason reason)
 {
     // This is how to handle a long loss of control signal failsafe.
     //  If the GCS is locked up we allow control to revert to RC
@@ -202,7 +202,7 @@ void Plane::failsafe_short_off_event(ModeReason reason)
 {
     // We're back in radio contact
     gcs().send_text(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
-    failsafe.state = FAILSAFE_NONE;
+    failsafe.state = failsafe_state::NONE;
     // restore entry mode if desired but check that our current mode is still due to failsafe
     if (control_mode_reason == ModeReason::RADIO_FAILSAFE) { 
        set_mode_by_number(failsafe.saved_mode_number, ModeReason::RADIO_FAILSAFE_RECOVERY);
@@ -219,7 +219,7 @@ void Plane::failsafe_long_off_event(ModeReason reason)
     else {
         gcs().send_text(MAV_SEVERITY_WARNING, "RC Long Failsafe Cleared");
     }
-    failsafe.state = FAILSAFE_NONE;
+    failsafe.state = failsafe_state::NONE;
 }
 
 void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -105,12 +105,14 @@ void Plane::failsafe_short_on_event(failsafe_state fstype, ModeReason reason)
     }
 }
 
-void Plane::failsafe_long_on_event(failsafe_state fstype, ModeReason reason)
+void Plane::failsafe_long_on_event(failsafe_state fstype)
 {
     // This is how to handle a long loss of control signal failsafe.
     //  If the GCS is locked up we allow control to revert to RC
     RC_Channels::clear_overrides();
     failsafe.state = fstype;
+
+    const ModeReason reason = (fstype == failsafe_state::GCS) ? ModeReason::GCS_FAILSAFE : ModeReason::RADIO_FAILSAFE;
     switch (control_mode->mode_number())
     {
     case Mode::Number::MANUAL:

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -125,6 +125,9 @@ public:
     // handle a guided target request from GCS
     virtual bool handle_guided_request(Location target_loc) { return false; }
 
+    // Return the long failsafe action that should be taken in this mode
+    virtual failsafe_action_long long_failsafe_action() const;
+
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -206,6 +209,9 @@ public:
     
     bool mode_allows_autotuning() const override { return true; }
 
+    // Return the long failsafe action that should be taken in this mode
+    failsafe_action_long long_failsafe_action() const override;
+
 protected:
 
     bool _enter() override;
@@ -259,6 +265,9 @@ public:
     void set_radius_and_direction(const float radius, const bool direction_is_ccw);
 
     void update_target_altitude() override;
+
+    // Return the long failsafe action that should be taken in this mode
+    failsafe_action_long long_failsafe_action() const override;
 
 protected:
 
@@ -334,6 +343,9 @@ public:
     // handle a guided target request from GCS
     bool handle_guided_request(Location target_loc) override;
 
+    // Do not change modes in failsafe
+    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
+
 protected:
     bool _enter() override;
 
@@ -376,6 +388,9 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    // Return the long failsafe action that should be taken in this mode
+    failsafe_action_long long_failsafe_action() const override;
 
 protected:
 
@@ -437,6 +452,9 @@ public:
     bool allows_throttle_nudging() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    // Do not change modes in failsafe
+    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
 
 protected:
     bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
@@ -534,6 +552,9 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
+    // Return the long failsafe action that should be taken in this mode
+    failsafe_action_long long_failsafe_action() const override;
+
 protected:
 
     bool _enter() override;
@@ -629,6 +650,9 @@ public:
 
     void run() override;
 
+    // Do not change modes in failsafe
+    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
+
 protected:
 
     bool _enter() override;
@@ -658,6 +682,9 @@ public:
     bool allows_throttle_nudging() const override;
 
     float get_VTOL_return_radius() const;
+
+    // Do not change modes in failsafe
+    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
 
 protected:
 
@@ -739,6 +766,9 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    // Do not change modes in failsafe
+    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
 
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -767,8 +767,8 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
-    // Do not change modes in failsafe
-    failsafe_action_long long_failsafe_action() const override { return failsafe_action_long::CONTINUE; }
+    // Return the long failsafe action that should be taken in this mode
+    failsafe_action_long long_failsafe_action() const override;
 
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -159,3 +159,21 @@ bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
     // Note that this bypasses the base class checks
     return true;
 }
+
+// Return the long failsafe action that should be taken in this mode
+failsafe_action_long ModeAuto::long_failsafe_action() const
+{
+    if (plane.failsafe_in_landing_sequence()) {
+        // don't failsafe in a landing sequence
+        return failsafe_action_long::CONTINUE;
+    }
+
+    if ((plane.g.fs_action_long == (int8_t)failsafe_action_long::DEPLOY_PARACHUTE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::GLIDE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::AUTO) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::RTL)) {
+        return failsafe_action_long(plane.g.fs_action_long.get());
+    }
+
+    return failsafe_action_long::CONTINUE;
+}

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -163,6 +163,11 @@ bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
 // Return the long failsafe action that should be taken in this mode
 failsafe_action_long ModeAuto::long_failsafe_action() const
 {
+    if (plane.flight_stage != AP_FixedWing::FlightStage::LAND) {
+        // postpone action in a land flight stage
+        return failsafe_action_long::POSTPONED;
+    }
+
     if (plane.failsafe_in_landing_sequence()) {
         // don't failsafe in a landing sequence
         return failsafe_action_long::CONTINUE;

--- a/ArduPlane/mode_avoidADSB.cpp
+++ b/ArduPlane/mode_avoidADSB.cpp
@@ -19,5 +19,18 @@ void ModeAvoidADSB::navigate()
     plane.update_loiter(0);
 }
 
+// Return the long failsafe action that should be taken in this mode
+failsafe_action_long ModeAvoidADSB::long_failsafe_action() const
+{
+    if ((plane.g.fs_action_long == (int8_t)failsafe_action_long::DEPLOY_PARACHUTE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::GLIDE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::AUTO) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::RTL)) {
+        return failsafe_action_long(plane.g.fs_action_long.get());
+    }
+
+    return failsafe_action_long::CONTINUE;
+}
+
 #endif // HAL_ADSB_ENABLED
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -151,3 +151,16 @@ void ModeGuided::update_target_altitude()
         Mode::update_target_altitude();
     }
 }
+
+// Return the long failsafe action that should be taken in this mode
+failsafe_action_long ModeGuided::long_failsafe_action() const
+{
+    if ((plane.g.fs_action_long == (int8_t)failsafe_action_long::DEPLOY_PARACHUTE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::GLIDE) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::AUTO) ||
+        (plane.g.fs_action_long == (int8_t)failsafe_action_long::RTL)) {
+        return failsafe_action_long(plane.g.fs_action_long.get());
+    }
+
+    return failsafe_action_long::CONTINUE;
+}

--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -154,3 +154,12 @@ bool ModeRTL::switch_QRTL()
 }
 
 #endif  // HAL_QUADPLANE_ENABLED
+
+// Return the long failsafe action that should be taken in this mode
+failsafe_action_long ModeRTL::long_failsafe_action() const
+{
+    if (plane.g.fs_action_long == (int8_t)failsafe_action_long::AUTO) {
+        return failsafe_action_long::AUTO;
+    }
+    return failsafe_action_long::CONTINUE;
+}

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -342,29 +342,29 @@ void Plane::check_long_failsafe()
     const uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_FixedWing::FlightStage::LAND) {
+    if (failsafe.state != failsafe_state::RC_LONG && failsafe.state != failsafe_state::GCS && flight_stage != AP_FixedWing::FlightStage::LAND) {
         uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
-        if (failsafe.state == FAILSAFE_SHORT) {
+        if (failsafe.state == failsafe_state::RC_SHORT) {
             // time is relative to when short failsafe enabled
             radio_timeout_ms = failsafe.short_timer_ms;
         }
         if (failsafe.rc_failsafe &&
             (tnow - radio_timeout_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_LONG, ModeReason::RADIO_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::RC_LONG, ModeReason::RADIO_FAILSAFE);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_AUTO && control_mode == &mode_auto &&
                    gcs_last_seen_ms != 0 &&
                    (tnow - gcs_last_seen_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
         } else if ((g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HEARTBEAT ||
                     g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI) &&
                    gcs_last_seen_ms != 0 &&
                    (tnow - gcs_last_seen_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
                    gcs().chan(0) != nullptr &&
                    gcs().chan(0)->last_radio_status_remrssi_ms() != 0 &&
                    (tnow - gcs().chan(0)->last_radio_status_remrssi_ms()) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(FAILSAFE_GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
         }
     } else {
         uint32_t timeout_seconds = g.fs_timeout_long;
@@ -373,10 +373,10 @@ void Plane::check_long_failsafe()
             timeout_seconds = g.fs_timeout_short;
         }
         // We do not change state but allow for user to change mode
-        if (failsafe.state == FAILSAFE_GCS && 
+        if (failsafe.state == failsafe_state::GCS && 
             (tnow - gcs_last_seen_ms) < timeout_seconds*1000) {
             failsafe_long_off_event(ModeReason::GCS_FAILSAFE);
-        } else if (failsafe.state == FAILSAFE_LONG && 
+        } else if (failsafe.state == failsafe_state::RC_LONG && 
                    !failsafe.rc_failsafe) {
             failsafe_long_off_event(ModeReason::RADIO_FAILSAFE);
         }
@@ -388,15 +388,15 @@ void Plane::check_short_failsafe()
     // only act on changes
     // -------------------
     if (g.fs_action_short != FS_ACTION_SHORT_DISABLED &&
-       failsafe.state == FAILSAFE_NONE &&
+       failsafe.state == failsafe_state::NONE &&
        flight_stage != AP_FixedWing::FlightStage::LAND) {
         // The condition is checked and the flag rc_failsafe is set in radio.cpp
         if(failsafe.rc_failsafe) {
-            failsafe_short_on_event(FAILSAFE_SHORT, ModeReason::RADIO_FAILSAFE);
+            failsafe_short_on_event(failsafe_state::RC_SHORT, ModeReason::RADIO_FAILSAFE);
         }
     }
 
-    if(failsafe.state == FAILSAFE_SHORT) {
+    if(failsafe.state == failsafe_state::RC_SHORT) {
         if(!failsafe.rc_failsafe || g.fs_action_short == FS_ACTION_SHORT_DISABLED) {
             failsafe_short_off_event(ModeReason::RADIO_FAILSAFE);
         }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -342,7 +342,7 @@ void Plane::check_long_failsafe()
     const uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != failsafe_state::RC_LONG && failsafe.state != failsafe_state::GCS && flight_stage != AP_FixedWing::FlightStage::LAND) {
+    if (failsafe.state != failsafe_state::RC_LONG && failsafe.state != failsafe_state::GCS) {
         uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
         if (failsafe.state == failsafe_state::RC_SHORT) {
             // time is relative to when short failsafe enabled

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -350,21 +350,21 @@ void Plane::check_long_failsafe()
         }
         if (failsafe.rc_failsafe &&
             (tnow - radio_timeout_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(failsafe_state::RC_LONG, ModeReason::RADIO_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::RC_LONG);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_AUTO && control_mode == &mode_auto &&
                    gcs_last_seen_ms != 0 &&
                    (tnow - gcs_last_seen_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS);
         } else if ((g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HEARTBEAT ||
                     g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI) &&
                    gcs_last_seen_ms != 0 &&
                    (tnow - gcs_last_seen_ms) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
                    gcs().chan(0) != nullptr &&
                    gcs().chan(0)->last_radio_status_remrssi_ms() != 0 &&
                    (tnow - gcs().chan(0)->last_radio_status_remrssi_ms()) > g.fs_timeout_long*1000) {
-            failsafe_long_on_event(failsafe_state::GCS, ModeReason::GCS_FAILSAFE);
+            failsafe_long_on_event(failsafe_state::GCS);
         }
     } else {
         uint32_t timeout_seconds = g.fs_timeout_long;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -373,10 +373,10 @@ void Plane::check_long_failsafe()
             timeout_seconds = g.fs_timeout_short;
         }
         // We do not change state but allow for user to change mode
-        if (failsafe.state == failsafe_state::GCS && 
+        if (((failsafe.state == failsafe_state::GCS) || (failsafe.state == failsafe_state::GCS_POSTPONED)) && 
             (tnow - gcs_last_seen_ms) < timeout_seconds*1000) {
             failsafe_long_off_event(ModeReason::GCS_FAILSAFE);
-        } else if (failsafe.state == failsafe_state::RC_LONG && 
+        } else if (((failsafe.state == failsafe_state::RC_LONG) || (failsafe.state == failsafe_state::RC_LONG_POSTPONED)) && 
                    !failsafe.rc_failsafe) {
             failsafe_long_off_event(ModeReason::RADIO_FAILSAFE);
         }


### PR DESCRIPTION
A WIP as to what moveing failsafe actions to be per-mode might look like. Allows posponed actions such the one proposed in: 
 https://github.com/ArduPilot/ardupilot/pull/23650

Also gives better failsafe messages, although it would be nice to give a extra string in the posponed case to give a hint as to when the postponment will end.