### PR TITLE
AP_Motors: Heli: move swash functionality down into swash lib

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -503,16 +503,6 @@ bool AP_MotorsHeli::parameter_check(bool display_msg) const
     return true;
 }
 
-// reset_swash_servo
-void AP_MotorsHeli::reset_swash_servo(SRV_Channel::Aux_servo_function_t function)
-{
-    // outputs are defined on a -500 to 500 range for swash servos
-    SRV_Channels::set_range(function, 1000);
-
-    // swash servos always use full endpoints as restricting them would lead to scaling errors
-    SRV_Channels::set_output_min_max(function, 1000, 2000);
-}
-
 // update the throttle input filter
 void AP_MotorsHeli::update_throttle_filter()
 {

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -535,17 +535,6 @@ void AP_MotorsHeli::reset_flight_controls()
     calculate_scalars();
 }
 
-// convert input in -1 to +1 range to pwm output for swashplate servo.
-// The value 0 corresponds to the trim value of the servo. Swashplate
-// servo travel range is fixed to 1000 pwm and therefore the input is
-// multiplied by 500 to get PWM output.
-void AP_MotorsHeli::rc_write_swash(uint8_t chan, float swash_in)
-{
-    uint16_t pwm = (uint16_t)(1500 + 500 * swash_in);
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
-    SRV_Channels::set_output_pwm_trimmed(function, pwm);
-}
-
 // update the collective input filter.  should be called at 100hz
 void AP_MotorsHeli::update_throttle_hover(float dt)
 {

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -206,9 +206,6 @@ protected:
     // move_actuators - moves swash plate and tail rotor
     virtual void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) = 0;
 
-    // reset_swash_servo - free up swash servo for maximum movement
-    void reset_swash_servo(SRV_Channel::Aux_servo_function_t function);
-
     // init_outputs - initialise Servo/PWM ranges and endpoints.  This
     // method also updates the initialised flag.
     virtual void init_outputs() = 0;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -223,9 +223,6 @@ protected:
     // to be overloaded by child classes, different vehicle types would have different movement patterns
     virtual void servo_test() = 0;
 
-    // write to a swash servo. output value is pwm
-    void rc_write_swash(uint8_t chan, float swash_in);
-
     // save parameters as part of disarming
     void save_params_on_disarm() override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -326,11 +326,9 @@ void AP_MotorsHeli_Dual::calculate_scalars()
 
     // configure swashplate 1 and update scalars
     _swashplate1.configure();
-    _swashplate1.calculate_roll_pitch_collective_factors();
 
     // configure swashplate 2 and update scalars
     _swashplate2.configure();
-    _swashplate2.calculate_roll_pitch_collective_factors();
 
     // set mode of main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_main_rotor._rsc_mode.get()));

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -557,21 +557,9 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     float swash2_roll = get_swashplate(2, AP_MOTORS_HELI_DUAL_SWASH_AXIS_ROLL, pitch_out, roll_out, yaw_out, collective2_out_scaled);
     float swash2_coll = get_swashplate(2, AP_MOTORS_HELI_DUAL_SWASH_AXIS_COLL, pitch_out, roll_out, yaw_out, collective2_out_scaled);
  
-    // get servo positions from swashplate library
-    _servo_out[CH_1] = _swashplate1.get_servo_out(CH_1,swash1_pitch,swash1_roll,swash1_coll);
-    _servo_out[CH_2] = _swashplate1.get_servo_out(CH_2,swash1_pitch,swash1_roll,swash1_coll);
-    _servo_out[CH_3] = _swashplate1.get_servo_out(CH_3,swash1_pitch,swash1_roll,swash1_coll);
-    if (_swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        _servo_out[CH_7] = _swashplate1.get_servo_out(CH_4,swash1_pitch,swash1_roll,swash1_coll);
-    }
-
-    // get servo positions from swashplate library
-    _servo_out[CH_4] = _swashplate2.get_servo_out(CH_1,swash2_pitch,swash2_roll,swash2_coll);
-    _servo_out[CH_5] = _swashplate2.get_servo_out(CH_2,swash2_pitch,swash2_roll,swash2_coll);
-    _servo_out[CH_6] = _swashplate2.get_servo_out(CH_3,swash2_pitch,swash2_roll,swash2_coll);
-    if (_swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        _servo_out[CH_8] = _swashplate2.get_servo_out(CH_4,swash2_pitch,swash2_roll,swash2_coll);
-    }
+    // Calculate servo positions in swashplate library
+    _swashplate1.calculate(swash1_roll, swash1_pitch, swash1_coll);
+    _swashplate2.calculate(swash2_roll, swash2_pitch, swash2_coll);
 
 }
 
@@ -580,19 +568,10 @@ void AP_MotorsHeli_Dual::output_to_motors()
     if (!initialised_ok()) {
         return;
     }
-    // actually move the servos.  PWM is sent based on nominal 1500 center.  servo output shifts center based on trim value.
-    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
-        rc_write_swash(i, _servo_out[CH_1+i]);
-    }
 
-    // write to servo for 4 servo of 4 servo swashplate
-    if (_swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        rc_write_swash(AP_MOTORS_MOT_7, _servo_out[CH_7]);
-    }
-    // write to servo for 4 servo of 4 servo swashplate
-    if (_swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        rc_write_swash(AP_MOTORS_MOT_8, _servo_out[CH_8]);
-    }
+    // Write swashplate outputs
+    _swashplate1.output();
+    _swashplate2.output();
 
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -215,16 +215,7 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    uint32_t mask = 0;
-    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
-        mask |= 1U << (AP_MOTORS_MOT_1+i);
-    }
-    if (_swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        mask |= 1U << (AP_MOTORS_MOT_7);
-    }
-    if (_swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        mask |= 1U << (AP_MOTORS_MOT_8);
-    }
+    uint32_t mask = _swashplate1.get_output_mask() | _swashplate2.get_output_mask();
 
     rc_set_freq(mask, _speed_hz);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -224,31 +224,8 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
 void AP_MotorsHeli_Dual::init_outputs()
 {
     if (!initialised_ok()) {
-        // make sure 6 output channels are mapped
-        for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
-            add_motor_num(CH_1+i);
-        }
-        if (_swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-            add_motor_num(CH_7);
-        }
-        if (_swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-            add_motor_num(CH_8);
-        }
-
         // set rotor servo range
         _main_rotor.init_servo();
-
-    }
-
-    // reset swash servo range and endpoints
-    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
-        reset_swash_servo(SRV_Channels::get_motor_function(i));
-    }
-    if (_swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate1.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        reset_swash_servo(SRV_Channels::get_motor_function(6));
-    }
-    if (_swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate2.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        reset_swash_servo(SRV_Channels::get_motor_function(7));
     }
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI_DUAL);

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -87,8 +87,8 @@ protected:
     const char* _get_frame_string() const override { return "HELI_DUAL"; }
 
     //  objects we depend upon
-    AP_MotorsHeli_Swash        _swashplate1;        // swashplate1
-    AP_MotorsHeli_Swash        _swashplate2;        // swashplate2
+    AP_MotorsHeli_Swash _swashplate1 { CH_1, CH_2, CH_3, CH_7 }; // swashplate1
+    AP_MotorsHeli_Swash _swashplate2 { CH_4, CH_5, CH_6, CH_8 }; // swashplate2
 
     // internal variables
     float _oscillate_angle = 0.0f;                  // cyclic oscillation angle, used by servo_test function

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -188,14 +188,8 @@ void AP_MotorsHeli_Single::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    uint32_t mask = 
-        1U << AP_MOTORS_MOT_1 |
-        1U << AP_MOTORS_MOT_2 |
-        1U << AP_MOTORS_MOT_3 |
-        1U << AP_MOTORS_MOT_4;
-    if (_swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        mask |= 1U << (AP_MOTORS_MOT_5);
-    }
+    uint32_t mask = (1U << AP_MOTORS_MOT_4) | _swashplate.get_output_mask();
+
     rc_set_freq(mask, _speed_hz);
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -460,13 +460,8 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     float collective_scalar = ((float)(_collective_max-_collective_min))*0.001f;
     float collective_out_scaled = collective_out * collective_scalar + (_collective_min - 1000)*0.001f;
 
-    // get servo positions from swashplate library
-    _servo1_out = _swashplate.get_servo_out(CH_1,pitch_out,roll_out,collective_out_scaled);
-    _servo2_out = _swashplate.get_servo_out(CH_2,pitch_out,roll_out,collective_out_scaled);
-    _servo3_out = _swashplate.get_servo_out(CH_3,pitch_out,roll_out,collective_out_scaled);
-    if (_swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        _servo5_out = _swashplate.get_servo_out(CH_4,pitch_out,roll_out,collective_out_scaled);
-    }
+    // Caculate servo positions from swashplate library
+    _swashplate.calculate(roll_out, pitch_out, collective_out_scaled);
 
     // update the yaw rate using the tail rotor/servo
     move_yaw(yaw_out + yaw_offset);
@@ -494,14 +489,9 @@ void AP_MotorsHeli_Single::output_to_motors()
         return;
     }
 
-    // actually move the servos.  PWM is sent based on nominal 1500 center.  servo output shifts center based on trim value.
-    rc_write_swash(AP_MOTORS_MOT_1, _servo1_out);
-    rc_write_swash(AP_MOTORS_MOT_2, _servo2_out);
-    rc_write_swash(AP_MOTORS_MOT_3, _servo3_out);
-    // get servo positions from swashplate library and write to servo for 4 servo of 4 servo swashplate
-    if (_swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        rc_write_swash(AP_MOTORS_MOT_5, _servo5_out);
-    }
+    // Write swashplate outputs
+    _swashplate.output();
+
     if (_tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_FIXEDPITCH_CW && _tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_FIXEDPITCH_CCW){
         rc_write_angle(AP_MOTORS_MOT_4, _servo4_out * YAW_SERVO_MAX_ANGLE);
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -317,7 +317,6 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
     // configure swashplate and update scalars
     _swashplate.configure();
-    _swashplate.calculate_roll_pitch_collective_factors();
 
     // send setpoints to main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_main_rotor._rsc_mode.get()));

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -197,14 +197,6 @@ void AP_MotorsHeli_Single::set_update_rate( uint16_t speed_hz )
 void AP_MotorsHeli_Single::init_outputs()
 {
     if (!initialised_ok()) {
-        // map primary swash servos
-        for (uint8_t i=0; i<AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS; i++) {
-            add_motor_num(CH_1+i);
-        }
-        if (_swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-            add_motor_num(CH_5);
-        }
-
         // yaw servo
         add_motor_num(CH_4);
 
@@ -222,14 +214,6 @@ void AP_MotorsHeli_Single::init_outputs()
     if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
         // External Gyro uses PWM output thus servo endpoints are forced
         SRV_Channels::set_output_min_max(SRV_Channels::get_motor_function(AP_MOTORS_HELI_SINGLE_EXTGYRO), 1000, 2000);
-    }
-
-    // reset swash servo range and endpoints
-    for (uint8_t i=0; i<AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS; i++) {
-        reset_swash_servo(SRV_Channels::get_motor_function(i));
-    }
-    if (_swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_90 || _swashplate.get_swash_type() == SWASHPLATE_TYPE_H4_45) {
-        reset_swash_servo(SRV_Channels::get_motor_function(4));
     }
 
     if (_tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPITCH && _tail_type != AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPIT_EXT_GOV) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -42,7 +42,7 @@ public:
     AP_MotorsHeli_Single(uint16_t speed_hz = AP_MOTORS_HELI_SPEED_DEFAULT) :
         AP_MotorsHeli(speed_hz),
         _tail_rotor(SRV_Channel::k_heli_tail_rsc, AP_MOTORS_HELI_SINGLE_TAILRSC),
-        _swashplate()
+        _swashplate(AP_MOTORS_MOT_1, AP_MOTORS_MOT_2, AP_MOTORS_MOT_3, AP_MOTORS_MOT_5)
     {
         AP_Param::setup_object_defaults(this, var_info);
     };
@@ -117,11 +117,7 @@ protected:
     float _roll_test = 0.0f;                    // over-ride for roll output, used by servo_test function
     float _pitch_test = 0.0f;                   // over-ride for pitch output, used by servo_test function
     float _yaw_test = 0.0f;                     // over-ride for yaw output, used by servo_test function
-    float _servo1_out = 0.0f;                   // output value sent to motor
-    float _servo2_out = 0.0f;                   // output value sent to motor
-    float _servo3_out = 0.0f;                   // output value sent to motor
     float _servo4_out = 0.0f;                   // output value sent to motor
-    float _servo5_out = 0.0f;                   // output value sent to motor
     uint16_t _ddfp_pwm_min = 0;                 // minimum ddfp servo min
     uint16_t _ddfp_pwm_max = 0;                 // minimum ddfp servo max
     uint16_t _ddfp_pwm_trim = 0;                // minimum ddfp servo trim

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -261,3 +261,15 @@ void AP_MotorsHeli_Swash::rc_write(uint8_t chan, float swash_in)
     SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
+
+// Get function output mask
+uint32_t AP_MotorsHeli_Swash::get_output_mask() const
+{
+    uint32_t mask = 0;
+    for (uint8_t i = 0; i < _max_num_servos; i++) {
+        if (_enabled[i]) {
+            mask |= 1U < _motor_num[i];
+        }
+    }
+    return mask;
+}

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -94,6 +94,8 @@ void AP_MotorsHeli_Swash::configure()
     _collective_direction = static_cast<CollectiveDirection>(_swash_coll_dir.get());
     _make_servo_linear = _linear_swash_servo != 0;
     enable.set(_swash_type == SWASHPLATE_TYPE_H3);
+
+    calculate_roll_pitch_collective_factors();
 }
 
 // CCPM Mixers - calculate mixing scale factors by swashplate type

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -199,6 +199,16 @@ void AP_MotorsHeli_Swash::add_servo_raw(uint8_t num, float roll, float pitch, fl
     _pitchFactor[num] = pitch * 0.45;
     _collectiveFactor[num] = collective;
 
+    // Setup output function
+    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(_motor_num[num]);
+    SRV_Channels::set_aux_channel_default(function, _motor_num[num]);
+
+    // outputs are defined on a -500 to 500 range for swash servos
+    SRV_Channels::set_range(function, 1000);
+
+    // swash servos always use full endpoints as restricting them would lead to scaling errors
+    SRV_Channels::set_output_min_max(function, 1000, 2000);
+
 }
 
 // calculates servo output

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -27,9 +27,6 @@ public:
     // configure - configure the swashplate settings for any updated parameters
     void configure();
 
-    // CCPM Mixers - calculate mixing scale factors by swashplate type
-    void calculate_roll_pitch_collective_factors();
-
     // get_swash_type - gets swashplate type
     SwashPlateType get_swash_type() const { return _swash_type; }
 
@@ -46,6 +43,9 @@ private:
 
     // linearize mechanical output of swashplate servo
     float get_linear_servo_output(float input) const;
+
+    // CCPM Mixers - calculate mixing scale factors by swashplate type
+    void calculate_roll_pitch_collective_factors();
 
     // Setup a servo
     void add_servo_angle(uint8_t num, float angle, float collective);

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -16,12 +16,6 @@ enum SwashPlateType {
     SWASHPLATE_TYPE_H4_45
 };
 
-// collective direction
-enum CollectiveDirection {
-    COLLECTIVE_DIRECTION_NORMAL = 0,
-    COLLECTIVE_DIRECTION_REVERSED
-};
-
 class AP_MotorsHeli_Swash {
 public:
 
@@ -42,9 +36,6 @@ public:
     // get_servo_out - calculates servo output
     float get_servo_out(int8_t servo_num, float pitch, float roll, float collective) const;
 
-    // linearize mechanical output of swashplate servo
-    float get_linear_servo_output(float input) const;
-
     // get_phase_angle - returns the rotor phase angle
     int16_t get_phase_angle() const { return _phase_angle; }
 
@@ -52,13 +43,30 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    // internal variables
+
+    // linearize mechanical output of swashplate servo
+    float get_linear_servo_output(float input) const;
+
+    // Setup a servo
+    void add_servo_angle(uint8_t num, float angle, float collective);
+    void add_servo_raw(uint8_t num, float roll, float pitch, float collective);
+
+    enum CollectiveDirection {
+        COLLECTIVE_DIRECTION_NORMAL = 0,
+        COLLECTIVE_DIRECTION_REVERSED
+    };
+
+    static const uint8_t _max_num_servos {4};
+
+    // Currently configured setup
     SwashPlateType       _swash_type;                 // Swashplate type
     CollectiveDirection  _collective_direction;       // Collective control direction, normal or reversed
-    float                _rollFactor[4];              // Roll axis scaling of servo output based on servo position
-    float                _pitchFactor[4];             // Pitch axis scaling of servo output based on servo position
-    float                _collectiveFactor[4];        // Collective axis scaling of servo output based on servo position
-    int8_t               _make_servo_linear;          // Sets servo output to be linearized
+    bool                 _make_servo_linear;          // Sets servo output to be linearized
+
+    // Internal variables
+    float                _rollFactor[_max_num_servos];              // Roll axis scaling of servo output based on servo position
+    float                _pitchFactor[_max_num_servos];             // Pitch axis scaling of servo output based on servo position
+    float                _collectiveFactor[_max_num_servos];        // Collective axis scaling of servo output based on servo position
 
     // parameters
     AP_Int8  _swashplate_type;                   // Swash Type Setting

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -36,6 +36,9 @@ public:
     // get_phase_angle - returns the rotor phase angle
     int16_t get_phase_angle() const { return _phase_angle; }
 
+    // Get function output mask
+    uint32_t get_output_mask() const;
+
     // var_info
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -19,10 +19,7 @@ enum SwashPlateType {
 class AP_MotorsHeli_Swash {
 public:
 
-    AP_MotorsHeli_Swash() 
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    };
+    AP_MotorsHeli_Swash(uint8_t mot_0, uint8_t mot_1, uint8_t mot_2, uint8_t mot_3);
 
     // configure - configure the swashplate settings for any updated parameters
     void configure();
@@ -30,8 +27,11 @@ public:
     // get_swash_type - gets swashplate type
     SwashPlateType get_swash_type() const { return _swash_type; }
 
-    // get_servo_out - calculates servo output
-    float get_servo_out(int8_t servo_num, float pitch, float roll, float collective) const;
+    // calculates servo output
+    void calculate(float roll, float pitch, float collective);
+
+    // Output calculated values to servos
+    void output();
 
     // get_phase_angle - returns the rotor phase angle
     int16_t get_phase_angle() const { return _phase_angle; }
@@ -51,6 +51,9 @@ private:
     void add_servo_angle(uint8_t num, float angle, float collective);
     void add_servo_raw(uint8_t num, float roll, float pitch, float collective);
 
+    // write to a swash servo. output value is pwm
+    void rc_write(uint8_t chan, float swash_in);
+
     enum CollectiveDirection {
         COLLECTIVE_DIRECTION_NORMAL = 0,
         COLLECTIVE_DIRECTION_REVERSED
@@ -64,9 +67,12 @@ private:
     bool                 _make_servo_linear;          // Sets servo output to be linearized
 
     // Internal variables
+    bool                 _enabled[_max_num_servos];                 // True if this output servo is enabled
     float                _rollFactor[_max_num_servos];              // Roll axis scaling of servo output based on servo position
     float                _pitchFactor[_max_num_servos];             // Pitch axis scaling of servo output based on servo position
     float                _collectiveFactor[_max_num_servos];        // Collective axis scaling of servo output based on servo position
+    float                _output[_max_num_servos];                  // Servo output value
+    uint8_t              _motor_num[_max_num_servos];               // Motor function to use for output
 
     // parameters
     AP_Int8  _swashplate_type;                   // Swash Type Setting

--- a/libraries/AP_Motors/examples/AP_Motors_test/run_heli_comparison.py
+++ b/libraries/AP_Motors/examples/AP_Motors_test/run_heli_comparison.py
@@ -25,7 +25,6 @@ import time
 # ==============================================================================
 class DataPoints:
 
-    HEADER_LINE = 3
 
     # --------------------------------------------------------------------------
     # Instantiate the object and parse the data from the provided file
@@ -34,27 +33,26 @@ class DataPoints:
         self.data = {}
         self.limit_case = []
         self.init_failed = False
+        self.seen_header = False
 
         with open(file, 'r') as csvfile:
             # creating a csv reader object
             csvreader = csv.reader(csvfile)
 
             # extracting field names through first row
-            line_num = 0
             for row in csvreader:
-                line_num += 1
 
-                if line_num < self.HEADER_LINE:
+                if not self.seen_header:
                     # Warn the user if the an init failed message has been found in the file
                     if 'initialisation failed' in row[0]:
                         print('\n%s\n' % row[0])
                         self.init_failed = True
-                    continue
+                        break
 
-                elif line_num == self.HEADER_LINE:
-                    # init all dict entries based on the header entries
-                    for field in row:
-                        self.data[field] = []
+                    if (row[0] == 'Roll') and (row[1] == 'Pitch') and (row[2] == 'Yaw') and (row[3] == 'Thr'):
+                        self.seen_header = True
+                        for field in row:
+                            self.data[field] = []
 
                 else:
                     # stow all of the data
@@ -66,6 +64,9 @@ class DataPoints:
                         if ('lim' in field.lower()) and (float(data) > 0.5):
                             case_is_limited = True
                     self.limit_case.append(case_is_limited)
+
+            if not self.seen_header:
+                self.init_failed = True
 
             # Make data immutable
             for field in self.data.keys():
@@ -94,7 +95,31 @@ class DataPoints:
 
 # ==============================================================================
 
-frame_class_lookup = {6:'Single_Heli', 11:'Dual_Heli', 13:'Heli_Quad'}
+frame_class_lookup = {6:'Single_Heli', 11:'Dual_Heli'}
+
+swash_type_lookup = {0:'H3',
+                     1:'H1',
+                     2:'H3_140',
+                     3:'H3_120',
+                     4:'H4_90',
+                     5:'H4_45',}
+
+# Run sweep over range of types
+def run_sweep(frame_class, swash_type, dir_name):
+
+    # configure and build the test
+    os.system('./waf configure --board linux')
+    os.system('./waf build --target examples/AP_Motors_test')
+
+    # Run sweep
+    for fc in frame_class:
+        for swash in swash_type:
+            print('Running motors test for frame class = %s (%i), swash = %s (%i)' % (frame_class_lookup[fc], fc, swash_type_lookup[swash], swash))
+
+            filename = '%s_%s_motor_test.csv' % (frame_class_lookup[fc], swash_type_lookup[swash])
+            os.system('./build/linux/examples/AP_Motors_test s frame_class=%d swash=%d > %s/%s' % (fc,swash,dir_name,filename))
+
+            print('Frame class = %s, swash = %s complete\n' % (frame_class_lookup[fc], swash_type_lookup[swash]))
 
 
 # ==============================================================================
@@ -104,162 +129,161 @@ if __name__ == '__main__':
     RED = [1,0,0]
     BLACK = [0,0,0]
 
-    dir_name = 'motors_comparison'
 
     # Build input parser
     parser = ArgumentParser(description='Find logs in which the input string is found in messages')
-    parser.add_argument("head", type=int, help='number of commits to roll back the head for comparing the work done')
-    parser.add_argument("-f","--frame-class", type=int, dest='frame_class', nargs="+", default=(6,11,13), help="list of frame classes to run comparison on. Defaults to 6 single heli.")
+    parser.add_argument("-H","--head", type=int, help='number of commits to roll back the head for comparing the work done')
+    parser.add_argument("-f","--frame-class", type=int, dest='frame_class', nargs="+", default=(6,11), help="list of frame classes to run comparison on. Defaults to test all helis.")
+    parser.add_argument("-s","--swash-type", type=int, dest='swash_type', nargs="+", default=(0,1,2,3,4,5), help="list of swashplate types to run comparison on. Defaults to test all types.")
+    parser.add_argument("-c","--compare", action='store_true', help='Compare only, do not re-run tests')
+    parser.add_argument("-p","--plot", action='store_true', help='Plot comparison results')
     args = parser.parse_args()
 
-    # Warn the user that we are about to move things around with git.
-    response = input("WARNING: this tool uses git to checkout older commits.  It is safest to do this in a separate test branch.\nDo you wish to continue y/n?:[n]")
-    if response.lower() != 'y':
-        quit()
+    dir_name = 'motors_comparison'
 
-    if not args.head:
-        print('Number of commits to roll back HEAD must be provided to run comparison. Add --help for more info.')
-        quit()
-    if args.head <= 0:
-        print('Number of commits to roll back HEAD must be a positive integer value')
-        quit()
+    if not args.compare:
+        # Create the new directory
+        if dir_name not in os.listdir('./'):
+            os.mkdir(dir_name)
 
-    # If we have already run this test, delete the old data
-    if dir_name in os.listdir('./'):
-        shutil.rmtree(dir_name)
+        new_name = dir_name + "/new"
+        if "new" not in os.listdir(dir_name):
+            os.mkdir(new_name)
 
-    # Create the new directory
-    os.mkdir(dir_name)
- 
-    # configure and build the test
-    os.system('./waf configure --board linux')
-    os.system('./waf build --target examples/AP_Motors_test')
+        print('\nRunning motor tests with current changes\n')
 
-    print('\nRunning motor tests with current changes\n')
+        # run the test
+        run_sweep(args.frame_class, args.swash_type, new_name)
 
-    # run the test
+        if args.head:
+            # rewind head and repeat test
+            if args.head <= 0:
+                print('Number of commits to roll back HEAD must be a positive integer value')
+                quit()
+
+            # Warn the user that we are about to move things around with git.
+            response = input("WARNING: this tool uses git to checkout older commits.  It is safest to do this in a separate test branch.\nDo you wish to continue y/n?:[n]")
+            if response.lower() != 'y':
+                quit()
+
+            # Rewind the HEAD by the requested number of commits
+            original_name = dir_name + "/original"
+            if "original" not in os.listdir(dir_name):
+                os.mkdir(original_name)
+
+            cmd = 'git log -%d --format=format:"%%H"' % (args.head+1)
+            result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
+            git_history = result.stdout.split('\n')
+            latest_commit = git_history[0]
+            base_commit = git_history[-1]
+
+            print('Rewinding head by %d commits to: %s\n' % (args.head, base_commit))
+
+            # Checkout to a detached head to test the old code before improvements
+            cmd = 'git checkout %s' % base_commit
+            result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
+            print('\n%s\n' % cmd)
+
+            if result.returncode > 0:
+                print('ERROR: Could not rewind HEAD.  Exited with error:\n%s\n%s' % (result.stdout, result.stderr))
+                quit()
+
+            # Rebuild 
+            os.system('./waf clean')
+
+            run_sweep(args.frame_class, args.swash_type, original_name)
+
+            # Move back to active branch
+            print('Returning to original branch, commit = %s\n' % latest_commit)
+            cmd = 'git switch -' 
+            result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
+            print('\n%s\n' % cmd)
+
+            if result.returncode > 0:
+                print('WARNING: Could not return head to branch with commit %s. \nError messages:\n%s\n%s' % (latest_commit, result.stdout, result.stderr))
+
+    # Print comparison
     for fc in args.frame_class:
-        filename = 'new_%s_motor_test.csv' % frame_class_lookup[fc]
-        os.system('./build/linux/examples/AP_Motors_test s > %s frame_class=%d' % (filename,fc))
+        for sw in args.swash_type:
+            frame = frame_class_lookup[fc]
+            swash = swash_type_lookup[sw]
+            name = frame + ' ' + swash
+            print('%s:' % name)
 
-        # move the csv to the directory for later comparison
-        shutil.move(filename, os.path.join(dir_name, filename))
+            filename = '%s_%s_motor_test.csv' % (frame, swash)
+            new_points = DataPoints(os.path.join(dir_name, 'new/%s' % filename))
+            old_points = DataPoints(os.path.join(dir_name, 'original/%s' % filename))
 
-        print('Frame class = %s complete\n' % frame_class_lookup[fc])
+            if new_points.init_failed:
+                print('\t failed!\n')
 
-    # Rewind the HEAD by the requested number of commits
-    cmd = 'git log -%d --format=format:"%%H"' % (args.head+1)
-    result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
-    git_history = result.stdout.split('\n')
-    latest_commit = git_history[0]
-    base_commit = git_history[-1]
+            print('\tInputs max change:')
+            INPUTS = ['Roll','Pitch','Yaw','Thr']
+            input_diff = {}
+            for field in INPUTS:
+                input_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs,input_diff[field]))))
 
-    print('Rewinding head by %d commits to: %s\n' % (args.head, base_commit))
+            # Find number of motors
+            num_motors = 0
+            while True:
+                num_motors += 1
+                if 'Mot%i' % (num_motors+1) not in new_points.get_fields():
+                    break
 
-    # Checkout to a detached head to test the old code before improvements
-    cmd = 'git checkout %s' % base_commit
-    result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
-    print('\n%s\n' % cmd)
+            print('\tOutputs max change:')
+            output_diff = {}
+            for i in range(num_motors):
+                field = 'Mot%i' % (i+1)
+                output_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs,output_diff[field]))))
 
-    if result.returncode > 0:
-        print('ERROR: Could not rewind HEAD.  Exited with error:\n%s\n%s' % (result.stdout, result.stderr))
-        quit()
+            print('\tLimits max change:')
+            LIMITS = ['LimR','LimP','LimY','LimThD','LimThU']
+            limit_diff = {}
+            for field in LIMITS:
+                limit_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs,limit_diff[field]))))
+            print('\n')
 
-    # Rebuild 
-    os.system('./waf clean')
-    os.system('./waf build --target examples/AP_Motors_test')
+            if not args.plot:
+                continue
 
-    # Run motors test for "old" comparison point
-    for fc in args.frame_class:
-        print('Running motors test for frame class = %s complete\n' % frame_class_lookup[fc])
+            # Plot comparison
+            fig_size = (16, 8)
+            fig, ax = plt.subplots(2, 2, figsize=fig_size)
+            fig.suptitle('%s Input Diff' % name, fontsize=16)
+            ax = ax.flatten()
+            for i, field in enumerate(INPUTS):
+                ax[i].plot(input_diff[field], color=RED)
+                ax[i].set_xlabel('Test Number')
+                ax[i].set_ylabel('%s Old - New' % field)
+            plt.tight_layout(rect=[0, 0.0, 1, 0.95])
 
-        filename = 'original_%s_motor_test.csv' % frame_class_lookup[fc]
-        os.system('./build/linux/examples/AP_Motors_test s > %s frame_class=%d' % (filename,fc))
+            fig, ax = plt.subplots(2, num_motors, figsize=fig_size)
+            fig.suptitle('%s Outputs' % name, fontsize=16)
+            for i in range(num_motors):
+                field = 'Mot%i' % (i+1)
+                ax[0,i].plot(old_points.data[field], color=RED)
+                ax[0,i].plot(new_points.data[field], color=BLUE)
+                ax[0,i].set_ylabel(field)
+                ax[0,i].set_xlabel('Test No')
+                ax[1,i].plot(output_diff[field], color=BLACK)
+                ax[1,i].set_ylabel('Change in %s' % field)
+                ax[1,i].set_xlabel('Test No')
+            plt.tight_layout(rect=[0, 0.0, 1, 0.95])
 
-        # move the csv to the directory for later comparison
-        shutil.move(filename, os.path.join(dir_name, filename))
+            fig, ax = plt.subplots(2, 5, figsize=fig_size)
+            fig.suptitle(name + ' Limits', fontsize=16)
+            for i, field in enumerate(LIMITS):
+                ax[0,i].plot(old_points.data[field], color=RED)
+                ax[0,i].plot(new_points.data[field], color=BLUE)
+                ax[0,i].set_ylabel(field)
+                ax[0,i].set_xlabel('Test No')
+                ax[1,i].plot(limit_diff[field], color=BLACK)
+                ax[1,i].set_ylabel('Change in %s' % field)
+                ax[1,i].set_xlabel('Test No')
+            plt.tight_layout(rect=[0, 0.0, 1, 0.95])
 
-        print('Frame class = %s, test complete\n' % frame_class_lookup[fc])
-
-    # Move back to active branch
-    print('Returning to original branch, commit = %s\n' % latest_commit)
-    cmd = 'git switch -' 
-    result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
-    print('\n%s\n' % cmd)
-
-    if result.returncode > 0:
-        print('WARNING: Could not return head to branch with commit %s. \nError messages:\n%s\n%s' % (latest_commit, result.stdout, result.stderr))
-
-    new_points = {}
-    old_points = {}
-    for fc in args.frame_class:
-        filename = '%s_motor_test.csv' % frame_class_lookup[fc]
-        new_points[frame_class_lookup[fc]] = DataPoints(os.path.join(dir_name, 'new_%s' % filename))
-        old_points[frame_class_lookup[fc]] = DataPoints(os.path.join(dir_name, 'original_%s' % filename))
-
-    # Plot all of the points for correlation comparison
-    for fc in args.frame_class:
-        frame = frame_class_lookup[fc]
-        fig_size = (16, 8)
-
-        # Ensure we didn't get an init fail before proceeding
-        if new_points[frame].init_failed:
-            # Create plot explaining issue to user, as the earlier cmd line warning may have been lost
-            fig, ax = plt.subplots(1, 1, figsize=fig_size)
-            fig.suptitle('%s: INIT FAILED' % frame, fontsize=16)
-            continue
-
-        # Plot inputs
-        fig, ax = plt.subplots(2, 2, figsize=fig_size)
-        fig.suptitle('%s Input Diff' % frame, fontsize=16)
-        ax = ax.flatten()
-
-        plot_index = 0
-        for field in ['Roll','Pitch','Yaw','Thr']:
-            diff = [i-j for i,j in zip(old_points[frame].data[field], new_points[frame].data[field])]
-            ax[plot_index].plot(diff, color=RED)
-            ax[plot_index].set_xlabel('Test Number')
-            ax[plot_index].set_ylabel('%s Old - New' % field)
-            plot_index += 1
-        plt.tight_layout(rect=[0, 0.0, 1, 0.95])
-
-        # Find number of motors
-        num_motors = 0
-        while True:
-            num_motors += 1
-            if 'Mot%i' % (num_motors+1) not in new_points[frame].get_fields():
-                break
-
-        # Plot outputs
-        fig, ax = plt.subplots(2, num_motors, figsize=fig_size)
-        fig.suptitle('%s Outputs' % frame, fontsize=16)
-        for i in range(num_motors):
-            field = 'Mot%i' % (i+1)
-            ax[0,i].plot(old_points[frame].data[field], color=RED)
-            ax[0,i].plot(new_points[frame].data[field], color=BLUE)
-            ax[0,i].set_ylabel(field)
-            ax[0,i].set_xlabel('Test No')
-
-            diff = [i-j for i,j in zip(old_points[frame].data[field], new_points[frame].data[field])]
-            ax[1,i].plot(diff, color=BLACK)
-            ax[1,i].set_ylabel('Change in %s' % field)
-            ax[1,i].set_xlabel('Test No')
-        plt.tight_layout(rect=[0, 0.0, 1, 0.95])
-
-        # Plot limits
-        fig, ax = plt.subplots(2, 5, figsize=fig_size)
-        fig.suptitle(frame + ' Limits', fontsize=16)
-        for i, field in enumerate(['LimR','LimP','LimY','LimThD','LimThU']):
-            ax[0,i].plot(old_points[frame].data[field], color=RED)
-            ax[0,i].plot(new_points[frame].data[field], color=BLUE)
-            ax[0,i].set_ylabel(field)
-            ax[0,i].set_xlabel('Test No')
-
-            diff = [i-j for i,j in zip(old_points[frame].data[field], new_points[frame].data[field])]
-            ax[1,i].plot(diff, color=BLACK)
-            ax[1,i].set_ylabel('Change in %s' % field)
-            ax[1,i].set_xlabel('Test No')
-        plt.tight_layout(rect=[0, 0.0, 1, 0.95])
-
-    print('*** Complete ***')
+if args.plot:
     plt.show()

--- a/libraries/AP_Motors/examples/AP_Motors_test/run_heli_comparison.py
+++ b/libraries/AP_Motors/examples/AP_Motors_test/run_heli_comparison.py
@@ -16,17 +16,13 @@
 
 import os
 import subprocess
-import shutil
 import csv
 from matplotlib import pyplot as plt
 from argparse import ArgumentParser
-import time
 
-# ==============================================================================
+
 class DataPoints:
 
-
-    # --------------------------------------------------------------------------
     # Instantiate the object and parse the data from the provided file
     # file: path to the csv file to be parsed
     def __init__(self, file):
@@ -71,9 +67,7 @@ class DataPoints:
             # Make data immutable
             for field in self.data.keys():
                 self.data[field] = tuple(self.data[field])
-    # --------------------------------------------------------------------------
 
-    # --------------------------------------------------------------------------
     # get the data from a given field
     # field: dict index, name of field data to be returned
     # lim_tf: limit bool, return limit cases or not
@@ -86,23 +80,20 @@ class DataPoints:
             if (flag == lim_tf):
                 ret.append(data)
         return ret
-    # --------------------------------------------------------------------------
 
-    # --------------------------------------------------------------------------
     def get_fields(self):
         return self.data.keys()
-    # --------------------------------------------------------------------------
 
-# ==============================================================================
 
-frame_class_lookup = {6:'Single_Heli', 11:'Dual_Heli'}
+frame_class_lookup = {6: 'Single_Heli', 11: 'Dual_Heli'}
 
-swash_type_lookup = {0:'H3',
-                     1:'H1',
-                     2:'H3_140',
-                     3:'H3_120',
-                     4:'H4_90',
-                     5:'H4_45',}
+swash_type_lookup = {0: 'H3',
+                     1: 'H1',
+                     2: 'H3_140',
+                     3: 'H3_120',
+                     4: 'H4_90',
+                     5: 'H4_45'}
+
 
 # Run sweep over range of types
 def run_sweep(frame_class, swash_type, dir_name):
@@ -117,26 +108,24 @@ def run_sweep(frame_class, swash_type, dir_name):
             print('Running motors test for frame class = %s (%i), swash = %s (%i)' % (frame_class_lookup[fc], fc, swash_type_lookup[swash], swash))
 
             filename = '%s_%s_motor_test.csv' % (frame_class_lookup[fc], swash_type_lookup[swash])
-            os.system('./build/linux/examples/AP_Motors_test s frame_class=%d swash=%d > %s/%s' % (fc,swash,dir_name,filename))
+            os.system('./build/linux/examples/AP_Motors_test s frame_class=%d swash=%d > %s/%s' % (fc, swash, dir_name, filename))
 
             print('Frame class = %s, swash = %s complete\n' % (frame_class_lookup[fc], swash_type_lookup[swash]))
 
 
-# ==============================================================================
 if __name__ == '__main__':
 
-    BLUE = [0,0,1]
-    RED = [1,0,0]
-    BLACK = [0,0,0]
-
+    BLUE =  [0, 0, 1]
+    RED =   [1, 0, 0]
+    BLACK = [0, 0, 0]
 
     # Build input parser
     parser = ArgumentParser(description='Find logs in which the input string is found in messages')
-    parser.add_argument("-H","--head", type=int, help='number of commits to roll back the head for comparing the work done')
-    parser.add_argument("-f","--frame-class", type=int, dest='frame_class', nargs="+", default=(6,11), help="list of frame classes to run comparison on. Defaults to test all helis.")
-    parser.add_argument("-s","--swash-type", type=int, dest='swash_type', nargs="+", default=(0,1,2,3,4,5), help="list of swashplate types to run comparison on. Defaults to test all types.")
-    parser.add_argument("-c","--compare", action='store_true', help='Compare only, do not re-run tests')
-    parser.add_argument("-p","--plot", action='store_true', help='Plot comparison results')
+    parser.add_argument("-H", "--head", type=int, help='number of commits to roll back the head for comparing the work done')
+    parser.add_argument("-f", "--frame-class", type=int, dest='frame_class', nargs="+", default=(6, 11), help="list of frame classes to run comparison on. Defaults to test all helis.")
+    parser.add_argument("-s", "--swash-type", type=int, dest='swash_type', nargs="+", default=(0, 1, 2, 3, 4, 5), help="list of swashplate types to run comparison on. Defaults to test all types.")
+    parser.add_argument("-c", "--compare", action='store_true', help='Compare only, do not re-run tests')
+    parser.add_argument("-p", "--plot", action='store_true', help='Plot comparison results')
     args = parser.parse_args()
 
     dir_name = 'motors_comparison'
@@ -188,14 +177,14 @@ if __name__ == '__main__':
                 print('ERROR: Could not rewind HEAD.  Exited with error:\n%s\n%s' % (result.stdout, result.stderr))
                 quit()
 
-            # Rebuild 
+            # Rebuild
             os.system('./waf clean')
 
             run_sweep(args.frame_class, args.swash_type, original_name)
 
             # Move back to active branch
             print('Returning to original branch, commit = %s\n' % latest_commit)
-            cmd = 'git switch -' 
+            cmd = 'git switch -'
             result = subprocess.run([cmd], shell=True, capture_output=True, text=True)
             print('\n%s\n' % cmd)
 
@@ -218,11 +207,11 @@ if __name__ == '__main__':
                 print('\t failed!\n')
 
             print('\tInputs max change:')
-            INPUTS = ['Roll','Pitch','Yaw','Thr']
+            INPUTS = ['Roll', 'Pitch', 'Yaw', 'Thr']
             input_diff = {}
             for field in INPUTS:
-                input_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
-                print('\t\t%s: %f' % (field, max(map(abs,input_diff[field]))))
+                input_diff[field] = [i-j for i, j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs, input_diff[field]))))
 
             # Find number of motors
             num_motors = 0
@@ -235,15 +224,15 @@ if __name__ == '__main__':
             output_diff = {}
             for i in range(num_motors):
                 field = 'Mot%i' % (i+1)
-                output_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
-                print('\t\t%s: %f' % (field, max(map(abs,output_diff[field]))))
+                output_diff[field] = [i-j for i, j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs, output_diff[field]))))
 
             print('\tLimits max change:')
-            LIMITS = ['LimR','LimP','LimY','LimThD','LimThU']
+            LIMITS = ['LimR', 'LimP', 'LimY', 'LimThD', 'LimThU']
             limit_diff = {}
             for field in LIMITS:
-                limit_diff[field] = [i-j for i,j in zip(old_points.data[field], new_points.data[field])]
-                print('\t\t%s: %f' % (field, max(map(abs,limit_diff[field]))))
+                limit_diff[field] = [i-j for i, j in zip(old_points.data[field], new_points.data[field])]
+                print('\t\t%s: %f' % (field, max(map(abs, limit_diff[field]))))
             print('\n')
 
             if not args.plot:
@@ -264,25 +253,25 @@ if __name__ == '__main__':
             fig.suptitle('%s Outputs' % name, fontsize=16)
             for i in range(num_motors):
                 field = 'Mot%i' % (i+1)
-                ax[0,i].plot(old_points.data[field], color=RED)
-                ax[0,i].plot(new_points.data[field], color=BLUE)
-                ax[0,i].set_ylabel(field)
-                ax[0,i].set_xlabel('Test No')
-                ax[1,i].plot(output_diff[field], color=BLACK)
-                ax[1,i].set_ylabel('Change in %s' % field)
-                ax[1,i].set_xlabel('Test No')
+                ax[0, i].plot(old_points.data[field], color=RED)
+                ax[0, i].plot(new_points.data[field], color=BLUE)
+                ax[0, i].set_ylabel(field)
+                ax[0, i].set_xlabel('Test No')
+                ax[1, i].plot(output_diff[field], color=BLACK)
+                ax[1, i].set_ylabel('Change in %s' % field)
+                ax[1, i].set_xlabel('Test No')
             plt.tight_layout(rect=[0, 0.0, 1, 0.95])
 
             fig, ax = plt.subplots(2, 5, figsize=fig_size)
             fig.suptitle(name + ' Limits', fontsize=16)
             for i, field in enumerate(LIMITS):
-                ax[0,i].plot(old_points.data[field], color=RED)
-                ax[0,i].plot(new_points.data[field], color=BLUE)
-                ax[0,i].set_ylabel(field)
-                ax[0,i].set_xlabel('Test No')
-                ax[1,i].plot(limit_diff[field], color=BLACK)
-                ax[1,i].set_ylabel('Change in %s' % field)
-                ax[1,i].set_xlabel('Test No')
+                ax[0, i].plot(old_points.data[field], color=RED)
+                ax[0, i].plot(new_points.data[field], color=BLUE)
+                ax[0, i].set_ylabel(field)
+                ax[0, i].set_xlabel('Test No')
+                ax[1, i].plot(limit_diff[field], color=BLACK)
+                ax[1, i].set_ylabel('Change in %s' % field)
+                ax[1, i].set_xlabel('Test No')
             plt.tight_layout(rect=[0, 0.0, 1, 0.95])
 
 if args.plot:


### PR DESCRIPTION
Moves a bunch of functionality down into the swash lib and tidies it up a bit. Should be functionally identical although I have not done significant testing yet. 

The only outstanding tidy up of the swash stuff is its use in `get_motor_mask` that is just wrong and should be removed. It should only return actual motors. I will do a PR for that at somepoint but I didn't want to confuse this PR with that issue. 