### PR TITLE
AP_Motors: Heli: remove incorrect set range call

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -227,9 +227,6 @@ void AP_MotorsHeli_RSC::init_servo()
     // setup RSC on specified channel by default
     SRV_Channels::set_aux_channel_default(_aux_fn, _default_channel);
 
-    // set servo range
-    SRV_Channels::set_range(SRV_Channels::get_motor_function(_aux_fn), 1000);
-
 }
 
 // set_power_output_range


### PR DESCRIPTION
`SRV_Channels::set_range(SRV_Channels::get_motor_function(_aux_fn), 1000);`

It passes `_aux_fun` heli_rsc. That is 31. It then incorrectly tries to convert "motor" 31 to a servo function. We take away 8 and then offset by `motor9` (82). 31 - 8 + 82 = 105. (Scripting 12)

The function should just be:

`SRV_Channels::set_range(_aux_fn, 1000);`

But as I say its unneeded anyway, as its set in the servos lib. This is also proved by the fact that it has been working up to now.