### PR TITLE
HAL_ChibiOS: fixed asserts in AnalogIn driver

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -73,6 +73,7 @@ public:
     void init() override;
     AP_HAL::AnalogSource* channel(int16_t pin) override;
     void _timer_tick(void);
+    void timer_tick_adc(uint8_t index);
     float board_voltage(void) override { return _board_voltage; }
     float servorail_voltage(void) override { return _servorail_voltage; }
     uint16_t power_status_flags(void) override { return _power_flags; }


### PR DESCRIPTION
when building with --enable-asserts on boards with ADC1 and ADC3 (eg. Holybro H7 based boards) we were triggering asserts on bad ADC index. In order to preserve the asserts (which are good for catching errors) we need to ifdef the relevant calls