### PR TITLE
Actions: test_size: fix elf diff for vehicles

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -284,7 +284,7 @@ jobs:
              TO_CHECK="arduplane arducopter"
           fi
           for CHECK in $TO_CHECK; do
-             python3 -m elf_diff --bin_prefix="$BIN_PREFIX" --html_dir=elf_diff/AP_Periph $GITHUB_WORKSPACE/base_branch_bin/$CHECK $GITHUB_WORKSPACE/pr_bin/$CHECK
+             python3 -m elf_diff --bin_prefix="$BIN_PREFIX" --html_dir=elf_diff/$CHECK $GITHUB_WORKSPACE/base_branch_bin/$CHECK $GITHUB_WORKSPACE/pr_bin/$CHECK
           done
 
           zip -r elf_diff.zip elf_diff


### PR DESCRIPTION
Hopefully this fixes... 

Broken since at least https://github.com/ArduPilot/ardupilot/pull/23037 no one noticed till now, so maybe we should just remove the test....

I would be fine with that if we uploaded the elf files from the build so its easy to download and check them locally without having to mess about trying to match up versions to get the same result as the size compare. 