### PR TITLE
AP_Compass: stop CAN auto replacement by default add option to re-enable

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -607,7 +607,9 @@ private:
     // bitmask of options
     enum class Option : uint16_t {
         CAL_REQUIRE_GPS = (1U<<0),
+        ALLOW_DRONECAN_AUTO_REPLACEMENT = (1U<<1),
     };
+    bool option_set(Option opt) const { return (_options.get() & uint16_t(opt)) != 0; }
     AP_Int16 _options;
 
 #if COMPASS_CAL_ENABLED

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -70,7 +70,7 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
         }
     }
 
-    if (_options.get() & uint16_t(Option::CAL_REQUIRE_GPS)) {
+    if (option_set(Option::CAL_REQUIRE_GPS)) {
         if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
             gcs().send_text(MAV_SEVERITY_ERROR, "Compass cal requires GPS lock");
             return false;


### PR DESCRIPTION
Currently if you have multiple CAN compasses but only use and calibrate the first if that compass ever does not show up at boot it will be replaced by the second. This removes that ability so compasses cannot change ordering unexpectedly. This can happen if the flight controller is powered from USB and the primary compass from battery. 

Because the second compass had not been calibrated its dev-id is never saved, this means the `expected_dev_id` is 0 and it is detected as a replacement compass. 

This can be avoided by setting all to use and calibrating all and then deselecting use for the unwanted compasses.

A alternate solution would be to save all dev-id's in a calibration to "lock" the ordering, however we would then also need to force offsets to 0 for the un-calibrated compasses so they still show up as un-calibrated. 

TLDR: You have to got to a GCS to calibrate the new compass that has come in as a replacement anyway, I don't see that manually removing the old one and moving the new one up is significantly more effort.
