### PR TITLE
AP_Motors: Keep message to 50 characters or less

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2299,7 +2299,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             // check roll and pitch difference
             const float rp_diff_rad = primary_quat.roll_pitch_difference(ekf2_quat);
             if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-                hal.util->snprintf(failure_msg, failure_msg_len, "EKF2 Roll/Pitch inconsistent by %d deg", (int)degrees(rp_diff_rad));
+                hal.util->snprintf(failure_msg, failure_msg_len, "EKF2 Roll/Pitch inconsist %d deg", (int)degrees(rp_diff_rad));
                 return false;
             }
 
@@ -2326,7 +2326,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             // check roll and pitch difference
             const float rp_diff_rad = primary_quat.roll_pitch_difference(ekf3_quat);
             if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-                hal.util->snprintf(failure_msg, failure_msg_len, "EKF3 Roll/Pitch inconsistent by %d deg", (int)degrees(rp_diff_rad));
+                hal.util->snprintf(failure_msg, failure_msg_len, "EKF3 Roll/Pitch inconsist %d deg", (int)degrees(rp_diff_rad));
                 return false;
             }
 
@@ -2351,7 +2351,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
         // check roll and pitch difference
         const float rp_diff_rad = primary_quat.roll_pitch_difference(dcm_quat);
         if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-            hal.util->snprintf(failure_msg, failure_msg_len, "DCM Roll/Pitch inconsistent by %d deg", (int)degrees(rp_diff_rad));
+            hal.util->snprintf(failure_msg, failure_msg_len, "DCM Roll/Pitch inconsist %d deg", (int)degrees(rp_diff_rad));
             return false;
         }
 

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -492,7 +492,7 @@ bool AP_MotorsHeli::parameter_check(bool display_msg) const
     // returns false if _collective_min_deg is not default value which indicates users set parameter
     if (is_equal((float)_collective_min_deg, (float)AP_MOTORS_HELI_COLLECTIVE_MIN_DEG)) {
         if (display_msg) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Set H_COL_ANG_MIN to measured min blade pitch in deg");
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Set H_COL_ANG_MIN to measured min pitch");
         }
         return false;
     }
@@ -500,7 +500,7 @@ bool AP_MotorsHeli::parameter_check(bool display_msg) const
     // returns false if _collective_max_deg is not default value which indicates users set parameter
     if (is_equal((float)_collective_max_deg, (float)AP_MOTORS_HELI_COLLECTIVE_MAX_DEG)) {
         if (display_msg) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Set H_COL_ANG_MAX to measured max blade pitch in deg");
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Set H_COL_ANG_MAX to measured max pitch");
         }
         return false;
     }


### PR DESCRIPTION
If more than 50 characters, the string is split.
GCS cannot concatenate split strings.
Therefore, change the wording to 50 characters or less.

BEFORE
5/7/2023 5:40:58 PM : eg
5/7/2023 5:40:58 PM : PreArm: AHRS: EKF3 Roll/Pitch inconsistent by 14 d