### PR TITLE
AR_WPNav_OA: fix short-term deviation route during each wp change

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -65,6 +65,9 @@ void AR_WPNav_OA::update(float dt)
             break;
 
         case AP_OAPathPlanner::OA_PROCESSING:
+            _oa_active = false;
+            break;
+            
         case AP_OAPathPlanner::OA_ERROR:
             // during processing or in case of error, slow vehicle to a stop
             stop_vehicle = true;


### PR DESCRIPTION
This helps improve two issues:

1. Make the turning of the ship more robust in turbulent currents, and repair the problem of deviation from the route caused by turning deceleration;

2. Differentiate OA_ PROCESS and OA_ EEROR, making decisions more detailed

Of course, a better approach is to set a minimum speed instead_ base_ speed_ Max, but I find it difficult to write code like this.