### PR TITLE
Use enum classes and shorten variable names in GSOF

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -46,7 +46,7 @@ AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                          AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
 {
-    gsof_msg.gsof_state = gsof_msg_parser_t::STARTTX;
+    gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::STARTTX;
 
     // baud request for port 0
     requestBaud(0);
@@ -91,49 +91,49 @@ AP_GPS_GSOF::parse(const uint8_t temp)
     switch (gsof_msg.gsof_state)
     {
     default:
-    case gsof_msg_parser_t::STARTTX:
+    case gsof_msg_parser_t::gsof_states::STARTTX:
         if (temp == GSOF_STX)
         {
-            gsof_msg.gsof_state = gsof_msg_parser_t::STATUS;
+            gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::STATUS;
             gsof_msg.read = 0;
             gsof_msg.checksumcalc = 0;
         }
         break;
-    case gsof_msg_parser_t::STATUS:
+    case gsof_msg_parser_t::gsof_states::STATUS:
         gsof_msg.status = temp;
-        gsof_msg.gsof_state = gsof_msg_parser_t::PACKETTYPE;
+        gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::PACKETTYPE;
         gsof_msg.checksumcalc += temp;
         break;
-    case gsof_msg_parser_t::PACKETTYPE:
+    case gsof_msg_parser_t::gsof_states::PACKETTYPE:
         gsof_msg.packettype = temp;
-        gsof_msg.gsof_state = gsof_msg_parser_t::LENGTH;
+        gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::LENGTH;
         gsof_msg.checksumcalc += temp;
         break;
-    case gsof_msg_parser_t::LENGTH:
+    case gsof_msg_parser_t::gsof_states::LENGTH:
         gsof_msg.length = temp;
-        gsof_msg.gsof_state = gsof_msg_parser_t::DATA;
+        gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::DATA;
         gsof_msg.checksumcalc += temp;
         break;
-    case gsof_msg_parser_t::DATA:
+    case gsof_msg_parser_t::gsof_states::DATA:
         gsof_msg.data[gsof_msg.read] = temp;
         gsof_msg.read++;
         gsof_msg.checksumcalc += temp;
         if (gsof_msg.read >= gsof_msg.length)
         {
-            gsof_msg.gsof_state = gsof_msg_parser_t::CHECKSUM;
+            gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::CHECKSUM;
         }
         break;
-    case gsof_msg_parser_t::CHECKSUM:
+    case gsof_msg_parser_t::gsof_states::CHECKSUM:
         gsof_msg.checksum = temp;
-        gsof_msg.gsof_state = gsof_msg_parser_t::ENDTX;
+        gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::ENDTX;
         if (gsof_msg.checksum == gsof_msg.checksumcalc)
         {
             return process_message();
         }
         break;
-    case gsof_msg_parser_t::ENDTX:
+    case gsof_msg_parser_t::gsof_states::ENDTX:
         gsof_msg.endtx = temp;
-        gsof_msg.gsof_state = gsof_msg_parser_t::STARTTX;
+        gsof_msg.gsof_state = gsof_msg_parser_t::gsof_states::STARTTX;
         break;
     }
 

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -48,10 +48,10 @@ private:
     uint32_t SwapUint32(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
     uint16_t SwapUint16(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
 
-
     struct gsof_msg_parser_t
     {
-        enum
+
+        enum class gsof_states
         {
             STARTTX = 0,
             STATUS,
@@ -60,7 +60,9 @@ private:
             DATA,
             CHECKSUM,
             ENDTX
-        } gsof_state;
+        };
+
+        gsof_states gsof_state;
 
         uint8_t status;
         uint8_t packettype;

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -48,10 +48,10 @@ private:
     uint32_t SwapUint32(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
     uint16_t SwapUint16(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
 
-    struct gsof_msg_parser_t
+    struct Msg_Parser
     {
 
-        enum class gsof_states
+        enum class State
         {
             STARTTX = 0,
             STATUS,
@@ -62,7 +62,7 @@ private:
             ENDTX
         };
 
-        gsof_states gsof_state;
+        State state;
 
         uint8_t status;
         uint8_t packettype;
@@ -73,10 +73,10 @@ private:
 
         uint16_t read;
         uint8_t checksumcalc;
-    } gsof_msg;
+    } msg;
 
-    static const uint8_t GSOF_STX = 0x02;
-    static const uint8_t GSOF_ETX = 0x03;
+    static const uint8_t STX = 0x02;
+    static const uint8_t ETX = 0x03;
 
     uint8_t packetcount = 0;
 


### PR DESCRIPTION
The GSOF code hasn't been touched in a while. Before I add support for some new messages and hardware, there are a few things that can be done to improve it. Expect some more (small) PR's. 

Why enum class? https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Renum-class

Per Peter's recommendation, I also removed all the extra `gsof` parts of the variable names, since it's in class scope and won't conflict with global scope. The class and enum names were not complying with the style guide, and are now updated. 

Before names
```c++
struct gsof_msg_parser_t {} gsof_msg;
enum {} gsof_state;
static const uint8_t GSOF_STX = 0x02;

```

After names
```c++
struct Msg_Parser {} msg;
enum class State {};
State state;
static const uint8_t STX = 0x02;
```

