### PR TITLE
Tools: AP_Periph: Add CAN_MIRROR

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -72,6 +72,10 @@
 #define AP_PERIPH_SAFETY_SWITCH_ENABLED defined(HAL_PERIPH_ENABLE_RC_OUT)
 #endif
 
+#ifndef HAL_PERIPH_CAN_MIRROR
+#define HAL_PERIPH_CAN_MIRROR 0
+#endif
+
 #include "Parameters.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -103,7 +107,6 @@ struct CanardRxTransfer;
     #define HAL_CAN_POOL_SIZE 4000
 #endif
 #endif
-
 
 class AP_Periph_FW {
 public:
@@ -439,6 +442,9 @@ public:
     void process1HzTasks(uint64_t timestamp_usec);
     void processTx(void);
     void processRx(void);
+#if HAL_PERIPH_CAN_MIRROR
+    void processMirror(void);
+#endif // HAL_PERIPH_CAN_MIRROR
     void cleanup_stale_transactions(uint64_t &timestamp_usec);
     void update_rx_protocol_stats(int16_t res);
     void node_status_send(void);

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -603,7 +603,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Param: CAN_MIRROR_PORTS
     // @DisplayName: CAN ports to mirror traffic between
     // @Description: Any set ports will participate in blindly mirroring traffic from one port to the other. It is the users responsibility to ensure that no loops exist that cause traffic to be infinitly repeated, and both ports must be running the same baud rates.
-    // @Bitmask: 0:CAN1, 1:CAN2
+    // @Bitmask: 0:CAN1, 1:CAN2, 2:CAN3
     // @User: Advanced
     GSCALAR(can_mirror_ports, "CAN_MIRROR_PORTS", 0),
 #endif // HAL_PERIPH_CAN_MIRROR

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -599,6 +599,15 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 #endif
 #endif // AP_SIM_ENABLED
 
+#if HAL_PERIPH_CAN_MIRROR
+    // @Param: CAN_MIRROR_PORTS
+    // @DisplayName: CAN ports to mirror traffic between
+    // @Description: Any set ports will participate in blindly mirroring traffic from one port to the other. It is the users responsibility to ensure that no loops exist that cause traffic to be infinitly repeated, and both ports must be running the same baud rates.
+    // @Bitmask: 0:CAN1, 1:CAN2
+    // @User: Advanced
+    GSCALAR(can_mirror_ports, "CAN_MIRROR_PORTS", 0),
+#endif // HAL_PERIPH_CAN_MIRROR
+
     AP_VAREND
 };
 

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -83,6 +83,7 @@ public:
         k_param_ahrs,
         k_param_battery_balance,
         k_param_battery_hide_mask,
+        k_param_can_mirror_ports,
     };
 
     AP_Int16 format_version;
@@ -192,6 +193,10 @@ public:
     AP_Int32 efi_baudrate;
     AP_Int8 efi_port;
 #endif
+
+#if HAL_PERIPH_CAN_MIRROR
+    AP_Int8 can_mirror_ports;
+#endif // HAL_PERIPH_CAN_MIRROR
     
 #if HAL_CANFD_SUPPORTED
     AP_Int8 can_fdmode;


### PR DESCRIPTION
This allows us to mirror CAN traffic between ports on demand. This allows you to run a separate CAN bus off of an AP_Periph node. This can be very useful for managing CAN bus stubs.

This was tested with CubeOrange-periph with `define HAL_PERIPH_CAN_MIRROR` added to the hwdef. I then connected a CubeOrangePlus to a Zubax babel (let's call this `BABEL1`), and the other babel port to the CubeOrange-periph on CAN1. From the periph node I then connected CAN2 to another babel (let's call this `BABEL2`). Without any changes `BABEL2` can only see data from the AP_Periph node, and can't see the cube, or `BABEL1`. If I then set the parameter and reboot `BABEL2` is able to see both the flight controller, and the `BABEL1`l, and from `BABEL1` I can actually see `BABEL2`.