### PR TITLE
.editorconfig: Update for more standards aware editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,8 +13,9 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false # These are the correct rules for APM coding standards, but fixing up old files causes git spam
-insert_final_newline = false
+# These are the correct rules for APM coding standards, but fixing up old files causes git spam
+trim_trailing_whitespace = false
+insert_final_newline = true
 
 [*.mk]
 indent_style = tab


### PR DESCRIPTION
I use neovim as my primary editor, it's started throwing errors recently that `.editorconfig` wasn't valid: `editorconfig: invalid value for option trim_trailing_whitespace: false # these are the correct rules for apm coding standards, but fixing up old files causes git spam. trim_trailing_whitespace must be either "true" or "false"`. This was happening on every file I opened, which was pretty frustrating. This was solvable by just moving the comment to it's own line.

The other change presented here was to swap the final newline. This was causing any file I edited to change the last line, which was just git noise. If we are are fine with these slowly moving to not having the trailing new line then I can drop this.

I'm not an expert on .editorconfig by any means, this was all just an effort to reduce frustrations.