### PR TITLE
AP_HAL_ChibiOS: do not build ChibiOS with debug symbols unless debug build

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -275,7 +275,7 @@ class Board:
             env.DEFINES.update(
                 HAL_DEBUG_BUILD = 1,
             )
-        elif cfg.options.g:
+        elif cfg.options.debug_symbols:
             env.CFLAGS += [
                 '-g',
             ]

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -492,6 +492,8 @@ def load_env_vars(env):
         else:
             env[k] = v
             print("env set %s=%s" % (k, v))
+    if env.DEBUG or env.DEBUG_SYMBOLS:
+        env.CHIBIOS_BUILD_FLAGS += ' ENABLE_DEBUG_SYMBOLS=yes'
     if env.ENABLE_ASSERTS:
         env.CHIBIOS_BUILD_FLAGS += ' ENABLE_ASSERTS=yes'
     if env.ENABLE_MALLOC_GUARD:

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
@@ -5,7 +5,11 @@
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -g -fomit-frame-pointer -falign-functions=16
+  USE_OPT = -fomit-frame-pointer -falign-functions=16
+endif
+
+ifeq ($(ENABLE_DEBUG_SYMBOLS), yes)
+  USE_OPT += -g
 endif
 
 # C specific options here (added to USE_OPT).

--- a/wscript
+++ b/wscript
@@ -126,7 +126,7 @@ def options(opt):
         default=False,
         help='Configure as debug variant.')
 
-    g.add_option('-g',
+    g.add_option('--debug-symbols', '-g',
         action='store_true',
         default=False,
         help='Add debug symbolds to build.')
@@ -432,6 +432,7 @@ def configure(cfg):
         
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
+    cfg.env.DEBUG_SYMBOLS = cfg.options.debug_symbols
     cfg.env.COVERAGE = cfg.options.coverage
     cfg.env.AUTOCONFIG = cfg.options.autoconfig
 
@@ -444,6 +445,7 @@ def configure(cfg):
 
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
+    cfg.env.DEBUG_SYMBOLS = cfg.options.debug_symbols
     cfg.env.COVERAGE = cfg.options.coverage
     cfg.env.FORCE32BIT = cfg.options.force_32bit
     cfg.env.ENABLE_ASSERTS = cfg.options.enable_asserts


### PR DESCRIPTION
debug symbols subtly change the compiler output which can lead to problems with repeatable builds