### PR TITLE
Feature/env Allow environement workflow to run on scripts changes

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -292,7 +292,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   fi
 
   if [ ${RELEASE_CODENAME} == 'lunar' ]; then
-      PYTHON_PKGS+=" wxPython opencv-python"
+      PYTHON_PKGS+=" opencv-python"
+      SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   elif [ ${RELEASE_CODENAME} == 'bullseye' ] ||
          [ ${RELEASE_CODENAME} == 'groovy' ] ||

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -151,7 +151,7 @@ if [ ${RELEASE_CODENAME} == 'bionic' ]; then
     # use fixed version for package that drop python2 support
     PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 requests==2.27.1 monotonic==1.6 geocoder empy configparser==4.0.2 click==7.1.2 decorator==4.4.2 dronecan"
 else
-    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder empy dronecan"
+    PYTHON_PKGS="wheel future lxml pymavlink MAVProxy pexpect flake8 geocoder empy dronecan"
 fi
 
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -87,8 +87,8 @@ if [ ${RELEASE_CODENAME} == 'bionic' ] ; then
 elif [ ${RELEASE_CODENAME} == 'buster' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
-    PYTHON_V="python"
-    PIP=pip2
+    PYTHON_V="python3"
+    PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'focal' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
@@ -264,13 +264,16 @@ elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
+elif [ ${RELEASE_CODENAME} == 'buster' ]; then
+    SITL_PKGS+=" libpython3-stdlib" # for argparse
 else
   SITL_PKGS+=" python-argparse"
 fi
 
 # Check for graphical package for MAVProxy
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-  if [ ${RELEASE_CODENAME} == 'bullseye' ]; then
+  if [ ${RELEASE_CODENAME} == 'bullseye' ] ||
+         [ ${RELEASE_CODENAME} == 'buster' ]; then
     SITL_PKGS+=" libjpeg62-turbo-dev"
   elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
            [ ${RELEASE_CODENAME} == 'focal' ]; then
@@ -293,6 +296,7 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   elif [ ${RELEASE_CODENAME} == 'bullseye' ] ||
          [ ${RELEASE_CODENAME} == 'groovy' ] ||
+         [ ${RELEASE_CODENAME} == 'buster' ] ||
          [ ${RELEASE_CODENAME} == 'focal' ] ||
          [ ${RELEASE_CODENAME} == 'jammy' ]; then
     SITL_PKGS+=" python3-wxgtk4.0"

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -149,9 +149,9 @@ fi
 BASE_PKGS="build-essential ccache g++ gawk git make wget"
 if [ ${RELEASE_CODENAME} == 'bionic' ]; then
     # use fixed version for package that drop python2 support
-    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 requests==2.27.1 monotonic==1.6 geocoder empy configparser==4.0.2 click==7.1.2 decorator==4.4.2 dronecan"
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 requests==2.27.1 monotonic==1.6 geocoder empy ptyprocess configparser==4.0.2 click==7.1.2 decorator==4.4.2 dronecan"
 else
-    PYTHON_PKGS="wheel future lxml pymavlink MAVProxy pexpect flake8 geocoder empy dronecan"
+    PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8 geocoder empy ptyprocess dronecan"
 fi
 
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:
@@ -167,7 +167,7 @@ ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 
 if [ ${RELEASE_CODENAME} == 'lunar' ]; then
     # on Lunar (and presumably later releases), we install in venv, below
-    PYTHON_PKGS+=" setuptools numpy pyparsing psutil"
+    PYTHON_PKGS+=" numpy pyparsing psutil"
     SITL_PKGS="python3-dev"
 else
 SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing ${PYTHON_V}-psutil"
@@ -358,6 +358,9 @@ if [ ${RELEASE_CODENAME} == 'bionic' ]; then
     # use fixed version for package that drop python2 support
     $PIP install --user -U pip==20.3 setuptools==44.0.0
 fi
+
+# try update setuptools and wheel before installing pip package that may need compilation
+$PIP install $PIP_USER_ARGUMENT -U setuptools wheel
 
 if [ ${RELEASE_CODENAME} == 'lunar' ]; then
     # must do this ahead of wxPython pip3 run :-/

--- a/Tools/scripts/apj_tool.py
+++ b/Tools/scripts/apj_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 tool to manipulate ArduPilot firmware files, changing default parameters
 '''

--- a/Tools/scripts/bin2hex.py
+++ b/Tools/scripts/bin2hex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2008,2010,2011,2012,2013 Alexander Belchenko
 # All rights reserved.

--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import re

--- a/Tools/scripts/build_iofirmware.py
+++ b/Tools/scripts/build_iofirmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 script to build iofirmware and copy to Tools/IO_Firmware

--- a/Tools/scripts/make_apj.py
+++ b/Tools/scripts/make_apj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Create an apj file from a *.bin binary firmware
 

--- a/Tools/scripts/make_intel_hex.py
+++ b/Tools/scripts/make_intel_hex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, struct
 import intelhex

--- a/Tools/scripts/param_unpack.py
+++ b/Tools/scripts/param_unpack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 unpack a param.pck file from @PARAM/param.pck via mavlink FTP
 '''


### PR DESCRIPTION
This allow to test our enviromnents setup scripts when we change them.

They are still run weekly
We are still able to run the test manually

On devenv scipts change, we only run the devenv testing and not the other autotest as they aren't impacted.

Update Debian buster to python3

Install wheel with pip and install setuptools and wheel before all other packages to prevent issue with package compilation and benefit from pre build wheels

Enforce python3 on some build tools to prevent issue if python is a valid command 

Remove old semaphore directory that is unused