### PR TITLE
.github: use fixed revision for docker dev containers

### DIFF
--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-${{ matrix.type }}:latest
+      image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.0.29
       options: --privileged
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   test-scripting:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-base:latest
+    container: ardupilot/ardupilot-dev-base:v0.0.29
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-base:latest
+    container: ardupilot/ardupilot-dev-base:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -72,7 +72,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -140,7 +140,7 @@ jobs:
   build-gcc-heli:
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     steps:
       # git checkout the PR
@@ -175,7 +175,7 @@ jobs:
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-base:latest
+    container: ardupilot/ardupilot-dev-base:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build-gcc-ap_periph:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-periph:latest
+    container: ardupilot/ardupilot-dev-periph:v0.0.29
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3
@@ -69,7 +69,7 @@ jobs:
     needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container: 
-      image: ardupilot/ardupilot-dev-periph:latest
+      image: ardupilot/ardupilot-dev-periph:v0.0.29
       options: --privileged
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -72,7 +72,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -72,7 +72,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -72,7 +72,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -72,7 +72,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-base:latest
+      image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
+      image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
       options: --user 1001
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails


### PR DESCRIPTION
Set fixed revision for docker container instead of using latest.
That will allow to update without breaking old releases.

