### PR TITLE
AP_DDS: add publisher for rosgraph_msgs/msg/Clock

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/time_listener.py
+++ b/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/time_listener.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Subscribe to Time messages on topic /ap/clock."""
+"""Subscribe to Time messages on topic /ap/time."""
 import rclpy
 import time
 
@@ -22,14 +22,14 @@ from builtin_interfaces.msg import Time
 
 
 class TimeListener(Node):
-    """Subscribe to Time messages on topic /ap/clock."""
+    """Subscribe to Time messages on topic /ap/time."""
 
     def __init__(self):
         """Initialise the node."""
         super().__init__("time_listener")
 
         # Declare and acquire `topic` parameter.
-        self.declare_parameter("topic", "ap/clock")
+        self.declare_parameter("topic", "ap/time")
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
         # Subscriptions.

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -28,7 +28,7 @@ from builtin_interfaces.msg import Time
 
 
 class TimeListener(rclpy.node.Node):
-    """Subscribe to Time messages on /ap/clock."""
+    """Subscribe to Time messages on /ap/time."""
 
     def __init__(self):
         """Initialise the node."""
@@ -36,7 +36,7 @@ class TimeListener(rclpy.node.Node):
         self.msg_event_object = threading.Event()
 
         # Declare and acquire `topic` parameter.
-        self.declare_parameter("topic", "ap/clock")
+        self.declare_parameter("topic", "ap/time")
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
     def start_subscriber(self):
@@ -94,8 +94,8 @@ def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)
-def test_dds_serial_clock_msg_recv(launch_context, launch_sitl_copter_dds_serial):
-    """Test /ap/clock is published by AP_DDS."""
+def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial):
+    """Test /ap/time is published by AP_DDS."""
     _, actions = launch_sitl_copter_dds_serial
     virtual_ports = actions["virtual_ports"].action
     micro_ros_agent = actions["micro_ros_agent"].action
@@ -120,8 +120,8 @@ def test_dds_serial_clock_msg_recv(launch_context, launch_sitl_copter_dds_serial
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_udp)
-def test_dds_udp_clock_msg_recv(launch_context, launch_sitl_copter_dds_udp):
-    """Test /ap/clock is published by AP_DDS."""
+def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp):
+    """Test /ap/time is published by AP_DDS."""
     _, actions = launch_sitl_copter_dds_udp
     micro_ros_agent = actions["micro_ros_agent"].action
     mavproxy = actions["mavproxy"].action

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -13,6 +13,7 @@
 #include "geometry_msgs/msg/PoseStamped.h"
 #include "geometry_msgs/msg/TwistStamped.h"
 #include "geographic_msgs/msg/GeoPoseStamped.h"
+#include "rosgraph_msgs/msg/Clock.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Scheduler.h>
@@ -60,6 +61,7 @@ private:
     geometry_msgs_msg_PoseStamped local_pose_topic;
     geometry_msgs_msg_TwistStamped local_velocity_topic;
     geographic_msgs_msg_GeoPoseStamped geo_pose_topic;
+    rosgraph_msgs_msg_Clock clock_topic;
 
     HAL_Semaphore csem;
 
@@ -73,6 +75,7 @@ private:
     static void update_topic(geometry_msgs_msg_PoseStamped& msg);
     static void update_topic(geometry_msgs_msg_TwistStamped& msg);
     static void update_topic(geographic_msgs_msg_GeoPoseStamped& msg);
+    static void update_topic(rosgraph_msgs_msg_Clock& msg);
 
     // The last ms timestamp AP_DDS wrote a Time message
     uint64_t last_time_time_ms;
@@ -86,6 +89,8 @@ private:
     uint64_t last_local_velocity_time_ms;
     // The last ms timestamp AP_DDS wrote a GeoPose message
     uint64_t last_geo_pose_time_ms;
+    // The last ms timestamp AP_DDS wrote a Clock message
+    uint64_t last_clock_time_ms;
 
     // functions for serial transport
     bool ddsSerialInit();
@@ -146,6 +151,8 @@ public:
     void write_local_velocity_topic();
     //! @brief Serialize the current geo_pose and publish to the IO stream(s)
     void write_geo_pose_topic();
+    //! @brief Serialize the current clock and publish to the IO stream(s)
+    void write_clock_topic();
     //! @brief Update the internally stored DDS messages with latest data
     void update();
 

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -83,4 +83,14 @@ const struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .deserialize = Generic_deserialize_topic_fn_t(&geographic_msgs_msg_GeoPoseStamped_deserialize_topic),
         .size_of = Generic_size_of_topic_fn_t(&geographic_msgs_msg_GeoPoseStamped_size_of_topic),
     },
+    {
+        .topic_id = 0x08,
+        .pub_id = 0x08,
+        .dw_id = uxrObjectId{.id=0x08, .type=UXR_DATAWRITER_ID},
+        .topic_profile_label = "clock__t",
+        .dw_profile_label = "clock__dw",
+        .serialize = Generic_serialize_topic_fn_t(&rosgraph_msgs_msg_Clock_serialize_topic),
+        .deserialize = Generic_deserialize_topic_fn_t(&rosgraph_msgs_msg_Clock_deserialize_topic),
+        .size_of = Generic_size_of_topic_fn_t(&rosgraph_msgs_msg_Clock_size_of_topic),
+    },
 };

--- a/libraries/AP_DDS/Idl/rosgraph_msgs/msg/Clock.idl
+++ b/libraries/AP_DDS/Idl/rosgraph_msgs/msg/Clock.idl
@@ -1,0 +1,17 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from rosgraph_msgs/msg/Clock.msg
+// generated code does not contain a copyright notice
+
+#include "builtin_interfaces/msg/Time.idl"
+
+module rosgraph_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+      "This message communicates the current time." "\n"
+      "" "\n"
+      "For more information, see https://design.ros2.org/articles/clock_and_time.html.")
+    struct Clock {
+      builtin_interfaces::msg::Time clock;
+    };
+  };
+};

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -154,21 +154,24 @@ After your setups are complete, do the following:
   $ ros2 topic list  -v
   Published topics:
   * /ap/battery/battery0 [sensor_msgs/msg/BatteryState] 1 publisher
-  * /ap/clock [builtin_interfaces/msg/Time] 1 publisher
+  * /ap/clock [rosgraph_msgs/msg/Clock] 1 publisher
+  * /ap/geopose/filtered [geographic_msgs/msg/GeoPoseStamped] 1 publisher
   * /ap/navsat/navsat0 [sensor_msgs/msg/NavSatFix] 1 publisher
   * /ap/pose/filtered [geometry_msgs/msg/PoseStamped] 1 publisher
   * /ap/tf_static [tf2_msgs/msg/TFMessage] 1 publisher
+  * /ap/time [builtin_interfaces/msg/Time] 1 publisher
+  * /ap/twist/filtered [geometry_msgs/msg/TwistStamped] 1 publisher
   * /parameter_events [rcl_interfaces/msg/ParameterEvent] 1 publisher
   * /rosout [rcl_interfaces/msg/Log] 1 publisher
 
   Subscribed topics:
 
 
-  $ ros2 topic hz /ap/clock
+  $ ros2 topic hz /ap/time
   average rate: 50.115
           min: 0.012s max: 0.024s std dev: 0.00328s window: 52
 
-  $ ros2 topic echo /ap/clock 
+  $ ros2 topic echo /ap/time 
   sec: 1678668735
   nanosec: 729410000
   ---

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -6,7 +6,7 @@
     </rtps>
   </participant>
   <topic profile_name="time__t">
-    <name>rt/ap/clock</name>
+    <name>rt/ap/time</name>
     <dataType>builtin_interfaces::msg::dds_::Time_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -22,7 +22,7 @@
     </qos>
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ap/clock</name>
+      <name>rt/ap/time</name>
       <dataType>builtin_interfaces::msg::dds_::Time_</dataType>
       <historyQos>
         <kind>KEEP_LAST</kind>

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -198,4 +198,29 @@
       </historyQos>
     </topic>
   </data_writer>
+  <topic profile_name="clock__t">
+    <name>rt/ap/clock</name>
+    <dataType>rosgraph_msgs::msg::dds_::Clock_</dataType>
+    <historyQos>
+      <kind>KEEP_LAST</kind>
+      <depth>20</depth>
+    </historyQos>
+  </topic>
+  <data_writer profile_name="clock__dw">
+    <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
+    <qos>
+      <reliability>
+        <kind>RELIABLE</kind>
+      </reliability>
+    </qos>
+    <topic>
+      <kind>NO_KEY</kind>
+      <name>rt/ap/clock</name>
+      <dataType>rosgraph_msgs::msg::dds_::Clock_</dataType>
+      <historyQos>
+        <kind>KEEP_LAST</kind>
+        <depth>20</depth>
+      </historyQos>
+    </topic>
+  </data_writer>
 </profiles>


### PR DESCRIPTION
Add a publisher for `rosgraph_msgs/msg/Clock` on topic `/ap/clock`.

ROS 2 nodes use the [`rosgraph_msgs/msg/Clock`](http://docs.ros.org/en/melodic/api/rosgraph_msgs/html/msg/Clock.html) message published on `/clock` to control the behaviour of time accessed via `Node.get_clock).now()` depending on the value of the parameter `use_sim_time`. 

The built-in type `builtin_interfaces/msg/Time` is not usually exposed as a ROS topic, but generally contained inside another message type - either `Clock` or in `Header`. Rather than remove publishing the `Time` message, it has been mapped instead to the topic `ap/time`.

## Details

- Publish `builtin_interfaces/msg/Time` to `/ap/time` (renamed from `/ap/clock`).
- Publish `rosgraph_msgs/msg/Clock` to `/ap/clock`.

## Testing

Launch SITL with the micro ROS agent:

```bash
ros2 launch ardupilot_sitl sitl_dds.launch.py tty0:=./dev/ttyROS0 tty1:=./dev/ttyROS1 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml baudrate:=115200 device:=./dev/ttyROS0 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 uartC:=uart:./dev/ttyROS1 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
```

You may need to  `param set DDS_ENABLE 1` using MAVPRoxy then relaunch. 

Verify topics:

```bash
ros2 topic list -v
Published topics:
 * /ap/battery/battery0 [sensor_msgs/msg/BatteryState] 1 publisher
 * /ap/clock [rosgraph_msgs/msg/Clock] 1 publisher
 * /ap/geopose/filtered [geographic_msgs/msg/GeoPoseStamped] 1 publisher
 * /ap/navsat/navsat0 [sensor_msgs/msg/NavSatFix] 1 publisher
 * /ap/pose/filtered [geometry_msgs/msg/PoseStamped] 1 publisher
 * /ap/tf_static [tf2_msgs/msg/TFMessage] 1 publisher
 * /ap/time [builtin_interfaces/msg/Time] 1 publisher
 * /ap/twist/filtered [geometry_msgs/msg/TwistStamped] 1 publisher
 * /parameter_events [rcl_interfaces/msg/ParameterEvent] 1 publisher
 * /rosout [rcl_interfaces/msg/Log] 1 publisher

Subscribed topics:
```

Echo topic:

```bash
ros2 topic echo /ap/clock
clock:
  sec: 5
  nanosec: 328701000
---
```

## References

- https://design.ros2.org/articles/clock_and_time.html
- http://wiki.ros.org/Clock
- http://docs.ros.org/en/melodic/api/rosgraph_msgs/html/msg/Clock.html