### PR TITLE
Consolidate AP_Periph serialmanager defaults

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2999,11 +2999,21 @@ INCLUDE common.ld
 #define HAL_GCS_ENABLED 0
 #endif
 
-// default to no protocols, AP_Periph enables with params
-#define DEFAULT_SERIAL1_PROTOCOL -1
-#define DEFAULT_SERIAL2_PROTOCOL -1
-#define DEFAULT_SERIAL3_PROTOCOL -1
-#define DEFAULT_SERIAL4_PROTOCOL -1
+/*
+  AP_Periph doesn't include the SERIAL parameter tree, instead each
+  supported serial device type has it's own parameter within AP_Periph
+  for which port is used.
+ */
+#define DEFAULT_SERIAL0_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL1_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL2_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL3_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL4_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL5_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL7_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL8_PROTOCOL SerialProtocol_None
+#define DEFAULT_SERIAL9_PROTOCOL SerialProtocol_None
 
 #ifndef HAL_LOGGING_MAVLINK_ENABLED
 #define HAL_LOGGING_MAVLINK_ENABLED 0

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -125,34 +125,6 @@ extern const AP_HAL::HAL& hal;
 #define DEFAULT_SERIAL9_OPTIONS 0
 #endif
 
-#ifdef HAL_BUILD_AP_PERIPH
-/*
-  AP_Periph doesn't include the SERIAL parameter tree, instead each
-  supported serial device type has it's own parameter within AP_Periph
-  for which port is used.
- */
-#undef DEFAULT_SERIAL0_PROTOCOL
-#undef DEFAULT_SERIAL1_PROTOCOL
-#undef DEFAULT_SERIAL2_PROTOCOL
-#undef DEFAULT_SERIAL3_PROTOCOL
-#undef DEFAULT_SERIAL4_PROTOCOL
-#undef DEFAULT_SERIAL5_PROTOCOL
-#undef DEFAULT_SERIAL6_PROTOCOL
-#undef DEFAULT_SERIAL7_PROTOCOL
-#undef DEFAULT_SERIAL8_PROTOCOL
-#undef DEFAULT_SERIAL9_PROTOCOL
-#define DEFAULT_SERIAL0_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL1_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL2_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL3_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL4_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL5_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL7_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL8_PROTOCOL SerialProtocol_None
-#define DEFAULT_SERIAL9_PROTOCOL SerialProtocol_None
-#endif // HAL_BUILD_AP_PERIPH
-
 const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
 #if SERIALMANAGER_NUM_PORTS > 0
     // @Param: 0_BAUD


### PR DESCRIPTION
No Periphs Were Harmed(tm)

```
Board,AP_Periph
ARK_GPS,*
ARK_RTK_GPS,*
AeroFox-Airspeed,*
AeroFox-Airspeed-DLVR,*
AeroFox-PMU,*
BirdCANdy,*
C-RTK2-HP,*
CUAV_GPS,*
CarbonixF405,*
CarbonixL496,*
CubeBlack-periph,*
CubeOrange-periph,*
CubeOrange-periph-heavy,*
CubePilot-CANMod,*
FreeflyRTK,*
G4-ESC,*
HerePro,*
Hitec-Airspeed,*
HitecMosaic,*
HolybroG4_Compass,*
HolybroG4_GPS,*
HolybroGPS,*
MatekH743-periph,*
MatekL431-Airspeed,*
MatekL431-BattMon,*
MatekL431-DShot,*
MatekL431-EFI,*
MatekL431-GPS,*
MatekL431-HWTelem,*
MatekL431-Periph,*
MatekL431-Proximity,*
MatekL431-Rangefinder,*
MatekL431-bdshot,*
Nucleo-G491,*
Nucleo-L476,*
Nucleo-L496,*
Pixracer-periph,*
f103-ADSB,*
f103-Airspeed,*
f103-GPS,*
f103-HWESC,*
f103-QiotekPeriph,*
f103-RangeFinder,*
f103-Trigger,*
f303-GPS,*
f303-HWESC,*
f303-M10025,*
f303-M10070,*
f303-MatekGPS,*
f303-PWM,*
f303-TempSensor,*
f303-Universal,*
f405-MatekAirspeed,*
f405-MatekGPS,*
mRo-M10095,*
mRoCANPWM-M10126,*
rGNSS,*
```
