### PR TITLE
AP_GPS: Add missing const to the rest of the headers

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -185,7 +185,7 @@ AP_GPS_GSOF::requestGSOF(const uint8_t messagetype, const uint8_t portindex)
 }
 
 double
-AP_GPS_GSOF::SwapDouble(uint8_t* src, const uint32_t pos) const
+AP_GPS_GSOF::SwapDouble(const uint8_t* src, const uint32_t pos) const
 {
     union {
         double d;
@@ -204,7 +204,7 @@ AP_GPS_GSOF::SwapDouble(uint8_t* src, const uint32_t pos) const
 }
 
 float
-AP_GPS_GSOF::SwapFloat(uint8_t* src, const uint32_t pos) const
+AP_GPS_GSOF::SwapFloat(const uint8_t* src, const uint32_t pos) const
 {
     union {
         float f;
@@ -219,7 +219,7 @@ AP_GPS_GSOF::SwapFloat(uint8_t* src, const uint32_t pos) const
 }
 
 uint32_t
-AP_GPS_GSOF::SwapUint32(uint8_t* src, const uint32_t pos) const
+AP_GPS_GSOF::SwapUint32(const uint8_t* src, const uint32_t pos) const
 {
     union {
         uint32_t u;
@@ -234,7 +234,7 @@ AP_GPS_GSOF::SwapUint32(uint8_t* src, const uint32_t pos) const
 }
 
 uint16_t
-AP_GPS_GSOF::SwapUint16(uint8_t* src, const uint32_t pos) const
+AP_GPS_GSOF::SwapUint16(const uint8_t* src, const uint32_t pos) const
 {
     union {
         uint16_t u;

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -43,10 +43,10 @@ private:
     bool process_message() WARN_IF_UNUSED;
     void requestBaud(const uint8_t portindex);
     void requestGSOF(const uint8_t messagetype, const uint8_t portindex);
-    double SwapDouble(uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
-    float SwapFloat(uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
-    uint32_t SwapUint32(uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
-    uint16_t SwapUint16(uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
+    double SwapDouble(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
+    float SwapFloat(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
+    uint32_t SwapUint32(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
+    uint16_t SwapUint16(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
 
 
     struct gsof_msg_parser_t


### PR DESCRIPTION
* Related to #23743, but I missed this since I didn't realize the buffer was not modified in-place