### PR TITLE
Tools: WSL2 python.exe uploader.py stdout to be unbuffered via -u

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -64,7 +64,7 @@ class upload_fw(Task.Task):
             if not self.wsl2_prereq_checks():
                 return
             print("If this takes takes too long here, try power-cycling your hardware\n")
-            cmd = "{} '{}/uploader.py' '{}'".format('python.exe', upload_tools, src.abspath())
+            cmd = "{} -u '{}/uploader.py' '{}'".format('python.exe', upload_tools, src.abspath())
         else:
             cmd = "{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src.abspath())
         if upload_port is not None:


### PR DESCRIPTION
When WSL2 runs python.exe to access the windows serial ports, the buffered print() msgs don't print. It relays on the several ```sys.stdout.flush()``` lines in that script.. but there are many more needed. Native systems seem to handle the buffering OK but not when it's crossing the platforms like this. When uploading via WSL, it looks like it hangs when encountering these non-flushed prints in the script

Solution, call ```python.exe -u <filename>``` instead of ```python.exe <filename>``` to force all prints to be unbuffered