### PR TITLE
Tools: add ./waf --upload-force arg to allow uploader.py to do --force

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -565,6 +565,11 @@ arducopter and upload it to my board".
         help='''Specify the port to be used with the --upload option. For example a port of /dev/ttyS10 indicates that serial port 10 shuld be used.
 ''')
 
+    g.add_option('--upload-force',
+        action='store_true',
+        help='''Override board type check and continue loading. Same as using uploader.py --force.
+''')
+
     g = opt.ap_groups['check']
 
     g.add_option('--check-verbose',

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -69,6 +69,8 @@ class upload_fw(Task.Task):
             cmd = "{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src.abspath())
         if upload_port is not None:
             cmd += " '--port' '%s'" % upload_port
+        if self.generator.bld.options.upload_force:
+            cmd += " '--force'"
         return self.exec_command(cmd)
 
     def wsl2_prereq_checks(self):


### PR DESCRIPTION
New ./waf compile argument --upload-force

Example using a fresh stock CubeOrange with vehicle code on it:
```
./waf configure --board CubeOrange-periph
./waf AP_Periph --upload
```

An error would be shown saying "Firmware not suitable...". Using this new argument allows it:
```
./waf AP_Periph --upload --upload-force
```


NOTE: This does not change the bootloader. You'll need to update that at runtime via the usual method
