### PR TITLE
AP_HAL: Add reference to sparse endian manpage

### DIFF
--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -18,6 +18,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
+// Reference: https://linux.die.net/man/3/be16toh
+
 #pragma once
 
 #include <byteswap.h>


### PR DESCRIPTION
As mentioned in https://github.com/ArduPilot/ardupilot/pull/23758#discussion_r1191869260, I didn't realize what sparse endian header was for. Once I found the manpage, it was more clear. I drop the link directly into the header here. 