### PR TITLE
AP_GPS: Remove unused member variable in gsof driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -94,7 +94,6 @@ AP_GPS_GSOF::parse(uint8_t temp)
     case gsof_msg_parser_t::STARTTX:
         if (temp == GSOF_STX)
         {
-            gsof_msg.starttx = temp;
             gsof_msg.gsof_state = gsof_msg_parser_t::STATUS;
             gsof_msg.read = 0;
             gsof_msg.checksumcalc = 0;

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -62,7 +62,6 @@ private:
             ENDTX
         } gsof_state;
 
-        uint8_t starttx;
         uint8_t status;
         uint8_t packettype;
         uint8_t length;


### PR DESCRIPTION
Another (trivial) GSOF improvement. This variable was set, but never used. The start character is always the same (it's known at compile time). No reason to store it. 