### PR TITLE
ChibiOS: fixed a lockup of sdcard on some boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/spi_hook.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/spi_hook.h
@@ -9,6 +9,8 @@ extern "C" {
 #if HAL_USE_MMC_SPI == TRUE
 void spiStartHook(SPIDriver *spip, const SPIConfig *config);
 void spiStopHook(SPIDriver *spip);
+void spiAcquireBusHook(SPIDriver *spip);
+void spiReleaseBusHook(SPIDriver *spip);
 void spiSelectHook(SPIDriver *spip);
 void spiUnselectHook(SPIDriver *spip);
 void spiIgnoreHook(SPIDriver *spip,size_t n);

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -213,6 +213,22 @@ void spiStopHook(SPIDriver *spip)
 {
 }
 
+__RAMFUNC__ void spiAcquireBusHook(SPIDriver *spip)
+{
+    if (sdcard_running) {
+        ChibiOS::SPIDevice *devptr = static_cast<ChibiOS::SPIDevice*>(device.get());
+        devptr->acquire_bus(true, true);
+    }
+}
+
+__RAMFUNC__ void spiReleaseBusHook(SPIDriver *spip)
+{
+    if (sdcard_running) {
+        ChibiOS::SPIDevice *devptr = static_cast<ChibiOS::SPIDevice*>(device.get());
+        devptr->acquire_bus(false, true);
+    }
+}
+
 __RAMFUNC__ void spiSelectHook(SPIDriver *spip)
 {
     if (sdcard_running) {


### PR DESCRIPTION
this affects boards that share sdcard on the same bus as another SPI device. In this case it was a QiotekZealotH743 where logging stopped
    
this issue is that the SPI hooks for MMC SPI did not do a DMA channel lock before the SPI device lock. So when the RAMTRON driver on the QiotekZealotH743 which is on the same SPI2 bus as the sdcard did an operation we had a lock order violation

We need to check if this affects 4.4 too ..... checked, it does not affect 4.4