### PR TITLE
Global: Delete crc.h since it is included in AP_Math.h

### DIFF
--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -41,7 +41,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include "ch.h"
 #include "hal.h"
 #include "hwdef.h"

--- a/Tools/AP_Bootloader/can.cpp
+++ b/Tools/AP_Bootloader/can.cpp
@@ -19,7 +19,6 @@
 #include <hal.h>
 #if HAL_USE_CAN == TRUE || HAL_NUM_CAN_IFACES
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <canard.h>
 #include "support.h"
 #include <dronecan_msgs.h>

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -28,7 +28,6 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <ctype.h>
 #include <AP_Notify/AP_Notify.h>
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -28,7 +28,6 @@
 #include <AP_HAL/I2CDevice.h>
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -20,7 +20,6 @@
 #include <stdio.h>
 
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -26,7 +26,6 @@
 #if HAL_RUNCAM_ENABLED
 
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -24,7 +24,6 @@
 
 #include "AP_ExternalAHRS_VectorNav.h"
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_GPS/AP_GPS.h>

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -58,7 +58,6 @@
 #include <AP_Param/AP_Param.h>
 
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 
 class AP_FETtecOneWire : public AP_ESC_Telem_Backend
 {

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -10,7 +10,6 @@
 #if HAL_WITH_IO_MCU
 
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_ROMFS/AP_ROMFS.h>
 #include <SRV_Channel/SRV_Channel.h>

--- a/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
+++ b/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
@@ -18,7 +18,6 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include "iofirmware.h"
 #include "hal.h"
 #include <AP_HAL_ChibiOS/RCInput.h>

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -27,7 +27,6 @@
 #include "AP_OpticalFlow_Pixart.h"
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Math/crc.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <utility>
 #include "AP_OpticalFlow.h"

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "AP_RAMTRON.h"
-#include <AP_Math/crc.h>
 #include <AP_Math/AP_Math.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -25,7 +25,6 @@
 #include "AP_RCProtocol_CRSF.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <AP_SerialManager/AP_SerialManager.h>

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -25,7 +25,6 @@
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -25,7 +25,6 @@
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.cpp
@@ -25,7 +25,6 @@
 #if AP_RCPROTOCOL_SRXL_ENABLED
 
 #include "AP_RCProtocol_SRXL.h"
-#include <AP_Math/crc.h>
 #include <AP_Math/AP_Math.h>
 
 // #define SUMD_DEBUG

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -17,7 +17,6 @@
 #include <StorageManager/StorageManager.h>
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
-#include <AP_Math/crc.h>
 #include <AP_Param/AP_Param.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_HAL/utility/dsm.h>
-#include <AP_Math/crc.h>
 #include "telem_structure.h"
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>


### PR DESCRIPTION
Delete crc.h since it is included in AP_Math.h.