### PR TITLE
SITL: guard against LP5562 not being included

### DIFF
--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -64,7 +64,9 @@ static MCP9600 mcp9600;
 static ICM40609 icm40609;
 static MS5525 ms5525;
 static MS5611 ms5611;
+#if AP_SIM_LP5562_ENABLED
 static LP5562 lp5562;
+#endif
 
 struct i2c_device_at_address {
     uint8_t bus;
@@ -87,7 +89,9 @@ struct i2c_device_at_address {
     { 2, 0x0B, maxell },        // Maxell: BATTx_MONITOR 16, BATTx_I2C_ADDR 13
     { 3, 0x0B, smbus_generic},  // BATTx_MONITOR 7, BATTx_I2C_ADDR 13
     { 2, 0x28, airspeed_dlvr }, // ARSPD_TYPE = 7 5inch H2O sensor
+#if AP_SIM_LP5562_ENABLED
     { 2, 0x30, lp5562 },        // LP5562 RGB LED driver
+#endif
     { 2, 0x77, ms5611 },        // MS5611: BARO_PROBE_EXT = 2
 };
 


### PR DESCRIPTION
... not included on SIMOnHardware, for  example