### PR TITLE
AP_AHRS: pre-declare Location object

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -111,7 +111,7 @@ public:
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
-    virtual bool get_location(Location &loc) const WARN_IF_UNUSED = 0;
+    virtual bool get_location(class Location &loc) const WARN_IF_UNUSED = 0;
 
     // get latest altitude estimate above ground level in meters and validity flag
     virtual bool get_hagl(float &height) const WARN_IF_UNUSED { return false; }


### PR DESCRIPTION
we don't need to know the storage, and if you cut enough stuff out then we don't end up transitively including the required header for this.