### PR TITLE
Tools: use methods to determine port numbers

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -600,11 +600,15 @@ def MAVProxy_version():
 def start_MAVProxy_SITL(atype,
                         aircraft=None,
                         setup=False,
-                        master='tcp:127.0.0.1:5762',
+                        master=None,
                         options=[],
+                        sitl_rcin_port=5501,
                         pexpect_timeout=60,
                         logfile=sys.stdout):
     """Launch mavproxy connected to a SITL instance."""
+    if master is None:
+        raise ValueError("Expected a master")
+
     local_mp_modules_dir = os.path.abspath(
         os.path.join(__file__, '..', '..', '..', 'mavproxy_modules'))
     env = dict(os.environ)
@@ -617,6 +621,7 @@ def start_MAVProxy_SITL(atype,
     cmd = []
     cmd.append(mavproxy_cmd())
     cmd.extend(['--master', master])
+    cmd.extend(['--sitl', "localhost:%u" % sitl_rcin_port])
     if setup:
         cmd.append('--setup')
     if aircraft is None:

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -624,8 +624,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def MAVProxy_SetModeUsingSwitch(self):
         """Set modes via mavproxy switch"""
+        port = self.sitl_rcin_port(offset=1)
         self.customise_SITL_commandline([
-            "--rc-in-port", "5502",
+            "--rc-in-port", str(port),
         ])
         ex = None
         try:
@@ -637,7 +638,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     (4, 'AUTO'),
                     (5, 'AUTO'),  # non-existant mode, should stay in RTL
                     (6, 'MANUAL')]
-            mavproxy = self.start_mavproxy()
+            mavproxy = self.start_mavproxy(sitl_rcin_port=port)
             for (num, expected) in fnoo:
                 mavproxy.send('switch %u\n' % num)
                 self.wait_mode(expected)
@@ -6181,7 +6182,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     def PrivateChannel(self):
         '''test the serial option bit specifying a mavlink channel as private'''
         global mav2
-        mav2 = mavutil.mavlink_connection("tcp:localhost:5763",
+        port = self.adjust_ardupilot_port(5763)
+        mav2 = mavutil.mavlink_connection("tcp:localhost:%u" % port,
                                           robust_parsing=True,
                                           source_system=7,
                                           source_component=7)


### PR DESCRIPTION
This is extracted from a larger PR that allows tests to be run in parallel.

When we run tests in parallel the default range of 10 ports between instances can not be enough.  Adding these methods allows that distance to be widened based on the number of threads.
