### PR TITLE
autotest: remove pause when starting SITL

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2681,6 +2681,8 @@ class AutoTestCopter(AutoTest):
         self.set_parameter("ARMING_CHECK", 1)
         self.stop_sup_program(instance=0)
         self.start_sup_program(instance=0, args="-M")
+        self.stop_sup_program(instance=1)
+        self.start_sup_program(instance=1, args="-M")
         self.delay_sim_time(2)
         self.context_collect('STATUSTEXT')
         self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
@@ -2696,6 +2698,8 @@ class AutoTestCopter(AutoTest):
         self.wait_statustext("Node {} unhealthy".format(gps1_nodeid), check_context=True)
         self.stop_sup_program(instance=0)
         self.start_sup_program(instance=0)
+        self.stop_sup_program(instance=1)
+        self.start_sup_program(instance=1)
         self.context_stop_collecting('STATUSTEXT')
         self.context_pop()
         self.CopterMission()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8173,6 +8173,7 @@ Also, ignores heartbeats not from our target system'''
                     start_sitl_args["customisations"] = [sup_binary[1], args]
                 start_sitl_args["supplementary"] = True
                 sup_prog_link = util.start_SITL(sup_binary[0], **start_sitl_args)
+                time.sleep(3)
                 self.sup_prog.append(sup_prog_link) # add to list
                 self.expect_list_add(sup_prog_link) # add to expect list
         else:
@@ -8182,6 +8183,7 @@ Also, ignores heartbeats not from our target system'''
                 start_sitl_args["customisations"] = [self.sup_binaries[instance][1], args]
             start_sitl_args["supplementary"] = True
             sup_prog_link = util.start_SITL(self.sup_binaries[instance][0], **start_sitl_args)
+            time.sleep(3)
             self.sup_prog[instance] = sup_prog_link # add to list
             self.expect_list_add(sup_prog_link) # add to expect list
 

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -601,8 +601,6 @@ def start_SITL(binary,
         rest = cmd[1:]
         child = pexpect.spawn(first, rest, logfile=pexpect_logfile, encoding=ENCODING, timeout=5)
         pexpect_autoclose(child)
-    # give time for parameters to properly setup
-    time.sleep(3)
     if gdb or lldb:
         # if we run GDB we do so in an xterm.  "Waiting for
         # connection" is never going to appear on xterm's output.


### PR DESCRIPTION
3 seconds every time we start SITL really adds up.
