### PR TITLE
AP_SerialManager/AP_Mount: generalise SToRM32 serial protocol description and enum

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -11,7 +11,7 @@ void AP_Mount_SToRM32_serial::init()
 {
     const AP_SerialManager& serial_manager = AP::serialmanager();
 
-    _port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_SToRM32, 0);
+    _port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
     if (_port) {
         _initialised = true;
         set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -28,7 +28,7 @@ void AP_Mount_Siyi::init()
 {
     const AP_SerialManager& serial_manager = AP::serialmanager();
 
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_SToRM32, 0);
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
     if (_uart != nullptr) {
         _initialised = true;
         set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -237,7 +237,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_OPTIONS
     // @DisplayName: Telem1 options
     // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire. The Swap option allows the RX and TX pins to be swapped on STM32F7 based boards.
-    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex, 3:Swap, 4: RX_PullDown, 5: RX_PullUp, 6: TX_PullDown, 7: TX_PullUp, 8: RX_NoDMA, 9: TX_NoDMA, 10: Don't forward mavlink to/from, 11: DisableFIFO, 12: Ignore Streamrate
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex, 3:SwapTXRX, 4: RX_PullDown, 5: RX_PullUp, 6: TX_PullDown, 7: TX_PullUp, 8: RX_NoDMA, 9: TX_NoDMA, 10: Don't forward mavlink to/from, 11: DisableFIFO, 12: Ignore Streamrate
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("1_OPTIONS",  14, AP_SerialManager, state[1].options, DEFAULT_SERIAL1_OPTIONS),

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -148,7 +148,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, DEFAULT_SERIAL1_PROTOCOL),
@@ -454,12 +454,12 @@ void AP_SerialManager::init()
                                          AP_SERIALMANAGER_ALEXMOS_BUFSIZE_RX,
                                          AP_SERIALMANAGER_ALEXMOS_BUFSIZE_TX);
                     break;
-                case SerialProtocol_SToRM32:
+                case SerialProtocol_Gimbal:
                     // Note baudrate is hardcoded to 115200
-                    state[i].baud.set_and_default(AP_SERIALMANAGER_SToRM32_BAUD / 1000);   // update baud param in case user looks at it
+                    state[i].baud.set_and_default(AP_SERIALMANAGER_GIMBAL_BAUD / 1000);     // update baud param in case user looks at it
                     uart->begin(state[i].baudrate(),
-                                         AP_SERIALMANAGER_SToRM32_BUFSIZE_RX,
-                                         AP_SERIALMANAGER_SToRM32_BUFSIZE_TX);
+                                         AP_SERIALMANAGER_GIMBAL_BUFSIZE_RX,
+                                         AP_SERIALMANAGER_GIMBAL_BUFSIZE_TX);
                     break;
                 case SerialProtocol_Aerotenna_USD1:
                     state[i].protocol.set_and_save(SerialProtocol_Rangefinder);

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -85,9 +85,9 @@
 #define AP_SERIALMANAGER_ALEXMOS_BUFSIZE_RX     128
 #define AP_SERIALMANAGER_ALEXMOS_BUFSIZE_TX     128
 
-#define AP_SERIALMANAGER_SToRM32_BAUD           115200
-#define AP_SERIALMANAGER_SToRM32_BUFSIZE_RX     128
-#define AP_SERIALMANAGER_SToRM32_BUFSIZE_TX     128
+#define AP_SERIALMANAGER_GIMBAL_BAUD            115200
+#define AP_SERIALMANAGER_GIMBAL_BUFSIZE_RX      128
+#define AP_SERIALMANAGER_GIMBAL_BUFSIZE_TX      128
 
 #define AP_SERIALMANAGER_VOLZ_BAUD           115
 #define AP_SERIALMANAGER_VOLZ_BUFSIZE_RX     128
@@ -132,7 +132,7 @@ public:
         SerialProtocol_GPS = 5,
         SerialProtocol_GPS2 = 6,                     // do not use - use GPS and provide instance of 1
         SerialProtocol_AlexMos = 7,
-        SerialProtocol_SToRM32 = 8,
+        SerialProtocol_Gimbal = 8,                   // SToRM32, Siyi custom serial protocols
         SerialProtocol_Rangefinder = 9,
         SerialProtocol_FrSky_SPort_Passthrough = 10, // FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
         SerialProtocol_Lidar360 = 11,                // Lightware SF40C, TeraRanger Tower or RPLidarA2


### PR DESCRIPTION
Both the [SToRM32 (serial) gimbal driver](https://ardupilot.org/copter/docs/common-storm32-gimbal.html) and [Siyi driver](https://ardupilot.org/copter/docs/common-siyi-zr10-gimbal.html) require the SERIALx_PROTOCOL = 8.

This PR generalises the serial protocol parameter description, enums and baud rate definitions to make it more clear that they apply to both gimbals.  E.g. SERIALx_PROTOCOL = 9 param description has been changed from "SToRM32 Gimbal Serial" to "Gimbal (SToRM32, Siyi)".  I hope this will clear up user confusion as found in [this discussion](https://discuss.ardupilot.org/t/ip-cameras-rtsp-mavlink-support/99893/20).

In a future PR we will change the Alexmos gimbal driver to also use this same serial protocol enum (or perhaps either this one or the previously used enum).

BTW Sharing the same SERIALx_PROTOCOL enum for different **types** of gimbals is consistent with other sensors including the rangefinder (see SERIALx_PROTOCOL = 9)

This has been tested on a real vehicle with a Siyi A8 camera/gimbal.

This PR also includes a drive-by change to rename SERIALx_OPTIONS's bit 3 from "Swap" to "SwapTXRX" which I think is more clear.