### PR TITLE
Update AP_HAL_Boards.h

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -290,9 +290,8 @@
 // The difference in CPU load between 1Khz backend and 2Khz backend is about 10%
 // So at 1Khz almost all notch combinations can be supported on F7 and certainly H7
 #if defined(STM32H7) || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-// Enough for a double-notch per motor on an octa using three IMUs and one harmonics
-// plus one static notch with one double-notch harmonics
-#define HAL_HNF_MAX_FILTERS 54
+// Enough for a triple-notch per motor on an octa using two IMUs at 4k loop rate
+#define HAL_HNF_MAX_FILTERS 56
 #elif defined(STM32F7)
 // Enough for a notch per motor on an octa using three IMUs and one harmonics
 // plus one static notch with one harmonics


### PR DESCRIPTION
Add two more notches to H7 boards so it could run a triple-notch per motor on an octa with dual IMU.
Tested on my X8 cinelifter with significant increase with filter performance and no increase on loop time. 
Run on Mamba H743v4 with dual MPU6000 and fast sampling at 2K with notch filter running at double the loop rate, triple-notch. 