### PR TITLE
Fix early exit from loiter to alt and loiter to time when using large WP_LOITER_NAV values

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -689,6 +689,9 @@ private:
 
         // The amount of time we should stay in a loiter for the Loiter Time command.  Milliseconds.
         uint32_t time_max_ms;
+
+        // current value of loiter radius in metres used by the controller
+        float radius;
     } loiter;
 
     // Conditional command

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -42,8 +42,7 @@ bool ModeLoiter::isHeadingLinedUp(const Location loiterCenterLoc, const Location
     // Return true if current heading is aligned to vector to targetLoc.
     // Tolerance is initially 10 degrees and grows at 10 degrees for each loiter circle completed.
 
-    const uint16_t loiterRadius = abs(plane.aparm.loiter_radius);
-    if (loiterCenterLoc.get_distance(targetLoc) < loiterRadius + loiterRadius*0.05) {
+    if (loiterCenterLoc.get_distance(targetLoc) < 1.05f * fabsf(plane.loiter.radius)) {
         /* Whenever next waypoint is within the loiter radius plus 5%,
            maintaining loiter would prevent us from ever pointing toward the next waypoint.
            Hence break out of loiter immediately

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -344,6 +344,9 @@ void Plane::update_loiter(uint16_t radius)
         }
     }
 
+    // the radius actually being used by the controller is required by other functions
+    loiter.radius = (float)radius;
+
     update_loiter_update_nav(radius);
 
     if (loiter.start_time_ms == 0) {


### PR DESCRIPTION
The check for the aircraft being lined up for a tangent exit has an early breakout condition if the next waypoint is too close to the loiter circle which can prevent the required ground course to waypoint ever being achieved. This check was using the WP_LOITER_RAD parameter value, not the actual radius being used which can be set differently by the mission plan. If a large value for WP_LOITER_RAD was set and being over-written by the mission plan with a smaller value compatible with the distance to the next waypoint, the aircraft would still exit early.

This bug was encountered when using a loiter to altitude waypoint with tangent exit followed by a landing waypoint. The WP_LOITER_NAV had been set to a large value prior to landing whilst flying in guided mode. The following figure shows the trajectory from just prior to landing entry loiter exit.

![image](https://github.com/ArduPilot/ardupilot/assets/3596952/3b349943-b3eb-40f6-8707-ddc9e90e6ad7)

I was able to replicate the early exit behaviour in SITL by setting WP_LOITER_RAD to 400m, a value larger than the horizontal distance from the loiter to alt start of approach waypoint and the landing waypoint. The following figure shows the trajectory from just prior to landing entry loiter exit.

![image](https://github.com/ArduPilot/ardupilot/assets/3596952/d9e8e535-7fbf-4972-a846-2731a8c39db0)

Adding this change fixed the behaviour in SITL

![image](https://github.com/ArduPilot/ardupilot/assets/3596952/f750b60a-b3d8-4b41-967b-141bba7ba7b1)
