### PR TITLE
Improve stability of EKF3 covariance calculation

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -25,7 +25,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -51,7 +51,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -77,7 +77,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -103,7 +103,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -25,7 +25,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     6.0E-03f
+#define ABIAS_P_NSE_DEFAULT     2.0E-02f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -51,7 +51,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     6.0E-03f
+#define ABIAS_P_NSE_DEFAULT     2.0E-02f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -77,7 +77,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     6.0E-03f
+#define ABIAS_P_NSE_DEFAULT     2.0E-02f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -103,7 +103,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     6.0E-03f
+#define ABIAS_P_NSE_DEFAULT     2.0E-02f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1926,12 +1926,11 @@ void NavEKF3_core::ConstrainVariances()
         zeroRows(P,10,12);
     }
 
-    const ftype minStateVarTarget = 1E-11;
+    const ftype minSafeStateVar = 1E-9;
     if (!inhibitDelVelBiasStates) {
 
         // Find the maximum delta velocity bias state variance and request a covariance reset if any variance is below the safe minimum
-        const ftype minSafeStateVar = minStateVarTarget * 0.1f;
-        ftype maxStateVar = minSafeStateVar;
+        ftype maxStateVar = 0.0F;
         bool resetRequired = false;
         for (uint8_t stateIndex=13; stateIndex<=15; stateIndex++) {
             if (P[stateIndex][stateIndex] > maxStateVar) {
@@ -1943,7 +1942,7 @@ void NavEKF3_core::ConstrainVariances()
 
         // To ensure stability of the covariance matrix operations, the ratio of a max and min variance must
         // not exceed 100 and the minimum variance must not fall below the target minimum
-        ftype minAllowedStateVar = fmaxF(0.01f * maxStateVar, minStateVarTarget);
+        ftype minAllowedStateVar = fmaxF(0.01f * maxStateVar, minSafeStateVar);
         for (uint8_t stateIndex=13; stateIndex<=15; stateIndex++) {
             P[stateIndex][stateIndex] = constrain_ftype(P[stateIndex][stateIndex], minAllowedStateVar, sq(10.0f * dtEkfAvg));
         }
@@ -1958,18 +1957,19 @@ void NavEKF3_core::ConstrainVariances()
             // reset all delta velocity bias covariances
             zeroCols(P,13,15);
             zeroRows(P,13,15);
-            // restore all delta velocity bias variances
+            // restore all delta velocity bias variances to a margin above the minimum safe value
             for (uint8_t i=0; i<=2; i++) {
-                P[i+13][i+13] = delVelBiasVar[i];
+                P[i+13][i+13] = MAX(delVelBiasVar[i], minSafeStateVar * 10.0F);
             }
         }
 
     } else {
         zeroCols(P,13,15);
         zeroRows(P,13,15);
+        // set all delta velocity bias variances to a margin above the minimum safe value
         for (uint8_t i=0; i<=2; i++) {
             const uint8_t stateIndex = i + 13;
-            P[stateIndex][stateIndex] = fmaxF(P[stateIndex][stateIndex], minStateVarTarget);
+            P[stateIndex][stateIndex] = fmaxF(P[stateIndex][stateIndex], minSafeStateVar * 10.0F);
         }
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1926,7 +1926,7 @@ void NavEKF3_core::ConstrainVariances()
         zeroRows(P,10,12);
     }
 
-    const ftype minSafeStateVar = 1E-9;
+    const ftype minSafeStateVar = 5E-9;
     if (!inhibitDelVelBiasStates) {
 
         // Find the maximum delta velocity bias state variance and request a covariance reset if any variance is below the safe minimum

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1949,18 +1949,14 @@ void NavEKF3_core::ConstrainVariances()
 
         // If any one axis has fallen below the safe minimum, all delta velocity covariance terms must be reset to zero
         if (resetRequired) {
-            ftype delVelBiasVar[3];
-            // store all delta velocity bias variances
-            for (uint8_t i=0; i<=2; i++) {
-                delVelBiasVar[i] = P[i+13][i+13];
-            }
             // reset all delta velocity bias covariances
             zeroCols(P,13,15);
             zeroRows(P,13,15);
-            // restore all delta velocity bias variances to a margin above the minimum safe value
-            for (uint8_t i=0; i<=2; i++) {
-                P[i+13][i+13] = MAX(delVelBiasVar[i], minSafeStateVar * 10.0F);
-            }
+            // set all delta velocity bias variances to initial values and zero bias states
+            P[13][13] = sq(ACCEL_BIAS_LIM_SCALER * frontend->_accBiasLim * dtEkfAvg);
+            P[14][14] = P[13][13];
+            P[15][15] = P[13][13];
+            stateStruct.accel_bias.zero();
         }
 
     } else {


### PR DESCRIPTION
A hardware setup using RTK GPs with a longer than usual time spent static on ground prior to flight ran into an issue where the covariance terms for the IMU delta velocity bias (accelerometer bias) became badly conditioned and the filter diverged in vertical position and velocity.

There is supposed to be a reset that occurs if the delta velocity state variances collapse below a minimum safe value, but this was not working correctly. This has been fixed the minimum allowed value determined based on replay of the log from the problem flight. This ended up being the same minimum safe value of 1E-9 for the delta velocity variance that PX4 uses for their estimator which uses the same underlying equations.

The figures show before [index 0] and after the patch  [index 100] using the default value of EK3_ABIAS_P_NSE=0.003.

The vertical position innovation IPD and vertical velocity innovation IVD diverge without the patch

<img width="1015" alt="Screen Shot 2023-05-16 at 7 32 56 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/34edb421-0745-4b4c-ac34-950e7b171b6c">

<img width="1031" alt="Screen Shot 2023-05-16 at 7 32 22 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/d0c9f6a6-75e8-49a5-9a89-22912a9abe1f">

Note the reset event that recovers the Z delta velocity bias state variance to a safe value after it collapses.

<img width="1036" alt="Screen Shot 2023-05-16 at 7 33 19 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/49a450a6-bcf8-49cc-b093-e6efd6f31f30">

Increasing the delta velocity bias process noise EK3_ABIS_P_NSE from 0.003 to 0.006 prevents the initial covariance collapse so that the reset is not required. An increase to only 0.0045 was not sufficient.

<img width="1008" alt="Screen Shot 2023-05-16 at 7 34 50 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/3e032c6a-4034-4d13-bbac-8fd64dba1d19">

It also did not result in a noisy accelerometer bias estimates. The following figures shows the accel bias estimates in m/s/s from two replays, the first with EK3_ABIAS_P_NSE = 0.003 (the current default) and the second using a value of 0.006. T

<img width="1051" alt="Screen Shot 2023-05-16 at 7 39 57 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/56317013-4a23-469b-ac3b-4d4cbc15997c">

<img width="1034" alt="Screen Shot 2023-05-16 at 7 37 08 pm" src="https://github.com/ArduPilot/ardupilot/assets/3596952/a034d690-e22a-421e-a225-a581085b5e65">

