### PR TITLE
Use chibios_hwdef to define NOTIFY_LED_OVERRIDE_DEFAULT for periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -3255,6 +3255,10 @@ INCLUDE common.ld
 #define AP_FILESYSTEM_ROMFS_ENABLED 0
 #endif
 
+#ifndef NOTIFY_LED_OVERRIDE_DEFAULT
+#define NOTIFY_LED_OVERRIDE_DEFAULT 1       // rgb_source_t::mavlink
+#endif
+
 // end AP_Periph defaults
 ''')
 

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -130,11 +130,7 @@ AP_Notify *AP_Notify::_singleton;
 #endif
 
 #ifndef NOTIFY_LED_OVERRIDE_DEFAULT
-#ifdef HAL_BUILD_AP_PERIPH
-    #define NOTIFY_LED_OVERRIDE_DEFAULT 1       // rgb_source_t::mavlink
-#else
-    #define NOTIFY_LED_OVERRIDE_DEFAULT 0       // rgb_source_t::standard
-#endif
+#define NOTIFY_LED_OVERRIDE_DEFAULT 0       // rgb_source_t::standard
 #endif
 
 #ifndef NOTIFY_LED_LEN_DEFAULT


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
