### PR TITLE
Prevent recursive DMA locks when running with assertions

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1608,7 +1608,7 @@ bool RCOutput::serial_led_send(pwm_group &group)
     }
 
 #ifndef DISABLE_DSHOT
-    if (irq.waiter || (group.dshot_state != DshotState::IDLE && group.dshot_state != DshotState::RECV_COMPLETE)) {
+    if (irq.waiter) {
         // doing serial output or DMAR input, don't send DShot pulses
         return false;
     }

--- a/libraries/AP_HAL_ChibiOS/shared_dma.cpp
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.cpp
@@ -87,6 +87,7 @@ bool Shared_DMA::lock_stream(uint8_t stream_id)
         const thread_t* curr_owner = locks[stream_id].mutex.owner;
         chMtxLock(&locks[stream_id].mutex);
         cont = curr_owner != nullptr && curr_owner != locks[stream_id].mutex.owner;
+        osalDbgAssert(curr_owner != locks[stream_id].mutex.owner, "Recursive DMA lock");
     }
     return cont;
 }


### PR DESCRIPTION
remove redundant dshot code from led thread