### PR TITLE
RC_Channel: add winch control to aux switch param description

### DIFF
--- a/Tools/autotest/default_params/copter-winch.parm
+++ b/Tools/autotest/default_params/copter-winch.parm
@@ -1,0 +1,6 @@
+# servo winch type
+# winch connected to servo output channel 9
+# rc input chnanel 9 used by pilot to control winch
+WINCH_TYPE 1
+SERVO9_FUNCTION 88
+RC9_OPTION 45

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane}: 41:ArmDisarm (4.1 and lower)
     // @Values{Copter, Rover}: 42:SmartRTL
     // @Values{Copter, Plane}: 43:InvertedFlight
-    // @Values{Copter}: 44:Winch Enable
+    // @Values{Copter}: 44:Winch Enable, 45:Winch Control
     // @Values{Copter, Rover, Plane, Blimp}: 46:RC Override Enable
     // @Values{Copter}: 47:User Function 1, 48:User Function 2, 49:User Function 3
     // @Values{Rover}: 50:LearnCruise


### PR DESCRIPTION
This adds the missing 45:Winch Control to the auxiliary switch parameter descriptions for Copter.

I've also added a copter-winch.parm file to slightly ease the SITL testing of the winch.  I've tested this in SITL.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/d82d5852-4c0a-44aa-96a4-0f61c49f180a)


Thanks to ohitstarik for pointing this out in [this discussion](https://discuss.ardupilot.org/t/do-winch-mission-waypoints-not-working-with-daiwa-winch/98946).