### PR TITLE
AP_Scripting/Copter: support is_landing and is_taking_off in lua script

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -443,6 +443,18 @@ bool Copter::has_ekf_failsafed() const
     return failsafe.ekf;
 }
 
+// returns true if vehicle is landing. Only used by Lua scripts
+bool Copter::is_landing() const
+{
+    return flightmode->is_landing();
+}
+
+// returns true if vehicle is taking off. Only used by Lua scripts
+bool Copter::is_taking_off() const
+{
+    return flightmode->is_taking_off();
+}
+
 #endif // AP_SCRIPTING_ENABLED
 
 bool Copter::current_mode_requires_mission() const

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -679,6 +679,8 @@ private:
     // lua scripts use this to retrieve EKF failsafe state
     // returns true if the EKF failsafe has triggered
     bool has_ekf_failsafed() const override;
+    bool is_landing() const override;
+    bool is_taking_off() const override;
 #endif // AP_SCRIPTING_ENABLED
     void rc_loop();
     void throttle_loop();

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2113,6 +2113,14 @@ function vehicle:nav_script_time() end
 function vehicle:reboot(hold_in_bootloader) end
 
 -- desc
+---@return boolean
+function vehicle:is_taking_off() end
+
+-- desc
+---@return boolean
+function vehicle:is_landing() end
+
+-- desc
 ---@class onvif
 onvif = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -277,6 +277,8 @@ singleton AP_Vehicle method set_velocity_match boolean Vector2f
 singleton AP_Vehicle method set_land_descent_rate boolean float'skip_check
 singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
+singleton AP_Vehicle method is_landing boolean
+singleton AP_Vehicle method is_taking_off boolean
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -214,6 +214,12 @@ public:
     // returns true on success and control_value is set to a value in the range -1 to +1
     virtual bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) { return false; }
 
+    // returns true if vehicle is in the process of landing
+    virtual bool is_landing() const { return false; }
+
+    // returns true if vehicle is in the process of taking off
+    virtual bool is_taking_off() const { return false; }
+
 #endif // AP_SCRIPTING_ENABLED
 
     // zeroing the RC outputs can prevent unwanted motor movement:


### PR DESCRIPTION
I added is_landing and is_taking_off function to the AP_Vehicle and Copter class to use these in LUA scripting.
These can be used, for example, to specify failsafe behavior during takeoff and landing at LUA.

I tested this in SITL and it works.