### PR TITLE
AP_GPS: Remove gsof zero initialization

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -79,10 +79,9 @@ private:
     static const uint8_t STX = 0x02;
     static const uint8_t ETX = 0x03;
 
-    uint8_t packetcount = 0;
-
-    uint32_t gsofmsg_time = 0;
-    uint8_t gsofmsgreq_index = 0;
+    uint8_t packetcount;
+    uint32_t gsofmsg_time;
+    uint8_t gsofmsgreq_index;
     const uint8_t gsofmsgreq[5] = {1,2,8,9,12};
 };
 #endif


### PR DESCRIPTION
https://ardupilot.org/dev/docs/style-guide.html?highlight=zero+initialization#implicit-zeroing-of-memory
https://en.cppreference.com/w/cpp/language/zero_initialization

Remove flash space by using implict zero'ing