### PR TITLE
AP_Logger: make SCR name field instance

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1342,7 +1342,7 @@ LOG_STRUCTURE_FROM_VISUALODOM \
       "FILE",   "NIBZ",       "FileName,Offset,Length,Data", "----", "----" }, \
 LOG_STRUCTURE_FROM_AIS \
     { LOG_SCRIPTING_MSG, sizeof(log_Scripting), \
-      "SCR",   "QNIii", "TimeUS,Name,Runtime,Total_mem,Run_mem", "s-sbb", "F-F--", true }, \
+      "SCR",   "QNIii", "TimeUS,Name,Runtime,Total_mem,Run_mem", "s#sbb", "F-F--", true }, \
     { LOG_VER_MSG, sizeof(log_VER), \
       "VER",   "QBHBBBBIZH", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ", "s---------", "F---------", false }, \
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt), \


### PR DESCRIPTION
This PR changes the formatting of the "SCR" (Script) logging message within the AP_Logger.
Specifically, the "Name" field has been modified to be an instance field.

I tested this in SILT, and I can see the script's name from log viewer in MP.
![image](https://github.com/ArduPilot/ardupilot/assets/16643069/8462c7a7-8372-4550-8cc3-51c73fa48d84)
