### PR TITLE
AP_GPS: Switch to enum class for output_type

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -82,6 +82,22 @@ private:
     uint8_t packetcount;
     uint32_t gsofmsg_time;
     uint8_t gsofmsgreq_index;
-    const uint8_t gsofmsgreq[5] = {1,2,8,9,12};
+
+    enum class OutputType
+    {
+        POS_TIME = 1,
+        POSITION = 2,
+        VELOCITY = 8,
+        DOP = 9,
+        POSITION_SIGMA = 12
+    };
+
+    const uint8_t gsofmsgreq[5] = {
+        uint8_t(OutputType::POS_TIME),
+        uint8_t(OutputType::POSITION),
+        uint8_t(OutputType::VELOCITY),
+        uint8_t(OutputType::DOP),
+        uint8_t(OutputType::POSITION_SIGMA)
+        };
 };
 #endif


### PR DESCRIPTION
This switches the output type to an enum class from an int+comment, and removes the magic numbers in `gsofmsgreq` variable by using the enum. Now, it's obvious what's happening for the message request - that configures which message types the gsof driver outputs. 

I could switch the type of gsofmsgreq from uint8 to the enum class, but then there would be a runtime conversion. Not sure which is better.  

Because of the indent to the switch statements, this is hard to review, so let's wait to merge it till we have SIM up and running (#23843). 