### PR TITLE
Copter: Add GCS Failsafe Brake option

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -162,7 +162,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_GCS_ENABLE
     // @DisplayName: Ground Station Failsafe Enable
     // @Description: Controls whether failsafe will be invoked (and what action to take) when connection with Ground station is lost for at least 5 seconds. See FS_OPTIONS param for additional actions, or for cases allowing Mission continuation, when GCS failsafe is enabled.
-    // @Values: 0:Disabled/NoAction,1:RTL,2:RTL or Continue with Mission in Auto Mode (Removed in 4.0+-see FS_OPTIONS),3:SmartRTL or RTL,4:SmartRTL or Land,5:Land,6:Auto DO_LAND_START or RTL
+    // @Values: 0:Disabled/NoAction,1:RTL,2:RTL or Continue with Mission in Auto Mode (Removed in 4.0+-see FS_OPTIONS),3:SmartRTL or RTL,4:SmartRTL or Land,5:Land,6:Auto DO_LAND_START or RTL,7:Brake or Land
     // @User: Standard
     GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_DISABLED),
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -151,6 +151,7 @@ enum LoggingParameters {
 #define FS_GCS_ENABLED_ALWAYS_SMARTRTL_OR_LAND 4
 #define FS_GCS_ENABLED_ALWAYS_LAND             5
 #define FS_GCS_ENABLED_AUTO_RTL_OR_RTL         6
+#define FS_GCS_ENABLED_BRAKE_OR_LAND           7
 
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -187,6 +187,9 @@ void Copter::failsafe_gcs_on_event(void)
         case FS_GCS_ENABLED_AUTO_RTL_OR_RTL:
             desired_action = FailsafeAction::AUTO_DO_LAND_START;
             break;
+        case FS_GCS_ENABLED_BRAKE_OR_LAND:
+            desired_action = FailsafeAction::BRAKE_LAND;
+            break;
         default: // if an invalid parameter value is set, the fallback is RTL
             desired_action = FailsafeAction::RTL;
     }


### PR DESCRIPTION
I've added a "Brake Mode" option, which allows the copter to hover in place (in Brake Mode) if the connection to the GCS is lost while in Auto or Guided flight modes.

When conducting BVLOS operations, it is crucial to maintain control over the drone via the GCS at all times. In the event of a GCS disconnection, the drone switches to Brake mode, halting flight without GCS control. Upon reestablishing the connection, the drone can be returned to Auto mode via the GCS.

In the case where the connection does not recover, the drone will take RTL or Land actions through a battery failsafe.

This feature follows a similar implementation as in the PR #23110, which added a Brake Mode option to the Radio Failsafe.

I tested this in SITL.
![image](https://github.com/ArduPilot/ardupilot/assets/16643069/72300806-3b73-41f5-9713-2ba5b6b14b8c)