### PR TITLE
AP_GPS: Update GSOF docs with newer links

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -16,7 +16,8 @@
 //
 //  Trimble GPS driver for ArduPilot.
 //	Code by Michael Oborne
-//
+//  https://receiverhelp.trimble.com/oem-gnss/index.html#Welcome.html?TocPath=_____1
+
 #pragma once
 
 #include "AP_GPS.h"


### PR DESCRIPTION
Add in new links for all the packets. The old link was dead. 

I think GSOF 2 (pos) is deprecated. It's no longer documented in the API. I can follow up with Applanix to see why. 