### PR TITLE
Enforce max of 10 GSOF outputs per the manual via static_assert

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -46,6 +46,9 @@ AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                          AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
 {
+    // https://receiverhelp.trimble.com/oem-gnss/index.html#GSOFmessages_Overview.html?TocPath=Output%2520Messages%257CGSOF%2520Messages%257COverview%257C_____0
+    static_assert(ARRAY_SIZE(gsofmsgreq) <= 10, "The maximum number of outputs allowed with GSOF is 10.");
+    
     msg.state = Msg_Parser::State::STARTTX;
 
     // baud request for port 0


### PR DESCRIPTION
The manual says the following: 
https://receiverhelp.trimble.com/oem-gnss/index.html#GSOFmessages_Overview.html?TocPath=Output%2520Messages%257CGSOF%2520Messages%257COverview%257C_____0

```
The receiver allows a maximum of ten GSOF messages to be output.
```

Right now, you could steadily increase the size of `gsofmsgreq` without concern. It is currently length `5`. Now, the compiler prevents you from exceeding the claimed limit in the manual. 