### PR TITLE
AP_Camera: Add mount angles in camera log message

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -583,6 +583,11 @@ void Copter::ten_hz_logging_loop()
         g2.winch.write_log();
     }
 #endif
+#if HAL_MOUNT_ENABLED
+    if (should_log(MASK_LOG_CAMERA)) {
+        camera_mount.write_log();
+    }
+#endif
 }
 
 // twentyfive_hz_logging - should be run at 25hz

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -245,7 +245,12 @@ void Plane::update_logging10(void)
         ahrs.Write_AOA_SSA();
     } else if (log_faster) {
         ahrs.Write_AOA_SSA();
-    } 
+    }
+#if HAL_MOUNT_ENABLED
+    if (should_log(MASK_LOG_CAMERA)) {
+        camera_mount.write_log();
+    }
+#endif
 }
 
 /*

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -210,6 +210,11 @@ void Sub::ten_hz_logging_loop()
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control.control_monitor_log();
     }
+#if HAL_MOUNT_ENABLED
+    if (should_log(MASK_LOG_CAMERA)) {
+        camera_mount.write_log();
+    }
+#endif
 }
 
 // twentyfive_hz_logging_loop

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -421,6 +421,11 @@ void Rover::update_logging2(void)
         gyro_fft.write_log_messages();
 #endif
     }
+#if HAL_MOUNT_ENABLED
+    if (should_log(MASK_LOG_CAMERA)) {
+        camera_mount.write_log();
+    }
+#endif
 }
 
 

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -1,11 +1,12 @@
 #include "AP_Camera_Backend.h"
+#include <AP_Mount/AP_Mount.h>
 
 #if AP_CAMERA_ENABLED
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 
-// Write a Camera packet
+// Write a Camera packet.  Also writes a Mount packet if available
 void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)
 {
     // exit immediately if no logger
@@ -41,9 +42,14 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
         altitude_gps = 0;
     }
 
+    // if timestamp is zero set to current system time
+    if (timestamp_us == 0) {
+        timestamp_us = AP_HAL::micros64();
+    }
+
     const struct log_Camera pkt{
         LOG_PACKET_HEADER_INIT(static_cast<uint8_t>(msg)),
-        time_us     : timestamp_us ? timestamp_us : AP_HAL::micros64(),
+        time_us     : timestamp_us,
         instance    : _instance,
         image_number: image_index,
         gps_time    : gps.time_week_ms(),
@@ -58,6 +64,14 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
         yaw         : (uint16_t)ahrs.yaw_sensor
     };
     AP::logger().WriteCriticalBlock(&pkt, sizeof(pkt));
+
+#if HAL_MOUNT_ENABLED
+    auto *mount = AP_Mount::get_singleton();
+    if (mount!= nullptr) {
+        // assuming camera instance matches mount instance
+        mount->write_log(_instance, timestamp_us);
+    }
+#endif
 }
 
 // Write a Camera packet

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Camera shutter (trigger) type
     // @Description: how to trigger the camera to take a picture
-    // @Values: 1:Servo,2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
+    // @Values: 0:None, 1:Servo, 2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE",  1, AP_Camera_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -131,6 +131,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_InertialSensor/LogStructure.h>
 #include <AP_AHRS/LogStructure.h>
 #include <AP_Camera/LogStructure.h>
+#include <AP_Mount/LogStructure.h>
 #include <AP_Baro/LogStructure.h>
 #include <AP_VisualOdom/LogStructure.h>
 #include <AC_PrecLand/LogStructure.h>
@@ -1260,6 +1261,7 @@ LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \
+LOG_STRUCTURE_FROM_MOUNT \
     { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBffB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hp,TR,Pri", "s#nPOPP-----", "F-00B00-----", true }, \
     LOG_STRUCTURE_FROM_BATTMONITOR \
     { LOG_MAG_MSG, sizeof(log_MAG), \
@@ -1370,6 +1372,7 @@ enum LogMessages : uint8_t {
     LOG_RADIO_MSG,
     LOG_ATRP_MSG,
     LOG_IDS_FROM_CAMERA,
+    LOG_IDS_FROM_MOUNT,
     LOG_TERRAIN_MSG,
     LOG_CSRV_MSG,
     LOG_IDS_FROM_ESC_TELEM,

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -646,7 +646,7 @@ bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
     return true;
 }
 
-// accessors for scripting backends
+// get target rate in deg/sec. returns true on success
 bool AP_Mount::get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
 {
     auto *backend = get_instance(instance);
@@ -656,6 +656,7 @@ bool AP_Mount::get_rate_target(uint8_t instance, float& roll_degs, float& pitch_
     return backend->get_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame);
 }
 
+// get target angle in deg. returns true on success
 bool AP_Mount::get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
 {
     auto *backend = get_instance(instance);
@@ -665,6 +666,7 @@ bool AP_Mount::get_angle_target(uint8_t instance, float& roll_deg, float& pitch_
     return backend->get_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
 }
 
+// accessors for scripting backends and logging
 bool AP_Mount::get_location_target(uint8_t instance, Location& target_loc)
 {
     auto *backend = get_instance(instance);
@@ -681,6 +683,26 @@ void AP_Mount::set_attitude_euler(uint8_t instance, float roll_deg, float pitch_
         return;
     }
     backend->set_attitude_euler(roll_deg, pitch_deg, yaw_bf_deg);
+}
+
+// write mount log packet for all backends
+void AP_Mount::write_log()
+{
+    // each instance writes log
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != nullptr) {
+            _backends[instance]->write_log(0);
+        }
+    }
+}
+
+void AP_Mount::write_log(uint8_t instance, uint64_t timestamp_us)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return;
+    }
+    backend->write_log(timestamp_us);
 }
 
 // point at system ID sysid

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -199,11 +199,21 @@ public:
     // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
 
-    // accessors for scripting backends
+    // get target rate in deg/sec. returns true on success
     bool get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame);
+
+    // get target angle in deg. returns true on success
     bool get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame);
+
+    // accessors for scripting backends and logging
     bool get_location_target(uint8_t instance, Location& target_loc);
     void set_attitude_euler(uint8_t instance, float roll_deg, float pitch_deg, float yaw_bf_deg);
+
+    // write mount log packet for all backends
+    void write_log();
+
+    // write mount log packet for a single backend (called by camera library)
+    void write_log(uint8_t instance, uint64_t timestamp_us);
 
     //
     // camera controls for gimbals that include a camera

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -30,58 +30,59 @@ void AP_Mount_Alexmos::update()
         // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &target = _params.retract_angles.get();
-            _angle_rad.roll = radians(target.x);
-            _angle_rad.pitch = radians(target.y);
-            _angle_rad.yaw = radians(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &target = _params.neutral_angles.get();
-            _angle_rad.roll = radians(target.x);
-            _angle_rad.pitch = radians(target.y);
-            _angle_rad.yaw = radians(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                _angle_rad = mavt_target.angle_rad;
-                break;
-            case MountTargetType::RATE:
-                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
-                break;
-            }
+            // mavlink targets are stored while handling the incoming message
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
             // update targets using pilot's RC inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                update_angle_target_from_rate(rc_target, _angle_rad);
-            } else if (get_rc_angle_target(rc_target)) {
-                _angle_rad = rc_target;
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             break;
         }
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            IGNORE_RETURN(get_angle_target_to_roi(_angle_rad));
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
+            }
             break;
 
+        // point mount to Home location
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            IGNORE_RETURN(get_angle_target_to_home(_angle_rad));
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
+            }
             break;
 
+        // point mount to another vehicle
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            IGNORE_RETURN(get_angle_target_to_sysid(_angle_rad));
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
+            }
             break;
 
         default:
@@ -89,8 +90,16 @@ void AP_Mount_Alexmos::update()
             break;
     }
 
-    // send latest targets to gimbal
-    control_axis(_angle_rad);
+    // send target angles or rates depending on the target type
+    switch (mnt_target.target_type) {
+        case MountTargetType::RATE:
+            update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
+            FALLTHROUGH;
+        case MountTargetType::ANGLE:
+            // send latest angle targets to gimbal
+            control_axis(mnt_target.angle_rad);
+            break;
+    }
 }
 
 // has_pan_control - returns true if this mount can control its pan (required for multicopters)

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -112,8 +112,6 @@ private:
     // read_incoming - detect and read the header of the incoming message from the gimbal
     void read_incoming();
 
-    MountTarget _angle_rad;         // latest angle target
-
     // structure for the Serial Protocol
 
     // CMD_BOARD_INFO

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -28,7 +28,7 @@
 #include <AP_Common/Location.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Camera/AP_Camera_shareddefs.h>
-#include "AP_Mount_Params.h"
+#include "AP_Mount.h"
 
 class AP_Mount_Backend
 {
@@ -133,11 +133,18 @@ public:
     // handle GIMBAL_DEVICE_ATTITUDE_STATUS message
     virtual void handle_gimbal_device_attitude_status(const mavlink_message_t &msg) {}
 
+    // get target rate in deg/sec. returns true on success
+    bool get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame);
+
+    // get target angle in deg. returns true on success
+    bool get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame);
+
     // accessors for scripting backends
-    virtual bool get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame) { return false; }
-    virtual bool get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame) { return false; }
     virtual bool get_location_target(Location &target_loc) { return false; }
     virtual void set_attitude_euler(float roll_deg, float pitch_deg, float yaw_bf_deg) {};
+
+    // write mount log packet
+    void write_log(uint64_t timestamp_us);
 
     //
     // camera controls for gimbals that include a camera
@@ -175,8 +182,9 @@ protected:
         RATE,
     };
 
-    // structure for a single angle or rate target
-    struct MountTarget {
+    // class for a single angle or rate target
+    class MountTarget {
+    public:
         float roll;
         float pitch;
         float yaw;
@@ -187,6 +195,9 @@ protected:
 
         // return earth-frame yaw angle from a mount target (in radians)
         float get_ef_yaw() const;
+
+        // set roll, pitch, yaw and yaw_is_ef from Vector3f
+        void set(const Vector3f& rpy, bool yaw_is_ef_in);
     };
 
     // returns true if user has configured a valid yaw angle range
@@ -199,13 +210,9 @@ protected:
     // get pilot input (in the range -1 to +1) received through RC
     void get_rc_input(float& roll_in, float& pitch_in, float& yaw_in) const;
 
-    // get rate targets (in rad/s) from pilot RC
-    // returns true on success (RC is providing rate targets), false on failure (RC is providing angle targets)
-    bool get_rc_rate_target(MountTarget& rate_rads) const WARN_IF_UNUSED;
-
-    // get angle targets (in radians) from pilot RC
-    // returns true on success (RC is providing angle targets), false on failure (RC is providing rate targets)
-    bool get_rc_angle_target(MountTarget& angle_rad) const WARN_IF_UNUSED;
+    // get angle or rate targets from pilot RC
+    // target_type will be either ANGLE or RATE, rpy will be the target angle in deg or rate in deg/s
+    void get_rc_target(MountTargetType& target_type, MountTarget& rpy) const;
 
     // get angle targets (in radians) to a Location
     // returns true on success, false on failure
@@ -246,7 +253,7 @@ protected:
         MountTargetType target_type;// MAVLink targeting mode's current target type (e.g. angle or rate)
         MountTarget angle_rad;      // angle target in radians
         MountTarget rate_rads;      // rate target in rad/s
-    } mavt_target;
+    } mnt_target;
 
     Location _roi_target;           // roi target location
     bool _roi_target_set;           // true if the roi target has been set

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -26,68 +26,73 @@ void AP_Mount_Gremsy::update()
         // move mount to a "retracted" position.  We disable motors
         case MAV_MOUNT_MODE_RETRACT:
             // handled below
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(Vector3f{0,0,0}, false);
             send_gimbal_device_retract();
             break;
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &angle_bf_target = _params.neutral_angles.get();
-            send_gimbal_device_set_attitude(ToRad(angle_bf_target.x), ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
-            }
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
             break;
+        }
 
-        // use angle or rate targets provided by a mavlink message or mission command
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                send_gimbal_device_set_attitude(mavt_target.angle_rad.roll, mavt_target.angle_rad.pitch, mavt_target.angle_rad.yaw, mavt_target.angle_rad.yaw_is_ef);
-                break;
-            case MountTargetType::RATE:
-                send_gimbal_device_set_rate(mavt_target.rate_rads.roll, mavt_target.rate_rads.pitch, mavt_target.rate_rads.yaw, mavt_target.rate_rads.yaw_is_ef);
-                break;
-            }
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
+            // mavlink targets are stored while handling the incoming message set_angle_target() or set_rate_target()
             break;
+        }
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's rc inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                send_gimbal_device_set_rate(rc_target.roll, rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
-            } else if (get_rc_angle_target(rc_target)) {
-                send_gimbal_device_set_attitude(rc_target.roll, rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
+            // update targets using pilot's RC inputs
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             break;
         }
 
         // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_roi(angle_target_rad)) {
-                send_gimbal_device_set_attitude(angle_target_rad.roll, angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        // point mount to home
-        case MAV_MOUNT_MODE_HOME_LOCATION: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_home(angle_target_rad)) {
-                send_gimbal_device_set_attitude(angle_target_rad.roll, angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to Home location
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_SYSID_TARGET: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_sysid(angle_target_rad)) {
-                send_gimbal_device_set_attitude(angle_target_rad.roll, angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
         default:
             // unknown mode so do nothing
+            break;
+    }
+
+    // send target angles or rates depending on the target type
+    switch (mnt_target.target_type) {
+        case MountTargetType::ANGLE:
+            send_gimbal_device_set_attitude(mnt_target.angle_rad.roll, mnt_target.angle_rad.pitch, mnt_target.angle_rad.yaw, mnt_target.angle_rad.yaw_is_ef);
+            break;
+        case MountTargetType::RATE:
+            send_gimbal_device_set_rate(mnt_target.rate_rads.roll, mnt_target.rate_rads.pitch, mnt_target.rate_rads.yaw, mnt_target.rate_rads.yaw_is_ef);
             break;
     }
 }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -128,12 +128,6 @@ bool AP_Mount_Gremsy::healthy() const
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_Gremsy::get_attitude_quaternion(Quaternion& att_quat)
 {
-    // check we have received an updated message
-    if (_gimbal_device_attitude_status.time_boot_ms == _sent_gimbal_device_attitude_status_ms) {
-        return false;
-    }
-    _sent_gimbal_device_attitude_status_ms = _gimbal_device_attitude_status.time_boot_ms;
-
     att_quat = _gimbal_device_attitude_status.q;
     return true;
 }

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -70,6 +70,5 @@ private:
     uint8_t _compid;                // component id of gimbal
     mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status
     uint32_t _last_attitude_status_ms;  // system time last attitude status was received (used for health reporting)
-    uint32_t _sent_gimbal_device_attitude_status_ms;    // time_boot_ms field of gimbal_device_status message last forwarded to the GCS (used to prevent sending duplicates)
 };
 #endif // HAL_MOUNT_GREMSY_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -26,32 +26,24 @@ void AP_Mount_SToRM32::update()
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &target = _params.retract_angles.get();
-            _angle_rad.roll = radians(target.x);
-            _angle_rad.pitch = radians(target.y);
-            _angle_rad.yaw = radians(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &target = _params.neutral_angles.get();
-            _angle_rad.roll = radians(target.x);
-            _angle_rad.pitch = radians(target.y);
-            _angle_rad.yaw = radians(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                _angle_rad = mavt_target.angle_rad;
-                break;
-            case MountTargetType::RATE:
-                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
-                break;
+            // mnt_target should have already been populated by set_angle_target() or set_rate_target(). Update target angle from rate if necessary
+            if (mnt_target.target_type == MountTargetType::RATE) {
+                update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
             }
             resend_now = true;
             break;
@@ -59,31 +51,40 @@ void AP_Mount_SToRM32::update()
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
             // update targets using pilot's RC inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                update_angle_target_from_rate(rc_target, _angle_rad);
-            } else if (get_rc_angle_target(rc_target)) {
-                _angle_rad = rc_target;
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             resend_now = true;
             break;
         }
 
-        // point mount to a GPS location
+        // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(_angle_rad)) {
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
 
+        // point mount to Home location
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(_angle_rad)) {
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
 
+        // point mount to another vehicle
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(_angle_rad)) {
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
@@ -95,14 +96,14 @@ void AP_Mount_SToRM32::update()
 
     // resend target angles at least once per second
     if (resend_now || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
-        send_do_mount_control(_angle_rad);
+        send_do_mount_control(mnt_target.angle_rad);
     }
 }
 
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_SToRM32::get_attitude_quaternion(Quaternion& att_quat)
 {
-    att_quat.from_euler(_angle_rad.roll, _angle_rad.pitch, _angle_rad.get_bf_yaw());
+    att_quat.from_euler(mnt_target.angle_rad.roll, mnt_target.angle_rad.pitch, mnt_target.angle_rad.get_bf_yaw());
     return true;
 }
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -42,6 +42,5 @@ private:
     uint8_t _compid;                // component id of gimbal
     mavlink_channel_t _chan = MAVLINK_COMM_0;        // mavlink channel used to communicate with gimbal
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
-    MountTarget _angle_rad;         // latest angle target
 };
 #endif // HAL_MOUNT_STORM32MAVLINK_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -37,32 +37,24 @@ void AP_Mount_SToRM32_serial::update()
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &target = _params.retract_angles.get();
-            _angle_rad.roll = ToRad(target.x);
-            _angle_rad.pitch = ToRad(target.y);
-            _angle_rad.yaw = ToRad(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &target = _params.neutral_angles.get();
-            _angle_rad.roll = ToRad(target.x);
-            _angle_rad.pitch = ToRad(target.y);
-            _angle_rad.yaw = ToRad(target.z);
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                _angle_rad = mavt_target.angle_rad;
-                break;
-            case MountTargetType::RATE:
-                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
-                break;
+            // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
+            if (mnt_target.target_type == MountTargetType::RATE) {
+                update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
             }
             resend_now = true;
             break;
@@ -70,11 +62,15 @@ void AP_Mount_SToRM32_serial::update()
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
             // update targets using pilot's RC inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                update_angle_target_from_rate(rc_target, _angle_rad);
-            } else if (get_rc_angle_target(rc_target)) {
-                _angle_rad = rc_target;
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             resend_now = true;
             break;
@@ -82,19 +78,24 @@ void AP_Mount_SToRM32_serial::update()
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(_angle_rad)) {
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
 
+        // point mount to Home location
         case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(_angle_rad)) {
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
 
+        // point mount to another vehicle
         case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(_angle_rad)) {
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
                 resend_now = true;
             }
             break;
@@ -112,7 +113,7 @@ void AP_Mount_SToRM32_serial::update()
     }
     if (can_send(resend_now)) {
         if (resend_now) {
-            send_target_angles(_angle_rad);
+            send_target_angles(mnt_target.angle_rad);
             get_angles();
             _reply_type = ReplyType_ACK;
             _reply_counter = 0;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -130,7 +130,6 @@ private:
     AP_HAL::UARTDriver *_port;
 
     bool _initialised;              // true once the driver has been initialised
-    MountTarget _angle_rad;         // latest angle target
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
 
     uint8_t _reply_length;

--- a/libraries/AP_Mount/AP_Mount_Scripting.cpp
+++ b/libraries/AP_Mount/AP_Mount_Scripting.cpp
@@ -20,14 +20,8 @@ void AP_Mount_Scripting::update()
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &angle_bf_target = _params.retract_angles.get();
-            target_angle_rad.roll = ToRad(angle_bf_target.x);
-            target_angle_rad.pitch = ToRad(angle_bf_target.y);
-            target_angle_rad.yaw = ToRad(angle_bf_target.z);
-            target_angle_rad.yaw_is_ef = false;
-            target_angle_rad_valid = true;
-
-            // mark other targets as invalid
-            target_rate_rads_valid = false;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             target_loc_valid = false;
             break;
         }
@@ -35,92 +29,55 @@ void AP_Mount_Scripting::update()
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &angle_bf_target = _params.neutral_angles.get();
-            target_angle_rad.roll = ToRad(angle_bf_target.x);
-            target_angle_rad.pitch = ToRad(angle_bf_target.y);
-            target_angle_rad.yaw = ToRad(angle_bf_target.z);
-            target_angle_rad.yaw_is_ef = false;
-            target_angle_rad_valid = true;
-
-            // mark other targets as invalid
-            target_rate_rads_valid = false;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             target_loc_valid = false;
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                target_angle_rad = mavt_target.angle_rad;
-                target_angle_rad_valid = true;
-                target_rate_rads_valid = false;
-                target_loc_valid = false;
-                break;
-            case MountTargetType::RATE:
-                target_rate_rads = mavt_target.rate_rads;
-                target_rate_rads_valid = true;
-                target_angle_rad_valid = false;
-                target_loc_valid = false;
-                break;
-            }
+            // mavlink targets should have been already stored while handling the message
+            target_loc_valid = false;
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's rc inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                target_rate_rads = rc_target;
-                target_rate_rads_valid = true;
-                target_angle_rad_valid = false;
-                target_loc_valid = false;
-            } else if (get_rc_angle_target(rc_target)) {
-                target_angle_rad = rc_target;
-                target_angle_rad_valid = true;
-                target_rate_rads_valid = false;
-                target_loc_valid = false;
+            // update targets using pilot's RC inputs
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
+            target_loc_valid = false;
             break;
         }
 
-        // point mount towards a GPS point
-        case MAV_MOUNT_MODE_GPS_POINT: {
-            target_loc_valid = _roi_target_set;
-            if (target_loc_valid) {
-                target_loc = _roi_target;
-                target_angle_rad_valid = get_angle_target_to_location(target_loc, target_angle_rad);
-            } else {
-                target_angle_rad_valid = false;
+        // point mount to a GPS point given by the mission planner
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
-            target_rate_rads_valid = false;
             break;
-        }
 
-        // point mount towards home
-        case MAV_MOUNT_MODE_HOME_LOCATION: {
-            target_loc_valid = AP::ahrs().home_is_set();
-            if (target_loc_valid) {
-                target_loc = AP::ahrs().get_home();
-                target_angle_rad_valid = get_angle_target_to_home(target_angle_rad);
-            } else {
-                target_angle_rad_valid = false;
+        // point mount to Home location
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
-            target_rate_rads_valid = false;
             break;
-        }
 
-        // point mount towards another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET: {
-            target_loc_valid = _target_sysid_location_set;
-            if (target_loc_valid) {
-                target_loc = _target_sysid_location;
-                target_angle_rad_valid = get_angle_target_to_location(target_loc, target_angle_rad);
-            } else {
-                target_angle_rad_valid = false;
+        // point mount to another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
-            target_rate_rads_valid = false;
             break;
-        }
 
         default:
             // we do not know this mode so raise internal error
@@ -134,31 +91,6 @@ bool AP_Mount_Scripting::healthy() const
 {
     // healthy if scripting backend has updated actual angles recently
     return (AP_HAL::millis() - last_update_ms <= AP_MOUNT_SCRIPTING_TIMEOUT_MS);
-}
-
-// accessors for scripting backends
-bool AP_Mount_Scripting::get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
-{
-    if (target_rate_rads_valid) {
-        roll_degs = degrees(target_rate_rads.roll);
-        pitch_degs = degrees(target_rate_rads.pitch);
-        yaw_degs = degrees(target_rate_rads.yaw);
-        yaw_is_earth_frame = target_rate_rads.yaw_is_ef;
-        return true;
-    }
-    return false;
-}
-
-bool AP_Mount_Scripting::get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
-{
-    if (target_angle_rad_valid) {
-        roll_deg = degrees(target_angle_rad.roll);
-        pitch_deg = degrees(target_angle_rad.pitch);
-        yaw_deg = degrees(target_angle_rad.yaw);
-        yaw_is_earth_frame = target_angle_rad.yaw_is_ef;
-        return true;
-    }
-    return false;
 }
 
 // return target location if available

--- a/libraries/AP_Mount/AP_Mount_Scripting.h
+++ b/libraries/AP_Mount/AP_Mount_Scripting.h
@@ -32,8 +32,6 @@ public:
     bool has_pan_control() const override { return yaw_range_valid(); };
 
     // accessors for scripting backends
-    bool get_rate_target(float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame) override;
-    bool get_angle_target(float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame) override;
     bool get_location_target(Location& _target_loc) override;
     void set_attitude_euler(float roll_deg, float pitch_deg, float yaw_bf_deg) override;
 
@@ -48,11 +46,8 @@ private:
     uint32_t last_update_ms;        // system time of last call to one of the get_ methods.  Used for health reporting
     Vector3f current_angle_deg;     // current gimbal angles in degrees (x=roll, y=pitch, z=yaw)
 
-    MountTarget target_rate_rads;   // rate target in rad/s
-    bool target_rate_rads_valid;    // true if _target_rate_degs holds a valid rate target
-
-    MountTarget target_angle_rad;   // angle target in radians
-    bool target_angle_rad_valid;    // true if _target_rate_degs holds a valid rate target
+    bool target_rate_rads_valid;    // true if mnt_target holds a valid rate target
+    bool target_angle_rad_valid;    // true if mnt_target holds a valid angle target
 
     Location target_loc;            // target location
     bool target_loc_valid;          // true if target_loc holds a valid target location

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -27,89 +27,87 @@ void AP_Mount_Servo::init()
 // update mount position - should be called periodically
 void AP_Mount_Servo::update()
 {
-    switch (get_mode()) {
+    auto mount_mode = get_mode();
+    switch (mount_mode) {
         // move mount to a "retracted position" or to a position where a fourth servo can retract the entire mount into the fuselage
         case MAV_MOUNT_MODE_RETRACT: {
             _angle_bf_output_rad = _params.retract_angles.get() * DEG_TO_RAD;
-
-            // initialise _angle_rad to smooth transition if user changes to RC_TARGETTING
-            _angle_rad.roll = _angle_bf_output_rad.x;
-            _angle_rad.pitch = _angle_bf_output_rad.y;
-            _angle_rad.yaw = _angle_bf_output_rad.z;
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(_angle_bf_output_rad, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             _angle_bf_output_rad = _params.neutral_angles.get() * DEG_TO_RAD;
-
-            // initialise _angle_rad to smooth transition if user changes to RC_TARGETTING
-            _angle_rad.roll = _angle_bf_output_rad.x;
-            _angle_rad.pitch = _angle_bf_output_rad.y;
-            _angle_rad.yaw = _angle_bf_output_rad.z;
-            _angle_rad.yaw_is_ef = false;
+            mnt_target.angle_rad.set(_angle_bf_output_rad, false);
+            mnt_target.target_type = MountTargetType::ANGLE;
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                _angle_rad = mavt_target.angle_rad;
-                break;
-            case MountTargetType::RATE:
-                update_angle_target_from_rate(mavt_target.rate_rads, _angle_rad);
-                break;
-            }
-            // update _angle_bf_output_rad based on angle target
-            update_angle_outputs(_angle_rad);
+            // mavlink targets are stored while handling the incoming message and considered valid
             break;
         }
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
             // update targets using pilot's RC inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                update_angle_target_from_rate(rc_target, _angle_rad);
-            } else if (get_rc_angle_target(rc_target)) {
-                _angle_rad = rc_target;
-            }
-            // update _angle_bf_output_rad based on angle target
-            update_angle_outputs(_angle_rad);
-            break;
-        }
-
-        // point mount to a GPS location
-        case MAV_MOUNT_MODE_GPS_POINT: {
-            if (get_angle_target_to_roi(_angle_rad)) {
-                update_angle_outputs(_angle_rad);
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             break;
         }
 
-        case MAV_MOUNT_MODE_HOME_LOCATION: {
-            if (get_angle_target_to_home(_angle_rad)) {
-                update_angle_outputs(_angle_rad);
+        // point mount to a GPS point given by the mission planner
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_SYSID_TARGET: {
-            if (get_angle_target_to_sysid(_angle_rad)) {
-                update_angle_outputs(_angle_rad);
+        // point mount to Home location
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
+
+        // point mount to another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
+            }
+            break;
 
         default:
             //do nothing
             break;
     }
 
+    // send target angles or rates depending on the target type
+    switch (mnt_target.target_type) {
+        case MountTargetType::RATE:
+            update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
+            FALLTHROUGH;
+        case MountTargetType::ANGLE:
+            // update _angle_bf_output_rad based on angle target
+            if ((mount_mode != MAV_MOUNT_MODE_RETRACT) & (mount_mode != MAV_MOUNT_MODE_NEUTRAL)) {
+                update_angle_outputs(mnt_target.angle_rad);
+            }
+            break;
+    }
+
     // move mount to a "retracted position" into the fuselage with a fourth servo
-    const bool mount_open = (get_mode() == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
+    const bool mount_open = (mount_mode == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
     move_servo(_open_idx, mount_open, 0, 1);
 
     // write the results to the servos

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -56,7 +56,6 @@ private:
     SRV_Channel::Aux_servo_function_t    _pan_idx;   // SRV_Channel mount pan  function index
     SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
 
-    MountTarget _angle_rad;         // angle target
     Vector3f _angle_bf_output_rad;  // final body frame output angle in radians
 };
 #endif // HAL_MOUNT_SERVO_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -68,74 +68,76 @@ void AP_Mount_Siyi::update()
     // run zoom control
     update_zoom_control();
 
-    // update based on mount mode
+    // Get the target angles or rates first depending on the current mount mode
     switch (get_mode()) {
-        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &angle_bf_target = _params.retract_angles.get();
-            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
             break;
         }
 
-        // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &angle_bf_target = _params.neutral_angles.get();
-            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
             break;
         }
 
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
+            // mavlink targets are stored while handling the incoming message
+            break;
+        }
+
+        case MAV_MOUNT_MODE_RC_TARGETING: {
+            // update targets using pilot's RC inputs
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
             case MountTargetType::ANGLE:
-                send_target_angles(mavt_target.angle_rad.pitch, mavt_target.angle_rad.yaw, mavt_target.angle_rad.yaw_is_ef);
+                mnt_target.angle_rad = rc_target;
                 break;
             case MountTargetType::RATE:
-                send_target_rates(mavt_target.rate_rads.pitch, mavt_target.rate_rads.yaw, mavt_target.rate_rads.yaw_is_ef);
+                mnt_target.rate_rads = rc_target;
                 break;
-            }
-            break;
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's rc inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                send_target_rates(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
-            } else if (get_rc_angle_target(rc_target)) {
-                send_target_angles(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
             }
             break;
         }
 
         // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_roi(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_HOME_LOCATION: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_home(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to Home location
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_SYSID_TARGET:{
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_sysid(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
         default:
             // we do not know this mode so raise internal error
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            break;
+    }
+
+    // send target angles or rates depending on the target type
+    switch (mnt_target.target_type) {
+        case MountTargetType::ANGLE:
+            send_target_angles(mnt_target.angle_rad.pitch, mnt_target.angle_rad.yaw, mnt_target.angle_rad.yaw_is_ef);
+            break;
+        case MountTargetType::RATE:
+            send_target_rates(mnt_target.rate_rads.pitch, mnt_target.rate_rads.yaw, mnt_target.rate_rads.yaw_is_ef);
             break;
     }
 }

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -54,7 +54,6 @@ private:
     void Log_Write_Gimbal(SoloGimbal &gimbal);
 
     bool _params_saved;
-    MountTarget _angle_rad;         // angle target
     SoloGimbal _gimbal;
 };
 

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -315,7 +315,7 @@ void AP_Mount_Viewpro::process_packet()
         _last_current_angle_rad_ms = AP_HAL::millis();
         _current_angle_rad.x = radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+23] & 0x0F, _msg_buff[_msg_buff_data_start+24]) * (180.0/4095.0) - 90.0);   // roll angle
         _current_angle_rad.z = radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+25], _msg_buff[_msg_buff_data_start+26]) * AP_MOUNT_VIEWPRO_OUTPUT_TO_DEG); // yaw angle
-        _current_angle_rad.y = radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+27], _msg_buff[_msg_buff_data_start+28]) * AP_MOUNT_VIEWPRO_OUTPUT_TO_DEG); // pitch angle
+        _current_angle_rad.y = -radians((int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+27], _msg_buff[_msg_buff_data_start+28]) * AP_MOUNT_VIEWPRO_OUTPUT_TO_DEG); // pitch angle
         debug("r:%4.1f p:%4.1f y:%4.1f", (double)degrees(_current_angle_rad.x), (double)degrees(_current_angle_rad.y), (double)degrees(_current_angle_rad.z));
         break;
     }

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -76,69 +76,74 @@ void AP_Mount_Viewpro::update()
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
         case MAV_MOUNT_MODE_RETRACT: {
             const Vector3f &angle_bf_target = _params.retract_angles.get();
-            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
             break;
         }
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {
             const Vector3f &angle_bf_target = _params.neutral_angles.get();
-            send_target_angles(ToRad(angle_bf_target.y), ToRad(angle_bf_target.z), false);
+            mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
             break;
         }
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            switch (mavt_target.target_type) {
-            case MountTargetType::ANGLE:
-                send_target_angles(mavt_target.angle_rad.pitch, mavt_target.angle_rad.yaw, mavt_target.angle_rad.yaw_is_ef);
-                break;
-            case MountTargetType::RATE:
-                send_target_rates(mavt_target.rate_rads.pitch, mavt_target.rate_rads.yaw, mavt_target.rate_rads.yaw_is_ef);
-                break;
-            }
+            // mavlink targets are stored while handling the incoming message
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's rc inputs
-            MountTarget rc_target {};
-            if (get_rc_rate_target(rc_target)) {
-                send_target_rates(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
-            } else if (get_rc_angle_target(rc_target)) {
-                send_target_angles(rc_target.pitch, rc_target.yaw, rc_target.yaw_is_ef);
+            // update targets using pilot's RC inputs
+            MountTarget rc_target;
+            get_rc_target(mnt_target.target_type, rc_target);
+            switch (mnt_target.target_type) {
+            case MountTargetType::ANGLE:
+                mnt_target.angle_rad = rc_target;
+                break;
+            case MountTargetType::RATE:
+                mnt_target.rate_rads = rc_target;
+                break;
             }
             break;
         }
 
         // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_roi(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_HOME_LOCATION: {
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_home(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to Home location
+        case MAV_MOUNT_MODE_HOME_LOCATION:
+            if (get_angle_target_to_home(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
-        case MAV_MOUNT_MODE_SYSID_TARGET:{
-            MountTarget angle_target_rad {};
-            if (get_angle_target_to_sysid(angle_target_rad)) {
-                send_target_angles(angle_target_rad.pitch, angle_target_rad.yaw, angle_target_rad.yaw_is_ef);
+        // point mount to another vehicle
+        case MAV_MOUNT_MODE_SYSID_TARGET:
+            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
+                mnt_target.target_type = MountTargetType::ANGLE;
             }
             break;
-        }
 
         default:
             // we do not know this mode so raise internal error
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+            break;
+    }
+
+    // send target angles or rates depending on the target type
+    switch (mnt_target.target_type) {
+        case MountTargetType::ANGLE:
+            send_target_angles(mnt_target.angle_rad.pitch, mnt_target.angle_rad.yaw, mnt_target.angle_rad.yaw_is_ef);
+            break;
+        case MountTargetType::RATE:
+            send_target_rates(mnt_target.rate_rads.pitch, mnt_target.rate_rads.yaw, mnt_target.rate_rads.yaw_is_ef);
             break;
     }
 }

--- a/libraries/AP_Mount/LogStructure.h
+++ b/libraries/AP_Mount/LogStructure.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_MOUNT \
+    LOG_MOUNT_MSG
+
+// @LoggerMessage: MNT
+// @Description: Mount's actual and Target/Desired RPY information
+// @Field: TimeUS: Time since system startup
+// @Field: I: Instance number
+// @Field: DesRoll: mount's desired roll
+// @Field: Roll: mount's actual roll
+// @Field: DesPitch: mount's desired pitch
+// @Field: Pitch: mount's actual pitch
+// @Field: DesYawB: mount's desired yaw in body frame
+// @Field: YawB: mount's actual yaw in body frame
+// @Field: DesYawE: mount's desired yaw in earth frame
+// @Field: YawE: mount's actual yaw in earth frame
+
+struct PACKED log_Mount {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  instance;
+    float    desired_roll;
+    float    actual_roll;
+    float    desired_pitch;
+    float    actual_pitch;
+    float    desired_yaw_bf;
+    float    actual_yaw_bf;
+    float    desired_yaw_ef;
+    float    actual_yaw_ef;
+};
+
+#define LOG_STRUCTURE_FROM_MOUNT \
+    { LOG_MOUNT_MSG, sizeof(log_Mount), \
+      "MNT", "QBffffffff","TimeUS,I,DesRoll,Roll,DesPitch,Pitch,DesYawB,YawB,DesYawE,YawE", "s#dddddddd", "F---------" },
+

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -462,7 +462,7 @@ function send_target_angles(roll_angle_deg, pitch_angle_deg, yaw_angle_deg, time
   end
 
   -- ensure angles are integers
-  roll_angle_deg = -math.floor(roll_angle_deg + 0.5)
+  roll_angle_deg = math.floor(roll_angle_deg + 0.5)
   pitch_angle_deg = math.floor(pitch_angle_deg + 0.5)
   yaw_angle_deg = math.floor(yaw_angle_deg + 0.5)
   time_sec = math.floor(time_sec + 0.5)
@@ -657,8 +657,8 @@ function parse_byte(b)
             local ret_code = parse_buff[13]
             if ret_code == RETURN_CODE.SUCCESS then
               local yaw_deg = int16_value(parse_buff[16],parse_buff[15]) * 0.1
-              local roll_deg = -int16_value(parse_buff[18],parse_buff[17]) * 0.1
-              local pitch_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
+              local pitch_deg = int16_value(parse_buff[18],parse_buff[17]) * 0.1
+              local roll_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
               mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
               if DJIR_DEBUG:get() > 1 then
                 gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR: roll:%4.1f pitch:%4.1f yaw:%4.1f", roll_deg, pitch_deg, yaw_deg))

--- a/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
@@ -379,7 +379,7 @@ function parse_byte(b)
             local servo_status = (parse_data_buff[24] & 0xF0 >> 4)
             local roll_deg = int16_value(parse_data_buff[24] & 0x0F, parse_data_buff[25]) * (180.0/4095.0) - 90.0
             local yaw_deg = int16_value(parse_data_buff[26], parse_data_buff[27]) * (360.0 / 65536.0)
-            local pitch_deg = int16_value(parse_data_buff[28], parse_data_buff[29]) * (360.0 / 65536.0)
+            local pitch_deg = -int16_value(parse_data_buff[28], parse_data_buff[29]) * (360.0 / 65536.0)
             mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
 
             if VIEP_DEBUG:get() > 0 then


### PR DESCRIPTION
This PR adds logging of the mount's desired and actual roll, pitch and yaw angles.  Both body-frame and earth-frame yaw angles are logged but only one of either DesYawE and DesYawB will ever be non-NaN (because the target will only ever be one of these two).

The mount's angles are logged at 10hz and then again whenever a camera picture is taken (in which case the CAM and MNT message's TimeUS fields will be identical).

Also included are numerous fixes found during testing:

- ViewPro driver pitch angle report ing fix (affected both cpp and lua drivers)
- DJI RS2 driver's angle reporting fix.  The target roll-angle was also reversed ([due to this MP bug](https://github.com/ArduPilot/MissionPlanner/issues/3150))
- Gremsy fix to attitude reporting
- CAMx_TYPE gets the "None" value

fixes #23816 which is an issue from #20985

This has been tested on real hardware including:

- SIYI A8 and ZR10
- Gremsy PixyU
- DJI RS2
- ViewPro A10TR
- Xacti GB100

Below is a sample picture of the tests run on the DJI RS2.  We can see how the actual angles follow behind the desired angles.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/6c634c68-1ef5-4b8d-af8c-0b5dc14f8053)


