### PR TITLE
Copter: Notify the reason for not switching to BRAKE mode

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -436,7 +436,11 @@ void Copter::set_mode_brake_or_land_with_pause(ModeReason reason)
     if (set_mode(Mode::Number::BRAKE, reason)) {
         AP_Notify::events.failsafe_mode_change = 1;
         return;
+    } else {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to change to Brake Mode");
     }
+#else
+    gcs().send_text(MAV_SEVERITY_WARNING, "Brake Mode not enabled");
 #endif
 
     gcs().send_text(MAV_SEVERITY_WARNING, "Trying Land Mode");


### PR DESCRIPTION
There is a PR to add and try to add BRAKE mode option in Radio Fail and GCS Fail.
Operators who set this option expect to switch to BRAKE mode.
I will notify why it did not switch to the expected mode.
The operator can see and understand this notification.