### PR TITLE
Remove type pun warnings and enable Werr in g++ SITL CI

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -775,6 +775,18 @@ class sitl(Board):
                 '-m32',
             ]
 
+        # whitelist of compilers which we should build with -Werror
+        gcc_whitelist = frozenset([
+            ('11','3','0'),
+        ])
+
+        if cfg.options.Werror or cfg.env.CC_VERSION in gcc_whitelist:
+            cfg.msg("Enabling -Werror", "yes")
+            if '-Werror' not in env.CXXFLAGS:
+                env.CXXFLAGS += [ '-Werror' ]
+        else:
+            cfg.msg("Enabling -Werror", "no")
+
     def get_name(self):
         return self.__class__.__name__
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -777,10 +777,12 @@ class sitl(Board):
 
         # whitelist of compilers which we should build with -Werror
         gcc_whitelist = frozenset([
-            ('11','3','0'),
-        ])
+                ('11','3','0'),
+            ])
 
-        if cfg.env.CC_VERSION in gcc_whitelist or cfg.options.Werror:
+        werr_enabled_default = bool('g++' == cfg.env.COMPILER_CXX and cfg.env.CC_VERSION in gcc_whitelist)
+
+        if werr_enabled_default or cfg.options.Werror:
             if not cfg.options.disable_Werror:
                 cfg.msg("Enabling -Werror", "yes")
                 if '-Werror' not in env.CXXFLAGS:

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1082,13 +1082,14 @@ class chibios(Board):
         ]
 
         # whitelist of compilers which we should build with -Werror
-        gcc_whitelist = [
+        gcc_whitelist = frozenset([
             ('4','9','3'),
             ('6','3','1'),
             ('9','2','1'),
             ('9','3','1'),
             ('10','2','1'),
-        ]
+            ('11','3','0'),
+        ])
 
         if cfg.env.HAL_CANFD_SUPPORTED:
             env.DEFINES.update(CANARD_ENABLE_CANFD=1)

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -780,13 +780,18 @@ class sitl(Board):
             ('11','3','0'),
         ])
 
-        if cfg.options.Werror or cfg.env.CC_VERSION in gcc_whitelist:
-            cfg.msg("Enabling -Werror", "yes")
-            if '-Werror' not in env.CXXFLAGS:
-                env.CXXFLAGS += [ '-Werror' ]
+        if cfg.env.CC_VERSION in gcc_whitelist or cfg.options.Werror:
+            if not cfg.options.disable_Werror:
+                cfg.msg("Enabling -Werror", "yes")
+                if '-Werror' not in env.CXXFLAGS:
+                    env.CXXFLAGS += [ '-Werror' ]
+            else:
+                cfg.msg("Enabling -Werror", "no")
+                if '-Werror' in env.CXXFLAGS:
+                    env.CXXFLAGS.remove('-Werror')
         else:
-            cfg.msg("Enabling -Werror", "no")
-
+            cfg.msg("Enabling -Werror", "yes")
+        
     def get_name(self):
         return self.__class__.__name__
 

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -365,10 +365,10 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "replay" ]; then
         echo "Building replay"
-        $waf configure --board sitl --debug --disable-scripting
+        $waf configure --board sitl --debug --disable-scripting --Werror
         $waf replay
         echo "Building AP_DAL standalone test"
-        $waf configure --board sitl --debug --disable-scripting --no-gcs
+        $waf configure --board sitl --debug --disable-scripting --no-gcs --Werror
         $waf --target tool/AP_DAL_Standalone
         $waf clean
         continue

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -365,17 +365,11 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "replay" ]; then
         echo "Building replay"
-
-        if [ $cxx_compiler == "g++" ]; then
-            # Only be strict about Werror on SITL when compiling with g++
-            # Once the warnings are gone in clang, remove this exception
-            maybe_werror="--Werror"
-        fi
-        $waf configure --board sitl --debug --disable-scripting $maybe_werror
+        $waf configure --board sitl --debug --disable-scripting
         
         $waf replay
         echo "Building AP_DAL standalone test"
-        $waf configure --board sitl --debug --disable-scripting --no-gcs $maybe_werror
+        $waf configure --board sitl --debug --disable-scripting --no-gcs
         
         $waf --target tool/AP_DAL_Standalone
         $waf clean

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -365,10 +365,18 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "replay" ]; then
         echo "Building replay"
-        $waf configure --board sitl --debug --disable-scripting --Werror
+
+        if [ $cxx_compiler == "g++" ]; then
+            # Only be strict about Werror on SITL when compiling with g++
+            # Once the warnings are gone in clang, remove this exception
+            maybe_werror="--Werror"
+        fi
+        $waf configure --board sitl --debug --disable-scripting $maybe_werror
+        
         $waf replay
         echo "Building AP_DAL standalone test"
-        $waf configure --board sitl --debug --disable-scripting --no-gcs --Werror
+        $waf configure --board sitl --debug --disable-scripting --no-gcs $maybe_werror
+        
         $waf --target tool/AP_DAL_Standalone
         $waf clean
         continue

--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -101,3 +101,39 @@ int16_t char_to_hex(char a)
     else
         return a - '0';
 }
+
+int32_t to_int32(const float value)
+{
+    int32_t out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}
+
+float to_float(const uint32_t value)
+{
+    float out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}
+
+double to_double(const uint64_t value)
+{
+    double out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}

--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -101,39 +101,3 @@ int16_t char_to_hex(char a)
     else
         return a - '0';
 }
-
-int32_t to_int32(const float value)
-{
-    int32_t out;
-    static_assert(sizeof(value) == sizeof(out));
-
-    // Use memcpy because it's the most portable.
-    // It might not be the fastest way on all hardware.
-    // At least it's defined behavior in both c and c++.
-    memcpy(&out, &value, sizeof(out));
-    return out;
-}
-
-float to_float(const uint32_t value)
-{
-    float out;
-    static_assert(sizeof(value) == sizeof(out));
-
-    // Use memcpy because it's the most portable.
-    // It might not be the fastest way on all hardware.
-    // At least it's defined behavior in both c and c++.
-    memcpy(&out, &value, sizeof(out));
-    return out;
-}
-
-double to_double(const uint64_t value)
-{
-    double out;
-    static_assert(sizeof(value) == sizeof(out));
-
-    // Use memcpy because it's the most portable.
-    // It might not be the fastest way on all hardware.
-    // At least it's defined behavior in both c and c++.
-    memcpy(&out, &value, sizeof(out));
-    return out;
-}

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -179,18 +179,3 @@ template <typename T> void BIT_CLEAR (T& value, uint8_t bitnumber) noexcept {
      ((value) &= ~((T)(1U) << (bitnumber)));
  }
 
-
-/*
-  Convert from float to int32_t without breaking Wstrict-aliasing due to type punning
-*/
-int32_t to_int32(const float value) WARN_IF_UNUSED;
-
-/*
-  Convert from uint32_t to float without breaking Wstrict-aliasing due to type punning
-*/
-float to_float(const uint32_t value) WARN_IF_UNUSED;
-
-/*
-  Convert from uint64_t to double without breaking Wstrict-aliasing due to type punning
-*/
-double to_double(const uint64_t value) WARN_IF_UNUSED;

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -178,3 +178,19 @@ template <typename T> void BIT_CLEAR (T& value, uint8_t bitnumber) noexcept {
      static_assert(std::is_integral<T>::value, "Integral required.");
      ((value) &= ~((T)(1U) << (bitnumber)));
  }
+
+
+/*
+  Convert from float to int32_t without breaking Wstrict-aliasing due to type punning
+*/
+int32_t to_int32(const float value) WARN_IF_UNUSED;
+
+/*
+  Convert from uint32_t to float without breaking Wstrict-aliasing due to type punning
+*/
+float to_float(const uint32_t value) WARN_IF_UNUSED;
+
+/*
+  Convert from uint64_t to double without breaking Wstrict-aliasing due to type punning
+*/
+double to_double(const uint64_t value) WARN_IF_UNUSED;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.cpp
@@ -575,14 +575,14 @@ float AP_ExternalAHRS_LORD::extract_float(const uint8_t *data, uint8_t offset) c
 {
     uint32_t tmp = be32toh_ptr(&data[offset]);
 
-    return *reinterpret_cast<float*>(&tmp);
+    return to_float(tmp);
 }
 
 double AP_ExternalAHRS_LORD::extract_double(const uint8_t *data, uint8_t offset) const
 {
     uint64_t tmp = be64toh_ptr(&data[offset]);
 
-    return *reinterpret_cast<double*>(&tmp);
+    return to_double(tmp);
 }
 
 #endif // AP_EXTERNAL_AHRS_LORD_ENABLE

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_LORD.h
@@ -145,8 +145,6 @@ private:
 
     Vector3f populate_vector3f(const uint8_t* data, uint8_t offset) const;
     Quaternion populate_quaternion(const uint8_t* data, uint8_t offset) const;
-    float extract_float(const uint8_t* data, uint8_t offset) const;
-    double extract_double(const uint8_t* data, uint8_t offset) const;
 
 };
 

--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
 #include <byteswap.h>
 #include <endian.h>
 #include <stdint.h>
@@ -98,10 +99,10 @@ static inline uint32_t be24toh_ptr(const uint8_t *p) { return p[2] | (p[1]<<8U) 
 static inline uint32_t be32toh_ptr(const uint8_t *p) { return p[3] | (p[2]<<8U) | (p[1]<<16U) | (p[0]<<24U); }
 static inline uint64_t be64toh_ptr(const uint8_t *p) { return (uint64_t) p[7] | ((uint64_t) p[6]<<8ULL) | ((uint64_t) p[5]<<16U) | ((uint64_t) p[4]<<24U) | ((uint64_t) p[3]<<32U) | ((uint64_t) p[2]<<40U) | ((uint64_t) p[1]<<48U) | ((uint64_t) p[0]<<56U); }
 
-static inline float be32tofloat_ptr(const uint8_t *p) { return to_float(be32toh_ptr(p)); }
+static inline float be32tofloat_ptr(const uint8_t *p) { return int32_to_float_le(be32toh_ptr(p)); }
 static inline float be32tofloat_ptr(const uint8_t *p, const uint8_t offset) { return be32tofloat_ptr(&p[offset]); }
 #ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
-static inline float be64todouble_ptr(const uint8_t *p) { return to_double(be64toh_ptr(p)); }
+static inline float be64todouble_ptr(const uint8_t *p) { return uint64_to_double_le(be64toh_ptr(p)); }
 static inline float be64todouble_ptr(const uint8_t *p, const uint8_t offset) { return be64todouble_ptr(&p[offset]); }
 #endif
 

--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <AP_Common/AP_Common.h>
 #include <byteswap.h>
 #include <endian.h>
 #include <stdint.h>
@@ -96,6 +97,13 @@ static inline uint16_t be16toh_ptr(const uint8_t *p) { return p[1] | (p[0]<<8U);
 static inline uint32_t be24toh_ptr(const uint8_t *p) { return p[2] | (p[1]<<8U) | (p[0]<<16U); }
 static inline uint32_t be32toh_ptr(const uint8_t *p) { return p[3] | (p[2]<<8U) | (p[1]<<16U) | (p[0]<<24U); }
 static inline uint64_t be64toh_ptr(const uint8_t *p) { return (uint64_t) p[7] | ((uint64_t) p[6]<<8ULL) | ((uint64_t) p[5]<<16U) | ((uint64_t) p[4]<<24U) | ((uint64_t) p[3]<<32U) | ((uint64_t) p[2]<<40U) | ((uint64_t) p[1]<<48U) | ((uint64_t) p[0]<<56U); }
+
+static inline float be32tofloat_ptr(const uint8_t *p) { return to_float(be32toh_ptr(p)); }
+static inline float be32tofloat_ptr(const uint8_t *p, const uint8_t offset) { return be32tofloat_ptr(&p[offset]); }
+#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+static inline float be64todouble_ptr(const uint8_t *p) { return to_double(be64toh_ptr(p)); }
+static inline float be64todouble_ptr(const uint8_t *p, const uint8_t offset) { return be64todouble_ptr(&p[offset]); }
+#endif
 
 static inline void put_le16_ptr(uint8_t *p, uint16_t v) { p[0] = (v&0xFF); p[1] = (v>>8); }
 static inline void put_le24_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; }

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -526,3 +526,40 @@ int32_t double_to_int32(const double v)
 {
     return int32_t(constrain_double(v, INT32_MIN, UINT32_MAX));
 }
+
+
+int32_t float_to_int32_le(const float& value)
+{
+    int32_t out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}
+
+float int32_to_float_le(const uint32_t& value)
+{
+    float out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}
+
+double uint64_to_double_le(const uint64_t& value)
+{
+    double out;
+    static_assert(sizeof(value) == sizeof(out));
+
+    // Use memcpy because it's the most portable.
+    // It might not be the fastest way on all hardware.
+    // At least it's defined behavior in both c and c++.
+    memcpy(&out, &value, sizeof(out));
+    return out;
+}

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -366,7 +366,7 @@ float fixedwing_turn_rate(float bank_angle_deg, float airspeed);
 float degF_to_Kelvin(float temp_f);
 
 /*
-  conversion functions to prevent undefined behaviour
+  constraining conversion functions to prevent undefined behaviour
  */
 int16_t float_to_int16(const float v);
 uint16_t float_to_uint16(const float v);
@@ -375,3 +375,17 @@ uint32_t float_to_uint32(const float v);
 uint32_t double_to_uint32(const double v);
 int32_t double_to_int32(const double v);
 
+/*
+  Convert from float to int32_t without breaking Wstrict-aliasing due to type punning
+*/
+int32_t float_to_int32_le(const float& value) WARN_IF_UNUSED;
+
+/*
+  Convert from uint32_t to float without breaking Wstrict-aliasing due to type punning
+*/
+float int32_to_float_le(const uint32_t& value) WARN_IF_UNUSED;
+
+/*
+  Convert from uint64_t to double without breaking Wstrict-aliasing due to type punning
+*/
+double uint64_to_double_le(const uint64_t& value) WARN_IF_UNUSED;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3018,8 +3018,8 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     }
 
     // check CRC
-    auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
-    const auto crc = to_int32(hinfo.def_value);
+    const auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
+    const int32_t crc = to_int32(hinfo.def_value);
 
     int32_t current_crc;
     if (load_int32(key, 0, current_crc) && current_crc != crc) {

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3019,7 +3019,7 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
 
     // check CRC
     auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
-    const int32_t crc = *(const int32_t *)(&hinfo.def_value);
+    const auto crc = to_int32(hinfo.def_value);
 
     int32_t current_crc;
     if (load_int32(key, 0, current_crc) && current_crc != crc) {

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3019,7 +3019,7 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
 
     // check CRC
     const auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
-    const int32_t crc = to_int32(hinfo.def_value);
+    const int32_t crc = float_to_int32_le(hinfo.def_value);
 
     int32_t current_crc;
     if (load_int32(key, 0, current_crc) && current_crc != crc) {

--- a/wscript
+++ b/wscript
@@ -143,8 +143,13 @@ def options(opt):
 
     g.add_option('--Werror',
         action='store_true',
-        default=False,
+        default=True,
         help='build with -Werror.')
+
+    g.add_option('--disable-Werror',
+        action='store_true',
+        default=False,
+        help='Disable -Werror.')
     
     g.add_option('--toolchain',
         action='store',
@@ -583,6 +588,12 @@ def configure(cfg):
 
     # Always use system extensions
     cfg.define('_GNU_SOURCE', 1)
+
+    if cfg.options.Werror:
+        if cfg.options.disable_Werror:
+            raise ValueError("Cannot enable and disable Werror at the same time")
+        else:
+            cfg.options.Werror = not cfg.options.disable_Werror
 
     cfg.write_config_header(os.path.join(cfg.variant, 'ap_config.h'), guard='_AP_CONFIG_H_')
 

--- a/wscript
+++ b/wscript
@@ -143,12 +143,12 @@ def options(opt):
 
     g.add_option('--Werror',
         action='store_true',
-        default=True,
+        default=False,
         help='build with -Werror.')
 
     g.add_option('--disable-Werror',
         action='store_true',
-        default=False,
+        default=True,
         help='Disable -Werror.')
     
     g.add_option('--toolchain',

--- a/wscript
+++ b/wscript
@@ -590,10 +590,9 @@ def configure(cfg):
     cfg.define('_GNU_SOURCE', 1)
 
     if cfg.options.Werror:
+        # print(cfg.options.Werror)
         if cfg.options.disable_Werror:
-            raise ValueError("Cannot enable and disable Werror at the same time")
-        else:
-            cfg.options.Werror = not cfg.options.disable_Werror
+            cfg.options.Werror = False
 
     cfg.write_config_header(os.path.join(cfg.variant, 'ap_config.h'), guard='_AP_CONFIG_H_')
 


### PR DESCRIPTION
I removed the type pun warnings plaguing our builds. In addition to work @peterbarker did in #23825, the SITL build now compiles without warnings, so I enabled `Werr` in CI to prevent regressions. 

The approach I took is to use `memcpy`. While type punning via `union` could also work in C, it's undefined behavior in the C++ standard.

I tried enabling `Werr` in other places, but there are more compiler warnings that need solving. They can be dealt with in a follow up PR.

Reference: See the example here for `memcpy`, the usage I switched to is exactly in line with it. 
https://en.cppreference.com/w/cpp/string/byte/memcpy

