### PR TITLE
Trimble GSOF GPS Simulator for SITL

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -13006,6 +13006,7 @@ switch value'''
             (6, "SBP", None, "SBP", 5, 'detected'),
             # (7, "SBP2", 9, "SBP2", 5),  # broken, "waiting for config data"
             (8, "NOVA", 15, "NOVA", 5, 'detected'),  # no attempt to auto-detect this in AP_GPS
+            (11, "GSOF", 11, "GSOF", 5, 'detected'),
             (19, "MSP", 19, "MSP", 32, 'specified'),  # no attempt to auto-detect this in AP_GPS
             # (9, "FILE"),
         ]

--- a/libraries/SITL/SIM_GPS.h
+++ b/libraries/SITL/SIM_GPS.h
@@ -59,7 +59,8 @@ public:
 #endif
         NOVA  =  8,
         SBP2  =  9,
-        MSP  =  19,
+        GSOF  = 11, // matches GPS_TYPE
+        MSP   = 19,
     };
 
     GPS(uint8_t _instance);
@@ -135,6 +136,14 @@ private:
     void nova_send_message(uint8_t *header, uint8_t headerlength, uint8_t *payload, uint8_t payloadlen);
     uint32_t CRC32Value(uint32_t icrc);
     uint32_t CalculateBlockCRC32(uint32_t length, uint8_t *buffer, uint32_t crc);
+
+    // If gsof gets data in, handle it. 
+    // Simply, it should respond to this: https://receiverhelp.trimble.com/oem-gnss/index.html#API_TestingComms.html
+    void on_data_gsof();
+    void update_gsof(const struct gps_data *d);
+    void send_gsof(const uint8_t *buf, const uint16_t size);
+    uint64_t pack_double_into_gsof_packet(const double& src) WARN_IF_UNUSED;
+    uint32_t pack_float_into_gsof_packet(const float& src) WARN_IF_UNUSED;
 
     // get delayed data
     gps_data interpolate_data(const gps_data &d, uint32_t delay_ms);


### PR DESCRIPTION
## Background

Here's the first draft of the GSOF Sim. A few fields aren't done, mainly the bitfields, or fields I don't know how to populate. It does the required data so far.

Tested in GDB, no crashes (yet). This should be a great tool to refactor the GSOF driver and verify it doesn't break anything. 

Doing this testing exposed #23842. There are other vulnerabilities I have found, mainly the `valid` flag is not safe, but nothing to crash it (yet). 

Please provide any initial feedback on any of the TODO's or any other improvements you see.

Thanks to @peterbarker and @tridge for the suggestion to make this; I learned a ton! 

## Testing

1. Use sim_vehicle and set the following params

```
sim_vehicle.py  -v Copter -DG
param set SIM_GPS_TYPE 11
param set GPS_TYPE 11
```

OR, break on the GSOF driver like so:
```
sim_vehicle.py  -v Copter -DGB AP_GPS_GSOF.cpp:324
```

2. Autotest suite
```
 autotest.py build.Copter test.CopterTests2b.MultipleGPS test.CopterTests2b.GPSTypes
```

## Dependencies:

https://github.com/ArduPilot/ardupilot/pull/24525
https://github.com/ArduPilot/ardupilot/pull/23857
