### PR TITLE
Copter: Explicitly state that variable values are not to be used

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -700,7 +700,7 @@ void Mode::land_run_horizontal_control()
 #endif
 
     if (!copter.ap.prec_land_active) {
-        Vector2f accel;
+        Vector2f accel;  // defined but not used in this scope
         pos_control->input_vel_accel_xy(vel_correction, accel);
     }
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -50,8 +50,7 @@ void ModeBrake::run()
     }
 
     // use position controller to stop
-    Vector2f vel;
-    Vector2f accel;
+    Vector2f vel, accel;  // defined but not used in this scope
     pos_control->input_vel_accel_xy(vel, accel);
     pos_control->update_xy_controller();
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -829,7 +829,7 @@ void ModeGuided::pause_control_run()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set the horizontal velocity and acceleration targets to zero
-    Vector2f vel_xy, accel_xy;
+    Vector2f vel_xy, accel_xy;  // defined but not used in this scope
     pos_control->input_vel_accel_xy(vel_xy, accel_xy, false);
 
     // set the vertical velocity and acceleration targets to zero

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -302,7 +302,7 @@ void ModeRTL::descent_run()
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
-    Vector2f accel;
+    Vector2f accel;  // defined but not used in this scope
     pos_control->input_vel_accel_xy(vel_correction, accel);
     pos_control->update_xy_controller();
 

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -185,8 +185,7 @@ void ModeThrow::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // use position controller to stop
-        Vector2f vel;
-        Vector2f accel;
+        Vector2f vel, accel;  // defined but not used in this scope
         pos_control->input_vel_accel_xy(vel, accel);
         pos_control->update_xy_controller();
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -187,8 +187,7 @@ void Mode::auto_takeoff_run()
         }
         pos_control->relax_velocity_controller_xy();
     } else {
-        Vector2f vel;
-        Vector2f accel;
+        Vector2f vel, accel;  // defined but not used in this scope
         pos_control->input_vel_accel_xy(vel, accel);
     }
     pos_control->update_xy_controller();


### PR DESCRIPTION
Explicitly state that the variable is not used by the referent.
Essentially, the created variable is used.
The area of this variable is used by the referenced method.
Since this is different from the basic use, it is clarified in the comment.