### PR TITLE
GCS_MAVLink: Fix for the Gopro/Solo Gimbal issue 

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -73,4 +73,7 @@ private:
     void handle_heartbeat(GCS_MAVLINK &link, const mavlink_message_t &msg);
 
     void send_to_components(const char *pkt, const mavlink_msg_entry_t *entry, uint8_t pkt_len);
+
+    // check for Gopro in Solo gimbal status
+    bool gopro_status_check; // default is none
 };


### PR DESCRIPTION
@rmackay9 @davidbuzz @proficnc This PR replaces the PR https://github.com/ArduPilot/ardupilot/pull/22692 which I accidentally closed last week.
It should work for CubeSolo, CubeGreen and fmuv3 boards when HAL_SOLO_GIMBAL_ENABLED is met and when a Gopro heartbeat is broadcasted. I tested it successfully with AC 4.4beta on a Solo with a CubeSolo board and a non-Solo copter with CubeBlack installed.