### PR TITLE
AP_DroneCAN: Implement opt-in ESC bidirectional support

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -138,7 +138,14 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
     // @Range: 1024 16384
     // @User: Advanced
     AP_GROUPINFO("POOL", 8, AP_DroneCAN, _pool_size, DRONECAN_NODE_POOL_SIZE),
-    
+
+    // @Param: ESC_3D
+    // @DisplayName: ESC channels which support reverse (3D)
+    // @Description: Bitmask with one set for each channel that allows reverse rotation
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16, 16: ESC 17, 17: ESC 18, 18: ESC 19, 19: ESC 20, 20: ESC 21, 21: ESC 22, 22: ESC 23, 23: ESC 24, 24: ESC 25, 25: ESC 26, 26: ESC 27, 27: ESC 28, 28: ESC 29, 29: ESC 30, 30: ESC 31, 31: ESC 32
+    // @User: Advanced
+    AP_GROUPINFO("ESC_3D", 9, AP_DroneCAN, _esc_3d_bm, 0),
+
     AP_GROUPEND
 };
 
@@ -600,6 +607,7 @@ void AP_DroneCAN::SRV_send_himark(void)
 void AP_DroneCAN::SRV_send_esc(void)
 {
     static const int cmd_max = ((1<<13)-1);
+    static const int cmd_min = -(1<<13);
     uavcan_equipment_esc_RawCommand esc_msg;
 
     uint8_t active_esc_num = 0, max_esc_num = 0;
@@ -626,10 +634,17 @@ void AP_DroneCAN::SRV_send_esc(void)
 
         for (uint8_t i = esc_offset; i < max_esc_num && k < 20; i++) {
             if ((((uint32_t) 1) << i) & _esc_bm) {
-                // TODO: ESC negative scaling for reverse thrust and reverse rotation
-                float scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
-
-                scaled = constrain_float(scaled, 0, cmd_max);
+                float scaled;
+                if ((((uint32_t) 1) << i) & _esc_3d_bm) {
+                    // min throttle is cmd_min (-8192), full speed reverse
+                    // mid throttle is 0, stopped
+                    scaled = cmd_max * hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse);
+                    scaled = constrain_float(scaled, cmd_min, cmd_max);
+                } else {
+                    // min throttle is 0, stopped
+                    scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
+                    scaled = constrain_float(scaled, 0, cmd_max);
+                }
 
                 esc_msg.cmd.data[k] = static_cast<int>(scaled);
             } else {
@@ -655,6 +670,7 @@ void AP_DroneCAN::SRV_send_esc(void)
 void AP_DroneCAN::SRV_send_esc_hobbywing(void)
 {
     static const int cmd_max = ((1<<13)-1);
+    static const int cmd_min = -(1<<13);
     com_hobbywing_esc_RawCommand esc_msg;
 
     uint8_t active_esc_num = 0, max_esc_num = 0;
@@ -681,10 +697,17 @@ void AP_DroneCAN::SRV_send_esc_hobbywing(void)
 
         for (uint8_t i = esc_offset; i < max_esc_num && k < 20; i++) {
             if ((((uint32_t) 1) << i) & _esc_bm) {
-                // TODO: ESC negative scaling for reverse thrust and reverse rotation
-                float scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
-
-                scaled = constrain_float(scaled, 0, cmd_max);
+                float scaled;
+                if ((((uint32_t) 1) << i) & _esc_3d_bm) {
+                    // min throttle is cmd_min (-8192), full speed reverse
+                    // mid throttle is 0, stopped
+                    scaled = cmd_max * hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse);
+                    scaled = constrain_float(scaled, cmd_min, cmd_max);
+                } else {
+                    // min throttle is 0, stopped
+                    scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
+                    scaled = constrain_float(scaled, 0, cmd_max);
+                }
 
                 esc_msg.command.data[k] = static_cast<int>(scaled);
             } else {

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -180,6 +180,7 @@ private:
     AP_Int8 _dronecan_node;
     AP_Int32 _servo_bm;
     AP_Int32 _esc_bm;
+    AP_Int32 _esc_3d_bm;
     AP_Int8 _esc_offset;
     AP_Int16 _servo_rate_hz;
     AP_Int16 _options;

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -118,6 +118,7 @@ public:
         SEND_GNSS                 = (1U<<5),
         USE_HIMARK_SERVO          = (1U<<6),
         USE_HOBBYWING_ESC         = (1U<<7),
+        DISABLE_ESC_WHEN_DISARMED = (1U<<8),
     };
 
     // check if a option is set
@@ -206,7 +207,8 @@ private:
     uint32_t _srv_send_count;
     uint32_t _fail_send_count;
 
-    uint8_t _SRV_armed;
+    bool _SRV_safety_off;
+    bool _SRV_armed;
     uint32_t _SRV_last_send_us;
     HAL_Semaphore SRV_sem;
 

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -139,17 +139,26 @@ public:
       microseconds, and represent minimum and maximum PWM values which
       will be used to convert channel writes into a percentage
      */
-    virtual void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) {}
+    virtual void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) {
+        _esc_pwm_min = min_pwm;
+        _esc_pwm_max = max_pwm;
+    }
 
     /*
       return ESC scaling value from set_esc_scaling()
      */
-    virtual bool     get_esc_scaling(uint16_t &min_pwm, uint16_t &max_pwm) { return false; }
-    
+    virtual bool     get_esc_scaling(uint16_t &min_pwm, uint16_t &max_pwm) {
+        min_pwm = _esc_pwm_min;
+        max_pwm = _esc_pwm_max;
+        return true;
+    }
+
     /*
       returns the pwm value scaled to [-1;1] regrading to set_esc_scaling ranges range without constraints.
      */
-    virtual float    scale_esc_to_unity(uint16_t pwm) { return 0; }
+    virtual float    scale_esc_to_unity(uint16_t pwm) {
+        return 2.0 * ((float) pwm - _esc_pwm_min) / (_esc_pwm_max - _esc_pwm_min) - 1.0;
+    }
 
     /*
       return the erpm and error rate for a channel if available
@@ -399,4 +408,7 @@ protected:
     // helper functions for implementation of get_output_mode_banner
     void append_to_banner(char banner_msg[], uint8_t banner_msg_len, output_mode out_mode, uint8_t low_ch, uint8_t high_ch) const;
     const char* get_output_mode_string(enum output_mode out_mode) const;
+
+    uint16_t _esc_pwm_min;
+    uint16_t _esc_pwm_max;
 };

--- a/libraries/AP_HAL/utility/RCOutput_Tap.h
+++ b/libraries/AP_HAL/utility/RCOutput_Tap.h
@@ -66,11 +66,6 @@ public:
     uint16_t read(uint8_t ch) override;
     void read(uint16_t *period_us, uint8_t len) override;
 
-    void set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override {
-        _esc_pwm_min = min_pwm;
-        _esc_pwm_max = max_pwm;
-    }
-
     void cork() override;
     void push() override;
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -51,15 +51,6 @@ public:
     void     read(uint16_t* period_us, uint8_t len) override;
     uint16_t read_last_sent(uint8_t ch) override;
     void     read_last_sent(uint16_t* period_us, uint8_t len) override;
-    void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override {
-        _esc_pwm_min = min_pwm;
-        _esc_pwm_max = max_pwm;
-    }
-    bool     get_esc_scaling(uint16_t &min_pwm, uint16_t &max_pwm) override {
-        min_pwm = _esc_pwm_min;
-        max_pwm = _esc_pwm_max;
-        return true;
-    }
     // surface dshot telemetry for use by the harmonic notch and status information
 #ifdef HAL_WITH_BIDIR_DSHOT
     uint16_t get_erpm(uint8_t chan) const override { return _bdshot.erpm[chan]; }
@@ -74,10 +65,6 @@ public:
      * return mask of channels that must be disabled because they share a group with a digital channel
      */
     uint32_t get_disabled_channels(uint32_t digital_mask) override;
-
-    float scale_esc_to_unity(uint16_t pwm) override {
-        return 2.0 * ((float) pwm - _esc_pwm_min) / (_esc_pwm_max - _esc_pwm_min) - 1.0;
-    }
 
     void     cork(void) override;
     void     push(void) override;
@@ -470,8 +457,6 @@ private:
 
     static pwm_group pwm_group_list[];
     static const uint8_t NUM_GROUPS;
-    uint16_t _esc_pwm_min;
-    uint16_t _esc_pwm_max;
 
     // offset of first local channel
     uint8_t chan_offset;

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -427,12 +427,6 @@ void RCOutput_Bebop::read(uint16_t* period_us, uint8_t len)
     }
 }
 
-void RCOutput_Bebop::set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm)
-{
-    _min_pwm = min_pwm;
-    _max_pwm = max_pwm;
-}
-
 /* Separate thread to handle the Bebop motors controller */
 void* RCOutput_Bebop::_control_thread(void *arg) {
     RCOutput_Bebop* rcout = (RCOutput_Bebop *) arg;

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -71,7 +71,6 @@ public:
     void     push() override;
     uint16_t read(uint8_t ch) override;
     void     read(uint16_t* period_us, uint8_t len) override;
-    void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override;
     int      read_obs_data(BebopBLDC_ObsData &data);
     void     play_note(uint8_t pwm, uint16_t period_us, uint16_t duration_ms);
 

--- a/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
@@ -106,11 +106,5 @@ void RCOutput_Disco::push(void)
     sysfs_out.push();
     bebop_out.push();
 }
-
-void RCOutput_Disco::set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm)
-{
-    sysfs_out.set_esc_scaling(min_pwm, max_pwm);
-    bebop_out.set_esc_scaling(min_pwm, max_pwm);
-}
     
 }

--- a/libraries/AP_HAL_Linux/RCOutput_Disco.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Disco.h
@@ -29,7 +29,6 @@ public:
     void read(uint16_t *period_us, uint8_t len) override;
     void cork() override;
     void push() override;
-    void set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override;
 
 private:
     // Disco RC output combines methods from Sysfs and Bebop


### PR DESCRIPTION
I can't quite believe that CAN ESCs have gone this long without reverse support, but I found this out the hard way on my rover (using [VESC](https://vesc-project.com/) hardware in UAVCAN mode) when the motors spun up to half speed at neutral throttle.

After a bit of digging I found the TODO and fixed it, but made it opt-in in through a new parameter given most CAN ESC users are presumably mapped into forward mode only.

I'm sure it's not lost on you guys that there's separate ways to configure reverse support in PWM, DSHOT and now CAN (and probably others). A generic way based on the servo output index might be nicer at some point?

I've also switched the code away from using `hal.rcout->scale_esc_to_unity` to reading the normalised value through `SRV_Channel` instead. There's probably a subtle difference there because I suspect the HAL one is hardwired to interpreting the pulse within a 1000 to 2000 range. At any rate there's only two places in the code calling `scale_esc_to_unity` now, and it wasn't implemented for `AP_HAL_Linux` (I'm on Beaglebone Blue) so it wasn't going to work for me anyway as it was.

I'm also still tracking down why exactly an ESC "zero" throttle command is sent to my ESC before arming, which is quite hazardous if the zero throttle sent is nowhere near zero for the ESC! It looks like the intention of the code is to send no ESC commands until the vehicle is armed, and certainly for VESC hardware no CAN command for 1 second is taken as a signal to disarm the motor, while a zero throttle will brake, which isn't quite the same thing. I'll update this if I discover a bug exists.

**Edit:**

Have reverted to using `scale_esc_to_unity` again as per comments below, but have made it work on all HALs.

Also found that the output check for `SRV_armed` was actually checking safety switch only. Have added optional checking of arming status to fix this, but only for ESCs, to behave like `MOT_SAFE_DISARM`.