### PR TITLE
Constexpr math conversions for double rad/deg conversions

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -305,8 +305,8 @@ AP_GPS_GSOF::process_message(void)
             else if (output_type == 2) // position
             {
                 // This packet is not documented in Trimble's receiver help as of May 18, 2023
-                state.location.lat = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(msg.data, a)) * (double)1e7);
-                state.location.lng = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(msg.data, a + 8)) * (double)1e7);
+                state.location.lat = (int32_t)(rad_to_deg_double(SwapDouble(msg.data, a)) * (double)1e7);
+                state.location.lng = (int32_t)(rad_to_deg_double(SwapDouble(msg.data, a + 8)) * (double)1e7);
                 state.location.alt = (int32_t)(SwapDouble(msg.data, a + 16) * 100);
 
                 state.last_gps_time_ms = AP_HAL::millis();

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -20,7 +20,9 @@
 
 #include "AP_GPS.h"
 #include "AP_GPS_SBF.h"
+#include "AP_Math/AP_Math.h"
 #include <GCS_MAVLink/GCS.h>
+
 #include <AP_InternalError/AP_InternalError.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -413,8 +415,8 @@ AP_GPS_SBF::process_message(void)
 
         // Update position state (don't use -2·10^10)
         if (temp.Latitude > -200000) {
-            state.location.lat = (int32_t)(temp.Latitude * RAD_TO_DEG_DOUBLE * (double)1e7);
-            state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * (double)1e7);
+            state.location.lat = (int32_t)(rad_to_deg_double(temp.Latitude) * (double)1e7);
+            state.location.lng = (int32_t)(rad_to_deg_double(temp.Longitude) * (double)1e7);
             state.location.alt = (int32_t)(((float)temp.Height - temp.Undulation) * 1e2f);
             state.have_undulation = true;
             state.undulation = temp.Undulation;

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -528,8 +528,8 @@ void SITL_State::_output_to_flightgear(void)
 
     fdm.version = 0x18;
     fdm.padding = 0;
-    fdm.longitude = DEG_TO_RAD_DOUBLE*sfdm.longitude;
-    fdm.latitude = DEG_TO_RAD_DOUBLE*sfdm.latitude;
+    fdm.longitude = deg_to_rad_double(sfdm.longitude);
+    fdm.latitude = deg_to_rad_double(sfdm.latitude);
     fdm.altitude = sfdm.altitude;
     fdm.agl = sfdm.altitude;
     fdm.phi   = radians(sfdm.rollDeg);

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -210,26 +210,26 @@ inline double constrain_double(const double amt, const double low, const double 
 }
 
 // degrees -> radians
-static inline constexpr ftype radians(ftype deg)
+static inline constexpr ftype radians(const ftype deg)
 {
     return deg * DEG_TO_RAD;
 }
 
 // radians -> degrees
-static inline constexpr float degrees(float rad)
+static inline constexpr float degrees(const float rad)
 {
     return rad * RAD_TO_DEG;
 }
 
 #ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
 // degrees -> radians
-static inline constexpr double deg_to_rad_double(double deg)
+static inline constexpr double deg_to_rad_double(const double deg)
 {
     return deg * DEG_TO_RAD_DOUBLE;
 }
 
 // radians -> degrees
-static inline constexpr double rad_to_deg_double(double rad)
+static inline constexpr double rad_to_deg_double(const double rad)
 {
     return rad * RAD_TO_DEG_DOUBLE;
 }

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -221,6 +221,20 @@ static inline constexpr float degrees(float rad)
     return rad * RAD_TO_DEG;
 }
 
+#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+// degrees -> radians
+static inline constexpr double deg_to_rad_double(double deg)
+{
+    return deg * DEG_TO_RAD_DOUBLE;
+}
+
+// radians -> degrees
+static inline constexpr double rad_to_deg_double(double rad)
+{
+    return rad * RAD_TO_DEG_DOUBLE;
+}
+#endif
+
 template<typename T>
 ftype sq(const T val)
 {

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -37,7 +37,10 @@ static constexpr float RAD_TO_DEG = 180.0f / M_PI;
 // The precision here does matter when using the wsg* functions for converting
 // between LLH and ECEF coordinates.
 #ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
-static constexpr double DEG_TO_RAD_DOUBLE = asin(1) / 90;
+// Constants taken from <numbers> available in C++20
+// https://en.cppreference.com/w/cpp/numeric/constants
+static constexpr double M_PI_DOUBLE = 3.141592653589793238462643383279502884L; 
+static constexpr double DEG_TO_RAD_DOUBLE = M_PI_DOUBLE / 90;
 static constexpr double RAD_TO_DEG_DOUBLE = 1 / DEG_TO_RAD_DOUBLE;
 #endif
 

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -7,16 +7,16 @@
 #ifdef M_PI
 # undef M_PI
 #endif
-#define M_PI      (3.141592653589793)
+static constexpr float M_PI = 3.141592653589793f;
 
 #ifdef M_PI_2
 # undef M_PI_2
 #endif
-#define M_PI_2    (M_PI / 2)
+static constexpr float M_PI_2 = M_PI / 2;
 
 #define M_GOLDEN  1.6180339f
 
-#define M_2PI         (M_PI * 2)
+static constexpr float M_2PI  = M_PI * 2;
 
 // MATH_CHECK_INDEXES modifies some objects (e.g. SoloGimbalEKF) to
 // include more debug information.  It is also used by some functions
@@ -27,8 +27,8 @@
   #define MATH_CHECK_INDEXES 0
 #endif
 
-#define DEG_TO_RAD      (M_PI / 180.0f)
-#define RAD_TO_DEG      (180.0f / M_PI)
+static constexpr float DEG_TO_RAD = M_PI / 180.0f;
+static constexpr float RAD_TO_DEG = 180.0f / M_PI;
 
 // Centi-degrees to radians
 #define DEGX100 5729.57795f
@@ -37,8 +37,8 @@
 // The precision here does matter when using the wsg* functions for converting
 // between LLH and ECEF coordinates.
 #ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
-static const double DEG_TO_RAD_DOUBLE = asin(1) / 90;
-static const double RAD_TO_DEG_DOUBLE = 1 / DEG_TO_RAD_DOUBLE;
+static constexpr double DEG_TO_RAD_DOUBLE = asin(1) / 90;
+static constexpr double RAD_TO_DEG_DOUBLE = 1 / DEG_TO_RAD_DOUBLE;
 #endif
 
 #define RadiansToCentiDegrees(x) (static_cast<float>(x) * RAD_TO_DEG * static_cast<float>(100))

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -242,14 +242,12 @@ static void test_wrap_cd(void)
 static void test_wgs_conversion_functions(void)
 {
 
-    #define D2R DEG_TO_RAD_DOUBLE
-
     /* Maximum allowable error in quantities with units of length (in meters). */
     static const double MAX_DIST_ERROR_M = 1e-6;
     /* Maximum allowable error in quantities with units of angle (in sec of arc).
      * 1 second of arc on the equator is ~31 meters. */
     static const double MAX_ANGLE_ERROR_SEC = 1e-7;
-    static const double MAX_ANGLE_ERROR_RAD = (MAX_ANGLE_ERROR_SEC * (D2R / (double)3600.0));
+    static const double MAX_ANGLE_ERROR_RAD = (MAX_ANGLE_ERROR_SEC * (DEG_TO_RAD / (double)3600.0));
 
     /* Semi-major axis. */
     static const double EARTH_A = 6378137.0;
@@ -259,16 +257,16 @@ static void test_wgs_conversion_functions(void)
 
     #define NUM_COORDS 10
     Vector3d llhs[NUM_COORDS];
-    llhs[0] = Vector3d(0, 0, 0);        /* On the Equator and Prime Meridian. */
-    llhs[1] = Vector3d(0, 180*D2R, 0);  /* On the Equator. */
-    llhs[2] = Vector3d(0, 90*D2R, 0);   /* On the Equator. */
-    llhs[3] = Vector3d(0, -90*D2R, 0);  /* On the Equator. */
-    llhs[4] = Vector3d(90*D2R, 0, 0);   /* North pole. */
-    llhs[5] = Vector3d(-90*D2R, 0, 0);  /* South pole. */
-    llhs[6] = Vector3d(90*D2R, 0, 22);  /* 22m above the north pole. */
-    llhs[7] = Vector3d(-90*D2R, 0, 22); /* 22m above the south pole. */
-    llhs[8] = Vector3d(0, 0, 22);       /* 22m above the Equator and Prime Meridian. */
-    llhs[9] = Vector3d(0, 180*D2R, 22); /* 22m above the Equator. */
+    llhs[0] = Vector3d(0, 0, 0);           /* On the Equator and Prime Meridian. */
+    llhs[1] = Vector3d(0, M_PI_2, 0);     /* On the Equator. */
+    llhs[2] = Vector3d(0, M_PI_2/2, 0);   /* On the Equator. */
+    llhs[3] = Vector3d(0, -M_PI_2/2, 0);  /* On the Equator. */
+    llhs[4] = Vector3d(M_PI_2/2, 0, 0);   /* North pole. */
+    llhs[5] = Vector3d(-M_PI_2/2, 0, 0);  /* South pole. */
+    llhs[6] = Vector3d(M_PI_2/2, 0, 22);  /* 22m above the north pole. */
+    llhs[7] = Vector3d(-M_PI_2/2, 0, 22); /* 22m above the south pole. */
+    llhs[8] = Vector3d(0, 0, 22);         /* 22m above the Equator and Prime Meridian. */
+    llhs[9] = Vector3d(0, M_PI_2, 22);    /* 22m above the Equator. */
 
     Vector3d ecefs[NUM_COORDS];
     ecefs[0] = Vector3d(EARTH_A, 0, 0);


### PR DESCRIPTION
While working on debugging the GSOF floating point exceptions, I could not debug the macros in GDB. In a quick test, switching to constexpr changed that, so I added constexpr double support for the radians to degrees conversions. 

I also did some research [here](https://sourceware.org/gdb/onlinedocs/gdb/Macros.html): `You may need to compile your program specially to provide GDB with information about preprocessor macros. Most compilers do not include macros in their debugging information, even when you compile with the -g flag.` 

Given the two options of modifying the build system or using constexpr, and the additional benefits of constexpr in terms of compile-time safety compared to macros, I chose to fix this issue by making  deg/rad conversions constexpr. 

See the picture at the end
https://github.com/ArduPilot/ardupilot/pull/23843#issuecomment-1558598144

Since constexpr provides compile-time length checking, this provides a clear advantage. I followed the given pattern for where to put the conversion functions, and replaced usage of the macro ratio with the new function, which is similar to the current float implementation. 

Based on recommendations in other PR's against overloading operations like these due to potential for expensive and implicit widening, I also named the function differently. 