### PR TITLE
Feature/coverage up

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Configure CAN
         if: ${{ matrix.config == 'sitltest-can'}}
         run: |
-          sudo apt update
-          sudo apt -y linux-modules-extra-$(uname -r)
+          sudo apt-get update
+          sudo apt-get -y install can-utils iproute2 linux-modules-extra-$(uname -r)
           sudo modprobe vcan
           sudo ip link add dev vcan0 type vcan
           sudo ip link set up vcan0

--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -228,6 +228,7 @@ class CoverageRunner(object):
                                     root_dir + "/modules/gtest/*",
                                     root_dir + "/modules/DroneCAN/libcanard/*",
                                     root_dir + "/build/linux/libraries/*",
+                                    root_dir + "/build/linux/modules/*",
                                     root_dir + "/build/sitl/libraries/*",
                                     root_dir + "/build/sitl/modules/*",
                                     root_dir + "/build/sitl_periph_gps/libraries/*",

--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -24,7 +24,7 @@ root_dir = os.path.realpath(os.path.join(tools_dir, '../..'))
 class CoverageRunner(object):
     """Coverage Runner Class."""
 
-    def __init__(self, verbose=False, check_tests=True):
+    def __init__(self, verbose=False, check_tests=True) -> None:
         """Set the files Path."""
         self.REPORT_DIR = os.path.join(root_dir, "reports/lcov-report")
         self.INFO_FILE = os.path.join(root_dir, self.REPORT_DIR, "lcov.info")
@@ -37,13 +37,13 @@ class CoverageRunner(object):
         self.check_tests = check_tests
         self.start_time = time.time()
 
-    def progress(self, text):
+    def progress(self, text) -> None:
         """Pretty printer."""
         delta_time = time.time() - self.start_time
         formatted_text = "****** AT-%06.1f: %s" % (delta_time, text)
         print(formatted_text)
 
-    def init_coverage(self, use_example=False):
+    def init_coverage(self, use_example=False) -> None:
         """Initialize ArduPilot for coverage.
 
         This needs to be run with the binaries built.
@@ -64,6 +64,7 @@ class CoverageRunner(object):
         binaries_dir = os.path.join(root_dir, 'build/sitl/bin')
         dirs_to_check = [["binaries", binaries_dir], ["tests", os.path.join(root_dir, 'build/linux/tests')]]
         if use_example:
+            self.progress("Adding examples")
             dirs_to_check.append(["examples", os.path.join(root_dir, 'build/linux/examples')])
         for dirc in dirs_to_check:
             if not (self.check_build(dirc[0], dirc[1])):
@@ -98,7 +99,7 @@ class CoverageRunner(object):
             exit(1)
         self.progress("Initialization done")
 
-    def check_build(self, name, path):
+    def check_build(self, name, path) -> bool:
         """Check that build directory is not empty and that binaries are built with the coverage flags."""
         self.progress("Checking that %s are set up and built" % name)
         if os.path.exists(path):
@@ -114,7 +115,7 @@ class CoverageRunner(object):
             self.progress("%s was't built with coverage support" % name)
             return False
 
-    def run_build(self, use_example=False):
+    def run_build(self, use_example=False) -> None:
         """Clean the build directory and build binaries for coverage."""
 
         os.chdir(root_dir)
@@ -127,6 +128,7 @@ class CoverageRunner(object):
 
         try:
             if use_example:
+                self.progress("Building examples")
                 subprocess.run([waf_light, "configure", "--board=linux", "--debug", "--coverage"], check=True)
                 subprocess.run([waf_light, "examples"], check=True)
             subprocess.run(
@@ -144,7 +146,7 @@ class CoverageRunner(object):
             exit(1)
         self.progress("Build examples and vehicle binaries done !")
 
-    def run_full(self, use_example=False):
+    def run_full(self, use_example=False) -> None:
         """Run full coverage on maximum of ArduPilot binaries and test functions."""
         self.progress("Running full test suite...")
         self.run_build()
@@ -158,6 +160,7 @@ class CoverageRunner(object):
             subprocess.run([self.autotest,
                             "--timeout=" + str(TIMEOUT),
                             "--debug",
+                            "--coverage",
                             "--no-clean",
                             "--speedup=" + str(SPEEDUP),
                             "run.examples"], check=self.check_tests)
@@ -183,7 +186,7 @@ class CoverageRunner(object):
         # used code, can we run other tests or things?  Replay, perhaps?
         self.update_stats()
 
-    def update_stats(self):
+    def update_stats(self) -> None:
         """Update Coverage statistics only.
 
         Assumes that coverage tests have been run.
@@ -277,6 +280,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Runs tests with gcov coverage support.')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Output everything on terminal.')
+    parser.add_argument('-c', '--no-check-tests', action='store_true',
+                        help='Do not fail if tests do not run.')
+    parser.add_argument('--add-examples', action='store_true',
+                        help='Add examples to coverage.')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-i', '--init', action='store_true',
                        help='Initialise ArduPilot for coverage. It should be run after building the binaries.')
@@ -286,20 +293,17 @@ if __name__ == '__main__':
                        help='Clean the build directory and build binaries for coverage.')
     group.add_argument('-u', '--update', action='store_true',
                        help='Update coverage statistics. To be used after running some tests.')
-    group.add_argument('-c', '--no-check-tests', action='store_true',
-                       help='Do not fail if tests do not run.')
-
     args = parser.parse_args()
 
     runner = CoverageRunner(verbose=args.verbose, check_tests=not args.no_check_tests)
     if args.init:
-        runner.init_coverage()
+        runner.init_coverage(args.add_examples)
         sys.exit(0)
     if args.full:
-        runner.run_full()
+        runner.run_full(args.add_examples)
         sys.exit(0)
     if args.build:
-        runner.run_build()
+        runner.run_build(args.add_examples)
         sys.exit(0)
     if args.update:
         runner.update_stats()

--- a/libraries/AP_Math/tests/test_rotations.cpp
+++ b/libraries/AP_Math/tests/test_rotations.cpp
@@ -1,0 +1,193 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/AP_Math.h>
+#include <AP_CustomRotations/AP_CustomRotations.h>
+
+
+AP_CustomRotations cust_rot;
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+
+static void test_euler(enum Rotation rotation, float roll, float pitch, float yaw)
+{
+    Vector3f v, v1, v2, diff;
+    Matrix3f rotmat;
+    const float accuracy = 1.0e-6f;
+
+    v.x = 1;
+    v.y = 2;
+    v.z = 3;
+    v1 = v;
+
+    v1.rotate(rotation);
+
+    rotmat.from_euler(radians(roll), radians(pitch), radians(yaw));
+    v2 = v;
+    v2 = rotmat * v2;
+
+    diff = (v2 - v1);
+    EXPECT_LE(diff.length(), accuracy);
+
+    // quaternion rotation test
+    const float q_accuracy = 1.0e-3f;
+    Quaternion q, qe;
+    q.from_rotation(rotation);
+    qe.from_euler(radians(roll), radians(pitch), radians(yaw));
+    float q_roll, q_pitch, q_yaw, qe_roll, qe_pitch, qe_yaw;
+    q.to_euler(q_roll, q_pitch, q_yaw);
+    qe.to_euler(qe_roll, qe_pitch, qe_yaw);
+    float roll_diff = fabsf(wrap_PI(q_roll - qe_roll));
+    float pitch_diff = fabsf(wrap_PI(q_pitch - qe_pitch));
+    float yaw_diff = fabsf(wrap_PI(q_yaw - qe_yaw));
+    EXPECT_LE(roll_diff, q_accuracy);
+    EXPECT_LE(pitch_diff, q_accuracy);
+    EXPECT_LE(yaw_diff, q_accuracy);
+
+    // test custom rotations
+    AP::custom_rotations().set(ROTATION_CUSTOM_1, roll, pitch, yaw);
+    v1 = v;
+    v1.rotate(ROTATION_CUSTOM_1);
+
+    diff = (v2 - v1);
+    EXPECT_LE(diff.length(), accuracy);
+
+    Quaternion qc;
+    qc.from_rotation(ROTATION_CUSTOM_1);
+    float qc_roll, qc_pitch, qc_yaw;
+    qc.to_euler(qc_roll, qc_pitch, qc_yaw);
+    roll_diff = fabsf(wrap_PI(qc_roll - qe_roll));
+    pitch_diff = fabsf(wrap_PI(qc_pitch - qe_pitch));
+    yaw_diff = fabsf(wrap_PI(qc_yaw - qe_yaw));
+    EXPECT_LE(roll_diff, q_accuracy);
+    EXPECT_LE(pitch_diff, q_accuracy);
+    EXPECT_LE(yaw_diff, q_accuracy);
+}
+
+TEST(RotationsTest, TestEulers)
+{
+    test_euler(ROTATION_NONE,               0,   0,   0);
+    test_euler(ROTATION_YAW_45,             0,   0,  45);
+    test_euler(ROTATION_YAW_90,             0,   0,  90);
+    test_euler(ROTATION_YAW_135,            0,   0, 135);
+    test_euler(ROTATION_YAW_180,            0,   0, 180);
+    test_euler(ROTATION_YAW_225,            0,   0, 225);
+    test_euler(ROTATION_YAW_270,            0,   0, 270);
+    test_euler(ROTATION_YAW_315,            0,   0, 315);
+    test_euler(ROTATION_ROLL_180,         180,   0,   0);
+    test_euler(ROTATION_ROLL_180_YAW_45,  180,   0,  45);
+    test_euler(ROTATION_ROLL_180_YAW_90,  180,   0,  90);
+    test_euler(ROTATION_ROLL_180_YAW_135, 180,   0, 135);
+    test_euler(ROTATION_PITCH_180,          0, 180,   0);
+    test_euler(ROTATION_ROLL_180_YAW_225, 180,   0, 225);
+    test_euler(ROTATION_ROLL_180_YAW_270, 180,   0, 270);
+    test_euler(ROTATION_ROLL_180_YAW_315, 180,   0, 315);
+    test_euler(ROTATION_ROLL_90,           90,   0,   0);
+    test_euler(ROTATION_ROLL_90_YAW_45,    90,   0,  45);
+    test_euler(ROTATION_ROLL_90_YAW_90,    90,   0,  90);
+    test_euler(ROTATION_ROLL_90_YAW_135,   90,   0, 135);
+    test_euler(ROTATION_ROLL_270,         270,   0,   0);
+    test_euler(ROTATION_ROLL_270_YAW_45,  270,   0,  45);
+    test_euler(ROTATION_ROLL_270_YAW_90,  270,   0,  90);
+    test_euler(ROTATION_ROLL_270_YAW_135, 270,   0, 135);
+    test_euler(ROTATION_PITCH_90,           0,  90,   0);
+    test_euler(ROTATION_PITCH_270,          0, 270,   0);
+    test_euler(ROTATION_PITCH_180_YAW_90,   0, 180,  90);
+    test_euler(ROTATION_PITCH_180_YAW_270,  0, 180, 270);
+    test_euler(ROTATION_ROLL_90_PITCH_90,  90,  90,   0);
+    test_euler(ROTATION_ROLL_180_PITCH_90,180,  90,   0);
+    test_euler(ROTATION_ROLL_270_PITCH_90,270,  90,   0);
+    test_euler(ROTATION_ROLL_90_PITCH_180, 90, 180,   0);
+    test_euler(ROTATION_ROLL_270_PITCH_180,270,180,   0);
+    test_euler(ROTATION_ROLL_90_PITCH_270, 90, 270,   0);
+    test_euler(ROTATION_ROLL_180_PITCH_270,180,270,   0);
+    test_euler(ROTATION_ROLL_270_PITCH_270,270,270,   0);
+    test_euler(ROTATION_ROLL_90_PITCH_180_YAW_90, 90, 180,  90);
+    test_euler(ROTATION_ROLL_90_YAW_270,   90,   0, 270);
+    test_euler(ROTATION_ROLL_90_PITCH_68_YAW_293,90,68.8,293.3);
+    test_euler(ROTATION_ROLL_45,45,0,0);
+    test_euler(ROTATION_ROLL_315,315,0,0);
+    test_euler(ROTATION_PITCH_7, 0, 7, 0);
+}
+
+
+TEST(RotationsTest, TestRotationInverse)
+{
+    // rotate inverse test(Vector (1,1,1))
+    Vector3f vec(1.0f,1.0f,1.0f), cmp_vec(1.0f, 1.0f, 1.0f);
+    for (enum Rotation r = ROTATION_NONE;
+         r < ROTATION_MAX;
+         r = (enum Rotation)((uint8_t)r+1)) {
+        vec.rotate(r);
+        vec.rotate_inverse(r);
+        EXPECT_LE((vec - cmp_vec).length(), 1e-5);
+    }
+}
+
+TEST(RotationsTest, TestRotateMatrix)
+{
+    for (enum Rotation r = ROTATION_NONE;
+         r < ROTATION_MAX;
+         r = (enum Rotation)((uint8_t)r+1)) {
+        Vector3f vec(1,2,3);
+        Vector3f vec2 = vec;
+        vec.rotate(r);
+        Matrix3f m;
+        m.from_rotation(r);
+        vec2 = m * vec2;
+        EXPECT_LE((vec - vec2).length(), 1e-5);
+    }
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+TEST(RotationsTest, TestFailedGetLinux)
+{
+    AP::custom_rotations().set(ROTATION_CUSTOM_OLD, 0, 0, 0);
+    Vector3f vec(1,2,3);
+    Vector3f vec2 = vec;
+    AP::custom_rotations().rotate(ROTATION_CUSTOM_OLD, vec2);
+    EXPECT_TRUE(vec == vec2);
+    Vector3d vecd(1,2,3);
+    Vector3d vecd2 = vecd;
+    AP::custom_rotations().rotate(ROTATION_CUSTOM_OLD, vecd2);
+    EXPECT_TRUE(vecd == vecd2);
+    Quaternion q(1.0f, 0.0f, 0.0f, 0.0f);
+    Quaternion q2(1.0f, 0.0f, 0.0f, 0.0f);
+    AP::custom_rotations().from_rotation(ROTATION_CUSTOM_OLD, q2);
+    for (int a = 0; a < 4; ++a) {
+        EXPECT_FLOAT_EQ(q[a], q2[a]);
+    }
+    QuaternionD qd(1.0, 0.0, 0.0, 0.0);
+    QuaternionD qd2(1.0, 0.0, 0.0, 0.0);
+    AP::custom_rotations().from_rotation(ROTATION_CUSTOM_OLD, qd2);
+    for (int a = 0; a < 4; ++a) {
+        EXPECT_FLOAT_EQ(qd[a], qd2[a]);
+    }
+}
+#endif
+
+static void breakSingleton()
+{
+    AP_CustomRotations cust_rot1;
+}
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+TEST(RotationsTest, TestFailedGetLinux)
+{
+    EXPECT_EXIT(AP::custom_rotations().set(ROTATION_CUSTOM_OLD, 0, 0, 0), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
+    EXPECT_EXIT(AP::custom_rotations().set(ROTATION_CUSTOM_END, 0, 0, 0), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
+    EXPECT_EXIT(breakSingleton(), testing::KilledBySignal(SIGABRT), "AP_CustomRotations must be singleton");
+}
+#endif
+
+/*TEST(RotationsTest, TestRotateEqual)
+{
+    for (enum Rotation r = (enum Rotation)((uint8_t)ROTATION_MAX-1); r > ROTATION_NONE; r = (enum Rotation)((uint8_t)r-1)) {
+        for (enum Rotation r2 = ROTATION_NONE; r2 < r; r2 = (enum Rotation)((uint8_t)r2+1)) {
+            if (rotation_equal(r,r2)) {
+                hal.console->printf("Rotation %i same as %i\n", r, r2);
+            }
+        }
+    }
+}*/
+
+AP_GTEST_PANIC()
+AP_GTEST_MAIN()


### PR DESCRIPTION
Fix coverage run for periph testing
add a bit of typing on run_coverage.py
add option to use examples on coverage (still broken)
remove /build/linux/modules/ from coverage stats
add test_rotations to test AP_CustomRotations

result build at https://github.com/khancyr/ardupilot/actions/runs/5062423974 : periph coverage is building now