### PR TITLE
Copter: Prevent position controller madness caused by bad MAVLink input

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -55,6 +55,11 @@ protected:
 
 private:
 
+    // sanity check velocity or acceleration vector components are numbers
+    // (e.g. not NaN) and below 1000. vec argument units are in meters/second or
+    // metres/second/second
+    bool sane_vel_or_acc_vector(const Vector3f &vec) const;
+
     MISSION_STATE mission_state(const class AP_Mission &mission) const override;
 
     void handleMessage(const mavlink_message_t &msg) override;

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9653,6 +9653,7 @@ class AutoTestCopter(AutoTest):
              self.SetpointGlobalPos,
              self.ThrowDoubleDrop,
              self.SetpointGlobalVel,
+             self.SetpointBadVel,
              self.SplineTerrain,
              self.TakeoffCheck,
         ])

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -10595,6 +10595,78 @@ Also, ignores heartbeats not from our target system'''
         self.do_RTL(distance_min=0, distance_max=wp_accuracy)
         self.disarm_vehicle()
 
+    def SetpointBadVel(self, timeout=30):
+        '''try feeding in a very, very bad velocity and make sure it is ignored'''
+        self.takeoff(mode='GUIDED')
+        # following values from a real log:
+        target_speed = Vector3(-3.6019095525029597e+30,
+                               1.7796490496925177e-41,
+                               3.0557017120313744e-26)
+
+        self.progress("Feeding in bad global data, hoping we don't move")
+
+        def send_speed_vector_global_int(vector , mav_frame):
+            self.mav.mav.set_position_target_global_int_send(
+                0,  # timestamp
+                self.sysid_thismav(),  # target system_id
+                1,  # target component id
+                mav_frame,
+                MAV_POS_TARGET_TYPE_MASK.POS_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.ACC_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE,
+                0,
+                0,
+                0,
+                vector.x,  # vx
+                vector.y,  # vy
+                vector.z,  # vz
+                0,  # afx
+                0,  # afy
+                0,  # afz
+                0,  # yaw
+                0,  # yawrate
+            )
+        self.wait_speed_vector(
+            Vector3(0, 0, 0),
+            timeout=timeout,
+            called_function=lambda plop, empty: send_speed_vector_global_int(target_speed, mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT),  # noqa
+            minimum_duration=10
+        )
+
+        self.progress("Feeding in bad local data, hoping we don't move")
+
+        def send_speed_vector_local_ned(vector , mav_frame):
+            self.mav.mav.set_position_target_local_ned_send(
+                0,  # timestamp
+                self.sysid_thismav(),  # target system_id
+                1,  # target component id
+                mav_frame,
+                MAV_POS_TARGET_TYPE_MASK.POS_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.ACC_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE,
+                0,
+                0,
+                0,
+                vector.x,  # vx
+                vector.y,  # vy
+                vector.z,  # vz
+                0,  # afx
+                0,  # afy
+                0,  # afz
+                0,  # yaw
+                0,  # yawrate
+            )
+        self.wait_speed_vector(
+            Vector3(0, 0, 0),
+            timeout=timeout,
+            called_function=lambda plop, empty: send_speed_vector_local_ned(target_speed, mavutil.mavlink.MAV_FRAME_LOCAL_NED),  # noqa
+            minimum_duration=10
+        )
+
+        self.do_RTL()
+
     def SetpointGlobalVel(self, timeout=30):
         """Test set position message in guided mode."""
         # Disable heading and yaw rate test on rover type


### PR DESCRIPTION
This PR prevents a *specific* problem which caused a user's vehicle to fly away.

The user input a bad value to the vehicle in GUIDED mode, which caused the position controller state to become corrupt - bunches of NaNs logged in the dataflash log etc.

The tests included in this PR recreate that user's input, but does not look at other supplied fields - accel, yaw and yaw-rate, all of which could create the same problem.

I left it here because there are other ways to accomplish the same thing - most notably, dropping it on the set_pos_vel_acc methods on guided mode (and making them boolean if they're not already) would also stop bad things getting in from scripting.  IMO we should also add periodic validation of the position controller's state - forcing an internal error and reset if we detect things have gone pear-shaped; this is a belts-and-braces approach because bugs happen.

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/8e9f3048-e992-4ce0-86b5-27365ac0d525)

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/7b1d1107-a195-4396-9205-01b00ad81c17)

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/015f28ee-1716-49d8-8b2b-b8ed3c9510ad)
