### PR TITLE
AP_OSD: Add missing labels for new serial protocols

### DIFF
--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -116,8 +116,10 @@ static const char* SERIAL_PROTOCOL_VALUES[] = {
     "", "MAV", "MAV2", "FSKY_D", "FSKY_S", "GPS", "", "ALEX", "STORM", "RNG", 
     "FSKY_TX", "LID360", "", "BEACN", "VOLZ", "SBUS", "ESC_TLM", "DEV_TLM", "OPTFLW", "RBTSRV",
     "NMEA", "WNDVNE", "SLCAN", "RCIN", "MGSQRT", "LTM", "RUNCAM", "HOT_TLM", "SCRIPT", "CRSF",
-    "GEN", "WNCH", "MSP", "DJI"
+    "GEN", "WNCH", "MSP", "DJI", "AIRSPD", "ADSB", "AHRS", "AUDIO", "FETTEC", "TORQ",
+    "AIS", "CD_ESC", "MSP_DP", "MAV_HL", "TRAMP", "DDS"
 };
+static_assert(AP_SerialManager::SerialProtocol_NumProtocols == ARRAY_SIZE(SERIAL_PROTOCOL_VALUES));
 
 static const char* SERVO_FUNCTIONS[] = {
     "NONE", "RCPASS", "FLAP", "FLAP_AUTO", "AIL", "", "MNT_PAN", "MNT_TLT", "MNT_RLL", "MNT_OPEN", 


### PR DESCRIPTION
Per the title, a number of new serial protocols have been added to [`AP_SerialManager`](https://github.com/ArduPilot/ardupilot/blob/fa800e23e2d05d3051c63b041051368308292ba6/libraries/AP_SerialManager/AP_SerialManager.h#L161), but the labels in `AP_OSD` have not been updated.