### PR TITLE
AP_CustomRotations: initialize memory to not have random object

### DIFF
--- a/libraries/AP_CustomRotations/AP_CustomRotations.h
+++ b/libraries/AP_CustomRotations/AP_CustomRotations.h
@@ -17,7 +17,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 
-#define NUM_CUST_ROT ROTATION_CUSTOM_END - ROTATION_CUSTOM_1
+#define NUM_CUST_ROT (ROTATION_CUSTOM_END - ROTATION_CUSTOM_1)
 
 struct AP_CustomRotation_params {
 public:
@@ -69,7 +69,7 @@ private:
 
     AP_CustomRotation* get_rotation(Rotation r);
 
-    AP_CustomRotation* rotations[NUM_CUST_ROT];
+    AP_CustomRotation* rotations[NUM_CUST_ROT] { nullptr };
 
     AP_CustomRotation_params params[NUM_CUST_ROT];
 

--- a/libraries/AP_Math/tests/test_rotations.cpp
+++ b/libraries/AP_Math/tests/test_rotations.cpp
@@ -3,7 +3,6 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_CustomRotations/AP_CustomRotations.h>
 
-
 AP_CustomRotations cust_rot;
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -170,7 +169,7 @@ static void breakSingleton()
     AP_CustomRotations cust_rot1;
 }
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-TEST(RotationsTest, TestFailedGetLinux)
+TEST(RotationsTest, TestFailedGetSITL)
 {
     EXPECT_EXIT(AP::custom_rotations().set(ROTATION_CUSTOM_OLD, 0, 0, 0), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
     EXPECT_EXIT(AP::custom_rotations().set(ROTATION_CUSTOM_END, 0, 0, 0), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");


### PR DESCRIPTION
explicitly initialize the rotation array with nullptr. 
otherwise the pointers are assigned and the first call to get_rotation() will success with what is randomly in memory. This cause a crash if we try to set the rotation value.