### PR TITLE
Tools: continue on coverage test failure

### DIFF
--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -177,11 +177,15 @@ class CoverageRunner(object):
         test_list = ["Plane", "QuadPlane", "Sub", "Copter", "Helicopter", "Rover", "Tracker", "BalanceBot", "Sailboat"]
         for test in test_list:
             self.progress("Running test.%s" % test)
-            subprocess.run([self.autotest,
-                            "--timeout=" + str(TIMEOUT),
-                            "--debug",
-                            "--no-clean",
-                            "test.%s" % test], check=self.check_tests)
+            try:
+                subprocess.run([self.autotest,
+                                "--timeout=" + str(TIMEOUT),
+                                "--debug",
+                                "--no-clean",
+                                "test.%s" % test], check=self.check_tests)
+            except subprocess.CalledProcessError:
+                # pass in case of failing tests
+                pass
         # TODO add any other execution path/s we can to maximise the actually
         # used code, can we run other tests or things?  Replay, perhaps?
         self.update_stats()


### PR DESCRIPTION
when a test fails on coverage that return exit code 1 and raise subprocess exception which stop the coverage scripts from running

This catch the exception and allow to continue the coverage gathering

