### PR TITLE
AP_HAL_ChibiOS: minimize VRUbrain-v51

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
@@ -173,9 +173,8 @@ define STM32_PWM_USE_ADVANCED TRUE
 
 # save some flash
 include ../include/save_some_flash.inc
-define HAL_RUNCAM_ENABLED 0
 define HAL_SPEKTRUM_TELEM_ENABLED 0
-define HAL_SOARING_ENABLED 0
 
 # minimal drivers to reduce flash usage
 include ../include/minimal.inc
+include ../include/minimize_features.inc


### PR DESCRIPTION
out of space for everything, or close to it

some reordering required to keep OSD and synthetic-current definitions happy.
