### PR TITLE
AP_Scripting: support get_sensor_status_flags in lua script 

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2263,6 +2263,12 @@ function gcs:get_high_latency_status() end
 ---@param text string
 function gcs:send_text(severity, text) end
 
+-- get sensor status flags represented by MAV_SYS_STATUS_SENSOR
+---@return uint32_t_ud -- onboard_control_sensors_present
+---@return uint32_t_ud -- onboard_control_sensors_enabled
+---@return uint32_t_ud -- onboard_control_sensors_health
+function gcs:get_sensor_status_flags() end
+
 -- desc
 ---@class relay
 relay = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -227,6 +227,7 @@ singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM
 singleton GCS method send_named_float void string float'skip_check
 singleton GCS method frame_type MAV_TYPE'enum
 singleton GCS method get_hud_throttle int16_t
+singleton GCS method get_sensor_status_flags void uint32_t'Ref uint32_t'Ref uint32_t'Ref
 
 singleton GCS depends HAL_HIGH_LATENCY2_ENABLED == 1
 singleton GCS method get_high_latency_status boolean


### PR DESCRIPTION
This allows to get onboard_control_sensors_present, onboard_control_sensors_enabled, and onboard_control_sensors_health from SYS_STATUS in Lua script. I added this functionality specifically to obtain the prearm check status, but it would be useful to access other statuses such as RC and AHRS as well.

I tested this in SITL.
![image](https://github.com/ArduPilot/ardupilot/assets/16643069/aaaf0c1e-4c55-4c0e-bddb-4ef8fc91ac72)

tested by this script.
```
local old_flag1 = 0
local old_flag2 = 0
local old_flag3 = 0
function update()
  local flag1, flag2, flag3 = gcs:get_sensor_status_flags()
  if old_flag1 ~= flag1 then
    gcs:send_text(0, string.format("present: %s", tostring(flag1)))
    old_flag1 = flag1
  end
  if old_flag2 ~= flag2 then
    gcs:send_text(0, string.format("enabled: %s", tostring(flag2)))
    old_flag2 = flag2
  end
  if old_flag3 ~= flag3 then
    gcs:send_text(0, string.format("health: %s", tostring(flag3)))
    if tostring(flag3 & 268435456) == tostring(268435456) then
      gcs:send_text(0, string.format("Ready to Arm"))
    else
      gcs:send_text(0, string.format("Not Ready to Arm"))
    end
    old_flag3 = flag3
  end
  return update, 1000
end
  
return update()
```