### PR TITLE
waf: also run Tools/gittools/submodule-sync.sh at distclean

### DIFF
--- a/wscript
+++ b/wscript
@@ -86,6 +86,11 @@ def _set_build_context_variant(board):
             continue
         c.variant = board
 
+# run Tools/gittools/submodule-sync.sh to sync submodules as well at distclean
+@conf
+def distclean(ctx):
+    subprocess.call(['Tools/gittools/submodule-sync.sh'])
+
 def init(ctx):
     # Generate Task List, so that VS Code extension can keep track
     # of changes to possible build targets


### PR DESCRIPTION
Make submodule-sync as part of the distclean. This way devs don't have to fight with weird errors even after distclean due to bad submodule state. Distclean should be a kill all clean state which should include cleaning up submodule states.