### PR TITLE
GCS_Common: handle CMD_DO_SET_ROI_NONE for command int packets

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5079,6 +5079,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_do_set_roi(packet);
     case MAV_CMD_DO_SET_ROI_SYSID:
         return handle_command_do_set_roi_sysid(packet);
+    case MAV_CMD_DO_SET_ROI_NONE:
+        return handle_command_do_set_roi_none();
     case MAV_CMD_DO_SET_HOME:
         return handle_command_int_do_set_home(packet);
 


### PR DESCRIPTION
CMD_DO_SET_ROI_NONE support was added recently, but it was only processed if sent as command long. 

QGroundControl allows to set a ROI, and for cancelling that ROI is sending a CMD_DO_SET_ROI_NONE as command int. QGC uses a command int instead of command long because Ardupilot returns the capability flags as supporting command int, and technically CMD_DO_SET_ROI_NONE is a location based command, even though it doesn't use location.

We have support for CMD_DO_SET_ROI processed as command int so I thought it would be better to fix it here rather than in QGC.