### PR TITLE
AP_Mount: use switch statement on mount type when creating backends

### DIFF
--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.h
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "AP_Camera_Backend.h"
-#include <AP_Mount/AP_Mount.h>
+#include "AP_Camera_config.h"
 
 #if AP_CAMERA_SOLOGIMBAL_ENABLED
 
+#include "AP_Camera_Backend.h"
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 class AP_Camera_SoloGimbal : public AP_Camera_Backend

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -61,71 +61,76 @@ void AP_Mount::init()
 
     // create each instance
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        Type mount_type = get_mount_type(instance);
-
-        // check for servo mounts
-        if (mount_type == Type::Servo) {
+        switch (get_mount_type(instance)) {
+        case Type::None:
+            break;
 #if HAL_MOUNT_SERVO_ENABLED
+        case Type::Servo:
             _backends[instance] = new AP_Mount_Servo(*this, _params[instance], true, instance);
             _num_instances++;
+            break;
 #endif
-
 #if HAL_SOLO_GIMBAL_ENABLED
-        // check for Solo mounts
-        } else if (mount_type == Type::SoloGimbal) {
+        case Type::SoloGimbal:
             _backends[instance] = new AP_Mount_SoloGimbal(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif // HAL_SOLO_GIMBAL_ENABLED
 
 #if HAL_MOUNT_ALEXMOS_ENABLED
-        // check for Alexmos mounts
-        } else if (mount_type == Type::Alexmos) {
+        case Type::Alexmos:
             _backends[instance] = new AP_Mount_Alexmos(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif
 
 #if HAL_MOUNT_STORM32MAVLINK_ENABLED
         // check for SToRM32 mounts using MAVLink protocol
-        } else if (mount_type == Type::SToRM32) {
+        case Type::SToRM32:
             _backends[instance] = new AP_Mount_SToRM32(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif
 
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
         // check for SToRM32 mounts using serial protocol
-        } else if (mount_type == Type::SToRM32_serial) {
+        case Type::SToRM32_serial:
             _backends[instance] = new AP_Mount_SToRM32_serial(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif
 
 #if HAL_MOUNT_GREMSY_ENABLED
         // check for Gremsy mounts
-        } else if (mount_type == Type::Gremsy) {
+        case Type::Gremsy:
             _backends[instance] = new AP_Mount_Gremsy(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif // HAL_MOUNT_GREMSY_ENABLED
 
 #if HAL_MOUNT_SERVO_ENABLED
         // check for BrushlessPWM mounts (uses Servo backend)
-        } else if (mount_type == Type::BrushlessPWM) {
+        case Type::BrushlessPWM:
             _backends[instance] = new AP_Mount_Servo(*this, _params[instance], false, instance);
             _num_instances++;
+            break;
 #endif
 
 #if HAL_MOUNT_SIYI_ENABLED
         // check for Siyi gimbal
-        } else if (mount_type == Type::Siyi) {
+        case Type::Siyi:
             _backends[instance] = new AP_Mount_Siyi(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif // HAL_MOUNT_SIYI_ENABLED
 
 #if HAL_MOUNT_SCRIPTING_ENABLED
         // check for Scripting gimbal
-        } else if (mount_type == Type::Scripting) {
+        case Type::Scripting:
             _backends[instance] = new AP_Mount_Scripting(*this, _params[instance], instance);
             _num_instances++;
+            break;
 #endif // HAL_MOUNT_SCRIPTING_ENABLED
-
         }
 
         // init new instance

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -76,15 +76,33 @@ public:
     // Enums
     enum class Type {
         None = 0,            /// no mount
+#if HAL_MOUNT_SERVO_ENABLED
         Servo = 1,           /// servo controlled mount
+#endif
+#if HAL_SOLO_GIMBAL_ENABLED
         SoloGimbal = 2,      /// Solo's gimbal
+#endif
+#if HAL_MOUNT_ALEXMOS_ENABLED
         Alexmos = 3,         /// Alexmos mount
+#endif
+#if HAL_MOUNT_STORM32MAVLINK_ENABLED
         SToRM32 = 4,         /// SToRM32 mount using MAVLink protocol
+#endif
+#if HAL_MOUNT_STORM32SERIAL_ENABLED
         SToRM32_serial = 5,  /// SToRM32 mount using custom serial protocol
+#endif
+#if HAL_MOUNT_GREMSY_ENABLED
         Gremsy = 6,          /// Gremsy gimbal using MAVLink v2 Gimbal protocol
+#endif
+#if HAL_MOUNT_SERVO_ENABLED
         BrushlessPWM = 7,    /// Brushless (stabilized) gimbal using PWM protocol
+#endif
+#if HAL_MOUNT_SIYI_ENABLED
         Siyi = 8,            /// Siyi gimbal using custom serial protocol
+#endif
+#if HAL_MOUNT_SCRIPTING_ENABLED
         Scripting = 9,       /// Scripting gimbal driver
+#endif
     };
 
     // init - detect and initialise all mounts

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -19,16 +19,22 @@
  */
 #pragma once
 
-#include "AP_Mount.h"
+#include "AP_Mount_config.h"
+
 #if HAL_MOUNT_ENABLED
+
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
 #include <RC_Channel/RC_Channel.h>
+#include <AP_Camera/AP_Camera_shareddefs.h>
+#include "AP_Mount_Params.h"
 
 class AP_Mount_Backend
 {
 public:
     // Constructor
-    AP_Mount_Backend(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
+    AP_Mount_Backend(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance) :
         _frontend(frontend),
         _params(params),
         _instance(instance)

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -6,16 +6,18 @@
 ************************************************************/
 #pragma once
 
-#include <AP_HAL/AP_HAL_Boards.h>
-#include "AP_Mount.h"
+#include "AP_Mount_config.h"
+
 #if HAL_SOLO_GIMBAL_ENABLED
-#include "SoloGimbalEKF.h"
-#include <AP_Math/AP_Math.h>
-#include <AP_Common/AP_Common.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
+
 #include <AP_AccelCal/AP_AccelCal.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 #include "SoloGimbal_Parameters.h"
+#include "SoloGimbalEKF.h"
 
 enum gimbal_state_t {
     GIMBAL_STATE_NOT_PRESENT = 0,

--- a/libraries/AP_Mount/SoloGimbalEKF.h
+++ b/libraries/AP_Mount/SoloGimbalEKF.h
@@ -18,11 +18,12 @@
  */
 #pragma once
 
+#include "AP_Mount_config.h"
+
+#if HAL_SOLO_GIMBAL_ENABLED
+
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
-//#include <AP_NavEKF2/AP_NavEKF2.h>
-#include "AP_Mount.h"
-#if HAL_SOLO_GIMBAL_ENABLED
 #include <AP_Math/vectorN.h>
 
 class SoloGimbalEKF

--- a/libraries/AP_Mount/SoloGimbal_Parameters.h
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.h
@@ -1,9 +1,12 @@
 #pragma once
+
+#include "AP_Mount_config.h"
+
+#if HAL_SOLO_GIMBAL_ENABLED
+
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include "AP_Mount.h"
-#if HAL_SOLO_GIMBAL_ENABLED
 
 enum gmb_param_state_t {
     GMB_PARAMSTATE_NOT_YET_READ=0, // parameter has yet to be initialized

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -21,7 +21,7 @@
 #include <AP_Filesystem/AP_Filesystem_config.h>
 #include <AP_Frsky_Telem/AP_Frsky_config.h>
 #include <AP_GPS/AP_GPS.h>
-#include <AP_Mount/AP_Mount.h>
+#include <AP_Mount/AP_Mount_config.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
 #include "ap_message.h"


### PR DESCRIPTION
Results are as expected:

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           -32     -32               -32    -32    -32
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           -24     -24               -24    -24    -24
MatekF405                      *      *           -40     -40               -40    -40    -40
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           -40     -40               -40    -40    -40
skyviper-v2450                                    *                                       
```
