### PR TITLE
Extended Dshot Telemetry (EDT)

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -247,6 +247,8 @@ public:
       DSHOT_3D_OFF = 9,
       DSHOT_3D_ON = 10,
       DSHOT_SAVE = 12,
+      DSHOT_EXTENDED_TELEMETRY_ENABLE = 13,
+      DSHOT_EXTENDED_TELEMETRY_DISABLE = 14,
       DSHOT_NORMAL = 20,
       DSHOT_REVERSE = 21,
       // The following options are only available on BLHeli32
@@ -265,7 +267,9 @@ public:
     enum DshotEscType {
       DSHOT_ESC_NONE = 0,
       DSHOT_ESC_BLHELI = 1,
-      DSHOT_ESC_BLHELI_S = 2
+      DSHOT_ESC_BLHELI_S = 2,
+      DSHOT_ESC_BLHELI_EDT = 3,
+      DSHOT_ESC_BLHELI_EDT_S = 4
     };
 
     virtual void    set_output_mode(uint32_t mask, enum output_mode mode) {}

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -539,6 +539,7 @@ void RCOutput::set_dshot_esc_type(DshotEscType dshot_esc_type)
     _dshot_esc_type = dshot_esc_type;
     switch (_dshot_esc_type) {
         case DSHOT_ESC_BLHELI_S:
+        case DSHOT_ESC_BLHELI_EDT_S:
             DSHOT_BIT_WIDTH_TICKS = DSHOT_BIT_WIDTH_TICKS_S;
             DSHOT_BIT_0_TICKS = DSHOT_BIT_0_TICKS_S;
             DSHOT_BIT_1_TICKS = DSHOT_BIT_1_TICKS_S;
@@ -1531,15 +1532,9 @@ void RCOutput::dshot_send(pwm_group &group, uint64_t time_out_us)
         uint8_t chan = group.chan[i];
         if (group.is_chan_enabled(i)) {
 #ifdef HAL_WITH_BIDIR_DSHOT
-            // retrieve the last erpm values
-            const uint16_t erpm = group.bdshot.erpm[i];
-#if HAL_WITH_ESC_TELEM
-            // update the ESC telemetry data
-            if (erpm < 0xFFFF && group.bdshot.enabled) {
-                update_rpm(chan, erpm * 200 / _bdshot.motor_poles, get_erpm_error_rate(chan));
+            if (group.bdshot.enabled) {
+                bdshot_decode_telemetry_from_erpm(group.bdshot.erpm[i], chan);
             }
-#endif
-            _bdshot.erpm[chan] = erpm;
 #endif
             if (safety_on && !(safety_mask & (1U<<(chan+chan_offset)))) {
                 // safety is on, don't output anything

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -222,7 +222,7 @@ public:
       Send a dshot command, if command timout is 0 then 10 commands are sent
       chan is the servo channel to send the command to
      */
-    void send_dshot_command(uint8_t command, uint8_t chan, uint32_t command_timeout_ms = 0, uint16_t repeat_count = 10, bool priority = false) override;
+    void send_dshot_command(uint8_t command, uint8_t chan = ALL_CHANNELS, uint32_t command_timeout_ms = 0, uint16_t repeat_count = 10, bool priority = false) override;
 
     /*
      * Update channel masks at 1Hz allowing for actions such as dshot commands to be sent
@@ -644,6 +644,7 @@ private:
     void bdshot_ic_dma_allocate(Shared_DMA *ctx);
     void bdshot_ic_dma_deallocate(Shared_DMA *ctx);
     static uint32_t bdshot_decode_telemetry_packet(uint32_t* buffer, uint32_t count);
+    bool bdshot_decode_telemetry_from_erpm(uint16_t erpm, uint8_t chan);
     bool bdshot_decode_dshot_telemetry(pwm_group& group, uint8_t chan);
     static uint8_t bdshot_find_next_ic_channel(const pwm_group& group);
     static void bdshot_dma_ic_irq_callback(void *p, uint32_t flags);

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -147,6 +147,8 @@ void RCOutput::update_channel_masks() {
         switch (_dshot_esc_type) {
             case DSHOT_ESC_BLHELI:
             case DSHOT_ESC_BLHELI_S:
+            case DSHOT_ESC_BLHELI_EDT:
+            case DSHOT_ESC_BLHELI_EDT_S:
                 if (_reversible_mask & (1U<<i)) {
                     send_dshot_command(DSHOT_3D_ON, i + chan_offset, 0, 10, true);
                 }
@@ -157,6 +159,10 @@ void RCOutput::update_channel_masks() {
             default:
                 break;
         }
+    }
+
+    if (_dshot_esc_type == DSHOT_ESC_BLHELI_EDT || _dshot_esc_type == DSHOT_ESC_BLHELI_EDT_S) {
+        send_dshot_command(DSHOT_EXTENDED_TELEMETRY_ENABLE, ALL_CHANNELS, 0, 10, true);
     }
 #endif
 }

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -228,8 +228,8 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
 
     // @Param: _DSHOT_ESC
     // @DisplayName: Servo DShot ESC type
-    // @Description: This sets the DShot ESC type for all outputs. The ESC type affects the range of DShot commands available. None means that no dshot commands will be executed.
-    // @Values: 0:None,1:BLHeli32/Kiss,2:BLHeli_S
+    // @Description: This sets the DShot ESC type for all outputs. The ESC type affects the range of DShot commands available and the bit widths used. None means that no dshot commands will be executed. Some ESC types support Extended DShot Telemetry (EDT) which allows telemetry other than RPM data to be returned when using bi-directional dshot. If you enable EDT you must install EDT capable firmware for correct operation.
+    // @Values: 0:None,1:BLHeli32/Kiss,2:BLHeli_S,3:BLHeli32/Kiss+EDT,4:BLHeli_S+EDT
     // @User: Advanced
     AP_GROUPINFO("_DSHOT_ESC",  24, SRV_Channels, dshot_esc_type, 0),
 


### PR DESCRIPTION
https://github.com/bird-sanctuary/extended-dshot-telemetry

Requires BLHeli32 32.93 (beta version) and setting ```SERVO_DSHOT_ESC``` to 3

Appears to be working!