### PR TITLE
AP_Mount: fix SiYi gimbal upside-down facing not working

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -136,6 +136,13 @@ private:
         ZR10
     } _hardware_model;
 
+    // gimbal mounting method/direction
+    enum class GimbalMountingDirection : uint8_t {
+        UNDEFINED = 0,
+        NORMAL = 1,
+        UPSIDE_DOWN = 2,
+    } _gimbal_mounting_dir;
+
     // reading incoming packets from gimbal and confirm they are of the correct format
     // results are held in the _parsed_msg structure
     void read_incoming_packets();


### PR DESCRIPTION
The SiYi gimbal when facing upside-down (Put on the table or maybe rover in future) doesn't takes mounting direction into account.
This PULL fixes that by taking advantage of  mounting direction information that zr10 and A8 provides. 