### PR TITLE
Improve autotest mavlink connection resiliency

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3381,17 +3381,19 @@ class AutoTest(ABC):
                 self.progress("Received: %s" % str(m))
             if m is None:
                 continue
-            if m.tc1 == 0:
-                self.progress("this is a timesync request, which we don't answer")
-                continue
             if m.ts1 % 1000 != self.mav.source_system:
                 self.progress("this isn't a response to our timesync (%s)" % (m.ts1 % 1000))
+                continue
+            if m.tc1 == 0:
+                # this should also not happen:
+                self.progress("this is a timesync request, which we don't answer")
                 continue
             if int(m.ts1 / 1000) != self.timesync_number:
                 self.progress("this isn't the one we just sent")
                 continue
             if m.get_srcSystem() != self.mav.target_system:
-                self.progress("response from system other than our target")
+                self.progress("response from system other than our target (want=%u got=%u" %
+                              (self.mav.target_system, m.get_srcSystem()))
                 continue
             # no component check ATM because we send broadcast...
 #            if m.get_srcComponent() != self.mav.target_component:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2059,6 +2059,7 @@ class AutoTest(ABC):
 
     def set_streamrate(self, streamrate, timeout=20, stream=mavutil.mavlink.MAV_DATA_STREAM_ALL):
         '''set MAV_DATA_STREAM_ALL; timeout is wallclock time'''
+        self.do_timesync_roundtrip(timeout_in_wallclock=True)
         tstart = time.time()
         while True:
             if time.time() - tstart > timeout:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8124,6 +8124,11 @@ Also, ignores heartbeats not from our target system'''
             self.sup_prog.append(sup_prog_link)
             self.expect_list_add(sup_prog_link)
 
+        # mavlink will have disconnected here.  Explicitly reconnect,
+        # or the first packet we send will be lost:
+        if self.mav is not None:
+            self.mav.reconnect()
+
     def get_suplementary_programs(self):
         return self.sup_prog
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -7734,6 +7734,10 @@ Also, ignores heartbeats not from our target system'''
         self.mav.mav.set_send_callback(self.send_message_hook, self)
         self.mav.idle_hooks.append(self.idle_hook)
 
+        # we need to wait for a heartbeat here.  If we don't then
+        # self.mav.target_system will be zero because it hasn't
+        # "locked on" to a target system yet.
+        self.wait_heartbeat()
         self.set_streamrate(self.sitl_streamrate())
 
     def show_test_timings_key_sorter(self, t):


### PR DESCRIPTION
This avoids some race conditions that we currently avoid with sleeps.

It also improves our diagnostics around timesyncs - moving a failure clause earlier which helps getting to the root-cause of timesync problems.


