### PR TITLE
waf: revert run Tools/gittools/submodule-sync.sh at distclean

### DIFF
--- a/wscript
+++ b/wscript
@@ -86,11 +86,6 @@ def _set_build_context_variant(board):
             continue
         c.variant = board
 
-# run Tools/gittools/submodule-sync.sh to sync submodules as well at distclean
-@conf
-def distclean(ctx):
-    subprocess.call(['Tools/gittools/submodule-sync.sh'])
-
 def init(ctx):
     # Generate Task List, so that VS Code extension can keep track
     # of changes to possible build targets


### PR DESCRIPTION
This reverts PR https://github.com/ArduPilot/ardupilot/pull/23898 which led to issue https://github.com/ArduPilot/ardupilot/issues/23913

I've confirmed the reported issue is real by switching between master and Copter-4.3 and confirming that the build fails and that the build directory is not being cleared in master.  After the commit is reverted the build directly is correctly cleared as part of "distclean".

