### PR TITLE
Allow source code to display in size_compare_branches.py elf_diff output

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -471,7 +471,7 @@ class SizeCompareBranches(object):
 
     def elf_diff_results(self, result_master, result_branch):
         master_branch = result_master["branch"]
-        branch = result_master["branch"]
+        branch = result_branch["branch"]
         for vehicle in result_master["vehicle"].keys():
             elf_filename = result_master["vehicle"][vehicle]["elf_filename"]
             master_elf_dir = result_master["vehicle"][vehicle]["elf_dir"]


### PR DESCRIPTION
Past this you get source in elf_diff:

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/20c27d91-1417-4480-9b23-2b5a341400df)

This requires the use of `--parallel-copies` - so we have old and new source trees available.  There must also be enough parallel copies to cover the number of tasks - so something like this works:

```
./Tools/scripts/size_compare_branches.py --board=Durandal --vehicle=plane --elf-diff --parallel=2
```

as there are exactly as many tasks as parallel-copies.
