### PR TITLE
AC_Avoidance: should consider consumed time between planning and control

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -68,6 +68,9 @@ private:
     // Logging function
     void Write_OABendyRuler(const uint8_t type, const bool active, const float target_yaw, const float target_pitch, const bool resist_chg, const float margin, const Location &final_dest, const Location &oa_dest) const;
 
+    // compute the real planning startpoint
+    void compute_planning_start_point(Location& current_loc, const Vector2f &ground_speed_vec, const float plannning_period_sec);
+
     // OA common parameters
     float _margin_max;              // object avoidance will ignore objects more than this many meters from vehicle
     


### PR DESCRIPTION
Due to the planning time period being 1 second and the control period being 50 ms or even faster, the starting point of the planning should not be the current position, but the mileage point corresponding to the last planning time. Here, a simple correction has been made: the robot saves a constant speed within 1 second!

After the repair, the spatiotemporal synchronization of planning and control has been improved, especially in the case of high-speed motion; An additional benefit is that it also reduces the problem of indecision in decision-making