### PR TITLE
Use low-memory footprint LFN

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
@@ -115,7 +115,7 @@
 */
 
 
-#define FF_USE_LFN		3
+#define FF_USE_LFN		1
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -242,7 +242,9 @@ bool sdcard_retry(void)
         if (sdcard_init()) {
 #if AP_FILESYSTEM_FILE_WRITING_ENABLED
             // create APM directory
-            AP::FS().mkdir("/APM");
+            if (AP::FS().mkdir("/APM") < 0) {
+                printf("Failed to create /APM\n");
+            }
 #endif
         }
     }


### PR DESCRIPTION
Currently if you have a blank SD card, ardupilot fails to create the "/APM" directory on Pixhawk6X and Zealot H743. This is because the create operation involves allocating a 32k bouncebuffer which is clearly not available as a continuous chunk on these boards. Instead of trying to free memory I investigated whether this 32k chunk was really necessary. It turns out to be required by long filename (LFN) support on exFAT and there are other ways of configuring LFN to reduce memory at some cost to performance. Since we don't really care about long file names I configured this option.