### PR TITLE
Fix height above ellipsoid and undulation for SBF GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -417,7 +417,7 @@ AP_GPS_SBF::process_message(void)
             state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * (double)1e7);
             state.location.alt = (int32_t)(((float)temp.Height - temp.Undulation) * 1e2f);
             state.have_undulation = true;
-            state.undulation = temp.Undulation;
+            state.undulation = -temp.Undulation;
         }
 
         if (temp.NrSV != 255) {


### PR DESCRIPTION
As pointed out in issue https://github.com/ArduPilot/ardupilot/issues/23613, the ellipsoid height and undulation are calculated incorrectly. This likely occurred because Ardupilot has an opposite definition of undulation as the Septentrio receiver (and virtually all GPS receivers for that matter). Septentrio defines undulation as the distance from the ellipsoid to the geoid with up being positive (geoid is above ellipsoid). Ardupilot defines down as positive. 

This PR reconciles the undulation definition and fixes the height above ellipsoid computed [here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_GPS/AP_GPS.cpp#L1421).

 @tridge, @hendjoshsr71 and/or @BluemarkInnovations

**Platform**
[X] All
[  ] AntennaTracker
[  ] Copter
[  ] Plane
[  ] Rover
[  ] Submarine
