### PR TITLE
SITL: simulated SF45b fixes and enhancements

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6811,14 +6811,14 @@ class AutoTestCopter(AutoTest):
         })
         sensors = [  # tuples of name, prx_type
             ('sf45b', 8, {
-                mavutil.mavlink.MAV_SENSOR_ROTATION_NONE: 285,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_45: 256,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_90: 1131,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_135: 1283,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_180: 625,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_225: 968,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_270: 760,
-                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_315: 762,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_NONE: 270,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_45: 258,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_90: 1146,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_135: 632,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_180: 629,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_225: 972,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_270: 774,
+                mavutil.mavlink.MAV_SENSOR_ROTATION_YAW_315: 774,
             }),
             ('rplidara2', 5, {
                 mavutil.mavlink.MAV_SENSOR_ROTATION_NONE: 277,

--- a/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.cpp
@@ -183,17 +183,17 @@ void PS_LightWare_SF45B::update_output_responses()
 
 void PS_LightWare_SF45B::update_output_scan(const Location &location)
 {
-    const uint32_t now = AP_HAL::millis();
-    if (last_scan_output_time_ms == 0) {
-        last_scan_output_time_ms = now;
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t time_delta_ms = (now_ms - last_scan_output_time_ms);
+    if (time_delta_ms > 1000) {
+        last_scan_output_time_ms = now_ms;
         return;
     }
-    const uint32_t time_delta = (now - last_scan_output_time_ms);
 
-    const uint32_t samples_per_second = 1000;
+    const uint32_t samples_per_second = 133;
     const float samples_per_ms = samples_per_second / 1000.0f;
-    const uint32_t sample_count = time_delta / samples_per_ms;
-    const float degrees_per_ms = 1000 / 1000.0f;  // Randy reports 1 degree increments
+    const uint32_t sample_count = samples_per_ms * time_delta_ms;
+    const float degrees_per_ms = 390 / 1000.0f;
     const float degrees_per_sample = degrees_per_ms / samples_per_ms;
 
 //    ::fprintf(stderr, "Packing %u samples in for %ums interval (%f degrees/sample)\n", sample_count, time_delta, degrees_per_sample);
@@ -201,16 +201,27 @@ void PS_LightWare_SF45B::update_output_scan(const Location &location)
     last_scan_output_time_ms += sample_count/samples_per_ms;
 
     for (uint32_t i=0; i<sample_count; i++) {
-        const float current_degrees_bf = fmod((last_degrees_bf + degrees_per_sample), 360.0f);
+
+        const float ANGLE_MIN_DEG = -170;
+        const float ANGLE_MAX_DEG = +170;
+        float current_degrees_bf = last_degrees_bf + (last_dir * degrees_per_sample);
+        if (current_degrees_bf < ANGLE_MIN_DEG) {
+            current_degrees_bf += (ANGLE_MIN_DEG - current_degrees_bf);
+            last_dir = -last_dir;
+        }
+        if (current_degrees_bf > ANGLE_MAX_DEG) {
+            current_degrees_bf += (ANGLE_MAX_DEG - current_degrees_bf);
+            last_dir = -last_dir;
+        }
         last_degrees_bf = current_degrees_bf;
 
 
-        const float MAX_RANGE = 16.0f;
+        const float MAX_RANGE = 53.0f;
         float distance = measure_distance_at_angle_bf(location, current_degrees_bf);
         // ::fprintf(stderr, "SIM: %f=%fm\n", current_degrees_bf, distance);
         if (distance > MAX_RANGE) {
-            // sensor returns zero for out-of-range
-            distance = 0.0f;
+            // sensor returns -1 for out-of-range
+            distance = -1.0f;
         }
 
         PackedMessage<DistanceDataCM> packed_distance_data {

--- a/libraries/SITL/SIM_PS_LightWare_SF45B.h
+++ b/libraries/SITL/SIM_PS_LightWare_SF45B.h
@@ -259,7 +259,8 @@ private:
 
     uint32_t last_scan_output_time_ms;
 
-    float last_degrees_bf;
+    float last_degrees_bf;  // previous iteration's lidar angle
+    float last_dir = 1;     // previous iterations movement direction.  +1 CW, -1 for CCW
 
 };
 


### PR DESCRIPTION
This adds some fixes and enhancements to our simulated SF45b 350deg lidar.

- Resolve SITL crash if time_delta_ms is too long
- Correct sample_count calculation (was sending too many samples)
- Sends one reading per 3deg which is closer to real device than the previous 1deg
- Distance max is 53m (was 16m which is far shorter than the real device)
- Returns distance of -1m on failure (instead of 0)
- Sweeps back and forth -190~190 deg (previously wrapped which the real device is not capable of doing)

I've tested this in SITL and below are some screen shots of dataflash logs after a debug message to record individual angles and distances was added.

Here's the real sensor.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/bdcf16c2-1b0f-4a0a-ab22-3aa3c8733725)

Here's the test sensor:
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/1fd81442-5832-406d-9691-2f9d2600258c)
