### PR TITLE
AP_HAL_ChibiOS: Optimizations for external flash targets (H750 etc.)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -236,7 +236,7 @@ void __early_init(void) {
 #if !defined(STM32F1)
   stm32_gpio_init();
 #endif
-#if !HAL_XIP_ENABLED || defined(STM32_FORCE_CLOCK_INIT)
+#if !HAL_XIP_ENABLED || defined(HAL_FORCE_CLOCK_INIT)
   // if running from external flash then the clocks must not be reset - instead rely on the bootloader to setup
   stm32_clock_init();
 #endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -236,7 +236,7 @@ void __early_init(void) {
 #if !defined(STM32F1)
   stm32_gpio_init();
 #endif
-#if !HAL_XIP_ENABLED
+#if !HAL_XIP_ENABLED || defined(STM32_FORCE_CLOCK_INIT)
   // if running from external flash then the clocks must not be reset - instead rely on the bootloader to setup
   stm32_clock_init();
 #endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chibios_board.mk
@@ -264,6 +264,10 @@ endif
 # Define ASM defines here
 UADEFS =
 
+ifeq ($(COPY_VECTORS_TO_RAM),yes)
+ UADEFS += -DCRT0_INIT_VECTORS=1
+endif
+
 # List all user directories here
 UINCDIR =
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
@@ -74,10 +74,14 @@ SECTIONS
     . = 0;
     _text = .;
 
-    startup : ALIGN(16) SUBALIGN(16)
+    /* Vector table: copied to RAM by startup script */
+    vectors : ALIGN(1024) SUBALIGN(16)
     {
+        __textvectors_base__ = LOADADDR(vectors);
+        __vectors_base__ = .;
         KEEP(*(.vectors))
-    } > default_flash
+        __vectors_end__ = .;
+    } > flashram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
@@ -81,7 +81,7 @@ SECTIONS
         __vectors_base__ = .;
         KEEP(*(.vectors))
         __vectors_end__ = .;
-    } > flashram AT > default_flash
+    } > dataram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
@@ -74,10 +74,14 @@ SECTIONS
     . = 0;
     _text = .;
 
-    startup : ALIGN(16) SUBALIGN(16)
+    /* Vector table: copied to RAM by startup script */
+    vectors : ALIGN(1024) SUBALIGN(16)
     {
+        __textvectors_base__ = LOADADDR(vectors);
+        __vectors_base__ = .;
         KEEP(*(.vectors))
-    } > default_flash
+        __vectors_end__ = .;
+    } > flashram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
@@ -81,7 +81,7 @@ SECTIONS
         __vectors_base__ = .;
         KEEP(*(.vectors))
         __vectors_end__ = .;
-    } > flashram AT > default_flash
+    } > dataram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -228,7 +228,14 @@ SECTIONS
         lib/lib*.a:vector3.*(.rodata*)
         lib/lib*.a:matrix3.*(.rodata*)
         *libm.a:*(.rodata*)
+        /* scheduler task table */
+        AntennaTracker/Tracker.*(.rodata*)
+        AP_Vehicle/AP_Vehicle.*(.rodata*)
         ArduCopter/Copter.*(.rodata*)
+        ArduPlane/ArduPlane.*(.rodata*)
+        ArduSub/ArduSub.*(.rodata*)
+        Blimp/Blimp.*(.rodata*)
+        Rover/Rover.*(.rodata*)
         *(.ramdata*)
         . = ALIGN(4);
     } > dataram AT > default_flash

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -74,10 +74,14 @@ SECTIONS
     . = 0;
     _text = .;
 
-    startup : ALIGN(16) SUBALIGN(16)
+    /* Vector table: copied to RAM by startup script */
+    vectors : ALIGN(1024) SUBALIGN(16)
     {
+        __textvectors_base__ = LOADADDR(vectors);
+        __vectors_base__ = .;
         KEEP(*(.vectors))
-    } > default_flash
+        __vectors_end__ = .;
+    } > flashram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -81,7 +81,7 @@ SECTIONS
         __vectors_base__ = .;
         KEEP(*(.vectors))
         __vectors_end__ = .;
-    } > flashram AT > default_flash
+    } > dataram AT > default_flash
 
     constructors : ALIGN(4) SUBALIGN(4)
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -125,6 +125,8 @@ SECTIONS
         /**libg_nano.a:*memset*(.text*)
         *libg_nano.a:*memcpy*(.text*)*/
         *libm.a:*(.text*)
+        *libc_nano.a:*memcpy*(.text*)
+        *libgcc.a:*(.text*)
         /* For some reason boards won't boot if libc is in RAM, but will with debug on */
         /**libc_nano.a:*(.text* .rodata*)
         *libstdc++_nano.a:(.text* .rodata*)*/
@@ -154,6 +156,7 @@ SECTIONS
         lib/lib*.a:*Filter2p.*(.text* .rodata*)
         lib/lib*.a:SPIDevice.*(.text* .rodata*)
         lib/lib*.a:I2CDevice.*(.text* .rodata*)
+        lib/lib*.a:UARTDriver.*(.text* .rodata*)
         lib/lib*.a:Util.*(.text* .rodata*)
         lib/lib*.a:Device.*(.text* .rodata*)
         lib/lib*.a:Scheduler.*(.text* .rodata*)
@@ -164,13 +167,20 @@ SECTIONS
         lib/lib*.a:matrix_alg.*(.text* .rodata*)
         lib/lib*.a:AP_NavEKF3*.*(.text* .rodata*)
         lib/lib*.a:AP_NavEKF_*.*(.text* .rodata*)
+        lib/lib*.a:AP_AHRS*.*(.text* .rodata*)
         lib/lib*.a:EKF*.*(.text* .rodata*)
+        lib/lib*.a:AP_Scheduler.*(.text* .rodata*)
+        lib/lib*.a:AP_InertialSensor*(.text* .rodata*)
         lib/lib*.a:AP_Compass_Backend.*(.text* .rodata*)
         lib/lib*.a:AP_RCProtocol_Backend.*(.text* .rodata*)
         lib/lib*.a:AP_RCProtocol.*(.text* .rodata*)
         lib/lib*.a:AP_RCProtocol_CRSF.*(.text* .rodata*)
         lib/lib*.a:AP_RCTelemetry.*(.text* .rodata*)
         lib/lib*.a:AP_CRSF_Telem.*(.text* .rodata*)
+        lib/lib*.a:AP_MotorsMatrix.*(.text* .rodata*)
+        lib/lib*.a:RC_Channel.*(.text* .rodata*)
+        lib/lib*.a:RCInput.*(.text* .rodata*)
+        lib/lib*.a:RCOutput.*(.text* .rodata*)
         lib/lib*.a:vector2.*(.text* .rodata*)
         lib/lib*.a:quaternion.*(.text* .rodata*)
         lib/lib*.a:polygon.*(.text* .rodata*)
@@ -178,6 +188,8 @@ SECTIONS
         /* uncomment these to test CPUInfo in FLASH_RAM */
         /*Tools/CPUInfo/CPUInfo.*(.text* .rodata*)
         Tools/CPUInfo/EKF_Maths.*(.text* .rodata*)*/
+        lib/lib*.a:AC_AttitudeControl*.*(.text* .rodata*)
+        lib/lib*.a:AC_PID*.*(.text* .rodata*)
         *(.ramfunc*)
         . = ALIGN(4);
     } > flashram AT > default_flash
@@ -216,6 +228,7 @@ SECTIONS
         lib/lib*.a:vector3.*(.rodata*)
         lib/lib*.a:matrix3.*(.rodata*)
         *libm.a:*(.rodata*)
+        ArduCopter/Copter.*(.rodata*)
         *(.ramdata*)
         . = ALIGN(4);
     } > dataram AT > default_flash
@@ -253,13 +266,13 @@ SECTIONS
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > default_flash
+    } > instram AT > default_flash
 
     .ARM.exidx : {
         __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
         __exidx_end = .;
-     } > default_flash
+     } > instram AT > default_flash
 
     .eh_frame_hdr :
     {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -266,12 +266,14 @@ SECTIONS
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
+    /* needs to be close to libgcc in memory */
     } > instram AT > default_flash
 
     .ARM.exidx : {
         __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
         __exidx_end = .;
+     /* needs to be close to libgcc in memory */
      } > instram AT > default_flash
 
     .eh_frame_hdr :

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -297,7 +297,9 @@
 #define STM32_CKPERSEL                      STM32_CKPERSEL_HSE_CK
 #endif
 #define STM32_SDMMCSEL                      STM32_SDMMCSEL_PLL1_Q_CK
+#ifndef STM32_QSPISEL
 #define STM32_QSPISEL                       STM32_QSPISEL_PLL2_R_CK
+#endif
 #define STM32_FMCSEL                        STM32_QSPISEL_HCLK
 
 #define STM32_SWPSEL                        STM32_SWPSEL_PCLK1

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -40,13 +40,13 @@ mcu = {
     'RAM_MAP_EXTERNAL_FLASH' : [
 		# SSBL checks that stack is in this region so needs to come first
         (0x30000000, 256, 0), # SRAM1, SRAM2
-        (0x24000000, 256, 4), # AXI SRAM. Use this for SDMMC IDMA ops
+        (0x24000000, 128, 4), # AXI SRAM. Use this for SDMMC IDMA ops
         (0x20000000,  64, 2), # DTCM, tightly coupled, no DMA, fast
         (0x30040000,  32, 0), # SRAM3.
         (0x38000000,  64, 1), # SRAM4.
     ],
     'INSTRUCTION_RAM' : (0x00000400,  63), # ITCM (first 1k removed, to keep address 0 unused)
-    'FLASH_RAM' : 		(0x24040000, 256), # AXI SRAM used for process stack and ram functions
+    'FLASH_RAM' : 		(0x24020000, 384), # AXI SRAM used for process stack and ram functions
     'DATA_RAM' :        (0x20010000,  64), # DTCM, tightly coupled, no DMA, fast
 
     # avoid a problem in the bootloader by making DTCM first. The DCache init
@@ -215,7 +215,7 @@ AltFunction_map = {
 	"PA10:TIM1_CH3"     	:	1,
 	"PA10:USART1_RX"    	:	7,
 	"PA10:USB_OTG_FS_ID"	:	10,
-	"PA11:FDCAN1_RX"    	:	9,
+	"PA11:CAN1_RX"    	:	9,
 	"PA11:HRTIM_CHD1"   	:	2,
 	"PA11:I2S2_WS"      	:	5,
 	"PA11:LPUART1_CTS"  	:	3,
@@ -226,7 +226,7 @@ AltFunction_map = {
 	"PA11:USART1_CTS"   	:	7,
 	"PA11:USART1_NSS"   	:	7,
 	"PA11:OTG_FS_DM"		:	10,
-	"PA12:FDCAN1_TX"    	:	9,
+	"PA12:CAN1_TX"    	:	9,
 	"PA12:HRTIM_CHD2"   	:	2,
 	"PA12:I2S2_CK"      	:	5,
 	"PA12:LPUART1_DE"   	:	3,
@@ -306,7 +306,7 @@ AltFunction_map = {
 	"PB4:UART7_TX"      	:	11,
 	"PB5:DCMI_D10"      	:	13,
 	"PB5:ETH_PPS_OUT"   	:	11,
-	"PB5:FDCAN2_RX"     	:	9,
+	"PB5:CAN2_RX"     	:	9,
 	"PB5:FMC_SDCKE1"    	:	12,
 	"PB5:HRTIM_EEV7"    	:	3,
 	"PB5:I2C1_SMBA"     	:	4,
@@ -323,7 +323,7 @@ AltFunction_map = {
 	"PB6:CEC"           	:	5,
 	"PB6:DCMI_D5"       	:	13,
 	"PB6:DFSDM1_DATIN5" 	:	11,
-	"PB6:FDCAN2_TX"     	:	9,
+	"PB6:CAN2_TX"     	:	9,
 	"PB6:FMC_SDNE1"     	:	12,
 	"PB6:HRTIM_EEV8"    	:	3,
 	"PB6:I2C1_SCL"      	:	4,
@@ -347,7 +347,7 @@ AltFunction_map = {
 	"PB8:DCMI_D6"       	:	13,
 	"PB8:DFSDM1_CKIN7"  	:	3,
 	"PB8:ETH_TXD3"      	:	11,
-	"PB8:FDCAN1_RX"     	:	9,
+	"PB8:CAN1_RX"     	:	9,
 	"PB8:I2C1_SCL"      	:	4,
 	"PB8:I2C4_SCL"      	:	6,
 	"PB8:LTDC_B6"       	:	14,
@@ -359,7 +359,7 @@ AltFunction_map = {
 	"PB8:UART4_RX"      	:	8,
 	"PB9:DCMI_D7"       	:	13,
 	"PB9:DFSDM1_DATIN7" 	:	3,
-	"PB9:FDCAN1_TX"     	:	9,
+	"PB9:CAN1_TX"     	:	9,
 	"PB9:I2C1_SDA"      	:	4,
 	"PB9:I2C4_SDA"      	:	6,
 	"PB9:I2C4_SMBA"     	:	11,
@@ -395,7 +395,7 @@ AltFunction_map = {
 	"PB11:USB_OTG_HS_ULPI_D4"	:	10,
 	"PB12:DFSDM1_DATIN1"	:	6,
 	"PB12:ETH_TXD0"     	:	11,
-	"PB12:FDCAN2_RX"    	:	9,
+	"PB12:CAN2_RX"    	:	9,
 	"PB12:I2C2_SMBA"    	:	4,
 	"PB12:I2S2_WS"      	:	5,
 	"PB12:SPI2_NSS"     	:	5,
@@ -408,7 +408,7 @@ AltFunction_map = {
 	"PB12:USB_OTG_HS_ULPI_D5"	:	10,
 	"PB13:DFSDM1_CKIN1" 	:	6,
 	"PB13:ETH_TXD1"     	:	11,
-	"PB13:FDCAN2_TX"    	:	9,
+	"PB13:CAN2_TX"    	:	9,
 	"PB13:I2S2_CK"      	:	5,
 	"PB13:LPTIM2_OUT"   	:	3,
 	"PB13:SPI2_SCK"     	:	5,
@@ -562,13 +562,13 @@ AltFunction_map = {
 	"PC12:UART5_TX"     	:	8,
 	"PC12:USART3_CK"    	:	7,
 	"PD0:DFSDM1_CKIN6"  	:	3,
-	"PD0:FDCAN1_RX"     	:	9,
+	"PD0:CAN1_RX"     	:	9,
 	"PD0:FMC_D2"        	:	12,
 	"PD0:FMC_DA2"       	:	12,
 	"PD0:SAI3_SCK_A"    	:	6,
 	"PD0:UART4_RX"      	:	8,
 	"PD1:DFSDM1_DATIN6" 	:	3,
-	"PD1:FDCAN1_TX"     	:	9,
+	"PD1:CAN1_TX"     	:	9,
 	"PD1:FMC_D3"        	:	12,
 	"PD1:FMC_DA3"       	:	12,
 	"PD1:SAI3_SD_A"     	:	6,
@@ -993,13 +993,13 @@ AltFunction_map = {
 	"PH12:I2C4_SDA"     	:	4,
 	"PH12:LTDC_R6"      	:	14,
 	"PH12:TIM5_CH3"     	:	2,
-	"PH13:FDCAN1_TX"    	:	9,
+	"PH13:CAN1_TX"    	:	9,
 	"PH13:FMC_D21"      	:	12,
 	"PH13:LTDC_G2"      	:	14,
 	"PH13:TIM8_CH1N"    	:	3,
 	"PH13:UART4_TX"     	:	8,
 	"PH14:DCMI_D4"      	:	13,
-	"PH14:FDCAN1_RX"    	:	9,
+	"PH14:CAN1_RX"    	:	9,
 	"PH14:FMC_D22"      	:	12,
 	"PH14:LTDC_G3"      	:	14,
 	"PH14:TIM8_CH2N"    	:	3,
@@ -1055,7 +1055,7 @@ AltFunction_map = {
 	"PI7:LTDC_B7"       	:	14,
 	"PI7:SAI2_FS_A"     	:	10,
 	"PI7:TIM8_CH3"      	:	3,
-	"PI9:FDCAN1_RX"     	:	9,
+	"PI9:CAN1_RX"     	:	9,
 	"PI9:FMC_D30"       	:	12,
 	"PI9:LTDC_VSYNC"    	:	14,
 	"PI9:UART4_RX"      	:	8,

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1363,6 +1363,7 @@ INCLUDE common_mixf.ld
 ''' % (flash_base, flash_length, ext_flash_base, ext_flash_length, ram0_start, ram0_len))
         else:
             self.env_vars['HAS_EXTERNAL_FLASH_SECTIONS'] = 1
+            self.build_flags.append('COPY_VECTORS_TO_RAM=yes')
             f.write('''/* generated ldscript.ld */
 MEMORY
 {


### PR DESCRIPTION
I have been working on support for a new target (BrainFPV RADIX 2 HD), which is STM32H750 based. The target uses a custom bootloader and the code is stored in an external flash connected via QUADSPI running at 120 MHz.

I found that the CPU load was quite high, about 80% with the default settings for Copter. Some of the time critical code had already been relocated to RAM. To optimize it further, I used a logic analyzer to capture the QUADSPI traffic and then analyzed it to see what functions / symbols are read most frequently within a 1 second period. The number of QUADSPI transactions in 1 second was about 1.1 million, which is quite impressive. I captured data repeatedly and moved functions and symbols to RAM (ITCM, DTCM, flashram). By doing so, I was able to reduce the CPU load for Copter to about 40%.  

Among the symbols I relocated is the vector table. This needed some changes to the makefile, hwdef script, and linker files so the ChibiOS startup script copies the vector table and sets the VTOR register to the new address.

There are some other changes that were needed to make the target work. Namely, the option to set the QUADSPI clock source and force the STM32 clock initialization. This is needed because the target uses a custom bootloader and the clock configuration the bootloader uses is different than in ArduPilot. By using the HCLK for the QUADSPI, the clock can be reconfigured even though the code is running from external flash. 

To summarize the changes:
- Copy the vector table to RAM if the code is running from external flash
- Move time critical functions to RAM for H750. The same optimizations should also be applied to other external flash targets, but this hasn't been done yet because I don't have hardware to test
- Allow setting the QUADSPI clock source and forcing the STM32 clock initialization
- Increase the flashram for H750 from 256k to 384k
- Fix CAN pin naming in the H750 script (was FDCAN instead of CAN)

I have bench tested this for Copter and Plane and also "hover tested" it for Copter. 