### PR TITLE
Fix ground speed undershoot correction bug

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -387,6 +387,7 @@ private:
     // Ground speed
     // The amount current ground speed is below min ground speed.  Centimeters per second
     int32_t groundspeed_undershoot;
+    bool groundspeed_undershoot_is_valid;
 
     // Difference between current altitude and desired altitude.  Centimeters
     int32_t altitude_error_cm;


### PR DESCRIPTION
The code had a bug where if GPS fix was lost, the demanded airspeed would be set to the measured or estimated airspeed causing unpredictable variations in the demanded airspeed. This patch prevents the minimum ground speed protection speed up from running if the ground speed undershoot cannot be calculated. This patch extends the range of conditions over which the minimum ground speed functionality can be used by enabling the ground speed undershoot to be calculated when the navigation system is able to estimate velocity.

The bug can be replicated in SITL with the following parameter modifications:

RC7_OPTION = 65 (enables GPS to be 'failed' by setting rc channel 7 to 2000)
MIN_GNDSPD_CM = 500
SIM_WIND_SPD = 5

Set mode to TAKEOFF and wait for pre-arm checks to pass
Arm and wait for takeoff to complete and the aircraft to fly a complete circle
Disable GPS 'rc 7 2000'
Wait for a complete orbit and re-enable GPS 'rc 7 1000'

The demanded airspeed surges when GPS is disabled
![01](https://github.com/ArduPilot/ardupilot/assets/3596952/d62f78ea-eff0-4d06-b32e-a997c372e6e4)

The groundspeed_undershoot value goes to zero when GPS is disabled
![02](https://github.com/ArduPilot/ardupilot/assets/3596952/f22f46b0-ce91-46f7-bdb9-d4949c2d25b7)


Repeating the SITL test with this patch eliminated the surging in demanded airspeed.
![03](https://github.com/ArduPilot/ardupilot/assets/3596952/6d0d6b1a-f79e-4be3-9830-a65a4fbc6076)


The groundspeed_undershoot continues to be updated when GPS is disabled
![04](https://github.com/ArduPilot/ardupilot/assets/3596952/75c6d8f2-cb88-448e-8f17-6978b73bff92)

