### PR TITLE
Fix USB on boards with single OTG

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -608,10 +608,10 @@
  * USB driver system settings.
  */
 #ifndef STM32_USB_USE_OTG1
-#define STM32_USB_USE_OTG1                  TRUE
+#define STM32_USB_USE_OTG1                  FALSE
 #endif
 #ifndef STM32_USB_USE_OTG2
-#define STM32_USB_USE_OTG2                  TRUE
+#define STM32_USB_USE_OTG2                  FALSE
 #endif
 #define STM32_USB_OTG1_IRQ_PRIORITY         14
 #define STM32_USB_OTG2_IRQ_PRIORITY         14

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
@@ -542,8 +542,12 @@
 /*
  * USB driver system settings.
  */
-#define STM32_USB_USE_OTG2                  TRUE
+#ifndef STM32_USB_USE_OTG2
+#define STM32_USB_USE_OTG2                  FALSE
+#endif
+#ifndef STM32_USB_USE_OTG1
 #define STM32_USB_USE_OTG1                  FALSE
+#endif
 #define STM32_USB_OTG1_IRQ_PRIORITY         14
 #define STM32_USB_OTG2_IRQ_PRIORITY         14
 #define STM32_USB_OTG1_RX_FIFO_SIZE         512


### PR DESCRIPTION
We were defaulting USB OTG2 to true and hence using USBD2 driver even when we wanted OTG1 and USBD1 from usbcfg.c