### PR TITLE
ChibiOS: support formatting microSD cards on all boards

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -277,6 +277,7 @@ BUILD_OPTIONS = [
     Feature('Other', 'NMEA_OUTPUT', 'HAL_NMEA_OUTPUT_ENABLED', 'Enable NMEA Output', 0, None),
     Feature('Other', 'BARO_WIND_COMP', 'HAL_BARO_WIND_COMP_ENABLED', 'Enable Baro Wind Compensation', 0, None),
     Feature('Other', 'ADVANCED_FAILSAFE', 'AP_ADVANCEDFAILSAFE_ENABLED', 'Enable Advanced Failsafe features', 0, None),
+    Feature('Other', 'SDCARD_FORMATTING', 'AP_FILESYSTEM_FORMAT_ENABLED', 'Enable formatting of microSD cards', 0, None),
 
     Feature('GPS Drivers', 'UBLOX', 'AP_GPS_UBLOX_ENABLED', 'Enable u-blox GPS', 1, None),
     Feature('GPS Drivers', 'SBP2', 'AP_GPS_SBP2_ENABLED', 'Enable SBP2 GPS', 0, 'SBP'),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -188,6 +188,7 @@ class ExtractFeatures(object):
             ('AP_NOTIFY_PROFILED_ENABLED', r'ProfiLED::init_ports'),
             ('AP_NOTIFY_PROFILED_SPI_ENABLED', r'ProfiLED_SPI::rgb_set_id'),
             ('AP_NOTIFY_NEOPIXEL_ENABLED', r'NeoPixel::init_ports'),
+            ('AP_FILESYSTEM_FORMAT_ENABLED', r'f_mkfs'),
         ]
 
     def progress(self, msg):

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -51,12 +51,7 @@ struct dirent {
 #include <unistd.h>
 
 #ifndef AP_FILESYSTEM_FORMAT_ENABLED
-// only enable for SDMMC filesystems for now as other types can't query
-// block size
-#ifndef HAL_USE_SDMMC
-#define HAL_USE_SDMMC 0
-#endif
-#define AP_FILESYSTEM_FORMAT_ENABLED HAL_USE_SDMMC
+#define AP_FILESYSTEM_FORMAT_ENABLED 1
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX || CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -68,10 +63,6 @@ struct dirent {
 #endif
 
 #include "AP_Filesystem_backend.h"
-
-#ifndef AP_FILESYSTEM_FORMAT_ENABLED
-#define AP_FILESYSTEM_FORMAT_ENABLED 0
-#endif
 
 class AP_Filesystem {
 private:

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
@@ -32,7 +32,7 @@
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
 
-#define FF_USE_MKFS		HAL_USE_SDC
+#define FF_USE_MKFS		1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
 


### PR DESCRIPTION
The new ChibiOS 21.xx supports formatting for SPI connected microSD cards. This enables the feature now for all boards
it is slow to format with a SPI microSD (takes about 15s for a 32G card) but it does work
