### PR TITLE
AP_Mount_Siyi: update ZR10 ACQUIRE_GIMBAL_CONFIG_INFO

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -391,7 +391,8 @@ void AP_Mount_Siyi::process_packet()
         break;
 
     case SiyiCommandId::ACQUIRE_GIMBAL_CONFIG_INFO: {
-        if (_parsed_msg.data_bytes_received != 5 &&     // ZR10 firmware version reply is 5 bytes
+        if (_parsed_msg.data_bytes_received != 5 &&     // ZR10 firmware version reply is 5 bytes - maybe can be removed in future
+            _parsed_msg.data_bytes_received != 6 &&     // ZR10 firmware version reply is 6 bytes after update to firmware v.0.2.8 and zoom 0.2.1
             _parsed_msg.data_bytes_received != 7) {     // A8 firmware version reply is 7 bytes
 #if AP_MOUNT_SIYI_DEBUG
             unexpected_len = true;


### PR DESCRIPTION
In the ZR10 firmware 0.2.8 and Zoom to 0.2.1 the ACQUIRE_GIMBAL_CONFIG_INFO length now is 6 instead 5.
How can I hadn't access to previous version I left the check for 5 for compatibility - maybe can be removed in the future.
Is working fine now.
