### PR TITLE
Replace __builtin_parity with custom implementation

### DIFF
--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include "crc.h"
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
 /**
  * crc4 method from datasheet for 16 bytes (8 short values)
  * 
@@ -540,7 +542,29 @@ uint64_t crc_crc64(const uint32_t *data, uint16_t num_words)
     return crc;
 }
 
+// return the parity of byte - "1" if there is an odd number of bits
+// set, "0" if there is an even number of bits set note that
+// __builtin_parity causes hardfaults on Pixracer-periph - and is
+// slower on 1 byte than this:
 uint8_t parity(uint8_t byte)
 {
-    return __builtin_parity(byte);
+    uint8_t p = 0;
+
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+
+    return p;
 }

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -539,3 +539,8 @@ uint64_t crc_crc64(const uint32_t *data, uint16_t num_words)
 
     return crc;
 }
+
+uint8_t parity(uint8_t byte)
+{
+    return __builtin_parity(byte);
+}

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -55,3 +55,7 @@ void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
 
 // CRC-64-WE using the polynomial of 0x42F0E1EBA9EA3693
 uint64_t crc_crc64(const uint32_t *data, uint16_t num_words);
+
+// return the parity of byte - "1" if there is an odd number of bits
+// set, "0" if there is an even number of bits set
+uint8_t parity(uint8_t byte);

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -680,6 +680,18 @@ TEST(MathTest, FIXEDWINGTURNRATE)
     EXPECT_NEAR(56.187965393066406f, fixedwing_turn_rate(45, 10.0f), accuracy);
 }
 
+TEST(CRCTest, parity)
+{
+    EXPECT_EQ(parity(0b1), 1);
+    EXPECT_EQ(parity(0b10), 1);
+    EXPECT_EQ(parity(0b100), 1);
+
+    EXPECT_EQ(parity(0b11), 0);
+    EXPECT_EQ(parity(0b110), 0);
+    EXPECT_EQ(parity(0b111), 1);
+    EXPECT_EQ(parity(0b11111111), 0);
+}
+
 AP_GTEST_PANIC()
 AP_GTEST_MAIN()
 

--- a/libraries/AP_RCProtocol/SoftSerial.cpp
+++ b/libraries/AP_RCProtocol/SoftSerial.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "SoftSerial.h"
+#include <AP_Math/crc.h>
 #include <stdio.h>
 
 SoftSerial::SoftSerial(uint32_t _baudrate, serial_config _config) :
@@ -85,7 +86,7 @@ bool SoftSerial::process_pulse(uint32_t width_high, uint32_t width_low, uint8_t 
         }
         if (config == SERIAL_CONFIG_8E2I) {
             // check parity
-            if (__builtin_parity((state.byte>>1)&0xFF) != (state.byte&0x200)>>9) {
+            if (parity((state.byte>>1)&0xFF) != (state.byte&0x200)>>9) {
                 goto reset;
             }
         }


### PR DESCRIPTION
 - we only need to do one byte, and we can do that faster that __builtin_popcount
 - __builtin_parity hardfaults AP_Periph

The last implementation here is the on we're going with:

```
    uint8_t popcount = 0;
    for (uint8_t i=0; i<8; i++) {
        if (byte & 1U<<i) {
            popcount++;
        }
    }
    return popcount & 0x1;
```
  parity(17)  0.4886 usec/call

```
    uint8_t popcount = 0;
    for (uint8_t i=0; i<8; i++) {
        if (byte & 0x1) {
            popcount++;
        }
        byte >>= 1;
    }
    return popcount & 0x1;
```
parity(17)  0.4882 usec/call

```
    uint8_t popcount = 0;
    for (uint8_t i=0; i<8; i++) {
        popcount += byte & 0x1;
        byte >>= 1;
    }
    return popcount & 0x1;
```
parity(17)  0.4388 usec/call


```
    return 0:
```
  parity(17)  0.0400 usec/call


```
    return (((byte * 0x0101010101010101ULL) & 0x8040201008040201ULL) % 0x1FF) & 1;
```
  parity(17)  0.8058 usec/call


```
   __builtin_parity(byte):
```
parity(17)  0.1498 usec/call


```
    uint8_t popcount = 0;

    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;
    byte >>= 1;
    popcount += byte & 0x1;

    return popcount & 0x1;
```
  parity(17)  0.1120 usec/call


```
    uint8_t p = 0;

    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;
    byte >>= 1;
    p ^= byte & 0x1;

    return p;
```
parity(17)  0.0890 usec/call
