### PR TITLE
Fix feature detection of AP_FILESYSTEM_FORMAT_ENABLED

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -189,7 +189,7 @@ class ExtractFeatures(object):
             ('AP_NOTIFY_PROFILED_ENABLED', r'ProfiLED::init_ports'),
             ('AP_NOTIFY_PROFILED_SPI_ENABLED', r'ProfiLED_SPI::rgb_set_id'),
             ('AP_NOTIFY_NEOPIXEL_ENABLED', r'NeoPixel::init_ports'),
-            ('AP_FILESYSTEM_FORMAT_ENABLED', r'f_mkfs'),
+            ('AP_FILESYSTEM_FORMAT_ENABLED', r'AP_Filesystem::format'),
 
             ('AP_INERTIALSENSOR_KILL_IMU_ENABLED', r'AP_InertialSensor::kill_imu'),
         ]

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -285,26 +285,20 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
     return true;
 }
 
+#if AP_FILESYSTEM_FORMAT_ENABLED
 // format filesystem
 bool AP_Filesystem::format(void)
 {
-#if AP_FILESYSTEM_FORMAT_ENABLED
     if (hal.util->get_soft_armed()) {
         return false;
     }
     return LOCAL_BACKEND.fs.format();
-#else
-    return false;
-#endif
 }
 AP_Filesystem_Backend::FormatStatus AP_Filesystem::get_format_status(void) const
 {
-#if AP_FILESYSTEM_FORMAT_ENABLED
     return LOCAL_BACKEND.fs.get_format_status();
-#else
-    return AP_Filesystem_Backend::FormatStatus::NOT_STARTED;
-#endif
 }
+#endif
 
 namespace AP
 {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1359,6 +1359,7 @@ void GCS_MAVLINK_InProgress::check_tasks()
             }
             break;
         case Type::SD_FORMAT:
+#if AP_FILESYSTEM_FORMAT_ENABLED
             switch (AP::FS().get_format_status()) {
             case AP_Filesystem_Backend::FormatStatus::NOT_STARTED:
                 // we shouldn't get here
@@ -1375,6 +1376,7 @@ void GCS_MAVLINK_InProgress::check_tasks()
                 task.conclude(MAV_RESULT_FAILED);
                 break;
             }
+#endif
             break;
         }
     }
@@ -5085,6 +5087,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const mavlink_command_long_t &
     return handle_command_do_set_roi(roi_loc);
 }
 
+#if AP_FILESYSTEM_FORMAT_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
     if (!is_equal(packet.param1, 1.0f) ||
@@ -5101,6 +5104,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_storage_format(const mavlink_command_int_
     }
     return MAV_RESULT_IN_PROGRESS;
 }
+#endif
 
 MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &packet)
 {
@@ -5145,9 +5149,11 @@ void GCS_MAVLINK::handle_command_int(const mavlink_message_t &msg)
 
     // special handling of messages that need the mavlink_message_t
     switch (packet.command) {
+#if AP_FILESYSTEM_FORMAT_ENABLED
     case MAV_CMD_STORAGE_FORMAT:
         result = handle_command_storage_format(packet, msg);
         break;
+#endif
     default:
         result = handle_command_int_packet(packet);
         break;


### PR DESCRIPTION
The mkfs symbol is stil present in ArduPilot even with this feature removed.  The following command found this problem: `./Tools/autotest/test_build_options.py --define-match-glob=AP_FILESYSTEM_FORMAT_ENABLED`

```
Traceback (most recent call last):
  File "/home/pbarker/rc/ardupilot/./Tools/autotest/test_build_options.py", line 451, in <module>
    tbo.run()
  File "/home/pbarker/rc/ardupilot/./Tools/autotest/test_build_options.py", line 396, in run
    self.run_disable_in_turn()
  File "/home/pbarker/rc/ardupilot/./Tools/autotest/test_build_options.py", line 314, in run_disable_in_turn
    self.test_disable_feature(feature, options)
  File "/home/pbarker/rc/ardupilot/./Tools/autotest/test_build_options.py", line 188, in test_disable_feature
    raise ValueError(error)
ValueError: feature gated by AP_FILESYSTEM_FORMAT_ENABLED still compiled into (copter); extract_features.py bug?
```
