### PR TITLE
A solution for broken usage of DEFAULTGPIO in hwdef

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2876,6 +2876,10 @@ INCLUDE common.ld
             self.error("ALT() invalid for %s" % a[0])
 
         if a[0] == 'DEFAULTGPIO':
+            if "MCU" in self.config:
+                # should be self.error(...)
+                print("DEPRECATED: the DEFAULTGPIO has NO EFFECT if used after MCU declaration!")
+
             self.default_gpio = a[1:]
             return
 


### PR DESCRIPTION
Houston, we have a problem.

Since `DEFAULTGPIO` was introduced (#15943) for `mRoPixracerPro`... Noone is using it correctly. 

While inspecting the code of `chibios_hwdef.py` I've noted that once parser meet `MCU` directive, it invokes `self.setup_mcu_type_defaults()`, which uses `default_gpio` var to initialize pins. That var may only be updated by `DEFAULTGPIO` directive. So using `DEFAULTGPIO` **after** `MCU` is pointless and in fact incorrect -- and there's no complains in `chibios_hwdef.py` about that.

The `mRoPixracerPro/hwdef.dat` is the only correct hwdef. **Others with `DEFAULTGPIO` are broken** (not only `hwdef.dat`, but also `hwdef-bl.dat`). Here's the complete list of affected files:

- AIRLink/hwdef.dat
- ARKV6X/hwdef-bl.dat
- ARKV6X/hwdef.dat
- C-RTK2-HP/hwdef.dat
- FlywooF405S-AIO/hwdef-bl.dat
- FoxeerH743v1/hwdef-bl.dat
- KakuteH7/hwdef-bl.dat
- KakuteH7Mini/hwdef-bl.dat
- MambaH743v4/hwdef-bl.dat
- Pixhawk5X/hwdef-bl.dat
- Pixhawk5X/hwdef.dat
- Pixhawk6C/hwdef-bl.dat
- Pixhawk6C/hwdef.dat
- Pixhawk6X/hwdef-bl.dat
- Pixhawk6X/hwdef.dat
- Pixracer-periph/hwdef.dat
- SPRacingH7/hwdef-bl.dat
- SPRacingH7RF/hwdef-bl.dat
- SkystarsH7HD/hwdef-bl.dat
- SpeedyBeeF405WING/hwdef-bl.dat
- modalai_fc-v1/hwdef-bl.dat
- modalai_fc-v1/hwdef.dat
- rFCU/hwdef.dat
- speedybeef4v3/hwdef-bl.dat
- thepeach-k1/hwdef-bl.dat
- thepeach-k1/hwdef.dat
- thepeach-r1/hwdef-bl.dat
- thepeach-r1/hwdef.dat

Also, should warn about `PixPilot-V6/hwdef.dat`: there's a `DEFAULTGPIO` line there in incorrect place, but it's commented out.

I think that just adding a `self.error("incorrect usage bro")` will really break things badly, so I suggest a several-step solution.

1. introduce a gentle deprecation warning in  `chibios_hwdef.py` -- see this PR
2. wait for board maintainers to update their configs and test things
3. convert deprecation to fatal error to avoid future misuses.

I really think this is a severe problem caused by missing the order check in original code and also a lack of documentation for introduced DEFAULTGPIO stanza.

I can't really know the development lifecycle internals, so providing that solution steps above just as a suggestion.