### PR TITLE
AP_Bootloader: add YJUAV_A6 and YJUAV_A6Nano to board types.

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -231,6 +231,9 @@ AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402
 AP_HW_SWBOOMBOARD_PERIPH             1403
 
+AP_HW_YJUAV_A6                       1500
+AP_HW_YJUAV_A6Nano                   1501
+
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140
 AP_HW_Pixhawk6_ODID                 10053


### PR DESCRIPTION
Add two new board id.