### PR TITLE
reload defaults file at end of AP_Vehicle::setup

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -497,7 +497,7 @@ void Copter::allocate_motors(void)
 #endif
 
     // reload lines from the defaults file that may now be accessible
-    AP_Param::reload_defaults_file(true);
+    AP_Param::reload_defaults_file();
     
     // now setup some frame-class specific defaults
     switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -126,7 +126,7 @@ void Plane::init_ardupilot()
     quadplane.setup();
 #endif
 
-    AP_Param::reload_defaults_file(true);
+    AP_Param::reload_defaults_file();
     
     startup_ground();
 

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -268,7 +268,7 @@ void Blimp::allocate_motors(void)
     AP_Param::load_object_from_eeprom(motors, Fins::var_info);
 
     // reload lines from the defaults file that may now be accessible
-    AP_Param::reload_defaults_file(true);
+    AP_Param::reload_defaults_file();
 
     // param count could have changed
     AP_Param::invalidate_count();

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -313,6 +313,12 @@ void AP_Vehicle::setup()
     }
 #endif
 
+    // reload lines from the defaults file that may now be accessible
+    // (for example, the generator backend does a
+    // setup_object_defaults, which allows defaults-file-loading to
+    // match its results against allocated object pointers)
+    AP_Param::reload_defaults_file(true);
+
     // invalidate count in case an enable parameter changed during
     // initialisation
     AP_Param::invalidate_count();


### PR DESCRIPTION
Some libraries are doing allocation of object defaults as part of their init methods, but defautls are not being applied.

We have to attempt to reload object defaults after doing these allocations.  It is unclear whether the vehicles still need to reload defaults where they are - but it shouldn't hurt.
