### PR TITLE
Copter/Plane/Rover: Add a bitmask parameter to block mode entry from GCS

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -857,6 +857,9 @@ private:
     void update_flight_mode();
     void notify_flight_mode();
 
+    // Check if this mode can be entered from the GCS
+    bool gcs_mode_enabled(const Mode::Number mode_num);
+
     // mode_land.cpp
     void set_mode_land_with_pause(ModeReason reason);
     bool landing_with_GPS();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1074,6 +1074,7 @@ private:
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);
     void notify_mode(const Mode& mode);
+    bool gcs_mode_enabled(const Mode::Number mode_num) const;
 
     // takeoff.cpp
     bool auto_takeoff_check(void);

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -360,6 +360,7 @@ private:
     void init_ardupilot() override;
     void startup_ground(void);
     void update_ahrs_flyforward();
+    bool gcs_mode_enabled(const Mode::Number mode_num) const;
     bool set_mode(Mode &new_mode, ModeReason reason);
     bool set_mode(const uint8_t new_mode, ModeReason reason) override;
     uint8_t get_mode() const override { return (uint8_t)control_mode->mode_number(); }

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -223,11 +223,41 @@ void Rover::update_ahrs_flyforward()
     ahrs.set_fly_forward(flyforward);
 }
 
+// Check if this mode can be entered from the GCS
+bool Rover::gcs_mode_enabled(const Mode::Number mode_num) const
+{
+    // List of modes that can be blocked, index is bit number in parameter bitmask
+    static const uint8_t mode_list [] {
+        (uint8_t)Mode::Number::MANUAL,
+        (uint8_t)Mode::Number::ACRO,
+        (uint8_t)Mode::Number::STEERING,
+        (uint8_t)Mode::Number::LOITER,
+        (uint8_t)Mode::Number::FOLLOW,
+        (uint8_t)Mode::Number::SIMPLE,
+        (uint8_t)Mode::Number::CIRCLE,
+        (uint8_t)Mode::Number::AUTO,
+        (uint8_t)Mode::Number::RTL,
+        (uint8_t)Mode::Number::SMART_RTL,
+        (uint8_t)Mode::Number::GUIDED,
+#if MODE_DOCK_ENABLED == ENABLED
+        (uint8_t)Mode::Number::DOCK
+#endif
+    };
+
+    return !block_GCS_mode_change((uint8_t)mode_num, mode_list, ARRAY_SIZE(mode_list));
+}
+
 bool Rover::set_mode(Mode &new_mode, ModeReason reason)
 {
     if (control_mode == &new_mode) {
         // don't switch modes if we are already in the correct mode.
         return true;
+    }
+
+    // Check if GCS mode change is disabled via parameter
+    if ((reason == ModeReason::GCS_COMMAND) && !gcs_mode_enabled((Mode::Number)new_mode.mode_number())) {
+        gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name4());
+        return false;
     }
 
     Mode &old_mode = *control_mode;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -137,6 +137,71 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(kdecan, "KDE_",  19, AP_Vehicle, AP_KDECAN),
 #endif
 
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)
+    // @Param: FLTMODE_GCSBLOCK
+    // @DisplayName: Flight mode block from GCS
+    // @Description: Bitmask of flight modes to disable for GCS selection. Mode can still be accessed via RC or failsafe.
+    // @Bitmask{Copter}: 0:Stabilize
+    // @Bitmask{Copter}: 1:Acro
+    // @Bitmask{Copter}: 2:AltHold
+    // @Bitmask{Copter}: 3:Auto
+    // @Bitmask{Copter}: 4:Guided
+    // @Bitmask{Copter}: 5:Loiter
+    // @Bitmask{Copter}: 6:Circle
+    // @Bitmask{Copter}: 7:Drift
+    // @Bitmask{Copter}: 8:Sport
+    // @Bitmask{Copter}: 9:Flip
+    // @Bitmask{Copter}: 10:AutoTune
+    // @Bitmask{Copter}: 11:PosHold
+    // @Bitmask{Copter}: 12:Brake
+    // @Bitmask{Copter}: 13:Throw
+    // @Bitmask{Copter}: 14:Avoid_ADSB
+    // @Bitmask{Copter}: 15:Guided_NoGPS
+    // @Bitmask{Copter}: 16:Smart_RTL
+    // @Bitmask{Copter}: 17:FlowHold
+    // @Bitmask{Copter}: 18:Follow
+    // @Bitmask{Copter}: 19:ZigZag
+    // @Bitmask{Copter}: 20:SystemID
+    // @Bitmask{Copter}: 21:Heli_Autorotate
+    // @Bitmask{Copter}: 22:Auto RTL
+    // @Bitmask{Copter}: 23:Turtle
+    // @Bitmask{Plane}: 0:Manual
+    // @Bitmask{Plane}: 1:Circle
+    // @Bitmask{Plane}: 2:Stabilize
+    // @Bitmask{Plane}: 3:Training
+    // @Bitmask{Plane}: 4:ACRO
+    // @Bitmask{Plane}: 5:FBWA
+    // @Bitmask{Plane}: 6:FBWB
+    // @Bitmask{Plane}: 7:CRUISE
+    // @Bitmask{Plane}: 8:AUTOTUNE
+    // @Bitmask{Plane}: 9:Auto
+    // @Bitmask{Plane}: 10:Loiter
+    // @Bitmask{Plane}: 11:Takeoff
+    // @Bitmask{Plane}: 12:AVOID_ADSB
+    // @Bitmask{Plane}: 13:Guided
+    // @Bitmask{Plane}: 14:THERMAL
+    // @Bitmask{Plane}: 15:QSTABILIZE
+    // @Bitmask{Plane}: 16:QHOVER
+    // @Bitmask{Plane}: 17:QLOITER
+    // @Bitmask{Plane}: 18:QACRO
+    // @Bitmask{Plane}: 19:QAUTOTUNE
+    // @Bitmask{Rover}: 0:Manual
+    // @Bitmask{Rover}: 1:Acro
+    // @Bitmask{Rover}: 2:Steering
+    // @Bitmask{Rover}: 3:Loiter
+    // @Bitmask{Rover}: 4:Follow
+    // @Bitmask{Rover}: 5:Simple
+    // @Bitmask{Rover}: 6:Circle
+    // @Bitmask{Rover}: 7:Auto
+    // @Bitmask{Rover}: 8:RTL
+    // @Bitmask{Rover}: 9:SmartRTL
+    // @Bitmask{Rover}: 10:Guided
+    // @Bitmask{Rover}: 11:Dock
+    // @User: Standard
+    AP_GROUPINFO("FLTMODE_GCSBLOCK", 20, AP_Vehicle, flight_mode_GCS_block, 0),
+#endif // APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)
+
+
     AP_GROUPEND
 };
 
@@ -851,6 +916,26 @@ bool AP_Vehicle::init_dds_client()
     return dds_client->start();
 }
 #endif // AP_DDS_ENABLED
+
+// Check if this mode can be entered from the GCS
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)
+bool AP_Vehicle::block_GCS_mode_change(uint8_t mode_num, const uint8_t *mode_list, uint8_t mode_list_length) const
+{
+    if (mode_list == nullptr) {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < mode_list_length; i++) {
+        // Find index of mode
+        if (mode_list[i] == mode_num) {
+            const uint32_t mask = 1U << i;
+            return (uint32_t(flight_mode_GCS_block) & mask) != 0;
+        }
+    }
+
+    return false;
+}
+#endif
 
 AP_Vehicle *AP_Vehicle::_singleton = nullptr;
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -418,6 +418,9 @@ protected:
     bool init_dds_client() WARN_IF_UNUSED;
 #endif
 
+    // Check if this mode can be entered from the GCS
+    bool block_GCS_mode_change(uint8_t mode_num, const uint8_t *mode_list, uint8_t mode_list_length) const;
+
 private:
 
     // delay() callback that processing MAVLink packets
@@ -457,6 +460,9 @@ private:
     uint32_t _last_internal_errors;  // backup of AP_InternalError::internal_errors bitmask
 
     AP_CustomRotations custom_rotations;
+
+    // Bitmask of modes to disable from gcs
+    AP_Int32 flight_mode_GCS_block;
 };
 
 namespace AP {


### PR DESCRIPTION
This adds a new parameter to block mode entry from GCS. This does not block mode entry from any other source. The idea is to prevent GCS mistakes from putting the vehicle into a mode that the pilot is not experienced with or expecting. For example if the GCS operator mean to hit alt-hold but accidentally selected acro. 

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/89e1f212-6f50-4e0c-b338-98ec0fc1b2d2)


This does not prevent entry from any other source, the main other candidate would be RC, but in that case you can just not setup switches for modes you don't want to use. 

There are some modes that it is not allowed to disable, stabilize, alt-hold RTL and land. Since this is only GCS I can see the case for also allowing disabling stabilize and alt-hold, switching into them without coordination with the pilot will also cause issues. 

Unfortunately there are too many modes to map over to the bitmask using the existing mode numbers, so I have had to re-map using a switch case. 

This is just copter, but if we think this is worth while I think it makes sense to do the other vehicles too.

This work is sponsored by ARACE. 

