### PR TITLE
Stop taking ServoRelayEvents in constructo for MotorsUGV

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -739,7 +739,7 @@ ParametersG2::ParametersG2(void)
 #if AP_BEACON_ENABLED
     beacon(),
 #endif
-    motors(rover.ServoRelayEvents, wheel_rate_control),
+    motors(wheel_rate_control),
     wheel_rate_control(wheel_encoder),
     attitude_control(),
     smart_rtl(),

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -16,6 +16,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
 #include "AP_MotorsUGV.h"
+#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
 #define SERVO_MAX 4500  // This value represents 45 degrees and is just an arbitrary representation of servo max travel.
 
@@ -113,9 +114,8 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     AP_GROUPEND
 };
 
-AP_MotorsUGV::AP_MotorsUGV(AP_ServoRelayEvents &relayEvents, AP_WheelRateControl& rate_controller) :
-        _relayEvents(relayEvents),
-        _rate_controller(rate_controller)
+AP_MotorsUGV::AP_MotorsUGV(AP_WheelRateControl& rate_controller) :
+    _rate_controller(rate_controller)
 {
     AP_Param::setup_object_defaults(this, var_info);
     _singleton = this;
@@ -847,6 +847,8 @@ void AP_MotorsUGV::output_throttle(SRV_Channel::Aux_servo_function_t function, f
 
     // set relay if necessary
     if (_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) {
+        auto &_relayEvents { *AP::servorelayevents() };
+
         // find the output channel, if not found return
         const SRV_Channel *out_chan = SRV_Channels::get_channel_for(function);
         if (out_chan == nullptr) {

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <AP_Arming/AP_Arming.h>
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_WheelEncoder/AP_WheelRateControl.h>
 #include <SRV_Channel/SRV_Channel.h>
 
 class AP_MotorsUGV {
 public:
     // Constructor
-    AP_MotorsUGV(AP_ServoRelayEvents &relayEvents, AP_WheelRateControl& rate_controller);
+    AP_MotorsUGV(AP_WheelRateControl& rate_controller);
 
     // singleton support
     static AP_MotorsUGV    *get_singleton(void) { return _singleton; }
@@ -190,7 +189,6 @@ private:
     float get_rate_controlled_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt);
 
     // external references
-    AP_ServoRelayEvents &_relayEvents;
     AP_WheelRateControl &_rate_controller;
 
     static const int8_t AP_MOTORS_NUM_MOTORS_MAX = 4;


### PR DESCRIPTION
... use the singleton instead.

This is extracted from a larger PR which allows Relay and ServoRelayEvents to be compiled out
