### PR TITLE
AP_Bootloader: add YJUAV_A6 and YJUAV_A6Nano to board types.

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -223,6 +223,8 @@ AP_HW_AEROFOX_GNSS_F9P               1109
 AP_HW_JFB110                         1110
 AP_HW_SDMODELH7V1                    1111
 AP_HW_FlyingMoonH743                 1112
+AP_HW_YJUAV_A6                       1113
+AP_HW_YJUAV_A6Nano                   1114
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
Add two new board id.