### PR TITLE
Tools: size_compare_branches.py: do not build SPRacingH7 bootloader

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -156,6 +156,8 @@ class SizeCompareBranches(object):
             'Pixhawk1-1M-bdshot',
             'Pixhawk1-bdshot',
             'SITL_arm_linux_gnueabihf',
+            'SPRacingH7',  # see https://github.com/ArduPilot/ardupilot/pull/23947
+            'SPRacingH7RF',
         ])
 
         # blacklist all linux boards for bootloader build:


### PR DESCRIPTION
We can't build the bootloader without a clean.  clean removes all the other binaries we've compiled.  We rely on those binaries all being present after building all the vehicles.