### PR TITLE
hwdef: save flash on boards with DFU

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/hwdef.dat
@@ -149,3 +149,6 @@ define HAL_DEFAULT_INS_FAST_SAMPLE 3
 define HAL_FRAME_TYPE_DEFAULT 12
 
 define DEFAULT_NTF_LED_TYPES 257
+
+# save some flash space
+include ../include/no_bootloader_DFU.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-TE/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-TE/hwdef.dat
@@ -180,6 +180,7 @@ define HAL_GYROFFT_ENABLED 0
 # --------------------- save flash ----------------------
 # save some flash
 include ../include/save_some_flash.inc
+include ../include/no_bootloader_DFU.inc
 define AP_BATTERY_SMBUS_ENABLED 0
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
@@ -133,3 +133,4 @@ define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 
 # minimal drivers to reduce flash usage
 include ../include/minimal.inc
+include ../include/no_bootloader_DFU.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/no_bootloader_DFU.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/no_bootloader_DFU.inc
@@ -1,0 +1,7 @@
+
+# on boards with a DFU button that are low on flash we can omit the
+# bootloader from ROMFS, saving about 11k of flash. The user can still
+# update using the apj and mission planner, but if they want to update
+# the bootloader they need to use DFU with the 'xxx_with_bl.hex'
+# firmware image
+define AP_BOOTLOADER_FLASHING_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4/hwdef.dat
@@ -146,4 +146,5 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 # minimal drivers to reduce flash usage
 include ../include/minimal.inc
+include ../include/no_bootloader_DFU.inc
 define AP_BATTERY_SYNTHETIC_CURRENT_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v3/hwdef.dat
@@ -155,6 +155,7 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 # minimal drivers to reduce flash usage
 include ../include/minimal.inc
+include ../include/no_bootloader_DFU.inc
 define AP_BATTERY_SYNTHETIC_CURRENT_ENABLED 0
 
 define DEFAULT_NTF_LED_TYPES 257


### PR DESCRIPTION
omit bootloader from ROMFS if the board is low on flash and has a DFU button
