### PR TITLE
Fix bodycentric attitude

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -377,7 +377,7 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     Quaternion q;
     q.from_euler(radians(roll_deg),radians(pitch_deg),radians(yaw_deg));
 
-    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false);
+    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false, false);
     return true;
 }
 #endif

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -197,7 +197,7 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     mavlink_msg_position_target_local_ned_send(
         chan,
         AP_HAL::millis(), // time boot ms
-        MAV_FRAME_LOCAL_NED, 
+        MAV_FRAME_LOCAL_NED,
         type_mask,
         target_pos.x,   // x in metres
         target_pos.y,   // y in metres
@@ -243,7 +243,7 @@ float GCS_MAVLINK_Copter::vfr_hud_airspeed() const
         return copter.airspeed.get_airspeed();
     }
 #endif
-    
+
     Vector3f airspeed_vec_bf;
     if (AP::ahrs().airspeed_vector_true(airspeed_vec_bf)) {
         // we are running the EKF3 wind estimation code which can give
@@ -1210,6 +1210,12 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
             ang_vel.z = packet.body_yaw_rate;
         }
 
+        bool use_body_roll_pitch_angle_yaw_rate = false;
+        if (roll_rate_ignore && pitch_rate_ignore && !yaw_rate_ignore && !attitude_ignore)
+        {
+            use_body_roll_pitch_angle_yaw_rate = true;
+        }
+
         copter.mode_guided.set_angle(attitude_quat, ang_vel,
                 climb_rate_or_thrust, use_thrust);
 
@@ -1448,7 +1454,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         copter.g2.toy_mode.handle_message(msg);
         break;
 #endif
-        
+
     default:
         handle_common_message(msg);
         break;
@@ -1537,7 +1543,7 @@ int16_t GCS_MAVLINK_Copter::high_latency_target_altitude() const
         return 0.01 * (global_position_current.alt + copter.pos_control->get_pos_error_z_cm());
     }
     return 0;
-    
+
 }
 
 uint8_t GCS_MAVLINK_Copter::high_latency_tgt_heading() const
@@ -1548,9 +1554,9 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_heading() const
         // need to convert -18000->18000 to 0->360/2
         return wrap_360_cd(flightmode->wp_bearing()) / 200;
     }
-    return 0;     
+    return 0;
 }
-    
+
 uint16_t GCS_MAVLINK_Copter::high_latency_tgt_dist() const
 {
     if (copter.ap.initialised) {
@@ -1567,7 +1573,7 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_airspeed() const
         // return units are m/s*5
         return MIN(copter.pos_control->get_vel_target_cms().length() * 5.0e-2, UINT8_MAX);
     }
-    return 0;  
+    return 0;
 }
 
 uint8_t GCS_MAVLINK_Copter::high_latency_wind_speed() const
@@ -1579,7 +1585,7 @@ uint8_t GCS_MAVLINK_Copter::high_latency_wind_speed() const
         wind = AP::ahrs().wind_estimate();
         return wind.length() * 5;
     }
-    return 0; 
+    return 0;
 }
 
 uint8_t GCS_MAVLINK_Copter::high_latency_wind_direction() const

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1217,7 +1217,7 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
         }
 
         copter.mode_guided.set_angle(attitude_quat, ang_vel,
-                climb_rate_or_thrust, use_thrust);
+                climb_rate_or_thrust, use_thrust, use_body_roll_pitch_angle_yaw_rate);
 
         break;
     }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -984,7 +984,9 @@ public:
     // climb_rate_cms_or_thrust: represents either the climb_rate (cm/s) or thrust scaled from [0, 1], unitless
     // use_thrust: IF true: climb_rate_cms_or_thrust represents thrust
     //             IF false: climb_rate_cms_or_thrust represents climb_rate (cm/s)
-    void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust);
+    // use_body_roll_pitch_angle_yaw_rate: If true: specify quaternion only pitch and roll will be used in a body centric way, Yaw rate will be used. Yaw angle is discarded.
+    //              IF false: the attitude quaternion will be used and vehicle will attempt to attain this attitude including yaw as the vehicle sees it.
+    void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust, bool use_body_roll_pitch_angle_yaw_rate);
 
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool terrain_alt = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -1012,7 +1014,7 @@ public:
     bool limit_check();
 
     bool is_taking_off() const override;
-    
+
     bool set_speed_xy(float speed_xy_cms) override;
     bool set_speed_up(float speed_up_cms) override;
     bool set_speed_down(float speed_down_cms) override;
@@ -1752,7 +1754,7 @@ protected:
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };
 
-class ModeZigZag : public Mode {        
+class ModeZigZag : public Mode {
 
 public:
     ModeZigZag(void);
@@ -1892,7 +1894,7 @@ private:
         FLARE,
         TOUCH_DOWN,
         BAIL_OUT } phase_switch;
-        
+
     enum class Navigation_Decision {
         USER_CONTROL_STABILISED,
         STRAIGHT_AHEAD,


### PR DESCRIPTION
Addresses #20444
This PR checks if the user wants to use attitude quaternion but also specifies yaw rate but not pitch or roll rates for attitude control. 
This then enables control in body centric pitch and roll, yaw is ignored from the quaternion. Yaw is specified by yaw rate.