### PR TITLE
AP_HAL_ChibiOS/Scheduler: add external watchdog for JFB100

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -765,7 +765,22 @@ void Scheduler::watchdog_pat(void)
 {
     stm32_watchdog_pat();
     last_watchdog_pat_ms = AP_HAL::millis();
+#if defined(HAL_GPIO_PIN_EXT_WDOG)
+    ext_watchdog_pat(last_watchdog_pat_ms);
+#endif
 }
+
+#if defined(HAL_GPIO_PIN_EXT_WDOG)
+// toggle the external watchdog gpio pin
+void Scheduler::ext_watchdog_pat(uint32_t now_ms)
+{
+    // toggle watchdog GPIO every WDI_OUT_INTERVAL_TIME_MS
+    if ((now_ms - last_ext_watchdog_ms) >= EXT_WDOG_INTERVAL_MS) {
+        palToggleLine(HAL_GPIO_PIN_EXT_WDOG);
+        last_ext_watchdog_ms = now_ms;
+    }
+}
+#endif
 
 #if CH_DBG_ENABLE_STACK_CHECK == TRUE
 /*

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -193,5 +193,11 @@ private:
 
     // check for free stack space
     void check_stack_free(void);
+
+#if defined(HAL_GPIO_PIN_EXT_WDOG)
+    // external watchdog GPIO support
+    void ext_watchdog_pat(uint32_t now_ms);
+    uint32_t last_ext_watchdog_ms;
+#endif
 };
 #endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB100/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB100/hwdef.dat
@@ -341,9 +341,9 @@ PG15 WA8 INPUT PULLUP
 # now we define the pins that USB is connected on
 PA9 VBAS INPUT PULLDOWN
 
-# External watchdog timer clear
-PH11 WDI_OUT OUTPUT SPEED_VERYLOW
-define WDI_OUT_INTERVAL_TIME_MS 100
+# External watchdog gpio
+PH11 EXT_WDOG OUTPUT SPEED_VERYLOW
+define EXT_WDOG_INTERVAL_MS 100
 
 # safety switch
 PE10 SAFETY_IN INPUT PULLUP


### PR DESCRIPTION
This PR replaces https://github.com/ArduPilot/ardupilot/pull/23750 and includes these minor changes from the earlier PR:

1. Renamed definition, function and local variables to be a little more consistent (I think)
2. Removed a call to AP_HAL::millis()
3. changed an "int" to an "int32_t"
4. The external watchdog pin is toggled no faster than 10hz (previously it could be as fast as 20hz)

This has been lightly tested on real hardware.

@jfbblue0922 could you confirm that you're ok with these changes?  Also could you tell me where on the board the external watchdog pin is?  