### PR TITLE
AP_Vehicle: initialise generator before init_ardupilot

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -220,6 +220,10 @@ void AP_Vehicle::setup()
     externalAHRS.init();
 #endif
 
+#if HAL_GENERATOR_ENABLED
+    generator.init();
+#endif
+
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
 
@@ -271,10 +275,6 @@ void AP_Vehicle::setup()
 #endif
 
     send_watchdog_reset_statustext();
-
-#if HAL_GENERATOR_ENABLED
-    generator.init();
-#endif
 
 #if AP_OPENDRONEID_ENABLED
     opendroneid.init();


### PR DESCRIPTION
each of the vehicles does a load-defaults-from-files.  Use that fact to ensure any generator backend parameter's defaults are loaded.

Raised as an alternative to https://github.com/ArduPilot/ardupilot/pull/24007
