### PR TITLE
Copter: add has_user_takeoff in ZigZag mode

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1786,6 +1786,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return true; }
     bool is_autopilot() const override { return true; }
+    bool has_user_takeoff(bool must_navigate) const override { return true; }
 
     // save current position as A or B.  If both A and B have been saved move to the one specified
     void save_or_move_to_destination(Destination ab_dest);


### PR DESCRIPTION
ZigZag mode has takeoff feature.

When I tried to takeoff in ZigZag mode, the error (attached later) has occured.
This change caught the error.
https://github.com/ArduPilot/ardupilot/pull/21158/commits/dbe4873347f92b3d5e9029c357688b11ade51c3f#diff-11eec0f85c4837d179da630ca2869de2df174424ae7b8e15452548c5e404e67f

After the change, I confirmed that the copter can takeoff in ZigZag mode on SITL.

```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007fd12b001c7f in __GI___wait4 (pid=26691, stat_loc=stat_loc@entry=0x7ffcd1299f48, options=options@entry=0, usage=usage@entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
27	../sysdeps/unix/sysv/linux/wait4.c: No such file or directory.
#0  0x00007fd12b001c7f in __GI___wait4 (pid=26691, stat_loc=stat_loc@entry=0x7ffcd1299f48, options=options@entry=0, usage=usage@entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
        resultvar = 18446744073709551104
        sc_cancel_oldtype = 0
        sc_ret = <optimized out>
#1  0x00007fd12b001bfb in __GI___waitpid (pid=<optimized out>, stat_loc=stat_loc@entry=0x7ffcd1299f48, options=options@entry=0) at waitpid.c:38
No locals.
#2  0x00007fd12af70f67 in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:172
        __result = <optimized out>
        _buffer = {__routine = 0x7fd12af71110 <cancel_handler>, __arg = 0x7ffcd1299f50, __canceltype = 0, __prev = 0x0}
        _avail = 1
        cancel_args = {quit = 0x7fd12b10d520 <quit>, intr = 0x7fd12b10d5c0 <intr>, pid = 26691}
        status = -1
        ret = 0
        pid = 26691
        sa = {__sigaction_handler = {sa_handler = 0x1, sa_sigaction = 0x1}, sa_mask = {__val = {65536, 0 <repeats 15 times>}}, sa_flags = 0, sa_restorer = 0x7fa00000ffffffff}
        omask = {__val = {0, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 140723817653456, 140723817653655, 9196350441231745024, 140723817653655, 2676586395008836901, 2676586395008836901}}
        reset = {__val = {6, 0 <repeats 15 times>}}
        spawn_attr = {__flags = 12, __pgrp = 0, __sd = {__val = {6, 0 <repeats 15 times>}}, __ss = {__val = {0, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 9196350441231745024, 140723817653456, 140723817653655, 9196350441231745024, 140723817653655, 2676586395008836901, 2676586395008836901}}, __sp = {sched_priority = 0}, __policy = 0, __pad = {0 <repeats 16 times>}}
        __cnt = <optimized out>
        __set = <optimized out>
        __cnt = <optimized out>
        __set = <optimized out>
#3  0x000055ebaafae9b8 in AP_HAL::run_command_on_ownpid (commandname=0x55ebab10bd67 "dumpstack.sh") at ../../libraries/AP_HAL_SITL/system.cpp:107
        command_filepath = 0x7ffcd129a3d0 "../Tools/scripts/dumpstack.sh"
        statbuf = {st_dev = 2080, st_ino = 295018, st_nlink = 1, st_mode = 33261, st_uid = 1000, st_gid = 1000, __pad0 = 0, st_rdev = 0, st_size = 265, st_blksize = 4096, st_blocks = 8, st_atim = {tv_sec = 1686622453, tv_nsec = 722820300}, st_mtim = {tv_sec = 1686279485, tv_nsec = 482032500}, st_ctim = {tv_sec = 1686279485, tv_nsec = 482032500}, __glibc_reserved = {0, 0, 0}}
        paths = {0x55ebab10bc20 "Tools/scripts/%s", 0x55ebab10bc31 "APM/Tools/scripts/%s", 0x55ebab10bc46 "../Tools/scripts/%s"}
        buffer = "../Tools/scripts/dumpstack.sh\000\000\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177"
        progname = "/home/drone/github/ardupilot/build/sitl/bin\000arducopter\000\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177"
        n = 54
        p = 0x7ffcd129a48b ""
        output_filepath = "dumpstack.sh_arducopter.26613.out\000\020+\321\177\000\000u\200\017\253\353U\000\000\340\251)\321\374\177\000\000$]\371*\321\177\000\000\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177"
        cmd = "sh ../Tools/scripts/dumpstack.sh 26613 >dumpstack.sh_arducopter.26613.out 2>&1\000\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177"
        fd = 2141192192
        buf = "\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177\000\000\240\177"...
#4  0x000055ebaafaeb4e in AP_HAL::dump_stack_trace () at ../../libraries/AP_HAL_SITL/system.cpp:139
No locals.
#5  0x000055ebaafae754 in AP_HAL::panic (errormsg=0x55ebab0f8075 "AP_InternalError::error_t::%s") at ../../libraries/AP_HAL_SITL/system.cpp:43
        ap = {{gp_offset = 16, fp_offset = 48, overflow_arg_area = 0x7ffcd129aac0, reg_save_area = 0x7ffcd129aa00}}
#6  0x000055ebaae9ef04 in AP_InternalError::error (this=0x55ebab203ef8 <instance>, e=AP_InternalError::error_t::flow_of_control, line=57) at ../../libraries/AP_InternalError/AP_InternalError.cpp:22
        buffer = "flow_of_ctrl", '\000' <repeats 37 times>
#7  0x000055ebaada0816 in Copter::update_land_detector (this=0x55ebab1f1dc0 <copter>) at ../../ArduCopter/land_detector.cpp:57
No locals.
#8  0x000055ebaada06d8 in Copter::update_land_and_crash_detectors (this=0x55ebab1f1dc0 <copter>) at ../../ArduCopter/land_detector.cpp:21
        accel_ef = {x = -0.00161652267, y = 0.00182674825, z = -2.67028809e-05}
#9  0x000055ebaad90027 in Functor<void>::method_wrapper<Copter, &Copter::update_land_and_crash_detectors> (obj=0x55ebab1f1dc0 <copter>) at ../../libraries/AP_HAL/utility/functor.h:88
        t = 0x55ebab1f1dc0 <copter>
#10 0x000055ebaae37fe2 in Functor<void>::operator() (this=0x55ebab1c7440 <Copter::scheduler_tasks+288>) at ../../libraries/AP_HAL/utility/functor.h:54
No locals.
#11 0x000055ebaae96f2a in AP_Scheduler::run (this=0x55ebab1f1f80 <copter+448>, time_available=2500) at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:255
        run_vehicle_task = true
        task = @0x55ebab1c7440: {function = {_obj = 0x55ebab1f1dc0 <copter>, _method = 0x55ebaad90003 <Functor<void>::method_wrapper<Copter, &Copter::update_land_and_crash_detectors>(void*)>}, name = 0x55ebab0dd960 "Copter::update_land_and_crash_detectors*", rate_hz = 0, max_time_micros = 0, priority = 0 '\000'}
        time_taken = 0
        overrun = false
        i = 9 '\t'
        run_started_usec = 63484596
        now = 63484596
        vehicle_tasks_offset = 10 '\n'
        common_tasks_offset = 0 '\000'
#12 0x000055ebaae973a4 in AP_Scheduler::loop (this=0x55ebab1f1f80 <copter+448>) at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:383
        sample_time_us = 63484596
        loop_us = 2500
        now = 63484596
        time_available = 2500
        loop_tick_us = 0
#13 0x000055ebaae9ca8f in AP_Vehicle::loop (this=0x55ebab1f1dc0 <copter>) at ../../libraries/AP_Vehicle/AP_Vehicle.cpp:331
        new_internal_errors = 21995
#14 0x000055ebaafa5201 in HAL_SITL::run (this=0x55ebab20b2e0 <AP_HAL::get_HAL()::hal>, argc=15, argv=0x7ffcd129ae98, callbacks=0x55ebab1f1dc0 <copter>) at ../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:278
        now = 63482
        __PRETTY_FUNCTION__ = "virtual void HAL_SITL::run(int, char* const*, AP_HAL::HAL::Callbacks*) const"
        new_argv_offset = 15 '\017'
        using_watchdog = false
        last_watchdog_save = 2269
        fill_count = 6 '\006'
#15 0x000055ebaad8fa68 in main (argc=15, argv=0x7ffcd129ae98) at ../../ArduCopter/Copter.cpp:816
No locals.
```