### PR TITLE
Copter: remove has_user_takeoff from ModeAuto class (NFC)

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -484,10 +484,6 @@ public:
 
     bool requires_terrain_failsafe() const override { return true; }
 
-    // return true if this flight mode supports user takeoff
-    //  must_nagivate is true if mode must also control horizontal position
-    virtual bool has_user_takeoff(bool must_navigate) const override { return false; }
-
     void payload_place_start();
 
     // for GCS_MAVLink to call:


### PR DESCRIPTION
This PR removes the has_user_takeoff method from ModeAuto class.
I think that it was redundant and not necessary.