### PR TITLE
Copter: The initial value of the ESC calibration specification is DISABLED

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -318,7 +318,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Controls whether ArduCopter will enter ESC calibration on the next restart.  Do not adjust this parameter manually.
     // @User: Advanced
     // @Values: 0:Normal Start-up, 1:Start-up in ESC Calibration mode if throttle high, 2:Start-up in ESC Calibration mode regardless of throttle, 3:Start-up and automatically calibrate ESCs, 9:Disabled
-    GSCALAR(esc_calibrate, "ESC_CALIBRATION",       0),
+    GSCALAR(esc_calibrate, "ESC_CALIBRATION",       ESCCalibrationModes::ESCCAL_DISABLED),
 
     // @Param: TUNE
     // @DisplayName: Channel 6 Tuning


### PR DESCRIPTION
I believe ESC calibration is performed only during aircraft adjustment and maintenance.
Normally, it should be disabled.
In fact, a poor contact of the battery connector caused an ESC calibration condition.
The ESC was set to an incorrect value and the aircraft was damaged.
I would like to change the default value to DISABLED, so that the value is changed consciously.

I think this change will have the effect of increasing safety.