### PR TITLE
AP_Notify: correct gate on inclusion of profiled_spi enum entry

### DIFF
--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -90,8 +90,8 @@ public:
 #if AP_NOTIFY_DSHOT_LED_ENABLED
         Notify_LED_DShot                    = (1 << 11),// Use dshot commands to set ESC LEDs
 #endif
-#if AP_NOTIFY_PROFILED_ENABLED
-        Notify_LED_ProfiLED_SPI             = (1 << 12), // ProfiLED
+#if AP_NOTIFY_PROFILED_SPI_ENABLED
+        Notify_LED_ProfiLED_SPI             = (1 << 12), // ProfiLED (SPI)
 #endif
 #if AP_NOTIFY_LP5562_ENABLED
         Notify_LED_LP5562_I2C_External          = (1 << 13), // LP5562


### PR DESCRIPTION
This was close, but not close enough...

`test_build_options.py` passes everything once this is applied.
