### PR TITLE
ChibiOS: added force mutex release for deadlock recovery

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -199,5 +199,7 @@ private:
     void ext_watchdog_pat(uint32_t now_ms);
     uint32_t last_ext_watchdog_ms;
 #endif
+
+    static void try_force_mutex(void);
 };
 #endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -578,6 +578,11 @@ protected:
     void handle_set_gps_global_origin(const mavlink_message_t &msg);
     void handle_setup_signing(const mavlink_message_t &msg) const;
     virtual MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
+    struct {
+        HAL_Semaphore sem;
+        bool taken;
+    } _deadlock_sem;
+    void deadlock_sem(void);
 
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);


### PR DESCRIPTION
This allows recovery from a mutex deadlock due to lock order violation by forcing the release of the mutex that is holding up the main thread.
Without the forced release we would watchdog. This type of deadlock should never happen, but we have had bugs like this in master, for example the bug fixed by this patch which was in master for a short time:
https://github.com/ArduPilot/ardupilot/pull/23982/commits/e795dc1bf1ae2eb4bac325068c8825f7d781ddc8
When the deadlock happens the monitor thread detects it and uses chMtxForceReleaseS() to force the release of the mutex. That has the potential to cause data corruption, but it is better than the alternative of a watchdog
This PR also adds test code to generate a deliberate deadlock
Log message:
```
1970-01-01 10:00:18.122 DLCK {TimeUS : 18122395, SemLine : 3187, ThdName : io, MtxP : 604463532}
```
Display to user:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/f442dad7-1977-4dc0-8970-2f868f7bfec8)

This was test flown without any issues on a CubeOrange quadplane