### PR TITLE
AP_HAL_SITL: Resolve missing-declarations errors

### DIFF
--- a/libraries/AP_HAL_SITL/Synth.hpp
+++ b/libraries/AP_HAL_SITL/Synth.hpp
@@ -29,7 +29,13 @@ struct sTone
     double dEndFrequency = 440.0;
     double dAmplitude = 1.0;
 };
-    
+
+double w(const double dHertz);
+double osc(double dHertz, double dTime, eWaveType waveType);
+double amplitude(double dTime, sEnvelope env);
+bool generate(sf::SoundBuffer* buffer, sEnvelope env, std::vector<sTone> tones, unsigned uMasterVol, unsigned uSampleRate);
+bool generate(sf::SoundBuffer* buffer, sEnvelope env, sTone tone, unsigned uMasterVol, unsigned uSampleRate);
+
 ////////////////////////////////////////////////////////////
 // Converts frequency (Hz) to angular velocity
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
I had a lot of missing-declarations errors in Synth.hpp when I did a SITL build.
I added method declarations to run SITL.