### PR TITLE
AP_Scripting: add binding to block MAVLink commands

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -259,6 +259,16 @@ void AP_Scripting::thread(void) {
         }
         num_pwm_source = 0;
 
+        // Clear blocked commands
+        {
+            WITH_SEMAPHORE(mavlink_command_block_list_sem);
+            while (mavlink_command_block_list != nullptr) {
+                command_block_list *next_item = mavlink_command_block_list->next;
+                delete mavlink_command_block_list;
+                mavlink_command_block_list = next_item;
+            }
+        }
+
         bool cleared = false;
         while(true) {
             // 1hz check if we should restart
@@ -359,6 +369,22 @@ void AP_Scripting::handle_message(const mavlink_message_t &msg, const mavlink_ch
             return;
         }
     }
+}
+
+bool AP_Scripting::is_handling_command(uint16_t cmd_id)
+{
+    WITH_SEMAPHORE(mavlink_command_block_list_sem);
+
+    // Look in linked list to see if id is registered
+    if (mavlink_command_block_list != nullptr) {
+        for (command_block_list *item = mavlink_command_block_list; item; item = item->next) {
+            if (item->id == cmd_id) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 AP_Scripting *AP_Scripting::_singleton = nullptr;

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -45,6 +45,9 @@ public:
 
     void handle_message(const mavlink_message_t &msg, const mavlink_channel_t chan);
 
+    // Check if command ID is blocked
+    bool is_handling_command(uint16_t cmd_id);
+
     static AP_Scripting * get_singleton(void) { return _singleton; }
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -111,6 +114,13 @@ public:
         uint16_t accept_msg_ids_size;
         HAL_Semaphore sem;
     } mavlink_data;
+
+    struct command_block_list {
+        uint16_t id;
+        command_block_list *next;
+    };
+    command_block_list *mavlink_command_block_list;
+    HAL_Semaphore mavlink_command_block_list_sem;
 
 private:
 

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -2308,9 +2308,9 @@ local function mavlink_receiver()
       local msg,_,timestamp_ms = mavlink.receive_chan()
       if msg then
          local parsed_msg = mavlink_msgs.decode(msg, msg_map)
-         if parsed_msg.msgid == NAMED_VALUE_FLOAT_msgid then
+         if (parsed_msg ~= nil) and (parsed_msg.msgid == NAMED_VALUE_FLOAT_msgid) then
             -- convert remote timestamp to local timestamp with jitter correction
-            local time_boot_ms = jitter_correction.correct_offboard_timestamp_msec(parsed_msg.time_boot_ms, timestamp_ms)
+            local time_boot_ms = jitter_correction.correct_offboard_timestamp_msec(parsed_msg.time_boot_ms, timestamp_ms:toint())
             local value = parsed_msg.value
             local name = bytes_to_string(parsed_msg.name)
             return time_boot_ms, name, value, parsed_msg.sysid

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -9,6 +9,7 @@
 
 -- set and get for field types share function names
 ---@diagnostic disable: duplicate-set-field
+---@diagnostic disable: missing-return
 
 -- manual bindings
 
@@ -2254,7 +2255,6 @@ function gcs:get_hud_throttle() end
 
 -- set high latency control state. Analogous to MAV_CMD_CONTROL_HIGH_LATENCY
 ---@param enabled boolean -- true to enable or false to disable
----@return void
 function gcs:enable_high_latency_connections(enabled) end
 
 -- get the the current state of high latency control
@@ -2861,12 +2861,12 @@ scripting = {}
 function scripting:restart_all() end
 
 -- desc
---@param directoryname
---@return list of filenames
+---@param directoryname string
+---@return table -- table of filenames
 function dirlist(directoryname) end
 
 --desc
---@param filename
+---@param filename string
 function remove(filename) end
 
 -- desc
@@ -2874,23 +2874,23 @@ function remove(filename) end
 mavlink = {}
 
 -- initializes mavlink
---@param num_rx_msgid number
---@param msg_queue_length
+---@param num_rx_msgid uint32_t_ud|integer
+---@param msg_queue_length uint32_t_ud|integer
 function mavlink:init(num_rx_msgid, msg_queue_length) end
 
 -- marks mavlink message for receive, message id can be get using mavlink_msgs.get_msgid("MSG_NAME")
---@param msg_id number
+---@param msg_id number
 function mavlink:register_rx_msgid(msg_id) end
 
 -- receives mavlink message marked for receive using mavlink:register_rx_msgid
---@return mavlink_message bytes
---@return mavlink_channel number
---@return receive_timestamp number
+---@return string -- bytes
+---@return number -- mavlink channel
+---@return uint32_t_ud -- receive_timestamp
 function mavlink:receive_chan() end
 
 -- sends mavlink message, to use this function the call should be like this:
 -- mavlink:send(chan, mavlink_msgs.encode("MSG_NAME", {param1 = value1, param2 = value2, ...}})
---@param mavlink_channel integer
---@param mavlink_message_id integer
---@param encoded_message_packet bytes
+---@param chan integer
+---@param msgid integer
+---@param message string
 function mavlink:send_chan(chan, msgid, message) end

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2894,3 +2894,7 @@ function mavlink:receive_chan() end
 ---@param msgid integer
 ---@param message string
 function mavlink:send_chan(chan, msgid, message) end
+
+-- Block a given MAV_CMD from being procceced by ArduPilot
+---@param comand_id integer
+function mavlink:block_command(comand_id) end

--- a/libraries/AP_Scripting/examples/MAVLink_Commands.lua
+++ b/libraries/AP_Scripting/examples/MAVLink_Commands.lua
@@ -1,0 +1,65 @@
+-- Example of receiving MAVLink commands
+
+local mavlink_msgs = require("MAVLink/mavlink_msgs")
+
+local COMMAND_ACK_ID = mavlink_msgs.get_msgid("COMMAND_ACK")
+local COMMAND_LONG_ID = mavlink_msgs.get_msgid("COMMAND_LONG")
+
+local msg_map = {}
+msg_map[COMMAND_ACK_ID] = "COMMAND_ACK"
+msg_map[COMMAND_LONG_ID] = "COMMAND_LONG"
+
+-- initialize MAVLink rx with number of messages, and buffer depth
+mavlink:init(1, 10)
+
+-- register message id to receive
+mavlink:register_rx_msgid(COMMAND_LONG_ID)
+
+local MAV_CMD_DO_SET_MODE = 176
+local MAV_CMD_WAYPOINT_USER_1 = 31000
+
+-- Block AP parsing user1 so we can deal with it in the script
+-- Prevents "unsupported" ack
+mavlink:block_command(MAV_CMD_WAYPOINT_USER_1)
+
+function handle_command_long(cmd)
+    if (cmd.command == MAV_CMD_DO_SET_MODE) then
+        gcs:send_text(0, "Got mode change")
+
+    elseif (cmd.command == MAV_CMD_WAYPOINT_USER_1) then
+        -- return ack from command param value
+        return math.min(math.max(math.floor(cmd.param1), 0), 5)
+    end
+    return nil
+end
+
+function update()
+    local msg, chan = mavlink:receive_chan()
+    if (msg ~= nil) then
+        local parsed_msg = mavlink_msgs.decode(msg, msg_map)
+        if (parsed_msg ~= nil) then
+
+            local result
+            if parsed_msg.msgid == COMMAND_LONG_ID then
+                result = handle_command_long(parsed_msg)
+            end
+
+            if (result ~= nil) then
+                -- Send ack if the command is one were intrested in
+                local ack = {}
+                ack.command = parsed_msg.command
+                ack.result = result
+                ack.progress = 0
+                ack.result_param2 = 0
+                ack.target_system = parsed_msg.sysid
+                ack.target_component = parsed_msg.compid
+
+                mavlink:send_chan(chan, mavlink_msgs.encode("COMMAND_ACK", ack))
+            end
+        end
+    end
+
+    return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -730,3 +730,4 @@ singleton mavlink manual init lua_mavlink_init 2
 singleton mavlink manual register_rx_msgid lua_mavlink_register_rx_msgid 1
 singleton mavlink manual send_chan lua_mavlink_send_chan 3
 singleton mavlink manual receive_chan lua_mavlink_receive_chan 0
+singleton mavlink manual block_command lua_mavlink_block_command 1

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -183,7 +183,7 @@ int lua_mavlink_send_chan(lua_State *L) {
 int lua_mavlink_block_command(lua_State *L) {
 
     // Allow : and . access
-    const int arg_offset = (luaL_testudata(L, 1, "mavlnk") != NULL) ? 1 : 0;
+    const int arg_offset = (luaL_testudata(L, 1, "mavlink") != NULL) ? 1 : 0;
 
     binding_argcheck(L, 1+arg_offset);
 

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -44,12 +44,16 @@ int lua_micros(lua_State *L) {
 }
 
 int lua_mavlink_init(lua_State *L) {
-    binding_argcheck(L, 2);
+
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "mavlink") != NULL) ? 1 : 0;
+
+    binding_argcheck(L, 2+arg_offset);
     WITH_SEMAPHORE(AP::scripting()->mavlink_data.sem);
     // get the depth of receive queue
-    const uint32_t queue_size = get_uint32(L, -1, 0, 25);
+    const uint32_t queue_size = get_uint32(L, 1+arg_offset, 0, 25);
     // get number of msgs to accept
-    const uint32_t num_msgs = get_uint32(L, -2, 0, 25);
+    const uint32_t num_msgs = get_uint32(L, 2+arg_offset, 0, 25);
 
     struct AP_Scripting::mavlink &data = AP::scripting()->mavlink_data;
     if (data.rx_buffer == nullptr) {
@@ -70,7 +74,11 @@ int lua_mavlink_init(lua_State *L) {
 }
 
 int lua_mavlink_receive_chan(lua_State *L) {
-    binding_argcheck(L, 0);
+
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "mavlink") != NULL) ? 1 : 0;
+
+    binding_argcheck(L, arg_offset);
 
     struct AP_Scripting::mavlink_msg msg;
     ObjectBuffer<struct AP_Scripting::mavlink_msg> *rx_buffer = AP::scripting()->mavlink_data.rx_buffer;
@@ -85,7 +93,8 @@ int lua_mavlink_receive_chan(lua_State *L) {
         luaL_addlstring(&b, (char *)&msg.msg, sizeof(msg.msg));
         luaL_pushresult(&b);
         lua_pushinteger(L, msg.chan);
-        lua_pushinteger(L, msg.timestamp_ms);
+        new_uint32_t(L);
+        *check_uint32_t(L, -1) = msg.timestamp_ms;
         return 3;
     } else {
         // no MAVLink to handle, just return no results
@@ -94,9 +103,13 @@ int lua_mavlink_receive_chan(lua_State *L) {
 }
 
 int lua_mavlink_register_rx_msgid(lua_State *L) {
-    binding_argcheck(L, 1);
-    
-    const uint32_t msgid = get_uint32(L, -1, 0, (1 << 24) - 1);
+
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "mavlink") != NULL) ? 1 : 0;
+
+    binding_argcheck(L, 1+arg_offset);
+
+    const uint32_t msgid = get_uint32(L, 1+arg_offset, 0, (1 << 24) - 1);
 
     struct AP_Scripting::mavlink &data = AP::scripting()->mavlink_data;
 
@@ -129,13 +142,17 @@ int lua_mavlink_register_rx_msgid(lua_State *L) {
 }
 
 int lua_mavlink_send_chan(lua_State *L) {
-    binding_argcheck(L, 3);
+
+    // Allow : and . access
+    const int arg_offset = (luaL_testudata(L, 1, "mavlink") != NULL) ? 1 : 0;
+
+    binding_argcheck(L, 3+arg_offset);
     
-    const mavlink_channel_t chan = (mavlink_channel_t)get_uint32(L, 1, 0, MAVLINK_COMM_NUM_BUFFERS - 1);
+    const mavlink_channel_t chan = (mavlink_channel_t)get_uint32(L, 1+arg_offset, 0, MAVLINK_COMM_NUM_BUFFERS - 1);
 
-    const uint32_t msgid = get_uint32(L, 2, 0, (1 << 24) - 1);
+    const uint32_t msgid = get_uint32(L, 2+arg_offset, 0, (1 << 24) - 1);
 
-    const char *packet = luaL_checkstring(L, 3);
+    const char *packet = luaL_checkstring(L, 3+arg_offset);
 
     // FIXME: The data that's in this mavlink_msg_entry_t should be provided from the script, which allows
     //        sending entirely new messages as outputs. At the moment we can only encode messages that

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -18,3 +18,4 @@ int lua_mavlink_init(lua_State *L);
 int lua_mavlink_receive_chan(lua_State *L);
 int lua_mavlink_register_rx_msgid(lua_State *L);
 int lua_mavlink_send_chan(lua_State *L);
+int lua_mavlink_block_command(lua_State *L);

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_ACK.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_ACK.lua
@@ -1,0 +1,11 @@
+local COMMAND_ACK = {}
+COMMAND_ACK.id = 77
+COMMAND_ACK.fields = {
+             { "command", "<I2" },
+             { "result", "<B" },
+             { "progress", "<B" },
+             { "result_param2", "<i4" },
+             { "target_system", "<B" },
+             { "target_component", "<B" },
+             }
+return COMMAND_ACK

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_LONG.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_LONG.lua
@@ -1,0 +1,16 @@
+local COMMAND_LONG = {}
+COMMAND_LONG.id = 76
+COMMAND_LONG.fields = {
+             { "param1", "<f" },
+             { "param2", "<f" },
+             { "param3", "<f" },
+             { "param4", "<f" },
+             { "param5", "<f" },
+             { "param6", "<f" },
+             { "param7", "<f" },
+             { "command", "<I2" },
+             { "target_system", "<B" },
+             { "target_component", "<B" },
+             { "confirmation", "<B" },
+             }
+return COMMAND_LONG

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msgs.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msgs.lua
@@ -1,0 +1,95 @@
+local mavlink_msgs = {}
+
+function mavlink_msgs.get_msgid(msgname)
+  local message_map = require("MAVLink/mavlink_msg_" .. msgname)
+  if not message_map then
+    error("Unknown MAVLink message " .. msgname)
+  end
+  return message_map.id
+end
+
+function mavlink_msgs.decode_header(message)
+  -- build up a map of the result
+  local result = {}
+
+  local read_marker = 3
+
+  -- id the MAVLink version
+  result.protocol_version, read_marker = string.unpack("<B", message, read_marker)
+  if (result.protocol_version == 0xFE) then -- mavlink 1
+    result.protocol_version = 1
+  elseif (result.protocol_version == 0XFD) then --mavlink 2
+    result.protocol_version = 2
+  else
+    error("Invalid magic byte")
+  end
+
+  _, read_marker = string.unpack("<B", message, read_marker) -- payload is always the second byte
+
+  -- strip the incompat/compat flags
+  result.incompat_flags, result.compat_flags, read_marker = string.unpack("<BB", message, read_marker)
+
+  -- fetch seq/sysid/compid
+  result.seq, result.sysid, result.compid, read_marker = string.unpack("<BBB", message, read_marker)
+
+  -- fetch the message id
+  result.msgid, read_marker = string.unpack("<I3", message, read_marker)
+
+  return result, read_marker
+end
+
+function mavlink_msgs.decode(message, msg_map)
+  local result, offset = mavlink_msgs.decode_header(message)
+  local message_map = require("MAVLink/mavlink_msg_" .. msg_map[result.msgid])
+  if not message_map then
+    -- we don't know how to decode this message, bail on it
+    return nil
+  end
+
+  -- map all the fields out
+  for _,v in ipairs(message_map.fields) do
+    if v[3] then
+      result[v[1]] = {}
+      for j=1,v[3] do
+        result[v[1]][j], offset = string.unpack(v[2], message, offset)
+      end
+    else
+      result[v[1]], offset = string.unpack(v[2], message, offset)
+    end
+  end
+
+  -- ignore the idea of a checksum
+
+  return result;
+end
+
+function mavlink_msgs.encode(msgname, message)
+  local message_map = require("MAVLink/mavlink_msg_" .. msgname)
+  if not message_map then
+    -- we don't know how to encode this message, bail on it
+    error("Unknown MAVLink message " .. msgname)
+  end
+
+  local packString = "<"
+  local packedTable = {}
+  local packedIndex = 1
+  for i,v in ipairs(message_map.fields) do
+    if v[3] then
+      packString = (packString .. string.rep(string.sub(v[2], 2), v[3]))
+      for j = 1, v[3] do
+        packedTable[packedIndex] = message[message_map.fields[i][1]][j]
+        if packedTable[packedIndex] == nil then
+          packedTable[packedIndex] = 0
+        end
+        packedIndex = packedIndex + 1
+      end
+    else
+      packString = (packString .. string.sub(v[2], 2))
+      packedTable[packedIndex] = message[message_map.fields[i][1]]
+      packedIndex = packedIndex + 1
+    end
+  end
+  return message_map.id, string.pack(packString, table.unpack(packedTable))
+end
+
+return mavlink_msgs

--- a/libraries/AP_Scripting/tests/mavlink_test.lua
+++ b/libraries/AP_Scripting/tests/mavlink_test.lua
@@ -21,7 +21,7 @@ end
 function update()
     local msg,chan,timestamp_ms = mavlink.receive_chan()
     if msg then
-        gcs:send_text(6, string.format("Received message on channel %d at %d", chan, timestamp_ms))
+        gcs:send_text(6, string.format("Received message on channel %d at %s", chan, tostring(timestamp_ms)))
         local parsed_msg = mavlink_msgs.decode(msg, msg_map)
         if parsed_msg.msgid == heartbeat_msgid then
             gcs:send_text(6, string.format("Received heartbeat from %d", parsed_msg.sysid))

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4884,6 +4884,14 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
     mavlink_command_long_t packet;
     mavlink_msg_command_long_decode(&msg, &packet);
 
+#if AP_SCRIPTING_ENABLED
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting != nullptr && scripting->is_handling_command(packet.command)) {
+        // Scripting has registered to receive this command, do not procces it internaly
+        return;
+    }
+#endif
+
     hal.util->persistent_data.last_mavlink_cmd = packet.command;
 
     MAV_RESULT result;
@@ -5148,6 +5156,14 @@ void GCS_MAVLINK::handle_command_int(const mavlink_message_t &msg)
     // decode packet
     mavlink_command_int_t packet;
     mavlink_msg_command_int_decode(&msg, &packet);
+
+#if AP_SCRIPTING_ENABLED
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting != nullptr && scripting->is_handling_command(packet.command)) {
+        // Scripting has registered to receive this command, do not procces it internaly
+        return;
+    }
+#endif
 
     hal.util->persistent_data.last_mavlink_cmd = packet.command;
 


### PR DESCRIPTION
This adds the ability for scripting to block MAVLink commands, this means we can process a command long or int in the script without AP acking unsupported, or override the default behavior of commands (or just block commands all together).

This also does a little re-work to the existing MAVLink bindings so they work like the rest, from `mavlink.receive_chan` to `mavlink:receive_chan`. This is a breaking change, we could support both as we do for logger, but they have not been in that long.

This also changes the uint32 receive timestamp to return as a uint32 rather than a native int and fixes up the docs. 

I have added a example of receive a user command.

This does bring some generated code into tree for the new example.
