### PR TITLE
Use new pymavlink mavlink_parse_char_buffer

### DIFF
--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -53,14 +53,7 @@ void AP_Periph_FW::adsb_init(void)
 }
 
 static mavlink_message_t chan_buffer;
-mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
-    return &chan_buffer;
-}
-
 static mavlink_status_t chan_status;
-mavlink_status_t* mavlink_get_channel_status(uint8_t chan) {
-    return &chan_status;
-}
 
 /*
   update ADSB subsystem
@@ -82,7 +75,7 @@ void AP_Periph_FW::adsb_update(void)
         const uint8_t c = (uint8_t)uart->read();
 
         // Try to get a new message
-        if (mavlink_parse_char(MAVLINK_COMM_0, c, &adsb.msg, &adsb.status)) {
+        if (mavlink_parse_char_buffer(&chan_buffer, &chan_status, c, &adsb.msg, &adsb.status)) {
             if (adsb.msg.msgid == MAVLINK_MSG_ID_ADSB_VEHICLE) {
                 // decode and send as UAVCAN TrafficReport
                 static mavlink_adsb_vehicle_t msg;

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -103,7 +103,7 @@ public:
 #endif
 
      // for Logger_MAVlink
-    virtual void remote_log_block_status_msg(const GCS_MAVLINK &link,
+    virtual void remote_log_block_status_msg(GCS_MAVLINK &link,
                                              const mavlink_message_t &msg) { }
     // end for Logger_MAVlink
 

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -220,7 +220,7 @@ void AP_Logger_MAVLink::stop_logging()
     }
 }
 
-void AP_Logger_MAVLink::handle_ack(const GCS_MAVLINK &link,
+void AP_Logger_MAVLink::handle_ack(GCS_MAVLINK &link,
                                    const mavlink_message_t &msg,
                                    uint32_t seqno)
 {
@@ -266,7 +266,7 @@ void AP_Logger_MAVLink::handle_ack(const GCS_MAVLINK &link,
     }
 }
 
-void AP_Logger_MAVLink::remote_log_block_status_msg(const GCS_MAVLINK &link,
+void AP_Logger_MAVLink::remote_log_block_status_msg(GCS_MAVLINK &link,
                                                     const mavlink_message_t& msg)
 {
     mavlink_remote_log_block_status_t packet;
@@ -581,7 +581,7 @@ bool AP_Logger_MAVLink::send_log_block(struct dm_block &block)
 // DM_packing: 267039 events, 0 overruns, 8440834us elapsed, 31us avg, min 31us max 32us 0.488us rms
 
     mavlink_message_t msg;
-    mavlink_status_t *chan_status = mavlink_get_channel_status(_link->get_chan());
+    mavlink_status_t *chan_status = _link->channel_status();
     uint8_t saved_seq = chan_status->current_tx_seq;
     chan_status->current_tx_seq = mavlink_seq++;
     // Debug("Sending block (%d)", block.seqno);

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -58,7 +58,7 @@ public:
     int16_t get_log_data(uint16_t log_num, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) override { return 0; }
     uint16_t get_num_logs(void) override { return 0; }
 
-    void remote_log_block_status_msg(const GCS_MAVLINK &link, const mavlink_message_t& msg) override;
+    void remote_log_block_status_msg(GCS_MAVLINK &link, const mavlink_message_t& msg) override;
     void vehicle_was_disarmed() override {}
 
 protected:
@@ -75,7 +75,7 @@ private:
         struct dm_block *next;
     };
     bool send_log_block(struct dm_block &block);
-    void handle_ack(const GCS_MAVLINK &link, const mavlink_message_t &msg, uint32_t seqno);
+    void handle_ack(GCS_MAVLINK &link, const mavlink_message_t &msg, uint32_t seqno);
     void handle_retry(uint32_t block_num);
     void do_resends(uint32_t now);
     void free_all_blocks();
@@ -122,7 +122,7 @@ private:
     bool logging_enabled() const override { return true; }
     bool logging_failed() const override;
 
-    const GCS_MAVLINK *_link;
+    GCS_MAVLINK *_link;
 
     uint8_t _target_system_id;
     uint8_t _target_component_id;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1752,7 +1752,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
         bool parsed_packet = false;
 
         // Try to get a new message
-        if (mavlink_parse_char(chan, c, &msg, &status)) {
+        if (mavlink_parse_char_buffer(&_channel_buffer, &_channel_status, c, &msg, &status)) {
             hal.util->persistent_data.last_mavlink_msgid = msg.msgid;
             packetReceived(status, msg);
             parsed_packet = true;

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -56,22 +56,6 @@ GCS_MAVLINK *GCS_MAVLINK::find_by_mavtype_and_compid(uint8_t mav_type, uint8_t c
     return gcs().chan(channel);
 }
 
-mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
-    GCS_MAVLINK *link = gcs().chan(chan);
-    if (link == nullptr) {
-        return nullptr;
-    }
-    return link->channel_buffer();
-}
-
-mavlink_status_t* mavlink_get_channel_status(uint8_t chan) {
-    GCS_MAVLINK *link = gcs().chan(chan);
-    if (link == nullptr) {
-        return nullptr;
-    }
-    return link->channel_status();
-}
-
 // set a channel as private. Private channels get sent heartbeats, but
 // don't get broadcast packets or forwarded packets
 void GCS_MAVLINK::set_channel_private(mavlink_channel_t _chan)

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -17,9 +17,6 @@
 // allow five telemetry ports
 #define MAVLINK_COMM_NUM_BUFFERS 5
 
-#define MAVLINK_GET_CHANNEL_BUFFER 1
-#define MAVLINK_GET_CHANNEL_STATUS 1
-
 /*
   The MAVLink protocol code generator does its own alignment, so
   alignment cast warnings can be ignored
@@ -54,9 +51,6 @@ static inline bool valid_channel(mavlink_channel_t chan)
     return chan < MAVLINK_COMM_NUM_BUFFERS;
 #pragma clang diagnostic pop
 }
-
-mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan);
-mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
 
 void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len);
 


### PR DESCRIPTION
Requires https://github.com/ArduPilot/pymavlink/pull/828

Had to remove `const` from mavlink-logger methods - they were able to violate the constiness because they were modifying the object indirectly via the mavlink layer...

Based on https://github.com/ArduPilot/ardupilot/pull/22558
