### PR TITLE
AP_Bootloader: Reserve IDs for CM4PILOT and F405AIO

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -225,6 +225,8 @@ AP_HW_SDMODELH7V1                    1111
 AP_HW_FlyingMoonH743                 1112
 AP_HW_YJUAV_A6                       1113
 AP_HW_YJUAV_A6Nano                   1114
+AP_HW_ACNS_CM4PILOT                  1115
+AP_HW_ACNS_F405AIO                   1116
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
Reserve IDs for CM4PILOT and F405AIO