### PR TITLE
HAL_ChibiOS: fixed CANFD timings

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -461,11 +461,6 @@ def setup_canmgr_build(cfg):
             'CANARD_ALLOCATE_SEM=1'
             ]
 
-    if cfg.env.HAL_CANFD_SUPPORTED:
-        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=1']
-    else:
-        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=0']
-
     cfg.get_board().with_can = True
 
 def setup_canperiph_build(cfg):
@@ -474,11 +469,6 @@ def setup_canperiph_build(cfg):
     env.DEFINES += [
         'CANARD_ENABLE_DEADLINE=1',
         ]
-
-    if cfg.env.HAL_CANFD_SUPPORTED:
-        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=1']
-    else:
-        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=0']
 
     cfg.get_board().with_can = True
     

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -89,7 +89,9 @@ extern const AP_HAL::HAL& hal;
 
 #define STR(x) #x
 #define XSTR(x) STR(x)
+#if !defined(HAL_LLD_USE_CLOCK_MANAGEMENT)
 static_assert(STM32_FDCANCLK == 80U*1000U*1000U, "FDCAN clock must be 80MHz, got " XSTR(STM32_FDCANCLK));
+#endif
 
 using namespace ChibiOS;
 

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -89,11 +89,7 @@ extern const AP_HAL::HAL& hal;
 
 #define STR(x) #x
 #define XSTR(x) STR(x)
-#if defined(STM32H7)
 static_assert(STM32_FDCANCLK == 80U*1000U*1000U, "FDCAN clock must be 80MHz, got " XSTR(STM32_FDCANCLK));
-#else
-static_assert(STM32_FDCANCLK <= 80U*1000U*1000U, "FDCAN clock must be max 80MHz, got " XSTR(STM32_FDCANCLK));
-#endif
 
 using namespace ChibiOS;
 

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.h
@@ -123,7 +123,8 @@ class ChibiOS::CANIface : public AP_HAL::CANIface
 
     const uint8_t self_index_;
 
-    bool computeTimings(uint32_t target_bitrate, Timings& out_timings);
+    bool computeTimings(uint32_t target_bitrate, Timings& out_timings) const;
+    bool computeFDTimings(uint32_t target_bitrate, Timings& out_timings) const;
 
     void setupMessageRam(void);
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32g4_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32g4_mcuconf.h
@@ -89,10 +89,10 @@
 #define STM32_LSI_ENABLED                   FALSE
 #define STM32_LSE_ENABLED                   FALSE
 #define STM32_SW                            STM32_SW_PLLRCLK
-#define STM32_PLLN_VALUE                    42
+#define STM32_PLLN_VALUE                    40
 #define STM32_PLLPDIV_VALUE                 0
 #define STM32_PLLP_VALUE                    7
-#define STM32_PLLQ_VALUE                    8
+#define STM32_PLLQ_VALUE                    4
 #define STM32_PLLR_VALUE                    2
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV1
@@ -117,11 +117,7 @@
 #define STM32_LPTIM1SEL                     STM32_LPTIM1SEL_PCLK1
 #define STM32_SAI1SEL                       STM32_SAI1SEL_SYSCLK
 #define STM32_I2S23SEL                      STM32_I2S23SEL_SYSCLK
-#if STM32_HSECLK == 0U
 #define STM32_FDCANSEL                      STM32_FDCANSEL_PLLQCLK
-#else
-#define STM32_FDCANSEL                      STM32_FDCANSEL_HSE
-#endif
 #define STM32_CLK48SEL                      STM32_CLK48SEL_HSI48
 #define STM32_ADC12SEL                      STM32_ADC12SEL_PLLPCLK
 #define STM32_ADC345SEL                     STM32_ADC345SEL_PLLPCLK

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32g4_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32g4_mcuconf.h
@@ -26,6 +26,12 @@
 #endif
 
 /*
+  we need to use HAL_LLD_USE_CLOCK_MANAGEMENT in order to allow a
+  different clock tree in the main firmware from the bootloader.
+ */
+#define HAL_LLD_USE_CLOCK_MANAGEMENT 1
+
+/*
  * STM32G4xx drivers configuration.
  * The following settings override the default settings present in
  * the various device driver implementation headers.

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G431xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G431xx.py
@@ -20,7 +20,7 @@ mcu = {
         (0x10000000, 10, 2), # CCM
     ],
 
-    'EXPECTED_CLOCK' : 168000000,
+    'EXPECTED_CLOCK' : 160000000,
 
     'DEFINES' : {
         'STM32G4' : '1',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G441xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G441xx.py
@@ -20,7 +20,7 @@ mcu = {
         (0x10000000, 10, 2), # CCM
     ],
 
-    'EXPECTED_CLOCK' : 168000000,
+    'EXPECTED_CLOCK' : 160000000,
 
     'DEFINES' : {
         'STM32G4' : '1',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G474xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G474xx.py
@@ -20,7 +20,7 @@ mcu = {
         (0x10000000, 32, 2), # CCM
     ],
 
-    'EXPECTED_CLOCK' : 168000000,
+    'EXPECTED_CLOCK' : 160000000,
 
     'DEFINES' : {
         'STM32G4' : '1',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G491xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G491xx.py
@@ -20,7 +20,7 @@ mcu = {
         (0x10000000, 16, 2), # CCM
     ],
 
-    'EXPECTED_CLOCK' : 168000000,
+    'EXPECTED_CLOCK' : 160000000,
 
     'DEFINES' : {
         'STM32G4' : '1',

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -33,6 +33,9 @@
 // we rely on systimestamp_t for 64 bit timestamps
 static_assert(sizeof(uint64_t) == sizeof(systimestamp_t), "unexpected systimestamp_t size");
 
+#define STR(x) #x
+#define XSTR(x) STR(x)
+
 #if CH_CFG_ST_RESOLUTION == 16
 static_assert(sizeof(systime_t) == 2, "expected 16 bit systime_t");
 #elif CH_CFG_ST_RESOLUTION == 32
@@ -42,9 +45,9 @@ static_assert(sizeof(systime_t) == sizeof(sysinterval_t), "expected systime_t sa
 
 #if defined(HAL_EXPECTED_SYSCLOCK)
 #ifdef STM32_SYS_CK
-static_assert(HAL_EXPECTED_SYSCLOCK == STM32_SYS_CK, "unexpected STM32_SYS_CK value");
+static_assert(HAL_EXPECTED_SYSCLOCK == STM32_SYS_CK, "unexpected STM32_SYS_CK value got " XSTR(STM32_HCLK) " expected " XSTR(HAL_EXPECTED_SYSCLOCK));
 #elif defined(STM32_HCLK)
-static_assert(HAL_EXPECTED_SYSCLOCK == STM32_HCLK, "unexpected STM32_HCLK value");
+static_assert(HAL_EXPECTED_SYSCLOCK == STM32_HCLK, "unexpected STM32_HCLK value got " XSTR(STM32_HCLK) " expected " XSTR(HAL_EXPECTED_SYSCLOCK));
 #else
 #error "unknown system clock"
 #endif


### PR DESCRIPTION
our CANFD timings were resulting in a lot of busoff errors. Here is an example of master at 1Mbit/5MBit:

Getting @SYS/can0_stats.txt as -
------- Clock Config -------
CAN_CLK_FREQ:   80MHz
Std Timings: bitrate=1000000 presc=7
sjw=0 bs1=7 bs2=0 sample_point=90.00000%
FD Timings:  bitrate=5000000 presc=1
sjw=0 bs1=5 bs2=0 sample_point=90.00000%
------- CAN Interface Stats -------
tx_requests:    2689
tx_rejected:    0
tx_overflow:    443
tx_success:     7
tx_timedout:    2232
tx_abort:       0
rx_received:    18470
rx_overflow:    0
rx_errors:      0
num_busoff_err: 34439
num_events:     18477
ECR:            F8
fdf_rx:         18467
fdf_tx_req:     2182
fdf_tx:         0

here is an example with the new timings:

------- Clock Config -------
CAN_CLK_FREQ:   80MHz
Std Timings: bitrate=1000000 presc=8
sjw=1 bs1=8 bs2=1 sample_point=90.00000%
FD Timings:  bitrate=8000000 presc=2
sjw=3 bs1=8 bs2=3 sample_point=80.00000%
------- CAN Interface Stats -------
tx_requests:    3023
tx_rejected:    0
tx_overflow:    0
tx_success:     3023
tx_timedout:    0
tx_abort:       0
rx_received:    27865
rx_overflow:    0
rx_errors:      0
num_busoff_err: 0
num_events:     30888
ECR:            0
fdf_rx:         27862
fdf_tx_req:     3016
fdf_tx:         3016

I am testing between a CubeOrange and a Pixhawk6X. I tested 1, 2, 4, 5 and 8 MBit (which are the only valid FD bitrates in our parameters)

Many thanks to Kai from Salient Motion for finding this issue and providing the corrected timing table.
I also fixed the display of the timings. We were displaying the register values, which are off by 1.
We were also not setting the SJW in the timing register