### PR TITLE
HAL_SITL: fixed multicast UDP on cygwin

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -568,6 +568,14 @@ void UARTDriver::_udp_start_multicast(const char *address, uint16_t port)
     // close on exec, to allow reboot
     fcntl(_mc_fd, F_SETFD, FD_CLOEXEC);
 
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
+    /*
+      on cygwin you need to bind to INADDR_ANY then use the multicast
+      IP_ADD_MEMBERSHIP to get on the right address
+     */
+    sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+#endif
+    
     ret = bind(_mc_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (ret == -1) {
         fprintf(stderr, "multicast bind failed on port %u - %s\n",


### PR DESCRIPTION
this will allow the SITL button on cygwin to work with multicast, allowing for complex vehicle interactions between machines
For example, you can do this:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/88ce040b-ca11-45f7-9245-9417d2f30ab4)
and the simulated vehicle will appear on multicast, along with other vehicles on the same LAN
