### PR TITLE
Add and use SetFocusResult for camera focus commands

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -126,8 +126,8 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value);
-    bool set_focus(uint8_t instance, FocusType focus_type, float focus_value);
+    SetFocusResult set_focus(FocusType focus_type, float focus_value);
+    SetFocusResult set_focus(uint8_t instance, FocusType focus_type, float focus_value);
 
     // set tracking to none, point or rectangle (see TrackingType enum)
     // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -63,7 +63,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
+    virtual SetFocusResult set_focus(FocusType focus_type, float focus_value) { return SetFocusResult::UNSUPPORTED; }
 
     // set tracking to none, point or rectangle (see TrackingType enum)
     // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -92,11 +92,11 @@ bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera_MAVLinkCamV2::set_focus(FocusType focus_type, float focus_value)
+SetFocusResult AP_Camera_MAVLinkCamV2::set_focus(FocusType focus_type, float focus_value)
 {
     // exit immediately if have not found camera or does not support focus
     if (_link == nullptr || !(_cam_info.flags & CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS)) {
-        return false;
+        return SetFocusResult::FAILED;
     }
 
     // prepare and send message
@@ -120,7 +120,7 @@ bool AP_Camera_MAVLinkCamV2::set_focus(FocusType focus_type, float focus_value)
 
     _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
 
-    return true;
+    return SetFocusResult::ACCEPTED;
 }
 
 // handle incoming mavlink message including CAMERA_INFORMATION

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -48,7 +48,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value) override;
+    SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
     // handle MAVLink messages from the camera
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) override;

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -39,13 +39,13 @@ bool AP_Camera_Mount::set_zoom(ZoomType zoom_type, float zoom_value)
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera_Mount::set_focus(FocusType focus_type, float focus_value)
+SetFocusResult AP_Camera_Mount::set_focus(FocusType focus_type, float focus_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
         return mount->set_focus(0, focus_type, focus_value);
     }
-    return false;
+    return SetFocusResult::FAILED;
 }
 
 // send camera information message to GCS

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -44,7 +44,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value) override;
+    SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const override;

--- a/libraries/AP_Camera/AP_Camera_Scripting.cpp
+++ b/libraries/AP_Camera/AP_Camera_Scripting.cpp
@@ -30,11 +30,11 @@ bool AP_Camera_Scripting::set_zoom(ZoomType zoom_type, float zoom_value)
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Camera_Scripting::set_focus(FocusType focus_type, float focus_value)
+SetFocusResult AP_Camera_Scripting::set_focus(FocusType focus_type, float focus_value)
 {
     _cam_state.focus_type = (uint8_t)focus_type;
     _cam_state.focus_value = focus_value;
-    return true;
+    return SetFocusResult::ACCEPTED;
 }
 
 // set tracking to none, point or rectangle (see TrackingType enum)

--- a/libraries/AP_Camera/AP_Camera_Scripting.h
+++ b/libraries/AP_Camera/AP_Camera_Scripting.h
@@ -44,7 +44,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value) override;
+    SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
     // set tracking to none, point or rectangle (see TrackingType enum)
     // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -20,9 +20,19 @@ enum class FocusType : uint8_t {
     AUTO = 4    // focus automatically. Same as FOCUS_TYPE_AUTO
 };
 
+// result type of set_focus.  Assumptions are made that this
+// enumeration can be cast directly to MAV_RESULT.
+enum class SetFocusResult : uint8_t {
+    ACCEPTED = 0,
+    INVALID_PARAMETERS = 2,  // supported but invalid parameters, like MAV_RESULT_DENIED
+    UNSUPPORTED = 3,
+    FAILED = 4,
+};
+
 // tracking types when tracking an object in the video stream
 enum class TrackingType : uint8_t {
     TRK_NONE = 0,       // tracking is inactive
     TRK_POINT = 1,      // tracking a point
     TRK_RECTANGLE = 2   // tracking a rectangle
 };
+

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -150,15 +150,15 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         if ((cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO) ||
             (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_SINGLE) ||
             (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_CONTINUOUS)) {
-            return camera->set_focus(FocusType::AUTO, 0);
+            return camera->set_focus(FocusType::AUTO, 0) == SetFocusResult::ACCEPTED;
         }
         // accept continuous manual focus
         if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_CONTINUOUS) {
-            return camera->set_focus(FocusType::RATE, cmd.content.set_camera_focus.focus_value);
+            return camera->set_focus(FocusType::RATE, cmd.content.set_camera_focus.focus_value) == SetFocusResult::ACCEPTED;
         }
         // accept range manual focus
         if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_RANGE) {
-            return camera->set_focus(FocusType::PCT, cmd.content.set_camera_focus.focus_value);
+            return camera->set_focus(FocusType::PCT, cmd.content.set_camera_focus.focus_value) == SetFocusResult::ACCEPTED;
         }
         return false;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -742,11 +742,11 @@ bool AP_Mount::set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value)
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Mount::set_focus(uint8_t instance, FocusType focus_type, float focus_value)
+SetFocusResult AP_Mount::set_focus(uint8_t instance, FocusType focus_type, float focus_value)
 {
     auto *backend = get_instance(instance);
     if (backend == nullptr) {
-        return false;
+        return SetFocusResult::FAILED;
     }
     return backend->set_focus(focus_type, focus_value);
 }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -216,7 +216,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(uint8_t instance, FocusType focus_type, float focus_value);
+    SetFocusResult set_focus(uint8_t instance, FocusType focus_type, float focus_value);
 
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -155,7 +155,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    virtual bool set_focus(FocusType focus_type, float focus_value) { return false; }
+    virtual SetFocusResult set_focus(FocusType focus_type, float focus_value) { return SetFocusResult::UNSUPPORTED; }
 
     // send camera information message to GCS
     virtual void send_camera_information(mavlink_channel_t chan) const {}

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -756,7 +756,7 @@ void AP_Mount_Siyi::update_zoom_control()
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Mount_Siyi::set_focus(FocusType focus_type, float focus_value)
+SetFocusResult AP_Mount_Siyi::set_focus(FocusType focus_type, float focus_value)
 {
     switch (focus_type) {
     case FocusType::RATE: {
@@ -767,17 +767,23 @@ bool AP_Mount_Siyi::set_focus(FocusType focus_type, float focus_value)
             // Siyi API specifies -1 should be sent as 255
             focus_step = UINT8_MAX;
         }
-        return send_1byte_packet(SiyiCommandId::MANUAL_FOCUS, (uint8_t)focus_step);
+        if (!send_1byte_packet(SiyiCommandId::MANUAL_FOCUS, (uint8_t)focus_step)) {
+            return SetFocusResult::FAILED;
+        }
+        return SetFocusResult::ACCEPTED;
     }
     case FocusType::PCT:
         // not supported
-        return false;
+        return SetFocusResult::INVALID_PARAMETERS;
     case FocusType::AUTO:
-        return send_1byte_packet(SiyiCommandId::AUTO_FOCUS, 1);
+        if (!send_1byte_packet(SiyiCommandId::AUTO_FOCUS, 1)) {
+            return SetFocusResult::FAILED;
+        }
+        return SetFocusResult::ACCEPTED;
     }
 
     // unsupported focus type
-    return false;
+    return SetFocusResult::INVALID_PARAMETERS;
 }
 
 // send camera information message to GCS

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -70,7 +70,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value) override;
+    SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const override;

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -164,10 +164,10 @@ bool AP_Mount_Xacti::record_video(bool start_recording)
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-bool AP_Mount_Xacti::set_focus(FocusType focus_type, float focus_value)
+SetFocusResult AP_Mount_Xacti::set_focus(FocusType focus_type, float focus_value)
 {
     if (_detected_modules[_instance].ap_dronecan == nullptr) {
-        return false;
+        return SetFocusResult::FAILED;
     }
 
     // convert focus type and value to parameter value
@@ -185,11 +185,14 @@ bool AP_Mount_Xacti::set_focus(FocusType focus_type, float focus_value)
         break;
     default:
         // unsupported forucs mode
-        return false;
+        return SetFocusResult::INVALID_PARAMETERS;
     }
 
     // set FocusMode parameter
-    return _detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, XACTI_PARAM_FOCUSMODE, focus_param_value, &param_int_cb);
+    if (!_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, XACTI_PARAM_FOCUSMODE, focus_param_value, &param_int_cb)) {
+        return SetFocusResult::FAILED;
+    }
+    return SetFocusResult::ACCEPTED;
 }
 
 // send camera information message to GCS

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -53,7 +53,7 @@ public:
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    bool set_focus(FocusType focus_type, float focus_value) override;
+    SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const override;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -972,7 +972,7 @@ bool RC_Channel::do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag)
         focus_step = -1;
         break;
     }
-    return camera->set_focus(FocusType::RATE, focus_step);
+    return camera->set_focus(FocusType::RATE, focus_step) == SetFocusResult::ACCEPTED;
 }
 
 bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
@@ -982,7 +982,7 @@ bool RC_Channel::do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag)
         if (camera == nullptr) {
             return false;
         }
-        return camera->set_focus(FocusType::AUTO, 0);
+        return camera->set_focus(FocusType::AUTO, 0) == SetFocusResult::ACCEPTED;
     }
     return false;
 }


### PR DESCRIPTION
This corrects the mavlink result codes being sent to the GCS.  Currently we just send through unsupported when there's actually a problem with the command (deserving a DENIED response)
