### PR TITLE
AP_EFI: move case labels inside ifdefs

### DIFF
--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -97,26 +97,26 @@ void AP_EFI::init(void)
         backend = new AP_EFI_Serial_Lutan(*this);
         break;
 #endif
-    case Type::NWPMU:
 #if AP_EFI_NWPWU_ENABLED
+    case Type::NWPMU:
         backend = new AP_EFI_NWPMU(*this);
-#endif
         break;
-    case Type::DroneCAN:
+#endif
 #if AP_EFI_DRONECAN_ENABLED
+    case Type::DroneCAN:
         backend = new AP_EFI_DroneCAN(*this);
-#endif
         break;
-    case Type::CurrawongECU:
+#endif
 #if AP_EFI_CURRAWONG_ECU_ENABLED
+    case Type::CurrawongECU:
         backend = new AP_EFI_Currawong_ECU(*this);
-#endif
         break;
-    case Type::SCRIPTING:
+#endif
 #if AP_EFI_SCRIPTING_ENABLED
+    case Type::SCRIPTING:
         backend = new AP_EFI_Scripting(*this);
-#endif
         break;
+#endif
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unknown EFI type");
         break;

--- a/libraries/AP_EFI/AP_EFI.h
+++ b/libraries/AP_EFI/AP_EFI.h
@@ -77,13 +77,25 @@ public:
     // Backend driver types
     enum class Type : uint8_t {
         NONE       = 0,
+#if AP_EFI_SERIAL_MS_ENABLED
         MegaSquirt = 1,
+#endif
+#if AP_EFI_NWPWU_ENABLED
         NWPMU      = 2,
+#endif
+#if AP_EFI_SERIAL_LUTAN_ENABLED
         Lutan      = 3,
+#endif
         // LOWEHEISER = 4,
+#if AP_EFI_DRONECAN_ENABLED
         DroneCAN = 5,
+#endif
+#if AP_EFI_CURRAWONG_ECU_ENABLED
         CurrawongECU = 6,
+#endif
+#if AP_EFI_SCRIPTING_ENABLED
         SCRIPTING  = 7,
+#endif
         // Hirth      = 8 /* Reserved for future implementation */
     };
 


### PR DESCRIPTION
I've run this through test-build-options with no problems

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                0      *           0       0                 0      0      0
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
