### PR TITLE
Move mktime implementation out of AP_RTC

### DIFF
--- a/libraries/AP_Common/time.cpp
+++ b/libraries/AP_Common/time.cpp
@@ -1,0 +1,44 @@
+#include "time.h"
+
+/*
+  mktime replacement from Samba
+ */
+time_t ap_mktime(const struct tm *t)
+{
+    time_t epoch = 0;
+    int n;
+    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
+    const unsigned MINUTE = 60;
+    const unsigned HOUR = 60*MINUTE;
+    const unsigned DAY = 24*HOUR;
+    const unsigned YEAR = 365*DAY;
+
+    if (t->tm_year < 70) {
+        return (time_t)-1;
+    }
+
+    n = t->tm_year + 1900 - 1;
+    epoch = (t->tm_year - 70) * YEAR +
+            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
+
+    y = t->tm_year + 1900;
+    m = 0;
+
+    for (i = 0; i < t->tm_mon; i++) {
+        epoch += mon [m] * DAY;
+        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
+            epoch += DAY;
+        }
+
+        if (++m > 11) {
+            m = 0;
+            y++;
+        }
+    }
+
+    epoch += (t->tm_mday - 1) * DAY;
+    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
+
+    return epoch;
+}
+

--- a/libraries/AP_Common/time.h
+++ b/libraries/AP_Common/time.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <time.h>
+
+// replacement for mktime()
+time_t ap_mktime(const struct tm *t);

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -9,7 +9,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
-#include <AP_RTC/AP_RTC.h>
+#include <AP_Common/time.h>
 
 #include <ff.h>
 #include <AP_HAL_ChibiOS/sdcard.h>
@@ -564,7 +564,7 @@ static time_t fat_time_to_unix(uint16_t date, uint16_t time)
     tp.tm_mday = (date & 0x1f);
     tp.tm_mon = ((date >> 5) & 0x0f) - 1;
     tp.tm_year = ((date >> 9) & 0x7f) + 80;
-    unix = AP::rtc().mktime(&tp);
+    unix = ap_mktime(&tp);
     return unix;
 }
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -17,7 +17,7 @@
 #include "GPS_Backend.h"
 #include <AP_Logger/AP_Logger.h>
 #include <time.h>
-#include <AP_RTC/AP_RTC.h>
+#include <AP_Common/time.h>
 #include <AP_InternalError/AP_InternalError.h>
 
 #define GPS_BACKEND_DEBUGGING 0
@@ -96,7 +96,7 @@ void AP_GPS_Backend::make_gps_time(uint32_t bcd_date, uint32_t bcd_milliseconds)
     tm.tm_hour = v % 100U;
 
     // convert from time structure to unix time
-    time_t unix_time = AP::rtc().mktime(&tm);
+    time_t unix_time = ap_mktime(&tm);
 
     // convert to time since GPS epoch
     const uint32_t unix_to_GPS_secs = 315964800UL;

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -3,7 +3,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
-#include <time.h>
+#include <AP_Common/time.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -209,7 +209,7 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
 /*
   mktime replacement from Samba
  */
-time_t AP_RTC::mktime(const struct tm *t)
+time_t ap_mktime(const struct tm *t)
 {
     time_t epoch = 0;
     int n;

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -205,49 +205,6 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
     return static_cast<uint32_t>(total_delay_ms);
 }
 
-
-/*
-  mktime replacement from Samba
- */
-time_t ap_mktime(const struct tm *t)
-{
-    time_t epoch = 0;
-    int n;
-    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
-    const unsigned MINUTE = 60;
-    const unsigned HOUR = 60*MINUTE;
-    const unsigned DAY = 24*HOUR;
-    const unsigned YEAR = 365*DAY;
-
-    if (t->tm_year < 70) {
-        return (time_t)-1;
-    }
-
-    n = t->tm_year + 1900 - 1;
-    epoch = (t->tm_year - 70) * YEAR +
-            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
-
-    y = t->tm_year + 1900;
-    m = 0;
-
-    for (i = 0; i < t->tm_mon; i++) {
-        epoch += mon [m] * DAY;
-        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
-            epoch += DAY;
-        }
-
-        if (++m > 11) {
-            m = 0;
-            y++;
-        }
-    }
-
-    epoch += (t->tm_mday - 1) * DAY;
-    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
-
-    return epoch;
-}
-
 // singleton instance
 AP_RTC *AP_RTC::_singleton;
 

--- a/libraries/AP_RTC/AP_RTC.h
+++ b/libraries/AP_RTC/AP_RTC.h
@@ -44,9 +44,6 @@ public:
 
     uint32_t get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
 
-    // replacement for mktime()
-    static time_t mktime(const struct tm *t);
-
     // get singleton instance
     static AP_RTC *get_singleton() {
         return _singleton;


### PR DESCRIPTION
RTC isn't required for this to be of use.
