### PR TITLE
AP_BoardConfig: fix conflicting param indexs

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -138,7 +138,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Values: 0:Disabled,1:Enabled,2:Auto
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("SER3_RTSCTS",    23, AP_BoardConfig, state.ser_rtscts[3], 2),
+    AP_GROUPINFO("SER3_RTSCTS",    26, AP_BoardConfig, state.ser_rtscts[3], 2),
 #endif
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL4
@@ -148,7 +148,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Values: 0:Disabled,1:Enabled,2:Auto
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("SER4_RTSCTS",    24, AP_BoardConfig, state.ser_rtscts[4], 2),
+    AP_GROUPINFO("SER4_RTSCTS",    27, AP_BoardConfig, state.ser_rtscts[4], 2),
 #endif
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL5
@@ -353,7 +353,11 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SD_MISSION", 24, AP_BoardConfig, sdcard_storage.mission_kb, 0),
 #endif
-    
+
+    // index 25 used by SER5_RTSCTS
+    // index 26 used by SER3_RTSCTS
+    // index 27 used by SER4_RTSCTS
+
     AP_GROUPEND
 };
 


### PR DESCRIPTION
Thanks to @andyp1per for spotting this.

We have conflicting parameter indexes between `BRD_SER3_RTSCTS` and `BRD_HEAT_LOWMGN` and between  `BRD_SER4_RTSCTS` and `BRD_SD_MISSION`. This is because the higher index params were hiding higher up in the table. This is not caught by CI because we don't have RTS and CTS pins or parameters in SITL. 

`BRD_SER3_RTSCTS` is easy, nothing actually uses it so we can just change the index. 

`BRD_SER4_RTSCTS` is used by four boards: PH4-mini, PH4-mini-bdshot, Swan-K1 and TBS-Colibri-F7. But the RTS CTS setting are rarely changed, so we will just loose the config on those boards. Alternatively we could move `BRD_SD_MISSION`, it hasn't been in that long, but all "high performance" boards would loose the config.

Checked what is using what by running `./Tools/scripts/configure_all.py --no-bl` and greping for `HAL_HAVE_RTSCTS_SERIAL3` and `HAL_HAVE_RTSCTS_SERIAL4` in the generated `hwdef.h` files.