### PR TITLE
Rover: Lower minimum circle tracking distance

### DIFF
--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -2,7 +2,7 @@
 
 #define AR_CIRCLE_ACCEL_DEFAULT         1.0 // default acceleration in m/s/s if not specified by user
 #define AR_CIRCLE_RADIUS_MIN            0.5 // minimum radius in meters
-#define AR_CIRCLE_REACHED_EDGE_DIST     1.0 // vehicle has reached edge if within 1m
+#define AR_CIRCLE_REACHED_EDGE_DIST     0.2 // vehicle has reached edge if within 0.2m
 
 const AP_Param::GroupInfo ModeCircle::var_info[] = {
 


### PR DESCRIPTION
From https://discuss.ardupilot.org/t/rover-boat-quiktune-alpha-testers-wanted/101989/46

The minimum tracking distance for Circle mode doesn't scale for smaller robots and circles.

This PR lowers that limit, allowing for much smaller circles (a few metres radius) to be tracked correctly.

Tested with a real vehicle and a 2m radius circle.

Circle tracking before this patch:
![Screenshot from 2023-06-20 16-31-07](https://github.com/ArduPilot/ardupilot/assets/1731976/933ec363-aa1f-4e5b-97ca-8db735339bc5)


Circle tracking with this patch:
![Screenshot from 2023-06-23 15-22-18](https://github.com/ArduPilot/ardupilot/assets/1731976/1e936144-fbe5-4240-b587-135d1edd42b3)
