### PR TITLE
GPS: fixed for RTCM injection

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -59,6 +59,8 @@ extern AP_Periph_FW periph;
 #ifndef HAL_CAN_POOL_SIZE
 #if HAL_CANFD_SUPPORTED
     #define HAL_CAN_POOL_SIZE 16000
+#elif GPS_MOVING_BASELINE
+    #define HAL_CAN_POOL_SIZE 8000
 #else
     #define HAL_CAN_POOL_SIZE 4000
 #endif
@@ -2151,9 +2153,11 @@ void AP_Periph_FW::send_moving_baseline_msg()
     } else 
 #endif
     {
+        // we use MEDIUM priority on this data as we need to get all
+        // the data through for RTK moving baseline yaw to work
         canard_broadcast(ARDUPILOT_GNSS_MOVINGBASELINEDATA_SIGNATURE,
                         ARDUPILOT_GNSS_MOVINGBASELINEDATA_ID,
-                        CANARD_TRANSFER_PRIORITY_LOW,
+                        CANARD_TRANSFER_PRIORITY_MEDIUM,
                         &buffer[0],
                         total_size);
     }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -763,7 +763,14 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
             dstate->current_baud = 0;
         }
         uint32_t baudrate = _baudrates[dstate->current_baud];
-        _port[instance]->begin(baudrate);
+        uint16_t rx_size=0, tx_size=0;
+        if (_type[instance] == GPS_TYPE_UBLOX_RTK_ROVER) {
+            tx_size = 2048;
+        }
+        if (_type[instance] == GPS_TYPE_UBLOX_RTK_BASE) {
+            rx_size = 2048;
+        }
+        _port[instance]->begin(baudrate, rx_size, tx_size);
         _port[instance]->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
         dstate->last_baud_change_ms = now;
 

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -798,8 +798,10 @@ void AP_GPS_DroneCAN::inject_data(const uint8_t *data, uint16_t len)
     // using a different uavcan instance than the first GPS, as we
     // send the data as broadcast on all DroneCAN devive ports and we
     // don't want to send duplicates
+    const uint32_t now_ms = AP_HAL::millis();
     if (_detected_module == 0 ||
-        _detected_modules[_detected_module].ap_dronecan != _detected_modules[0].ap_dronecan) {
+        _detected_modules[_detected_module].ap_dronecan != _detected_modules[0].ap_dronecan ||
+        now_ms - _detected_modules[0].last_inject_ms > 2000) {
         if (_rtcm_stream.buf == nullptr) {
             // give enough space for a full round from a NTRIP server with all
             // constellations
@@ -808,6 +810,7 @@ void AP_GPS_DroneCAN::inject_data(const uint8_t *data, uint16_t len)
                 return;
             }
         }
+        _detected_modules[_detected_module].last_inject_ms = now_ms;
         _rtcm_stream.buf->write(data, len);
         send_rtcm();
     }

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.h
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.h
@@ -119,6 +119,7 @@ private:
         AP_DroneCAN* ap_dronecan;
         uint8_t node_id;
         uint8_t instance;
+        uint32_t last_inject_ms;
         AP_GPS_DroneCAN* driver;
     } _detected_modules[GPS_MAX_RECEIVERS];
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HolybroG4_GPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HolybroG4_GPS/hwdef.dat
@@ -23,6 +23,10 @@ define CH_CFG_ST_FREQUENCY 1000000
 # assume 512k flash part
 FLASH_SIZE_KB 512
 
+# ensure NRST_MODE is set to "Reset input only". This fixes
+# an issue with resetting the CAN node and firmware update
+define HAL_FLASH_SET_NRST_MODE 0x01
+
 # debug on USART2
 STDOUT_SERIAL SD2
 STDOUT_BAUDRATE 57600

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -18,6 +18,7 @@
 #include "hal.h"
 #include "usbcfg.h"
 #include "stm32_util.h"
+#include "flash.h"
 #include "watchdog.h"
 
 
@@ -293,6 +294,11 @@ void __late_init(void) {
 #endif
 #ifdef HAL_USB_PRODUCT_ID
   setup_usb_strings();
+#endif
+
+#ifdef HAL_FLASH_SET_NRST_MODE
+  // ensure NRST_MODE is set correctly
+  stm32_flash_set_NRST_MODE(HAL_FLASH_SET_NRST_MODE);
 #endif
 }
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
@@ -29,6 +29,7 @@ void stm32_flash_keep_unlocked(bool set);
 bool stm32_flash_ispageerased(uint32_t page);
 void stm32_flash_protect_flash(bool bootloader, bool protect);
 void stm32_flash_unprotect_flash(void);
+void stm32_flash_set_NRST_MODE(uint8_t nrst_mode);
 #ifndef HAL_BOOTLOADER_BUILD
 bool stm32_flash_recent_erase(void);
 #endif


### PR DESCRIPTION
This fixes the following issues:
 - if the RTK base is the 2nd DroneCAN GPS then it couldn't receive RTMStream data from GCS
 - the buffer sizes on the GPS uarts were too small for RTCM data to be fully reliable
 - increase CAN priortity of MovingBaseline data
 - increase CAN buffer size when doing moving baseline
 - fixed a power reset issue on the HolybroG4 GPS by setting the NRST_MODE bits in the option registers

This test by Foxtech shows it fixes their issue
![image](https://github.com/ArduPilot/ardupilot/assets/831867/bc800ba7-f4bf-4084-871f-38e4a47df3db)

