### PR TITLE
AP_GPS: use AP_AHRS_ENABLED in place of HAL_BUILD_AP_PERIPH

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -828,6 +828,7 @@ class sitl_periph_gps(sitl):
             AP_CAN_SLCAN_ENABLED = 0,
             HAL_PROXIMITY_ENABLED = 0,
             AP_SCRIPTING_ENABLED = 0,
+            AP_AHRS_ENABLED = 0,
         )
 
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -397,7 +397,7 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
             goto bad_yaw;
         }
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_AHRS_ENABLED
         {
             // get lag
             float lag = 0.1;
@@ -425,7 +425,7 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
                 goto bad_yaw;
             }
         }
-#endif // HAL_BUILD_AP_PERIPH
+#endif // AP_AHRS_ENABLED
 
         {
             // at this point the offsets are looking okay, go ahead and actually calculate a useful heading


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```

```
Board                    AP_Periph
ARK_GPS                  *
ARK_RTK_GPS              *
AeroFox-Airspeed         *
AeroFox-Airspeed-DLVR    *
AeroFox-GNSS_F9P         *
AeroFox-PMU              *
BirdCANdy                *
C-RTK2-HP                *
CUAV_GPS                 *
CarbonixF405             *
CarbonixL496             *
CubeBlack-periph         *
CubeOrange-periph        *
CubeOrange-periph-heavy  *
CubePilot-CANMod         *
FreeflyRTK               *
G4-ESC                   *
HerePro                  *
Hitec-Airspeed           *
HitecMosaic              *
HolybroG4_Compass        *
HolybroG4_GPS            *
HolybroGPS               *
MatekH743-periph         *
MatekL431-ADSB           *
MatekL431-Airspeed       *
MatekL431-BattMon        *
MatekL431-DShot          *
MatekL431-EFI            *
MatekL431-GPS            *
MatekL431-HWTelem        *
MatekL431-Periph         *
MatekL431-Proximity      *
MatekL431-Rangefinder    *
MatekL431-bdshot         *
Nucleo-G491              *
Nucleo-L476              *
Nucleo-L496              *
Pixracer-periph          *
Sierra-F405              *
Sierra-F412              *
Sierra-F9P               *
Sierra-L431              *
ZubaxGNSS                *
f103-ADSB                *
f103-Airspeed            *
f103-GPS                 *
f103-HWESC               *
f103-QiotekPeriph        *
f103-RangeFinder         *
f103-Trigger             *
f303-GPS                 *
f303-HWESC               *
f303-M10025              *
f303-M10070              *
f303-MatekGPS            *
f303-PWM                 *
f303-TempSensor          *
f303-Universal           *
f405-MatekAirspeed       *
f405-MatekGPS            *
mRo-M10095               *
mRoCANPWM-M10126         *
rGNSS                    *
```
