### PR TITLE
DroneCAN: NofityState msg to include is_landing and is_taking_off

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -445,6 +445,8 @@ bool Copter::has_ekf_failsafed() const
     return failsafe.ekf;
 }
 
+#endif // AP_SCRIPTING_ENABLED
+
 // returns true if vehicle is landing. Only used by Lua scripts
 bool Copter::is_landing() const
 {
@@ -456,8 +458,6 @@ bool Copter::is_taking_off() const
 {
     return flightmode->is_taking_off();
 }
-
-#endif // AP_SCRIPTING_ENABLED
 
 bool Copter::current_mode_requires_mission() const
 {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -679,9 +679,9 @@ private:
     // lua scripts use this to retrieve EKF failsafe state
     // returns true if the EKF failsafe has triggered
     bool has_ekf_failsafed() const override;
+#endif // AP_SCRIPTING_ENABLED
     bool is_landing() const override;
     bool is_taking_off() const override;
-#endif // AP_SCRIPTING_ENABLED
     void rc_loop();
     void throttle_loop();
     void update_batt_compass(void);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -863,6 +863,7 @@ bool Plane::set_land_descent_rate(float descent_rate)
 #endif
     return false;
 }
+#endif // AP_SCRIPTING_ENABLED
 
 // returns true if vehicle is landing.
 bool Plane::is_landing() const
@@ -885,8 +886,6 @@ bool Plane::is_taking_off() const
 #endif
     return control_mode->is_taking_off();
 }
-
-#endif // AP_SCRIPTING_ENABLED
 
 // correct AHRS pitch for TRIM_PITCH_CD in non-VTOL modes, and return VTOL view in VTOL
 void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1237,6 +1237,8 @@ private:
 
 public:
     void failsafe_check(void);
+    bool is_landing() const override;
+    bool is_taking_off() const override;
 #if AP_SCRIPTING_ENABLED
     bool set_target_location(const Location& target_loc) override;
     bool get_target_location(Location& target_loc) override;
@@ -1245,8 +1247,6 @@ public:
 
     // allow for landing descent rate to be overridden by a script, may be -ve to climb
     bool set_land_descent_rate(float descent_rate) override;
-    bool is_landing() const override;
-    bool is_taking_off() const override;
 #endif // AP_SCRIPTING_ENABLED
 
 };

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -29,6 +29,7 @@
 #include <AP_GPS/AP_GPS_DroneCAN.h>
 #include <AP_Compass/AP_Compass_DroneCAN.h>
 #include <AP_Baro/AP_Baro_DroneCAN.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_BattMonitor/AP_BattMonitor_DroneCAN.h>
 #include <AP_Airspeed/AP_Airspeed_DroneCAN.h>
 #include <AP_OpticalFlow/AP_OpticalFlow_HereFlow.h>
@@ -801,6 +802,18 @@ void AP_DroneCAN::notify_state_send()
     if (AP_Notify::flags.waiting_for_throw) {
         msg.vehicle_state |= 1 << ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_STATE_THROW_READY;
     }
+
+#ifndef HAL_BUILD_AP_PERIPH
+    const AP_Vehicle* vehicle = AP::vehicle();
+    if (vehicle != nullptr) {
+        if (vehicle->is_landing()) {
+            msg.vehicle_state |= 1 << ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_STATE_IS_LANDING;
+        }
+        if (vehicle->is_taking_off()) {
+            msg.vehicle_state |= 1 << ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_STATE_IS_TAKING_OFF;
+        }
+    }
+#endif // HAL_BUILD_AP_PERIPH
 
     msg.aux_data_type = ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_YAW_EARTH_CENTIDEGREES;
     uint16_t yaw_cd = (uint16_t)(360.0f - degrees(AP::ahrs().get_yaw()))*100.0f;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -214,13 +214,13 @@ public:
     // returns true on success and control_value is set to a value in the range -1 to +1
     virtual bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) { return false; }
 
+#endif // AP_SCRIPTING_ENABLED
+
     // returns true if vehicle is in the process of landing
     virtual bool is_landing() const { return false; }
 
     // returns true if vehicle is in the process of taking off
     virtual bool is_taking_off() const { return false; }
-
-#endif // AP_SCRIPTING_ENABLED
 
     // zeroing the RC outputs can prevent unwanted motor movement:
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }


### PR DESCRIPTION
This implements the new NotifeState.is_landing and Notifystate.is_taking_off flags from PR https://github.com/dronecan/DSDL/pull/34.