### PR TITLE
Plane: is_landing to use mission_landing_seq

### DIFF
--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -162,5 +162,5 @@ bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
 
 bool ModeAuto::is_landing() const
 {
-    return (plane.flight_stage == AP_FixedWing::FlightStage::LAND);
+    return (plane.flight_stage == AP_FixedWing::FlightStage::LAND) || (plane.mission.get_in_landing_sequence_flag());
 }


### PR DESCRIPTION
Plane's AP_Vehicle()->is_landing() to also check if the mission thinks it's landing soon.

This is a follow-up from PR https://github.com/ArduPilot/ardupilot/pull/24021