### PR TITLE
AP_BattMonitor: Allow INA2xx shunt resistor value to be configured as a parameter

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
@@ -50,6 +50,7 @@ private:
     DevType dev_type;
     uint32_t last_detect_ms;
 
+    AP_Float ina_shunt;
     AP_Int8 i2c_bus;
     AP_Int8 i2c_address;
     AP_Float max_amps;


### PR DESCRIPTION
The default value for the ina2xx current sensor shunt resistor is .0005, previously this was hard-coded. However, for vehicles with different hardware this value needs to be configurable. I have tested functionality by changing this parameter on several machines running two INA228 current sensors with a shunt resistor value different from the default of .0005.