### PR TITLE
Tools: Add Board ID for RADIX2HD

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -228,6 +228,7 @@ AP_HW_YJUAV_A6Nano                   1114
 AP_HW_ACNS_CM4PILOT                  1115
 AP_HW_ACNS_F405AIO                   1116
 AP_HW_BLITZF7                        1117
+AP_HW_RADIX2HD                       1118
 AP_HW_HEEWING_F405                   1119
 
 AP_HW_ESP32_PERIPH                   1205


### PR DESCRIPTION
Adds the board ID for RADIX2HD, see #23948