### PR TITLE
Tools: fixed airport parameters in Flight Gear shell scripts

### DIFF
--- a/Tools/autotest/fg_plane_view.sh
+++ b/Tools/autotest/fg_plane_view.sh
@@ -7,7 +7,7 @@ nice fgfs \
     --fdm=external \
     --aircraft=Rascal110-JSBSim \
     --fg-aircraft="$AUTOTESTDIR/aircraft" \
-    --airport=YKRY \
+    --airport=KSFO \
     --geometry=650x550 \
     --bpp=32 \
     --disable-hud-3d \

--- a/Tools/autotest/fg_quad_view.sh
+++ b/Tools/autotest/fg_quad_view.sh
@@ -7,7 +7,7 @@ nice fgfs \
     --fdm=external \
     --aircraft=arducopter \
     --fg-aircraft="$AUTOTESTDIR/aircraft" \
-    --airport=YKRY \
+    --airport=KSFO \
     --geometry=650x550 \
     --bpp=32 \
     --disable-hud-3d \


### PR DESCRIPTION
When synchronizing with SITL, values that did not exist in the current Flight Gear: "YKRY" were set in the "airport" parameters defined on the each shells below that started the Flight Gear simulator, so the Flight Gear did not start up.

- Tools/autotest/fg_plane_view.sh (for ArduPlane)
- Tools/autotest/fg_quad_view.sh (for ArduCopter)

Because of that, I set the "airport" parameters on the shells to the values that exist in the FlightGear simulator: "KSFO", and modified the Flight Gear to start up normally.


### ArduPlane (Tools/autotest/fg_plane_view.sh)
#### Before:
![before_plane](https://github.com/k-slash27/ardupilot/assets/33851510/7e0a7b5c-fe39-4a1d-8e21-492f4bbb6cb3)

#### After:
![after_plane](https://github.com/k-slash27/ardupilot/assets/33851510/d9f92fbd-11ab-4b02-81c9-8e17b5710395)

### ArduCopter (Tools/autotest/fg_quad_view.sh)

#### Before:
![before_copter](https://github.com/k-slash27/ardupilot/assets/33851510/4bfc2305-69c6-43af-9fbb-aa58dbf1a4d4)

#### After:
![after_copter](https://github.com/k-slash27/ardupilot/assets/33851510/97376cc6-1a33-46ea-a80b-151f0a488a06)
