### PR TITLE
Rover: circle mode safety improvements

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -451,6 +451,14 @@ protected:
     // if there is no current position estimate target_yaw_rad is set to vehicle yaw
     void init_target_yaw_rad();
 
+    // limit config speed so that lateral acceleration is within limits
+    // outputs warning to user if speed is reduced
+    void check_config_speed();
+
+    // ensure config radius is no smaller then vehicle's TURN_RADIUS
+    // radius is increased if necessary and warning is output to the user
+    void check_config_radius();
+
     // enum for Direction parameter
     enum class Direction {
         CW = 0,

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -177,7 +177,7 @@ void ModeCircle::update()
     target.accel = Vector2f(sq(target.speed) / config.radius, 0);
     target.accel.rotate(target.yaw_rad + radians(180));
 
-    g2.pos_control.input_pos_vel_accel_target(target.pos, target.vel, target.accel, rover.G_Dt);
+    g2.pos_control.set_pos_vel_accel_target(target.pos, target.vel, target.accel);
     g2.pos_control.update(rover.G_Dt);
 
     // get desired speed and turn rate from pos_control

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -56,6 +56,7 @@ bool ModeCircle::set_center(const Location& center_loc, float radius_m, bool dir
 
     // set radius
     config.radius = MAX(fabsf(radius_m), AR_CIRCLE_RADIUS_MIN);
+    check_config_radius();
 
     // set direction
     config.dir = dir_ccw ? Direction::CCW : Direction::CW;
@@ -77,10 +78,15 @@ bool ModeCircle::_enter()
         return false;
     }
     config.radius = MAX(fabsf(radius), AR_CIRCLE_RADIUS_MIN);
+    check_config_radius();
+
     config.dir = (direction == 1) ? Direction::CCW : Direction::CW;
     config.speed = is_positive(speed) ? speed : g2.wp_nav.get_default_speed();
     target.yaw_rad = AP::ahrs().get_yaw();
     target.speed = 0;
+
+    // check speed around circle does not lead to excessive lateral acceleration
+    check_config_speed();
 
     // calculate speed, accel and jerk limits
     // otherwise the vehicle uses wp_nav default speed limit
@@ -219,6 +225,9 @@ bool ModeCircle::set_desired_speed(float speed_ms)
     if (is_positive(speed_ms)) {
         config.speed = speed_ms;
 
+        // check desired speed does not lead to excessive lateral acceleration
+        check_config_speed();
+
         // update position controller limits if required
         if (config.speed > g2.pos_control.get_speed_max()) {
             g2.pos_control.set_limits(config.speed, g2.pos_control.get_accel_max(), g2.pos_control.get_lat_accel_max(), g2.pos_control.get_jerk_max());
@@ -234,4 +243,30 @@ bool ModeCircle::get_desired_location(Location& destination) const
 {
     destination = config.center_loc;
     return true;
+}
+
+// limit config speed so that lateral acceleration is within limits
+// assumes that config.radius and attitude controller lat accel max have been set
+// outputs warning to user if speed is reduced
+void ModeCircle::check_config_speed()
+{
+    // calculate maximum speed based on radius and max lateral acceleration max
+    const float speed_max = MAX(safe_sqrt(g2.attitude_control.get_turn_lat_accel_max() * config.radius), 0);
+
+    if (config.speed > speed_max) {
+        config.speed = speed_max;
+        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: max speed is %4.1f", (double)config.speed);
+    }
+}
+
+// ensure config radius is no smaller then vehicle's TURN_RADIUS
+// assumes that config.radius has been set
+// radius is increased if necessary and warning is output to the user
+void ModeCircle::check_config_radius()
+{
+    // ensure radius is at least as large as vehicle's turn radius
+    if (config.radius < rover.g2.turn_radius) {
+        config.radius = rover.g2.turn_radius;
+        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: radius increased to TURN_RADIUS (%4.1f)", (double)rover.g2.turn_radius);
+    }
 }

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -155,8 +155,9 @@ void ModeCircle::update()
 
     // accelerate speed up to desired speed
     const float speed_max = reached_edge ? config.speed : 0.0;
-    const float speed_change_max = (g2.pos_control.get_accel_max() * rover.G_Dt);
-    target.speed = constrain_float(speed_max, target.speed - speed_change_max, target.speed + speed_change_max);
+    const float speed_change_max = (g2.pos_control.get_accel_max() * 0.5 * rover.G_Dt);
+    const float accel_fb = constrain_float(speed_max - target.speed, -speed_change_max, speed_change_max);
+    target.speed += accel_fb;
 
     // calculate angular rate and update target angle
     const float circumference = 2.0 * M_PI * config.radius;
@@ -174,8 +175,8 @@ void ModeCircle::update()
     target.vel.rotate(target.yaw_rad + radians(90));
 
     // acceleration is towards center of circle and is speed^2 / radius
-    target.accel = Vector2f(sq(target.speed) / config.radius, 0);
-    target.accel.rotate(target.yaw_rad + radians(180));
+    target.accel = Vector2f(-sq(target.speed) / config.radius, accel_fb / rover.G_Dt);
+    target.accel.rotate(target.yaw_rad);
 
     g2.pos_control.set_pos_vel_accel_target(target.pos, target.vel, target.accel);
     g2.pos_control.update(rover.G_Dt);


### PR DESCRIPTION
Circle mode can behave very badly if the user sets the target speed to be very high (for example >10m/s) while leaving the acceleration limits at their defaults (or lower).  Changes include:

1. Speed checked to ensure it does not lead to a lateral acceleration beyond the TURN_MAX_G value (speed is reduced and a warning displayed)
2. Radius checked to ensure it is not below the TURN_RADIUS value (radius is increased if necessary and a warning displayed)
3. Target position, velocity and acceleration are input to the position controller with no input shaping performed.  The input shaping was the main cause of the wild path shown below (perhaps there is still a bug in the Rover's input shaping code)
4. Target acceleration is fixed to include the forward-back acceleration

Below are before and after screenshots from SITL of a default rover which has been commanded to circle at 10m/s.

![sitl-10ms-before](https://github.com/ArduPilot/ardupilot/assets/1498098/f3efaa05-ae55-4a37-8a69-ab978cf7a942)

![sitl-10ms-after](https://github.com/ArduPilot/ardupilot/assets/1498098/fcf22296-f237-4fca-99e4-0b6b87254d10)

The above tests can be replicated in SITL by doing the following:

- Tools/autotest/sim_vehicle.py --map --console --speedup=3
- arm throttle
- mode 9 (Circle mode)
- setspeed 10

Here is a screen shot of what is displayed when the user attempts to set the speed too high (e.g. "setspeed 20")
![circle-speed-sitl-debug-output](https://github.com/ArduPilot/ardupilot/assets/1498098/10698c68-aaf6-4a11-bc8e-31a9b6d3a65f)
