### PR TITLE
Fix ELRS Failsafes at 500Hz and CRSFv3 RX loss on reboot

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -293,8 +293,12 @@ static const AP_RCProtocol::SerialConfig serial_configs[] {
     // FastSBUS:
     { 200000,  2,   2, true },
 #endif
+#if AP_RCPROTOCOL_CRSF_ENABLED
     // CrossFire:
     { 416666,  0,   1, false },
+    // CRSFv3 can negotiate higher rates which are sticky on soft reboot
+    { 2000000, 0,   1, false },
+#endif
 };
 
 static_assert(ARRAY_SIZE(serial_configs) > 1, "must have at least one serial config");

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -146,11 +146,12 @@ static const char* get_frame_type(uint8_t byte, uint8_t subtype = 0)
 # define debug(fmt, args...)	do {} while(0)
 #endif
 
-#define CRSF_FRAME_TIMEOUT_US      10000U // 10ms to account for scheduling delays
 #define CRSF_INTER_FRAME_TIME_US_250HZ    4000U // At fastest, frames are sent by the transmitter every 4 ms, 250 Hz
 #define CRSF_INTER_FRAME_TIME_US_150HZ    6667U // At medium, frames are sent by the transmitter every 6.667 ms, 150 Hz
 #define CRSF_INTER_FRAME_TIME_US_50HZ    20000U // At slowest, frames are sent by the transmitter every 20ms, 50 Hz
+#define ELRS_INTER_FRAME_TIME_US_500HZ    2000U // At fastest (CRSF), frames are sent by the transmitter every 2 ms, 500 Hz
 #define CSRF_HEADER_TYPE_LEN     (CSRF_HEADER_LEN + 1)           // header length including type
+#define CRSF_FRAME_TIMEOUT_US           ELRS_INTER_FRAME_TIME_US_500HZ // set to the shortest inter-frame time
 
 #define CRSF_DIGITAL_CHANNEL_MIN 172
 #define CRSF_DIGITAL_CHANNEL_MAX 1811

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -156,6 +156,8 @@ static const char* get_frame_type(uint8_t byte, uint8_t subtype = 0)
 #define CRSF_DIGITAL_CHANNEL_MIN 172
 #define CRSF_DIGITAL_CHANNEL_MAX 1811
 
+#define CRSF_BAUDRATE_1MBIT      1000000U
+#define CRSF_BAUDRATE_2MBIT      2000000U
 
 const uint16_t AP_RCProtocol_CRSF::RF_MODE_RATES[RFMode::RF_MODE_MAX_MODES] = {
     4, 50, 150, 250,    // CRSF
@@ -569,7 +571,7 @@ void AP_RCProtocol_CRSF::process_link_stats_tx_frame(const void* data)
 void AP_RCProtocol_CRSF::process_byte(uint8_t byte, uint32_t baudrate)
 {
     // reject RC data if we have been configured for standalone mode
-    if (baudrate != CRSF_BAUDRATE || _uart) {
+    if ((baudrate != CRSF_BAUDRATE && baudrate != CRSF_BAUDRATE_1MBIT && baudrate != CRSF_BAUDRATE_2MBIT) || _uart) {
         return;
     }
     _process_byte(AP_HAL::micros(), byte);
@@ -598,7 +600,7 @@ bool AP_RCProtocol_CRSF::change_baud_rate(uint32_t baudrate)
         return false;
     }
 #endif
-    if (baudrate > 2000000) {
+    if (baudrate > CRSF_BAUDRATE_2MBIT) {
         return false;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -204,6 +204,8 @@ const char* AP_RCProtocol_CRSF::get_protocol_string(ProtocolType protocol) const
 uint16_t AP_RCProtocol_CRSF::get_link_rate(ProtocolType protocol) const {
     if (protocol == ProtocolType::PROTOCOL_ELRS) {
         return RF_MODE_RATES[_link_status.rf_mode + RFMode::ELRS_RF_MODE_4HZ];
+    } else if (protocol == ProtocolType::PROTOCOL_TRACER) {
+        return 250;
     } else {
         return RF_MODE_RATES[_link_status.rf_mode];
     }


### PR DESCRIPTION
Even with RC_OPTIONS = 8192 it was possible to get ELRS failsafes when running at high rates (500Hz).
This PR ensures that rcin ticks run at a fixed period to ensure that we don't miss frames and allows us to lower the CRSF frame timeout meaning we don't miss many multiples of frames in case of failure.

This PR also corrects the reporting of tracer rates and fixes an issues where if CRSFv3 was negotiated the RX could not be reconnected after a soft reboot

Fixes https://github.com/ArduPilot/ardupilot/issues/23853 and https://github.com/ArduPilot/ardupilot/issues/22886