### PR TITLE
Tools: Param Parse: add reference name to vehicle parameter table

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -111,7 +111,7 @@ libraries = []
 
 # AP_Vehicle also has parameters rooted at "", but isn't referenced
 # from the vehicle in any way:
-ap_vehicle_lib = Library("") # the "" is tacked onto the front of param name
+ap_vehicle_lib = Library("", reference="VEHICLE") # the "" is tacked onto the front of param name
 setattr(ap_vehicle_lib, "Path", os.path.join('..', 'libraries', 'AP_Vehicle', 'AP_Vehicle.cpp'))
 libraries.append(ap_vehicle_lib)
 


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/24017 added our first direct parameter at the vehicle level `FLTMODE_GCSBLOCK`. This exposed a issue with the param parser always expecting a name. This adds the a name, `VEHICLE`.

Previously we had only had subgroups in vehicle which get the group prefix as the reference name.

