### PR TITLE
Rover: limit velocity controller I-term build-up in forward-back direction

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -529,12 +529,18 @@ float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float ra
     return desired_rate;
 }
 
-// return a steering servo output from -1 to +1 given a
-// desired yaw rate in radians/sec. Positive yaw is to the right.
+// return a steering servo output given a desired yaw rate in radians/sec.
+// positive yaw is to the right
+// return value is normally in range -1.0 to +1.0 but can be higher or lower
+// also sets steering_limit_left and steering_limit_right flags
 float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right, float dt)
 {
     // sanity check dt
     dt = constrain_float(dt, 0.0f, 1.0f);
+
+    // update steering limit flags used by higher level controllers (e.g. position controller)
+    _steering_limit_left = motor_limit_left;
+    _steering_limit_right = motor_limit_right;
 
     // if not called recently, reset input filter and desired turn rate to actual turn rate (used for accel limiting)
     const uint32_t now = AP_HAL::millis();
@@ -548,6 +554,12 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_l
     // acceleration limit desired turn rate
     if (is_positive(_steer_accel_max)) {
         const float change_max = radians(_steer_accel_max) * dt;
+        if (desired_rate <= _desired_turn_rate - change_max) {
+            _steering_limit_left = true;
+        }
+        if (desired_rate >= _desired_turn_rate + change_max) {
+            _steering_limit_right = true;
+        }
         desired_rate = constrain_float(desired_rate, _desired_turn_rate - change_max, _desired_turn_rate + change_max);
     }
     _desired_turn_rate = desired_rate;
@@ -555,6 +567,12 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_l
     // rate limit desired turn rate
     if (is_positive(_steer_rate_max)) {
         const float steer_rate_max_rad = radians(_steer_rate_max);
+        if (_desired_turn_rate <= -steer_rate_max_rad) {
+            _steering_limit_left = true;
+        }
+        if (_desired_turn_rate >= steer_rate_max_rad) {
+            _steering_limit_right = true;
+        }
         _desired_turn_rate = constrain_float(_desired_turn_rate, -steer_rate_max_rad, steer_rate_max_rad);
     }
 
@@ -563,9 +581,16 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_l
     if (get_forward_speed(speed)) {
         // do not limit to less than 1 deg/s
         const float turn_rate_max = MAX(get_turn_rate_from_lat_accel(get_turn_lat_accel_max(), fabsf(speed)), radians(1.0f));
+        if (_desired_turn_rate <= -turn_rate_max) {
+            _steering_limit_left = true;
+        }
+        if (_desired_turn_rate >= turn_rate_max) {
+            _steering_limit_right = true;
+        }
         _desired_turn_rate = constrain_float(_desired_turn_rate, -turn_rate_max, turn_rate_max);
     }
 
+    // update pid to calculate output to motors
     float output = _steer_rate_pid.update_all(_desired_turn_rate, AP::ahrs().get_yaw_rate_earth(), dt, (motor_limit_left || motor_limit_right));
     output += _steer_rate_pid.get_ff();
     // constrain and return final output

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -31,6 +31,7 @@ public:
     // return a steering servo output given a desired yaw rate in radians/sec.
     // positive yaw is to the right
     // return value is normally in range -1.0 to +1.0 but can be higher or lower
+    // also sets steering_limit_left and steering_limit_right flags
     float get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only
@@ -47,6 +48,11 @@ public:
 
     // get the lateral acceleration limit (in m/s/s).  Returns at least 0.1G or approximately 1 m/s/s
     float get_turn_lat_accel_max() const { return MAX(_turn_lateral_G_max, 0.1f) * GRAVITY_MSS; }
+
+    // returns true if the steering has been limited which can be caused by the physical steering surface
+    // reaching its physical limits (aka motor limits) or acceleration or turn rate limits being applied
+    bool steering_limit_left() const { return _steering_limit_left; }
+    bool steering_limit_right() const { return _steering_limit_right; }
 
     //
     // throttle / speed controller
@@ -143,6 +149,8 @@ private:
     uint32_t _steer_turn_last_ms;   // system time of last call to steering rate controller
     float    _desired_lat_accel;    // desired lateral acceleration (in m/s/s) from latest call to get_steering_out_lat_accel (for reporting purposes)
     float    _desired_turn_rate;    // desired turn rate (in radians/sec) either from external caller or from lateral acceleration controller
+    bool     _steering_limit_left;  // true when the steering control has reached its left limit (e.g. motor has reached limits or accel or turn rate limits applied)
+    bool     _steering_limit_right; // true when the steering control has reached its right limit (e.g. motor has reached limits or accel or turn rate limits applied)
 
     // throttle control
     uint32_t _speed_last_ms;        // system time of last call to get_throttle_out_speed

--- a/libraries/APM_Control/AR_PosControl.h
+++ b/libraries/APM_Control/AR_PosControl.h
@@ -98,7 +98,6 @@ private:
     float _lat_accel_max;           // lateral acceleration maximum in m/s/s
     float _jerk_max;                // maximum jerk in m/s/s/s (used for both forward and lateral input shaping)
     float _turn_radius;             // vehicle turn radius in meters
-    Vector2f _limit_vel;            // To-Do: explain what this is
 
     // position and velocity targets
     Vector2p _pos_target;           // position target as an offset (in meters) from the EKF origin

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -295,7 +295,7 @@ void Vector2<T>::project(const Vector2<T> &v)
 
 // returns this vector projected onto v
 template <typename T>
-Vector2<T> Vector2<T>::projected(const Vector2<T> &v)
+Vector2<T> Vector2<T>::projected(const Vector2<T> &v) const
 {
     return v * (*this * v)/(v*v);
 }

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -161,7 +161,7 @@ struct Vector2
     void project(const Vector2<T> &v);
 
     // returns this vector projected onto v
-    Vector2<T> projected(const Vector2<T> &v);
+    Vector2<T> projected(const Vector2<T> &v) const;
 
     // adjust position by a given bearing (in degrees) and distance
     void offset_bearing(T bearing, T distance);


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/23989 by zeroing Rover's position controller's velocity controller's I-term in the vehicle's forward-back direction.  The lateral I-term is also limited based on a new pair of steering limit flags from the attitude controller.

This is a good idea because:

- The speed controller already has an I-term so we do not need an other I-term in the higher level velocity controller (in general Leonard recommends that we keep the I-term a the lowest level possible)
- Zeroing out the I-term ensures that it does not get transferred to the vehicle's lateral direction when the vehicle turns at a waypoint (see SITL testing images below).
- By the way, we do need the velocity controller I-term in the lateral direction because this is a different axis from the lower level turn-rate controller.  I'm actually tempted to split the 2d position controller into separate forward and lateral controllers.

Below are before and after screen shots from SITL testing showing the velocity controller's I-term and position error.  We can see there is less of both (which is good) in the After image.
![vel-i-term-before](https://github.com/ArduPilot/ardupilot/assets/1498098/aff7130f-db83-4dc1-a27b-f3291703ff1f)
![vel-i-term-after](https://github.com/ArduPilot/ardupilot/assets/1498098/ec116cd3-0134-4061-a579-a90a5060afd5)

This has been tested in SITL including testing the new attitude controller steering flags.  These were tested by adding some extra debug output of the flags and then driving the vehicle around in acro and steering mode to ensure the flags were set when the pilot input exceeded the limits.
![atc-steer-lim-testing](https://github.com/ArduPilot/ardupilot/assets/1498098/3488988b-f1fc-4aa9-8295-f9a2d65424a5)