### PR TITLE
Change chibios_hwdef.py to pre-process defaults files

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/defaults.parm
@@ -1,7 +1,1 @@
-# setup for LEDs on chan9
-SERVO9_FUNCTION 120
-# Default VTX power to on
-RELAY_DEFAULT 1
-# UART1 for DJI Goggles
-SERIAL1_PROTOCOL 33
-
+@include ../KakuteH7Mini/defaults.parm

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2745,12 +2745,16 @@ INCLUDE common.ld
         defaults_path = os.path.join(os.path.dirname(args.hwdef[0]), args.params)
 
         if not args.bootloader:
+            defaults_abspath = None
             if os.path.exists(defaults_path):
-                self.env_vars['DEFAULT_PARAMETERS'] = os.path.abspath(self.default_params_filepath)
+                defaults_abspath = os.path.abspath(self.default_params_filepath)
                 print("Default parameters path from command line: %s" % self.default_params_filepath)
             elif os.path.exists(defaults_filename):
-                self.env_vars['DEFAULT_PARAMETERS'] = os.path.abspath(defaults_filename)
+                defaults_abspath = os.path.abspath(defaults_filename)
                 print("Default parameters path from hwdef: %s" % defaults_filename)
+
+            if defaults_abspath is not None:
+                self.env_vars['DEFAULT_PARAMETERS'] = defaults_abspath
             else:
                 print("No default parameter file found")
 


### PR DESCRIPTION
Reads the old filepath in, writes the pre-processed result into the builds directory as `preprocessed_defaults.py`.

The only pre-processing directive understood is `@include FILEPATH`.

This PR also changes `KakuteH7Mini-Nand` to not have a copy of `KakuteH7Mini`'s defaults.parm, but rather include `KakuteH7Mini`'s.  It's build is byte-for-byte identical afterwards.

I've also included a file from /tmp/ into a CUAVv5 build and ensured that the default in there appears after flashing.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
KakuteH7Mini-Nand              *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
(note the `KakuteH7Mini-Nand` in the above table)

This work sponsored by Harris Aerial
