### PR TITLE
AP_BattMonitor: fix missing INA2xx param descriptions

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -57,6 +57,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: _
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_var_info[0]),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
@@ -76,6 +78,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 2_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_var_info[1]),
 #endif
 
@@ -96,6 +100,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 3_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_var_info[2]),
 #endif
 
@@ -116,6 +122,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 4_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_var_info[3]),
 #endif
 
@@ -136,6 +144,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 5_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_var_info[4]),
 #endif
 
@@ -156,6 +166,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 6_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_var_info[5]),
 #endif
 
@@ -176,6 +188,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 7_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_var_info[6]),
 #endif
 
@@ -196,6 +210,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 8_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_var_info[7]),
 #endif
 
@@ -216,6 +232,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
     // @Group: 9_
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_INA2xx.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
 


### PR DESCRIPTION
We forgot to add the group.