### PR TITLE
AP_Motors: Heli: Remove unused init_output return and don't assume single for initialised OK

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -173,16 +173,10 @@ void AP_MotorsHeli::init(motor_frame_class frame_class, motor_frame_type frame_t
     _throttle_radio_passthrough = 0.5f;
 
     // initialise Servo/PWM ranges and endpoints
-    if (!init_outputs()) {
-        // don't set initialised_ok
-        return;
-    }
+    init_outputs();
 
     // calculate all scalars
     calculate_scalars();
-
-    // record successful initialisation if what we setup was the desired frame_class
-    set_initialised_ok(frame_class == MOTOR_FRAME_HELI);
 
     // set flag to true so targets are initialized once aircraft is armed for first time
     _heliflags.init_targets_on_arming = true;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -211,7 +211,7 @@ protected:
 
     // init_outputs - initialise Servo/PWM ranges and endpoints.  This
     // method also updates the initialised flag.
-    virtual bool init_outputs() = 0;
+    virtual void init_outputs() = 0;
 
     // calculate_armed_scalars - must be implemented by child classes
     virtual void calculate_armed_scalars() = 0;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -230,7 +230,7 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
 }
 
 // init_outputs
-bool AP_MotorsHeli_Dual::init_outputs()
+void AP_MotorsHeli_Dual::init_outputs()
 {
     if (!initialised_ok()) {
         // make sure 6 output channels are mapped
@@ -261,8 +261,6 @@ bool AP_MotorsHeli_Dual::init_outputs()
     }
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI_DUAL);
-
-    return true;
 }
 
 // calculate_armed_scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -73,7 +73,7 @@ public:
 protected:
 
     // init_outputs
-    bool init_outputs () override;
+    void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
     void update_motor_control(RotorControlState state) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -46,10 +46,10 @@ void AP_MotorsHeli_Quad::set_update_rate( uint16_t speed_hz )
 }
 
 // init_outputs
-bool AP_MotorsHeli_Quad::init_outputs()
+void AP_MotorsHeli_Quad::init_outputs()
 {
     if (initialised_ok()) {
-        return true;
+        return;
     }
 
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
@@ -61,8 +61,6 @@ bool AP_MotorsHeli_Quad::init_outputs()
     _main_rotor.init_servo();
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI_QUAD);
-
-    return true;
 }
 
 // calculate_armed_scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -52,7 +52,7 @@ public:
 protected:
 
     // init_outputs
-    bool init_outputs () override;
+    void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
     void update_motor_control(RotorControlState state) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -200,7 +200,7 @@ void AP_MotorsHeli_Single::set_update_rate( uint16_t speed_hz )
 }
 
 // init_outputs - initialise Servo/PWM ranges and endpoints
-bool AP_MotorsHeli_Single::init_outputs()
+void AP_MotorsHeli_Single::init_outputs()
 {
     if (!initialised_ok()) {
         // map primary swash servos
@@ -244,8 +244,6 @@ bool AP_MotorsHeli_Single::init_outputs()
     }
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI);
-
-    return true;
 }
 
 // set_desired_rotor_speed

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -89,7 +89,7 @@ public:
 protected:
 
     // init_outputs - initialise Servo/PWM ranges and endpoints
-    bool init_outputs() override;
+    void init_outputs() override;
 
     // update_motor_controls - sends commands to motor controllers
     void update_motor_control(RotorControlState state) override;


### PR DESCRIPTION
```
set_initialised_ok(frame_class == MOTOR_FRAME_HELI);
```
In `AP_MotorsHeli` base class is incorrect because it is used by all heli backends not just single. The correct check is already done in `init_outputs` for each heli backend. This means the after init dual and heli quad are not `initialised_ok` this does not cause issues because we call `init_outputs` continually in `output_disarmed` so the init is set true again almost immediately.

This also removes the unused return of `init_outputs`, it always returned true. This is just a tidy up.
