### PR TITLE
Plane: add default to tilt rate param metadata

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo Tiltrotor::var_info[] = {
 
     // @Param: RATE_UP
     // @DisplayName: Tiltrotor upwards tilt rate
-    // @Description: This is the maximum speed at which the motor angle will change for a tiltrotor when moving from forward flight to hover
+    // @Description: This is the maximum speed at which the motor angle will change for a tiltrotor when moving from forward flight to hover. Default is 40deg/s.
     // @Units: deg/s
     // @Increment: 1
     // @Range: 10 300


### PR DESCRIPTION
NFC...this important param should have default shown in wiki description since another param can use its value