### PR TITLE
Plane: fixed TECS state reset in VTOL auto

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -204,7 +204,13 @@ void Plane::ahrs_update()
  */
 void Plane::update_speed_height(void)
 {
-    if (control_mode->does_auto_throttle()) {
+    bool should_run_tecs = control_mode->does_auto_throttle();
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.should_disable_TECS()) {
+        should_run_tecs = false;
+    }
+#endif
+    if (should_run_tecs) {
 	    // Call TECS 50Hz update. Note that we call this regardless of
 	    // throttle suppressed, as this needs to be running for
 	    // takeoff detection
@@ -538,7 +544,14 @@ void Plane::update_alt()
     }
 #endif
 
-    if (control_mode->does_auto_throttle() && !throttle_suppressed) {
+    bool should_run_tecs = control_mode->does_auto_throttle();
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.should_disable_TECS()) {
+        should_run_tecs = false;
+    }
+#endif
+    
+    if (should_run_tecs && !throttle_suppressed) {
 
         float distance_beyond_land_wp = 0;
         if (flight_stage == AP_FixedWing::FlightStage::LAND &&

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4560,4 +4560,20 @@ bool QuadPlane::allow_stick_mixing() const
     return transition->allow_stick_mixing();
 }
 
+/*
+  return true if we should disable TECS in the current flight state
+  this ensures that TECS resets when we change height in a VTOL mode
+ */
+bool QuadPlane::should_disable_TECS() const
+{
+    if (in_vtol_land_descent()) {
+        return true;
+    }
+    if (plane.control_mode == &plane.mode_guided &&
+        plane.auto_state.vtol_loiter) {
+        return true;
+    }
+    return false;
+}
+
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -184,6 +184,12 @@ public:
     // Should we allow stick mixing from the pilot
     bool allow_stick_mixing() const;
 
+    /*
+      should we disable the TECS controller?
+      only called when in an auto-throttle mode
+     */
+    bool should_disable_TECS() const;
+
 private:
     AP_AHRS &ahrs;
 


### PR DESCRIPTION
this fixes a bug where TECS maintains its slow integrator while in a VTOL hover mode in AUTO or GUIDED.

Among other things this affects PAYLOAD_PLACE and DO_VTOL_TRANSITION. In those states the height can change while hovering outside the control of TECS. When TECS regains control in a fwd transition then can lead to a very large height loss or gain until the TECS integrator can catch up
By not running TECS when in these VTOL states we force it to reset when we start needing it again, preventing the integrator issue.
This bug affects 4.4.x as well
Without the fix we get this:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/79340c2d-c9e0-4184-b742-a461a5dbe022)
with the fix we get this:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/aa17838a-f4bd-4e77-94ba-dc8ecf98c47b)


