### PR TITLE
AP_Camera: add CAMx_OPTION support for start/stop recording when arm/Disarm

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -16,6 +16,14 @@ AP_Camera_Backend::AP_Camera_Backend(AP_Camera &frontend, AP_Camera_Params &para
 // update - should be called at 50hz
 void AP_Camera_Backend::update()
 {
+    // Check CAMx_OPTIONS and start/stop recording based on arm/disarm
+    if (_params.options.get() & CAMOPTIONS::REC_ARM_DISARM) {
+        if (hal.util->get_soft_armed() != last_is_armed) {
+            last_is_armed = hal.util->get_soft_armed();
+            record_video(last_is_armed);
+        }
+    }
+
     // try to take picture if pending
     if (trigger_pending) {
         take_picture();

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -36,6 +36,11 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_Camera_Backend);
 
+    enum CAMOPTIONS {
+        NONE = 0,
+        REC_ARM_DISARM = 1, // Recording start/stop on Arm/Disarm
+    };
+
     // init - performs any required initialisation
     virtual void init() {};
 
@@ -138,6 +143,7 @@ protected:
     uint32_t last_photo_time_ms;    // system time that photo was last taken
     Location last_location;         // Location that last picture was taken at (used for trigg_dist calculation)
     uint16_t image_index;           // number of pictures taken since boot
+    bool last_is_armed;             // stores last arm/disarm state. true if it was armed lastly
 };
 
 #endif // AP_CAMERA_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -74,6 +74,13 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_FEEDBAK_POL", 9, AP_Camera_Params, feedback_polarity, 1),
 
+    // @Param: _OPTIONS
+    // @DisplayName: Camera options
+    // @Description: Camera options bitmask
+    // @Bitmask: 0:None,1: Recording Starts at arming and stops at disarming
+    // @User: Standard
+    AP_GROUPINFO("_OPTIONS", 10, AP_Camera_Params, options, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_Camera/AP_Camera_Params.h
+++ b/libraries/AP_Camera/AP_Camera_Params.h
@@ -21,6 +21,7 @@ public:
     AP_Float trigg_dist;        // distance between trigger points (meters)
     AP_Int8 relay_on;           // relay value to trigger camera
     AP_Float interval_min;      // minimum time (in seconds) between shots required by camera
+    AP_Int8 options;            // whether to start recording when armed and stop when disarmed
 
     // pin number for accurate camera feedback messages
     AP_Int8 feedback_pin;


### PR DESCRIPTION
Tested on SiYI zr10.

**Possible Problems**: It works great if there is no auxiliary fucntions for recording is set. If set then Arm/disarm based start and stop takes precedence. Also you can't stop recording in flight (in Air) without Force disarming i.e. crash the plane :(
May be @rmackay9 @peterbarker you can give a hint how i can solve this suggesting me a different approach.