### PR TITLE
Add battery status MSP handling to BLHeli

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -450,6 +450,18 @@ void AP_BLHeli::msp_process_command(void)
         break;
     }
 
+    case MSP_BATTERY_STATE: {
+        debug("MSP_BATTERY_STATE");
+        uint8_t buf[8];
+        buf[0] = 4; // cell count
+        putU16(&buf[1], 1500); // mAh
+        buf[3] = 16; // V
+        putU16(&buf[4], 1500); // mAh
+        putU16(&buf[6], 1); // A
+        msp_send_reply(msp.cmdMSP, buf, sizeof(buf));
+        break;
+    }
+
     case MSP_MOTOR_CONFIG: {
         debug("MSP_MOTOR_CONFIG");
         uint8_t buf[10];


### PR DESCRIPTION
This MSP command is now being request by esc-configurator and causes it to hang if we don't return data. This just returns valid data.

Also gives internal error if an unknown MSP command occurs.