### PR TITLE
AP_Scripting: added QUIK_MAX_REDUCE to VTOL-quicktune.lua

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -5,7 +5,6 @@
  for copters, although it will work in other VTOL modes
 
 --]]
--- luacheck: only 0
 
 
 --[[
@@ -22,7 +21,6 @@ local MAV_SEVERITY_EMERGENCY = 0
 local PARAM_TABLE_KEY = 8
 local PARAM_TABLE_PREFIX = "QUIK_"
 
-local is_quadplane = false
 local atc_prefix = "ATC"
 
 -- bind a parameter to a variable
@@ -206,7 +204,6 @@ local stage = stages[1]
 local last_stage_change = get_time()
 local last_gain_report = get_time()
 local last_pilot_input = get_time()
-local last_notice = get_time()
 local tune_done_time = nil
 local slew_parm = nil
 local slew_target = 0
@@ -222,8 +219,8 @@ local param_saved = {}
 local param_changed = {}
 local need_restore = false
 
-for i, axis in ipairs(axis_names) do
-   for j, suffix in ipairs(param_suffixes) do
+for _, axis in ipairs(axis_names) do
+   for _, suffix in ipairs(param_suffixes) do
       local pname = axis .. "_" .. suffix
       params[pname] = bind_param(atc_prefix .. "_" .. "RAT_" .. pname)
       param_changed[pname] = false
@@ -232,7 +229,7 @@ end
 
 -- reset to start
 function reset_axes_done()
-   for i, axis in ipairs(axis_names) do
+   for _, axis in ipairs(axis_names) do
       axes_done[axis] = false
       filters_done[axis] = false
    end
@@ -249,7 +246,6 @@ end
 -- restore all param values from param_saved dictionary
 function restore_all_params()
    for pname in pairs(params) do
-      local changed = param_changed[pname] and 1 or 0
       if param_changed[pname] then
          params[pname]:set(param_saved[pname])
          param_changed[pname] = false
@@ -270,7 +266,7 @@ end
 
 -- setup a default SMAX if zero
 function setup_SMAX()
-   for i, axis in ipairs(axis_names) do
+   for _, axis in ipairs(axis_names) do
       local smax = axis .. "_SMAX"
       if params[smax]:get() <= 0 then
          adjust_gain(smax, DEFAULT_SMAX)
@@ -362,8 +358,8 @@ function advance_stage(axis)
 end
 
 -- get param name, such as RLL_P, used as index into param dictionaries
-function get_pname(axis, stage)
-   return axis .. "_" .. stage
+function get_pname(axis, tstage)
+   return axis .. "_" .. tstage
 end
 
 -- get axis name from parameter name
@@ -408,7 +404,6 @@ end
 
 -- limit a gain change to QUIK_MAX_REDUCE
 function limit_gain(pname, value)
-   local P = params[pname]
    local saved_value = param_saved[pname]
    local max_reduction = QUIK_MAX_REDUCE:get()
    if max_reduction >= 0 and max_reduction < 100 and saved_value > 0 then

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -484,6 +484,9 @@ end
 -- main update function
 local last_warning = get_time()
 function update()
+   if QUIK_ENABLE:get() < 1 then
+      return
+   end
    if have_pilot_input() then
       last_pilot_input = get_time()
    end

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.md
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.md
@@ -99,6 +99,17 @@ this to a non-zero value allows you to use quicktune with a 2-position
 switch, with the switch settings as low and mid positions. A zero
 value disables auto-save and you need to have a 3 position switch.
 
+## QUIK_MAX_REDUCE
+
+This controls how much quicktune is allowed to lower gains from the
+original gains. If the vehicle already has a reasonable tune and is
+not oscillating then you can set this to zero to prevent gain
+reductions. The default of 20% is reasonable for most vehicles. Using
+a maximum gain reduction lowers the chance of an angle P oscillation
+happening if quicktune gets a false positive oscillation at a low
+gain, which can result in very low rate gains and a dangerous angle P
+oscillation.
+
 # Operation
 
 First you should setup harmonic notch filtering using the guide in the


### PR DESCRIPTION
this limits the amount that rate gains can reduce from the original values in a quicktune. Large reductions in rate gains can be incorrectly triggered by a frame resonance or gust of wind which can result in gains that are dangerously low, which can trigger an angle P oscillation

This PR also fixes QUIK_ENABLE, which was lost in the change to use aux cached values, and fixes lua check errors

