### PR TITLE
AP_ESC_Telem: Add ESC_TLM_LOG_MASK to control which motors are logged

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -39,7 +39,15 @@ const AP_Param::GroupInfo AP_ESC_Telem::var_info[] = {
     // @Range: 0 31
     // @User: Standard
     AP_GROUPINFO("_MAV_OFS", 1, AP_ESC_Telem, mavlink_offset, 0),
-    
+
+    // @Param: _LOG_MASK
+    // @DisplayName: ESC Telemetry logging bitmask
+    // @Description: A bitmask describing which motors will be logged when their telemetry gets updated. This allows to decrease the log file sizes when, for instance, telemetry-based filtering is working, and logging is no longer needed. Bit 0 corresponds to motor 1, bit 1 corresponds to motor 2, and so on.
+    // @Increment: 1
+    // @Range: 0 2147483647
+    // @User: Standard
+    AP_GROUPINFO("_LOG_MASK", 2, AP_ESC_Telem, logging_bitmask, 0xFFFF),
+
     AP_GROUPEND
 };
 
@@ -494,8 +502,9 @@ void AP_ESC_Telem::update()
     if (logger && logger->logging_enabled()) {
 
         for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
-            if (_telem_data[i].last_update_ms != _last_telem_log_ms[i]
-                || _rpm_data[i].last_update_us != _last_rpm_log_us[i]) {
+            if ((logging_bitmask & (1UL << i)) != 0 &&
+                (_telem_data[i].last_update_ms != _last_telem_log_ms[i]
+                 || _rpm_data[i].last_update_us != _last_rpm_log_us[i])) {
 
                 float rpm = 0.0f;
                 get_rpm(i, rpm);

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -127,6 +127,7 @@ private:
     bool _have_data;
 
     AP_Int8 mavlink_offset;
+    AP_Int32 logging_bitmask;
 
     static AP_ESC_Telem *_singleton;
 };


### PR DESCRIPTION
My whoop flight controller has only 8Mb memory for logging, and with bidirectional DShot enabled it could not contain a flight of 6+ minutes long. By inspection, I found that a vast majority of the entries are ESC entries. After I realized that nothing controls whether and how these entries are logged, I decided to introduce a parameter to do that.

The new parameter `ESC_TLM_LOG_MASK` is a bitmask where the i-th bit enables logging of the (i+1)-th motor (i-th if counting from zero). The implementation is pretty straightforward and entirely contained within `AP_ESC_Telem.{h, cpp}`.

This has just been tested on my ArduWhoop build. Particularly with the parameter set to 0, the log size for 6 minutes was below 4.5 megabytes, whereas it reached 8 megabytes for some 4 minutes before the change.

- **Why bitmask**? I can imagine that in VTOLs one may be interested only in a subset of motors being logged.
- **Why not extending `LOG_BITMASK`**? It seems to be vehicle-dependent in a strong way.
- **Why is the default 0xFFFF**? The basic idea is to enable logging of all motors for backward compatibility, so that the users should not do anything on an update if they do not want to change the behavior. However, one cannot set the default to 0xFFFFFFFF, as it cannot be converted to a float. So I picked the approach from another 32-bit bitmask, `CAN_D1_PC_ESC_BM`.