### PR TITLE
AP_NavEKF3: define Yaw alignment min GPS speed per vehicle

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -6,6 +6,13 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
 
+// minimum GPS horizontal speed required to use GPS ground course for yaw alignment (m/s)
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+  #define GPS_VEL_YAW_ALIGN_MIN_SPD 5.0F
+#else
+  #define GPS_VEL_YAW_ALIGN_MIN_SPD 1.0F
+#endif
+
 /********************************************************
 *                   RESET FUNCTIONS                     *
 ********************************************************/

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -118,9 +118,6 @@
 // number of continuous valid GPS velocity samples required to reset yaw
 #define GPS_VEL_YAW_ALIGN_COUNT_THRESHOLD 5
 
-// minimum GPS horizontal speed required to use GPS ground course for yaw alignment (m/s)
-#define GPS_VEL_YAW_ALIGN_MIN_SPD 5.0F
-
 // maximum GPs ground course uncertainty allowed for yaw alignment (deg)
 #define GPS_VEL_YAW_ALIGN_MAX_ANG_ERR 15.0F
 


### PR DESCRIPTION
This improves GSF performance for Copter and Rover 4.4 by reducing the minimum speed the vehicle must be travelling at for a GSF reset to occur.

The minimum speed requirement issue (see https://github.com/ArduPilot/ardupilot/issues/24183) was introduced with PR https://github.com/ArduPilot/ardupilot/pull/23515 but the minimum (5m/s) was likely designed with Planes in mind.This PR reduces the limit to 1m/s for all other vehicles (Copter, Helis, Boats, Rover, etc).  While slightly arbitrary I have tested these and I could not make GSF produce an incorrect yaw even if I set the speed limit to zero.

Related discussion [is here](https://discuss.ardupilot.org/t/yaw-not-aligning-to-gsf-anymore-after-updating-from-4-2-3-to-4-4-0-beta1/101844/13)

Alternatively we could add a parameter although i wonder if anyone would ever set it.

This has been tested in SITL and on real vehicles for Copter, Rover and Boat and GSF always calculated the correct Yaw even when the limit was reduced to zero  The user who reported the problem (and discovered the fix) has successfully tested 0.5m/s for Rover.

Below is a screen shot of a couple of tests on Copter and Rover.  Some debug was added to show the exact GPS speed at the moment GSF was calculated.  In these particular tests I was specifically trying to trigger GSF at low speeds to see if it would calculate the wrong heading (it didn't).
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/de2d89f4-9608-4fbf-95f0-fa466e6dbe65)

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/ebdaf286-5bd7-437d-a75d-77f3149924ea)
