### PR TITLE
Feed-forward scaling based on angle gain ratio

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -131,6 +131,16 @@ float Plane::stabilize_roll_get_roll_out()
     if (!quadplane.use_fw_attitude_controllers()) {
         // use the VTOL rate for control, to ensure consistency
         const auto &pid_info = quadplane.attitude_control->get_rate_roll_pid().get_pid_info();
+
+        // scale FF to angle P
+        if (quadplane.option_is_set(QuadPlane::OPTION::SCALE_FF_ANGLE_P)) {
+            const float mc_angR = quadplane.attitude_control->get_angle_roll_p().kP()
+                * quadplane.attitude_control->get_last_angle_P_scale().x;
+            if (is_positive(mc_angR)) {
+                rollController.set_ff_scale(MIN(1.0, 1.0 / (mc_angR * rollController.tau())));
+            }
+        }
+
         const float roll_out = rollController.get_rate_out(degrees(pid_info.target), speed_scaler);
         /* when slaving fixed wing control to VTOL control we need to decay the integrator to prevent
            opposing integrators balancing between the two controllers
@@ -174,6 +184,16 @@ float Plane::stabilize_pitch_get_pitch_out()
     if (!quadplane.use_fw_attitude_controllers()) {
         // use the VTOL rate for control, to ensure consistency
         const auto &pid_info = quadplane.attitude_control->get_rate_pitch_pid().get_pid_info();
+
+        // scale FF to angle P
+        if (quadplane.option_is_set(QuadPlane::OPTION::SCALE_FF_ANGLE_P)) {
+            const float mc_angP = quadplane.attitude_control->get_angle_pitch_p().kP()
+                * quadplane.attitude_control->get_last_angle_P_scale().y;
+            if (is_positive(mc_angP)) {
+                pitchController.set_ff_scale(MIN(1.0, 1.0 / (mc_angP * pitchController.tau())));
+            }
+        }
+
         const int32_t pitch_out = pitchController.get_rate_out(degrees(pid_info.target), speed_scaler);
         /* when slaving fixed wing control to VTOL control we need to decay the integrator to prevent
            opposing integrators balancing between the two controllers

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -279,6 +279,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Bitmask: 19: CompleteTransition-to fixed wing if Q_TRANS_FAIL timer times out instead of QLAND
     // @Bitmask: 20: Force RTL mode-forces RTL mode on rc failsafe in VTOL modes overriding bit 5(USE_QRTL)
     // @Bitmask: 21: Tilt rotor-tilt motors up when disarmed in FW modes (except manual) to prevent ground strikes.
+    // @Bitmask: 22: Scale FF by the ratio of VTOL/plane angle P gains in VTOL modes rather than reducing VTOL angle P based on airspeed.
     AP_GROUPINFO("OPTIONS", 58, QuadPlane, options, 0),
 
     AP_SUBGROUPEXTENSION("",59, QuadPlane, var_info2),

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -581,6 +581,7 @@ private:
         TRANS_FAIL_TO_FW=(1<<19),
         FS_RTL=(1<<20),
         DISARMED_TILT_UP=(1<<21),
+        SCALE_FF_ANGLE_P=(1<<22),
     };
     bool option_is_set(OPTION option) const {
         return (options.get() & int32_t(option)) != 0;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -1033,7 +1033,7 @@ Vector3f AC_AttitudeControl::update_ang_vel_target_from_att_error(const Vector3f
         rate_target_ang_vel.z = angleP_yaw * attitude_error_rot_vec_rad.z;
     }
 
-    // reset angle P scaling, saving used value for logging
+    // reset angle P scaling, saving used value
     _angle_P_scale_used = _angle_P_scale;
     _angle_P_scale = VECTORF_111;
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -394,8 +394,8 @@ public:
     // purposes
     void set_angle_P_scale_mult(const Vector3f &angle_P_scale) { _angle_P_scale *= angle_P_scale; }
 
-    // get the value of the angle P scale that was used in the last loop, for logging
-    const Vector3f &get_angle_P_scale_logging(void) const { return _angle_P_scale_used; }
+    // get the value of the angle P scale that was used in the last loop
+    const Vector3f &get_last_angle_P_scale(void) const { return _angle_P_scale_used; }
     
     // setup a one loop PD scale multiplier, multiplying by any
     // previously applied scale from this loop. This allows for more
@@ -530,7 +530,7 @@ protected:
     // angle P scaling vector for roll, pitch, yaw
     Vector3f            _angle_P_scale{1,1,1};
 
-    // angle scale used for last loop, used for logging
+    // angle scale used for last loop, used for logging and quadplane angle P scaling
     Vector3f            _angle_P_scale_used;
 
     // PD scaling vector for roll, pitch, yaw

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -177,7 +177,8 @@ float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool d
     // FF should be scaled by scaler/eas2tas, but since we have scaled
     // the AC_PID target above by scaler*scaler we need to instead
     // divide by scaler*eas2tas to get the right scaling
-    const float ff = degrees(rate_pid.get_ff() / (scaler * eas2tas));
+    const float ff = degrees(ff_scale * rate_pid.get_ff() / (scaler * eas2tas));
+    ff_scale = 1.0;
 
     if (disable_integrator) {
         rate_pid.reset_I();

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -16,6 +16,10 @@ public:
     float get_rate_out(float desired_rate, float scaler);
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
+    // setup a one loop FF scale multiplier. This replaces any previous scale applied
+    // so should only be used when only one source of scaling is needed
+    void set_ff_scale(float _ff_scale) { ff_scale = _ff_scale; }
+
     void reset_I();
 
     /*
@@ -56,6 +60,7 @@ private:
     float _last_out;
     AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 150, 1};
     float angle_err_deg;
+    float ff_scale = 1.0;
 
     AP_PIDInfo _pid_info;
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -165,7 +165,8 @@ float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool di
     // FF should be scaled by scaler/eas2tas, but since we have scaled
     // the AC_PID target above by scaler*scaler we need to instead
     // divide by scaler*eas2tas to get the right scaling
-    const float ff = degrees(rate_pid.get_ff() / (scaler * eas2tas));
+    const float ff = degrees(ff_scale * rate_pid.get_ff() / (scaler * eas2tas));
+    ff_scale = 1.0;
 
     if (disable_integrator) {
         rate_pid.reset_I();

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -16,6 +16,10 @@ public:
     float get_rate_out(float desired_rate, float scaler);
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
 
+    // setup a one loop FF scale multiplier. This replaces any previous scale applied
+    // so should only be used when only one source of scaling is needed
+    void set_ff_scale(float _ff_scale) { ff_scale = _ff_scale; }
+
     void reset_I();
 
     /*
@@ -56,6 +60,7 @@ private:
     float _last_out;
     AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 150, 1};
     float angle_err_deg;
+    float ff_scale = 1.0;
 
     AP_PIDInfo _pid_info;
 

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -168,7 +168,7 @@ void AP_AHRS_View::Write_Rate(const AP_Motors &motors, const AC_AttitudeControl 
     /*
       log P/PD gain scale if not == 1.0
      */
-    const Vector3f &scale = attitude_control.get_angle_P_scale_logging();
+    const Vector3f &scale = attitude_control.get_last_angle_P_scale();
     const Vector3f &pd_scale = attitude_control.get_PD_scale_logging();
     if (scale != AC_AttitudeControl::VECTORF_111 || pd_scale != AC_AttitudeControl::VECTORF_111) {
         const struct log_ATSC pkt_ATSC {


### PR DESCRIPTION
The idea behind this PR is to allow higher angle P in VTOL modes - which is proven to provide superior disturbance rejection in copters - without compromising the stability of transitions. Experimentation shows that plane tunes tend to have very low angle P tunes (1/time constant - typically 2 in the default parameter setup), and relatively high feed forward gains. This combination means that in VTOL modes oscillation is driven by the fixed-wing feed forward component and the VTOL controller is constantly having to compensate for this. Solutions to date have focused on backing off the VTOL gains (angle P in particular) based on airspeed, but this leads to lowest common denominator tunes that do not oscillate but have poor position holding capability. Instead this PR scales the angle P gains based on the ratio of fixed wing to VTOL angle P. Thus if the fixed wing angle P is 2 and the VTOL angle P is 10 this PR would backoff the FF component of fixed wing PIDs by 2/10 in VTOL modes. The corollary  would be to do the inverse in fixed wing modes, but since angle P for VTOL is invariably higher than for fixed wing there is nothing to do.

Test flights in RealFlight and on a T1 Ranger show a very positive beneficial effect of this change.

Tested on T1-Ranger - very definitely better than the current code. Much more stable in QRTL

Full flight tests QLoiter -> FWBA -> QLoiter shows remarkable stability in transitions whilst allowing tight VTOL tunes that have good position hold capability.

To enable support add 4194304 to Q_OPTIONS (bit 22)