### PR TITLE
AP_Periph: Move ADSB CAN function into adsb.cpp

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -328,6 +328,12 @@ public:
 
     static bool no_iface_finished_dna;
     static constexpr auto can_printf = ::can_printf;
+
+    static void canard_broadcast(uint64_t data_type_signature,
+                                 uint16_t data_type_id,
+                                 uint8_t priority,
+                                 const void* payload,
+                                 uint16_t payload_len);
 };
 
 namespace AP

--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -93,4 +93,62 @@ void AP_Periph_FW::adsb_update(void)
     }
 }
 
+/*
+  map an ADSB_VEHICLE MAVLink message to a UAVCAN TrafficReport message
+ */
+void AP_Periph_FW::can_send_ADSB(struct __mavlink_adsb_vehicle_t &msg)
+{
+    ardupilot_equipment_trafficmonitor_TrafficReport pkt {};
+    pkt.timestamp.usec = 0;
+    pkt.icao_address = msg.ICAO_address;
+    pkt.tslc = msg.tslc;
+    pkt.latitude_deg_1e7 = msg.lat;
+    pkt.longitude_deg_1e7 = msg.lon;
+    pkt.alt_m = msg.altitude * 1e-3;
+
+    pkt.heading = radians(msg.heading * 1e-2);
+
+    pkt.velocity[0] = cosf(pkt.heading) * msg.hor_velocity * 1e-2;
+    pkt.velocity[1] = sinf(pkt.heading) * msg.hor_velocity * 1e-2;
+    pkt.velocity[2] = -msg.ver_velocity * 1e-2;
+
+    pkt.squawk = msg.squawk;
+    memcpy(pkt.callsign, msg.callsign, MIN(sizeof(msg.callsign),sizeof(pkt.callsign)));
+    if (msg.flags & 0x8000) {
+        pkt.source = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SOURCE_ADSB_UAT;
+    } else {
+        pkt.source = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SOURCE_ADSB;
+    }
+
+    pkt.traffic_type = msg.emitter_type;
+
+    if ((msg.flags & ADSB_FLAGS_VALID_ALTITUDE) != 0 && msg.altitude_type == 0) {
+        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_PRESSURE_AMSL;
+    } else if ((msg.flags & ADSB_FLAGS_VALID_ALTITUDE) != 0 && msg.altitude_type == 1) {
+        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_WGS84;
+    } else {
+        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_ALT_UNKNOWN;
+    }
+
+    pkt.lat_lon_valid = (msg.flags & ADSB_FLAGS_VALID_COORDS) != 0;
+    pkt.heading_valid = (msg.flags & ADSB_FLAGS_VALID_HEADING) != 0;
+    pkt.velocity_valid = (msg.flags & ADSB_FLAGS_VALID_VELOCITY) != 0;
+    pkt.callsign_valid = (msg.flags & ADSB_FLAGS_VALID_CALLSIGN) != 0;
+    pkt.ident_valid = (msg.flags & ADSB_FLAGS_VALID_SQUAWK) != 0;
+    pkt.simulated_report = (msg.flags & ADSB_FLAGS_SIMULATED) != 0;
+
+    // these flags are not in common.xml
+    pkt.vertical_velocity_valid = (msg.flags & 0x0080) != 0;
+    pkt.baro_valid = (msg.flags & 0x0100) != 0;
+
+    uint8_t buffer[ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_MAX_SIZE] {};
+    uint16_t total_size = ardupilot_equipment_trafficmonitor_TrafficReport_encode(&pkt, buffer, !periph.canfdout());
+
+    canard_broadcast(ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SIGNATURE,
+                    ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ID,
+                    CANARD_TRANSFER_PRIORITY_LOWEST,
+                    &buffer[0],
+                    total_size);
+}
+
 #endif // HAL_PERIPH_ENABLE_ADSB

--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -23,6 +23,7 @@
 #ifdef HAL_PERIPH_ENABLE_ADSB
 
 #include <AP_SerialManager/AP_SerialManager.h>
+#include <dronecan_msgs.h>
 
 extern const AP_HAL::HAL &hal;
 

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -2460,66 +2460,6 @@ void AP_Periph_FW::can_proximity_update()
 #endif
 }
 
-#ifdef HAL_PERIPH_ENABLE_ADSB
-/*
-  map an ADSB_VEHICLE MAVLink message to a UAVCAN TrafficReport message
- */
-void AP_Periph_FW::can_send_ADSB(struct __mavlink_adsb_vehicle_t &msg)
-{
-    ardupilot_equipment_trafficmonitor_TrafficReport pkt {};
-    pkt.timestamp.usec = 0;
-    pkt.icao_address = msg.ICAO_address;
-    pkt.tslc = msg.tslc;
-    pkt.latitude_deg_1e7 = msg.lat;
-    pkt.longitude_deg_1e7 = msg.lon;
-    pkt.alt_m = msg.altitude * 1e-3;
-
-    pkt.heading = radians(msg.heading * 1e-2);
-
-    pkt.velocity[0] = cosf(pkt.heading) * msg.hor_velocity * 1e-2;
-    pkt.velocity[1] = sinf(pkt.heading) * msg.hor_velocity * 1e-2;
-    pkt.velocity[2] = -msg.ver_velocity * 1e-2;
-
-    pkt.squawk = msg.squawk;
-    memcpy(pkt.callsign, msg.callsign, MIN(sizeof(msg.callsign),sizeof(pkt.callsign)));
-    if (msg.flags & 0x8000) {
-        pkt.source = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SOURCE_ADSB_UAT;
-    } else {
-        pkt.source = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SOURCE_ADSB;
-    }
-
-    pkt.traffic_type = msg.emitter_type;
-
-    if ((msg.flags & ADSB_FLAGS_VALID_ALTITUDE) != 0 && msg.altitude_type == 0) {
-        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_PRESSURE_AMSL;
-    } else if ((msg.flags & ADSB_FLAGS_VALID_ALTITUDE) != 0 && msg.altitude_type == 1) {
-        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_WGS84;
-    } else {
-        pkt.alt_type = ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ALT_TYPE_ALT_UNKNOWN;
-    }
-
-    pkt.lat_lon_valid = (msg.flags & ADSB_FLAGS_VALID_COORDS) != 0;
-    pkt.heading_valid = (msg.flags & ADSB_FLAGS_VALID_HEADING) != 0;
-    pkt.velocity_valid = (msg.flags & ADSB_FLAGS_VALID_VELOCITY) != 0;
-    pkt.callsign_valid = (msg.flags & ADSB_FLAGS_VALID_CALLSIGN) != 0;
-    pkt.ident_valid = (msg.flags & ADSB_FLAGS_VALID_SQUAWK) != 0;
-    pkt.simulated_report = (msg.flags & ADSB_FLAGS_SIMULATED) != 0;
-
-    // these flags are not in common.xml
-    pkt.vertical_velocity_valid = (msg.flags & 0x0080) != 0;
-    pkt.baro_valid = (msg.flags & 0x0100) != 0;
-
-    uint8_t buffer[ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_MAX_SIZE] {};
-    uint16_t total_size = ardupilot_equipment_trafficmonitor_TrafficReport_encode(&pkt, buffer, !periph.canfdout());
-
-    canard_broadcast(ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_SIGNATURE,
-                    ARDUPILOT_EQUIPMENT_TRAFFICMONITOR_TRAFFICREPORT_ID,
-                    CANARD_TRANSFER_PRIORITY_LOWEST,
-                    &buffer[0],
-                    total_size);
-}
-#endif // HAL_PERIPH_ENABLE_ADSB
-
 
 #ifdef HAL_PERIPH_ENABLE_EFI
 /*

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -426,11 +426,6 @@ static void handle_param_executeopcode(CanardInstance* ins, CanardRxTransfer* tr
 );
 }
 
-static void canard_broadcast(uint64_t data_type_signature,
-                                uint16_t data_type_id,
-                                uint8_t priority,
-                                const void* payload,
-                                uint16_t payload_len);
 static void processTx(void);
 static void processRx(void);
 
@@ -882,11 +877,11 @@ static void can_safety_button_update(void)
     uint8_t buffer[ARDUPILOT_INDICATION_BUTTON_MAX_SIZE] {};
     uint16_t total_size = ardupilot_indication_Button_encode(&pkt, buffer, !periph.canfdout());
 
-    canard_broadcast(ARDUPILOT_INDICATION_BUTTON_SIGNATURE,
-                    ARDUPILOT_INDICATION_BUTTON_ID,
-                    CANARD_TRANSFER_PRIORITY_LOW,
-                    &buffer[0],
-                    total_size);
+    periph.canard_broadcast(ARDUPILOT_INDICATION_BUTTON_SIGNATURE,
+                            ARDUPILOT_INDICATION_BUTTON_ID,
+                            CANARD_TRANSFER_PRIORITY_LOW,
+                            &buffer[0],
+                            total_size);
 }
 #endif // HAL_GPIO_PIN_SAFE_BUTTON
 
@@ -1136,11 +1131,11 @@ static uint8_t* get_tid_ptr(uint32_t transfer_desc)
     return &tid_map_ptr->next->tid;
 }
 
-static void canard_broadcast(uint64_t data_type_signature,
-                                uint16_t data_type_id,
-                                uint8_t priority,
-                                const void* payload,
-                                uint16_t payload_len)
+void AP_Periph_FW::canard_broadcast(uint64_t data_type_signature,
+                                    uint16_t data_type_id,
+                                    uint8_t priority,
+                                    const void* payload,
+                                    uint16_t payload_len)
 {
     if (canardGetLocalNodeID(&dronecan.canard) == CANARD_BROADCAST_NODE_ID) {
         return;
@@ -1295,11 +1290,11 @@ static void node_status_send(void)
 
     uint32_t len = uavcan_protocol_NodeStatus_encode(&node_status, buffer, !periph.canfdout());
 
-    canard_broadcast(UAVCAN_PROTOCOL_NODESTATUS_SIGNATURE,
-                    UAVCAN_PROTOCOL_NODESTATUS_ID,
-                    CANARD_TRANSFER_PRIORITY_LOW,
-                    buffer,
-                    len);
+    periph.canard_broadcast(UAVCAN_PROTOCOL_NODESTATUS_SIGNATURE,
+                            UAVCAN_PROTOCOL_NODESTATUS_ID,
+                            CANARD_TRANSFER_PRIORITY_LOW,
+                            buffer,
+                            len);
 }
 
 
@@ -2674,11 +2669,11 @@ void can_printf(const char *fmt, ...)
         uint8_t buffer_packet[UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_MAX_SIZE] {};
         const uint32_t len = uavcan_protocol_debug_LogMessage_encode(&pkt, buffer_packet, !periph.canfdout());
 
-        canard_broadcast(UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_SIGNATURE,
-                        UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_ID,
-                        CANARD_TRANSFER_PRIORITY_LOW,
-                        buffer_packet,
-                        len);
+        periph.canard_broadcast(UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_SIGNATURE,
+                                UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_ID,
+                                CANARD_TRANSFER_PRIORITY_LOW,
+                                buffer_packet,
+                                len);
     }
     
 #else
@@ -2692,11 +2687,11 @@ void can_printf(const char *fmt, ...)
 
     uint32_t len = uavcan_protocol_debug_LogMessage_encode(&pkt, buffer, !periph.canfdout());
 
-    canard_broadcast(UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_SIGNATURE,
-                    UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_ID,
-                    CANARD_TRANSFER_PRIORITY_LOW,
-                    buffer,
-                    len);
+    periph.canard_broadcast(UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_SIGNATURE,
+                            UAVCAN_PROTOCOL_DEBUG_LOGMESSAGE_ID,
+                            CANARD_TRANSFER_PRIORITY_LOW,
+                            buffer,
+                            len);
 
 #endif
 }


### PR DESCRIPTION
as discussed on DevCall.  Moved canard_broadcast to be non-static, and simply moved the method.
