### PR TITLE
AP_AccellCal: initialize HAL_INS_ACCELCAL_ENABLED for periph

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -5,7 +5,8 @@
 
 #ifndef HAL_INS_ACCELCAL_ENABLED
 #if HAL_GCS_ENABLED
-#define HAL_INS_ACCELCAL_ENABLED 1
+#include <AP_InertialSensor/AP_InertialSensor_config.h>
+#define HAL_INS_ACCELCAL_ENABLED AP_INERTIALSENSOR_ENABLED
 #else
 #define HAL_INS_ACCELCAL_ENABLED 0
 #endif


### PR DESCRIPTION
AccelCal should probably never be enabled on AP_Periph, but just in case AccelCal rewuires InertialSensor so check for that instead of force enabling