### PR TITLE
Tools: Scripts: run_luacheck: allow passing extra arguments

### DIFF
--- a/Tools/scripts/run_luacheck.sh
+++ b/Tools/scripts/run_luacheck.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Run lua check for all lua files passing AP specific config
+# Can also pass any number of arguments that are passed onto luacheck
+# for example the path of a single script could be given
 
 cd "$(dirname "$0")"
 cd ../..
 
-luacheck */ --config libraries/AP_Scripting/tests/luacheck.lua
+CHECK_PATH="$*"
+if test -z "$CHECK_PATH"
+then
+    CHECK_PATH="*/"
+fi
+
+luacheck ${CHECK_PATH} --config libraries/AP_Scripting/tests/luacheck.lua


### PR DESCRIPTION
This allows passing a file name to run just a single file such as:
```
./Tools/scripts/run_luacheck.sh  ./libraries/AP_Scripting/examples/terrain_warning.lua 
```
With no arguments it runs as before. 