### PR TITLE
ChibiOS: fixed use of sbrk based allocation in newlib

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -717,6 +717,7 @@ def build(bld):
                 'fopen', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
                 'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',
                 'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf',
-                '_gettimeofday', '_times', '_times_r', '_gettimeofday_r', 'time', 'clock' ]
+                '_gettimeofday', '_times', '_times_r', '_gettimeofday_r', 'time', 'clock',
+                '_sbrk_r', '_malloc_r', '_calloc_r', '_free_r']
     for w in wraplist:
         bld.env.LINKFLAGS += ['-Wl,--wrap,%s' % w]

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -537,6 +537,28 @@ void* get_addr_mem_region_end_addr(void *addr)
     return 0;
 }
 
+/*
+  alloction functions for newlib
+ */
+void *__wrap__calloc_r(void *rptr, size_t nmemb, size_t size)
+{
+    (void)rptr;
+    return calloc(nmemb, size);
+}
+
+void *__wrap__malloc_r(void *rptr, size_t size)
+{
+    (void)rptr;
+    // we want consistent zero memory
+    return calloc(1, size);
+}
+
+void __wrap__free_r(void *rptr, void *ptr)
+{
+    (void)rptr;
+    return free(ptr);
+}
+
 #ifdef USE_POSIX
 /*
   allocation functions for FATFS


### PR DESCRIPTION
this fixes the crash found by @IamPete1 in PR #24106 

the issue was the way scripting used string functions that called down to newlib allocation functions that are not thread safe. Using sbrk based functions on ChibiOS is a really bad idea

