### PR TITLE
waf: wrap _sbrk to prevent its use

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -718,6 +718,6 @@ def build(bld):
                 'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',
                 'ftell', 'freopen', 'remove', 'vfprintf', 'fscanf',
                 '_gettimeofday', '_times', '_times_r', '_gettimeofday_r', 'time', 'clock',
-                '_sbrk_r', '_malloc_r', '_calloc_r', '_free_r']
+                '_sbrk', '_sbrk_r', '_malloc_r', '_calloc_r', '_free_r']
     for w in wraplist:
         bld.env.LINKFLAGS += ['-Wl,--wrap,%s' % w]


### PR DESCRIPTION
while _sbrk isn't used now, this will prevent a repeat of the bug in #24218