### PR TITLE
AP_RangeFinder: allocate a JRE driver ID

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -540,6 +540,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         serial_create_fn = AP_RangeFinder_NoopLoop::create;
 #endif
         break;
+    case Type::JRE_Serial:
+        break;
 
     case Type::NONE:
         break;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -98,6 +98,7 @@ public:
         TeraRanger_Serial = 35,
         Lua_Scripting = 36,
         NoopLoop_P = 37,
+        JRE_Serial = 38,
         SIM = 100,
     };
 


### PR DESCRIPTION
JAE is creating a new radio altimeter(JRE).
So PR the ID of that serial driver.

Thank you.

