### PR TITLE
Plane: output rudder and steering directly removing steering_control struct

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -222,6 +222,7 @@ struct PACKED log_AETR {
     float throttle;
     float rudder;
     float flap;
+    float steering;
     float speed_scaler;
 };
 
@@ -235,6 +236,7 @@ void Plane::Log_Write_AETR()
         ,throttle : SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)
         ,rudder   : SRV_Channels::get_output_scaled(SRV_Channel::k_rudder)
         ,flap     : SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::k_flap_auto)
+        ,steering : SRV_Channels::get_output_scaled(SRV_Channel::k_steering)
         ,speed_scaler : get_speed_scaler(),
         };
 
@@ -430,9 +432,10 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: Thr: Pre-mixer value for throttle output (between -100 and 100)
 // @Field: Rudd: Pre-mixer value for rudder output (between -4500 and 4500)
 // @Field: Flap: Pre-mixer value for flaps output (between 0 and 100)
+// @Field: Steer: Pre-mixer value for steering output (between -4500 and 4500)
 // @Field: SS: Surface movement / airspeed scaling value
     { LOG_AETR_MSG, sizeof(log_AETR),
-      "AETR", "Qffffff",  "TimeUS,Ail,Elev,Thr,Rudd,Flap,SS", "s------", "F------" , true },
+      "AETR", "Qfffffff",  "TimeUS,Ail,Elev,Thr,Rudd,Flap,Steer,SS", "s-------", "F-------" , true },
 
 // @LoggerMessage: OFG
 // @Description: OFfboard-Guided - an advanced version of GUIDED for companion computers that includes rate/s.  

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -211,16 +211,6 @@ private:
     bool training_manual_roll;  // user has manual roll control
     bool training_manual_pitch; // user has manual pitch control
 
-    /*
-      keep steering and rudder control separated until we update servos,
-      to allow for a separate wheel servo from rudder servo
-    */
-    struct {
-        bool ground_steering; // are we doing ground steering?
-        int16_t steering; // value for nose/tail wheel
-        int16_t rudder;   // value for rudder
-    } steering_control;
-
     // should throttle be pass-thru in guided?
     bool guided_throttle_passthru;
 
@@ -868,9 +858,9 @@ private:
     float stabilize_pitch_get_pitch_out();
     void stabilize_stick_mixing_fbw();
     void stabilize_yaw();
-    void calc_nav_yaw_coordinated();
-    void calc_nav_yaw_course(void);
-    void calc_nav_yaw_ground(void);
+    int16_t calc_nav_yaw_coordinated();
+    int16_t calc_nav_yaw_course(void);
+    int16_t calc_nav_yaw_ground(void);
 
     // Log.cpp
     uint32_t last_log_fast_ms;

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -230,3 +230,10 @@ bool Mode::is_taking_off() const
 {
     return (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF);
 }
+
+// Helper to output to both k_rudder and k_steering servo functions
+void Mode::output_rudder_and_steering(float val)
+{
+    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, val);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_steering, val);
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -146,6 +146,9 @@ protected:
     // mode specific pre-arm checks
     virtual bool _pre_arm_checks(size_t buflen, char *buffer) const;
 
+    // Helper to output to both k_rudder and k_steering servo functions
+    void output_rudder_and_steering(float val);
+
 #if HAL_QUADPLANE_ENABLED
     // References for convenience, used by QModes
     AC_PosControl*& pos_control;

--- a/ArduPlane/mode_acro.cpp
+++ b/ArduPlane/mode_acro.cpp
@@ -104,22 +104,24 @@ void ModeAcro::stabilize()
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.pitchController.get_rate_out(pitch_rate, speed_scaler));
     }
 
-    plane.steering_control.steering = plane.rudder_input();
-
+    float rudder_output;
     if (plane.g.acro_yaw_rate > 0 && plane.yawController.rate_control_enabled()) {
         // user has asked for yaw rate control with yaw rate scaled by ACRO_YAW_RATE
         const float rudd_expo = plane.rudder_in_expo(true);
         const float yaw_rate = (rudd_expo/SERVO_MAX) * plane.g.acro_yaw_rate;
-        plane.steering_control.steering = plane.steering_control.rudder = plane.yawController.get_rate_out(yaw_rate,  speed_scaler, false);
+        rudder_output = plane.yawController.get_rate_out(yaw_rate,  speed_scaler, false);
     } else if (plane.flight_option_enabled(FlightOptions::ACRO_YAW_DAMPER)) {
         // use yaw controller
-        plane.calc_nav_yaw_coordinated();
+        rudder_output = plane.calc_nav_yaw_coordinated();
     } else {
         /*
           manual rudder
         */
-        plane.steering_control.rudder = plane.steering_control.steering;
+        rudder_output = plane.rudder_input();
     }
+
+    output_rudder_and_steering(rudder_output);
+
 }
 
 /*
@@ -215,7 +217,7 @@ void ModeAcro::stabilize_quaternion()
     // call to rate controllers
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron,  plane.rollController.get_rate_out(desired_rates.x, speed_scaler));
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.pitchController.get_rate_out(desired_rates.y, speed_scaler));
-    plane.steering_control.steering = plane.steering_control.rudder = plane.yawController.get_rate_out(desired_rates.z,  speed_scaler, false);
+    output_rudder_and_steering(plane.yawController.get_rate_out(desired_rates.z,  speed_scaler, false));
 
     acro_state.roll_active_last = roll_active;
     acro_state.pitch_active_last = pitch_active;

--- a/ArduPlane/mode_manual.cpp
+++ b/ArduPlane/mode_manual.cpp
@@ -5,9 +5,7 @@ void ModeManual::update()
 {
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.roll_in_expo(false));
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.pitch_in_expo(false));
-    //rudder in sets rudder, but is also assigned to steering values used later in servos.cpp for steering
-    plane.steering_control.steering = plane.steering_control.rudder = plane.rudder_in_expo(false);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, plane.steering_control.steering);
+    output_rudder_and_steering(plane.rudder_in_expo(false));
     float throttle = plane.get_throttle_input(true);
 
 

--- a/ArduPlane/mode_training.cpp
+++ b/ArduPlane/mode_training.cpp
@@ -64,9 +64,6 @@ void ModeTraining::run()
     }
 
     // Always manual rudder control
-    const float pilot_rudder = plane.rudder_in_expo(false);
-    plane.steering_control.rudder = pilot_rudder;
-    plane.steering_control.steering = pilot_rudder;
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, pilot_rudder);
+    output_rudder_and_steering(plane.rudder_in_expo(false));
 
 }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -819,28 +819,6 @@ void Plane::set_servos(void)
         return;
     }
 
-    /*
-      see if we are doing ground steering.
-     */
-    if (!steering_control.ground_steering) {
-        // we are not at an altitude for ground steering. Set the nose
-        // wheel to the rudder just in case the barometer has drifted
-        // a lot
-        steering_control.steering = steering_control.rudder;
-    } else if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
-        // we are within the ground steering altitude but don't have a
-        // dedicated steering channel. Set the rudder to the ground
-        // steering output
-        steering_control.rudder = steering_control.steering;
-    }
-
-    // clear ground_steering to ensure manual control if the yaw stabilizer doesn't run
-    steering_control.ground_steering = false;
-
-
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, steering_control.rudder);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_steering, steering_control.steering);
-
     if (control_mode != &mode_manual) {
         set_servos_controlled();
     }


### PR DESCRIPTION
Some more rudder output tidying. This removes the `steering_control` struct and instead outputs directly to the `k_steering` and `k_rudder` servo output functions as we do for roll/pitch/throttle.