### PR TITLE
Create templated iterator creator and use it in AP_Logger

### DIFF
--- a/libraries/AP_Common/AP_BackendIterator.h
+++ b/libraries/AP_Common/AP_BackendIterator.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdint.h>
+
+template <typename T>
+class AP_BackendIterator
+{
+public:
+    AP_BackendIterator(T**_backends, uint8_t &_num_backends) :
+        backends{_backends},
+        num_backends{_num_backends}
+        {}
+
+    // see
+    // https://www.internalpointers.com/post/writing-custom-iterators-modern-cpp
+    // - search for "done by implementing some custom"
+    struct Iterator {
+        Iterator(T **_backend) : backend{_backend} {}
+        T& operator*() const { return **backend; }
+        T* operator->() { return *backend; }
+
+        // Prefix increment
+        Iterator& operator++() { backend++; return *this; };
+        // Postfix increment
+        Iterator operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+
+        friend bool operator== (const Iterator& a, const Iterator& b) { return a.backend == b.backend; };
+        friend bool operator!= (const Iterator& a, const Iterator& b) { return a.backend != b.backend; };
+    private:
+        T **backend;
+    };
+
+    Iterator begin() { return Iterator(&backends[0]); }
+    Iterator end()   { return Iterator(&backends[num_backends]); }
+
+    Iterator begin() const { return Iterator(&backends[0]); }
+    Iterator end() const { return Iterator(&backends[num_backends]); }
+
+private:
+
+    T**backends;
+    uint8_t &num_backends;
+};

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -239,15 +239,15 @@ void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
         if (message_writer == nullptr)  {
             AP_BoardConfig::allocation_error("message writer");
         }
-        backends[_next_backend] = backend_config.probe_fn(*this, message_writer);
-        if (backends[_next_backend] == nullptr) {
+        backends_array[_next_backend] = backend_config.probe_fn(*this, message_writer);
+        if (backends_array[_next_backend] == nullptr) {
             AP_BoardConfig::allocation_error("logger backend");
         }
         _next_backend++;
     }
 
-    for (uint8_t i=0; i<_next_backend; i++) {
-        backends[i]->Init();
+    for (auto &b : backends) {
+        b.Init();
     }
 
     start_io_thread();
@@ -566,8 +566,8 @@ bool AP_Logger::logging_enabled() const
     if (_next_backend == 0) {
         return false;
     }
-    for (uint8_t i=0; i<_next_backend; i++) {
-        if (backends[i]->logging_enabled()) {
+    for (const auto &b : backends) {
+        if (b.logging_enabled()) {
             return true;
         }
     }
@@ -579,8 +579,8 @@ bool AP_Logger::logging_failed() const
         // we should not have been called!
         return true;
     }
-    for (uint8_t i=0; i<_next_backend; i++) {
-        if (backends[i]->logging_failed()) {
+    for (const auto &b : backends) {
+        if (b.logging_failed()) {
             return true;
         }
     }
@@ -604,7 +604,7 @@ void AP_Logger::backend_starting_new_log(const AP_Logger_Backend *backend)
     _log_start_count++;
 
     for (uint8_t i=0; i<_next_backend; i++) {
-        if (backends[i] == backend) { // pointer comparison!
+        if (backends_array[i] == backend) { // pointer comparison!
             // reset sent masks
             for (struct log_write_fmt *f = log_write_fmts; f; f=f->next) {
                 f->sent_mask &= ~(1<<i);
@@ -658,8 +658,8 @@ const struct MultiplierStructure *AP_Logger::multiplier(uint16_t num) const
 
 #define FOR_EACH_BACKEND(methodcall)              \
     do {                                          \
-        for (uint8_t i=0; i<_next_backend; i++) { \
-            backends[i]->methodcall;              \
+        for (auto &b : backends) {                         \
+            b.methodcall;              \
         }                                         \
     } while (0)
 
@@ -729,12 +729,12 @@ bool AP_Logger::WriteBlock_first_succeed(const void *pBuffer, uint16_t size)
     if (_next_backend == 0) {
         return false;
     }
-    
+
     for (uint8_t i=1; i<_next_backend; i++) {
-        backends[i]->WriteBlock(pBuffer, size);
+        backends_array[i]->WriteBlock(pBuffer, size);
     }
 
-    return backends[0]->WriteBlock(pBuffer, size);
+    return backends_array[0]->WriteBlock(pBuffer, size);
 }
 
 // write a replay block. This differs from other as it returns false if a backend doesn't
@@ -747,8 +747,8 @@ bool AP_Logger::WriteReplayBlock(uint8_t msg_id, const void *pBuffer, uint16_t s
         buf[1] = HEAD_BYTE2;
         buf[2] = msg_id;
         memcpy(&buf[3], pBuffer, size);
-        for (uint8_t i=0; i<_next_backend; i++) {
-            if (!backends[i]->WritePrioritisedBlock(buf, sizeof(buf), true)) {
+        for (auto &b : backends) {
+            if (!b.WritePrioritisedBlock(buf, sizeof(buf), true)) {
                 ret = false;
             }
         }
@@ -778,8 +778,8 @@ void AP_Logger::EraseAll() {
 }
 // change me to "LoggingAvailable"?
 bool AP_Logger::CardInserted(void) {
-    for (uint8_t i=0; i< _next_backend; i++) {
-        if (backends[i]->CardInserted()) {
+    for (auto &b : backends) {
+        if (b.CardInserted()) {
             return true;
         }
     }
@@ -795,37 +795,37 @@ uint16_t AP_Logger::find_last_log() const {
     if (_next_backend == 0) {
         return 0;
     }
-    return backends[0]->find_last_log();
+    return backends_array[0]->find_last_log();
 }
 void AP_Logger::get_log_boundaries(uint16_t log_num, uint32_t & start_page, uint32_t & end_page) {
     if (_next_backend == 0) {
         return;
     }
-    backends[0]->get_log_boundaries(log_num, start_page, end_page);
+    backends_array[0]->get_log_boundaries(log_num, start_page, end_page);
 }
 void AP_Logger::get_log_info(uint16_t log_num, uint32_t &size, uint32_t &time_utc) {
     if (_next_backend == 0) {
         return;
     }
-    backends[0]->get_log_info(log_num, size, time_utc);
+    backends_array[0]->get_log_info(log_num, size, time_utc);
 }
 int16_t AP_Logger::get_log_data(uint16_t log_num, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) {
     if (_next_backend == 0) {
         return 0;
     }
-    return backends[0]->get_log_data(log_num, page, offset, len, data);
+    return backends_array[0]->get_log_data(log_num, page, offset, len, data);
 }
 uint16_t AP_Logger::get_num_logs(void) {
     if (_next_backend == 0) {
         return 0;
     }
-    return backends[0]->get_num_logs();
+    return backends_array[0]->get_num_logs();
 }
 
 /* we're started if any of the backends are started */
 bool AP_Logger::logging_started(void) {
-    for (uint8_t i=0; i< _next_backend; i++) {
-        if (backends[i]->logging_started()) {
+    for (auto &b : backends) {
+        if (b.logging_started()) {
             return true;
         }
     }
@@ -917,7 +917,7 @@ void AP_Logger::Safe_Write_Emit_FMT(log_write_fmt *f)
 {
     for (uint8_t i=0; i<_next_backend; i++) {
         if (!(f->sent_mask & (1U<<i))) {
-            if (!backends[i]->Write_Emit_FMT(f->msg_type)) {
+            if (!backends_array[i]->Write_Emit_FMT(f->msg_type)) {
                 continue;
             }
             f->sent_mask |= (1U<<i);
@@ -930,7 +930,7 @@ uint32_t AP_Logger::num_dropped() const
     if (_next_backend == 0) {
         return 0;
     }
-    return backends[0]->num_dropped();
+    return backends_array[0]->num_dropped();
 }
 
 
@@ -1008,14 +1008,14 @@ void AP_Logger::WriteV(const char *name, const char *labels, const char *units, 
 
     for (uint8_t i=0; i<_next_backend; i++) {
         if (!(f->sent_mask & (1U<<i))) {
-            if (!backends[i]->Write_Emit_FMT(f->msg_type)) {
+            if (!backends_array[i]->Write_Emit_FMT(f->msg_type)) {
                 continue;
             }
             f->sent_mask |= (1U<<i);
         }
         va_list arg_copy;
         va_copy(arg_copy, arg_list);
-        backends[i]->Write(f->msg_type, arg_copy, is_critical, is_streaming);
+        backends_array[i]->Write(f->msg_type, arg_copy, is_critical, is_streaming);
         va_end(arg_copy);
     }
 }
@@ -1031,8 +1031,8 @@ bool AP_Logger::allow_start_ekf() const
         return true;
     }
 
-    for (uint8_t i=0; i<_next_backend; i++) {
-        if (!backends[i]->allow_start_ekf()) {
+    for (auto &b : backends) {
+        if (!b.allow_start_ekf()) {
             return false;
         }
     }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -11,6 +11,7 @@
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Logger/LogStructure.h>
 #include <AP_Vehicle/ModeReason.h>
+#include <AP_Common/AP_BackendIterator.h>
 
 #include <stdint.h>
 
@@ -402,6 +403,8 @@ public:
     // add a filename to list of files to log. The name must be a constant string, not allocated
     void log_file_content(const char *name);
 
+    AP_BackendIterator<AP_Logger_Backend> backends{backends_array, _next_backend};
+
 protected:
 
     const struct LogStructure *_structures;
@@ -420,7 +423,7 @@ protected:
 private:
     #define LOGGER_MAX_BACKENDS 2
     uint8_t _next_backend;
-    AP_Logger_Backend *backends[LOGGER_MAX_BACKENDS];
+    AP_Logger_Backend *backends_array[LOGGER_MAX_BACKENDS];
     const AP_Int32 &_log_bitmask;
 
     enum class Backend_Type : uint8_t {


### PR DESCRIPTION
Comment on the GCS-iterator equivalent was that all the verbiage in the gcs class was bad.  So this moves it out into a template in common code.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -192   *           -272    -216              -216   -184   -208
HerePro             -8                                                                    
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -56    *           -88     -40               -24    -8     -208
MatekF405                      -16    *           -32     -32               24     -56    -64
Pixhawk1-1M-bdshot             8                  72      -80               48     -8     64
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      -24    *           -24     -40               -16    -16    8
skyviper-v2450                                    -40                                     
```
