### PR TITLE
Tools: reinstantiate MacOSX brew update call

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -103,7 +103,7 @@ function maybe_prompt_user() {
 # see https://github.com/orgs/Homebrew/discussions/3895
 find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
 
-# brew update  # tmporarily removed, see https://github.com/orgs/Homebrew/discussions/4612
+brew update
 brew install gawk curl coreutils wget
 
 PIP=pip


### PR DESCRIPTION
this was temporarily removed to allow MacOSX to pass; github's repository seemed to be corrupt somehow

~~Whatever was happening on github seems to have been resolved, judging from the CI results on my own repo.~~  (edit: or, you know, not)
