### PR TITLE
autotest: remove binary before attempting to build it

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -485,6 +485,11 @@ def run_step(step):
         return util.build_replay(board='SITL')
 
     if vehicle_binary is not None:
+        try:
+            binary = binary_path(step, debug=opts.debug)
+            os.unlink(binary)
+        except (FileNotFoundError, ValueError):
+            pass
         if len(vehicle_binary.split(".")) == 1:
             return util.build_SITL(vehicle_binary, **build_opts)
         else:


### PR DESCRIPTION
this fixes behaviour when --no-configure and --no-build are passed in, causing subsequent test steps to fail rather than proceed with an old binary