### PR TITLE
Make safety switch in SITL affect RC outputs

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9795,6 +9795,37 @@ class AutoTestCopter(AutoTest):
         self.context_pop()
         self.reboot_sitl()
 
+    def turn_safety_x(self, value):
+        self.mav.mav.set_mode_send(
+            self.mav.target_system,
+            mavutil.mavlink.MAV_MODE_FLAG_DECODE_POSITION_SAFETY,
+            value)
+
+    def turn_safety_off(self):
+        self.turn_safety_x(0)
+
+    def turn_safety_on(self):
+        self.turn_safety_x(1)
+
+    def SafetySwitch(self):
+        '''test safety switch behaviour'''
+        self.wait_ready_to_arm()
+
+        self.turn_safety_on()
+        self.assert_prearm_failure("safety switch")
+
+        self.turn_safety_off()
+        self.wait_ready_to_arm()
+
+        self.takeoff(2, mode='LOITER')
+        self.turn_safety_on()
+
+        self.wait_servo_channel_value(1, 0)
+        self.turn_safety_off()
+
+        self.change_mode('LAND')
+        self.wait_disarmed()
+
     def GuidedYawRate(self):
         '''ensuer guided yaw rate is not affected by rate of sewt-attitude messages'''
         self.takeoff(30, mode='GUIDED')
@@ -9959,6 +9990,7 @@ class AutoTestCopter(AutoTest):
             self.NoArmWithoutMissionItems,
             self.RPLidarA1,
             self.RPLidarA2,
+            self.SafetySwitch,
         ])
         return ret
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2500,7 +2500,6 @@ class AutoTest(ABC):
             "SIM_RC_CHANCOUNT",
             "SIM_RICH_CTRL",
             "SIM_RICH_ENABLE",
-            "SIM_SAFETY_STATE",
             "SIM_SERVO_SPEED",
             "SIM_SHIP_DSIZE",
             "SIM_SHIP_ENABLE",

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -47,7 +47,7 @@
 
 #define HAL_HAVE_BOARD_VOLTAGE 1
 #define HAL_HAVE_SERVO_VOLTAGE 1
-#define HAL_HAVE_SAFETY_SWITCH 0
+#define HAL_HAVE_SAFETY_SWITCH 1
 
 // only include if compiling C++ code
 #ifdef __cplusplus

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -22,11 +22,21 @@ public:
     /*
       force the safety switch on, disabling PWM output from the IO board
      */
-    bool force_safety_on(void) override;
+    bool force_safety_on(void) override {
+        safety_state = AP_HAL::Util::SAFETY_DISARMED;
+        return true;
+    }
     /*
       force the safety switch off, enabling PWM output from the IO board
      */
-    void force_safety_off(void) override;
+    void force_safety_off(void) override {
+        safety_state = AP_HAL::Util::SAFETY_ARMED;
+    }
+
+    /*
+      get safety switch state, used by Util.cpp
+    */
+    AP_HAL::Util::safety_state _safety_switch_state(void) { return safety_state; }
 
     /*
       Serial LED emulation
@@ -43,6 +53,8 @@ private:
     uint32_t _enable_mask;
     bool _corked;
     uint16_t _pending[SITL_NUM_CHANNELS];
+
+    AP_HAL::Util::safety_state safety_state;
 };
 
 #endif

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -1,6 +1,9 @@
 #include "Util.h"
 #include <sys/time.h>
 #include <AP_Param/AP_Param.h>
+#include "RCOutput.h"
+
+extern const AP_HAL::HAL& hal;
 
 #ifdef WITH_SITL_TONEALARM
 HALSITL::ToneAlarm_SF HALSITL::Util::_toneAlarm;
@@ -143,11 +146,12 @@ void *HALSITL::Util::heap_realloc(void *heap_ptr, void *ptr, size_t old_size, si
 #if !defined(HAL_BUILD_AP_PERIPH)
 enum AP_HAL::Util::safety_state HALSITL::Util::safety_switch_state(void)
 {
-    const SITL::SIM *sitl = AP::sitl();
-    if (sitl == nullptr) {
-        return AP_HAL::Util::SAFETY_NONE;
-    }
-    return sitl->safety_switch_state();
+#define HAL_USE_PWM 1
+#if HAL_USE_PWM
+    return ((RCOutput *)hal.rcout)->_safety_switch_state();
+#else
+    return SAFETY_NONE;
+#endif
 }
 
 void HALSITL::Util::set_cmdline_parameters()

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -240,7 +240,7 @@ const AP_Param::GroupInfo SIM::var_info2[] = {
 
     AP_GROUPINFO("EFI_TYPE",    58, SIM,  efi_type,  SIM::EFI_TYPE_NONE),
 
-    AP_GROUPINFO("SAFETY_STATE",    59, SIM,  _safety_switch_state, 0),
+    // 59 was SAFETY_STATE
 
     // motor harmonics
     AP_GROUPINFO("VIB_MOT_HMNC", 60, SIM,  vibe_motor_harmonics, 1),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -392,19 +392,6 @@ public:
         AP_Float hdg; // 0 to 360
     } opos;
 
-    AP_Int8 _safety_switch_state;
-
-    AP_HAL::Util::safety_state safety_switch_state() const {
-        return (AP_HAL::Util::safety_state)_safety_switch_state.get();
-    }
-    void force_safety_off() {
-        _safety_switch_state.set((uint8_t)AP_HAL::Util::SAFETY_ARMED);
-    }
-    bool force_safety_on() {
-        _safety_switch_state.set((uint8_t)AP_HAL::Util::SAFETY_DISARMED);
-        return true;
-    }
-
     uint16_t irlock_port;
 
     time_t start_time_UTC;


### PR DESCRIPTION
 - makes this look a lot like the ChibiOS HAL
 - moves the state from being in SITL to being in RCOutput (same as in ChibiOS; the safety switch state should never have been in the simulation itself, in the same way that a real autopilot doesn't have a safety state as such.
 - adds a simple autotest

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/460d6bb5-9f6a-4632-8c4e-eecb7a189f8a)

.... tested in.... SITL.....
