### PR TITLE
AP_Motors: If frame specification is FALSE, frame name is unsupported

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -765,7 +765,6 @@ bool AP_MotorsMatrix::setup_quad_matrix(motor_frame_type frame_type)
         break;
     default:
         // quad frame class does not support this frame type
-        _frame_type_string = "UNSUPPORTED";
         return false;
     }
     return true;
@@ -845,7 +844,6 @@ bool AP_MotorsMatrix::setup_hexa_matrix(motor_frame_type frame_type)
     }
     default:
         // hexa frame class does not support this frame type
-        _frame_type_string = "UNSUPPORTED";
         return false;
     } //hexa
     return true;
@@ -965,7 +963,6 @@ bool AP_MotorsMatrix::setup_octa_matrix(motor_frame_type frame_type)
     }
     default:
         // octa frame class does not support this frame type
-        _frame_type_string = "UNSUPPORTED";
         return false;
     } // octa frame type
     return true;
@@ -1088,7 +1085,6 @@ bool AP_MotorsMatrix::setup_octaquad_matrix(motor_frame_type frame_type)
     }
     default:
         // octaquad frame class does not support this frame type
-        _frame_type_string = "UNSUPPORTED";
         return false;
     } //octaquad
     return true;
@@ -1140,7 +1136,6 @@ bool AP_MotorsMatrix::setup_dodecahexa_matrix(motor_frame_type frame_type)
     }
     default:
         // dodeca-hexa frame class does not support this frame type
-        _frame_type_string = "UNSUPPORTED";
         return false;
     } //dodecahexa
     return true;
@@ -1293,7 +1288,6 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
 #endif //AP_MOTORS_FRAME_DECA_ENABLED
     default:
         // matrix doesn't support the configured class
-        _frame_class_string = "UNSUPPORTED";
         success = false;
         _mav_type = MAV_TYPE_GENERIC;
         break;
@@ -1302,6 +1296,9 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
     // normalise factors to magnitude 0.5
     normalise_rpy_factors();
 
+    if (!success) {
+        _frame_class_string = "UNSUPPORTED";
+    }
     set_initialised_ok(success);
 }
 


### PR DESCRIPTION
If unsupported by each frame method, the frame name is set to UNSUPPORTED and FALSE is returned in the processing result.
This frame name is tied to FALSE.
Therefore, when the processing result is FALSE, the frame name should be changed to "set to unsupported.

When the setup_deca_matrix method is FALSE, it is not unsupported.
This bug will no longer occur.