### PR TITLE
Filter: notchfilter: reset and replay on center move to reduce shot noise

### DIFF
--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -20,10 +20,6 @@
 
 #include "NotchFilter.h"
 
-const static float NOTCH_MAX_SLEW       = 0.05f;
-const static float NOTCH_MAX_SLEW_LOWER = 1.0f - NOTCH_MAX_SLEW;
-const static float NOTCH_MAX_SLEW_UPPER = 1.0f / NOTCH_MAX_SLEW_LOWER;
-
 /*
    calculate the attenuation and quality factors of the filter
  */
@@ -65,12 +61,6 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
 
     float new_center_freq = center_freq_hz;
 
-    // constrain the new center frequency by a percentage of the old frequency
-    if (initialised && !need_reset && !is_zero(_center_freq_hz)) {
-        new_center_freq = constrain_float(new_center_freq, _center_freq_hz * NOTCH_MAX_SLEW_LOWER,
-                                          _center_freq_hz * NOTCH_MAX_SLEW_UPPER);
-    }
-
     if ((new_center_freq > 0.0) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)) {
         float omega = 2.0 * M_PI * new_center_freq / sample_freq_hz;
         float alpha = sinf(omega) / (2 * Q);
@@ -83,6 +73,17 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
         _center_freq_hz = new_center_freq;
         _sample_freq_hz = sample_freq_hz;
         initialised = true;
+
+        // reset filter and replay last samples
+        // filter is left in the state it would be if coefficients
+        // had been changed and the reset was done three samples ago
+        const T input_0 = ntchsig;
+        const T input_1 = ntchsig1;
+        need_reset = true;
+        apply(ntchsig2);
+        apply(input_1);
+        apply(input_0);
+
     } else {
         // leave center_freq_hz at last value
         initialised = false;

--- a/libraries/Filter/Tools/NotchFilter/NotchFilter.m
+++ b/libraries/Filter/Tools/NotchFilter/NotchFilter.m
@@ -1,0 +1,124 @@
+
+% notch implmentation
+classdef NotchFilter
+    properties (SetAccess = private)
+        initialised = false;
+        need_reset = false;
+        b0 = single(0);
+        b1 = single(0);
+        b2 = single(0);
+        a1 = single(0);
+        a2 = single(0);
+        a0_inv = single(0);
+        center_freq_hz = single(0);
+        sample_freq_hz = single(0);
+        ntchsig = single(0);
+        ntchsig1 = single(0);
+        ntchsig2 = single(0);
+        signal2 = single(0);
+        signal1 = single(0);
+
+        NOTCH_MAX_SLEW = single(0.05);
+        NOTCH_MAX_SLEW_LOWER = 1.0 - single(0.05);
+        NOTCH_MAX_SLEW_UPPER = 1.0 / (1 - single(0.05));
+    end
+    methods
+
+        function [A, Q] = calculate_A_and_Q(~, center_freq_hz, bandwidth_hz, attenuation_dB)
+            A = power(10, -attenuation_dB / 40.0);
+            if center_freq_hz > (0.5 * bandwidth_hz)
+                octaves = log2(center_freq_hz / (center_freq_hz - bandwidth_hz / 2.0)) * 2.0;
+                Q = sqrt(power(2, octaves)) / (power(2, octaves) - 1.0);
+            else
+                Q = 0.0;
+            end
+        end
+
+        function obj = init(obj, sample_freq_hz, center_freq_hz, bandwidth_hz, attenuation_dB)
+            % check center frequency is in the allowable range
+            if ((center_freq_hz > 0.5 * bandwidth_hz) && (center_freq_hz < 0.5 * sample_freq_hz))
+                obj.initialised = false;    % force center frequency change
+                [A, Q] = calculate_A_and_Q(obj, center_freq_hz, bandwidth_hz, attenuation_dB);
+                obj = init_with_A_and_Q(obj, sample_freq_hz, center_freq_hz, A, Q);
+            else
+                obj.initialised = false;
+            end
+        end
+
+
+        function obj = init_with_A_and_Q(obj, sample_freq_hz, center_freq_hz, A, Q)
+            % don't update if no updates required
+            if obj.initialised && (center_freq_hz == obj.center_freq_hz) && (sample_freq_hz ==  obj.sample_freq_hz)
+                return;
+            end
+
+            new_center_freq = center_freq_hz;
+
+            % constrain the new center frequency by a percentage of the old frequency
+            if obj.initialised && ~obj.need_reset && (obj.center_freq_hz ~= 0)
+                new_center_freq = max(new_center_freq, obj.center_freq_hz * obj.NOTCH_MAX_SLEW_LOWER);
+                new_center_freq = min(new_center_freq, obj.center_freq_hz * obj.NOTCH_MAX_SLEW_UPPER);
+            end
+
+            if (new_center_freq > 0.0) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)
+                omega = 2.0 * pi * new_center_freq / sample_freq_hz;
+                alpha = sin(omega) / (2 * Q);
+                obj.b0 =  1.0 + alpha*(A*A);
+                obj.b1 = -2.0 * cos(omega);
+                obj.b2 =  1.0 - alpha*(A*A);
+                obj.a0_inv =  1.0/(1.0 + alpha);
+                obj.a1 = obj.b1;
+                obj.a2 = 1.0 - alpha;
+                obj.center_freq_hz = new_center_freq;
+                obj.sample_freq_hz = sample_freq_hz;
+                obj.initialised = true;
+            else
+                % leave center_freq_hz at last value
+                obj.initialised = false;
+            end
+        end
+
+
+        function [obj, ret] = apply(obj, sample)
+            if ~obj.initialised || obj.need_reset
+                % if we have not been initialised when return the input
+                % sample as output and update delayed samples
+                obj.signal1 = sample;
+                obj.signal2 = sample;
+                obj.ntchsig = sample;
+                obj.ntchsig1 = sample;
+                obj.ntchsig2 = sample;
+                obj.need_reset = false;
+                ret = sample;
+                return
+            end
+            obj.ntchsig2 = obj.ntchsig1;
+            obj.ntchsig1 = obj.ntchsig;
+            obj.ntchsig = sample;
+
+            output = (obj.ntchsig*obj.b0 + obj.ntchsig1*obj.b1 + obj.ntchsig2*obj.b2 - obj.signal1*obj.a1 - obj.signal2*obj.a2) * obj.a0_inv;
+
+            obj.signal2 = obj.signal1;
+            obj.signal1 = output;
+            ret = output;
+        end
+
+
+        function obj = reset(obj)
+            obj.need_reset = true;
+        end
+    end
+end
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/libraries/Filter/Tools/NotchFilter/NotchFilter2.m
+++ b/libraries/Filter/Tools/NotchFilter/NotchFilter2.m
@@ -1,0 +1,124 @@
+
+% notch implmentation
+classdef NotchFilter2
+    properties (SetAccess = private)
+        initialised = false;
+        need_reset = false;
+        b0 = single(0);
+        b1 = single(0);
+        b2 = single(0);
+        a1 = single(0);
+        a2 = single(0);
+        a0_inv = single(0);
+        center_freq_hz = single(0);
+        sample_freq_hz = single(0);
+        ntchsig = single(0);
+        ntchsig1 = single(0);
+        ntchsig2 = single(0);
+        signal2 = single(0);
+        signal1 = single(0);
+    end
+    methods
+
+        function [A, Q] = calculate_A_and_Q(~, center_freq_hz, bandwidth_hz, attenuation_dB)
+            A = power(10, -attenuation_dB / 40.0);
+            if center_freq_hz > (0.5 * bandwidth_hz)
+                octaves = log2(center_freq_hz / (center_freq_hz - bandwidth_hz / 2.0)) * 2.0;
+                Q = sqrt(power(2, octaves)) / (power(2, octaves) - 1.0);
+            else
+                Q = 0.0;
+            end
+        end
+
+        function obj = init(obj, sample_freq_hz, center_freq_hz, bandwidth_hz, attenuation_dB)
+            % check center frequency is in the allowable range
+            if ((center_freq_hz > 0.5 * bandwidth_hz) && (center_freq_hz < 0.5 * sample_freq_hz))
+                obj.initialised = false;    % force center frequency change
+                [A, Q] = calculate_A_and_Q(obj, center_freq_hz, bandwidth_hz, attenuation_dB);
+                obj = init_with_A_and_Q(obj, sample_freq_hz, center_freq_hz, A, Q);
+            else
+                obj.initialised = false;
+            end
+        end
+
+
+        function obj = init_with_A_and_Q(obj, sample_freq_hz, center_freq_hz, A, Q)
+            % don't update if no updates required
+            if obj.initialised && (center_freq_hz == obj.center_freq_hz) && (sample_freq_hz ==  obj.sample_freq_hz)
+                return;
+            end
+
+            new_center_freq = center_freq_hz;
+
+            if (new_center_freq > 0.0) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)
+                omega = 2.0 * pi * new_center_freq / sample_freq_hz;
+                alpha = sin(omega) / (2 * Q);
+                obj.b0 =  1.0 + alpha*(A*A);
+                obj.b1 = -2.0 * cos(omega);
+                obj.b2 =  1.0 - alpha*(A*A);
+                obj.a0_inv =  1.0/(1.0 + alpha);
+                obj.a1 = obj.b1;
+                obj.a2 = 1.0 - alpha;
+                obj.center_freq_hz = new_center_freq;
+                obj.sample_freq_hz = sample_freq_hz;
+                obj.initialised = true;
+
+                % reset and replay the last inputs 
+                input0 = obj.ntchsig;
+                input1 = obj.ntchsig1;
+                input2 = obj.ntchsig2;
+
+                obj.need_reset = true;
+                obj = apply(obj, input2);
+                obj = apply(obj, input1);
+                obj = apply(obj, input0);
+            else
+                % leave center_freq_hz at last value
+                obj.initialised = false;
+            end
+        end
+
+
+        function [obj, ret] = apply(obj, sample)
+            if ~obj.initialised || obj.need_reset
+                % if we have not been initialised when return the input
+                % sample as output and update delayed samples
+                obj.signal1 = sample;
+                obj.signal2 = sample;
+                obj.ntchsig = sample;
+                obj.ntchsig1 = sample;
+                obj.ntchsig2 = sample;
+                obj.need_reset = false;
+                ret = sample;
+                return
+            end
+            obj.ntchsig2 = obj.ntchsig1;
+            obj.ntchsig1 = obj.ntchsig;
+            obj.ntchsig = sample;
+
+            output = (obj.ntchsig*obj.b0 + obj.ntchsig1*obj.b1 + obj.ntchsig2*obj.b2 - obj.signal1*obj.a1 - obj.signal2*obj.a2) * obj.a0_inv;
+
+            obj.signal2 = obj.signal1;
+            obj.signal1 = output;
+            ret = output;
+        end
+
+
+        function obj = reset(obj)
+            obj.need_reset = true;
+        end
+    end
+end
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/libraries/Filter/Tools/NotchFilter/ShotNoise.m
+++ b/libraries/Filter/Tools/NotchFilter/ShotNoise.m
@@ -1,0 +1,87 @@
+close all
+clear
+clc
+
+rate = single(2000);
+dT = 1/rate;
+
+time = dT:dT:1000;
+samples = single(numel(time));
+
+target_freq = 200;
+
+signal = sin(time*2*pi*target_freq) * 10 + randn(1,samples) * 3;
+
+center_move_freq = single(1/3);
+
+steps = time(end) / center_move_freq;
+center = target_freq + randn(1,steps)*50;
+center = repmat(center, [ceil(samples/steps),1]);
+center = center(:);
+
+center = single(center);
+
+bandwidth = single(5);
+attenuation = single(40);
+
+notch1 = NotchFilter;
+notch2 = NotchFilter2;
+
+
+[A, Q] = notch1.calculate_A_and_Q(center(1), bandwidth, attenuation);
+
+center_update_freq = 400;
+
+output1 = zeros(size(signal),'single');
+output2 = zeros(size(signal),'single');
+notch_center = zeros(size(signal),'single');
+notch_factor = zeros([numel(signal),5],'single');
+last_center_update = 0;
+for i = 1:numel(signal)
+
+    if (last_center_update == 0) || ((time(i) - last_center_update) > (1/center_update_freq))
+        % centers are only moved at loop rate not sample rate
+        notch1 = notch1.init_with_A_and_Q(rate, center(i), A, Q);
+        notch2 = notch2.init_with_A_and_Q(rate, center(i), A, Q);
+        last_center_update = time(i);
+    end
+
+    notch_center(i) = notch1.center_freq_hz;
+
+    [notch1, output1(i)] = notch1.apply(signal(i));
+    [notch2, output2(i)] = notch2.apply(signal(i));
+end
+
+max_input = max(abs(signal));
+max_output1 = max(abs(output1));
+max_output2 = max(abs(output2));
+
+figure
+tiledlayout(2,1)
+ax{1} = nexttile;
+hold all
+plot(time,signal)
+plot(time,output1)
+plot(time,output2)
+xlabel("time (s)")
+ylabel("amplitude")
+legend('input','current output','new output','location','eastoutside')
+ylim([-1,1]*max([max_input,max_output1,max_output2])*1.05)
+
+ax{2} = nexttile;
+hold all
+plot(time,center(1:numel(time)))
+plot(time,notch_center)
+yline(target_freq,'--k')
+xlabel("time (s)")
+ylabel("notch center freq")
+legend('target center','slewed center','signal freq','location','eastoutside')
+
+
+fprintf('Max input: %0.2f\n',max_input)
+fprintf('Max output 1: %0.2f\n',max_output1)
+fprintf('Max output 2: %0.2f\n',max_output2)
+
+linkaxes([ax{:}],'x')
+
+


### PR DESCRIPTION
This is a attempt to reduce shot noise, rather than slewing the center frequency this resets the filter and uses the input values that are already stored to "warm start" with the new coefficients.  

I have done a little messing about in MATLAB (code is included in this PR), in my testing the shot noise seems worse when filtering a signal close to the center frequency. Low bandwidth filters are the worst as it takes a while for the noise to decay away due to the high Q. 

Testing on a sine with some random noise, we see slightly larger spikes with the current method vs the new method.

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/b4a49c25-3892-433c-8a67-2e5485622320)

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/44fdd52d-56b8-4299-a068-799ef079cc16)

I have not tested this on a real vehicle or with cascaded filters.
