### PR TITLE
Filter: notch filter: remove unneeded value and pre-multiply for speed

### DIFF
--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -41,9 +41,9 @@ public:
 protected:
 
     bool initialised, need_reset;
-    float b0, b1, b2, a1, a2, a0_inv;
+    float b0, b1, b2, a1, a2;
     float _center_freq_hz, _sample_freq_hz;
-    T ntchsig, ntchsig1, ntchsig2, signal2, signal1;
+    T ntchsig1, ntchsig2, signal2, signal1;
 };
 
 /*

--- a/libraries/Filter/examples/TransferFunctionCheck/TransferFunctionCheck.cpp
+++ b/libraries/Filter/examples/TransferFunctionCheck/TransferFunctionCheck.cpp
@@ -61,7 +61,7 @@ public:
         hal.console->printf("NotchFilterFloat\n");
         hal.console->printf("Sample rate: %.9f Hz, Center: %.9f Hz\n", _sample_freq_hz, _center_freq_hz);
         hal.console->printf("Notch filter in the form: H(z) = (b0 + b1*z^-1 + b2*z^-2)/(a0 + a1*z^-1 + a2*z^-2)\n");
-        hal.console->printf("a0: %.9f, a1: %.9f, a2: %.9f, b0: %.9f, b1: %.9f, b2: %.9f\n", 1.0/a0_inv, a1, a2, b0, b1, b2);
+        hal.console->printf("a0: %.9f, a1: %.9f, a2: %.9f, b0: %.9f, b1: %.9f, b2: %.9f\n", 1.0, a1, a2, b0, b1, b2);
     }
 };
 


### PR DESCRIPTION
I had spotted we could pre-multiply by a0 to same some runtime calculation and was looking at the betaflight filter code and they also have different handling of the "memory" elements that saves one value. 

https://github.com/betaflight/betaflight/blob/90d09e2e5bccc9e21101811618be79621286f56e/src/main/common/filter.c#L210-L224

I have run this in my MATLAB thingy (https://github.com/ArduPilot/ardupilot/pull/24249) result is the same to 10^-4. floating point math does mean the result comes out a tiny bit different. The difference is only due to the pre-multiplication of a0. The removal of `ntchsig` makes no difference to the result.
