### PR TITLE
AP_CheckFirmware: fixed error code for bad firmware

### DIFF
--- a/libraries/AP_CheckFirmware/AP_CheckFirmware.cpp
+++ b/libraries/AP_CheckFirmware/AP_CheckFirmware.cpp
@@ -192,7 +192,10 @@ check_fw_result_t check_good_firmware(void)
         // allows for booting of a signed firmware with an unsigned
         // bootloader, which allows for bootstrapping a system up from
         // unsigned to signed
-        return check_good_firmware_signed();
+        const auto ret2 = check_good_firmware_signed();
+        if (ret2 == check_fw_result_t::CHECK_FW_OK) {
+            return check_fw_result_t::CHECK_FW_OK;
+        }
     }
     return ret;
 #endif


### PR DESCRIPTION
when we have a bad unsigned firmware we check if it is a good signed firmware. If it is then we should return OK, if not we should return the original error code, otherwise we end up giving a misleading reason for not booting a peripheral