### PR TITLE
GCS_MAVLink: support HIGHRES_IMU

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -351,6 +351,7 @@ public:
     void send_rc_channels() const;
     void send_rc_channels_raw() const;
     void send_raw_imu();
+    void send_highres_imu();
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature, int16_t temperature_press_diff));
     void send_scaled_pressure();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -955,6 +955,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_SCALED_IMU,            MSG_SCALED_IMU},
         { MAVLINK_MSG_ID_SCALED_IMU2,           MSG_SCALED_IMU2},
         { MAVLINK_MSG_ID_SCALED_IMU3,           MSG_SCALED_IMU3},
+        { MAVLINK_MSG_ID_HIGHRES_IMU,           MSG_HIGHRES_IMU},
         { MAVLINK_MSG_ID_SCALED_PRESSURE,       MSG_SCALED_PRESSURE},
         { MAVLINK_MSG_ID_SCALED_PRESSURE2,      MSG_SCALED_PRESSURE2},
         { MAVLINK_MSG_ID_SCALED_PRESSURE3,      MSG_SCALED_PRESSURE3},
@@ -2009,6 +2010,34 @@ void GCS_MAVLINK::send_raw_imu()
         mag.z,
         0,  // we use SCALED_IMU and SCALED_IMU2 for other IMUs
         int16_t(ins.get_temperature(0)*100));
+#endif
+}
+
+void GCS_MAVLINK::send_highres_imu()
+{
+#if AP_INERTIALSENSOR_ENABLED
+    const AP_InertialSensor &ins = AP::ins();
+    const Vector3f &accel = ins.get_accel(0);
+    const Vector3f &gyro = ins.get_gyro(0);
+
+    mavlink_msg_highres_imu_send(
+        chan,
+        AP_HAL::micros64(),
+        accel.x,
+        accel.y,
+        accel.z,
+        gyro.x,
+        gyro.y,
+        gyro.z,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x3f,
+        0);
 #endif
 }
 
@@ -5880,6 +5909,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_SCALED_IMU3:
         CHECK_PAYLOAD_SIZE(SCALED_IMU3);
         send_scaled_imu(2, mavlink_msg_scaled_imu3_send);
+        break;
+
+    case MSG_HIGHRES_IMU:
+        CHECK_PAYLOAD_SIZE(HIGHRES_IMU);
+        send_highres_imu();
         break;
 
     case MSG_SCALED_PRESSURE:

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -87,5 +87,6 @@ enum ap_message : uint8_t {
     MSG_ATTITUDE_TARGET,
     MSG_HYGROMETER,
     MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE,
+    MSG_HIGHRES_IMU,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
It allows CC to use FC IMU for VIO. Please refer https://discuss.ardupilot.org/t/a-small-vio-system-using-raspberry-pi-and-arducam-ov9281/103299