### PR TITLE
Tools: Allocate board IDs for M10044 and M10053

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -231,6 +231,8 @@ AP_HW_BLITZF7                        1117
 AP_HW_RADIX2HD                       1118
 AP_HW_HEEWING_F405                   1119
 AP_HW_PodmanH7                       1120
+AP_HW_mRo-M10053                     1121
+AP_HW_mRo-M10044                     1122
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
Allocating BL IDs for new mRo AP_Periph boards.