### PR TITLE
AP_ADSB: correct bad port read in Sagetech driver

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -73,7 +73,7 @@ void AP_ADSB_Sagetech::update()
         if (!_port->read(data)) {
             break;
         }
-        if (parse_byte_XP((uint8_t)data)) {
+        if (parse_byte_XP(data)) {
             handle_packet_XP(message_in.packet);
         }
     } // while nbytes

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -69,8 +69,8 @@ void AP_ADSB_Sagetech::update()
     // -----------------------------
     uint32_t nbytes = MIN(_port->available(), 10 * PAYLOAD_XP_MAX_SIZE);
     while (nbytes-- > 0) {
-        const int16_t data = (uint8_t)_port->read();
-        if (data < 0) {
+        uint8_t data;
+        if (!_port->read(data)) {
             break;
         }
         if (parse_byte_XP((uint8_t)data)) {

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
@@ -78,11 +78,11 @@ void AP_ADSB_Sagetech_MXS::update()
     // -----------------------------
     uint32_t nbytes = MIN(_port->available(), 10 * PAYLOAD_MXS_MAX_SIZE);
     while (nbytes-- > 0) {
-        const int16_t data = _port->read();
-        if (data < 0) {
+        uint8_t data;
+        if (!_port->read(data)) {
             break;
         }
-        parse_byte((uint8_t)data);
+        parse_byte(data);
     }
 
     const uint32_t now_ms = AP_HAL::millis();

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -76,12 +76,11 @@ void AP_ADSB_uAvionix_UCP::update()
     // -----------------------------
     uint32_t nbytes = MIN(_port->available(), 10UL * GDL90_RX_MAX_PACKET_LENGTH);
     while (nbytes-- > 0) {
-        const int16_t data = (uint8_t)_port->read();
-        if (data < 0) {
+        uint8_t data;
+        if (!_port->read(data)) {
             break;
         }
-
-        if (parseByte((uint8_t)data, rx.msg, rx.status)) {
+        if (parseByte(data, rx.msg, rx.status)) {
             rx.last_msg_ms = now_ms;
             handle_msg(rx.msg);
         }


### PR DESCRIPTION
In the case rad returns -1 `data` will take on the value of 255, which is > 0 so parsing of that byte will be attempted (and we'll continue the loop.... a lot....)

I don't think this can happen in practice on master, but if threads got involved somehow it might happen when ports get stolen by pas-through.

Untested past compilation.
