### PR TITLE
AP_Mount: Xacti fix for gnss format

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -382,7 +382,7 @@ void AP_Mount_Xacti::handle_gnss_status_req(AP_DroneCAN* ap_dronecan, const Cana
     }
 
     // get current location
-    uint8_t gps_status = 3;
+    uint8_t gps_status = 2;
     Location loc;
     if (!AP::ahrs().get_location(loc)) {
         gps_status = 0;
@@ -401,7 +401,7 @@ void AP_Mount_Xacti::handle_gnss_status_req(AP_DroneCAN* ap_dronecan, const Cana
     xacti_gnss_status_msg.order = msg.requirement;
     xacti_gnss_status_msg.remain_buffer = 1;
     xacti_gnss_status_msg.utc_year = year;
-    xacti_gnss_status_msg.utc_month = month;
+    xacti_gnss_status_msg.utc_month = month + 1;
     xacti_gnss_status_msg.utc_day = day;
     xacti_gnss_status_msg.utc_hour = hour;
     xacti_gnss_status_msg.utc_minute = min;


### PR DESCRIPTION
This fixes the lat, lon, alt and date EXIF data stored in pictures taken by the Xacti camera.

In fact, the two issues are  quite clear when looking at the [DroneCAN definition for the GnssStatus message](https://github.com/dronecan/DSDL/blob/master/com/xacti/20305.GnssStatus.uavcan) and the comments above the get [AP_RTC::get_date_and_time_utc()](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RTC/AP_RTC.h#L48) method.

This has been tested on real hardware by taking a picture and confirming that the lat, lon, alt and GPS date appear correctly (previously they did not)

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/98792974-193f-4dc1-9fcc-97fa46546b0f)



