### PR TITLE
Tools: add custom ROS 2 messages and service interfaces

### DIFF
--- a/Tools/ros2/ardupilot_msgs/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_msgs/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.8)
+project(ardupilot_msgs)
+
+# --------------------------------------------------------------------------- #
+# Find dependencies.
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+# --------------------------------------------------------------------------- #
+# Generate and export message interfaces.
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/ArmMotors.srv"
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+# --------------------------------------------------------------------------- #
+# Call last.
+
+ament_package()

--- a/Tools/ros2/ardupilot_msgs/package.xml
+++ b/Tools/ros2/ardupilot_msgs/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ardupilot_msgs</name>
+  <version>0.0.0</version>
+  <description>Custom ROS 2 messages and services for ArduPilot</description>
+  <maintainer email="rhys.mainwaring@me.com">maintainer</maintainer>
+  <license>GPL-3.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/Tools/ros2/ardupilot_msgs/srv/ArmMotors.srv
+++ b/Tools/ros2/ardupilot_msgs/srv/ArmMotors.srv
@@ -1,0 +1,8 @@
+
+# This service requests the vehicle to arm or disarm its motors.
+
+# Set true to arm motors, false to disarm motors.
+bool arm
+---
+# True if the vehicle is armed.
+bool result


### PR DESCRIPTION
Add ROS 2 service interface to `Tools/ros2`.

- Defines a ROS 2 service interface for arming motors.
- Pre-requisite for https://github.com/ArduPilot/ardupilot/pull/24145.

