### PR TITLE
Tools: Add ROS 2 launch file for eProsima integration service

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -4,7 +4,7 @@
   <name>ardupilot_dds_tests</name>
   <version>0.0.0</version>
   <description>Tests for the ArduPilot AP_DDS library</description>
-  <maintainer email="rhys.mainwaring@me.com">rhys</maintainer>
+  <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GLP-3.0</license>
 
   <exec_depend>ament_index_python</exec_depend>

--- a/Tools/ros2/ardupilot_sitl/launch/integration_service.launch.py
+++ b/Tools/ros2/ardupilot_sitl/launch/integration_service.launch.py
@@ -1,0 +1,29 @@
+# Copyright 2023 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Launch the eProsima Integration Service.
+
+Run with default arguments:
+
+ros2 launch ardupilot_sitl integration_service.launch.py
+"""
+from launch import LaunchDescription
+from ardupilot_sitl.launch import IntegrationServiceLaunch
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Generate a launch description for the eProsima Integration Service."""
+    return IntegrationServiceLaunch.generate_launch_description()

--- a/Tools/ros2/ardupilot_sitl/package.xml
+++ b/Tools/ros2/ardupilot_sitl/package.xml
@@ -5,7 +5,7 @@
   <name>ardupilot_sitl</name>
   <version>0.0.0</version>
   <description>ArduPlane, ArduCopter, ArduRover, ArduSub source</description>
-  <maintainer email="rhys.mainwaring@me.com">maintainer</maintainer>
+  <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -655,3 +655,101 @@ class SITLLaunch:
             serial_args.append(arg)
 
         return launch_args + uart_args + serial_args
+
+
+class IntegrationServiceLaunch:
+    """Launch functions for the eProsima Integration Service."""
+
+    @staticmethod
+    def generate_action(context: LaunchContext, *args, **kwargs) -> ExecuteProcess:
+        """Launch the eProsima Integration Service."""
+        # Declare the command.
+        command = "integration-service"
+
+        # Arguments.
+        config_file = LaunchConfiguration("config_file").perform(context)
+
+        # Display launch arguments.
+        print(f"command:          {command}")
+        print(f"config_file:      {config_file}")
+
+        # Required arguments
+        # - `config_file` is a positional argument
+        args = [
+            f"{command} ",
+            f"{config_file} ",
+        ]
+
+        # Optional arguments.
+        # - `is_prefix_path` is a colon delimited list of paths
+        is_prefix_path = LaunchConfiguration("is_prefix_path").perform(context)
+        if is_prefix_path:
+            for path in is_prefix_path.split(":"):
+                args.append("--is-prefix-path ")
+                args.append(f"{path} ")
+                print(f"is_prefix_path:   {path}")
+
+        # debug information
+        # print()
+        # print(f"cmd: {args}")
+        # print()
+
+        # Create action.
+        action = ExecuteProcess(
+            cmd=[args],
+            shell=True,
+            output="both",
+            respawn=False,
+            cached_output=True,
+        )
+        return action
+
+    @staticmethod
+    def generate_launch_description_with_actions() -> (
+        Tuple[LaunchDescription, Dict[Text, ExecuteFunction]]
+    ):
+        """Generate a launch description with actions."""
+        launch_arguments = IntegrationServiceLaunch.generate_launch_arguments()
+
+        action = ExecuteFunction(function=IntegrationServiceLaunch.generate_action)
+
+        ld = LaunchDescription(
+            launch_arguments
+            + [
+                action,
+            ]
+        )
+        actions = {
+            "integration_service": action,
+        }
+        return ld, actions
+
+    @staticmethod
+    def generate_launch_description() -> LaunchDescription:
+        """Generate a launch description."""
+        ld, _ = IntegrationServiceLaunch.generate_launch_description_with_actions()
+        return ld
+
+    @staticmethod
+    def generate_launch_arguments() -> List[DeclareLaunchArgument]:
+        """Generate a list of launch arguments."""
+        return [
+            # Required launch arguments.
+            DeclareLaunchArgument(
+                "config_file",
+                default_value="",
+                description="The YAML file that describes how this instance "
+                "of the eProsima Integration Service "
+                "should be configured.",
+            ),
+            # Optional launch arguments.
+            DeclareLaunchArgument(
+                "is_prefix_path",
+                default_value="",
+                description="Specify a list of the eProsima "
+                "Integration Service prefix paths to use when searching "
+                "for Middleware Interface eXtension (.mix) files. "
+                "The environment variable IS_PREFIX_PATH can be set to "
+                "a colon-separated list instead of using this flag.",
+            ),
+        ]

--- a/Tools/ros2/ros2.repos
+++ b/Tools/ros2/ros2.repos
@@ -7,3 +7,15 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
     version: humble
+  integration_service:
+    type: git
+    url: https://github.com/eProsima/Integration-Service.git
+    version: main
+  fastdds_sh:
+    type: git
+    url: https://github.com/eProsima/FastDDS-SH
+    version: main
+  ros2_sh:
+    type: git
+    url: https://github.com/eProsima/ROS2-SH.git
+    version: main

--- a/Tools/ros2/ros2_macos.repos
+++ b/Tools/ros2/ros2_macos.repos
@@ -1,12 +1,12 @@
 repositories:
   ardupilot:
     type: git
-    url: https://github.com/srmainwaring/ardupilot.git
-    version: pr/pr-dds-launch-tests
+    url: https://github.com/ArduPilot/ardupilot.git
+    version: master
   microxrcedds_gen:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Gen.git
-    version: develop
+    version: master
   micro_ros_agent:
     type: git
     url: https://github.com/srmainwaring/micro-ROS-Agent.git
@@ -15,3 +15,15 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git
     version: humble
+  integration_service:
+    type: git
+    url: https://github.com/eProsima/Integration-Service.git
+    version: main
+  fastdds_sh:
+    type: git
+    url: https://github.com/eProsima/FastDDS-SH
+    version: main
+  ros2_sh:
+    type: git
+    url: https://github.com/eProsima/ROS2-SH.git
+    version: main


### PR DESCRIPTION
Add a ROS 2 launch file for the eProsima Integration Service.

- Allows bring-up of the integration service to be composed with other launch files and launch tests.

Other minor changes

- Fix maintainer description in the ROS 2 package.xml.
- Correct dependencies for `ardupilot` and `microxrcedds_gen` in macOS rosdep file.