### PR TITLE
AP_HAL_SITL: remove race in SITL::UARTDriver::_write

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -256,8 +256,9 @@ void UARTDriver::_flush(void)
 
 size_t UARTDriver::_write(const uint8_t *buffer, size_t size)
 {
-    if (txspace() <= size) {
-        size = txspace();
+    const auto _txspace = txspace();
+    if (_txspace < size) {
+        size = _txspace;
     }
     if (size <= 0) {
         return 0;


### PR DESCRIPTION
txspace could change if another thread is involved