### PR TITLE
.vscode: Recommend mermaid extension for rendering mermaid diagrams in markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,8 @@ GRTAGS
 GTAGS
 *.apj
 .gdbinit
-/.vscode
+.vscode/*
+!.vscode/extensions.json
 /.history
 Parameters.html
 Parameters.md

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "bierner.markdown-mermaid",
         "ms-vscode.cpptools",
         "sumneko.lua",
         "ms-python.python",


### PR DESCRIPTION
Allow you to add extensions to staging without git complaing it's in the vscode folder

This extensions lets you render the diagrams I made in the AP_DDS/README.md inside VSCode liek so:
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/cd03ee41-ab97-4bbc-afbe-74c08c100b37)
