### PR TITLE
AP_Mount: fix setting default mode redundantly in each backend

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -12,7 +12,6 @@ void AP_Mount_Alexmos::init()
         _initialised = true;
         get_boardinfo();
         read_params(0); //we request parameters for profile 0 and therfore get global and profile parameters
-        set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());
     }
     AP_Mount_Backend::init();
 }

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -14,7 +14,6 @@ void AP_Mount_SToRM32_serial::init()
     _port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
     if (_port) {
         _initialised = true;
-        set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());
     }
     AP_Mount_Backend::init();
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -31,7 +31,6 @@ void AP_Mount_Siyi::init()
     _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
     if (_uart != nullptr) {
         _initialised = true;
-        set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());
     }
     AP_Mount_Backend::init();
 }

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -15,7 +15,6 @@ AP_Mount_SoloGimbal::AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount_Params &pa
 void AP_Mount_SoloGimbal::init()
 {
     _initialised = true;
-    set_mode((enum MAV_MOUNT_MODE)_params.default_mode.get());
     AP_Mount_Backend::init();
 }
 


### PR DESCRIPTION
We dont need to set default mode again in each backend when we already have set  default mode [here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mount/AP_Mount.cpp#L158). 

Tested on **SiYi zr10**