### PR TITLE
AP_OpticalFlow: use vector rotate method

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.cpp
@@ -41,12 +41,7 @@ void OpticalFlow_backend::_applyYaw(Vector2f &v)
     if (is_zero(yawAngleRad)) {
         return;
     }
-    float cosYaw = cosf(yawAngleRad);
-    float sinYaw = sinf(yawAngleRad);
-    float x = v.x;
-    float y = v.y;
-    v.x = cosYaw * x - sinYaw * y;
-    v.y = sinYaw * x + cosYaw * y;
+    v.rotate(yawAngleRad);
 }
 
 #endif


### PR DESCRIPTION
Tested this in SITL to make sure the answers are the same; I used a rotation of 26 degrees for this testing.

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/8fed337d-e6dd-44b7-afc0-201d20435441)
