### PR TITLE
AP_HAL_SITL: correct parsing of --rate on SITL commandline 

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -438,6 +438,7 @@ def start_SITL(binary,
                home=None,
                model=None,
                speedup=1,
+               sim_rate_hz=None,
                defaults_filepath=None,
                unhide_parameters=False,
                gdbserver=False,
@@ -531,8 +532,10 @@ def start_SITL(binary,
         if home is not None:
             cmd.extend(['--home', home])
         cmd.extend(['--model', model])
-        if speedup != 1:
+        if speedup is not None and speedup != 1:
             cmd.extend(['--speedup', str(speedup)])
+        if sim_rate_hz is not None:
+            cmd.extend(['--rate', str(sim_rate_hz)])
         if defaults_filepath is not None:
             if type(defaults_filepath) == list:
                 defaults = [reltopdir(path) for path in defaults_filepath]

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -203,6 +203,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 {
     int opt;
     float speedup = 1.0f;
+    float sim_rate_hz = 0;
     _instance = 0;
     _synthetic_clock_mode = false;
     // default to CMAC
@@ -380,6 +381,12 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             temp_cmdline_param = {"SIM_SPEEDUP", speedup};
             cmdline_param.push_back(temp_cmdline_param);
             printf("Setting SIM_SPEEDUP=%f\n", speedup);
+            break;
+        case 'r':
+            sim_rate_hz = strtof(gopt.optarg, nullptr);
+            temp_cmdline_param = {"SIM_RATE_HZ", sim_rate_hz};
+            cmdline_param.push_back(temp_cmdline_param);
+            printf("Setting SIM_RATE_HZ=%f\n", sim_rate_hz);
             break;
         case 'C':
             HALSITL::UARTDriver::_console = true;


### PR DESCRIPTION
tested as part of https://github.com/ArduPilot/ardupilot/pull/24297
