### PR TITLE
AP_Vehicle: dynamic notch use min ratio  for RPM tracking

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -656,7 +656,7 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
             float rpm;
             if (rpm_sensor != nullptr && rpm_sensor->get_rpm(sensor, rpm)) {
                 // set the harmonic notch filter frequency from the main rotor rpm
-                notch.update_freq_hz(MAX(ref_freq, rpm * ref * (1.0/60)));
+                notch.update_freq_hz(MAX(ref_freq * notch.params.freq_min_ratio(), rpm * ref * (1.0/60)));
             } else {
                 notch.update_freq_hz(ref_freq);
             }


### PR DESCRIPTION
For RPM the reference frequency is both a minimum for tracking and the default value used if RPM goes bad, these two uses conflict. By using the existing minimum ratio parameter, which defaults to 1, we can allow the RPM to track below the reference. This is useful on a heli where the head should be a fixed speed as set by the governor we can now set that as the reference point to be used if RPM fails and use the ratio to allow the RPM to track lower than that in run-up or run-down. 