### PR TITLE
AP_InertialSensor: use batch logging options to allow pre-post raw gyro logging

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -674,6 +674,13 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     AP_SUBGROUPINFO(params[1], "5_", 55, AP_InertialSensor, AP_InertialSensor_Params),
 #endif
 
+    // @Param: _RAW_LOG_OPT
+    // @DisplayName: Raw logging options
+    // @Description: Raw logging options bitmask
+    // @Bitmask: 0:Log primary gyro only, 1:Log all gyros, 2:Post filter, 3: Pre and post filter
+    // @User: Advanced
+    AP_GROUPINFO("_RAW_LOG_OPT", 56, AP_InertialSensor, raw_logging_options, 0),
+
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -766,6 +766,18 @@ private:
     AP_Int32 tcal_options;
     bool tcal_learning;
 #endif
+
+    // Raw logging options bitmask and parameter
+    enum class RAW_LOGGING_OPTION {
+        PRIMARY_GYRO_ONLY   = (1U<<0),
+        ALL_GYROS           = (1U<<1),
+        POST_FILTER         = (1U<<2),
+        PRE_AND_POST_FILTER = (1U<<3),
+    };
+    AP_Int16 raw_logging_options;
+    bool raw_logging_option_set(RAW_LOGGING_OPTION option) const {
+        return (raw_logging_options.get() & int32_t(option)) != 0;
+    }
 };
 
 namespace AP {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -315,7 +315,7 @@ private:
 
     bool should_log_imu_raw() const ;
     void log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel) __RAMFUNC__;
-    void log_gyro_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &gryo) __RAMFUNC__;
+    void log_gyro_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &raw_gyro, const Vector3f &filtered_gyro) __RAMFUNC__;
 
     // logging
     void Write_ACC(const uint8_t instance, const uint64_t sample_us, const Vector3f &accel) const __RAMFUNC__; // Write ACC data packet: raw accel data


### PR DESCRIPTION
This expands the capability of raw sensor logging to allow post filter and pre-post. If the board can keep up with it raw sensor is much nicer than batch logging.

- logs as float, much less quantization noise
- its continuous so you can change FFT window size after the fact, also much better for seeing how the frequency tracking is doing
- Pre-post is of the same samples so a true comparison can be made in dynamic flight

This re-uses the batch sampler options, which means we loose this functionality if batch sampler is compiled out. This will be a change in behavior if users have left over options from filter setup but now have disabled the batch mask. We could also add a new param for just raw sensor logging, this would allow us to add a new bits "primary IMU only" and "gyro only" that would reduce the logging rate.