### PR TITLE
AP_Logger: add Write_NamedValueFloat

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -912,6 +912,20 @@ void AP_Logger::Write_Fence()
 }
 #endif
 
+void AP_Logger::Write_NamedValueFloat(const char *name, float value)
+{
+    WriteStreaming(
+        "NVF",
+        "TimeUS,Name,Value",
+        "s#-",
+        "F--",
+        "QNf",
+        AP_HAL::micros(),
+        name,
+        value
+        );
+}
+
 // output a FMT message for each backend if not already done so
 void AP_Logger::Safe_Write_Emit_FMT(log_write_fmt *f)
 {

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -247,6 +247,7 @@ public:
 #if HAL_LOGGER_FENCE_ENABLED
     void Write_Fence();
 #endif
+    void Write_NamedValueFloat(const char *name, float value);
     void Write_Power(void);
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);


### PR DESCRIPTION
for getting diagnostics into the code during ddebug fast

This doesn't use any flash until you use it:
```
Board               AP_Periph  blimp  bootloader  copter  heli  plane  rover  sub
Durandal                       *      *           *       *     *      *      *
Hitec-Airspeed      *
KakuteH7-bdshot                *      *           *       *     *      *      *
MatekF405                      *      *           *       *     *      *      *
Pixhawk1-1M-bdshot             *                  *       *     *      *      *
f103-QiotekPeriph   *
f303-Universal      *
```