### PR TITLE
GCS_MAVLink: convert to COMMAND_INT to handle MAV_CMD_DO_SET_HOME

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -518,7 +518,7 @@ protected:
     void handle_set_mode(const mavlink_message_t &msg);
     void handle_command_int(const mavlink_message_t &msg);
 
-    MAV_RESULT handle_command_int_do_set_home(const mavlink_command_int_t &packet);
+    MAV_RESULT handle_command_do_set_home(const mavlink_command_int_t &packet);
     virtual MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_int_external_position_estimate(const mavlink_command_int_t &packet);
 
@@ -526,7 +526,6 @@ protected:
     virtual bool set_home(const Location& loc, bool lock) = 0;
 
     virtual MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_int_t &packet);
-    MAV_RESULT handle_command_do_set_home(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_aux_function(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
     void handle_mission_request_list(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4601,32 +4601,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
 #endif
 }
 
-MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_long_t &packet)
-{
-    if (is_equal(packet.param1, 1.0f) || (is_zero(packet.param5) && is_zero(packet.param6))) {
-        // param1 is 1 (or both lat and lon are zero); use current location
-        if (!set_home_to_current_location(true)) {
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_ACCEPTED;
-    }
-
-    // ensure param1 is zero
-    if (!is_zero(packet.param1)) {
-        return MAV_RESULT_FAILED;
-    }
-
-    Location new_home_loc;
-    if (!location_from_command_t(packet, MAV_FRAME_GLOBAL, new_home_loc)) {
-        return MAV_RESULT_DENIED;
-    }
-
-    if (!set_home(new_home_loc, true)) {
-        return MAV_RESULT_FAILED;
-    }
-    return MAV_RESULT_ACCEPTED;
-}
-
 MAV_RESULT GCS_MAVLINK::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
     if (is_equal(packet.param1,1.0f)) {
@@ -4667,6 +4641,7 @@ MAV_RESULT GCS_MAVLINK::try_command_long_as_command_int(const mavlink_command_lo
             { MAV_CMD_FIXED_MAG_CAL_YAW, MAV_FRAME_GLOBAL_RELATIVE_ALT },
             { MAV_CMD_DO_SET_ROI, MAV_FRAME_GLOBAL_RELATIVE_ALT },
             { MAV_CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_RELATIVE_ALT },
+            { MAV_CMD_DO_SET_HOME, MAV_FRAME_GLOBAL },
         };
 
         // map from command to frame:
@@ -4709,10 +4684,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
 
     case MAV_CMD_DO_SEND_BANNER:
         result = handle_command_do_send_banner(packet);
-        break;
-
-    case MAV_CMD_DO_SET_HOME:
-        result = handle_command_do_set_home(packet);
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:
@@ -5039,7 +5010,7 @@ void GCS_MAVLINK::handle_landing_target(const mavlink_message_t &msg)
 }
 
 
-MAV_RESULT GCS_MAVLINK::handle_command_int_do_set_home(const mavlink_command_int_t &packet)
+MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_int_t &packet)
 {
     if (is_equal(packet.param1, 1.0f) || (packet.x == 0 && packet.y == 0)) {
         // param1 is 1 (or both lat and lon are zero); use current location
@@ -5182,7 +5153,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
     case MAV_CMD_DO_SET_ROI_NONE:
         return handle_command_do_set_roi_none();
     case MAV_CMD_DO_SET_HOME:
-        return handle_command_int_do_set_home(packet);
+        return handle_command_do_set_home(packet);
 #if AP_AHRS_POSITION_RESET_ENABLED
     case MAV_CMD_EXTERNAL_POSITION_ESTIMATE:
         return handle_command_int_external_position_estimate(packet);


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -152   *           -152    -160              -152   -152   -152
HerePro             -208                                                                  
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -216   *           -248    -248              -248   -216   -224
MatekF405                      -216   *           -232    -240              -240   -216   -216
Pixhawk1-1M-bdshot             -200               -192    -192              -200   -200   -200
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      -208   *           -216    -224              -224   -208   -208
skyviper-v2450                                    -184                                    
```

autotest tests both cases.

Also tested in SITL; MAVProxy sends `command_long` for "Set Home (with height)" and `command_int` for "Set Home".
```
Setting home to:  -35.36111181492978 149.16259379385926
Got COMMAND_ACK: DO_SET_HOME: ACCEPTED
< HOME_POSITION {latitude : -353611118, longitude : 1491625937, altitude : 584090, x : 239.368896484375, y : -239.99937438964844, z : -0.0, q : [1.0, 0.0, 0.0, 0.0], approach_x : 0.0, approach_y : 0.0, approach_z : 0.0, time_usec : 47834192}
Setting home to:  -35.36423335882884 149.16169881789722 590.4801835676544
Got COMMAND_ACK: DO_SET_HOME: ACCEPTED
< HOME_POSITION {latitude : -353642349, longitude : 1491616973, altitude : 590480, x : -108.29097747802734, y : -321.36981201171875, z : -6.389999866485596, q : [1.0, 0.0, 0.0, 0.0], approach_x : 0.0, approach_y : 0.0, approach_z : 0.0, time_usec : 63687015}
```

 
