### PR TITLE
AP_HAL_Linux: support UNIX FIFO(named pipe) interface

### DIFF
--- a/libraries/AP_HAL_Linux/FIFODevice.cpp
+++ b/libraries/AP_HAL_Linux/FIFODevice.cpp
@@ -1,0 +1,110 @@
+#include "FIFODevice.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <AP_HAL/AP_HAL.h>
+
+FIFODevice::FIFODevice(const char *rd_device, const char *wr_device):
+    _rd_device(rd_device), _wr_device(wr_device),
+    _rd_fd(-1), _wr_fd(-1)
+{
+}
+
+FIFODevice::~FIFODevice()
+{
+}
+
+bool FIFODevice::close()
+{
+    bool ret = true;
+
+    if (_rd_fd >= 0) {
+        if (::close(_rd_fd) < 0) {
+            ret = false;
+        }
+        _rd_fd = -1;
+    }
+
+    if (_wr_fd >= 0) {
+        if (::close(_wr_fd) < 0) {
+            ret = false;
+        }
+        _wr_fd = -1;
+    }
+
+    return ret;
+}
+
+bool FIFODevice::open()
+{
+    _rd_fd = ::open(_rd_device, O_CLOEXEC | O_NONBLOCK | O_RDONLY);
+
+    if (_rd_fd < 0) {
+        ::fprintf(stderr, "Failed to open FIFO device %s for reading - %s\n",
+                  _rd_device, strerror(errno));
+        return false;
+    }
+
+    //O_RDWR is used only to allow opening a FIFO that has not been opened yet.
+    _wr_fd = ::open(_wr_device, O_CLOEXEC | O_NONBLOCK | O_RDWR);
+
+    if (_wr_fd < 0) {
+        ::fprintf(stderr, "Failed to open FIFO device %s for writing - %s\n",
+                  _wr_device, strerror(errno));
+        ::close(_rd_fd);
+        _rd_fd = -1;
+        return false;
+    }
+
+    return true;
+}
+
+ssize_t FIFODevice::read(uint8_t *buf, uint16_t n)
+{
+    return ::read(_rd_fd, buf, n);
+}
+
+ssize_t FIFODevice::write(const uint8_t *buf, uint16_t n)
+{
+    return ::write(_wr_fd, buf, n);
+}
+
+static void fifo_set_fd_blocking_helper(int fd, const char * devname, bool blocking)
+{
+    int flags  = fcntl(fd, F_GETFL, 0);
+
+    if (blocking) {
+        flags = flags & ~O_NONBLOCK;
+    } else {
+        flags = flags | O_NONBLOCK;
+    }
+
+    if (fcntl(fd, F_SETFL, flags) < 0) {
+        ::fprintf(stderr, "Failed to set FIFO %s nonblocking: %s\n", devname, strerror(errno));
+    }
+}
+
+void FIFODevice::set_blocking(bool blocking)
+{
+    fifo_set_fd_blocking_helper(_rd_fd, _rd_device, blocking);
+    fifo_set_fd_blocking_helper(_wr_fd, _wr_device, blocking);
+}
+
+void FIFODevice::set_speed(uint32_t baudrate)
+{
+    //Ignored for FIFO: quite fast.
+}
+
+void FIFODevice::set_flow_control(AP_HAL::UARTDriver::flow_control flow_control_setting)
+{
+    //Ignored for FIFO: effectively FLOW_CONTROL_ENABLE once pipe is opened
+}
+
+void FIFODevice::set_parity(int v)
+{
+    //Ignored for FIFO: in-memory ring buffer
+}

--- a/libraries/AP_HAL_Linux/FIFODevice.h
+++ b/libraries/AP_HAL_Linux/FIFODevice.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "SerialDevice.h"
+
+class FIFODevice: public SerialDevice
+{
+public:
+    FIFODevice(const char *rd_device, const char *wr_device);
+    virtual ~FIFODevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual ssize_t write(const uint8_t *buf, uint16_t n) override;
+    virtual ssize_t read(uint8_t *buf, uint16_t n) override;
+    virtual void set_blocking(bool blocking) override;
+    virtual void set_speed(uint32_t speed) override;
+    virtual void set_flow_control(enum AP_HAL::UARTDriver::flow_control flow_control_setting) override;
+    virtual AP_HAL::UARTDriver::flow_control get_flow_control(void) override
+    {
+        return AP_HAL::UARTDriver::flow_control::FLOW_CONTROL_DISABLE;
+    }
+    virtual void set_parity(int v) override;
+
+private:
+    int _rd_fd = -1;
+    int _wr_fd = -1;
+    const char *_rd_device;
+    const char *_wr_device;
+};

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -299,6 +299,8 @@ void _usage(void)
     printf("\tnetworking UDP:\n");
     printf("\t                  --serial0 udp:11.0.0.255:14550:bcast\n");
     printf("\t                  --serial0 udpin:0.0.0.0:14550\n");
+    printf("\tUnix Named Pipe / FIFO:\n");
+    printf("\t                  --serial0 fifo:/dev/socket/read_fifo:/dev/socket/write_fifo\n");
     printf("\tcustom log path:\n");
     printf("\t                  --log-directory /var/APM/logs\n");
     printf("\t                  -l /var/APM/logs\n");
@@ -478,6 +480,11 @@ void HAL_Linux::setup_signal_handlers() const
     sa.sa_handler = HAL_Linux::exit_signal_handler;
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
+
+    struct sigaction sa_pipe = {};
+    sigemptyset(&sa_pipe.sa_mask);
+    sa_pipe.sa_handler = SIG_IGN; /* No-op SIGPIPE handler - handled by individual drivers */
+    sigaction(SIGPIPE, &sa_pipe, nullptr);
 }
 
 HAL_Linux hal_linux;

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -58,9 +58,9 @@ private:
     AP_HAL::OwnPtr<SerialDevice> _device;
     bool _console;
     volatile bool _in_timer;
-    uint16_t _base_port;
     uint32_t _baudrate;
     char *_ip;
+    char *_port;
     char *_flag;
     bool _connected; // true if a client has connected
     bool _packetise; // true if writes should try to be on mavlink boundaries


### PR DESCRIPTION
Create a new serial device backend that connects to a pair(RX/TX) of named pipes.