### PR TITLE
AP_HAL_Linux: make all semaphores priority-inherit

### DIFF
--- a/libraries/AP_HAL_Linux/Semaphores.cpp
+++ b/libraries/AP_HAL_Linux/Semaphores.cpp
@@ -11,6 +11,7 @@ Semaphore::Semaphore()
 {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
+    pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&_lock, &attr);
 }


### PR DESCRIPTION
Make semaphores use priority-inheritance to reduce the rate of "MPU: temp reset IMU" when running fast sampling(8KHz) on linux.