### PR TITLE
Periph: make uCenter fw update more reliable

### DIFF
--- a/libraries/AP_HAL/utility/RingBuffer.cpp
+++ b/libraries/AP_HAL/utility/RingBuffer.cpp
@@ -41,6 +41,20 @@ bool ByteBuffer::set_size(uint32_t _size)
     return true;
 }
 
+/*
+  set buffer size, accepting a smaller size if desired size isn't achievable
+ */
+bool ByteBuffer::set_size_best(uint32_t _size)
+{
+    while (_size > 0) {
+        if (set_size(_size)) {
+            return true;
+        }
+        _size = (3 * _size)/4;
+    }
+    return false;
+}
+
 uint32_t ByteBuffer::available(void) const
 {
     /* use a copy on stack to avoid race conditions of @tail being updated by

--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -52,6 +52,9 @@ public:
     // set size of ringbuffer, caller responsible for locking
     bool set_size(uint32_t size);
 
+    // set size of ringbuffer, reducing down if size can't be achieved
+    bool set_size_best(uint32_t size);
+    
     // advance the read pointer (discarding bytes)
     bool advance(uint32_t n);
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -291,7 +291,7 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
     }
     if (rxS != _readbuf.get_size()) {
         _rx_initialised = false;
-        _readbuf.set_size(rxS);
+        _readbuf.set_size_best(rxS);
     }
 
     bool clear_buffers = false;
@@ -354,7 +354,7 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
     }
     if (txS != _writebuf.get_size()) {
         _tx_initialised = false;
-        _writebuf.set_size(txS);
+        _writebuf.set_size_best(txS);
     }
 
     if (clear_buffers) {


### PR DESCRIPTION
this ensures we have reasonable UART buffer sizes. As blocks are written 520 bytes at a time the default 512 is not reliable
