### PR TITLE
UART framing API

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -185,7 +185,7 @@ private:
     struct {
         volatile uint8_t bounce_idx;
         volatile uint8_t read_bounce_idx;
-        volatile bool idle;
+        virtual_timer_t rx_timeout;
         uint8_t *bounce_buf[2];
         uint16_t bounce_len[2];
     } _frame;
@@ -293,6 +293,7 @@ protected:
 
 private:
     void transfer_frame();
+    static void transfer_frame(virtual_timer_t* vt, void *p);
 };
 
 // access to usb init for stdio.cpp

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -94,6 +94,7 @@ public:
     void process_pulse(uint32_t width_s0, uint32_t width_s1);
     void process_pulse_list(const uint32_t *widths, uint16_t n, bool need_swap);
     bool process_byte(uint8_t byte, uint32_t baudrate);
+    bool process_frame(const uint8_t* buf, ssize_t nbytes);
     void process_handshake(uint32_t baudrate);
     void update(void);
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -67,6 +67,10 @@ public:
         return frontend.rc_protocols_mask;
     }
 
+    bool protocol_enabled(enum AP_RCProtocol::rcprotocol_t protocol) const {
+        return frontend.protocol_enabled(protocol);
+    }
+
     // get RSSI
     int16_t get_RSSI(void) const {
         return rssi;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -99,6 +99,11 @@ public:
         return frontend._detected_protocol != AP_RCProtocol::NONE && frontend.backend[frontend._detected_protocol] == this;
     }
 
+    // framing API
+    virtual void frame_input_enabled(AP_HAL::UARTDriver* uart, bool onoff) { _framing_enabled = onoff; }
+    bool frame_input_enabled() const { return _framing_enabled; }
+    virtual void process_frame(const uint8_t* buffer, uint16_t buflen) { }
+
 #if AP_VIDEOTX_ENABLED
     // called by static methods to confiig video transmitters:
     static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);
@@ -132,11 +137,14 @@ private:
     uint32_t rc_input_count;
     uint32_t last_rc_input_count;
     uint32_t rc_frame_count;
+    bool _framing_enabled;
 
     uint16_t _pwm_values[MAX_RCIN_CHANNELS];
     uint8_t  _num_channels;
     int16_t rssi = -1;
     int16_t rx_link_quality = -1;
 };
+
+#define PROTOCOL_MAX_FRAME_SIZE 64
 
 #endif  // AP_RCPROTOCOL_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -302,7 +302,7 @@ void AP_RCProtocol_CRSF::frame_input_enabled(AP_HAL::UARTDriver* uart, bool onof
     }
 
     // due to bugs in CRSFv3, framing is not possible at higher baudrates
-    if (onoff && uart->get_baud_rate() > CRSF_BAUDRATE) {
+    if (onoff && uart->get_baud_rate() > CRSF_BAUDRATE_1MBIT) {
         return;
     }
 
@@ -644,7 +644,7 @@ bool AP_RCProtocol_CRSF::change_baud_rate(uint32_t baudrate)
     }
 #endif
 
-    if (AP_RCProtocol_Backend::frame_input_enabled()) {
+    if (baudrate > CRSF_BAUDRATE_1MBIT && AP_RCProtocol_Backend::frame_input_enabled()) {
         return false;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -667,7 +667,7 @@ void AP_RCProtocol_CRSF::process_handshake(uint32_t baudrate)
         || baudrate != CRSF_BAUDRATE
         || baudrate == get_bootstrap_baud_rate()
         || uart->get_baud_rate() == get_bootstrap_baud_rate()
-        || (get_rc_protocols_mask() & ((1U<<(uint8_t(AP_RCProtocol::CRSF)+1))+1)) == 0) {
+        || !protocol_enabled(AP_RCProtocol::CRSF)) {
         return;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -54,6 +54,9 @@ public:
 #endif
     }
 
+    void frame_input_enabled(AP_HAL::UARTDriver* uart, bool onoff) override;
+    void process_frame(const uint8_t* buffer, uint16_t buflen) override;
+
     // is the receiver active, used to detect power loss and baudrate changes
     bool is_rx_active() const override {
         // later versions of CRSFv3 will send link rate frames every 200ms
@@ -298,6 +301,7 @@ private:
     static AP_RCProtocol_CRSF* _singleton;
 
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    void _process_raw_byte(uint32_t timestamp_us, uint8_t byte);
     bool decode_crsf_packet();
     bool process_telemetry(bool check_constraint = true);
     void process_link_stats_frame(const void* data);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
@@ -152,6 +152,10 @@ void AP_RCProtocol_GHST::_process_byte(uint32_t timestamp_us, uint8_t byte)
         return;
     }
 
+    if (_frame.device_address != DeviceAddress::GHST_ADDRESS_FLIGHT_CONTROLLER) {
+        return;
+    }
+
     // parse the length
     if (_frame_ofs == GHST_HEADER_TYPE_LEN) {
         _frame_crc = crc8_dvb_s2(0, _frame.type);
@@ -421,17 +425,17 @@ void AP_RCProtocol_GHST::process_byte(uint8_t byte, uint32_t baudrate)
     _process_byte(AP_HAL::micros(), byte);
 }
 
-// change the bootstrap baud rate to ELRS standard if configured
+// change the bootstrap baud rate to Ghost standard if configured
 void AP_RCProtocol_GHST::process_handshake(uint32_t baudrate)
 {
     AP_HAL::UARTDriver *uart = get_current_UART();
 
-    // only change the baudrate if we are bootstrapping CRSF
+    // only change the baudrate if we are specifically bootstrapping Ghost
     if (uart == nullptr
         || baudrate != CRSF_BAUDRATE
         || baudrate == GHST_BAUDRATE
         || uart->get_baud_rate() == GHST_BAUDRATE
-        || (get_rc_protocols_mask() & ((1U<<(uint8_t(AP_RCProtocol::GHST)+1))+1)) == 0) {
+        || (get_rc_protocols_mask() & (1U<<(uint8_t(AP_RCProtocol::GHST)+1))) == 0) {
         return;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
@@ -435,7 +435,8 @@ void AP_RCProtocol_GHST::process_handshake(uint32_t baudrate)
         || baudrate != CRSF_BAUDRATE
         || baudrate == GHST_BAUDRATE
         || uart->get_baud_rate() == GHST_BAUDRATE
-        || (get_rc_protocols_mask() & (1U<<(uint8_t(AP_RCProtocol::GHST)+1))) == 0) {
+        || !protocol_enabled(AP_RCProtocol::GHST)
+        || protocol_enabled(AP_RCProtocol::CRSF)) {
         return;
     }
 


### PR DESCRIPTION
This implements a UART framing API and uses it in our CRSF protocol implementation.

Flown briefly using CRSF tracer on a 3" quad.