### PR TITLE
hwdef: remove bootloader flashing from MambaF405US-I2C and omnibusf4p…

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F35Lightning/hwdef.dat
@@ -166,4 +166,4 @@ define AP_BATTERY_SYNTHETIC_CURRENT_ENABLED 0
 define HAL_DEFAULT_INS_FAST_SAMPLE 1
 
 # no space for bootloader:
-define AP_BOOTLOADER_FLASHING_ENABLED 0
+include ../include/no_bootloader_DFU.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405US-I2C/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405US-I2C/hwdef.dat
@@ -155,3 +155,6 @@ define HAL_OSD_TYPE_DEFAULT 1
 
 # Font for OSD
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
+
+# no space for bootloader:
+include ../include/no_bootloader_DFU.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-RangeFinder/hwdef.dat
@@ -12,7 +12,7 @@ define AP_PERIPH_RANGEFINDER_PORT_DEFAULT 3
 
 # we're too low on flash with old compiler for bootloader
 define HAL_NO_ROMFS_SUPPORT
-define AP_BOOTLOADER_FLASHING_ENABLED 0
+include ../include/no_bootloader_DFU.inc
 
 # setup for MSP
 define HAL_MSP_ENABLED 1

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro-bdshot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro-bdshot/hwdef.dat
@@ -11,3 +11,6 @@ PB1 TIM3_CH4  TIM3 PWM(2) GPIO(51) BIDIR
 PA3 TIM2_CH4  TIM2 PWM(3) GPIO(52) BIDIR
 PA2 TIM2_CH3  TIM2 PWM(4) GPIO(53)
 # PWM 5 is disabled as it shares a timer with PWM 3&4
+
+# no space for bootloader:
+include ../include/no_bootloader_DFU.inc


### PR DESCRIPTION
…ro-bdshot

also use an include where appropriate on a pair of other boards