### PR TITLE
Plane: On vtol landings if from a mission perform crosstracking

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2407,7 +2407,7 @@ void QuadPlane::vtol_position_controller(void)
         const float aspeed_threshold = MAX(plane.aparm.airspeed_min-2, assist_speed);
 
         // run fixed wing navigation
-        plane.nav_controller->update_waypoint(plane.current_loc, loc);
+        plane.nav_controller->update_waypoint(plane.auto_state.crosstrack ? plane.prev_WP_loc : plane.current_loc, loc);
 
         // use TECS for throttle
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.TECS_controller.get_throttle_demand());
@@ -3240,7 +3240,8 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
     plane.crash_state.is_crashed = false;
     
     // also update nav_controller for status output
-    plane.nav_controller->update_waypoint(plane.current_loc, plane.next_WP_loc);
+    plane.nav_controller->update_waypoint(plane.auto_state.crosstrack ? plane.prev_WP_loc : plane.current_loc,
+                                          plane.next_WP_loc);
 
     poscontrol_init_approach();
     return true;


### PR DESCRIPTION
I was planning quadplane landings like a manned aircraft (downwind, base, and final at 90 degree turns), and found that when on final the plane didn't attempt to get back on the line from the last waypoint to the landing location. This has a couple significant failure modes, mostly the plane could be blown past the desired final line during the turn, but it would never attempt to get back on it, or it could experience strong wind pushing it off of the target line, which resulted in flying a parallel to desired path. This is particularly bad when trying to operate in confined areas in a narrowly controlled manner.

This shouldn't have any impact upon QRTL, and should only apply if we are flying from the previous waypoint in auto. I've flown this a bunch in the simulator, and am planning to get out with a real aircraft as well.