### PR TITLE
Change SITL's unbufferedsemantics to be closer to ChibiOS's

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -139,7 +139,7 @@ protected:
     bool _discard_input() override;
 
 private:
-    void handle_writing_from_writebuffer_to_output();
+    void handle_writing_from_writebuffer_to_device();
     void handle_reading_from_device_to_readbuffer();
 };
 

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -106,7 +106,10 @@ private:
     bool _is_udp;
     bool _packetise;
     uint16_t _mc_myport;
-    uint32_t last_tick_us;
+
+    // for baud-rate limiting:
+    uint32_t last_read_tick_us;
+    uint32_t last_write_tick_us;
 
     SITL::SerialDevice *_sim_serial_device;
 
@@ -134,6 +137,10 @@ protected:
     void _end() override;
     void _flush() override;
     bool _discard_input() override;
+
+private:
+    void handle_writing_from_writebuffer_to_output();
+    void handle_reading_from_device_to_readbuffer();
 };
 
 #endif


### PR DESCRIPTION
We don't ever actually do unbuffered writes in ChibiOS.  We just poke the relevant thread to say there's data available.  This kind of mimics that my instantly evoking the same routine the timer-tick method does, which may or may not get all of the bytes out in good order.
