### PR TITLE
Handle DO_SET_ROI_NONE conversion from long-to-int rather than directly

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5131,6 +5131,7 @@ class AutoTestCopter(AutoTest):
 
             self.progress("Using MAV_CMD_DO_SET_ROI_NONE")
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE)
+            self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE)
             self.test_mount_pitch(0, 1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
 
             start = self.mav.location()

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4742,9 +4742,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     }
 #endif
 
-    case MAV_CMD_DO_SET_ROI_NONE:
-        return handle_command_do_set_roi_none();
-
     case MAV_CMD_DO_SET_ROI_SYSID:
         return handle_command_do_set_roi_sysid(packet);
 
@@ -5063,19 +5060,17 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_external_position_estimate(const mavl
 }
 #endif // AP_AHRS_POSITION_RESET_ENABLED
 
+#if HAL_MOUNT_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_none()
 {
-#if HAL_MOUNT_ENABLED
     AP_Mount *mount = AP::mount();
     if (mount == nullptr) {
         return MAV_RESULT_UNSUPPORTED;
     }
     mount->set_mode_to_default();
     return MAV_RESULT_ACCEPTED;
-#else
-    return MAV_RESULT_UNSUPPORTED;
-#endif
 }
+#endif
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_sysid(const uint8_t sysid)
 {
@@ -5150,8 +5145,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_do_set_roi(packet);
     case MAV_CMD_DO_SET_ROI_SYSID:
         return handle_command_do_set_roi_sysid(packet);
+#if HAL_MOUNT_ENABLED
     case MAV_CMD_DO_SET_ROI_NONE:
         return handle_command_do_set_roi_none();
+#endif
     case MAV_CMD_DO_SET_HOME:
         return handle_command_do_set_home(packet);
 #if AP_AHRS_POSITION_RESET_ENABLED
@@ -5173,8 +5170,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
             return scripting->handle_command_int_packet(packet);
         }
 #endif // AP_SCRIPTING_ENABLED
-    default:
-        break;
     }
     return MAV_RESULT_UNSUPPORTED;
 }


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -16    *           -24     -24               -24    -24    -24
HerePro             -8                                                                    
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -32    *           -8      -8                -8     -40    -32
MatekF405                      -32    *           -16     -8                -16    -32    -32
Pixhawk1-1M-bdshot             -136               -136    -128              -136   -136   -136
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      -16    *           -32     -40               -40    -16    -16
skyviper-v2450                                    -128                                    
```
