### PR TITLE
AP_Mount/RC_Channel: viewpro supports setting active lens

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -529,6 +529,30 @@ bool AP_Camera::set_tracking(uint8_t instance, TrackingType tracking_type, const
     return backend->set_tracking(tracking_type, p1, p2);
 }
 
+// set camera lens as a value from 0 to 5
+bool AP_Camera::set_lens(uint8_t lens)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    if (primary == nullptr) {
+        return false;
+    }
+    return primary->set_lens(lens);
+}
+
+bool AP_Camera::set_lens(uint8_t instance, uint8_t lens)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+
+    // call instance
+    return backend->set_lens(lens);
+}
+
 #if AP_CAMERA_SCRIPTING_ENABLED
 // accessor to allow scripting backend to retrieve state
 // returns true on success and cam_state is filled in

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -135,6 +135,10 @@ public:
     bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
     bool set_tracking(uint8_t instance, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
 
+    // set camera lens as a value from 0 to 5
+    bool set_lens(uint8_t lens);
+    bool set_lens(uint8_t instance, uint8_t lens);
+
     // set if vehicle is in AUTO mode
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -75,6 +75,9 @@ public:
     // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
     virtual bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2) { return false; }
 
+    // set camera lens as a value from 0 to 5
+    virtual bool set_lens(uint8_t lens) { return false; }
+
     // handle MAVLink messages from the camera
     virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}
 

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -60,6 +60,17 @@ bool AP_Camera_Mount::set_tracking(TrackingType tracking_type, const Vector2f& p
     return false;
 }
 
+
+// set camera lens as a value from 0 to 5
+bool AP_Camera_Mount::set_lens(uint8_t lens)
+{
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->set_lens(0, lens);
+    }
+    return false;
+}
+
 // send camera information message to GCS
 void AP_Camera_Mount::send_camera_information(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -51,6 +51,9 @@ public:
     // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
     bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2) override;
 
+    // set camera lens as a value from 0 to 5
+    bool set_lens(uint8_t lens) override;
+
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const override;
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -794,6 +794,16 @@ bool AP_Mount::set_tracking(uint8_t instance, TrackingType tracking_type, const 
     return backend->set_tracking(tracking_type, p1, p2);
 }
 
+// set camera lens as a value from 0 to 5
+bool AP_Mount::set_lens(uint8_t instance, uint8_t lens)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->set_lens(lens);
+}
+
 // send camera information message to GCS
 void AP_Mount::send_camera_information(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -238,6 +238,9 @@ public:
     // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
     bool set_tracking(uint8_t instance, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
 
+    // set camera lens as a value from 0 to 5
+    bool set_lens(uint8_t instance, uint8_t lens);
+
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const;
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -169,6 +169,9 @@ public:
     // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
     virtual bool set_tracking(TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2) { return false; }
 
+    // set camera lens as a value from 0 to 5
+    virtual bool set_lens(uint8_t lens) { return false; }
+
     // send camera information message to GCS
     virtual void send_camera_information(mavlink_channel_t chan) const {}
 

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -679,10 +679,13 @@ bool AP_Mount_Viewpro::send_m_ahrs()
     // get vehicle velocity in m/s in NED Frame
     Vector3f vel_NED;
     IGNORE_RETURN(AP::ahrs().get_velocity_NED(vel_NED));
-    float vel_yaw_deg = degrees(vel_NED.xy().angle());
+    float vel_yaw_deg = wrap_360(degrees(vel_NED.xy().angle()));
 
     // get GPS vdop
     uint16_t gps_vdop = AP::gps().get_vdop();
+
+    // get vehicle yaw in the range 0 to 360
+    const uint16_t veh_yaw_deg = wrap_360(degrees(AP::ahrs().get_yaw()));
 
     // fill in packet
     const M_AHRSPacket mahrs_packet {
@@ -691,7 +694,7 @@ bool AP_Mount_Viewpro::send_m_ahrs()
             data_type: 0x07,                        // Bit0: Attitude, Bit1: GPS, Bit2 Gyro
             pitch_be: htobe16(-degrees(AP::ahrs().get_pitch()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),   // vehicle pitch angle.  1bit=360deg/65536
             roll_be: htobe16(degrees(AP::ahrs().get_roll()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),      // vehicle roll angle.  1bit=360deg/65536
-            yaw_be: htobe16(degrees(AP::ahrs().get_yaw()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),        // vehicle yaw angle.  1bit=360deg/65536
+            yaw_be: htobe16(veh_yaw_deg * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),                          // vehicle yaw angle.  1bit=360deg/65536
             date_be: htobe16(date),                 // bit0~6:year, bit7~10:month, bit11~15:day
             seconds_utc: {uint8_t((second_hundredths & 0xFF0000ULL) >> 16), // seconds * 100 MSB.  1bit = 0.01sec
                           uint8_t((second_hundredths & 0xFF00ULL) >> 8),    // seconds * 100 next MSB.  1bit = 0.01sec

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -474,7 +474,7 @@ bool AP_Mount_Viewpro::set_lock(bool lock)
     const A1Packet a1_packet {
         .content = {
             frame_id: FrameId::A1,
-            servo_status: lock ? ServoStatus::follow_yaw_disable : ServoStatus::follow_yaw
+            servo_status: lock ? ServoStatus::FOLLOW_YAW_DISABLE : ServoStatus::FOLLOW_YAW
         }
     };
 
@@ -518,7 +518,7 @@ bool AP_Mount_Viewpro::send_target_rates(float pitch_rads, float yaw_rads, bool 
     const A1Packet a1_packet {
         .content = {
             frame_id: FrameId::A1,
-            servo_status: ServoStatus::manual_speed_mode,
+            servo_status: ServoStatus::MANUAL_SPEED_MODE,
             yaw_be: htobe16(yaw_rate_output),
             pitch_be: htobe16(pitch_rate_output)
         }
@@ -556,7 +556,7 @@ bool AP_Mount_Viewpro::send_target_angles(float pitch_rad, float yaw_rad, bool y
     const A1Packet a1_packet {
         .content = {
             frame_id: FrameId::A1,
-            servo_status: ServoStatus::manual_absolute_angle_mode,
+            servo_status: ServoStatus::MANUAL_ABSOLUTE_ANGLE_MODE,
             yaw_be: htobe16(yaw_angle_output),
             pitch_be: htobe16(pitch_angle_output)
         }

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -117,10 +117,10 @@ private:
 
     // A1 servo status enum (used in A1, B1 packets)
     enum class ServoStatus : uint8_t {
-        manual_speed_mode = 0x01,
-        follow_yaw = 0x03,
-        manual_absolute_angle_mode = 0x0B,
-        follow_yaw_disable = 0x0A,
+        MANUAL_SPEED_MODE = 0x01,
+        FOLLOW_YAW = 0x03,
+        MANUAL_ABSOLUTE_ANGLE_MODE = 0x0B,
+        FOLLOW_YAW_DISABLE = 0x0A,
     };
 
     // C1 image sensor choice

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -231,6 +231,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Blimp}: 172:Battery MPPT Enable
     // @Values{Plane}: 173:Plane AUTO Mode Landing Abort
     // @Values{Copter, Rover, Plane, Blimp}: 174:Camera Image Tracking
+    // @Values{Copter, Rover, Plane, Blimp}: 175:Camera Lens
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail
@@ -762,6 +763,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::CAMERA_MANUAL_FOCUS, "Camera Manual Focus"},
     { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
     { AUX_FUNC::CAMERA_IMAGE_TRACKING, "Camera Image Tracking"},
+    { AUX_FUNC::CAMERA_LENS, "Camera Lens"},
 };
 
 /* lookup the announcement for switch change */
@@ -989,6 +991,16 @@ bool RC_Channel::do_aux_function_camera_image_tracking(const AuxSwitchPos ch_fla
     // High position enables tracking a POINT in middle of image
     // Low or Mediums disables tracking.  (0.5,0.5) is still passed in but ignored
     return camera->set_tracking(ch_flag == AuxSwitchPos::HIGH ? TrackingType::TRK_POINT : TrackingType::TRK_NONE, Vector2f{0.5, 0.5}, Vector2f{});
+}
+
+bool RC_Channel::do_aux_function_camera_lens(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    // Low selects lens 0 (default), Mediums selects lens1, High selects lens2
+    return camera->set_lens((uint8_t)ch_flag);
 }
 #endif
 
@@ -1491,6 +1503,9 @@ bool RC_Channel::do_aux_function(const aux_func_t ch_option, const AuxSwitchPos 
 
     case AUX_FUNC::CAMERA_IMAGE_TRACKING:
         return do_aux_function_camera_image_tracking(ch_flag);
+
+    case AUX_FUNC::CAMERA_LENS:
+        return do_aux_function_camera_lens(ch_flag);
 #endif
 
 #if HAL_MOUNT_ENABLED

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -247,6 +247,7 @@ public:
         BATTERY_MPPT_ENABLE = 172,// Battery MPPT Power enable. high = ON, mid = auto (controlled by mppt/batt driver), low = OFF. This effects all MPPTs.
         PLANE_AUTO_LANDING_ABORT = 173, // Abort Glide-slope or VTOL landing during payload place or do_land type mission items
         CAMERA_IMAGE_TRACKING = 174, // camera image tracking
+        CAMERA_LENS =        175, // camera lens selection
 
 
         // inputs from 200 will eventually used to replace RCMAP
@@ -346,6 +347,7 @@ protected:
     bool do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_image_tracking(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_lens(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_control(const AuxSwitchPos ch_flag);
     void do_aux_function_runcam_osd_control(const AuxSwitchPos ch_flag);
     void do_aux_function_fence(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
This allows users to change the active video feed (aka "lens") using an auxiliary switch.  This is only implemented for the ViewPro backend.

There are also some other unrelated improvements to the Viewpro driver:

1. recording state is taken from the gimbal instead of assuming the start recording is always successful.  This means the state will remain correct in case of SD card failure or when another interface is used to start/stop recording.
2. zoom level, model name and firmware version are retrieved from the gimbal and displayed to the user and reported to the GCS
3. packet structures are filled in all at once as requested by @peterbarker
4. minor capitalisation fix to some enum values

This has been tested on real hardware.