### PR TITLE
AP_DDS: fix reliable stream buffer size

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -480,12 +480,12 @@ bool AP_DDS_Client::init()
     }
 
     // setup reliable stream buffers
-    input_reliable_stream = new uint8_t[DDS_STREAM_HISTORY*DDS_BUFFER_SIZE];
+    input_reliable_stream = new uint8_t[DDS_BUFFER_SIZE];
     if (input_reliable_stream == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"DDS Client: allocation failed");
         return false;
     }
-    output_reliable_stream = new uint8_t[DDS_STREAM_HISTORY*DDS_BUFFER_SIZE];
+    output_reliable_stream = new uint8_t[DDS_BUFFER_SIZE];
     if (output_reliable_stream == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"DDS Client: allocation failed");
         return false;

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -24,8 +24,9 @@
 
 #include <AP_Param/AP_Param.h>
 
-#define DDS_STREAM_HISTORY 8
-#define DDS_BUFFER_SIZE 512
+#define DDS_MTU             512
+#define DDS_STREAM_HISTORY  8
+#define DDS_BUFFER_SIZE     DDS_MTU * DDS_STREAM_HISTORY
 
 // UDP only on SITL for now
 #define AP_DDS_UDP_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)


### PR DESCRIPTION
Fix reliable stream buffer size and ensure correct arg passed to `uxr_create_input_reliable_stream` etc.

- Fixes segfault observed in https://github.com/ArduPilot/ardupilot/pull/24155#pullrequestreview-1529549217

When the message payload is larger than supported by the client the agent emits a warning, for example:

```bash
[micro_ros_agent-1] 2023-07-18 21:04:48.463 [RTPS_READER_HISTORY Error] Change payload size of '1068' bytes is larger than the history payload size of '1031' bytes and cannot be resized. -> Function can_change_be_added_nts
```