### PR TITLE
AP_InertialSensor: Notify that there is no sensor that can be switched

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1808,13 +1808,29 @@ void AP_InertialSensor::update(void)
         }
 
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            if (_gyro_healthy[i] && _gyro_error_count[i] > _gyro_startup_error_count[i] && have_zero_gyro_error_count) {
-                // we prefer not to use a gyro that has had errors
-                _gyro_healthy[i] = false;
+            if (_gyro_healthy[i] && _gyro_error_count[i] > _gyro_startup_error_count[i]) {
+                if (have_zero_gyro_error_count) {
+                    // we prefer not to use a gyro that has had errors
+                    _gyro_healthy[i] = false;
+                } else {
+                    static uint32_t lastTimeGyro; 
+                    if (AP_HAL::millis() - lastTimeGyro > 1000) {
+                        lastTimeGyro = AP_HAL::millis();
+                        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Gyro sensor cannot be switched.");
+                    }
+                }   
             }
-            if (_accel_healthy[i] && _accel_error_count[i] > _accel_startup_error_count[i] && have_zero_accel_error_count) {
-                // we prefer not to use a accel that has had errors
-                _accel_healthy[i] = false;
+            if (_accel_healthy[i] && _accel_error_count[i] > _accel_startup_error_count[i]) {
+                if (have_zero_accel_error_count) {
+                    // we prefer not to use a accel that has had errors
+                    _accel_healthy[i] = false;
+                } else {
+                    static uint32_t lastTimeAccel; 
+                    if (AP_HAL::millis() - lastTimeAccel > 1000) {
+                        lastTimeAccel = AP_HAL::millis();
+                        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Accelerometer cannot be switched.");
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
 Notify the operator that all of the acceleration and gyro sensors are abnormal.
Notifying the operator makes him aware that the attitude control is unstable.