### PR TITLE
wip ArduPlane: Mode RTL to not consider stopping distance

### DIFF
--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -140,7 +140,7 @@ bool ModeRTL::switch_QRTL()
 
     if (plane.nav_controller->reached_loiter_target() ||
          plane.current_loc.past_interval_finish_line(plane.prev_WP_loc, plane.next_WP_loc) ||
-         plane.auto_state.wp_distance < MAX(qrtl_radius, plane.quadplane.stopping_distance())) {
+         plane.auto_state.wp_distance < qrtl_radius) {
         /*
           for a quadplane in RTL mode we switch to QRTL when we
           are within the maximum of the stopping distance and the


### PR DESCRIPTION
In particular our case we think having the stopping distance as a set of measure for going  QRTL is too big as the stopping distance we keep normally is around 300m. This is  a long time to be hover.

I would prefer it being a config or lua . but open to ideas

@lachlanConn