### PR TITLE
DroneCAN: enable libcanard asserts in SITL

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -649,7 +649,8 @@ class sitl(Board):
             cfg.define('HAL_NUM_CAN_IFACES', 2)
             env.DEFINES.update(CANARD_MULTI_IFACE=1,
                                CANARD_IFACE_ALL = 0x3,
-                                CANARD_ENABLE_CANFD = 1)
+                                CANARD_ENABLE_CANFD = 1,
+                                CANARD_ENABLE_ASSERTS = 1)
 
         env.CXXFLAGS += [
             '-Werror=float-equal',


### PR DESCRIPTION
We've had a report of a bad assert from APD:
https://github.com/dronecan/libcanard/commit/1dc4796df6ead87ee6878ba2977ce3d7f637fbae

