### PR TITLE
AP_Camera/AP_Mount: camera info msg gets device id to improve multi camera support

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -174,7 +174,8 @@ void AP_Camera_Backend::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id, uint8_t
         cap_flags,              // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        0);                     // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -176,7 +176,8 @@ void AP_Camera_MAVLinkCamV2::send_camera_information(mavlink_channel_t chan) con
         _cam_info.lens_id,          // lens_id, uint8_t
         _cam_info.flags,            // flags uint32_t (CAMERA_CAP_FLAGS)
         _cam_info.cam_definition_version,   // cam_definition_version uint16_t
-        _cam_info.cam_definition_uri);      // cam_definition_uri char[140]
+        _cam_info.cam_definition_uri,       // cam_definition_uri char[140]
+        _cam_info.gimbal_device_id);        // gimbal_device_id uint8_t
 }
 
 // search for camera in GCS_MAVLink routing table

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -138,7 +138,10 @@ void AP_Mount_Backend::send_gimbal_device_attitude_status(mavlink_channel_t chan
                                                    std::numeric_limits<double>::quiet_NaN(),    // roll axis angular velocity (NaN for unknown)
                                                    std::numeric_limits<double>::quiet_NaN(),    // pitch axis angular velocity (NaN for unknown)
                                                    std::numeric_limits<double>::quiet_NaN(),    // yaw axis angular velocity (NaN for unknown)
-                                                   0);  // failure flags (not supported)
+                                                   0,  // failure flags (not supported)
+                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw (NaN for unknonw)
+                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw_velocity (NaN for unknonw)
+                                                   _instance + 1);  // gimbal_device_id
 }
 
 // return gimbal manager capability flags used by GIMBAL_MANAGER_INFORMATION message

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -838,7 +838,8 @@ void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -752,7 +752,8 @@ void AP_Mount_Viewpro::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -228,7 +228,8 @@ void AP_Mount_Xacti::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5594,7 +5594,8 @@ void GCS_MAVLINK::send_autopilot_state_for_gimbal_device() const
         0,      // velocity estimated delay in micros
         rate_ef_targets.z,  // feed forward angular velocity z
         est_status_flags,   // estimator status
-        0);     // landed_state (see MAV_LANDED_STATE)
+        0,      // landed_state (see MAV_LANDED_STATE)
+        AP::ahrs().get_yaw_rate_earth());  // [rad/s] Z component of angular velocity in NED (North, East, Down). NaN if unknown
 }
 
 void GCS_MAVLINK::send_received_message_deprecation_warning(const char * message)


### PR DESCRIPTION
This PR matches the following mavlink PR https://github.com/ArduPilot/mavlink/pull/323. **It won't build until that PR is in.**

Gimbal protocol v2 messages are not WIP anymore, and this commit adds support for the latest extra fields.

The first commits are straightforward, they basically add the gimbal_device_id field for all the backends involved. 

- For AP_Mount_Backend: it enables GCS to understand to which gimbal corresponds gimbal_device_attitude_status message. Right now it is impossible to understand where this message is coming from if AP has more than 1 gimbal.

- For the rest of aditions it enables GCS to understand if a particular gimbal is linked to a particular camera. This is useful for a feature that is being developed in QGC to move gimbal clicking over video feed. QGC needs to know the fov/zoom of the camera to scale clicks appropiately.

The latest 2 commits are marked as WIP:

- For the GCS_Common one I am not 100% sure what should be sent there. My understanding is that z angular speed is what should be sent, as we are sending angular z target for feed_forward_angular_velocity_z field, but I would love to get some feedback to confirm this. Once confirmed I will fix it and squash.

- For the AP_Camera_Backend one it is marked as WIP in case we want to include a parameter to select the gimbal_device_id the camera belongs to. As it is now it is fine and it will work for mavlink cameras and gimbal cameras ( Siyi, viewpro, xacti, etc ) so I am happy as well leaving it as it is ( default to 0 ).

Please @rmackay9 if you could give me your opinion on this one as well. Thanks!
