### PR TITLE
Autotune options to allow filter control

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -38,6 +38,14 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     ASCALAR(autotune_level, "AUTOTUNE_LEVEL",  6),
 
+    // @Param: AUTOTUNE_OPTIONS
+    // @DisplayName: Autotune options bitmask
+    // @Description: Autotune specific options
+    // @Bitmask: 0: Disable FLTD update
+    // @Bitmask: 1: Disable FLTT update
+    // @User: Advanced
+    ASCALAR(autotune_options, "AUTOTUNE_OPTIONS",  0),
+
     // @Param: TELEM_DELAY
     // @DisplayName: Telemetry startup delay 
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
@@ -1247,8 +1255,6 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 0:Roll,1:Pitch,2:Yaw
     // @User: Standard
     AP_GROUPINFO("AUTOTUNE_AXES", 34, ParametersG2, axis_bitmask, 7),
-
-
     
     AP_GROUPEND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -356,6 +356,7 @@ public:
         k_param_fence,         // vehicle fence - unused
         k_param_acro_yaw_rate,
         k_param_takeoff_throttle_max_t,
+        k_param_autotune_options,
     };
 
     AP_Int16 format_version;

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3911,6 +3911,18 @@ class AutoTestPlane(AutoTest):
         self.change_mode('FBWA')
         self.fly_home_land_and_disarm(timeout=tdelta+240)
 
+    def AutotuneFiltering(self):
+        '''Test AutoTune mode with filter updates disabled'''
+        self.set_parameters({
+            "AUTOTUNE_OPTIONS": 3,
+            # some filtering is required for autotune to complete
+            "RLL_RATE_FLTD": 10,
+            "PTCH_RATE_FLTD": 10,
+            "RLL_RATE_FLTT": 20,
+            "PTCH_RATE_FLTT": 20,
+        })
+        self.AUTOTUNE()
+
     def LandingDrift(self):
         '''Circuit with baro drift'''
         self.customise_SITL_commandline([], wipe=True)
@@ -4692,6 +4704,7 @@ class AutoTestPlane(AutoTest):
             self.DCMFallback,
             self.MAVFTP,
             self.AUTOTUNE,
+            self.AutotuneFiltering,
             self.MegaSquirt,
             self.MSP_DJI,
             self.SpeedToFly,

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -424,9 +424,17 @@ void AP_AutoTune::update(AP_PIDInfo &pinfo, float scaler, float angle_err_deg)
     }
 
     // setup filters to be suitable for time constant and gyro filter
-    rpid.filt_T_hz().set(10.0/(current.tau * 2 * M_PI));
+    // filtering T can  prevent P/D oscillation being seen, so allow the
+    // user to switch it off
+    if (!has_option(DISABLE_FLTT_UPDATE)) {
+        rpid.filt_T_hz().set(10.0/(current.tau * 2 * M_PI));
+    }
     rpid.filt_E_hz().set(0);
-    rpid.filt_D_hz().set(AP::ins().get_gyro_filter_hz()*0.5);
+    // filtering D at the same level as VTOL can allow unwanted oscillations to be seen,
+    // so allow the user to switch it off and select their own (usually lower) value
+    if (!has_option(DISABLE_FLTD_UPDATE)) {
+        rpid.filt_D_hz().set(AP::ins().get_gyro_filter_hz()*0.5);
+    }
 
     current.FF = FF;
     current.P = P;

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -25,6 +25,11 @@ public:
         AUTOTUNE_YAW = 2,
     };
 
+    enum Options {
+        DISABLE_FLTD_UPDATE = 0,
+        DISABLE_FLTT_UPDATE = 1
+    };
+
     struct PACKED log_ATRP {
         LOG_PACKET_HEADER;
         uint64_t time_us;
@@ -115,6 +120,10 @@ private:
 
     // update rmax and tau towards target
     void update_rmax();
+
+    bool has_option(Options option) {
+        return (aparm.autotune_options.get() & uint32_t(1<<uint32_t(option))) != 0;
+    }
 
     // 5 point mode filter for FF estimate
     ModeFilterFloat_Size5 ff_filter;

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -20,6 +20,7 @@ struct AP_FixedWing {
     AP_Int16 pitch_limit_max_cd;
     AP_Int16 pitch_limit_min_cd;
     AP_Int8  autotune_level;
+    AP_Int32 autotune_options;
     AP_Int8  stall_prevention;
     AP_Int16 loiter_radius;
     AP_Int16 pitch_trim_cd;


### PR DESCRIPTION
Fixed wing autotune sets FLTT and FLTD. This can have two unwanted side-effects:

- VTOL setups typically require higher gyro, D and notch filter setups in VTOL modes but these filter settings can be too high for fixed-wing control
- FLTT filters the feed-forward component, but also the pilot input meaning that it can hide P/D oscillation that is occurring during autotune as well hiding pilot input resulting in a very soft tune

We have seen similar issues in copter autotune in the past with FLTT masking input and creating a very soft tune.

This PR adds an AUTOTUNE_OPTIONS bitmask that allows users to switch off the update of these settings so that they can be selected manually (so for instance a higher value for FLTT and a lower value for FLTD)