### PR TITLE
GCS_MAVLink: use long-to-int conversion code for SET_ROI_SYSID

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5213,6 +5213,11 @@ class AutoTestCopter(AutoTest):
             )
             self.test_mount_pitch(-89, 5, mavutil.mavlink.MAV_MOUNT_MODE_SYSID_TARGET, hold=2)
 
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE)
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_DO_SET_ROI_SYSID,
+                p1=self.mav.source_system,
+            )
             self.mav.mav.global_position_int_send(
                 0, # time boot ms
                 int(roi_lat * 1e7),

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4742,9 +4742,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     }
 #endif
 
-    case MAV_CMD_DO_SET_ROI_SYSID:
-        return handle_command_do_set_roi_sysid(packet);
-
     case MAV_CMD_DO_JUMP_TAG:
     case MAV_CMD_DO_SET_MISSION_CURRENT:
         result = handle_command_do_set_mission_current(packet);
@@ -5070,31 +5067,23 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_none()
     mount->set_mode_to_default();
     return MAV_RESULT_ACCEPTED;
 }
-#endif
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_sysid(const uint8_t sysid)
 {
-#if HAL_MOUNT_ENABLED
     AP_Mount *mount = AP::mount();
     if (mount == nullptr) {
         return MAV_RESULT_UNSUPPORTED;
     }
     mount->set_target_sysid(sysid);
+
     return MAV_RESULT_ACCEPTED;
-#else
-    return MAV_RESULT_UNSUPPORTED;
-#endif
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_sysid(const mavlink_command_int_t &packet)
 {
     return handle_command_do_set_roi_sysid((uint8_t)packet.param1);
 }
-
-MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_sysid(const mavlink_command_long_t &packet)
-{
-    return handle_command_do_set_roi_sysid((uint8_t)packet.param1);
-}
+#endif
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const mavlink_command_int_t &packet)
 {
@@ -5143,9 +5132,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
     case MAV_CMD_DO_SET_ROI:
     case MAV_CMD_DO_SET_ROI_LOCATION:
         return handle_command_do_set_roi(packet);
+#if HAL_MOUNT_ENABLED
     case MAV_CMD_DO_SET_ROI_SYSID:
         return handle_command_do_set_roi_sysid(packet);
-#if HAL_MOUNT_ENABLED
     case MAV_CMD_DO_SET_ROI_NONE:
         return handle_command_do_set_roi_none();
 #endif


### PR DESCRIPTION
```
Board,AP_Periph,blimp,bootloader,copter,heli,iofirmware,plane,rover,sub
Durandal,,-48,*,-24,-16,,-24,-48,-48
HerePro,-72,,,,,,,,
Hitec-Airspeed,*,,,,,,,,
KakuteH7-bdshot,,-48,*,-48,-48,,-48,-48,-48
MatekF405,,-48,*,-48,-48,,-48,-48,-48
Pixhawk1-1M-bdshot,,-8,,-8,0,,-8,-8,-8
f103-QiotekPeriph,*,,,,,,,,
f303-Universal,*,,,,,,,,
iomcu,,,,,,*,,,
revo-mini,,-72,*,-48,-48,,-48,-72,-72
skyviper-v2450,,,,-16,,,,,
```