### PR TITLE
AP_RobotisServo: fix delay after subsequent Robotis servo detections

### DIFF
--- a/libraries/AP_RobotisServo/AP_RobotisServo.cpp
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.cpp
@@ -373,6 +373,7 @@ void AP_RobotisServo::update()
     if (detection_count < DETECT_SERVO_COUNT) {
         detection_count++;
         detect_servos();
+        return;
     }
 
     if (servo_mask == 0) {


### PR DESCRIPTION
This fix probably reflects the original intention of the code author, because without it delays set in detect_servos() are ignored. Without this fix Dynamixel XC330-T288-T does not start and enters something like a "soft bricked" state (no errors reported, but not responding to any commands). This adds a delay after ping messages so that servos have time to respond to the pings and are ready to be configured further.