### PR TITLE
Copter: Notify distance over fence

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -24,7 +24,14 @@ void Copter::fence_check()
     if (new_breaches) {
 
         if (!copter.ap.land_complete) {
-            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+            if (new_breaches & AC_FENCE_TYPE_CIRCLE) {
+                Vector2f home;
+                if (AP::ahrs().get_relative_position_NE_home(home)) {
+                    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached %.2fm", home.length());
+                }
+            } else { 
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence Breached");
+            }
         }
 
         // if the user wants some kind of response and motors are armed


### PR DESCRIPTION
Circle fences are not created with any regularity and distances are indicated.
Circle fences are not aware of the speed at which vehicles are moving.

AFTER
![Screenshot from 2023-07-22 21-49-55](https://github.com/ArduPilot/ardupilot/assets/646194/bad10016-8cf1-4c6c-947b-916fd6932b1f)