### PR TITLE
Plane: fix throttle going bellow min in fbwa RC failsafe

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -546,7 +546,7 @@ void Plane::set_servos_controlled(void)
                control_mode == &mode_autotune) {
         // a manual throttle mode
         if (!rc().has_valid_input()) {
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0.0);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, g.throttle_passthru_stabilize ? 0.0 : MAX(min_throttle,0));
         } else if (g.throttle_passthru_stabilize) {
             // manual pass through of throttle while in FBWA or
             // STABILIZE mode with THR_PASS_STAB set


### PR DESCRIPTION
fixes #24363 

This fixes a momentary bypassing of the set minimum throttle in FBWA/stabilize/acro/training/autotune. `has_valid_input` goes false for a few seconds before the failsafe action kicks in and changes modes. This can lead an ICE engine to stop.

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/3b38b0e0-190b-4ec0-bad7-479bba1f7578)

Our throttle handling is very complex, it is next getting near to the top of my list for re-work.