### PR TITLE
AP_DroneCAN: Update DroneCAN to allow sending negative RawCommands to ESCs

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -140,6 +140,13 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
     // @Range: 1024 16384
     // @User: Advanced
     AP_GROUPINFO("POOL", 8, AP_DroneCAN, _pool_size, DRONECAN_NODE_POOL_SIZE),
+
+    // @Param: ESC_RV
+    // @DisplayName: Bitmask for output channels for reversible ESCs over DroneCAN.
+    // @Description: Bitmask with one set for each output channel that uses a reversible ESC over DroneCAN. Reversible ESCs use both positive and negative values in RawCommands, with positive commanding the forward direction and negative commanding the reverse direction.
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16, 16: ESC 17, 17: ESC 18, 18: ESC 19, 19: ESC 20, 20: ESC 21, 21: ESC 22, 22: ESC 23, 23: ESC 24, 24: ESC 25, 25: ESC 26, 26: ESC 27, 27: ESC 28, 28: ESC 29, 29: ESC 30, 30: ESC 31, 31: ESC 32
+    // @User: Advanced
+    AP_GROUPINFO("ESC_RV", 9, AP_DroneCAN, _esc_rv, 0),
     
     AP_GROUPEND
 };
@@ -536,6 +543,20 @@ void AP_DroneCAN::handle_node_info_request(const CanardRxTransfer& transfer, con
     node_info_server.respond(transfer, node_info_rsp);
 }
 
+int16_t AP_DroneCAN::scale_esc_output(uint8_t idx){
+    static const int16_t cmd_max = ((1<<13)-1);
+    float scaled = 0;
+
+    //Check if this channel has a reversible ESC. If it does, we can send negative commands.
+    if ((((uint32_t) 1) << idx) & _esc_rv) {
+        scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[idx].pulse));
+    } else {
+        scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[idx].pulse) + 1.0) / 2.0;
+        scaled = constrain_float(scaled, 0, cmd_max);
+    }
+
+    return static_cast<int16_t>(scaled);
+}
 
 ///// SRV output /////
 
@@ -629,7 +650,6 @@ void AP_DroneCAN::SRV_send_himark(void)
 
 void AP_DroneCAN::SRV_send_esc(void)
 {
-    static const int cmd_max = ((1<<13)-1);
     uavcan_equipment_esc_RawCommand esc_msg;
 
     uint8_t active_esc_num = 0, max_esc_num = 0;
@@ -654,12 +674,7 @@ void AP_DroneCAN::SRV_send_esc(void)
 
         for (uint8_t i = esc_offset; i < max_esc_num && k < 20; i++) {
             if ((((uint32_t) 1) << i) & _ESC_armed_mask) {
-                // TODO: ESC negative scaling for reverse thrust and reverse rotation
-                float scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
-
-                scaled = constrain_float(scaled, 0, cmd_max);
-
-                esc_msg.cmd.data[k] = static_cast<int>(scaled);
+                esc_msg.cmd.data[k] = scale_esc_output(i);
             } else {
                 esc_msg.cmd.data[k] = static_cast<unsigned>(0);
             }
@@ -688,7 +703,6 @@ void AP_DroneCAN::SRV_send_esc(void)
  */
 void AP_DroneCAN::SRV_send_esc_hobbywing(void)
 {
-    static const int cmd_max = ((1<<13)-1);
     com_hobbywing_esc_RawCommand esc_msg;
 
     uint8_t active_esc_num = 0, max_esc_num = 0;
@@ -713,12 +727,7 @@ void AP_DroneCAN::SRV_send_esc_hobbywing(void)
 
         for (uint8_t i = esc_offset; i < max_esc_num && k < 20; i++) {
             if ((((uint32_t) 1) << i) & _ESC_armed_mask) {
-                // TODO: ESC negative scaling for reverse thrust and reverse rotation
-                float scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[i].pulse) + 1.0) / 2.0;
-
-                scaled = constrain_float(scaled, 0, cmd_max);
-
-                esc_msg.command.data[k] = static_cast<int>(scaled);
+                esc_msg.command.data[k] = scale_esc_output(i);
             } else {
                 esc_msg.command.data[k] = static_cast<unsigned>(0);
             }

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -147,6 +147,9 @@ private:
     void SRV_send_esc();
     void SRV_send_himark();
 
+    //scale servo output appropriately before sending
+    int16_t scale_esc_output(uint8_t idx);
+
     // SafetyState
     void safety_state_send();
 
@@ -188,6 +191,7 @@ private:
     AP_Int16 _options;
     AP_Int16 _notify_state_hz;
     AP_Int16 _pool_size;
+    AP_Int32 _esc_rv;
 
     uint32_t *mem_pool;
 


### PR DESCRIPTION
### Description
These changes are aimed at making it possible to control reversible DroneCAN ESCs in both directions. Previously,[  RawCommands](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#rawcommand) were restricted to the range [0,8191], so according to the DroneCAN specification attached ESCs could only spin in the forward direction. See #17497 , this should address that issue.

I added a new parameter (ESC_RM) which provides a bitmask that can be used to indicate if an ESC is reversible. This parameter name is tacked onto CAN_D1_UC, so there are not many characters left before hitting the 16 character limit. So I chose this relatively terse name. If an ESC is not reversible, the RawCommands are created and scaled in the same way they were before, which should help with backwards compatibility for existing users. If ESC_RM does indicate that the ESC is reversible, the command can use the full range of positiv and negative RawCommands.

I believe that currently only Plane and Rover fully support reversible ESCs based on what I've seen in some of the documentation, though I may be off on that. Currently, I have not restricted this parameter to only appear on some vehicle types, but I can change that if desired. It may make sense to hide it from Copter based on some of the testing results I discuss below in the Copter Testing section.

### Rover Testing
I did some testing on Rover using a Zubax Babel-Babel and a Vertiq 8108 to confirm that the RawCommands produced when using Motor Test in Mission Planner match my expectations

#### Motor Test with 0% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/f9183d0d-1736-4708-a415-e77202682601)

#### Motor Test with 50% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/c115ebe9-a8e1-4baa-8808-ab189a2e5055)

#### Motor Test with 100% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/765f88da-f4b1-4e48-9b5e-33307e1d7cad)

#### Motor Test with -25% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/cb54d6a0-61af-460c-b6e6-383de35ca45d)

#### Motor Test with -50% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/081ae787-2f25-4bb1-8a30-079b4f5abbf7)

#### Motor Test with -100% Throttle and ESC_RM Set
![image](https://github.com/ArduPilot/ardupilot/assets/95372252/aa978474-0154-47ed-b0af-9c38ab97b119)

### Copter Testing
I also did some testing with Copter out of curiosity. Copter does not support reversible ESCs as far as I understand. When ESC_RM was not set, the outputs acted the same as they always had, unsurprisingly. When it was set, 0% throttle produced -8191, 50% throttle produced 0, and 100% throttle produced 8191. The positive throttle range was divided between negative and positive DroneCAN commands. Negative throttles produced strange results, with -5% producing 7366, -10% producing 6555, and anything from -20% and below producing -8191. So, unsurprisingly, it seems that using this reversible ESC bitmask with Copter would produce strange results for now. Possibly someone would be interested in using the divided 0% to 100% throttle range, but that would probably cause other issues.


