### PR TITLE
AP_Camera: add support for the user to specify which gimbal each camera is in

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -78,6 +78,16 @@ void AP_Camera_Backend::update()
     take_picture();
 }
 
+// get corresponding mount instance for the camera
+uint8_t AP_Camera_Backend::get_mount_instance() const
+{
+    // instance 0 means default
+    if (_params.mount_instance.get() == 0) {
+        return _instance;
+    }
+    return _params.mount_instance.get() - 1;
+}
+
 // take a picture.  returns true on success
 bool AP_Camera_Backend::take_picture()
 {

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -134,6 +134,9 @@ protected:
     void Write_Trigger();
     void Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us=0);
 
+    // get corresponding mount instance for the camera
+    uint8_t get_mount_instance() const;
+
     // internal members
     uint8_t _instance;      // this instance's number
     bool timer_installed;   // true if feedback pin change detected using timer

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -68,8 +68,7 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
 #if HAL_MOUNT_ENABLED
     auto *mount = AP_Mount::get_singleton();
     if (mount!= nullptr) {
-        // assuming camera instance matches mount instance
-        mount->write_log(_instance, timestamp_us);
+        mount->write_log(get_mount_instance(), timestamp_us);
     }
 #endif
 }

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -10,7 +10,7 @@ bool AP_Camera_Mount::trigger_pic()
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        mount->take_picture(0);
+        mount->take_picture(get_mount_instance());
         return true;
     }
     return false;
@@ -22,7 +22,7 @@ bool AP_Camera_Mount::record_video(bool start_recording)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->record_video(0, start_recording);
+        return mount->record_video(get_mount_instance(), start_recording);
     }
     return false;
 }
@@ -32,7 +32,7 @@ bool AP_Camera_Mount::set_zoom(ZoomType zoom_type, float zoom_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_zoom(0, zoom_type, zoom_value);
+        return mount->set_zoom(get_mount_instance(), zoom_type, zoom_value);
     }
     return false;
 }
@@ -43,7 +43,7 @@ SetFocusResult AP_Camera_Mount::set_focus(FocusType focus_type, float focus_valu
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_focus(0, focus_type, focus_value);
+        return mount->set_focus(get_mount_instance(), focus_type, focus_value);
     }
     return SetFocusResult::FAILED;
 }
@@ -55,7 +55,7 @@ bool AP_Camera_Mount::set_tracking(TrackingType tracking_type, const Vector2f& p
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_tracking(0, tracking_type, p1, p2);
+        return mount->set_tracking(get_mount_instance(), tracking_type, p1, p2);
     }
     return false;
 }
@@ -66,7 +66,7 @@ bool AP_Camera_Mount::set_lens(uint8_t lens)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_lens(0, lens);
+        return mount->set_lens(get_mount_instance(), lens);
     }
     return false;
 }
@@ -76,7 +76,7 @@ void AP_Camera_Mount::send_camera_information(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_information(0, chan);
+        return mount->send_camera_information(get_mount_instance(), chan);
     }
 }
 
@@ -85,7 +85,7 @@ void AP_Camera_Mount::send_camera_settings(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_settings(0, chan);
+        return mount->send_camera_settings(get_mount_instance(), chan);
     }
 }
 

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -76,7 +76,7 @@ void AP_Camera_Mount::send_camera_information(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_information(chan);
+        return mount->send_camera_information(0, chan);
     }
 }
 
@@ -85,7 +85,7 @@ void AP_Camera_Mount::send_camera_settings(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_settings(chan);
+        return mount->send_camera_settings(0, chan);
     }
 }
 

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -81,6 +81,12 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 10, AP_Camera_Params, options, 0),
 
+    // @Param: _MNT_INST
+    // @DisplayName: Camera Mount instance
+    // @Description: Mount instance camera is associated with. 0 means camera and mount have identical instance numbers e.g. camera1 and mount1
+    // @User: Standard
+    AP_GROUPINFO("_MNT_INST", 11, AP_Camera_Params, mount_instance, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_Camera/AP_Camera_Params.h
+++ b/libraries/AP_Camera/AP_Camera_Params.h
@@ -22,6 +22,7 @@ public:
     AP_Int8 relay_on;           // relay value to trigger camera
     AP_Float interval_min;      // minimum time (in seconds) between shots required by camera
     AP_Int8 options;            // whether to start recording when armed and stop when disarmed
+    AP_Int8 mount_instance;     // mount instance to which camera is associated with
 
     // pin number for accurate camera feedback messages
     AP_Int8 feedback_pin;

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -805,25 +805,23 @@ bool AP_Mount::set_lens(uint8_t instance, uint8_t lens)
 }
 
 // send camera information message to GCS
-void AP_Mount::send_camera_information(mavlink_channel_t chan) const
+void AP_Mount::send_camera_information(uint8_t instance, mavlink_channel_t chan) const
 {
-    // call send_camera_information for each instance
-    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        if (_backends[instance] != nullptr) {
-            _backends[instance]->send_camera_information(chan);
-        }
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return;
     }
+    _backends[instance]->send_camera_information(chan);
 }
 
 // send camera settings message to GCS
-void AP_Mount::send_camera_settings(mavlink_channel_t chan) const
+void AP_Mount::send_camera_settings(uint8_t instance, mavlink_channel_t chan) const
 {
-    // call send_camera_settings for each instance
-    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        if (_backends[instance] != nullptr) {
-            _backends[instance]->send_camera_settings(chan);
-        }
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return;
     }
+    _backends[instance]->send_camera_settings(chan);
 }
 
 AP_Mount_Backend *AP_Mount::get_primary() const

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -486,7 +486,7 @@ void AP_Mount::handle_command_gimbal_manager_set_pitchyaw(const mavlink_message_
     if (!isnan(packet.pitch) && !isnan(packet.yaw)) {
         const float pitch_angle_deg = degrees(packet.pitch);
         const float yaw_angle_deg = degrees(packet.yaw);
-        set_angle_target(instance, 0, pitch_angle_deg, yaw_angle_deg, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        backend->set_angle_target(0, pitch_angle_deg, yaw_angle_deg, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return;
     }
 
@@ -494,7 +494,7 @@ void AP_Mount::handle_command_gimbal_manager_set_pitchyaw(const mavlink_message_
     if (!isnan(packet.pitch_rate) && !isnan(packet.yaw_rate)) {
         const float pitch_rate_degs = degrees(packet.pitch_rate);
         const float yaw_rate_degs = degrees(packet.yaw_rate);
-        set_rate_target(instance, 0, pitch_rate_degs, yaw_rate_degs, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        backend->set_rate_target(0, pitch_rate_degs, yaw_rate_degs, flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return;
     }
 }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -242,10 +242,10 @@ public:
     bool set_lens(uint8_t instance, uint8_t lens);
 
     // send camera information message to GCS
-    void send_camera_information(mavlink_channel_t chan) const;
+    void send_camera_information(uint8_t instance, mavlink_channel_t chan) const;
 
     // send camera settings message to GCS
-    void send_camera_settings(mavlink_channel_t chan) const;
+    void send_camera_settings(uint8_t instance, mavlink_channel_t chan) const;
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];


### PR DESCRIPTION
This adds a new parameter, CAMx_MNT_INST to allow users to specify which mount the camera is in.  This is useful in numerous situations including allowing the correct mount angles to be logged at the moment a picture is taken.
