### PR TITLE
Sub: AC_AttitudeControl_Sub: Improved yaw control

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
@@ -23,6 +23,8 @@
 #define AC_ATC_SUB_RATE_YAW_IMAX       0.222f
 #define AC_ATC_SUB_RATE_YAW_FILT_HZ    5.0f
 
+#define MAX_YAW_ERROR                  radians(5)
+
 class AC_AttitudeControl_Sub : public AC_AttitudeControl {
 public:
     AC_AttitudeControl_Sub(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors);
@@ -59,6 +61,9 @@ public:
 
     // sanity check parameters.  should be called once before take-off
     void parameter_sanity_check() override;
+
+    // This function ensures that the ROV reaches the target orientation with the desired yaw rate
+    void input_euler_angle_roll_pitch_slew_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float slew_yaw);
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This function ensures that the vehicle reaches the target orientation with the desired yaw rate.

Defined MAX_YAW_ERROR = 5 radians. This parameter defines the error between the current and target heading/yaw.

1. Computes the error between current vehicle heading and desired/target heading.
2. Computes the directionality of movement.
3. If the error is greater than MAX_YAW_ERROR, then rotate with desired yaw rate until the target heading is reached.
4. Else, hold the vehicle's orientation.