### PR TITLE
Plane: motor test index=0 to mean k_throttle

### DIFF
--- a/ArduPlane/motor_test.cpp
+++ b/ArduPlane/motor_test.cpp
@@ -24,7 +24,11 @@ void QuadPlane::motor_test_output()
         if (motor_test.motor_count > 1) {
             if (now - motor_test.start_ms < motor_test.timeout_ms*1.5) {
                 // output zero for 0.5s
-                motors->output_min();
+                if (motor_test.seq == 0) {
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
+                } else {
+                    motors->output_min();
+                }
             } else {
                 // move onto next motor
                 motor_test.seq++;
@@ -48,15 +52,27 @@ void QuadPlane::motor_test_output()
     case MOTOR_TEST_THROTTLE_PERCENT:
         // sanity check motor_test.throttle value
         if (motor_test.throttle_value <= 100) {
+            if (motor_test.seq == 0) {
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, motor_test.throttle_value);
+                return;
+            }
             pwm = thr_min_pwm + (thr_max_pwm - thr_min_pwm) * (float)motor_test.throttle_value*0.01f;
         }
         break;
 
     case MOTOR_TEST_THROTTLE_PWM:
+        if (motor_test.seq == 0) {
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, motor_test.throttle_value);
+            return;
+        }
         pwm = motor_test.throttle_value;
         break;
 
     case MOTOR_TEST_THROTTLE_PILOT:
+        if (motor_test.seq == 0) {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.get_throttle_input());
+            return;
+        }
         pwm = thr_min_pwm + (thr_max_pwm - thr_min_pwm) * plane.get_throttle_input()*0.01f;
         break;
 


### PR DESCRIPTION
MAVLink spec:
```
<entry name="MAV_CMD_DO_MOTOR_TEST" value="209">
<description>Mission command to perform motor test</description>
<param index="1">motor sequence number (a number from 1 to max number of motors on the vehicle)</param>
...
```
There is no "motor test" for forward throttle like there is for the other VTOL motors and other vehicles. This PR allows sequence=0 to mean k_throttle for planes. If this is something we like then we could also consider something for k_throttle_left/right and maybe others.. and then I'll make a MAVLink PR to update the docs. 


The only argument against this change that I can think of is the scenario of someone already using index 0 with a count of, lets say 5, and that would automatically cycle through running motors 0 then 1-4 with index=0 doing nothing. That could intentionally be used as an initial delay... which would now be spinning a motor that they aren't expecting causing a safety problem. However, if they *were* doing that then they're not following the spec and you probably shouldn't be doing hacks on a safety-critical thing like this.. so... maybe that's not our problem?