### PR TITLE
hwdef: arkv6x default to no IO MCU

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
@@ -82,10 +82,9 @@ PD9 USART3_RX USART3
 # USART6 is for IOMCU
 PC6 USART6_TX USART6
 PC7 USART6_RX USART6
-IOMCU_UART USART6
 
-# uart6, RX only, RC input, if no IOMCU
-# PC7 USART6_RX USART6
+# Uncomment this line for carriers boards with an IO MCU
+# IOMCU_UART USART6
 
 # ethernet (not implemented yet)
 #PA1 ETH_REF_CLK


### PR DESCRIPTION
This PR updates the ARKV6X hwdef to default to no IO MCU.