### PR TITLE
Blimp: Loiter class, add RTL and other improvements

### DIFF
--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -107,7 +107,7 @@ bool AP_Arming_Blimp::parameter_checks(bool display_failure)
         // failsafe parameter checks
         if (blimp.g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
-            if (blimp.channel_down->get_radio_min() <= blimp.g.failsafe_throttle_value+10 || blimp.g.failsafe_throttle_value < 910) {
+            if (blimp.channel_up->get_radio_min() <= blimp.g.failsafe_throttle_value+10 || blimp.g.failsafe_throttle_value < 910) {
                 check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check FS_THR_VALUE");
                 return false;
             }

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -217,12 +217,27 @@ void Blimp::read_AHRS(void)
     ahrs.update(true);
 
     IGNORE_RETURN(ahrs.get_velocity_NED(vel_ned));
-    IGNORE_RETURN(ahrs.get_relative_position_NED_home(pos_ned));
+    IGNORE_RETURN(ahrs.get_relative_position_NED_origin(pos_ned));
 
     vel_yaw = ahrs.get_yaw_rate_earth();
     Vector2f vel_xy_filtd = vel_xy_filter.apply({vel_ned.x, vel_ned.y});
     vel_ned_filtd = {vel_xy_filtd.x, vel_xy_filtd.y, vel_z_filter.apply(vel_ned.z)};
     vel_yaw_filtd = vel_yaw_filter.apply(vel_yaw);
+
+    AP::logger().WriteStreaming("VNF", "TimeUS,X,XF,Y,YF,Z,ZF,Yaw,YawF,PX,PY,PZ,PYaw", "Qffffffffffff",
+                                AP_HAL::micros64(),
+                                vel_ned.x,
+                                vel_ned_filtd.x,
+                                vel_ned.y,
+                                vel_ned_filtd.y,
+                                vel_ned.z,
+                                vel_ned_filtd.z,
+                                vel_yaw,
+                                vel_yaw_filtd,
+                                pos_ned.x,
+                                pos_ned.y,
+                                pos_ned.z,
+                                blimp.ahrs.get_yaw());
 }
 
 // read baro and log control tuning

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -111,7 +111,7 @@ private:
     // primary input control channels
     RC_Channel *channel_right;
     RC_Channel *channel_front;
-    RC_Channel *channel_down;
+    RC_Channel *channel_up;
     RC_Channel *channel_yaw;
 
     AP_Logger logger;

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -364,8 +364,8 @@ private:
     void Log_Write_Data(LogDataID id, float value);
     void Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, float tune_min, float tune_max);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
-    void Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out);
-    void Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z);
+
+
     void Log_Write_Vehicle_Startup_Messages();
     void log_init(void);
     void Write_FINI(float right, float front, float down, float yaw);
@@ -382,7 +382,7 @@ private:
     void notify_flight_mode();
 
     // mode_land.cpp
-    void set_mode_land_with_pause(ModeReason reason);
+    void set_mode_land_failsafe(ModeReason reason);
     bool landing_with_GPS();
 
     // // motors.cpp

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -59,6 +59,7 @@
 #include "config.h"
 
 #include "Fins.h"
+#include "Loiter.h"
 
 #include "RC_Channel.h"         // RC Channel Library
 
@@ -91,8 +92,10 @@ public:
     friend class ModeLand;
     friend class ModeVelocity;
     friend class ModeLoiter;
+    friend class ModeRTL;
 
     friend class Fins;
+    friend class Loiter;
 
     Blimp(void);
 
@@ -191,6 +194,7 @@ private:
 
     // Motor Output
     Fins *motors;
+    Loiter *loiter;
 
     int32_t _home_bearing;
     uint32_t _home_distance;
@@ -430,6 +434,7 @@ private:
     ModeLand mode_land;
     ModeVelocity mode_velocity;
     ModeLoiter mode_loiter;
+    ModeRTL mode_rtl;
 
     // mode.cpp
     Mode *mode_from_mode_num(const Mode::Number mode);

--- a/Blimp/Fins.h
+++ b/Blimp/Fins.h
@@ -10,6 +10,7 @@ class Fins
 {
 public:
     friend class Blimp;
+    friend class Loiter;
 
     enum motor_frame_class {
         MOTOR_FRAME_UNDEFINED = 0,
@@ -95,7 +96,7 @@ public:
     float get_throttle()
     {
         //Only for Mavlink - essentially just an indicator of how hard the fins are working.
-        //Note that this is the unconstrained version, so if the higher level control gives too high input, 
+        //Note that this is the unconstrained version, so if the higher level control gives too high input,
         //throttle will be displayed as more than 100.
         return fmaxf(fmaxf(fabsf(down_out),fabsf(front_out)), fmaxf(fabsf(right_out),fabsf(yaw_out)));
     }

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -102,11 +102,11 @@ int16_t GCS_MAVLINK_Blimp::vfr_hud_throttle() const
  */
 void GCS_MAVLINK_Blimp::send_pid_tuning()
 {
-    if(blimp.control_mode == Mode::Number::MANUAL || blimp.control_mode == Mode::Number::LAND) {
+    if (blimp.control_mode == Mode::Number::MANUAL || blimp.control_mode == Mode::Number::LAND) {
         //No PIDs are used in Manual or Land mode.
         return;
     }
-    
+
     static const int8_t axes[] = {
         PID_SEND::VELX,
         PID_SEND::VELY,

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -73,7 +73,7 @@ private:
         POSZ =        7,
         POSYAW =      8,
     };
-    
+
 #if HAL_HIGH_LATENCY2_ENABLED
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;

--- a/Blimp/Log.cpp
+++ b/Blimp/Log.cpp
@@ -92,7 +92,9 @@ void Blimp::Log_Write_PIDs()
 // Write an attitude packet
 void Blimp::Log_Write_Attitude()
 {
-
+    //Attitude targets are all zero since Blimp doesn't have attitude control,
+    //but the rest of the log message is useful.
+    ahrs.Write_Attitude(Vector3f{0,0,0});
 }
 
 // Write an EKF and POS packet
@@ -231,7 +233,6 @@ tuning_max     : tune_max
 
     logger.WriteBlock(&pkt_tune, sizeof(pkt_tune));
 }
-
 
 // type and unit information can be found in
 // libraries/AP_Logger/Logstructure.h; search for "log_Units" for
@@ -403,8 +404,6 @@ void Blimp::Log_Write_Data(LogDataID id, uint16_t value) {}
 void Blimp::Log_Write_Data(LogDataID id, float value) {}
 void Blimp::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, float tune_min, float tune_max) {}
 void Blimp::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
-void Blimp::Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out) {}
-void Blimp::Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z) {}
 void Blimp::Log_Write_Vehicle_Startup_Messages() {}
 
 void Blimp::log_init(void) {}

--- a/Blimp/Loiter.cpp
+++ b/Blimp/Loiter.cpp
@@ -1,0 +1,170 @@
+#include "Blimp.h"
+
+#define MA 0.99
+#define MO (1-MA)
+
+void Loiter::run(Vector3f& target_pos, float& target_yaw, Vector4b axes_disabled)
+{
+    const float dt = blimp.scheduler.get_last_loop_time_s();
+
+    float scaler_xz_n;
+    float xz_out = fabsf(blimp.motors->front_out) + fabsf(blimp.motors->down_out);
+    if (xz_out > 1) scaler_xz_n = 1 / xz_out;
+    else scaler_xz_n = 1;
+    scaler_xz = scaler_xz*MA + scaler_xz_n*MO;
+
+    float scaler_yyaw_n;
+    float yyaw_out = fabsf(blimp.motors->right_out) + fabsf(blimp.motors->yaw_out);
+    if (yyaw_out > 1) scaler_yyaw_n = 1 / yyaw_out;
+    else scaler_yyaw_n = 1;
+    scaler_yyaw = scaler_yyaw*MA + scaler_yyaw_n*MO;
+
+    AP::logger().WriteStreaming("BSC", "TimeUS,xz,yyaw,xzn,yyawn",
+                                "Qffff",
+                                AP_HAL::micros64(),
+                                scaler_xz, scaler_yyaw, scaler_xz_n, scaler_yyaw_n);
+
+    float yaw_ef = blimp.ahrs.get_yaw();
+    Vector3f err_xyz = target_pos - blimp.pos_ned;
+    float err_yaw = wrap_PI(target_yaw - yaw_ef);
+
+    Vector4b zero;
+    if((fabsf(err_xyz.x) < blimp.g.pid_dz) || !blimp.motors->_armed || (blimp.g.dis_mask & (1<<(2-1)))) zero.x = true;
+    if((fabsf(err_xyz.y) < blimp.g.pid_dz) || !blimp.motors->_armed || (blimp.g.dis_mask & (1<<(1-1)))) zero.y = true;
+    if((fabsf(err_xyz.z) < blimp.g.pid_dz) || !blimp.motors->_armed || (blimp.g.dis_mask & (1<<(3-1)))) zero.z = true;
+    if((fabsf(err_yaw)   < blimp.g.pid_dz) || !blimp.motors->_armed || (blimp.g.dis_mask & (1<<(4-1)))) zero.yaw = true;
+
+    //Disabled means "don't update PIDs or output anything at all". Zero means actually output zero thrust. I term is limited in either case."
+    Vector4b limit = zero || axes_disabled;
+
+    Vector3f target_vel_ef;
+    if(!axes_disabled.x && !axes_disabled.y) target_vel_ef = {blimp.pid_pos_xy.update_all(target_pos, blimp.pos_ned, dt, {(float)limit.x, (float)limit.y, (float)limit.z}), 0};
+    if(!axes_disabled.z) target_vel_ef.z = blimp.pid_pos_z.update_all(target_pos.z, blimp.pos_ned.z, dt, limit.z);
+
+    float target_vel_yaw = 0;
+    if (!axes_disabled.yaw) {
+        target_vel_yaw = blimp.pid_pos_yaw.update_error(wrap_PI(target_yaw - yaw_ef), dt, limit.yaw);
+        blimp.pid_pos_yaw.set_target_rate(target_yaw);
+        blimp.pid_pos_yaw.set_actual_rate(yaw_ef);
+    }
+
+    Vector3f target_vel_ef_c{constrain_float(target_vel_ef.x, -blimp.g.max_vel_xy, blimp.g.max_vel_xy),
+                             constrain_float(target_vel_ef.y, -blimp.g.max_vel_xy, blimp.g.max_vel_xy),
+                             constrain_float(target_vel_ef.z, -blimp.g.max_vel_z, blimp.g.max_vel_z)};
+    float target_vel_yaw_c = constrain_float(target_vel_yaw, -blimp.g.max_vel_yaw, blimp.g.max_vel_yaw);
+
+    Vector2f target_vel_ef_c_scaled_xy = {target_vel_ef_c.x * scaler_xz, target_vel_ef_c.y * scaler_yyaw};
+    Vector2f vel_ned_filtd_scaled_xy = {blimp.vel_ned_filtd.x * scaler_xz, blimp.vel_ned_filtd.y * scaler_yyaw};
+
+    Vector2f actuator;
+    if (!axes_disabled.x && !axes_disabled.y) actuator = blimp.pid_vel_xy.update_all(target_vel_ef_c_scaled_xy, vel_ned_filtd_scaled_xy, dt, {(float)limit.x, (float)limit.y});
+    float act_down = 0;
+    if(!axes_disabled.z) act_down = blimp.pid_vel_z.update_all(target_vel_ef_c.z * scaler_xz, blimp.vel_ned_filtd.z * scaler_xz, dt, limit.z);
+    blimp.rotate_NE_to_BF(actuator);
+    float act_yaw = 0;
+    if(!axes_disabled.yaw) act_yaw = blimp.pid_vel_yaw.update_all(target_vel_yaw_c * scaler_yyaw, blimp.vel_yaw_filtd * scaler_yyaw, dt, limit.yaw);
+
+    if (!blimp.motors->armed()) {
+        blimp.pid_pos_xy.set_integrator(Vector2f(0,0));
+        blimp.pid_pos_z.set_integrator(0);
+        blimp.pid_pos_yaw.set_integrator(0);
+        blimp.pid_vel_xy.set_integrator(Vector2f(0,0));
+        blimp.pid_vel_z.set_integrator(0);
+        blimp.pid_vel_yaw.set_integrator(0);
+        target_pos = blimp.pos_ned;
+        target_yaw = blimp.ahrs.get_yaw();
+    }
+
+    if (zero.x) {
+        blimp.motors->front_out = 0;
+    } else if (axes_disabled.x);
+    else {
+        blimp.motors->front_out = actuator.x;
+    }
+    if (zero.y) {
+        blimp.motors->right_out = 0;
+    } else if (axes_disabled.y);
+    else {
+        blimp.motors->right_out = actuator.y;
+    }
+    if (zero.z) {
+        blimp.motors->down_out = 0;
+    } else if (axes_disabled.z);
+    else {
+        blimp.motors->down_out = act_down;
+    }
+    if (zero.yaw) {
+        blimp.motors->yaw_out  = 0;
+    } else if (axes_disabled.yaw);
+    else {
+        blimp.motors->yaw_out = act_yaw;
+    }
+
+    AP::logger().Write_PSCN(target_pos.x * 100.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
+    AP::logger().Write_PSCE(target_pos.y * 100.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
+    AP::logger().Write_PSCD(-target_pos.z * 100.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+}
+
+void Loiter::run_vel(Vector3f& target_vel_ef, float& target_vel_yaw, Vector4b axes_disabled)
+{
+    const float dt = blimp.scheduler.get_last_loop_time_s();
+
+    Vector4b zero;
+    if(!blimp.motors->_armed || (blimp.g.dis_mask & (1<<(2-1)))) zero.x = true;
+    if(!blimp.motors->_armed || (blimp.g.dis_mask & (1<<(1-1)))) zero.y = true;
+    if(!blimp.motors->_armed || (blimp.g.dis_mask & (1<<(3-1)))) zero.z = true;
+    if(!blimp.motors->_armed || (blimp.g.dis_mask & (1<<(4-1)))) zero.yaw = true;
+    //Disabled means "don't update PIDs or output anything at all". Zero means actually output zero thrust. I term is limited in either case."
+    Vector4b limit = zero || axes_disabled;
+
+    Vector3f target_vel_ef_c{constrain_float(target_vel_ef.x, -blimp.g.max_vel_xy, blimp.g.max_vel_xy),
+                             constrain_float(target_vel_ef.y, -blimp.g.max_vel_xy, blimp.g.max_vel_xy),
+                             constrain_float(target_vel_ef.z, -blimp.g.max_vel_z, blimp.g.max_vel_z)};
+    float target_vel_yaw_c = constrain_float(target_vel_yaw, -blimp.g.max_vel_yaw, blimp.g.max_vel_yaw);
+
+    Vector2f target_vel_ef_c_scaled_xy = {target_vel_ef_c.x * scaler_xz, target_vel_ef_c.y * scaler_yyaw};
+    Vector2f vel_ned_filtd_scaled_xy = {blimp.vel_ned_filtd.x * scaler_xz, blimp.vel_ned_filtd.y * scaler_yyaw};
+
+    Vector2f actuator;
+    if (!axes_disabled.x && !axes_disabled.y) actuator = blimp.pid_vel_xy.update_all(target_vel_ef_c_scaled_xy, vel_ned_filtd_scaled_xy, dt, {(float)limit.x, (float)limit.y});
+    float act_down = 0;
+    if(!axes_disabled.z) act_down = blimp.pid_vel_z.update_all(target_vel_ef_c.z * scaler_xz, blimp.vel_ned_filtd.z * scaler_xz, dt, limit.z);
+    blimp.rotate_NE_to_BF(actuator);
+    float act_yaw = 0;
+    if(!axes_disabled.yaw) act_yaw = blimp.pid_vel_yaw.update_all(target_vel_yaw_c * scaler_yyaw, blimp.vel_yaw_filtd * scaler_yyaw, dt, limit.yaw);
+
+    if (!blimp.motors->armed()) {
+        blimp.pid_vel_xy.set_integrator(Vector2f(0,0));
+        blimp.pid_vel_z.set_integrator(0);
+        blimp.pid_vel_yaw.set_integrator(0);
+    }
+
+    if (zero.x) {
+        blimp.motors->front_out = 0;
+    } else if (axes_disabled.x);
+    else {
+        blimp.motors->front_out = actuator.x;
+    }
+    if (zero.y) {
+        blimp.motors->right_out = 0;
+    } else if (axes_disabled.y);
+    else {
+        blimp.motors->right_out = actuator.y;
+    }
+    if (zero.z) {
+        blimp.motors->down_out = 0;
+    } else if (axes_disabled.z);
+    else {
+        blimp.motors->down_out = act_down;
+    }
+    if (zero.yaw) {
+        blimp.motors->yaw_out  = 0;
+    } else if (axes_disabled.yaw);
+    else {
+        blimp.motors->yaw_out = act_yaw;
+    }
+
+    AP::logger().Write_PSCN(0.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
+    AP::logger().Write_PSCE(0.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
+    AP::logger().Write_PSCD(0.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+}

--- a/Blimp/Loiter.h
+++ b/Blimp/Loiter.h
@@ -1,0 +1,59 @@
+#pragma once
+
+class Vector4b
+{
+public:
+    bool    x;
+    bool    y;
+    bool    z;
+    bool    yaw;
+
+    constexpr Vector4b()
+        : x(0)
+        , y(0)
+        , z(0)
+        , yaw(0) {}
+
+    constexpr Vector4b(const bool x0, const bool y0, const bool z0, const bool yaw0)
+        : x(x0)
+        , y(y0)
+        , z(z0)
+        , yaw(yaw0) {}
+
+    Vector4b operator &&(const Vector4b &v)
+    {
+        Vector4b temp{x && v.x, y && v.y, z && v.z, yaw && v.yaw};
+        return temp;
+    }
+
+    Vector4b operator ||(const Vector4b &v)
+    {
+        Vector4b temp{x || v.x, y || v.y, z || v.z, yaw || v.yaw};
+        return temp;
+    }
+
+};
+
+
+
+class Loiter
+{
+public:
+    friend class Blimp;
+    friend class Fins;
+
+    float scaler_xz;
+    float scaler_yyaw;
+
+    //constructor
+    Loiter(uint16_t loop_rate)
+    {
+        scaler_xz = 1;
+        scaler_yyaw = 1;
+    };
+
+    //Run Loiter controller with target position and yaw in global frame. Expects to be called at loop rate.
+    void run(Vector3f& target_pos, float& target_yaw, Vector4b axes_disabled);
+    //Run Loiter controller with target velocity and velocity in global frame. Expects to be called at loop rate.
+    void run_vel(Vector3f& target_vel, float& target_vel_yaw, Vector4b axes_disabled);
+};

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -53,15 +53,6 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Increment: .5
     GSCALAR(throttle_filt,  "PILOT_THR_FILT",     0),
 
-    // @Param: PILOT_TKOFF_ALT
-    // @DisplayName: Pilot takeoff altitude
-    // @Description: Altitude that altitude control modes will climb to when a takeoff is triggered with the throttle stick.
-    // @User: Standard
-    // @Units: cm
-    // @Range: 0.0 1000.0
-    // @Increment: 10
-    GSCALAR(pilot_takeoff_alt,  "PILOT_TKOFF_ALT",  PILOT_TKOFF_ALT_DEFAULT),
-
     // @Param: PILOT_THR_BHV
     // @DisplayName: Throttle stick behavior
     // @Description: Bitmask containing various throttle stick options. TX with sprung throttle can set PILOT_THR_BHV to "1" so motor feedback when landed starts from mid-stick instead of bottom of stick.
@@ -184,7 +175,7 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in on-board logger. This value is made up of the sum of each of the log types you want to be saved. On boards supporting microSD cards or other large block-storage devices it is usually best just to enable all basic log types by setting this to 65535.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:System Performance,4:Control Tuning,6:RC Input,7:IMU,9:Battery Monitor,10:RC Output,11:Optical Flow,12:PID,13:Compass
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:System Performance,4:Control Tuning,6:RC Input,7:IMU,9:Battery Monitor,10:RC Output,12:PID,13:Compass
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 
@@ -272,7 +263,7 @@ const AP_Param::Info Blimp::var_info[] = {
 
     // @Param: DIS_MASK
     // @DisplayName: Disable output mask
-    // @Description: Mask for disabling one or more of the 4 output axis in mode Velocity or Loiter
+    // @Description: Mask for disabling (setting to zero) one or more of the 4 output axis in mode Velocity or Loiter
     // @Values: 0:All enabled,1:Right,2:Front,4:Down,8:Yaw,3:Down and Yaw only,12:Front & Right only
     // @Bitmask: 0:Right,1:Front,2:Down,3:Yaw
     // @User: Standard

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -278,6 +278,14 @@ const AP_Param::Info Blimp::var_info[] = {
     // @User: Standard
     GSCALAR(dis_mask, "DIS_MASK", 0),
 
+    // @Param: PID_DZ
+    // @DisplayName: Deadzone for the position PIDs
+    // @Description: Output 0 thrust signal when blimp is within this distance (in meters) of the target position. Warning: If this param is greater than MAX_POS_XY param then the blimp won't move at all in the XY plane in Loiter mode as it does not allow more than a second's lag. Same for the other axes.
+    // @Units: m
+    // @Range: 0.1 1
+    // @User: Standard
+    GSCALAR(pid_dz, "PID_DZ", 0),
+
     // @Param: RC_SPEED
     // @DisplayName: ESC Update Speed
     // @Description: This is the speed in Hertz that your ESCs will receive updates

--- a/Blimp/Parameters.h
+++ b/Blimp/Parameters.h
@@ -110,6 +110,7 @@ public:
         k_param_max_pos_yaw,
         k_param_simple_mode,
         k_param_dis_mask,
+        k_param_pid_dz,
 
         //
         // 90: misc2
@@ -254,6 +255,7 @@ public:
 
     AP_Int8         simple_mode;
     AP_Int16        dis_mask;
+    AP_Float        pid_dz;
 
     AP_Int8         rtl_alt_type;
 

--- a/Blimp/Parameters.h
+++ b/Blimp/Parameters.h
@@ -87,7 +87,7 @@ public:
         k_param_log_bitmask,
         k_param_throttle_filt,
         k_param_throttle_behavior,
-        k_param_pilot_takeoff_alt,
+        k_param_pilot_takeoff_alt, //unused
 
         // AP_ADSB Library
         k_param_adsb,
@@ -136,7 +136,7 @@ public:
         k_param_gcs2,
         k_param_serial_manager,
         k_param_gcs3,
-        k_param_gcs_pid_mask,    // 126
+        k_param_gcs_pid_mask,
         k_param_gcs4,
         k_param_gcs5,
         k_param_gcs6,
@@ -214,7 +214,6 @@ public:
 
     AP_Float        throttle_filt;
     AP_Int16        throttle_behavior;
-    AP_Float        pilot_takeoff_alt;
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position

--- a/Blimp/RC_Channel.cpp
+++ b/Blimp/RC_Channel.cpp
@@ -106,7 +106,7 @@ bool RC_Channel_Blimp::do_aux_function(const aux_func_t ch_option, const AuxSwit
     case AUX_FUNC::SAVE_TRIM:
         if ((ch_flag == AuxSwitchPos::HIGH) &&
             (blimp.control_mode <= Mode::Number::MANUAL) &&
-            (blimp.channel_down->get_control_in() == 0)) {
+            (blimp.channel_up->get_control_in() == 0)) {
             blimp.save_trim();
         }
         break;

--- a/Blimp/config.h
+++ b/Blimp/config.h
@@ -23,64 +23,10 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
-// FRAME_CONFIG
-//
-#ifndef FRAME_CONFIG
-# define FRAME_CONFIG   MULTICOPTER_FRAME
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
 // PWM control
 // default RC speed in Hz
 #ifndef RC_FAST_SPEED
 #   define RC_FAST_SPEED 490
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Rangefinder
-//
-
-#ifndef RANGEFINDER_ENABLED
-# define RANGEFINDER_ENABLED ENABLED
-#endif
-
-#ifndef RANGEFINDER_HEALTH_MAX
-# define RANGEFINDER_HEALTH_MAX 3          // number of good reads that indicates a healthy rangefinder
-#endif
-
-#ifndef RANGEFINDER_TIMEOUT_MS
-# define RANGEFINDER_TIMEOUT_MS 1000        // rangefinder filter reset if no updates from sensor in 1 second
-#endif
-
-#ifndef RANGEFINDER_GAIN_DEFAULT
-# define RANGEFINDER_GAIN_DEFAULT 0.8f     // gain for controlling how quickly rangefinder range adjusts target altitude (lower means slower reaction)
-#endif
-
-#ifndef SURFACE_TRACKING_TIMEOUT_MS
-# define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
-#endif
-
-#ifndef RANGEFINDER_WPNAV_FILT_HZ
-# define RANGEFINDER_WPNAV_FILT_HZ   0.25f // filter frequency for rangefinder altitude provided to waypoint navigation class
-#endif
-
-#ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF
-# define RANGEFINDER_TILT_CORRECTION ENABLED
-#endif
-
-#ifndef RANGEFINDER_GLITCH_ALT_CM
-# define RANGEFINDER_GLITCH_ALT_CM  200      // amount of rangefinder change to be considered a glitch
-#endif
-
-#ifndef RANGEFINDER_GLITCH_NUM_SAMPLES
-# define RANGEFINDER_GLITCH_NUM_SAMPLES  3   // number of rangefinder glitches in a row to take new reading
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Proximity sensor
-//
-#ifndef PROXIMITY_ENABLED
-# define PROXIMITY_ENABLED ENABLED
 #endif
 
 #ifndef MAV_SYSTEM_ID
@@ -126,99 +72,8 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
-//  OPTICAL_FLOW
-#ifndef OPTFLOW
-# define OPTFLOW       ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-//  Auto Tuning
-#ifndef AUTOTUNE_ENABLED
-# define AUTOTUNE_ENABLED  ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Parachute release
-#ifndef PARACHUTE
-# define PARACHUTE HAL_PARACHUTE_ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Acro - fly vehicle in acrobatic mode
-#ifndef MODE_ACRO_ENABLED
-# define MODE_ACRO_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Auto mode - allows vehicle to trace waypoints and perform automated actions
-#ifndef MODE_AUTO_ENABLED
-# define MODE_AUTO_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Brake mode - bring vehicle to stop
-#ifndef MODE_BRAKE_ENABLED
-# define MODE_BRAKE_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Circle - fly vehicle around a central point
-#ifndef MODE_CIRCLE_ENABLED
-# define MODE_CIRCLE_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Drift - fly vehicle in altitude-held, coordinated-turn mode
-#ifndef MODE_DRIFT_ENABLED
-# define MODE_DRIFT_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// flip - fly vehicle in flip in pitch and roll direction mode
-#ifndef MODE_FLIP_ENABLED
-# define MODE_FLIP_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Guided mode - control vehicle's position or angles from GCS
-#ifndef MODE_GUIDED_ENABLED
-# define MODE_GUIDED_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Loiter mode - allows vehicle to hold global position
-#ifndef MODE_LOITER_ENABLED
-# define MODE_LOITER_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Position Hold - enable holding of global position
-#ifndef MODE_POSHOLD_ENABLED
-# define MODE_POSHOLD_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// RTL - Return To Launch
-#ifndef MODE_RTL_ENABLED
-# define MODE_RTL_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// SmartRTL - allows vehicle to retrace a (loop-eliminated) breadcrumb home
-#ifndef MODE_SMARTRTL_ENABLED
-# define MODE_SMARTRTL_ENABLED ENABLED
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// RADIO CONFIGURATION
-//////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
-
-
-//////////////////////////////////////////////////////////////////////////////
 // FLIGHT_MODE
 //
-
 #ifndef FLIGHT_MODE_1
 # define FLIGHT_MODE_1                  Mode::Number::MANUAL
 #endif
@@ -238,7 +93,6 @@
 # define FLIGHT_MODE_6                  Mode::Number::MANUAL
 #endif
 
-
 //////////////////////////////////////////////////////////////////////////////
 // Throttle Failsafe
 //
@@ -247,185 +101,14 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
-// Takeoff
-//
-#ifndef PILOT_TKOFF_ALT_DEFAULT
-# define PILOT_TKOFF_ALT_DEFAULT           0     // default final alt above home for pilot initiated takeoff
-#endif
-
-
-//////////////////////////////////////////////////////////////////////////////
-// Landing
-//
-#ifndef LAND_SPEED
-# define LAND_SPEED    50          // the descent speed for the final stage of landing in cm/s
-#endif
-#ifndef LAND_REPOSITION_DEFAULT
-# define LAND_REPOSITION_DEFAULT   1   // by default the pilot can override roll/pitch during landing
-#endif
-#ifndef LAND_WITH_DELAY_MS
-# define LAND_WITH_DELAY_MS        4000    // default delay (in milliseconds) when a land-with-delay is triggered during a failsafe event
-#endif
-#ifndef LAND_CANCEL_TRIGGER_THR
-# define LAND_CANCEL_TRIGGER_THR   700     // land is cancelled by input throttle above 700
-#endif
-#ifndef LAND_RANGEFINDER_MIN_ALT_CM
-#define LAND_RANGEFINDER_MIN_ALT_CM 200
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Landing Detector
-//
-#ifndef LAND_DETECTOR_TRIGGER_SEC
-# define LAND_DETECTOR_TRIGGER_SEC         1.0f    // number of seconds to detect a landing
-#endif
-#ifndef LAND_DETECTOR_MAYBE_TRIGGER_SEC
-# define LAND_DETECTOR_MAYBE_TRIGGER_SEC   0.2f    // number of seconds that means we might be landed (used to reset horizontal position targets to prevent tipping over)
-#endif
-#ifndef LAND_DETECTOR_ACCEL_LPF_CUTOFF
-# define LAND_DETECTOR_ACCEL_LPF_CUTOFF     1.0f    // frequency cutoff of land detector accelerometer filter
-#endif
-#ifndef LAND_DETECTOR_ACCEL_MAX
-# define LAND_DETECTOR_ACCEL_MAX            1.0f    // vehicle acceleration must be under 1m/s/s
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Flight mode definitions
-//
-
-// Acro Mode
-#ifndef ACRO_RP_P
-# define ACRO_RP_P                 4.5f
-#endif
-
-#ifndef ACRO_YAW_P
-# define ACRO_YAW_P                4.5f
-#endif
-
-#ifndef ACRO_LEVEL_MAX_ANGLE
-# define ACRO_LEVEL_MAX_ANGLE      3000
-#endif
-
-#ifndef ACRO_BALANCE_ROLL
-#define ACRO_BALANCE_ROLL          1.0f
-#endif
-
-#ifndef ACRO_BALANCE_PITCH
-#define ACRO_BALANCE_PITCH         1.0f
-#endif
-
-#ifndef ACRO_RP_EXPO_DEFAULT
-#define ACRO_RP_EXPO_DEFAULT       0.3f
-#endif
-
-#ifndef ACRO_Y_EXPO_DEFAULT
-#define ACRO_Y_EXPO_DEFAULT        0.0f
-#endif
-
-#ifndef ACRO_THR_MID_DEFAULT
-#define ACRO_THR_MID_DEFAULT       0.0f
-#endif
-
-// RTL Mode
-#ifndef RTL_ALT_FINAL
-# define RTL_ALT_FINAL             0       // the altitude the vehicle will move to as the final stage of Returning to Launch.  Set to zero to land.
-#endif
-
-#ifndef RTL_ALT
-# define RTL_ALT                   1500    // default alt to return to home in cm, 0 = Maintain current altitude
-#endif
-
-#ifndef RTL_ALT_MIN
-# define RTL_ALT_MIN               200     // min height above ground for RTL (i.e 2m)
-#endif
-
-#ifndef RTL_CLIMB_MIN_DEFAULT
-# define RTL_CLIMB_MIN_DEFAULT     0       // vehicle will always climb this many cm as first stage of RTL
-#endif
-
-#ifndef RTL_ABS_MIN_CLIMB
-# define RTL_ABS_MIN_CLIMB         250     // absolute minimum initial climb
-#endif
-
-#ifndef RTL_CONE_SLOPE_DEFAULT
-# define RTL_CONE_SLOPE_DEFAULT    3.0f    // slope of RTL cone (height / distance). 0 = No cone
-#endif
-
-#ifndef RTL_MIN_CONE_SLOPE
-# define RTL_MIN_CONE_SLOPE        0.5f    // minimum slope of cone
-#endif
-
-#ifndef RTL_LOITER_TIME
-# define RTL_LOITER_TIME           5000    // Time (in milliseconds) to loiter above home before beginning final descent
-#endif
-
-// AUTO Mode
-#ifndef WP_YAW_BEHAVIOR_DEFAULT
-# define WP_YAW_BEHAVIOR_DEFAULT   WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL
-#endif
-
-#ifndef YAW_LOOK_AHEAD_MIN_SPEED
-# define YAW_LOOK_AHEAD_MIN_SPEED  100             // minimum ground speed in cm/s required before blimp is aimed at ground course
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Stabilize Rate Control
-//
-#ifndef ROLL_PITCH_YAW_INPUT_MAX
-# define ROLL_PITCH_YAW_INPUT_MAX      4500        // roll, pitch and yaw input range
-#endif
-#ifndef DEFAULT_ANGLE_MAX
-# define DEFAULT_ANGLE_MAX         4500            // ANGLE_MAX parameters default value
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Stop mode defaults
-//
-#ifndef BRAKE_MODE_SPEED_Z
-# define BRAKE_MODE_SPEED_Z     250 // z-axis speed in cm/s in Brake Mode
-#endif
-#ifndef BRAKE_MODE_DECEL_RATE
-# define BRAKE_MODE_DECEL_RATE  750 // acceleration rate in cm/s/s in Brake Mode
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// PosHold parameter defaults
-//
-#ifndef POSHOLD_BRAKE_RATE_DEFAULT
-# define POSHOLD_BRAKE_RATE_DEFAULT    8       // default POSHOLD_BRAKE_RATE param value.  Rotation rate during braking in deg/sec
-#endif
-#ifndef POSHOLD_BRAKE_ANGLE_DEFAULT
-# define POSHOLD_BRAKE_ANGLE_DEFAULT   3000    // default POSHOLD_BRAKE_ANGLE param value.  Max lean angle during braking in centi-degrees
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
 // Throttle control defaults
 //
-
 #ifndef THR_DZ_DEFAULT
 # define THR_DZ_DEFAULT         100             // the deadzone above and below mid throttle while in althold or loiter
 #endif
 
-// default maximum vertical velocity and acceleration the pilot may request
-#ifndef PILOT_VELZ_MAX
-# define PILOT_VELZ_MAX    250     // maximum vertical velocity in cm/s
-#endif
-#ifndef PILOT_ACCEL_Z_DEFAULT
-# define PILOT_ACCEL_Z_DEFAULT 250 // vertical acceleration in cm/s/s while altitude is under pilot control
-#endif
-
 #ifndef AUTO_DISARMING_DELAY
 # define AUTO_DISARMING_DELAY  10
-#endif
-
-//////////////////////////////////////////////////////////////////////////////
-// Throw mode configuration
-//
-#ifndef THROW_HIGH_SPEED
-# define THROW_HIGH_SPEED       500.0f  // vehicle much reach this total 3D speed in cm/s (or be free falling)
-#endif
-#ifndef THROW_VERTICAL_SPEED
-# define THROW_VERTICAL_SPEED   50.0f   // motors start when vehicle reaches this total 3D speed in cm/s
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/Blimp/defines.h
+++ b/Blimp/defines.h
@@ -10,111 +10,6 @@
 #define ENABLE ENABLED
 #define DISABLE DISABLED
 
-// Autopilot Yaw Mode enumeration
-enum autopilot_yaw_mode {
-    AUTO_YAW_HOLD =             0,  // pilot controls the heading
-    AUTO_YAW_LOOK_AT_NEXT_WP =  1,  // point towards next waypoint (no pilot input accepted)
-    AUTO_YAW_ROI =              2,  // point towards a location held in roi (no pilot input accepted)
-    AUTO_YAW_FIXED =            3,  // point towards a particular angle (no pilot input accepted)
-    AUTO_YAW_LOOK_AHEAD =       4,  // point in the direction the blimp is moving
-    AUTO_YAW_RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
-    AUTO_YAW_RATE =             6,  // turn at a specified rate (held in auto_yaw_rate)
-    AUTO_YAW_CIRCLE =           7,  // use AC_Circle's provided yaw (used during Loiter-Turns commands)
-};
-
-// Frame types
-#define UNDEFINED_FRAME 0
-#define MULTICOPTER_FRAME 1
-#define HELI_FRAME 2
-
-// Tuning enumeration
-enum tuning_func {
-    TUNING_NONE =                        0, //
-    TUNING_STABILIZE_ROLL_PITCH_KP =     1, // stabilize roll/pitch angle controller's P term
-    TUNING_STABILIZE_YAW_KP =            3, // stabilize yaw heading controller's P term
-    TUNING_RATE_ROLL_PITCH_KP =          4, // body frame roll/pitch rate controller's P term
-    TUNING_RATE_ROLL_PITCH_KI =          5, // body frame roll/pitch rate controller's I term
-    TUNING_YAW_RATE_KP =                 6, // body frame yaw rate controller's P term
-    TUNING_THROTTLE_RATE_KP =            7, // throttle rate controller's P term (desired rate to acceleration or motor output)
-    TUNING_WP_SPEED =                   10, // maximum speed to next way point (0 to 10m/s)
-    TUNING_LOITER_POSITION_KP =         12, // loiter distance controller's P term (position error to speed)
-    TUNING_HELI_EXTERNAL_GYRO =         13, // TradHeli specific external tail gyro gain
-    TUNING_ALTITUDE_HOLD_KP =           14, // altitude hold controller's P term (alt error to desired rate)
-    TUNING_RATE_ROLL_PITCH_KD =         21, // body frame roll/pitch rate controller's D term
-    TUNING_VEL_XY_KP =                  22, // loiter rate controller's P term (speed error to tilt angle)
-    TUNING_ACRO_RP_KP =                 25, // acro controller's P term.  converts pilot input to a desired roll, pitch or yaw rate
-    TUNING_YAW_RATE_KD =                26, // body frame yaw rate controller's D term
-    TUNING_VEL_XY_KI =                  28, // loiter rate controller's I term (speed error to tilt angle)
-    TUNING_AHRS_YAW_KP =                30, // ahrs's compass effect on yaw angle (0 = very low, 1 = very high)
-    TUNING_AHRS_KP =                    31, // accelerometer effect on roll/pitch angle (0=low)
-    TUNING_ACCEL_Z_KP =                 34, // accel based throttle controller's P term
-    TUNING_ACCEL_Z_KI =                 35, // accel based throttle controller's I term
-    TUNING_ACCEL_Z_KD =                 36, // accel based throttle controller's D term
-    TUNING_DECLINATION =                38, // compass declination in radians
-    TUNING_CIRCLE_RATE =                39, // circle turn rate in degrees (hard coded to about 45 degrees in either direction)
-    TUNING_ACRO_YAW_KP =                40, // acro controller's P term.  converts pilot input to a desired roll, pitch or yaw rate
-    TUNING_RANGEFINDER_GAIN =           41, // rangefinder gain
-    TUNING_EKF_VERTICAL_POS =           42, // unused
-    TUNING_EKF_HORIZONTAL_POS =         43, // unused
-    TUNING_EKF_ACCEL_NOISE =            44, // unused
-    TUNING_RC_FEEL_RP =                 45, // roll-pitch input smoothing
-    TUNING_RATE_PITCH_KP =              46, // body frame pitch rate controller's P term
-    TUNING_RATE_PITCH_KI =              47, // body frame pitch rate controller's I term
-    TUNING_RATE_PITCH_KD =              48, // body frame pitch rate controller's D term
-    TUNING_RATE_ROLL_KP =               49, // body frame roll rate controller's P term
-    TUNING_RATE_ROLL_KI =               50, // body frame roll rate controller's I term
-    TUNING_RATE_ROLL_KD =               51, // body frame roll rate controller's D term
-    TUNING_RATE_PITCH_FF =              52, // body frame pitch rate controller FF term
-    TUNING_RATE_ROLL_FF =               53, // body frame roll rate controller FF term
-    TUNING_RATE_YAW_FF =                54, // body frame yaw rate controller FF term
-    TUNING_RATE_MOT_YAW_HEADROOM =      55, // motors yaw headroom minimum
-    TUNING_RATE_YAW_FILT =              56, // yaw rate input filter
-    UNUSED =                            57, // was winch control
-    TUNING_SYSTEM_ID_MAGNITUDE =        58  // magnitude of the system ID signal
-};
-
-// Yaw behaviours during missions - possible values for WP_YAW_BEHAVIOR parameter
-#define WP_YAW_BEHAVIOR_NONE                          0   // auto pilot will never control yaw during missions or rtl (except for DO_CONDITIONAL_YAW command received)
-#define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP               1   // auto pilot will face next waypoint or home during rtl
-#define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL    2   // auto pilot will face next waypoint except when doing RTL at which time it will stay in it's last
-#define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicopters)
-
-// Auto modes
-enum AutoMode {
-    Auto_TakeOff,
-    Auto_WP,
-    Auto_Land,
-    Auto_RTL,
-    Auto_CircleMoveToEdge,
-    Auto_Circle,
-    Auto_Spline,
-    Auto_NavGuided,
-    Auto_Loiter,
-    Auto_LoiterToAlt,
-    Auto_NavPayloadPlace,
-};
-
-// Guided modes
-enum GuidedMode {
-    Guided_TakeOff,
-    Guided_WP,
-    Guided_Velocity,
-    Guided_PosVel,
-    Guided_Angle,
-};
-
-enum PayloadPlaceStateType {
-    PayloadPlaceStateType_FlyToLocation,
-    PayloadPlaceStateType_Descent_Start,
-    PayloadPlaceStateType_Descent,
-    PayloadPlaceStateType_Release,
-    PayloadPlaceStateType_Releasing,
-    PayloadPlaceStateType_Delay,
-    PayloadPlaceStateType_Ascent_Start,
-    PayloadPlaceStateType_Ascent,
-    PayloadPlaceStateType_Done,
-};
-
 // bit options for DEV_OPTIONS parameter
 enum DevOptions {
     DevOptionADSBMAVLink = 1,
@@ -184,8 +79,7 @@ enum LoggingParameters {
 
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe
-#define FS_EKF_ACTION_ALTHOLD               2       // switch to ALTHOLD mode on EKF failsafe
-#define FS_EKF_ACTION_LAND_EVEN_STABILIZE   3       // switch to Land mode on EKF failsafe even if in a manual flight mode like stabilize
+#define FS_EKF_ACTION_LAND_EVEN_MANUAL      3       // switch to Land mode on EKF failsafe even if in Manual mode
 
 // for PILOT_THR_BHV parameter
 #define THR_BEHAVE_FEEDBACK_FROM_MID_STICK (1<<0)

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -148,16 +148,16 @@ void Blimp::failsafe_ekf_event()
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_OCCURRED);
 
     // does this mode require position?
-    if (!blimp.flightmode->requires_GPS() && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE)) {
+    if (!blimp.flightmode->requires_GPS() && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_MANUAL)) {
         return;
     }
 
     // take action based on fs_ekf_action parameter
     switch (g.fs_ekf_action) {
     case FS_EKF_ACTION_LAND:
-    case FS_EKF_ACTION_LAND_EVEN_STABILIZE:
+    case FS_EKF_ACTION_LAND_EVEN_MANUAL:
     default:
-        set_mode_land_with_pause(ModeReason::EKF_FAILSAFE);
+        set_mode_land_failsafe(ModeReason::EKF_FAILSAFE);
         break;
     }
 }

--- a/Blimp/events.cpp
+++ b/Blimp/events.cpp
@@ -98,8 +98,8 @@ void Blimp::failsafe_gcs_check()
 
     const uint32_t gcs_last_seen_ms = gcs().sysid_myggcs_last_seen_time_ms();
     if (gcs_last_seen_ms == 0) {
-         return;
-     }
+        return;
+    }
 
     // calc time since last gcs update
     // note: this only looks at the heartbeat from the device id set by g.sysid_my_gcs
@@ -148,7 +148,7 @@ void Blimp::do_failsafe_action(Failsafe_Action action, ModeReason reason)
     case Failsafe_Action_None:
         return;
     case Failsafe_Action_Land:
-        set_mode_land_with_pause(reason);
+        set_mode_land_failsafe(reason);
         break;
     case Failsafe_Action_Terminate: {
         arming.disarm(AP_Arming::Method::FAILSAFE_ACTION_TERMINATE);

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -16,6 +16,7 @@ Mode::Mode(void) :
     inertial_nav(blimp.inertial_nav),
     ahrs(blimp.ahrs),
     motors(blimp.motors),
+    loiter(blimp.loiter),
     channel_right(blimp.channel_right),
     channel_front(blimp.channel_front),
     channel_down(blimp.channel_down),
@@ -40,6 +41,9 @@ Mode *Blimp::mode_from_mode_num(const Mode::Number mode)
         break;
     case Mode::Number::LOITER:
         ret = &mode_loiter;
+        break;
+    case Mode::Number::RTL:
+        ret = &mode_rtl;
         break;
     default:
         break;
@@ -152,18 +156,23 @@ void Mode::update_navigation()
     run_autopilot();
 }
 
-// returns desired angle in centi-degrees
-void Mode::get_pilot_desired_accelerations(float &right_out, float &front_out) const
+// returns desired thrust/acceleration
+void Mode::get_pilot_input(Vector3f &pilot, float &yaw)
 {
     // throttle failsafe check
     if (blimp.failsafe.radio || !blimp.ap.rc_receiver_present) {
-        right_out = 0;
-        front_out = 0;
+        pilot.y = 0;
+        pilot.x = 0;
+        pilot.z = 0;
+        yaw = 0;
         return;
     }
-    // fetch roll and pitch inputs
-    right_out = channel_right->get_control_in();
-    front_out = channel_front->get_control_in();
+    // fetch pilot inputs
+    pilot.y = channel_right->get_control_in() / float(RC_SCALE);
+    pilot.x = channel_front->get_control_in() / float(RC_SCALE);
+    //TODO: need to make this channel_up instead, and then have it .negative. before being sent to pilot.z -> this is "throttle" channel, so higher = up.
+    pilot.z = -channel_up->get_control_in() / float(RC_SCALE);
+    yaw = channel_yaw->get_control_in() / float(RC_SCALE);
 }
 
 bool Mode::is_disarmed_or_landed() const

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -19,7 +19,7 @@ Mode::Mode(void) :
     loiter(blimp.loiter),
     channel_right(blimp.channel_right),
     channel_front(blimp.channel_front),
-    channel_down(blimp.channel_down),
+    channel_up(blimp.channel_up),
     channel_yaw(blimp.channel_yaw),
     G_Dt(blimp.G_Dt)
 { };

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -113,65 +113,6 @@ protected:
     float &G_Dt;
 
 public:
-    // Navigation Yaw control
-    class AutoYaw
-    {
-
-    public:
-        // mode(): current method of determining desired yaw:
-        autopilot_yaw_mode mode() const
-        {
-            return (autopilot_yaw_mode)_mode;
-        }
-        void set_mode_to_default(bool rtl);
-        void set_mode(autopilot_yaw_mode new_mode);
-        autopilot_yaw_mode default_mode(bool rtl) const;
-
-        void set_rate(float new_rate_cds);
-
-        // set_roi(...): set a "look at" location:
-        void set_roi(const Location &roi_location);
-
-        void set_fixed_yaw(float angle_deg,
-                           float turn_rate_dps,
-                           int8_t direction,
-                           bool relative_angle);
-
-    private:
-
-        // yaw_cd(): main product of AutoYaw; the heading:
-        float yaw_cd();
-
-        // rate_cds(): desired yaw rate in centidegrees/second:
-        float rate_cds();
-
-        float look_ahead_yaw();
-        float roi_yaw();
-
-        // auto flight mode's yaw mode
-        uint8_t _mode = AUTO_YAW_LOOK_AT_NEXT_WP;
-
-        // Yaw will point at this location if mode is set to AUTO_YAW_ROI
-        Vector3f roi;
-
-        // bearing from current location to the ROI
-        float _roi_yaw;
-
-        // yaw used for YAW_FIXED yaw_mode
-        int32_t _fixed_yaw;
-
-        // Deg/s we should turn
-        int16_t _fixed_yaw_slewrate;
-
-        // heading when in yaw_look_ahead_yaw
-        float _look_ahead_yaw;
-
-        // used to reduce update rate to 100hz:
-        uint8_t roi_yaw_counter;
-
-    };
-    static AutoYaw auto_yaw;
-
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -17,6 +17,7 @@ public:
         MANUAL =        1,  // manual control
         VELOCITY =      2,  // velocity mode
         LOITER =        3,  // loiter mode (position hold)
+        RTL =           4,  // rtl
     };
 
     // constructor
@@ -83,7 +84,7 @@ public:
     void update_navigation();
 
     // pilot input processing
-    void get_pilot_desired_accelerations(float &right_out, float &front_out) const;
+    void get_pilot_input(Vector3f &pilot, float &yaw);
 
 protected:
 
@@ -104,6 +105,7 @@ protected:
     AP_InertialNav &inertial_nav;
     AP_AHRS &ahrs;
     Fins *&motors;
+    Loiter *&loiter;
     RC_Channel *&channel_right;
     RC_Channel *&channel_front;
     RC_Channel *&channel_down;
@@ -304,7 +306,6 @@ protected:
 private:
     Vector3f target_pos;
     float target_yaw;
-    float loop_period;
 };
 
 class ModeLand : public Mode
@@ -346,4 +347,44 @@ protected:
 
 private:
 
+};
+
+class ModeRTL : public Mode
+{
+
+public:
+    // inherit constructor
+    using Mode::Mode;
+
+    virtual bool init(bool ignore_checks) override;
+    virtual void run() override;
+
+    bool requires_GPS() const override
+    {
+        return true;
+    }
+    bool has_manual_throttle() const override
+    {
+        return false;
+    }
+    bool allows_arming(bool from_gcs) const override
+    {
+        return true;
+    };
+    bool is_autopilot() const override
+    {
+        return false;
+        //TODO
+    }
+
+protected:
+
+    const char *name() const override
+    {
+        return "RTL";
+    }
+    const char *name4() const override
+    {
+        return "RTL";
+    }
 };

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -108,7 +108,7 @@ protected:
     Loiter *&loiter;
     RC_Channel *&channel_right;
     RC_Channel *&channel_front;
-    RC_Channel *&channel_down;
+    RC_Channel *&channel_up;
     RC_Channel *&channel_yaw;
     float &G_Dt;
 

--- a/Blimp/mode_land.cpp
+++ b/Blimp/mode_land.cpp
@@ -13,12 +13,11 @@ void ModeLand::run()
     motors->down_out = 0;
 }
 
-// set_mode_land_with_pause - sets mode to LAND and triggers 4 second delay before descent starts
-//  this is always called from a failsafe so we trigger notification to pilot
-void Blimp::set_mode_land_with_pause(ModeReason reason)
+// set_mode_land_failsafe - sets mode to LAND
+// this is always called from a failsafe so we trigger notification to pilot
+void Blimp::set_mode_land_failsafe(ModeReason reason)
 {
     set_mode(Mode::Number::LAND, reason);
-    //TODO: Add pause
 
     // alert pilot to mode change
     AP_Notify::events.failsafe_mode_change = 1;

--- a/Blimp/mode_loiter.cpp
+++ b/Blimp/mode_loiter.cpp
@@ -3,66 +3,39 @@
  * Init and run calls for loiter flight mode
  */
 
+//Number of seconds of movement that the target position can be ahead of actual position.
+#define POS_LAG 1
 
- bool ModeLoiter::init(bool ignore_checks){
+bool ModeLoiter::init(bool ignore_checks)
+{
     target_pos = blimp.pos_ned;
     target_yaw = blimp.ahrs.get_yaw();
 
     return true;
- }
+}
 
 //Runs the main loiter controller
 void ModeLoiter::run()
 {
     const float dt = blimp.scheduler.get_last_loop_time_s();
-    
-    Vector3f pilot;
-    pilot.x = channel_front->get_control_in() / float(RC_SCALE) * g.max_pos_xy * dt;
-    pilot.y = channel_right->get_control_in() / float(RC_SCALE) * g.max_pos_xy * dt;
-    pilot.z = channel_down->get_control_in()  / float(RC_SCALE) * g.max_pos_z * dt;
-    float pilot_yaw = channel_yaw->get_control_in()  / float(RC_SCALE) * g.max_pos_yaw * dt;
 
-    if (g.simple_mode == 0){
+    Vector3f pilot;
+    float pilot_yaw;
+    get_pilot_input(pilot, pilot_yaw);
+    pilot.x *= g.max_pos_xy * dt;
+    pilot.y *= g.max_pos_xy * dt;
+    pilot.z *= g.max_pos_z * dt;
+    pilot_yaw *= g.max_pos_yaw * dt;
+
+    if (g.simple_mode == 0) {
         //If simple mode is disabled, input is in body-frame, thus needs to be rotated.
         blimp.rotate_BF_to_NE(pilot.xy());
     }
-    target_pos.x += pilot.x;
-    target_pos.y += pilot.y;
-    target_pos.z += pilot.z;
-    target_yaw = wrap_PI(target_yaw + pilot_yaw);
 
-    //Pos controller's output becomes target for velocity controller
-    Vector3f target_vel_ef{blimp.pid_pos_xy.update_all(target_pos, blimp.pos_ned, dt, {0,0,0}), 0};
-    target_vel_ef.z = blimp.pid_pos_z.update_all(target_pos.z, blimp.pos_ned.z, dt);
-    float yaw_ef = blimp.ahrs.get_yaw();
-    float target_vel_yaw = blimp.pid_pos_yaw.update_error(wrap_PI(target_yaw - yaw_ef), dt);
-    blimp.pid_pos_yaw.set_target_rate(target_yaw);
-    blimp.pid_pos_yaw.set_actual_rate(yaw_ef);
+    if(fabsf(target_pos.x-blimp.pos_ned.x) < (g.max_pos_xy*POS_LAG)) target_pos.x += pilot.x;
+    if(fabsf(target_pos.y-blimp.pos_ned.y) < (g.max_pos_xy*POS_LAG)) target_pos.y += pilot.y;
+    if(fabsf(target_pos.z-blimp.pos_ned.z) < (g.max_pos_z*POS_LAG)) target_pos.z += pilot.z;
+    if(fabsf(wrap_PI(target_yaw-ahrs.get_yaw())) < (g.max_pos_yaw*POS_LAG)) target_yaw = wrap_PI(target_yaw + pilot_yaw);
 
-    Vector3f target_vel_ef_c{constrain_float(target_vel_ef.x, -g.max_vel_xy, g.max_vel_xy),
-                              constrain_float(target_vel_ef.y, -g.max_vel_xy, g.max_vel_xy),
-                              constrain_float(target_vel_ef.z, -g.max_vel_z, g.max_vel_z)};
-    float target_vel_yaw_c = constrain_float(target_vel_yaw, -g.max_vel_yaw, g.max_vel_yaw);
-
-    Vector2f actuator = blimp.pid_vel_xy.update_all(target_vel_ef_c, blimp.vel_ned_filtd, dt, {0,0,0});
-    float act_down = blimp.pid_vel_z.update_all(target_vel_ef_c.z, blimp.vel_ned_filtd.z, dt);
-    blimp.rotate_NE_to_BF(actuator);
-    float act_yaw = blimp.pid_vel_yaw.update_all(target_vel_yaw_c, blimp.vel_yaw_filtd, dt);
-
-    if(!(blimp.g.dis_mask & (1<<(2-1)))){
-        motors->front_out = actuator.x;
-    }
-    if(!(blimp.g.dis_mask & (1<<(1-1)))){
-        motors->right_out = actuator.y;
-    }
-    if(!(blimp.g.dis_mask & (1<<(3-1)))){
-        motors->down_out = act_down;
-    }
-    if(!(blimp.g.dis_mask & (1<<(4-1)))){
-        motors->yaw_out  = act_yaw;
-    }
-
-    AP::logger().Write_PSCN(target_pos.x * 100.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
-    AP::logger().Write_PSCE(target_pos.y * 100.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
-    AP::logger().Write_PSCD(-target_pos.z * 100.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+    blimp.loiter->run(target_pos, target_yaw, Vector4b{false,false,false,false});
 }

--- a/Blimp/mode_manual.cpp
+++ b/Blimp/mode_manual.cpp
@@ -6,8 +6,11 @@
 // Runs the main manual controller
 void ModeManual::run()
 {
-    motors->right_out = channel_right->get_control_in() / float(RC_SCALE);
-    motors->front_out = channel_front->get_control_in() / float(RC_SCALE);
-    motors->yaw_out = channel_yaw->get_control_in() / float(RC_SCALE);
-    motors->down_out = channel_down->get_control_in() / float(RC_SCALE);
+    Vector3f pilot;
+    float pilot_yaw;
+    get_pilot_input(pilot, pilot_yaw);
+    motors->right_out = pilot.y;
+    motors->front_out = pilot.x;
+    motors->yaw_out = pilot_yaw;
+    motors->down_out = pilot.z;
 }

--- a/Blimp/mode_rtl.cpp
+++ b/Blimp/mode_rtl.cpp
@@ -1,0 +1,20 @@
+#include "Blimp.h"
+/*
+ * Init and run calls for rtl flight mode
+ */
+
+//Number of seconds of movement that the target position can be ahead of actual position.
+#define POS_LAG 1
+
+bool ModeRTL::init(bool ignore_checks)
+{
+    return true;
+}
+
+//Runs the main rtl controller
+void ModeRTL::run()
+{
+    Vector3f target_pos = {0,0,0};
+    float target_yaw = 0;
+    blimp.loiter->run(target_pos, target_yaw, Vector4b{false,false,false,false});
+}

--- a/Blimp/mode_velocity.cpp
+++ b/Blimp/mode_velocity.cpp
@@ -8,34 +8,17 @@
 // Runs the main velocity controller
 void ModeVelocity::run()
 {
-    const float dt = blimp.scheduler.get_last_loop_time_s();
-    
     Vector3f target_vel;
-    target_vel.x = channel_front->get_control_in() / float(RC_SCALE) * g.max_vel_xy;
-    target_vel.y = channel_right->get_control_in() / float(RC_SCALE) * g.max_vel_xy;
-    blimp.rotate_BF_to_NE(target_vel.xy());
-    target_vel.z = channel_down->get_control_in()  / float(RC_SCALE) * g.max_vel_z;
-    float target_vel_yaw = channel_yaw->get_control_in() / float(RC_SCALE) * g.max_vel_yaw;
+    float target_vel_yaw;
+    get_pilot_input(target_vel, target_vel_yaw);
+    target_vel.x *= g.max_vel_xy;
+    target_vel.y *= g.max_vel_xy;
+    if (g.simple_mode == 0) {
+        //If simple mode is disabled, input is in body-frame, thus needs to be rotated.
+        blimp.rotate_BF_to_NE(target_vel.xy());
+    }
+    target_vel.z *= g.max_vel_z;
+    target_vel_yaw *= g.max_vel_yaw;
 
-    Vector2f actuator = blimp.pid_vel_xy.update_all(target_vel, blimp.vel_ned_filtd, dt, {0,0,0});
-    blimp.rotate_NE_to_BF(actuator);
-    float act_down = blimp.pid_vel_z.update_all(target_vel.z, blimp.vel_ned_filtd.z, dt);
-    float act_yaw = blimp.pid_vel_yaw.update_all(target_vel_yaw, blimp.vel_yaw_filtd, dt);
-
-    if(!(blimp.g.dis_mask & (1<<(2-1)))){
-        motors->front_out = actuator.x;
-    }
-    if(!(blimp.g.dis_mask & (1<<(1-1)))){
-        motors->right_out = actuator.y;
-    }
-    if(!(blimp.g.dis_mask & (1<<(3-1)))){
-        motors->down_out = act_down;
-    }
-    if(!(blimp.g.dis_mask & (1<<(4-1)))){
-        motors->yaw_out = act_yaw;
-    }
-
-    AP::logger().Write_PSCN(0.0, blimp.pos_ned.x * 100.0, 0.0, 0.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
-    AP::logger().Write_PSCE(0.0, blimp.pos_ned.y * 100.0, 0.0, 0.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
-    AP::logger().Write_PSCD(0.0, -blimp.pos_ned.z * 100.0, 0.0, 0.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+    blimp.loiter->run_vel(target_vel, target_vel_yaw, Vector4b{false,false,false,false});
 }

--- a/Blimp/motors.cpp
+++ b/Blimp/motors.cpp
@@ -18,7 +18,7 @@ void Blimp::arm_motors_check()
     }
 
     // ensure throttle is down
-    if (channel_down->get_control_in() > 0) { //MIR what dow we do with this?
+    if (channel_up->get_control_in() > 0) { //MIR what dow we do with this?
         arming_counter = 0;
         return;
     }

--- a/Blimp/radio.cpp
+++ b/Blimp/radio.cpp
@@ -8,23 +8,23 @@ void Blimp::default_dead_zones()
 {
     channel_right->set_default_dead_zone(20);
     channel_front->set_default_dead_zone(20);
-    channel_down->set_default_dead_zone(30);
+    channel_up->set_default_dead_zone(30);
     channel_yaw->set_default_dead_zone(20);
     rc().channel(CH_6)->set_default_dead_zone(0);
 }
 
 void Blimp::init_rc_in()
 {
-    channel_right     = rc().channel(rcmap.roll()-1);
-    channel_front    = rc().channel(rcmap.pitch()-1);
-    channel_down = rc().channel(rcmap.throttle()-1);
-    channel_yaw      = rc().channel(rcmap.yaw()-1);
+    channel_right = rc().channel(rcmap.roll()-1);
+    channel_front = rc().channel(rcmap.pitch()-1);
+    channel_up    = rc().channel(rcmap.throttle()-1);
+    channel_yaw   = rc().channel(rcmap.yaw()-1);
 
     // set rc channel ranges
     channel_right->set_angle(RC_SCALE);
     channel_front->set_angle(RC_SCALE);
     channel_yaw->set_angle(RC_SCALE);
-    channel_down->set_angle(RC_SCALE);
+    channel_up->set_angle(RC_SCALE);
 
     // set default dead zones
     default_dead_zones();
@@ -58,14 +58,14 @@ void Blimp::read_radio()
     if (rc().read_input()) {
         ap.new_radio_frame = true;
 
-        set_throttle_and_failsafe(channel_down->get_radio_in());
-        set_throttle_zero_flag(channel_down->get_control_in());
+        set_throttle_and_failsafe(channel_up->get_radio_in());
+        set_throttle_zero_flag(channel_up->get_control_in());
 
         // RC receiver must be attached if we've just got input
         ap.rc_receiver_present = true;
 
         const float dt = (tnow_ms - last_radio_update_ms)*1.0e-3f;
-        rc_throttle_control_in_filter.apply(channel_down->get_control_in(), dt);
+        rc_throttle_control_in_filter.apply(channel_up->get_control_in(), dt);
         last_radio_update_ms = tnow_ms;
         return;
     }

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -46,6 +46,7 @@ void Blimp::init_ardupilot()
 
     // allocate the motors class
     allocate_motors();
+    loiter = new Loiter(blimp.scheduler.get_loop_rate_hz());
 
     // initialise rc channels including setting mode
     rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);

--- a/Blimp/wscript
+++ b/Blimp/wscript
@@ -7,9 +7,7 @@ def build(bld):
         name=vehicle + '_libs',
         ap_vehicle=vehicle,
         ap_libraries=bld.ap_common_vehicle_libraries() + [
-            'AC_AttitudeControl',
             'AC_InputManager',
-            'AC_WPNav',
             'AP_InertialNav',
             'AP_RCMapper',
             'AP_Avoidance',
@@ -27,5 +25,4 @@ def build(bld):
         program_name='blimp',
         program_groups=['bin', 'blimp'],
         use=vehicle + '_libs',
-        defines=['FRAME_CONFIG=MULTICOPTER_FRAME'],
         )

--- a/Tools/autotest/default_params/blimp.parm
+++ b/Tools/autotest/default_params/blimp.parm
@@ -38,6 +38,18 @@ RC7_TRIM        1500
 RC8_MAX         2000
 RC8_MIN         1000
 RC8_TRIM        1500
+SERVO1_MAX       2200
+SERVO1_MIN       500
+SERVO1_TRIM      1350
+SERVO2_MAX       2200
+SERVO2_MIN       500
+SERVO2_TRIM      1350
+SERVO3_MAX       2200
+SERVO3_MIN       500
+SERVO3_TRIM      1350
+SERVO4_MAX       2200
+SERVO4_MIN       500
+SERVO4_TRIM      1350
 
 # setting servo functions for the four fins
 SERVO1_FUNCTION 33
@@ -76,16 +88,18 @@ INS_ACC3SCAL_Z   1.000
 
 ARMING_RUDDER 0
 GCS_PID_MASK 255
+SIM_SERVO_SPEED 0.06
+LOG_BITMASK      65535
 
 # default PID params for position and velocity-controlled modes
-MAX_POS_XY       0.3
+MAX_POS_XY       0.15
 MAX_POS_YAW      0.3
 MAX_POS_Z        0.15
-MAX_VEL_XY       0.4
-MAX_VEL_YAW      0.5
+MAX_VEL_XY       0.2
+MAX_VEL_YAW      0.4
 MAX_VEL_Z        0.2
 
-VELXY_D          0.0
+VELXY_D          1.0
 VELXY_FF         0.0
 VELXY_FLTD       3.0
 VELXY_FLTE       3.0
@@ -98,7 +112,7 @@ VELYAW_FLTD      3.0
 VELYAW_FLTE      3.0
 VELYAW_I         0.8
 VELYAW_IMAX      5.0
-VELYAW_P         15.0
+VELYAW_P         10.0
 VELZ_D           0.0
 VELZ_FF          0.0
 VELZ_FLTD        3.0

--- a/libraries/SITL/SIM_Blimp.cpp
+++ b/libraries/SITL/SIM_Blimp.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "SIM_Blimp.h"
+#include <AP_Logger/AP_Logger.h>
 
 #include <stdio.h>
 
@@ -30,17 +31,21 @@ Blimp::Blimp(const char *frame_str) :
     mass = 0.07;
     radius = 0.25;
     moment_of_inertia = {0.004375, 0.004375, 0.004375}; //m*r^2 for hoop...
-    k_tan = 5.52e-4; //Tangential (thrust) multiplier
+    cog = {0, 0, 0.1}; //10 cm down from center (i.e. center of buoyancy), for now
+    k_tan = 0.6e-7; //Tangential (thrust) and normal force multipliers
+    k_nor = 0;//3.4e-7;
     drag_constant = 0.05;
-    drag_gyr_constant = 0.08;
+    drag_gyr_constant = 0.15;
 
     lock_step_scheduled = true;
-    ::printf("Starting Blimp AirFish model...\n");
+    ::printf("Starting Blimp model\n");
 }
 
 // calculate rotational and linear accelerations
-void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
+void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &body_acc, Vector3f &rot_accel)
 {
+  float delta_time = frame_time_us * 1.0e-6f;
+
   if (!hal.scheduler->is_system_initialized()) {
       return;
   }
@@ -48,55 +53,131 @@ void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
   //all fin setup
   for (uint8_t i=0; i<4; i++) {
     fin[i].last_angle = fin[i].angle;
-    fin[i].angle = filtered_servo_angle(input, i)*radians(75.0f); //for servo range of -75 deg to +75 deg
-    
+    if (input.servos[i] == 0) {
+        fin[i].angle = 0;
+        fin[1].servo_angle = 0;
+    } else {
+        fin[i].angle = filtered_servo_angle(input, i)*radians(45.0f)+radians(13.5); //for servo range of -75 deg to +75 deg
+        fin[i].servo_angle = filtered_servo_angle(input, i);
+    }
+
     if (fin[i].angle < fin[i].last_angle) fin[i].dir = 0; //thus 0 = "angle is reducing"
     else fin[i].dir = 1;
-    
-    fin[i].vel = (fin[i].angle - fin[i].last_angle)/delta_time; //rad/s
-    fin[i].vel = constrain_float(fin[i].vel, radians(-450), radians(450));
-    fin[i].T = pow(fin[i].vel,2) * k_tan;
-    
+
+    fin[i].vel = degrees(fin[i].angle - fin[i].last_angle)/delta_time; //Could also do multi-point derivative filter - DerivativeFilter.cpp
+    //deg/s (should really be rad/s, but that would require modifying k_tan, k_nor)
+    //all other angles should be in radians.
+    fin[i].vel = constrain_float(fin[i].vel, -450, 450);
+    fin[i].T = sq(fin[i].vel) * k_tan;
+    fin[i].N = sq(fin[i].vel) * k_nor;
+    if (fin[i].dir == 0) fin[i].N = -fin[1].N; //normal force flips when fin changes direction
+
     fin[i].Fx = 0;
     fin[i].Fy = 0;
     fin[i].Fz = 0;
   }
 
-  //TODO: Add normal force calculations and include roll & pitch oscillation.
   //Back fin
-  fin[0].Fx =  fin[0].T*cos(fin[0].angle); //causes forward movement
-  fin[0].Fz =  fin[0].T*sin(fin[0].angle); //causes height change
+  fin[0].Fx =  fin[0].T*cos(fin[0].angle);// + fin[0].N*sin(fin[0].angle); //causes forward movement
+  fin[0].Fz =  fin[0].T*sin(fin[0].angle);// - fin[0].N*cos(fin[0].angle); //causes height & wobble in y
 
   //Front fin
-  fin[1].Fx = -fin[1].T*cos(fin[1].angle); //causes backward movement
-  fin[1].Fz =  fin[1].T*sin(fin[1].angle); //causes height change
+  fin[1].Fx = -fin[1].T*cos(fin[1].angle);// - fin[1].N*sin(fin[1].angle); //causes backward movement
+  fin[1].Fz =  fin[1].T*sin(fin[1].angle);// - fin[1].N*cos(fin[1].angle); //causes height & wobble in y
 
   //Right fin
-  fin[2].Fy = -fin[2].T*cos(fin[2].angle); //causes left movement
-  fin[2].Fx =  fin[2].T*sin(fin[2].angle); //causes yaw
+  fin[2].Fy = -fin[2].T*cos(fin[2].angle);// - fin[2].N*sin(fin[2].angle); //causes left movement
+  fin[2].Fx =  fin[2].T*sin(fin[2].angle);// - fin[2].N*cos(fin[2].angle); //cause yaw & wobble in z
 
   //Left fin
-  fin[3].Fy =  fin[3].T*cos(fin[3].angle); //causes right movement
-  fin[3].Fx = -fin[3].T*sin(fin[3].angle); //causes yaw
+  fin[3].Fy =  fin[3].T*cos(fin[3].angle);// + fin[3].N*sin(fin[3].angle); //causes right movement
+  fin[3].Fx =  fin[3].T*sin(fin[3].angle);// + fin[3].N*cos(fin[3].angle); //causes yaw & wobble in z
 
-  Vector3f force_bf{0,0,0}; 
+  Vector3f F_BF{0,0,0};
   for (uint8_t i=0; i<4; i++) {
-    force_bf.x = force_bf.x + fin[i].Fx;
-    force_bf.y = force_bf.y + fin[i].Fy;
-    force_bf.z = force_bf.z + fin[i].Fz;
+    F_BF.x = F_BF.x + fin[i].Fx;
+    F_BF.y = F_BF.y + fin[i].Fy;
+    F_BF.z = F_BF.z + fin[i].Fz;
   }
 
-  //mass in kg, thus accel in m/s/s
-  body_accel.x = force_bf.x/mass;
-  body_accel.y = force_bf.y/mass;
-  body_accel.z = force_bf.z/mass;
+  body_acc.x = F_BF.x/mass; //mass in kg, thus accel in m/s/s
+  body_acc.y = F_BF.y/mass;
+  body_acc.z = F_BF.z/mass;
 
   Vector3f rot_T{0,0,0};
-  rot_T.z = fin[2].Fx * radius + fin[3].Fx * radius;//in N*m (Torque = force * lever arm)
 
+  AP::logger().WriteStreaming("SFT", "TimeUS,f0,f1,f2,f3",
+                              "Qffff",
+                              AP_HAL::micros64(),
+                              fin[0].T, fin[1].T, fin[2].T, fin[3].T);
+  AP::logger().WriteStreaming("SFN", "TimeUS,n0,n1,n2,n3",
+                              "Qffff",
+                              AP_HAL::micros64(),
+                              fin[0].N, fin[1].N, fin[2].N, fin[3].N);
+  AP::logger().WriteStreaming("SBA1", "TimeUS,ax,ay,az",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              body_acc.x, body_acc.y, body_acc.z);
+  AP::logger().WriteStreaming("SFA1", "TimeUS,f0,f1,f2,f3",
+                              "Qffff",
+                              AP_HAL::micros64(),
+                              fin[0].angle, fin[1].angle, fin[2].angle, fin[3].angle);
+  AP::logger().WriteStreaming("SFAN", "TimeUS,f0,f1,f2,f3",
+                              "Qffff",
+                              AP_HAL::micros64(),
+                              fin[0].servo_angle, fin[1].servo_angle, fin[2].servo_angle, fin[3].servo_angle);
+  AP::logger().WriteStreaming("SSAN", "TimeUS,f0,f1,f2,f3",
+                              "QHHHH",
+                              AP_HAL::micros64(),
+                              input.servos[0], input.servos[1], input.servos[2], input.servos[3]);
+  AP::logger().WriteStreaming("SFV1", "TimeUS,f0,f1,f2,f3",
+                              "Qffff",
+                              AP_HAL::micros64(),
+                              fin[0].vel, fin[1].vel, fin[2].vel, fin[3].vel);
+  AP::logger().WriteStreaming("SRT1", "TimeUS,rtx,rty,rtz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              rot_T.x, rot_T.y, rot_T.z);
+
+#if 0 //"Wobble" attempt
+  rot_T.y = fin[0].Fz * radius + fin[1].Fz * radius;
+  AP::logger().WriteStreaming("SRT2", "TimeUS,rtx,rty,rtz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              rot_T.x, rot_T.y, rot_T.z);
+  // the blimp has pendulum stability due to the centre of gravity being lower than the centre of buoyancy
+  Vector3f ang; //x,y,z correspond to roll, pitch, yaw.
+  dcm.to_euler(&ang.x, &ang.y, &ang.z); //rpy in radians
+  Vector3f ang_ef = dcm * ang;
+  rot_T.x -= mass*GRAVITY_MSS*sinf(M_PI-ang_ef.x)/cog.z;
+  rot_T.y -= mass*GRAVITY_MSS*sinf(M_PI-ang_ef.y)/cog.z;
+  AP::logger().WriteStreaming("SRT3", "TimeUS,rtx,rty,rtz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              rot_T.x, rot_T.y, rot_T.z);
+  AP::logger().WriteStreaming("SAN1", "TimeUS,anx,any,anz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              ang.x, ang.y, ang.z);
+  AP::logger().WriteStreaming("SAN2", "TimeUS,anx,any,anz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              ang_ef.x, ang_ef.y, ang_ef.z);
+  AP::logger().WriteStreaming("SAF1", "TimeUS,afx,afy,afz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              sinf(ang.x), sinf(ang.y), sinf(ang.z));
+  AP::logger().WriteStreaming("SMGC", "TimeUS,m,g,cz",
+                              "Qfff",
+                              AP_HAL::micros64(),
+                              mass, GRAVITY_MSS, cog.z);
+#endif
+
+  rot_T.z = fin[2].Fx * radius - fin[3].Fx * radius;//in N*m (Torque = force * lever arm)
   //rot accel = torque / moment of inertia
-  rot_accel.x = 0;
-  rot_accel.y = 0;
+  //Torque = moment force.
+  rot_accel.x = rot_T.x / moment_of_inertia.x;
+  rot_accel.y = rot_T.y / moment_of_inertia.y;
   rot_accel.z = rot_T.z / moment_of_inertia.z;
 }
 
@@ -105,10 +186,10 @@ void Blimp::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
  */
 void Blimp::update(const struct sitl_input &input)
 {
-  delta_time = frame_time_us * 1.0e-6f;
+  float delta_time = frame_time_us * 1.0e-6f;
 
   Vector3f rot_accel = Vector3f(0,0,0);
-  calculate_forces(input, rot_accel, accel_body);
+  calculate_forces(input, accel_body, rot_accel);
 
   if (hal.scheduler->is_system_initialized()) {
     float gyr_sq = gyro.length_squared();
@@ -120,12 +201,23 @@ void Blimp::update(const struct sitl_input &input)
     }
   }
 
+#if 0
+  AP::logger().WriteStreaming("SBLM", "TimeUS,RAx,RAy,RAz",
+                                "Qfff",
+                                AP_HAL::micros64(),
+                                rot_accel.x, rot_accel.y, rot_accel.z);
+#endif
+
   // update rotational rates in body frame
   gyro += rot_accel * delta_time;
+
   gyro.x = constrain_float(gyro.x, -radians(2000.0f), radians(2000.0f));
   gyro.y = constrain_float(gyro.y, -radians(2000.0f), radians(2000.0f));
   gyro.z = constrain_float(gyro.z, -radians(2000.0f), radians(2000.0f));
 
+  // Vector3f ang; //x,y,z correspond to roll, pitch, yaw.
+  // dcm.to_euler(&ang.x, &ang.y, &ang.z); //rpy in radians
+  // dcm.from_euler(0.0f, 0.0f, ang.z);
   // update attitude
   dcm.rotate(gyro * delta_time);
   dcm.normalize();
@@ -139,10 +231,10 @@ void Blimp::update(const struct sitl_input &input)
         accel_body += bf_drag_accel;
     }
 
-    // add lifting force exactly equal to gravity, for neutral buoyancy
+    // add lifting force exactly equal to gravity, for neutral buoyancy (buoyancy in ef)
     accel_body += dcm.transposed() * Vector3f(0,0,-GRAVITY_MSS);
   }
-  
+
   Vector3f accel_earth = dcm * accel_body;
   accel_earth += Vector3f(0.0f, 0.0f, GRAVITY_MSS); //add gravity
   velocity_ef += accel_earth * delta_time;
@@ -151,4 +243,6 @@ void Blimp::update(const struct sitl_input &input)
   update_position(); //updates the position from the Vector3f position
   time_advance();
   update_mag_field_bf();
+  rate_hz = sitl->loop_rate_hz;
+
 }

--- a/libraries/SITL/SIM_Blimp.h
+++ b/libraries/SITL/SIM_Blimp.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include "SIM_Aircraft.h"
+// #include "SIM_Motor.h"
+// #include "SIM_Frame.h"
 
 namespace SITL {
 
@@ -26,9 +28,11 @@ struct Fins
 {
   float angle;
   float last_angle;
+  float servo_angle;
   bool dir;
-  float vel; // velocity, in rad/s
+  float vel; // velocity, in m/s
   float T; //Tangential (thrust) force, in Neutons
+  float N; //Normal force, in Newtons
   float Fx; //Fx,y,z = Force in bodyframe orientation at servo position, in Newtons
   float Fy;
   float Fz;
@@ -54,15 +58,17 @@ protected:
     float mass; //kilograms
     float radius; //metres
     Vector3f moment_of_inertia;
+    Vector3f cog; //centre of gravity location relative to center of blimp
 
     //Airfish-specific variables
     Fins fin[4];
-    float k_tan; //Tangential force multiplier
+    float k_tan; //Tangential and normal force multipliers
+    float k_nor;
     float drag_constant;
     float drag_gyr_constant;
-    float delta_time;
 
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
+    float sq(float a) {return pow(a,2);}
 };
 
 }


### PR DESCRIPTION
This PR moves the Loiter and Velocity mode PIDs into a separate class for neatness and also adds a very simple RTL mode using that class.

It also fixes the inverted throttle and removes a bunch of unused code.