### PR TITLE
PID notches and D feed-foward

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -387,6 +387,47 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Units: d%
     // @User: Advanced
 
+    // @Param: PITCH2SRV_ADV
+    // @DisplayName: Advanced Pitch parameters enable
+    // @Description: Advanced Pitch parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: PITCH2SRV_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.1
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: PITCH2SRV_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: PITCH2SRV_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: PITCH2SRV_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: PITCH2SRV_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     GGROUP(pidPitch2Srv,       "PITCH2SRV_", AC_PID),
 
     // @Param: YAW2SRV_P
@@ -462,6 +503,47 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Range: 0 4000
     // @Increment: 10
     // @Units: d%
+    // @User: Advanced
+
+    // @Param: YAW2SRV_ADV
+    // @DisplayName: Advanced Yaw parameters enable
+    // @Description: Advanced Yaw parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: YAW2SRV_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.1
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: YAW2SRV_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: YAW2SRV_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: YAW2SRV_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: YAW2SRV_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -387,45 +387,23 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Units: d%
     // @User: Advanced
 
-    // @Param: PITCH2SRV_ADV
-    // @DisplayName: Advanced Pitch parameters enable
-    // @Description: Advanced Pitch parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: PITCH2SRV_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.1
+    // @Range: 0 0.1
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: PITCH2SRV_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: PITCH2SRV_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: PITCH2SRV_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: PITCH2SRV_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     GGROUP(pidPitch2Srv,       "PITCH2SRV_", AC_PID),
@@ -505,45 +483,23 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Units: d%
     // @User: Advanced
 
-    // @Param: YAW2SRV_ADV
-    // @DisplayName: Advanced Yaw parameters enable
-    // @Description: Advanced Yaw parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: YAW2SRV_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.1
+    // @Range: 0 0.1
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: YAW2SRV_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: YAW2SRV_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: YAW2SRV_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: YAW2SRV_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),

--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -103,6 +103,8 @@ void Tracker::one_second_loop()
     set_likely_flying(hal.util->get_soft_armed());
 
     AP_Notify::flags.flying = hal.util->get_soft_armed();
+
+    g.pidYaw2Srv.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 }
 
 void Tracker::ten_hz_logging_loop()

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -671,6 +671,13 @@ void Copter::one_hz_loop()
 #endif
 
     AP_Notify::flags.flying = !ap.land_complete;
+
+    // slowly update the PID notches with the average loop rate
+    attitude_control->set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+    pos_control->get_accel_z_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+#if AC_CUSTOMCONTROL_MULTI_ENABLED == ENABLED
+    custom_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+#endif
 }
 
 void Copter::init_simple_bearing()

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -357,6 +357,16 @@ void Plane::one_second_loop()
         !is_equal(G_Dt, scheduler.get_loop_period_s())) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
+
+    const float loop_rate = AP::scheduler().get_filtered_loop_rate_hz();
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.available()) {
+        quadplane.attitude_control->set_notch_sample_rate(loop_rate);
+    }
+#endif
+    rollController.set_notch_sample_rate(loop_rate);
+    pitchController.set_notch_sample_rate(loop_rate);
+    yawController.set_notch_sample_rate(loop_rate);
 }
 
 void Plane::three_hz_loop()

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -401,6 +401,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: I: integral part of PID
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
+// @Field: DFF: controller derivative feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
 // @Field: SRate: slew rate
 // @Field: Flags: bitmask of PID state flags
@@ -424,6 +425,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: I: integral part of PID
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
+// @Field: DFF: controller derivative feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
 // @Field: SRate: slew rate
 // @Field: Flags: bitmask of PID state flags

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -291,6 +291,9 @@ void Sub::one_hz_loop()
     // need to set "likely flying" when armed to allow for compass
     // learning to run
     set_likely_flying(hal.util->get_soft_armed());
+
+    attitude_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+    pos_control.get_accel_z_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 }
 
 void Sub::read_AHRS()

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -209,6 +209,8 @@ void Blimp::one_hz_loop()
     SRV_Channels::enable_aux_servos();
 
     AP_Notify::flags.flying = !ap.land_complete;
+
+    blimp.pid_pos_yaw.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 }
 
 void Blimp::read_AHRS(void)

--- a/Blimp/Log.cpp
+++ b/Blimp/Log.cpp
@@ -280,6 +280,7 @@ const struct LogStructure Blimp::log_structure[] = {
     // @Field: I: integral part of PID
     // @Field: D: derivative part of PID
     // @Field: FF: controller feed-forward portion of response
+    // @Field: DFF: controller derivative feed-forward portion of response
     // @Field: Dmod: scaler applied to D gain to reduce limit cycling
     // @Field: SRate: slew rate
     // @Field: Flags: bitmask of PID state flags

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -729,6 +729,48 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Increment: 10
     // @Units: d%
     // @User: Advanced
+
+    // @Param: POSYAW_ADV
+    // @DisplayName: Advanced Yaw parameters enable
+    // @Description: Advanced Yaw parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: POSYAW_D_FF
+    // @DisplayName: Position (yaw) Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.1
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: POSYAW_NTF
+    // @DisplayName: Position (yaw) Target notch Filter center frequency
+    // @Description: Position (yaw) Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: POSYAW_NEF
+    // @DisplayName: Position (yaw) Error notch Filter center frequency
+    // @Description: Position (yaw) Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: POSYAW_NBW
+    // @DisplayName: Position (yaw) notch Filter bandwidth
+    // @Description: Position (yaw) notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: POSYAW_NATT
+    // @DisplayName: Position (yaw) notch Filter attenuation
+    // @Description: Position (yaw) notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     GOBJECT(pid_pos_yaw, "POSYAW_", AC_PID),
 
     // @Group:

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -730,45 +730,23 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Units: d%
     // @User: Advanced
 
-    // @Param: POSYAW_ADV
-    // @DisplayName: Advanced Yaw parameters enable
-    // @Description: Advanced Yaw parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: POSYAW_D_FF
     // @DisplayName: Position (yaw) Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.1
+    // @Range: 0 0.1
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: POSYAW_NTF
-    // @DisplayName: Position (yaw) Target notch Filter center frequency
-    // @Description: Position (yaw) Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Position (yaw) Target notch filter index
+    // @Description: Position (yaw) Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: POSYAW_NEF
-    // @DisplayName: Position (yaw) Error notch Filter center frequency
-    // @Description: Position (yaw) Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: POSYAW_NBW
-    // @DisplayName: Position (yaw) notch Filter bandwidth
-    // @Description: Position (yaw) notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: POSYAW_NATT
-    // @DisplayName: Position (yaw) notch Filter attenuation
-    // @Description: Position (yaw) notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Position (yaw) Error notch filter index
+    // @Description: Position (yaw) Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     GOBJECT(pid_pos_yaw, "POSYAW_", AC_PID),

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -468,6 +468,7 @@ void Rover::one_second_loop(void)
     // send latest param values to wp_nav
     g2.wp_nav.set_turn_params(g2.turn_radius, g2.motors.have_skid_steering());
     g2.pos_control.set_turn_params(g2.turn_radius, g2.motors.have_skid_steering());
+    g2.wheel_rate_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 }
 
 void Rover::update_current_mode(void)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5960,6 +5960,49 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             freqs.append(m.PkAvg)
         return numpy.median(numpy.asarray(freqs)), len(freqs)
 
+    def PIDNotches(self):
+        """Use dynamic harmonic notch to control motor noise."""
+        self.progress("Flying with PID notches")
+        self.context_push()
+
+        ex = None
+        try:
+            self.set_parameters({
+                "AHRS_EKF_TYPE": 10,
+                "INS_LOG_BAT_MASK": 3,
+                "INS_LOG_BAT_OPT": 0,
+                "INS_GYRO_FILTER": 100, # set the gyro filter high so we can observe behaviour
+                "LOG_BITMASK": 65535,
+                "LOG_DISARMED": 0,
+                "SIM_VIB_FREQ_X": 120,  # roll
+                "SIM_VIB_FREQ_Y": 120,  # pitch
+                "SIM_VIB_FREQ_Z": 180,  # yaw
+                "ATC_RAT_RLL_ADV": 1,
+                "ATC_RAT_RLL_NEF": 120,
+                "ATC_RAT_RLL_NBW": 50,
+                "ATC_RAT_PIT_ADV": 1,
+                "ATC_RAT_PIT_NEF": 120,
+                "ATC_RAT_PIT_NBW": 50,
+                "ATC_RAT_YAW_ADV": 1,
+                "ATC_RAT_YAW_NEF": 180,
+                "ATC_RAT_YAW_NBW": 50,
+                "SIM_GYR1_RND": 5,
+            })
+            self.reboot_sitl()
+
+            self.takeoff(10, mode="ALT_HOLD")
+
+            freq, hover_throttle, peakdb1 = self.hover_and_check_matched_frequency_with_fft(5, 20, 350, reverse=True)
+
+        except Exception as e:
+            self.print_exception_caught(e)
+            ex = e
+
+        self.context_pop()
+
+        if ex is not None:
+            raise ex
+
     def ThrottleGainBoost(self):
         """Use PD and Angle P boost for anti-gravity."""
         # basic gyro sample rate test
@@ -10561,6 +10604,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             Test(self.DynamicNotches, attempts=4),
             self.PositionWhenGPSIsZero,
             Test(self.DynamicRpmNotches, attempts=4),
+            self.PIDNotches,
             self.RefindGPS,
             Test(self.GyroFFT, attempts=1, speedup=8),
             Test(self.GyroFFTHarmonic, attempts=4, speedup=8),

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5968,6 +5968,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ex = None
         try:
             self.set_parameters({
+                "FILT1_TYPE": 1,
                 "AHRS_EKF_TYPE": 10,
                 "INS_LOG_BAT_MASK": 3,
                 "INS_LOG_BAT_OPT": 0,
@@ -5977,15 +5978,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "SIM_VIB_FREQ_X": 120,  # roll
                 "SIM_VIB_FREQ_Y": 120,  # pitch
                 "SIM_VIB_FREQ_Z": 180,  # yaw
-                "ATC_RAT_RLL_ADV": 1,
-                "ATC_RAT_RLL_NEF": 120,
-                "ATC_RAT_RLL_NBW": 50,
-                "ATC_RAT_PIT_ADV": 1,
-                "ATC_RAT_PIT_NEF": 120,
-                "ATC_RAT_PIT_NBW": 50,
-                "ATC_RAT_YAW_ADV": 1,
-                "ATC_RAT_YAW_NEF": 180,
-                "ATC_RAT_YAW_NBW": 50,
+                "FILT1_NOTCH_FREQ": 120,
+                "ATC_RAT_RLL_NEF": 1,
+                "ATC_RAT_PIT_NEF": 1,
+                "ATC_RAT_YAW_NEF": 1,
                 "SIM_GYR1_RND": 5,
             })
             self.reboot_sitl()

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -801,6 +801,49 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(8, 1000)
         self.disarm_vehicle()
 
+    def PIDNotches(self):
+        """Use dynamic harmonic notch to control motor noise."""
+        self.progress("Flying with PID notches")
+        self.context_push()
+
+        ex = None
+        try:
+            self.set_parameters({
+                "AHRS_EKF_TYPE": 10,
+                "INS_LOG_BAT_MASK": 3,
+                "INS_LOG_BAT_OPT": 0,
+                "INS_GYRO_FILTER": 100, # set the gyro filter high so we can observe behaviour
+                "LOG_BITMASK": 65535,
+                "LOG_DISARMED": 0,
+                "SIM_VIB_FREQ_X": 120,  # roll
+                "SIM_VIB_FREQ_Y": 120,  # pitch
+                "SIM_VIB_FREQ_Z": 180,  # yaw
+                "ATC_RAT_RLL_ADV": 1,
+                "ATC_RAT_RLL_NEF": 120,
+                "ATC_RAT_RLL_NBW": 50,
+                "ATC_RAT_PIT_ADV": 1,
+                "ATC_RAT_PIT_NEF": 120,
+                "ATC_RAT_PIT_NBW": 50,
+                "ATC_RAT_YAW_ADV": 1,
+                "ATC_RAT_YAW_NEF": 180,
+                "ATC_RAT_YAW_NBW": 50,
+                "SIM_GYR1_RND": 5,
+            })
+            self.reboot_sitl()
+
+            self.takeoff(10, mode="ALT_HOLD")
+
+            freq, hover_throttle, peakdb1 = self.hover_and_check_matched_frequency_with_fft(5, 20, 350, reverse=True)
+
+        except Exception as e:
+            self.print_exception_caught(e)
+            ex = e
+
+        self.context_pop()
+
+        if ex is not None:
+            raise ex
+
     def tests(self):
         '''return list of all tests'''
         ret = vehicle_test_suite.TestSuite.tests(self)
@@ -817,6 +860,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.AirspeedDrivers,
             self.TurbineStart,
             self.NastyMission,
+            self.PIDNotches,
         ])
         return ret
 

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -809,6 +809,8 @@ class AutoTestHelicopter(AutoTestCopter):
         ex = None
         try:
             self.set_parameters({
+                "FILT1_TYPE": 1,
+                "FILT2_TYPE": 1,
                 "AHRS_EKF_TYPE": 10,
                 "INS_LOG_BAT_MASK": 3,
                 "INS_LOG_BAT_OPT": 0,
@@ -818,15 +820,11 @@ class AutoTestHelicopter(AutoTestCopter):
                 "SIM_VIB_FREQ_X": 120,  # roll
                 "SIM_VIB_FREQ_Y": 120,  # pitch
                 "SIM_VIB_FREQ_Z": 180,  # yaw
-                "ATC_RAT_RLL_ADV": 1,
-                "ATC_RAT_RLL_NEF": 120,
-                "ATC_RAT_RLL_NBW": 50,
-                "ATC_RAT_PIT_ADV": 1,
-                "ATC_RAT_PIT_NEF": 120,
-                "ATC_RAT_PIT_NBW": 50,
-                "ATC_RAT_YAW_ADV": 1,
-                "ATC_RAT_YAW_NEF": 180,
-                "ATC_RAT_YAW_NBW": 50,
+                "FILT1_NOTCH_FREQ": 120,
+                "FILT2_NOTCH_FREQ": 180,
+                "ATC_RAT_RLL_NEF": 1,
+                "ATC_RAT_PIT_NEF": 1,
+                "ATC_RAT_YAW_NEF": 2,
                 "SIM_GYR1_RND": 5,
             })
             self.reboot_sitl()

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -342,6 +342,9 @@ public:
     // sanity check parameters.  should be called once before take-off
     virtual void parameter_sanity_check() {}
 
+    // set the PID notch sample rates
+    virtual void set_notch_sample_rate(float sample_rate) {}
+
     // return true if the rpy mix is at lowest value
     virtual bool is_throttle_mix_min() const { return true; }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -1,5 +1,6 @@
 #include "AC_AttitudeControl_Heli.h"
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
@@ -87,6 +88,47 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_RLL_ADV
+    // @DisplayName: Roll Advanced parameters enable
+    // @Description: Roll Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_RLL_D_FF
+    // @DisplayName: Roll Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NTF
+    // @DisplayName: Roll Target notch Filter center frequency
+    // @Description: Roll Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NEF
+    // @DisplayName: Roll Error notch Filter center frequency
+    // @Description: Roll Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NBW
+    // @DisplayName: Roll notch Filter bandwidth
+    // @Description: Roll notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NATT
+    // @DisplayName: Roll notch Filter attenuation
+    // @Description: Roll notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 2, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: RAT_PIT_P
@@ -159,6 +201,47 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.
     // @Range: 0 200
     // @Increment: 0.5
+    // @User: Advanced
+
+    // @Param: RAT_PIT_ADV
+    // @DisplayName: Pitch Advanced parameters enable
+    // @Description: Pitch Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_PIT_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 3, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -235,6 +318,47 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
+    // @Param: RAT_YAW_ADV
+    // @DisplayName: Yaw Advanced parameters enable
+    // @Description: Yaw Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_YAW_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 4, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: PIRO_COMP
@@ -246,6 +370,23 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     
     AP_GROUPEND
 };
+
+AC_AttitudeControl_Heli::AC_AttitudeControl_Heli(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsHeli& motors) :
+    AC_AttitudeControl(ahrs, aparm, motors),
+    _pid_rate_roll(AC_ATC_HELI_RATE_RP_P, AC_ATC_HELI_RATE_RP_I, AC_ATC_HELI_RATE_RP_D, AC_ATC_HELI_RATE_RP_FF, AC_ATC_HELI_RATE_RP_IMAX, AC_ATTITUDE_HELI_RATE_RP_FF_FILTER, AC_ATC_HELI_RATE_RP_FILT_HZ, 0.0f),
+    _pid_rate_pitch(AC_ATC_HELI_RATE_RP_P, AC_ATC_HELI_RATE_RP_I, AC_ATC_HELI_RATE_RP_D, AC_ATC_HELI_RATE_RP_FF, AC_ATC_HELI_RATE_RP_IMAX, AC_ATTITUDE_HELI_RATE_RP_FF_FILTER, AC_ATC_HELI_RATE_RP_FILT_HZ, 0.0f),
+    _pid_rate_yaw(AC_ATC_HELI_RATE_YAW_P, AC_ATC_HELI_RATE_YAW_I, AC_ATC_HELI_RATE_YAW_D, AC_ATC_HELI_RATE_YAW_FF, AC_ATC_HELI_RATE_YAW_IMAX, AC_ATTITUDE_HELI_RATE_Y_FF_FILTER, AC_ATC_HELI_RATE_YAW_FILT_HZ, 0.0f)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+    // initialise flags
+    _flags_heli.leaky_i = true;
+    _flags_heli.flybar_passthrough = false;
+    _flags_heli.tail_passthrough = false;
+#if AC_PID_ADVANCED_ENABLED
+    set_notch_sample_rate(AP::scheduler().get_loop_rate_hz());
+#endif
+}
 
 // passthrough_bf_roll_pitch_rate_yaw - passthrough the pilots roll and pitch inputs directly to swashplate for flybar acro mode
 void AC_AttitudeControl_Heli::passthrough_bf_roll_pitch_rate_yaw(float roll_passthrough, float pitch_passthrough, float yaw_rate_bf_cds)
@@ -484,4 +625,13 @@ void AC_AttitudeControl_Heli::input_euler_angle_roll_pitch_yaw(float euler_roll_
         euler_roll_angle_cd = wrap_180_cd(euler_roll_angle_cd + 18000);
     }
     AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_angle_cd, slew_yaw);
+}
+
+void AC_AttitudeControl_Heli::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _pid_rate_roll.set_notch_sample_rate(sample_rate);
+    _pid_rate_pitch.set_notch_sample_rate(sample_rate);
+    _pid_rate_yaw.set_notch_sample_rate(sample_rate);
+#endif
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -88,12 +88,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
-    // @Param: RAT_RLL_ADV
-    // @DisplayName: Roll Advanced parameters enable
-    // @Description: Roll Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_RLL_D_FF
     // @DisplayName: Roll Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -102,31 +96,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_RLL_NTF
-    // @DisplayName: Roll Target notch Filter center frequency
-    // @Description: Roll Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Roll Target notch filter index
+    // @Description: Roll Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
-    // @DisplayName: Roll Error notch Filter center frequency
-    // @Description: Roll Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NBW
-    // @DisplayName: Roll notch Filter bandwidth
-    // @Description: Roll notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NATT
-    // @DisplayName: Roll notch Filter attenuation
-    // @Description: Roll notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Roll Error notch filter index
+    // @Description: Roll Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 2, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -203,12 +181,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
-    // @Param: RAT_PIT_ADV
-    // @DisplayName: Pitch Advanced parameters enable
-    // @Description: Pitch Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_PIT_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -217,31 +189,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_PIT_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 3, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -318,12 +274,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Increment: 0.5
     // @User: Advanced
 
-    // @Param: RAT_YAW_ADV
-    // @DisplayName: Yaw Advanced parameters enable
-    // @Description: Yaw Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_YAW_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -332,31 +282,16 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_YAW_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 4, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -383,7 +318,7 @@ AC_AttitudeControl_Heli::AC_AttitudeControl_Heli(AP_AHRS_View &ahrs, const AP_Mu
     _flags_heli.leaky_i = true;
     _flags_heli.flybar_passthrough = false;
     _flags_heli.tail_passthrough = false;
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     set_notch_sample_rate(AP::scheduler().get_loop_rate_hz());
 #endif
 }
@@ -629,7 +564,7 @@ void AC_AttitudeControl_Heli::input_euler_angle_roll_pitch_yaw(float euler_roll_
 
 void AC_AttitudeControl_Heli::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _pid_rate_roll.set_notch_sample_rate(sample_rate);
     _pid_rate_pitch.set_notch_sample_rate(sample_rate);
     _pid_rate_yaw.set_notch_sample_rate(sample_rate);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -33,19 +33,7 @@ class AC_AttitudeControl_Heli : public AC_AttitudeControl {
 public:
     AC_AttitudeControl_Heli( AP_AHRS_View &ahrs,
                         const AP_MultiCopter &aparm,
-                        AP_MotorsHeli& motors) :
-        AC_AttitudeControl(ahrs, aparm, motors),
-        _pid_rate_roll(AC_ATC_HELI_RATE_RP_P, AC_ATC_HELI_RATE_RP_I, AC_ATC_HELI_RATE_RP_D, AC_ATC_HELI_RATE_RP_FF, AC_ATC_HELI_RATE_RP_IMAX, AC_ATTITUDE_HELI_RATE_RP_FF_FILTER, AC_ATC_HELI_RATE_RP_FILT_HZ, 0.0f),
-        _pid_rate_pitch(AC_ATC_HELI_RATE_RP_P, AC_ATC_HELI_RATE_RP_I, AC_ATC_HELI_RATE_RP_D, AC_ATC_HELI_RATE_RP_FF, AC_ATC_HELI_RATE_RP_IMAX, AC_ATTITUDE_HELI_RATE_RP_FF_FILTER, AC_ATC_HELI_RATE_RP_FILT_HZ, 0.0f),
-        _pid_rate_yaw(AC_ATC_HELI_RATE_YAW_P, AC_ATC_HELI_RATE_YAW_I, AC_ATC_HELI_RATE_YAW_D, AC_ATC_HELI_RATE_YAW_FF, AC_ATC_HELI_RATE_YAW_IMAX, AC_ATTITUDE_HELI_RATE_Y_FF_FILTER, AC_ATC_HELI_RATE_YAW_FILT_HZ, 0.0f)
-        {
-            AP_Param::setup_object_defaults(this, var_info);
-
-            // initialise flags
-            _flags_heli.leaky_i = true;
-            _flags_heli.flybar_passthrough = false;
-            _flags_heli.tail_passthrough = false;
-        }
+                        AP_MotorsHeli& motors);
 
     // pid accessors
     AC_PID& get_rate_roll_pid() override { return _pid_rate_roll; }
@@ -97,7 +85,10 @@ public:
     void set_inverted_flight(bool inverted) override {
         _inverted_flight = inverted;
     }
-    
+
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) override;
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -81,12 +81,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_RLL_ADV
-    // @DisplayName: Roll Advanced parameters enable
-    // @Description: Roll Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_RLL_D_FF
     // @DisplayName: Roll Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -95,31 +89,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_RLL_NTF
-    // @DisplayName: Roll Target notch Filter center frequency
-    // @Description: Roll Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Roll Target notch filter index
+    // @Description: Roll Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
-    // @DisplayName: Roll Error notch Filter center frequency
-    // @Description: Roll Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NBW
-    // @DisplayName: Roll notch Filter bandwidth
-    // @Description: Roll notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-    
-    // @Param: RAT_RLL_NATT
-    // @DisplayName: Roll notch Filter attenuation
-    // @Description: Roll notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Roll Error notch filter index
+    // @Description: Roll Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID),
@@ -196,12 +174,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_PIT_ADV
-    // @DisplayName: Pitch Advanced parameters enable
-    // @Description: Pitch Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_PIT_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -210,31 +182,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_PIT_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID),
@@ -311,12 +267,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_YAW_ADV
-    // @DisplayName: Yaw Advanced parameters enable
-    // @Description: Yaw Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_YAW_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -325,31 +275,16 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_YAW_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID),
@@ -391,7 +326,7 @@ AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_
 {
     AP_Param::setup_object_defaults(this, var_info);
 
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     set_notch_sample_rate(AP::scheduler().get_loop_rate_hz());
 #endif
 }
@@ -559,7 +494,7 @@ void AC_AttitudeControl_Multi::parameter_sanity_check()
 
 void AC_AttitudeControl_Multi::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _pid_rate_roll.set_notch_sample_rate(sample_rate);
     _pid_rate_pitch.set_notch_sample_rate(sample_rate);
     _pid_rate_yaw.set_notch_sample_rate(sample_rate);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -2,6 +2,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PID.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
@@ -79,6 +80,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Roll axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_RLL_ADV
+    // @DisplayName: Roll Advanced parameters enable
+    // @Description: Roll Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_RLL_D_FF
+    // @DisplayName: Roll Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NTF
+    // @DisplayName: Roll Target notch Filter center frequency
+    // @Description: Roll Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NEF
+    // @DisplayName: Roll Error notch Filter center frequency
+    // @Description: Roll Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NBW
+    // @DisplayName: Roll notch Filter bandwidth
+    // @Description: Roll notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+    
+    // @Param: RAT_RLL_NATT
+    // @DisplayName: Roll notch Filter attenuation
+    // @Description: Roll notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID),
@@ -154,6 +195,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Pitch axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_PIT_ADV
+    // @DisplayName: Pitch Advanced parameters enable
+    // @Description: Pitch Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_PIT_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID),
@@ -229,6 +310,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Yaw axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_YAW_ADV
+    // @DisplayName: Yaw Advanced parameters enable
+    // @Description: Yaw Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_YAW_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID),
@@ -269,6 +390,10 @@ AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_
     _motors_multi(motors)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+#if AC_PID_ADVANCED_ENABLED
+    set_notch_sample_rate(AP::scheduler().get_loop_rate_hz());
+#endif
 }
 
 // Update Alt_Hold angle maximum
@@ -430,4 +555,13 @@ void AC_AttitudeControl_Multi::parameter_sanity_check()
         _thr_mix_min.set_and_save(AC_ATTITUDE_CONTROL_MIN_DEFAULT);
         _thr_mix_max.set_and_save(AC_ATTITUDE_CONTROL_MAX_DEFAULT);
     }
+}
+
+void AC_AttitudeControl_Multi::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _pid_rate_roll.set_notch_sample_rate(sample_rate);
+    _pid_rate_pitch.set_notch_sample_rate(sample_rate);
+    _pid_rate_yaw.set_notch_sample_rate(sample_rate);
+#endif
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -81,6 +81,9 @@ public:
     // sanity check parameters.  should be called once before take-off
     void parameter_sanity_check() override;
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) override;
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -79,12 +79,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_RLL_ADV
-    // @DisplayName: Roll Advanced parameters enable
-    // @Description: Roll Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_RLL_D_FF
     // @DisplayName: Roll Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -93,31 +87,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_RLL_NTF
-    // @DisplayName: Roll Target notch Filter center frequency
-    // @Description: Roll Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Roll Target notch filter index
+    // @Description: Roll Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
-    // @DisplayName: Roll Error notch Filter center frequency
-    // @Description: Roll Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NBW
-    // @DisplayName: Roll notch Filter bandwidth
-    // @Description: Roll notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NATT
-    // @DisplayName: Roll notch Filter attenuation
-    // @Description: Roll notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Roll Error notch filter index
+    // @Description: Roll Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Sub, AC_PID),
@@ -194,12 +172,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_PIT_ADV
-    // @DisplayName: Pitch Advanced parameters enable
-    // @Description: Pitch Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_PIT_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -208,31 +180,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_PIT_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Sub, AC_PID),
@@ -309,12 +265,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: RAT_YAW_ADV
-    // @DisplayName: Yaw Advanced parameters enable
-    // @Description: Yaw Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_YAW_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -323,31 +273,15 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_YAW_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Sub, AC_PID),
@@ -552,7 +486,7 @@ void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw(float euler_r
 
 void AC_AttitudeControl_Sub::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _pid_rate_roll.set_notch_sample_rate(sample_rate);
     _pid_rate_pitch.set_notch_sample_rate(sample_rate);
     _pid_rate_yaw.set_notch_sample_rate(sample_rate);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -78,6 +78,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Roll axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_RLL_ADV
+    // @DisplayName: Roll Advanced parameters enable
+    // @Description: Roll Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_RLL_D_FF
+    // @DisplayName: Roll Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NTF
+    // @DisplayName: Roll Target notch Filter center frequency
+    // @Description: Roll Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NEF
+    // @DisplayName: Roll Error notch Filter center frequency
+    // @Description: Roll Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NBW
+    // @DisplayName: Roll notch Filter bandwidth
+    // @Description: Roll notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NATT
+    // @DisplayName: Roll notch Filter attenuation
+    // @Description: Roll notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Sub, AC_PID),
@@ -153,6 +193,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Pitch axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_PIT_ADV
+    // @DisplayName: Pitch Advanced parameters enable
+    // @Description: Pitch Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_PIT_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Sub, AC_PID),
@@ -228,6 +308,46 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Yaw axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: RAT_YAW_ADV
+    // @DisplayName: Yaw Advanced parameters enable
+    // @Description: Yaw Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_YAW_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Sub, AC_PID),
@@ -428,4 +548,13 @@ void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw(float euler_r
         // holds the rov's angles
         input_euler_angle_roll_pitch_yaw(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_angle_cd, true);
     }
+}
+
+void AC_AttitudeControl_Sub::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _pid_rate_roll.set_notch_sample_rate(sample_rate);
+    _pid_rate_pitch.set_notch_sample_rate(sample_rate);
+    _pid_rate_yaw.set_notch_sample_rate(sample_rate);
+#endif
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
@@ -65,6 +65,9 @@ public:
     // sanity check parameters.  should be called once before take-off
     void parameter_sanity_check() override;
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) override;
+
     // This function ensures that the ROV reaches the target orientation with the desired yaw rate
     void input_euler_angle_roll_pitch_slew_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float slew_yaw);
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -209,6 +209,46 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Acceleration (vertical) controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1000
     // @Units: d%
+
+    // @Param: _ACCZ_ADV
+    // @DisplayName: Accel (vertical) Advanced parameters enable
+    // @Description: Accel (vertical) Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _ACCZ_D_FF
+    // @DisplayName: Accel (vertical) Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: _ACCZ_NTF
+    // @DisplayName: Accel (vertical) Target notch Filter center frequency
+    // @Description: Accel (vertical) Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _ACCZ_NEF
+    // @DisplayName: Accel (vertical) Error notch Filter center frequency
+    // @Description: Accel (vertical) Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _ACCZ_NBW
+    // @DisplayName: Accel (vertical) notch Filter bandwidth
+    // @Description: Accel (vertical) notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _ACCZ_NATT
+    // @DisplayName: Accel (vertical) notch Filter attenuation
+    // @Description: Accel (vertical) notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_accel_z, "_ACCZ_", 4, AC_PosControl, AC_PID),

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -210,12 +210,6 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 0 1000
     // @Units: d%
 
-    // @Param: _ACCZ_ADV
-    // @DisplayName: Accel (vertical) Advanced parameters enable
-    // @Description: Accel (vertical) Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _ACCZ_D_FF
     // @DisplayName: Accel (vertical) Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -224,31 +218,15 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @User: Advanced
 
     // @Param: _ACCZ_NTF
-    // @DisplayName: Accel (vertical) Target notch Filter center frequency
-    // @Description: Accel (vertical) Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Accel (vertical) Target notch filter index
+    // @Description: Accel (vertical) Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _ACCZ_NEF
-    // @DisplayName: Accel (vertical) Error notch Filter center frequency
-    // @Description: Accel (vertical) Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _ACCZ_NBW
-    // @DisplayName: Accel (vertical) notch Filter bandwidth
-    // @Description: Accel (vertical) notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _ACCZ_NATT
-    // @DisplayName: Accel (vertical) notch Filter attenuation
-    // @Description: Accel (vertical) notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Accel (vertical) Error notch filter index
+    // @Description: Accel (vertical) Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_accel_z, "_ACCZ_", 4, AC_PosControl, AC_PID),

--- a/libraries/AC_CustomControl/AC_CustomControl.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl.cpp
@@ -184,4 +184,13 @@ void AC_CustomControl::log_switch(void) {
                             _custom_controller_active);
 }
 
+void AC_CustomControl::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    if (_backend != nullptr) {
+        _backend->set_notch_sample_rate(sample_rate);
+    }
+#endif
+}
+
 #endif

--- a/libraries/AC_CustomControl/AC_CustomControl.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl.cpp
@@ -186,7 +186,7 @@ void AC_CustomControl::log_switch(void) {
 
 void AC_CustomControl::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     if (_backend != nullptr) {
         _backend->set_notch_sample_rate(sample_rate);
     }

--- a/libraries/AC_CustomControl/AC_CustomControl.h
+++ b/libraries/AC_CustomControl/AC_CustomControl.h
@@ -32,6 +32,9 @@ public:
     bool is_safe_to_run(void);
     void log_switch(void);
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate);
+
     // zero index controller type param, only use it to access _backend or _backend_var_info array
     uint8_t get_type() { return _controller_type > 0 ? (_controller_type - 1) : 0; };
 

--- a/libraries/AC_CustomControl/AC_CustomControl_Backend.h
+++ b/libraries/AC_CustomControl/AC_CustomControl_Backend.h
@@ -23,6 +23,9 @@ public:
     // reset controller to avoid build up or abrupt response upon switch, ex: integrator, filter
     virtual void reset() = 0;
 
+    // set the PID notch sample rates
+    virtual void set_notch_sample_rate(float sample_rate) {};
+
 protected:
     // References to external libraries
     AP_AHRS_View*& _ahrs;

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
@@ -102,12 +102,6 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: RAT_RLL_ADV
-    // @DisplayName: Roll Advanced parameters enable
-    // @Description: Roll Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_RLL_D_FF
     // @DisplayName: Roll Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -116,31 +110,15 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_RLL_NTF
-    // @DisplayName: Roll Target notch Filter center frequency
-    // @Description: Roll Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Roll Target notch filter index
+    // @Description: Roll Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
-    // @DisplayName: Roll Error notch Filter center frequency
-    // @Description: Roll Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NBW
-    // @DisplayName: Roll notch Filter bandwidth
-    // @Description: Roll notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_RLL_NATT
-    // @DisplayName: Roll notch Filter attenuation
-    // @Description: Roll notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Roll Error notch filter index
+    // @Description: Roll Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_roll, "RAT_RLL_", 4, AC_CustomControl_PID, AC_PID),
@@ -218,12 +196,6 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: RAT_PIT_ADV
-    // @DisplayName: Pitch Advanced parameters enable
-    // @Description: Pitch Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_PIT_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -232,31 +204,15 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_PIT_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_PIT_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_pitch, "RAT_PIT_", 5, AC_CustomControl_PID, AC_PID),
@@ -335,12 +291,6 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
 
-    // @Param: RAT_YAW_ADV
-    // @DisplayName: Yaw Advanced parameters enable
-    // @Description: Yaw Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: RAT_YAW_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -349,31 +299,15 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @User: Advanced
 
     // @Param: RAT_YAW_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: RAT_YAW_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_yaw, "RAT_YAW_", 6, AC_CustomControl_PID, AC_PID),
@@ -461,7 +395,7 @@ void AC_CustomControl_PID::reset(void)
 
 void AC_CustomControl_PID::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _pid_atti_rate_roll.set_notch_sample_rate(sample_rate);
     _pid_atti_rate_pitch.set_notch_sample_rate(sample_rate);
     _pid_atti_rate_yaw.set_notch_sample_rate(sample_rate);

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
@@ -101,6 +101,48 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Advanced
+
+    // @Param: RAT_RLL_ADV
+    // @DisplayName: Roll Advanced parameters enable
+    // @Description: Roll Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_RLL_D_FF
+    // @DisplayName: Roll Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NTF
+    // @DisplayName: Roll Target notch Filter center frequency
+    // @Description: Roll Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NEF
+    // @DisplayName: Roll Error notch Filter center frequency
+    // @Description: Roll Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NBW
+    // @DisplayName: Roll notch Filter bandwidth
+    // @Description: Roll notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_RLL_NATT
+    // @DisplayName: Roll notch Filter attenuation
+    // @Description: Roll notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_atti_rate_roll, "RAT_RLL_", 4, AC_CustomControl_PID, AC_PID),
 
     // @Param: RAT_PIT_P
@@ -175,6 +217,48 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Advanced
+
+    // @Param: RAT_PIT_ADV
+    // @DisplayName: Pitch Advanced parameters enable
+    // @Description: Pitch Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_PIT_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_PIT_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_atti_rate_pitch, "RAT_PIT_", 5, AC_CustomControl_PID, AC_PID),
 
 
@@ -250,6 +334,48 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Advanced
+
+    // @Param: RAT_YAW_ADV
+    // @DisplayName: Yaw Advanced parameters enable
+    // @Description: Yaw Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: RAT_YAW_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: RAT_YAW_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+
     AP_SUBGROUPINFO(_pid_atti_rate_yaw, "RAT_YAW_", 6, AC_CustomControl_PID, AC_PID),
 
     AP_GROUPEND
@@ -330,6 +456,16 @@ void AC_CustomControl_PID::reset(void)
     _pid_atti_rate_roll.reset_filter();
     _pid_atti_rate_pitch.reset_filter();
     _pid_atti_rate_yaw.reset_filter();
+}
+
+
+void AC_CustomControl_PID::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _pid_atti_rate_roll.set_notch_sample_rate(sample_rate);
+    _pid_atti_rate_pitch.set_notch_sample_rate(sample_rate);
+    _pid_atti_rate_yaw.set_notch_sample_rate(sample_rate);
+#endif
 }
 
 #endif

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.h
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.h
@@ -21,6 +21,9 @@ public:
     Vector3f update() override;
     void reset(void) override;
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) override;
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -69,12 +69,62 @@ const AP_Param::GroupInfo AC_HELI_PID::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SMAX", 12, AC_HELI_PID, _slew_rate_max, 0),
 
+#if AC_PID_ADVANCED_ENABLED
+    // @Param: ADV
+    // @DisplayName: Advanced parameters enable
+    // @Description: Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ADV", 32, AC_HELI_PID, _adv_enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: D_FF
+    // @DisplayName: PID Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0 0.02
+    // @Increment: 0.0001
+    // @User: Advanced
+    AP_GROUPINFO("D_FF", 33, AC_HELI_PID, _kdff, 0),
+
+    // @Param: NTF
+    // @DisplayName: PID Target notch Filter center frequency
+    // @Description: PID Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NTF", 34, AC_HELI_PID, _notch_T_center_freq_hz, 0),
+
+    // @Param: NEF
+    // @DisplayName: PID Error notch Filter center frequency
+    // @Description: PID Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NEF", 35, AC_HELI_PID, _notch_E_center_freq_hz, 0),
+
+    // @Param: NBW
+    // @DisplayName: PID notch Filter bandwidth
+    // @Description: PID notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NBW", 36, AC_HELI_PID, _notch_bandwidth_hz, 0),
+
+    // @Param: NATT
+    // @DisplayName: PID notch Filter attenuation
+    // @Description: PID notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+    AP_GROUPINFO("NATT", 37, AC_HELI_PID, _notch_attenuation_dB, 40),
+
+#endif
+
     AP_GROUPEND
 };
 
 /// Constructor for PID
-AC_HELI_PID::AC_HELI_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz) :
-    AC_PID(initial_p, initial_i, initial_d, initial_ff, initial_imax, initial_filt_T_hz, initial_filt_E_hz, initial_filt_D_hz)
+AC_HELI_PID::AC_HELI_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz, float dff_val) :
+    AC_PID(initial_p, initial_i, initial_d, initial_ff, initial_imax, initial_filt_T_hz, initial_filt_E_hz, initial_filt_D_hz, dff_val)
 {
     _last_requested_rate = 0;
 }

--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -69,13 +69,11 @@ const AP_Param::GroupInfo AC_HELI_PID::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SMAX", 12, AC_HELI_PID, _slew_rate_max, 0),
 
-#if AC_PID_ADVANCED_ENABLED
-    // @Param: ADV
-    // @DisplayName: Advanced parameters enable
-    // @Description: Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
+    // @Param: PDMX
+    // @DisplayName: PD sum maximum
+    // @Description: The maximum/minimum value that the sum of the P and D term can output
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ADV", 32, AC_HELI_PID, _adv_enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO("PDMX", 13, AC_HELI_PID, _kpdmax, 0),
 
     // @Param: D_FF
     // @DisplayName: PID Derivative FeedForward Gain
@@ -83,40 +81,22 @@ const AP_Param::GroupInfo AC_HELI_PID::var_info[] = {
     // @Range: 0 0.02
     // @Increment: 0.0001
     // @User: Advanced
-    AP_GROUPINFO("D_FF", 33, AC_HELI_PID, _kdff, 0),
+    AP_GROUPINFO("D_FF", 14, AC_HELI_PID, _kdff, 0),
 
+#if AP_FILTER_ENABLED
     // @Param: NTF
-    // @DisplayName: PID Target notch Filter center frequency
-    // @Description: PID Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: PID Target notch filter index
+    // @Description: PID Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
-    AP_GROUPINFO("NTF", 34, AC_HELI_PID, _notch_T_center_freq_hz, 0),
+    AP_GROUPINFO("NTF", 15, AC_HELI_PID, _notch_T_filter, 0),
 
     // @Param: NEF
-    // @DisplayName: PID Error notch Filter center frequency
-    // @Description: PID Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: PID Error notch filter index
+    // @Description: PID Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
-    AP_GROUPINFO("NEF", 35, AC_HELI_PID, _notch_E_center_freq_hz, 0),
-
-    // @Param: NBW
-    // @DisplayName: PID notch Filter bandwidth
-    // @Description: PID notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-    AP_GROUPINFO("NBW", 36, AC_HELI_PID, _notch_bandwidth_hz, 0),
-
-    // @Param: NATT
-    // @DisplayName: PID notch Filter attenuation
-    // @Description: PID notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
-    // @User: Advanced
-    AP_GROUPINFO("NATT", 37, AC_HELI_PID, _notch_attenuation_dB, 40),
-
+    AP_GROUPINFO("NEF", 16, AC_HELI_PID, _notch_E_filter, 0),
 #endif
 
     AP_GROUPEND

--- a/libraries/AC_PID/AC_HELI_PID.h
+++ b/libraries/AC_PID/AC_HELI_PID.h
@@ -17,7 +17,7 @@ class AC_HELI_PID : public AC_PID {
 public:
 
     /// Constructor for PID
-    AC_HELI_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz);
+    AC_HELI_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz, float dff_val=0);
 
     CLASS_NO_COPY(AC_HELI_PID);
 

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -8,11 +8,16 @@
 #include <stdlib.h>
 #include <cmath>
 #include <Filter/SlewLimiter.h>
+#include <Filter/NotchFilter.h>
 
 #define AC_PID_TFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_EFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_DFILT_HZ_DEFAULT  20.0f   // default input filter frequency
 #define AC_PID_RESET_TC          0.16f   // Time constant for integrator reset decay to zero
+
+#ifndef AC_PID_ADVANCED_ENABLED
+#define AC_PID_ADVANCED_ENABLED 0
+#endif
 
 #include "AP_PIDInfo.h"
 
@@ -32,11 +37,12 @@ public:
         float filt_D_hz;
         float srmax;
         float srtau;
+        float dff;
     };
 
     // Constructor for PID
     AC_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz,
-           float initial_srmax=0, float initial_srtau=1.0);
+           float initial_srmax=0, float initial_srtau=1.0, float initial_dff=0);
     AC_PID(const AC_PID::Defaults &defaults) :
         AC_PID(
             defaults.p,
@@ -48,7 +54,8 @@ public:
             defaults.filt_E_hz,
             defaults.filt_D_hz,
             defaults.srmax,
-            defaults.srtau
+            defaults.srtau,
+            defaults.dff
             )
         { }
 
@@ -95,7 +102,7 @@ public:
     void save_gains();
 
     /// operator function call for easy initialisation
-    void operator()(float p_val, float i_val, float d_val, float ff_val, float imax_val, float input_filt_T_hz, float input_filt_E_hz, float input_filt_D_hz);
+    void operator()(float p_val, float i_val, float d_val, float ff_val, float imax_val, float input_filt_T_hz, float input_filt_E_hz, float input_filt_D_hz, float dff_val=0);
 
     // get accessors
     const AP_Float &kP() const { return _kp; }
@@ -146,6 +153,11 @@ public:
 
     const AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
+#if AC_PID_ADVANCED_ENABLED
+    AP_Float &kDff() { return _kdff; }
+    void kDff(const float v) { _kdff.set(v); }
+#endif
+    void set_notch_sample_rate(float);
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -168,7 +180,14 @@ protected:
     AP_Float _filt_E_hz;         // PID error filter frequency in Hz
     AP_Float _filt_D_hz;         // PID derivative filter frequency in Hz
     AP_Float _slew_rate_max;
-
+#if AC_PID_ADVANCED_ENABLED
+    AP_Int8  _adv_enable;
+    AP_Float _kdff;
+    AP_Float _notch_T_center_freq_hz;
+    AP_Float _notch_E_center_freq_hz;
+    AP_Float _notch_bandwidth_hz;
+    AP_Float _notch_attenuation_dB;
+#endif
     SlewLimiter _slew_limiter{_slew_rate_max, _slew_rate_tau};
 
     // flags
@@ -182,6 +201,11 @@ protected:
     float _error;             // error value to enable filtering
     float _derivative;        // derivative value to enable filtering
     int8_t _slew_limit_scale;
+    float _target_derivative; // target derivative value to enable dff
+#if AC_PID_ADVANCED_ENABLED
+    NotchFilterFloat _target_notch;
+    NotchFilterFloat _error_notch;
+#endif
 
     AP_PIDInfo _pid_info;
 
@@ -190,6 +214,7 @@ private:
     const float default_ki;
     const float default_kd;
     const float default_kff;
+    const float default_kdff;
     const float default_kimax;
     const float default_filt_T_hz;
     const float default_filt_E_hz;

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -9,15 +9,12 @@
 #include <cmath>
 #include <Filter/SlewLimiter.h>
 #include <Filter/NotchFilter.h>
+#include <Filter/AP_Filter.h>
 
 #define AC_PID_TFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_EFILT_HZ_DEFAULT  0.0f   // default input filter frequency
 #define AC_PID_DFILT_HZ_DEFAULT  20.0f   // default input filter frequency
 #define AC_PID_RESET_TC          0.16f   // Time constant for integrator reset decay to zero
-
-#ifndef AC_PID_ADVANCED_ENABLED
-#define AC_PID_ADVANCED_ENABLED 0
-#endif
 
 #include "AP_PIDInfo.h"
 
@@ -153,10 +150,8 @@ public:
 
     const AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
-#if AC_PID_ADVANCED_ENABLED
     AP_Float &kDff() { return _kdff; }
     void kDff(const float v) { _kdff.set(v); }
-#endif
     void set_notch_sample_rate(float);
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
@@ -180,13 +175,10 @@ protected:
     AP_Float _filt_E_hz;         // PID error filter frequency in Hz
     AP_Float _filt_D_hz;         // PID derivative filter frequency in Hz
     AP_Float _slew_rate_max;
-#if AC_PID_ADVANCED_ENABLED
-    AP_Int8  _adv_enable;
     AP_Float _kdff;
-    AP_Float _notch_T_center_freq_hz;
-    AP_Float _notch_E_center_freq_hz;
-    AP_Float _notch_bandwidth_hz;
-    AP_Float _notch_attenuation_dB;
+#if AP_FILTER_ENABLED
+    AP_Int8 _notch_T_filter;
+    AP_Int8 _notch_E_filter;
 #endif
     SlewLimiter _slew_limiter{_slew_rate_max, _slew_rate_tau};
 
@@ -202,9 +194,9 @@ protected:
     float _derivative;        // derivative value to enable filtering
     int8_t _slew_limit_scale;
     float _target_derivative; // target derivative value to enable dff
-#if AC_PID_ADVANCED_ENABLED
-    NotchFilterFloat _target_notch;
-    NotchFilterFloat _error_notch;
+#if AP_FILTER_ENABLED
+    NotchFilterFloat* _target_notch;
+    NotchFilterFloat* _error_notch;
 #endif
 
     AP_PIDInfo _pid_info;

--- a/libraries/AC_PID/AP_PIDInfo.h
+++ b/libraries/AC_PID/AP_PIDInfo.h
@@ -14,6 +14,7 @@ struct AP_PIDInfo {
     float I;
     float D;
     float FF;
+    float DFF;
     float Dmod;
     float slew_rate;
     bool limit;

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -179,7 +179,7 @@ void AP_AutoTune::update(AP_PIDInfo &pinfo, float scaler, float angle_err_deg)
     // filter actuator without I term so we can take ratios without
     // accounting for trim offsets. We first need to include the I and
     // clip to 45 degrees to get the right value of the real surface
-    const float clipped_actuator = constrain_float(pinfo.FF + pinfo.P + pinfo.D + pinfo.I, -45, 45) - pinfo.I;
+    const float clipped_actuator = constrain_float(pinfo.FF + pinfo.P + pinfo.D + pinfo.DFF + pinfo.I, -45, 45) - pinfo.I;
     const float actuator = actuator_filter.apply(clipped_actuator);
     const float actual_rate = rate_filter.apply(pinfo.actual);
 

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -218,13 +218,14 @@ float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool d
     pinfo.P *= deg_scale;
     pinfo.I *= deg_scale;
     pinfo.D *= deg_scale;
+    pinfo.DFF *= deg_scale;
 
     // fix the logged target and actual values to not have the scalers applied
     pinfo.target = desired_rate;
     pinfo.actual = degrees(rate_y);
 
     // sum components
-    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D;
+    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
     if (ground_mode) {
         // when on ground suppress D and half P term to prevent oscillations
         out -= pinfo.D + 0.5*pinfo.P;

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -136,6 +136,46 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Description: Pitch axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: _RATE_ADV
+    // @DisplayName: Pitch Advanced parameters enable
+    // @Description: Pitch Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _RATE_D_FF
+    // @DisplayName: Pitch Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _RATE_NTF
+    // @DisplayName: Pitch Target notch Filter center frequency
+    // @Description: Pitch Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NEF
+    // @DisplayName: Pitch Error notch Filter center frequency
+    // @Description: Pitch Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NBW
+    // @DisplayName: Pitch notch Filter bandwidth
+    // @Description: Pitch notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NATT
+    // @DisplayName: Pitch notch Filter attenuation
+    // @Description: Pitch notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 11, AP_PitchController, AC_PID),

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -137,45 +137,23 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: _RATE_ADV
-    // @DisplayName: Pitch Advanced parameters enable
-    // @Description: Pitch Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _RATE_D_FF
     // @DisplayName: Pitch Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _RATE_NTF
-    // @DisplayName: Pitch Target notch Filter center frequency
-    // @Description: Pitch Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch Target notch filter index
+    // @Description: Pitch Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
-    // @DisplayName: Pitch Error notch Filter center frequency
-    // @Description: Pitch Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NBW
-    // @DisplayName: Pitch notch Filter bandwidth
-    // @Description: Pitch notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NATT
-    // @DisplayName: Pitch notch Filter attenuation
-    // @Description: Pitch notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch Error notch filter index
+    // @Description: Pitch Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 11, AP_PitchController, AC_PID),

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -40,6 +40,9 @@ public:
         return _pid_info;
     }
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+
     static const struct AP_Param::GroupInfo var_info[];
 
     AP_Float &kP(void) { return rate_pid.kP(); }

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -206,13 +206,14 @@ float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool di
     pinfo.P *= deg_scale;
     pinfo.I *= deg_scale;
     pinfo.D *= deg_scale;
+    pinfo.DFF *= deg_scale;
 
     // fix the logged target and actual values to not have the scalers applied
     pinfo.target = desired_rate;
     pinfo.actual = degrees(rate_x);
 
     // sum components
-    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D;
+    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
     if (ground_mode) {
         // when on ground suppress D term to prevent oscillations
         out -= pinfo.D + 0.5*pinfo.P;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -119,6 +119,46 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Description: Roll axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: _RATE_ADV
+    // @DisplayName: Roll Advanced parameters enable
+    // @Description: Roll Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _RATE_D_FF
+    // @DisplayName: Roll Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _RATE_NTF
+    // @DisplayName: Roll Target notch Filter center frequency
+    // @Description: Roll Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NEF
+    // @DisplayName: Roll Error notch Filter center frequency
+    // @Description: Roll Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NBW
+    // @DisplayName: Roll notch Filter bandwidth
+    // @Description: Roll notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NATT
+    // @DisplayName: Roll notch Filter attenuation
+    // @Description: Roll notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_RollController, AC_PID),

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -120,45 +120,23 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: _RATE_ADV
-    // @DisplayName: Roll Advanced parameters enable
-    // @Description: Roll Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _RATE_D_FF
     // @DisplayName: Roll Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _RATE_NTF
-    // @DisplayName: Roll Target notch Filter center frequency
-    // @Description: Roll Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Roll Target notch filter index
+    // @Description: Roll Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
-    // @DisplayName: Roll Error notch Filter center frequency
-    // @Description: Roll Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NBW
-    // @DisplayName: Roll notch Filter bandwidth
-    // @Description: Roll notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NATT
-    // @DisplayName: Roll notch Filter attenuation
-    // @Description: Roll notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Roll Error notch filter index
+    // @Description: Roll Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_RollController, AC_PID),

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -40,6 +40,9 @@ public:
         return _pid_info;
     }
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+
     static const struct AP_Param::GroupInfo var_info[];
 
 

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -150,6 +150,46 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Description: Yaw axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0 1
     // @Increment: 0.01
+
+    // @Param: _RATE_ADV
+    // @DisplayName: Yaw Advanced parameters enable
+    // @Description: Yaw Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _RATE_D_FF
+    // @DisplayName: Yaw Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _RATE_NTF
+    // @DisplayName: Yaw Target notch Filter center frequency
+    // @Description: Yaw Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NEF
+    // @DisplayName: Yaw Error notch Filter center frequency
+    // @Description: Yaw Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NBW
+    // @DisplayName: Yaw notch Filter bandwidth
+    // @Description: Yaw notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NATT
+    // @DisplayName: Yaw notch Filter attenuation
+    // @Description: Yaw notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_YawController, AC_PID),

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -344,6 +344,7 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
     pinfo.P *= deg_scale;
     pinfo.I *= deg_scale;
     pinfo.D *= deg_scale;
+    pinfo.DFF *= deg_scale;
     pinfo.limit = limit_I;
 
     // fix the logged target and actual values to not have the scalers applied
@@ -351,7 +352,7 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
     pinfo.actual = degrees(rate_z);
 
     // sum components
-    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D;
+    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
 
     // remember the last output to trigger the I limit
     _last_out = out;

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -151,45 +151,23 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
 
-    // @Param: _RATE_ADV
-    // @DisplayName: Yaw Advanced parameters enable
-    // @Description: Yaw Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _RATE_D_FF
     // @DisplayName: Yaw Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _RATE_NTF
-    // @DisplayName: Yaw Target notch Filter center frequency
-    // @Description: Yaw Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Yaw Target notch filter index
+    // @Description: Yaw Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
-    // @DisplayName: Yaw Error notch Filter center frequency
-    // @Description: Yaw Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NBW
-    // @DisplayName: Yaw notch Filter bandwidth
-    // @Description: Yaw notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NATT
-    // @DisplayName: Yaw notch Filter attenuation
-    // @Description: Yaw notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Yaw Error notch filter index
+    // @Description: Yaw Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_YawController, AC_PID),

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -43,6 +43,9 @@ public:
         return _pid_info;
     }
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+
     // start/stop auto tuner
     void autotune_start(void);
     void autotune_restore(void);

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -146,6 +146,46 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Steering control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
     // @Increment: 0.01
+
+    // @Param: _STR_RAT_ADV
+    // @DisplayName: Steering control Advanced parameters enable
+    // @Description: Steering control Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _STR_RAT_D_FF
+    // @DisplayName: Steering control Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _STR_RAT_NTF
+    // @DisplayName: Steering control Target notch Filter center frequency
+    // @Description: Steering control Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _STR_RAT_NEF
+    // @DisplayName: Steering control Error notch Filter center frequency
+    // @Description: Steering control Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _STR_RAT_NBW
+    // @DisplayName: Steering control notch Filter bandwidth
+    // @Description: Steering control notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _STR_RAT_NATT
+    // @DisplayName: Steering control notch Filter attenuation
+    // @Description: Steering control notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_steer_rate_pid, "_STR_RAT_", 1, AR_AttitudeControl, AC_PID),
@@ -229,6 +269,46 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Speed control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
     // @Increment: 0.01
+
+    // @Param: _SPEED_ADV
+    // @DisplayName: Speed control Advanced parameters enable
+    // @Description: Speed control Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _SPEED_D_FF
+    // @DisplayName: Speed control Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _SPEED_NTF
+    // @DisplayName: Speed control Target notch Filter center frequency
+    // @Description: Speed control Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SPEED_NEF
+    // @DisplayName: Speed control Error notch Filter center frequency
+    // @Description: Speed control Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SPEED_NBW
+    // @DisplayName: Speed control notch Filter bandwidth
+    // @Description: Speed control notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SPEED_NATT
+    // @DisplayName: Speed control notch Filter attenuation
+    // @Description: Speed control notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_throttle_speed_pid, "_SPEED_", 2, AR_AttitudeControl, AC_PID),
@@ -372,6 +452,46 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Pitch control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
     // @Increment: 0.01
+
+    // @Param: _BAL_ADV
+    // @DisplayName: Pitch control Advanced parameters enable
+    // @Description: Pitch control Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _BAL_D_FF
+    // @DisplayName: Pitch control Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _BAL_NTF
+    // @DisplayName: Pitch control Target notch Filter center frequency
+    // @Description: Pitch control Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _BAL_NEF
+    // @DisplayName: Pitch control Error notch Filter center frequency
+    // @Description: Pitch control Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _BAL_NBW
+    // @DisplayName: Pitch control notch Filter bandwidth
+    // @Description: Pitch control notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _BAL_NATT
+    // @DisplayName: Pitch control notch Filter attenuation
+    // @Description: Pitch control notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pitch_to_throttle_pid, "_BAL_", 10, AR_AttitudeControl, AC_PID),
@@ -463,6 +583,46 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Description: Sail Heel control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
     // @Increment: 0.01
+
+    // @Param: _SAIL_ADV
+    // @DisplayName: Sail Heel Advanced parameters enable
+    // @Description: Sail Heel Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _SAIL_D_FF
+    // @DisplayName: Sail Heel Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.001 0.03
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _SAIL_NTF
+    // @DisplayName: Sail Heel Target notch Filter center frequency
+    // @Description: Sail Heel Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SAIL_NEF
+    // @DisplayName: Sail Heel Error notch Filter center frequency
+    // @Description: Sail Heel Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SAIL_NBW
+    // @DisplayName: Sail Heel notch Filter bandwidth
+    // @Description: Sail Heel notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _SAIL_NATT
+    // @DisplayName: Sail Heel notch Filter attenuation
+    // @Description: Sail Heel notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),
@@ -1003,4 +1163,13 @@ void AR_AttitudeControl::relax_I()
     _steer_rate_pid.reset_I();
     _throttle_speed_pid.reset_I();
     _pitch_to_throttle_pid.reset_I();
+}
+
+void AR_AttitudeControl::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _steer_rate_pid.set_notch_sample_rate(sample_rate);
+    _throttle_speed_pid.set_notch_sample_rate(sample_rate);
+    _pitch_to_throttle_pid.set_notch_sample_rate(sample_rate);
+#endif
 }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -147,45 +147,23 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Range: 0.000 1.000
     // @Increment: 0.01
 
-    // @Param: _STR_RAT_ADV
-    // @DisplayName: Steering control Advanced parameters enable
-    // @Description: Steering control Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _STR_RAT_D_FF
     // @DisplayName: Steering control Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _STR_RAT_NTF
-    // @DisplayName: Steering control Target notch Filter center frequency
-    // @Description: Steering control Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Steering control Target notch filter index
+    // @Description: Steering control Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _STR_RAT_NEF
-    // @DisplayName: Steering control Error notch Filter center frequency
-    // @Description: Steering control Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _STR_RAT_NBW
-    // @DisplayName: Steering control notch Filter bandwidth
-    // @Description: Steering control notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _STR_RAT_NATT
-    // @DisplayName: Steering control notch Filter attenuation
-    // @Description: Steering control notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Steering control Error notch filter index
+    // @Description: Steering control Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_steer_rate_pid, "_STR_RAT_", 1, AR_AttitudeControl, AC_PID),
@@ -270,45 +248,23 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Range: 0.000 1.000
     // @Increment: 0.01
 
-    // @Param: _SPEED_ADV
-    // @DisplayName: Speed control Advanced parameters enable
-    // @Description: Speed control Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _SPEED_D_FF
     // @DisplayName: Speed control Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _SPEED_NTF
-    // @DisplayName: Speed control Target notch Filter center frequency
-    // @Description: Speed control Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Speed control Target notch filter index
+    // @Description: Speed control Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _SPEED_NEF
-    // @DisplayName: Speed control Error notch Filter center frequency
-    // @Description: Speed control Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _SPEED_NBW
-    // @DisplayName: Speed control notch Filter bandwidth
-    // @Description: Speed control notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _SPEED_NATT
-    // @DisplayName: Speed control notch Filter attenuation
-    // @Description: Speed control notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Speed control Error notch filter index
+    // @Description: Speed control Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_throttle_speed_pid, "_SPEED_", 2, AR_AttitudeControl, AC_PID),
@@ -453,45 +409,23 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Range: 0.000 1.000
     // @Increment: 0.01
 
-    // @Param: _BAL_ADV
-    // @DisplayName: Pitch control Advanced parameters enable
-    // @Description: Pitch control Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _BAL_D_FF
     // @DisplayName: Pitch control Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _BAL_NTF
-    // @DisplayName: Pitch control Target notch Filter center frequency
-    // @Description: Pitch control Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Pitch control Target notch filter index
+    // @Description: Pitch control Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _BAL_NEF
-    // @DisplayName: Pitch control Error notch Filter center frequency
-    // @Description: Pitch control Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _BAL_NBW
-    // @DisplayName: Pitch control notch Filter bandwidth
-    // @Description: Pitch control notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _BAL_NATT
-    // @DisplayName: Pitch control notch Filter attenuation
-    // @Description: Pitch control notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Pitch control Error notch filter index
+    // @Description: Pitch control Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pitch_to_throttle_pid, "_BAL_", 10, AR_AttitudeControl, AC_PID),
@@ -584,45 +518,23 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Range: 0.000 1.000
     // @Increment: 0.01
 
-    // @Param: _SAIL_ADV
-    // @DisplayName: Sail Heel Advanced parameters enable
-    // @Description: Sail Heel Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _SAIL_D_FF
     // @DisplayName: Sail Heel Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Advanced
 
     // @Param: _SAIL_NTF
-    // @DisplayName: Sail Heel Target notch Filter center frequency
-    // @Description: Sail Heel Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Sail Heel Target notch filter index
+    // @Description: Sail Heel Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _SAIL_NEF
-    // @DisplayName: Sail Heel Error notch Filter center frequency
-    // @Description: Sail Heel Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _SAIL_NBW
-    // @DisplayName: Sail Heel notch Filter bandwidth
-    // @Description: Sail Heel notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _SAIL_NATT
-    // @DisplayName: Sail Heel notch Filter attenuation
-    // @Description: Sail Heel notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Sail Heel Error notch filter index
+    // @Description: Sail Heel Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),
@@ -1167,7 +1079,7 @@ void AR_AttitudeControl::relax_I()
 
 void AR_AttitudeControl::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _steer_rate_pid.set_notch_sample_rate(sample_rate);
     _throttle_speed_pid.set_notch_sample_rate(sample_rate);
     _pitch_to_throttle_pid.set_notch_sample_rate(sample_rate);

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -100,6 +100,9 @@ public:
     AC_PID& get_sailboat_heel_pid() { return _sailboat_heel_pid; }
     const AP_PIDInfo& get_throttle_speed_pid_info() const { return _throttle_speed_pid_info; }
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate);
+
     // get the slew rate value for speed and steering for oscillation detection in lua scripts
     void get_srate(float &steering_srate, float &speed_srate);
 

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -82,3 +82,7 @@
 #ifndef AP_UART_MONITOR_ENABLED
 #define AP_UART_MONITOR_ENABLED 1
 #endif
+
+#ifndef AP_FILTER_ENABLED
+#define AP_FILTER_ENABLED 1
+#endif

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -496,6 +496,7 @@ void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
         I               : info.I,
         D               : info.D,
         FF              : info.FF,
+        DFF             : info.DFF,
         Dmod            : info.Dmod,
         slew_rate       : info.slew_rate,
         flags           : flags

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -405,6 +405,7 @@ struct PACKED log_PID {
     float   I;
     float   D;
     float   FF;
+    float   DFF;
     float   Dmod;
     float   slew_rate;
     uint8_t flags;
@@ -679,10 +680,10 @@ struct PACKED log_VER {
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
 
-#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,Dmod,SRate,Flags"
-#define PID_FMT    "QfffffffffB"
-#define PID_UNITS  "s----------"
-#define PID_MULTS  "F----------"
+#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,DFF,Dmod,SRate,Flags"
+#define PID_FMT    "QffffffffffB"
+#define PID_UNITS  "s-----------"
+#define PID_MULTS  "F-----------"
 
 #define PIDx_FMT "Qffffffff"
 #define PIDx_UNITS "smmnnnooo"
@@ -910,6 +911,7 @@ struct PACKED log_VER {
 // @Field: I: integral part of PID
 // @Field: D: derivative part of PID
 // @Field: FF: controller feed-forward portion of response
+// @Field: DFF: controller derivative feed-forward portion of response
 // @Field: Dmod: scaler applied to D gain to reduce limit cycling
 // @Field: SRate: slew rate used in slew limiter
 // @Field: Flags: bitmask of PID state flags

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -241,6 +241,11 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
 #endif
 #endif // AP_NETWORKING_ENABLED
 
+#if AP_FILTER_ENABLED
+    // @Group: FILT
+    // @Path: ../Filter/AP_Filter.cpp
+    AP_SUBGROUPINFO(filters, "FILT", 26, AP_Vehicle, AP_Filters),
+#endif
     AP_GROUPEND
 };
 
@@ -419,6 +424,10 @@ void AP_Vehicle::setup()
 
     custom_rotations.init();
 
+#if AP_FILTER_ENABLED
+    filters.init();
+#endif
+
 #if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
     for (uint8_t i = 0; i<ESC_TELEM_MAX_ESCS; i++) {
         esc_noise[i].set_cutoff_frequency(2);
@@ -558,6 +567,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
     SCHED_TASK(check_motor_noise,      5,     50, 252),
+#endif
+#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+    SCHED_TASK_CLASS(AP_Filters,   &vehicle.filters,        update,                   1, 100, 252),
 #endif
     SCHED_TASK(update_arming,          1,     50, 253),
 };

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -62,6 +62,7 @@
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 #include <Filter/LowPassFilter.h>
 #include <AP_KDECAN/AP_KDECAN.h>
+#include <Filter/AP_Filter.h>
 
 class AP_DDS_Client;
 
@@ -469,6 +470,9 @@ private:
     uint32_t _last_internal_errors;  // backup of AP_InternalError::internal_errors bitmask
 
     AP_CustomRotations custom_rotations;
+#if AP_FILTER_ENABLED
+    AP_Filters filters;
+#endif
 
     // Bitmask of modes to disable from gcs
     AP_Int32 flight_mode_GCS_block;

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -90,6 +90,46 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @DisplayName: Wheel rate control PD sum maximum
     // @Description: Wheel rate control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
+
+    // @Param: _RATE_ADV
+    // @DisplayName: Wheel rate Advanced parameters enable
+    // @Description: Wheel rate Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: _RATE_D_FF
+    // @DisplayName: Wheel rate Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the error
+    // @Range: 0.000 0.400
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: _RATE_NTF
+    // @DisplayName: Wheel rate Target notch Filter center frequency
+    // @Description: Wheel rate Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NEF
+    // @DisplayName: Wheel rate Error notch Filter center frequency
+    // @Description: Wheel rate Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NBW
+    // @DisplayName: Wheel rate notch Filter bandwidth
+    // @Description: Wheel rate notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: _RATE_NATT
+    // @DisplayName: Wheel rate notch Filter attenuation
+    // @Description: Wheel rate notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
@@ -166,6 +206,46 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @DisplayName: Wheel rate control PD sum maximum
     // @Description: Wheel rate control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
+
+    // @Param: 2_RATE_ADV
+    // @DisplayName: Wheel rate Advanced parameters enable
+    // @Description: Wheel rate Advanced parameters enable
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+
+    // @Param: 2_RATE_D_FF
+    // @DisplayName: Wheel rate Derivative FeedForward Gain
+    // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
+    // @Range: 0.000 0.400
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: 2_RATE_NTF
+    // @DisplayName: Wheel rate Target notch Filter center frequency
+    // @Description: Wheel rate Target notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: 2_RATE_NEF
+    // @DisplayName: Wheel rate Error notch Filter center frequency
+    // @Description: Wheel rate Error notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: 2_RATE_NBW
+    // @DisplayName: Wheel rate notch Filter bandwidth
+    // @Description: Wheel rate notch Filter bandwidth in Hz.
+    // @Range: 5 250
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: 2_RATE_NATT
+    // @DisplayName: Wheel rate notch Filter attenuation
+    // @Description: Wheel rate notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),
@@ -236,4 +316,12 @@ AC_PID& AP_WheelRateControl::get_pid(uint8_t instance)
     } else {
         return _rate_pid1;
     }
+}
+
+void AP_WheelRateControl::set_notch_sample_rate(float sample_rate)
+{
+#if AC_PID_ADVANCED_ENABLED
+    _rate_pid0.set_notch_sample_rate(sample_rate);
+    _rate_pid1.set_notch_sample_rate(sample_rate);
+#endif
 }

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -91,12 +91,6 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Description: Wheel rate control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
 
-    // @Param: _RATE_ADV
-    // @DisplayName: Wheel rate Advanced parameters enable
-    // @Description: Wheel rate Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: _RATE_D_FF
     // @DisplayName: Wheel rate Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the error
@@ -105,31 +99,15 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @User: Advanced
 
     // @Param: _RATE_NTF
-    // @DisplayName: Wheel rate Target notch Filter center frequency
-    // @Description: Wheel rate Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Wheel rate Target notch filter index
+    // @Description: Wheel rate Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
-    // @DisplayName: Wheel rate Error notch Filter center frequency
-    // @Description: Wheel rate Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NBW
-    // @DisplayName: Wheel rate notch Filter bandwidth
-    // @Description: Wheel rate notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: _RATE_NATT
-    // @DisplayName: Wheel rate notch Filter attenuation
-    // @Description: Wheel rate notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Wheel rate Error notch filter index
+    // @Description: Wheel rate Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
@@ -207,12 +185,6 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Description: Wheel rate control PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output
     // @Range: 0.000 1.000
 
-    // @Param: 2_RATE_ADV
-    // @DisplayName: Wheel rate Advanced parameters enable
-    // @Description: Wheel rate Advanced parameters enable
-    // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
-
     // @Param: 2_RATE_D_FF
     // @DisplayName: Wheel rate Derivative FeedForward Gain
     // @Description: FF D Gain which produces an output that is proportional to the rate of change of the target
@@ -221,31 +193,15 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @User: Advanced
 
     // @Param: 2_RATE_NTF
-    // @DisplayName: Wheel rate Target notch Filter center frequency
-    // @Description: Wheel rate Target notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
+    // @DisplayName: Wheel rate Target notch filter index
+    // @Description: Wheel rate Target notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     // @Param: 2_RATE_NEF
-    // @DisplayName: Wheel rate Error notch Filter center frequency
-    // @Description: Wheel rate Error notch Filter center frequency in Hz.
-    // @Range: 10 495
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: 2_RATE_NBW
-    // @DisplayName: Wheel rate notch Filter bandwidth
-    // @Description: Wheel rate notch Filter bandwidth in Hz.
-    // @Range: 5 250
-    // @Units: Hz
-    // @User: Advanced
-
-    // @Param: 2_RATE_NATT
-    // @DisplayName: Wheel rate notch Filter attenuation
-    // @Description: Wheel rate notch Filter attenuation in dB.
-    // @Range: 5 50
-    // @Units: dB
+    // @DisplayName: Wheel rate Error notch filter index
+    // @Description: Wheel rate Error notch filter index
+    // @Range: 1 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),
@@ -320,7 +276,7 @@ AC_PID& AP_WheelRateControl::get_pid(uint8_t instance)
 
 void AP_WheelRateControl::set_notch_sample_rate(float sample_rate)
 {
-#if AC_PID_ADVANCED_ENABLED
+#if AP_FILTER_ENABLED
     _rate_pid0.set_notch_sample_rate(sample_rate);
     _rate_pid1.set_notch_sample_rate(sample_rate);
 #endif

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.h
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.h
@@ -51,6 +51,9 @@ public:
     // get pid objects for reporting
     AC_PID& get_pid(uint8_t instance);
 
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate);
+
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:

--- a/libraries/Filter/AP_Filter.cpp
+++ b/libraries/Filter/AP_Filter.cpp
@@ -1,0 +1,155 @@
+#include "AP_Filter.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_Filters::var_info[] = {
+
+#if AP_FILTER_NUM_FILTERS >= 1
+    // @Group: 1_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[0], "1_", 2, AP_Filters, AP_Filter_params),
+    // @Group: 1_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[0], "1_", 3, AP_Filters, backend_var_info[0]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 2
+    // @Group: 2_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[1], "2_", 4, AP_Filters, AP_Filter_params),
+    // @Group: 2_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[1], "2_", 5, AP_Filters, backend_var_info[1]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 3
+    // @Group: 3_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[2], "3_", 6, AP_Filters, AP_Filter_params),
+    // @Group: 3_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[2], "3_", 7, AP_Filters, backend_var_info[2]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 4
+    // @Group: 4_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[3], "4_", 8, AP_Filters, AP_Filter_params),
+    // @Group: 4_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[3], "4_", 9, AP_Filters, backend_var_info[3]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 5
+    // @Group: 5_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[4], "5_", 10, AP_Filters, AP_Filter_params),
+    // @Group: 5_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[4], "5_", 11, AP_Filters, backend_var_info[4]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 6
+    // @Group: 6_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[5], "6_", 12, AP_Filters, AP_Filter_params),
+    // @Group: 6_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[5], "6_", 13, AP_Filters, backend_var_info[5]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 7
+    // @Group: 7_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[6], "7_", 14, AP_Filters, AP_Filter_params),
+    // @Group: 7_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[6], "7_", 15, AP_Filters, backend_var_info[6]),
+#endif
+#if AP_FILTER_NUM_FILTERS >= 8
+    // @Group: 8_
+    // @Path: AP_Filter_params.cpp
+    AP_SUBGROUPINFO(params[7], "8_", 16, AP_Filters, AP_Filter_params),
+    // @Group: 8_
+    // @Path: AP_NotchFilter_params.cpp
+    AP_SUBGROUPVARPTR(filters[7], "8_", 17, AP_Filters, backend_var_info[7]),
+#endif
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo *AP_Filters::backend_var_info[AP_FILTER_NUM_FILTERS];
+
+AP_Filter::AP_Filter(FilterType type):
+    _type(type)
+{
+}
+
+AP_Filters::AP_Filters()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (singleton != nullptr) {
+        AP_HAL::panic("AP_Filters must be singleton");
+    }
+#endif
+    singleton = this;
+}
+
+void AP_Filters::init()
+{
+    update();
+}
+
+// 1Hz update to process config changes
+void AP_Filters::update()
+{
+    if (hal.util->get_soft_armed()) {
+        return;
+    }
+
+    // make sure all filters are allocated
+    for (uint8_t i = 0; i < AP_FILTER_NUM_FILTERS; i++) {
+        bool update = false;
+        switch (AP_Filter::FilterType(params[i]._type)) {
+            case AP_Filter::FilterType::FILTER_NONE:
+                break;
+            case AP_Filter::FilterType::FILTER_NOTCH:
+                if (filters[i] == nullptr) {
+                    filters[i] = new AP_NotchFilter_params();
+                    backend_var_info[i] = AP_NotchFilter_params::var_info;
+                    update = true;
+                }
+                break;
+            default:
+                return;
+        }
+
+        if (update) {
+            AP_Param::load_object_from_eeprom(filters[i], backend_var_info[i]);
+            AP_Param::invalidate_count();
+        }
+    }
+}
+
+AP_Filter* AP_Filters::get_filter(uint8_t index)
+{
+    if (index >= AP_FILTER_NUM_FILTERS) {
+        return nullptr;
+    }
+
+    return filters[index-1];
+}
+
+// singleton instance
+AP_Filters *AP_Filters::singleton;
+
+namespace AP {
+
+AP_Filters &filters()
+{
+    return *AP_Filters::get_singleton();
+}
+
+}
+
+#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)

--- a/libraries/Filter/AP_Filter.h
+++ b/libraries/Filter/AP_Filter.h
@@ -1,0 +1,92 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_Filter_config.h"
+#include "NotchFilter.h"
+
+#if AP_FILTER_ENABLED
+
+class AP_Filter {
+public:
+    enum class FilterType : uint8_t {
+        FILTER_NONE            = 0,
+        FILTER_NOTCH           = 1,
+    };   
+
+    AP_Filter(FilterType type);
+
+    void init();
+
+    virtual bool setup_notch_filter(NotchFilterFloat& filter, float sample_rate) { return false; }
+
+    FilterType _type;
+};
+
+struct AP_Filter_params {
+public:
+    AP_Filter_params();
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    AP_Enum<AP_Filter::FilterType> _type;
+};
+
+struct AP_NotchFilter_params : public AP_Filter {
+public:
+    AP_NotchFilter_params();
+
+    bool setup_notch_filter(NotchFilterFloat& filter, float sample_rate) override;
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    AP_Float _center_freq_hz;
+    AP_Float _quality;
+    AP_Float _attenuation_dB;
+};
+
+class AP_Filters {
+public:
+    AP_Filters();
+
+    CLASS_NO_COPY(AP_Filters);
+
+    static AP_Filters *get_singleton(void) { return singleton; }
+
+    void init();
+    // 1Hz update to process config changes
+    void update();
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    static const struct AP_Param::GroupInfo *backend_var_info[AP_FILTER_NUM_FILTERS];
+
+    AP_Filter* get_filter(uint8_t filt_num);
+
+private:
+    AP_Filter* filters[AP_FILTER_NUM_FILTERS];
+    AP_Filter_params params[AP_FILTER_NUM_FILTERS];
+
+    static AP_Filters *singleton;
+};
+
+namespace AP {
+    AP_Filters &filters();
+};
+
+#endif // AP_FILTER_ENABLED
+

--- a/libraries/Filter/AP_Filter_config.h
+++ b/libraries/Filter/AP_Filter_config.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_FILTER_NUM_FILTERS
+#if BOARD_FLASH_SIZE > 1024
+#define AP_FILTER_NUM_FILTERS 8
+#else
+#define AP_FILTER_NUM_FILTERS 0
+#endif
+#endif
+
+#ifndef AP_FILTER_ENABLED
+#define AP_FILTER_ENABLED AP_FILTER_NUM_FILTERS > 0
+#endif

--- a/libraries/Filter/AP_Filter_params.cpp
+++ b/libraries/Filter/AP_Filter_params.cpp
@@ -1,0 +1,25 @@
+#include "AP_Filter.h"
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
+#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+
+const AP_Param::GroupInfo AP_Filter_params::var_info[] = {
+
+    // @Param: TYPE
+    // @DisplayName: Filter Type
+    // @Values: 0:Disable, 1:Notch Filter
+    // @Description: Filter Type
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO_FLAGS("TYPE", 1, AP_Filter_params, _type, int8_t(AP_Filter::FilterType::FILTER_NONE), AP_PARAM_FLAG_ENABLE),
+
+    AP_GROUPEND
+};
+
+AP_Filter_params::AP_Filter_params()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)

--- a/libraries/Filter/AP_NotchFilter_params.cpp
+++ b/libraries/Filter/AP_NotchFilter_params.cpp
@@ -1,0 +1,53 @@
+#include "AP_Filter.h"
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
+#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+
+const AP_Param::GroupInfo AP_NotchFilter_params::var_info[] = {
+  
+    // @Param: NOTCH_FREQ
+    // @DisplayName: Notch Filter center frequency
+    // @Description: Notch Filter center frequency in Hz.
+    // @Range: 10 495
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("NOTCH_FREQ", 1, AP_NotchFilter_params, _center_freq_hz, 0),
+
+    // @Param: NOTCH_Q
+    // @DisplayName: Notch Filter quality factor
+    // @Description: Notch Filter quality factor given by the notch centre frequency divided by its bandwidth.
+    // @Range: 1 10
+    // @User: Advanced
+    AP_GROUPINFO("NOTCH_Q", 2, AP_NotchFilter_params, _quality, 2),
+
+    // @Param: NOTCH_ATT
+    // @DisplayName: Notch Filter attenuation
+    // @Description: Notch Filter attenuation in dB.
+    // @Range: 5 50
+    // @Units: dB
+    // @User: Advanced
+    AP_GROUPINFO("NOTCH_ATT", 3, AP_NotchFilter_params, _attenuation_dB, 40),
+
+    AP_GROUPEND
+};
+
+AP_NotchFilter_params::AP_NotchFilter_params() : AP_Filter(AP_Filter::FilterType::FILTER_NOTCH)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+bool AP_NotchFilter_params::setup_notch_filter(NotchFilterFloat& filter, float sample_rate)
+{
+    if (is_zero(_quality) || is_zero(_center_freq_hz) || is_zero(_attenuation_dB)) {
+        return false;
+    }
+
+    if (!is_equal(sample_rate, filter.sample_freq_hz())
+        || !is_equal(_center_freq_hz.get(), filter.center_freq_hz())) {
+        filter.init(sample_rate, _center_freq_hz, _center_freq_hz / _quality, _attenuation_dB);
+    }
+    return true;
+}
+
+#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -34,6 +34,8 @@ public:
     void init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q);
     T apply(const T &sample);
     void reset();
+    float center_freq_hz() const { return _center_freq_hz; }
+    float sample_freq_hz() const { return _sample_freq_hz; }
 
     // calculate attenuation and quality from provided center frequency and bandwidth
     static void calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q); 


### PR DESCRIPTION
This is a PR for discussion and experimentation only. We have discussed how notch filtering of the target and error terms might be useful for things like frame resonance and how allowing target D feedforward might bring some of the benefits in control that betaflight see. This change lumps them all together so that they can be tried.