### PR TITLE
Sub: Guided Mode: Helper funtion to set target yaw state

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -295,6 +295,9 @@ private:
     // Navigation Yaw control
     // auto flight mode's yaw mode
     uint8_t auto_yaw_mode;
+    
+    // Parameter to set yaw rate only
+    bool yaw_rate_only;
 
     // Yaw will point at this location if auto_yaw_mode is set to AUTO_YAW_ROI
     Vector3f roi_WP;

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -294,10 +294,10 @@ public:
     bool guided_set_destination(const Vector3f& destination);
     bool guided_set_destination(const Location&);
     void guided_set_velocity(const Vector3f& velocity);
+    void guided_set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
     float get_auto_heading();
     void guided_limit_clear();
     void set_auto_yaw_mode(autopilot_yaw_mode yaw_mode);
-    void set_yaw_rate(float turn_rate_dps);
 
 protected:
 
@@ -341,6 +341,7 @@ public:
     void auto_nav_guided_start();
     void set_auto_yaw_roi(const Location &roi_location);
     void set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, int8_t direction, uint8_t relative_angle);
+    void set_yaw_rate(float turn_rate_dps);
     bool auto_terrain_recover_start();
 
 protected:

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -345,7 +345,7 @@ void ModeAuto::auto_loiter_run()
 // set_auto_yaw_look_at_heading - sets the yaw look at heading for auto mode
 void ModeAuto::set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, int8_t direction, uint8_t relative_angle)
 {
-    // get current yaw target
+    // get current yaw
     int32_t curr_yaw_target = attitude_control->get_att_target_euler_cd().z;
 
     // get final angle, 1 = Relative, 0 = Absolute
@@ -357,18 +357,15 @@ void ModeAuto::set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps
         if (direction < 0) {
             angle_deg = -angle_deg;
         }
-        sub.yaw_look_at_heading = wrap_360_cd((angle_deg*100+curr_yaw_target));
+        sub.yaw_look_at_heading = wrap_360_cd((angle_deg * 100 + curr_yaw_target));
     }
 
     // get turn speed
-    // TODO actually implement this, right now, yaw_look_at_heading_slew is unused
-    // see AP_Float _slew_yaw in AC_AttitudeControl
     if (is_zero(turn_rate_dps)) {
         // default to regular auto slew rate
         sub.yaw_look_at_heading_slew = AUTO_YAW_SLEW_RATE;
     } else {
-        int32_t turn_rate = (wrap_180_cd(sub.yaw_look_at_heading - curr_yaw_target) / 100) / turn_rate_dps;
-        sub.yaw_look_at_heading_slew = constrain_int32(turn_rate, 1, 360);    // deg / sec
+        sub.yaw_look_at_heading_slew = MIN(turn_rate_dps, AUTO_YAW_SLEW_RATE);    // deg / sec
     }
 
     // set yaw mode
@@ -379,7 +376,7 @@ void ModeAuto::set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps
 
 
 // sets the desired yaw rate
-void ModeGuided::set_yaw_rate(float turn_rate_dps)
+void ModeAuto::set_yaw_rate(float turn_rate_dps)
 {    
     // set sub to desired yaw rate
     sub.yaw_look_at_heading_slew = MIN(turn_rate_dps, AUTO_YAW_SLEW_RATE);    // deg / sec


### PR DESCRIPTION
1. Added a helper function to set desired yaw state while in guided mode.
    - Computes the directionality based on the error between current heading and desired heading.
    - Created for different cases to handle the incoming yaw commands:
        - Target yaw
        - Target yaw and yaw rate
        - Target yaw rate
        - Hold vehicle's current yaw
         
2. Updated **set_auto_yaw_look_at_heading()** to use yaw_look_at_heading_slew.
3. Moved **set_yaw_rate()** from ModeGuided to ModeAuto.