### PR TITLE
Plane: add motor_test MOTOR_TEST_ORDER

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1085,7 +1085,8 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
                                                         (uint8_t)packet.param2,
                                                         (uint16_t)packet.param3,
                                                         packet.param4,
-                                                        (uint8_t)packet.param5);
+                                                        (uint8_t)packet.param5,
+                                                        (uint8_t)packet.param6);
 
     case MAV_CMD_DO_VTOL_TRANSITION:
         if (!plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)packet.param1)) {

--- a/ArduPlane/motor_test.cpp
+++ b/ArduPlane/motor_test.cpp
@@ -18,18 +18,32 @@ void QuadPlane::motor_test_output()
         return;
     }
 
+    // if the order test is ORDER_BOARD then servo must be non-null and configured to continue.
+    // So, if it's ever non-null then we should use it.
+    SRV_Channel *servo = nullptr;
+    if (motor_test.order == MOTOR_TEST_ORDER_BOARD) {
+        servo = SRV_Channels::srv_channel(motor_test.seq-1);
+        if (servo == nullptr || !servo->valid_function()) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Motor Test: SERVO%d_FUNCTION not configured", (unsigned)motor_test.seq);
+            motor_test_stop();
+            return;
+        }
+    }
+
     // check for test timeout
     uint32_t now = AP_HAL::millis();
     if ((now - motor_test.start_ms) >= motor_test.timeout_ms) {
         if (motor_test.motor_count > 1) {
-            if (now - motor_test.start_ms < motor_test.timeout_ms*1.5) {
-                // output zero for 0.5s
-                motors->output_min();
-            } else {
+            if (now - motor_test.start_ms >= motor_test.timeout_ms*1.5) {
                 // move onto next motor
                 motor_test.seq++;
                 motor_test.motor_count--;
                 motor_test.start_ms = now;
+            } else if (servo != nullptr) { // MOTOR_TEST_ORDER_BOARD
+                servo->set_output_pwm(servo->get_output_min());
+            } else { // MOTOR_TEST_ORDER_DEFAULT
+                // output zero for 0.5s
+                motors->output_min();
             }
             return;
         }
@@ -41,8 +55,8 @@ void QuadPlane::motor_test_output()
     int16_t pwm = 0;   // pwm that will be output to the motors
 
     // calculate pwm based on throttle type
-    const int16_t thr_min_pwm = motors->get_pwm_output_min();
-    const int16_t thr_max_pwm = motors->get_pwm_output_max();
+    const int16_t thr_min_pwm = (servo != nullptr) ? servo->get_output_min() : motors->get_pwm_output_min();
+    const int16_t thr_max_pwm = (servo != nullptr) ? servo->get_output_max() : motors->get_pwm_output_max();
 
     switch (motor_test.throttle_type) {
     case MOTOR_TEST_THROTTLE_PERCENT:
@@ -65,19 +79,20 @@ void QuadPlane::motor_test_output()
         return;
     }
 
-    // sanity check throttle values
-    if (pwm >= RC_Channel::RC_MIN_LIMIT_PWM && pwm <= RC_Channel::RC_MAX_LIMIT_PWM) {
-        // turn on motor to specified pwm vlaue
-        motors->output_test_seq(motor_test.seq, pwm);
-    } else {
+    // sanity check throttle values and turn on motor to specified pwm value
+    if (pwm < RC_Channel::RC_MIN_LIMIT_PWM || pwm > RC_Channel::RC_MAX_LIMIT_PWM) {
         motor_test_stop();
+    } else if (servo != nullptr) {
+        servo->set_output_pwm(pwm);
+    } else {
+        motors->output_test_seq(motor_test.seq, pwm);
     }
 }
 
 // mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
 //  returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
 MAV_RESULT QuadPlane::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type,
-                                            uint16_t throttle_value, float timeout_sec, uint8_t motor_count)
+                                            uint16_t throttle_value, float timeout_sec, uint8_t motor_count, uint8_t motor_test_order)
 {
     if (!available() || motors == nullptr) {
         return MAV_RESULT_FAILED;
@@ -85,6 +100,11 @@ MAV_RESULT QuadPlane::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t m
 
     if (motors->armed()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Must be disarmed for motor test");
+        return MAV_RESULT_FAILED;
+    }
+
+    if (motor_test_order != MOTOR_TEST_ORDER_DEFAULT && motor_test_order != MOTOR_TEST_ORDER_BOARD) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Motor Test: Bad test type %u", (unsigned)motor_test_order);
         return MAV_RESULT_FAILED;
     }
 
@@ -116,6 +136,7 @@ MAV_RESULT QuadPlane::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t m
     motor_test.throttle_type = throttle_type;
     motor_test.throttle_value = throttle_value;
     motor_test.motor_count = MIN(motor_count, 8);
+    motor_test.order = motor_test_order;
 
     // return success
     return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -523,6 +523,7 @@ private:
         uint8_t throttle_type = 0;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
         uint16_t throttle_value = 0;  // throttle to be sent to motor, value depends upon it's type
         uint8_t motor_count;          // number of motors to cycle
+        uint8_t order;                // MAVLink enum MOTOR_TEST_ORDER: Sequence that motors are tested when using MAV_CMD_DO_MOTOR_TEST
     } motor_test;
 
     // time of last control log message
@@ -696,7 +697,7 @@ public:
     void motor_test_output();
     MAV_RESULT mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type,
                                         uint16_t throttle_value, float timeout_sec,
-                                        uint8_t motor_count);
+                                        uint8_t motor_count, uint8_t motor_test_order);
 private:
     void motor_test_stop();
 


### PR DESCRIPTION
Follow up from https://github.com/ArduPilot/ardupilot/pull/24406. This PR implements https://mavlink.io/en/messages/common.html#MOTOR_TEST_ORDER in Plane which is already in [the MAVLink spec in ArduPilot master](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1293). This is already [implemented in Sub](https://github.com/ArduPilot/ardupilot/blob/master/ArduSub/motors.cpp#L106-L111).

The purpose of this PR is with param6=2 we can do "motor test" on any arbitrary servo for Plane VTOL aircraft. This allows you to test k_throttle (or anything else) along with the vtol motors.

No change to existing behavior, requires param6=2 to do anything different.