### PR TITLE
AP_DroneCAN: pass all the variables to AP_DroneCAN_DNA_Server by value

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
 AP_DroneCAN::AP_DroneCAN(const int driver_index) :
 _driver_index(driver_index),
 canard_iface(driver_index),
-_dna_server(*this)
+_dna_server(*this, canard_iface, driver_index)
 {
     AP_Param::setup_object_defaults(this, var_info);
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -36,12 +36,12 @@ extern const AP_HAL::HAL& hal;
 
 #define debug_dronecan(level_debug, fmt, args...) do { AP::can().log_text(level_debug, "DroneCAN", fmt, ##args); } while (0)
 
-AP_DroneCAN_DNA_Server::AP_DroneCAN_DNA_Server(AP_DroneCAN &ap_dronecan) :
+AP_DroneCAN_DNA_Server::AP_DroneCAN_DNA_Server(AP_DroneCAN &ap_dronecan, CanardInterface &canard_iface, uint8_t driver_index) :
     _ap_dronecan(ap_dronecan),
-    _canard_iface(ap_dronecan.canard_iface),
+    _canard_iface(canard_iface),
     storage(StorageManager::StorageCANDNA),
-    allocation_sub(allocation_cb, _ap_dronecan.get_driver_index()),
-    node_status_sub(node_status_cb, _ap_dronecan.get_driver_index()),
+    allocation_sub(allocation_cb, driver_index),
+    node_status_sub(node_status_cb, driver_index),
     node_info_client(_canard_iface, node_info_cb)
 {}
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -104,7 +104,7 @@ class AP_DroneCAN_DNA_Server
     Canard::Client<uavcan_protocol_GetNodeInfoResponse> node_info_client;
 
 public:
-    AP_DroneCAN_DNA_Server(AP_DroneCAN &ap_dronecan);
+    AP_DroneCAN_DNA_Server(AP_DroneCAN &ap_dronecan, CanardInterface &canard_iface, uint8_t driver_index);
 
 
     // Do not allow copies


### PR DESCRIPTION
We were using the values from passed AP_DroneCAN object to AP_DroneCAN_DNA_Server. But the members might not have been initialized if they are out of order.  More specifically the driver_index wasn't initialised and we were registering subscribers to the wrong driver. This lead to the DroneCAN 2nd driver to not receive any packets.

Resolves issue: https://github.com/ArduPilot/ardupilot/issues/24415