### PR TITLE
AP_Scripting: added battery state of charge estimator

### DIFF
--- a/Tools/scripts/battery_fit.py
+++ b/Tools/scripts/battery_fit.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+'''
+fit coefficients for battery percentate from resting voltage
+
+See AP_Scripting/applets/BattEstimate.lua
+'''
+
+from argparse import ArgumentParser
+parser = ArgumentParser(description=__doc__)
+parser.add_argument("--no-graph", action='store_true', default=False, help='disable graph display')
+parser.add_argument("--num-cells", type=int, default=0, help='cell count, zero for auto-detection')
+parser.add_argument("--batidx", type=int, default=1, help='battery index')
+parser.add_argument("--condition", default=None, help='match condition')
+parser.add_argument("--final-pct", type=float, default=100.0, help='set final percentage in log')
+parser.add_argument("--comparison", type=str, default=None, help='comparison coefficients')
+parser.add_argument("log", metavar="LOG")
+
+args = parser.parse_args()
+
+import sys
+import math
+from pymavlink import mavutil
+import numpy as np
+import matplotlib.pyplot as pyplot
+
+def constrain(value, minv, maxv):
+    """Constrain a value to a range."""
+    return max(min(value,maxv),minv)
+
+def SOC_model(cell_volt, c):
+    '''simple model of state of charge versus resting voltage.
+    With thanks to Roho for the form of the equation
+    https://electronics.stackexchange.com/questions/435837/calculate-battery-percentage-on-lipo-battery
+    '''
+    p0 = 80.0
+    p1 = c[2]
+    return constrain(c[0]*(1.0-1.0/math.pow(1+math.pow(cell_volt/c[1],p0),p1)),0,100)
+
+def fit_batt(data):
+    '''fit a set of battery data to the SOC model'''
+    from scipy import optimize
+
+    def fit_error(p):
+        p = list(p)
+        ret = 0
+        for (voltR,pct) in data:
+            error = pct - SOC_model(voltR, p)
+            ret += abs(error)
+
+        ret /= len(data)
+        return ret
+
+    p = [123.0, 3.7, 0.165]
+    bounds = [(100.0, 10000.0), (3.0,3.9), (0.001, 0.4)]
+
+    (p,err,iterations,imode,smode) = optimize.fmin_slsqp(fit_error, p, bounds=bounds, iter=10000, full_output=True)
+    if imode != 0:
+        print("Fit failed: %s" % smode)
+        sys.exit(1)
+    return p
+
+def ExtractDataLog(logfile):
+    '''find battery fit parameters from a log file'''
+    print("Processing log %s" % logfile)
+    mlog = mavutil.mavlink_connection(logfile)
+
+    Wh_total = 0.0
+    last_t = None
+    data = []
+    last_voltR = None
+
+    while True:
+        msg = mlog.recv_match(type=['BAT'], condition=args.condition)
+        if msg is None:
+            break
+
+        if msg.get_type() == 'BAT' and msg.Instance == args.batidx-1 and msg.VoltR > 1:
+            current = msg.Curr
+            voltR = msg.VoltR
+            if last_voltR is not None and voltR > last_voltR:
+                continue
+            last_voltR = voltR
+            power = current*voltR
+            t = msg.TimeUS*1.0e-6
+
+            if last_t is None:
+                last_t = t
+                continue
+
+            dt = t - last_t
+            if dt < 0.5:
+                # 2Hz data is plenty
+                continue
+            last_t = t
+            Wh_total += (power*dt)/3600.0
+
+            data.append((voltR,Wh_total))
+
+    if len(data) == 0:
+        print("No data found")
+        sys.exit(1)
+
+    # calculate total pack capacity based on final percentage
+    Wh_max = data[-1][1]/(args.final_pct*0.01)
+
+    fit_data = []
+
+    for i in range(len(data)):
+        (voltR,Wh) = data[i]
+        SOC = 100-100*Wh/Wh_max
+        fit_data.append((voltR, SOC))
+
+    print("Loaded %u samples" % len(data))
+    return fit_data
+
+def ExtractDataCSV(logfile):
+    '''find battery fit parameters from a CSV file'''
+    print("Processing CSV %s" % logfile)
+    lines = open(logfile,'r').readlines()
+    fit_data = []
+    for line in lines:
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+        v = line.split(',')
+        if len(v) != 2:
+            continue
+        if not v[0][0].isnumeric() or not v[1][0].isnumeric():
+            continue
+        fit_data.append((float(v[1]),float(v[0])))
+    return fit_data
+
+def BattFit(fit_data, num_cells):
+
+    fit_data = [ (v/num_cells,p) for (v,p) in fit_data ]
+
+    c = fit_batt(fit_data)
+    print("Coefficients C1=%.4f C2=%.4f C3=%.4f" % (c[0], c[1], c[2]))
+
+    if args.no_graph:
+        return
+
+    fig, axs = pyplot.subplots()
+
+    np_volt = np.array([v for (v,p) in fit_data])
+    np_pct = np.array([p for (v,p) in fit_data])
+    axs.invert_xaxis()
+    axs.plot(np_volt, np_pct, label='SOC')
+    np_rem = np.zeros(0,dtype=float)
+
+    # pad down to 3.2V to make it easier to visualise for logs that don't go to a low voltage
+    low_volt = np_volt[-1]
+    while low_volt > 3.2:
+        low_volt -= 0.1
+        np_volt = np.append(np_volt, low_volt)
+
+    for i in range(np_volt.size):
+        voltR = np_volt[i]
+        np_rem = np.append(np_rem, SOC_model(voltR, c))
+
+    axs.plot(np_volt, np_rem, label='SOC Fit')
+
+    if args.comparison:
+        c2 = args.comparison.split(',')
+        c2 = [ float(x) for x in c2 ]
+        np_rem2 = np.zeros(0,dtype=float)
+        for i in range(np_volt.size):
+            voltR = np_volt[i]
+            np_rem2 = np.append(np_rem2, SOC_model(voltR, c2))
+        axs.plot(np_volt, np_rem2, label='SOC Fit2')
+
+    axs.legend(loc='upper left')
+    axs.set_title('Battery Fit')
+
+    pyplot.show()
+
+def get_cell_count(data):
+    if args.num_cells != 0:
+        return args.num_cells
+    volts = [ v[0] for v in data ]
+    volts = sorted(volts)
+    num_cells = round(volts[-1]/4.2)
+    print("Max voltags %.1f num_cells %u" % (volts[-1], num_cells))
+    return num_cells
+
+if args.log.upper().endswith(".CSV"):
+    fit_data = ExtractDataCSV(args.log)
+else:
+    fit_data = ExtractDataLog(args.log)
+
+num_cells = get_cell_count(fit_data)
+BattFit(fit_data, num_cells)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA239.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA239.h
@@ -18,7 +18,6 @@ public:
     bool has_cell_voltages() const override { return false; }
     bool has_temperature() const override { return false; }
     bool has_current() const override { return true; }
-    bool reset_remaining(float percentage) override { return false; }
     bool get_cycle_count(uint16_t &cycles) const override { return false; }
 
     void init(void) override;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.h
@@ -19,7 +19,6 @@ public:
     bool has_cell_voltages() const override { return false; }
     bool has_temperature() const override { return false; }
     bool has_current() const override { return true; }
-    bool reset_remaining(float percentage) override { return false; }
     bool get_cycle_count(uint16_t &cycles) const override { return false; }
 
     void init(void) override;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_LTC2946.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_LTC2946.h
@@ -16,7 +16,6 @@ public:
     bool has_cell_voltages() const override { return false; }
     bool has_temperature() const override { return false; }
     bool has_current() const override { return true; }
-    bool reset_remaining(float percentage) override { return false; }
     bool get_cycle_count(uint16_t &cycles) const override { return false; }
 
     virtual void init(void) override;

--- a/libraries/AP_Scripting/applets/BattEstimate.lua
+++ b/libraries/AP_Scripting/applets/BattEstimate.lua
@@ -1,0 +1,282 @@
+--[[
+   battery state of charge (SOC) estimator based on resting voltage
+
+   See Tools/scripts/battery_fit.py for a tool to calculate the coefficients from a log
+--]]
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+local PARAM_TABLE_KEY = 14
+local PARAM_TABLE_PREFIX = "BATT_SOC"
+
+-- bind a parameter to a variable
+function bind_param(name)
+   local p = Parameter()
+   assert(p:init(name), string.format('could not find %s parameter', name))
+   return p
+end
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+   assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+   return bind_param(PARAM_TABLE_PREFIX .. name)
+end
+
+-- setup quicktune specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 32), 'could not add param table')
+
+--[[
+  // @Param: BATT_SOC_COUNT
+  // @DisplayName: Count of SOC estimators
+  // @Description: Number of battery SOC estimators
+  // @Range: 0 4
+  // @User: Standard
+--]]
+local BATT_SOC_COUNT     = bind_add_param('_COUNT', 1, 0)
+
+if BATT_SOC_COUNT:get() <= 0 then
+   return
+end
+
+--[[
+  // @Param: BATT_SOC1_IDX
+  // @DisplayName: Battery estimator index
+  // @Description: Battery estimator index
+  // @Range: 0 4
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC1_NCELL
+  // @DisplayName: Battery estimator cell count
+  // @Description: Battery estimator cell count
+  // @Range: 0 48
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC1_C1
+  // @DisplayName: Battery estimator coefficient1
+  // @Description: Battery estimator coefficient1
+  // @Range: 100 200
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC1_C2
+  // @DisplayName: Battery estimator coefficient2
+  // @Description: Battery estimator coefficient2
+  // @Range: 2 5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC1_C3
+  // @DisplayName: Battery estimator coefficient3
+  // @Description: Battery estimator coefficient3
+  // @Range: 0.01 0.5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_IDX
+  // @DisplayName: Battery estimator index
+  // @Description: Battery estimator index
+  // @Range: 0 4
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_NCELL
+  // @DisplayName: Battery estimator cell count
+  // @Description: Battery estimator cell count
+  // @Range: 0 48
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_C1
+  // @DisplayName: Battery estimator coefficient1
+  // @Description: Battery estimator coefficient1
+  // @Range: 100 200
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_C2
+  // @DisplayName: Battery estimator coefficient2
+  // @Description: Battery estimator coefficient2
+  // @Range: 2 5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_C3
+  // @DisplayName: Battery estimator coefficient3
+  // @Description: Battery estimator coefficient3
+  // @Range: 0.01 0.5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC3_IDX
+  // @DisplayName: Battery estimator index
+  // @Description: Battery estimator index
+  // @Range: 0 4
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC3_NCELL
+  // @DisplayName: Battery estimator cell count
+  // @Description: Battery estimator cell count
+  // @Range: 0 48
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC3_C1
+  // @DisplayName: Battery estimator coefficient1
+  // @Description: Battery estimator coefficient1
+  // @Range: 100 200
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC3_C2
+  // @DisplayName: Battery estimator coefficient2
+  // @Description: Battery estimator coefficient2
+  // @Range: 2 5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC3_C3
+  // @DisplayName: Battery estimator coefficient3
+  // @Description: Battery estimator coefficient3
+  // @Range: 0.01 0.5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC4_IDX
+  // @DisplayName: Battery estimator index
+  // @Description: Battery estimator index
+  // @Range: 0 4
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC4_NCELL
+  // @DisplayName: Battery estimator cell count
+  // @Description: Battery estimator cell count
+  // @Range: 0 48
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC4_C1
+  // @DisplayName: Battery estimator coefficient1
+  // @Description: Battery estimator coefficient1
+  // @Range: 100 200
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC4_C2
+  // @DisplayName: Battery estimator coefficient2
+  // @Description: Battery estimator coefficient2
+  // @Range: 2 5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC4_C3
+  // @DisplayName: Battery estimator coefficient3
+  // @Description: Battery estimator coefficient3
+  // @Range: 0.01 0.5
+  // @User: Standard
+--]]
+
+local params = {}
+local last_armed_ms = 0
+
+--[[
+   add parameters for an estimator
+--]]
+function add_estimator(i)
+   id = string.format("%u_", i)
+   pidx = 2+(i-1)*5
+   params[i] = {}
+   params[i]['IDX']   = bind_add_param(id .. "IDX",     pidx+0, 0)
+   params[i]['NCELL'] = bind_add_param(id .. "NCELL", pidx+1, 0)
+   params[i]['C1']    = bind_add_param(id .. "C1", pidx+2, 111.56)
+   params[i]['C2']    = bind_add_param(id .. "C2", pidx+3, 3.65)
+   params[i]['C3']    = bind_add_param(id .. "C3", pidx+4, 0.205)
+end
+
+local count = math.floor(BATT_SOC_COUNT:get())
+for i = 1, count do
+   add_estimator(i)
+end
+
+local function constrain(v, vmin, vmax)
+   return math.max(math.min(v, vmax), vmin)
+end
+
+--[[
+   simple model of state of charge versus resting voltage.
+   With thanks to Roho for the form of the equation
+   https://electronics.stackexchange.com/questions/435837/calculate-battery-percentage-on-lipo-battery
+--]]
+local function SOC_model(cell_volt, c1, c2, c3)
+    local p0 = 80.0
+    local soc = c1*(1.0-1.0/(1+(cell_volt/c2)^p0)^c3)
+    return constrain(soc, 0, 100)
+end
+
+--[[
+   update one estimator
+--]]
+local function update_estimator(i)
+   local idx = math.floor(params[i]['IDX']:get())
+   local ncell = math.floor(params[i]['NCELL']:get())
+   if idx <= 0 or ncell <= 0 then
+      return
+   end
+   local C1 = params[i]['C1']:get()
+   local C2 = params[i]['C2']:get()
+   local C3 = params[i]['C3']:get()
+   local num_batts = battery:num_instances()
+   if idx > num_batts then
+      return
+   end
+   local voltR = battery:voltage_resting_estimate(idx-1)
+   local soc = SOC_model(voltR/ncell, C1, C2, C3)
+   battery:reset_remaining(idx-1, soc)
+end
+
+--[[
+   main update function, called at 1Hz
+--]]
+function update()
+   local now_ms = millis()
+   if arming:is_armed() then
+      last_armed_ms = now_ms
+      return update, 1000
+   end
+   -- don't update for 10s after disarm, to get logging of charge recovery
+   if now_ms - last_armed_ms < 10000 then
+      return update, 1000
+   end
+   for i = 1, #params do
+      update_estimator(i)
+   end
+   return update, 1000
+end
+
+gcs:send_text(MAV_SEVERITY.INFO, string.format("Loaded BattEstimate for %u batteries", #params))
+
+-- start running update loop
+return update, 1000
+

--- a/libraries/AP_Scripting/applets/BattEstimate.md
+++ b/libraries/AP_Scripting/applets/BattEstimate.md
@@ -1,0 +1,62 @@
+# Battery State of Charge Estimator
+
+This script implements a battery state of charge estimator based on
+resting voltage and a simple LiPo cell model.
+
+This allows the remaining battery percentage to be automatically set
+based on the resting voltage when disarmed.
+
+# Parameters
+
+You will need to start by setting BATT_SOC_COUNT to the number of
+estimators you want (how many batteries you want to do SoC estimation
+for).
+
+Then you should restart scripting or reboot and set the following
+parameters per SoC estimator.
+
+## BATT_SOCn_IDX
+
+The IDX is the battery index, starting at 1.
+
+## BATT_SOCn_NCELL
+
+Set the number of cells in your battery in the NCELL parameter
+
+## BATT_SOCn_C1
+
+C1 is the first coefficient from your fit of your battery
+
+## BATT_SOCn_C2
+
+C2 is the second coefficient from your fit of your battery
+
+## BATT_SOCn_C3
+
+C3 is the second coefficient from your fit of your battery
+
+# Usage
+
+You need to start by working out the coefficients C1, C2 and C3 for your
+battery. You can do this by starting with a fully charged battery and
+slowly discharging it with LOG_DISARMED set to 1. Alternatively you
+can provide a CSV file with battery percentage in the first column and
+voltage in the 2nd column.
+
+Then run the resulting log or csv file through the script at
+Tools/scripts/battery_fit.py. You will need to tell the script the
+following:
+
+ - the number of cells
+ - the final percentage charge your log stops at
+ - the battery index you want to fit to (1 is the first battery)
+
+That will produce a graph and a set of coefficients like this:
+ - Coefficients C1=111.5629 C2=3.6577 C3=0.2048
+
+Use the C1, C2 and C3 parameters in the parameters for this script.
+
+The remaining battery percentage is only set when disarmed, and won't
+be set till 10 seconds after you disarm from a flight.
+
+


### PR DESCRIPTION
This implements a simple model based SoC estimator for LiPo batteries.
To use it please read BattEstimate.md in the AP_Scripting/applets directory
here is an example fit for a 12S LiPo:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/dc4b73db-26a3-4849-9b77-b6651c95d52a)

Here is a 3s LiOn from Henry:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/907e234b-30e7-40a2-8d9c-a4afcec0798c)
here is a 4s LiOn from henry:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/9e0b4bc1-0ac4-4190-8c57-afc12601c22c)
here is a 6S LiOn from Alex
![image](https://github.com/ArduPilot/ardupilot/assets/831867/9dea6851-9cc7-462b-acb9-f51d272aaa32)


