### PR TITLE
AP_HAL_ESP32: added implementation of GPIO function

### DIFF
--- a/libraries/AP_HAL_ESP32/GPIO.cpp
+++ b/libraries/AP_HAL_ESP32/GPIO.cpp
@@ -1,0 +1,62 @@
+#include "driver/gpio.h"
+#include "GPIO.h"
+
+
+using namespace ESP32;
+
+GPIO::GPIO()
+{}
+
+void GPIO::init()
+{}
+
+void GPIO::pinMode(uint8_t pin, uint8_t output)
+{
+    gpio_mode_t mode = output?GPIO_MODE_OUTPUT:GPIO_MODE_INPUT;
+    gpio_set_direction((gpio_num_t)pin, mode);
+}
+
+uint8_t GPIO::read(uint8_t pin)
+{
+    return gpio_get_level((gpio_num_t)pin);
+}
+
+void GPIO::write(uint8_t pin, uint8_t value)
+{
+    gpio_set_level((gpio_num_t)pin, value);
+}
+
+void GPIO::toggle(uint8_t pin)
+{
+    gpio_set_level((gpio_num_t)pin, !gpio_get_level((gpio_num_t)pin));
+}
+
+//below is the remaining undefined function. for now we're borrowing AP_HAL_Empty's definition
+
+AP_HAL::DigitalSource* GPIO::channel(uint16_t n) {
+    return new DigitalSource(0);
+}
+
+bool GPIO::usb_connected(void)
+{
+    return false;
+}
+
+DigitalSource::DigitalSource(uint8_t v) :
+    _v(v)
+{}
+
+void DigitalSource::mode(uint8_t output)
+{}
+
+uint8_t DigitalSource::read() {
+    return _v;
+}
+
+void DigitalSource::write(uint8_t value) {
+    _v = value;
+}
+
+void DigitalSource::toggle() {
+    _v = !_v;
+}

--- a/libraries/AP_HAL_ESP32/GPIO.h
+++ b/libraries/AP_HAL_ESP32/GPIO.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "AP_HAL_ESP32.h"
+
+class ESP32::GPIO : public AP_HAL::GPIO {
+public:
+    GPIO();
+    void    init() override;
+    void    pinMode(uint8_t pin, uint8_t output) override;
+    uint8_t read(uint8_t pin) override;
+    void    write(uint8_t pin, uint8_t value) override;
+    void    toggle(uint8_t pin) override;
+
+    /* Alternative interface: */
+    AP_HAL::DigitalSource* channel(uint16_t n) override;
+
+    /* return true if USB cable is connected */
+    bool    usb_connected(void) override;
+};
+
+class ESP32::DigitalSource : public AP_HAL::DigitalSource {
+public:
+    DigitalSource(uint8_t v);
+    void    mode(uint8_t output) override;
+    uint8_t read() override;
+    void    write(uint8_t value) override;
+    void    toggle() override;
+private:
+    uint8_t _v;
+};


### PR DESCRIPTION
implementation of GPIO function for ESP32 HAL.
class DigitalSource and USB detection have not been implemented and currently using AP_HAL_Empty's definition