### PR TITLE
AP_HAL_ESP32: update Util library to work with ToneAlarm

### DIFF
--- a/libraries/AP_HAL_ESP32/Util.cpp
+++ b/libraries/AP_HAL_ESP32/Util.cpp
@@ -153,26 +153,50 @@ Util::safety_state Util::safety_switch_state(void)
 #endif
 }
 
-#ifdef HAL_PWM_ALARM
-struct Util::ToneAlarmPwmGroup Util::_toneAlarm_pwm_group = HAL_PWM_ALARM;
+#if AP_NOTIFY_TONEALARM_ENABLED
+/*
+    in order to use ToneAlarm(PWM_ALARM), you must define the pin you'll use with
+    #define HAL_PWM_BUZZER_PIN
+    note that currently it doesn't support DShot PWM Alarm
+*/
+ledc_timer_config_t timer = {
+	.speed_mode = LEDC_HIGH_SPEED_MODE,
+	.duty_resolution = LEDC_TIMER_8_BIT,  
+	.timer_num 	= LEDC_TIMER_0,
+	.freq_hz	= 10,
+	.clk_cfg = LEDC_AUTO_CLK
+};
 
-bool Util::toneAlarm_init()
-{
-    _toneAlarm_pwm_group.pwm_cfg.period = 1000;
-    pwmStart(_toneAlarm_pwm_group.pwm_drv, &_toneAlarm_pwm_group.pwm_cfg);
+ledc_channel_config_t channel = {
+	.gpio_num = HAL_PWM_BUZZER_PIN,
+	.speed_mode = LEDC_HIGH_SPEED_MODE,
+	.channel = LEDC_CHANNEL_0,
+	.timer_sel = LEDC_TIMER_0,
+	.duty = 100,
+	.hpoint = 0,
+};
 
+struct Util::ToneAlarmPwmGroup Util::_toneAlarm_pwm_group = {
+	.timer_config = timer, 
+	.channel_config = channel
+};
+
+bool Util::toneAlarm_init(uint8_t types) {
+    ledc_channel_config(&_toneAlarm_pwm_group.channel_config);
+    ledc_timer_config(&_toneAlarm_pwm_group.timer_config);
+    ledc_stop(_toneAlarm_pwm_group.channel_config.speed_mode, _toneAlarm_pwm_group.channel_config.channel, 0);
     return true;
 }
 
 void Util::toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms)
 {
-    if (is_zero(frequency) || is_zero(volume)) {
-        pwmDisableChannel(_toneAlarm_pwm_group.pwm_drv, _toneAlarm_pwm_group.chan);
-    } else {
-        pwmChangePeriod(_toneAlarm_pwm_group.pwm_drv,
-                        roundf(_toneAlarm_pwm_group.pwm_cfg.frequency/frequency));
-
-        pwmEnableChannel(_toneAlarm_pwm_group.pwm_drv, _toneAlarm_pwm_group.chan, roundf(volume*_toneAlarm_pwm_group.pwm_cfg.frequency/frequency)/2);
+    if (frequency == 0){
+    	ledc_stop(_toneAlarm_pwm_group.channel_config.speed_mode, _toneAlarm_pwm_group.channel_config.channel, 0);
+    }
+    else {
+    	ledc_set_freq(_toneAlarm_pwm_group.timer_config.speed_mode, _toneAlarm_pwm_group.timer_config.timer_num, (uint32_t)frequency); 
+    	ledc_set_duty(_toneAlarm_pwm_group.channel_config.speed_mode, _toneAlarm_pwm_group.channel_config.channel,(uint32_t)volume*50); 
+		ledc_update_duty(_toneAlarm_pwm_group.channel_config.speed_mode, _toneAlarm_pwm_group.channel_config.channel);    
     }
 }
 #endif // HAL_PWM_ALARM

--- a/libraries/AP_HAL_ESP32/Util.h
+++ b/libraries/AP_HAL_ESP32/Util.h
@@ -19,6 +19,10 @@
 #include <AP_HAL/AP_HAL.h>
 #include "HAL_ESP32_Namespace.h"
 #include "AP_HAL_ESP32.h"
+#if AP_NOTIFY_TONEALARM_ENABLED
+#include "driver/ledc.h"
+#include "AP_Notify/AP_Notify.h"
+#endif
 
 class ESP32::Util : public AP_HAL::Util
 {
@@ -54,9 +58,10 @@ public:
     bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
-#ifdef HAL_PWM_ALARM
-    bool toneAlarm_init() override;
+#if HAL_PWM_ALARM == TRUE
+    bool toneAlarm_init(uint8_t types) override;
     void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) override;
+    static uint8_t _toneAlarm_types;
 #endif
 
     // return true if the reason for the reboot was a watchdog reset
@@ -68,11 +73,11 @@ public:
 #endif
 
 private:
-#ifdef HAL_PWM_ALARM
-    struct ToneAlarmPwmGroup {
-        pwmchannel_t chan;
-        PWMConfig pwm_cfg;
-        PWMDriver* pwm_drv;
+#if AP_NOTIFY_TONEALARM_ENABLED
+    struct ToneAlarmPwmGroup 
+    {
+        ledc_timer_config_t timer_config;
+        ledc_channel_config_t channel_config;
     };
 
     static ToneAlarmPwmGroup _toneAlarm_pwm_group;

--- a/libraries/AP_HAL_ESP32/Util.h
+++ b/libraries/AP_HAL_ESP32/Util.h
@@ -58,7 +58,7 @@ public:
     bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
-#if HAL_PWM_ALARM == TRUE
+#if AP_NOTIFY_TONEALARM_ENABLED
     bool toneAlarm_init(uint8_t types) override;
     void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) override;
     static uint8_t _toneAlarm_types;


### PR DESCRIPTION
implemented tonealarm init and set buzzer frequency function for ESP32
to use ToneAlarm, define HAL_NOTIFY_TONEALARM_ENABLED TRUE and 
HAL_PWM_BUZZER_PIN to corresponding ESP32 pin 