### PR TITLE
Copter: Change from fast_loop method to FAST_TASK(NFC)

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -744,7 +744,7 @@ void Copter::update_super_simple_bearing(bool force_update)
 
 void Copter::read_AHRS(void)
 {
-    // we tell AHRS to skip INS update as we have already done it in fast_loop()
+    // we tell AHRS to skip INS update as we have already done it in FAST_TASK.
     ahrs.update(true);
 }
 


### PR DESCRIPTION
There is no fast_loop method.
It is registered as FAST_TASK.
I will change it.