### PR TITLE
Copter: Check the voltage applied to the FC

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -694,6 +694,7 @@ private:
     void update_simple_mode(void);
     void update_super_simple_bearing(bool force_update);
     void read_AHRS(void);
+    void check_fc_vcc(void);
     void update_altitude();
     bool get_wp_distance_m(float &distance) const override;
     bool get_wp_bearing_deg(float &bearing) const override;


### PR DESCRIPTION
The voltage applied to the FC is not stable.
During the pre-arm check, the voltage is stable because the battery is not under load.
However, during the arm, the battery voltage changes due to motor control, and the FC voltage also fluctuates due to this change.
The GNSS receiver is powered by the FC.
Therefore, it is necessary to guarantee the voltage of the GNSS receiver in order to achieve the performance of the GNSS receiver.
I monitor the FC voltage and notify the operator if I detect a voltage below the performance maintenance voltage.

AFTER
![Screenshot from 2023-07-30 12-57-54](https://github.com/ArduPilot/ardupilot/assets/646194/32d8799b-c5ab-440e-be1c-c08f8a4225cc)

