### PR TITLE
Rover: fixed constructor ordering build error with gcc-12.2

### DIFF
--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -316,12 +316,12 @@ public:
     AP_Beacon beacon;
 #endif
 
-    // Motor library
-    AP_MotorsUGV motors;
-
     // wheel encoders
     AP_WheelEncoder wheel_encoder;
     AP_WheelRateControl wheel_rate_control;
+
+    // Motor library
+    AP_MotorsUGV motors;
 
     // steering and throttle controller
     AR_AttitudeControl attitude_control;


### PR DESCRIPTION
the constructor order comes from the order in the class