### PR TITLE
waf: tidy interpretation of -Werror

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -774,22 +774,31 @@ class sitl(Board):
         # whitelist of compilers which we should build with -Werror
         gcc_whitelist = frozenset([
                 ('11','3','0'),
+                ('12','1','0'),
             ])
 
-        werr_enabled_default = bool('g++' == cfg.env.COMPILER_CXX and cfg.env.CC_VERSION in gcc_whitelist)
+        # initialise werr_enabled from defaults:
+        werr_enabled = bool('g++' in cfg.env.COMPILER_CXX and cfg.env.CC_VERSION in gcc_whitelist)
 
-        if werr_enabled_default or cfg.options.Werror:
-            if not cfg.options.disable_Werror:
-                cfg.msg("Enabling -Werror", "yes")
-                if '-Werror' not in env.CXXFLAGS:
-                    env.CXXFLAGS += [ '-Werror' ]
-            else:
-                cfg.msg("Enabling -Werror", "no")
-                if '-Werror' in env.CXXFLAGS:
-                    env.CXXFLAGS.remove('-Werror')
-        else:
+        # now process overrides to that default:
+        if (cfg.options.Werror is not None and
+                cfg.options.Werror == cfg.options.disable_Werror):
+            cfg.fatal("Asked to both enable and disable Werror")
+
+        if cfg.options.Werror is not None:
+            werr_enabled = cfg.options.Werror
+        elif cfg.options.disable_Werror is not None:
+            werr_enabled = not cfg.options.disable_Werror
+
+        if werr_enabled:
             cfg.msg("Enabling -Werror", "yes")
-        
+            if '-Werror' not in env.CXXFLAGS:
+                env.CXXFLAGS += [ '-Werror' ]
+        else:
+            cfg.msg("Enabling -Werror", "no")
+            if '-Werror' in env.CXXFLAGS:
+                env.CXXFLAGS.remove('-Werror')
+
     def get_name(self):
         return self.__class__.__name__
 

--- a/wscript
+++ b/wscript
@@ -143,12 +143,12 @@ def options(opt):
 
     g.add_option('--Werror',
         action='store_true',
-        default=False,
+        default=None,
         help='build with -Werror.')
 
     g.add_option('--disable-Werror',
         action='store_true',
-        default=True,
+        default=None,
         help='Disable -Werror.')
     
     g.add_option('--toolchain',


### PR DESCRIPTION
Before this fix:
```
pbarker@fx:~/rc/ardupilot(master)$ CXX=g++-10 CC=gcc-10 ./waf configure --board=sitl | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(master)$ 
```
(wrong as 11.3.0 is the only whitelisted compiler; this is actually lying with a bad message, it's not really enabled)

```
pbarker@fx:~/rc/ardupilot(master)$ CXX=g++-11 CC=gcc-11 ./waf configure --board=sitl --enable-Werror | grep Werror
Enabling -Werror                         : no 
pbarker@fx:~/rc/ardupilot(master)$ 
```
This message is correct, it's not enabling it, even 'though it should.  The option `--disable-Werror` is set to true in the waf config by default.

After this fix:
```
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ g++-10 --version
g++-11 --version
g++-12 --version
g++-10 (Ubuntu 10.4.0-4ubuntu1~22.04) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

g++-11 (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

g++-12 (Ubuntu 12.1.0-2ubuntu1~22.04) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-10 CC=gcc-10 ./waf configure --board=sitl | grep Werror
Enabling -Werror                         : no 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-11 CC=gcc-11 ./waf configure --board=sitl | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-12 CC=gcc-12 ./waf configure --board=sitl | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-10 CC=gcc-10 ./waf configure --board=sitl --Werror | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-11 CC=gcc-11 ./waf configure --board=sitl --Werror | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-12 CC=gcc-12 ./waf configure --board=sitl --Werror | grep Werror
Enabling -Werror                         : yes 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-10 CC=gcc-10 ./waf configure --board=sitl --disable-Werror | grep Werror
Enabling -Werror                         : no 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-11 CC=gcc-11 ./waf configure --board=sitl --disable-Werror | grep Werror
Enabling -Werror                         : no 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-12 CC=gcc-12 ./waf configure --board=sitl --disable-Werror | grep Werror
Enabling -Werror                         : no 
pbarker@fx:~/rc/ardupilot(pr/werror-cleanup)$ CXX=g++-12 CC=gcc-12 ./waf configure --board=sitl --disable-Werror --Werror
Setting top to                           : /home/pbarker/rc/ardupilot 
Setting out to                           : /home/pbarker/rc/ardupilot/build 
Autoconfiguration                        : enabled 
Checking for program 'python'            : /usr/bin/python3 
Checking for python version >= 3.6.9     : 3.10.6 
Setting board to                         : sitl 
Using toolchain                          : native 
Checking for 'g++' (C++ compiler)        : g++-12 
Checking for 'gcc' (C compiler)          : gcc-12 
Checking for c flags '-MMD'              : yes 
Checking for cxx flags '-MMD'            : yes 
CXX Compiler                             : g++ 12.1.0 
Checking for need to link with librt     : not necessary 
Checking for feenableexcept              : yes 
Asked to both enable and disable Werror
(complete log in /home/pbarker/rc/ardupilot/build/config.log)
```
