### PR TITLE
AP_Scripting: Account for nil battery in Rockblock and MAVLink_HL scripts

### DIFF
--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -784,7 +784,7 @@ function HLSatcom()
 
         hl2.temperature_air = math.floor(baro:get_external_temperature())
         
-        if battery:num_instances() > 0 then
+        if battery:num_instances() > 0 and battery:capacity_remaining_pct(0) ~= nil then
             hl2.battery = battery:capacity_remaining_pct(0)
         else
             hl2.battery = 0

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -440,7 +440,7 @@ function HLSatcom()
 
         hl2.temperature_air = math.floor(baro:get_external_temperature())
 
-        if battery:num_instances() > 0 then
+        if battery:num_instances() > 0 and battery:capacity_remaining_pct(0) ~= nil then
             hl2.battery = battery:capacity_remaining_pct(0)
         else
             hl2.battery = 0


### PR DESCRIPTION
``battery:capacity_remaining_pct(0)`` returns nil in some cases, so just return 0 for the Rockblock and MAVLinkHL scripts if that's the case.