### PR TITLE
ChibiOS: disable DMA on I2C on F7 and H7 by default (4.4 backport)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32f47_mcuconf.h
@@ -579,3 +579,10 @@
 
 // limit ISR count per byte
 #define STM32_I2C_ISR_LIMIT                 6
+
+#if defined(STM32F7xx_MCUCONF)
+// disable DMA on I2C by default on F7
+#ifndef STM32_I2C_USE_DMA
+#define STM32_I2C_USE_DMA FALSE
+#endif
+#endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -626,3 +626,7 @@
 #define STM32_SPI_SPI6_TX_BDMA_STREAM 5
 #define STM32_ADC_ADC3_BDMA_STREAM 7
 
+// disable DMA on I2C by default on H7
+#ifndef STM32_I2C_USE_DMA
+#define STM32_I2C_USE_DMA FALSE
+#endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -151,7 +151,7 @@ def get_mcu_lib(mcu):
 
 def setup_mcu_type_defaults():
     '''setup defaults for given mcu type'''
-    global pincount, ports, portmap, vtypes, mcu_type
+    global pincount, ports, portmap, vtypes, mcu_type, dma_exclude_pattern
     lib = get_mcu_lib(mcu_type)
     if hasattr(lib, 'pincount'):
         pincount = lib.pincount
@@ -166,6 +166,9 @@ def setup_mcu_type_defaults():
         for pin in range(pincount[port]):
             portmap[port].append(generic_pin(port, pin, None, default_gpio[0], default_gpio[1:]))
 
+    if mcu_series.startswith("STM32H7") or mcu_series.startswith("STM32F7"):
+        # default DMA off on I2C for H7, we're much better off reducing DMA sharing
+        dma_exclude_pattern = ['I2C*']
 
 def get_alt_function(mcu, pin, function):
     '''return alternative function number for a pin'''


### PR DESCRIPTION
this was already done on many (most?) boards, and greatly reduces DMA sharing which improves performance of UARTs. This changes the default to no DMA on I2C
this is an alternative to #24454  which works on a lot more boards
