### PR TITLE
AP_Periph: rename ins locals to avoid conflict with ins member variable

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -345,7 +345,7 @@ public:
                                  uint16_t payload_len);
 
 #if AP_UART_MONITOR_ENABLED
-    void handle_tunnel_Targetted(CanardInstance* ins, CanardRxTransfer* transfer);
+    void handle_tunnel_Targetted(CanardInstance* canard_instance, CanardRxTransfer* transfer);
     void send_serial_monitor_data();
     int8_t get_default_tunnel_serial_port(void) const;
 

--- a/Tools/AP_Periph/serial_tunnel.cpp
+++ b/Tools/AP_Periph/serial_tunnel.cpp
@@ -69,13 +69,13 @@ int8_t AP_Periph_FW::get_default_tunnel_serial_port(void) const
 /*
   handle tunnel data
  */
-void AP_Periph_FW::handle_tunnel_Targetted(CanardInstance* ins, CanardRxTransfer* transfer)
+void AP_Periph_FW::handle_tunnel_Targetted(CanardInstance* canard_ins, CanardRxTransfer* transfer)
 {
     uavcan_tunnel_Targetted pkt;
     if (uavcan_tunnel_Targetted_decode(transfer, &pkt)) {
         return;
     }
-    if (pkt.target_node != canardGetLocalNodeID(ins)) {
+    if (pkt.target_node != canardGetLocalNodeID(canard_ins)) {
         return;
     }
     if (uart_monitor.buffer == nullptr) {


### PR DESCRIPTION
I'd like to use `ins` for inertial sensor.
