### PR TITLE
AP_Scripting: mount-djirs2: fix reporting issues

### DIFF
--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -653,12 +653,12 @@ function parse_byte(b)
           end
 
           -- parse attitude reply message
-          if (expected_reply == REPLY_TYPE.ATTITUDE) and (parse_length >= 20) then
-            local ret_code = parse_buff[13]
+          if (expected_reply == REPLY_TYPE.ATTITUDE) and (parse_length >= 22) then
+            local ret_code = parse_buff[15]
             if ret_code == RETURN_CODE.SUCCESS then
-              local yaw_deg = int16_value(parse_buff[16],parse_buff[15]) * 0.1
-              local pitch_deg = int16_value(parse_buff[18],parse_buff[17]) * 0.1
-              local roll_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
+              local yaw_deg = int16_value(parse_buff[18],parse_buff[17]) * 0.1
+              local pitch_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
+              local roll_deg = int16_value(parse_buff[22],parse_buff[21]) * 0.1
               mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
               if DJIR_DEBUG:get() > 1 then
                 gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR: roll:%4.1f pitch:%4.1f yaw:%4.1f", roll_deg, pitch_deg, yaw_deg))
@@ -669,16 +669,16 @@ function parse_byte(b)
           end
 
           -- parse position control reply message
-          if (expected_reply == REPLY_TYPE.POSITION_CONTROL) and (parse_length >= 13) then
-            local ret_code = parse_buff[13]
+          if (expected_reply == REPLY_TYPE.POSITION_CONTROL) and (parse_length >= 15) then
+            local ret_code = parse_buff[15]
             if ret_code ~= RETURN_CODE.SUCCESS then
               execute_fails = execute_fails + 1
             end
           end
 
           -- parse speed control reply message
-          if (expected_reply == REPLY_TYPE.SPEED_CONTROL) and (parse_length >= 13) then
-            local ret_code = parse_buff[13]
+          if (expected_reply == REPLY_TYPE.SPEED_CONTROL) and (parse_length >= 15) then
+            local ret_code = parse_buff[15]
             if ret_code ~= RETURN_CODE.SUCCESS then
               execute_fails = execute_fails + 1
             end

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -657,8 +657,12 @@ function parse_byte(b)
             local ret_code = parse_buff[15]
             if ret_code == RETURN_CODE.SUCCESS then
               local yaw_deg = int16_value(parse_buff[18],parse_buff[17]) * 0.1
-              local pitch_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
-              local roll_deg = int16_value(parse_buff[22],parse_buff[21]) * 0.1
+              local roll_deg = int16_value(parse_buff[20],parse_buff[19]) * 0.1
+              local pitch_deg = int16_value(parse_buff[22],parse_buff[21]) * 0.1
+              -- if upsidedown, subtract 180deg from yaw to undo addition of target
+              if DJIR_UPSIDEDOWN:get() > 0 then
+                yaw_deg = wrap_180(yaw_deg - 180)
+              end
               mount:set_attitude_euler(MOUNT_INSTANCE, roll_deg, pitch_deg, yaw_deg)
               if DJIR_DEBUG:get() > 1 then
                 gcs:send_text(MAV_SEVERITY.INFO, string.format("DJIR: roll:%4.1f pitch:%4.1f yaw:%4.1f", roll_deg, pitch_deg, yaw_deg))

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.md
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.md
@@ -12,3 +12,10 @@ DJI RS2 and RS3-Pro gimbal mount driver lua script
 - Set MNT1_TYPE = 9 (Scripting) to enable the mount/gimbal scripting driver
 - Reboot the autopilot
 - Copy the mount-djirs2-driver.lua script to the autopilot's SD card in the APM/scripts directory and reboot the autopilot
+
+## Issues
+
+If the ground station reports "Pre-arm: Mount not healthy", update the 
+gimbal firmware using the DJI Ronin phone app to version 01.04.00.20 or 
+later to correct a mismatch in the way data is received from the gimbal. 
+Completing this update may take more than an hour.


### PR DESCRIPTION
Decently recent firmware for the RS2 sends replies back in a slightly different format than expected by the script. I've corrected the script to parse the new packets correctly but now it will not work with the old style. The documentation is updated to inform users to update.

I also fixed the reporting of angles as it was broken by a recent change for reasons I can't determine. I made sure that the reported angles and directions match the drone frame (positive roll right/clockwise from rear, positive pitch up/clockwise from left, positive yaw right/clockwise from top) in both right side up and upside down modes.

cc: @rmackay9 who wrote the original script