### PR TITLE
AP_Periph: add support for RawAirData.Pitot_temperature

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
@@ -90,6 +90,7 @@ void AP_TemperatureSensor_Backend::update_external_libraries(const float tempera
 #endif
 
         case AP_TemperatureSensor_Params::Source::None:
+        case AP_TemperatureSensor_Params::Source::Pitot_tube:
         default:
             break;
     }

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Params::var_info[] = {
     // @Param: SRC
     // @DisplayName: Sensor Source
     // @Description: Sensor Source is used to designate which device's temperature report will be replaced by this temperature sensor's data. If 0 (None) then the data is only available via log. In the future a new Motor temperature report will be created for returning data directly.
-    // @Values: 0: None, 1:ESC, 2:Motor(not implemented yet), 3:Battery Index, 4:Battery ID/SerialNumber
+    // @Values: 0: None, 1:ESC, 2:Motor(not implemented yet), 3:Battery Index, 4:Battery ID/SerialNumber, 5: Pitot tube
     // @User: Standard
     AP_GROUPINFO("SRC", 4, AP_TemperatureSensor_Params, source, (float)Source::None),
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
@@ -40,6 +40,7 @@ public:
         Motor                       = 2,
         Battery_Index               = 3,
         Battery_ID_SerialNumber     = 4,
+        Pitot_tube                  = 5,
     };
 
     AP_Enum<Type> type;             // 0=disabled, others see frontend enum TYPE


### PR DESCRIPTION
AP_Periph: add support for RawAirData.Pitot_temperature in outbound packets

As of now, Ardupilot does not yet have any inbound use for this yet - it's for reporting only. There is a coming PR for a thermostat-based heated pitot tube to take advantage of this.