### PR TITLE
CAN: fixed SLCAN

### DIFF
--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -722,7 +722,7 @@ int16_t SLCAN::CANIface::receive(AP_HAL::CANFrame& out_frame, uint64_t& rx_time,
         // flush bytes from port
         while (num_bytes--) {
             uint8_t b;
-            if (!_port->read_locked(&b, 1, _serial_lock_key)) {
+            if (_port->read_locked(&b, 1, _serial_lock_key) != 1) {
                 break;
             }
             addByte(b);

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -658,6 +658,9 @@ bool SLCAN::CANIface::select(bool &read, bool &write, const AP_HAL::CANFrame* co
         return ret;
     }
 
+    // ensure we own the UART. Locking is handled at the CAN interface level
+    _port->begin_locked(0, 0, 0, _serial_lock_key);
+    
     // if under passthrough, we only do send when can_iface also allows it
     if (_port->available_locked(_serial_lock_key) || rx_queue_.available()) {
         // allow for receiving messages over slcan

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -231,6 +231,12 @@ static int hal_console_vprintf(const char *fmt, va_list arg)
 
 void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
 {
+    if (b == 0 && txS == 0 && rxS == 0 && _tx_initialised && _rx_initialised) {
+        // just changing port owner
+        _uart_owner_thd = chThdGetSelfX();
+        return;
+    }
+
     thread_rx_init();
 
     if (sdef.serial == nullptr) {


### PR DESCRIPTION
SLCAN broke when we moved to the unified AP_HAL locking system for  UARTs. The SLCAN code relied on the fact that the thread owner check was not done for the read_locked() path. Now that we have a higher level consistent API that check is done and SLCAN broke
