### PR TITLE
AP_BattMonitor: add health logging

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Logging.cpp
@@ -22,6 +22,7 @@ void AP_BattMonitor_Backend::Log_Write_BAT(const uint8_t instance, const uint64_
         temperature         : (int16_t) ( has_temperature() ? _state.temperature * 100 : 0),
         resistance          : _state.resistance,
         rem_percent         : percent,
+        health              : _state.healthy
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_BattMonitor/LogStructure.h
+++ b/libraries/AP_BattMonitor/LogStructure.h
@@ -9,7 +9,7 @@
 // @LoggerMessage: BAT
 // @Description: Gathered battery data
 // @Field: TimeUS: Time since system startup
-// @Field: Instance: battery instance number
+// @Field: Inst: battery instance number
 // @Field: Volt: measured voltage
 // @Field: VoltR: estimated resting voltage
 // @Field: Curr: measured current
@@ -18,6 +18,7 @@
 // @Field: Temp: measured temperature
 // @Field: Res: estimated battery resistance
 // @Field: RemPct: remaining percentage
+// @Field: H: health
 struct PACKED log_BAT {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -30,6 +31,7 @@ struct PACKED log_BAT {
     int16_t  temperature; // degrees C * 100
     float    resistance;
     uint8_t  rem_percent;
+    uint8_t  health;
 };
 
 // @LoggerMessage: BCL
@@ -59,6 +61,6 @@ struct PACKED log_BCL {
 
 #define LOG_STRUCTURE_FROM_BATTMONITOR        \
     { LOG_BAT_MSG, sizeof(log_BAT), \
-        "BAT", "QBfffffcfB", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res,RemPct", "s#vvAaXOw%", "F-000C0?00" , true },  \
+        "BAT", "QBfffffcfBB", "TimeUS,Inst,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res,RemPct,H", "s#vvAaXOw%-", "F-000C0?000" , true },  \
     { LOG_BCL_MSG, sizeof(log_BCL), \
         "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" , true },


### PR DESCRIPTION
Currently we may have a sensor not working in the GCS because its unhealthy, but seemingly working fine in the log since health is not logged.