### PR TITLE
Copter: The preprocessor determines whether rangefinder initialization is possible

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -153,8 +153,10 @@ void Copter::init_ardupilot()
     barometer.set_log_baro_bit(MASK_LOG_IMU);
     barometer.calibrate();
 
+#if RANGEFINDER_ENABLED == ENABLED
     // initialise rangefinder
     init_rangefinder();
+#endif
 
 #if HAL_PROXIMITY_ENABLED
     // init proximity sensor


### PR DESCRIPTION
Class initialization availability is done by preprocessor.
The range finder is also enabled/disabled by the preprocessor.