### PR TITLE
Allow compass mag cal command to come in as COMMAND_INT

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -196,7 +196,7 @@ public:
     /*
       handle an incoming MAG_CAL command
     */
-    MAV_RESULT handle_mag_cal_command(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_mag_cal_command(const mavlink_command_int_t &packet);
 
     bool send_mag_cal_progress(const class GCS_MAVLINK& link);
     bool send_mag_cal_report(const class GCS_MAVLINK& link);

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -371,7 +371,7 @@ uint8_t Compass::_get_cal_mask()
 /*
   handle an incoming MAG_CAL command
  */
-MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
+MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_int_t &packet)
 {
     MAV_RESULT result = MAV_RESULT_FAILED;
 
@@ -392,7 +392,7 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
         bool retry = !is_zero(packet.param2);
         bool autosave = !is_zero(packet.param3);
         float delay = packet.param4;
-        bool autoreboot = !is_zero(packet.param5);
+        bool autoreboot = packet.x != 0;
 
         if (mag_mask == 0) { // 0 means all
             _reset_compass_id();

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -649,7 +649,10 @@ protected:
     MAV_RESULT handle_command_do_set_roi_none();
 
     virtual MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet, const mavlink_message_t &msg);
-    MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
+
+    MAV_RESULT handle_command_mag_cal(const mavlink_command_int_t &packet);
+    MAV_RESULT handle_command_fixed_mag_cal_yaw(const mavlink_command_int_t &packet);
+
     MAV_RESULT try_command_long_as_command_int(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);
@@ -673,8 +676,6 @@ protected:
     void handle_can_frame(const mavlink_message_t &msg) const;
 
     void handle_optical_flow(const mavlink_message_t &msg);
-
-    MAV_RESULT handle_command_fixed_mag_cal_yaw(const mavlink_command_int_t &packet);
 
     void handle_manual_control(const mavlink_message_t &msg);
 


### PR DESCRIPTION
```
+ column -ts, /tmp/some.csv
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -88    *           -88     -88               -88    -88    -96
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -40    *           -32     -40               -40    -32    -32
MatekF405                      -8     *           -16     -8                -16    -8     -8
Pixhawk1-1M-bdshot             -16                -16     -16               -16    -16    -16
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      0      *           -8      -8                -8     8      0
skyviper-v2450                                    -16                                     
```

Tested in SITL + MAVProxy.  We also test this in autotest.
