### PR TITLE
AP_BATTMonitor: Reserve ID 28 for AD7091R5  I2C ADC

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -107,6 +107,7 @@ public:
         Analog_Volt_Synthetic_Current  = 25,
         INA239_SPI                     = 26,
         EFI                            = 27,
+        // AD7091R5_I2C_Analog         = 28, reserve ID for future use
     };
 
     FUNCTOR_TYPEDEF(battery_failsafe_handler_fn_t, void, const char *, const int8_t);


### PR DESCRIPTION
Reserving an ID for a Battmonitor type which reads the analog value from an I2C ADC IC.

Replaces https://github.com/ArduPilot/ardupilot/pull/24350 which is having CI problems and I can't force-push.
