### PR TITLE
size_compare_branches.py: blacklist build of RADIX2HD bootloader

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -156,6 +156,7 @@ class SizeCompareBranches(object):
             'Pixhawk1-1M-bdshot',
             'Pixhawk1-bdshot',
             'SITL_arm_linux_gnueabihf',
+            'RADIX2HD',
         ])
 
         # blacklist all linux boards for bootloader build:


### PR DESCRIPTION
we don't have a hardware definition for this