### PR TITLE
hwdef: remove un-needed lines in KakuteH7 config

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/hwdef.dat
@@ -152,8 +152,6 @@ BARO BMP280 I2C:0:0x76
 define HAL_OS_FATFS_IO 1
 
 # setup for OSD
-undef OSD_ENABLED  # minimize_features.inc removes this
-define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 


### PR DESCRIPTION
these are thge default values, and KakuteH7 isn't minimized

```
Board     copter
KakuteH7  -16
```
