### PR TITLE
AP_GPS: avoid use of mavlink_channel_t when GCS not compiled in

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1294,6 +1294,7 @@ void AP_GPS::update_primary(void)
 }
 #endif  // GPS_MAX_RECEIVERS > 1
 
+#if HAL_GCS_ENABLED
 void AP_GPS::handle_gps_inject(const mavlink_message_t &msg)
 {
     mavlink_gps_inject_data_t packet;
@@ -1331,6 +1332,7 @@ void AP_GPS::handle_msg(const mavlink_message_t &msg)
     }
     }
 }
+#endif
 
 #if HAL_MSP_GPS_ENABLED
 void AP_GPS::handle_msp(const MSP::msp_gps_data_message_t &pkt)
@@ -1496,6 +1498,7 @@ void AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
 }
 #endif // GPS_MAX_RECEIVERS
 
+#if HAL_GCS_ENABLED
 void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)
 {
     if (inst >= GPS_MAX_RECEIVERS) {
@@ -1505,6 +1508,7 @@ void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)
         drivers[inst]->send_mavlink_gps_rtk(chan);
     }
 }
+#endif
 
 bool AP_GPS::first_unconfigured_gps(uint8_t &instance) const
 {

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -34,7 +34,9 @@ public:
 
     AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
+#if HAL_GCS_ENABLED
     bool supports_mavlink_gps_rtk_message() const override { return true; }
+#endif
 
     static bool _detect(struct ERB_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -16,10 +16,13 @@
 //
 //  MAVLINK GPS driver
 //
-#include "AP_GPS_MAV.h"
-#include <stdint.h>
+
+#include "AP_GPS_config.h"
 
 #if AP_GPS_MAV_ENABLED
+
+#include "AP_GPS_MAV.h"
+#include <stdint.h>
 
 // Reading does nothing in this class; we simply return whether or not
 // the latest reading has been consumed.  By calling this function we assume

--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -19,16 +19,15 @@
 //
 #pragma once
 
+#include "AP_GPS_config.h"
+
+#if AP_GPS_MAV_ENABLED
+
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
 
-#ifndef AP_GPS_MAV_ENABLED
-  #define AP_GPS_MAV_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
-#endif 
-
-#if AP_GPS_MAV_ENABLED
 class AP_GPS_MAV : public AP_GPS_Backend {
 public:
 
@@ -47,4 +46,5 @@ private:
     uint32_t first_week;
     JitterCorrection jitter{2000};
 };
-#endif
+
+#endif  // AP_GPS_MAV_ENABLED

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -45,7 +45,9 @@ public:
 
     void broadcast_configuration_failure_reason(void) const override;
 
+#if HAL_GCS_ENABLED
     bool supports_mavlink_gps_rtk_message(void) const override { return true; };
+#endif
 
     // get the velocity lag, returns true if the driver is confident in the returned value
     bool get_lag(float &lag_sec) const override { lag_sec = 0.08f; return true; } ;

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -32,7 +32,9 @@ public:
 
     AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
+#if HAL_GCS_ENABLED
     bool supports_mavlink_gps_rtk_message() const override { return true; }
+#endif
 
     // Methods
     bool read() override;

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
+#include <GCS_MAVLink/GCS_config.h>
 
 #ifndef AP_GPS_ENABLED
 #define AP_GPS_ENABLED 1
@@ -20,6 +21,10 @@
 
 #ifndef AP_GPS_GSOF_ENABLED
   #define AP_GPS_GSOF_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED
+#endif
+
+#ifndef AP_GPS_MAV_ENABLED
+  #define AP_GPS_MAV_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED && HAL_GCS_ENABLED
 #endif
 
 #ifndef AP_GPS_NMEA_ENABLED

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -197,9 +197,9 @@ bool AP_GPS_Backend::should_log() const
 }
 
 
+#if HAL_GCS_ENABLED
 void AP_GPS_Backend::send_mavlink_gps_rtk(mavlink_channel_t chan)
 {
-#if HAL_GCS_ENABLED
     const uint8_t instance = state.instance;
     // send status
     switch (instance) {
@@ -236,8 +236,8 @@ void AP_GPS_Backend::send_mavlink_gps_rtk(mavlink_channel_t chan)
                                  state.rtk_iar_num_hypotheses);
             break;
     }
-#endif
 }
+#endif
 
 
 /*

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS_config.h>
 #include <AP_RTC/JitterCorrection.h>
 #include "AP_GPS.h"
 #include "AP_GPS_config.h"
@@ -55,13 +56,15 @@ public:
 
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
+#if HAL_GCS_ENABLED
     //MAVLink methods
     virtual bool supports_mavlink_gps_rtk_message() const { return false; }
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);
+    virtual void handle_msg(const mavlink_message_t &msg) { return ; }
+#endif
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }
 
-    virtual void handle_msg(const mavlink_message_t &msg) { return ; }
 #if HAL_MSP_GPS_ENABLED
     virtual void handle_msp(const MSP::msp_gps_data_message_t &pkt) { return; }
 #endif


### PR DESCRIPTION
![image](https://github.com/ArduPilot/ardupilot/assets/7077857/502dbcda-a06b-4709-8a4b-a29ec867a088)

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/4c899748-15dc-4c03-a343-c072164f0f82)

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       0      *           0       0                 0      0      0
HerePro             0                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                0      *           0       0                 0      0      0
MatekF405                      0      *           0       0                 0      0      0
Pixhawk1-1M-bdshot             0                  0       0                 0      0      0
f103-QiotekPeriph   *                                                                     
f303-Universal      -72                                                                   
iomcu                                                           *                         
revo-mini                      0      *           0       0                 0      0      0
skyviper-v2450                                    0                                       
```
