### PR TITLE
AP_GPS: tidy is_healthy calculations

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2109,13 +2109,11 @@ bool AP_GPS::is_healthy(uint8_t instance) const
         return false;
     }
 
-#ifdef HAL_BUILD_AP_PERIPH
+#ifndef HAL_BUILD_AP_PERIPH
     /*
       on AP_Periph handling of timing is done by the flight controller
       receiving the DroneCAN messages
      */
-    return drivers[instance] != nullptr && drivers[instance]->is_healthy();
-#else
     /*
       allow two lost frames before declaring the GPS unhealthy, but
       require the average frame rate to be close to 5Hz. We allow for
@@ -2131,6 +2129,7 @@ bool AP_GPS::is_healthy(uint8_t instance) const
     if (!delay_ok) {
         return false;
     }
+#endif // HAL_BUILD_AP_PERIPH
 
 #if defined(GPS_BLENDED_INSTANCE)
     if (instance == GPS_BLENDED_INSTANCE) {
@@ -2140,7 +2139,6 @@ bool AP_GPS::is_healthy(uint8_t instance) const
 
     return drivers[instance] != nullptr &&
            drivers[instance]->is_healthy();
-#endif // HAL_BUILD_AP_PERIPH
 }
 
 bool AP_GPS::prepare_for_arming(void) {


### PR DESCRIPTION
this removes some duplicate code and simplifies the flow of control

Will prevent a bug if we ever do blended on a periph

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
