### PR TITLE
AP_Arming: mag field check vs world magnetic model

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -169,6 +169,10 @@ class AutoTestQuadPlane(AutoTest):
             self.wait_ready_to_arm()
 
         self.start_subtest("Verify that arming with switch does not spin motors in other modes")
+        # disable compass magnetic field arming check that is triggered by the simulated lean of vehicle
+        # this is required because adjusting the AHRS_TRIM values only affects the IMU and not external compasses
+        arming_magthresh = self.get_parameter("ARMING_MAGTHRESH")
+        self.set_parameter("ARMING_MAGTHRESH", 0)
         # introduce a large attitude error to verify that stabilization is not active
         ahrs_trim_x = self.get_parameter("AHRS_TRIM_X")
         self.set_parameter("AHRS_TRIM_X", math.radians(-60))
@@ -207,8 +211,9 @@ class AutoTestQuadPlane(AutoTest):
             self.progress("Waiting for Motor1 to stop")
             self.wait_servo_channel_value(5, min_pwm, comparator=operator.le)
             self.wait_ready_to_arm()
-        # remove attitude error
+        # remove attitude error and reinstance compass arming check
         self.set_parameter("AHRS_TRIM_X", ahrs_trim_x)
+        self.set_parameter("ARMING_MAGTHRESH", arming_magthresh)
 
         self.start_subtest("verify that AIRMODE auxswitch turns airmode on/off while armed")
         """set  RC7_OPTION to AIRMODE"""

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -157,6 +157,7 @@ protected:
     AP_Int8                 _rudder_arming;
     AP_Int32                _required_mission_items;
     AP_Int32                _arming_options;
+    AP_Int16                magfield_error_threshold;
 
     // internal members
     bool                    armed;


### PR DESCRIPTION
This adds an arming check of the vehicle's primary compass's magnetic field vs the world magnetic model.  The purpose is to try and catch situations where metal objects in the environment near the vehicle result in a bad yaw estimate which can lead to short-term loss of control soon after takeoff.  The loss of control is "short-term" because normally the [EKF failsafe](https://ardupilot.org/copter/docs/ekf-inav-failsafe.html) and/of [GSF's emergency yaw reset](https://ardupilot.org/copter/docs/common-compassless.html) lead to regaining control if given enough time and space.

The vehicle's primary compass magnetic field values are rotated into earth frame and then each axis is compared vs the expected value to ensure it is less than the threshold held in a new ARMING_MAGTHRESH parameter.  Note that for the Z-axis 2x the threshold parameter value is used.

The threshold is 100 mgauss by default.

The check can be disabled by setting ARMING_MAGTHRESH to zero.

I've tested this on real hardware (a CubeOrange with a Here3 GPS/compass) moving it closer/farther from a Rode microphone which is a surprisingly good source of magnetic interference.

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/83166b19-fbc4-4147-ba33-f49880c346c4)

Some discussion points:

- maybe we should only enable the check if the user calibrated the compass while they had GPS (so scaling has been applied)
- is checking each individual axis the right approach?  It's easy and it seems to work
- this does not catch situations where the the compass orientation has been incorrectly set