### PR TITLE
AP_Scripting: generator: fix dependancy start and end miss-match

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1709,8 +1709,8 @@ void emit_userdata_fields() {
         emit_userdata_field(node, field);
         field = field->next;
       }
+      end_dependency(source, node->dependency);
     }
-    end_dependency(source, node->dependency);
     node = node->next;
   }
 }


### PR DESCRIPTION
This fixes a bug for depends on userdata fields. We don't currently have any uerdata items with no feilds and a depends, so there is no change in generated output with the current bindings, this is needed for https://github.com/ArduPilot/ardupilot/pull/24429