### PR TITLE
autotest: fixed using GNU screen for opening gdb

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -506,7 +506,7 @@ def start_SITL(binary,
                         '-d',
                         '-m',
                         '-S', 'ardupilot-gdb',
-                        'gdb', '-x', '/tmp/x.gdb', binary, '--args'])
+                        'gdb', '--cd', os.getcwd(), '-x', '/tmp/x.gdb', binary, '--args'])
     elif lldb:
         f = open("/tmp/x.lldb", "w")
         for breakingpoint in breakpoints:

--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -43,7 +43,7 @@ elif [ -n "$DISPLAY" -a -n "$(which gnome-terminal)" ]; then
   gnome-terminal -e "$*"
 elif [ -n "$STY" ]; then
   # We are running inside of screen, try to start it there
-  screen -X screen -t "$name" $*
+  screen -X screen -t "$name" bash -c "cd $PWD; $*"
 else
   filename="/tmp/$name.log"
   echo "RiTW: Window access not found, logging to $filename"


### PR DESCRIPTION
screen doesn't start the process in the current working directory