### PR TITLE
Tools: Add missing GNU screen that's required for autotest

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -146,7 +146,7 @@ else
 fi
 
 # Lists of packages to install
-BASE_PKGS="build-essential ccache g++ gawk git make wget valgrind"
+BASE_PKGS="build-essential ccache g++ gawk git make wget valgrind screen"
 if [ ${RELEASE_CODENAME} == 'bionic' ]; then
     # use fixed version for package that drop python2 support
     PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect flake8==3.7.9 requests==2.27.1 monotonic==1.6 geocoder empy ptyprocess configparser==4.0.2 click==7.1.2 decorator==4.4.2 dronecan"


### PR DESCRIPTION
`Tools/autotest/pysim/util.py` requires `screen` for GDB; it doesn't support any other terminal types, yet screen wasn't installed by the setup scripts. 

In the future, it would be great for autotest to make use of other terminal types such as `tmux`, which is what I prefer, and conveniently also supported in `Tools/autotest/run_in_terminal_window.sh`