### PR TITLE
SITL: Increase max sats for UBX to 13 

### DIFF
--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -289,7 +289,7 @@ void GPS::update_ubx(const struct gps_data *d)
         uint32_t headVeh;
         uint8_t reserved2[4]; 
     } pvt {};
-    const uint8_t SV_COUNT = 10;
+    const uint8_t SV_COUNT = 13;
     struct PACKED ubx_nav_svinfo {
         uint32_t itow;
         uint8_t numCh;


### PR DESCRIPTION
since the autotest suite sets the SIM param to 13 sats in the test. 

In the autotest suite, it's set to 13 here: https://github.com/ArduPilot/ardupilot/blob/9374b374de3751a0b73aa0a6092582a00b1ef9fd/Tools/autotest/common.py#L13072

Honestly, I have no idea how this works as-is. 