### PR TITLE
 Update the WiFi init code to the newer ESP-IDF (4.2+) and add WiFi station mode for both TCP and UDP.

### DIFF
--- a/libraries/AP_HAL_ESP32/WiFiDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiDriver.cpp
@@ -24,6 +24,7 @@
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
+#include "esp_log.h"
 #include "nvs_flash.h"
 
 #include "lwip/err.h"
@@ -208,31 +209,158 @@ bool WiFiDriver::write_data()
     return true;
 }
 
+#if WIFI_STATION
+
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT      BIT1
+
+#ifndef ESP_STATION_MAXIMUM_RETRY
+#define ESP_STATION_MAXIMUM_RETRY 10
+#endif
+
+static const char *TAG = "wifi station";
+static int s_retry_num = 0;
+static EventGroupHandle_t s_wifi_event_group;
+
+static void _sta_event_handler(void* arg, esp_event_base_t event_base,
+                                int32_t event_id, void* event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_num < ESP_STATION_MAXIMUM_RETRY) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "retry to connect to the AP");
+        } else {
+            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+        }
+        ESP_LOGI(TAG,"connect to the AP fail");
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        s_retry_num = 0;
+        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+#endif
+
 void WiFiDriver::initialize_wifi()
 {
-    tcpip_adapter_init();
-    nvs_flash_init();
-    esp_event_loop_init(nullptr, nullptr);
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    esp_wifi_init(&cfg);
-    esp_wifi_set_storage(WIFI_STORAGE_FLASH);
+#ifndef WIFI_PWD
+    #default WIFI_PWD "ardupilot1"
+#endif
+    //Initialize NVS
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+      ESP_ERROR_CHECK(nvs_flash_erase());
+      ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
     wifi_config_t wifi_config;
-    memset(&wifi_config, 0, sizeof(wifi_config));
-#ifdef WIFI_SSID
+    bzero(&wifi_config, sizeof(wifi_config));
+
+/*
+	Acting as an Access Point (softAP)
+*/
+#if !WIFI_STATION
+#ifndef WIFI_SSID
+    #define WIFI_SSID "ardupilot"
+#endif
+#ifndef WIFI_CHANNEL
+	#define WIFI_CHANNEL 1
+#endif
+
+    esp_netif_create_default_wifi_ap();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+
     strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-#else
-    strcpy((char *)wifi_config.ap.ssid, "ardupilot");
-#endif
-#ifdef WIFI_PWD
     strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    wifi_config.ap.ssid_len = strlen(WIFI_SSID),
+    wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
+    wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+    wifi_config.ap.channel = WIFI_CHANNEL;
+
+    if (strlen(WIFI_PWD) == 0) {
+        wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    hal.console->printf("WiFi softAP init finished. SSID: %s password: %s channel: %d\n",
+                        wifi_config.ap.ssid, wifi_config.ap.password, wifi_config.ap.channel);
+
+/*
+	Acting as a Station (WiFi Client)
+*/
 #else
-    strcpy((char *)wifi_config.ap.password, "ardupilot1");
+#ifndef WIFI_SSID_STATION
+    #define WIFI_SSID_STATION "ardupilot"
 #endif
-    wifi_config.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
-    wifi_config.ap.max_connection = WIFI_MAX_CONNECTION;
-    esp_wifi_set_mode(WIFI_MODE_AP);
-    esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
-    esp_wifi_start();
+#ifndef WIFI_HOSTNAME
+    #define WIFI_HOSTNAME "ArduPilotESP32"
+#endif
+    s_wifi_event_group = xEventGroupCreate();
+    esp_netif_t *netif = esp_netif_create_default_wifi_sta();
+    esp_netif_set_hostname(netif, WIFI_HOSTNAME);
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    esp_event_handler_instance_t instance_any_id;
+    esp_event_handler_instance_t instance_got_ip;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
+                                                        ESP_EVENT_ANY_ID,
+                                                        &_sta_event_handler,
+                                                        NULL,
+                                                        &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT,
+                                                        IP_EVENT_STA_GOT_IP,
+                                                        &_sta_event_handler,
+                                                        NULL,
+                                                        &instance_got_ip));
+
+    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
+    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
+    wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config) );
+    ESP_ERROR_CHECK(esp_wifi_start() );
+
+    hal.console->printf("WiFi Station init finished. Connecting:\n");
+
+    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
+     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+            pdFALSE, pdFALSE, portMAX_DELAY);
+
+    /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
+     * happened. */
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "connected to ap SSID: %s password: %s",
+                 wifi_config.sta.ssid, wifi_config.sta.password);
+    } else if (bits & WIFI_FAIL_BIT) {
+        ESP_LOGI(TAG, "Failed to connect to SSID: %s, password: %s",
+                 wifi_config.sta.ssid, wifi_config.sta.password);
+    } else {
+        ESP_LOGE(TAG, "UNEXPECTED EVENT");
+    }
+
+    /* The event will not be processed after unregister */
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, instance_got_ip));
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, instance_any_id));
+    vEventGroupDelete(s_wifi_event_group);
+#endif
 }
 
 size_t WiFiDriver::_write(const uint8_t *buffer, size_t size)

--- a/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
@@ -178,33 +178,158 @@ bool WiFiUdpDriver::write_data()
     return true;
 }
 
+#if WIFI_STATION
+
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT      BIT1
+
+#ifndef ESP_STATION_MAXIMUM_RETRY
+#define ESP_STATION_MAXIMUM_RETRY 10
+#endif
+
+static const char *TAG = "wifi station";
+static int s_retry_num = 0;
+static EventGroupHandle_t s_wifi_event_group;
+
+static void _sta_event_handler(void* arg, esp_event_base_t event_base,
+                                int32_t event_id, void* event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_num < ESP_STATION_MAXIMUM_RETRY) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "retry to connect to the AP");
+        } else {
+            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+        }
+        ESP_LOGI(TAG,"connect to the AP fail");
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        s_retry_num = 0;
+        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+#endif
+
 void WiFiUdpDriver::initialize_wifi()
 {
-    esp_event_loop_init(nullptr, nullptr);
+#ifndef WIFI_PWD
+    #default WIFI_PWD "ardupilot1"
+#endif
+    //Initialize NVS
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+      ESP_ERROR_CHECK(nvs_flash_erase());
+      ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
 
-    tcpip_adapter_init();
-    nvs_flash_init();
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    wifi_config_t wifi_config;
+    bzero(&wifi_config, sizeof(wifi_config));
+
+/*
+	Acting as an Access Point (softAP)
+*/
+#if !WIFI_STATION
+#ifndef WIFI_SSID
+    #define WIFI_SSID "ardupilot"
+#endif
+#ifndef WIFI_CHANNEL
+	#define WIFI_CHANNEL 1
+#endif
+
+    esp_netif_create_default_wifi_ap();
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    esp_wifi_init(&cfg);
-    esp_wifi_set_storage(WIFI_STORAGE_FLASH);
-    wifi_config_t wifi_config;
-    memset(&wifi_config, 0, sizeof(wifi_config));
-#ifdef WIFI_SSID
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+
     strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-#else
-    strcpy((char *)wifi_config.ap.ssid, "ardupilot");
-#endif
-#ifdef WIFI_PWD
     strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    wifi_config.ap.ssid_len = strlen(WIFI_SSID),
+    wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
+    wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+    wifi_config.ap.channel = WIFI_CHANNEL;
+
+    if (strlen(WIFI_PWD) == 0) {
+        wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    hal.console->printf("WiFi softAP init finished. SSID: %s password: %s channel: %d\n",
+                        wifi_config.ap.ssid, wifi_config.ap.password, wifi_config.ap.channel);
+
+/*
+	Acting as a Station (WiFi Client)
+*/
 #else
-    strcpy((char *)wifi_config.ap.password, "ardupilot1");
+#ifndef WIFI_SSID_STATION
+    #define WIFI_SSID_STATION "ardupilot"
 #endif
-    wifi_config.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
-    wifi_config.ap.max_connection = 4;
-    esp_wifi_set_mode(WIFI_MODE_AP);
-    esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
-    esp_wifi_start();
+#ifndef WIFI_HOSTNAME
+    #define WIFI_HOSTNAME "ArduPilotESP32"
+#endif
+    s_wifi_event_group = xEventGroupCreate();
+    esp_netif_t *netif = esp_netif_create_default_wifi_sta();
+    esp_netif_set_hostname(netif, WIFI_HOSTNAME);
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    esp_event_handler_instance_t instance_any_id;
+    esp_event_handler_instance_t instance_got_ip;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
+                                                        ESP_EVENT_ANY_ID,
+                                                        &_sta_event_handler,
+                                                        NULL,
+                                                        &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT,
+                                                        IP_EVENT_STA_GOT_IP,
+                                                        &_sta_event_handler,
+                                                        NULL,
+                                                        &instance_got_ip));
+
+    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
+    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
+    wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config) );
+    ESP_ERROR_CHECK(esp_wifi_start() );
+
+    hal.console->printf("WiFi Station init finished. Connecting:\n");
+
+    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
+     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+            pdFALSE, pdFALSE, portMAX_DELAY);
+
+    /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
+     * happened. */
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "connected to ap SSID: %s password: %s",
+                 wifi_config.sta.ssid, wifi_config.sta.password);
+    } else if (bits & WIFI_FAIL_BIT) {
+        ESP_LOGI(TAG, "Failed to connect to SSID: %s, password: %s",
+                 wifi_config.sta.ssid, wifi_config.sta.password);
+    } else {
+        ESP_LOGE(TAG, "UNEXPECTED EVENT");
+    }
+
+    /* The event will not be processed after unregister */
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, instance_got_ip));
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, instance_any_id));
+    vEventGroupDelete(s_wifi_event_group);
+#endif
 }
 
 size_t WiFiUdpDriver::_write(const uint8_t *buffer, size_t size)

--- a/libraries/AP_HAL_ESP32/WiFiUdpDriver.h
+++ b/libraries/AP_HAL_ESP32/WiFiUdpDriver.h
@@ -22,6 +22,9 @@
 #include "lwip/sockets.h"
 #include "esp_event.h"
 
+#ifndef WIFI_MAX_CONNECTION
+#define WIFI_MAX_CONNECTION 5
+#endif
 
 class ESP32::WiFiUdpDriver : public AP_HAL::UARTDriver
 {


### PR DESCRIPTION
 Update the WiFi initialization code to the newer ESP-IDF (4.2+) and add WiFi station mode for both TCP and UDP.
Added ability to select the softAP channel too.
Additional definitions:
```
#define WIFI_STATION 1
#define WIFI_HOSTNAME "ArduPilotESP32"
#define WIFI_SSID_STATION "myhomeSSID"
#define WIFI_CHANNEL 7

```