### PR TITLE
Plane: reset guided target altitude time on mode enter

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -59,6 +59,7 @@ bool Mode::enter()
     plane.guided_state.target_heading_type = GUIDED_HEADING_NONE;
     plane.guided_state.target_airspeed_cm = -1; // same as above, although an airspeed of -1 is rare on plane.
     plane.guided_state.target_alt = -1; // same as above, although a target alt of -1 is rare on plane.
+    plane.guided_state.target_alt_time_ms = 0;
     plane.guided_state.last_target_alt = 0;
 #endif
 


### PR DESCRIPTION
One-liner: This PR fixes a bug that leads to the plane crashing while using offboard guidance and switching between modes.

### Description
This PR resets the plane guided state `target_alt_time_ms` field on mode switch. This field is not currently being reset to its [initialized](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/Plane.h#L537-L542) value on [mode enter](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode.cpp#L57-L63). The other guided state fields are reset to their [initialized](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/Plane.h#L537-L542) values on [mode enter](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode.cpp#L57-L63). Not resetting the `target_alt_time_ms` field makes the [ModeGuided::update_target_altitude](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode_guided.cpp#L129) function use the reset target altitude of -1 next time guided mode is entered. This causes the plane to dive into the ground. The sequence of events are:
1. Switch to GUIDED mode
2. Issue a `MAV_CMD_GUIDED_CHANGE_ALTITUDE` command
3. Switch to another mode
4. Switch to GUIDED mode

### Testing
This change was tested in ardupilot sitl with the following sequence:

1. Takeoff the plane
2. Send an unlimited loiter at 400m and set the mode to auto
1. Set the mode to guided
4. Send `MAV_CMD_GUIDED_CHANGE_ALTITUDE` at 500m
5. Set the mode to auto
6. Set the mode to guided

**Before** 
```bash
COMMAND_LONG_DATA { param1: 1.0, param2: 15.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 15, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }

COMMAND_INT_DATA { param1: 0.0, param2: 0.0, param3: 0.0, param4: 0.0, x: 0, y: 0, z: 500.0, command: MAV_CMD_GUIDED_CHANGE_ALTITUDE, target_system: 0, target_component: 1, frame: MAV_FRAME_GLOBAL, current: 0, autocontinue: 0 }

COMMAND_LONG_DATA { param1: 1.0, param2: 10.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 10, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }

COMMAND_LONG_DATA { param1: 1.0, param2: 15.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 15, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }
```

![sitl-cruise-before](https://github.com/ArduPilot/ardupilot/assets/9022220/41a7f040-693a-45ef-88b5-fa5c820dfde2)

Things to note:
1. GUIDED->AUTO
  * OFG.ALT is reset to -1
2. AUTO->GUIDED
  * NTUN.TALT drops to the negatives
  * Throttle drops to practically 0
  * Altitude drifts down till the plane hits the ground

**After**
```bash
COMMAND_LONG_DATA { param1: 1.0, param2: 15.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 15, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }

COMMAND_INT_DATA { param1: 0.0, param2: 0.0, param3: 0.0, param4: 0.0, x: 0, y: 0, z: 500.0, command: MAV_CMD_GUIDED_CHANGE_ALTITUDE, target_system: 0, target_component: 1, frame: MAV_FRAME_GLOBAL, current: 0, autocontinue: 0 }

COMMAND_LONG_DATA { param1: 1.0, param2: 10.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 10, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }

COMMAND_LONG_DATA { param1: 1.0, param2: 15.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_DO_SET_MODE, target_system: 0, target_component: 0, confirmation: 0 }
HEARTBEAT_DATA { custom_mode: 15, mavtype: MAV_TYPE_FIXED_WING, autopilot: MAV_AUTOPILOT_ARDUPILOTMEGA, base_mode: MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_STABILIZE_ENABLED | MAV_MODE_FLAG_GUIDED_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, system_status: MAV_STATE_ACTIVE, mavlink_version: 3 }

COMMAND_LONG_DATA { param1: 0.0, param2: 21196.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0, command: MAV_CMD_COMPONENT_ARM_DISARM, target_system: 0, target_component: 1, confirmation: 0 }
```

![sitl-cruise-after](https://github.com/ArduPilot/ardupilot/assets/9022220/94295f46-0d2e-428d-8907-c728395273a1)

Things to note:
1. GUIDED->AUTO
  * OFG.ALT is reset to -1
2. AUTO->GUIDED
  * NTUN.TALT holds
  * Throttle holds
  * Altitude holds