### PR TITLE
AP_Arming: fixed auto-enable of fence with forced arm

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1551,16 +1551,6 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
         }
     }
 
-#if AP_FENCE_ENABLED
-    AC_Fence *fence = AP::fence();
-    if (fence != nullptr) {
-        // If a fence is set to auto-enable, turn on the fence
-        if(fence->auto_enabled() == AC_Fence::AutoEnable::ONLY_WHEN_ARMED) {
-            fence->enable(true);
-        }
-    }
-#endif
-
     // note that this will prepare AP_Logger to start logging
     // so should be the last check to be done before arming
 
@@ -1634,6 +1624,19 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         auto *terrain = AP::terrain();
         if (terrain != nullptr) {
             terrain->set_reference_location();
+        }
+    }
+#endif
+
+#if AP_FENCE_ENABLED
+    if (armed) {
+        auto *fence = AP::fence();
+        if (fence != nullptr) {
+            // If a fence is set to auto-enable, turn on the fence
+            if (fence->auto_enabled() == AC_Fence::AutoEnable::ONLY_WHEN_ARMED) {
+                fence->enable(true);
+                gcs().send_text(MAV_SEVERITY_INFO, "Fence: auto-enabled");
+            }
         }
     }
 #endif


### PR DESCRIPTION
when a user forced armed and had FENCE_AUTOENABLE=3 for enable on arming then the fence did not enable