### PR TITLE
chibios_hwdef: default GPS_MAX_RECEIVERS to 1 for AP_Periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
@@ -198,6 +198,10 @@
 #define HAL_SIM_GPS_ENABLED (AP_SIM_ENABLED && defined(HAL_PERIPH_ENABLE_GPS))
 #endif
 
+#ifndef GPS_MAX_RECEIVERS
+#define GPS_MAX_RECEIVERS 1
+#endif
+
 /*
  * Airspeed Backends - we selectively turn backends *off*
  */


### PR DESCRIPTION
we don't take care to reduce the number of GPS instances supported, even 'though we only have parameters for one.