### PR TITLE
Enforce line endings in AP_DDS with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
       rev: v4.2.0
       hooks:
         #-   id: trailing-whitespace
-        #-   id: end-of-file-fixer
+        -   id: end-of-file-fixer
+            files: libraries\/AP_DDS\/.*$
         -   id: mixed-line-ending
             name: Check line ending character (LF)
             args: ["--fix=lf"]

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -810,5 +810,3 @@ int clock_gettime(clockid_t clockid, struct timespec *ts)
 #endif // CONFIG_HAL_BOARD
 
 #endif // AP_DDS_ENABLED
-
-

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -197,5 +197,3 @@ public:
 };
 
 #endif // AP_DDS_ENABLED
-
-

--- a/libraries/AP_DDS/Idl/builtin_interfaces/msg/Duration.idl
+++ b/libraries/AP_DDS/Idl/builtin_interfaces/msg/Duration.idl
@@ -20,4 +20,3 @@ module builtin_interfaces {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/builtin_interfaces/msg/Time.idl
+++ b/libraries/AP_DDS/Idl/builtin_interfaces/msg/Time.idl
@@ -19,4 +19,3 @@ module builtin_interfaces {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/Point.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/Point.idl
@@ -16,4 +16,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/Pose.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/Pose.idl
@@ -16,4 +16,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/PoseStamped.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/PoseStamped.idl
@@ -16,4 +16,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/Quaternion.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/Quaternion.idl
@@ -22,4 +22,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/Twist.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/Twist.idl
@@ -15,4 +15,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/TwistStamped.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/TwistStamped.idl
@@ -16,4 +16,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/Vector3.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/Vector3.idl
@@ -20,4 +20,3 @@ module geometry_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/sensor_msgs/msg/BatteryState.idl
+++ b/libraries/AP_DDS/Idl/sensor_msgs/msg/BatteryState.idl
@@ -103,4 +103,3 @@ module sensor_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/sensor_msgs/msg/NavSatFix.idl
+++ b/libraries/AP_DDS/Idl/sensor_msgs/msg/NavSatFix.idl
@@ -65,4 +65,3 @@ module sensor_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/sensor_msgs/msg/NavSatStatus.idl
+++ b/libraries/AP_DDS/Idl/sensor_msgs/msg/NavSatStatus.idl
@@ -40,4 +40,3 @@ module sensor_msgs {
     };
   };
 };
-

--- a/libraries/AP_DDS/Idl/std_msgs/msg/Header.idl
+++ b/libraries/AP_DDS/Idl/std_msgs/msg/Header.idl
@@ -21,4 +21,3 @@ module std_msgs {
     };
   };
 };
-


### PR DESCRIPTION
Github is warning me about files in my DDS PR's that are missing a newline. There's a pre-commit hook that could be run before I push to fix this problem. 
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/13e900a6-49d3-403d-a724-bfe8d8b4e68a)

There are only a few files in ArduPilot violating the hook, perhaps we might as well fix all of them and enforce this hook?

Here's a good reason we should do it in the whole codebase - it's a UNIX standard: https://stackoverflow.com/a/729795/11032285


See #24555