### PR TITLE
DroneCAN: add get/set param timeout

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1264,6 +1264,11 @@ void AP_DroneCAN::handle_debug(const CanardRxTransfer& transfer, const uavcan_pr
 #endif
 }
 
+/*
+/*
+  send any queued request to get/set parameter
+  called from loop
+*/
 void AP_DroneCAN::send_parameter_request()
 {
     WITH_SEMAPHORE(_param_sem);
@@ -1274,12 +1279,16 @@ void AP_DroneCAN::send_parameter_request()
     param_request_sent = true;
 }
 
+/*
+  set named float parameter on node
+*/
 bool AP_DroneCAN::set_parameter_on_node(uint8_t node_id, const char *name, float value, ParamGetSetFloatCb *cb)
 {
     WITH_SEMAPHORE(_param_sem);
+
+    // fail if waiting for any previous get/set request
     if (param_int_cb != nullptr ||
         param_float_cb != nullptr) {
-        //busy
         return false;
     }
     param_getset_req.index = 0;
@@ -1292,12 +1301,16 @@ bool AP_DroneCAN::set_parameter_on_node(uint8_t node_id, const char *name, float
     return true;
 }
 
+/*
+  set named integer parameter on node
+*/
 bool AP_DroneCAN::set_parameter_on_node(uint8_t node_id, const char *name, int32_t value, ParamGetSetIntCb *cb)
 {
     WITH_SEMAPHORE(_param_sem);
+
+    // fail if waiting for any previous get/set request
     if (param_int_cb != nullptr ||
         param_float_cb != nullptr) {
-        //busy
         return false;
     }
     param_getset_req.index = 0;
@@ -1310,12 +1323,16 @@ bool AP_DroneCAN::set_parameter_on_node(uint8_t node_id, const char *name, int32
     return true;
 }
 
+/*
+  get named float parameter on node
+*/
 bool AP_DroneCAN::get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetFloatCb *cb)
 {
     WITH_SEMAPHORE(_param_sem);
+
+    // fail if waiting for any previous get/set request
     if (param_int_cb != nullptr ||
         param_float_cb != nullptr) {
-        //busy
         return false;
     }
     param_getset_req.index = 0;
@@ -1327,12 +1344,16 @@ bool AP_DroneCAN::get_parameter_on_node(uint8_t node_id, const char *name, Param
     return true;
 }
 
+/*
+  get named integer parameter on node
+*/
 bool AP_DroneCAN::get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetIntCb *cb)
 {
     WITH_SEMAPHORE(_param_sem);
+
+    // fail if waiting for any previous get/set request
     if (param_int_cb != nullptr ||
         param_float_cb != nullptr) {
-        //busy
         return false;
     }
     param_getset_req.index = 0;

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -153,6 +153,9 @@ private:
     // send notify vehicle state
     void notify_state_send();
 
+    // check for parameter get/set response timeout
+    void check_parameter_callback_timeout();
+
     // send queued parameter get/set request. called from loop
     void send_parameter_request();
     
@@ -166,6 +169,7 @@ private:
     ParamGetSetIntCb *param_int_cb;         // latest get param request callback function (for integers)
     ParamGetSetFloatCb *param_float_cb;     // latest get param request callback function (for floats)
     bool param_request_sent = true;         // true after a param request has been sent, false when queued to be sent
+    uint32_t param_request_sent_ms;         // system time that get param request was sent
     HAL_Semaphore _param_sem;               // semaphore protecting this block of variables
     uint8_t param_request_node_id;          // node id of most recent get param request
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -95,7 +95,9 @@ public:
     // THIS IS NOT A THREAD SAFE API!
     void send_reboot_request(uint8_t node_id);
 
-    // set param value
+    // get or set param value
+    // returns true on success, false on failure
+    // failures occur when waiting on node to respond to previous get or set request
     bool set_parameter_on_node(uint8_t node_id, const char *name, float value, ParamGetSetFloatCb *cb);
     bool set_parameter_on_node(uint8_t node_id, const char *name, int32_t value, ParamGetSetIntCb *cb);
     bool get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetFloatCb *cb);
@@ -151,27 +153,27 @@ private:
     // send notify vehicle state
     void notify_state_send();
 
-    // send parameter get/set request
+    // send queued parameter get/set request. called from loop
     void send_parameter_request();
     
-    // send parameter save request
+    // send queued parameter save request. called from loop
     void send_parameter_save_request();
 
     // periodic logging
     void logging();
     
-    // set parameter on a node
-    ParamGetSetIntCb *param_int_cb;
-    ParamGetSetFloatCb *param_float_cb;
-    bool param_request_sent = true;
-    HAL_Semaphore _param_sem;
-    uint8_t param_request_node_id;
+    // get parameter on a node
+    ParamGetSetIntCb *param_int_cb;         // latest get param request callback function (for integers)
+    ParamGetSetFloatCb *param_float_cb;     // latest get param request callback function (for floats)
+    bool param_request_sent = true;         // true after a param request has been sent, false when queued to be sent
+    HAL_Semaphore _param_sem;               // semaphore protecting this block of variables
+    uint8_t param_request_node_id;          // node id of most recent get param request
 
     // save parameters on a node
-    ParamSaveCb *save_param_cb;
-    bool param_save_request_sent = true;
-    HAL_Semaphore _param_save_sem;
-    uint8_t param_save_request_node_id;
+    ParamSaveCb *save_param_cb;             // latest save param request callback function
+    bool param_save_request_sent = true;    // true after a save param request has been sent, false when queued to be sent
+    HAL_Semaphore _param_save_sem;          // semaphore protecting this block of variables
+    uint8_t param_save_request_node_id;     // node id of most recent save param request
 
     // UAVCAN parameters
     AP_Int8 _dronecan_node;


### PR DESCRIPTION
This adds a 0.1 sec timeout while waiting for a response after attempting to get or set a parameter on a device/node which resolves issue https://github.com/ArduPilot/ardupilot/issues/24541

I've also attempted to improve the comments around the methods involved.

This has been tested on real hardware using a Xacti camera/gimbal which may fail to respond to get/set parameter requests if it is busy handling the latest gimbal target message.  Without this change once the device failed to respond, AP would never send another get/set request.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/189a9c3c-c59b-4aab-8413-1fc09c2e017e)

I have also lightly tested with a Here4 DroneCAN GPS to confirm that it still works and that parameters can be retrieved.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/124e89a2-76c7-4ba2-80c2-a517515a0520)

This was written after a discussion with @bugobliterator.

One small thing that I'm not completely happy with is that we assumption that the state of these variables is kept consistent:

- param_request_sent_ms == 0   <-- the system time that the caller requested to get or set a parameter 
- param_int_cb != nullptr  <-- the caller provided an integer parameter call back function
- param_float_cb != nullptr  <-- the caller provided an float parameter call back function

So for example in check_parameter_callback_timeout() we check the top one while in get_parameter_on_node() (and many other methods) we check the bottom two.  I think this is acceptable though especially with the improved comments.