### PR TITLE
Copter: rely on magic COMMAND_INT transform for MAV_CMD_DO_PAUSE_CONTINUE

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1003,12 +1003,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         return MAV_RESULT_ACCEPTED;
     }
 
-    // pause or resume an auto mission
-    case MAV_CMD_DO_PAUSE_CONTINUE: {
-        mavlink_command_int_t packet_int;
-        GCS_MAVLINK_Copter::convert_COMMAND_LONG_to_COMMAND_INT(packet, packet_int);
-        return handle_command_pause_continue(packet_int);
-    }
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet);
     }


### PR DESCRIPTION
Tested by using breakpoints with the existing autotest suite,


The code in the base class does exactly what Copter is doing here, so this clause is entirely redundant.
