### PR TITLE
AP_ExternalControl: initial implementation of external control library

### DIFF
--- a/ArduCopter/AP_ExternalControl_Copter.cpp
+++ b/ArduCopter/AP_ExternalControl_Copter.cpp
@@ -1,0 +1,37 @@
+/*
+  external control library for copter
+ */
+
+
+#include "AP_ExternalControl_Copter.h"
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+#include "Copter.h"
+
+/*
+  set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw
+  velocity is in earth frame, NED, m/s
+*/
+bool AP_ExternalControl_Copter::set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)
+{
+    if (!ready_for_external_control()) {
+        return false;
+    }
+    const float yaw_rate_cds = isnan(yaw_rate_rads)? 0: degrees(yaw_rate_rads)*100;
+
+    // Copter velocity is positive if aicraft is moving up which is opposite the incoming NED frame.
+    Vector3f velocity_NEU_ms {
+        linear_velocity.x,
+        linear_velocity.y,
+        -linear_velocity.z };
+    Vector3f velocity_up_cms = velocity_NEU_ms * 100;
+    copter.mode_guided.set_velocity(velocity_up_cms, false, 0, !isnan(yaw_rate_rads), yaw_rate_cds);
+    return true;
+}
+
+bool AP_ExternalControl_Copter::ready_for_external_control()
+{
+    return copter.flightmode->in_guided_mode() && copter.motors->armed();
+}
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduCopter/AP_ExternalControl_Copter.h
+++ b/ArduCopter/AP_ExternalControl_Copter.h
@@ -1,0 +1,26 @@
+/*
+  external control library for copter
+ */
+#pragma once
+
+#include <AP_ExternalControl/AP_ExternalControl.h>
+
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+class AP_ExternalControl_Copter : public AP_ExternalControl {
+public:
+    /*
+      Set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw.
+      Velocity is in earth frame, NED [m/s].
+      Yaw is in earth frame, NED [rad/s].
+     */
+    bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads) override;
+private:
+    /*
+      Return true if Copter is ready to handle external control data.
+      Currently checks mode and arm states.
+    */
+    bool ready_for_external_control();
+};
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -100,6 +100,11 @@
 #include "AP_Rally.h"           // Rally point library
 #include "AP_Arming.h"
 
+#include <AP_ExternalControl/AP_ExternalControl_config.h>
+#if AP_EXTERNAL_CONTROL_ENABLED
+#include "AP_ExternalControl_Copter.h"
+#endif
+
 #include <AP_Beacon/AP_Beacon_config.h>
 #if AP_BEACON_ENABLED
  #include <AP_Beacon/AP_Beacon.h>
@@ -193,6 +198,9 @@ public:
     friend class AP_AdvancedFailsafe_Copter;
 #endif
     friend class AP_Arming_Copter;
+#if AP_EXTERNAL_CONTROL_ENABLED
+    friend class AP_ExternalControl_Copter;
+#endif
     friend class ToyMode;
     friend class RC_Channel_Copter;
     friend class RC_Channels_Copter;
@@ -318,6 +326,12 @@ private:
 #if AP_OPTICALFLOW_ENABLED
     AP_OpticalFlow optflow;
 #endif
+
+    // external control library
+#if AP_EXTERNAL_CONTROL_ENABLED
+    AP_ExternalControl_Copter external_control;
+#endif
+
 
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -2,6 +2,7 @@
 
 #include "Copter.h"
 #include <AP_Math/chirp.h>
+#include <AP_ExternalControl/AP_ExternalControl_config.h> // TODO why is this needed if Copter.h includes this
 class Parameters;
 class ParametersG2;
 
@@ -957,6 +958,10 @@ private:
 class ModeGuided : public Mode {
 
 public:
+#if AP_EXTERNAL_CONTROL_ENABLED
+    friend class AP_ExternalControl_Copter;
+#endif
+
     // inherit constructor
     using Mode::Mode;
     Number mode_number() const override { return Number::GUIDED; }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -83,6 +83,10 @@
 #include <AP_Landing/AP_Landing.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
 #include <AP_Follow/AP_Follow.h>
+#include <AP_ExternalControl/AP_ExternalControl_config.h>
+#if AP_EXTERNAL_CONTROL_ENABLED
+#include <AP_ExternalControl/AP_ExternalControl.h>
+#endif
 
 #include "GCS_Mavlink.h"
 #include "GCS_Plane.h"
@@ -769,6 +773,11 @@ private:
     AP_Arming_Plane arming;
 
     AP_Param param_loader {var_info};
+
+    // dummy implementation of external control
+#if AP_EXTERNAL_CONTROL_ENABLED
+    AP_ExternalControl external_control;
+#endif
 
     static const AP_Scheduler::Task scheduler_tasks[];
     static const AP_Param::Info var_info[];

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -44,6 +44,10 @@
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AC_PrecLand/AC_PrecLand_config.h>
 #include <AP_Follow/AP_Follow_config.h>
+#include <AP_ExternalControl/AP_ExternalControl_config.h>
+#if AP_EXTERNAL_CONTROL_ENABLED
+#include <AP_ExternalControl/AP_ExternalControl.h>
+#endif
 
 // Configuration
 #include "defines.h"
@@ -142,6 +146,11 @@ private:
 
     // Arming/Disarming management class
     AP_Arming_Rover arming;
+
+    // dummy external control implementation
+#if AP_EXTERNAL_CONTROL_ENABLED
+    AP_ExternalControl external_control;
+#endif
 
 #if AP_OPTICALFLOW_ENABLED
     AP_OpticalFlow optflow;

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -115,6 +115,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_AIS',
     'AP_OpenDroneID',
     'AP_CheckFirmware',
+    'AP_ExternalControl',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/Tools/scripts/run_astyle.py
+++ b/Tools/scripts/run_astyle.py
@@ -21,6 +21,7 @@ class AStyleChecker(object):
         self.retcode = 0
         self.directories_to_check = [
             'libraries/AP_DDS',
+            'libraries/AP_ExternalControl'
         ]
         self.files_to_check = []
 

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -1,0 +1,32 @@
+#if AP_DDS_ENABLED
+
+#include "AP_DDS_ExternalControl.h"
+#include "AP_DDS_Frames.h"
+
+#include <AP_ExternalControl/AP_ExternalControl.h>
+
+bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistStamped& cmd_vel)
+{
+    auto *external_control = AP::externalcontrol();
+    if (external_control == nullptr) {
+        return false;
+    }
+    if (strcmp(cmd_vel.header.frame_id, MAP_FRAME) != 0) {
+        // Although REP-147 says cmd_vel should be in body frame, all the AP math is done in earth frame.
+        // This is because accounting for the gravity vector.
+        // Although the ROS 2 interface could support body-frame velocity control in the future,
+        // it is currently not supported.
+        return false;
+    }
+
+    // Convert commands from ENU to NED frame
+    Vector3f linear_velocity {
+        float(cmd_vel.twist.linear.y),
+        float(cmd_vel.twist.linear.x),
+        float(-cmd_vel.twist.linear.z) };
+    const float yaw_rate = -cmd_vel.twist.angular.z;
+    return external_control->set_linear_velocity_and_yaw_rate(linear_velocity, yaw_rate);
+}
+
+
+#endif // AP_DDS_ENABLED

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.h
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if AP_DDS_ENABLED
+#include "geometry_msgs/msg/TwistStamped.h"
+
+class AP_DDS_External_Control
+{
+public:
+    static bool handle_velocity_control(geometry_msgs_msg_TwistStamped& cmd_vel);
+};
+#endif // AP_DDS_ENABLED

--- a/libraries/AP_DDS/AP_DDS_Frames.h
+++ b/libraries/AP_DDS/AP_DDS_Frames.h
@@ -1,0 +1,7 @@
+#pragma once
+
+static constexpr char WGS_84_FRAME_ID[] = "WGS-84";
+// https://www.ros.org/reps/rep-0105.html#base-link
+static constexpr char BASE_LINK_FRAME_ID[] = "base_link";
+// https://www.ros.org/reps/rep-0105.html#map
+static constexpr char MAP_FRAME[] = "map";

--- a/libraries/AP_ExternalControl/AP_ExternalControl.cpp
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.cpp
@@ -1,0 +1,24 @@
+#include "AP_ExternalControl.h"
+
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+// singleton instance
+AP_ExternalControl *AP_ExternalControl::singleton;
+
+AP_ExternalControl::AP_ExternalControl()
+{
+    singleton = this;
+}
+
+
+namespace AP
+{
+
+AP_ExternalControl *externalcontrol()
+{
+    return AP_ExternalControl::get_singleton();
+}
+
+};
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/libraries/AP_ExternalControl/AP_ExternalControl.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.h
@@ -1,0 +1,43 @@
+/*
+  external control library for MAVLink, DDS and scripting
+ */
+
+#pragma once
+
+#include "AP_ExternalControl_config.h"
+
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+#include <AP_Math/AP_Math.h>
+
+class AP_ExternalControl
+{
+public:
+
+    AP_ExternalControl();
+    /*
+      Set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw.
+      Velocity is in earth frame, NED [m/s].
+      Yaw is in earth frame, NED [rad/s].
+     */
+    virtual bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)
+    {
+        return false;
+    }
+
+    static AP_ExternalControl *get_singleton(void)
+    {
+        return singleton;
+    }
+
+private:
+    static AP_ExternalControl *singleton;
+};
+
+
+namespace AP
+{
+AP_ExternalControl *externalcontrol();
+};
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/libraries/AP_ExternalControl/AP_ExternalControl_config.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl_config.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_EXTERNAL_CONTROL_ENABLED
+#define AP_EXTERNAL_CONTROL_ENABLED 1
+#endif
+
+


### PR DESCRIPTION
This is a very basic implementation of an external control library, just to unblock @pedro-fuoco 

Relates to #23363 

## Testing Instructions

1. Run sim_vehicle with --enable-dds --console --map
2. Set DDS_ENABLED param to 1
3. Use mavproxy to arm the vehicle, set the mode to guided, and takeoff to ~50m
4. Run the microROS agent like normal
5. Verify with ros2 CLI that you see the `ap/cmd_vel` topic
6. Publish commands to `ap/cmd_vel`, or use rqt. Current behavior is this
    ```
    # Go up at 1 m/s
    ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped '{twist: {linear: {z: 1.0}}}'
    # Go down at 2 m/s
    ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped '{twist: {linear: {z: -1.0}}}'
    # Go east at 1 m/s
    ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped '{twist: {linear: {x: 1.0}}}'
    # Rotate the quadcopter 180 degrees and repeat the above tests. Regardless of the orientation, x always makes the copter go north because the cmd_vel topic is odom frame ENU.
    ```
    
    We do need to decide if the cmd_vel topic should be in body frame or map frame. According to REP-147, the cmd_vel topic i in body frame. Perhaps we should use the frame ID to either `body` or `map` for these different ones? Or a different topic? We have to decide based on clarity (topics are easier to notice than frame ID's), but additional subscribers impact flash, code size, and RAM/CPU usage.  https://ros.org/reps/rep-0147.html#rate-interface
    
    