### PR TITLE
AP_Camera/AP_Mount: camera info msg gets device id to improve multi camera support

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -147,6 +147,9 @@ protected:
     // get corresponding mount instance for the camera
     uint8_t get_mount_instance() const;
 
+    // get mavlink gimbal device id which is normally mount_instance+1
+    uint8_t get_gimbal_device_id() const;
+
     // internal members
     uint8_t _instance;      // this instance's number
     bool timer_installed;   // true if feedback pin change detected using timer

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -176,7 +176,8 @@ void AP_Camera_MAVLinkCamV2::send_camera_information(mavlink_channel_t chan) con
         _cam_info.lens_id,          // lens_id, uint8_t
         _cam_info.flags,            // flags uint32_t (CAMERA_CAP_FLAGS)
         _cam_info.cam_definition_version,   // cam_definition_version uint16_t
-        _cam_info.cam_definition_uri);      // cam_definition_uri char[140]
+        _cam_info.cam_definition_uri,       // cam_definition_uri char[140]
+        get_gimbal_device_id());    // gimbal_device_id uint8_t
 }
 
 // search for camera in GCS_MAVLink routing table

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -139,7 +139,10 @@ void AP_Mount_Backend::send_gimbal_device_attitude_status(mavlink_channel_t chan
                                                    std::numeric_limits<double>::quiet_NaN(),    // roll axis angular velocity (NaN for unknown)
                                                    std::numeric_limits<double>::quiet_NaN(),    // pitch axis angular velocity (NaN for unknown)
                                                    std::numeric_limits<double>::quiet_NaN(),    // yaw axis angular velocity (NaN for unknown)
-                                                   0);  // failure flags (not supported)
+                                                   0,                                           // failure flags (not supported)
+                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw (NaN for unknonw)
+                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw_velocity (NaN for unknonw)
+                                                   _instance + 1);  // gimbal_device_id
 }
 
 // return gimbal manager capability flags used by GIMBAL_MANAGER_INFORMATION message

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -840,7 +840,8 @@ void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -889,7 +889,8 @@ void AP_Mount_Viewpro::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -231,7 +231,8 @@ void AP_Mount_Xacti::send_camera_information(mavlink_channel_t chan) const
         0,                      // lens_id uint8_t
         flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
         0,                      // cam_definition_version uint16_t
-        cam_definition_uri);    // cam_definition_uri char[140]
+        cam_definition_uri,     // cam_definition_uri char[140]
+        _instance + 1);         // gimbal_device_id uint8_t
 }
 
 // send camera settings message to GCS

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5593,7 +5593,8 @@ void GCS_MAVLINK::send_autopilot_state_for_gimbal_device() const
         0,      // velocity estimated delay in micros
         rate_ef_targets.z,  // feed forward angular velocity z
         est_status_flags,   // estimator status
-        0);     // landed_state (see MAV_LANDED_STATE)
+        0,      // landed_state (see MAV_LANDED_STATE)
+        AP::ahrs().get_yaw_rate_earth());   // [rad/s] Z component of angular velocity in NED (North, East, Down). NaN if unknown
 }
 
 void GCS_MAVLINK::send_received_message_deprecation_warning(const char * message)


### PR DESCRIPTION
This is a rebased version of PR https://github.com/ArduPilot/ardupilot/pull/24354

This PR allows ground station to know which camera is in which gimbal

- mavlink module updated to HEAD so that the camera info message includes the gimbal id field (see https://github.com/ArduPilot/mavlink/pull/323)
- AP_Mount backends (default, MAVLinkCAMv2, Siyi, ViewPro, Xacti) fill in the gimbal_device_id field of the [CAMERA_INFORMATION mavlink message](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5744C1-L5744C49)

There is an additional drive-by enhancement to vehicle's actual z-axis rotation rate which only affects MAVLink enabled gimbals which means the Gremsy gimbals.

This has been lightly tested on real hardware including a Gremsy PixyU.  Testing included:

- Added debug messages to confirm that the expected "gimbal_device_id" was sent when using a Siyi A8.  MP's mavlink inspector does not yet know about this new field yet because it is still using the older mavlink definitions
- Added debug to output the AHRS yaw rate and then moved the vehicle around to confirm the expected values were output.  Also tested that the PixyU still moved as expected.

@Davidsastresas, @khanasif786, @peterbarker could you confirm that you're happy with this PR?