### PR TITLE
SITL: Make SIM_Aircraft use double precision to stop SITL's short-range teleporting

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -16,8 +16,6 @@
   parent class for aircraft simulators
 */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
-
 #include "SIM_Aircraft.h"
 
 #include <stdio.h>

--- a/libraries/SITL/wscript
+++ b/libraries/SITL/wscript
@@ -1,0 +1,2 @@
+def configure(cfg):
+    cfg.env.DOUBLE_PRECISION_SOURCES['SITL'] = ['SIM_Aircraft.cpp']

--- a/wscript
+++ b/wscript
@@ -541,6 +541,7 @@ def configure(cfg):
 
     cfg.recurse('libraries/AP_GPS')
     cfg.recurse('libraries/AP_HAL_SITL')
+    cfg.recurse('libraries/SITL')
 
     cfg.start_msg('Scripting runtime checks')
     if cfg.options.scripting_checks:


### PR DESCRIPTION
The change to use single precision by default apparently included the SITL folder, and unfortunately that made the position jump around. I originally noticed this on Blimp, but Copter does it too, and the screenshots below are with Copter.

This PR changes SIM_Aircraft to use double precision which fixes the problem.

Before:
![image](https://github.com/ArduPilot/ardupilot/assets/64898873/debc9f0d-1b80-4e6e-ace0-aaaeeafcebb5)

After:
![image](https://github.com/ArduPilot/ardupilot/assets/64898873/cecfc256-f983-4dce-9c11-1ea68bc1a42c)

Grid size is 1m in both images.

