### PR TITLE
Docker: Add args to allow changing base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE="ubuntu"
+ARG TAG="22.04"
+FROM ${BASE_IMAGE}:${TAG}
 WORKDIR /ardupilot
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This allows you to override the base image like so, so ROS developers have an environment. I'll add some docker-compose files and associated documentation later. If no options are suggested, the current behavior is used.
```
docker build . -t ardupilot_ros --build-arg "BASE_IMAGE=ros" --build-arg "TAG=humble"
```