### PR TITLE
waf: Enable DDS automatically if ROS 2 is installed and sourced

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -71,7 +71,7 @@ class Board:
             env.CXXFLAGS += ['-DHAL_GCS_ENABLED=0']
 
         # configurations for XRCE-DDS
-        if cfg.options.enable_dds:
+        if cfg.options.enable_dds or "humble" == os.environ.get("ROS_DISTRO"):
             cfg.recurse('libraries/AP_DDS')
             env.ENABLE_DDS = True
             env.AP_LIBRARIES += [
@@ -79,7 +79,7 @@ class Board:
             ]
             env.DEFINES.update(AP_DDS_ENABLED = 1)
             # check for microxrceddsgen
-            cfg.find_program('microxrceddsgen',mandatory=True)
+            microxrceddsgen = cfg.find_program('microxrceddsgen',mandatory=True)
         else:
             env.ENABLE_DDS = False
             env.DEFINES.update(AP_DDS_ENABLED = 0)


### PR DESCRIPTION
This removes the need for ROS 2 developers to always set `--enable-dds` if the already installed ROS2 humble. It will not impact non-ROS users, because that variable is not set.

The other option is to just enable it if microxrceddsgen is found, and disable it otherwise.