### PR TITLE
AP_GPS_NOVA: avoid infinite reading of bytes

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -86,8 +86,11 @@ AP_GPS_NOVA::read(void)
     }
 
     bool ret = false;
-    while (port->available() > 0) {
-        uint8_t temp = port->read();
+    for (uint16_t i=0; i<8192; i++) {
+        uint8_t temp;
+        if (!port->read(temp)) {
+            break;
+        }
 #if AP_GPS_DEBUG_LOGGING_ENABLED
         log_data(&temp, 1);
 #endif


### PR DESCRIPTION
if we have a very fast stream of garbage coming in available() may never return 0