### PR TITLE
AP_Airspeed: fixed handling of unhealthy airspeed

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -609,6 +609,14 @@ void AP_Airspeed::read(uint8_t i)
         return;
     }
 
+#ifndef HAL_BUILD_AP_PERIPH
+    /*
+      get the healthy state before we call get_pressure() as
+      get_pressure() overwrites the healthy state
+     */
+    bool prev_healthy = state[i].healthy;
+#endif
+
     float raw_pressure = get_pressure(i);
     float airspeed_pressure = raw_pressure - get_offset(i);
 
@@ -616,7 +624,6 @@ void AP_Airspeed::read(uint8_t i)
     state[i].corrected_pressure = airspeed_pressure;
 
 #ifndef HAL_BUILD_AP_PERIPH
-    bool prev_healthy = state[i].healthy;
     if (state[i].cal.start_ms != 0) {
         update_calibration(i, raw_pressure);
     }

--- a/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
@@ -148,7 +148,7 @@ bool AP_Airspeed_DroneCAN::get_differential_pressure(float &pressure)
 {
     WITH_SEMAPHORE(_sem_airspeed);
 
-    if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 250) {
         return false;
     }
 


### PR DESCRIPTION
this fixes a bug introduced in
https://github.com/ArduPilot/ardupilot/pull/22416 which results in using bad airspeed data on timeout. The prev_health variable is updated by the get_pressure call
This defeated the IIR bad data protections:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/223e21dc-a5f8-4c13-a694-5194b6d6ef50)
