### PR TITLE
SITL: correct compilation for CubeOrange-SimOnHardware

### DIFF
--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -18,6 +18,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_HAL/AP_HAL.h>
 #include <SITL/SITL.h>
+#include <AP_InternalError/AP_InternalError.h>
 #include <AP_Common/NMEA.h>
 #include <AP_HAL/utility/sparse-endian.h>
 


### PR DESCRIPTION
Clearly lacking an include:

```
../../libraries/SITL/SIM_GPS.cpp: In member function 'void SITL::GPS::send_gsof(const uint8_t*, uint16_t)': ../../libraries/SITL/SIM_GPS.cpp:1292:24: error: 'AP_InternalError' has not been declared
 1292 |         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
```
