### PR TITLE
vscode: Add extension for automatically picking process

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "augustocdias.tasks-shell-input",
         "bierner.markdown-mermaid",
         "ms-vscode.cpptools",
         "sumneko.lua",
@@ -7,6 +8,6 @@
         "ms-python.vscode-pylance",
         "streetsidesoftware.code-spell-checker",
         "chiehyu.vscode-astyle",
-        "ardupilot-org.ardupilot-devenv"
+        "ardupilot-org.ardupilot-devenv",
     ]
 }


### PR DESCRIPTION
This relates to #24521 and now prompts VSCode users who open the ArduPilot source tree to install a new extension. The extension supports automatically attaching to a process by allowing use of shell commands. Previous behavior means it pops up a window, you type in arducopter, then click it. I used `pgrep arducopter` which worked great to reliably find the process ID of the ArduCopter binary when run under SITL. Saves me ~5 seconds every time I run. 

**.vscode/tasks.json**
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Copter Attach",
            "type": "cppdbg",
            "request": "attach",
            "program": "${workspaceFolder}/build/sitl/bin/arducopter",
            "processId": "${input:FindCopterPID}",
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ]
        },
        

    ],
    "inputs": [
        {
            "id": "FindCopterPID",
            "type": "command",
            "command": "shellCommand.execute",
            "args": {
              "command": "pgrep arducopter",
              "description": "Select your ArduCopter PID",
              "useFirstResult": true,
            }
        }
    ]
}
````

