### PR TITLE
AP_Mission: show tag or jump index on WP change

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -397,7 +397,12 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         set_in_landing_sequence_flag(false);
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Mission: %u %s", cmd.index, cmd.type());
+    if (cmd.id == MAV_CMD_DO_JUMP || cmd.id == MAV_CMD_JUMP_TAG || cmd.id == MAV_CMD_DO_JUMP_TAG) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Mission: %u %s %u", cmd.index, cmd.type(), (unsigned)cmd.p1);
+    } else {
+        gcs().send_text(MAV_SEVERITY_INFO, "Mission: %u %s", cmd.index, cmd.type());
+    }
+
     switch (cmd.id) {
     case MAV_CMD_DO_AUX_FUNCTION:
         return start_command_do_aux_function(cmd);


### PR DESCRIPTION
Change mission send_text msg when starting new wp item to also show p1 value for MAV_CMD_DO_JUMP, MAV_CMD_JUMP_TAG, and MAV_CMD_DO_JUMP_TAG. This makes the message more useful for GCSs to know whats going on in-the-moment instead of having to wait and see what happens next... if that's even possible to know.


