### PR TITLE
autotest: disarm vehicle in exception handle for PrecLand test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4613,6 +4613,7 @@ class AutoTestCopter(AutoTest):
 
         except Exception as e:
             self.print_exception_caught(e)
+            self.disarm_vehicle(force=True)
             ex = e
 
         self.context_pop()


### PR DESCRIPTION
This is clouding a real error where we're not within 1m of where we are supposed to be
