### PR TITLE
AP_DDS: Enable the DDS parameter by default

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -12,6 +12,9 @@
 
 #include "AP_DDS_Client.h"
 
+// Enable DDS at runtime by default
+static constexpr uint8_t ENABLED_BY_DEFAULT = 1;
+
 static constexpr uint16_t DELAY_TIME_TOPIC_MS = 10;
 static constexpr uint16_t DELAY_BATTERY_STATE_TOPIC_MS = 1000;
 static constexpr uint16_t DELAY_LOCAL_POSE_TOPIC_MS = 33;
@@ -37,7 +40,7 @@ const AP_Param::GroupInfo AP_DDS_Client::var_info[] {
     // @Values: 0:Disabled,1:Enabled
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_DDS_Client, enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_DDS_Client, enabled, ENABLED_BY_DEFAULT, AP_PARAM_FLAG_ENABLE),
 
 #if AP_DDS_UDP_ENABLED
     // @Param: _UDP_PORT

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -104,25 +104,28 @@ sudo apt-get install socat
 Set up your [SITL](https://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html).
 Run the simulator with the following command. If using UDP, the only parameter you need to set it `DDS_ENABLE`.
 
-| Name | Description |
-| - | - |
-| DDS_ENABLE | Set to 1 to enable DDS |
-| SERIAL1_BAUD | The serial baud rate for DDS |
-| SERIAL1_PROTOCOL | Set this to 45 to use DDS on the serial port |
+| Name | Description | Default |
+| - | - | - |
+| DDS_ENABLE | Set to 1 to enable DDS, or 0 to disable | 1 |
+| SERIAL1_BAUD | The serial baud rate for DDS | 57 |
+| SERIAL1_PROTOCOL | Set this to 45 to use DDS on the serial port | 0 |
 ```bash
 # Wipe params till you see "AP: ArduPilot Ready"
 # Select your favorite vehicle type
 sim_vehicle.py -w -v ArduPlane --console -DG --enable-dds
 
-# Enable DDS (both for UDP or Serial)
-param set DDS_ENABLE 1
-
-# Only for Serial
+# Only set this for Serial, which means 115200 baud
 param set SERIAL1_BAUD 115
 # See libraries/AP_SerialManager/AP_SerialManager.h AP_SerialManager SerialProtocol_DDS_XRCE
 param set SERIAL1_PROTOCOL 45
 ```
-Because `DDS_ENABLE` requires a reboot, stop the simulator with ctrl+C and proceed to the next section.
+
+DDS is currently enabled by default, if it's part of the build. To disable it, run the following and reboot the simulator.
+```
+param set DDS_ENABLE 0
+REBOOT
+```
+
 ## Setup ROS 2 and micro-ROS
 
 Follow the steps to use the microROS Agent


### PR DESCRIPTION
# Background

* DDS is still disabled by default in all builds for the library level compile flag
* This parameter was blocking running ROS 2 automated testing in CI
* This can be changed once ENABLE_DDS compiler flag is enabled in SITL or for the 4.5 release

When we try to run tests in CI, the testing framework doesn't work on MacOS. @srmainwaring has spent a signficant amount of time already on it, but no luck yet without some poor workarounds. Instead of spending time on that now, I'd like to prioritize augmenting the automated ROS 2 test infrastructure as a means of validating all the recent GSoC work. Additionally, augmented testing at the ROS level will give us the confidence to perform refactors, switch to MicroROS, or adjust any of the ArduPilot internals without breaking ROS 2 users. 

Overall, DDS will still be disabled by default on all builds unless you supply `--enable-dds`. The difference now is that if you supply `--enable-dds`, you no longer have to set another param to turn it on. We assume if you compiled with DDS, you want it running. I know there are costs with this, however, I'm asking for an allowance now during development to have this enabled. 

Current workarounds:
* Preserving parameters across tests (this is what's currently done), but is risky in testing for cross-pollution between tests. 
```
Rhys: Good to know it's working. I'm aware of the issue setting the ENABLE_DDS param. The idea is to add a node that can automatically detect, set and reboot the FCU if the parameter is not set. Unfortunately the reboot is causing an error in my env and shuts down the process completely. The current workaround is to not wipe the eeprom between launches - and set the parameter manually once.
```
```
Pedro: The main problem I had was with the ENABLE_DDS param, I saw that it is set in dds_udp.param but the launch did not set the parameter to ardupilot and I had to do that manually (in addition to rebooting the simulation since this param requires it)
```

After speaking to both Rhys and Pedro today, we collectively believe in changing the default of this parameter will offer a big benefit.


Situations we should reconsider this parameter:
* In SITL, if we set `--enable-dds` by default
* Release 4.5 date

Until then, changing this default will unblock our CI testing and allow for quicker development. This has zero impact on the rest of the ArduPilot dev team because DDS is still hidden behind `--enable-dds`. 

## Test instructions

* Follow README and check it still works
* `sim_vehicle.py -v Plane -w --enable--dds`
* `param show DDS_ENABLE` -> expect 1`
* Start the agent, expect it to automatically connect