### PR TITLE
Tools: write features json at same place we write manifest

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -664,6 +664,7 @@ is bob we will attempt to checkout bob-AVR'''
         generator.run()
 
         generator.write_manifest_json(os.path.join(self.binaries, "manifest.json"))
+        generator.write_features_json(os.path.join(self.binaries, "features.json"))
         self.progress("Manifest generation successful")
 
         self.progress("Generating stable releases")


### PR DESCRIPTION
This line got lost somewhere....

I've tested `build_binaries.py` locally and the relevant file is written out correctly.

Fix for @Hwurzburg 's features.json Wiki generation warnings.