### PR TITLE
Copter: 4.4.0 stable release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.4.0-beta4 27-July-2023
+Copter 4.4.0 11-Aug-2023 / 4.4.0-beta4 27-July-2023
 Changes from 4.4.0-beta3
 1) Autopilots specific changes
     - Diatone-Mamba-MK4-H743v2 uses SPL06 baro (was DPS280)

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.4.0-beta4"
+#define THISFIRMWARE "ArduCopter V4.4.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+4
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,22 @@
+Release 4.4.0 beta4
+-------------------
+
+Changes from 4.4.0-beta3
+
+1) flight controller specific changes
+    - Diatone-Mamba-MK4-H743v2 uses SPL06 baro (was DPS280)
+    - DMA for I2C disabled on F7 and H7 boards
+    - Foxeer H743v1 default serial protocol config fixes
+    - HeeWing-F405 and F405v2 support
+    - iFlight BlitzF7 support
+2) Scripts may take action based on VTOL motor loss
+3) Bug fixes
+    - BLHeli returns battery status requested via MSP (avoids hang when using esc-configurator)
+    - CRSFv3 rescans at baudrates to avoid RX loss
+    - EK3_ABIAS_P_NSE param range fix
+    - Scripting restart memory corruption bug fixed
+    - Siyi A8/ZR10 driver fix to avoid crash if serial port not configured
+
 Release 4.4.0 beta3
 -------------------
 

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,11 @@
+Release 4.4.0 11th August 2023
+------------------------------
+
+Changes from 4.4.0-beta4
+
+- fixed handling of missing DroneCAN airspeed packet
+- fixed reset of target altitude in plane GUIDED mode
+
 Release 4.4.0 beta4
 -------------------
 

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -56,6 +56,7 @@ bool Mode::enter()
     plane.guided_state.target_heading_type = GUIDED_HEADING_NONE;
     plane.guided_state.target_airspeed_cm = -1; // same as above, although an airspeed of -1 is rare on plane.
     plane.guided_state.target_alt = -1; // same as above, although a target alt of -1 is rare on plane.
+    plane.guided_state.target_alt_time_ms = 0;
     plane.guided_state.last_target_alt = 0;
 #endif
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.4.0-beta4"
+#define THISFIRMWARE "ArduPlane V4.4.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+3
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+3
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.4.0-beta3"
+#define THISFIRMWARE "ArduPlane V4.4.0-beta4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+2
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+3
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+2
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+3
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1119,7 +1119,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode("LAND")
 
         # check vehicle descends to 2m or less within 40 seconds
-        self.wait_altitude(-5, 2, timeout=40, relative=True)
+        self.wait_altitude(-5, 2, timeout=50, relative=True)
 
         # force disarm of vehicle (it will likely not automatically disarm)
         self.disarm_vehicle(force=True)

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -605,6 +605,14 @@ void AP_Airspeed::read(uint8_t i)
         return;
     }
 
+#ifndef HAL_BUILD_AP_PERIPH
+    /*
+      get the healthy state before we call get_pressure() as
+      get_pressure() overwrites the healthy state
+     */
+    bool prev_healthy = state[i].healthy;
+#endif
+
     float raw_pressure = get_pressure(i);
     float airspeed_pressure = raw_pressure - get_offset(i);
 
@@ -612,7 +620,6 @@ void AP_Airspeed::read(uint8_t i)
     state[i].corrected_pressure = airspeed_pressure;
 
 #ifndef HAL_BUILD_AP_PERIPH
-    bool prev_healthy = state[i].healthy;
     if (state[i].cal.start_ms != 0) {
         update_calibration(i, raw_pressure);
     }

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -172,7 +172,7 @@ bool AP_Airspeed_UAVCAN::get_differential_pressure(float &pressure)
 {
     WITH_SEMAPHORE(_sem_airspeed);
 
-    if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 250) {
         return false;
     }
 


### PR DESCRIPTION
This is the Copter-4.4.0 release which is the same as the Plane-4.4.0 release (see PR https://github.com/ArduPilot/ardupilot/pull/24585).

Copter-4.4.0 is the same as the final beta (-beta4) but with two additions:

- https://github.com/ArduPilot/ardupilot/pull/24535
- https://github.com/ArduPilot/ardupilot/pull/24570

These two additions are very low risk for Copter and TradHeli so we've decided we can directly include them in the stable release without the need for an additional beta.

A new "4.4.0" column has been added to [this project](https://github.com/ArduPilot/ardupilot/projects/27) to allow anyone to easily see what has been included in each release and the "pending" column shows what we are considering for future "point" releases.