### PR TITLE
AC_PosControl: add singleton

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -74,6 +74,8 @@ extern const AP_HAL::HAL& hal;
 #define POSCONTROL_VIBE_COMP_P_GAIN 0.250f
 #define POSCONTROL_VIBE_COMP_I_GAIN 0.125f
 
+AC_PosControl *AC_PosControl::_singleton = nullptr;
+
 const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // 0 was used for HOVER
 
@@ -319,6 +321,7 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
     _jerk_max_xy_cmsss(POSCONTROL_JERK_XY * 100.0),
     _jerk_max_z_cmsss(POSCONTROL_JERK_Z * 100.0)
 {
+    _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
 }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -43,6 +43,11 @@ public:
 
 
 
+    // do not allow copying
+    CLASS_NO_COPY(AC_PosControl);
+
+    static AC_PosControl *get_singleton() { return _singleton; }
+
     /// set_dt / get_dt - dt is the time since the last time the position controllers were updated
     ///   _dt should be set based on the time of the last IMU read used by these controllers
     ///   the position controller should run updates for active controllers on each loop to ensure normal operation
@@ -424,6 +429,8 @@ protected:
     const AP_InertialNav&   _inav;
     const class AP_Motors&  _motors;
     AC_AttitudeControl&     _attitude_control;
+
+    static AC_PosControl *_singleton;
 
     // parameters
     AP_Float        _lean_angle_max;    // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max


### PR DESCRIPTION
## Background
This follows the same method as the recent PR [#23981](https://github.com/ArduPilot/ardupilot/pull/23981) that added the singleton to AR_PosControl.

This can be used to expose the functions in `AC_PosControl` for use in Lua scripting.