### PR TITLE
GCS_MAVLink: Add singleton support to GCS_MAVLINK class

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -191,6 +191,11 @@ public:
     GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters, AP_HAL::UARTDriver &uart);
     virtual ~GCS_MAVLINK() {}
 
+    // do not allow copying
+    CLASS_NO_COPY(GCS_MAVLINK);
+
+    static GCS_MAVLINK *get_singleton() { return _singleton; }
+
     // accessors used to retrieve objects used for parsing incoming messages:
     mavlink_message_t *channel_buffer() { return &_channel_buffer; }
     mavlink_status_t *channel_status() { return &_channel_status; }
@@ -1088,6 +1093,8 @@ private:
     // true if we should NOT do MAVLink on this port (usually because
     // someone's doing SERIAL_CONTROL over mavlink)
     bool _locked;
+
+    static GCS_MAVLINK *_singleton;
 };
 
 /// @class GCS

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -102,6 +102,7 @@ uint32_t GCS_MAVLINK::reserve_param_space_start_ms;
 uint8_t GCS_MAVLINK::mavlink_private = 0;
 
 GCS *GCS::_singleton = nullptr;
+GCS_MAVLINK *GCS_MAVLINK::_singleton = nullptr;
 
 GCS_MAVLINK_InProgress GCS_MAVLINK_InProgress::in_progress_tasks[1];
 uint32_t GCS_MAVLINK_InProgress::last_check_ms;
@@ -112,6 +113,7 @@ GCS_MAVLINK::GCS_MAVLINK(GCS_MAVLINK_Parameters &parameters,
     _port = &uart;
 
     streamRates = parameters.streamRates;
+    _singleton = this;
 }
 
 bool GCS_MAVLINK::init(uint8_t instance)


### PR DESCRIPTION
Just like #24599, except this one's a pre-requisite for #24518 to be able to call `GCS_MAVLINK::correct_offboard_timestamp_usec_to_ms` to perform jitter correction on the incoming localization data from ROS 2 (in AP terminology, this is a source of odometry into the AP_VisualOdom library).