### PR TITLE
autotest: relax Copter vibration failsafe timeout

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1099,7 +1099,7 @@ class AutoTestCopter(AutoTest):
         self.change_mode("LAND")
 
         # check vehicle descends to 2m or less within 40 seconds
-        self.wait_altitude(-5, 2, timeout=40, relative=True)
+        self.wait_altitude(-5, 2, timeout=50, relative=True)
 
         # force disarm of vehicle (it will likely not automatically disarm)
         self.disarm_vehicle(force=True)


### PR DESCRIPTION
This relaxes the Copter VibrationFailsafe autotest so that the vehicle has 50 seconds instead of 40 seconds to reach the ground.  This is required in the 4.4 branch in order to past the test.  Master does not need the extra time but it is very close.  [Here's a link to the Copter-4.4 vibration failsafe autotest](https://github.com/ArduPilot/ardupilot/blob/Copter-4.4/Tools/autotest/arducopter.py#L1103).

BTW, while testing I noticed a change in behaviour of this test between 4.4 and 4.5.  There is no change in behaviour between 4.3 and 4.4 though so we don't need to delay the 4.4.0 release.  The cause of the change in behaviour is PR https://github.com/ArduPilot/ardupilot/pull/23807.

Below are screenshots of the desired and actual altitude and horizontal position (see map) for 4.3.7, 4.4.0 and 4.5.0-dev.  Note that there are differences both in the vertical and horizontal behaviour.  For example in 4.4.0 the vehicle holds the original position target (in Loiter mode) while in master the position estimate and target reset a number of times.

![437-behaviour](https://github.com/ArduPilot/ardupilot/assets/1498098/29bfb126-2f8b-4e6f-989f-3bd498f3470b)

![440-behaviour](https://github.com/ArduPilot/ardupilot/assets/1498098/96271e3a-c341-4c88-b731-ecb0d524835c)

![450-dev-behaviour](https://github.com/ArduPilot/ardupilot/assets/1498098/605640c8-b4b9-48a3-8c2c-3472d2e2079b)


[I've placed copies of the onboard logs from the Copter vibration failsafe for 4.3.7, 4.4.0 and 4.5.0-dev here](https://www.dropbox.com/scl/fi/rh3kd3wboqpr91580upt9/copter-437-440-450-vibration-failsafe.zip?rlkey=90lfcf9nw7ouf15jzfas90tz7&dl=0).

