### PR TITLE
AP_RPM: correct compilation when AP_RPM_ESC_TELEM_ENABLED is disabled

### DIFF
--- a/libraries/AP_RPM/AP_RPM_config.h
+++ b/libraries/AP_RPM/AP_RPM_config.h
@@ -5,6 +5,7 @@
 #include <AP_EFI/AP_EFI_config.h>
 #include <AP_Generator/AP_Generator_config.h>
 #include <AP_InertialSensor/AP_InertialSensor_config.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_config.h>
 
 #ifndef AP_RPM_ENABLED
 #define AP_RPM_ENABLED 1
@@ -23,7 +24,7 @@
 #endif
 
 #ifndef AP_RPM_ESC_TELEM_ENABLED
-#define AP_RPM_ESC_TELEM_ENABLED AP_RPM_BACKEND_DEFAULT_ENABLED
+#define AP_RPM_ESC_TELEM_ENABLED AP_RPM_BACKEND_DEFAULT_ENABLED && HAL_WITH_ESC_TELEM
 #endif
 
 #ifndef AP_RPM_HARMONICNOTCH_ENABLED

--- a/libraries/AP_RPM/RPM_ESC_Telem.cpp
+++ b/libraries/AP_RPM/RPM_ESC_Telem.cpp
@@ -33,13 +33,11 @@ AP_RPM_ESC_Telem::AP_RPM_ESC_Telem(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::R
 
 void AP_RPM_ESC_Telem::update(void)
 {
-#if HAL_WITH_ESC_TELEM
     AP_ESC_Telem &esc_telem = AP::esc_telem();
     float esc_rpm = esc_telem.get_average_motor_rpm(ap_rpm._params[state.instance].esc_mask);
     state.rate_rpm = esc_rpm * ap_rpm._params[state.instance].scaling;
     state.signal_quality = 0.5f;
     state.last_reading_ms = AP_HAL::millis();
-#endif
 }
 
 #endif  // AP_RPM_ESC_TELEM_ENABLED


### PR DESCRIPTION
Wrong define, `RPM_TYPE_ESC_TELEM` is not available if ~AP_RPM_ESC_TELEM_ENABLED, and that's being used in this block
