### PR TITLE
Copter: Adding a class name

### DIFF
--- a/ArduCopter/failsafe.cpp
+++ b/ArduCopter/failsafe.cpp
@@ -18,7 +18,7 @@ static bool in_failsafe;
 void Copter::failsafe_enable()
 {
     failsafe_enabled = true;
-    failsafe_last_timestamp = micros();
+    failsafe_last_timestamp = AP_HAL::micros();
 }
 
 //


### PR DESCRIPTION
In other methods, the class name is appended.
I match the format.