### PR TITLE
Copter: Optional time to terminate the motor

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -441,6 +441,24 @@ const AP_Param::Info Copter::var_info[] = {
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     (uint8_t)ModeAcro::Trainer::LIMITED),
 #endif
 
+    // @Param: TERMING_TIME
+    // @DisplayName: Terminating Time
+    // @Description: Terminating time to minimize motor rotation
+    // @Units: ms
+    // @Range: 100 10000
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(terming_time,   "TERMING_TIME",     2000),
+
+    // @Param: TERMED_TIME
+    // @DisplayName: Terminated Time
+    // @Description: terminated Time to motor rotation
+    // @Units: ms
+    // @Range: 0 10000
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(termed_time,   "TERMED_TIME",     1000),
+
     // variables not in the g class which contain EEPROM saved variables
 
 #if AP_CAMERA_ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -384,6 +384,9 @@ public:
 
         k_param_vehicle = 257, // vehicle common block of parameters
 
+        k_param_terming_time = 258,  // Terminating Time
+        k_param_termed_time  = 259,  // Terminated Time
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -477,6 +480,9 @@ public:
     // Acro parameters
     AP_Int8                 acro_trainer;
 #endif
+
+    AP_Int16                terming_time;  // Terminating Time
+    AP_Int16                termed_time;   // Terminated Time
 
     // Note: keep initializers here in the same order as they are declared
     // above.

--- a/ArduCopter/failsafe.cpp
+++ b/ArduCopter/failsafe.cpp
@@ -48,7 +48,7 @@ void Copter::failsafe_check()
         return;
     }
 
-    if (!in_failsafe && failsafe_enabled && tnow - failsafe_last_timestamp > 2000000) {
+    if (!in_failsafe && failsafe_enabled && tnow - failsafe_last_timestamp > uint32_t(g.terming_time * 1000)) {
         // motors are running but we have gone 2 second since the
         // main loop ran. That means we're in trouble and should
         // disarm the motors->
@@ -61,7 +61,7 @@ void Copter::failsafe_check()
         AP::logger().Write_Error(LogErrorSubsystem::CPU, LogErrorCode::FAILSAFE_OCCURRED);
     }
 
-    if (failsafe_enabled && in_failsafe && tnow - failsafe_last_timestamp > 1000000) {
+    if (failsafe_enabled && in_failsafe && tnow - failsafe_last_timestamp > uint32_t(g.termed_time * 1000)) {
         // disarm motors every second
         failsafe_last_timestamp = tnow;
         if(motors->armed()) {


### PR DESCRIPTION
Any time to terminate the motor.
I think 2 seconds is too long for log output.
I think 1 second is too long to stop the motor.
Allow users to set it arbitrarily.