### PR TITLE
GCS_MAVLink: fixed corruption of FTP reply component ID

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -169,7 +169,7 @@ void GCS_MAVLINK::ftp_worker(void) {
         }
 
         // if it's a rerequest and we still have the last response then send it
-        if ((request.sysid == reply.sysid) && (request.compid = reply.compid) &&
+        if ((request.sysid == reply.sysid) && (request.compid == reply.compid) &&
             (request.session == reply.session) && (request.seq_number + 1 == reply.seq_number)) {
             ftp_push_replies(reply);
             continue;


### PR DESCRIPTION
this led to not being able to do FTP transfers with support.ardupilot.org unless MissionPlanner used the same component ID as the support engineer GCS
this led to a very frustrating support session where I could not upload a lua script