### PR TITLE
AP_Logger: correct use of nullptr in SITL structure sanity checks

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -381,6 +381,7 @@ void AP_Logger_Backend::validate_WritePrioritisedBlock(const void *pBuffer,
     }
     const uint8_t type = ((uint8_t*)pBuffer)[2];
     uint8_t type_len;
+    const char *name_src;
     const struct LogStructure *s = _front.structure_for_msg_type(type);
     if (s == nullptr) {
         const struct AP_Logger::log_write_fmt *t = _front.log_write_fmt_for_msg_type(type);
@@ -388,13 +389,15 @@ void AP_Logger_Backend::validate_WritePrioritisedBlock(const void *pBuffer,
             AP_HAL::panic("No structure for msg_type=%u", type);
         }
         type_len = t->msg_len;
+        name_src = t->name;
     } else {
         type_len = s->msg_len;
+        name_src = s->name;
     }
     if (type_len != size) {
         char name[5] = {}; // get a null-terminated string
-        if (s->name != nullptr) {
-            memcpy(name, s->name, 4);
+        if (name_src != nullptr) {
+            memcpy(name, name_src, 4);
         } else {
             strncpy(name, "?NM?", ARRAY_SIZE(name));
         }


### PR DESCRIPTION
A developer might be able to craft a fault such that s could be nullptr here.  They would need to work at it, but we can do better.

Note that here we are forming up a string to pass to `AP_HAL::panic`, so we're already going to stop execution.
