### PR TITLE
AP_Mount: fix SiYi doesn't zoom continuously while manual zoom control

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -195,8 +195,7 @@ private:
     // get zoom multiple max
     float get_zoom_mult_max() const;
 
-    // update absolute zoom controller
-    // only used for A8 that does not support abs zoom control
+    // update zoom controller
     void update_zoom_control();
 
     // internal variables
@@ -238,6 +237,8 @@ private:
     bool _last_record_video;                        // last record_video state sent to gimbal
 
     // absolute zoom control.  only used for A8 that does not support abs zoom control
+    ZoomType _zoom_type;                            // current zoom type
+    float _zoom_rate_target;                        // current zoom rate target
     float _zoom_mult_target;                        // current zoom multiple target.  0 if no target
     float _zoom_mult;                               // most recent actual zoom multiple received from camera
     uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run


### PR DESCRIPTION
While sending a Manual zoom (rate) command to SiYi. zoom stops multiple time in between. This Pull fixes this by sending the same command multiple time at 20Hz. Tested on Zr10.
Support issue link [here](https://discuss.ardupilot.org/t/zr10-2k-qhd-30x-hybrid-zoom-gimbal-camera-siyis-first-industry-gimbal-camera-and-it-wont-be-the-last/86069/429)
I find out one more bug that is probably SiYI side. that is when we watch the zoom value on the SiYI FPV app the values are different than real zoom. eg: on 30x sometime it tell 20x, 22x, 27x etc. 