### PR TITLE
AP_RPM: Fwd rpm data to ESC_Telem

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -199,6 +199,10 @@ void AP_RPM::update(void)
             }
 
             drivers[i]->update();
+
+#if AP_RPM_ESC_TELEM_OUTBOUND_ENABLED
+            drivers[i]->update_esc_telem_outbound();
+#endif
         }
     }
 

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -23,7 +23,6 @@
 #include "RPM_Generator.h"
 #include "RPM_HarmonicNotch.h"
 #include "RPM_ESC_Telem.h"
-#include "AP_ESC_Telem/AP_ESC_Telem.h"
 
 #include <AP_Logger/AP_Logger.h>
 
@@ -200,19 +199,6 @@ void AP_RPM::update(void)
             }
 
             drivers[i]->update();
-
-#if HAL_WITH_ESC_TELEM
-            // Check if we need to write to esc_telem(). Note:
-            // RPM_TYPE_ESC_TELEM = read ESC_TELEM and store it in AP_RPM
-            // RPM_TYPE_EverythingElse = write to ESC_TELEM with data generated from AP_RPM
-            if (_params[i].type != RPM_TYPE_ESC_TELEM && _params[i].esc_mask > 0 && healthy(i)) {
-                for (uint32_t esc=0; esc<ESC_TELEM_MAX_ESCS; esc++) {
-                    if (_params[i].esc_mask & (1U<<esc)) {
-                        AP::esc_telem().update_rpm(esc, state[i].rate_rpm, 0);
-                    }
-                }
-            }
-#endif
         }
     }
 

--- a/libraries/AP_RPM/AP_RPM_Params.cpp
+++ b/libraries/AP_RPM/AP_RPM_Params.cpp
@@ -68,6 +68,16 @@ const AP_Param::GroupInfo AP_RPM_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ESC_MASK", 7, AP_RPM_Params, esc_mask, 0),
 
+#if AP_RPM_ESC_TELEM_OUTBOUND_ENABLED
+    // @Param: ESC_INDEX
+    // @DisplayName: ESC Telemetry Index to write RPM to
+    // @Description: ESC Telemetry Index to write RPM to. Use 0 to disable.
+    // @Range: 0 10
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("ESC_INDEX", 8, AP_RPM_Params, esc_telem_outbound_index, 0),
+#endif
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RPM/AP_RPM_Params.cpp
+++ b/libraries/AP_RPM/AP_RPM_Params.cpp
@@ -62,8 +62,8 @@ const AP_Param::GroupInfo AP_RPM_Params::var_info[] = {
     AP_GROUPINFO("PIN", 6, AP_RPM_Params, pin, -1),
 
     // @Param: ESC_MASK
-    // @DisplayName: Bitmask of ESC telemetry channels
-    // @Description: Mask of channels to use with ESC rpm telemetry. When TYPE = 5, this will fetch and average the RPM telemetry from all the selected ESC telemetry channels. For all other TYPE values, the ESC telemetry will set the RPM on the selected channel(s).
+    // @DisplayName: Bitmask of ESC telemetry channels to average
+    // @Description: Mask of channels which support ESC rpm telemetry. RPM telemetry of the selected channels will be averaged
     // @Bitmask: 0:Channel1,1:Channel2,2:Channel3,3:Channel4,4:Channel5,5:Channel6,6:Channel7,7:Channel8,8:Channel9,9:Channel10,10:Channel11,11:Channel12,12:Channel13,13:Channel14,14:Channel15,15:Channel16
     // @User: Advanced
     AP_GROUPINFO("ESC_MASK", 7, AP_RPM_Params, esc_mask, 0),

--- a/libraries/AP_RPM/AP_RPM_Params.h
+++ b/libraries/AP_RPM/AP_RPM_Params.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 #include <AP_Param/AP_Param.h>
+#include "AP_RPM_config.h"
 
 class AP_RPM_Params {
 
@@ -29,6 +30,9 @@ public:
     AP_Float minimum;
     AP_Float quality_min;
     AP_Int32 esc_mask;
+#if AP_RPM_ESC_TELEM_OUTBOUND_ENABLED
+    AP_Int8  esc_telem_outbound_index;
+#endif
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_RPM/AP_RPM_config.h
+++ b/libraries/AP_RPM/AP_RPM_config.h
@@ -5,6 +5,7 @@
 #include <AP_EFI/AP_EFI_config.h>
 #include <AP_Generator/AP_Generator_config.h>
 #include <AP_InertialSensor/AP_InertialSensor_config.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_config.h>
 
 #ifndef AP_RPM_ENABLED
 #define AP_RPM_ENABLED 1
@@ -40,4 +41,8 @@
 
 #ifndef AP_RPM_GENERATOR_ENABLED
 #define AP_RPM_GENERATOR_ENABLED AP_RPM_BACKEND_DEFAULT_ENABLED && HAL_GENERATOR_ENABLED
+#endif
+
+#ifndef AP_RPM_ESC_TELEM_OUTBOUND_ENABLED
+#define AP_RPM_ESC_TELEM_OUTBOUND_ENABLED AP_RPM_BACKEND_DEFAULT_ENABLED && HAL_WITH_ESC_TELEM
 #endif

--- a/libraries/AP_RPM/RPM_Backend.cpp
+++ b/libraries/AP_RPM/RPM_Backend.cpp
@@ -19,6 +19,10 @@
 
 #include "AP_RPM.h"
 
+#if HAL_WITH_ESC_TELEM
+#include "AP_ESC_Telem/AP_ESC_Telem.h"
+#endif
+
 /*
   base class constructor. 
 */
@@ -28,5 +32,23 @@ AP_RPM_Backend::AP_RPM_Backend(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_St
 {
     state.instance = instance;
 }
+
+#if AP_RPM_ESC_TELEM_OUTBOUND_ENABLED
+void AP_RPM_Backend::update_esc_telem_outbound()
+{
+    const uint8_t esc_index = ap_rpm._params[state.instance].esc_telem_outbound_index;
+    if (esc_index == 0) {
+        // Disabled if there's no ESC identified to route the data to
+        return;
+    }
+    if (!ap_rpm.healthy(state.instance)) {
+        // If we're unhealthy don't update the telemetry. Let it
+        // timeout on it's own instead of showing potentially wrong data
+        return;
+    }
+
+    AP::esc_telem().update_rpm(esc_index-1, state.rate_rpm, 0);
+}
+#endif
 
 #endif  // AP_RPM_ENABLED

--- a/libraries/AP_RPM/RPM_Backend.h
+++ b/libraries/AP_RPM/RPM_Backend.h
@@ -38,6 +38,8 @@ public:
         return ap_rpm._params[state.instance].pin.get();
     }
 
+    void update_esc_telem_outbound();
+
 protected:
 
     AP_RPM &ap_rpm;


### PR DESCRIPTION
This reverts PR https://github.com/ArduPilot/ardupilot/pull/24486 and replaces it with a new param RPMn_ESC_INDEX as discussed in the devcall. It also moves the work to the backend wrapped in a cute AP_RPM_ESC_TELEM_OUTBOUND_ENABLED bow.