### PR TITLE
Pr/remove iomcu fw defines

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -820,14 +820,18 @@ void Scheduler::check_stack_free(void)
 
     if (stack_free(&__main_stack_base__) < min_stack) {
         // use "line number" of 0xFFFF for ISR stack low
+#if AP_INTERNALERROR_ENABLED
         AP::internalerror().error(AP_InternalError::error_t::stack_overflow, 0xFFFF);
+#endif
     }
 
     for (thread_t *tp = chRegFirstThread(); tp; tp = chRegNextThread(tp)) {
         if (stack_free(tp->wabase) < min_stack) {
             // use task priority for line number. This allows us to
             // identify the task fairly reliably
+#if AP_INTERNALERROR_ENABLED
             AP::internalerror().error(AP_InternalError::error_t::stack_overflow, tp->realprio);
+#endif
         }
     }
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_iofirmware.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_iofirmware.h
@@ -37,3 +37,7 @@
 
 // allow the IOMCU to have its allowed protocols to be set:
 #define AP_RCPROTOCOL_ENABLE_SET_RC_PROTOCOLS 1
+
+#ifndef AP_INTERNALERROR_ENABLED
+#define AP_INTERNALERROR_ENABLED 0
+#endif

--- a/libraries/AP_InternalError/AP_InternalError.cpp
+++ b/libraries/AP_InternalError/AP_InternalError.cpp
@@ -1,6 +1,12 @@
+#include "AP_InternalError_config.h"
+
+#if AP_INTERNALERROR_ENABLED
+
 #include "AP_InternalError.h"
 
-#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_HAL/HAL.h>
+#include <AP_HAL/Util.h>
+
 #include <stdio.h>
 
 extern const AP_HAL::HAL &hal;
@@ -137,3 +143,5 @@ void AP_memory_guard_error(uint32_t size)
         AP_HAL::panic("memory guard size=%u\n", unsigned(size));
     }
 }
+
+#endif  // AP_INTERNALERROR_ENABLED

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include "AP_InternalError_config.h"
+
+#if AP_INTERNALERROR_ENABLED
+
 #include <stdint.h>
 
 class AP_InternalError {
@@ -113,3 +117,7 @@ extern "C" {
 
 #define INTERNAL_ERROR(error_number) \
     AP::internalerror().error(error_number, __AP_LINE__);
+
+#else  // AP_INTERNALERROR_ENABLED is false
+#define INTERNAL_ERROR(error_number)
+#endif // AP_INTERNALERROR_ENABLED

--- a/libraries/AP_InternalError/AP_InternalError_config.h
+++ b/libraries/AP_InternalError/AP_InternalError_config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_INTERNALERROR_ENABLED
+#define AP_INTERNALERROR_ENABLED 1
+#endif

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -270,7 +270,7 @@ T constrain_value_line(const T amt, const T low, const T high, uint32_t line)
     // errors through any function that uses constrain_value(). The normal
     // float semantics already handle -Inf and +Inf
     if (isnan(amt)) {
-#if !defined(IOMCU_FW)
+#if AP_INTERNALERROR_ENABLED
         AP::internalerror().error(AP_InternalError::error_t::constraining_nan, line);
 #endif
         return (low + high) / 2;


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```

Should we create `AP_INTERNAL_ERROR_LINE(error, line)` ?
