### PR TITLE
README: fix GPL license URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It is continually being expanded to provide support for new emerging vehicle typ
 The ArduPilot project is licensed under the GNU General Public
 License, version 3.
 
-- [Overview of license](https://dev.ardupilot.com/wiki/license-gplv3)
+- [Overview of license](https://ardupilot.org/dev/docs/license-gplv3.html)
 
 - [Full Text](https://github.com/ArduPilot/ardupilot/blob/master/COPYING.txt)
 


### PR DESCRIPTION


The old URL shows a security warning on browsers due to invalid ssl certificate for domain ardupilot.com
