### PR TITLE
AP_BattMonitor: remove AP_BATT_MONITOR_MAX_INSTANCES 16 limit

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -373,12 +373,12 @@ class AutoTestSub(AutoTest):
 
     def reboot_sitl(self):
         """Reboot SITL instance and wait it to reconnect."""
-        # out battery is reset to full on reboot.  So reduce it to 10%
+        # our battery is reset to full on reboot.  So reduce it to 10%
         # and wait for it to go above 50.
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_BATTERY_RESET,
-            p1=255,  # battery mask
-            p2=10,   # percentage
+            p1=65535,   # battery mask
+            p2=10,      # percentage
         )
         self.run_cmd_reboot()
         tstart = time.time()

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -377,8 +377,8 @@ class AutoTestSub(AutoTest):
         # and wait for it to go above 50.
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_BATTERY_RESET,
-            p1=65535,   # battery mask
-            p2=10,      # percentage
+            p1=-1,   # battery mask
+            p2=10,   # percentage
         )
         self.run_cmd_reboot()
         tstart = time.time()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -12687,8 +12687,8 @@ switch value'''
         # grab a battery-remaining percentage
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_BATTERY_RESET,
-            p1=255,  # battery mask
-            p2=96,   # percentage
+            p1=65535,   # battery mask
+            p2=96,      # percentage
         )
         m = self.assert_receive_message('BATTERY_STATUS', timeout=1)
         want_battery_remaining_pct = m.battery_remaining

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -12687,8 +12687,8 @@ switch value'''
         # grab a battery-remaining percentage
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_BATTERY_RESET,
-            p1=65535,   # battery mask
-            p2=96,      # percentage
+            p1=-1,   # battery mask
+            p2=96,   # percentage
         )
         m = self.assert_receive_message('BATTERY_STATUS', timeout=1)
         want_battery_remaining_pct = m.battery_remaining

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -237,6 +237,164 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
 
+#if AP_BATT_MONITOR_MAX_INSTANCES > 9
+    // @Group: A_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[9], "A_", 32, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: A_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[9], "A_", 50, AP_BattMonitor, backend_var_info[9]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 10
+    // @Group: B_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[10], "B_", 33, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: B_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[10], "B_", 51, AP_BattMonitor, backend_var_info[10]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 11
+    // @Group: C_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[11], "C_", 34, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: C_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[11], "C_", 52, AP_BattMonitor, backend_var_info[11]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 12
+    // @Group: D_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[12], "D_", 35, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: D_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[12], "D_", 53, AP_BattMonitor, backend_var_info[12]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 13
+    // @Group: E_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[13], "E_", 36, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: E_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[13], "E_", 54, AP_BattMonitor, backend_var_info[13]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 14
+    // @Group: F_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[14], "F_", 37, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: F_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[14], "F_", 55, AP_BattMonitor, backend_var_info[14]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 15
+    // @Group: G_
+    // @Path: AP_BattMonitor_Params.cpp
+    AP_SUBGROUPINFO(_params[15], "G_", 38, AP_BattMonitor, AP_BattMonitor_Params),
+
+    // @Group: G_
+    // @Path: AP_BattMonitor_Analog.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_SMBus.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_Sum.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_DroneCAN.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_FuelLevel_Analog.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_Synthetic_Current.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_INA2xx.cpp
+    AP_SUBGROUPVARPTR(drivers[15], "G_", 56, AP_BattMonitor, backend_var_info[15]),
+#endif
+
+#if AP_BATT_MONITOR_MAX_INSTANCES > 16
+    #error "AP_BATT_MONITOR_MAX_INSTANCES too large, reset_remaining_mask() will cause an assert above 16"
+#endif
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -962,9 +962,8 @@ void AP_BattMonitor::checkPoweringOff(void)
   reset battery remaining percentage for batteries that integrate to
   calculate percentage remaining
 */
-bool AP_BattMonitor::reset_remaining_mask(uint16_t battery_mask, float percentage)
+bool AP_BattMonitor::reset_remaining_mask(uint32_t battery_mask, float percentage)
 {
-    static_assert(AP_BATT_MONITOR_MAX_INSTANCES <= 16, "More batteries are enabled then can be reset");
     bool ret = true;
     Failsafe highest_failsafe = Failsafe::None;
     for (uint8_t i = 0; i < _num_instances; i++) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -258,7 +258,7 @@ public:
     void checkPoweringOff(void);
 
     // reset battery remaining percentage
-    bool reset_remaining_mask(uint16_t battery_mask, float percentage);
+    bool reset_remaining_mask(uint32_t battery_mask, float percentage);
     bool reset_remaining(uint8_t instance, float percentage) { return reset_remaining_mask(1U<<instance, percentage);}
 
     // Returns mavlink charge state

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4457,7 +4457,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
 MAV_RESULT GCS_MAVLINK::handle_command_battery_reset(const mavlink_command_long_t &packet)
 {
 #if AP_BATTERY_ENABLED
-    const uint16_t battery_mask = packet.param1;
+    const uint32_t battery_mask = is_equal(packet.param1, -1.0) ? 0xFFFFFFFF : packet.param1;
     const float percentage = packet.param2;
     if (AP::battery().reset_remaining_mask(battery_mask, percentage)) {
         return MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
This is on top of PR https://github.com/ArduPilot/ardupilot/pull/24660 which bumps the max value of AP_BATT_MONITOR_MAX_INSTANCES  up to 16

That PR is limited to uint16 by arbitrarily treating a command_long packet.param1 as uint16 for reset_remaining_mask(). This PR bumps that to uint32 and allows using ```packet.param1 = -1.0``` to mean **ALL** batteries without having to know how many there are. I think that itself is a good change we should keep either way.

If this is accepted, TODOs are:
- [The MAVlink docs](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml#L269) would need to be updated
- Optionally add another 16 param initializers (new params BATTH_MONITOR...BATTR_MONITOR) because he/she who dies with the most params wins!