### PR TITLE
AP_Bootloader: reserve board id for QioTekAdept_6C

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -238,6 +238,7 @@ AP_HW_mRoCZOEM_revG                  1124
 AP_HW_BETAFPV_F405                   1125
 AP_HW_QioTekAdeptH743                1126
 AP_HW_YJUAV_A6SE                     1127
+AP_HW_QioTekAdept_6C                 1128
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
Reserve board id for QioTekAdept_6C