### PR TITLE
Tools/autotest: extend WindEstimate duration

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3074,7 +3074,7 @@ class AutoTestPlane(AutoTest):
             self.wait_and_maintain_wind_estimate(
                 5, 45,
                 speed_tolerance=1,
-                timeout=20
+                timeout=30
             )
         self.fly_home_land_and_disarm()
 


### PR DESCRIPTION
The WindEstimate CI test thresholds occasionally don't get reached but they're still twiddling so a little extra time will likely make it pass much more reliably