### PR TITLE
AP_RPM: tidy constructors and use of config.h

### DIFF
--- a/libraries/AP_RPM/RPM_EFI.cpp
+++ b/libraries/AP_RPM/RPM_EFI.cpp
@@ -13,18 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
-
-#include "RPM_EFI.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_EFI_ENABLED
 
+#include "RPM_EFI.h"
+#include <AP_HAL/AP_HAL.h>
 #include <AP_EFI/AP_EFI.h>
-
-AP_RPM_EFI::AP_RPM_EFI(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
-    AP_RPM_Backend(_ap_rpm, _instance, _state)
-{
-}
 
 void AP_RPM_EFI::update(void)
 {

--- a/libraries/AP_RPM/RPM_EFI.h
+++ b/libraries/AP_RPM/RPM_EFI.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#include "AP_RPM.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_EFI_ENABLED
 
@@ -23,13 +23,13 @@
 class AP_RPM_EFI : public AP_RPM_Backend
 {
 public:
+
     // constructor
-    AP_RPM_EFI(AP_RPM &ranger, uint8_t instance, AP_RPM::RPM_State &_state);
+    using AP_RPM_Backend::AP_RPM_Backend;
 
     // update state
     void update(void) override;
 
-private:
 };
 
 #endif

--- a/libraries/AP_RPM/RPM_ESC_Telem.cpp
+++ b/libraries/AP_RPM/RPM_ESC_Telem.cpp
@@ -13,23 +13,13 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_ESC_Telem/AP_ESC_Telem.h>
-
-#include "RPM_ESC_Telem.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_ESC_TELEM_ENABLED
 
-extern const AP_HAL::HAL& hal;
-
-/*
-   open the sensor in constructor
-*/
-AP_RPM_ESC_Telem::AP_RPM_ESC_Telem(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
-    AP_RPM_Backend(_ap_rpm, _instance, _state)
-{
-}
-
+#include <AP_ESC_Telem/AP_ESC_Telem.h>
+#include "RPM_ESC_Telem.h"
+#include <AP_HAL/AP_HAL.h>
 
 void AP_RPM_ESC_Telem::update(void)
 {

--- a/libraries/AP_RPM/RPM_ESC_Telem.h
+++ b/libraries/AP_RPM/RPM_ESC_Telem.h
@@ -14,16 +14,17 @@
  */
 #pragma once
 
-#include "AP_RPM.h"
-#include "RPM_Backend.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_ESC_TELEM_ENABLED
+
+#include "RPM_Backend.h"
 
 class AP_RPM_ESC_Telem : public AP_RPM_Backend
 {
 public:
     // constructor
-    AP_RPM_ESC_Telem(AP_RPM &ranger, uint8_t instance, AP_RPM::RPM_State &_state);
+    using AP_RPM_Backend::AP_RPM_Backend;
 
     // update state
     void update(void) override;

--- a/libraries/AP_RPM/RPM_Generator.cpp
+++ b/libraries/AP_RPM/RPM_Generator.cpp
@@ -13,12 +13,12 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <AP_HAL/AP_HAL.h>
-
-#include "RPM_Generator.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_GENERATOR_ENABLED
-extern const AP_HAL::HAL& hal;
+
+#include "RPM_Generator.h"
+#include <AP_Generator/AP_Generator.h>
 
 void AP_RPM_Generator::update(void)
 {

--- a/libraries/AP_RPM/RPM_Generator.h
+++ b/libraries/AP_RPM/RPM_Generator.h
@@ -14,11 +14,11 @@
  */
 #pragma once
 
-#include "AP_RPM.h"
-#include "RPM_Backend.h"
-#include <AP_Generator/AP_Generator.h>
+#include "AP_RPM_config.h"
 
 #if AP_RPM_GENERATOR_ENABLED
+
+#include "RPM_Backend.h"
 
 class AP_RPM_Generator : public AP_RPM_Backend
 {

--- a/libraries/AP_RPM/RPM_HarmonicNotch.cpp
+++ b/libraries/AP_RPM/RPM_HarmonicNotch.cpp
@@ -13,17 +13,14 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "RPM_HarmonicNotch.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_HARMONICNOTCH_ENABLED
 
+#include "RPM_HarmonicNotch.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
-
-AP_RPM_HarmonicNotch::AP_RPM_HarmonicNotch(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
-    AP_RPM_Backend(_ap_rpm, _instance, _state)
-{
-}
 
 void AP_RPM_HarmonicNotch::update(void)
 {

--- a/libraries/AP_RPM/RPM_HarmonicNotch.h
+++ b/libraries/AP_RPM/RPM_HarmonicNotch.h
@@ -14,16 +14,17 @@
  */
 #pragma once
 
-#include "AP_RPM.h"
-#include "RPM_Backend.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_HARMONICNOTCH_ENABLED
+
+#include "RPM_Backend.h"
 
 class AP_RPM_HarmonicNotch : public AP_RPM_Backend
 {
 public:
     // constructor
-    AP_RPM_HarmonicNotch(AP_RPM &ranger, uint8_t instance, AP_RPM::RPM_State &_state);
+    using AP_RPM_Backend::AP_RPM_Backend;
 
     // update state
     void update(void) override;

--- a/libraries/AP_RPM/RPM_Pin.cpp
+++ b/libraries/AP_RPM/RPM_Pin.cpp
@@ -13,25 +13,19 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "RPM_Pin.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_PIN_ENABLED
 
-#include <AP_HAL/AP_HAL.h>
+#include "RPM_Pin.h"
 
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/GPIO.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Math/AP_Math.h>
 
 extern const AP_HAL::HAL& hal;
 AP_RPM_Pin::IrqState AP_RPM_Pin::irq_state[RPM_MAX_INSTANCES];
-
-/* 
-   open the sensor in constructor
-*/
-AP_RPM_Pin::AP_RPM_Pin(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_State &_state) :
-	AP_RPM_Backend(_ap_rpm, instance, _state)
-{
-}
 
 /*
   handle interrupt on an instance

--- a/libraries/AP_RPM/RPM_Pin.h
+++ b/libraries/AP_RPM/RPM_Pin.h
@@ -14,20 +14,19 @@
  */
 #pragma once
 
-#include "AP_RPM.h"
-
-#include "RPM_Backend.h"
+#include "AP_RPM_config.h"
 
 #if AP_RPM_PIN_ENABLED
 
+#include "RPM_Backend.h"
+
 #include <Filter/Filter.h>
-#include <AP_Math/AP_Math.h>
 
 class AP_RPM_Pin : public AP_RPM_Backend
 {
 public:
-    // constructor
-    AP_RPM_Pin(AP_RPM &ranger, uint8_t instance, AP_RPM::RPM_State &_state);
+
+    using AP_RPM_Backend::AP_RPM_Backend;
 
     // update state
     void update(void) override;


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           -40     -48               -40    -40    -40
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           -48     -48               -48    -48    -40
MatekF405                      *      *           -32     -40               -40    -32    -40
Pixhawk1-1M-bdshot             *                  -32     -40               -40    -40    -32
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           -32     -32               -32    -32    -32
skyviper-v2450                                    *                                       
```
