### PR TITLE
Tools: Allow enforcing astyle in CLI automatically

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -415,7 +415,7 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "astyle-cleanliness" ]; then
         echo "Checking AStyle code cleanliness"
-        ./Tools/scripts/run_astyle.py
+        ./Tools/scripts/run_astyle.py --dry-run
         continue
     fi
 

--- a/Tools/scripts/run_astyle.py
+++ b/Tools/scripts/run_astyle.py
@@ -14,15 +14,17 @@ import sys
 import argparse
 
 os.environ['PYTHONUNBUFFERED'] = '1'
+DRY_RUN_DEFAULT = False
 
 
 class AStyleChecker(object):
-    def __init__(self):
+    def __init__(self, *, dry_run=DRY_RUN_DEFAULT):
         self.retcode = 0
         self.directories_to_check = [
             'libraries/AP_DDS',
         ]
         self.files_to_check = []
+        self.dry_run = dry_run
 
     def progress(self, string):
         print("****** %s" % (string,))
@@ -31,7 +33,10 @@ class AStyleChecker(object):
         '''run astyle on all files in self.files_to_check'''
         # for path in self.files_to_check:
         #     self.progress("Checking (%s)" % path)
-        astyle_command = ["astyle", "--dry-run"]
+        astyle_command = ["astyle"]
+        if self.dry_run:
+            astyle_command.append("--dry-run")
+
         astyle_command.append("--options=Tools/CodeStyle/astylerc")
         astyle_command.extend(self.files_to_check)
         ret = subprocess.run(
@@ -58,8 +63,11 @@ class AStyleChecker(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Check all Python files for astyle cleanliness')
-    # parser.add_argument('--build', action='store_true', default=False, help='build as well as configure')
+    parser.add_argument('--dry-run',
+                        action='store_true',
+                        default=DRY_RUN_DEFAULT,
+                        help='Perform a trial run with no changes made to check for formatting')
     args = parser.parse_args()
 
-    checker = AStyleChecker()
+    checker = AStyleChecker(dry_run=args.dry_run)
     sys.exit(checker.run())


### PR DESCRIPTION
Instead of running:
`./Tools/CodeStyle/ardupilot-astyle.sh libraries/AP_DDS/*.h libraries/AP_DDS/*.cpp` and so on

You now run:
`./Tools/scripts/run_astyle.py`

CI now specifically has to set the dry-run option, so users don't have to.

This makes it easier to avoid astyle violations in CI. 