### PR TITLE
AP_Networking: Delete entity class pointer

### DIFF
--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -109,6 +109,7 @@ void AP_Networking::init()
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "NET: backend init failed");
         delete backend;
         backend = nullptr;
+        return;
     }
 
     announce_address_changes();

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -107,7 +107,7 @@ void AP_Networking::init()
 
     if (!backend->init()) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "NET: backend init failed");
-        delete backend;
+        // the backend init function creates a thread which references the backend pointer; that thread may be running so don't remove the backend allocation.
         backend = nullptr;
         return;
     }

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -107,6 +107,7 @@ void AP_Networking::init()
 
     if (!backend->init()) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "NET: backend init failed");
+        delete backend;
         backend = nullptr;
     }
 


### PR DESCRIPTION
The generated class pointer variable is set to NULLPTR.
The generated class pointer is released before setting.

AND、I have found the bug.
After setting NULLPTR, this variable was used.
The initialization failed and the process was terminated.