### PR TITLE
Allow multiple External AHRS GPS instances

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain.cpp
@@ -434,7 +434,10 @@ void AP_ExternalAHRS_MicroStrain::post_filter() const
         state.have_origin = true;
     }
 
-    AP::gps().handle_external(gps);
+    uint8_t instance;
+    if (AP::gps().get_first_external_instance(instance)) {
+        AP::gps().handle_external(gps, instance);
+    }
 }
 
 int8_t AP_ExternalAHRS_MicroStrain::get_port(void) const

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -581,8 +581,10 @@ void AP_ExternalAHRS_VectorNav::process_packet2(const uint8_t *b)
                                 Location::AltFrame::ABSOLUTE};
         state.have_origin = true;
     }
-
-    AP::gps().handle_external(gps);
+    uint8_t instance;
+    if (AP::gps().get_first_external_instance(instance)) {
+        AP::gps().handle_external(gps, instance);
+    }
 }
 
 /*

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1346,12 +1346,22 @@ void AP_GPS::handle_msp(const MSP::msp_gps_data_message_t &pkt)
 #endif // HAL_MSP_GPS_ENABLED
 
 #if HAL_EXTERNAL_AHRS_ENABLED
-void AP_GPS::handle_external(const AP_ExternalAHRS::gps_data_message_t &pkt)
+
+bool AP_GPS::get_first_external_instance(uint8_t& instance) const
 {
     for (uint8_t i=0; i<num_instances; i++) {
         if (drivers[i] != nullptr && _type[i] == GPS_TYPE_EXTERNAL_AHRS) {
-            drivers[i]->handle_external(pkt);
+            instance = i;
+            return true;
         }
+    }
+    return false;
+}
+
+void AP_GPS::handle_external(const AP_ExternalAHRS::gps_data_message_t &pkt, const uint8_t instance)
+{
+    if (_type[instance] == GPS_TYPE_EXTERNAL_AHRS && drivers[instance] != nullptr) {
+        drivers[instance]->handle_external(pkt);
     }
 }
 #endif // HAL_EXTERNAL_AHRS_ENABLED

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -249,7 +249,11 @@ public:
     void handle_msp(const MSP::msp_gps_data_message_t &pkt);
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
-    void handle_external(const AP_ExternalAHRS::gps_data_message_t &pkt);
+    // Retrieve the first instance ID that is configured as type GPS_TYPE_EXTERNAL_AHRS.
+    // Can be used by external AHRS systems that only report one GPS to get the instance ID.
+    // Returns true if an instance was found, false otherwise.
+    bool get_first_external_instance(uint8_t& instance) const WARN_IF_UNUSED;
+    void handle_external(const AP_ExternalAHRS::gps_data_message_t &pkt, const uint8_t instance);
 #endif
 
     // Accessor functions


### PR DESCRIPTION
Certain GNSS drivers, like the MicroStrain GQ7, have multiple GPS antennas that get reported separately to the driver. Rather than only handling GPS data for one GPS sensor, or publishing the same GPS data to two external GPS types like recommended in the [tutorial](https://ardupilot.org/copter/docs/common-external-ahrs.html), this will allow future drivers to uniquely populate two GPS instances with data. 

To preserve existing behavior, I added a utility to get the first external AHRS instance, which is what the code was doing before.

To consume this new behavior, an external AHRS system could do the following:
```
switch(packet_id)
   case gps_0_packet:
       gps_data = parse_gps_packet(packet)
       AP::gps().handle_external(gps_data , 0)
   case gps_1_packet:
       gps_data = parse_gps_packet(packet)
       AP::gps().handle_external(gps_data , 1)
       
   case imu_packet:
      // like normal
```

I plan to add support for this in MicroStrain's GQ7 AHRS, which reports two unique GPS sensor data packets. 