### PR TITLE
AP_MISSION: Add nan mission sanity checks to various mission commands

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -942,6 +942,15 @@ MAV_MISSION_RESULT AP_Mission::sanity_check_params(const mavlink_mission_item_in
     case MAV_CMD_NAV_VTOL_LAND:
         nan_mask = ~((1 << 2) | (1 << 3)); // param 3 and 4 can be nan
         break;
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        nan_mask = ~((1 << 1) | (1 << 2) | (1 << 3)); // param 2, 3 and 4 can be nan
+        break;
+    case MAV_CMD_VIDEO_START_CAPTURE:
+        nan_mask = ~((1 << 2) | (1 << 3)); // param 3 and 4 can be nan
+        break;
+    case MAV_CMD_VIDEO_STOP_CAPTURE:
+        nan_mask = ~((1 << 1) | (1 << 2) | (1 << 3)); // param 2, 3 and 4 can be nan
+        break;
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:    // Special case for MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW: replicates sanity check in AP_MOUNT library
         if ((!isnan(packet.param1) != !isnan(packet.param2)) ||             // Reject if only one angle is NaN
             (!isnan(packet.param3) != !isnan(packet.param4)) ||             // Reject if only one turn rate is NaN


### PR DESCRIPTION
Hello,
As I continue to troubleshoot ArduPilot compatibility with MAVSDK Mission module (https://github.com/mavlink/MAVSDK/issues/2110), I noticed that several camera action commands did not have proper NaN support. ArduPilot was rejecting what are valid commands according to Mavlink due to invalid parameters:

**MAV_CMD_IMAGE_STOP_CAPTURE:**
Params 2, 3 and 4 [can be set to NaN](https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_STOP_CAPTURE). Since these are reserved commands, their values are not saved to EEPROM and having these params as NaN has no effect.

**MAV_CMD_VIDEO_START_CAPTURE:**
Params 3 and 4 [can be set to NaN](https://mavlink.io/en/messages/common.html#MAV_CMD_VIDEO_START_CAPTURE). Since these are reserved commands, their values are not saved to EEPROM and having these params as NaN has no effect.

**MAV_CMD_VIDEO_STOP_CAPTURE:**
Params 2, 3 and 4 [can be set to NaN](https://mavlink.io/en/messages/common.html#MAV_CMD_VIDEO_STOP_CAPTURE). Since these are reserved commands, their values are not saved to EEPROM and having these params as NaN has no effect.

**MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:**
Params 1, 2, 3 and 4 [can be set to NaN](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW). This command is special as 
commands stored to EEPROM can be NaN. To address this, I wrote the sanity check in a way that only accepts the following three cases:
1. Both angles are defined and both turn rates are NaN
2. Both angles are NaN and both turn rates are defined
3. All angles and turn rates are defined, angles will be set and turn rates will be ignored
These three cases are consistent with the implementation in AP_Mount https://github.com/ArduPilot/ardupilot/issues/23053.
Since these are the only cases that are accepted, I created a workaround to allow for a NaN value to be saved to mission storage. In case 2, I set the first angle to 100 degrees, which is outside of the allowed tolerance of +/- 90 degrees. This causes the angle set method to skip and allows for setting the turn rates. 

In terms of testing, the only testing I have done is in ArduPilot SITL is to see if the commands are accepted. I have not tested with real hardware.