### PR TITLE
AP_MISSION: Add missing do nothing commands mavsdk compatability

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -376,6 +376,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_AUX_FUNCTION:
     case MAV_CMD_DO_SET_RESUME_REPEAT_DIST:
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
+    case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
     case MAV_CMD_JUMP_TAG:
     case MAV_CMD_IMAGE_START_CAPTURE:
     case MAV_CMD_SET_CAMERA_ZOOM:
@@ -438,6 +439,8 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         return command_do_set_repeat_dist(cmd);
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         return start_command_do_gimbal_manager_pitchyaw(cmd);
+    case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:   //  Does nothing as current ArduPilot codebase does not check for who has gimbal control
+        return true;
     case MAV_CMD_JUMP_TAG:
         _jump_tag.tag = cmd.content.jump.target;
         _jump_tag.age = 1;
@@ -1335,6 +1338,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.video_stop_capture.video_stream_id = packet.param1;
         break;
 
+    case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:           // MAV ID: 1001
+        break;                                          // Does nothing as current ArduPilot codebase does not check for who has gimbal control
+
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1847,6 +1853,9 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_VIDEO_STOP_CAPTURE:
         packet.param1 = cmd.content.video_stop_capture.video_stream_id;
         break;
+
+    case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:           // MAV ID: 1001
+        break;                                          // Does nothing as current ArduPilot codebase does not check for who has gimbal control
 
     default:
         // unrecognised command
@@ -2651,6 +2660,8 @@ const char *AP_Mission::Mission_Command::type() const
         return "PauseContinue";
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         return "GimbalPitchYaw";
+    case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
+        return "GimbalConfigure";
     case MAV_CMD_IMAGE_START_CAPTURE:
         return "ImageStartCapture";
     case MAV_CMD_SET_CAMERA_ZOOM:

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -379,6 +379,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
     case MAV_CMD_JUMP_TAG:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_VIDEO_START_CAPTURE:
@@ -423,6 +424,7 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     case MAV_CMD_DO_DIGICAM_CONTROL:
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_VIDEO_START_CAPTURE:
@@ -1320,6 +1322,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.image_start_capture.start_seq_number = packet.param4;
         break;
 
+    case MAV_CMD_IMAGE_STOP_CAPTURE:        // Does nothing as current ArduPilot codebase has not implemented this command
+        break;
+
     case MAV_CMD_SET_CAMERA_ZOOM:
         cmd.content.set_camera_zoom.zoom_type = packet.param1;
         cmd.content.set_camera_zoom.zoom_value = packet.param2;
@@ -1834,6 +1839,9 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param2 = cmd.content.image_start_capture.interval_s;
         packet.param3 = cmd.content.image_start_capture.total_num_images;
         packet.param4 = cmd.content.image_start_capture.start_seq_number;
+        break;
+
+    case MAV_CMD_IMAGE_STOP_CAPTURE:        // Does nothing as current ArduPilot codebase has not implemented this command
         break;
 
     case MAV_CMD_SET_CAMERA_ZOOM:
@@ -2664,6 +2672,8 @@ const char *AP_Mission::Mission_Command::type() const
         return "GimbalConfigure";
     case MAV_CMD_IMAGE_START_CAPTURE:
         return "ImageStartCapture";
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        return "ImageStopCapture";
     case MAV_CMD_SET_CAMERA_ZOOM:
         return "SetCameraZoom";
     case MAV_CMD_SET_CAMERA_FOCUS:

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -166,6 +166,9 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         camera->take_picture();
         return true;
 
+    case MAV_CMD_IMAGE_STOP_CAPTURE:        // Does nothing as current ArduPilot codebase has not implemented this command
+        return true;
+        
     case MAV_CMD_VIDEO_START_CAPTURE:
     case MAV_CMD_VIDEO_STOP_CAPTURE:
     {


### PR DESCRIPTION
_In support of https://github.com/ArduPilot/ardupilot/issues/24692_
Hello,
As I continue to troubleshoot ArduPilot compatibility with MAVSDK Mission module, I noticed that several camera action commands are missing. ArduPilot was rejecting mission sequences generated by MAVSDK that included MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE and MAV_CMD_IMAGE_STOP_CAPTURE.

After examining the code in the AP_Mount and AP_Camera libraries, I concluded that these two commands do not do anything of importance. My solution to extend MAVSDK compatibility is to add these two commands as mission commands that do nothing for now and then implement the proper functions of the commands as they are implemented in AP_Mount/AP_Camera.

**MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:** 
Support for this command was recently added to AP_Mount from PR https://github.com/ArduPilot/ardupilot/pull/23737. This PR added the ability to set who is in primary control of a gimbal to the struct mavlink_control_id. https://github.com/ArduPilot/ardupilot/blob/7d264f1700d1d931ec401774be71bc170f158157/libraries/AP_Mount/AP_Mount_Backend.h#L270-L275
This struct is not used anywhere except to broadcast who is in control of the gimbal in the gimbal_manager_status message.
Since this struct is not used for actual gimbal control, my interim solution to allow for MAVSDK compatibility is to allow for MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE to be accepted as a mission command and have it do nothing. In the future, I can try to implement this command like in PR https://github.com/ArduPilot/ardupilot/pull/23737 to allow for the gimbal control struct to be populated (if it is deemed important enough to need to be done now) and definately once gimbal development advances to a point where gimbal control is developed. 

**MAV_CMD_IMAGE_STOP_CAPTURE:**
This command currently not implemented in the AP_Camera library. My interim solution to allow for MAVSDK compatibility is to allow for this mission command to be accepted and do nothing until support is added into AP_Camera.

In terms of testing, the only testing I have done is in ArduPilot SITL is to see if the commands are accepted. I have not tested with real hardware.

Does this sound like a reasonable solution to add MAVSDK compatibility now while allowing for further gimbal/camera development? 