### PR TITLE
Tools : Added custom ROS-2 service definition for switching drive modes

### DIFF
--- a/Tools/ros2/ardupilot_msgs/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ArmMotors.srv"
+  "srv/ModeSwitch.srv"
   ADD_LINTER_TESTS
 )
 

--- a/Tools/ros2/ardupilot_msgs/srv/ModeSwitch.srv
+++ b/Tools/ros2/ardupilot_msgs/srv/ModeSwitch.srv
@@ -1,0 +1,15 @@
+
+# This service requests the vehicle to switch its drive/flight mode
+
+# mode : Set the value to the drive/flight mode to be used
+# Copter : https://mavlink.io/en/messages/ardupilotmega.html#COPTER_MODE
+# Rover  : https://mavlink.io/en/messages/ardupilotmega.html#ROVER_MODE
+# Plane  : https://mavlink.io/en/messages/ardupilotmega.html#PLANE_MODE
+
+uint8 mode
+---
+# status    : True if the request for mode switch was successful, False otherwise
+# curr_mode : Returns the code for the current drive/flight mode , after the processing the request
+
+bool status
+uint8 curr_mode


### PR DESCRIPTION
Added custom ROS-2 service definition for switching drive modes.
Service definition used from [here](https://github.com/arshPratap/ardupilot_ros2/blob/main/ap_custom_services/srv/ModeSelect.srv)
@Ryanf55 @srmainwaring @tridge 