### PR TITLE
Global: Class definition of AC_FENCE_TYPE and AC_FENCE_ACTION

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -345,7 +345,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     bool fence_requires_gps = false;
     #if AP_FENCE_ENABLED
     // if circular or polygon fence is enabled we need GPS
-    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
+    fence_requires_gps = (copter.fence.get_enabled_fences() & (uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON))) > 0;
     #endif
 
     // check if flight mode requires GPS
@@ -447,7 +447,7 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     bool fence_requires_gps = false;
     #if AP_FENCE_ENABLED
     // if circular or polygon fence is enabled we need GPS
-    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
+    fence_requires_gps = (copter.fence.get_enabled_fences() & (uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON))) > 0;
     #endif
 
     if (mode_requires_gps) {

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -29,11 +29,11 @@ void Copter::fence_check()
 
         // if the user wants some kind of response and motors are armed
         uint8_t fence_act = fence.get_action();
-        if (fence_act != AC_FENCE_ACTION_REPORT_ONLY ) {
+        if (fence_act != uint8_t(AC_FENCE_ACTION::REPORT_ONLY) ) {
 
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down
-            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))){
+            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & uint8_t(AC_FENCE_TYPE::ALT_MAX))== 0))){
                 arming.disarm(AP_Arming::Method::FENCEBREACH);
 
             } else {
@@ -42,19 +42,19 @@ void Copter::fence_check()
                 if (fence.get_breach_distance(new_breaches) > AC_FENCE_GIVE_UP_DISTANCE) {
                     set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                 } else {
-                    switch (fence_act) {
-                    case AC_FENCE_ACTION_RTL_AND_LAND:
+                    switch (AC_FENCE_ACTION(fence_act)) {
+                    case AC_FENCE_ACTION::RTL_AND_LAND:
                     default:
                         // switch to RTL, if that fails then Land
                         if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         }
                         break;
-                    case AC_FENCE_ACTION_ALWAYS_LAND:
+                    case AC_FENCE_ACTION::ALWAYS_LAND:
                         // if always land option mode is specified, land
                         set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         break;
-                    case AC_FENCE_ACTION_SMART_RTL:
+                    case AC_FENCE_ACTION::SMART_RTL:
                         // Try SmartRTL, if that fails, RTL, if that fails Land
                         if (!set_mode(Mode::Number::SMART_RTL, ModeReason::FENCE_BREACHED)) {
                             if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
@@ -62,13 +62,13 @@ void Copter::fence_check()
                             }
                         }
                         break;
-                    case AC_FENCE_ACTION_BRAKE:
+                    case AC_FENCE_ACTION::BRAKE:
                         // Try Brake, if that fails Land
                         if (!set_mode(Mode::Number::BRAKE, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         }
                         break;
-                    case AC_FENCE_ACTION_SMART_RTL_OR_LAND:
+                    case AC_FENCE_ACTION::SMART_RTL_OR_LAND:
                         // Try SmartRTL, if that fails, Land
                         if (!set_mode(Mode::Number::SMART_RTL, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -501,7 +501,7 @@ void ModeRTL::compute_return_target()
     //       if terrain altitudes are being used, the code below which reduces the return_target's altitude can lead to
     //       the vehicle not climbing at all as RTL begins.  This can be overly conservative and it might be better
     //       to apply the fence alt limit independently on the origin_point and return_target
-    if ((copter.fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    if ((copter.fence.get_enabled_fences() & uint8_t(AC_FENCE_TYPE::ALT_MAX)) != 0) {
         // get return target as alt-above-home so it can be compared to fence's alt
         if (rtl_path.return_target.get_alt_cm(Location::AltFrame::ABOVE_HOME, target_alt)) {
             float fence_alt = copter.fence.get_safe_alt_max()*100.0f;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1402,7 +1402,7 @@ void Plane::load_parameters(void)
     if (fence_type_new && !fence_type_new->configured()) {
         // If we find the new parameter and it hasn't been configured
         // attempt to upgrade the altitude fences.
-        int8_t fence_type_new_val = AC_FENCE_TYPE_POLYGON;
+        int8_t fence_type_new_val = int8_t(AC_FENCE_TYPE::POLYGON);
         AP_Int16 fence_alt_min_old;
         AP_Param::ConversionInfo fence_alt_min_info_old = {
             Parameters::k_param_fence_minalt,
@@ -1413,7 +1413,7 @@ void Plane::load_parameters(void)
         if (AP_Param::find_old_parameter(&fence_alt_min_info_old, &fence_alt_min_old)) {
             if (fence_alt_min_old.configured()) {
                 //
-                fence_type_new_val |= AC_FENCE_TYPE_ALT_MIN;
+                fence_type_new_val |= int8_t(AC_FENCE_TYPE::ALT_MIN);
             }
         }
 
@@ -1426,7 +1426,7 @@ void Plane::load_parameters(void)
         };
         if (AP_Param::find_old_parameter(&fence_alt_max_info_old, &fence_alt_max_old)) {
             if (fence_alt_max_old.configured()) {
-                fence_type_new_val |= AC_FENCE_TYPE_ALT_MAX;
+                fence_type_new_val |= int8_t(AC_FENCE_TYPE::ALT_MAX);
             }
         }
 
@@ -1449,16 +1449,16 @@ void Plane::load_parameters(void)
                 case 0: // FENCE_ACTION_NONE
                 case 2: // FENCE_ACTION_REPORT_ONLY
                 default:
-                    fence_action_new_val = AC_FENCE_ACTION_REPORT_ONLY;
+                    fence_action_new_val = uint8_t(AC_FENCE_ACTION::REPORT_ONLY);
                     break;
                 case 1: // FENCE_ACTION_GUIDED
-                    fence_action_new_val = AC_FENCE_ACTION_GUIDED;
+                    fence_action_new_val = uint8_t(AC_FENCE_ACTION::GUIDED);
                     break;
                 case 3: // FENCE_ACTION_GUIDED_THR_PASS
-                    fence_action_new_val = AC_FENCE_ACTION_GUIDED_THROTTLE_PASS;
+                    fence_action_new_val = uint8_t(AC_FENCE_ACTION::GUIDED_THROTTLE_PASS);
                     break;
                 case 4: // FENCE_ACTION_RTL
-                    fence_action_new_val = AC_FENCE_ACTION_RTL_AND_LAND;
+                    fence_action_new_val = uint8_t(AC_FENCE_ACTION::RTL_AND_LAND);
                     break;
             }
             fence_action_new->set_and_save((int8_t)fence_action_new_val);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -343,11 +343,11 @@ void Plane::check_fbwb_altitude(void)
 #if AP_FENCE_ENABLED
     // taking fence max and min altitude (with margin)
     const uint8_t enabled_fences = plane.fence.get_enabled_fences();
-    if ((enabled_fences & AC_FENCE_TYPE_ALT_MIN) != 0) {
+    if ((enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MIN)) != 0) {
         min_alt_cm = plane.fence.get_safe_alt_min()*100.0;
         should_check_min = true;
     }
-    if ((enabled_fences & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    if ((enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MAX)) != 0) {
         max_alt_cm = plane.fence.get_safe_alt_max()*100.0;
         should_check_max = true;
     }

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -15,10 +15,10 @@ void Plane::fence_check()
     if (!fence.enabled()) {
         // Switch back to the chosen control mode if still in
         // GUIDED to the return point
-        switch(fence.get_action()) {
-            case AC_FENCE_ACTION_GUIDED:
-            case AC_FENCE_ACTION_GUIDED_THROTTLE_PASS:
-            case AC_FENCE_ACTION_RTL_AND_LAND:
+        switch(AC_FENCE_ACTION(fence.get_action())) {
+            case AC_FENCE_ACTION::GUIDED:
+            case AC_FENCE_ACTION::GUIDED_THROTTLE_PASS:
+            case AC_FENCE_ACTION::RTL_AND_LAND:
                 if (plane.control_mode_reason == ModeReason::FENCE_BREACHED &&
                     control_mode->is_guided_mode()) {
                     set_mode(*previous_mode, ModeReason::FENCE_RETURN_PREVIOUS_MODE);
@@ -54,13 +54,14 @@ void Plane::fence_check()
 
         // if the user wants some kind of response and motors are armed
         const uint8_t fence_act = fence.get_action();
-        switch (fence_act) {
-        case AC_FENCE_ACTION_REPORT_ONLY:
+        switch (AC_FENCE_ACTION(fence_act)) {
+        case AC_FENCE_ACTION::REPORT_ONLY:
+        default:
             break;
-        case AC_FENCE_ACTION_GUIDED:
-        case AC_FENCE_ACTION_GUIDED_THROTTLE_PASS:
-        case AC_FENCE_ACTION_RTL_AND_LAND:
-            if (fence_act == AC_FENCE_ACTION_RTL_AND_LAND) {
+        case AC_FENCE_ACTION::GUIDED:
+        case AC_FENCE_ACTION::GUIDED_THROTTLE_PASS:
+        case AC_FENCE_ACTION::RTL_AND_LAND:
+            if (AC_FENCE_ACTION(fence_act) == AC_FENCE_ACTION::RTL_AND_LAND) {
                 if (control_mode == &mode_auto &&
                     mission.get_in_landing_sequence_flag() &&
                     (g.rtl_autoland == RtlAutoland::RTL_THEN_DO_LAND_START ||
@@ -74,7 +75,7 @@ void Plane::fence_check()
             }
 
             Location loc;
-            if (fence.get_return_rally() != 0 || fence_act == AC_FENCE_ACTION_RTL_AND_LAND) {
+            if (fence.get_return_rally() != 0 || AC_FENCE_ACTION(fence_act) == AC_FENCE_ACTION::RTL_AND_LAND) {
                 loc = calc_best_rally_or_home_location(current_loc, get_RTL_altitude_cm());
             } else {
                 //return to fence return point, not a rally point
@@ -103,12 +104,12 @@ void Plane::fence_check()
                 }
             }
 
-            if (fence.get_action() != AC_FENCE_ACTION_RTL_AND_LAND) {
+            if (AC_FENCE_ACTION(fence.get_action()) != AC_FENCE_ACTION::RTL_AND_LAND) {
                 setup_terrain_target_alt(loc);
                 set_guided_WP(loc);
             }
 
-            if (fence.get_action() == AC_FENCE_ACTION_GUIDED_THROTTLE_PASS) {
+            if (AC_FENCE_ACTION(fence.get_action()) == AC_FENCE_ACTION::GUIDED_THROTTLE_PASS) {
                 guided_throttle_passthru = true;
             }
             break;

--- a/ArduSub/fence.cpp
+++ b/ArduSub/fence.cpp
@@ -22,7 +22,7 @@ void Sub::fence_check()
     if (new_breaches) {
 
         // if the user wants some kind of response and motors are armed
-        if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
+        if (fence.get_action() != AC_FENCE_ACTION::REPORT_ONLY) {
             //
             //            // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             //            // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1493,7 +1493,7 @@ class AutoTestPlane(AutoTest):
             # test a rather unfortunate behaviour:
             self.progress("Killing a live fence with fence-clear")
             self.load_fence("CMAC-fence.txt")
-            self.set_parameter("FENCE_ACTION", 1) # AC_FENCE_ACTION_RTL_AND_LAND == 1. mavutil.mavlink.FENCE_ACTION_RTL == 4
+            self.set_parameter("FENCE_ACTION", 1) # AC_FENCE_ACTION::RTL_AND_LAND == 1. mavutil.mavlink.FENCE_ACTION_RTL == 4
             self.do_fence_enable()
             self.assert_fence_sys_status(True, True, True)
             self.clear_fence()
@@ -1589,7 +1589,7 @@ class AutoTestPlane(AutoTest):
             self.set_parameters({
                 "RTL_RADIUS": want_radius,
                 "NAVL1_LIM_BANK": 60,
-                "FENCE_ACTION": 1, # AC_FENCE_ACTION_RTL_AND_LAND == 1. mavutil.mavlink.FENCE_ACTION_RTL == 4
+                "FENCE_ACTION": 1, # AC_FENCE_ACTION::RTL_AND_LAND == 1. mavutil.mavlink.FENCE_ACTION_RTL == 4
             })
 
             self.wait_ready_to_arm()  # need an origin to load fence

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -373,7 +373,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
 #if AP_FENCE_ENABLED
     // calculate distance below fence
     AC_Fence *fence = AP::fence();
-    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0 && fence && (fence->get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) > 0) {
+    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0 && fence && (fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::ALT_MAX)) > 0) {
         // calculate distance from vehicle to safe altitude
         float veh_alt;
         _ahrs.get_relative_position_D_home(veh_alt);
@@ -681,12 +681,12 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     AC_Fence &_fence = *fence;
 
     // exit if circular fence is not enabled
-    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+    if ((_fence.get_enabled_fences() & uint8_t(AC_FENCE_TYPE::CIRCLE)) == 0) {
         return;
     }
 
     // exit if the circular fence has already been breached
-    if ((_fence.get_breaches() & AC_FENCE_TYPE_CIRCLE) != 0) {
+    if ((_fence.get_breaches() & uint8_t(AC_FENCE_TYPE::CIRCLE)) != 0) {
         return;
     }
 
@@ -796,7 +796,7 @@ void AC_Avoid::adjust_velocity_inclusion_and_exclusion_polygons(float kP, float 
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) == 0) {
         return;
     }
 
@@ -845,7 +845,7 @@ void AC_Avoid::adjust_velocity_inclusion_circles(float kP, float accel_cmss, Vec
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) == 0) {
         return;
     }
 
@@ -982,7 +982,7 @@ void AC_Avoid::adjust_velocity_exclusion_circles(float kP, float accel_cmss, Vec
     }
 
     // exit if polygon fences are not enabled
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) == 0) {
         return;
     }
 

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -463,7 +463,7 @@ bool AP_OABendyRuler::calc_margin_from_circular_fence(const Location &start, con
     if (fence == nullptr) {
         return false;
     }
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::CIRCLE)) == 0) {
         return false;
     }
 
@@ -493,7 +493,7 @@ bool AP_OABendyRuler::calc_margin_from_alt_fence(const Location &start, const Lo
     if (fence == nullptr) {
         return false;
     }
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::ALT_MAX)) == 0) {
         return false;
     }
 
@@ -530,7 +530,7 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_polygons(const Lo
     }
 
     // exclusion polygons enabled along with polygon fences
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) == 0) {
         return false;
     }
 
@@ -601,7 +601,7 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_circles(const Loc
     }
 
     // inclusion/exclusion circles enabled along with polygon fences
-    if ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+    if ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) == 0) {
         return false;
     }
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -200,7 +200,7 @@ bool AP_OADijkstra::some_fences_enabled() const
         (fence->polyfence().get_exclusion_circle_count() == 0)) {
         return false;
     }
-    return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
+    return ((fence->get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON)) > 0);
 }
 
 // return error message for a given error id

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -18,11 +18,11 @@
 extern const AP_HAL::HAL& hal;
 
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
-#define AC_FENCE_TYPE_DEFAULT AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON
+#define AC_FENCE_TYPE_DEFAULT uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON)
 #elif APM_BUILD_TYPE(APM_BUILD_ArduPlane)
-#define AC_FENCE_TYPE_DEFAULT AC_FENCE_TYPE_POLYGON
+#define AC_FENCE_TYPE_DEFAULT uint8_t(AC_FENCE_TYPE::POLYGON)
 #else
-#define AC_FENCE_TYPE_DEFAULT AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON
+#define AC_FENCE_TYPE_DEFAULT uint8_t(AC_FENCE_TYPE::ALT_MAX) | uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON)
 #endif
 
 // default boundaries
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Values{Plane}: 0:Report Only,1:RTL,6:Guided,7:GuidedThrottlePass
     // @Values: 0:Report Only,1:RTL or Land
     // @User: Standard
-    AP_GROUPINFO("ACTION",      2,  AC_Fence,   _action,        AC_FENCE_ACTION_RTL_AND_LAND),
+    AP_GROUPINFO("ACTION",      2,  AC_Fence,   _action,        uint8_t(AC_FENCE_ACTION::RTL_AND_LAND)),
 
     // @Param{Copter, Plane, Sub}: ALT_MAX
     // @DisplayName: Fence Maximum Altitude
@@ -167,7 +167,7 @@ void AC_Fence::enable(bool value)
     }
     _enabled.set(value);
     if (!value) {
-        clear_breach(AC_FENCE_TYPE_ALT_MIN | AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON);
+        clear_breach(uint8_t(AC_FENCE_TYPE::ALT_MIN) | uint8_t(AC_FENCE_TYPE::ALT_MAX) | uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON));
         disable_floor();
     } else {
         enable_floor();
@@ -191,7 +191,7 @@ void AC_Fence::disable_floor()
         AP::logger().Write_Event(LogEvent::FENCE_FLOOR_DISABLE);
     }
     _floor_enabled = false;
-    clear_breach(AC_FENCE_TYPE_ALT_MIN);
+    clear_breach(uint8_t(AC_FENCE_TYPE::ALT_MIN));
 }
 
 /*
@@ -238,10 +238,10 @@ bool AC_Fence::present() const
     //   * tin can (circle) is enabled
     //   * min or max alt is enabled
     //   * polygon fences are enabled and any fence has been uploaded
-    if (enabled_fences & AC_FENCE_TYPE_CIRCLE ||
-        enabled_fences & AC_FENCE_TYPE_ALT_MIN ||
-        enabled_fences & AC_FENCE_TYPE_ALT_MAX ||
-        ((enabled_fences & AC_FENCE_TYPE_POLYGON) && _poly_loader.total_fence_count() > 0)) {
+    if (enabled_fences & uint8_t(AC_FENCE_TYPE::CIRCLE) ||
+        enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MIN) ||
+        enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MAX) ||
+        ((enabled_fences & uint8_t(AC_FENCE_TYPE::POLYGON)) && _poly_loader.total_fence_count() > 0)) {
         return true;
     }
 
@@ -260,7 +260,7 @@ uint8_t AC_Fence::get_enabled_fences() const
 // additional checks for the polygon fence:
 bool AC_Fence::pre_arm_check_polygon(const char* &fail_msg) const
 {
-    if (!(_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
+    if (!(_enabled_fences & uint8_t(AC_FENCE_TYPE::POLYGON))) {
         // not enabled; all good
         return true;
     }
@@ -327,8 +327,8 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
 
     // if we have horizontal limits enabled, check we can get a
     // relative position from the AHRS
-    if ((_enabled_fences & AC_FENCE_TYPE_CIRCLE) ||
-        (_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
+    if ((_enabled_fences & uint8_t(AC_FENCE_TYPE::CIRCLE)) ||
+        (_enabled_fences & uint8_t(AC_FENCE_TYPE::POLYGON))) {
         Vector2f position;
         if (!AP::ahrs().get_relative_position_NE_home(position)) {
             fail_msg = "Fence requires position";
@@ -380,7 +380,7 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
 bool AC_Fence::check_fence_alt_max()
 {
     // altitude fence check
-    if (!(_enabled_fences & AC_FENCE_TYPE_ALT_MAX)) {
+    if (!(_enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MAX))) {
         // not enabled; no breach
         return false;
     }
@@ -395,11 +395,11 @@ bool AC_Fence::check_fence_alt_max()
         _alt_max_breach_distance = _curr_alt - _alt_max;
 
         // check for a new breach or a breach of the backup fence
-        if (!(_breached_fences & AC_FENCE_TYPE_ALT_MAX) ||
+        if (!(_breached_fences & uint8_t(AC_FENCE_TYPE::ALT_MAX)) ||
             (!is_zero(_alt_max_backup) && _curr_alt >= _alt_max_backup)) {
 
             // new breach
-            record_breach(AC_FENCE_TYPE_ALT_MAX);
+            record_breach(uint8_t(AC_FENCE_TYPE::ALT_MAX));
 
             // create a backup fence 20m higher up
             _alt_max_backup = _curr_alt + AC_FENCE_ALT_MAX_BACKUP_DISTANCE;
@@ -413,8 +413,8 @@ bool AC_Fence::check_fence_alt_max()
     // not breached
 
     // clear max alt breach if present
-    if ((_breached_fences & AC_FENCE_TYPE_ALT_MAX) != 0) {
-        clear_breach(AC_FENCE_TYPE_ALT_MAX);
+    if ((_breached_fences & uint8_t(AC_FENCE_TYPE::ALT_MAX)) != 0) {
+        clear_breach(uint8_t(AC_FENCE_TYPE::ALT_MAX));
         _alt_max_backup = 0.0f;
         _alt_max_breach_distance = 0.0f;
     }
@@ -428,7 +428,7 @@ bool AC_Fence::check_fence_alt_max()
 bool AC_Fence::check_fence_alt_min()
 {
     // altitude fence check
-    if (!(_enabled_fences & AC_FENCE_TYPE_ALT_MIN)) {
+    if (!(_enabled_fences & uint8_t(AC_FENCE_TYPE::ALT_MIN))) {
         // not enabled; no breach
         return false;
     }
@@ -443,11 +443,11 @@ bool AC_Fence::check_fence_alt_min()
         _alt_min_breach_distance = _alt_min - _curr_alt;
 
         // check for a new breach or a breach of the backup fence
-        if (!(_breached_fences & AC_FENCE_TYPE_ALT_MIN) ||
+        if (!(_breached_fences & uint8_t(AC_FENCE_TYPE::ALT_MIN)) ||
             (!is_zero(_alt_min_backup) && _curr_alt <= _alt_min_backup)) {
 
             // new breach
-            record_breach(AC_FENCE_TYPE_ALT_MIN);
+            record_breach(uint8_t(AC_FENCE_TYPE::ALT_MIN));
 
             // create a backup fence 20m lower down
             _alt_min_backup = _curr_alt - AC_FENCE_ALT_MIN_BACKUP_DISTANCE;
@@ -461,8 +461,8 @@ bool AC_Fence::check_fence_alt_min()
     // not breached
 
     // clear min alt breach if present
-    if ((_breached_fences & AC_FENCE_TYPE_ALT_MIN) != 0) {
-        clear_breach(AC_FENCE_TYPE_ALT_MIN);
+    if ((_breached_fences & uint8_t(AC_FENCE_TYPE::ALT_MIN)) != 0) {
+        clear_breach(uint8_t(AC_FENCE_TYPE::ALT_MIN));
         _alt_min_backup = 0.0f;
         _alt_min_breach_distance = 0.0f;
     }
@@ -475,18 +475,18 @@ bool AC_Fence::check_fence_alt_min()
 // inclusions zones
 bool AC_Fence::check_fence_polygon()
 {
-    const bool was_breached = _breached_fences & AC_FENCE_TYPE_POLYGON;
-    const bool breached = ((_enabled_fences & AC_FENCE_TYPE_POLYGON) &&
+    const bool was_breached = _breached_fences & uint8_t(AC_FENCE_TYPE::POLYGON);
+    const bool breached = ((_enabled_fences & uint8_t(AC_FENCE_TYPE::POLYGON)) &&
                            _poly_loader.breached());
     if (breached) {
         if (!was_breached) {
-            record_breach(AC_FENCE_TYPE_POLYGON);
+            record_breach(uint8_t(AC_FENCE_TYPE::POLYGON));
             return true;
         }
         return false;
     }
     if (was_breached) {
-        clear_breach(AC_FENCE_TYPE_POLYGON);
+        clear_breach(uint8_t(AC_FENCE_TYPE::POLYGON));
     }
     return false;
 }
@@ -497,7 +497,7 @@ bool AC_Fence::check_fence_polygon()
 /// fence is breaced.
 bool AC_Fence::check_fence_circle()
 {
-    if (!(_enabled_fences & AC_FENCE_TYPE_CIRCLE)) {
+    if (!(_enabled_fences & uint8_t(AC_FENCE_TYPE::CIRCLE))) {
         // not enabled; no breach
         return false;
     }
@@ -515,11 +515,11 @@ bool AC_Fence::check_fence_circle()
         _circle_breach_distance = _home_distance - _circle_radius;
 
         // check for a new breach or a breach of the backup fence
-        if (!(_breached_fences & AC_FENCE_TYPE_CIRCLE) ||
+        if (!(_breached_fences & uint8_t(AC_FENCE_TYPE::CIRCLE)) ||
             (!is_zero(_circle_radius_backup) && _home_distance >= _circle_radius_backup)) {
             // new breach
             // create a backup fence 20m further out
-            record_breach(AC_FENCE_TYPE_CIRCLE);
+            record_breach(uint8_t(AC_FENCE_TYPE::CIRCLE));
             _circle_radius_backup = _home_distance + AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE;
             return true;
         }
@@ -529,8 +529,8 @@ bool AC_Fence::check_fence_circle()
     // not currently breached
 
     // clear circle breach if present
-    if (_breached_fences & AC_FENCE_TYPE_CIRCLE) {
-        clear_breach(AC_FENCE_TYPE_CIRCLE);
+    if (_breached_fences & uint8_t(AC_FENCE_TYPE::CIRCLE)) {
+        clear_breach(uint8_t(AC_FENCE_TYPE::CIRCLE));
         _circle_radius_backup = 0.0f;
         _circle_breach_distance = 0.0f;
     }
@@ -565,22 +565,22 @@ uint8_t AC_Fence::check()
 
     // maximum altitude fence check
     if (check_fence_alt_max()) {
-        ret |= AC_FENCE_TYPE_ALT_MAX;
+        ret |= uint8_t(AC_FENCE_TYPE::ALT_MAX);
     }
 
     // minimum altitude fence check
     if (_floor_enabled && check_fence_alt_min()) {
-        ret |= AC_FENCE_TYPE_ALT_MIN;
+        ret |= uint8_t(AC_FENCE_TYPE::ALT_MIN);
     }
 
     // circle fence check
     if (check_fence_circle()) {
-        ret |= AC_FENCE_TYPE_CIRCLE;
+        ret |= uint8_t(AC_FENCE_TYPE::CIRCLE);
     }
 
     // polygon fence check
     if (check_fence_polygon()) {
-        ret |= AC_FENCE_TYPE_POLYGON;
+        ret |= uint8_t(AC_FENCE_TYPE::POLYGON);
     }
 
     // return any new breaches that have occurred
@@ -591,7 +591,7 @@ uint8_t AC_Fence::check()
 bool AC_Fence::check_destination_within_fence(const Location& loc)
 {
     // Altitude fence check - Fence Ceiling
-    if ((get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX)) {
+    if ((get_enabled_fences() & uint8_t(AC_FENCE_TYPE::ALT_MAX))) {
         int32_t alt_above_home_cm;
         if (loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm)) {
             if ((alt_above_home_cm * 0.01f) > _alt_max) {
@@ -601,7 +601,7 @@ bool AC_Fence::check_destination_within_fence(const Location& loc)
     }
 
     // Altitude fence check - Fence Floor
-    if ((get_enabled_fences() & AC_FENCE_TYPE_ALT_MIN)) {
+    if ((get_enabled_fences() & uint8_t(AC_FENCE_TYPE::ALT_MIN))) {
         int32_t alt_above_home_cm;
         if (loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, alt_above_home_cm)) {
             if ((alt_above_home_cm * 0.01f) < _alt_min) {
@@ -611,14 +611,14 @@ bool AC_Fence::check_destination_within_fence(const Location& loc)
     }
 
     // Circular fence check
-    if ((get_enabled_fences() & AC_FENCE_TYPE_CIRCLE)) {
+    if ((get_enabled_fences() & uint8_t(AC_FENCE_TYPE::CIRCLE))) {
         if (AP::ahrs().get_home().get_distance(loc) > _circle_radius) {
             return false;
         }
     }
 
     // polygon fence check
-    if ((get_enabled_fences() & AC_FENCE_TYPE_POLYGON)) {
+    if ((get_enabled_fences() & uint8_t(AC_FENCE_TYPE::POLYGON))) {
         if (_poly_loader.breached(loc)) {
             return false;
         }
@@ -663,13 +663,13 @@ float AC_Fence::get_breach_distance(uint8_t fence_type) const
 {
     float max = 0.0f;
 
-    if (fence_type & AC_FENCE_TYPE_ALT_MAX) {
+    if (fence_type & uint8_t(AC_FENCE_TYPE::ALT_MAX)) {
         max = MAX(_alt_max_breach_distance, max);
     }
-    if (fence_type & AC_FENCE_TYPE_ALT_MIN) {
+    if (fence_type & uint8_t(AC_FENCE_TYPE::ALT_MIN)) {
         max = MAX(_alt_min_breach_distance, max);
     }
-    if (fence_type & AC_FENCE_TYPE_CIRCLE) {
+    if (fence_type & uint8_t(AC_FENCE_TYPE::CIRCLE)) {
         max = MAX(_circle_breach_distance, max);
     }
     return max;
@@ -699,7 +699,7 @@ bool AC_Fence::sys_status_enabled() const
     if (!sys_status_present()) {
         return false;
     }
-    if (_action == AC_FENCE_ACTION_REPORT_ONLY) {
+    if (_action == uint8_t(AC_FENCE_ACTION::REPORT_ONLY)) {
         return false;
     }
     // Fence is only enabled when the flag is enabled

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -11,20 +11,24 @@
 #include <AC_Fence/AC_PolyFence_loader.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
-#define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
-#define AC_FENCE_TYPE_CIRCLE                        2       // circular horizontal fence (usually initiates an RTL)
-#define AC_FENCE_TYPE_POLYGON                       4       // polygon horizontal fence
-#define AC_FENCE_TYPE_ALT_MIN                       8       // low alt fence which usually initiates an RTL
+enum class AC_FENCE_TYPE : uint8_t {
+    ALT_MAX = 1,  // high alt fence which usually initiates an RTL
+    CIRCLE  = 2,  // circular horizontal fence (usually initiates an RTL)
+    POLYGON = 4,  // polygon horizontal fence
+    ALT_MIN = 8,  // low alt fence which usually initiates an RTL
+};
 
 // valid actions should a fence be breached
-#define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
-#define AC_FENCE_ACTION_RTL_AND_LAND                1       // return to launch and, if that fails, land
-#define AC_FENCE_ACTION_ALWAYS_LAND                 2       // always land
-#define AC_FENCE_ACTION_SMART_RTL                   3       // smartRTL, if that fails, RTL, it that still fails, land
-#define AC_FENCE_ACTION_BRAKE                       4       // brake, if that fails, land
-#define AC_FENCE_ACTION_SMART_RTL_OR_LAND           5       // SmartRTL, if that fails, Land
-#define AC_FENCE_ACTION_GUIDED                      6       // guided mode, with target waypoint as fence return point
-#define AC_FENCE_ACTION_GUIDED_THROTTLE_PASS        7       // guided mode, but pilot retains manual throttle control
+enum class AC_FENCE_ACTION : uint8_t {
+    REPORT_ONLY          = 0,  // report to GCS that boundary has been breached but take no further action
+    RTL_AND_LAND         = 1,  // return to launch and, if that fails, land
+    ALWAYS_LAND          = 2,  // always land
+    SMART_RTL            = 3,  // smartRTL, if that fails, RTL, it that still fails, land
+    BRAKE                = 4,  // brake, if that fails, land
+    SMART_RTL_OR_LAND    = 5,  // SmartRTL, if that fails, Land
+    GUIDED               = 6,  // guided mode, with target waypoint as fence return point
+    GUIDED_THROTTLE_PASS = 7,  // guided mode, but pilot retains manual throttle control
+};
 
 // give up distance
 #define AC_FENCE_GIVE_UP_DISTANCE                   100.0f  // distance outside the fence at which we should give up and just land.  Note: this is not used by library directly but is intended to be used by the main code

--- a/libraries/GCS_MAVLink/GCS_Fence.cpp
+++ b/libraries/GCS_MAVLink/GCS_Fence.cpp
@@ -71,13 +71,13 @@ void GCS_MAVLINK::send_fence_status() const
     // traslate fence library breach types to mavlink breach types
     uint8_t mavlink_breach_type = FENCE_BREACH_NONE;
     const uint8_t breaches = fence->get_breaches();
-    if ((breaches & AC_FENCE_TYPE_ALT_MIN) != 0) {
+    if ((breaches & uint8_t(AC_FENCE_TYPE::ALT_MIN)) != 0) {
         mavlink_breach_type = FENCE_BREACH_MINALT;
     }
-    if ((breaches & AC_FENCE_TYPE_ALT_MAX) != 0) {
+    if ((breaches & uint8_t(AC_FENCE_TYPE::ALT_MAX)) != 0) {
         mavlink_breach_type = FENCE_BREACH_MAXALT;
     }
-    if ((breaches & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) != 0) {
+    if ((breaches & (uint8_t(AC_FENCE_TYPE::CIRCLE) | uint8_t(AC_FENCE_TYPE::POLYGON))) != 0) {
         mavlink_breach_type = FENCE_BREACH_BOUNDARY;
     }
 


### PR DESCRIPTION
I will make the AC_FENCE_TYPE_XXX and AC_FENCE_ACTION_XXX define definitions into ENUM CLASS definitions.
By defining ENUM CLASS, I can find omissions in the SWITCH statement.