### PR TITLE
Feature/docker update

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # `actions:write` permission is required to delete caches
       #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -145,7 +145,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -145,7 +145,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -125,7 +125,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -126,7 +126,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -125,7 +125,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -133,7 +133,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -134,7 +134,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -133,7 +133,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.0.29
+      image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.1.0
       options: --privileged
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.0.29
       options: --privileged

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.1.0
       options: --privileged
@@ -91,7 +91,7 @@ jobs:
   finish:
     if: always()
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -139,7 +139,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-ros:latest
       options: --user 1001

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -139,7 +139,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-ros:latest
       options: --user 1001

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ${{matrix.os}}:${{matrix.name}}
       options: --privileged

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -68,7 +68,7 @@ jobs:
           software-properties-common
           ;;
           *"archlinux"*)
-          pacman -Sy --noconfirm --needed git sudo
+          pacman -Syu --noconfirm --needed git sudo
           ;;
           esac
 

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ${{matrix.os}}:${{matrix.name}}
       options: --privileged

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -134,7 +134,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -135,7 +135,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -134,7 +134,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -147,7 +147,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -147,7 +147,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -148,7 +148,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test-scripting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-base:v0.0.29
     steps:
       # git checkout the PR

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   test-scripting:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-base:v0.0.29
+    container: ardupilot/ardupilot-dev-base:v0.1.0
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test-scripting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-base:v0.1.0
     steps:
       # git checkout the PR

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -30,6 +30,4 @@ jobs:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
         run: |
-          sudo apt update
-          sudo apt-get install -y astyle
           Tools/scripts/build_ci.sh

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-base:v0.0.29
+    container: ardupilot/ardupilot-dev-base:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-base:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-base:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -161,7 +161,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -207,7 +207,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -275,7 +275,7 @@ jobs:
   build-gcc-heli:
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     steps:
       # git checkout the PR
@@ -310,7 +310,7 @@ jobs:
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-base:v0.0.29
+    container: ardupilot/ardupilot-dev-base:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -160,7 +160,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -205,7 +205,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -273,7 +273,7 @@ jobs:
            retention-days: 7
 
   build-gcc-heli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -309,7 +309,7 @@ jobs:
 
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-base:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -160,7 +160,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -205,7 +205,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -273,7 +273,7 @@ jobs:
            retention-days: 7
 
   build-gcc-heli:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -309,7 +309,7 @@ jobs:
 
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-base:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -159,7 +159,7 @@ concurrency:
 
 jobs:
   build-gcc-ap_periph:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-periph:v0.1.0
     steps:
       # git checkout the PR
@@ -199,7 +199,7 @@ jobs:
 
   autotest-can:
     needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: 
       image: ardupilot/ardupilot-dev-periph:v0.1.0
       options: --privileged

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -159,7 +159,7 @@ concurrency:
 
 jobs:
   build-gcc-ap_periph:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-periph:v0.0.29
     steps:
       # git checkout the PR
@@ -199,7 +199,7 @@ jobs:
 
   autotest-can:
     needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: 
       image: ardupilot/ardupilot-dev-periph:v0.0.29
       options: --privileged

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -160,7 +160,7 @@ concurrency:
 jobs:
   build-gcc-ap_periph:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-periph:v0.0.29
+    container: ardupilot/ardupilot-dev-periph:v0.1.0
     steps:
       # git checkout the PR
       - uses: actions/checkout@v3
@@ -201,7 +201,7 @@ jobs:
     needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container: 
-      image: ardupilot/ardupilot-dev-periph:v0.0.29
+      image: ardupilot/ardupilot-dev-periph:v0.1.0
       options: --privileged
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -162,7 +162,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -208,7 +208,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -161,7 +161,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -206,7 +206,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -161,7 +161,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -206,7 +206,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -160,7 +160,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -205,7 +205,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -160,7 +160,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -205,7 +205,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -161,7 +161,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -207,7 +207,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -164,7 +164,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -210,7 +210,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -163,7 +163,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -208,7 +208,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -163,7 +163,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -208,7 +208,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -164,7 +164,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -210,7 +210,7 @@ jobs:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-base:v0.0.29
+      image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -163,7 +163,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -208,7 +208,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -163,7 +163,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -208,7 +208,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-base:v0.0.29
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -60,7 +60,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -60,7 +60,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -101,7 +101,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
+      image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
       options: --user 1001
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -99,7 +99,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.0.29
       options: --user 1001

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -99,7 +99,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.0
       options: --user 1001

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -544,7 +544,7 @@ def start_SITL(binary,
             cmd.append("--disable-fgview")
 
     if defaults_filepath is not None:
-        if type(defaults_filepath) == list:
+        if isinstance(defaults_filepath, list):
             defaults = [reltopdir(path) for path in defaults_filepath]
             if len(defaults):
                 cmd.extend(['--defaults', ",".join(defaults)])

--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -52,7 +52,7 @@ function maybe_prompt_user() {
 
 sudo usermod -a -G uucp "$USER"
 
-sudo pacman -Sy --noconfirm --needed $BASE_PKGS $SITL_PKGS $PX4_PKGS
+sudo pacman -Syu --noconfirm --needed $BASE_PKGS $SITL_PKGS $PX4_PKGS
 
 python3 -m venv "$HOME"/venv-ardupilot
 


### PR DESCRIPTION
switch github action workers to latest ubuntu (22.04) : impact only test that aren't into a container so esp32 build

Change our docker container to Ubuntu 22.04, this brings :
- gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0 for SITL build and all testing as this is more in sync with developpers environements and newcomers.
- remove arm-none-eabi-gcc6 from the container as we are using gcc-10 as default toolchain now and don't use gcc6 on test
- move to clang-14
- update flake8 to flake8==6.1.0 to match new install and install script, so it will need some fixing on our master branch

only impact master branch and next release. It doesn't impact current 4.3 and 4.3 release as we got versionned docker 

Results from the environement build test are not to be taken into account as their failure aren't related : https://github.com/ArduPilot/ardupilot/pull/24531 will fix them.
