### PR TITLE
AP_Bootloader: Reserve 100 IDs for SYPAQ Systems

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -248,7 +248,7 @@ AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402
 AP_HW_SWBOOMBOARD_PERIPH             1403
 
-# IDs 5000-5100 reserved for Carbonix
+# IDs 5000-5099 reserved for Carbonix
 # IDs 6000-6100 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -249,7 +249,7 @@ AP_HW_PIXRACER_PERIPH                1402
 AP_HW_SWBOOMBOARD_PERIPH             1403
 
 # IDs 5000-5099 reserved for Carbonix
-# IDs 6000-6100 reserved for SpektreWorks
+# IDs 6000-6099 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -249,6 +249,7 @@ AP_HW_PIXRACER_PERIPH                1402
 AP_HW_SWBOOMBOARD_PERIPH             1403
 
 # IDs 5000-5099 reserved for Carbonix
+# IDs 5100-5199 reserved for SYPAQ Systems
 # IDs 6000-6099 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID


### PR DESCRIPTION
And adjust the reservations for Carbonix and SpektreWorks to reserve 100 IDs instead of 101.