### PR TITLE
pre-commit: Run autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ exclude: |
 
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.2.0
+      rev: v4.4.0
       hooks:
         #-   id: trailing-whitespace
         #-   id: end-of-file-fixer
@@ -37,12 +37,12 @@ repos:
         -   id: check-yaml
 
   -   repo: https://github.com/lsst-ts/pre-commit-xmllint
-      rev: v1.0.0
+      rev: 6f36260b537bf9a42b6ea5262c915ae50786296e
       hooks:
         - id: format-xmllint
           files: libraries/AP_DDS/dds_xrce_profile.xml
   -   repo: https://github.com/psf/black
-      rev: 23.1.0
+      rev: 23.7.0
       hooks:
         - id: black
           files: libraries\/AP_DDS\/(wscript|.*\.py)$


### PR DESCRIPTION
* To fix https://github.com/pre-commit/pre-commit/issues/2782
* Discovered in https://github.com/ArduPilot/ardupilot/pull/24683#issuecomment-1687242147

This should fix the issue of not being able to commit on older branches when using pre-commit once installed. If we want to help out developers working on old releases, this would require a backport of the pre-commit config. This is super low risk to the release, and I don't see it needing a beta, since pre-commit is only used when changing code, and does not affect any flight behavior. 


To do this on a release branch, you can see running the autoupdate brings in the new `isort` version which has the fix for the poetry error.
```
ryan@ryan-B650-970:~/Development/ardu_ws/src/ardupilot$ pre-commit autoupdate
[https://github.com/pre-commit/pre-commit-hooks] updating v4.2.0 -> v4.4.0
[https://github.com/pycqa/isort] updating 5.10.1 -> 5.12.0
[https://github.com/pre-commit/mirrors-mypy] updating v0.950 -> v1.5.1
```
