### PR TITLE
GCS_MAVLink: Remove unreachable return in handle_command_mount()

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4629,7 +4629,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_long_t &packe
         return MAV_RESULT_UNSUPPORTED;
     }
     return mount->handle_command_long(packet, msg);
-    return MAV_RESULT_UNSUPPORTED;
 }
 #endif
 


### PR DESCRIPTION
Slipped through in https://github.com/ArduPilot/ardupilot/pull/24679

FYI: @peterbarker 