### PR TITLE
ardupilotwaf: Fix incorrect comment for cmake minimum version

### DIFF
--- a/Tools/ardupilotwaf/cmake.py
+++ b/Tools/ardupilotwaf/cmake.py
@@ -23,7 +23,7 @@ You can use CMAKE_MIN_VERSION environment variable before loading this tool in
 the configuration to set a minimum version required for cmake. Example::
 
     def configure(cfg):
-        cfg.CMAKE_MIN_VERSION = '3.5.2'
+        cfg.env.CMAKE_MIN_VERSION = '3.5.2'
         cfg.load('cmake')
 
 Usage example::


### PR DESCRIPTION
Before the comment, the variable had no effect. 

Now, you get this when you use the min cmake version
```
Checking for program 'cmake'                   : /usr/local/bin/cmake 
Checking cmake version                         : 3.27.0 
```