### PR TITLE
Rover: allow motor test to be issued as COMMAND_INT

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -663,6 +663,17 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
         }
         return MAV_RESULT_FAILED;
 
+    case MAV_CMD_DO_MOTOR_TEST:
+        // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
+        // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
+        // param3 : throttle (range depends upon param2)
+        // param4 : timeout (in seconds)
+        return rover.mavlink_motor_test_start(*this,
+                                              (AP_MotorsUGV::motor_test_order)packet.param1,
+                                              static_cast<uint8_t>(packet.param2),
+                                              static_cast<int16_t>(packet.param3),
+                                              packet.param4);
+
     default:
         return GCS_MAVLINK::handle_command_int_packet(packet, msg);
     }
@@ -707,17 +718,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
         }
         return MAV_RESULT_ACCEPTED;
     }
-
-    case MAV_CMD_DO_MOTOR_TEST:
-        // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
-        // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
-        // param3 : throttle (range depends upon param2)
-        // param4 : timeout (in seconds)
-        return rover.mavlink_motor_test_start(*this,
-                                              (AP_MotorsUGV::motor_test_order)packet.param1,
-                                              static_cast<uint8_t>(packet.param2),
-                                              static_cast<int16_t>(packet.param3),
-                                              packet.param4);
 
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet, msg);


### PR DESCRIPTION
I've tested this in SITL, both before and after; before the COMMAND_INT gets `UNSUPPORTED`, afterwards it works.

```
MANUAL> 
MANUAL> gservo6
MANUAL> Adding graph: ['SERVO_OUTPUT_RAW.servo1_raw', 'SERVO_OUTPUT_RAW.servo2_raw', 'SERVO_OUTPUT_RAW.servo3_raw', 'SERVO_OUTPUT_RAW.servo4_raw', 'SERVO_OUTPUT_RAW.servo5_raw', 'SERVO_OUTPUT_RAW.servo6_raw', 'SERVO_OUTPUT_RAW.servo7_raw', 'SERVO_OUTPUT_RAW.servo8_raw']

MANUAL> 
MANUAL> 
MANUAL> 
MANUAL> command_int 1 DO_MOTOR_TEST 1 1 1 1 1200 4 0 0 0
MANUAL> Got COMMAND_ACK: DO_MOTOR_TEST: ACCEPTED
AP: Throttle armed
ARMED
AP: EKF variance
AP: Throttle disarmed
AP: EKF failsafe cleared
DISARMED
command_int 1 DO_MOTOR_TEST 1 1 1 1 1200 4 0 0 0
MANUAL> Got COMMAND_ACK: DO_MOTOR_TEST: ACCEPTED
AP: Throttle armed
ARMED
AP: EKF3 IMU0 is using GPS
AP: EKF3 IMU1 is using GPS
AP: AHRS: EKF3 active
height 588
AP: EKF failsafe cleared
AP: Throttle disarmed
DISARMED
height 5
command_int 1 DO_MOTOR_TEST 1 1 1 1 1200 4 0 0 0
MANUAL> Got COMMAND_ACK: DO_MOTOR_TEST: ACCEPTED
AP: Throttle armed
ARMED
AP: Throttle disarmed
DISARMED

MANUAL> 
MANUAL> 
MANUAL> Flight battery 100 percent

MANUAL> long DO_MOTOR_TEST 1 1 1200 4
MANUAL> Got COMMAND_ACK: DO_MOTOR_TEST: ACCEPTED
AP: Throttle armed
ARMED
AP: Throttle disarmed
DISARMED
SIM_VEHICLE: Keyboard Interrupt received ...
SIM_VEHICLE: Killing tasks
EOF on TCP socket
```
