### PR TITLE
AP_Mount: Siyi supports set_lens and get_rangefinder_distance

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -797,6 +797,50 @@ SetFocusResult AP_Mount_Siyi::set_focus(FocusType focus_type, float focus_value)
     return SetFocusResult::INVALID_PARAMETERS;
 }
 
+// set camera lens as a value from 0 to 8
+bool AP_Mount_Siyi::set_lens(uint8_t lens)
+{
+    // only supported on ZT30.  sanity check lens values
+    if ((_hardware_model != HardwareModel::ZT30) || (lens > 8)) {
+        return false;
+    }
+
+    // maps lens to siyi camera image type so that lens of 0, 1, 2 are more useful
+    CameraImageType cam_image_type = CameraImageType::MAIN_ZOOM_SUB_THERMAL;
+    switch (lens) {
+        case 0:
+            cam_image_type = CameraImageType::MAIN_ZOOM_SUB_THERMAL; // 3
+            break;
+        case 1:
+            cam_image_type = CameraImageType::MAIN_WIDEANGLE_SUB_THERMAL; // 5
+            break;
+        case 2:
+            cam_image_type = CameraImageType::MAIN_THERMAL_SUB_ZOOM; // 7
+            break;
+        case 3:
+            cam_image_type = CameraImageType::MAIN_PIP_ZOOM_THERMAL_SUB_WIDEANGLE; // 0
+            break;
+        case 4:
+            cam_image_type = CameraImageType::MAIN_PIP_WIDEANGLE_THERMAL_SUB_ZOOM; // 1
+            break;
+        case 5:
+            cam_image_type = CameraImageType::MAIN_PIP_ZOOM_WIDEANGLE_SUB_THERMAL; // 2
+            break;
+        case 6:
+            cam_image_type = CameraImageType::MAIN_ZOOM_SUB_WIDEANGLE; // 4
+            break;
+        case 7:
+            cam_image_type = CameraImageType::MAIN_WIDEANGLE_SUB_ZOOM; // 6
+            break;
+        case 8:
+            cam_image_type = CameraImageType::MAIN_THERMAL_SUB_WIDEANGLE; // 8
+            break;
+    }
+
+    // send desired image type to camera
+    return send_1byte_packet(SiyiCommandId::SET_CAMERA_IMAGE_TYPE, (uint8_t)cam_image_type);
+}
+
 // send camera information message to GCS
 void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -21,6 +21,16 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_SIYI_DEBUG 0
 #define debug(fmt, args ...) do { if (AP_MOUNT_SIYI_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Siyi: " fmt, ## args); } } while (0)
 
+// hardware lookup table indexed by HardwareModel enum values
+const AP_Mount_Siyi::HWInfo AP_Mount_Siyi::hardware_lookup_table[] {
+        {{'0','0'}, "Unknown"},
+        {{'7','5'}, "A2"},
+        {{'7','3'}, "A8"},
+        {{'6','B'}, "ZR10"},
+        {{'7','8'}, "ZR30"},
+        {{'7','A'}, "ZT30"},
+};
+
 // init - performs any required initialisation for this instance
 void AP_Mount_Siyi::init()
 {
@@ -51,6 +61,9 @@ void AP_Mount_Siyi::update()
         _last_send_ms = now_ms;
         if (!_got_firmware_version) {
             request_firmware_version();
+            return;
+        } else if (!_got_hardware_id) {
+            request_hardware_id();
             return;
         } else {
             request_configuration();
@@ -307,9 +320,6 @@ void AP_Mount_Siyi::process_packet()
         }
         _got_firmware_version = true;
 
-        // set hardware version based on message length
-        _hardware_model = (_parsed_msg.data_bytes_received <= 8) ? HardwareModel::A8 : HardwareModel::ZR10;
-
         // consume and display camera firmware version
         _cam_firmware_version = {
             _msg_buff[_msg_buff_data_start+2],      // firmware major version
@@ -340,9 +350,19 @@ void AP_Mount_Siyi::process_packet()
         break;
     }
 
-    case SiyiCommandId::HARDWARE_ID:
-        // unsupported
+    case SiyiCommandId::HARDWARE_ID: {
+        // lookup first two digits of hardware id
+        const uint8_t hwid0 = _msg_buff[_msg_buff_data_start];
+        const uint8_t hwid1 = _msg_buff[_msg_buff_data_start+1];
+        for (uint8_t i=1; i<ARRAY_SIZE(hardware_lookup_table); i++) {
+            if (hwid0 == hardware_lookup_table[i].hwid[0] && hwid1 == hardware_lookup_table[i].hwid[1]) {
+               _hardware_model = (HardwareModel)i;
+               gcs().send_text(MAV_SEVERITY_INFO, "Mount: Siyi %s", get_model_name());
+            }
+        }
+        _got_hardware_id = true;
         break;
+    }
 
     case SiyiCommandId::AUTO_FOCUS:
 #if AP_MOUNT_SIYI_DEBUG
@@ -684,11 +704,14 @@ float AP_Mount_Siyi::get_zoom_mult_max() const
     switch (_hardware_model) {
     case HardwareModel::UNKNOWN:
         return 0;
+    case HardwareModel::A2:
     case HardwareModel::A8:
         // a8 has 6x digital zoom
         return 6;
     case HardwareModel::ZR10:
-        // zr10 has 30x hybrid zoom (optical + digital)
+    case HardwareModel::ZR30:
+    case HardwareModel::ZT30:
+        // 30x hybrid zoom (optical + digital)
         return 30;
     }
     return 0;
@@ -785,21 +808,25 @@ void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
     }
 
     static const uint8_t vendor_name[32] = "Siyi";
-    static uint8_t model_name[32] = "Unknown";
+    static uint8_t model_name[32] {};
     const uint32_t fw_version = _cam_firmware_version.major | (_cam_firmware_version.minor << 8) | (_cam_firmware_version.patch << 16);
     const char cam_definition_uri[140] {};
 
+    // copy model name
+    strncpy((char *)model_name, get_model_name(), sizeof(model_name)-1);
+
     // focal length
+    // To-Do: check these values are correct for A2, ZR30, ZT30
     float focal_length_mm = 0;
     switch (_hardware_model) {
     case HardwareModel::UNKNOWN:
-        break;
+    case HardwareModel::A2:
     case HardwareModel::A8:
-        strncpy((char *)model_name, "A8", sizeof(model_name));
         focal_length_mm = 21;
         break;
     case HardwareModel::ZR10:
-        strncpy((char *)model_name, "ZR10", sizeof(model_name));
+    case HardwareModel::ZR30:
+    case HardwareModel::ZT30:
         // focal length range from 5.15 ~ 47.38
         focal_length_mm = 5.15;
         break;
@@ -844,6 +871,16 @@ void AP_Mount_Siyi::send_camera_settings(mavlink_channel_t chan) const
         _last_record_video ? CAMERA_MODE_VIDEO : CAMERA_MODE_IMAGE, // camera mode (0:image, 1:video, 2:image survey)
         zoom_pct,           // zoomLevel float, percentage from 0 to 100, NaN if unknown
         NaN);               // focusLevel float, percentage from 0 to 100, NaN if unknown
+}
+
+// get model name string. returns "Unknown" if hardware model is not yet known
+const char* AP_Mount_Siyi::get_model_name() const
+{
+    uint8_t model_idx = (uint8_t)_hardware_model;
+    if (model_idx < ARRAY_SIZE(hardware_lookup_table)) {
+        return hardware_lookup_table[model_idx].model_name;
+    }
+    return hardware_lookup_table[0].model_name;
 }
 
 #endif // HAL_MOUNT_SIYI_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -17,6 +17,7 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_SIYI_PITCH_P       1.50    // pitch controller P gain (converts pitch angle error to target rate)
 #define AP_MOUNT_SIYI_YAW_P         1.50    // yaw controller P gain (converts yaw angle error to target rate)
 #define AP_MOUNT_SIYI_LOCK_RESEND_COUNT 5   // lock value is resent to gimbal every 5 iterations
+#define AP_MOUNT_SIYI_TIMEOUT_MS    1000    // timeout for health and rangefinder readings
 
 #define AP_MOUNT_SIYI_DEBUG 0
 #define debug(fmt, args ...) do { if (AP_MOUNT_SIYI_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Siyi: " fmt, ## args); } } while (0)
@@ -163,7 +164,7 @@ bool AP_Mount_Siyi::healthy() const
 
     // unhealthy if attitude information NOT received recently
     const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _last_current_angle_rad_ms > 1000) {
+    if (now_ms - _last_current_angle_rad_ms > AP_MOUNT_SIYI_TIMEOUT_MS) {
         return false;
     }
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -338,15 +338,13 @@ void AP_Mount_Siyi::process_packet()
                 (unsigned)_msg_buff[_msg_buff_data_start+5],    // firmware minor version
                 (unsigned)_msg_buff[_msg_buff_data_start+4]);   // firmware revision
 
-        // display zoom firmware version
-#if AP_MOUNT_SIYI_DEBUG
+        // display zoom firmware version for those that have it
         if (_parsed_msg.data_bytes_received >= 12) {
-            debug("Mount: SiyiZoom fw:%u.%u.%u",
+            gcs().send_text(MAV_SEVERITY_INFO, "Mount: SiyiZoom fw:%u.%u.%u",
                 (unsigned)_msg_buff[_msg_buff_data_start+10],    // firmware major version
                 (unsigned)_msg_buff[_msg_buff_data_start+9],     // firmware minor version
                 (unsigned)_msg_buff[_msg_buff_data_start+8]);    // firmware revision
         }
-#endif
         break;
     }
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -81,6 +81,13 @@ public:
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;
 
+    //
+    // rangefinder
+    //
+
+    // get rangefinder distance.  Returns true on success
+    bool get_rangefinder_distance(float& distance_m) const override;
+
 protected:
 
     // get attitude as a quaternion.  returns true on success
@@ -103,6 +110,7 @@ private:
         ACQUIRE_GIMBAL_ATTITUDE = 0x0D,
         ABSOLUTE_ZOOM = 0x0F,
         SET_CAMERA_IMAGE_TYPE = 0x11,
+        READ_RANGEFINDER = 0x15,
     };
 
     // Function Feedback Info packet info_type values
@@ -187,6 +195,7 @@ private:
     void request_configuration() { send_packet(SiyiCommandId::ACQUIRE_GIMBAL_CONFIG_INFO, nullptr, 0); }
     void request_function_feedback_info() { send_packet(SiyiCommandId::FUNCTION_FEEDBACK_INFO, nullptr, 0); }
     void request_gimbal_attitude() { send_packet(SiyiCommandId::ACQUIRE_GIMBAL_ATTITUDE, nullptr, 0); }
+    void request_rangefinder_distance() { send_packet(SiyiCommandId::READ_RANGEFINDER, nullptr, 0); }
 
     // rotate gimbal.  pitch_rate and yaw_rate are scalars in the range -100 ~ +100
     // yaw_is_ef should be true if gimbal should maintain an earth-frame target (aka lock)
@@ -264,6 +273,11 @@ private:
     float _zoom_rate_target;                        // current zoom rate target
     float _zoom_mult;                               // most recent actual zoom multiple received from camera
     uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run
+
+    // rangefinder variables
+    uint32_t _last_rangefinder_req_ms;              // system time of last request for rangefinder distance
+    uint32_t _last_rangefinder_dist_ms;             // system time of last successful read of rangefinder distance
+    float _rangefinder_dist_m;                      // distance received from rangefinder
 
     // hardware lookup table indexed by HardwareModel enum values (see above)
     struct HWInfo {

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -137,9 +137,12 @@ private:
 
     // hardware model enum
     enum class HardwareModel : uint8_t {
-        UNKNOWN,
+        UNKNOWN = 0,
+        A2,
         A8,
-        ZR10
+        ZR10,
+        ZR30,
+        ZT30
     } _hardware_model;
 
     // gimbal mounting method/direction
@@ -197,10 +200,14 @@ private:
     // update zoom controller
     void update_zoom_control();
 
+    // get model name string, returns nullptr if hardware id is unknown
+    const char* get_model_name() const;
+
     // internal variables
     AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
     bool _initialised;                              // true once the driver has been initialised
     bool _got_firmware_version;                     // true once gimbal firmware version has been received
+    bool _got_hardware_id;                          // true once hardware id ha been received
     struct {
         uint8_t major;
         uint8_t minor;
@@ -240,6 +247,13 @@ private:
     float _zoom_rate_target;                        // current zoom rate target
     float _zoom_mult;                               // most recent actual zoom multiple received from camera
     uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run
+
+    // hardware lookup table indexed by HardwareModel enum values (see above)
+    struct HWInfo {
+        uint8_t hwid[2];
+        const char* model_name;
+    };
+    static const HWInfo hardware_lookup_table[];
 };
 
 #endif // HAL_MOUNT_SIYISERIAL_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -72,6 +72,9 @@ public:
     // focus in = -1, focus hold = 0, focus out = 1
     SetFocusResult set_focus(FocusType focus_type, float focus_value) override;
 
+    // set camera lens as a value from 0 to 8.  ZT30 only
+    bool set_lens(uint8_t lens) override;
+
     // send camera information message to GCS
     void send_camera_information(mavlink_channel_t chan) const override;
 
@@ -98,7 +101,8 @@ private:
         FUNCTION_FEEDBACK_INFO = 0x0B,
         PHOTO = 0x0C,
         ACQUIRE_GIMBAL_ATTITUDE = 0x0D,
-        ABSOLUTE_ZOOM = 0x0F
+        ABSOLUTE_ZOOM = 0x0F,
+        SET_CAMERA_IMAGE_TYPE = 0x11,
     };
 
     // Function Feedback Info packet info_type values
@@ -145,12 +149,25 @@ private:
         ZT30
     } _hardware_model;
 
-    // gimbal mounting method/direction
+    // lens value
     enum class GimbalMountingDirection : uint8_t {
         UNDEFINED = 0,
         NORMAL = 1,
         UPSIDE_DOWN = 2,
     } _gimbal_mounting_dir;
+
+    // camera image types (aka lens)
+    enum class CameraImageType : uint8_t {
+        MAIN_PIP_ZOOM_THERMAL_SUB_WIDEANGLE = 0,
+        MAIN_PIP_WIDEANGLE_THERMAL_SUB_ZOOM = 1,
+        MAIN_PIP_ZOOM_WIDEANGLE_SUB_THERMAL = 2,
+        MAIN_ZOOM_SUB_THERMAL = 3,
+        MAIN_ZOOM_SUB_WIDEANGLE = 4,
+        MAIN_WIDEANGLE_SUB_THERMAL = 5,
+        MAIN_WIDEANGLE_SUB_ZOOM = 6,
+        MAIN_THERMAL_SUB_ZOOM = 7,
+        MAIN_THERMAL_SUB_WIDEANGLE = 8
+    };
 
     // reading incoming packets from gimbal and confirm they are of the correct format
     // results are held in the _parsed_msg structure


### PR DESCRIPTION
This PR adds the following enhancements to the Siyi driver:

- set_lens allows specifying which cameras(s) are streamed in real-time to the GCS
- supports rangefinder on ZT30.  Updates are at 10hz and the outputs are currently only logged
- model detection is improved by using the reported hardware id which allows detecting the A2, A8, ZR10, ZR30, ZT30.  The model name is also displayed to the user
- Zoom firmware version is displayed to the user on cameras with a zoom

This has been lightly tested on an A8 and ZR10 to confirm:

- model names are displayed to the user and appear in the CAMERA_INFORMATION mavlink message
- zoom still works


Testing required:

- [x] confirm set_lens works on ZT30 (the only camera with multiple lens)
   - set RCx_OPTION = 175 (CAMERA_LENS)
   - ensure real-time video is being streamed to the ground station
   - move RC aux switch to low, med and high positions and confirm the video changes between these values.  Note that if these aren't good defaults we can change them
       - low/0: Split Screen (Main: Zoom & Thermal. Sub: Wide Angle)
       - med/1: Split Screen (Main: Wide Angle & Thermal. Sub: Zoom)
       - high/2: Split Screen (Main: Zoom & Wide Angle. Sub: Thermal)
- [ ] confirm get_rangefinder_distance works on ZT30.  These distances will only be visible in the MNT log message

below is a screenshot of some testing showing the model still appears correctly in the CAMERA_INFORMATION mavlink message and in the messages tab.  Also all 3 firmware versions now appear for the Siyi.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/c4413d07-e2c4-41f7-b30d-1882a0ff4c58)
