### PR TITLE
Fix AP_InertialSensor_NONE to work with esp32empty

### DIFF
--- a/libraries/AP_HAL_ESP32/Scheduler.h
+++ b/libraries/AP_HAL_ESP32/Scheduler.h
@@ -49,6 +49,8 @@ public:
     bool     is_system_initialized() override;
 
     void     print_stats(void) ;
+    void     print_main_loop_rate(void);
+
     uint16_t get_loop_rate_hz(void);
     AP_Int16 _active_loop_rate_hz;
     AP_Int16 _loop_rate_hz;

--- a/libraries/AP_HAL_ESP32/boards/esp32empty.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32empty.h
@@ -23,108 +23,128 @@
 
 #define HAL_ESP32_BOARD_NAME "esp32-empty"
 
-#define TRUE						1
-#define FALSE						0
+#define TRUE  1
+#define FALSE 0
 
 //Protocols
-//list of protocols/enum:	ardupilot/libraries/AP_SerialManager/AP_SerialManager.h
-//default protocols:		ardupilot/libraries/AP_SerialManager/AP_SerialManager.cpp
-//ESP32 serials:		AP_HAL_ESP32/HAL_ESP32_Class.cpp
+// list of protocols/enum:  ardupilot/libraries/AP_SerialManager/AP_SerialManager.h
+// default protocols:    ardupilot/libraries/AP_SerialManager/AP_SerialManager.cpp
+// ESP32 serials:    AP_HAL_ESP32/HAL_ESP32_Class.cpp
 
-//#define DEFAULT_SERIAL0_PROTOCOL				SerialProtocol_MAVLink2			//A	UART0: Always: Console, MAVLink2
-//#define DEFAULT_SERIAL0_BAUD				AP_SERIALMANAGER_CONSOLE_BAUD/1000	//115200
+//#define DEFAULT_SERIAL0_PROTOCOL        SerialProtocol_MAVLink2   //A  UART0: Always: Console, MAVLink2
+//#define DEFAULT_SERIAL0_BAUD            AP_SERIALMANAGER_CONSOLE_BAUD/1000  //115200
 
-//#define DEFAULT_SERIAL1_PROTOCOL				SerialProtocol_MAVLink2			//C	WiFi:  TCP, UDP, or disable (depends on HAL_ESP32_WIFI)
-//#define DEFAULT_SERIAL1_BAUD				AP_SERIALMANAGER_MAVLINK_BAUD/1000	//57600
+//#define DEFAULT_SERIAL1_PROTOCOL        SerialProtocol_MAVLink2   //C  WiFi:  TCP, UDP, or disable (depends on HAL_ESP32_WIFI)
+//#define DEFAULT_SERIAL1_BAUD            AP_SERIALMANAGER_MAVLINK_BAUD/1000  //57600
 
-#define DEFAULT_SERIAL2_PROTOCOL				SerialProtocol_MAVLink2			//D	UART2: Always: MAVLink2 on ESP32
-//#define DEFAULT_SERIAL2_BAUD				AP_SERIALMANAGER_MAVLINK_BAUD/1000	//57600
+#define DEFAULT_SERIAL2_PROTOCOL        SerialProtocol_MAVLink2   //D  UART2
+#define DEFAULT_SERIAL2_BAUD            AP_SERIALMANAGER_MAVLINK_BAUD/1000  //57600
 
-#define DEFAULT_SERIAL3_PROTOCOL				SerialProtocol_GPS			//B	UART1: GPS1
-//#define DEFAULT_SERIAL4_BAUD				AP_SERIALMANAGER_GPS_BAUD/1000		//38400, Can not define default baudrate here (by config only)
+#define DEFAULT_SERIAL3_PROTOCOL        SerialProtocol_GPS        //B  UART1: GPS1
+#define DEFAULT_SERIAL3_BAUD            AP_SERIALMANAGER_GPS_BAUD/1000    //38400, Can not define default baudrate here (by config only)
+//#define DEFAULT_SERIAL3_PROTOCOL        SerialProtocol_None       //B
+//#define DEFAULT_SERIAL3_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL4_PROTOCOL				SerialProtocol_None			//E
-//#define DEFAULT_SERIAL4_BAUD				AP_SERIALMANAGER_GPS_BAUD/1000		//38400, Can not define default baudrate here (by config only)
+#define DEFAULT_SERIAL4_PROTOCOL        SerialProtocol_None       //E
+#define DEFAULT_SERIAL5_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL5_PROTOCOL				SerialProtocol_None			//F
-#define DEFAULT_SERIAL5_BAUD				(115200/1000)
+#define DEFAULT_SERIAL5_PROTOCOL        SerialProtocol_None       //F
+#define DEFAULT_SERIAL5_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL6_PROTOCOL				SerialProtocol_None			//G
-#define DEFAULT_SERIAL6_BAUD				(115200/1000)
+#define DEFAULT_SERIAL6_PROTOCOL        SerialProtocol_None       //G
+#define DEFAULT_SERIAL6_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL7_PROTOCOL				SerialProtocol_None			//H
-#define DEFAULT_SERIAL7_BAUD				(115200/1000)
+#define DEFAULT_SERIAL7_PROTOCOL        SerialProtocol_None       //H
+#define DEFAULT_SERIAL7_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL8_PROTOCOL				SerialProtocol_None			//I
-#define DEFAULT_SERIAL8_BAUD				(115200/1000)
+#define DEFAULT_SERIAL8_PROTOCOL        SerialProtocol_None       //I
+#define DEFAULT_SERIAL8_BAUD            (115200/1000)
 
-#define DEFAULT_SERIAL9_PROTOCOL				SerialProtocol_None			//J
-#define DEFAULT_SERIAL9_BAUD				(115200/1000)
+#define DEFAULT_SERIAL9_PROTOCOL        SerialProtocol_None       //J
+#define DEFAULT_SERIAL9_BAUD            (115200/1000)
 
 //Inertial sensors
-//#define HAL_INS_DEFAULT				HAL_INS_MPU9250_I2C
-//#define PROBE_IMU_I2C(driver, bus, addr, args ...)	ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,GET_I2C_DEVICE(bus, addr),##args))
-//#define HAL_INS_PROBE_LIST				PROBE_IMU_I2C(Invensense, 0, 0x68, ROTATION_NONE)
+#define HAL_INS_DEFAULT HAL_INS_NONE
+//#define HAL_INS_DEFAULT HAL_INS_MPU9250_I2C
+//#define PROBE_IMU_I2C(driver, bus, addr, args ...) ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,GET_I2C_DEVICE(bus, addr),##args))
+//#define HAL_INS_PROBE_LIST PROBE_IMU_I2C(Invensense, 0, 0x68, ROTATION_NONE)
 
 //I2C Buses
-#define HAL_ESP32_I2C_BUSES				{.port=I2C_NUM_0, .sda=GPIO_NUM_13, .scl=GPIO_NUM_14, .speed=400*KHZ, .internal=true, .soft=true}
+#define HAL_ESP32_I2C_BUSES {.port=I2C_NUM_0, .sda=GPIO_NUM_13, .scl=GPIO_NUM_14, .speed=400*KHZ, .internal=true, .soft=true}
 
 //SPI Buses
-#define HAL_ESP32_SPI_BUSES				{}
+#define HAL_ESP32_SPI_BUSES {}
 
 //SPI Devices
-#define HAL_ESP32_SPI_DEVICES				{}
+#define HAL_ESP32_SPI_DEVICES {}
 
 //RCIN
-#define HAL_ESP32_RCIN					GPIO_NUM_36
+#define HAL_ESP32_RCIN GPIO_NUM_36
 
 //RCOUT
-#define HAL_ESP32_RCOUT					{ GPIO_NUM_25, GPIO_NUM_27, GPIO_NUM_33, GPIO_NUM_32, GPIO_NUM_22, GPIO_NUM_21 }
+#define HAL_ESP32_RCOUT {GPIO_NUM_25, GPIO_NUM_27, GPIO_NUM_33, GPIO_NUM_32, GPIO_NUM_22, GPIO_NUM_21}
+
+//AIRSPEED
+#define AP_AIRSPEED_ENABLED 0
+#define AP_AIRSPEED_ANALOG_ENABLED 0
+#define AP_AIRSPEED_BACKEND_DEFAULT_ENABLED 0
 
 //BAROMETER
-#define HAL_BARO_ALLOW_INIT_NO_BARO			1
+#define HAL_BARO_ALLOW_INIT_NO_BARO 1
+
+//IMU
+// #define AP_INERTIALSENSOR_ENABLED 1
+// #define AP_INERTIALSENSOR_KILL_IMU_ENABLED 0
 
 //COMPASS
+#define AP_COMPASS_ENABLE_DEFAULT 0
 #define ALLOW_ARM_NO_COMPASS
 
+//See boards.py
+#ifndef ENABLE_HEAP
+#define ENABLE_HEAP 1
+#endif
+
 //WIFI
-#define HAL_ESP32_WIFI					1	//1-TCP, 2-UDP, comment this line = without wifi
-#define WIFI_SSID					"ardupilot-empty"
-#define WIFI_PWD					"ardupilot-empty"
+#define HAL_ESP32_WIFI 1  //1-TCP, 2-UDP, comment this line = without wifi
+#define WIFI_SSID "ardupilot-esp32"
+#define WIFI_PWD "ardupilot-esp32"
 
 //UARTs
+// UART_NUM_0 and UART_NUM_2 are configured to use defaults
 #define HAL_ESP32_UART_DEVICES \
     {.port=UART_NUM_0, .rx=GPIO_NUM_3 , .tx=GPIO_NUM_1 },\
     {.port=UART_NUM_1, .rx=GPIO_NUM_34, .tx=GPIO_NUM_18},\
-    {.port=UART_NUM_2, .rx=GPIO_NUM_35, .tx=GPIO_NUM_19}
+    {.port=UART_NUM_2, .rx=GPIO_NUM_16, .tx=GPIO_NUM_17}
 
 //ADC
-#define HAL_DISABLE_ADC_DRIVER				1
-#define HAL_USE_ADC					0
+#define HAL_DISABLE_ADC_DRIVER 1
+#define HAL_USE_ADC 0
 
 //LED
-#define DEFAULT_NTF_LED_TYPES				Notify_LED_None
+#define DEFAULT_NTF_LED_TYPES Notify_LED_None
 
 //RMT pin number
-#define HAL_ESP32_RMT_RX_PIN_NUMBER			4
+#define HAL_ESP32_RMT_RX_PIN_NUMBER 4
 
 //SD CARD
-// Do u want to use mmc or spi mode for the sd card, this is board specific ,
-//  as mmc uses specific pins but is quicker,
-// and spi is more flexible pinouts....  dont forget vspi/hspi should be selected to NOT conflict with HAL_ESP32_SPI_BUSES
+// Do u want to use mmc or spi mode for the sd card, this is board specific,
+// as mmc uses specific pins but is quicker,
+// and spi is more flexible pinouts....
+// dont forget vspi/hspi should be selected to NOT conflict with HAL_ESP32_SPI_BUSES
 
 //#define HAL_ESP32_SDCARD //after enabled, uncomment one of below
 //#define HAL_ESP32_SDMMC
-//#define HAL_ESP32_SDSPI				{.host=VSPI_HOST, .dma_ch=2, .mosi=GPIO_NUM_2, .miso=GPIO_NUM_15, .sclk=GPIO_NUM_26, .cs=GPIO_NUM_21}
+//#define HAL_ESP32_SDSPI {.host=VSPI_HOST, .dma_ch=2, .mosi=GPIO_NUM_2, .miso=GPIO_NUM_15, .sclk=GPIO_NUM_26, .cs=GPIO_NUM_21}
 
-#define HAL_LOGGING_FILESYSTEM_ENABLED			0
-#define HAL_LOGGING_DATAFLASH_ENABLED			0
-#define HAL_LOGGING_MAVLINK_ENABLED			0
+#define HAL_LOGGING_FILESYSTEM_ENABLED 0
+#define HAL_LOGGING_DATAFLASH_ENABLED 0
+#define HAL_LOGGING_MAVLINK_ENABLED 0
 
-#define HAL_BOARD_LOG_DIRECTORY				"/SDCARD/APM/LOGS"
-#define HAL_BOARD_STORAGE_DIRECTORY			"/SDCARD/APM/STORAGE"
-#define HAL_BOARD_LOG_DIRECTORY				"/SDCARD/APM/LOGS"
-#define HAL_BOARD_TERRAIN_DIRECTORY			"/SDCARD/APM/TERRAIN"
+#define HAL_BOARD_LOG_DIRECTORY "/SDCARD/APM/LOGS"
+#define HAL_BOARD_STORAGE_DIRECTORY "/SDCARD/APM/STORAGE"
+#define HAL_BOARD_LOG_DIRECTORY "/SDCARD/APM/LOGS"
+#define HAL_BOARD_TERRAIN_DIRECTORY "/SDCARD/APM/TERRAIN"
 
-#define HAL_LOGGING_BACKENDS_DEFAULT			1
+#define HAL_LOGGING_BACKENDS_DEFAULT 1
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
@@ -255,17 +255,10 @@ void AP_InertialSensor_NONE::generate_gyro()
 
 void AP_InertialSensor_NONE::timer_update(void)
 {
-
     uint64_t now = AP_HAL::micros64();
 
-    static uint64_t last_msg_sent = 0;
-    if (now > last_msg_sent + 2000000) { //2sec= 2000ms = 2000000us
-        //gcs().send_text(MAV_SEVERITY_WARNING, "NO IMU FOUND");
-        DEV_PRINTF("INS: NO IMU FOUND\n");
-        last_msg_sent = now;
-    }
     if (now >= next_accel_sample) {
-        if (((1U << accel_instance) ) == 0) {
+        {
             generate_accel();
             if (next_accel_sample == 0) {
                 next_accel_sample = now + 1000000UL / accel_sample_hz;
@@ -277,7 +270,7 @@ void AP_InertialSensor_NONE::timer_update(void)
         }
     }
     if (now >= next_gyro_sample) {
-        if (((1U << gyro_instance) ) == 0) {
+        {
             generate_gyro();
             if (next_gyro_sample == 0) {
                 next_gyro_sample = now + 1000000UL / gyro_sample_hz;


### PR DESCRIPTION
Update AP_InertialSensor_NONE and the EPS32 scheduler to allow the esp32empty board to run.

The main change is to disable the initialisation check in the timer thread as this was preventing the IMU from completing its initialisation checks.

The changes to esp32empty.h are mainly formatting - tabs to whitespace. UART_NUM_2 is changed to use the default pinout which uses the IO_MUX rather than the GPIO matrix.

There is a recurring message arising from a Fence breach which is not addressed in this PR.

Baseline for future profiling and optimisation changes:

```bash
APM_MAIN        26222159                43%
IDLE            44275628                73%
IDLE            12344488                20%
APM_UART        2487045         4%
APM_WIFI1       2225550         3%
APM_RCIN        913707          1%
log_io          571936          <1%
SchedulerIO:APM 1275341         2%
APM_STORAGE     519093          <1%
APM_TIMER       21238237                35%
tiT             3323274         5%
APM_RCOUT       276007          <1%
sys_evt         688             <1%
ipc0            87622           <1%
ipc1            75395           <1%
esp_timer       53239           <1%
wifi            4093037         6%
Tmr Svc         15              <1%

Heap summary for capabilities 0x00000000:
  At 0x3ffae6e0 len 6432 free 4 allocated 5892 min_free 4
    largest_free_block 0 alloc_blocks 39 free_blocks 0 total_blocks 39
  At 0x3ffc5de8 len 107032 free 4 allocated 105056 min_free 4
    largest_free_block 0 alloc_blocks 275 free_blocks 0 total_blocks 275
  At 0x3ffe0440 len 15072 free 68 allocated 14376 min_free 4
    largest_free_block 20 alloc_blocks 53 free_blocks 3 total_blocks 56
  At 0x3ffe4350 len 113840 free 95592 allocated 17264 min_free 65784
    largest_free_block 94208 alloc_blocks 28 free_blocks 2 total_blocks 30
  At 0x40095dec len 41492 free 40688 allocated 0 min_free 40672
    largest_free_block 38912 alloc_blocks 0 free_blocks 1 total_blocks 1
  Totals:
    free 136356 allocated 142588 min_free 106468 largest_free_block 94208
loop_rate: actual: 122Hz, expected: 400Hz
loop_rate: actual: 128Hz, expected: 400Hz
loop_rate: actual: 124Hz, expected: 400Hz
loop_rate: actual: 126Hz, expected: 400Hz
``` 

With some tuning a main loop rate of 250Hz can be achieved (to follow).

** should have changed the branch name before posting PR - not a wip.
