### PR TITLE
hwdef: allow for MCO pin to be configured

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -285,9 +285,15 @@
 #ifndef STM32_MCO1SEL
 #define STM32_MCO1SEL                       STM32_MCO1SEL_HSE_CK
 #endif
+#ifndef STM32_MCO1PRE_VALUE
 #define STM32_MCO1PRE_VALUE                 4
+#endif
+#ifndef STM32_MCO2SEL
 #define STM32_MCO2SEL                       STM32_MCO2SEL_SYS_CK
+#endif
+#ifndef STM32_MCO2PRE_VALUE
 #define STM32_MCO2PRE_VALUE                 4
+#endif
 #define STM32_TIMPRE_ENABLE                 TRUE
 #define STM32_HRTIMSEL                      0
 #define STM32_STOPKERWUCK                   0

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
@@ -228,10 +228,18 @@
  * Peripherals clocks static settings.
  * Reading STM32 Reference Manual is required.
  */
+#ifndef STM32_MCO1SEL
 #define STM32_MCO1SEL                       STM32_MCO1SEL_HSE_CK
+#endif
+#ifndef STM32_MCO1PRE_VALUE
 #define STM32_MCO1PRE_VALUE                 1
+#endif
+#ifndef STM32_MCO2SEL
 #define STM32_MCO2SEL                       STM32_MCO2SEL_SYS_CK
+#endif
+#ifndef STM32_MCO2PRE_VALUE
 #define STM32_MCO2PRE_VALUE                 1
+#endif
 #define STM32_TIMPRE_ENABLE                 TRUE
 #define STM32_HRTIMSEL                      0
 #define STM32_STOPKERWUCK                   0

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -23,7 +23,7 @@ class ChibiOSHWDef(object):
     # output variables for each pin
     f4f7_vtypes = ['MODER', 'OTYPER', 'OSPEEDR', 'PUPDR', 'ODR', 'AFRL', 'AFRH']
     f1_vtypes = ['CRL', 'CRH', 'ODR']
-    af_labels = ['USART', 'UART', 'SPI', 'I2C', 'SDIO', 'SDMMC', 'OTG', 'JT', 'TIM', 'CAN', 'QUADSPI', 'OCTOSPI', 'ETH']
+    af_labels = ['USART', 'UART', 'SPI', 'I2C', 'SDIO', 'SDMMC', 'OTG', 'JT', 'TIM', 'CAN', 'QUADSPI', 'OCTOSPI', 'ETH', 'MCO' ]
 
     def __init__(self, bootloader=False, signed_fw=False, outdir=None, hwdef=[], default_params_filepath=None):
         self.outdir = outdir
@@ -2849,7 +2849,7 @@ INCLUDE common.ld
         patterns = [
             r'INPUT', r'OUTPUT', r'TIM\d+', r'USART\d+', r'UART\d+', r'ADC\d+',
             r'SPI\d+', r'OTG\d+', r'SWD', r'CAN\d?', r'I2C\d+', r'CS',
-            r'SDMMC\d+', r'SDIO', r'QUADSPI\d', r'OCTOSPI\d', r'ETH\d'
+            r'SDMMC\d+', r'SDIO', r'QUADSPI\d', r'OCTOSPI\d', r'ETH\d', r'RCC',
         ]
         matches = False
         for p in patterns:


### PR DESCRIPTION
this allows for hwdef.dat lines like this:

  PA8 MCO1 RCC
  PC9 MCO2 RCC

you can control the scaling by defining the following:

- STM32_MCO1SEL
- STM32_MCO1PRE_VALUE
- STM32_MCO2SEL
- STM32_MCO2PRE_VALUE