### PR TITLE
Copter: 4.3.8 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.3.8-beta1 12-Aug-2023
+Copter 4.3.8 24-Aug-2023 / 4.3.8-beta1 12-Aug-2023
 Changes from 4.3.7
 1) Bug fixes
     - DroneCAN GPS RTK injection fix

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.8-beta1"
+#define THISFIRMWARE "ArduCopter V4.3.8"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,8,FIRMWARE_VERSION_TYPE_BETA+1
+#define FIRMWARE_VERSION 4,3,8,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
 #define FW_PATCH 8
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.3.8 release which has no functional changes vs the 4.3.8-beta1 release that's been out since last week.