### PR TITLE
autotest: set ICE_RPM_THRESH for quadplance-ice

### DIFF
--- a/Tools/autotest/default_params/quadplane-ice.parm
+++ b/Tools/autotest/default_params/quadplane-ice.parm
@@ -1,1 +1,2 @@
 Q_OPTIONS 64
+ICE_RPM_THRESH 50  # idles at 70 (1% thrust)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -962,7 +962,7 @@ class AutoTestQuadPlane(AutoTest):
         self.wait_rpm(1, 6500, 7500, minimum_duration=30, timeout=40)
         self.progress("Setting min-throttle")
         self.set_rc(3, 1000)
-        self.wait_rpm(1, 300, 400, minimum_duration=1)
+        self.wait_rpm(1, 65, 75, minimum_duration=1)
         self.progress("Setting engine-start RC switch to LOW")
         self.set_rc(rc_engine_start_chan, 1000)
         self.wait_rpm(1, 0, 0, minimum_duration=1)

--- a/libraries/SITL/SIM_ICEngine.cpp
+++ b/libraries/SITL/SIM_ICEngine.cpp
@@ -21,6 +21,8 @@
 
 using namespace SITL;
 
+#include <GCS_MAVLink/GCS.h>
+
 /*
   update engine state, returning power output from 0 to 1
  */
@@ -49,12 +51,12 @@ float ICEngine::update(const struct sitl_input &input)
     }
 
     if (state.value != last_state.value) {
-        printf("choke:%u starter:%u ignition:%u\n",
-               (unsigned)state.choke,
-               (unsigned)state.starter,
-               (unsigned)state.ignition);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ICEngine: choke:%u starter:%u ignition:%u",
+                      (unsigned)state.choke,
+                      (unsigned)state.starter,
+                      (unsigned)state.ignition);
     }
-    
+
     if (have_ignition && !state.ignition) {
         // engine is off
         if (!state.starter) {
@@ -75,11 +77,11 @@ float ICEngine::update(const struct sitl_input &input)
     }
     if (start_time_us == 0 && state.starter) {
         if (throttle_demand > 0.2) {
-            printf("too much throttle to start: %.2f\n", throttle_demand);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ICEngine: too much throttle to start: %.2f", throttle_demand);
         } else {
             // start the motor
             if (start_time_us == 0) {
-                printf("Engine started\n");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ICEngine: Engine started");
             }
             start_time_us = now;
         }
@@ -88,7 +90,7 @@ float ICEngine::update(const struct sitl_input &input)
         uint32_t starter_time_us = (now - start_time_us);
         if (starter_time_us > 3000*1000UL && !overheat) {
             overheat = true;
-            printf("Starter overheat\n");            
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ICEngine: Starter overheat");
         }
     } else {
         overheat = false;
@@ -109,7 +111,7 @@ output:
 
 engine_off:
     if (start_time_us != 0) {
-        printf("Engine stopped\n");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ICEngine: Engine stopped");
     }
     last_update_us = AP_HAL::micros64();
     start_time_us = 0;


### PR DESCRIPTION
without this we continuously try to restart the motor as the minimum thrust output from the ICE is translated into a value less than the default ICE_RPM_THRESH (so the ICEngine library believes the engine to be stopped, when it is really just at idle).

Also send SIM_ICEngine diagnostics to GCS.  They're pretty much useless on stdout.

