### PR TITLE
bugfix for tricks-on-a-switch activation cleanup

### DIFF
--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
@@ -84,6 +84,7 @@ TRIK_SEL_FN = bind_add_param2("_SEL_FN", 2, 301)
 TRIK_ACT_FN = bind_add_param2("_ACT_FN", 3, 300)
 TRIK_COUNT  = bind_add_param2("_COUNT",  4, 3)
 TRICKS = {}
+local last_trick_action_state = rc:get_aux_cached(TRIK_ACT_FN:get())
 
 
 function tricks_exist()
@@ -764,7 +765,6 @@ function check_auto_mission()
    end
 end
   
-local last_trick_action_state = rc:get_aux_cached(TRIK_ACT_FN:get())
 local trick_sel_chan = nil
 local last_trick_selection = 0
 

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -334,6 +334,7 @@ local function sq(x)
    return x*x
 end
 
+local last_trick_action_state = nil
 if TRIK_ENABLE:get() > 0 then
 --[[
     // @Param: TRIK_SEL_FN
@@ -357,6 +358,8 @@ if TRIK_ENABLE:get() > 0 then
 --]]
    TRIK_COUNT  = bind_add_param2("_COUNT",  4, 3)
    TRICKS = {}
+
+   last_trick_action_state = rc:get_aux_cached(TRIK_ACT_FN:get())
 
    -- setup parameters for tricks
    local count = math.floor(constrain(TRIK_COUNT:get(),1,11))
@@ -3110,7 +3113,6 @@ function check_auto_mission()
    end
 end
 
-local last_trick_action_state = rc:get_aux_cached(TRIK_ACT_FN:get())
 local trick_sel_chan = nil
 local last_trick_selection = nil
 


### PR DESCRIPTION
Make last_trick_action_state fetch conditional on TRIK_ENABLE in plane_aerobatics.lua
and (cosmetic change for clarity) move declaration near TRIK_ACT_FN param setup in sport_aerobatics.lua.
Tested both scripts in SITL with RealFlight PA Addiction.