### PR TITLE
AP_Mission/AP_Camera: add mavlink STOP_CAPTURE/START_CAPTURE command support and fixes to existing implementation

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -120,6 +120,10 @@ public:
     void take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
     bool take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num);
 
+    // stop capturing multiple image sequence
+    void stop_capture();
+    bool stop_capture(uint8_t instance);
+
     // start/stop recording video
     // start_recording should be true to start recording, false to stop recording
     bool record_video(bool start_recording);

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -113,11 +113,12 @@ public:
 
     // take a picture
     void take_picture();
-    void take_picture(uint8_t instance);
+    bool take_picture(uint8_t instance);
 
     // take multiple pictures, time_interval between two consecutive pictures is in miliseconds
     // total_num is number of pictures to be taken, -1 means capture forever
     void take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
+    bool take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num);
 
     // start/stop recording video
     // start_recording should be true to start recording, false to stop recording

--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -154,6 +154,12 @@ void AP_Camera_Backend::take_multiple_pictures(uint32_t time_interval_ms, int16_
     time_interval_settings = {time_interval_ms, total_num};
 }
 
+// stop capturing multiple image sequence
+void AP_Camera_Backend::stop_capture()
+{
+    time_interval_settings = {0, 0};
+}
+
 // handle camera control
 void AP_Camera_Backend::control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id)
 {

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -60,6 +60,9 @@ public:
     // total_num is number of pictures to be taken, -1 means capture forever
     void take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
 
+    // stop capturing multiple image sequence
+    void stop_capture();
+
     // entry point to actually take a picture.  returns true on success
     virtual bool trigger_pic() = 0;
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1312,6 +1312,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_IMAGE_START_CAPTURE:
+        cmd.content.image_start_capture.instance = packet.param1;
         cmd.content.image_start_capture.interval_s = packet.param2;
         cmd.content.image_start_capture.total_num_images = packet.param3;
         cmd.content.image_start_capture.start_seq_number = packet.param4;
@@ -1807,6 +1808,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         break;
 
     case MAV_CMD_IMAGE_START_CAPTURE:
+        packet.param1 = cmd.content.image_start_capture.instance;
         packet.param2 = cmd.content.image_start_capture.interval_s;
         packet.param3 = cmd.content.image_start_capture.total_num_images;
         packet.param4 = cmd.content.image_start_capture.start_seq_number;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -378,6 +378,7 @@ bool AP_Mission::verify_command(const Mission_Command& cmd)
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
     case MAV_CMD_JUMP_TAG:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_VIDEO_START_CAPTURE:
@@ -422,6 +423,7 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     case MAV_CMD_DO_DIGICAM_CONTROL:
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_VIDEO_START_CAPTURE:
@@ -1318,6 +1320,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.image_start_capture.start_seq_number = packet.param4;
         break;
 
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        cmd.p1 = packet.param1;
+        break;
+
     case MAV_CMD_SET_CAMERA_ZOOM:
         cmd.content.set_camera_zoom.zoom_type = packet.param1;
         cmd.content.set_camera_zoom.zoom_value = packet.param2;
@@ -1812,6 +1818,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param2 = cmd.content.image_start_capture.interval_s;
         packet.param3 = cmd.content.image_start_capture.total_num_images;
         packet.param4 = cmd.content.image_start_capture.start_seq_number;
+        break;
+
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        packet.param1 = cmd.p1;
         break;
 
     case MAV_CMD_SET_CAMERA_ZOOM:
@@ -2637,6 +2647,8 @@ const char *AP_Mission::Mission_Command::type() const
         return "GimbalPitchYaw";
     case MAV_CMD_IMAGE_START_CAPTURE:
         return "ImageStartCapture";
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        return "ImageStopCapture";
     case MAV_CMD_SET_CAMERA_ZOOM:
         return "SetCameraZoom";
     case MAV_CMD_SET_CAMERA_FOCUS:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -269,6 +269,7 @@ public:
 
     // MAV_CMD_IMAGE_START_CAPTURE support
     struct PACKED image_start_capture_Command {
+        uint8_t instance;
         float interval_s;
         uint16_t total_num_images;
         uint16_t start_seq_number;

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -163,8 +163,31 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         return false;
 
     case MAV_CMD_IMAGE_START_CAPTURE:
-        camera->take_picture();
-        return true;
+        // check if this is a single picture request
+        if (cmd.content.image_start_capture.total_num_images == 1) {
+            if (cmd.content.image_start_capture.instance == 0) {
+                // take pictures for every backend
+                camera->take_picture();
+                return true;
+            }
+            return camera->take_picture(cmd.content.image_start_capture.instance-1);
+        } else if (cmd.content.image_start_capture.total_num_images == 0) {
+            // multiple picture request, take pictures forever
+            if (cmd.content.image_start_capture.instance == 0) {
+                // take pictures for every backend
+                camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, -1);
+                return true;
+            }
+            return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, -1);
+        } else {
+            if (cmd.content.image_start_capture.instance == 0) {
+                // take pictures for every backend
+                camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
+                return true;
+            }
+            return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
+        }
+        return false;
 
     case MAV_CMD_VIDEO_START_CAPTURE:
     case MAV_CMD_VIDEO_STOP_CAPTURE:

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -189,6 +189,14 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         }
         return false;
 
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
+        if (cmd.p1 == 0) {
+            // stop capture for each backend
+            camera->stop_capture();
+            return true;
+        }
+        return camera->stop_capture(cmd.p1);
+
     case MAV_CMD_VIDEO_START_CAPTURE:
     case MAV_CMD_VIDEO_STOP_CAPTURE:
     {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4756,6 +4756,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_SET_CAMERA_ZOOM:
     case MAV_CMD_SET_CAMERA_FOCUS:
     case MAV_CMD_IMAGE_START_CAPTURE:
+    case MAV_CMD_IMAGE_STOP_CAPTURE:
     case MAV_CMD_CAMERA_TRACK_POINT:
     case MAV_CMD_CAMERA_TRACK_RECTANGLE:
     case MAV_CMD_CAMERA_STOP_TRACKING:


### PR DESCRIPTION
This adds support for [MAV_CMD_IMAGE_STOP_CAPTURE](https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_STOP_CAPTURE).  This is from the camera enhancements list  #23151 
Thanks to @trolledbypro for initial work on this
This has been tested latest in Mission and with simple mavlink command. (Single camera is used) Multiple should work.