### PR TITLE
Periph: Add BATT_HIDE_MASK to not broadcast (hide) battery instances

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -231,7 +231,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
 
     // @Param: BATT_HIDE_MASK
     // @DisplayName: Battery hide mask
-    // @Description: Instance mask of battery index(es) to not transmit their status over CAN. This is useful for hiding a "battery" instance that is used by other libraries but don't want to be treated as a battery source to the autopilot. For example, an AP_Periph based motor controller (ESC) that is reporting as an ESC. It should not be reporting "batteries", only ESC telemetry type data which includes voltage and current.
+    // @Description: Instance mask of local battery index(es) to prevent transmitting their status over CAN. This is useful for hiding a "battery" instance that is used locally in the peripheral but don't want them to be treated as a battery source(s) to the autopilot. For example, an AP_Periph battery monitor with multiple batteries that monitors each locally for diagnostic or other purposes, but only reports as a single SUM battery monitor to the autopilot.
     // @Bitmask: 0:BATT, 1:BATT2, 2:BATT3, 3:BATT4, 4:BATT5, 5:BATT6, 6:BATT7, 7:BATT8, 8:BATT9, 9:BATTA, 10:BATTB, 11:BATTC, 12:BATTD, 13:BATTE, 14:BATTF, 15:BATTG
     // @User: Advanced
     GSCALAR(battery_hide_mask, "BATT_HIDE_MASK", HAL_PERIPH_BATT_HIDE_MASK_DEFAULT),

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -43,6 +43,10 @@ extern const AP_HAL::HAL &hal;
 #define AP_PERIPH_BARO_ENABLE_DEFAULT 1
 #endif
 
+#ifndef HAL_PERIPH_BATT_HIDE_MASK_DEFAULT
+#define HAL_PERIPH_BATT_HIDE_MASK_DEFAULT 0
+#endif
+
 #ifndef AP_PERIPH_EFI_PORT_DEFAULT
 #define AP_PERIPH_EFI_PORT_DEFAULT 3
 #endif
@@ -224,6 +228,13 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Group: BATT
     // @Path: ../libraries/AP_BattMonitor/AP_BattMonitor.cpp
     GOBJECT(battery_lib, "BATT", AP_BattMonitor),
+
+    // @Param: BATT_HIDE_MASK
+    // @DisplayName: Battery hide mask
+    // @Description: Instance mask of battery index(es) to not transmit their status over CAN. This is useful for hiding a "battery" instance that is used by other libraries but don't want to be treated as a battery source to the autopilot. For example, an AP_Periph based motor controller (ESC) that is reporting as an ESC. It should not be reporting "batteries", only ESC telemetry type data which includes voltage and current.
+    // @Bitmask: 0:BATT, 1:BATT2, 2:BATT3, 3:BATT4, 4:BATT5, 5:BATT6, 6:BATT7, 7:BATT8, 8:BATT9, 9:BATTA, 10:BATTB, 11:BATTC, 12:BATTD, 13:BATTE, 14:BATTF, 15:BATTG
+    // @User: Advanced
+    GSCALAR(battery_hide_mask, "BATT_HIDE_MASK", HAL_PERIPH_BATT_HIDE_MASK_DEFAULT),
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_MAG

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -82,6 +82,7 @@ public:
         k_param_sitl,
         k_param_ahrs,
         k_param_battery_balance,
+        k_param_battery_hide_mask,
     };
 
     AP_Int16 format_version;
@@ -181,6 +182,10 @@ public:
 
 #if HAL_GCS_ENABLED
     AP_Int16 sysid_this_mav;
+#endif
+
+#ifdef HAL_PERIPH_ENABLE_BATTERY
+    AP_Int32 battery_hide_mask;
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_EFI

--- a/Tools/AP_Periph/battery.cpp
+++ b/Tools/AP_Periph/battery.cpp
@@ -27,6 +27,10 @@ void AP_Periph_FW::can_battery_update(void)
 
     const uint8_t battery_instances = battery_lib.num_instances();
     for (uint8_t i=0; i<battery_instances; i++) {
+        if (BIT_IS_SET(g.battery_hide_mask, i)) {
+            // do not transmit this battery
+            continue;
+        }
         if (!battery_lib.healthy(i)) {
             continue;
         }


### PR DESCRIPTION
This will allow you to keep Battery instance info internal and not send them over CAN as a BATTERYINFO msg.

Use-case:
1 - Smart-battery or a battery with sub-packs or a periph that is also acting as a power manager. On this periph I have multiple battery instances and one of them is BATTn_MONITOR=10 for SUM. I don't want to consume CAN bandwidth or confuse other systems with sending battery CAN packets of batteries that don't apply to systems outside of the periph. I only want to send the SUM battery instance over the CAN bus.

2- Periph-based ESC or Servo. You want feedback that also includes voltage/current. This allows you to use AP_BattMon without having to spam the bus with your battery data as if you're a battery supply. You can make your own Acturator::Status or ESC:; status messages. Related merged PR https://github.com/ArduPilot/ardupilot/pull/24658 where a battery can populate ESC_Telemetry.
