### PR TITLE
AP_ExternalAHRS: correct AP_ExternalAHRS init

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -92,21 +92,20 @@ void AP_ExternalAHRS::init(void)
     switch (DevType(devtype)) {
     case DevType::None:
         // nothing to do
-        break;
+        return;
 #if AP_EXTERNAL_AHRS_VECTORNAV_ENABLED
     case DevType::VecNav:
         backend = new AP_ExternalAHRS_VectorNav(this, state);
-        break;
+        return;
 #endif
 #if AP_EXTERNAL_AHRS_MICROSTRAIN_ENABLED
     case DevType::MicroStrain:
         backend = new AP_ExternalAHRS_MicroStrain(this, state);
-        break;
-    default:
+        return;
 #endif
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unsupported ExternalAHRS type %u", unsigned(devtype));
-        break;
     }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unsupported ExternalAHRS type %u", unsigned(devtype));
 }
 
 bool AP_ExternalAHRS::enabled() const


### PR DESCRIPTION
default clause is in wrong place and shouldn't be present to start with...

Sponsored by Spektreworks
