### PR TITLE
AP_Mount: Viewpro date fix (and other small fixes)

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Params.cpp
+++ b/libraries/AP_Mount/AP_Mount_Params.cpp
@@ -162,7 +162,6 @@ const AP_Param::GroupInfo AP_Mount_Params::var_info[] = {
     // @Param: _DEVID
     // @DisplayName: Mount Device ID
     // @Description: Mount device ID, taking into account its type, bus and instance
-    // @ReadOnly: True
     // @User: Advanced
     AP_GROUPINFO_FLAGS("_DEVID", 15, AP_Mount_Params, dev_id, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
 

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -672,9 +672,9 @@ bool AP_Mount_Viewpro::send_m_ahrs()
     uint16_t year, ms;
     uint8_t month, day, hour, min, sec;
     if (!AP::rtc().get_date_and_time_utc(year, month, day, hour, min, sec, ms)) {
-        year = month = day = hour = min = sec = 0;
+        year = month = day = hour = min = sec = ms = 0;
     }
-    uint16_t date = ((year-2000) & 0x7f) | (((month+1) & 0x0F) << 7) | ((day & 0x0F) << 11);
+    uint16_t date = ((year-2000) & 0x7f) | (((month+1) & 0x0F) << 7) | ((day & 0x1F) << 11);
     uint64_t second_hundredths = (((hour * 60 * 60) + (min * 60) + sec) * 100) + (ms * 0.1);
 
     // get vehicle velocity in m/s in NED Frame

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -661,6 +661,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::MOUNT2_YAW:
     case AUX_FUNC::LOWEHEISER_STARTER:
     case AUX_FUNC::MAG_CAL:
+    case AUX_FUNC::CAMERA_IMAGE_TRACKING:
         break;
 
     // not really aux functions:
@@ -697,6 +698,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const AuxSwitchPo
     case AUX_FUNC::CAMERA_ZOOM:
     case AUX_FUNC::CAMERA_MANUAL_FOCUS:
     case AUX_FUNC::CAMERA_AUTO_FOCUS:
+    case AUX_FUNC::CAMERA_LENS:
         run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
         break;
     default:


### PR DESCRIPTION
This makes 3 unrelated fixes to AP's camera and mount subsystems found during recent testing.  These changes have been tested on real hardware.

1. Viewpro driver fix to the date sent to the camera gimbal.  The mask applied to the date was incorrect meaning it was incorrect after the 15th of the month.  Below is a screenshot of the Viewlink app showing the correct date after this PR was applied.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/12da0011-084e-47df-ad0c-b5f98d08c1d9)
2. AP_Mount's DEVID field should be writeable so that users can reset it to zero in case they swap one Xacti camera for another (assuming the other has a different DroneCAN node id).
3. RC_Channel's init_aux_function was missing entries for the recently added CAMERA_IMAGE_TRACKING and CAMERA_LENS features.  For image tracking we don't need to initialise the state but for set-lens we should.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/45d2421e-da94-4bda-8498-16df46cad1d9)
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/fdaf2c32-4c3c-420f-be14-76b44fe485c0)

