### PR TITLE
Eahrs test gps output

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10184,6 +10184,7 @@ class AutoTestCopter(AutoTest):
             self.GPSForYaw,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
+            self.EAHRSGPSTypes,
             self.MultipleGPS,
             self.WatchAlts,
             self.GuidedEKFLaneChange,

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -13045,7 +13045,6 @@ switch value'''
     def EAHRSGPSTypes(self):
         '''check each AHRS GPS sensor works'''
         self.reboot_sitl()
-
         # (AHRS_EKF_TYPE, EAHRS_TYPE, detect_name, EAHRS_OPTIONS, uart_sim_name)
         sim_ahrs = [
             (11, 1, "VectorNAV", 0, "VectorNav"), # VN300 only, VN100 is skipped for this test
@@ -13054,7 +13053,6 @@ switch value'''
         for (ahrs_ekf_type, eahrs_type, detect_name, eahrs_options, uart_sim_name) in sim_ahrs:
             self.customise_SITL_commandline(["--uartE=sim:%s" % uart_sim_name])
             orig = self.poll_home_position(timeout=60)
-            self.context_collect("STATUSTEXT")
             self.start_subtest("Checking GPS type %s" % detect_name)
 
             SERIAL_PROTOCOL_EAHRS = 36
@@ -13069,7 +13067,7 @@ switch value'''
                 "EAHRS_OPTIONS": eahrs_options,
             })
 
-            self.context_clear_collection('STATUSTEXT')
+            self.context_collect("STATUSTEXT")
             self.reboot_sitl()
             self.wait_statustext("%s ExternalAHRS initialised" % (detect_name), check_context=True, timeout=30)
             self.wait_ready_to_arm()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -13042,6 +13042,35 @@ switch value'''
             if distance > 1:
                 raise NotAchievedException("gps type %u misbehaving" % name)
 
+    def EAHRSGPSTypes(self):
+        '''check each AHRS GPS sensor works'''
+        self.reboot_sitl()
+        orig = self.poll_home_position(timeout=60)
+        # (AHRS_EKF_TYPE, EAHRS_TYPE, detect_name, EAHRS_OPTIONS)
+        sim_ahrs = [
+            (11, 1, "VectorNAV", 0), # VN300 only, VN100 is skipped for this test
+            (11, 2, "MicroStrain", 0),
+        ]
+        self.context_collect("STATUSTEXT")
+        for (ahrs_ekf_type, eahrs_type, detect_name, eahrs_options) in sim_ahrs:
+            self.start_subtest("Checking GPS type %s" % detect_name)
+            SERIAL_PROTOCOL_EAHRS = 36
+            SERIAL_BAUD = 115
+            GPS_TYPE_EAHRS = 21
+            self.set_parameter("SERIAL3_PROTOCOL", SERIAL_PROTOCOL_EAHRS)
+            self.set_parameter("SERIAL3_BAUD", SERIAL_BAUD)
+            self.set_parameter("GPS_TYPE", GPS_TYPE_EAHRS)
+            self.set_parameter("AHRS_EKF_TYPE", ahrs_ekf_type)
+            self.set_parameter("EAHRS_TYPE", eahrs_type)
+            self.set_parameter("EAHRS_OPTIONS", eahrs_options)
+            self.context_clear_collection('STATUSTEXT')
+            self.reboot_sitl()
+            self.wait_statustext("%s ExternalAHRS initialised" % (detect_name), check_context=True)
+            n = self.poll_home_position(timeout=120)
+            distance = self.get_distance_int(orig, n)
+            if distance > 1:
+                raise NotAchievedException("gps type %u misbehaving" % detect_name)
+
     def assert_gps_satellite_count(self, messagename, count):
         m = self.assert_receive_message(messagename)
         if m.satellites_visible != count:

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -13058,23 +13058,29 @@ switch value'''
             SERIAL_PROTOCOL_EAHRS = 36
             SERIAL_BAUD = 115
             GPS_TYPE_EAHRS = 21
-            self.set_parameters({
-                "SERIAL3_PROTOCOL": SERIAL_PROTOCOL_EAHRS,
-                "SERIAL3_BAUD": SERIAL_BAUD,
+            params = {
+                "SERIAL4_PROTOCOL": SERIAL_PROTOCOL_EAHRS,
+                "SERIAL4_BAUD": SERIAL_BAUD,
                 "GPS_TYPE": GPS_TYPE_EAHRS,
                 "AHRS_EKF_TYPE": ahrs_ekf_type,
                 "EAHRS_TYPE": eahrs_type,
                 "EAHRS_OPTIONS": eahrs_options,
-            })
+            }
+
+            # VN-300 Specific Setup
+            if detect_name == "VectorNAV":
+                params.update({"GPS_TYPE2": GPS_TYPE_EAHRS})
+
+            self.set_parameters(params)
 
             self.context_collect("STATUSTEXT")
             self.reboot_sitl()
             self.wait_statustext("%s ExternalAHRS initialised" % (detect_name), check_context=True, timeout=30)
-            self.wait_ready_to_arm()
             n = self.poll_home_position(timeout=120)
             distance = self.get_distance_int(orig, n)
             if distance > 1:
                 raise NotAchievedException("gps type %u misbehaving" % detect_name)
+            self.wait_ready_to_arm()
 
     def assert_gps_satellite_count(self, messagename, count):
         m = self.assert_receive_message(messagename)

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -193,7 +193,7 @@ AP_ExternalAHRS_VectorNav::AP_ExternalAHRS_VectorNav(AP_ExternalAHRS *_frontend,
     if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_ExternalAHRS_VectorNav::update_thread, void), "AHRS", 2048, AP_HAL::Scheduler::PRIORITY_SPI, 0)) {
         AP_HAL::panic("Failed to start ExternalAHRS update thread");
     }
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ExternalAHRS initialised");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "VectorNav ExternalAHRS initialised");
 }
 
 /*


### PR DESCRIPTION
This tests the GPS output from the EAHRS system is working. I had to modify the VectorNav initialization message to get the initialization to pass. 

Currently, the test is failing arming checks. The goal is to be able to check the sign of the reported velocity in the Z axis (up/down earth frame), as its not yet covered in CI.
