### PR TITLE
AP_ExternalAHRS: Fix MicroStrain nullptr crash on bootup

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
@@ -73,6 +73,10 @@ void AP_ExternalAHRS_MicroStrain5::update_thread(void)
 // Builds packets by looking at each individual byte, once a full packet has been read in it checks the checksum then handles the packet.
 void AP_ExternalAHRS_MicroStrain5::build_packet()
 {
+    if (uart == nullptr) {
+        return;
+    }
+    
     WITH_SEMAPHORE(sem);
     uint32_t nbytes = MIN(uart->available(), 2048u);
     while (nbytes--> 0) {


### PR DESCRIPTION
If you didn't set the serial port parameter correctly, but enabled MicroStrain AHRS, it would crash on boot. VectorNAV is not subject to this issue because it has checks before reading the uart. 

Discovered here: https://github.com/ArduPilot/ardupilot/pull/24723#issuecomment-1694833045