### PR TITLE
AP_Mount: Siyi absolute zoom simplification

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -13,8 +13,6 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_SIYI_HEADER2       0x66    // second header byte
 #define AP_MOUNT_SIYI_PACKETLEN_MIN 10      // minimum number of bytes in a packet.  this is a packet with no data bytes
 #define AP_MOUNT_SIYI_DATALEN_MAX   (AP_MOUNT_SIYI_PACKETLEN_MAX-AP_MOUNT_SIYI_PACKETLEN_MIN) // max bytes for data portion of packet
-#define AP_MOUNT_SIYI_SERIAL_RESEND_MS   1000    // resend angle targets to gimbal once per second
-#define AP_MOUNT_SIYI_MSG_BUF_DATA_START 8  // data starts at this byte in _msg_buf
 #define AP_MOUNT_SIYI_RATE_MAX_RADS radians(90) // maximum physical rotation rate of gimbal in radans/sec
 #define AP_MOUNT_SIYI_PITCH_P       1.50    // pitch controller P gain (converts pitch angle error to target rate)
 #define AP_MOUNT_SIYI_YAW_P         1.50    // yaw controller P gain (converts yaw angle error to target rate)

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -189,7 +189,6 @@ private:
     bool send_zoom_rate(float zoom_value);
 
     // send zoom multiple command to camera. e.g. 1x, 10x, 30x
-    // only supported by ZR10 and ZR30
     bool send_zoom_mult(float zoom_mult);
 
     // get zoom multiple max
@@ -239,7 +238,6 @@ private:
     // absolute zoom control.  only used for A8 that does not support abs zoom control
     ZoomType _zoom_type;                            // current zoom type
     float _zoom_rate_target;                        // current zoom rate target
-    float _zoom_mult_target;                        // current zoom multiple target.  0 if no target
     float _zoom_mult;                               // most recent actual zoom multiple received from camera
     uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run
 };


### PR DESCRIPTION
Siyi's recent firmware for the A8 includes absolute zoom control so we can remove the simple absolute-to-rate-zoom controller we required previously.

It seems this addition was made to Siyi firmware ver 1.3 or 1.4 (released July 2023).  The latest firmware is ver 1.5 (released Aug 2023).

This has been tested on the A8 and ZR10.