### PR TITLE
gitignore: Add Python venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,13 @@ dumpstack_*out
 build.tmp.binaries/
 tasklist.json
 modules/esp_idf
+
+# Ignore Python virtual environments
+#   from: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore#L125
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
I often use a Python virtual environment to ensure I'm using the correct versions of Python modules. This PR adds the default `venv` folder to the `.gitignore`.