### PR TITLE
Allow initialisation of AC_AttitudeControl pids with a structure

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -1,6 +1,7 @@
 #include "AC_AttitudeControl_Multi.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+#include <AC_PID/AC_PID.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
@@ -244,10 +245,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
 
 AC_AttitudeControl_Multi::AC_AttitudeControl_Multi(AP_AHRS_View &ahrs, const AP_MultiCopter &aparm, AP_MotorsMulticopter& motors) :
     AC_AttitudeControl(ahrs, aparm, motors),
-    _motors_multi(motors),
-    _pid_rate_roll(AC_ATC_MULTI_RATE_RP_P, AC_ATC_MULTI_RATE_RP_I, AC_ATC_MULTI_RATE_RP_D, 0.0f, AC_ATC_MULTI_RATE_RP_IMAX, AC_ATC_MULTI_RATE_RP_FILT_HZ, 0.0f, AC_ATC_MULTI_RATE_RP_FILT_HZ),
-    _pid_rate_pitch(AC_ATC_MULTI_RATE_RP_P, AC_ATC_MULTI_RATE_RP_I, AC_ATC_MULTI_RATE_RP_D, 0.0f, AC_ATC_MULTI_RATE_RP_IMAX, AC_ATC_MULTI_RATE_RP_FILT_HZ, 0.0f, AC_ATC_MULTI_RATE_RP_FILT_HZ),
-    _pid_rate_yaw(AC_ATC_MULTI_RATE_YAW_P, AC_ATC_MULTI_RATE_YAW_I, AC_ATC_MULTI_RATE_YAW_D, 0.0f, AC_ATC_MULTI_RATE_YAW_IMAX, AC_ATC_MULTI_RATE_RP_FILT_HZ, AC_ATC_MULTI_RATE_YAW_FILT_HZ, 0.0f)
+    _motors_multi(motors)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -93,9 +93,49 @@ protected:
     float get_throttle_avg_max(float throttle_in);
 
     AP_MotorsMulticopter& _motors_multi;
-    AC_PID                _pid_rate_roll;
-    AC_PID                _pid_rate_pitch;
-    AC_PID                _pid_rate_yaw;
+    AC_PID                _pid_rate_roll {
+        AC_PID::Defaults{
+            .p         = AC_ATC_MULTI_RATE_RP_P,
+            .i         = AC_ATC_MULTI_RATE_RP_I,
+            .d         = AC_ATC_MULTI_RATE_RP_D,
+            .ff        = 0.0f,
+            .imax      = AC_ATC_MULTI_RATE_RP_IMAX,
+            .filt_T_hz = AC_ATC_MULTI_RATE_RP_FILT_HZ,
+            .filt_E_hz = 0.0f,
+            .filt_D_hz = AC_ATC_MULTI_RATE_RP_FILT_HZ,
+            .srmax     = 0,
+            .srtau     = 1.0
+        }
+    };
+    AC_PID                _pid_rate_pitch{
+        AC_PID::Defaults{
+            .p         = AC_ATC_MULTI_RATE_RP_P,
+            .i         = AC_ATC_MULTI_RATE_RP_I,
+            .d         = AC_ATC_MULTI_RATE_RP_D,
+            .ff        = 0.0f,
+            .imax      = AC_ATC_MULTI_RATE_RP_IMAX,
+            .filt_T_hz = AC_ATC_MULTI_RATE_RP_FILT_HZ,
+            .filt_E_hz = 0.0f,
+            .filt_D_hz = AC_ATC_MULTI_RATE_RP_FILT_HZ,
+            .srmax     = 0,
+            .srtau     = 1.0
+        }
+    };
+
+    AC_PID                _pid_rate_yaw{
+        AC_PID::Defaults{
+            .p         = AC_ATC_MULTI_RATE_YAW_P,
+            .i         = AC_ATC_MULTI_RATE_YAW_I,
+            .d         = AC_ATC_MULTI_RATE_YAW_D,
+            .ff        = 0.0f,
+            .imax      = AC_ATC_MULTI_RATE_YAW_IMAX,
+            .filt_T_hz = AC_ATC_MULTI_RATE_RP_FILT_HZ,
+            .filt_E_hz = AC_ATC_MULTI_RATE_YAW_FILT_HZ,
+            .filt_D_hz = 0.0f,
+            .srmax     = 0,
+            .srtau     = 1.0
+        }
+    };
 
     AP_Float              _thr_mix_man;     // throttle vs attitude control prioritisation used when using manual throttle (higher values mean we prioritise attitude control over throttle)
     AP_Float              _thr_mix_min;     // throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -21,9 +21,36 @@
 class AC_PID {
 public:
 
+    struct Defaults {
+        float p;
+        float i;
+        float d;
+        float ff;
+        float imax;
+        float filt_T_hz;
+        float filt_E_hz;
+        float filt_D_hz;
+        float srmax;
+        float srtau;
+    };
+
     // Constructor for PID
     AC_PID(float initial_p, float initial_i, float initial_d, float initial_ff, float initial_imax, float initial_filt_T_hz, float initial_filt_E_hz, float initial_filt_D_hz,
            float initial_srmax=0, float initial_srtau=1.0);
+    AC_PID(const AC_PID::Defaults &defaults) :
+        AC_PID(
+            defaults.p,
+            defaults.i,
+            defaults.d,
+            defaults.ff,
+            defaults.imax,
+            defaults.filt_T_hz,
+            defaults.filt_E_hz,
+            defaults.filt_D_hz,
+            defaults.srmax,
+            defaults.srtau
+            )
+        { }
 
     CLASS_NO_COPY(AC_PID);
 


### PR DESCRIPTION
Came up on the DevCall that the current constructor for AC_PID is a bit of a nightmare to work with.

Perhaps this structure might be better?

I've only converted one PID here, and if we do go down this path we'd remove the old constructor and move the content into the new constructor.
