### PR TITLE
Backport 24728 to copter 4.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ exclude: |
 
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.2.0
+      rev: v4.4.0
       hooks:
         #-   id: trailing-whitespace
         #-   id: end-of-file-fixer
@@ -38,7 +38,7 @@ repos:
 
 # Use to sort python imports by name and put system import first.
   -   repo: https://github.com/pycqa/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
         - id: isort
           args: [--check-only]
@@ -46,7 +46,7 @@ repos:
 
 # Use to check python typing to show errors.
   -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v0.950'
+      rev: 'v1.5.1'
       hooks:
         - id: mypy
           args: [--no-strict-optional, --ignore-missing-imports]


### PR DESCRIPTION
Backport of https://github.com/ArduPilot/ardupilot/pull/24728, or at least the method of running pre-commit autoupdate. The commit hooks are slightly different. 