### PR TITLE
Plane: accept DO_CHANGE_SPEED as command_int

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -981,16 +981,16 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_in
         return MAV_RESULT_ACCEPTED;
 #endif
 
+    case MAV_CMD_DO_CHANGE_SPEED:
+        return handle_command_DO_CHANGE_SPEED(packet);
+
     default:
         return GCS_MAVLINK::handle_command_int_packet(packet, msg);
     }
 }
 
-MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
+MAV_RESULT GCS_MAVLINK_Plane::handle_command_DO_CHANGE_SPEED(const mavlink_command_int_t &packet)
 {
-    switch(packet.command) {
-
-    case MAV_CMD_DO_CHANGE_SPEED: {
         // if we're in failsafe modes (e.g., RTL, LOITER) or in pilot
         // controlled modes (e.g., MANUAL, TRAINING)
         // this command should be ignored since it comes in from GCS
@@ -1001,15 +1001,15 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
             return MAV_RESULT_FAILED;
         }
 
-        AP_Mission::Mission_Command cmd;
-        if (AP_Mission::mavlink_cmd_long_to_mission_cmd(packet, cmd) != MAV_MISSION_ACCEPTED) {
-            return MAV_RESULT_DENIED;
-        }
-        if (plane.do_change_speed(cmd)) {
+        if (plane.do_change_speed(packet.param1, packet.param2, packet.param3)) {
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;
-    }
+}
+
+MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_long_t &packet, const mavlink_message_t &msg)
+{
+    switch(packet.command) {
 
     case MAV_CMD_NAV_LOITER_UNLIM:
         plane.set_mode(plane.mode_loiter, ModeReason::GCS_COMMAND);

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -54,7 +54,7 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_int_guided_slew_commands(const mavlink_command_int_t &packet);
-
+    MAV_RESULT handle_command_DO_CHANGE_SPEED(const mavlink_command_int_t &packet);
 
     bool try_send_message(enum ap_message id) override;
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -945,6 +945,7 @@ private:
 
     bool is_land_command(uint16_t cmd) const;
 
+    bool do_change_speed(uint8_t speedtype, float speed_target_ms, float rhtottle_pct);
     /*
       return true if in a specific AUTO mission command
     */

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -946,28 +946,36 @@ void Plane::do_loiter_at_location()
 
 bool Plane::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
-    switch (cmd.content.speed.speed_type)
-    {
+    return do_change_speed(
+        (uint8_t)cmd.content.speed.speed_type,
+        cmd.content.speed.target_ms,
+         cmd.content.speed.throttle_pct
+        );
+}
+
+bool Plane::do_change_speed(uint8_t speedtype, float speed_target_ms, float throttle_pct)
+{
+    switch (speedtype) {
     case 0:             // Airspeed
-        if (is_equal(cmd.content.speed.target_ms, -2.0f)) {
+        if (is_equal(speed_target_ms, -2.0f)) {
             new_airspeed_cm = -1; // return to default airspeed
             return true;
-        } else if ((cmd.content.speed.target_ms >= aparm.airspeed_min.get()) &&
-                   (cmd.content.speed.target_ms <= aparm.airspeed_max.get()))  {
-            new_airspeed_cm = cmd.content.speed.target_ms * 100; //new airspeed target for AUTO or GUIDED modes
-            gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)cmd.content.speed.target_ms);
+        } else if ((speed_target_ms >= aparm.airspeed_min.get()) &&
+                   (speed_target_ms <= aparm.airspeed_max.get()))  {
+            new_airspeed_cm = speed_target_ms * 100; //new airspeed target for AUTO or GUIDED modes
+            gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)speed_target_ms);
             return true;
         }
         break;
     case 1:             // Ground speed
-        gcs().send_text(MAV_SEVERITY_INFO, "Set groundspeed %u", (unsigned)cmd.content.speed.target_ms);
-        aparm.min_gndspeed_cm.set(cmd.content.speed.target_ms * 100);
+        gcs().send_text(MAV_SEVERITY_INFO, "Set groundspeed %u", (unsigned)speed_target_ms);
+        aparm.min_gndspeed_cm.set(speed_target_ms * 100);
         return true;
     }
 
-    if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Set throttle %u", (unsigned)cmd.content.speed.throttle_pct);
-        aparm.throttle_cruise.set(cmd.content.speed.throttle_pct);
+    if (throttle_pct > 0 && throttle_pct <= 100) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Set throttle %u", (unsigned)throttle_pct);
+        aparm.throttle_cruise.set(throttle_pct);
         return true;
     }
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3952,14 +3952,25 @@ class AutoTest(ABC):
         self.assert_message_field_values(m, fieldvalues, verbose=verbose, epsilon=epsilon)
         return m
 
-    def wait_message_field_values(self, message, fieldvalues, timeout=10, epsilon=None, instance=None):
+    # FIXME: try to use wait_and_maintain here?
+    def wait_message_field_values(self, message, fieldvalues, timeout=10, epsilon=None, instance=None, minimum_duration=None):
+
         tstart = self.get_sim_time_cached()
+        pass_start = None
         while True:
-            if self.get_sim_time_cached() - tstart > timeout:
+            now = self.get_sim_time_cached()
+            if now - tstart > timeout:
                 raise NotAchievedException("Field never reached values")
             m = self.assert_receive_message(message, instance=instance)
             if self.message_has_field_values(m, fieldvalues, epsilon=epsilon):
+                if minimum_duration is not None:
+                    if pass_start is None:
+                        pass_start = now
+                        continue
+                    if now - pass_start < minimum_duration:
+                        continue
                 return m
+            pass_start = None
 
     def onboard_logging_not_log_disarmed(self):
         self.start_subtest("Test LOG_DISARMED-is-false behaviour")
@@ -6362,9 +6373,12 @@ class AutoTest(ABC):
             **kwargs
         )
 
-    def wait_altitude(self, altitude_min, altitude_max, relative=False, timeout=30, **kwargs):
+    def wait_altitude(self, altitude_min, altitude_max, relative=False, timeout=None, **kwargs):
         """Wait for a given altitude range."""
         assert altitude_min <= altitude_max, "Minimum altitude should be less than maximum altitude."
+
+        if timeout is None:
+            timeout = 30
 
         def validator(value2, target2=None):
             if altitude_min <= value2 <= altitude_max:

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1475,24 +1475,6 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(const ma
     return MAV_MISSION_ACCEPTED;
 }
 
-// mavlink_cmd_long_to_mission_cmd - converts a mavlink cmd long to an AP_Mission::Mission_Command object which can be stored to eeprom
-// return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
-MAV_MISSION_RESULT AP_Mission::mavlink_cmd_long_to_mission_cmd(const mavlink_command_long_t& packet, AP_Mission::Mission_Command& cmd)
-{
-    mavlink_mission_item_int_t miss_item = {0};
-
-    miss_item.param1 = packet.param1;
-    miss_item.param2 = packet.param2;
-    miss_item.param3 = packet.param3;
-    miss_item.param4 = packet.param4;
-
-    miss_item.command = packet.command;
-    miss_item.target_system = packet.target_system;
-    miss_item.target_component = packet.target_component;
-
-    return mavlink_int_to_mission_cmd(miss_item, cmd);
-}
-
 // mission_cmd_to_mavlink_int - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
 //  return true on success, false on failure
 //  NOTE: callers to this method current fill parts of "packet" in before calling this method, so do NOT attempt to zero the entire packet in here

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -627,10 +627,6 @@ public:
     //  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
     static MAV_MISSION_RESULT mavlink_int_to_mission_cmd(const mavlink_mission_item_int_t& packet, AP_Mission::Mission_Command& cmd);
 
-    // mavlink_cmd_long_to_mission_cmd - converts a mavlink cmd long to an AP_Mission::Mission_Command object which can be stored to eeprom
-    // return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
-    static MAV_MISSION_RESULT mavlink_cmd_long_to_mission_cmd(const mavlink_command_long_t& packet, AP_Mission::Mission_Command& cmd);
-
     // mission_cmd_to_mavlink_int - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
     //  return true on success, false on failure
     static bool mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_int_t& packet);


### PR DESCRIPTION
This also stops us converting the mavlink command into a mission item before trying to handle it.  It was the last user of the method which did the conversion from command_long into a mission command, so that method is now removed.  I factored the existing handler  to cut out the complicated conversion process.  I could have converted from command_int -> mission_cmd instead, but this seemed neater.

Critical lines in AP_Mission.cpp to do with conversion from cmd_long -> mission_item_it_t -> mission_cmd -> field values change in this PR:
```
    case MAV_CMD_DO_CHANGE_SPEED:                       // MAV ID: 178
        cmd.content.speed.speed_type = packet.param1;   // 0 = airspeed, 1 = ground speed
        cmd.content.speed.target_ms = packet.param2;    // target speed in m/s
        cmd.content.speed.throttle_pct = packet.param3; // throttle as a percentage from 1 ~ 100%
        break;
```

```
Board,AP_Periph,blimp,bootloader,copter,heli,iofirmware,plane,rover,sub
Durandal,,*,*,*,*,,-64,*,*
HerePro,*,,,,,,,,
Hitec-Airspeed,*,,,,,,,,
KakuteH7-bdshot,,*,*,*,*,,-88,*,*
MatekF405,,*,*,*,*,,-48,*,*
Pixhawk1-1M-bdshot,,*,,*,*,,-88,*,*
f103-QiotekPeriph,*,,,,,,,,
f303-Universal,*,,,,,,,,
iomcu,,,,,,*,,,
revo-mini,,*,*,*,*,,-96,*,*
skyviper-v2450,,,,*,,,,,
```
