### PR TITLE
AP_Mount: Do not perform unnecessary processing

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -38,9 +38,11 @@ void AP_Mount_Siyi::init()
     const AP_SerialManager& serial_manager = AP::serialmanager();
 
     _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
-    if (_uart != nullptr) {
-        _initialised = true;
+    if (_uart == nullptr) {
+        return;
     }
+
+    _initialised = true;
     AP_Mount_Backend::init();
 }
 

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -34,10 +34,11 @@ void AP_Mount_Viewpro::init()
     const AP_SerialManager& serial_manager = AP::serialmanager();
 
     _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
-    if (_uart != nullptr) {
-        _initialised = true;
+    if (_uart == nullptr) {
+        return;
     }
 
+    _initialised = true;
     AP_Mount_Backend::init();
 }
 


### PR DESCRIPTION
If there is no instance, I think it is unnecessary to execute the following process.