### PR TITLE
AP_DDS: use /tf  instead of /ap/tf

### DIFF
--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -216,8 +216,8 @@ Next, follow the associated section for your chosen transport, and finally you c
 
   Subscribed topics:
   * /ap/joy [sensor_msgs/msg/Joy] 1 subscriber
-  * /ap/tf [tf2_msgs/msg/TFMessage] 1 subscriber
   * /ap/cmd_vel [geometry_msgs/msg/TwistStamped] 1 subscriber
+  * /tf [tf2_msgs/msg/TFMessage] 1 subscriber
 
   $ ros2 topic hz /ap/time
   average rate: 50.115

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -239,7 +239,7 @@
     </topic>
   </data_reader>
   <topic profile_name="dynamictf__t">
-    <name>rt/ap/tf</name>
+    <name>rt/tf</name>
     <dataType>tf2_msgs::msg::dds_::TFMessage_</dataType>
     <historyQos>
       <kind>KEEP_LAST</kind>
@@ -249,7 +249,7 @@
   <data_reader profile_name="dynamictf__dr">
     <topic>
       <kind>NO_KEY</kind>
-      <name>rt/ap/tf</name>
+      <name>rt/tf</name>
       <dataType>tf2_msgs::msg::dds_::TFMessage_</dataType>
     </topic>
   </data_reader>


### PR DESCRIPTION
This PR is part of a group of PRs with focus on eliminating the excessive remaps in `ardupilot_gz`, `AP_DDS` and `ardupilot_ros`

https://github.com/ArduPilot/ardupilot_gz/pull/27
https://github.com/ArduPilot/ardupilot_ros/pull/14