### PR TITLE
AP_HAL_ESP32: change storage sector size to 128K

### DIFF
--- a/libraries/AP_HAL_ESP32/Storage.h
+++ b/libraries/AP_HAL_ESP32/Storage.h
@@ -23,7 +23,7 @@
 #include "esp_partition.h"
 
 #define STORAGE_SIZE HAL_STORAGE_SIZE
-#define STORAGE_SECTOR_SIZE (64*1024)
+#define STORAGE_SECTOR_SIZE (128*1024)
 
 #define STORAGE_LINE_SHIFT 3
 

--- a/libraries/AP_HAL_ESP32/targets/esp32/partitions.csv
+++ b/libraries/AP_HAL_ESP32/targets/esp32/partitions.csv
@@ -2,4 +2,4 @@
 nvs,      data, nvs,           ,  0x6000
 phy_init, data, phy,           ,  0x1000
 factory,   app, factory,       ,  3M
-storage,  0x45, 0x0,           ,  128K
+storage,  0x45, 0x0,           ,  256K


### PR DESCRIPTION
Increase the storage partition for esp32 to 256K to allow for two 128K sectors when using `AP_FlashStorage`.

This fixes an issue where the EEPROM was always erased on boot for rover and plane builds as the `format_version` loaded from flash did not match the version in the build.

## Testing

- build, flash and run for `esp32buzz` (plane), `esp32nick` (plane) - bare board only - so run up to hardware init.
- verified that params changes are persisted and EEPROM not cleared on reboot for `esp32empty` (copter, plane, rover). 
 