### PR TITLE
AP_Compass: Compare with string

### DIFF
--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -332,9 +332,7 @@ bool AP_Compass_HMC5843::_check_whoami()
         // can't talk on bus
         return false;        
     }
-    if (id[0] != 'H' ||
-        id[1] != '4' ||
-        id[2] != '3') {
+    if (strncmp((const char*)id, "H43", sizeof(id)) != 0) {
         // not a HMC5x83 device
         return false;
     }


### PR DESCRIPTION
If you get a string from a device, determine it by the string.