### PR TITLE
AP_L1_Control: check vehicle yaw (heading) and ground track agree

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -240,7 +240,11 @@ void AP_L1_Control::update_waypoint(const Location &prev_WP, const Location &nex
 
     //Calculate groundspeed
     float groundSpeed = _groundspeed_vector.length();
-    if (groundSpeed < 0.1f) {
+
+    // check if we are moving in the direction of the front of the vehicle
+    const bool moving_forwards = fabsf(wrap_PI(_groundspeed_vector.angle() - get_yaw())) < M_PI_2;
+
+    if (groundSpeed < 0.1f || !moving_forwards) {
         // use a small ground speed vector in the right direction,
         // allowing us to use the compass heading at zero GPS velocity
         groundSpeed = 0.1f;


### PR DESCRIPTION
## Context
It appears that the L1 navigation controller assume the vehicle heading (yaw) is always in a direction that will close the distance to the desired ground track between waypoints.

In the case of an aircraft flying into a large headwind (higher than `TRIM_ARSPD_CM`), the controller will begin to swing between left and right roll.

This is possibly related to: https://github.com/ArduPilot/ardupilot/issues/20080 ; however, this is more of a corner case than general wrapping of the calculation.

### SITL quadplane with 30 m/s wind from 180 deg
**SITL command from top level directory**: `python ./Tools/autotest/sim_vehicle.py --vehicle ArduPlane --out=tcpin:localhost:5760 --out=tcpin:127.0.0.1:14550 --frame quadplane -D -w`

**Waypoints**: [canberra_180.txt](https://github.com/ArduPilot/ardupilot/files/12490556/canberra_180.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/34d59384-9250-449a-931e-3730d04c116c)


**BIN log (remove .txt extension)**:
[canberra_left_hand_180_baseline_30wind.BIN.txt](https://github.com/ArduPilot/ardupilot/files/12490563/canberra_left_hand_180_baseline_30wind.BIN.txt)

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/82cbde4a-7294-48c1-8cce-9e6a73e8b248)
_Figure: Roll begins commanding left and right when GPS speed changes direction. GPS speed is always positive, zero indicates where the direction changed._

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/b59911f0-72a9-48a1-9fa9-da47b03c337d)
_Figure: Ground course is oscillating about north because the winds are out of 180 degrees._

## Proposal
Check that vehicle yaw (heading) is within 90 degrees of the ground track (any greater than this means we are moving away from the ground track and will not be able to close). In the event we are moving backwards, use the existing code for small groundspeeds where we use the vehicle heading to adjust the ground track path.

This will not do anything to progress the flight plan. Ideally it will keep the aircraft stable while the operator can take an appropriate course of action.

### SITL quadplane with 30 m/s wind from 180 deg
**SITL command from top level directory**: `python ./Tools/autotest/sim_vehicle.py --vehicle ArduPlane --out=tcpin:localhost:5760 --out=tcpin:127.0.0.1:14550 --frame quadplane -D -w`

**Waypoints**: [canberra_180.txt](https://github.com/ArduPilot/ardupilot/files/12490556/canberra_180.txt)

**BIN log (remove .txt extension)**:
[canberra_left_hand_180_new_30wind.BIN.txt](https://github.com/ArduPilot/ardupilot/files/12490628/canberra_left_hand_180_new_30wind.BIN.txt)

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/f9763c89-a076-4623-90e8-832bf0493ee5)
_Figure: Roll remains smooth when GPS speed changes direction. GPS speed is always positive, zero indicates where the direction changed._

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/0abea6aa-7c99-4d0d-87a2-2a5a5614b9d1)
_Figure: Ground course swings from 0 to 360 degrees and roll remains constant._

## Simulation results with zero wind to check behavior

A flight plan with 180 degrees waypoint difference was used to ensure this does not affect the current `_prevent_indecision(Nu)` code.

**Baseline**: https://drive.google.com/file/d/1x7_GJDk8OymB14a0-PHF1HqWN7079t4e/view?usp=drive_link
**New**: https://drive.google.com/file/d/1z0hhpeV6oGJCSEggN1ptlwXUbgpwdB5B/view?usp=drive_link

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/0e8379f5-c042-46d9-ba0c-73a11b1af882)
_Figure: Baseline results. At 180 degree waypoint turn, aircraft decided left hand turn._

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/56a6f3e3-433e-407d-ae6e-00848c88b5ef)
_Figure: New code results. At 180 degree waypoint turn, aircarft decided right hand turn._

## Additional simulation results
### Wind direction 270 degrees, step increase to 30 m/s
**Waypoints**: [canberra_270dir.txt](https://github.com/ArduPilot/ardupilot/files/12490705/canberra_270dir.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/79f05734-0651-4d96-aeb7-c29972a1d11b)

**Baseline log (remove .txt extension)**: 
[canberra_left_hand_winddir270_30_baseline.BIN.txt](https://github.com/ArduPilot/ardupilot/files/12490708/canberra_left_hand_winddir270_30_baseline.BIN.txt)

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/d6ea1e76-5086-44b6-b10f-2f27f3aca717)
_Figure: DesRoll alternates left and right when groundspeed reverses. Indicated by the zero point._

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/5bda049a-7e4d-459f-a08e-65bfa194f241)
_Figure: Ground course reverses and DesRoll starts changing between left and right roll._

**New log (remove .txt extension)**: 
[canberra_left_hand_winddir270_30_new.BIN.txt](https://github.com/ArduPilot/ardupilot/files/12490721/canberra_left_hand_winddir270_30_new.BIN.txt)

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/443e9172-1dab-4204-a7e4-dd49901ebbcc)
_Figure: GPS speed reverses direction (indicated by zero point) and DesRoll stays smooth._

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/308bee3c-0f18-4e61-9c56-c78023acf1b4)
_Figure: Ground course reverses direcition (270 degrees to 90 degrees). DesRoll remains smooth and vehicle yaw (heading) remains constant._
