### PR TITLE
AP_HAL_Linux: update Navigator available GPIOs

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_Navigator.h
+++ b/libraries/AP_HAL_Linux/GPIO_Navigator.h
@@ -14,8 +14,9 @@ public:
     uint8_t read(uint8_t pin) override;
     void    write(uint8_t pin, uint8_t value) override;
 private:
-    uint8_t AllowedGPIOS[2] = {
-        RPI_GPIO_<26>(), // Aux Output for PWMs
+    uint8_t AllowedGPIOS[3] = {
+        RPI_GPIO_<18>(), // Aux Output for PWMs
+        RPI_GPIO_<26>(), // PCA OUTPUT_ENABLE
         RPI_GPIO_<27>()  // Leak detection
     };
     bool    pinAllowed(uint8_t pin);


### PR DESCRIPTION
The comment was wrong. gpio 26 is actually used for the PCA Output Enable signal. This also adds GPIO18, which is the one broken out to the PWM0 pin