### PR TITLE
autotest: paper over problem with EKF heading not recovering

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -12985,6 +12985,11 @@ switch value'''
         self.assert_prearm_failure("Compasses inconsistent")
         self.context_pop()
         self.wait_ready_to_arm()
+        # the following line papers over a probably problem with the
+        # EKF recovering from bad compass offsets.  Without it, the
+        # EKF will maintain a 10-degree offset from the true compass
+        # heading seemingly indefinitely.
+        self.reboot_sitl()
 
     def AHRS_ORIENTATION(self):
         '''test AHRS_ORIENTATION parameter works'''


### PR DESCRIPTION
```
        # the following line papers over a probably problem with the
        # EKF recovering from bad compass offsets.  Without it, the
        # EKF will maintain a 10-degree offset from the true compass
        # heading seemingly indefinitely.
```

This resolves the flapping `MAV_CMD_DO_SET_REVERSE` test; it's not that tests' fault, it's this one leaving the vehicle in a state it won't seem to recover from.
