### PR TITLE
Add missing internal-error includes

### DIFF
--- a/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
+++ b/libraries/AP_DAL/AP_DAL_RangeFinder.cpp
@@ -6,6 +6,7 @@
 #include "AP_DAL.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_InternalError/AP_InternalError.h>
 
 AP_DAL_RangeFinder::AP_DAL_RangeFinder()
 {

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Calibrator.cpp
@@ -18,6 +18,7 @@
 #if AP_OPTICALFLOW_CALIBRATOR_ENABLED
 
 #include "AP_OpticalFlow_Calibrator.h"
+#include <AP_InternalError/AP_InternalError.h>
 
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -59,6 +59,7 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_HAL/I2CDevice.h>
+#include <AP_InternalError/AP_InternalError.h>
 
 extern const AP_HAL::HAL &hal;
 


### PR DESCRIPTION
These cpp files are using the library without getting the header file.  If transitive includes break then you can get errors in seemingly unrelated places.....

