### PR TITLE
Allow SITL on HW to drive actuators

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -156,8 +156,10 @@ void AP_Relay::set(const uint8_t instance, const bool value)
        _last_log_ms = now;
        _last_logged_pin_states = _pin_states;
     }
-#if AP_SIM_ENABLED && (CONFIG_HAL_BOARD != HAL_BOARD_SITL)
-    return;
+#if AP_SIM_ENABLED
+    if (!(AP::sitl()->on_hardware_relay_enable_mask & (1U << instance))) {
+        return;
+    }
 #endif
     hal.gpio->pinMode(_pin[instance], HAL_GPIO_OUTPUT);
     hal.gpio->write(_pin[instance], value);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -47,6 +47,15 @@ extern const AP_HAL::HAL& hal;
 #endif
 #endif
 
+#if (CONFIG_HAL_BOARD != HAL_BOARD_SITL)
+// For on-hardware, set allowed relay channels to zero.
+// Requires user to change the param to allow hadware access.
+#define SIM_DEFAULT_ENABLED_RELAY_CHANNELS 0
+#else
+// For SITL, set allowed relay channels to the full mask.
+#define SIM_DEFAULT_ENABLED_RELAY_CHANNELS UINT16_MAX
+#endif
+
 namespace SITL {
 
 SIM *SIM::_singleton = nullptr;
@@ -1028,6 +1037,11 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
 
     AP_GROUPINFO("GYR5_BIAS",    47, SIM, gyro_bias[4], 0),
 #endif
+
+    // @Param: OH_RELAY_MSK
+    // @DisplayName: SIM-on_hardware Relay Enable Mask
+    // @Description: Allow relay output operation when running SIM-on-hardware
+    AP_GROUPINFO("OH_RELAY_MSK",     48, SIM, on_hardware_relay_enable_mask, SIM_DEFAULT_ENABLED_RELAY_CHANNELS),
 
     // the IMUT parameters must be last due to the enable parameters
 #if HAL_INS_TEMPERATURE_CAL_ENABLE

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -246,6 +246,7 @@ public:
     AP_Int16 loop_rate_hz;
     AP_Int16 loop_time_jitter_us;
     AP_Int32 on_hardware_output_enable_mask;  // mask of output channels passed through to actual hardware
+    AP_Int16 on_hardware_relay_enable_mask;   // mask of relays passed through to actual hardware
 
     AP_Float uart_byte_loss_pct;
 


### PR DESCRIPTION
Adds a parameter for allowing relays to be driven by SIM on HW.
This reflects similar changes that allowed driving servo channels with SIM on HW.