### PR TITLE
AP_Scripting: Examples: UART log: remove spaces in log description

### DIFF
--- a/libraries/AP_Scripting/examples/UART_log.lua
+++ b/libraries/AP_Scripting/examples/UART_log.lua
@@ -100,7 +100,7 @@ function update()
             -- format characters specify the type of variable to be logged, see AP_Logger/README.md
             -- not all format types are supported by scripting only: i, L, e, f, n, M, B, I, E, N, and Z
             -- Note that Lua automatically adds a timestamp in micro seconds
-            logger:write('SCR','Sensor1, Sensor2, Sensor3','fff',table.unpack(log_data))
+            logger:write('SCR','Sensor1,Sensor2,Sensor3','fff',table.unpack(log_data))
 
             -- reset for the next message
             log_data = {}


### PR DESCRIPTION
The spaces cause issues for some log viewers, Mission planner is OK so this was not spotted in the first place.