### PR TITLE
AP_HAL_ChibiOS: Fix H7 PLL1 Q clock for 480 MHz clock (4.4 backport)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -171,7 +171,9 @@
 #define STM32_PLL1_DIVN_VALUE               100
 #endif
 #define STM32_PLL1_DIVP_VALUE               2
+#ifndef STM32_PLL1_DIVQ_VALUE
 #define STM32_PLL1_DIVQ_VALUE               10
+#endif
 #define STM32_PLL1_DIVR_VALUE               2
 
 #define STM32_PLL2_DIVN_VALUE               45


### PR DESCRIPTION
There is a mistake in the H7 clock tree that results in an incorrect clock for the FDCAN peripheral when a core clock of 480 MHz is used. This changes the PLL1 Q divider such that the 80 MHz clock needed for FDCAN can be generated.

Note: The same values for `STM32_PLL1_DIVQ_VALUE` are also used in the `master` branch.