### PR TITLE
AP_Periph: add AP_PERIPH_SAFETY_SWITCH_ENABLED

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -68,6 +68,10 @@
     #endif
 #endif
 
+#ifndef AP_PERIPH_SAFETY_SWITCH_ENABLED
+#define AP_PERIPH_SAFETY_SWITCH_ENABLED defined(HAL_PERIPH_ENABLE_RC_OUT)
+#endif
+
 #include "Parameters.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -509,7 +509,7 @@ void AP_Periph_FW::handle_safety_state(CanardInstance* canard_instance, CanardRx
         return;
     }
     safety_state = req.status;
-#ifdef HAL_PERIPH_ENABLE_RC_OUT
+#if AP_PERIPH_SAFETY_SWITCH_ENABLED
     rcout_handle_safety_state(safety_state);
 #endif
 }

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -28,8 +28,12 @@ extern const AP_HAL::HAL &hal;
 
 void AP_Periph_FW::rcout_init()
 {
+#if AP_PERIPH_SAFETY_SWITCH_ENABLED
     // start up with safety enabled. This disables the pwm output until we receive an packet from the rempte system
     hal.rcout->force_safety_on();
+#else
+    hal.rcout->force_safety_off();
+#endif
 
 #if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
     if (g.esc_telem_port >= 0) {


### PR DESCRIPTION
Add define HAL_PERIPH_ALWAYS_ARMED to always be safety_off for Periph.

I've had trouble with a race condition on a periph with a PWM/ESC output.

Scenario:
- Autopilot is sending ESC/SERVO commands fast (like 20-50Hz)
- Autopilot is sending armed state slow (1-2Hz)
- on autopilot I switch to AUTO/TAKEOFF and then arm.
- over CAN we see the ESC values ramp up quickly but the disarmed msg hasn't gone out yet.
- The Periph is still disarmed but is getting ESC signals going up
- The Peirph then gets the ARMED state change and immediately outputs this rising (maybe always maxxed) throttle.
- ESC is just now getting it's first valid PWM signal but it needs a low PWM to initialize and thus rejects the PWM

Notes:
- This is equivalent to setting BRD_SAFETYENABLE = 0 and ARMING_REQUIRE = 0 and ARMING_CHECK = 0.
- This does not effect the LED notify. If enabled, it will show the correct arming state reported by the autopilot.