### PR TITLE
Update logical error in grouping of 4 escs in AP_ESC_Telem.cpp

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -309,7 +309,7 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
 
     // loop through groups of 4 ESCs
     const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
-    const uint8_t num_idx //initializing num_idx
+    const uint8_t num_idx; //initializing num_idx
     //This ensures that number of escs are present in a group of 4 
     if(ESC_TELEM_MAX_ESCS % 4 == 0){
          num_idx = ESC_TELEM_MAX_ESCS/4;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -309,13 +309,13 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
 
     // loop through groups of 4 ESCs
     const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
-    
+    const uint8_t num_idx //initializing num_idx
     //This ensures that number of escs are present in a group of 4 
     if(ESC_TELEM_MAX_ESCS % 4 == 0){
-        const uint8_t num_idx = ESC_TELEM_MAX_ESCS/4;
+         num_idx = ESC_TELEM_MAX_ESCS/4;
     }
     else{
-        const uint8_t num_idx = (ESC_TELEM_MAX_ESCS/4) + 1; //when escs are not in group of 4 then it will skip only a single loop which can be rectified by adding 1 to it
+         num_idx = (ESC_TELEM_MAX_ESCS/4) + 1; //when escs are not in group of 4 then it will skip only a single loop which can be rectified by adding 1 to it
     }
     
     for (uint8_t idx = 0; idx < num_idx; idx++) {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -310,7 +310,7 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
     // loop through groups of 4 ESCs
     const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
     
-    //This ensures that number of escs are present in a group of 4 and if not then it will rectify it by adding 1
+    // ensure we send out partially-full groups:
     const uint8_t num_idx = (ESC_TELEM_MAX_ESCS % 4 == 0) ? ESC_TELEM_MAX_ESCS / 4 : (ESC_TELEM_MAX_ESCS / 4) + 1; 
     
     for (uint8_t idx = 0; idx < num_idx; idx++) {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -309,14 +309,9 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
 
     // loop through groups of 4 ESCs
     const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
-    const uint8_t num_idx; //initializing num_idx
-    //This ensures that number of escs are present in a group of 4 
-    if(ESC_TELEM_MAX_ESCS % 4 == 0){
-         num_idx = ESC_TELEM_MAX_ESCS/4;
-    }
-    else{
-         num_idx = (ESC_TELEM_MAX_ESCS/4) + 1; //when escs are not in group of 4 then it will skip only a single loop which can be rectified by adding 1 to it
-    }
+    
+    //This ensures that number of escs are present in a group of 4 and if not then it will rectify it by adding 1
+    const uint8_t num_idx = (ESC_TELEM_MAX_ESCS % 4 == 0) ? ESC_TELEM_MAX_ESCS / 4 : (ESC_TELEM_MAX_ESCS / 4) + 1; 
     
     for (uint8_t idx = 0; idx < num_idx; idx++) {
         const uint8_t i = (next_idx + idx) % num_idx;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -309,7 +309,15 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
 
     // loop through groups of 4 ESCs
     const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
-    const uint8_t num_idx = ESC_TELEM_MAX_ESCS/4;
+    
+    //This ensures that number of escs are present in a group of 4 
+    if(ESC_TELEM_MAX_ESCS % 4 == 0){
+        const uint8_t num_idx = ESC_TELEM_MAX_ESCS/4;
+    }
+    else{
+        const uint8_t num_idx = (ESC_TELEM_MAX_ESCS/4) + 1; //when escs are not in group of 4 then it will skip only a single loop which can be rectified by adding 1 to it
+    }
+    
     for (uint8_t idx = 0; idx < num_idx; idx++) {
         const uint8_t i = (next_idx + idx) % num_idx;
 


### PR DESCRIPTION
ESC_Telemetry will not send MAVLink MSG_ESC_TELEMETRY_1_TO_4 if ESC_TELEM_MAX_ESCS (PWM/SERVO) count is <=3 as logic was to keep idx = ESC_TELEM_MAX_ESCS/4  It gives rise to 3 big issues that are :-
1.It will leave some values if ESC_TELEM_MAX_ESCS which are not completely divisible by 4 e.g. 1,2,3,5,6,7,9....
2. (next_idx + idx) % num_idx it will give error if escs are less than 4
3. for loop will never start if escs count is less than 4 i.e the message inside loop  will be skipped even if escs are present. Also if escs are not in multiple of 4 then it will skip 1 iteration

Solution in commit:
This is rectified by logic to add 1 to num_idx if ESC_TELEM_MAX_ESCS is not multiple of 4.