### PR TITLE
AP_ESC_Telem: fix fake value of SITL ESC

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
@@ -67,7 +67,7 @@ void AP_ESC_Telem_SITL::update()
 
         // some fake values so that is_telemetry_active() returns true
         TelemetryData t {
-            .temperature_cdeg = 32,
+            .temperature_cdeg = 3200,
             .voltage = 16.8f,
             .current = 0.8f,
             .consumption_mah = 1.0f,


### PR DESCRIPTION
I noticed that ESC temp of SITL displays 0 due to the difference in units between cdeg and deg.
After this fix, I can see the value.
![image](https://github.com/ArduPilot/ardupilot/assets/16643069/70f95b3d-7100-43c1-9eea-870b18c712b0)
