### PR TITLE
AP_Mount: In Siyi, add check for minimum supported firmware version

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -60,7 +60,7 @@ void AP_Mount_Siyi::update()
     uint32_t now_ms = AP_HAL::millis();
     if ((now_ms - _last_send_ms) >= 1000) {
         _last_send_ms = now_ms;
-        if (!_firmware_version.received) {
+        if (!_fw_version.received) {
             request_firmware_version();
             return;
         } else if (!_got_hardware_id) {
@@ -164,7 +164,7 @@ void AP_Mount_Siyi::update()
 bool AP_Mount_Siyi::healthy() const
 {
     // unhealthy until gimbal has been found and replied with firmware version info
-    if (!_initialised || !_firmware_version.received) {
+    if (!_initialised || !_fw_version.received) {
         return false;
     }
 
@@ -327,7 +327,7 @@ void AP_Mount_Siyi::process_packet()
         }
 
         // consume and display camera firmware version
-        _firmware_version = {
+        _fw_version = {
             .camera = {
                 .major = _msg_buff[_msg_buff_data_start+2],  // firmware major version
                 .minor = _msg_buff[_msg_buff_data_start+1],  // firmware minor version
@@ -343,25 +343,25 @@ void AP_Mount_Siyi::process_packet()
 
         // display camera info to user
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: Siyi camera fw v%u.%u.%u",
-                (unsigned)_firmware_version.camera.major,
-                (unsigned)_firmware_version.camera.minor,
-                (unsigned)_firmware_version.camera.patch);
+                _fw_version.camera.major,
+                _fw_version.camera.minor,
+                _fw_version.camera.patch);
 
         // display gimbal info to user
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: Siyi gimbal fw v%u.%u.%u",
-                (unsigned)_firmware_version.gimbal.major,
-                (unsigned)_firmware_version.gimbal.minor,
-                (unsigned)_firmware_version.gimbal.patch);
+                _fw_version.gimbal.major,
+                _fw_version.gimbal.minor,
+                _fw_version.gimbal.patch);
 
         // display zoom firmware version for those that have it
         if (_parsed_msg.data_bytes_received >= 12) {
-            _firmware_version.zoom.major = _msg_buff[_msg_buff_data_start+10];
-            _firmware_version.zoom.minor = _msg_buff[_msg_buff_data_start+ 9];
-            _firmware_version.zoom.patch = _msg_buff[_msg_buff_data_start+ 8];
+            _fw_version.zoom.major = _msg_buff[_msg_buff_data_start+10];
+            _fw_version.zoom.minor = _msg_buff[_msg_buff_data_start+ 9];
+            _fw_version.zoom.patch = _msg_buff[_msg_buff_data_start+ 8];
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: Siyi zoom fw v%u.%u.%u",
-                (unsigned)_firmware_version.zoom.major,
-                (unsigned)_firmware_version.zoom.minor,
-                (unsigned)_firmware_version.zoom.patch);
+                _fw_version.zoom.major,
+                _fw_version.zoom.minor,
+                _fw_version.zoom.patch);
         }
         break;
     }
@@ -869,13 +869,13 @@ bool AP_Mount_Siyi::set_lens(uint8_t lens)
 void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
 {
     // exit immediately if not initialised
-    if (!_initialised || !_firmware_version.received) {
+    if (!_initialised || !_fw_version.received) {
         return;
     }
 
     static const uint8_t vendor_name[32] = "Siyi";
     static uint8_t model_name[32] {};
-    const uint32_t fw_version = _firmware_version.camera.major | (_firmware_version.camera.minor << 8) | (_firmware_version.camera.patch << 16);
+    const uint32_t fw_version = _fw_version.camera.major | (_fw_version.camera.minor << 8) | (_fw_version.camera.patch << 16);
     const char cam_definition_uri[140] {};
 
     // copy model name

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -60,11 +60,11 @@ void AP_Mount_Siyi::update()
     uint32_t now_ms = AP_HAL::millis();
     if ((now_ms - _last_send_ms) >= 1000) {
         _last_send_ms = now_ms;
-        if (!_fw_version.received) {
-            request_firmware_version();
-            return;
-        } else if (!_got_hardware_id) {
+        if (!_got_hardware_id) {
             request_hardware_id();
+            return;
+        } else if (!_fw_version.received) {
+            request_firmware_version();
             return;
         } else {
             request_configuration();
@@ -78,7 +78,7 @@ void AP_Mount_Siyi::update()
     }
 
     // request rangefinder distance from ZT30 at 10hz
-    if ((_hardware_model == HardwareModel::ZT30) && (now_ms - _last_rangefinder_req_ms > 100)) {    
+    if ((_hardware_model == HardwareModel::ZT30) && (now_ms - _last_rangefinder_req_ms > 100)) {
         request_rangefinder_distance();
         _last_rangefinder_req_ms = now_ms;
     }
@@ -363,6 +363,10 @@ void AP_Mount_Siyi::process_packet()
                 _fw_version.zoom.minor,
                 _fw_version.zoom.patch);
         }
+
+        // report to the user if gimbal firmware is not up-to-date
+        check_firmware_version();
+
         break;
     }
 
@@ -502,7 +506,7 @@ void AP_Mount_Siyi::process_packet()
         //const float pitch_rate_deg = (int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+9], _msg_buff[_msg_buff_data_start+8]) * 0.1;   // pitch rate
         //const float roll_rate_deg = (int16_t)UINT16_VALUE(_msg_buff[_msg_buff_data_start+11], _msg_buff[_msg_buff_data_start+10]) * 0.1;  // roll rate
         break;
-    
+
     case SiyiCommandId::READ_RANGEFINDER:
         _rangefinder_dist_m = UINT16_VALUE(_msg_buff[_msg_buff_data_start+1], _msg_buff[_msg_buff_data_start]);
         _last_rangefinder_dist_ms = AP_HAL::millis();
@@ -965,6 +969,53 @@ bool AP_Mount_Siyi::get_rangefinder_distance(float& distance_m) const
 
     distance_m = _rangefinder_dist_m;
     return true;
+}
+
+// Checks that the firmware version on the Gimbal meets the minimum supported version.
+void AP_Mount_Siyi::check_firmware_version() const
+{
+    if (!_fw_version.received) {
+        debug("Can't check firmware if we haven't received it...");
+        return;
+    }
+
+    if (!_got_hardware_id) {
+        debug("Can't check firmware without Hardware ID!");
+        return;
+    }
+
+    FirmwareVersion minimum_ver {};
+    switch (_hardware_model) {
+        case HardwareModel::A8:
+            minimum_ver.camera.major = 0;
+            minimum_ver.camera.minor = 2;
+            minimum_ver.camera.patch = 1;
+            break;
+
+        case HardwareModel::A2:
+        case HardwareModel::ZR10:
+        case HardwareModel::ZR30:
+        case HardwareModel::ZT30:
+            // TBD
+            break;
+
+        case HardwareModel::UNKNOWN:
+            debug("Can't check FW on unknown hardware model!");
+            return;
+    }
+
+    const uint32_t minimum_camera_val =  (minimum_ver.camera.major << 16) + (minimum_ver.camera.minor << 8) + minimum_ver.camera.patch;
+    const uint32_t firmware_camera_val = (_fw_version.camera.major << 16) + (_fw_version.camera.minor << 8) + _fw_version.camera.patch;
+
+    const bool is_camera_supported = firmware_camera_val >= minimum_camera_val;
+
+    if (!is_camera_supported) {
+        GCS_SEND_TEXT(
+            MAV_SEVERITY_WARNING,
+            "Mount: Siyi running old camera fw (need v%u.%u.%u)",
+            minimum_ver.camera.major, minimum_ver.camera.minor, minimum_ver.camera.patch
+        );
+    }
 }
 
 #endif // HAL_MOUNT_SIYI_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -241,6 +241,9 @@ private:
     // get model name string, returns nullptr if hardware id is unknown
     const char* get_model_name() const;
 
+    // Checks that the firmware version on the Gimbal meets the minimum supported version.
+    void check_firmware_version() const;
+
     // internal variables
     AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
     bool _initialised;                              // true once the driver has been initialised

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -246,7 +246,7 @@ private:
     bool _initialised;                              // true once the driver has been initialised
     bool _got_hardware_id;                          // true once hardware id ha been received
 
-    FirmwareVersion _firmware_version;              // firmware version (for reporting for GCS)
+    FirmwareVersion _fw_version;                    // firmware version (for reporting for GCS)
 
     // buffer holding bytes from latest packet.  This is only used to calculate the crc
     uint8_t _msg_buff[AP_MOUNT_SIYI_PACKETLEN_MAX];

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -177,6 +177,18 @@ private:
         MAIN_THERMAL_SUB_WIDEANGLE = 8
     };
 
+    typedef struct {
+        uint8_t major;
+        uint8_t minor;
+        uint8_t patch;
+    } Version;
+    typedef struct {
+        Version camera;
+        Version gimbal;
+        Version zoom;
+        bool received; // true once version information has been received
+    } FirmwareVersion;
+
     // reading incoming packets from gimbal and confirm they are of the correct format
     // results are held in the _parsed_msg structure
     void read_incoming_packets();
@@ -232,13 +244,9 @@ private:
     // internal variables
     AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
     bool _initialised;                              // true once the driver has been initialised
-    bool _got_firmware_version;                     // true once gimbal firmware version has been received
     bool _got_hardware_id;                          // true once hardware id ha been received
-    struct {
-        uint8_t major;
-        uint8_t minor;
-        uint8_t patch;
-    } _cam_firmware_version;                        // camera firmware version (for reporting for GCS)
+
+    FirmwareVersion _firmware_version;              // firmware version (for reporting for GCS)
 
     // buffer holding bytes from latest packet.  This is only used to calculate the crc
     uint8_t _msg_buff[AP_MOUNT_SIYI_PACKETLEN_MAX];


### PR DESCRIPTION
The Siyi driver is in active development, and may be using features that are only available in the latest firmware. This PR adds a check to make sure that the connected Siyi gimbal is running a supported firmware version.

Tested on Siyi A8.

FYI: @rmackay9 