### PR TITLE
AP_TECS: ensure good TECS state before running update_pitch_throttle

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1155,8 +1155,18 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     float hgt_afe,
                                     float load_factor)
 {
-    // Calculate time in seconds since last update
     uint64_t now = AP_HAL::micros64();
+    // check how long since we last did the 50Hz update; do nothing in
+    // this loop if that hasn't run for some signficant period of
+    // time.  Notably, it may never have run, leaving _TAS_state as
+    // zero and subsequently division-by-zero errors.
+    const float _DT_for_update_50hz = (now - _update_50hz_last_usec) * 1.0e-6f;
+    if (_update_50hz_last_usec == 0 || _DT_for_update_50hz > 1.0) {
+        // more than 1 second since it was run, don't do anything yet:
+        return;
+    }
+
+    // Calculate time in seconds since last update
     _DT = (now - _update_pitch_throttle_last_usec) * 1.0e-6f;
     _DT = MAX(_DT, 0.001f);
     _update_pitch_throttle_last_usec = now;


### PR DESCRIPTION
update_pitch_throttle can be called when update_50hz hasn't run in a very long time, or ever.  This requires a main loop rate >50Hz, and for the mode change to occur in the same loop that update_50Hz doesn't run but update_pitch_throttle does.

Tested with these patches - fails before this patch, passes after:
```
diff --git a/ArduPlane/ArduPlane.cpp b/ArduPlane/ArduPlane.cpp
index 61d76425333..63bd6fefd8d 100644
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -69,7 +69,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(navigate,               10,    150,  36),
     SCHED_TASK(update_compass,         10,    200,  39),
     SCHED_TASK(calc_airspeed_errors,   10,    100,  42),
-    SCHED_TASK(update_alt,             10,    200,  45),
+    SCHED_TASK(update_alt,             300,    200,  45),
     SCHED_TASK(adjust_altitude_target, 10,    200,  48),
 #if AP_ADVANCEDFAILSAFE_ENABLED
     SCHED_TASK(afs_fs_check,           10,    100,  51),
diff --git a/Tools/autotest/arduplane.py b/Tools/autotest/arduplane.py
index 65fbb0fa771..bdd142b9d1b 100644
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4674,6 +4674,23 @@ class AutoTestPlane(AutoTest):
         )
         self.fly_home_land_and_disarm()
 
+    def TECSTesting(self):
+        '''simple program to test going to tecs-controlled-mode in-flight'''
+        self.set_parameters({
+            'SCHED_LOOP_RATE': 300,
+        })
+        self.reboot_sitl()
+        i = 0
+        while True:
+            self.progress("loop %u" % i)
+            i += 1
+            self.takeoff(20)
+            self.change_mode('GUIDED')
+            self.zero_throttle()
+            self.delay_sim_time(1)
+            self.disarm_vehicle(force=True)
+            self.reboot_sitl()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -4765,6 +4782,7 @@ class AutoTestPlane(AutoTest):
             self.MODE_SWITCH_RESET,
             self.ExternalPositionEstimate,
             self.MAV_CMD_GUIDED_CHANGE_ALTITUDE,
+            self.TECSTesting,
         ])
         return ret
 
```

(branch with those patches: https://github.com/peterbarker/ardupilot/tree/pr/tecs-init-testing-tests )
