### PR TITLE
AP_NavEKF3: do not use fmaxF on floating point values

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -621,7 +621,7 @@ void NavEKF3_core::send_status_report(GCS_MAVLINK &link) const
         velVar,
         posVar,
         hgtVar,
-        fmaxF(fmaxF(magVar.x,magVar.y),magVar.z),
+        fmaxf(fmaxf(magVar.x,magVar.y),magVar.z),
         temp,
         flags,
         tasVar


### PR DESCRIPTION
it returns double, which will not fit into this float