### PR TITLE
AP_Mount: In Siyi, fix calculation of attitude quaternion

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -181,7 +181,8 @@ bool AP_Mount_Siyi::healthy() const
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_Siyi::get_attitude_quaternion(Quaternion& att_quat)
 {
-    att_quat.from_euler(_current_angle_rad.x, _current_angle_rad.y, _current_angle_rad.z);
+    // Order of rotation for Siyi gimbals is (yaw, roll, pitch), which is 312 order
+    att_quat.from_vector312(_current_angle_rad.x, _current_angle_rad.y, _current_angle_rad.z);
     return true;
 }
 


### PR DESCRIPTION
Order of rotation for Siyi gimbals is `(yaw, roll, pitch)`, which is 312 order. `Quaternion::from_euler()` function assumes a 321 order of rotation `(yaw, pitch, roll)`.

Currently a draft, because:
* I need to investigate the handling of the quaternions coming in; and
* we need to check if this problem affects other gimbals.

FYI: @rmackay9, @tridge, @priseborough 