### PR TITLE
AP_Camera, AP_Mount: Add ZOOM_TYPE_STEP support to Siyi

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -229,6 +229,10 @@ MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
             set_zoom(ZoomType::PCT, packet.param2)) {
             return MAV_RESULT_ACCEPTED;
         }
+        if (is_equal(packet.param1, (float)ZOOM_TYPE_STEP) &&
+            set_zoom(ZoomType::STEP, packet.param2)) {
+            return MAV_RESULT_ACCEPTED;
+        }
         return MAV_RESULT_UNSUPPORTED;
     case MAV_CMD_SET_CAMERA_FOCUS:
         // accept any of the auto focus types

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -82,6 +82,9 @@ bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
     case ZoomType::PCT:
         pkt.param1 = ZOOM_TYPE_RANGE;
         break;
+    case ZoomType::STEP:
+        pkt.param1 = ZOOM_TYPE_STEP;
+        break;
     }
     pkt.param2 = zoom_value;            // Zoom Value
 

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -8,8 +8,9 @@
 // set zoom specified as a rate or percentage
 // enumerators match MAVLink CAMERA_ZOOM_TYPE
 enum class ZoomType : uint8_t {
+    STEP = 0,   // zoom one step increment (-1 for wide, 1 for tele). Same as ZOOM_TYPE_STEP
     RATE = 1,   // zoom in, out or hold (zoom out = -1, hold = 0, zoom in = 1). Same as ZOOM_TYPE_CONTINUOUS
-    PCT = 2     // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
+    PCT = 2,    // zoom to a percentage (from 0 to 100) of the full range. Same as ZOOM_TYPE_RANGE
 };
 
 // set focus specified as a rate or percentage

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -223,7 +223,7 @@ bool AP_Mission::starts_with_takeoff_cmd()
 /*
     return true if MIS_OPTIONS is set to allow continue of mission
     logic after a land and the next waypoint is a takeoff. If this
-    is false then after a landing is complete the vehicle should 
+    is false then after a landing is complete the vehicle should
     disarm and mission logic should stop
 */
 bool AP_Mission::continue_after_land_check_for_takeoff()
@@ -940,6 +940,7 @@ MAV_MISSION_RESULT AP_Mission::sanity_check_params(const mavlink_mission_item_in
         nan_mask = ~(1 << 3); // param 4 can be nan
         break;
     case MAV_CMD_NAV_VTOL_LAND:
+    case MAV_CMD_SET_CAMERA_ZOOM:
         nan_mask = ~((1 << 2) | (1 << 3)); // param 3 and 4 can be nan
         break;
     default:
@@ -2296,7 +2297,7 @@ uint16_t AP_Mission::get_landing_sequence_start()
                 // 2D distance - no altitude
                 tmp_distance = tmp.content.location.get_distance(current_loc);
             }
-            
+
             if (min_distance < 0 || tmp_distance < min_distance) {
                 min_distance = tmp_distance;
                 landing_start_index = i;

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -143,6 +143,9 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_RANGE) {
             return camera->set_zoom(ZoomType::PCT, cmd.content.set_camera_zoom.zoom_value);
         }
+        if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_STEP) {
+            return camera->set_zoom(ZoomType::STEP, cmd.content.set_camera_zoom.zoom_value);
+        }
         return false;
 
     case MAV_CMD_SET_CAMERA_FOCUS:

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -941,10 +941,17 @@ void AP_Mount_Siyi::update_zoom_control()
         }
         _zoom.rate.last_control_ms = now_ms;
 
-        // only send zoom rate target if it's non-zero because if zero it has already been sent
-        // and sending zero rate also triggers autofocus
-        if (!is_zero(_zoom.rate.target)) {
+        // only send zoom rate target if it's non-zero and hasn't reached the limit.
+        // if target is zero, it has already been sent, and sending zero rate also triggers autofocus
+        const bool is_zooming_in  = is_positive(_zoom.rate.target) && _zoom.multiple < get_zoom_mult_max();
+        const bool is_zooming_out = is_negative(_zoom.rate.target) && _zoom.multiple > 1.0;
+        if (is_zooming_in || is_zooming_out) {
             send_zoom_rate(_zoom.rate.target);
+        } else {
+            // if we've reached a limit, clear the rate target
+            if (!is_zero(_zoom.rate.target)) {
+                _zoom.rate.target = 0.0f;
+            }
         }
     } else {
         // limit updates to 10hz

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -832,6 +832,28 @@ bool AP_Mount_Siyi::set_zoom(ZoomType zoom_type, float zoom_value)
         }
         return false;
     }
+    case ZoomType::STEP: {
+        const float zoom_mult_max = get_zoom_mult_max();
+        if (zoom_mult_max <= 1.0) {
+            return false;
+        }
+
+        // Calculate a step value to give n steps between min and max zoom
+        const float num_steps = 10.0;
+        const float step = (zoom_mult_max - 1.0) / num_steps;
+        float delta = 0.0;
+        if (zoom_value > 0.0) {
+            delta = step;
+        } else if (zoom_value < 0.0) {
+            delta = -step;
+        } else {
+            // A step of zero is a no-op, so return true.
+            return true;
+        }
+
+        const float new_zoom = constrain_float(this->_zoom_mult + delta, 1.0, zoom_mult_max);
+        return send_zoom_mult(new_zoom);
+    }
     }
 
     // unsupported zoom type

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -527,6 +527,22 @@ void AP_Mount_Siyi::process_packet()
         break;
     }
 
+    case SiyiCommandId::ABSOLUTE_ZOOM:
+#if AP_MOUNT_SIYI_DEBUG
+        // always returns uint8_t(1)
+        if (_parsed_msg.data_bytes_received != 1) {
+            unexpected_len = true;
+        }
+#endif
+        break;
+
+    case SiyiCommandId::ACQUIRE_ZOOM_MAX: {
+        float max = (float)_msg_buff[_msg_buff_data_start];
+        max += (float)_msg_buff[_msg_buff_data_start + 1] / 10;
+        debug("Max Zoom response: %.02f", max);
+        break;
+    }
+
     case SiyiCommandId::READ_RANGEFINDER: {
         _rangefinder_dist_m = UINT16_VALUE(_msg_buff[_msg_buff_data_start+1], _msg_buff[_msg_buff_data_start]);
         _last_rangefinder_dist_ms = AP_HAL::millis();

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -44,6 +44,14 @@ void AP_Mount_Siyi::init()
     // Invalidate the reported maximum zoom
     _zoom.multiple_max = -1.0;
 
+    // Request the information required to correctly drive the gimbal
+    request_hardware_id();
+    request_firmware_version();
+
+    // Set the zoom rate to zero (this sends the MANUAL_ZOOM_AND_AUTO_FOCUS
+    // command, which is the only way to get the current zoom level).
+    send_zoom_rate(0.0);
+
     AP_Mount_Backend::init();
 }
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -111,6 +111,7 @@ private:
         ABSOLUTE_ZOOM = 0x0F,
         SET_CAMERA_IMAGE_TYPE = 0x11,
         READ_RANGEFINDER = 0x15,
+        ACQUIRE_ZOOM_MAX = 0x16,
     };
 
     // Function Feedback Info packet info_type values
@@ -242,6 +243,7 @@ private:
     void request_function_feedback_info() { send_packet(SiyiCommandId::FUNCTION_FEEDBACK_INFO, nullptr, 0); }
     void request_gimbal_attitude() { send_packet(SiyiCommandId::ACQUIRE_GIMBAL_ATTITUDE, nullptr, 0); }
     void request_rangefinder_distance() { send_packet(SiyiCommandId::READ_RANGEFINDER, nullptr, 0); }
+    void request_zoom_max() { send_packet(SiyiCommandId::ACQUIRE_ZOOM_MAX, nullptr, 0); }
 
     // rotate gimbal.  pitch_rate and yaw_rate are scalars in the range -100 ~ +100
     // yaw_is_ef should be true if gimbal should maintain an earth-frame target (aka lock)

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -313,11 +313,18 @@ private:
     uint32_t _last_req_current_angle_rad_ms;        // system time that this driver last requested current angle
 
     // absolute zoom control.  only used for A8 that does not support abs zoom control
-    ZoomType _zoom_type;                            // current zoom type
-    float _zoom_rate_target;                        // current zoom rate target
-    float _zoom_mult;                               // most recent actual zoom multiple received from camera
-    uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run
     struct {
+        ZoomType type;
+        struct {
+            float target;                         // current zoom rate target
+            float last_control_ms;                // system time that zoom rate control was last run
+        } rate;
+        struct {
+            float target;                         // current zoom abs target
+            float last_control_ms;                // system time that zoom abs control was last run
+        } abs;
+
+        float multiple;                           // most recent actual zoom multiple received from camera
         float multiple_max;                       // max zoom level received from camera
     } _zoom;
 

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -317,6 +317,9 @@ private:
     float _zoom_rate_target;                        // current zoom rate target
     float _zoom_mult;                               // most recent actual zoom multiple received from camera
     uint32_t _last_zoom_control_ms;                 // system time that zoom control was last run
+    struct {
+        float multiple_max;                       // max zoom level received from camera
+    } _zoom;
 
     // Configuration info received from gimbal
     GimbalConfigInfo _config_info;


### PR DESCRIPTION
Also updates the Siyi driver to:
* request and use the maximum zoom as reported by the gimbal;
* update `update_zoom_control()` to periodically send absolute zoom commands;
    * stops when the reported zoom multiple matches the commanded value.
* update `update_zoom_control()` to stop sending zoom rate commands when upper or lower zoom limit is reached.

Tested on a Siyi A8 running camera firmware `v0.2.1` and `v0.2.2`.. Will likely need testing on other models.