### PR TITLE
autotest: tweak Soaring test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2573,11 +2573,6 @@ class AutoTestPlane(AutoTest):
 
         self.load_mission('CMAC-soar.txt', strict=False)
 
-        self.set_current_waypoint(1)
-        self.change_mode('AUTO')
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
         # Enable thermalling RC
         rc_chan = 0
         for i in range(8):
@@ -2591,14 +2586,21 @@ class AutoTestPlane(AutoTest):
 
         self.set_rc_from_map({
             rc_chan: 1900,
-            3: 1500, # Use trim airspeed.
         })
+
+        self.set_parameters({
+            "SOAR_VSPEED": 0.55,
+            "SOAR_MIN_THML_S": 25,
+        })
+
+        self.set_current_waypoint(1)
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
 
         # Wait to detect thermal
         self.progress("Waiting for thermal")
         self.wait_mode('THERMAL', timeout=600)
-
-        self.set_parameter("SOAR_VSPEED", 0.6)
 
         # Wait to climb to SOAR_ALT_MAX
         self.progress("Waiting for climb to max altitude")


### PR DESCRIPTION
autotest is failing because our vspeed is below the 0.6 threshold after we exceed the minimal thermal time.

Tweak both numbers to try to make test reliable

Also re-arrange to try to reduce race conditions.

This is a passing test:
![image](https://github.com/ArduPilot/ardupilot/assets/7077857/819bb461-f863-40c9-9149-a17904b8433f)

... and this is a failing test:
![image](https://github.com/ArduPilot/ardupilot/assets/7077857/46bb0068-bbdc-47c2-8a55-8d96f3c80e11)

vspeed may travel the correct way past this,allowing the test to pass.

We could probably reduce vspeed to basically nothing here, as we really only care about the eventual height...
