### PR TITLE
AP_Logger: remove AP_Logger.h include in AP_Logger_Backend

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -11,6 +11,7 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include "AP_Logger.h"
 
 #if HAL_LOGGER_FENCE_ENABLED
     #include <AC_Fence/AC_Fence.h>

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -4,9 +4,11 @@
 
 #if HAL_LOGGING_ENABLED
 
-#include "AP_Logger.h"
-
 #include <AP_Common/Bitmask.h>
+#include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Mission/AP_Mission.h>
+#include <AP_Vehicle/ModeReason.h>
 
 class LoggerMessageWriter_DFLogStart;
 
@@ -16,7 +18,7 @@ class LoggerMessageWriter_DFLogStart;
 class AP_Logger_RateLimiter
 {
 public:
-    AP_Logger_RateLimiter(const AP_Logger &_front, const AP_Float &_limit_hz, const AP_Float &_disarm_limit_hz);
+    AP_Logger_RateLimiter(const class AP_Logger &_front, const AP_Float &_limit_hz, const AP_Float &_disarm_limit_hz);
 
     // return true if message passes the rate limit test
     bool should_log(uint8_t msgid, bool writev_streaming);
@@ -107,7 +109,7 @@ public:
 #endif
 
      // for Logger_MAVlink
-    virtual void remote_log_block_status_msg(const GCS_MAVLINK &link,
+    virtual void remote_log_block_status_msg(const class GCS_MAVLINK &link,
                                              const mavlink_message_t &msg) { }
     // end for Logger_MAVlink
 

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -2,10 +2,12 @@
   block based logging, for boards with flash logging
  */
 
-#include "AP_Logger_Block.h"
+#include "AP_Logger_config.h"
 
 #if HAL_LOGGING_BLOCK_ENABLED
 
+#include "AP_Logger_Block.h"
+#include "AP_Logger.h"
 #include <AP_HAL/AP_HAL.h>
 #include <stdio.h>
 #include <AP_RTC/AP_RTC.h>

--- a/libraries/AP_Logger/AP_Logger_DataFlash.cpp
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.cpp
@@ -2,12 +2,13 @@
   logging to a DataFlash block based storage device on SPI
 */
 
+#include "AP_Logger_config.h"
+
+#if HAL_LOGGING_DATAFLASH_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_Logger_DataFlash.h"
-
-#if HAL_LOGGING_DATAFLASH_ENABLED
 
 #include <stdio.h>
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -10,17 +10,21 @@
     - readdir loop of 511 entry directory ~62,000 microseconds
  */
 
+#include "AP_Logger_config.h"
+
+#if HAL_LOGGING_FILESYSTEM_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 
+#include "AP_Logger.h"
 #include "AP_Logger_File.h"
-
-#if HAL_LOGGING_FILESYSTEM_ENABLED
 
 #include <AP_Common/AP_Common.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_RTC/AP_RTC.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -2,11 +2,14 @@
    AP_Logger Remote(via MAVLink) logging
 */
 
-#include "AP_Logger_MAVLink.h"
+#include "AP_Logger_config.h"
 
 #if HAL_LOGGING_MAVLINK_ENABLED
 
+#include "AP_Logger_MAVLink.h"
+
 #include "LogStructure.h"
+#include <AP_Logger/AP_Logger.h>
 
 #define REMOTE_LOG_DEBUGGING 0
 
@@ -22,6 +25,13 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_Logger_MAVLink::AP_Logger_MAVLink(AP_Logger &front, LoggerMessageWriter_DFLogStart *writer) :
+    AP_Logger_Backend(front, writer),
+    _max_blocks_per_send_blocks(8)
+{
+    _blockcount = 1024*((uint8_t)_front._params.mav_bufsize) / sizeof(struct dm_block);
+    // ::fprintf(stderr, "DM: Using %u blocks\n", _blockcount);
+}
 
 // initialisation
 void AP_Logger_MAVLink::Init()

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -17,13 +17,7 @@ class AP_Logger_MAVLink : public AP_Logger_Backend
 {
 public:
     // constructor
-    AP_Logger_MAVLink(AP_Logger &front, LoggerMessageWriter_DFLogStart *writer) :
-        AP_Logger_Backend(front, writer),
-        _max_blocks_per_send_blocks(8)
-        {
-            _blockcount = 1024*((uint8_t)_front._params.mav_bufsize) / sizeof(struct dm_block);
-            // ::fprintf(stderr, "DM: Using %u blocks\n", _blockcount);
-        }
+    AP_Logger_MAVLink(class AP_Logger &front, LoggerMessageWriter_DFLogStart *writer);
 
     static AP_Logger_Backend  *probe(AP_Logger &front,
                                      LoggerMessageWriter_DFLogStart *ls) {

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -6,6 +6,7 @@
 #include "LoggerMessageWriter.h"
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include "AP_Logger.h"
 
 #if HAL_LOGGER_FENCE_ENABLED
     #include <AC_Fence/AC_Fence.h>


### PR DESCRIPTION
Don't need the storage size in the header