### PR TITLE
Plane:add taildrag holdown to TAKEOFF mode

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -262,7 +262,7 @@ int16_t Plane::get_takeoff_pitch_min_cd(void)
  */
 int8_t Plane::takeoff_tail_hold(void)
 {
-    bool in_takeoff = ((control_mode == &mode_auto && !auto_state.takeoff_complete) ||
+    bool in_takeoff = ((plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF) ||
                        (control_mode == &mode_fbwa && auto_state.fbwa_tdrag_takeoff_mode));
     if (!in_takeoff) {
         // not in takeoff


### PR DESCRIPTION
taildragger elevator holdown was omitted on TAKEOFF mode....this fixes it
holdown possible if setup, in auto and takeoff mode while in Flight Stage TAKEOFF and still with aux switch in FBWA


Tested by Yakman on his vehicle