### PR TITLE
AP_OSD_Screen : Changed horizon line on OSD when inverted to aviation standards #24855

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1579,6 +1579,7 @@ void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
     //inverted roll AH
     if (check_option(AP_OSD::OPTION_INVERTED_AH_ROLL)) {
         roll = -roll;
+        pitch = -pitch;  // Invert the pitch as well
     }
 
     pitch = constrain_float(pitch, -ah_max_pitch, ah_max_pitch);


### PR DESCRIPTION
Changed the way the horizon line is drawn on OSD when inverted to conform with aviation standards, When flying inverted, the artificial horizon pitch indication on the OSD is reversed compared to any full-size aviation ADI. Updated  AP_OSD_Screen::draw_horizon to invert the pitch when check_option(AP_OSD::OPTION_INVERTED_AH_ROLL). Refer the issue #24855