### PR TITLE
AP_Torqeedo: error code reporting fix

### DIFF
--- a/libraries/AP_Torqeedo/AP_Torqeedo.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo.cpp
@@ -351,7 +351,7 @@ void AP_Torqeedo::report_error_codes()
     if (_display_system_state.flags.temp_warning) {
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "%s high temp", msg_prefix);
     }
-    if (_display_system_state.flags.temp_warning) {
+    if (_display_system_state.flags.batt_nearly_empty) {
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "%s batt nearly empty", msg_prefix);
     }
     if (_display_system_state.master_error_code > 0) {


### PR DESCRIPTION
This fixes a copy-paste error in the Torqeedo libraries error reporting.  This bug would cause two errors to be sent to the user in case the battery is too hot but worse yet it would send no message when the battery is nearly empty.

This has not been tested on real hardware because I don't currently have access to my Torqeedo motor but surely this is correct.

Thanks very much to skyfox00 for reporting this!