### PR TITLE
Tools: Deprecate calling setuptools directly

### DIFF
--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -65,6 +65,8 @@ ROS_DISTRO=humble
 
 ```bash
 cd ~/ros_ws
+colcon build --packages-up-to colcon-python-project
+. install/local_setup.bash
 colcon build --cmake-args -DBUILD_TESTING=ON
 ```
 

--- a/Tools/ros2/ros2.repos
+++ b/Tools/ros2/ros2.repos
@@ -7,3 +7,7 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
     version: humble
+  colcon-python-project:
+    type: git
+    url: https://github.com/colcon/colcon-python-project.git
+    branch: devel

--- a/Tools/ros2/ros2_macos.repos
+++ b/Tools/ros2/ros2_macos.repos
@@ -15,3 +15,7 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git
     version: humble
+  colcon-python-project:
+    type: git
+    url: https://github.com/colcon/colcon-python-project.git
+    branch: devel


### PR DESCRIPTION
This is a draft to support fixing #24862. It doesn't work. I'll let the ROS maintainers know. 
https://discourse.ros.org/t/call-for-testing-standards-based-python-packaging-with-colcon/32008

