### PR TITLE
AP_VideoTX: Added frequency change support for Matek VTX-1G3SE. IRC Tramp protocol.

### DIFF
--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -29,7 +29,7 @@
 
 #define VTX_TRAMP_POWER_COUNT 5
 
-#define VTX_TRAMP_MIN_FREQUENCY_MHZ 5000             //min freq in MHz
+#define VTX_TRAMP_MIN_FREQUENCY_MHZ 1000             //min freq in MHz
 #define VTX_TRAMP_MAX_FREQUENCY_MHZ 5999             //max freq in MHz
 // Maximum number of requests sent to try a config change
 // Some VTX fail to respond to every request (like Matek FCHUB-VTX) so

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
     // @DisplayName: Video Transmitter Band
     // @Description: Video Transmitter Band
     // @User: Standard
-    // @Values: 0:Band A,1:Band B,2:Band E,3:Airwave,4:RaceBand,5:Low RaceBand
+    // @Values: 0:Band A,1:Band B,2:Band E,3:Airwave,4:RaceBand,5:Low RaceBand,6:1G3 Band A,7:1G3 Band B
     AP_GROUPINFO("BAND",  4, AP_VideoTX, _band, 0),
 
     // @Param: FREQ
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
     // @Description: Video Transmitter Frequency. The frequency is derived from the setting of BAND and CHANNEL
     // @User: Standard
     // @ReadOnly: True
-    // @Range: 5000 6000
+    // @Range: 1000 6000
     AP_GROUPINFO("FREQ",  5, AP_VideoTX, _frequency_mhz, 0),
 
     // @Param: OPTIONS
@@ -96,7 +96,9 @@ const uint16_t AP_VideoTX::VIDEO_CHANNELS[AP_VideoTX::MAX_BANDS][VTX_MAX_CHANNEL
     { 5705, 5685, 5665, 5645, 5885, 5905, 5925, 5945}, /* Band E */
     { 5740, 5760, 5780, 5800, 5820, 5840, 5860, 5880}, /* Airwave */
     { 5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917}, /* Race */
-    { 5621, 5584, 5547, 5510, 5473, 5436, 5399, 5362}  /* LO Race */
+    { 5621, 5584, 5547, 5510, 5473, 5436, 5399, 5362}, /* LO Race */
+    { 1080, 1120, 1160, 1200, 1240, 1280, 1320, 1360}, /* Band 1G3_A */
+    { 1080, 1120, 1160, 1200, 1258, 1280, 1320, 1360}  /* Band 1G3_B */
 };
 
 // mapping of power level to milliwatt to dbm

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -62,6 +62,8 @@ public:
         FATSHARK,
         RACEBAND,
         LOW_RACEBAND,
+        BAND_1G3_A,
+        BAND_1G3_B,
         MAX_BANDS
     };
 


### PR DESCRIPTION
Added frequency change support for Matek VTX-1G3SE 1.2/1.3GHZ.
IRC Tramp protocol.

Frequencies:
VTX_BAND = 6 // 1G3_A
1080, 1120, 1160, 1200, 1240, 1280, 1320, 1360
VTX_BAND = 7 // 1G3_B
1080, 1120, 1160, 1200, 1258, 1280, 1320, 1360

Works with Matek VTX 1G3SE and green version.
