### PR TITLE
autotest: improve STATUSTEXT handling

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -4705,7 +4705,6 @@ class AutoTest(ABC):
         self.upload_using_mission_protocol(mission_type, items)
         self.progress("check %s upload/download: download items" % itype)
         downloaded_items = self.download_using_mission_protocol(mission_type)
-        self.progress("Downloaded items: (%s)" % str(downloaded_items))
         if len(items) != len(downloaded_items):
             raise NotAchievedException("Did not download same number of items as uploaded want=%u got=%u" %
                                        (len(items), len(downloaded_items)))

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -3138,7 +3138,7 @@ class AutoTest(ABC):
         """Called as each mavlink msg is received."""
 #        print("msg: %s" % str(msg))
         if msg.get_type() == 'STATUSTEXT':
-            self.progress("AP: %s" % msg.text)
+            self.progress("AP: %s" % msg.text, send_statustext=False)
 
         self.write_msg_to_tlog(msg)
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1590,6 +1590,7 @@ class AutoTest(ABC):
         )
         self.terrain_data_messages_sent = 0  # count of messages back
         self.dronecan_tests = dronecan_tests
+        self.statustext_id = 1
 
     def __del__(self):
         if self.rc_thread is not None:
@@ -7718,7 +7719,14 @@ Also, ignores heartbeats not from our target system'''
             text = bytes(text, "ascii")
         elif 'unicode' in str(type(text)):
             text = text.encode('ascii')
-        self.mav.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_WARNING, text)
+        seq = 0
+        while len(text):
+            self.mav.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_WARNING, text[:50], id=self.statustext_id, chunk_seq=seq)
+            text = text[50:]
+            seq += 1
+        self.statustext_id += 1
+        if self.statustext_id > 255:
+            self.statustext_id = 1
 
     def get_stacktrace(self):
         return ''.join(traceback.format_stack())


### PR DESCRIPTION
 - don't echo statustexts back to autopilot, there's no point
 - send all of autotest message rather than just first chunk
