### PR TITLE
AP_Notify: tidy use of DiscreteRGB

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -155,10 +155,6 @@ AP_Notify *AP_Notify::_singleton;
 #define DEFAULT_BUZZ_ON_LVL 1
 #endif
 
-#ifndef AP_NOTIFY_DISCRETE_RGB_ENABLED
-#define AP_NOTIFY_DISCRETE_RGB_ENABLED 0
-#endif
-
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Notify::var_info[] = {
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -94,7 +94,9 @@ public:
         Notify_LED_IS31FL3195_I2C_External  = (1 << 15), // IS31FL3195
         Notify_LED_IS31FL3195_I2C_Internal  = (1 << 16), // IS31FL3195
 #endif
+#if AP_NOTIFY_DISCRETE_RGB_ENABLED
         Notify_LED_DiscreteRGB              = (1 << 17), // DiscreteRGB
+#endif
         Notify_LED_MAX
     };
 

--- a/libraries/AP_Notify/AP_Notify_config.h
+++ b/libraries/AP_Notify/AP_Notify_config.h
@@ -9,6 +9,10 @@
 #include <AP_SerialLED/AP_SerialLED_config.h>
 #include <AP_Scripting/AP_Scripting_config.h>
 
+#ifndef AP_NOTIFY_DISCRETE_RGB_ENABLED
+#define AP_NOTIFY_DISCRETE_RGB_ENABLED 0
+#endif
+
 #ifndef HAL_DISPLAY_ENABLED
 #define HAL_DISPLAY_ENABLED 1
 #endif

--- a/libraries/AP_Notify/DiscreteRGBLed.cpp
+++ b/libraries/AP_Notify/DiscreteRGBLed.cpp
@@ -11,6 +11,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "AP_Notify_config.h"
+
+#if AP_NOTIFY_DISCRETE_RGB_ENABLED
+
 #include "DiscreteRGBLed.h"
 
 #include <AP_HAL/HAL.h>
@@ -55,3 +59,5 @@ bool DiscreteRGBLed::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 
     return true;
 }
+
+#endif  // AP_NOTIFY_DISCRETE_RGB_ENABLED

--- a/libraries/AP_Notify/DiscreteRGBLed.h
+++ b/libraries/AP_Notify/DiscreteRGBLed.h
@@ -18,6 +18,10 @@
 
 #pragma once
 
+#include "AP_Notify_config.h"
+
+#if AP_NOTIFY_DISCRETE_RGB_ENABLED
+
 #include "RGBLed.h"
 
 class DiscreteRGBLed: public RGBLed {
@@ -35,3 +39,5 @@ private:
 
     uint16_t red_pin_number, green_pin_number, blue_pin_number;
 };
+
+#endif  // AP_NOTIFY_DISCRETE_RGB_ENABLED


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       0      *           0       0                 0      0      0
HerePro             0                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                0      *           0       0                 0      0      0
MatekF405                      0      *           0       0                 0      0      0
Pixhawk1-1M-bdshot             0                  0       0                 0      0      0
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      0      *           0       0                 0      0      0
skyviper-v2450                                    0                                       
```
