### PR TITLE
AP_Mount: Fix brace enclosed initializer list

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -328,19 +328,16 @@ void AP_Mount_Siyi::process_packet()
         }
 
         // consume and display camera firmware version
-        _fw_version = {
-            .camera = {
-                .major = _msg_buff[_msg_buff_data_start+2],  // firmware major version
-                .minor = _msg_buff[_msg_buff_data_start+1],  // firmware minor version
-                .patch = _msg_buff[_msg_buff_data_start+0],  // firmware revision (aka patch)
-            },
-            .gimbal = {
-                .major = _msg_buff[_msg_buff_data_start+6],  // firmware major version
-                .minor = _msg_buff[_msg_buff_data_start+5],  // firmware minor version
-                .patch = _msg_buff[_msg_buff_data_start+4],  // firmware revision (aka patch)
-            },
-            .received = true,
-        };
+        _fw_version = {};
+        _fw_version.camera.major = _msg_buff[_msg_buff_data_start+2];  // firmware major version
+        _fw_version.camera.minor = _msg_buff[_msg_buff_data_start+1];  // firmware minor version
+        _fw_version.camera.patch = _msg_buff[_msg_buff_data_start+0];  // firmware revision (aka patch)
+        
+        _fw_version.gimbal.major = _msg_buff[_msg_buff_data_start+6];  // firmware major version
+        _fw_version.gimbal.minor = _msg_buff[_msg_buff_data_start+5];  // firmware minor version
+        _fw_version.gimbal.patch = _msg_buff[_msg_buff_data_start+4];  // firmware revision (aka patch)
+        
+        _fw_version.received = true;
 
         // display camera info to user
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: Siyi camera fw v%u.%u.%u",


### PR DESCRIPTION
Removes the braced list initialisers because the environment tests are failing.

Looks like older compiler versions don't support this and the build is failing. 