### PR TITLE
AP_Mount/AP_DroneCAN: Xacti accepts gimbal firmware version and status

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -78,8 +78,12 @@ public:
 
     uint8_t get_driver_index() const { return _driver_index; }
 
+    // define string with length structure
+    struct string { uint8_t len; uint8_t data[128]; };
+
     FUNCTOR_TYPEDEF(ParamGetSetIntCb, bool, AP_DroneCAN*, const uint8_t, const char*, int32_t &);
     FUNCTOR_TYPEDEF(ParamGetSetFloatCb, bool, AP_DroneCAN*, const uint8_t, const char*, float &);
+    FUNCTOR_TYPEDEF(ParamGetSetStringCb, bool, AP_DroneCAN*, const uint8_t, const char*, string &);
     FUNCTOR_TYPEDEF(ParamSaveCb, void, AP_DroneCAN*,  const uint8_t, bool);
 
     void send_node_status();
@@ -104,8 +108,10 @@ public:
     // failures occur when waiting on node to respond to previous get or set request
     bool set_parameter_on_node(uint8_t node_id, const char *name, float value, ParamGetSetFloatCb *cb);
     bool set_parameter_on_node(uint8_t node_id, const char *name, int32_t value, ParamGetSetIntCb *cb);
+    bool set_parameter_on_node(uint8_t node_id, const char *name, const string &value, ParamGetSetStringCb *cb);
     bool get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetFloatCb *cb);
     bool get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetIntCb *cb);
+    bool get_parameter_on_node(uint8_t node_id, const char *name, ParamGetSetStringCb *cb);
 
     // Save parameters
     bool save_parameters_on_node(uint8_t node_id, ParamSaveCb *cb);
@@ -177,6 +183,7 @@ private:
     // get parameter on a node
     ParamGetSetIntCb *param_int_cb;         // latest get param request callback function (for integers)
     ParamGetSetFloatCb *param_float_cb;     // latest get param request callback function (for floats)
+    ParamGetSetStringCb *param_string_cb;   // latest get param request callback function (for strings)
     bool param_request_sent = true;         // true after a param request has been sent, false when queued to be sent
     uint32_t param_request_sent_ms;         // system time that get param request was sent
     HAL_Semaphore _param_sem;               // semaphore protecting this block of variables

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -343,7 +343,7 @@ void AP_Mount_Xacti::subscribe_msgs(AP_DroneCAN* ap_dronecan)
 {
     // return immediately if DroneCAN is unavailable
     if (ap_dronecan == nullptr) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Xacti: DroneCAN subscribe failed");
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "%s DroneCAN subscribe failed", send_text_prefix);
         return;
     }
 
@@ -496,7 +496,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
             gcs().send_text(MAV_SEVERITY_ERROR, "%s record", err_prefix_str);
         } else {
             _recording_video = (value == 1);
-            gcs().send_text(MAV_SEVERITY_INFO, "Xacti: recording %s", _recording_video ? "ON" : "OFF");
+            gcs().send_text(MAV_SEVERITY_INFO, "%s recording %s", send_text_prefix, _recording_video ? "ON" : "OFF");
         }
         return false;
     }
@@ -504,7 +504,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s change focus", err_prefix_str);
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "Xacti: %s focus", value == 0 ? "manual" : "auto");
+            gcs().send_text(MAV_SEVERITY_INFO, "%s %s focus", send_text_prefix, value == 0 ? "manual" : "auto");
         }
         return false;
     }
@@ -512,7 +512,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s change lens", err_prefix_str);
         } else if ((uint32_t)value < ARRAY_SIZE(sensor_mode_str)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Xacti: %s", sensor_mode_str[(uint8_t)value]);
+            gcs().send_text(MAV_SEVERITY_INFO, "%s %s", send_text_prefix, sensor_mode_str[(uint8_t)value]);
         }
         return false;
     }
@@ -527,7 +527,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         return false;
     }
     // unhandled parameter get or set
-    gcs().send_text(MAV_SEVERITY_INFO, "Xacti: get/set %s res:%ld", name, (long int)value);
+    gcs().send_text(MAV_SEVERITY_INFO, "%s get/set %s res:%ld", send_text_prefix, name, (long int)value);
     return false;
 }
 
@@ -607,7 +607,7 @@ void AP_Mount_Xacti::handle_param_save_response(AP_DroneCAN* ap_dronecan, const 
 {
     // display failure to save parameter
     if (!success) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Xacti: CAM%u failed to set param", (int)_instance+1);
+        gcs().send_text(MAV_SEVERITY_ERROR, "%s CAM%u failed to set param", send_text_prefix, (int)_instance+1);
     }
 }
 

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -128,24 +128,25 @@ private:
     // yaw_cd is angle in centi-degrees or yaw rate in cds
     void send_gimbal_control(uint8_t mode, int16_t pitch_cd, int16_t yaw_cd);
 
-    // send vehicle attitude to gimbal via DroneCAN
+    // send vehicle attitude to gimbal via DroneCAN.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
-    bool send_copter_att_status();
+    bool send_copter_att_status(uint32_t now_ms);
 
-    // update zoom rate controller
+    // update zoom rate controller.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
-    bool update_zoom_rate_control();
+    bool update_zoom_rate_control(uint32_t now_ms);
 
-    // request firmware version
+    // request firmware version.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
-    bool request_firmware_version();
+    bool request_firmware_version(uint32_t now_ms);
 
-    // request status
+    // request status.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
-    bool request_status();
+    bool request_status(uint32_t now_ms);
 
     // check if safe to send message (if messages sent too often camera will not respond)
-    bool is_safe_to_send() const;
+    // now_ms is current system time
+    bool is_safe_to_send(uint32_t now_ms) const;
 
     // internal variables
     bool _initialised;                              // true once the driver has been initialised

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -120,6 +120,7 @@ private:
 
     // helper function to get and set parameters
     bool set_param_int32(const char* param_name, int32_t param_value);
+    bool set_param_string(const char* param_name, const AP_DroneCAN::string& param_value);
     bool get_param_string(const char* param_name);
 
     // send gimbal control message via DroneCAN
@@ -139,6 +140,9 @@ private:
     // request firmware version.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
     bool request_firmware_version(uint32_t now_ms);
+
+    // set date and time.  now_ms is current system time
+    bool set_datetime(uint32_t now_ms);
 
     // request status.  now_ms is current system time
     // returns true if sent so that we avoid immediately trying to also send other messages
@@ -169,6 +173,12 @@ private:
         char str[12] {};                            // firmware version string (11 bytes + 1 null byte)
         uint32_t mav_ver;                           // version formatted for reporting to GCS via CAMERA_INFORMATION message
     } _firmware_version;
+
+    // date and time handling
+    struct {
+        uint32_t last_request_ms;                   // system time that date/time was last requested
+        bool set;                                   // true once date/time has been set
+    } _datetime;
 
     // gimbal status handling
     enum class ErrorStatus : uint32_t {


### PR DESCRIPTION
This PR enhances the Xacti driver by displaying the gimbal's firmware version and also error status to the user.  It also sets the camera's date and time which means the date/time on the video and image files is correct.

Changes include:

- AP_DroneCAN supports getting and setting string parameters
- AP_Mount_Xacti gets these enhancements
  - request_firmware_version() method requests the FirmwareVersion parameter at 1hz until received
  - request_status() method requests the Status parameter every 3 seconds
  - handle_param_get_set_response_string() processes the replies:
    - the FirmwareVersion string is decoded and displayed to the user via send_text() and also included in the CAMERA_INFORMATION mavlink message
    - the Status message is backed up to a new _status structure and changes to the _error_status are displayed to the user via send_text.  The motor and control related bits also affect the health() reporting
    - set set_datetime() sets the camera's time to match the autopilot's
- AP_Mount Xacti also gets two drive-by enhancements to reduce flash cost from send_text() methods and also reduces the number of calls to AP_HAL::millis().

This has been tested on real hardware and below is a screen shot showing the firmware version being displayed and also error messages when the SD card is temporarily removed.

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/9cdbecd0-815a-40eb-85f6-8b759d79c11c)

Here is a screen shot of the date/time being correctly set on image files
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/54ce0d7f-05c1-4bed-857d-9a40de36a1f8)

