### PR TITLE
AP_OSD: correct compilation when OSD compiled out

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -352,8 +352,8 @@ bool AP_OSD::init_backend(const AP_OSD::osd_types type, const uint8_t instance)
         _backends[instance]->init_symbol_set(AP_OSD_AbstractScreen::symbols_lookup_table, AP_OSD_NUM_SYMBOLS);
         return true;
     }
-    return false;
 #endif
+    return false;
 }
 
 #if OSD_ENABLED


### PR DESCRIPTION
control reaches end of non-void function
