### PR TITLE
Update/correct DisplayPort BF MSP symbols

### DIFF
--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -73,13 +73,13 @@ private:
     static const uint8_t SYM_FS = 0x99;
     static const uint8_t SYM_KMH = 0x9E;
     static const uint8_t SYM_MPH = 0x9D;
-    static const uint8_t SYM_DEGR = 0x1D;
+    static const uint8_t SYM_DEGR = 0x08;
     static const uint8_t SYM_PCNT = 0x25;
     static const uint8_t SYM_RPM = 0x12;
     static const uint8_t SYM_ASPD = 0x41;
-    static const uint8_t SYM_GSPD = 0x70;
-    static const uint8_t SYM_WSPD = 0x1B;
-    static const uint8_t SYM_VSPD = 0x7F;
+    static const uint8_t SYM_GSPD = 0x47;
+    static const uint8_t SYM_WSPD = 0x57;
+    static const uint8_t SYM_VSPD = 0x5E;
     static const uint8_t SYM_WPNO = 0x23;
     static const uint8_t SYM_WPDIR = 0xE6;
     static const uint8_t SYM_WPDST = 0xE7;
@@ -88,10 +88,10 @@ private:
 
     static const uint8_t SYM_SAT_L = 0x1E;
     static const uint8_t SYM_SAT_R = 0x1F;
-    static const uint8_t SYM_HDOP_L = 0x11;
-    static const uint8_t SYM_HDOP_R = 0x08;
+    static const uint8_t SYM_HDOP_L = 0x48;
+    static const uint8_t SYM_HDOP_R = 0x44;
 
-    static const uint8_t SYM_HOME = 0x05;
+    static const uint8_t SYM_HOME = 0x11;
     static const uint8_t SYM_WIND = 0x57;
 
     static const uint8_t SYM_ARROW_START = 0x60;
@@ -120,30 +120,30 @@ private:
 
     static const uint8_t SYM_DEGREES_C = 0x0E;
     static const uint8_t SYM_DEGREES_F = 0x0D;
-    static const uint8_t SYM_GPS_LAT = 0x68;
-    static const uint8_t SYM_GPS_LONG = 0x6C;
-    static const uint8_t SYM_ARMED = 0x08;
-    static const uint8_t SYM_DISARMED = 0x08;
+    static const uint8_t SYM_GPS_LAT = 0x89;
+    static const uint8_t SYM_GPS_LONG = 0x98;
+    static const uint8_t SYM_ARMED = 0x00;
+    static const uint8_t SYM_DISARMED = 0x2A;
     static const uint8_t SYM_ROLL0 = 0x2D;
     static const uint8_t SYM_ROLLR = 0x64;
     static const uint8_t SYM_ROLLL = 0x6C;
     static const uint8_t SYM_PTCH0 = 0x7C;
     static const uint8_t SYM_PTCHUP = 0x68;
     static const uint8_t SYM_PTCHDWN = 0x60;
-    static const uint8_t SYM_XERR = 0xEE;
+    static const uint8_t SYM_XERR = 0x21;
     static const uint8_t SYM_KN = 0xF0;
     static const uint8_t SYM_NM = 0xF1;
-    static const uint8_t SYM_DIST = 0x22;
+    static const uint8_t SYM_DIST = 0x04;
     static const uint8_t SYM_FLY = 0x9C;
     static const uint8_t SYM_EFF = 0xF2;
     static const uint8_t SYM_AH = 0xF3;
     static const uint8_t SYM_MW = 0xF4;
     static const uint8_t SYM_CLK = 0x08;
     static const uint8_t SYM_KILO = 0x4B;
-    static const uint8_t SYM_TERALT = 0xEF;
+    static const uint8_t SYM_TERALT = 0x7F;
     static const uint8_t SYM_FENCE_ENABLED = 0xF5;
     static const uint8_t SYM_FENCE_DISABLED = 0xF6;
-    static const uint8_t SYM_RNGFD = 0x72;
+    static const uint8_t SYM_RNGFD = 0x7F;
     static const uint8_t SYM_LQ = 0xF8;
 
     static constexpr uint8_t symbols[AP_OSD_NUM_SYMBOLS] {


### PR DESCRIPTION
Update the BF symbol translation for DJI DisplayPort when using O3 vehicle units...
The original translation table was based on an obsolete BF font set and has multiple errors....this corrects these plus enhances with better icons some panels...
unfortunately DJI O3 mode cannot record the OSD, so I had to wedge my phone into the goggles to show the before and after images..
This should be a backport into 4.4 since its no risk and does not change function, only a table of icon lookups...

CURRENT
![20230916_110106](https://github.com/ArduPilot/ardupilot/assets/6076534/4c0006d2-b188-4d7f-b690-22afde129363)

After PR
![20230916_105652](https://github.com/ArduPilot/ardupilot/assets/6076534/f535f868-079d-4a4c-ac20-7205671134b3)
