### PR TITLE
AP_HAL: relax F4 notch constraints slightly to allow triple notch on quads

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -318,7 +318,8 @@
 #else
 // Enough for a notch per motor on an octa quad using two IMUs and one harmonic
 // plus one static notch with one harmonic
-#define HAL_HNF_MAX_FILTERS 18
+// Or triple-notch per motor on one IMU with one harmonic
+#define HAL_HNF_MAX_FILTERS 24
 #endif
 #endif // HAL_HNF_MAX_FILTERS
 


### PR DESCRIPTION
Our notch constraints prevents using the triple notch per motor with a harmonic. With one IMU this is perfectly acceptable from a performance perspective