### PR TITLE
AP_AHRS: simplify primary/accel indexes

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2871,7 +2871,6 @@ uint8_t AP_AHRS::_get_primary_IMU_index() const
     int8_t imu = -1;
     switch (active_EKF_type()) {
     case EKFType::NONE:
-        imu = AP::ins().get_primary_gyro();
         break;
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
@@ -2895,7 +2894,7 @@ uint8_t AP_AHRS::_get_primary_IMU_index() const
 #endif
     }
     if (imu == -1) {
-        imu = AP::ins().get_primary_accel();
+        imu = AP::ins().get_primary_gyro();
     }
     return imu;
 }
@@ -2933,19 +2932,13 @@ int8_t AP_AHRS::_get_primary_core_index() const
 // get the index of the current primary accelerometer sensor
 uint8_t AP_AHRS::_get_primary_accel_index(void) const
 {
-    if (ekf_type() != EKFType::NONE) {
-        return _get_primary_IMU_index();
-    }
-    return AP::ins().get_primary_accel();
+    return _get_primary_IMU_index();
 }
 
 // get the index of the current primary gyro sensor
 uint8_t AP_AHRS::_get_primary_gyro_index(void) const
 {
-    if (ekf_type() != EKFType::NONE) {
-        return _get_primary_IMU_index();
-    }
-    return AP::ins().get_primary_gyro();
+    return _get_primary_IMU_index();
 }
 
 // see if EKF lane switching is possible to avoid EKF failsafe

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2934,7 +2934,7 @@ int8_t AP_AHRS::_get_primary_core_index() const
 uint8_t AP_AHRS::_get_primary_accel_index(void) const
 {
     if (ekf_type() != EKFType::NONE) {
-        return get_primary_IMU_index();
+        return _get_primary_IMU_index();
     }
     return AP::ins().get_primary_accel();
 }
@@ -2943,7 +2943,7 @@ uint8_t AP_AHRS::_get_primary_accel_index(void) const
 uint8_t AP_AHRS::_get_primary_gyro_index(void) const
 {
     if (ekf_type() != EKFType::NONE) {
-        return get_primary_IMU_index();
+        return _get_primary_IMU_index();
     }
     return AP::ins().get_primary_gyro();
 }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -727,9 +727,6 @@ private:
     EKFType ekf_type(void) const;
     void update_DCM();
 
-    // get the index of the current primary IMU
-    uint8_t get_primary_IMU_index(void) const { return state.primary_IMU; }
-
     /*
      * home-related state
      */


### PR DESCRIPTION
```
given that DCM doesn't specify to use the primary accel or gyro when fetching the data from the Ins library, it shouldn't be special-cased here when asked what the primary IMU and accel are.  Note that this was asking for the *configured* backend type, rather than the active EKF type, making these clauses even stranger.

This also changes the definition of the "primary IMU index" to be whichever gyro is active rather than the accel.  Since we don't currently split primary gyro/primary accel, this is a reasonable change.
```

Also remove `get_primary_IMU_index` from the public interface.  In the case that we ever split gyros and accels we will want to be able to e.g. have separate position offsets for each.

```
Durandal                       -72    *           -72     -72               -72    -72    -72
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -64    *           -64     -64               -64    -64    -64
MatekF405                      -72    *           -64     -64               -72    -64    -72
Pixhawk1-1M-bdshot             -72                -72     -72               -64    -72    -72
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      -72    *           -64     -72               -72    -64    -64
skyviper-v2450                                    -64                                     
```
