### PR TITLE
GCS_MAVLink: correct sensors when no baros found

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -184,10 +184,12 @@ void GCS::update_sensor_status_flags()
 
 #if AP_BARO_ENABLED
     const AP_Baro &barometer = AP::baro();
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
-    control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
-    if (barometer.all_healthy()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
+    if (barometer.num_instances() > 0) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
+        if (barometer.all_healthy()) {
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
+        }
     }
 #endif
 


### PR DESCRIPTION
GCSs will know we have no baros on-board, as will the RC telemetry library

Alternative to https://github.com/ArduPilot/ardupilot/pull/25001/files
