### PR TITLE
AP_AHRS: remove un-needed AP_AHRS_Backend::getCorrectedDeltaVelocityNED

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2272,11 +2272,11 @@ void AP_AHRS::_getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const
         break;
 #endif
     }
+    ret.zero();
     if (imu_idx == -1) {
-        dcm.getCorrectedDeltaVelocityNED(ret, dt);
+        AP::ins().get_delta_velocity(ret, dt);
         return;
     }
-    ret.zero();
     AP::ins().get_delta_velocity((uint8_t)imu_idx, ret, dt);
     ret -= accel_bias*dt;
     ret = state.dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -304,12 +304,6 @@ public:
 
     virtual void send_ekf_status_report(class GCS_MAVLINK &link) const = 0;
 
-    // Retrieves the corrected NED delta velocity in use by the inertial navigation
-    virtual void getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const {
-        ret.zero();
-        AP::ins().get_delta_velocity(ret, dt);
-    }
-
     // get_hgt_ctrl_limit - get maximum height to be observed by the
     // control loops in meters and a validity flag.  It will return
     // false when no limiting is required


### PR DESCRIPTION
over-kill, and can be derived from backend biases if required

I think this can be rather more-simplified if we can include that rotation-into-vehicle-body-frame in the DCM result; I wonder if having these in separate files caused this discrepancy...


