### PR TITLE
AP_SmartRTL: fix disable if second point fails to add

### DIFF
--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -230,7 +230,9 @@ void AP_SmartRTL::set_home(bool position_ok, const Vector3f& current_pos)
     }
 
     // successfully added point and reset path
-    _last_good_position_ms = AP_HAL::millis();
+    const uint32_t now = AP_HAL::millis();
+    _last_good_position_ms = now;
+    _last_position_save_ms = now;
     _active = true;
     _home_saved = true;
 }


### PR DESCRIPTION
Currently `_last_position_save_ms` is not set when `set_home` is called. This means if the next point fails to add, due to failing to get the semaphore, then it has been more than the time out since boot, or since the last point was added in a previous flight SRLT will deactivate reporting "buffer full", in this case its actually just a failure to get the semaphore one time. 

https://github.com/ArduPilot/ardupilot/blob/23150a0830cb5af405754db9af7e105d6192a3aa/libraries/AP_SmartRTL/AP_SmartRTL.cpp#L265-L270

This can be seen in the log as the addition of a point (action 0) followed by a semaphore fail (action 3) then a deactivate (action 10).

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/ecb64f24-a317-4a78-8ab2-9935acbea0f8)


 