### PR TITLE
AP_HAL_ChibiOS: Explicitly include InternalError in Util

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -27,6 +27,7 @@
 #include "hwdef/common/flash.h"
 #include <AP_ROMFS/AP_ROMFS.h>
 #include <AP_Common/ExpandingString.h>
+#include <AP_InternalError/AP_InternalError.h>
 #include "sdcard.h"
 #include "shared_dma.h"
 #if defined(HAL_PWM_ALARM) || HAL_DSHOT_ALARM_ENABLED || HAL_CANMANAGER_ENABLED || HAL_USE_PWM == TRUE


### PR DESCRIPTION
AP_Periph debug builds fail because InternalError is not being included - The Util class uses InternalError.
AP_Periph debug is built using `./waf configure --board f405-MatekGPS --debug AP_Periph` 

The include was being passed up from Logger->LoggerMessageWriter->LoggerBackend->Bitmask. Periph Builds tend not to have HAL_LOGGING_ENABLED, and so the include was not present.