### PR TITLE
AP_GPS:SBF using COMx data response as actual COM port id value inste…

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -108,17 +108,17 @@ AP_GPS_SBF::read(void)
                     if (config_string == nullptr) {
                         switch (config_step) {
                             case Config_State::Baud_Rate:
-                                if (asprintf(&config_string, "scs,COM%d,baud%d,bits8,No,bit1,%s\n",
-                                             (int)gps._com_port[state.instance],
+                                if (asprintf(&config_string, "scs,COM%c,baud%d,bits8,No,bit1,%s\n",
+                                             portIdChar,
                                              230400,
                                              port->get_flow_control() != AP_HAL::UARTDriver::flow_control::FLOW_CONTROL_ENABLE ? "none" : "RTS|CTS") == -1) {
                                     config_string = nullptr;
                                 }
                                 break;
                             case Config_State::SSO:
-                                if (asprintf(&config_string, "sso,Stream%d,COM%d,PVTGeodetic+DOP+ReceiverStatus+VelCovGeodetic+BaseVectorGeod,msec100\n",
+                                if (asprintf(&config_string, "sso,Stream%d,COM%c,PVTGeodetic+DOP+ReceiverStatus+VelCovGeodetic+BaseVectorGeod,msec100\n",
                                              (int)GPS_SBF_STREAM_NUMBER,
-                                             (int)gps._com_port[state.instance]) == -1) {
+                                             portIdChar) == -1) {
                                     config_string = nullptr;
                                 }
                                 break;
@@ -216,6 +216,7 @@ AP_GPS_SBF::parse(uint8_t temp)
                             }
                         } else if (portLength >= sizeof(portIdentifier)) {
                             if ((char)temp == '>') {
+                                portIdChar = portIdentifier[portLength-2];
                                 readyForCommand = true;
                                 Debug("SBF: Ready for command");
                             }

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -265,5 +265,6 @@ private:
     char portIdentifier[5];
     uint8_t portLength;
     bool readyForCommand;
+    char portIdChar;
 };
 #endif


### PR DESCRIPTION
SBF using COMx data response as actual COM port id value instead of using AP_GPS instance id
ie. Connect Mosaic UART2 with ardupilot GPS1, the code will config COM 1 instead COM 2(actual port) since using GPS instance id