### PR TITLE
Plane:clarify CTUN.SAs message meaning

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -306,7 +306,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: RdrOut: scaled output rudder
 // @Field: ThD: demanded speed-height-controller throttle
 // @Field: As: airspeed estimate (or measurement if airspeed sensor healthy and ARSPD_USE>0)
-// @Field: SAs: synthetic airspeed measurement derived from non-airspeed sensors, NaN if not available
+// @Field: SAs: DCM's airspeed estimate, NaN if not available
 // @Field: E2T: equivalent to true airspeed ratio
 // @Field: GU: groundspeed undershoot when flying with minimum groundspeed
 


### PR DESCRIPTION
NFC.....this has some of us confused when analyzing logs since CTUN.As can be "synthetic" also when no airspeed sensor is used while CTUN.As is the cannonical airspeed, synthetic or measured 