### PR TITLE
AP_Scripting: added logging to EFI_Halo6000.lua driver

### DIFF
--- a/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
+++ b/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
@@ -199,8 +199,11 @@ local function engine_control()
        
        efi_state:last_updated_ms(millis())
 
-        -- Set the EFI_State into the EFI scripting driver
-        efi_backend:handle_scripting(efi_state)
+       -- Set the EFI_State into the EFI scripting driver
+       efi_backend:handle_scripting(efi_state)
+
+       logger.write('H6K','Curr,Volt,CoolT,CylT,FuelPct', 'fffff',
+                    out_current, out_volt, cool_temp, cyl_temp, fuel_pct)
     end
 
     -- update telemetry output for extra telemetry values


### PR DESCRIPTION
allows for log analysis of current/voltage