### PR TITLE
Copter: Add hard landing to radio failsafe

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -226,7 +226,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_THR_ENABLE
     // @DisplayName: Throttle Failsafe Enable
     // @Description: The throttle failsafe allows you to configure a software failsafe activated by a setting on the throttle input channel
-    // @Values:  0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode (Removed in 4.0+),3:Enabled always Land,4:Enabled always SmartRTL or RTL,5:Enabled always SmartRTL or Land,6:Enabled Auto DO_LAND_START or RTL,7:Enabled always Brake or Land
+    // @Values:  0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode (Removed in 4.0+),3:Enabled always Land,4:Enabled always SmartRTL or RTL,5:Enabled always SmartRTL or Land,6:Enabled Auto DO_LAND_START or RTL,7:Enabled always Brake or Land,8:Terminate
     // @User: Standard
     GSCALAR(failsafe_throttle,  "FS_THR_ENABLE",   FS_THR_ENABLED_ALWAYS_RTL),
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -142,6 +142,7 @@ enum LoggingParameters {
 #define FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_LAND     5
 #define FS_THR_ENABLED_AUTO_RTL_OR_RTL             6
 #define FS_THR_ENABLED_BRAKE_OR_LAND               7
+#define FS_THR_ENABLED_TERMINATE                   8
 
 // GCS failsafe definitions (FS_GCS_ENABLE parameter)
 #define FS_GCS_DISABLED                        0

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -39,6 +39,9 @@ void Copter::failsafe_radio_on_event()
         case FS_THR_ENABLED_BRAKE_OR_LAND:
             desired_action = FailsafeAction::BRAKE_LAND;
             break;
+        case FS_THR_ENABLED_TERMINATE:
+            desired_action = FailsafeAction::TERMINATE;
+            break;
         default:
             desired_action = FailsafeAction::LAND;
     }


### PR DESCRIPTION
Operate the vehicle within radio range of the radio transmitter.
If the vehicle is unable to operate the radio, we want to make a hard landing on the spot as an emergency response.
For this purpose, TERMINATE is added to the radio fail-safe designation.

![Screenshot from 2023-09-21 00-41-25](https://github.com/ArduPilot/ardupilot/assets/646194/01f560e5-ede4-4225-bf59-d93852d42a6e)
![Screenshot from 2023-09-21 00-39-32](https://github.com/ArduPilot/ardupilot/assets/646194/86bdf0a4-ae6e-4bcf-a92a-3c9ca2d72b58)

