### PR TITLE
AP_ICEngine: Add an option to disable starting while disarmed

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: ICE options
     // @Description: Options for ICE control. The Disable ignition in RC failsafe option will cause the ignition to be set off on any R/C failsafe. If Throttle while disarmed is set then throttle control will be allowed while disarmed for planes when in MANUAL mode. If disable while disarmed is set the engine will not start while the vehicle is disarmed.
-    // @Bitmask: 0:Disable ignition in RC failsafe,1:Disable redine governor,2:ThrottleWhileDisarmed,3:Disable while disarmed
+    // @Bitmask: 0:Disable ignition in RC failsafe,1:Disable redline governor,2:Throttle while disarmed,3:Disable while disarmed
     AP_GROUPINFO("OPTIONS", 15, AP_ICEngine, options, 0),
 
     // @Param: STARTCHN_MIN

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -142,8 +142,8 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: ICE options
-    // @Description: Options for ICE control. The DisableIgnitionRCFailsafe option will cause the ignition to be set off on any R/C failsafe. If ThrottleWhileDisarmed is set then throttle control will be allowed while disarmed for planes when in MANUAL mode.
-    // @Bitmask: 0:DisableIgnitionRCFailsafe,1:DisableRedineGovernor,2:ThrottleWhileDisarmed
+    // @Description: Options for ICE control. The Disable ignition in RC failsafe option will cause the ignition to be set off on any R/C failsafe. If Throttle while disarmed is set then throttle control will be allowed while disarmed for planes when in MANUAL mode. If disable while disarmed is set the engine will not start while the vehicle is disarmed.
+    // @Bitmask: 0:Disable ignition in RC failsafe,1:Disable redine governor,2:ThrottleWhileDisarmed,3:Disable while disarmed
     AP_GROUPINFO("OPTIONS", 15, AP_ICEngine, options, 0),
 
     // @Param: STARTCHN_MIN
@@ -244,6 +244,11 @@ void AP_ICEngine::update(void)
 
     if (option_set(Options::DISABLE_IGNITION_RC_FAILSAFE) && AP_Notify::flags.failsafe_radio) {
         // user has requested ignition kill on RC failsafe
+        should_run = false;
+    }
+
+    if (option_set(Options::NO_RUNNING_WHILE_DISARMED) && !hal.util->get_soft_armed()) {
+        // disable the engine if disarmed
         should_run = false;
     }
 
@@ -551,7 +556,7 @@ void AP_ICEngine::update_idle_governor(int8_t &min_throttle)
     // Calculate the change per loop to achieve the desired slew rate of 1 percent per second
     static const float idle_setpoint_step = idle_slew * AP::scheduler().get_loop_period_s();
 
-    // Update Integrator 
+    // Update Integrator
     if (underspeed) {
         idle_governor_integrator += idle_setpoint_step;
     } else {

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -141,9 +141,10 @@ private:
     float idle_governor_integrator;
 
     enum class Options : uint16_t {
-        DISABLE_IGNITION_RC_FAILSAFE=(1U<<0),
-        DISABLE_REDLINE_GOVERNOR = (1U << 1),
-        THROTTLE_WHILE_DISARMED = (1U << 2),
+        DISABLE_IGNITION_RC_FAILSAFE = (1U << 0),
+        DISABLE_REDLINE_GOVERNOR     = (1U << 1),
+        THROTTLE_WHILE_DISARMED      = (1U << 2),
+        NO_RUNNING_WHILE_DISARMED    = (1U << 3),
     };
     AP_Int16 options;
 


### PR DESCRIPTION
Basically I don't want to start the engine while disarmed. Currently it's a flick of a switch away. To replicate the start while disarmed in SITL set `ICE_IDLE_PCT` to a non 0 value like 20, set the start channel and raise it. You can then set ICE_OPTIONS 8 and it won't do this anymore unless you have armed the aircraft.

This has only been SITL tested. I have some follow ups that will build off of this.