### PR TITLE
AP_ICEngine: Move out of start delay faster rather then waiting for the next loop

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -283,11 +283,13 @@ void AP_ICEngine::update(void)
     case ICE_START_DELAY:
         if (!should_run) {
             state = ICE_OFF;
-        } else if (now - starter_last_run_ms >= starter_delay*1000) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Starting engine");
-            state = ICE_STARTING;
+            break;
+        } else if (now - starter_last_run_ms <= starter_delay*1000) {
+            break;
         }
-        break;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Starting engine");
+        state = ICE_STARTING;
+        FALLTHROUGH;
 
     case ICE_STARTING:
         if (!should_run) {


### PR DESCRIPTION
Very minor change, to move through the engine start delay faster. This mostly helps if you set `ICE_START_DELAY` to 0.

This was a small patch from a different change set that I don't think will go anywhere. I pulled this out on the basis that it makes the system slightly more responsive and makes the build the very smallest bit smaller.

SITL tested only.