### PR TITLE
AP_Generator: use HAL_LOGGING_ENABLED

### DIFF
--- a/libraries/AP_Generator/AP_Generator_IE_2400.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.cpp
@@ -182,6 +182,7 @@ bool AP_Generator_IE_2400::check_for_err_code(char* msg_txt, uint8_t msg_len) co
     return true;
 }
 
+#if HAL_LOGGING_ENABLED
 // log generator status to the onboard log
 void AP_Generator_IE_2400::log_write()
 {
@@ -203,4 +204,6 @@ void AP_Generator_IE_2400::log_write()
         _err_code
         );
 }
+#endif  // HAL_LOGGING_ENABLED
+
 #endif  // AP_GENERATOR_IE_2400_ENABLED

--- a/libraries/AP_Generator/AP_Generator_IE_2400.h
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.h
@@ -32,7 +32,9 @@ private:
     // Check for error codes that are deemed severe and would be cause to trigger a battery monitor low failsafe action
     bool is_low_error(const uint32_t err_in) const;
 
+#if HAL_LOGGING_ENABLED
     void log_write(void) override;
+#endif
 
     // IE 2.4kW failsafes
     enum class ErrorCode {

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -67,7 +67,9 @@ void AP_Generator_IE_FuelCell::update()
 
     update_frontend();
 
+#if HAL_LOGGING_ENABLED
     log_write();
+#endif
 }
 
 // Add a single character to the buffer and attempt to decode

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
@@ -4,6 +4,8 @@
 
 #if AP_GENERATOR_IE_ENABLED
 
+#include <AP_Logger/AP_Logger_config.h>
+
 class AP_Generator_IE_FuelCell : public AP_Generator_Backend
 {
 
@@ -81,7 +83,9 @@ protected:
     // Assigns the unit specific measurements once a valid sentence is obtained
     virtual void assign_measurements(const uint32_t now) = 0;
 
+#if HAL_LOGGING_ENABLED
     virtual void log_write(void) {}
+#endif
 
     // Add a single character to the buffer and attempt to decode.
     // Returns true if a complete sentence was successfully decoded or if the buffer is full.

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -235,7 +235,9 @@ void AP_Generator_RichenPower::update(void)
 
     update_frontend_readings();
 
+#if HAL_LOGGING_ENABLED
     Log_Write();
+#endif
 }
 
 // update_runstate updates the servo output we use to control the
@@ -308,6 +310,7 @@ void AP_Generator_RichenPower::update_runstate()
     }
 }
 
+#if HAL_LOGGING_ENABLED
 // log generator status to the onboard log
 void AP_Generator_RichenPower::Log_Write()
 {
@@ -336,6 +339,7 @@ void AP_Generator_RichenPower::Log_Write()
         last_reading.mode
         );
 }
+#endif
 
 // generator prearm checks; notably, if we never see a generator we do
 // not run the checks.  Generators are attached/detached at will, and

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -5,6 +5,7 @@
 
 #if AP_GENERATOR_RICHENPOWER_ENABLED
 
+#include <AP_Logger/AP_Logger_config.h>
 #include <AP_Common/AP_Common.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -93,9 +94,11 @@ private:
         Mode        mode;
     };
 
+#if HAL_LOGGING_ENABLED
     // method and state to write and entry to the onboard log:
     void Log_Write();
     uint32_t last_logged_reading_ms;
+#endif
 
     struct Reading last_reading;
     uint32_t last_reading_ms;


### PR DESCRIPTION
Tested for compilation (when logging compiled out) only.  Which it does.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
