### PR TITLE
SITL: update SIM_STATE msg to use integer lat/lng

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1144,7 +1144,9 @@ void SIM::sim_state_send(mavlink_channel_t chan) const
             0.0,
             state.speedN,
             state.speedE,
-            state.speedD);
+            state.speedD,
+	        (int32_t)(state.latitude*1.0e7),
+            (int32_t)(state.longitude*1.0e7));
 }
 
 /* report SITL state to AP_Logger */


### PR DESCRIPTION
Requires https://github.com/ArduPilot/mavlink/pull/329

This brings in the upstream mavlink SIM_STATE with integer lat/lng and sends that message.

Authored by @samuelctabor 