### PR TITLE
SRV_Channel: Consider igntion something that should be e-stopped

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -322,6 +322,7 @@ bool SRV_Channel::should_e_stop(SRV_Channel::Aux_servo_function_t function)
     case Aux_servo_function_t::k_motor6:
     case Aux_servo_function_t::k_motor7:
     case Aux_servo_function_t::k_motor8:
+    case Aux_servo_function_t::k_ignition:
     case Aux_servo_function_t::k_starter:
     case Aux_servo_function_t::k_throttle:
     case Aux_servo_function_t::k_throttleLeft:


### PR DESCRIPTION
This is a bit of a drive by, but the comment at the top of the function is:
```
// return true if function is for anything that should be stopped in a e-stop situation, ie is dangerous
```

and ignition control sounds exactly like that to me.