### PR TITLE
AP_InertialSensor: ensure indirect registers are not modified with sensors active on ICM-42688

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -629,9 +629,8 @@ void AP_InertialSensor_Invensensev3::set_filter_and_scaling(void)
         }
     }
 
-    // enable gyro and accel in low-noise modes
-    register_write(INV3REG_PWR_MGMT0, 0x0F);
-    hal.scheduler->delay_microseconds(300);
+    // disable gyro and accel as per 12.9 in the ICM-42688 docs
+    register_write(INV3REG_PWR_MGMT0, 0x00);
 
     // setup gyro for backend rate
     register_write(INV3REG_GYRO_CONFIG0, odr_config);
@@ -650,6 +649,10 @@ void AP_InertialSensor_Invensensev3::set_filter_and_scaling(void)
     register_write_bank(2, INV3REG_ACCEL_CONFIG_STATIC2, accel_aaf_delt<<1); // ACCEL_AAF_DELT | enabled bit
     register_write_bank(2, INV3REG_ACCEL_CONFIG_STATIC3, (accel_aaf_deltsqr & 0xFF)); // ACCEL_AAF_DELTSQR
     register_write_bank(2, INV3REG_ACCEL_CONFIG_STATIC4, ((accel_aaf_bitshift<<4) & 0xF0) | ((accel_aaf_deltsqr>>8) & 0x0F)); // ACCEL_AAF_BITSHIFT | ACCEL_AAF_DELTSQR
+
+    // enable gyro and accel in low-noise modes
+    register_write(INV3REG_PWR_MGMT0, 0x0F);
+    hal.scheduler->delay_microseconds(300);
 }
 
 /*


### PR DESCRIPTION
As per the ICM-42688 docs:
```
12.9 REGISTER VALUES MODIFICATION
The only register settings that user can modify during sensor operation are for ODR selection, FSR selection, and sensor mode changes (register parameters GYRO_ODR, ACCEL_ODR, GYRO_FS_SEL, ACCEL_FS_SEL, GYRO_MODE, ACCEL_MODE). User must not modify any other register values during sensor operation. The following procedure must be used for other register values modification.
• Turn Accel and Gyro Off
• Modify register values
• Turn Accel and/or Gyro On
```
The docs for ICM-45686 and 42670 do not have this restriction.