### PR TITLE
Camera: image start/stop capture fixes

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -358,12 +358,15 @@ MAV_RESULT AP_Camera::handle_command_long(const mavlink_command_long_t &packet)
         }
     case MAV_CMD_IMAGE_STOP_CAPTURE:
         // param1 : camera id
+        if (is_negative(packet.param1)) {
+            return MAV_RESULT_UNSUPPORTED;
+        }
         if (is_zero(packet.param1)) {
             // stop capture for every backend
             stop_capture();
             return MAV_RESULT_ACCEPTED;
         }
-        if (stop_capture(packet.param1)) {
+        if (stop_capture(packet.param1-1)) {
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_UNSUPPORTED;

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -111,13 +111,17 @@ public:
     void cam_mode_toggle();
     void cam_mode_toggle(uint8_t instance);
 
-    // take a picture
-    void take_picture();
+    // take a picture.  If instance is not provided, all available cameras affected
+    // returns true if at least one camera took a picture
+    bool take_picture();
     bool take_picture(uint8_t instance);
 
     // take multiple pictures, time_interval between two consecutive pictures is in miliseconds
+    // if instance is not provided, all available cameras affected
+    // time_interval_ms must be positive
     // total_num is number of pictures to be taken, -1 means capture forever
-    void take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
+    // returns true if at least one camera is successful
+    bool take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
     bool take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num);
 
     // stop capturing multiple image sequence

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -10,8 +10,7 @@ bool AP_Camera_Mount::trigger_pic()
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        mount->take_picture(get_mount_instance());
-        return true;
+        return mount->take_picture(get_mount_instance());
     }
     return false;
 }

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -163,32 +163,28 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         return false;
 
     case MAV_CMD_IMAGE_START_CAPTURE:
-        // check if this is a single picture request
-        if (cmd.content.image_start_capture.total_num_images == 1) {
+        // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
+        if ((cmd.content.image_start_capture.total_num_images == 1) ||
+            (cmd.content.image_start_capture.total_num_images == 0 && is_zero(cmd.content.image_start_capture.interval_s))) {
             if (cmd.content.image_start_capture.instance == 0) {
                 // take pictures for every backend
-                camera->take_picture();
-                return true;
+                return camera->take_picture();
             }
             return camera->take_picture(cmd.content.image_start_capture.instance-1);
         } else if (cmd.content.image_start_capture.total_num_images == 0) {
             // multiple picture request, take pictures forever
             if (cmd.content.image_start_capture.instance == 0) {
                 // take pictures for every backend
-                camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, -1);
-                return true;
+                return camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, -1);
             }
             return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, -1);
         } else {
             if (cmd.content.image_start_capture.instance == 0) {
                 // take pictures for every backend
-                camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
-                return true;
+                return camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
             }
             return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
         }
-        return false;
-
     case MAV_CMD_IMAGE_STOP_CAPTURE:
         if (cmd.p1 == 0) {
             // stop capture for each backend

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -191,7 +191,7 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
             camera->stop_capture();
             return true;
         }
-        return camera->stop_capture(cmd.p1);
+        return camera->stop_capture(cmd.p1 - 1);
 
     case MAV_CMD_VIDEO_START_CAPTURE:
     case MAV_CMD_VIDEO_STOP_CAPTURE:


### PR DESCRIPTION
This is a follow-up to PR https://github.com/ArduPilot/ardupilot/pull/24772 to fix some issues found with the [IMAGE_START_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1670) and  [IMAGE_STOP_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1693) support both when sent as real-time commands and when included in missions.

The issues fixed are:

1. IMAGE_START_CAPTURE with zero "interval" and "total images" fields would lead to potentially huge numbers of images being taken.  With this PR we only take one picture.  This may be slightly unintuitive in that an IMAGE_START_CAPTURE with "Total Images = 0" has the same effect as "Total Images = 1" but I think it is safer.
2. IMAGE_STOP_CAPTURE was incorrectly converting the "Id" field to "instance" meaning the user might not be able to stop taking pictures.
4. IMAGE_START_CAPTURE (sent in real-time) would return ACCEPTED even when no cameras had been setup (e.g. CAM1_TYPE=0).  With this PR it returns FAILED.  Note though that if the "Id" field (aka instance) is incorrect, before it would report UNSUPPORTED but now it reports FAILED.  This is perhaps incorrect and maybe @peterbarker can confirm.
5. AP_Camera_Mount::trigger-pic() was always reporting success even if the AP_Mount library reported it could not take a pic.  This is a drive-by fix unrelated to the other changes.

This has been fairly extensively tested in SITL both using real-time commands and mission commands.  Below are before-and-after screen shots of the 1st issue.
![billion-pic-before-and-after](https://github.com/ArduPilot/ardupilot/assets/1498098/50b0e32e-30c3-4e67-acd0-374d08fe81d9)

This resolves https://github.com/ArduPilot/ardupilot/issues/25073