### PR TITLE
AP_DroneCAN: Add a servo offset to match ESC offset

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -149,6 +149,13 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ESC_RV", 9, AP_DroneCAN, _esc_rv, 0),
     
+    // @Param: SRV_OF
+    // @DisplayName: Servo output channels offset
+    // @Description: Offset for servo numbering in DroneCAN Actuator messages. This allows for more efficient packing of servo commands. If your servos are on servo functions 5 to 8 and you set this parameter to 4 then the Actuator command will be sent with the first 4 slots filled. This can be used for more efficint usage of CAN bandwidth
+    // @Range: 0 18
+    // @User: Advanced
+    AP_GROUPINFO("SRV_OF", 10, AP_DroneCAN, _servo_offset, 0),
+
     AP_GROUPEND
 };
 
@@ -573,7 +580,7 @@ int16_t AP_DroneCAN::scale_esc_output(uint8_t idx){
 
 void AP_DroneCAN::SRV_send_actuator(void)
 {
-    uint8_t starting_servo = 0;
+    uint8_t starting_servo = MAX(_servo_offset, 0);
     bool repeat_send;
 
     WITH_SEMAPHORE(SRV_sem);

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -200,6 +200,7 @@ private:
     AP_Int32 _servo_bm;
     AP_Int32 _esc_bm;
     AP_Int8 _esc_offset;
+    AP_Int8 _servo_offset;
     AP_Int16 _servo_rate_hz;
     AP_Int16 _options;
     AP_Int16 _notify_state_hz;


### PR DESCRIPTION
Tested on real hardware. This mimics ESC offset, and works quite nicely in my testing, keeps the bandwidth down, allows me to run my CAN servos on ID's > 16, and leave the lower 12 standard outputs for normal PWM use.