### PR TITLE
Telem sag volt

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -711,6 +711,19 @@ float AP_BattMonitor::gcs_voltage(uint8_t instance) const
     return state[instance].voltage;
 }
 
+/// Get voltage for telemetry, which will be resting voltage if option is enabled.
+/// Will not use resting voltage if disarmed.
+float AP_BattMonitor::telem_voltage(uint8_t instance) const
+{
+    if (instance >= _num_instances || drivers[instance] == nullptr) {
+        return 0.0f;
+    }
+    if (hal.util->get_soft_armed() && drivers[instance]->option_is_set(AP_BattMonitor_Params::Options::Telem_Resting_Voltage)) {
+        return voltage_resting_estimate(instance);
+    }
+    return voltage(instance);
+}
+
 /// current_amps - returns the instantaneous current draw in amperes
 bool AP_BattMonitor::current_amps(float &current, uint8_t instance) const {
     if ((instance < _num_instances) && (drivers[instance] != nullptr) && drivers[instance]->has_current()) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -175,14 +175,18 @@ public:
     float voltage(uint8_t instance) const;
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
 
-    // voltage for a GCS, may be resistance compensated
-    float gcs_voltage(uint8_t instance) const;
-    float gcs_voltage(void) const { return gcs_voltage(AP_BATT_PRIMARY_INSTANCE); }
-
     /// get voltage with sag removed (based on battery current draw and resistance)
     /// this will always be greater than or equal to the raw voltage
     float voltage_resting_estimate(uint8_t instance) const;
     float voltage_resting_estimate() const { return voltage_resting_estimate(AP_BATT_PRIMARY_INSTANCE); }
+
+    // voltage for a GCS, may be resistance compensated
+    float gcs_voltage(uint8_t instance) const;
+    float gcs_voltage(void) const { return gcs_voltage(AP_BATT_PRIMARY_INSTANCE); }
+
+    // voltage for telemetry
+    float telem_voltage(uint8_t instance) const;
+    float telem_voltage(void) const { return telem_voltage(AP_BATT_PRIMARY_INSTANCE); }
 
     /// current_amps - returns the instantaneous current draw in amperes
     bool current_amps(float &current, const uint8_t instance = AP_BATT_PRIMARY_INSTANCE) const WARN_IF_UNUSED;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -150,7 +150,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options
     // @Description: This sets options to change the behaviour of the battery monitor
-    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS
+    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Send resistence compensated voltage to telemetry
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 #endif // HAL_BUILD_AP_PERIPH

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -25,6 +25,7 @@ public:
         MPPT_Power_Off_At_Boot              = (1U<<4),  // MPPT Disabled at startup (aka boot), if HW supports it
         MPPT_Power_On_At_Boot               = (1U<<5),  // MPPT Enabled at startup (aka boot), if HW supports it. If Power_Off_at_Boot is also set, the behavior is Power_Off_at_Boot
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
+        Telem_Resting_Voltage               = (1U<<7),  // Send resting voltage to telemetry
     };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -537,7 +537,7 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_batt(uint8_t instance)
     }
 
     // battery voltage in decivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
-    uint32_t batt = (((uint16_t)roundf(_battery.voltage(instance) * 10.0f)) & BATT_VOLTAGE_LIMIT);
+    uint32_t batt = (((uint16_t)roundf(_battery.telem_voltage(instance) * 10.0f)) & BATT_VOLTAGE_LIMIT);
     // battery current draw in deciamps
     batt |= prep_number(roundf(current * 10.0f), 2, 1)<<BATT_CURRENT_OFFSET;
     // battery current drawn since power on in mAh (limit to 32767 (0x7FFF) since value is stored on 15 bits)

--- a/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
+++ b/libraries/AP_Hott_Telem/AP_Hott_Telem.cpp
@@ -111,10 +111,10 @@ void AP_Hott_Telem::send_EAM(void)
 
     const AP_BattMonitor &battery = AP::battery();
     if (battery.num_instances() > 0) {
-        msg.batt1_voltage = uint16_t(battery.voltage(0) * 10);
+        msg.batt1_voltage = uint16_t(battery.telem_voltage(0) * 10);
     }
     if (battery.num_instances() > 1) {
-        msg.batt2_voltage = uint16_t(battery.voltage(1) * 10);
+        msg.batt2_voltage = uint16_t(battery.telem_voltage(1) * 10);
     }
     float current;
     if (battery.current_amps(current)) {

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -872,7 +872,7 @@ void AP_CRSF_Telem::calc_battery()
 {
     const AP_BattMonitor &_battery = AP::battery();
 
-    _telem.bcast.battery.voltage = htobe16(uint16_t(roundf(_battery.voltage(0) * 10.0f)));
+    _telem.bcast.battery.voltage = htobe16(uint16_t(roundf(_battery.telem_voltage(0) * 10.0f)));
 
     float current;
     if (!_battery.current_amps(current, 0)) {

--- a/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_Spektrum_Telem.cpp
@@ -301,7 +301,7 @@ void AP_Spektrum_Telem::calc_rpm()
     _telem.rpm.identifier = TELE_DEVICE_RPM;
     _telem.rpm.sID = 0;
     // battery voltage in centivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
-    _telem.rpm.volts = htobe16(((uint16_t)roundf(_battery.voltage(0) * 100.0f)));
+    _telem.rpm.volts = htobe16(((uint16_t)roundf(_battery.telem_voltage(0) * 100.0f)));
     _telem.rpm.temperature = htobe16(int16_t(roundf(32.0f + AP::baro().get_temperature(0) * 9.0f / 5.0f)));
 #if AP_RPM_ENABLED
     const AP_RPM *rpm = AP::rpm();
@@ -331,7 +331,7 @@ void AP_Spektrum_Telem::calc_batt_volts(uint8_t instance)
     const AP_BattMonitor &_battery = AP::battery();
 
     // battery voltage in centivolts, can have up to a 12S battery (4.25Vx12S = 51.0V)
-    _telem.hv.volts = htobe16(uint16_t(roundf(_battery.voltage(instance) * 100.0f)));
+    _telem.hv.volts = htobe16(uint16_t(roundf(_battery.telem_voltage(instance) * 100.0f)));
     _telem.hv.identifier = TELE_DEVICE_VOLTAGE;
     _telem.hv.sID = 0;
     _telem_pending = true;


### PR DESCRIPTION
Added option to use resting voltage for battery voltage telemetry.
telem_voltage() was added and is used in place of voltage() for getting telemetry battery voltage.
The function will check if Telem_Resting_Voltage option is selected. If so, it will use resting voltage.
It will not use resting voltage if disarmed, as the value is inaccurate and unhelpful.

I have tested this for CRSF and Frsky telemetry using a TX16s. I have not tested it with Hott or Spektrum telem, as I cannot do that.