### PR TITLE
Copter: Change to ternary operator

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -585,27 +585,15 @@ void ModeZigZag::spray(bool b)
 
 uint32_t ModeZigZag::wp_distance() const
 {
-    if (is_auto) {
-        return wp_nav->get_wp_distance_to_destination();
-    } else {
-        return 0;
-    }
+    return is_auto ? wp_nav->get_wp_distance_to_destination() : 0;
 }
 int32_t ModeZigZag::wp_bearing() const
 {
-    if (is_auto) {
-        return wp_nav->get_wp_bearing_to_destination();
-    } else {
-        return 0;
-    }
+    return is_auto ? wp_nav->get_wp_bearing_to_destination() : 0;
 }
 float ModeZigZag::crosstrack_error() const
 {
-    if (is_auto) {
-        return wp_nav->crosstrack_error();
-    } else {
-        return 0;
-    }
+    return is_auto ? wp_nav->crosstrack_error() : 0;
 }
 
 #endif // MODE_ZIGZAG_ENABLED == ENABLED


### PR DESCRIPTION
Ternary operators are numerous in the ArduPilot code.
There is no reason not to make this method a ternary operator.
I would change it to a ternary operator.