### PR TITLE
AP_Mount: improve Xacti picture taking reliability

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -633,12 +633,13 @@ void AP_Mount_Xacti::handle_param_save_response(AP_DroneCAN* ap_dronecan, const 
 }
 
 // get parameter name for a particular param enum value
+// returns an empty string if not found (which should never happen)
 const char* AP_Mount_Xacti::get_param_name_str(Param param) const
 {
     // check to avoid reading beyond end of array.  This should never happen
     if ((uint8_t)param > ARRAY_SIZE(_param_names)) {
         INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        return nullptr;
+        return "";
     }
     return _param_names[(uint8_t)param];
 }
@@ -683,10 +684,6 @@ bool AP_Mount_Xacti::get_param_string(Param param)
 
     // convert param to string
     const char* param_name_str = get_param_name_str(param);
-    if (param_name_str == nullptr) {
-        return false;
-    }
-
     if (_detected_modules[_instance].ap_dronecan->get_parameter_on_node(_detected_modules[_instance].node_id, param_name_str, &param_string_cb)) {
         last_send_getset_param_ms = AP_HAL::millis();
         return true;
@@ -705,9 +702,6 @@ bool AP_Mount_Xacti::process_set_param_int32_queue()
     if (_set_param_int32_queue->pop(param_to_set)) {
         // convert param to string
         const char* param_name_str = get_param_name_str(param_to_set.param);
-        if (param_name_str == nullptr) {
-            return false;
-        }
         if (_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, param_name_str, param_to_set.value, &param_int_cb)) {
             last_send_getset_param_ms = AP_HAL::millis();
             return true;

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -12,18 +12,10 @@
 extern const AP_HAL::HAL& hal;
 
 #define LOG_TAG "Mount"
-#define XACTI_PARAM_SINGLESHOT "SingleShot"
-#define XACTI_PARAM_RECORDING "Recording"
-#define XACTI_PARAM_FOCUSMODE "FocusMode"
-#define XACTI_PARAM_SENSORMODE "SensorMode"
-#define XACTI_PARAM_DIGITALZOOM "DigitalZoomMagnification"
-#define XACTI_PARAM_FIRMWAREVERSION "FirmwareVersion"
-#define XACTI_PARAM_STATUS "Status"
-#define XACTI_PARAM_DATETIME "DateTime"
-
 #define XACTI_MSG_SEND_MIN_MS 20                    // messages should not be sent to camera more often than 20ms
 #define XACTI_ZOOM_RATE_UPDATE_INTERVAL_MS  500     // zoom rate control increments zoom by 10% up or down every 0.5sec
 #define XACTI_STATUS_REQ_INTERVAL_MS 3000           // request status every 3 seconds
+#define XACTI_SET_PARAM_QUEUE_SIZE 3                // three set-param requests may be queued
 
 #define AP_MOUNT_XACTI_DEBUG 0
 #define debug(fmt, args ...) do { if (AP_MOUNT_XACTI_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Xacti: " fmt, ## args); } } while (0)
@@ -33,6 +25,7 @@ AP_Mount_Xacti::DetectedModules AP_Mount_Xacti::_detected_modules[];
 HAL_Semaphore AP_Mount_Xacti::_sem_registry;
 const char* AP_Mount_Xacti::send_text_prefix = "Xacti:";
 const char* AP_Mount_Xacti::sensor_mode_str[] = { "RGB", "IR", "PIP", "NDVI" };
+const char* AP_Mount_Xacti::_param_names[] = {"SingleShot", "Recording", "FocusMode", "SensorMode", "DigitalZoomMagnification", "FirmwareVersion", "Status", "DateTime"};
 
 // Constructor
 AP_Mount_Xacti::AP_Mount_Xacti(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance) :
@@ -43,11 +36,20 @@ AP_Mount_Xacti::AP_Mount_Xacti(class AP_Mount &frontend, class AP_Mount_Params &
     param_int_cb = FUNCTOR_BIND_MEMBER(&AP_Mount_Xacti::handle_param_get_set_response_int, bool, AP_DroneCAN*, const uint8_t, const char*, int32_t &);
     param_string_cb = FUNCTOR_BIND_MEMBER(&AP_Mount_Xacti::handle_param_get_set_response_string, bool, AP_DroneCAN*, const uint8_t, const char*, AP_DroneCAN::string &);
     param_save_cb = FUNCTOR_BIND_MEMBER(&AP_Mount_Xacti::handle_param_save_response, void, AP_DroneCAN*, const uint8_t, bool);
+
+    // static assert that Param enum matches parameter names array
+    static_assert((uint8_t)AP_Mount_Xacti::Param::LAST+1 == ARRAY_SIZE(AP_Mount_Xacti::_param_names), "AP_Mount_Xacti::_param_names array must match Param enum");
 }
 
 // init - performs any required initialisation for this instance
 void AP_Mount_Xacti::init()
 {
+    // instantiate parameter queue, return on failure so init fails
+    _set_param_int32_queue = new ObjectArray<SetParamQueueItem>(XACTI_SET_PARAM_QUEUE_SIZE);
+    if (_set_param_int32_queue == nullptr) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "%s init failed", send_text_prefix);
+        return;
+    }
     _initialised = true;
 }
 
@@ -77,6 +79,11 @@ void AP_Mount_Xacti::update()
 
     // request status
     if (request_status(now_ms)) {
+        return;
+    }
+
+    // process queue of set parameter items
+    if (process_set_param_int32_queue()) {
         return;
     }
 
@@ -188,19 +195,20 @@ bool AP_Mount_Xacti::healthy() const
 // take a picture.  returns true on success
 bool AP_Mount_Xacti::take_picture()
 {
-    if (_detected_modules[_instance].ap_dronecan == nullptr) {
+    // fail if camera errored
+    if (_camera_error) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "%s unable to take pic", send_text_prefix);
         return false;
     }
 
-    // set SingleShot parameter
-    return set_param_int32(XACTI_PARAM_SINGLESHOT, 0);
+    return set_param_int32(Param::SingleShot, 0);
 }
 
 // start or stop video recording.  returns true on success
 // set start_recording = true to start record, false to stop recording
 bool AP_Mount_Xacti::record_video(bool start_recording)
 {
-    return set_param_int32(XACTI_PARAM_RECORDING, start_recording ? 1 : 0);
+    return set_param_int32(Param::Recording, start_recording ? 1 : 0);
 }
 
 // set zoom specified as a rate or percentage
@@ -224,7 +232,7 @@ bool AP_Mount_Xacti::set_zoom(ZoomType zoom_type, float zoom_value)
         // convert zoom percentage (0 ~ 100) to zoom parameter value (100, 200, 300, ... 1000)
         // 0~9pct:100, 10~19pct:200, ... 90~100pct:1000
         uint16_t zoom_param_value = constrain_uint16(uint16_t(zoom_value * 0.1) * 10, 100, 1000);
-        return set_param_int32(XACTI_PARAM_DIGITALZOOM, zoom_param_value);
+        return set_param_int32(Param::DigitalZoomMagnification, zoom_param_value);
     }
 
     // unsupported zoom type
@@ -254,7 +262,7 @@ SetFocusResult AP_Mount_Xacti::set_focus(FocusType focus_type, float focus_value
     }
 
     // set FocusMode parameter
-    return set_param_int32(XACTI_PARAM_FOCUSMODE, focus_param_value) ? SetFocusResult::ACCEPTED : SetFocusResult::FAILED;
+    return set_param_int32(Param::FocusMode, focus_param_value) ? SetFocusResult::ACCEPTED : SetFocusResult::FAILED;
 }
 
 // set camera lens as a value from 0 to 5
@@ -265,7 +273,7 @@ bool AP_Mount_Xacti::set_lens(uint8_t lens)
         return false;
     }
 
-    return set_param_int32(XACTI_PARAM_SENSORMODE, lens);
+    return set_param_int32(Param::SensorMode, lens);
 }
 
 // send camera information message to GCS
@@ -491,13 +499,13 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
 {
     // display errors
     const char* err_prefix_str = "Xacti: failed to";
-    if (strcmp(name, XACTI_PARAM_SINGLESHOT) == 0) {
+    if (strcmp(name, get_param_name_str(Param::SingleShot)) == 0) {
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s take pic", err_prefix_str);
         }
         return false;
     }
-    if (strcmp(name, XACTI_PARAM_RECORDING) == 0) {
+    if (strcmp(name, get_param_name_str(Param::Recording)) == 0) {
         if (value < 0) {
             _recording_video = false;
             gcs().send_text(MAV_SEVERITY_ERROR, "%s record", err_prefix_str);
@@ -507,7 +515,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
-    if (strcmp(name, XACTI_PARAM_FOCUSMODE) == 0) {
+    if (strcmp(name, get_param_name_str(Param::FocusMode)) == 0) {
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s change focus", err_prefix_str);
         } else {
@@ -515,7 +523,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
-    if (strcmp(name, XACTI_PARAM_SENSORMODE) == 0) {
+    if (strcmp(name, get_param_name_str(Param::SensorMode)) == 0) {
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s change lens", err_prefix_str);
         } else if ((uint32_t)value < ARRAY_SIZE(sensor_mode_str)) {
@@ -523,7 +531,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
-    if (strcmp(name, XACTI_PARAM_DIGITALZOOM) == 0) {
+    if (strcmp(name, get_param_name_str(Param::DigitalZoomMagnification)) == 0) {
         if (value < 0) {
             gcs().send_text(MAV_SEVERITY_ERROR, "%s change zoom", err_prefix_str);
             // disable zoom rate control (if active) to avoid repeated failures
@@ -541,7 +549,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
 // handle param get/set response
 bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronecan, uint8_t node_id, const char* name, AP_DroneCAN::string &value)
 {
-    if (strcmp(name, XACTI_PARAM_FIRMWAREVERSION) == 0) {
+    if (strcmp(name, get_param_name_str(Param::FirmwareVersion)) == 0) {
         _firmware_version.received = true;
         const uint8_t len = MIN(value.len, ARRAY_SIZE(_firmware_version.str)-1);
         memcpy(_firmware_version.str, (const char*)value.data, len);
@@ -560,11 +568,11 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
             _firmware_version.mav_ver = UINT32_VALUE(dev_ver_num, patch_ver_num, minor_ver_num, major_ver_num);
         }
         return false;
-    } else if (strcmp(name, XACTI_PARAM_DATETIME) == 0) {
+    } else if (strcmp(name, get_param_name_str(Param::DateTime)) == 0) {
         // display when time and date have been set
         gcs().send_text(MAV_SEVERITY_INFO, "%s datetime set %s", send_text_prefix, (const char*)value.data);
         return false;
-    } else if (strcmp(name, XACTI_PARAM_STATUS) == 0) {
+    } else if (strcmp(name, get_param_name_str(Param::Status)) == 0) {
         // check for expected length
         const char* error_str = "error";
         if (value.len != sizeof(_status)) {
@@ -580,7 +588,11 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
         uint32_t changed_bits = last_error_status ^ _status.error_status;
         const char* ok_str = "OK";
         if (changed_bits & (uint32_t)ErrorStatus::TIME_NOT_SET) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s time %sset", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET ? "not " : " ");
+            gcs().send_text(MAV_SEVERITY_INFO, "%s time %sset", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET ? "not " : "");
+            if (_status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET) {
+                // try to set time again
+                _datetime.set = false;
+            }
         }
         if (changed_bits & (uint32_t)ErrorStatus::MEDIA_ERROR) {
             gcs().send_text(MAV_SEVERITY_INFO, "%s media %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MEDIA_ERROR ? error_str : ok_str);
@@ -603,6 +615,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
 
         // set motor error for health reporting
         _motor_error = _status.error_status & ((uint32_t)ErrorStatus::MOTOR_INIT_ERROR | (uint32_t)ErrorStatus::MOTOR_OPERATION_ERROR | (uint32_t)ErrorStatus::GIMBAL_CONTROL_ERROR);
+        _camera_error = _status.error_status & ((uint32_t)ErrorStatus::LENS_ERROR | (uint32_t)ErrorStatus::MEDIA_ERROR);
         return false;
     }
 
@@ -619,27 +632,42 @@ void AP_Mount_Xacti::handle_param_save_response(AP_DroneCAN* ap_dronecan, const 
     }
 }
 
-// helper function to set integer parameters
-bool AP_Mount_Xacti::set_param_int32(const char* param_name, int32_t param_value)
+// get parameter name for a particular param enum value
+const char* AP_Mount_Xacti::get_param_name_str(Param param) const
 {
-    if (_detected_modules[_instance].ap_dronecan == nullptr) {
-        return false;
+    // check to avoid reading beyond end of array.  This should never happen
+    if ((uint8_t)param > ARRAY_SIZE(_param_names)) {
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        return nullptr;
     }
-
-    if (_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, param_name, param_value, &param_int_cb)) {
-        last_send_getset_param_ms = AP_HAL::millis();
-        return true;
-    }
-    return false;
+    return _param_names[(uint8_t)param];
 }
 
-bool AP_Mount_Xacti::set_param_string(const char* param_name, const AP_DroneCAN::string& param_value)
+// helper function to set integer parameters
+bool AP_Mount_Xacti::set_param_int32(Param param, int32_t param_value)
+{
+    if (_set_param_int32_queue == nullptr) {
+        return false;
+    }
+
+    // set param request added to queue to be sent.  throttling requests improves reliability
+    return _set_param_int32_queue->push(SetParamQueueItem{param, param_value});
+}
+
+// helper function to set string parameters
+bool AP_Mount_Xacti::set_param_string(Param param, const AP_DroneCAN::string& param_value)
 {
     if (_detected_modules[_instance].ap_dronecan == nullptr) {
         return false;
     }
 
-    if (_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, param_name, param_value, &param_string_cb)) {
+    // convert param to string
+    const char* param_name_str = get_param_name_str(param);
+    if (param_name_str == nullptr) {
+        return false;
+    }
+
+    if (_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, param_name_str, param_value, &param_string_cb)) {
         last_send_getset_param_ms = AP_HAL::millis();
         return true;
     }
@@ -647,15 +675,44 @@ bool AP_Mount_Xacti::set_param_string(const char* param_name, const AP_DroneCAN:
 }
 
 // helper function to get string parameters
-bool AP_Mount_Xacti::get_param_string(const char* param_name)
+bool AP_Mount_Xacti::get_param_string(Param param)
 {
     if (_detected_modules[_instance].ap_dronecan == nullptr) {
         return false;
     }
 
-    if (_detected_modules[_instance].ap_dronecan->get_parameter_on_node(_detected_modules[_instance].node_id, param_name, &param_string_cb)) {
+    // convert param to string
+    const char* param_name_str = get_param_name_str(param);
+    if (param_name_str == nullptr) {
+        return false;
+    }
+
+    if (_detected_modules[_instance].ap_dronecan->get_parameter_on_node(_detected_modules[_instance].node_id, param_name_str, &param_string_cb)) {
         last_send_getset_param_ms = AP_HAL::millis();
         return true;
+    }
+    return false;
+}
+
+// process queue of set parameter items
+bool AP_Mount_Xacti::process_set_param_int32_queue()
+{
+    if ((_set_param_int32_queue == nullptr) || (_detected_modules[_instance].ap_dronecan == nullptr)) {
+        return false;
+    }
+
+    SetParamQueueItem param_to_set;
+    if (_set_param_int32_queue->pop(param_to_set)) {
+        // convert param to string
+        const char* param_name_str = get_param_name_str(param_to_set.param);
+        if (param_name_str == nullptr) {
+            return false;
+        }
+        if (_detected_modules[_instance].ap_dronecan->set_parameter_on_node(_detected_modules[_instance].node_id, param_name_str, param_to_set.value, &param_int_cb)) {
+            last_send_getset_param_ms = AP_HAL::millis();
+            return true;
+        }
+        return false;
     }
     return false;
 }
@@ -745,7 +802,7 @@ bool AP_Mount_Xacti::update_zoom_rate_control(uint32_t now_ms)
     }
 
     // send desired zoom to camera
-    return set_param_int32(XACTI_PARAM_DIGITALZOOM, zoom_value);
+    return set_param_int32(Param::DigitalZoomMagnification, zoom_value);
 }
 
 // request firmware version. now_ms should be current system time (reduces calls to AP_HAL::millis)
@@ -762,7 +819,7 @@ bool AP_Mount_Xacti::request_firmware_version(uint32_t now_ms)
         return false;
     }
     _firmware_version.last_request_ms = now_ms;
-    return get_param_string(XACTI_PARAM_FIRMWAREVERSION);
+    return get_param_string(Param::FirmwareVersion);
 }
 
 // set date and time.  now_ms is current system time
@@ -797,7 +854,7 @@ bool AP_Mount_Xacti::set_datetime(uint32_t now_ms)
         return false;
     }
     datetime_string.len = num_bytes;
-    _datetime.set = set_param_string(XACTI_PARAM_DATETIME, datetime_string);
+    _datetime.set = set_param_string(Param::DateTime, datetime_string);
     if (!_datetime.set) {
         gcs().send_text(MAV_SEVERITY_ERROR, "%s failed to set date/time", send_text_prefix);
     }
@@ -815,7 +872,7 @@ bool AP_Mount_Xacti::request_status(uint32_t now_ms)
     }
 
     _status_report.last_request_ms = now_ms;
-    return get_param_string(XACTI_PARAM_STATUS);
+    return get_param_string(Param::Status);
 }
 
 // check if safe to send message (if messages sent too often camera will not respond)

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -47,7 +47,7 @@ void AP_Mount_Xacti::init()
     // instantiate parameter queue, return on failure so init fails
     _set_param_int32_queue = new ObjectArray<SetParamQueueItem>(XACTI_SET_PARAM_QUEUE_SIZE);
     if (_set_param_int32_queue == nullptr) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "%s init failed", send_text_prefix);
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s init failed", send_text_prefix);
         return;
     }
     _initialised = true;
@@ -197,7 +197,7 @@ bool AP_Mount_Xacti::take_picture()
 {
     // fail if camera errored
     if (_camera_error) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "%s unable to take pic", send_text_prefix);
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s unable to take pic", send_text_prefix);
         return false;
     }
 
@@ -358,7 +358,7 @@ void AP_Mount_Xacti::subscribe_msgs(AP_DroneCAN* ap_dronecan)
 {
     // return immediately if DroneCAN is unavailable
     if (ap_dronecan == nullptr) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "%s DroneCAN subscribe failed", send_text_prefix);
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "%s DroneCAN subscribe failed", send_text_prefix);
         return;
     }
 
@@ -501,39 +501,39 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
     const char* err_prefix_str = "Xacti: failed to";
     if (strcmp(name, get_param_name_str(Param::SingleShot)) == 0) {
         if (value < 0) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "%s take pic", err_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s take pic", err_prefix_str);
         }
         return false;
     }
     if (strcmp(name, get_param_name_str(Param::Recording)) == 0) {
         if (value < 0) {
             _recording_video = false;
-            gcs().send_text(MAV_SEVERITY_ERROR, "%s record", err_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s record", err_prefix_str);
         } else {
             _recording_video = (value == 1);
-            gcs().send_text(MAV_SEVERITY_INFO, "%s recording %s", send_text_prefix, _recording_video ? "ON" : "OFF");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s recording %s", send_text_prefix, _recording_video ? "ON" : "OFF");
         }
         return false;
     }
     if (strcmp(name, get_param_name_str(Param::FocusMode)) == 0) {
         if (value < 0) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "%s change focus", err_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change focus", err_prefix_str);
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s %s focus", send_text_prefix, value == 0 ? "manual" : "auto");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s %s focus", send_text_prefix, value == 0 ? "manual" : "auto");
         }
         return false;
     }
     if (strcmp(name, get_param_name_str(Param::SensorMode)) == 0) {
         if (value < 0) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "%s change lens", err_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change lens", err_prefix_str);
         } else if ((uint32_t)value < ARRAY_SIZE(sensor_mode_str)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s %s", send_text_prefix, sensor_mode_str[(uint8_t)value]);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s %s", send_text_prefix, sensor_mode_str[(uint8_t)value]);
         }
         return false;
     }
     if (strcmp(name, get_param_name_str(Param::DigitalZoomMagnification)) == 0) {
         if (value < 0) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "%s change zoom", err_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change zoom", err_prefix_str);
             // disable zoom rate control (if active) to avoid repeated failures
             _zoom_rate_control.enabled = false;
         } else if (value >= 100 && value <= 1000) {
@@ -542,7 +542,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         return false;
     }
     // unhandled parameter get or set
-    gcs().send_text(MAV_SEVERITY_INFO, "%s get/set %s res:%ld", send_text_prefix, name, (long int)value);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s get/set %s res:%ld", send_text_prefix, name, (long int)value);
     return false;
 }
 
@@ -553,7 +553,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
         _firmware_version.received = true;
         const uint8_t len = MIN(value.len, ARRAY_SIZE(_firmware_version.str)-1);
         memcpy(_firmware_version.str, (const char*)value.data, len);
-        gcs().send_text(MAV_SEVERITY_INFO, "Mount: Xacti fw:%s", _firmware_version.str);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: Xacti fw:%s", _firmware_version.str);
 
         // firmware str from gimbal is of the format YYMMDD[b]xx.  Convert to uint32 for reporting to GCS
         if (len >= 9) {
@@ -570,7 +570,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
         return false;
     } else if (strcmp(name, get_param_name_str(Param::DateTime)) == 0) {
         // display when time and date have been set
-        gcs().send_text(MAV_SEVERITY_INFO, "%s datetime set %s", send_text_prefix, (const char*)value.data);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s datetime set %s", send_text_prefix, (const char*)value.data);
         return false;
     } else if (strcmp(name, get_param_name_str(Param::Status)) == 0) {
         // check for expected length
@@ -588,29 +588,29 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
         uint32_t changed_bits = last_error_status ^ _status.error_status;
         const char* ok_str = "OK";
         if (changed_bits & (uint32_t)ErrorStatus::TIME_NOT_SET) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s time %sset", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET ? "not " : "");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s time %sset", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET ? "not " : "");
             if (_status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET) {
                 // try to set time again
                 _datetime.set = false;
             }
         }
         if (changed_bits & (uint32_t)ErrorStatus::MEDIA_ERROR) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s media %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MEDIA_ERROR ? error_str : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s media %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MEDIA_ERROR ? error_str : ok_str);
         }
         if (changed_bits & (uint32_t)ErrorStatus::LENS_ERROR) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s lens %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::LENS_ERROR ? error_str : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s lens %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::LENS_ERROR ? error_str : ok_str);
         }
         if (changed_bits & (uint32_t)ErrorStatus::MOTOR_INIT_ERROR) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s motor %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MOTOR_INIT_ERROR ? "init error" : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s motor %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MOTOR_INIT_ERROR ? "init error" : ok_str);
         }
         if (changed_bits & (uint32_t)ErrorStatus::MOTOR_OPERATION_ERROR) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s motor op %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MOTOR_OPERATION_ERROR ? error_str : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s motor op %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::MOTOR_OPERATION_ERROR ? error_str : ok_str);
         }
         if (changed_bits & (uint32_t)ErrorStatus::GIMBAL_CONTROL_ERROR) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s control %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::GIMBAL_CONTROL_ERROR ? error_str : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s control %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::GIMBAL_CONTROL_ERROR ? error_str : ok_str);
         }
         if (changed_bits & (uint32_t)ErrorStatus::TEMP_WARNING) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s temp %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TEMP_WARNING ? "warning" : ok_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s temp %s", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TEMP_WARNING ? "warning" : ok_str);
         }
 
         // set motor error for health reporting
@@ -620,7 +620,7 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
     }
 
     // unhandled parameter get or set
-    gcs().send_text(MAV_SEVERITY_INFO, "%s get/set string %s res:%s", send_text_prefix, name, (const char*)value.data);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s get/set string %s res:%s", send_text_prefix, name, (const char*)value.data);
     return false;
 }
 
@@ -628,7 +628,7 @@ void AP_Mount_Xacti::handle_param_save_response(AP_DroneCAN* ap_dronecan, const 
 {
     // display failure to save parameter
     if (!success) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "%s CAM%u failed to set param", send_text_prefix, (int)_instance+1);
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s CAM%u failed to set param", send_text_prefix, (int)_instance+1);
     }
 }
 
@@ -856,7 +856,7 @@ bool AP_Mount_Xacti::set_datetime(uint32_t now_ms)
     datetime_string.len = num_bytes;
     _datetime.set = set_param_string(Param::DateTime, datetime_string);
     if (!_datetime.set) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "%s failed to set date/time", send_text_prefix);
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s failed to set date/time", send_text_prefix);
     }
 
     return _datetime.set;

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -579,9 +579,6 @@ bool AP_Mount_Xacti::handle_param_get_set_response_string(AP_DroneCAN* ap_dronec
         // report change in status
         uint32_t changed_bits = last_error_status ^ _status.error_status;
         const char* ok_str = "OK";
-        if (changed_bits & (uint32_t)ErrorStatus::CANNOT_TAKE_PIC) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s %s take pic", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::CANNOT_TAKE_PIC ? "cannot" : "can");
-        }
         if (changed_bits & (uint32_t)ErrorStatus::TIME_NOT_SET) {
             gcs().send_text(MAV_SEVERITY_INFO, "%s time %sset", send_text_prefix, _status.error_status & (uint32_t)ErrorStatus::TIME_NOT_SET ? "not " : " ");
         }

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -134,6 +134,7 @@ private:
     static const char* _param_names[];              // array of Xacti parameter strings
 
     // get parameter name for a particular param enum value
+    // returns an empty string if not found (which should never happen)
     const char* get_param_name_str(Param param) const;
 
     // helper function to get and set parameters


### PR DESCRIPTION
This PR is built on top of https://github.com/ArduPilot/ardupilot/pull/25075

This improves Xacti's picture taking reliability in two ways:

1. Set parameter commands are put in a queue before being sent to ensure that they are spaced at least 20ms apart from any other commands sent to the gimbal.
2. If the camera reports that the time is not set, the driver resends the time

This has been tested on real hardware to ensure that existing features (take picture, record video, zoom, focus) all still work and that 100 pictures can reliably be taken.  This was done with a short mission shown below.
![xacti-take100-pic-mission](https://github.com/ArduPilot/ardupilot/assets/1498098/814a17fe-0f87-4d8f-a04e-c4a4f7c1e256)

Below are before vs after screen shots showing that before only 95 pics were taken and the date/time of the files was incorrect.  After we see that 100 pics were taken and the date/time on the files is correct.
![xacti-pic-reliability-before-vs-after](https://github.com/ArduPilot/ardupilot/assets/1498098/fcb1411b-8028-4719-ab9b-8dca5564d358)

Below is what is shown in the MP messages tab when the camera reports that (for whatever reason) the camera gimbal's time has not been sets.  I actually don't know why sometimes the time needs to be set twice but in any case this resolves the problem.
![xacti-time-set-again](https://github.com/ArduPilot/ardupilot/assets/1498098/ba8d732e-32ca-49d3-8b3a-5b15e46d64d1)




