### PR TITLE
Plane: fix guided heading control anti windup

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -919,11 +919,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_guided_slew_commands(const mavl
 
         float new_target_heading = radians(wrap_180(packet.param2));
 
-        // if packet is requesting us to go to the heading we are already going to, we-re already on it.
-        if ( (is_equal(new_target_heading,plane.guided_state.target_heading))) { // compare two floats as near-enough
-            return MAV_RESULT_ACCEPTED;
-        }
-
         // course over ground
         if ( int(packet.param1) == HEADING_TYPE_COURSE_OVER_GROUND) { // compare as nearest int
             plane.guided_state.target_heading_type = GUIDED_HEADING_COG;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -548,7 +548,7 @@ public:
 
 #if OFFBOARD_GUIDED == ENABLED
     // guided yaw heading PID
-    AC_PID guidedHeading{5000.0,  0.0,   0.0, 0 ,  10.0,   5.0,  5.0 ,  5.0  , 0.2};
+    AC_PID guidedHeading{5000.0,  0.0,   0.0, 0 ,  10.0,   5.0,  5.0 ,  5.0  , 0.0};
 #endif
 
 #if AP_SCRIPTING_ENABLED && AP_FOLLOW_ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -556,8 +556,7 @@ private:
         float target_heading_accel_limit;
         uint32_t target_heading_time_ms;
         guided_heading_type_t target_heading_type;
-        bool target_heading_limit_low;
-        bool target_heading_limit_high;
+        bool target_heading_limit;
 #endif // OFFBOARD_GUIDED == ENABLED
     } guided_state;
 


### PR DESCRIPTION
Spotted while looking into the last users of `update_error` for https://github.com/ArduPilot/ardupilot/pull/25084. 

The current anti windup handling just does nothing, it fetches `I`, then it fetches it again. `AC_PID` will already handle anti windup correctly if we pass a limit flag.

