### PR TITLE
AP_AHRS: fill in error string when invalid backend specified

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -192,7 +192,12 @@ bool AP_ExternalAHRS::get_speed_down(float &speedD)
 
 bool AP_ExternalAHRS::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
 {
-    return backend && backend->pre_arm_check(failure_msg, failure_msg_len);
+    if (backend == nullptr) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "ExternalAHRS: Invalid backend");
+        return false;
+    }
+
+    return backend->pre_arm_check(failure_msg, failure_msg_len);
 }
 
 /*


### PR DESCRIPTION
After:

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/a331f0c6-1e84-4daf-8356-9d4230a94fe1)
