### PR TITLE
AP_Winch: Options param for init state and verbose output

### DIFF
--- a/libraries/AP_Winch/AP_Winch.cpp
+++ b/libraries/AP_Winch/AP_Winch.cpp
@@ -2,6 +2,7 @@
 
 #if AP_WINCH_ENABLED
 
+#include <GCS_MAVLink/GCS.h>
 #include "AP_Winch_PWM.h"
 #include "AP_Winch_Daiwa.h"
 
@@ -31,6 +32,13 @@ const AP_Param::GroupInfo AP_Winch::var_info[] = {
     // @Range: 0.01 10.0
     // @User: Standard
     AP_GROUPINFO("_POS_P", 3, AP_Winch, config.pos_p, 1.0f),
+
+    // @Param: _OPTIONS
+    // @DisplayName: Winch options
+    // @Description: Winch options
+    // @Bitmask:  0:Spin freely on startup, 1:Verbose output
+    // @User: Standard
+    AP_GROUPINFO("_OPTIONS", 4, AP_Winch, config.options, 3.0f),
 
     // 4 was _RATE_PID
 
@@ -81,6 +89,13 @@ void AP_Winch::init()
     }
     if (backend != nullptr) {
         backend->init();
+
+        // initialise control mode
+        if (backend->option_enabled(Options::SpinFreelyOnStartup)) {
+            relax();
+        } else {
+            set_desired_rate(0);
+        }
     }
 }
 
@@ -92,6 +107,11 @@ void AP_Winch::release_length(float length)
     }
     config.length_desired = backend->get_current_length() + length;
     config.control_mode = ControlMode::POSITION;
+
+    // display verbose output to user
+    if (backend->option_enabled(Options::VerboseOutput)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Winch: lowering %4.1fm to %4.1fm", (double)length, (double)config.length_desired);
+    }
 }
 
 // deploy line at specified speed in m/s (+ve deploys line, -ve retracts line, 0 stops)

--- a/libraries/AP_Winch/AP_Winch.h
+++ b/libraries/AP_Winch/AP_Winch.h
@@ -82,6 +82,12 @@ private:
         DAIWA = 2
     };
 
+    // enum for OPTIONS parameter
+    enum class Options : int16_t {
+        SpinFreelyOnStartup = (1U << 0),
+        VerboseOutput = (1U << 1),
+    };
+
     // winch states
     enum class ControlMode : uint8_t {
         RELAXED = 0,    // winch is realxed
@@ -94,6 +100,7 @@ private:
         AP_Int8     type;               // winch type
         AP_Float    rate_max;           // deploy or retract rate maximum (in m/s).
         AP_Float    pos_p;              // position error P gain
+        AP_Int16    options;            // options bitmask
         ControlMode control_mode;       // state of winch control (using target position or target rate)
         float       length_desired;     // target desired length (in meters)
         float       rate_desired;       // target deploy rate (in m/s, +ve = deploying, -ve = retracting)

--- a/libraries/AP_Winch/AP_Winch_Backend.h
+++ b/libraries/AP_Winch/AP_Winch_Backend.h
@@ -42,6 +42,11 @@ public:
     // write log
     virtual void write_log() = 0;
 
+    // helper to check if option enabled
+    bool option_enabled(AP_Winch::Options option) const {
+        return (config.options & uint16_t(option)) != 0;
+    }
+
 protected:
 
     // calculate the pilot desired rate (+ve deploys line, -ve retracts line, 0 stops) from rc input

--- a/libraries/AP_Winch/AP_Winch_Daiwa.h
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.h
@@ -106,6 +106,18 @@ private:
         WAITING_FOR_PCB_TEMP,
         WAITING_FOR_MOTOR_TEMP
     } parse_state;
+
+    // update user with changes to winch state via send text messages
+    static const char* send_text_prefix;// send text prefix string to reduce flash cost
+    void update_user();
+    struct {
+        uint32_t last_ms;               // system time of last update to user
+        bool healthy;                   // latest reported health
+        float line_length;
+        bool thread_end;                // true if end of thread has been detected
+        uint8_t moving;                 // 0:stopped, 1:retracting line, 2:extending line, 3:clutch engaged, 4:zero reset
+        uint8_t clutch;                 // 0:clutch off, 1:clutch engaged weakly, 2:clutch engaged strongly, motor can spin freely
+    } user_update;
 };
 
 #endif  // AP_WINCH_DAIWA_ENABLED


### PR DESCRIPTION
This PR aims to ease the use of the Daiwa winch in particular which I'm planning to use at the [Japan Innovation Challenge](https://japan-innovation-challenge.com/en/) in a couple of weeks.

1. WINCH_OPTIONS parameter is added with two bits
    - bit0: Spin freely on startup allows the line to be pulled out after startup.  This is the current default but is actually quite annoying because we need to remember to disengage the clutch before takeoff or the package will likely be left on the ground.
    - bit1: Verbose output sends text to the user when any important state of the winch changes (healthy, moving up or down, clutch position, line length).  In previous competitions we've stared at the WINCH_STATUS message but it's tough to interpret in the heat of the moment (see below)

By the way, I debated whether the param should default to 0 (no bits set) or 3 (both bits set).  I'm actually happy either way although "3" is how I like it.

This has been tested on real hardware.

Below is the slightly difficult to interpret WINCH_STATUS message output
![mavlink-winch-status](https://github.com/ArduPilot/ardupilot/assets/1498098/969b06fc-5d70-4944-8f2c-06ef82e62498)

