### PR TITLE
Copter: 4.4.1 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.4.1-beta2 14-Sep-2023
+Copter 4.4.1 26-Sep-2023 / 4.4.1-beta2 14-Sep-2023
 Changes from 4.4.1-beta1
 1) Autopilot related enhancements
     - H750 external flash optimisations for to lower CPU load

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.4.1-beta2"
+#define THISFIRMWARE "ArduCopter V4.4.1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,1,FIRMWARE_VERSION_TYPE_BETA+1
+#define FIRMWARE_VERSION 4,4,1,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,3 +1,8 @@
+Release 4.4.1 26th September 2023
+---------------------------------
+
+No changes from beta2
+
 Release 4.4.1-beta2 12th September 2023
 --------------------------------------
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.4.1-beta2"
+#define THISFIRMWARE "ArduPlane V4.4.1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,1,FIRMWARE_VERSION_TYPE_BETA+1
+#define FIRMWARE_VERSION 4,4,1,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.4.1 release which has been rebased on the Plane-4.4 branch and is otherwise the same as the 4.4.1-beta2.