### PR TITLE
AP_Periph: Fix bad conversion of APD ESC telemetry

### DIFF
--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -48,7 +48,7 @@ bool ESC_APD_Telem::update() {
                     // valid packet, copy the data we need and reset length
                     decoded.voltage = le16toh(received.packet.voltage) * 1e-2f;
                     decoded.temperature = convert_temperature(le16toh(received.packet.temperature));
-                    decoded.current = le16toh(received.packet.bus_current) * (1 / 12.5f);
+                    decoded.current = ((int16_t)le16toh(received.packet.bus_current)) * (1 / 12.5f);
                     decoded.rpm = le32toh(received.packet.erpm) / pole_count;
                     decoded.power_rating_pct = le16toh(received.packet.motor_duty) * 1e-2f;
                     ret = true;


### PR DESCRIPTION
le16toh() returns an unsigned type, which keeps the number as positive when cast to float. It needs to be explictly converted to a signed number first. Without this very small negative numbers are reported as insanely high currents.

Tested with real hardware.