### PR TITLE
AP_OSD: Make per-cell voltage be shown to two decimal places again

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1354,7 +1354,7 @@ void AP_OSD_Screen::draw_bat_volt(uint8_t instance, VoltageType type, uint8_t x,
     case VoltageType::RESTING_CELL: { 
         blinkvolt = osd->warn_avgcellrestvolt;
         v = battery.voltage_resting_estimate(instance);
-         FALLTHROUGH;
+        FALLTHROUGH;
     }
     case VoltageType::AVG_CELL: {         
        if (type == VoltageType::AVG_CELL) { //for fallthrough of RESTING_CELL
@@ -1376,10 +1376,18 @@ void AP_OSD_Screen::draw_bat_volt(uint8_t instance, VoltageType type, uint8_t x,
     }    
     if (!show_remaining_pct) {
         // Do not show battery percentage
-        backend->write(x,y, v < blinkvolt, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
+        if (type == VoltageType::RESTING_CELL || type == VoltageType::AVG_CELL) {
+            backend->write(x,y, v < blinkvolt, "%1.2f%c", (double)v, SYMBOL(SYM_VOLT));
+        } else {
+            backend->write(x,y, v < blinkvolt, "%2.1f%c", (double)v, SYMBOL(SYM_VOLT));
+        }
         return;
     }
-    backend->write(x,y, v < blinkvolt, "%c%2.1f%c", SYMBOL(SYM_BATT_FULL) + p, (double)v, SYMBOL(SYM_VOLT));
+    if (type == VoltageType::RESTING_CELL || type == VoltageType::AVG_CELL) {
+        backend->write(x,y, v < blinkvolt, "%c%1.2f%c", SYMBOL(SYM_BATT_FULL) + p, (double)v, SYMBOL(SYM_VOLT));
+    } else {
+        backend->write(x,y, v < blinkvolt, "%c%2.1f%c", SYMBOL(SYM_BATT_FULL) + p, (double)v, SYMBOL(SYM_VOLT));
+    }
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)


### PR DESCRIPTION
This fixes the regression introduced by https://github.com/ArduPilot/ardupilot/pull/22843 where per cell voltage is only shown to one decimal place (which isn't really enough for single cell voltages).

I guess that's why that previous PR saved flash, because it removed this functionality.

On Copter version 4.2.0
![image](https://github.com/ArduPilot/ardupilot/assets/64898873/2830772d-ea2c-46ff-bed3-095bc84016fe)
 
On current master
![image](https://github.com/ArduPilot/ardupilot/assets/64898873/01c36535-e6c1-4b91-bc78-5c4615c42803)
 
After this PR
![image](https://github.com/ArduPilot/ardupilot/assets/64898873/3eb98800-3f6f-4ec1-9114-877978fd2df0)

