### PR TITLE
AP_AHRS: Make the message 50 bytes in size

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2423,7 +2423,7 @@ void AP_AHRS::_getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const
 
 void AP_AHRS::set_failure_inconsistent_message(const char *estimator, const char *axis, float diff_rad, char *failure_msg, const uint8_t failure_msg_len) const
 {
-    hal.util->snprintf(failure_msg, failure_msg_len, "%s %s inconsistent %d deg. Wait or reboot", estimator, axis, (int)degrees(diff_rad));
+    hal.util->snprintf(failure_msg, failure_msg_len, "%s %s incon %d. Wait or reboot", estimator, axis, (int)degrees(diff_rad));
 }
 
 // check all cores providing consistent attitudes for prearm checks
@@ -2446,7 +2446,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             // check roll and pitch difference
             const float rp_diff_rad = primary_quat.roll_pitch_difference(ekf2_quat);
             if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-                set_failure_inconsistent_message("EKF2", "Roll/Pitch", rp_diff_rad, failure_msg, failure_msg_len);
+                set_failure_inconsistent_message("EKF2", "R/P", rp_diff_rad, failure_msg, failure_msg_len);
                 return false;
             }
 
@@ -2455,7 +2455,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             primary_quat.angular_difference(ekf2_quat).to_axis_angle(angle_diff);
             const float yaw_diff = fabsf(angle_diff.z);
             if (check_yaw && (yaw_diff > ATTITUDE_CHECK_THRESH_YAW_RAD)) {
-                set_failure_inconsistent_message("EKF2", "Yaw", yaw_diff, failure_msg, failure_msg_len);
+                set_failure_inconsistent_message("EKF2", "Y", yaw_diff, failure_msg, failure_msg_len);
                 return false;
             }
         }
@@ -2473,7 +2473,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             // check roll and pitch difference
             const float rp_diff_rad = primary_quat.roll_pitch_difference(ekf3_quat);
             if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-                set_failure_inconsistent_message("EKF3", "Roll/Pitch", rp_diff_rad, failure_msg, failure_msg_len);
+                set_failure_inconsistent_message("EKF3", "R/P", rp_diff_rad, failure_msg, failure_msg_len);
                 return false;
             }
 
@@ -2482,7 +2482,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             primary_quat.angular_difference(ekf3_quat).to_axis_angle(angle_diff);
             const float yaw_diff = fabsf(angle_diff.z);
             if (check_yaw && (yaw_diff > ATTITUDE_CHECK_THRESH_YAW_RAD)) {
-                set_failure_inconsistent_message("EKF3", "Yaw", yaw_diff, failure_msg, failure_msg_len);
+                set_failure_inconsistent_message("EKF3", "Y", yaw_diff, failure_msg, failure_msg_len);
                 return false;
             }
         }
@@ -2499,7 +2499,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
         // check roll and pitch difference
         const float rp_diff_rad = primary_quat.roll_pitch_difference(dcm_quat);
         if (rp_diff_rad > ATTITUDE_CHECK_THRESH_ROLL_PITCH_RAD) {
-            set_failure_inconsistent_message("DCM", "Roll/Pitch", rp_diff_rad, failure_msg, failure_msg_len);
+            set_failure_inconsistent_message("DCM", "R/P", rp_diff_rad, failure_msg, failure_msg_len);
             return false;
         }
 
@@ -2514,7 +2514,7 @@ bool AP_AHRS::attitudes_consistent(char *failure_msg, const uint8_t failure_msg_
             primary_quat.angular_difference(dcm_quat).to_axis_angle(angle_diff);
             const float yaw_diff = fabsf(angle_diff.z);
             if (check_yaw && (yaw_diff > ATTITUDE_CHECK_THRESH_YAW_RAD)) {
-                set_failure_inconsistent_message("DCM", "Yaw", yaw_diff, failure_msg, failure_msg_len);
+                set_failure_inconsistent_message("DCM", "Y", yaw_diff, failure_msg, failure_msg_len);
                 return false;
             }
         }


### PR DESCRIPTION
Message byte size is 50 bytes.
MISSION PLANNER and APM PLANNER2 use this rule to display messages.

AFTER
![Screenshot from 2023-09-27 17-27-13](https://github.com/ArduPilot/ardupilot/assets/646194/1a562416-7d76-40a3-8ca9-fcf9725243f3)


BEFORE
![Screenshot from 2023-09-27 16-36-38](https://github.com/ArduPilot/ardupilot/assets/646194/b331e25c-8ad0-4f00-a292-1b1dd54b6cc9)
