### PR TITLE
Add KakuteF7 and MatekH743-bdshot to the test size boards

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -71,6 +71,8 @@ jobs:
         config: [
             Durandal,
             MatekF405,
+            KakuteF7,
+            MatekH743-bdshot,
             Pixhawk1-1M,
             MatekF405-CAN,  # see special "build bootloader" code below
             DrotekP3Pro,  # see special "build bootloader" code below


### PR DESCRIPTION
Add KakuteF7 and MatekH743-bdshot to the test size boards to represent boards intended for FPV a bit better.

I realised that the Matek board doesn't have the FPV include because that is specifically for 1MB boards. But since the only other H743 board we have there is the Durandal (which is quite different since it has an IOMCU) I thought it would be good to have it in there in any case.

Added the KakuteF7 since that one does have the FPV include.

