### PR TITLE
AP_Bootloader: update board id for TMotor H7

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -248,8 +248,8 @@ AP_HW_PixFlamingoH743V               1133
 
 AP_HW_AR-F407SmartBat                1134
 AP_HW_SPEEDYBEEF4MINI                1135
-AP_HW_TMOTORH7                       1136
 AP_HW_FlywooF405Pro                  1137
+AP_HW_TMOTORH7                       1138
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
I erroneously used the wrong one