### PR TITLE
AP_RCProtocol: disable raw logging if no RC_Channel

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -178,7 +178,8 @@ void AP_RCProtocol_Backend::configure_vtx(uint8_t band, uint8_t channel, uint8_t
  */
 void AP_RCProtocol_Backend::log_data(AP_RCProtocol::rcprotocol_t prot, uint32_t timestamp, const uint8_t *data, uint8_t len) const
 {
-#if HAL_LOGGING_ENABLED
+#if HAL_LOGGING_ENABLED && AP_RC_CHANNEL_ENABLED
+
 #if (CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX)
     if (&rc() == nullptr) { // allow running without RC_Channels if we are doing the examples
         return;
@@ -214,7 +215,7 @@ void AP_RCProtocol_Backend::log_data(AP_RCProtocol::rcprotocol_t prot, uint32_t 
                            u32[0], u32[1], u32[2], u32[3], u32[4],
                            u32[5], u32[6], u32[7], u32[8], u32[9]);
     }
-#endif  // HAL_LOGGING_ENABLED
+#endif  // HAL_LOGGING_ENABLED && AP_RC_CHANNEL_ENABLED
 }
 
 #endif  // AP_RCPROTOCOL_ENABLED


### PR DESCRIPTION
We're asking the singleton here for information on whether we should do raw logging.  We may not actually be compiling the RC_Channel library in.

Solves the compilation problem.  We can probably do better here by creating a new define, but there's even better things that could be done to remove this method and its callers to save bytes....
