### PR TITLE
Xacti: support optical zoom

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -497,14 +497,18 @@ void AP_Mount_Xacti::handle_gnss_status_req(AP_DroneCAN* ap_dronecan, const Cana
 // handle param get/set response
 bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan, uint8_t node_id, const char* name, int32_t &value)
 {
-    // display errors
+    // error string prefix to save on flash
     const char* err_prefix_str = "Xacti: failed to";
+
+    // take picture
     if (strcmp(name, get_param_name_str(Param::SingleShot)) == 0) {
         if (value < 0) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s take pic", err_prefix_str);
         }
         return false;
     }
+
+    // recording
     if (strcmp(name, get_param_name_str(Param::Recording)) == 0) {
         if (value < 0) {
             _recording_video = false;
@@ -515,6 +519,8 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
+
+    // focus
     if (strcmp(name, get_param_name_str(Param::FocusMode)) == 0) {
         if (value < 0) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change focus", err_prefix_str);
@@ -523,6 +529,8 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
+
+    // camera lens (aka sensor mode)
     if (strcmp(name, get_param_name_str(Param::SensorMode)) == 0) {
         if (value < 0) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change lens", err_prefix_str);
@@ -531,6 +539,8 @@ bool AP_Mount_Xacti::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan,
         }
         return false;
     }
+
+    // digital zoom
     if (strcmp(name, get_param_name_str(Param::DigitalZoomMagnification)) == 0) {
         if (value < 0) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s change zoom", err_prefix_str);

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -259,8 +259,8 @@ bool AP_Mount_Xacti::set_zoom(ZoomType zoom_type, float zoom_value)
         }
         // digital only zoom
         // convert zoom percentage (0 ~ 100) to zoom parameter value (100, 200, 300, ... 1000)
-        // 0~9pct:100, 10~19pct:200, ... 90~100pct:1000
-        uint16_t zoom_param_value = constrain_uint16(uint16_t(zoom_value * 0.1) * 10, 100, 1000);
+        // 0~11pct:100, 12~22pct:200, 23~33pct:300, 34~44pct:400, 45~55pct:500, 56~66pct:600, 67~77pct:700, 78~88pct:800, 89~99pct:900, 100:1000
+        const uint16_t zoom_param_value = uint16_t(linear_interpolate(1, 10, zoom_value, 0, 100)) * 100;
         return set_param_int32(Param::DigitalZoomMagnification, zoom_param_value);
     }
 


### PR DESCRIPTION
This PR is built upon https://github.com/ArduPilot/ardupilot/pull/25082

This PR adds optical zoom support for the Xacti cameras that support it (e.g. the [CX-GB400](https://ardupilot.org/copter/docs/common-xacti-gimbal.html))

We cannot currently retrieve the model directly from the Xacti cameras so instead the driver determines if the camera supports optical zoom by attempting to change the optical zoom parameter value to 100 (1x zoom) soon after startup.  If this succeeds we assume the camera supports optical zoom, if there is no reply then it doesn't.

The driver's existing zoom rate and zoom percentage controls have been updated so that optical zoom is used for the 1x to 2.5x range and digital zoom is used beyond this (e.g. 2.5x to 25x).

There's a small drive-by change to how zoom percentages are interpreted on digital-zoom-only cameras.

These changes should be tested on real hardware before it can be merged.  Tests include:

- [x] Are cameras with and without optical zoom detected properly?  Look for, "Xacti: optical zoom supported" and "Xacti: optical zoom NOT supported" in MP's messages tab.
- [x] When the pilot is using zoom rate control, is the zoom speed acceptable?  The camera zoom from 1x to 2.5x in about 4 seconds.  It zooms from 2.5x to 25x (using digital zoom) in another 4.5 seconds.
- [x] Is using zoom percentage control working correctly in the 1x ~ 2.5 and 2.5 ~ 25x ranges?  This can only be tested using Auto mode's SET_CAMERA_ZOOM mission command.
- [x] Cameras without optical zoom should be unaffected by this change

This has been fairly extensively tested on two Xacti cameras (one with optical zoom support and one without) including testing both zoom rate and zoom percentage as outlined on [this wiki page.](https://ardupilot.org/dev/docs/mavlink-camera.html#mav-cmd-set-camera-zoom-to-control-the-camera-zoom)
![xacti-optzoom-testing-pic2](https://github.com/ArduPilot/ardupilot/assets/1498098/0dadf3a6-23d8-4770-b540-c0196d801931)
