### PR TITLE
Plane: Allow a ICE start even if disable while disarmed is set

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -977,7 +977,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_in
 
 #if AP_ICENGINE_ENABLED
     case MAV_CMD_DO_ENGINE_CONTROL:
-        if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3)) {
+        if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3, (uint32_t)packet.param4)) {
             return MAV_RESULT_FAILED;
         }
         return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -199,7 +199,8 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_ENGINE_CONTROL:
         plane.g2.ice_control.engine_control(cmd.content.do_engine_control.start_control,
                                             cmd.content.do_engine_control.cold_start,
-                                            cmd.content.do_engine_control.height_delay_cm*0.01f);
+                                            cmd.content.do_engine_control.height_delay_cm*0.01f,
+                                            cmd.content.do_engine_control.allow_disarmed_start);
         break;
 #endif
 

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -104,7 +104,7 @@ void ModeQLoiter::run()
 #if AP_ICENGINE_ENABLED
             // cut IC engine if enabled
             if (quadplane.land_icengine_cut != 0) {
-                plane.g2.ice_control.engine_control(0, 0, 0);
+                plane.g2.ice_control.engine_control(0, 0, 0, false);
             }
 #endif  // AP_ICENGINE_ENABLED
         }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3610,7 +3610,7 @@ bool QuadPlane::verify_vtol_land(void)
 #if AP_ICENGINE_ENABLED
         // cut IC engine if enabled
         if (land_icengine_cut != 0) {
-            plane.g2.ice_control.engine_control(0, 0, 0);
+            plane.g2.ice_control.engine_control(0, 0, 0, false);
         }
 #endif  // AP_ICENGINE_ENABLED
         gcs().send_text(MAV_SEVERITY_INFO,"Land final started");

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -52,7 +52,7 @@ public:
     ICE_State get_state(void) const { return !enable?ICE_DISABLED:state; }
 
     // handle DO_ENGINE_CONTROL messages via MAVLink or mission
-    bool engine_control(float start_control, float cold_start, float height_delay);
+    bool engine_control(float start_control, float cold_start, float height_delay, uint32_t flags);
 
     // update min throttle for idle governor
     void update_idle_governor(int8_t &min_throttle);
@@ -137,6 +137,8 @@ private:
 
     // we are waiting for valid height data
     bool height_pending:1;
+
+    bool allow_single_start_while_disarmed;
 
     // idle governor
     float idle_governor_integrator;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1247,6 +1247,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.do_engine_control.start_control = (packet.param1>0);
         cmd.content.do_engine_control.cold_start = (packet.param2>0);
         cmd.content.do_engine_control.height_delay_cm = packet.param3*100;
+        cmd.content.do_engine_control.allow_disarmed_start = (((uint32_t)packet.param4) & ENGINE_CONTROL_OPTIONS_ALLOW_START_WHILE_DISARMED) != 0;
         break;
 
     case MAV_CMD_NAV_PAYLOAD_PLACE:
@@ -1751,6 +1752,9 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param1 = cmd.content.do_engine_control.start_control?1:0;
         packet.param2 = cmd.content.do_engine_control.cold_start?1:0;
         packet.param3 = cmd.content.do_engine_control.height_delay_cm*0.01f;
+        if (cmd.content.do_engine_control.allow_disarmed_start) {
+            packet.param4 = ENGINE_CONTROL_OPTIONS_ALLOW_START_WHILE_DISARMED;
+        }
         break;
 
     case MAV_CMD_NAV_PAYLOAD_PLACE:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -203,6 +203,7 @@ public:
         bool start_control; // start or stop engine
         bool cold_start; // use cold start procedure
         uint16_t height_delay_cm; // height delay for start
+        bool allow_disarmed_start; // allow starting the engine while disarmed
     };
 
     // NAV_SET_YAW_SPEED support


### PR DESCRIPTION
This allows you to bypass the disable starting while disarmed option in #25053 once. The workflow this enables is as follows:

1. Start with a disarmed/safety enabled aircraft
2. Disable the safety switch (physically or with software)
3. Preform inspections of the fixed wing flight control surfaces/motor test as desired
4. Send the MAVLink command (or jump via the mission) to allow starting while disarmed
5. Start the engine, preform engine checks
6. Arm the aircraft and start the flight.

The main target here is the minimization of risk as we move through the system. When inspecting the fixed wing surfaces we don't want to risk starting the ICE engine, but when we get to starting it we'd actually like to be disarmed, as that stops us from risking taking off by accident or flying the mission.

This had been tested before, but it has since been cherry-picked and rebased, so I need to actually retest this with hardware. This needs an accompanying MAVLink commit to define the usage of param4. (I'm planning to use it as an options bit mask). 

Accompanying MAVLink PR is https://github.com/ArduPilot/mavlink/pull/331