### PR TITLE
Support NeoPixel RGB

### DIFF
--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -30,6 +30,7 @@ const char* AP_HAL::RCOutput::get_output_mode_string(enum output_mode out_mode) 
     case MODE_PWM_DSHOT1200:
         return "DS1200";
     case MODE_NEOPIXEL:
+    case MODE_NEOPIXELRGB:
         return "NeoP";
     case MODE_PROFILED:
         return "ProfiLED";

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -215,6 +215,7 @@ public:
         MODE_PWM_DSHOT1200,
         MODE_NEOPIXEL,  // same as MODE_PWM_DSHOT at 800kHz but it's an LED
         MODE_PROFILED,  // same as MODE_PWM_DSHOT using separate clock and data
+        MODE_NEOPIXELRGB,  // same as MODE_NEOPIXEL but RGB ordering
     };
     // true when the output mode is of type dshot
     // static to allow use in the ChibiOS thread stuff
@@ -223,6 +224,7 @@ public:
     static bool is_led_protocol(const enum output_mode mode) {
       switch (mode) {
       case MODE_NEOPIXEL:
+      case MODE_NEOPIXELRGB:
       case MODE_PROFILED:
         return true;
       default:
@@ -351,7 +353,7 @@ public:
       and led number. A led number of -1 means all LEDs. LED 0 is the first LED
      */
     virtual void set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) {}
-    
+
     /*
       trigger send of serial led
      */

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -794,6 +794,7 @@ void RCOutput::push_local(void)
                 if (group.current_mode == MODE_PWM_ONESHOT ||
                     group.current_mode == MODE_PWM_ONESHOT125 ||
                     group.current_mode == MODE_NEOPIXEL ||
+                    group.current_mode == MODE_NEOPIXELRGB ||
                     group.current_mode == MODE_PROFILED ||
                     is_dshot_protocol(group.current_mode)) {
                     // only control widest pulse for oneshot and dshot
@@ -1056,6 +1057,7 @@ void RCOutput::set_group_mode(pwm_group &group)
         break;
 
     case MODE_NEOPIXEL:
+    case MODE_NEOPIXELRGB:
     case MODE_PROFILED:
 #if HAL_SERIALLED_ENABLED
     {
@@ -2413,6 +2415,7 @@ uint32_t RCOutput::protocol_bitrate(const enum output_mode mode)
     case MODE_PWM_DSHOT1200:
         return 1200000;
     case MODE_NEOPIXEL:
+    case MODE_NEOPIXELRGB:
         return 800000;
     case MODE_PROFILED:
         return 1500000; // experiment winding this up 3000000 max from data sheet
@@ -2452,9 +2455,11 @@ bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, ou
     }
 
     switch (mode) {
-        case MODE_NEOPIXEL: {
+
+        case MODE_NEOPIXEL:
+        case MODE_NEOPIXELRGB: {
             grp->serial_nleds = MAX(num_leds, grp->serial_nleds);
-            grp->led_mode = MODE_NEOPIXEL;
+            grp->led_mode = mode;
             return true;
         }
         case MODE_PROFILED: {
@@ -2504,6 +2509,9 @@ void RCOutput::fill_DMA_buffer_serial_led(pwm_group& group)
             switch (group.current_mode) {
                 case MODE_NEOPIXEL:
                     _set_neopixel_rgb_data(&group, j, i, led.red, led.green, led.blue);
+                    break;
+                case MODE_NEOPIXELRGB:
+                    _set_neopixel_rgb_data(&group, j, i, led.green, led.red, led.blue);
                     break;
                 case MODE_PROFILED: {
                     if (i < group.serial_nleds - 2) {
@@ -2677,6 +2685,7 @@ void RCOutput::serial_led_set_single_rgb_data(pwm_group& group, uint8_t idx, uin
     switch (group.current_mode) {
         case MODE_PROFILED:
         case MODE_NEOPIXEL:
+        case MODE_NEOPIXELRGB:
             group.serial_led_data[idx][led].red = red;
             group.serial_led_data[idx][led].green = green;
             group.serial_led_data[idx][led].blue = blue;

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -207,7 +207,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Param: LED_TYPES
     // @DisplayName: LED Driver Types
     // @Description: Controls what types of LEDs will be enabled
-    // @Bitmask: 0:Built-in LED, 1:Internal ToshibaLED, 2:External ToshibaLED, 3:External PCA9685, 4:Oreo LED, 5:DroneCAN, 6:NCP5623 External, 7:NCP5623 Internal, 8:NeoPixel, 9:ProfiLED, 10:Scripting, 11:DShot, 12:ProfiLED_SPI, 13:LP5562 External, 14: LP5562 Internal, 17: DiscreteRGB
+    // @Bitmask: 0:Built-in LED, 1:Internal ToshibaLED, 2:External ToshibaLED, 3:External PCA9685, 4:Oreo LED, 5:DroneCAN, 6:NCP5623 External, 7:NCP5623 Internal, 8:NeoPixel, 9:ProfiLED, 10:Scripting, 11:DShot, 12:ProfiLED_SPI, 13:LP5562 External, 14: LP5562 Internal, 17: DiscreteRGB, 18: NeoPixelRGB
     // @User: Advanced
     AP_GROUPINFO("LED_TYPES", 6, AP_Notify, _led_type, DEFAULT_NTF_LED_TYPES),
 
@@ -339,6 +339,7 @@ void AP_Notify::add_backends(void)
 #endif
 #if AP_NOTIFY_NEOPIXEL_ENABLED
             case Notify_LED_NeoPixel:
+            case Notify_LED_NeoPixelRGB:
                 ADD_BACKEND(new NeoPixel());
                 break;
 #endif

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -97,6 +97,9 @@ public:
 #if AP_NOTIFY_DISCRETE_RGB_ENABLED
         Notify_LED_DiscreteRGB              = (1 << 17), // DiscreteRGB
 #endif
+#if AP_NOTIFY_NEOPIXEL_ENABLED
+        Notify_LED_NeoPixelRGB              = (1 << 18), // NeoPixel AdaFruit 4544 Worldsemi WS2811
+#endif
         Notify_LED_MAX
     };
 
@@ -213,6 +216,7 @@ public:
     uint8_t get_buzz_level() const  { return _buzzer_level; }
     uint8_t get_buzz_volume() const  { return _buzzer_volume; }
     uint8_t get_led_len() const { return _led_len; }
+    uint32_t get_led_type() const { return _led_type; }
     int8_t get_rgb_led_brightness_percent() const;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_Notify/NeoPixel.cpp
+++ b/libraries/AP_Notify/NeoPixel.cpp
@@ -61,7 +61,11 @@ uint16_t NeoPixel::init_ports()
 
     for (uint16_t chan=0; chan<16; chan++) {
         if ((1U<<chan) & mask) {
-            led->set_num_neopixel(chan+1, (pNotify->get_led_len()));
+            if (pNotify->get_led_type() & AP_Notify::Notify_LED_NeoPixel) {
+                led->set_num_neopixel(chan+1, pNotify->get_led_len());
+            } else if (pNotify->get_led_type() & AP_Notify::Notify_LED_NeoPixelRGB) {
+                led->set_num_neopixel_rgb(chan+1, pNotify->get_led_len());
+            }
         }
     }
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1968,6 +1968,11 @@ function serialLED:set_num_profiled(chan, num_leds) end
 ---@return boolean
 function serialLED:set_num_neopixel(chan, num_leds) end
 
+-- desc
+---@param chan integer
+---@param num_leds integer
+---@return boolean
+function serialLED:set_num_neopixel_rgb(chan, num_leds) end
 
 -- desc
 ---@class vehicle

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -298,6 +298,7 @@ include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED
 singleton AP_SerialLED depends AP_SERIALLED_ENABLED
 singleton AP_SerialLED method set_num_neopixel boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
+singleton AP_SerialLED method set_num_neopixel_rgb boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
 singleton AP_SerialLED method set_num_profiled boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
 singleton AP_SerialLED method set_RGB void uint8_t 1 16 int8_t -1 INT8_MAX uint8_t'skip_check uint8_t'skip_check uint8_t'skip_check
 singleton AP_SerialLED method send void uint8_t 1 16

--- a/libraries/AP_SerialLED/AP_SerialLED.cpp
+++ b/libraries/AP_SerialLED/AP_SerialLED.cpp
@@ -36,6 +36,15 @@ bool AP_SerialLED::set_num_neopixel(uint8_t chan, uint8_t num_leds)
     return false;
 }
 
+// set number of NeoPixels per pin in RGB mode
+bool AP_SerialLED::set_num_neopixel_rgb(uint8_t chan, uint8_t num_leds)
+{
+    if (chan >= 1 && chan <= 16 && num_leds <= AP_SERIALLED_MAX_LEDS) {
+        return hal.rcout->set_serial_led_num_LEDs(chan-1, num_leds, AP_HAL::RCOutput::MODE_NEOPIXELRGB);
+    }
+    return false;
+}
+
 // set number of ProfiLEDs per pin
 bool AP_SerialLED::set_num_profiled(uint8_t chan, uint8_t num_leds)
 {

--- a/libraries/AP_SerialLED/AP_SerialLED.h
+++ b/libraries/AP_SerialLED/AP_SerialLED.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/RCOutput.h>
 
 #include "AP_SerialLED_config.h"
 
@@ -34,13 +35,15 @@ public:
     // set number of LEDs per pin
     bool set_num_neopixel(uint8_t chan, uint8_t num_leds);
     bool set_num_profiled(uint8_t chan, uint8_t num_leds);
+    // set number of LEDs per pin in RGB mode
+    bool set_num_neopixel_rgb(uint8_t chan, uint8_t num_leds);
 
     // set RGB value on mask of LEDs. chan is PWM output, 1..16
     void set_RGB_mask(uint8_t chan, uint32_t ledmask, uint8_t red, uint8_t green, uint8_t blue);
 
     // set RGB value on LED. LED -1 is all LEDs. LED 0 is first LED. chan is PWM output, 1..16
     void set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue);
-    
+
     // trigger sending of LED changes to LEDs
     void send(uint8_t chan);
 


### PR DESCRIPTION
NeoPixels can take either RGB or GRB order, with GRB being the default. This adds support for RGB order.

This work was sponsored by Proto Systems