### PR TITLE
AP_DDS: standardise GCS_SEND_TEXT message prefix

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -179,6 +179,9 @@ public:
     //! @brief Update the internally stored DDS messages with latest data
     void update();
 
+    //! @brief GCS message prefix
+    static constexpr const char* msg_prefix = "DDS:";
+
     //! @brief Parameter storage
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -404,7 +404,7 @@ void AP_Vehicle::setup()
 
 #if AP_DDS_ENABLED
     if (!init_dds_client()) {
-        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "DDS Client: Failed to Initialize");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Failed to Initialize", AP_DDS_Client::msg_prefix);
     }
 #endif
 }


### PR DESCRIPTION
Housekeeping to replace use of GCS message prefix `XRCE Client:` and use prefix `DDS Client:` consistently.

### Testing

1. Run the DDS examples and monitor the GCS messages in MAVProxy console. 

Figure: GCS messages using consistent prefix.
<img width="912" alt="dds-gcs-prefix" src="https://github.com/ArduPilot/ardupilot/assets/24916364/47f46ef0-b970-49b3-b8ae-9bf9481819dd">


Figure: previous output for comparison
<img width="912" alt="dds-gcs-prefix-before" src="https://github.com/ArduPilot/ardupilot/assets/24916364/ba874cf9-b51a-4412-9047-7f65ee3fb4b2">