### PR TITLE
AP_DDS: use ROS convention for node name

### DIFF
--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -200,7 +200,7 @@ You should be able to see the agent here and view the data output.
 
 ```bash
 $ ros2 node list
-/Ardupilot_DDS_XRCE_Client
+/ardupilot_dds
 ```
 
 ```bash

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -2,7 +2,7 @@
 <profiles>
   <participant profile_name="participant_profile">
     <rtps>
-      <name>Ardupilot_DDS_XRCE_Client</name>
+      <name>ardupilot_dds</name>
     </rtps>
   </participant>
   <topic profile_name="time__t">


### PR DESCRIPTION
Change the `AP_DDS` node name to use ROS conventions - lower case underscore.

See: http://wiki.ros.org/ROS/Patterns/Conventions 


## Testing

Launch the iris runway example:

```bash
ros2 launch ardupilot_gz_bringup iris_runway.launch.py rviz:=true use_gz_tf:=true
```
Check the node properties:

```bash
# list nodes
% ros2 node list
/ardupilot_dds
/relay
/robot_state_publisher
/ros_gz_bridge
/rviz
/transform_listener_impl_600003f9ab68

# node info
% ros2 node info /ardupilot_dds 
/ardupilot_dds
  Subscribers:
    /ap/cmd_vel: geometry_msgs/msg/TwistStamped
    /ap/joy: sensor_msgs/msg/Joy
    /tf: tf2_msgs/msg/TFMessage
  Publishers:
    /ap/battery/battery0: sensor_msgs/msg/BatteryState
    /ap/clock: rosgraph_msgs/msg/Clock
    /ap/geopose/filtered: geographic_msgs/msg/GeoPoseStamped
    /ap/navsat/navsat0: sensor_msgs/msg/NavSatFix
    /ap/pose/filtered: geometry_msgs/msg/PoseStamped
    /ap/tf_static: tf2_msgs/msg/TFMessage
    /ap/time: builtin_interfaces/msg/Time
    /ap/twist/filtered: geometry_msgs/msg/TwistStamped
  Service Servers:
    /ap/arm_motors: ardupilot_msgs/srv/ArmMotors
    /ap/mode_switch: ardupilot_msgs/srv/ModeSwitch
  Service Clients:

  Action Servers:

  Action Clients:

```


