### PR TITLE
AP_Landing: new option to treat NAV_LAND as flair point

### DIFF
--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -141,7 +141,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Landing options bitmask
     // @Description: Bitmask of options to use with landing.
-    // @Bitmask: 0: honor min throttle during landing flare,1: Increase Target landing airspeed constraint From Trim Airspeed to ARSPD_FBW_MAX
+    // @Bitmask: 0: honor min throttle during landing flare,1: Increase Target landing airspeed constraint From Trim Airspeed to ARSPD_FBW_MAX,2: Treat LAND waypoint as the flare point
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 16, AP_Landing, _options, 0),
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -62,6 +62,7 @@ public:
     enum OptionsMask {
         ON_LANDING_FLARE_USE_THR_MIN                   = (1<<0),   // If set then set trottle to thr_min instead of zero on final flare
         ON_LANDING_USE_ARSPD_MAX                       = (1<<1),   // If set then allow landing throttle constraint to be increased from trim airspeed to max airspeed (ARSPD_FBW_MAX)
+        LAND_POINT_IS_FLARE_POINT                      = (1<<2),   // Treat NAV_LAND waypoint as flare target instead of land target
     };
 
     void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);


### PR DESCRIPTION
Adds a new LAND_OPTIONS bit to treat NAV_LAND as flair point. This is useful if the flare behavior is more known and consistent than the glide slope behavior. This will cause the landing to further beyond the NAV_LAND point so you must plan the mission accordingly.