### PR TITLE
HAL_ChibiOS: default RTS pins to PULLDOWN

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -411,9 +411,14 @@ class ChibiOSHWDef(object):
                 self.type.startswith('UART')) and (
                 (self.label.endswith('_TX') or
                  self.label.endswith('_RX') or
-                 self.label.endswith('_CTS') or
-                 self.label.endswith('_RTS'))):
+                 self.label.endswith('_CTS'))):
                 v = "PULLUP"
+
+            # pulldown on RTS to prevent radios from staying in bootloader
+            if (self.type.startswith('USART') or
+                self.type.startswith('UART')) and (
+                 self.label.endswith('_RTS')):
+                v = "PULLDOWN"
 
             if (self.type.startswith('SWD') and
                     'SWDIO' in self.label):


### PR DESCRIPTION
this avoids issues with SiK and RFD900x radios getting stuck in bootloader mode due to a high RTS pin on power on.

We did this for Pixhawk6C in this PR:
https://github.com/ArduPilot/ardupilot/pull/24169

this now applies it to all boards