### PR TITLE
Motor restart on desync

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -754,6 +754,9 @@ private:
     void crash_check();
     void thrust_loss_check();
     void yaw_imbalance_check();
+    void desync_check();
+    uint32_t motor_failure_start_ms;
+
     LowPassFilterFloat yaw_I_filt{0.05f};
     uint32_t last_yaw_warn_ms;
     void parachute_check();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1225,8 +1225,22 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @Range: 0 10000
     // @User: Standard
     AP_GROUPINFO("TKOFF_RPM_MAX", 7, ParametersG2, takeoff_rpm_max, 0),
-#endif
 
+    // @Param: FS_MR_ENABLE
+    // @DisplayName: Motor restart Failsafe Action
+    // @Description: Failsafe action taken immediately after a motor restart
+    // @Values: 0:Disabled/NoAction,1:Land, 2:RTL, 3:SmartRTL or RTL, 4:SmartRTL or Land, 6:Auto DO_LAND_START or RTL
+    // @User: Advanced
+    AP_GROUPINFO("FS_MR_ENABLE", 8, ParametersG2, failsafe_mr_enable, (uint8_t)Copter::FailsafeAction::RTL),
+
+    // @Param: FS_MR_TIMEOUT
+    // @DisplayName: Motor restart Failsafe Timeout
+    // @Description: If a motor is lost for more than this many milliseonds the motor restart logic will be run and the failsafe action triggered. A value of zero indicates no attempt to restart motors.
+    // @Range: 0 1000
+    // @Units: ms
+    // @User: Advanced
+    AP_GROUPINFO("FS_MR_TIMEOUT", 9, ParametersG2, failsafe_mr_timeout, 0),
+#endif
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -675,7 +675,10 @@ public:
     AP_Int8                 failsafe_dr_enable;
     AP_Int16                failsafe_dr_timeout;
     AP_Float                surftrak_tc;
-
+#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
+    AP_Int8                 failsafe_mr_enable;
+    AP_Int16                failsafe_mr_timeout;
+#endif
     // ramp time of throttle during take-off
     AP_Float takeoff_throttle_slew_time;
     AP_Float takeoff_throttle_max;

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -229,6 +229,56 @@ void Copter::yaw_imbalance_check()
     }
 }
 
+// check for motor desync
+void Copter::desync_check()
+{
+#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
+    // If we are on the ground do nothing
+    if (!motors->armed() || motors->restarting() || copter.g2.failsafe_mr_timeout == 0
+#ifndef AP_MOTOR_DESYNC_DEBUG
+        || ap.land_complete
+#endif
+        ) {
+        return;
+    }
+
+#ifdef AP_MOTOR_DESYNC_DEBUG
+    if (motors->get_spool_state() == AP_Motors::SpoolState::SHUT_DOWN) {
+        return;
+    }
+#endif
+    // check ESCs are sending RPM at expected level
+    uint32_t motor_mask = motors->get_motor_mask();
+    const bool telem_active = AP::esc_telem().is_telemetry_active(motor_mask);
+    // check that all motors are running
+    const uint32_t failed_motors = AP::esc_telem().get_motors_not_running(motor_mask);
+    uint32_t now_ms = AP_HAL::millis();
+
+    // all good
+    if ((telem_active && !failed_motors) || !telem_active) {
+        motor_failure_start_ms = 0;
+        return;
+    }
+
+    // start the clock on restart logic
+    if (!motor_failure_start_ms) {
+        motor_failure_start_ms = now_ms;
+        return;
+    }
+
+    // see whether the timeout has expired
+    if (now_ms - motor_failure_start_ms < copter.g2.failsafe_mr_timeout) {
+        return;
+    }
+
+    motors->restart_motors(failed_motors);
+    motor_failure_start_ms = 0;
+
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Desync detected on %u motor(s), first motor: %u - restarting",
+        __builtin_popcount(failed_motors), __builtin_ffs(failed_motors));
+#endif
+}
+
 #if PARACHUTE == ENABLED
 
 // Code to detect a crash main ArduCopter code

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -28,6 +28,7 @@ void Copter::update_land_and_crash_detectors()
     crash_check();
     thrust_loss_check();
     yaw_imbalance_check();
+    desync_check();
 }
 
 // update_land_detector - checks if we have landed and updates the ap.land_complete flag

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -41,6 +41,9 @@ public:
     // determine whether all the motors in servo_channel_mask are running
     bool are_motors_running(uint32_t servo_channel_mask, float min_rpm, float max_rpm) const;
 
+    // return all the motors in servo_channel_mask that are not running
+    uint32_t get_motors_not_running(uint32_t servo_channel_mask) const;
+
     // get an individual ESC's temperature in centi-degrees if available, returns true on success
     bool get_temperature(uint8_t esc_index, int16_t& temp) const;
 

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -84,7 +84,7 @@ public:
     /*
      * Update channel masks at 1Hz allowing for actions such as dshot commands to be sent
      */
-    virtual void     update_channel_masks() {}
+    virtual void     update_channel_masks(bool force = false) {}
 
     /*
      * Allow channel mask updates to be temporarily suspended

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -234,7 +234,7 @@ public:
     /*
      * Update channel masks at 1Hz allowing for actions such as dshot commands to be sent
      */
-    void update_channel_masks() override;
+    void update_channel_masks(bool force) override;
 
     /*
      * Allow channel mask updates to be temporarily suspended

--- a/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_serial.cpp
@@ -149,10 +149,10 @@ void RCOutput::set_reversible_mask(uint32_t chanmask) {
 }
 
 // Update the dshot outputs that should be reversible/3D at 1Hz
-void RCOutput::update_channel_masks() {
+void RCOutput::update_channel_masks(bool force) {
 
     // post arming dshot commands will not be accepted
-    if (hal.util->get_soft_armed() || _disable_channel_mask_updates) {
+    if (!force && (hal.util->get_soft_armed() || _disable_channel_mask_updates)) {
         return;
     }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -75,6 +75,10 @@ public:
     // as vectoring is used for yaw control
     void                disable_yaw_torque(void) override;
 
+    // restart motors
+    void                restart_motors(uint32_t failed_motor_mask) override;
+    bool                restarting() const override { return _restart_state != MotorRestartState::Running; };
+
     // add_motor using raw roll, pitch, throttle and yaw factors
     void                add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order, float throttle_factor = 1.0f);
 
@@ -149,6 +153,18 @@ protected:
     float               _thrust_rpyt_out_filt[AP_MOTORS_MAX_NUM_MOTORS];    // filtered thrust outputs with 1 second time constant
     uint8_t             _motor_lost_index;  // index number of the lost motor
 
+    // motor restart handling
+    enum class MotorRestartState {
+        Running,
+        Disarming,
+        Arming,
+        SpoolingUp
+    };
+    uint32_t            _motors_to_restart;
+    MotorRestartState   _restart_state;
+    uint32_t            _restart_start_ms;
+    uint32_t            _channel_mask_update_ms;
+
     motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
     motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
 
@@ -168,6 +184,8 @@ private:
     bool setup_dodecahexa_matrix(motor_frame_type frame_type);
     bool setup_y6_matrix(motor_frame_type frame_type);
     bool setup_octaquad_matrix(motor_frame_type frame_type);
+
+    void run_restart_motors();
 
     static AP_MotorsMatrix *_singleton;
 };

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -257,6 +257,9 @@ public:
     // This function is overriden in motors_heli class.   Always true for multicopters.
     virtual bool init_targets_on_arming() const { return true; }
 
+    virtual void restart_motors(uint32_t failed_motor_mask) {}
+    virtual bool restarting() const { return false; }
+
     // returns true if the configured PWM type is digital and should have fixed endpoints
     bool is_digital_pwm_type() const;
 


### PR DESCRIPTION
Very experimental, and I have no idea whether this will work in practice. The idea is that if you get a desync you need to disarm and rearm the motor in order to get it turning again. This also prevents large currents going through a stationary motor. Only works with ESC telemetry and dshot at the moment. If you want to try it out set ```FS_MR_TIMEOUT``` to a value in ms after which a motor should be considered failed because its rpm data is 0 or non-existant.

I have got as far as being able to stop a motor with my hands and have it rearm and restart. To do this on the bench you need to define ```AP_MOTOR_DESYNC_DEBUG``` in crash_check.cpp otherwise the logic will only trigger if you are flying.

Caveat Emptor