### PR TITLE
AP_UROS: add micro-ROS client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+libraries/AP_UROS/uros

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 	path = modules/Micro-CDR
 	url = https://github.com/ardupilot/Micro-CDR.git
 	branch = master
+[submodule "modules/ardupilot_uros"]
+	path = modules/ardupilot_uros
+	url = https://github.com/srmainwaring/ardupilot_uros.git

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -138,6 +138,7 @@ IGNORED_AP_LIBRARIES = [
     'doc',
     'AP_Scripting', # this gets explicitly included when it is needed and should otherwise never be globbed in
     'AP_DDS',
+    'AP_UROS',
 ]
 
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -84,6 +84,18 @@ class Board:
             env.ENABLE_DDS = False
             env.DEFINES.update(AP_DDS_ENABLED = 0)
 
+        # configurations for UROS
+        if cfg.options.enable_uros:
+            cfg.recurse('libraries/AP_UROS')
+            env.ENABLE_UROS = True
+            env.AP_LIBRARIES += [
+                'AP_UROS'
+            ]
+            env.DEFINES.update(AP_UROS_ENABLED = 1)
+        else:
+            env.ENABLE_UROS = False
+            env.DEFINES.update(AP_UROS_ENABLED = 0)
+
         # setup for supporting onvif cam control
         if cfg.options.enable_onvif:
             cfg.recurse('libraries/AP_ONVIF')

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -411,6 +411,9 @@ def do_build(opts, frame_options):
     if opts.enable_dds:
         cmd_configure.append("--enable-dds")
 
+    if opts.enable_uros:
+        cmd_configure.append("--enable-uros")
+
     pieces = [shlex.split(x) for x in opts.waf_configure_args]
     for piece in pieces:
         cmd_configure.extend(piece)
@@ -1326,6 +1329,8 @@ group_sim.add_option("", "--sim-address",
                      help="IP address of the simulator. Defaults to localhost")
 group_sim.add_option("--enable-dds", action='store_true',
                      help="Enable the dds client to connect with ROS2/DDS")
+group_sim.add_option("--enable-uros", action='store_true',
+                     help="Enable the micro-ros client to connect with ROS2/DDS")
 
 parser.add_option_group(group_sim)
 

--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -239,8 +239,28 @@ master:=tcp:127.0.0.1:5760 \
 sitl:=127.0.0.1:5501
 ```
 
-UDP version
+### DDS UDP version
 
-```
+```bash
 ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
+```
+
+### UROS UDP
+
+Launch agent:
+
+```bash
+ros2 launch ardupilot_sitl micro_ros_agent.launch.py transport:=udp4 port:=2019 verbose:=6
+```
+
+Launch SITL:
+
+```bash
+ros2 launch ardupilot_sitl sitl.launch.py synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1
+```
+
+Launch non-interactive MAVProxy:
+
+```bash
+ros2 launch ardupilot_sitl mavproxy.launch.py master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
 ```

--- a/Tools/ros2/ardupilot_sitl/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_sitl/CMakeLists.txt
@@ -24,12 +24,12 @@ message(STATUS "WAF_COMMAND: ${WAF_COMMAND}")
 set(WAF_CONFIG $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:"--debug">)
 
 add_custom_target(ardupilot_configure ALL
-  ${WAF_COMMAND} configure --board sitl --enable-dds ${WAF_CONFIG}
+  ${WAF_COMMAND} configure --board sitl --enable-dds --enable-uros ${WAF_CONFIG}
   WORKING_DIRECTORY ${ARDUPILOT_ROOT}
 )
 
 add_custom_target(ardupilot_build ALL
-  ${WAF_COMMAND} build --enable-dds ${WAF_CONFIG}
+  ${WAF_COMMAND} build --enable-dds --enable-uros ${WAF_CONFIG}
   WORKING_DIRECTORY ${ARDUPILOT_ROOT}
 )
 add_dependencies(ardupilot_build ardupilot_configure)

--- a/Tools/ros2/ardupilot_sitl/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_sitl/CMakeLists.txt
@@ -24,12 +24,12 @@ message(STATUS "WAF_COMMAND: ${WAF_COMMAND}")
 set(WAF_CONFIG $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:"--debug">)
 
 add_custom_target(ardupilot_configure ALL
-  ${WAF_COMMAND} configure --board sitl --enable-dds --enable-uros ${WAF_CONFIG}
+  ${WAF_COMMAND} configure --board sitl --enable-uros ${WAF_CONFIG}
   WORKING_DIRECTORY ${ARDUPILOT_ROOT}
 )
 
 add_custom_target(ardupilot_build ALL
-  ${WAF_COMMAND} build --enable-dds --enable-uros ${WAF_CONFIG}
+  ${WAF_COMMAND} build --enable-uros ${WAF_CONFIG}
   WORKING_DIRECTORY ${ARDUPILOT_ROOT}
 )
 add_dependencies(ardupilot_build ardupilot_configure)

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -415,7 +415,7 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
     rcl_clock_t * clock;
     RCSOFTCHECK(rcl_timer_clock(timer, &clock));
 
-    /// \todo(srmainwaring) - use the rcl_clock...
+    //! @todo(srmainwaring) - use the rcl_clock...
     const auto cur_time_ms = AP_HAL::millis64();
 
     if (timer != NULL) {

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -347,8 +347,13 @@ bool AP_UROS_Client::create()
         RCL_MS_TO_NS(timer_timeout_ms),
         timer_callback));
 
+    // number of entities
+    constexpr size_t number_of_publishers = 7;
+    constexpr size_t number_of_subscribers = 1;
+    constexpr size_t number_of_handles =
+        number_of_publishers + number_of_subscribers;
+
     // create executor
-    const size_t number_of_handles = 7 + 1;
     executor = rclc_executor_get_zero_initialized_executor();
     RCCHECK(rclc_executor_init(&executor, &support.context,
         number_of_handles, &allocator));

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -143,7 +143,7 @@ void update_topic(sensor_msgs__msg__BatteryState& msg)
 
     msg.power_supply_technology = 0; //POWER_SUPPLY_TECHNOLOGY_UNKNOWN
 
-    // TODO(srmainwaring) - initialise cell_voltage sequence
+    //! @todo(srmainwaring) - initialise cell_voltage sequence
     // if (battery.has_cell_voltages(instance)) {
     //     const uint16_t* cellVoltages = battery.get_cell_voltages(instance).cells;
     //     std::copy(cellVoltages, cellVoltages + AP_BATT_MONITOR_CELLS_MAX, msg.cell_voltage);
@@ -163,7 +163,7 @@ void update_topic(geometry_msgs__msg__PoseStamped& msg)
 {
     update_topic(msg.header.stamp);
 
-    // TODO(srmainwaring) - initialise frame_id memory
+    //! @todo(srmainwaring) - initialise frame_id memory
     // strcpy(msg.header.frame_id, BASE_LINK_FRAME_ID);
 
     auto &ahrs = AP::ahrs();
@@ -214,7 +214,7 @@ void update_topic(geometry_msgs__msg__TwistStamped& msg)
 {
     update_topic(msg.header.stamp);
 
-    // TODO(srmainwaring) - initialise frame_id memory
+    //! @todo(srmainwaring) - initialise frame_id memory
     // strcpy(msg.header.frame_id, BASE_LINK_FRAME_ID);
 
     auto &ahrs = AP::ahrs();
@@ -255,13 +255,54 @@ void update_topic(geometry_msgs__msg__TwistStamped& msg)
 }
 
 // implementation copied from:
+// void AP_DDS_Client::populate_static_transforms(tf2_msgs_msg_TFMessage& msg)
+//! @todo(srmainwaring) - initialise TFMessage correctly.
 void update_topic(tf2_msgs__msg__TFMessage& msg)
 {
+    //! @todo(srmainwaring) - use micro-ROS version of TFMessage
+    // msg.transforms_size = 0;
+
+#if 0
+    auto &gps = AP::gps();
+    for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+        const auto gps_type = gps.get_type(i);
+        if (gps_type == AP_GPS::GPS_Type::GPS_TYPE_NONE) {
+            continue;
+        }
+        update_topic(msg.transforms[i].header.stamp);
+        char gps_frame_id[16];
+        //! @todo should GPS frame ID's be 0 or 1 indexed in ROS?
+        hal.util->snprintf(gps_frame_id, sizeof(gps_frame_id), "GPS_%u", i);
+
+        //! @todo(srmainwaring) - initialise string memory
+        // strcpy(msg.transforms[i].header.frame_id, BASE_LINK_FRAME_ID);
+        // strcpy(msg.transforms[i].child_frame_id, gps_frame_id);
+        // The body-frame offsets
+        // X - Forward
+        // Y - Right
+        // Z - Down
+        // https://ardupilot.org/copter/docs/common-sensor-offset-compensation.html#sensor-position-offset-compensation
+
+        const auto offset = gps.get_antenna_offset(i);
+
+        // In ROS REP 103, it follows this convention
+        // X - Forward
+        // Y - Left
+        // Z - Up
+        // https://www.ros.org/reps/rep-0103.html#axis-orientation
+
+        msg.transforms[i].transform.translation.x = offset[0];
+        msg.transforms[i].transform.translation.y = -1 * offset[1];
+        msg.transforms[i].transform.translation.z = -1 * offset[2];
+
+        msg.transforms_size++;
+    }
+#endif
 }
 
 // implementation copied from:
 // bool AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance)
-// TODO(srmainwaring) - this version always provides an update - which may be valid;
+//! @todo(srmainwaring) - this version always provides an update - which may be valid;
 //                      update scheduling to match AP_DDS
 void update_topic(sensor_msgs__msg__NavSatFix& msg)
 {
@@ -301,7 +342,7 @@ void update_topic(sensor_msgs__msg__NavSatFix& msg)
 
     update_topic(msg.header.stamp);
 
-    // TODO(srmainwaring) - initialise frame_id memory
+    //! @todo(srmainwaring) - initialise frame_id memory
     // strcpy(msg.header.frame_id, WGS_84_FRAME_ID);
     msg.status.service = 0; // SERVICE_GPS
     msg.status.status = -1; // STATUS_NO_FIX
@@ -387,7 +428,7 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
     rcl_clock_t * clock;
     RCSOFTCHECK(rcl_timer_clock(timer, &clock));
 
-    // TODO(srmainwaring) - use the rcl_clock...
+    /// \todo(srmainwaring) - use the rcl_clock...
     const auto cur_time_ms = AP_HAL::millis64();
 
     if (timer != NULL) {

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -42,7 +42,7 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
     (void) last_call_time;
     if (timer != NULL) {
         RCSOFTCHECK(rcl_publish(&publisher, &int32_msg, NULL));
-        printf("Sent: %d\n", int32_msg.data);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UROS: sent: %d", int32_msg.data);
         int32_msg.data++;
     }
 }

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -32,15 +32,15 @@
 }
 
 // publishers
-rcl_publisher_t int32_publisher;
-std_msgs__msg__Int32 int32_msg;
-uint64_t last_int32_time_ms;
-static constexpr uint16_t DELAY_INT32_TOPIC_MS = 1000;
+rcl_publisher_t battery_state_publisher;
+sensor_msgs__msg__BatteryState battery_state_msg;
+uint64_t last_battery_state_time_ms;
+static constexpr uint16_t DELAY_BATTERY_STATE_TOPIC_MS = 1000;
 
-rcl_publisher_t time_publisher;
-builtin_interfaces__msg__Time time_msg;
-uint64_t last_time_time_ms;
-static constexpr uint16_t DELAY_TIME_TOPIC_MS = 10;
+rcl_publisher_t clock_publisher;
+rosgraph_msgs__msg__Clock clock_msg;
+uint64_t last_clock_time_ms;
+static constexpr uint16_t DELAY_CLOCK_TOPIC_MS = 10;
 
 rcl_publisher_t local_pose_publisher;
 geometry_msgs__msg__PoseStamped local_pose_msg;
@@ -52,14 +52,48 @@ geometry_msgs__msg__TwistStamped local_twist_msg;
 uint64_t last_local_twist_time_ms;
 static constexpr uint16_t DELAY_LOCAL_TWIST_TOPIC_MS = 33;
 
+rcl_publisher_t nav_sat_fix_publisher;
+sensor_msgs__msg__NavSatFix nav_sat_fix_msg;
+uint64_t last_nav_sat_fix_time_ms;
+static constexpr uint16_t DELAY_NAV_SAT_FIX_TOPIC_MS = 1000;
+
+rcl_publisher_t static_transform_publisher;
+tf2_msgs__msg__TFMessage static_transform_msg;
+uint64_t last_static_transform_time_ms;
+static constexpr uint16_t DELAY_STATIC_TRANSFORM_TOPIC_MS = 1000;
+
+rcl_publisher_t time_publisher;
+builtin_interfaces__msg__Time time_msg;
+uint64_t last_time_time_ms;
+static constexpr uint16_t DELAY_TIME_TOPIC_MS = 10;
+
 // subscribers
 rcl_subscription_t vector3_subscriber;
 geometry_msgs__msg__Vector3 vector3_msg;
 
-// update topics
-void update_topic(std_msgs__msg__Int32& msg)
+// update published topics
+void update_topic(sensor_msgs__msg__BatteryState& msg)
 {
-    msg.data++;
+}
+
+void update_topic(rosgraph_msgs__msg__Clock& msg)
+{
+}
+
+void update_topic(geometry_msgs__msg__PoseStamped& msg)
+{
+}
+
+void update_topic(geometry_msgs__msg__TwistStamped& msg)
+{
+}
+
+void update_topic(tf2_msgs__msg__TFMessage& msg)
+{
+}
+
+void update_topic(sensor_msgs__msg__NavSatFix& msg)
+{
 }
 
 void update_topic(builtin_interfaces__msg__Time& msg)
@@ -72,14 +106,7 @@ void update_topic(builtin_interfaces__msg__Time& msg)
     msg.nanosec = (utc_usec % 1000000ULL) * 1000UL;
 }
 
-void update_topic(geometry_msgs__msg__PoseStamped& msg)
-{
-}
-
-void update_topic(geometry_msgs__msg__TwistStamped& msg)
-{
-}
-
+// subscriber callbacks
 void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
     (void) last_call_time;
@@ -95,20 +122,16 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 
     if (timer != NULL) {
 
-        if (cur_time_ms - last_int32_time_ms > DELAY_INT32_TOPIC_MS) {
-            update_topic(time_msg);
-            last_int32_time_ms = cur_time_ms;
-            RCSOFTCHECK(rcl_publish(&int32_publisher, &int32_msg, NULL));
-            // GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,
-            //     "UROS: sent int32: %d", int32_msg.data);
+        if (cur_time_ms - last_battery_state_time_ms > DELAY_BATTERY_STATE_TOPIC_MS) {
+            update_topic(battery_state_msg);
+            last_battery_state_time_ms = cur_time_ms;
+            RCSOFTCHECK(rcl_publish(&battery_state_publisher, &battery_state_msg, NULL));
         }
 
-        if (cur_time_ms - last_time_time_ms > DELAY_TIME_TOPIC_MS) {
-            update_topic(time_msg);
-            last_time_time_ms = cur_time_ms;
-            RCSOFTCHECK(rcl_publish(&time_publisher, &time_msg, NULL));
-            // GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,
-            //     "UROS: sent time: %d, %d", time_msg.sec, time_msg.nanosec);
+        if (cur_time_ms - last_clock_time_ms > DELAY_CLOCK_TOPIC_MS) {
+            update_topic(clock_msg);
+            last_clock_time_ms = cur_time_ms;
+            RCSOFTCHECK(rcl_publish(&clock_publisher, &clock_msg, NULL));
         }
 
         if (cur_time_ms - last_local_pose_time_ms > DELAY_LOCAL_POSE_TOPIC_MS) {
@@ -121,6 +144,26 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
             update_topic(local_twist_msg);
             last_local_twist_time_ms = cur_time_ms;
             RCSOFTCHECK(rcl_publish(&local_twist_publisher, &local_twist_msg, NULL));
+        }
+
+        if (cur_time_ms - last_nav_sat_fix_time_ms > DELAY_NAV_SAT_FIX_TOPIC_MS) {
+            update_topic(nav_sat_fix_msg);
+            last_nav_sat_fix_time_ms = cur_time_ms;
+            RCSOFTCHECK(rcl_publish(&nav_sat_fix_publisher, &nav_sat_fix_msg, NULL));
+        }
+
+        if (cur_time_ms - last_static_transform_time_ms > DELAY_STATIC_TRANSFORM_TOPIC_MS) {
+            update_topic(static_transform_msg);
+            last_static_transform_time_ms = cur_time_ms;
+            RCSOFTCHECK(rcl_publish(&static_transform_publisher, &static_transform_msg, NULL));
+        }
+
+        if (cur_time_ms - last_time_time_ms > DELAY_TIME_TOPIC_MS) {
+            update_topic(time_msg);
+            last_time_time_ms = cur_time_ms;
+            RCSOFTCHECK(rcl_publish(&time_publisher, &time_msg, NULL));
+            // GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,
+            //     "UROS: sent time: %d, %d", time_msg.sec, time_msg.nanosec);
         }
     }
 }
@@ -196,10 +239,13 @@ void AP_UROS_Client::main_loop(void)
 
     RCSOFTCHECK(rcl_subscription_fini(&vector3_subscriber, &node));
 
-    RCSOFTCHECK(rcl_publisher_fini(&int32_publisher, &node));
-    RCSOFTCHECK(rcl_publisher_fini(&time_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&battery_state_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&clock_publisher, &node));
     RCSOFTCHECK(rcl_publisher_fini(&local_pose_publisher, &node));
     RCSOFTCHECK(rcl_publisher_fini(&local_twist_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&nav_sat_fix_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&static_transform_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&time_publisher, &node));
 
     RCSOFTCHECK(rcl_node_fini(&node));
 }
@@ -246,16 +292,16 @@ bool AP_UROS_Client::create()
 
     // create publishers
     RCCHECK(rclc_publisher_init_default(
-        &int32_publisher,
+        &battery_state_publisher,
         &node,
-        ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32),
-        "std_msgs_msg_Int32"));
+        ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, BatteryState),
+        "ap/battery/battery0"));
 
     RCCHECK(rclc_publisher_init_default(
-        &time_publisher,
+        &clock_publisher,
         &node,
-        ROSIDL_GET_MSG_TYPE_SUPPORT(builtin_interfaces, msg, Time),
-        "ap/time"));
+        ROSIDL_GET_MSG_TYPE_SUPPORT(rosgraph_msgs, msg, Clock),
+        "ap/clock"));
 
     RCCHECK(rclc_publisher_init_default(
         &local_pose_publisher,
@@ -268,6 +314,24 @@ bool AP_UROS_Client::create()
         &node,
         ROSIDL_GET_MSG_TYPE_SUPPORT(geometry_msgs, msg, TwistStamped),
         "ap/twist/filtered"));
+
+    RCCHECK(rclc_publisher_init_default(
+        &nav_sat_fix_publisher,
+        &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, NavSatFix),
+        "ap/navsat/navsat0"));
+
+    RCCHECK(rclc_publisher_init_default(
+        &static_transform_publisher,
+        &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(tf2_msgs, msg, TFMessage),
+        "ap/tf_static"));
+
+    RCCHECK(rclc_publisher_init_default(
+        &time_publisher,
+        &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(builtin_interfaces, msg, Time),
+        "ap/time"));
 
     // create subscribers
     RCCHECK(rclc_subscription_init_default(
@@ -284,7 +348,7 @@ bool AP_UROS_Client::create()
         timer_callback));
 
     // create executor
-    const size_t number_of_handles = 5;
+    const size_t number_of_handles = 7 + 1;
     executor = rclc_executor_get_zero_initialized_executor();
     RCCHECK(rclc_executor_init(&executor, &support.context,
         number_of_handles, &allocator));

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -12,6 +12,42 @@
 
 #include "AP_UROS_Client.h"
 
+// micro-ROS
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+
+#include <std_msgs/msg/int32.h>
+#include <geometry_msgs/msg/vector3.h>
+
+#define RCCHECK(fn) {\
+  rcl_ret_t temp_rc = fn;\
+  if ((temp_rc != RCL_RET_OK)) {\
+    printf("Failed status on line %d: %d. Aborting.\n", \
+        __LINE__, (int)temp_rc);\
+  } \
+}
+
+#define RCSOFTCHECK(fn) {\
+  rcl_ret_t temp_rc = fn;\
+  if ((temp_rc != RCL_RET_OK)) {\
+    printf("Failed status on line %d: %d. Continuing.\n", \
+        __LINE__, (int)temp_rc);\
+  }\
+}
+
+rcl_subscription_t subscriber;
+geometry_msgs__msg__Vector3 msg;
+
+void subscription_callback(const void * msgin)
+{
+    const geometry_msgs__msg__Vector3 * pmsg =
+        (const geometry_msgs__msg__Vector3 *)msgin;
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"UROS: x: %f, y: %f, z: %f",
+        pmsg->x, pmsg->y, pmsg->z);
+}
+
 const AP_Param::GroupInfo AP_UROS_Client::var_info[] {
 
     // @Param: _ENABLE
@@ -57,6 +93,38 @@ void AP_UROS_Client::main_loop(void)
     }
     GCS_SEND_TEXT(MAV_SEVERITY_INFO,"UROS: initialization passed");
 
+    // one-time actions
+
+    rcl_allocator_t allocator = rcl_get_default_allocator();
+    rclc_support_t support;
+
+    // create init_options
+    RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
+
+    // create node
+    rcl_node_t node;
+    RCCHECK(rclc_node_init_default(
+        &node, "vector3_subscriber_rclc", "", &support));
+
+    // create subscriber
+    RCCHECK(rclc_subscription_init_default(
+        &subscriber,
+        &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(geometry_msgs, msg, Vector3),
+        "geometry_msgs_msg_Vector3"));
+
+    // create executor
+    rclc_executor_t executor = rclc_executor_get_zero_initialized_executor();
+    RCCHECK(rclc_executor_init(&executor, &support.context, 1, &allocator));
+    RCCHECK(rclc_executor_add_subscription(
+        &executor, &subscriber, &msg, &subscription_callback, ON_NEW_DATA));
+
+    rclc_executor_spin(&executor);
+
+    RCCHECK(rcl_subscription_fini(&subscriber, &node));
+    RCCHECK(rcl_node_fini(&node));
+
+    // periodic actions
     while (true) {
         hal.scheduler->delay(1);
         update();

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -87,8 +87,19 @@ rcl_subscription_t joy_subscriber;
 sensor_msgs__msg__Joy joy_msg;
 micro_ros_utilities_memory_conf_t joy_conf;
 
-// update published topics
+// declarations
 void update_topic(builtin_interfaces__msg__Time& msg);
+void update_topic(sensor_msgs__msg__BatteryState& msg);
+void update_topic(rosgraph_msgs__msg__Clock& msg);
+void update_topic(geometry_msgs__msg__PoseStamped& msg);
+void update_topic(geometry_msgs__msg__TwistStamped& msg);
+void update_topic(tf2_msgs__msg__TFMessage& msg);
+bool update_topic(sensor_msgs__msg__NavSatFix& msg);
+void update_topic(builtin_interfaces__msg__Time& msg);
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time);
+void on_joy_msg(const void * msgin);
+
+// update published topics
 
 // implementation copied from:
 // void AP_DDS_Client::update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_t instance) 

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -1,0 +1,108 @@
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#if AP_UROS_ENABLED
+
+#include <AP_GPS/AP_GPS.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_RTC/AP_RTC.h>
+#include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+#include "AP_UROS_Client.h"
+
+const AP_Param::GroupInfo AP_UROS_Client::var_info[] {
+
+    // @Param: _ENABLE
+    // @DisplayName: UROS enable
+    // @Description: Enable UROS subsystem
+    // @Values: 0:Disabled,1:Enabled
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_UROS_Client, enabled, 0, AP_PARAM_FLAG_ENABLE),
+
+    AP_GROUPEND
+};
+
+/*
+  start the DDS thread
+ */
+bool AP_UROS_Client::start(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    AP_Param::load_object_from_eeprom(this, var_info);
+
+    if (enabled == 0) {
+        return true;
+    }
+
+    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_UROS_Client::main_loop, void),
+                                      "UROS",
+                                      8192, AP_HAL::Scheduler::PRIORITY_IO, 1)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"UROS: thread create failed");
+        return false;
+    }
+    return true;
+}
+
+/*
+  main loop for UROS thread
+ */
+void AP_UROS_Client::main_loop(void)
+{
+    if (!init() || !create()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"UROS: creation failed");
+        return;
+    }
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"UROS: initialization passed");
+
+    while (true) {
+        hal.scheduler->delay(1);
+        update();
+    }
+}
+
+bool AP_UROS_Client::init()
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"UROS: init complete");
+
+    return true;
+}
+
+bool AP_UROS_Client::create()
+{
+    WITH_SEMAPHORE(csem);
+
+   GCS_SEND_TEXT(MAV_SEVERITY_INFO,"UROS: create complete");
+
+    return true;
+}
+
+void AP_UROS_Client::update()
+{
+    WITH_SEMAPHORE(csem);
+}
+
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
+extern "C" {
+    int clock_gettime(clockid_t clockid, struct timespec *ts);
+}
+
+int clock_gettime(clockid_t clockid, struct timespec *ts)
+{
+    //! @todo the value of clockid is ignored here.
+    //! A fallback mechanism is employed against the caller's choice of clock.
+    uint64_t utc_usec;
+    if (!AP::rtc().get_utc_usec(utc_usec)) {
+        utc_usec = AP_HAL::micros64();
+    }
+    ts->tv_sec = utc_usec / 1000000ULL;
+    ts->tv_nsec = (utc_usec % 1000000ULL) * 1000UL;
+    return 0;
+}
+#endif // CONFIG_HAL_BOARD
+
+#endif // AP_UROS_ENABLED
+
+

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -111,7 +111,7 @@ void AP_UROS_Client::main_loop(void)
 bool AP_UROS_Client::init()
 {
     // initialize transport
-    bool initTransportStatus = true;
+    bool initTransportStatus = false;
 
 #if AP_UROS_UDP_ENABLED
     // fallback to UDP if available

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -2,6 +2,9 @@
 
 #if AP_UROS_ENABLED
 
+#include <algorithm>
+#include <string.h>
+
 #include <AP_GPS/AP_GPS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_RTC/AP_RTC.h>
@@ -30,6 +33,11 @@
             __LINE__, (int)temp_rc);\
     }\
 }
+
+// topic constants
+// static char WGS_84_FRAME_ID[] = "WGS-84";
+// https://www.ros.org/reps/rep-0105.html#base-link
+// static char BASE_LINK_FRAME_ID[] = "base_link";
 
 // publishers
 rcl_publisher_t battery_state_publisher;
@@ -72,30 +80,292 @@ rcl_subscription_t vector3_subscriber;
 geometry_msgs__msg__Vector3 vector3_msg;
 
 // update published topics
+
+void update_topic(builtin_interfaces__msg__Time& msg);
+
+// implementation copied from:
+// void AP_DDS_Client::update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_t instance) 
 void update_topic(sensor_msgs__msg__BatteryState& msg)
 {
+    const uint8_t instance = 0;
+
+    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES) {
+        return;
+    }
+
+    update_topic(msg.header.stamp);
+    auto &battery = AP::battery();
+
+    if (!battery.healthy(instance)) {
+        msg.power_supply_status = 3; //POWER_SUPPLY_HEALTH_DEAD
+        msg.present = false;
+        return;
+    }
+    msg.present = true;
+
+    msg.voltage = battery.voltage(instance);
+
+    float temperature;
+    msg.temperature = (battery.get_temperature(temperature, instance)) ? temperature : NAN;
+
+    float current;
+    msg.current = (battery.current_amps(current, instance)) ? -1 * current : NAN;
+
+    const float design_capacity = (float)battery.pack_capacity_mah(instance) * 0.001;
+    msg.design_capacity = design_capacity;
+
+    uint8_t percentage;
+    if (battery.capacity_remaining_pct(percentage, instance)) {
+        msg.percentage = percentage * 0.01;
+        msg.charge = (percentage * design_capacity) * 0.01;
+    } else {
+        msg.percentage = NAN;
+        msg.charge = NAN;
+    }
+
+    msg.capacity = NAN;
+
+    if (battery.current_amps(current, instance)) {
+        if (percentage == 100) {
+            msg.power_supply_status = 4;   //POWER_SUPPLY_STATUS_FULL
+        } else if (current < 0.0) {
+            msg.power_supply_status = 1;   //POWER_SUPPLY_STATUS_CHARGING
+        } else if (current > 0.0) {
+            msg.power_supply_status = 2;   //POWER_SUPPLY_STATUS_DISCHARGING
+        } else {
+            msg.power_supply_status = 3;   //POWER_SUPPLY_STATUS_NOT_CHARGING
+        }
+    } else {
+        msg.power_supply_status = 0; //POWER_SUPPLY_STATUS_UNKNOWN
+    }
+
+    msg.power_supply_health = (battery.overpower_detected(instance)) ? 4 : 1; //POWER_SUPPLY_HEALTH_OVERVOLTAGE or POWER_SUPPLY_HEALTH_GOOD
+
+    msg.power_supply_technology = 0; //POWER_SUPPLY_TECHNOLOGY_UNKNOWN
+
+    // TODO(srmainwaring) - initialise cell_voltage sequence
+    // if (battery.has_cell_voltages(instance)) {
+    //     const uint16_t* cellVoltages = battery.get_cell_voltages(instance).cells;
+    //     std::copy(cellVoltages, cellVoltages + AP_BATT_MONITOR_CELLS_MAX, msg.cell_voltage);
+    // }
 }
 
+// implementation copied from:
+// void AP_DDS_Client::update_topic(rosgraph_msgs_msg_Clock& msg)
 void update_topic(rosgraph_msgs__msg__Clock& msg)
 {
+    update_topic(msg.clock);
 }
 
+// implementation copied from:
+// void AP_DDS_Client::update_topic(geometry_msgs_msg_PoseStamped& msg)
 void update_topic(geometry_msgs__msg__PoseStamped& msg)
 {
+    update_topic(msg.header.stamp);
+
+    // TODO(srmainwaring) - initialise frame_id memory
+    // strcpy(msg.header.frame_id, BASE_LINK_FRAME_ID);
+
+    auto &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
+    // ROS REP 103 uses the ENU convention:
+    // X - East
+    // Y - North
+    // Z - Up
+    // https://www.ros.org/reps/rep-0103.html#axis-orientation
+    // AP_AHRS uses the NED convention
+    // X - North
+    // Y - East
+    // Z - Down
+    // As a consequence, to follow ROS REP 103, it is necessary to switch X and Y,
+    // as well as invert Z
+
+    Vector3f position;
+    if (ahrs.get_relative_position_NED_home(position)) {
+        msg.pose.position.x = position[1];
+        msg.pose.position.y = position[0];
+        msg.pose.position.z = -position[2];
+    }
+
+    // In ROS REP 103, axis orientation uses the following convention:
+    // X - Forward
+    // Y - Left
+    // Z - Up
+    // https://www.ros.org/reps/rep-0103.html#axis-orientation
+    // As a consequence, to follow ROS REP 103, it is necessary to switch X and Y,
+    // as well as invert Z (NED to ENU convertion) as well as a 90 degree rotation in the Z axis
+    // for x to point forward
+    Quaternion orientation;
+    if (ahrs.get_quaternion(orientation)) {
+        Quaternion aux(orientation[0], orientation[2], orientation[1], -orientation[3]); //NED to ENU transformation
+        Quaternion transformation (sqrtF(2) * 0.5,0,0,sqrtF(2) * 0.5); // Z axis 90 degree rotation
+        orientation = aux * transformation;
+        msg.pose.orientation.w = orientation[0];
+        msg.pose.orientation.x = orientation[1];
+        msg.pose.orientation.y = orientation[2];
+        msg.pose.orientation.z = orientation[3];
+    }
 }
 
+// implementation copied from:
+// void AP_DDS_Client::update_topic(geometry_msgs_msg_TwistStamped& msg)
 void update_topic(geometry_msgs__msg__TwistStamped& msg)
 {
+    update_topic(msg.header.stamp);
+
+    // TODO(srmainwaring) - initialise frame_id memory
+    // strcpy(msg.header.frame_id, BASE_LINK_FRAME_ID);
+
+    auto &ahrs = AP::ahrs();
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
+    // ROS REP 103 uses the ENU convention:
+    // X - East
+    // Y - North
+    // Z - Up
+    // https://www.ros.org/reps/rep-0103.html#axis-orientation
+    // AP_AHRS uses the NED convention
+    // X - North
+    // Y - East
+    // Z - Down
+    // As a consequence, to follow ROS REP 103, it is necessary to switch X and Y,
+    // as well as invert Z
+    Vector3f velocity;
+    if (ahrs.get_velocity_NED(velocity)) {
+        msg.twist.linear.x = velocity[1];
+        msg.twist.linear.y = velocity[0];
+        msg.twist.linear.z = -velocity[2];
+    }
+
+    // In ROS REP 103, axis orientation uses the following convention:
+    // X - Forward
+    // Y - Left
+    // Z - Up
+    // https://www.ros.org/reps/rep-0103.html#axis-orientation
+    // The gyro data is received from AP_AHRS in body-frame
+    // X - Forward
+    // Y - Right
+    // Z - Down
+    // As a consequence, to follow ROS REP 103, it is necessary to invert Y and Z
+    Vector3f angular_velocity = ahrs.get_gyro();
+    msg.twist.angular.x = angular_velocity[0];
+    msg.twist.angular.y = -angular_velocity[1];
+    msg.twist.angular.z = -angular_velocity[2];
 }
 
+// implementation copied from:
 void update_topic(tf2_msgs__msg__TFMessage& msg)
 {
 }
 
+// implementation copied from:
+// bool AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance)
+// TODO(srmainwaring) - this version always provides an update - which may be valid;
+//                      update scheduling to match AP_DDS
 void update_topic(sensor_msgs__msg__NavSatFix& msg)
 {
+    const uint8_t instance = 0;
+
+    // Add a lambda that takes in navsatfix msg and populates the cov
+    // Make it constexpr if possible
+    // https://www.fluentcpp.com/2021/12/13/the-evolutions-of-lambdas-in-c14-c17-and-c20/
+    // constexpr auto times2 = [] (sensor_msgs_msg_NavSatFix* msg) { return n * 2; };
+
+    // assert(instance >= GPS_MAX_RECEIVERS);
+    if (instance >= GPS_MAX_RECEIVERS) {
+        // return false;
+        return;
+    }
+
+    auto &gps = AP::gps();
+    WITH_SEMAPHORE(gps.get_semaphore());
+
+    if (!gps.is_healthy(instance)) {
+        msg.status.status = -1; // STATUS_NO_FIX
+        msg.status.service = 0; // No services supported
+        msg.position_covariance_type = 0; // COVARIANCE_TYPE_UNKNOWN
+        // return false;
+        return;
+    }
+
+    // No update is needed
+    const auto last_fix_time_ms = gps.last_fix_time_ms(instance);
+    if (last_nav_sat_fix_time_ms == last_fix_time_ms) {
+        // return false;
+        return;
+    } else {
+        last_nav_sat_fix_time_ms = last_fix_time_ms;
+    }
+
+
+    update_topic(msg.header.stamp);
+
+    // TODO(srmainwaring) - initialise frame_id memory
+    // strcpy(msg.header.frame_id, WGS_84_FRAME_ID);
+    msg.status.service = 0; // SERVICE_GPS
+    msg.status.status = -1; // STATUS_NO_FIX
+
+
+    //! @todo What about glonass, compass, galileo?
+    //! This will be properly designed and implemented to spec in #23277
+    msg.status.service = 1; // SERVICE_GPS
+
+    const auto status = gps.status(instance);
+    switch (status) {
+    case AP_GPS::NO_GPS:
+    case AP_GPS::NO_FIX:
+        msg.status.status = -1; // STATUS_NO_FIX
+        msg.position_covariance_type = 0; // COVARIANCE_TYPE_UNKNOWN
+        // return true;
+        return;
+    case AP_GPS::GPS_OK_FIX_2D:
+    case AP_GPS::GPS_OK_FIX_3D:
+        msg.status.status = 0; // STATUS_FIX
+        break;
+    case AP_GPS::GPS_OK_FIX_3D_DGPS:
+        msg.status.status = 1; // STATUS_SBAS_FIX
+        break;
+    case AP_GPS::GPS_OK_FIX_3D_RTK_FLOAT:
+    case AP_GPS::GPS_OK_FIX_3D_RTK_FIXED:
+        msg.status.status = 2; // STATUS_SBAS_FIX
+        break;
+    default:
+        //! @todo Can we not just use an enum class and not worry about this condition?
+        break;
+    }
+    const auto loc = gps.location(instance);
+    msg.latitude = loc.lat * 1E-7;
+    msg.longitude = loc.lng * 1E-7;
+
+    int32_t alt_cm;
+    if (!loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_cm)) {
+        // With absolute frame, this condition is unlikely
+        msg.status.status = -1; // STATUS_NO_FIX
+        msg.position_covariance_type = 0; // COVARIANCE_TYPE_UNKNOWN
+        // return true;
+        return;
+    }
+    msg.altitude = alt_cm * 0.01;
+
+    // ROS allows double precision, ArduPilot exposes float precision today
+    Matrix3f cov;
+    msg.position_covariance_type = (uint8_t)gps.position_covariance(instance, cov);
+    msg.position_covariance[0] = cov[0][0];
+    msg.position_covariance[1] = cov[0][1];
+    msg.position_covariance[2] = cov[0][2];
+    msg.position_covariance[3] = cov[1][0];
+    msg.position_covariance[4] = cov[1][1];
+    msg.position_covariance[5] = cov[1][2];
+    msg.position_covariance[6] = cov[2][0];
+    msg.position_covariance[7] = cov[2][1];
+    msg.position_covariance[8] = cov[2][2];
+
+    // return true;
 }
 
+// implementation copied from:
+// void AP_DDS_Client::update_topic(builtin_interfaces_msg_Time& msg)
 void update_topic(builtin_interfaces__msg__Time& msg)
 {
     uint64_t utc_usec;

--- a/libraries/AP_UROS/AP_UROS_Client.cpp
+++ b/libraries/AP_UROS/AP_UROS_Client.cpp
@@ -87,9 +87,6 @@ rcl_subscription_t joy_subscriber;
 sensor_msgs__msg__Joy joy_msg;
 micro_ros_utilities_memory_conf_t joy_conf;
 
-rcl_subscription_t vector3_subscriber;
-geometry_msgs__msg__Vector3 vector3_msg;
-
 // update published topics
 void update_topic(builtin_interfaces__msg__Time& msg);
 
@@ -481,14 +478,6 @@ void on_joy_msg(const void * msgin)
     }
 }
 
-void on_vector3_msg(const void * msgin)
-{
-    const geometry_msgs__msg__Vector3 * msg =
-        (const geometry_msgs__msg__Vector3 *)msgin;
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UROS: x: %f, y: %f, z: %f",
-        msg->x, msg->y, msg->z);
-}
-
 const AP_Param::GroupInfo AP_UROS_Client::var_info[] {
 
     // @Param: _ENABLE
@@ -551,7 +540,6 @@ void AP_UROS_Client::main_loop(void)
     rclc_executor_spin(&executor);
 
     RCSOFTCHECK(rcl_subscription_fini(&joy_subscriber, &node));
-    RCSOFTCHECK(rcl_subscription_fini(&vector3_subscriber, &node));
 
     RCSOFTCHECK(rcl_publisher_fini(&battery_state_publisher, &node));
     RCSOFTCHECK(rcl_publisher_fini(&clock_publisher, &node));
@@ -731,12 +719,6 @@ bool AP_UROS_Client::create()
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Joy),
         "ap/joy"));
 
-    RCCHECK(rclc_subscription_init_default(
-        &vector3_subscriber,
-        &node,
-        ROSIDL_GET_MSG_TYPE_SUPPORT(geometry_msgs, msg, Vector3),
-        "geometry_msgs_msg_Vector3"));
-
     // create timer
     RCCHECK(rclc_timer_init_default(
         &timer,
@@ -746,7 +728,7 @@ bool AP_UROS_Client::create()
 
     // number of entities
     constexpr size_t number_of_publishers = 7;
-    constexpr size_t number_of_subscribers = 2;
+    constexpr size_t number_of_subscribers = 1;
     constexpr size_t number_of_handles =
         number_of_publishers + number_of_subscribers;
 
@@ -759,9 +741,6 @@ bool AP_UROS_Client::create()
 
     RCCHECK(rclc_executor_add_subscription(&executor, &joy_subscriber,
         &joy_msg, &on_joy_msg, ON_NEW_DATA));
-
-    RCCHECK(rclc_executor_add_subscription(&executor, &vector3_subscriber,
-        &vector3_msg, &on_vector3_msg, ON_NEW_DATA));
 
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UROS: create complete");
 

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -5,6 +5,24 @@
 // micro-xrce-dds
 #include "uxr/client/client.h"
 
+// micro-ROS
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+
+// ROS msgs
+#include <builtin_interfaces/msg/time.h>
+#include <geometry_msgs/msg/pose_stamped.h>
+#include <geometry_msgs/msg/twist_stamped.h>
+#include <geometry_msgs/msg/vector3.h>
+#include <rosgraph_msgs/msg/clock.h>
+#include <sensor_msgs/msg/battery_state.h>
+#include <sensor_msgs/msg/joy.h>
+#include <sensor_msgs/msg/nav_sat_fix.h>
+#include <std_msgs/msg/int32.h>
+#include <tf2_msgs/msg/tf_message.h>
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Scheduler.h>
 #include <AP_HAL/Semaphores.h>
@@ -13,15 +31,6 @@
 #include "fcntl.h"
 
 #include <AP_Param/AP_Param.h>
-
-// micro-ROS
-#include <rcl/rcl.h>
-#include <rcl/error_handling.h>
-#include <rclc/rclc.h>
-#include <rclc/executor.h>
-
-#include <std_msgs/msg/int32.h>
-#include <geometry_msgs/msg/vector3.h>
 
 // UDP only on SITL for now
 #define AP_UROS_UDP_ENABLED 1 //(CONFIG_HAL_BOARD == HAL_BOARD_SITL)

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -45,6 +45,8 @@ private:
     rclc_support_t support;
     rcl_node_t node;
     rclc_executor_t executor;
+    rcl_timer_t timer;
+    const unsigned int timer_timeout = 1000;
 
 #if AP_UROS_UDP_ENABLED
     // functions for udp transport

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -55,7 +55,7 @@ private:
     rcl_node_t node;
     rclc_executor_t executor;
     rcl_timer_t timer;
-    const unsigned int timer_timeout = 1000;
+    const unsigned int timer_timeout_ms = 1;
 
 #if AP_UROS_UDP_ENABLED
     // functions for udp transport

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#if AP_UROS_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Scheduler.h>
+#include <AP_HAL/Semaphores.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+#include "fcntl.h"
+
+#include <AP_Param/AP_Param.h>
+
+extern const AP_HAL::HAL& hal;
+
+class AP_UROS_Client
+{
+private:
+
+    AP_Int8 enabled;
+
+    HAL_Semaphore csem;
+
+public:
+    bool start(void);
+    void main_loop(void);
+
+    //! @brief Initialize the client.
+    //! @return True on successful initialization, false on failure.
+    bool init() WARN_IF_UNUSED;
+
+    //! @brief Set up the client.
+    //! @return True on successful creation, false on failure
+    bool create() WARN_IF_UNUSED;
+
+    //! @brief Update the client.
+    void update();
+
+    //! @brief Parameter storage.
+    static const struct AP_Param::GroupInfo var_info[];
+};
+
+#endif // AP_UROS_ENABLED

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -11,6 +11,15 @@
 
 #include <AP_Param/AP_Param.h>
 
+// micro-ROS
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+
+#include <std_msgs/msg/int32.h>
+#include <geometry_msgs/msg/vector3.h>
+
 extern const AP_HAL::HAL& hal;
 
 class AP_UROS_Client
@@ -20,6 +29,12 @@ private:
     AP_Int8 enabled;
 
     HAL_Semaphore csem;
+
+    // micro-ROS
+    rcl_allocator_t allocator;
+    rclc_support_t support;
+    rcl_node_t node;
+    rclc_executor_t executor;
 
 public:
     bool start(void);
@@ -32,9 +47,6 @@ public:
     //! @brief Set up the client.
     //! @return True on successful creation, false on failure
     bool create() WARN_IF_UNUSED;
-
-    //! @brief Update the client.
-    void update();
 
     //! @brief Parameter storage.
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -24,7 +24,7 @@
 #include <geometry_msgs/msg/vector3.h>
 
 // UDP only on SITL for now
-#define AP_UROS_UDP_ENABLED 0 //(CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#define AP_UROS_UDP_ENABLED 1 //(CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 
 #if AP_UROS_UDP_ENABLED
 #include <AP_HAL/utility/Socket.h>

--- a/libraries/AP_UROS/AP_UROS_Client.h
+++ b/libraries/AP_UROS/AP_UROS_Client.h
@@ -20,7 +20,6 @@
 #include <sensor_msgs/msg/battery_state.h>
 #include <sensor_msgs/msg/joy.h>
 #include <sensor_msgs/msg/nav_sat_fix.h>
-#include <std_msgs/msg/int32.h>
 #include <tf2_msgs/msg/tf_message.h>
 
 #include <AP_HAL/AP_HAL.h>

--- a/libraries/AP_UROS/AP_UROS_UDP.cpp
+++ b/libraries/AP_UROS/AP_UROS_UDP.cpp
@@ -1,0 +1,92 @@
+#include "AP_UROS_Client.h"
+
+#if AP_UROS_UDP_ENABLED
+
+#include <rmw_microros/custom_transport.h>
+
+#include <errno.h>
+
+/*
+  open connection on UDP
+ */
+bool AP_UROS_Client::udp_transport_open(uxrCustomTransport *t)
+{
+    AP_UROS_Client *uros = (AP_UROS_Client *)t->args;
+    auto *sock = new SocketAPM(true);
+    if (sock == nullptr) {
+        return false;
+    }
+    if (!sock->connect(uros->udp.ip, uros->udp.port.get())) {
+        return false;
+    }
+    uros->udp.socket = sock;
+    return true;
+}
+
+/*
+  close UDP connection
+ */
+bool AP_UROS_Client::udp_transport_close(uxrCustomTransport *t)
+{
+    AP_UROS_Client *uros = (AP_UROS_Client *)t->args;
+    delete uros->udp.socket;
+    uros->udp.socket = nullptr;
+    return true;
+}
+
+/*
+  write on UDP
+ */
+size_t AP_UROS_Client::udp_transport_write(uxrCustomTransport *t,
+    const uint8_t* buf, size_t len, uint8_t* error)
+{
+    AP_UROS_Client *uros = (AP_UROS_Client *)t->args;
+    if (uros->udp.socket == nullptr) {
+        *error = EINVAL;
+        return 0;
+    }
+    const ssize_t ret = uros->udp.socket->send(buf, len);
+    if (ret <= 0) {
+        *error = errno;
+        return 0;
+    }
+    return ret;
+}
+
+/*
+  read from UDP
+ */
+size_t AP_UROS_Client::udp_transport_read(uxrCustomTransport *t,
+    uint8_t* buf, size_t len, int timeout_ms, uint8_t* error)
+{
+    AP_UROS_Client *uros = (AP_UROS_Client *)t->args;
+    if (uros->udp.socket == nullptr) {
+        *error = EINVAL;
+        return 0;
+    }
+    const ssize_t ret = uros->udp.socket->recv(buf, len, timeout_ms);
+    if (ret <= 0) {
+        *error = errno;
+        return 0;
+    }
+    return ret;
+}
+
+/*
+  initialise UDP connection
+ */
+bool AP_UROS_Client::urosUdpInit()
+{
+    // setup a non-framed transport for UDP
+    rmw_ret_t rcl_ret = rmw_uros_set_custom_transport(
+            false,
+            (void*)this,
+            udp_transport_open,
+            udp_transport_close,
+            udp_transport_write,
+            udp_transport_read);
+
+    return (rcl_ret == RCL_RET_OK);
+}
+
+#endif // AP_UROS_UDP_ENABLED

--- a/libraries/AP_UROS/wscript
+++ b/libraries/AP_UROS/wscript
@@ -29,6 +29,10 @@ def configure(cfg):
     # fatal error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Wundef]
     # #if __STDC_VERSION__ >= 201112L && !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
     #
+    # Better to edit error_handling.h:139:5 ??
+    # 
+    # #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
+    # 
     cfg.env.AP_LIB_EXTRA_CXXFLAGS['AP_UROS'] = ['-Wno-undef']
 
 

--- a/libraries/AP_UROS/wscript
+++ b/libraries/AP_UROS/wscript
@@ -16,6 +16,8 @@ def configure(cfg):
         'libraries/AP_UROS/uros/include/action_msgs',
         'libraries/AP_UROS/uros/include/builtin_interfaces',
         'libraries/AP_UROS/uros/include/geometry_msgs',
+        'libraries/AP_UROS/uros/include/rosgraph_msgs',
+        'libraries/AP_UROS/uros/include/sensor_msgs',
         'libraries/AP_UROS/uros/include/std_msgs',
         'libraries/AP_UROS/uros/include/tf2_msgs',
         'libraries/AP_UROS/uros/include/unique_identifier_msgs',

--- a/libraries/AP_UROS/wscript
+++ b/libraries/AP_UROS/wscript
@@ -1,97 +1,37 @@
 #!/usr/bin/env python3
 
-
 import pathlib
 
 
 def configure(cfg):
-    extra_src = [
-        # 'modules/Micro-XRCE-DDS-Client/src/c/core/session/stream/*.c',
-        # 'modules/Micro-XRCE-DDS-Client/src/c/core/session/*.c',
-        # 'modules/Micro-XRCE-DDS-Client/src/c/core/serialization/*.c',
-        # 'modules/Micro-XRCE-DDS-Client/src/c/util/*.c',
-        # 'modules/Micro-XRCE-DDS-Client/src/c/profile/transport/custom/custom_transport.c',
-        # 'modules/Micro-XRCE-DDS-Client/src/c/profile/transport/stream_framing/stream_framing_protocol.c',
-        # 'modules/Micro-CDR/src/c/types/*.c',
-        # 'modules/Micro-CDR/src/c/common.c',
-    ]
-
-    cfg.env.AP_LIB_EXTRA_SOURCES['AP_UROS'] = []
-    for pattern in extra_src:
-        s = cfg.srcnode.ant_glob(pattern, dir=False, src=True)
-        for x in s:
-            cfg.env.AP_LIB_EXTRA_SOURCES['AP_UROS'].append(str(x))
-
     extra_src_inc = [
-        # 'modules/Micro-XRCE-DDS-Client/include',
-        # 'modules/Micro-XRCE-DDS-Client/include/uxr/client',
-        # 'modules/Micro-CDR/src/c',
-        # 'modules/Micro-CDR/include',
-        # 'modules/Micro-CDR/include/ucdr',
+        'libraries/AP_UROS/uros/include',
+        'libraries/AP_UROS/uros/include/rcl',
+        'libraries/AP_UROS/uros/include/rcl_action',
+        'libraries/AP_UROS/uros/include/rcutils',
+        'libraries/AP_UROS/uros/include/rmw',
+        'libraries/AP_UROS/uros/include/rosidl_runtime_c',
+        'libraries/AP_UROS/uros/include/rosidl_typesupport_interface',
+        'libraries/AP_UROS/uros/include/rosidl_typesupport_introspection_c',
+        'libraries/AP_UROS/uros/include/action_msgs',
+        'libraries/AP_UROS/uros/include/builtin_interfaces',
+        'libraries/AP_UROS/uros/include/geometry_msgs',
+        'libraries/AP_UROS/uros/include/std_msgs',
+        'libraries/AP_UROS/uros/include/tf2_msgs',
+        'libraries/AP_UROS/uros/include/unique_identifier_msgs',
     ]
     for inc in extra_src_inc:
         cfg.env.INCLUDES += [str(cfg.srcnode.make_node(inc))]
 
-    # auto update submodules
-    # cfg.env.append_value('GIT_SUBMODULES', 'Micro-XRCE-DDS-Client')
-    # cfg.env.append_value('GIT_SUBMODULES', 'Micro-CDR')
+    # Suppress build error:
+    #
+    # ../../libraries/AP_UROS/uros/include/rcutils/rcutils/error_handling.h:139:5:
+    # fatal error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Wundef]
+    # #if __STDC_VERSION__ >= 201112L && !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
+    #
+    cfg.env.AP_LIB_EXTRA_CXXFLAGS['AP_UROS'] = ['-Wno-undef']
 
 
 def build(bld):
-    config_h_in = [
-        # 'modules/Micro-XRCE-DDS-Client/include/uxr/client/config.h.in',
-        # 'modules/Micro-CDR/include/ucdr/config.h.in',
-    ]
-    # config_h_in_nodes = [bld.srcnode.make_node(h) for h in config_h_in]
-    # config_h_nodes = [bld.bldnode.find_or_declare(h[:-3]) for h in config_h_in]
-
-    # gen_path = "libraries/AP_UROS"
-    extra_bld_inc = [
-        # 'modules/Micro-CDR/include',
-        # 'modules/Micro-XRCE-DDS-Client/include',
-        # str(pathlib.PurePath(gen_path, "generated")),
-    ]
-    for inc in extra_bld_inc:
-        bld.env.INCLUDES += [bld.bldnode.find_or_declare(inc).abspath()]
-
-    # for i in range(len(config_h_nodes)):
-    #     print(f"building {config_h_nodes[i].abspath()}")
-    #     bld(
-    #         # build config.h file
-    #         source=config_h_in_nodes[i],
-    #         target=config_h_nodes[i],
-    #         rule="%s %s/%s %s %s"
-    #         % (
-    #             bld.env.get_flat('PYTHON'),
-    #             bld.env.SRCROOT,
-    #             "libraries/AP_UROS/gen_config_h.py",
-    #             config_h_in_nodes[i].abspath(),
-    #             config_h_nodes[i].abspath(),
-    #         ),
-    #         group='dynamic_sources',
-    #     )
-
-    # TODO instead of keeping standard IDL files in the source tree, copy them with "ros2 pkg prefix --share " tools
-    # idl_files = bld.srcnode.ant_glob('libraries/AP_UROS/Idl/**/*.idl')
-    # idl_include_path = bld.srcnode.make_node(str(pathlib.PurePath(gen_path, "Idl"))).abspath()
-
-    # for idl in idl_files:
-    #     idl_path = pathlib.PurePath(idl.abspath())
-    #     b = idl_path.name
-
-    #     gen_h = idl_path.with_suffix('.h').name
-    #     gen_c = idl_path.with_suffix('.c').name
-
-    #     idl_folder = idl_path.parts[-3:-1]
-    #     dst_dir = pathlib.PurePath(gen_path, "generated", *idl_folder)
-    #     gen = [bld.bldnode.find_or_declare(str(dst_dir / name)) for name in [gen_h, gen_c]]
-    #     gen_cmd = f"{bld.env.MICROXRCEDDSGEN[0]} -cs -replace -d {dst_dir} -I {idl_include_path} {idl}"
-    #     bld(
-    #         # build IDL file
-    #         source=idl,
-    #         target=gen,
-    #         rule=gen_cmd,
-    #         group='dynamic_sources',
-    #     )
-
-    #     bld.env.AP_LIB_EXTRA_SOURCES['AP_UROS'] += [str(gen[1])]
+    bld.env.LIB += ['microros']
+    bld.env.LIBPATH += [bld.env.SRCROOT + '/libraries/AP_UROS/uros/']

--- a/libraries/AP_UROS/wscript
+++ b/libraries/AP_UROS/wscript
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+
+import pathlib
+
+
+def configure(cfg):
+    extra_src = [
+        # 'modules/Micro-XRCE-DDS-Client/src/c/core/session/stream/*.c',
+        # 'modules/Micro-XRCE-DDS-Client/src/c/core/session/*.c',
+        # 'modules/Micro-XRCE-DDS-Client/src/c/core/serialization/*.c',
+        # 'modules/Micro-XRCE-DDS-Client/src/c/util/*.c',
+        # 'modules/Micro-XRCE-DDS-Client/src/c/profile/transport/custom/custom_transport.c',
+        # 'modules/Micro-XRCE-DDS-Client/src/c/profile/transport/stream_framing/stream_framing_protocol.c',
+        # 'modules/Micro-CDR/src/c/types/*.c',
+        # 'modules/Micro-CDR/src/c/common.c',
+    ]
+
+    cfg.env.AP_LIB_EXTRA_SOURCES['AP_UROS'] = []
+    for pattern in extra_src:
+        s = cfg.srcnode.ant_glob(pattern, dir=False, src=True)
+        for x in s:
+            cfg.env.AP_LIB_EXTRA_SOURCES['AP_UROS'].append(str(x))
+
+    extra_src_inc = [
+        # 'modules/Micro-XRCE-DDS-Client/include',
+        # 'modules/Micro-XRCE-DDS-Client/include/uxr/client',
+        # 'modules/Micro-CDR/src/c',
+        # 'modules/Micro-CDR/include',
+        # 'modules/Micro-CDR/include/ucdr',
+    ]
+    for inc in extra_src_inc:
+        cfg.env.INCLUDES += [str(cfg.srcnode.make_node(inc))]
+
+    # auto update submodules
+    # cfg.env.append_value('GIT_SUBMODULES', 'Micro-XRCE-DDS-Client')
+    # cfg.env.append_value('GIT_SUBMODULES', 'Micro-CDR')
+
+
+def build(bld):
+    config_h_in = [
+        # 'modules/Micro-XRCE-DDS-Client/include/uxr/client/config.h.in',
+        # 'modules/Micro-CDR/include/ucdr/config.h.in',
+    ]
+    # config_h_in_nodes = [bld.srcnode.make_node(h) for h in config_h_in]
+    # config_h_nodes = [bld.bldnode.find_or_declare(h[:-3]) for h in config_h_in]
+
+    # gen_path = "libraries/AP_UROS"
+    extra_bld_inc = [
+        # 'modules/Micro-CDR/include',
+        # 'modules/Micro-XRCE-DDS-Client/include',
+        # str(pathlib.PurePath(gen_path, "generated")),
+    ]
+    for inc in extra_bld_inc:
+        bld.env.INCLUDES += [bld.bldnode.find_or_declare(inc).abspath()]
+
+    # for i in range(len(config_h_nodes)):
+    #     print(f"building {config_h_nodes[i].abspath()}")
+    #     bld(
+    #         # build config.h file
+    #         source=config_h_in_nodes[i],
+    #         target=config_h_nodes[i],
+    #         rule="%s %s/%s %s %s"
+    #         % (
+    #             bld.env.get_flat('PYTHON'),
+    #             bld.env.SRCROOT,
+    #             "libraries/AP_UROS/gen_config_h.py",
+    #             config_h_in_nodes[i].abspath(),
+    #             config_h_nodes[i].abspath(),
+    #         ),
+    #         group='dynamic_sources',
+    #     )
+
+    # TODO instead of keeping standard IDL files in the source tree, copy them with "ros2 pkg prefix --share " tools
+    # idl_files = bld.srcnode.ant_glob('libraries/AP_UROS/Idl/**/*.idl')
+    # idl_include_path = bld.srcnode.make_node(str(pathlib.PurePath(gen_path, "Idl"))).abspath()
+
+    # for idl in idl_files:
+    #     idl_path = pathlib.PurePath(idl.abspath())
+    #     b = idl_path.name
+
+    #     gen_h = idl_path.with_suffix('.h').name
+    #     gen_c = idl_path.with_suffix('.c').name
+
+    #     idl_folder = idl_path.parts[-3:-1]
+    #     dst_dir = pathlib.PurePath(gen_path, "generated", *idl_folder)
+    #     gen = [bld.bldnode.find_or_declare(str(dst_dir / name)) for name in [gen_h, gen_c]]
+    #     gen_cmd = f"{bld.env.MICROXRCEDDSGEN[0]} -cs -replace -d {dst_dir} -I {idl_include_path} {idl}"
+    #     bld(
+    #         # build IDL file
+    #         source=idl,
+    #         target=gen,
+    #         rule=gen_cmd,
+    #         group='dynamic_sources',
+    #     )
+
+    #     bld.env.AP_LIB_EXTRA_SOURCES['AP_UROS'] += [str(gen[1])]

--- a/libraries/AP_UROS/wscript
+++ b/libraries/AP_UROS/wscript
@@ -2,42 +2,35 @@
 
 import pathlib
 
+distro = 'uros-macos-13.4-arm64' 
+uros_include_dir = f'modules/ardupilot_uros/{distro}/uros/include' 
+uros_library_dir = f'modules/ardupilot_uros/{distro}/uros/lib' 
+
 
 def configure(cfg):
+    
     extra_src_inc = [
-        'libraries/AP_UROS/uros/include',
-        'libraries/AP_UROS/uros/include/rcl',
-        'libraries/AP_UROS/uros/include/rcl_action',
-        'libraries/AP_UROS/uros/include/rcutils',
-        'libraries/AP_UROS/uros/include/rmw',
-        'libraries/AP_UROS/uros/include/rosidl_runtime_c',
-        'libraries/AP_UROS/uros/include/rosidl_typesupport_interface',
-        'libraries/AP_UROS/uros/include/rosidl_typesupport_introspection_c',
-        'libraries/AP_UROS/uros/include/action_msgs',
-        'libraries/AP_UROS/uros/include/builtin_interfaces',
-        'libraries/AP_UROS/uros/include/geometry_msgs',
-        'libraries/AP_UROS/uros/include/rosgraph_msgs',
-        'libraries/AP_UROS/uros/include/sensor_msgs',
-        'libraries/AP_UROS/uros/include/std_msgs',
-        'libraries/AP_UROS/uros/include/tf2_msgs',
-        'libraries/AP_UROS/uros/include/unique_identifier_msgs',
+        f'{uros_include_dir}',
+        f'{uros_include_dir}/rcl',
+        f'{uros_include_dir}/rcl_action',
+        f'{uros_include_dir}/rcutils',
+        f'{uros_include_dir}/rmw',
+        f'{uros_include_dir}/rosidl_runtime_c',
+        f'{uros_include_dir}/rosidl_typesupport_interface',
+        f'{uros_include_dir}/rosidl_typesupport_introspection_c',
+        f'{uros_include_dir}/action_msgs',
+        f'{uros_include_dir}/builtin_interfaces',
+        f'{uros_include_dir}/geometry_msgs',
+        f'{uros_include_dir}/rosgraph_msgs',
+        f'{uros_include_dir}/sensor_msgs',
+        f'{uros_include_dir}/std_msgs',
+        f'{uros_include_dir}/tf2_msgs',
+        f'{uros_include_dir}/unique_identifier_msgs',
     ]
     for inc in extra_src_inc:
         cfg.env.INCLUDES += [str(cfg.srcnode.make_node(inc))]
 
-    # Suppress build error:
-    #
-    # ../../libraries/AP_UROS/uros/include/rcutils/rcutils/error_handling.h:139:5:
-    # fatal error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Wundef]
-    # #if __STDC_VERSION__ >= 201112L && !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
-    #
-    # Better to edit error_handling.h:139:5 ??
-    # 
-    # #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
-    # 
-    cfg.env.AP_LIB_EXTRA_CXXFLAGS['AP_UROS'] = ['-Wno-undef']
-
 
 def build(bld):
     bld.env.LIB += ['microros']
-    bld.env.LIBPATH += [bld.env.SRCROOT + '/libraries/AP_UROS/uros/']
+    bld.env.LIBPATH += [bld.env.SRCROOT + f'/{uros_library_dir}/']

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -18,6 +18,7 @@
 #include <AP_HAL_ChibiOS/hwdef/common/stm32_util.h>
 #endif
 #include <AP_DDS/AP_DDS_Client.h>
+#include <AP_UROS/AP_UROS_Client.h>
 #if HAL_WITH_IO_MCU
 #include <AP_IOMCU/AP_IOMCU.h>
 extern AP_IOMCU iomcu;
@@ -205,6 +206,11 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_GROUPINFO("FLTMODE_GCSBLOCK", 20, AP_Vehicle, flight_mode_GCS_block, 0),
 #endif // APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)
 
+#if AP_UROS_ENABLED
+    // @Group: UROS
+    // @Path: ../AP_UROS/AP_UROS_Client.cpp
+    AP_SUBGROUPPTR(uros_client, "UROS", 21, AP_Vehicle, AP_UROS_Client),
+#endif // AP_UROS_ENABLED
 
 #if AP_NETWORKING_ENABLED
     // @Group: NET_
@@ -405,6 +411,12 @@ void AP_Vehicle::setup()
 #if AP_DDS_ENABLED
     if (!init_dds_client()) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "DDS Client: Failed to Initialize");
+    }
+#endif
+
+#if AP_UROS_ENABLED
+    if (!init_uros_client()) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "UROS: Failed to initialize");
     }
 #endif
 }
@@ -944,6 +956,17 @@ bool AP_Vehicle::init_dds_client()
     return dds_client->start();
 }
 #endif // AP_DDS_ENABLED
+
+#if AP_UROS_ENABLED
+bool AP_Vehicle::init_uros_client()
+{
+    uros_client = new AP_UROS_Client();
+    if (uros_client == nullptr) {
+        return false;
+    }
+    return uros_client->start();
+}
+#endif // AP_UROS_ENABLED
 
 // Check if this mode can be entered from the GCS
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -64,6 +64,7 @@
 #include <AP_KDECAN/AP_KDECAN.h>
 
 class AP_DDS_Client;
+class AP_UROS_Client;
 
 class AP_Vehicle : public AP_HAL::HAL::Callbacks {
 
@@ -425,6 +426,12 @@ protected:
     // Declare the dds client for communication with ROS2 and DDS(common for all vehicles)
     AP_DDS_Client *dds_client;
     bool init_dds_client() WARN_IF_UNUSED;
+#endif
+
+#if AP_UROS_ENABLED
+    // Declare the micro-ros client for communication with ROS 2 and DDS (common for all vehicles)
+    AP_UROS_Client *uros_client;
+    bool init_uros_client() WARN_IF_UNUSED;
 #endif
 
     // Check if this mode can be entered from the GCS

--- a/wscript
+++ b/wscript
@@ -267,8 +267,10 @@ submodules at specific revisions.
                  help="Enables GPS logging")
     
     g.add_option('--enable-dds', action='store_true',
-                 help="Enable the dds client to connect with ROS2/DDS"
-    )
+                 help="Enable the dds client to connect with ROS2/DDS")
+
+    g.add_option('--enable-uros', action='store_true',
+                 help="Enable the micro-ros client to connect with ROS2/DDS")
 
     g.add_option('--enable-dronecan-tests', action='store_true',
                  default=False,
@@ -719,6 +721,9 @@ def _build_dynamic_sources(bld):
 
     if bld.env.ENABLE_DDS:
         bld.recurse("libraries/AP_DDS")
+
+    if bld.env.ENABLE_UROS:
+        bld.recurse("libraries/AP_UROS")
 
     def write_version_header(tsk):
         bld = tsk.generator.bld


### PR DESCRIPTION
A draft PR to investigate using the micro-ROS client library directly as an alternative to AP_DDS.

See: https://github.com/ArduPilot/ardupilot/issues/23424 and the comment on the [micro-ROS PoC](https://github.com/ArduPilot/ardupilot/issues/23424#issuecomment-1644609275).

### Dependencies

The PR adds a module containing pre-built instances of the micro-ROS client library for various target platforms.

- https://github.com/srmainwaring/ardupilot_uros

This is to separate out the fairly complex process of configuring and building the client libraries. Including this step directly in the `waf` build would add a dependency on `colcon` and `ROS`.

### micro-ROS links

The following micro-ROS tutorials describe the process of creating the client libraries:

- [Creating custom static micro-ROS library](https://micro.ros.org/docs/tutorials/advanced/create_custom_static_library/)
- [How to include a custom ROS message in micro-ROS](https://micro.ros.org/docs/tutorials/advanced/create_new_type/)
- [Creating custom micro-ROS transports](https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/)
- [Middleware Configuration](https://micro.ros.org/docs/tutorials/advanced/microxrcedds_rmw_configuration/)

### Tasks

- [ ] Fully document process for building the client libraries for each platform (Ubuntu, macOS, stm32, esp32, ).
- [ ] Remove hardcoded platform target in `AP_UROS` `wscript`.
- [ ] Factor out common code with `AP_DDS`.
- [ ] Remove hardcoded flags from `ardupilot_sitl` `CMakeLists.txt`.


