### PR TITLE
solved the logical error in grouping of escs into 4

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -318,8 +318,11 @@ void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
     const uint32_t now_us = AP_HAL::micros();
 
     // loop through groups of 4 ESCs
-    const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS - 1);
-    const uint8_t num_idx = ESC_TELEM_MAX_ESCS / 4;
+    const uint8_t esc_offset = constrain_int16(mavlink_offset, 0, ESC_TELEM_MAX_ESCS-1);
+
+    // ensure we send out partially-full groups:
+    const uint8_t num_idx = (ESC_TELEM_MAX_ESCS + 3) / 4;
+
     for (uint8_t idx = 0; idx < num_idx; idx++) {
         const uint8_t i = (next_idx + idx) % num_idx;
 


### PR DESCRIPTION
ESC_Telemetry will not send MAVLink MSG_ESC_TELEMETRY_1_TO_4 if ESC_TELEM_MAX_ESCS (PWM/SERVO) count is <=3 as logic was to keep idx = ESC_TELEM_MAX_ESCS/4 It gives rise to 3 big issues that are :-
1.It will leave some values if ESC_TELEM_MAX_ESCS which are not completely divisible by 4 e.g. 1,2,3,5,6,7,9....
2. (next_idx + idx) % num_idx it will give error if escs are less than 4
3. for loop will never start if escs count is less than 4 i.e the message inside loop will be skipped even if escs are present. Also if escs are not in multiple of 4 then it will skip 1 iteration

Solution in commit:
This is rectified by logic to add 1 to num_idx if ESC_TELEM_MAX_ESCS is not multiple of 4.