### PR TITLE
AP_Scripting: add basic print

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -45,6 +45,11 @@ function micros() end
 ---@return number|nil -- command param 4
 function mission_receive() end
 
+-- Print text, if MAVLink is available the value will be sent with debug severity
+-- If no MAVLink the value will be sent over can
+-- equivalent to gcs:send_text(7, text) or periph:can_printf(text)
+---@param text string|number|integer
+function print(text) end
 
 -- data flash logging to SD card
 ---@class logger

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -759,6 +759,7 @@ userdata uint32_t manual tofloat uint32_t_tofloat 0
 
 global manual dirlist lua_dirlist 1
 global manual remove lua_removefile 1
+global manual print lua_print 1
 
 singleton mavlink depends HAL_GCS_ENABLED
 singleton mavlink manual init lua_mavlink_init 2

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -759,4 +759,14 @@ int lua_get_current_ref()
     return scripting->get_current_ref();
 }
 
+// Simple print to GCS or over CAN
+int lua_print(lua_State *L) {
+    // Only support a single argument
+    binding_argcheck(L, 1);
+
+    GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "%s", luaL_checkstring(L, 1));
+
+    return 0;
+}
+
 #endif  // AP_SCRIPTING_ENABLED

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -19,3 +19,4 @@ int lua_mavlink_receive_chan(lua_State *L);
 int lua_mavlink_register_rx_msgid(lua_State *L);
 int lua_mavlink_send_chan(lua_State *L);
 int lua_mavlink_block_command(lua_State *L);
+int lua_print(lua_State *L);


### PR DESCRIPTION
This adds a very basic print method, its not as clever as the build in print which can handle multiple arguments.

https://www.lua.org/manual/5.3/manual.html#pdf-print

This is a quick method for debug that should work on all platforms. It uses the `GCS_SEND_TEXT` macro, so will print over CAN on periph.