### PR TITLE
AP_Winch: Daiwa driver gets stuck protection

### DIFF
--- a/libraries/AP_Winch/AP_Winch.cpp
+++ b/libraries/AP_Winch/AP_Winch.cpp
@@ -36,9 +36,9 @@ const AP_Param::GroupInfo AP_Winch::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: Winch options
     // @Description: Winch options
-    // @Bitmask:  0:Spin freely on startup, 1:Verbose output
+    // @Bitmask:  0:Spin freely on startup, 1:Verbose output, 2:Retry if stuck (Daiwa only)
     // @User: Standard
-    AP_GROUPINFO("_OPTIONS", 4, AP_Winch, config.options, 3.0f),
+    AP_GROUPINFO("_OPTIONS", 4, AP_Winch, config.options, 7.0f),
 
     // 4 was _RATE_PID
 

--- a/libraries/AP_Winch/AP_Winch.h
+++ b/libraries/AP_Winch/AP_Winch.h
@@ -86,6 +86,7 @@ private:
     enum class Options : int16_t {
         SpinFreelyOnStartup = (1U << 0),    // winch allows line to be manually pulled out soon after startup
         VerboseOutput = (1U << 1),          // verbose output of winch state sent to GCS
+        RetryIfStuck = (1U << 2),           // retries to raise or lower if winch stops
     };
 
     // winch states

--- a/libraries/AP_Winch/AP_Winch.h
+++ b/libraries/AP_Winch/AP_Winch.h
@@ -84,8 +84,8 @@ private:
 
     // enum for OPTIONS parameter
     enum class Options : int16_t {
-        SpinFreelyOnStartup = (1U << 0),
-        VerboseOutput = (1U << 1),
+        SpinFreelyOnStartup = (1U << 0),    // winch allows line to be manually pulled out soon after startup
+        VerboseOutput = (1U << 1),          // verbose output of winch state sent to GCS
     };
 
     // winch states

--- a/libraries/AP_Winch/AP_Winch_Daiwa.h
+++ b/libraries/AP_Winch/AP_Winch_Daiwa.h
@@ -63,6 +63,12 @@ private:
     // update pwm outputs to control winch
     void control_winch();
 
+    // returns the rate which may be modified to unstick the winch
+    // if the winch stops, the rate is temporarily set to zero
+    // now_ms should be set to the current system time
+    // rate should be the rate used to calculate the final PWM output to the winch
+    float get_stuck_protected_rate(uint32_t now_ms, float rate);
+
     static const uint8_t buff_len_max = 20; // buffer maximum length
     static const int16_t output_dz = 100;   // output deadzone in scale of -1000 to +1000
     const float line_length_correction_factor = 0.003333f;  // convert winch counter to meters
@@ -118,6 +124,13 @@ private:
         uint8_t moving;                 // 0:stopped, 1:retracting line, 2:extending line, 3:clutch engaged, 4:zero reset
         uint8_t clutch;                 // 0:clutch off, 1:clutch engaged weakly, 2:clutch engaged strongly, motor can spin freely
     } user_update;
+
+    // stuck protection
+    struct {
+        uint32_t last_update_ms;        // system time that stuck protection was last called
+        uint32_t stuck_start_ms;        // system time that winch became stuck (0 if not stuck)
+        bool user_notified;             // true if user has been notified that winch is stuck
+    } stuck_protection;
 };
 
 #endif  // AP_WINCH_DAIWA_ENABLED


### PR DESCRIPTION
The [Daiwa winch](https://ardupilot.org/copter/docs/common-daiwa-winch.html) will stop raising or lowering the package if the tension on the line falls below a (supposedly configurable) weight.  The reason for this "failsafe" behaviour is to protect the winch line from getting tangled but it can also be falsely triggered during a real delivery if the vehicle hits turbulence.  The result being that the package is not lowered or the empty hook is not raised without manual intervention.

This PR adds an optional "stuck protection" feature that checks if the winch has stopped unexpectedly and if it does it momentarily (for 1 sec) returns the desired rate to zero which normally clears the issue.

This has been fairly extensively tested on real hardware and below is a screenshot of some output from the following test:

- I command the winch to retract an empty hook
- As the hook was being retracted, I lifted the hook manually so as to reduce the tension on the winch to zero
- The winch stopped retracting (which is OK) and most importantly it started retracting again when I let go of the hook
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/b849379d-a9eb-4076-b703-86c2dd289178)



