### PR TITLE
Tracker: enable EK2 and EK3 parameters

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -541,6 +541,18 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Path: ../libraries/AP_Logger/AP_Logger.cpp
     GOBJECT(logger,           "LOG",  AP_Logger),
 
+#if HAL_NAVEKF2_AVAILABLE
+    // @Group: EK2_
+    // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
+    GOBJECTN(ahrs.EKF2, NavEKF2, "EK2_", NavEKF2),
+#endif
+
+#if HAL_NAVEKF3_AVAILABLE
+    // @Group: EK3_
+    // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
+    GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
+#endif
+
     AP_VAREND
 };
 

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -130,6 +130,8 @@ public:
         k_param_disarm_pwm,
 
         k_param_auto_opts,
+        k_param_NavEKF2,
+        k_param_NavEKF3,
 
         k_param_logger = 253, // 253 - Logging Group
 


### PR DESCRIPTION
Tested in SITL and on CubeOrange.

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/576c68e7-1ef2-4254-b5dd-2c595793b127)

