### PR TITLE
AP_InertialSensor: fixed the error value for BMI088

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -400,7 +400,7 @@ void AP_InertialSensor_BMI088::read_fifo_gyro(void)
     }
     const float scale = radians(2000.0f) / 32767.0f;
     const uint8_t max_frames = 8;
-    const Vector3i bad_frame{int16_t(0xffff), int16_t(0xffff), int16_t(0xffff)};
+    const Vector3i bad_frame{INT16_MIN,INT16_MIN,INT16_MIN};
     Vector3i data[max_frames];
 
     if (num_frames & 0x80) {


### PR DESCRIPTION
the bad value is -32767 not 0xffff (which is -1)

-32767 badly corrupts the low-pass filter, and is what we see in logs (a large negative spike on all 3 axes)

update to bug fix from:
https://github.com/ArduPilot/ardupilot/pull/23033

