### PR TITLE
Waf add submodulesclean

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -102,6 +102,11 @@ list some basic and more used commands as example.
     Cleaning the build is very often not necessary and discouraged. We do
     incremental builds reducing the build time by orders of magnitude.
 
+    If submodules are failing to be synchronized, `submodulesync` may be used
+    to resync the submodules. This is usually necessary when shifting development
+    between stable releases or a stable release and the master branch.
+
+    In some some cases `submodule_force_clean` may be necessary. This removes all submodules and then performs a `submodulesync`. (Note whitelisted modules like esp_idf is not removed.)
 
 * **Upload or install**
 

--- a/Tools/completion/bash/_waf
+++ b/Tools/completion/bash/_waf
@@ -31,6 +31,8 @@ _waf()
     opts+=" configure"
     opts+=" clean"
     opts+=" distclean"
+    opts+=" submodule_force_clean"
+    opts+=" submodulesync"
 
     # Prevent word reuse TODO: add -vvv case
     lim=$((COMP_CWORD - 1))

--- a/Tools/completion/zsh/_waf
+++ b/Tools/completion/zsh/_waf
@@ -89,7 +89,9 @@ _waf_cmds() {
     'build:executes the build' \
     'configure:configures the project' \
     'clean:cleans the project' \
-    'distclean:removes build folders and data'
+    'distclean:removes build folders and data' \
+    'submodule_force_clean:removes all submodules, then checkouts all current submodules and synchronizes them' \
+    'submodulesync:checkouts all current submodules and synchronizes them'
   )
   _describe -t commands 'command' commands "$@" && ret=0
 }

--- a/wscript
+++ b/wscript
@@ -86,6 +86,29 @@ def _set_build_context_variant(board):
             continue
         c.variant = board
 
+# Remove all submodules and then sync
+@conf
+def submodule_force_clean(ctx):
+    whitelist = {
+                            'COLCON_IGNORE',
+                            'esp_idf',
+                          }
+
+    # Get all items in the modules folder
+    module_list = os.scandir('modules')
+
+    # Delete all directories except those in the whitelist
+    for module in module_list:
+        if (module.is_dir()) and (module.name not in whitelist):
+            shutil.rmtree(module)
+
+    submodulesync(ctx)
+
+# run Tools/gittools/submodule-sync.sh to sync submodules
+@conf
+def submodulesync(ctx):
+    subprocess.call(['Tools/gittools/submodule-sync.sh'])
+
 def init(ctx):
     # Generate Task List, so that VS Code extension can keep track
     # of changes to possible build targets


### PR DESCRIPTION
This adds a waf command and completions for the submodulesync script.
Simpler version of https://github.com/ArduPilot/ardupilot/pull/23898 since it doesn't mess with normal distclean

Note : I called it `submodulesclean` to be more in common with other projects but am not tied to it. 

To Fix:  I couldn't get `./waf --help` to show the `submodulesclean` command ?