### PR TITLE
AP_Baro: Change variable values to real values

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -324,9 +324,8 @@ void AP_Baro::calibrate(bool save)
     // now average over 5 values for the ground pressure settings
     float sum_pressure[BARO_MAX_INSTANCES] = {0};
     uint8_t count[BARO_MAX_INSTANCES] = {0};
-    const uint8_t num_samples = 5;
 
-    for (uint8_t c = 0; c < num_samples; c++) {
+    for (uint8_t c = 0; c < 5u; c++) {  // 5 samples
         uint32_t tstart = AP_HAL::millis();
         do {
             update();


### PR DESCRIPTION
I don't think it makes sense to set the number of loops to a variable.
The actual value should be used to determine the number of loops.