### PR TITLE
Copter: remove duplicate friend declaration

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -234,7 +234,6 @@ public:
     friend class ModeZigZag;
     friend class ModeAutorotate;
     friend class ModeTurtle;
-    friend class AP_ExternalControl_Copter;
 
     Copter(void);
 


### PR DESCRIPTION
Remove duplicate declaration of `friend class AP_ExternalControl_Copter`.
