### PR TITLE
AP_Arming: Defined by the process used

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -739,7 +739,6 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
     const RCMapper * rcmap = AP::rcmap();
     if (rcmap != nullptr) {
         if (!rc().option_is_enabled(RC_Channels::Option::ARMING_SKIP_CHECK_RPY)) {
-            const char *names[3] = {"Roll", "Pitch", "Yaw"};
             const uint8_t channels[3] = {rcmap->roll(), rcmap->pitch(), rcmap->yaw()};
             for (uint8_t i = 0; i < ARRAY_SIZE(channels); i++) {
                 const RC_Channel *c = rc().channel(channels[i] - 1);
@@ -748,6 +747,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
                 }
                 if (c->get_control_in() != 0) {
                     if ((method != Method::RUDDER) || (c != rc().get_arming_channel())) { // ignore the yaw input channel if rudder arming
+                        const char *names[3] = {"Roll", "Pitch", "Yaw"};
                         check_failed(ARMING_CHECK_RC, true, "%s (RC%d) is not neutral", names[i], channels[i]);
                         check_passed = false;
                     }


### PR DESCRIPTION
The array of strings is far from the actual processing used.
Define this array in the process that will use it.

AFTER
![Screenshot from 2023-10-08 15-20-19](https://github.com/ArduPilot/ardupilot/assets/646194/f2262580-d9ea-4d2f-b295-1830cadb5c4b)
