### PR TITLE
Common: Integrate methods for converting hexadecimal characters to numbers

### DIFF
--- a/Tools/AP_Bootloader/flash_from_sd.cpp
+++ b/Tools/AP_Bootloader/flash_from_sd.cpp
@@ -30,7 +30,7 @@ static const uint8_t *flash_base = (const uint8_t *)(0x08000000 + (FLASH_BOOTLOA
  * @param[in] a Hexadecimal character 
  * @return  Returns a binary value
  */
-int16_t char_to_hex(char a)
+uint8_t char_to_hex(char a)
 {
     if (a >= 'A' && a <= 'F')
         return a - 'A' + 10;

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -82,24 +82,7 @@ static uint8_t nibble2hex(uint8_t x)
 
 static uint8_t hex2nibble(char c)
 {
-    // Must go into RAM, not flash, because flash is slow
-    static uint8_t NumConversionTable[] = {
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-    };
-
-    static uint8_t AlphaConversionTable[] = {
-        10, 11, 12, 13, 14, 15
-    };
-
-    uint8_t out = 255;
-
-    if (c >= '0' && c <= '9') {
-        out = NumConversionTable[int(c) - int('0')];
-    } else if (c >= 'a' && c <= 'f') {
-        out = AlphaConversionTable[int(c) - int('a')];
-    } else if (c >= 'A' && c <= 'F') {
-        out = AlphaConversionTable[int(c) - int('A')];
-    }
+    uint8_t out = char_to_hex(c);
 
     if (out == 255) {
         hex2nibble_error = true;

--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -93,9 +93,9 @@ size_t strncpy_noterm(char *dest, const char *src, size_t n)
  * return the numeric value of an ascii hex character
  * 
  * @param[in] a Hexadecimal character 
- * @return  Returns a binary value
+ * @return  Returns a binary value.  If 'a' is not a valid hex character 255 (AKA -1) is returned
  */
-int16_t char_to_hex(char a)
+uint8_t char_to_hex(char a)
 {
     if (a >= 'A' && a <= 'F') {
         return a - 'A' + 10;
@@ -104,5 +104,5 @@ int16_t char_to_hex(char a)
     } else if (a >= '0' && a <= '9') {
         return a - '0';
     }
-    return 0;
+    return 255;
 }

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -169,7 +169,7 @@ bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an asc
 size_t strncpy_noterm(char *dest, const char *src, size_t n);
 
 // return the numeric value of an ascii hex character
-int16_t char_to_hex(char a);
+uint8_t char_to_hex(char a);
 
 /*
   Bit manipulation


### PR DESCRIPTION
It can be integrated by adding a process to detect illegal values to the char_to_hex method of AP_COMMON.
Integration eliminates the need for a numeric table.