### PR TITLE
autotest: don't build examples for fmuv2

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -98,7 +98,7 @@ def build_binaries():
 
 def build_examples(**kwargs):
     """Build examples."""
-    for target in 'fmuv2', 'Pixhawk1', 'navio', 'linux':
+    for target in 'Pixhawk1', 'navio', 'linux':
         print("Running build.examples for %s" % target)
         try:
             util.build_examples(target, **kwargs)


### PR DESCRIPTION
needs extra defines as we kill features from it

Not working on autotest server as AP_Beacon isn't available on this board by default.

