### PR TITLE
gitignore mission.stg (missions on sd card)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ logs/
 mav.log
 mav.log.raw
 mav.parm
+mission.stg
 /defaults.parm
 /ArduCopter/defaults.parm
 /ArduPlane/defaults.parm


### PR DESCRIPTION
gitignore mission.stg (missions on sd card)

This file gets left behind in SITL