### PR TITLE
AP_Scripting: Fix Location desc method needing AHRS

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -15,6 +15,7 @@ userdata Location method offset void float'skip_check float'skip_check
 userdata Location method offset_bearing void float'skip_check float'skip_check
 userdata Location method offset_bearing_and_pitch void float'skip_check float'skip_check float'skip_check
 userdata Location method get_vector_from_origin_NEU boolean Vector3f'Null
+userdata Location method get_vector_from_origin_NEU depends AP_AHRS_ENABLED
 userdata Location method get_bearing float Location
 userdata Location method get_distance_NED Vector3f Location
 userdata Location method get_distance_NE Vector2f Location
@@ -25,6 +26,7 @@ userdata Location method copy Location
 include AP_AHRS/AP_AHRS.h
 
 singleton AP_AHRS rename ahrs
+singleton AP_AHRS depends AP_AHRS_ENABLED
 singleton AP_AHRS semaphore
 singleton AP_AHRS method get_roll float
 singleton AP_AHRS method get_pitch float


### PR DESCRIPTION
This fixes a build error where Scripting is enabled but AHRS is not.. such as AP_Periph

Location::get_vector_from_origin_NEU(Vector3f) is wrapped in AP_AHRS_ENABLED which it needs.
