### PR TITLE
AP_ChibiOS: Delete the same definition

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_bootloader.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_bootloader.h
@@ -27,10 +27,6 @@
 #define HAL_ENABLE_SAVE_PERSISTENT_PARAMS 0
 #endif
 
-#ifndef HAL_GCS_ENABLED
-#define HAL_GCS_ENABLED 0
-#endif
-
 // make diagnosing Faults (e.g. HardFault) harder, but save bytes:
 #ifndef AP_FAULTHANDLER_DEBUG_VARIABLES_ENABLED
 #define AP_FAULTHANDLER_DEBUG_VARIABLES_ENABLED 0


### PR DESCRIPTION
There are two definition judgments for HAL_GCS_ENABLED.
Both are the same.
I would like to remove.