### PR TITLE
AP_ServoRelayEvents: allow mavlink command of rcin scaled functions

### DIFF
--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -44,6 +44,14 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
     case SRV_Channel::k_gripper:
     case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
         break;
+    case SRV_Channel::k_rcin1_mapped ... SRV_Channel::k_rcin16_mapped: {
+        // mapped channels are set up with a -/+ 4500 angle range by
+        // SRV_Channel::aux_servo_function_setup
+        int16_t angle_scaled = constrain_uint16(pwm, 1000, 2000);
+        angle_scaled = (angle_scaled - 1500) * 9; // 1000 ... 2000 -> -500 ... 500 -> -4500 ... 4500
+        pwm = c->pwm_from_scaled_value(angle_scaled);
+        break;
+    }
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
@@ -101,6 +109,14 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     case SRV_Channel::k_gripper:
     case SRV_Channel::k_rcin1 ... SRV_Channel::k_rcin16: // rc pass-thru
         break;
+    case SRV_Channel::k_rcin1_mapped ... SRV_Channel::k_rcin16_mapped: {
+        // mapped channels are set up with a -/+ 4500 angle range by
+        // SRV_Channel::aux_servo_function_setup
+        int16_t angle_scaled = constrain_uint16(_servo_value, 1000, 2000);
+        angle_scaled = (angle_scaled - 1500) * 9; // 1000 ... 2000 -> -500 ... 500 -> -4500 ... 4500
+        _servo_value = c->pwm_from_scaled_value(angle_scaled);
+        break;
+    }
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -201,6 +201,15 @@ uint16_t SRV_Channel::pwm_from_angle(float scaled_value) const
     }
 }
 
+uint16_t SRV_Channel::pwm_from_scaled_value(float scaled_value) const
+{
+    if (type_angle) {
+        return pwm_from_angle(scaled_value);
+    } else {
+        return pwm_from_range(scaled_value);
+    }
+}
+
 void SRV_Channel::calc_pwm(float output_scaled)
 {
     if (have_pwm_mask & (1U<<ch_num)) {
@@ -221,11 +230,7 @@ void SRV_Channel::calc_pwm(float output_scaled)
         return;
     }
 
-    if (type_angle) {
-        output_pwm = pwm_from_angle(output_scaled);
-    } else {
-        output_pwm = pwm_from_range(output_scaled);
-    }
+    output_pwm = pwm_from_scaled_value(output_scaled);
 }
 
 void SRV_Channel::set_output_pwm(uint16_t pwm, bool force)
@@ -240,11 +245,7 @@ void SRV_Channel::set_output_pwm(uint16_t pwm, bool force)
 void SRV_Channel::set_output_norm(float value)
 {
     // convert normalised value to pwm
-    if (type_angle) {
-        set_output_pwm(pwm_from_angle(value * high_out));
-    } else {
-        set_output_pwm(pwm_from_range(value * high_out));
-    }
+    set_output_pwm(pwm_from_scaled_value(value * high_out));
 }
 
 // set angular range of scaled output

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -280,6 +280,9 @@ public:
         return function.configured();
     }
 
+    // convert a scaled value (either range or angle depending on setup) to a pwm
+    uint16_t pwm_from_scaled_value(float scaled_value) const;
+
     // specify that small rc input changes should be ignored during passthrough
     // used by DO_SET_SERVO commands
     void ignore_small_rcin_changes() { ign_small_rcin_changes = true; }


### PR DESCRIPTION
Allow `MAV_CMD_DO_SET_SERVO` and `MAV_CMD_DO_REPEAT_SERVO` to be used on
a servo output set to an RCINnScaled function (i.e. k_rcinN_mapped).

Scaling is applied so that a commanded servo PWM of <=1000 maps to
SERVOn_MIN, a PWM of 1500 maps to SERVOn_TRIM, and a PWM of >=2000 maps to
SERVOn_MAX. Linear interpolation is performed between ranges.

This allows control of servos/hardware with reasonable/safe scaling applied by firmware and allows more functionality from mission scripts.

In our use case we have a variable aperture controlled by a hobby servo for releasing crop seeds. The scaling is controlled by the mechanical geometry and programmed in the autopilot firmware so that SERVOn_MIN is fully closed and SERVOn_MAX is fully open. By setting the servo function to an RC scaled value, we can have straightforward controls from both an RC controller programmed to send 1000-2000 on a knob and mission scripts with that same range without danger of going overrange and damaging the mechanism or servo. This concept should extend logically to many other types of actuators one may wish to attach which don't fall under e.g. camera or sprayer headings.

Tested on SITL (on top of master) and on a real copter (on top of Copter-4.4.1).