### PR TITLE
hwdef: correct compilation of CubeOrange-SimOnHW

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-SimOnHardWare/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-SimOnHardWare/hwdef.dat
@@ -3,6 +3,9 @@
 include ../CubeOrangePlus/hwdef.dat
 include ../include/SimOnHW.inc
 
+undef INS_AUX_INSTANCES
+define INS_AUX_INSTANCES 0
+
 # short board name override (23 chars)
 define CHIBIOS_SHORT_BOARD_NAME "CubeOrange+SimOnHW"
 


### PR DESCRIPTION
../../libraries/AP_InertialSensor/AP_InertialSensor_config.h:20:2: error: #error "INS_AUX_INSTANCES must be zero if INS_MAX_INSTANCES is less than 3"
   20 | #error "INS_AUX_INSTANCES must be zero if INS_MAX_INSTANCES is less than 3"
      |  ^~~~~