### PR TITLE
Copter: auto mode takeoff sends "Reached command" on completion

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -592,7 +592,7 @@ private:
 #endif
     void do_nav_attitude_time(const AP_Mission::Mission_Command& cmd);
 
-    bool verify_takeoff();
+    bool verify_takeoff(const AP_Mission::Mission_Command& cmd);
     bool verify_land();
     bool verify_payload_place();
     bool verify_loiter_unlimited();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -614,6 +614,9 @@ private:
 #endif
     bool verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd);
 
+    // send text to GCS when command completes
+    void sendtext_command_complete(uint16_t cmd_index);
+
     // Loiter control
     uint16_t loiter_time_max;                // How long we should stay in Loiter Mode for mission scripting (time in seconds)
     uint32_t loiter_time;                    // How long have we been loitering - The start time in millis

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2066,7 +2066,7 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
 
     // check if loiter timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        sendtext_command_complete(cmd.index);
         return true;
     }
 
@@ -2149,7 +2149,7 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
             // play a tone
             AP_Notify::events.waypoint_complete = 1;
         }
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        sendtext_command_complete(cmd.index);
         return true;
     }
     return false;
@@ -2186,7 +2186,7 @@ bool ModeAuto::verify_spline_wp(const AP_Mission::Mission_Command& cmd)
 
     // check if timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        sendtext_command_complete(cmd.index);
         return true;
     }
     return false;
@@ -2234,6 +2234,12 @@ bool ModeAuto::verify_nav_script_time()
 bool ModeAuto::verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd)
 {
     return ((AP_HAL::millis() - nav_attitude_time.start_ms) > (cmd.content.nav_attitude_time.time_sec * 1000));
+}
+
+// send text to GCS when command completes
+void ModeAuto::sendtext_command_complete(uint16_t cmd_index)
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached command #%i", cmd_index);
 }
 
 // pause - Prevent aircraft from progressing along the track

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -853,7 +853,7 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
     //
     case MAV_CMD_NAV_VTOL_TAKEOFF:
     case MAV_CMD_NAV_TAKEOFF:
-        cmd_complete = verify_takeoff();
+        cmd_complete = verify_takeoff(cmd);
         break;
 
     case MAV_CMD_NAV_WAYPOINT:
@@ -1970,15 +1970,17 @@ void ModeAuto::do_RTL(void)
 /********************************************************************************/
 
 // verify_takeoff - check if we have completed the takeoff
-bool ModeAuto::verify_takeoff()
+bool ModeAuto::verify_takeoff(const AP_Mission::Mission_Command& cmd)
 {
-#if AP_LANDINGGEAR_ENABLED
     // if we have reached our destination
     if (auto_takeoff_complete) {
+#if AP_LANDINGGEAR_ENABLED
         // retract the landing gear
         copter.landinggear.retract_after_takeoff();
-    }
 #endif
+        // notify user
+        sendtext_command_complete(cmd.index);
+    }
 
     return auto_takeoff_complete;
 }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2060,7 +2060,7 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
     }
 
     // start our loiter timer
-    if ( loiter_time == 0 ) {
+    if (loiter_time == 0) {
         loiter_time = millis();
     }
 
@@ -2130,7 +2130,7 @@ bool ModeAuto::verify_yaw()
 bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
     // check if we have reached the waypoint
-    if ( !copter.wp_nav->reached_wp_destination() ) {
+    if (!copter.wp_nav->reached_wp_destination()) {
         return false;
     }
 
@@ -2175,7 +2175,7 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
 bool ModeAuto::verify_spline_wp(const AP_Mission::Mission_Command& cmd)
 {
     // check if we have reached the waypoint
-    if ( !copter.wp_nav->reached_wp_destination() ) {
+    if (!copter.wp_nav->reached_wp_destination()) {
         return false;
     }
 


### PR DESCRIPTION
This adds a "Reached command" send text when takeoff completes as it does for waypoint and spline commands.

This has been lightly tested in SITL, see screen shot below
![takeoff-sendtext-testing-after](https://github.com/ArduPilot/ardupilot/assets/1498098/786e8b4d-f5db-4f06-95ef-26dfa592e64d)

This was requested from a Partner company that appears to be parsing the send-text although they should perhaps instead be consuming the [MISSION_CURRENT message](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L4429).  In any case, I think this is harmless and because of the code consolidation probably slightly reduces flash.

![mp-mavlink-inspector-missioncurrent](https://github.com/ArduPilot/ardupilot/assets/1498098/9ee8eb48-bfd7-41fa-8236-4b76877c84ba)
