### PR TITLE
Expose Attitude Target Signals to the GCS

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -525,6 +525,7 @@ static const ap_message STREAM_RC_CHANNELS_msgs[] = {
 };
 static const ap_message STREAM_EXTRA1_msgs[] = {
     MSG_ATTITUDE,
+    MSG_ATTITUDE_TARGET,
     MSG_SIMSTATE,
     MSG_AHRS2,
     MSG_PID_TUNING // Up to four PID_TUNING messages are sent, depending on GCS_PID_MASK parameter


### PR DESCRIPTION
Add MSG_ATTITUDE_TARGET to the message stream.

Might be useful for external in-flight PID tuning desktop applications (or eg. a plugin for the Mission Planner).