### PR TITLE
AP_BattMonitor: DroneCAN: always have consumed energy

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -157,7 +157,6 @@ void AP_BattMonitor_DroneCAN::handle_battery_info_aux(const ardupilot_equipment_
 
     _has_cell_voltages = true;
     _has_time_remaining = true;
-    _has_consumed_energy = true;
     _has_battery_info_aux = true;
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.h
@@ -35,7 +35,8 @@ public:
 
     bool has_current() const override { return true; }
 
-    bool has_consumed_energy() const override { return _has_consumed_energy; }
+    // Always have consumed energy, either directly from BatteryInfoAux msg or by cumulative current draw
+    bool has_consumed_energy() const override { return true; }
 
     bool has_time_remaining() const override { return _has_time_remaining; }
 
@@ -99,7 +100,6 @@ private:
     bool _has_temperature;
     bool _has_cell_voltages;
     bool _has_time_remaining;
-    bool _has_consumed_energy;
     bool _has_battery_info_aux;
     uint8_t _instance;                  // instance of this battery monitor
 


### PR DESCRIPTION
If we do not receive consumed energy directly it is already calculated from current draw.

https://github.com/ArduPilot/ardupilot/blob/fcd4152b30aa1f50b110303e7cae1f9f35f5e645/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp#L129-L134

This just changes to report true for the "manually" calculated case.