### PR TITLE
AC_Fence: Add a value for OUTSIDE FENCE

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -350,7 +350,9 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
 
     // check no limits are currently breached
     if (_breached_fences) {
-        fail_msg =  "vehicle outside fence";
+        static char msg[25];
+        hal.util->snprintf(msg, sizeof(msg), "vehicle outside fence %d", _breached_fences);
+        fail_msg =  msg;
         return false;
     }
 


### PR DESCRIPTION
It is notified as OUTSIDE FENCE.
There are multiple fences.
I checked the config parameters for each of them.
I could facilitate the parameter check by notifying the fence determination result value.

AFTER
![Screenshot from 2023-10-14 08-29-01](https://github.com/ArduPilot/ardupilot/assets/646194/5347c9bb-58d5-4f60-9533-ba4cadeb8bdc)

BEFORE
![Screenshot from 2023-10-14 08-16-16](https://github.com/ArduPilot/ardupilot/assets/646194/fcdcf7f3-02eb-48bf-86da-5e3bae7c30c1)

