### PR TITLE
hwdef: Cite CubeOrange-SimOnHW as the default file

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-SimOnHardWare/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-SimOnHardWare/defaults.parm
@@ -1,1 +1,1 @@
-@include ../CubeOrangePlus/defaults.parm
+@include ../CubeOrange-SimOnHardWare/defaults.parm


### PR DESCRIPTION
I implemented SimOnHW with CUBE ORANGE PLUS.
I received a "PreArm: 3D Accel Calibration needed" message.
I got advice from ArduPilot member Petter.
I quoted "CubeOrange-SimOnHardWare/defaults.parm" in INCLUDE.

Petter's advice:
Compare libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-SimOnHardWare/defaults.parm and libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus- SimOnHardWare/defaults.parm - the latter should look much like the former. So whoever created the CubeOrangePlus one forgot a step. Try copying the CubeOrange-SimOnHW defaults.parm over the CubeOrangePlus-SimOnHardWare defaults.parm and recompile/flash


AFTER
![Screenshot from 2023-10-14 08-16-16](https://github.com/ArduPilot/ardupilot/assets/646194/16964c87-96c1-4f34-8ac3-dc915ba18a10)

BEFORE
![Screenshot from 2023-10-14 07-20-49](https://github.com/ArduPilot/ardupilot/assets/646194/441e7616-e6eb-456c-848d-b74110bf27cc)