### PR TITLE
Plane:reset in landing seq on mode change while disarmed

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -125,6 +125,13 @@ bool Mode::enter()
         // but it should be harmless to disable the fence temporarily in these situations as well
         plane.fence.manual_recovery_start();
 #endif
+        //reset mission if in landing sequence, disarmed, not flying, and have changed to a non-autothrottle mode to clear prearm
+        if (plane.mission.get_in_landing_sequence_flag() &&
+            !plane.is_flying() && !plane.arming.is_armed_and_safety_off() &&
+            !plane.control_mode->does_auto_navigation()) {
+           GCS_SEND_TEXT(MAV_SEVERITY_INFO, "In landing sequence: mission reset");
+           plane.mission.reset();
+        }
     }
 
     return enter_result;


### PR DESCRIPTION
if you lose rc or accidentally change mode to rtl while disarmed on the ground with a DO_LAND_START setup you will prevented from arming when rc is restored or mode changed,if you dont have a gcs to reset the mission ...unless you power cycle

this will reset the mission to allow arming on non-autothrottle mode entry IF.....in landing sequence, disarmed, and not flying

tested in SITL