### PR TITLE
Global: Replace with GCS_SEND_TEXT

### DIFF
--- a/AntennaTracker/mode_guided.cpp
+++ b/AntennaTracker/mode_guided.cpp
@@ -11,7 +11,7 @@ void ModeGuided::update()
     _target_att.to_euler(target_roll, target_pitch, target_yaw);
     if (now - last_debug > 5000) {
         last_debug = now;
-        gcs().send_text(MAV_SEVERITY_INFO, "target_yaw=%f target_pitch=%f", degrees(target_yaw), degrees(target_pitch));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "target_yaw=%f target_pitch=%f", degrees(target_yaw), degrees(target_pitch));
     }
     calc_angle_error(degrees(target_pitch)*100, degrees(target_yaw)*100, false);
     float bf_pitch;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -73,7 +73,7 @@ void Tracker::init_ardupilot()
         current_loc.lat = g.start_latitude * 1.0e7f;
         current_loc.lng = g.start_longitude * 1.0e7f;
     } else {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Ignoring invalid START_LATITUDE or START_LONGITUDE parameter");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Ignoring invalid START_LATITUDE or START_LONGITUDE parameter");
     }
 
     // see if EEPROM has a default location as well

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -708,7 +708,7 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Arming motors");
 #endif
 
     // Remember Orientation
@@ -800,7 +800,7 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Disarming motors");
 #endif
 
     auto &ahrs = AP::ahrs();

--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -25,17 +25,17 @@ void Copter::set_simple_mode(SimpleMode b)
         switch (b) {
             case SimpleMode::NONE:
                 AP::logger().Write_Event(LogEvent::SET_SIMPLE_OFF);
-                gcs().send_text(MAV_SEVERITY_INFO, "SIMPLE mode off");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIMPLE mode off");
                 break;
             case SimpleMode::SIMPLE:
                 AP::logger().Write_Event(LogEvent::SET_SIMPLE_ON);
-                gcs().send_text(MAV_SEVERITY_INFO, "SIMPLE mode on");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIMPLE mode on");
                 break;
             case SimpleMode::SUPERSIMPLE:
                 // initialise super simple heading
                 update_super_simple_bearing(true);
                 AP::logger().Write_Event(LogEvent::SET_SUPERSIMPLE_ON);
-                gcs().send_text(MAV_SEVERITY_INFO, "SUPERSIMPLE mode on");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SUPERSIMPLE mode on");
                 break;
         }
         simple_mode = b;

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -541,12 +541,12 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
                 case AuxSwitchPos::HIGH:
                     copter.standby_active = true;
                     AP::logger().Write_Event(LogEvent::STANDBY_ENABLE);
-                    gcs().send_text(MAV_SEVERITY_INFO, "Stand By Enabled");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Stand By Enabled");
                     break;
                 default:
                     copter.standby_active = false;
                     AP::logger().Write_Event(LogEvent::STANDBY_DISABLE);
-                    gcs().send_text(MAV_SEVERITY_INFO, "Stand By Disabled");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Stand By Disabled");
                     break;
                 }
             break;
@@ -607,7 +607,7 @@ bool RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const AuxSwi
         case AUX_FUNC::SIMPLE_HEADING_RESET:
             if (ch_flag == AuxSwitchPos::HIGH) {
                 copter.init_simple_bearing();
-                gcs().send_text(MAV_SEVERITY_INFO, "Simple heading reset");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Simple heading reset");
             }
             break;
 
@@ -684,7 +684,7 @@ void Copter::save_trim()
     float pitch_trim = ToRad((float)channel_pitch->get_control_in()/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     AP::logger().Write_Event(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Trim saved");
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions
@@ -693,7 +693,7 @@ void Copter::auto_trim_cancel()
 {
     auto_trim_counter = 0;
     AP_Notify::flags.save_trim = false;
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim cancelled");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim cancelled");
 }
 
 void Copter::auto_trim()
@@ -737,7 +737,7 @@ void Copter::auto_trim()
         // on last iteration restore leds and accel gains to normal
         if (auto_trim_counter == 0) {
             AP_Notify::flags.save_trim = false;
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim: Trims saved");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim: Trims saved");
         }
     }
 }

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -90,7 +90,7 @@ void Copter::crash_check()
     if (crash_counter >= (CRASH_CHECK_TRIGGER_SEC * scheduler.get_loop_rate_hz())) {
         AP::logger().Write_Error(LogErrorSubsystem::CRASH_CHECK, LogErrorCode::CRASH_CHECK_CRASH);
         // send message to gcs
-        gcs().send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming: AngErr=%.0f>%.0f, Accel=%.1f<%.1f", angle_error, CRASH_CHECK_ANGLE_DEVIATION_DEG, filtered_acc, CRASH_CHECK_ACCEL_MAX);
+        GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY,"Crash: Disarming: AngErr=%.0f>%.0f, Accel=%.1f<%.1f", angle_error, CRASH_CHECK_ANGLE_DEVIATION_DEG, filtered_acc, CRASH_CHECK_ACCEL_MAX);
         // disarm motors
         copter.arming.disarm(AP_Arming::Method::CRASH);
     }
@@ -165,7 +165,7 @@ void Copter::thrust_loss_check()
         thrust_loss_counter = 0;
         AP::logger().Write_Error(LogErrorSubsystem::THRUST_LOSS_CHECK, LogErrorCode::FAILSAFE_OCCURRED);
         // send message to gcs
-        gcs().send_text(MAV_SEVERITY_EMERGENCY, "Potential Thrust Loss (%d)", (int)motors->get_lost_motor() + 1);
+        GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Potential Thrust Loss (%d)", (int)motors->get_lost_motor() + 1);
         // enable thrust loss handling
         motors->set_thrust_boost(true);
         // the motors library disables this when it is no longer needed to achieve the commanded output
@@ -224,7 +224,7 @@ void Copter::yaw_imbalance_check()
         const uint32_t now = millis();
         if (now - last_yaw_warn_ms > YAW_IMBALANCE_WARN_MS) {
             last_yaw_warn_ms = now;
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.0f%%", I *100);
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.0f%%", I *100);
         }
     }
 }
@@ -356,7 +356,7 @@ void Copter::parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if (ap.land_complete) {
         // warn user of reason for failure
-        gcs().send_text(MAV_SEVERITY_INFO,"Parachute: Landed");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Parachute: Landed");
         AP::logger().Write_Error(LogErrorSubsystem::PARACHUTES, LogErrorCode::PARACHUTE_LANDED);
         return;
     }
@@ -364,7 +364,7 @@ void Copter::parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if ((parachute.alt_min() != 0 && (current_loc.alt < (int32_t)parachute.alt_min() * 100))) {
         // warn user of reason for failure
-        gcs().send_text(MAV_SEVERITY_ALERT,"Parachute: Too low");
+        GCS_SEND_TEXT(MAV_SEVERITY_ALERT,"Parachute: Too low");
         AP::logger().Write_Error(LogErrorSubsystem::PARACHUTES, LogErrorCode::PARACHUTE_TOO_LOW);
         return;
     }

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -83,7 +83,7 @@ void Copter::ekf_check()
                 AP::logger().Write_Error(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();
@@ -191,7 +191,7 @@ void Copter::failsafe_ekf_event()
 
     // set true if ekf action is triggered
     AP_Notify::flags.failsafe_ekf = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe: changed to %s Mode", flightmode->name());
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF Failsafe: changed to %s Mode", flightmode->name());
 }
 
 // failsafe_ekf_off_event - actions to take when EKF failsafe is cleared
@@ -205,7 +205,7 @@ void Copter::failsafe_ekf_off_event(void)
     failsafe.ekf = false;
     if (AP_Notify::flags.failsafe_ekf) {
         AP_Notify::flags.failsafe_ekf = false;
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe Cleared");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF Failsafe Cleared");
     }
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_RESOLVED);
 }
@@ -240,7 +240,7 @@ void Copter::check_ekf_reset()
         attitude_control->inertial_frame_reset();
         ekf_primary_core = ahrs.get_primary_core_index();
         AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }
 }
 
@@ -286,7 +286,7 @@ void Copter::check_vibration()
             vibration_check.high_vibes = true;
             pos_control->set_vibe_comp(true);
             AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_VIBE, LogErrorCode::FAILSAFE_OCCURRED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Vibration compensation ON");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Vibration compensation ON");
         }
     } else {
         // initialise timer
@@ -301,7 +301,7 @@ void Copter::check_vibration()
             pos_control->set_vibe_comp(false);
             vibration_check.clear_ms = 0;
             AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_VIBE, LogErrorCode::FAILSAFE_RESOLVED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Vibration compensation OFF");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Vibration compensation OFF");
         }
     }
 

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -39,7 +39,7 @@ void Copter::esc_calibration_startup_check()
                 // we will enter esc_calibrate mode on next reboot
                 g.esc_calibrate.set_and_save(ESCCalibrationModes::ESCCAL_PASSTHROUGH_IF_THROTTLE_HIGH);
                 // send message to gcs
-                gcs().send_text(MAV_SEVERITY_CRITICAL,"ESC calibration: Restart board");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"ESC calibration: Restart board");
                 // turn on esc calibration notification
                 AP_Notify::flags.esc_calibration = true;
                 // block until we restart
@@ -79,7 +79,7 @@ void Copter::esc_calibration_passthrough()
 {
 #if FRAME_CONFIG != HELI_FRAME
     // send message to GCS
-    gcs().send_text(MAV_SEVERITY_INFO,"ESC calibration: Passing pilot throttle to ESCs");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"ESC calibration: Passing pilot throttle to ESCs");
 
     esc_calibration_setup();
 
@@ -107,7 +107,7 @@ void Copter::esc_calibration_auto()
 {
 #if FRAME_CONFIG != HELI_FRAME
     // send message to GCS
-    gcs().send_text(MAV_SEVERITY_INFO,"ESC calibration: Auto calibration");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"ESC calibration: Auto calibration");
 
     esc_calibration_setup();
 
@@ -169,7 +169,7 @@ void Copter::esc_calibration_setup()
     while (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         const uint32_t tnow = AP_HAL::millis();
         if (tnow - tstart >= 5000) {
-            gcs().send_text(MAV_SEVERITY_INFO,"ESC calibration: Push safety switch");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"ESC calibration: Push safety switch");
             tstart = tnow;
         }
         esc_calibration_notify();

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -84,15 +84,15 @@ void Copter::failsafe_radio_off_event()
     // no need to do anything except log the error as resolved
     // user can now override roll, pitch, yaw and throttle and even use flight mode switch to restore previous flight mode
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_RADIO, LogErrorCode::FAILSAFE_RESOLVED);
-    gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe Cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio Failsafe Cleared");
 }
 
 void Copter::announce_failsafe(const char *type, const char *action_undertaken)
 {
     if (action_undertaken != nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe - %s", type, action_undertaken);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Failsafe - %s", type, action_undertaken);
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe", type);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Failsafe", type);
     }
 }
 
@@ -235,7 +235,7 @@ void Copter::failsafe_gcs_on_event(void)
 // failsafe_gcs_off_event - actions to take when GCS contact is restored
 void Copter::failsafe_gcs_off_event(void)
 {
-    gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe Cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "GCS Failsafe Cleared");
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_GCS, LogErrorCode::FAILSAFE_RESOLVED);
 }
 
@@ -281,7 +281,7 @@ void Copter::failsafe_terrain_set_status(bool data_ok)
 void Copter::failsafe_terrain_on_event()
 {
     failsafe.terrain = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing");
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_TERRAIN, LogErrorCode::FAILSAFE_OCCURRED);
 
     if (should_disarm_on_failsafe()) {
@@ -307,10 +307,10 @@ void Copter::gpsglitch_check()
         ap.gps_glitching = gps_glitching;
         if (gps_glitching) {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::GPS_GLITCH);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"GPS Glitch or Compass error");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"GPS Glitch or Compass error");
         } else {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::ERROR_RESOLVED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"Glitch cleared");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Glitch cleared");
         }
     }
 }
@@ -330,11 +330,11 @@ void Copter::failsafe_deadreckon_check()
         dead_reckoning.active = ekf_dead_reckoning;
         if (dead_reckoning.active) {
             dead_reckoning.start_ms = now_ms;
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"%s started", dr_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"%s started", dr_prefix_str);
         } else {
             dead_reckoning.start_ms = 0;
             dead_reckoning.timeout = false;
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"%s stopped", dr_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"%s stopped", dr_prefix_str);
         }
     }
 
@@ -343,7 +343,7 @@ void Copter::failsafe_deadreckon_check()
         const uint32_t dr_timeout_ms = uint32_t(constrain_float(g2.failsafe_dr_timeout * 1000.0f, 0.0f, UINT32_MAX));
         if (now_ms - dead_reckoning.start_ms > dr_timeout_ms) {
             dead_reckoning.timeout = true;
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"%s timeout", dr_prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"%s timeout", dr_prefix_str);
         }
     }
 
@@ -395,7 +395,7 @@ void Copter::set_mode_SmartRTL_or_land_with_pause(ModeReason reason)
 {
     // attempt to switch to SMART_RTL, if this failed then switch to Land
     if (!set_mode(Mode::Number::SMART_RTL, reason)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Using Land Mode");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Using Land Mode");
         set_mode_land_with_pause(reason);
     } else {
         AP_Notify::events.failsafe_mode_change = 1;
@@ -409,7 +409,7 @@ void Copter::set_mode_SmartRTL_or_RTL(ModeReason reason)
     // attempt to switch to SmartRTL, if this failed then attempt to RTL
     // if that fails, then land
     if (!set_mode(Mode::Number::SMART_RTL, reason)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Trying RTL Mode");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Trying RTL Mode");
         set_mode_RTL_or_land_with_pause(reason);
     } else {
         AP_Notify::events.failsafe_mode_change = 1;
@@ -427,7 +427,7 @@ void Copter::set_mode_auto_do_land_start_or_RTL(ModeReason reason)
     }
 #endif
 
-    gcs().send_text(MAV_SEVERITY_WARNING, "Trying RTL Mode");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Trying RTL Mode");
     set_mode_RTL_or_land_with_pause(reason);
 }
 
@@ -442,7 +442,7 @@ void Copter::set_mode_brake_or_land_with_pause(ModeReason reason)
     }
 #endif
 
-    gcs().send_text(MAV_SEVERITY_WARNING, "Trying Land Mode");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Trying Land Mode");
     set_mode_land_with_pause(reason);
 }
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -186,7 +186,7 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
 // called when an attempt to change into a mode is unsuccessful:
 void Copter::mode_change_failed(const Mode *mode, const char *reason)
 {
-    gcs().send_text(MAV_SEVERITY_WARNING, "Mode change to %s failed: %s", mode->name(), reason);
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change to %s failed: %s", mode->name(), reason);
     AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode->mode_number()));
     // make sad noise
     if (copter.ap.initialised) {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -26,7 +26,7 @@ bool ModeAuto::init(bool ignore_checks)
     if (mission.num_commands() > 1 || ignore_checks) {
         // reject switching to auto mode if landed with motors armed but first command is not a takeoff (reduce chance of flips)
         if (motors->armed() && copter.ap.land_complete && !mission.starts_with_takeoff_cmd()) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: Missing Takeoff Cmd");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto: Missing Takeoff Cmd");
             return false;
         }
 
@@ -99,10 +99,10 @@ void ModeAuto::run()
             // if mission is running restart the current command if it is a waypoint or spline command
             if ((mission.state() == AP_Mission::MISSION_RUNNING) && (_mode == SubMode::WP)) {
                 if (mission.restart_current_nav_cmd()) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
                 } else {
                     // failed to restart mission for some reason
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
                 }
             }
         }
@@ -226,9 +226,9 @@ bool ModeAuto::jump_to_landing_sequence_auto_RTL(ModeReason reason)
         // mode change failed, revert force resume flag
         mission.set_force_resume(false);
 
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change to AUTO RTL failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change to AUTO RTL failed");
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change to AUTO RTL failed: No landing sequence found");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change to AUTO RTL failed: No landing sequence found");
     }
 
     AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(Number::AUTO_RTL));
@@ -711,10 +711,10 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
 #if AP_FENCE_ENABLED
         if (cmd.p1 == 0) { //disable
             copter.fence.enable(false);
-            gcs().send_text(MAV_SEVERITY_INFO, "Fence Disabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fence Disabled");
         } else { //enable fence
             copter.fence.enable(true);
-            gcs().send_text(MAV_SEVERITY_INFO, "Fence Enabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fence Enabled");
         }
 #endif //AP_FENCE_ENABLED
         break;
@@ -941,7 +941,7 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 
     default:
         // error message
-        gcs().send_text(MAV_SEVERITY_WARNING,"Skipping invalid cmd #%i",cmd.id);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Skipping invalid cmd #%i",cmd.id);
         // return true if we do not recognize the command so that we move on to the next command
         cmd_complete = true;
         break;
@@ -1189,7 +1189,7 @@ void ModeAuto::payload_place_run()
             // do nothing on this loop
             break;
         case PayloadPlaceStateType_Descent:
-            gcs().send_text(MAV_SEVERITY_INFO, "%s landed", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s landed", prefix_str);
             nav_payload_place.state = PayloadPlaceStateType_Release;
             break;
         case PayloadPlaceStateType_Release:
@@ -1209,11 +1209,11 @@ void ModeAuto::payload_place_run()
         case PayloadPlaceStateType_FlyToLocation:
         case PayloadPlaceStateType_Descent_Start:
             set_submode(SubMode::NAV_PAYLOAD_PLACE);
-            gcs().send_text(MAV_SEVERITY_INFO, "%s Manual release", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Manual release", prefix_str);
             nav_payload_place.state = PayloadPlaceStateType_Done;
             break;
         case PayloadPlaceStateType_Descent:
-            gcs().send_text(MAV_SEVERITY_INFO, "%s Manual release", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Manual release", prefix_str);
             nav_payload_place.state = PayloadPlaceStateType_Release;
             break;
         case PayloadPlaceStateType_Release:
@@ -1248,7 +1248,7 @@ void ModeAuto::payload_place_run()
         if (!is_zero(nav_payload_place.descent_max_cm) &&
             nav_payload_place.descent_start_altitude_cm - inertial_nav.get_position_z_up_cm() > nav_payload_place.descent_max_cm) {
             nav_payload_place.state = PayloadPlaceStateType_Ascent_Start;
-            gcs().send_text(MAV_SEVERITY_WARNING, "%s Reached maximum descent", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Reached maximum descent", prefix_str);
             break;
         }
         // calibrate the decent thrust after aircraft has reached constant decent rate and release if threshold is reached
@@ -1269,7 +1269,7 @@ void ModeAuto::payload_place_run()
             if (!copter.rangefinder_state.enabled) {
                 // abort payload place because rangefinder is not enabled
                 nav_payload_place.state = PayloadPlaceStateType_Ascent_Start;
-                gcs().send_text(MAV_SEVERITY_WARNING, "%s PLDP_RNG_MIN set and rangefinder not enabled", prefix_str);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s PLDP_RNG_MIN set and rangefinder not enabled", prefix_str);
                 break;
             } else if (copter.rangefinder_alt_ok() && (copter.rangefinder_state.glitch_count == 0) && (copter.rangefinder_state.alt_cm > g2.pldp_range_finder_minimum_m * 100.0)) {
                 // range finder altitude is above minimum
@@ -1289,7 +1289,7 @@ void ModeAuto::payload_place_run()
 
         if (now_ms - nav_payload_place.place_start_time_ms > placed_check_duration_ms) {
             nav_payload_place.state = PayloadPlaceStateType_Release;
-            gcs().send_text(MAV_SEVERITY_INFO, "%s payload release thrust threshold: %f", prefix_str, static_cast<double>(g2.pldp_thrust_placed_fraction * nav_payload_place.descent_thrust_level));
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s payload release thrust threshold: %f", prefix_str, static_cast<double>(g2.pldp_thrust_placed_fraction * nav_payload_place.descent_thrust_level));
         }
         break;
 
@@ -1298,7 +1298,7 @@ void ModeAuto::payload_place_run()
         pos_control->init_z_controller_no_descent();
 #if AP_GRIPPER_ENABLED == ENABLED
         if (g2.gripper.valid()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "%s Releasing the gripper", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Releasing the gripper", prefix_str);
             g2.gripper.release();
             nav_payload_place.state = PayloadPlaceStateType_Releasing;
         } else {
@@ -1567,7 +1567,7 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
             // use current alt-above-home and report error
             target_loc.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
             AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Land: no terrain data, using alt-above-home");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Land: no terrain data, using alt-above-home");
         }
 
         if (!wp_start(target_loc)) {
@@ -1673,7 +1673,7 @@ void ModeAuto::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
     if (!target_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, loiter_to_alt.alt)) {
         loiter_to_alt.reached_destination_xy = true;
         loiter_to_alt.reached_alt = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "bad do_loiter_to_alt");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "bad do_loiter_to_alt");
         return;
     }
     loiter_to_alt.reached_destination_xy = false;
@@ -1788,7 +1788,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max_ms = 0;
 #endif
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 #if AP_SCRIPTING_ENABLED
@@ -1942,7 +1942,7 @@ void ModeAuto::do_payload_place(const AP_Mission::Mission_Command& cmd)
             // use current alt-above-home and report error
             target_loc.set_alt_cm(copter.current_loc.alt, Location::AltFrame::ABOVE_HOME);
             AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PayloadPlace: no terrain data, using alt-above-home");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PayloadPlace: no terrain data, using alt-above-home");
         }
         if (!wp_start(target_loc)) {
             // failure to set next destination can only be because of missing terrain data
@@ -2066,7 +2066,7 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
 
     // check if loiter timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }
 
@@ -2149,7 +2149,7 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
             // play a tone
             AP_Notify::events.waypoint_complete = 1;
         }
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }
     return false;
@@ -2186,7 +2186,7 @@ bool ModeAuto::verify_spline_wp(const AP_Mission::Mission_Command& cmd)
 
     // check if timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }
     return false;

--- a/ArduCopter/mode_autorotate.cpp
+++ b/ArduCopter/mode_autorotate.cpp
@@ -26,13 +26,13 @@ bool ModeAutorotate::init(bool ignore_checks)
 
     // Check that mode is enabled
     if (!g2.arot.is_enable()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Autorot Mode Not Enabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Autorot Mode Not Enabled");
         return false;
     }
 
     // Check that interlock is disengaged
     if (motors->get_interlock()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Autorot Mode Change Fail: Interlock Engaged");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Autorot Mode Change Fail: Interlock Engaged");
         return false;
     }
 
@@ -45,7 +45,7 @@ bool ModeAutorotate::init(bool ignore_checks)
     _initial_rpm = g2.arot.get_rpm(true);
 
     // Display message 
-    gcs().send_text(MAV_SEVERITY_INFO, "Autorotation initiated");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Autorotation initiated");
 
      // Set all intial flags to on
     _flags.entry_initial = 1;
@@ -117,7 +117,7 @@ void ModeAutorotate::run()
             if (_flags.entry_initial == 1) {
 
                 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "Entry Phase");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Entry Phase");
                 #endif
 
                 // Set following trim low pass cut off frequency
@@ -163,7 +163,7 @@ void ModeAutorotate::run()
             if (_flags.ss_glide_initial == 1) {
 
                 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "SS Glide Phase");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SS Glide Phase");
                 #endif
 
                 // Set following trim low pass cut off frequency
@@ -206,7 +206,7 @@ void ModeAutorotate::run()
                 // Functions and settings to be done once are done here.
 
                 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "Bailing Out of Autorotation");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Bailing Out of Autorotation");
                 #endif
 
                 // Set bail out timer remaining equal to the parameter value, bailout time 
@@ -311,8 +311,8 @@ void ModeAutorotate::warning_message(uint8_t message_n)
         {
             if (_msg_flags.bad_rpm) {
                 // Bad rpm sensor health.
-                gcs().send_text(MAV_SEVERITY_INFO, "Warning: Poor RPM Sensor Health");
-                gcs().send_text(MAV_SEVERITY_INFO, "Action: Minimum Collective Applied");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Warning: Poor RPM Sensor Health");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Action: Minimum Collective Applied");
                 _msg_flags.bad_rpm = false;
             }
             break;

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -17,7 +17,7 @@
 bool ModeFollow::init(const bool ignore_checks)
 {
     if (!g2.follow.enabled()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Set FOLL_ENABLE = 1");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Set FOLL_ENABLE = 1");
         return false;
     }
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -43,7 +43,7 @@ void ModeRTL::restart_without_terrain()
     terrain_following_allowed = false;
     _state = SubMode::STARTING;
     _state_complete = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
 }
 
 ModeRTL::RTLAltType ModeRTL::get_alt_type() const
@@ -133,7 +133,7 @@ void ModeRTL::climb_start()
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
         // this should not happen because rtl_build_path will have checked terrain data was available
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
         return;
@@ -426,7 +426,7 @@ void ModeRTL::compute_return_target()
         case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
             alt_type = ReturnTargetAltType::RELATIVE;
             AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RTL_MISSING_RNGFND);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
             break;
         case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
             alt_type = ReturnTargetAltType::RANGEFINDER;
@@ -445,7 +445,7 @@ void ModeRTL::compute_return_target()
         } else {
             // fallback to relative alt and warn user
             alt_type = ReturnTargetAltType::RELATIVE;
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: rangefinder unhealthy, using alt-above-home");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "RTL: rangefinder unhealthy, using alt-above-home");
             AP::logger().Write_Error(LogErrorSubsystem::NAVIGATION, LogErrorCode::RTL_MISSING_RNGFND);
         }
     }
@@ -463,7 +463,7 @@ void ModeRTL::compute_return_target()
             // fallback to relative alt and warn user
             alt_type = ReturnTargetAltType::RELATIVE;
             AP::logger().Write_Error(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "RTL: no terrain data, using alt-above-home");
         }
     }
 
@@ -472,7 +472,7 @@ void ModeRTL::compute_return_target()
         if (!rtl_path.return_target.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
             // this should never happen but just in case
             rtl_path.return_target.set_alt_cm(0, Location::AltFrame::ABOVE_HOME);
-            gcs().send_text(MAV_SEVERITY_WARNING, "RTL: unexpected error calculating target alt");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RTL: unexpected error calculating target alt");
         }
     }
 

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -76,7 +76,7 @@ bool ModeSystemId::init(bool ignore_checks)
 {
     // check if enabled
     if (axis == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "No axis selected, SID_AXIS = 0");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "No axis selected, SID_AXIS = 0");
         return false;
     }
 
@@ -97,7 +97,7 @@ bool ModeSystemId::init(bool ignore_checks)
 
     chirp_input.init(time_record, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
 
-    gcs().send_text(MAV_SEVERITY_INFO, "SystemID Starting: axis=%d", (unsigned)axis);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Starting: axis=%d", (unsigned)axis);
 
     copter.Log_Write_SysID_Setup(axis, waveform_magnitude, frequency_start, frequency_stop, time_fade_in, time_const_freq, time_record, time_fade_out);
 
@@ -177,7 +177,7 @@ void ModeSystemId::run()
     if ((systemid_state == SystemIDModeState::SYSTEMID_STATE_TESTING) &&
         (!is_positive(frequency_start) || !is_positive(frequency_stop) || is_negative(time_fade_in) || !is_positive(time_record) || is_negative(time_fade_out) || (time_record <= time_const_freq))) {
         systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;
-        gcs().send_text(MAV_SEVERITY_INFO, "SystemID Parameter Error");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Parameter Error");
     }
 
     waveform_time += G_Dt;
@@ -192,24 +192,24 @@ void ModeSystemId::run()
 
             if (copter.ap.land_complete) {
                 systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;
-                gcs().send_text(MAV_SEVERITY_INFO, "SystemID Stopped: Landed");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Stopped: Landed");
                 break;
             }
             if (attitude_control->lean_angle_deg()*100 > attitude_control->lean_angle_max_cd()) {
                 systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;
-                gcs().send_text(MAV_SEVERITY_INFO, "SystemID Stopped: lean=%f max=%f", (double)attitude_control->lean_angle_deg(), (double)attitude_control->lean_angle_max_cd());
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Stopped: lean=%f max=%f", (double)attitude_control->lean_angle_deg(), (double)attitude_control->lean_angle_max_cd());
                 break;
             }
             if (waveform_time > SYSTEM_ID_DELAY + time_fade_in + time_const_freq + time_record + time_fade_out) {
                 systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;
-                gcs().send_text(MAV_SEVERITY_INFO, "SystemID Finished");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Finished");
                 break;
             }
 
             switch ((AxisType)axis.get()) {
                 case AxisType::NONE:
                     systemid_state = SystemIDModeState::SYSTEMID_STATE_STOPPED;
-                    gcs().send_text(MAV_SEVERITY_INFO, "SystemID Stopped: axis = 0");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SystemID Stopped: axis = 0");
                     break;
                 case AxisType::INPUT_ROLL:
                     target_roll += waveform_sample*100.0f;

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -47,11 +47,11 @@ void ModeThrow::run()
         stage = Throw_Disarmed;
 
     } else if (stage == Throw_Disarmed && motors->armed()) {
-        gcs().send_text(MAV_SEVERITY_INFO,"waiting for throw");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"waiting for throw");
         stage = Throw_Detecting;
 
     } else if (stage == Throw_Detecting && throw_detected()){
-        gcs().send_text(MAV_SEVERITY_INFO,"throw detected - spooling motors");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"throw detected - spooling motors");
         copter.set_land_complete(false);
         stage = Throw_Wait_Throttle_Unlimited;
 
@@ -60,10 +60,10 @@ void ModeThrow::run()
 
     } else if (stage == Throw_Wait_Throttle_Unlimited &&
                motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
-        gcs().send_text(MAV_SEVERITY_INFO,"throttle is unlimited - uprighting");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"throttle is unlimited - uprighting");
         stage = Throw_Uprighting;
     } else if (stage == Throw_Uprighting && throw_attitude_good()) {
-        gcs().send_text(MAV_SEVERITY_INFO,"uprighted - controlling height");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"uprighted - controlling height");
         stage = Throw_HgtStabilise;
 
         // initialise the z controller
@@ -81,7 +81,7 @@ void ModeThrow::run()
         copter.set_auto_armed(true);
 
     } else if (stage == Throw_HgtStabilise && throw_height_good()) {
-        gcs().send_text(MAV_SEVERITY_INFO,"height achieved - controlling position");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"height achieved - controlling position");
         stage = Throw_PosHold;
 
         // initialise position controller

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -173,7 +173,7 @@ void ModeTurtle::output_to_motors()
     if (is_zero(channel_throttle->norm_input_dz())) {
         const uint32_t now = AP_HAL::millis();
         if (now - last_throttle_warning_output_ms > 5000) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Turtle: raise throttle to arm");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Turtle: raise throttle to arm");
             last_throttle_warning_output_ms = now;
         }
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -170,12 +170,12 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
             if (ab_dest == Destination::A) {
                 // store point A
                 dest_A = curr_pos;
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: point A stored");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: point A stored");
                 AP::logger().Write_Event(LogEvent::ZIGZAG_STORE_A);
             } else {
                 // store point B
                 dest_B = curr_pos;
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: point B stored");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: point B stored");
                 AP::logger().Write_Event(LogEvent::ZIGZAG_STORE_B);
             }
             // if both A and B have been stored advance state
@@ -203,10 +203,10 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
                     spray(true);
                     reach_wp_time_ms = 0;
                     if (is_auto == false || line_num == ZIGZAG_LINE_INFINITY) {
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
+                        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: moving to %s", (ab_dest == Destination::A) ? "A" : "B");
                     } else {
                         line_count++;
-                        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s (line %d/%d)", (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
+                        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: moving to %s (line %d/%d)", (ab_dest == Destination::A) ? "A" : "B", line_count, line_num);
                     }
                 }
             }
@@ -228,7 +228,7 @@ void ModeZigZag::move_to_side()
                 current_terr_alt = terr_alt;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }
         }
     }
@@ -251,7 +251,7 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
             loiter_nav->init_target();
         }
         is_auto = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: manual control");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: manual control");
     }
 }
 
@@ -542,7 +542,7 @@ void ModeZigZag::run_auto()
                 stage = AUTO;
                 reach_wp_time_ms = 0;
                 char const *dir[] = {"forward", "right", "backward", "left"};
-                gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ZigZag: moving to %s", dir[(uint8_t)zigzag_direction]);
             }
         }
     } else {

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -154,7 +154,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             return MAV_RESULT_FAILED;
         } else {
             // start test
-            gcs().send_text(MAV_SEVERITY_INFO, "starting motor test");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "starting motor test");
             ap.motor_test = true;
 
             EXPECT_DELAY_MS(3000);
@@ -201,7 +201,7 @@ void Copter::motor_test_stop()
         return;
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "finished motor test");    
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "finished motor test");    
 
     // flag test is complete
     ap.motor_test = false;

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -52,7 +52,7 @@ void Copter::arm_motors_check()
 
         // arm the motors and configure for flight
         if (arming_counter == AUTO_TRIM_DELAY && motors->armed() && flightmode->mode_number() == Mode::Number::STABILIZE) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim start");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim start");
             auto_trim_counter = 250;
             auto_trim_started = false;
             // ensure auto-disarm doesn't trigger immediately
@@ -198,7 +198,7 @@ void Copter::lost_vehicle_check()
         if (soundalarm_counter >= LOST_VEHICLE_DELAY) {
             if (AP_Notify::flags.vehicle_lost == false) {
                 AP_Notify::flags.vehicle_lost = true;
-                gcs().send_text(MAV_SEVERITY_NOTICE,"Locate Copter alarm");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Locate Copter alarm");
             }
         } else {
             soundalarm_counter++;

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -105,7 +105,9 @@ void Copter::SurfaceTracking::set_surface(Surface new_surface)
         return;
     }
     if ((new_surface == Surface::CEILING) && !copter.rangefinder.has_orientation(ROTATION_PITCH_90)) {
+#if !defined(HAL_BUILD_AP_PERIPH)
         copter.gcs().send_text(MAV_SEVERITY_WARNING, "SurfaceTracking: no upward rangefinder");
+#endif
         AP_Notify::events.user_mode_change_failed = 1;
         return;
     }

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -47,9 +47,9 @@ void Copter::takeoff_check()
         takeoff_check_warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";
         if (!telem_active) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s waiting for ESC RPM", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "%s waiting for ESC RPM", prefix_str);
         } else if (!rpm_adequate) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s ESC RPM out of range", prefix_str);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "%s ESC RPM out of range", prefix_str);
         }
     }
 #endif

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -301,7 +301,7 @@ void ToyMode::update()
             reset_turtle_start_ms = now;
         }
         if (now - reset_turtle_start_ms > TOY_RESET_TURTLE_TIME) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: WiFi reset");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: WiFi reset");
             reset_turtle_start_ms = 0;
             send_named_int("WIFIRESET", 1);
         }
@@ -390,7 +390,7 @@ void ToyMode::update()
     }
     
     if (action != ACTION_NONE) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Tmode: action %u", action);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: action %u", action);
         last_action_ms = now;
     }
 
@@ -409,7 +409,7 @@ void ToyMode::update()
         throttle_low_counter++;
         const uint8_t disarm_limit = copter.flightmode->has_manual_throttle()?TOY_LAND_MANUAL_DISARM_COUNT:TOY_LAND_DISARM_COUNT;
         if (throttle_low_counter >= disarm_limit) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: throttle disarm");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: throttle disarm");
             copter.arming.disarm(AP_Arming::Method::TOYMODELANDTHROTTLE);
         }
     } else {
@@ -422,20 +422,20 @@ void ToyMode::update()
     if ((flags & FLAG_THR_ARM) && throttle_near_max && !copter.motors->armed()) {
         throttle_high_counter++;
         if (throttle_high_counter >= TOY_LAND_ARM_COUNT) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: throttle arm");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: throttle arm");
             arm_check_compass();
             if (!copter.arming.arm(AP_Arming::Method::MAVLINK) && (flags & FLAG_UPGRADE_LOITER) && copter.flightmode->mode_number() == Mode::Number::LOITER) {
                 /*
                   support auto-switching to ALT_HOLD, then upgrade to LOITER once GPS available
                  */
                 if (set_and_remember_mode(Mode::Number::ALT_HOLD, ModeReason::TOY_MODE)) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "Tmode: ALT_HOLD update arm");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: ALT_HOLD update arm");
 #if AP_FENCE_ENABLED
                     copter.fence.enable(false);
 #endif
                     if (!copter.arming.arm(AP_Arming::Method::MAVLINK)) {
                         // go back to LOITER
-                        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: ALT_HOLD arm failed");
+                        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: ALT_HOLD arm failed");
                         set_and_remember_mode(Mode::Number::LOITER, ModeReason::TOY_MODE);
                     } else {
                         upgrade_to_loiter = true;
@@ -462,12 +462,12 @@ void ToyMode::update()
 #if AP_FENCE_ENABLED
             copter.fence.enable(true);
 #endif
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: LOITER update");            
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: LOITER update");            
         }
     }
 
     if (copter.flightmode->mode_number() == Mode::Number::RTL && (flags & FLAG_RTL_CANCEL) && throttle_near_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Tmode: RTL cancel");        
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: RTL cancel");        
         set_and_remember_mode(Mode::Number::LOITER, ModeReason::TOY_MODE);
     }
     
@@ -493,7 +493,7 @@ void ToyMode::update()
 #if MODE_ACRO_ENABLED == ENABLED
         new_mode = Mode::Number::ACRO;
 #else
-        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: ACRO is disabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: ACRO is disabled");
 #endif
         break;
 
@@ -545,7 +545,7 @@ void ToyMode::update()
 #if MODE_THROW_ENABLED == ENABLED
         new_mode = Mode::Number::THROW;
 #else
-        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: THROW is disabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: THROW is disabled");
 #endif
         break;
 
@@ -568,7 +568,7 @@ void ToyMode::update()
         
     case ACTION_DISARM:
         if (copter.motors->armed()) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: Force disarm");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: Force disarm");
             copter.arming.disarm(AP_Arming::Method::TOYMODELANDFORCE);
         }
         break;
@@ -617,7 +617,7 @@ void ToyMode::update()
         }
         if (load_test.running) {
             load_test.running = false;
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test off");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: load_test off");
             copter.init_disarm_motors();
             copter.set_mode(Mode::Number::ALT_HOLD, ModeReason::TOY_MODE);
         } else {
@@ -627,9 +627,9 @@ void ToyMode::update()
 #endif
             if (copter.arming.arm(AP_Arming::Method::MAVLINK)) {
                 load_test.running = true;
-                gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test on");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: load_test on");
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: load_test failed");
             }
         }
 #endif
@@ -647,7 +647,7 @@ void ToyMode::update()
         copter.fence.enable(false);
 #endif
         if (set_and_remember_mode(new_mode, ModeReason::TOY_MODE)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: mode %s", copter.flightmode->name4());
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: mode %s", copter.flightmode->name4());
             // force fence on in all GPS flight modes
 #if AP_FENCE_ENABLED
             if (copter.flightmode->requires_GPS()) {
@@ -655,10 +655,10 @@ void ToyMode::update()
             }
 #endif
         } else {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: %u FAILED", (unsigned)new_mode);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: %u FAILED", (unsigned)new_mode);
             if (new_mode == Mode::Number::RTL) {
                 // if we can't RTL then land
-                gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: LANDING");
+                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: LANDING");
                 set_and_remember_mode(Mode::Number::LAND, ModeReason::TOY_MODE);
 #if AP_FENCE_ENABLED
                 if (copter.landing_with_GPS()) {
@@ -709,7 +709,7 @@ void ToyMode::trim_update(void)
         int16_t new_value = 1000UL * (throttle_trim - ch_min) / (ch_max - ch_min);
         if (new_value != throttle_mid) {
             throttle_mid = new_value;
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: thr mid %d",
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: thr mid %d",
                                              throttle_mid);
         }
     }
@@ -773,7 +773,7 @@ void ToyMode::trim_update(void)
         }
     }
 
-    gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: trim %u %u %u %u",
+    GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: trim %u %u %u %u",
                                      chan[0], chan[1], chan[2], chan[3]);
 }
 
@@ -792,7 +792,7 @@ void ToyMode::action_arm(void)
         copter.channel_yaw->get_control_in() == 0;
 
     if (!sticks_centered) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: sticks not centered");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: sticks not centered");
         return;
     }
 
@@ -806,14 +806,14 @@ void ToyMode::action_arm(void)
         copter.arming.arm(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
         } else {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: GPS armed motors");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: GPS armed motors");
         }
     } else if (needs_gps) {
         // notify of arming fail
         AP_Notify::events.arming_failed = true;
-        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
     } else {
 #if AP_FENCE_ENABLED
         // non-GPS mode
@@ -822,9 +822,9 @@ void ToyMode::action_arm(void)
         copter.arming.arm(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: non-GPS arming failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: non-GPS arming failed");
         } else {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: non-GPS armed motors");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Tmode: non-GPS armed motors");
         }
     }
 }
@@ -1057,7 +1057,7 @@ void ToyMode::load_test_run(void)
     }
 
     if (copter.failsafe.battery) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test off (battery)");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: load_test off (battery)");
         copter.init_disarm_motors();
         load_test.running = false;
     }    
@@ -1079,7 +1079,7 @@ void ToyMode::arm_check_compass(void)
         field < 200 || field > 800 ||
         !copter.compass.configured(unused_compass_configured_error_message, ARRAY_SIZE(unused_compass_configured_error_message))) {
         if (copter.compass.get_learn_type() != Compass::LEARN_INFLIGHT) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Tmode: enable compass learning");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tmode: enable compass learning");
             copter.compass.set_learn_type(Compass::LEARN_INFLIGHT, false);
         }
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -277,7 +277,7 @@ bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
         // in-flight arming if we were armed before the reset. This
         // allows a reset on a BVLOS flight to return home if the
         // operator can command arming over telemetry
-        gcs().send_text(MAV_SEVERITY_WARNING, "watchdog: Bypassing arming checks");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "watchdog: Bypassing arming checks");
         return true;
     }
 
@@ -319,7 +319,7 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
     // rising edge of delay_arming oneshot
     delay_arming = true;
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Throttle armed");
 
     return true;
 }
@@ -341,7 +341,7 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
     if (do_disarm_checks && method == AP_Arming::Method::RUDDER) {
         // option must be enabled:
         if (get_rudder_arming_type() != AP_Arming::RudderArming::ARMDISARM) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Rudder disarm: disabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Rudder disarm: disabled");
             return false;
         }
     }
@@ -380,7 +380,7 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
     // DO_CHANGE_SPEED commands
     plane.new_airspeed_cm = -1;
     
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Throttle disarmed");
 
     return true;
 }
@@ -416,10 +416,10 @@ void AP_Arming_Plane::update_soft_armed()
             hal.rcout->force_safety_on();
             AP_Param::set_by_name("RC_PROTOCOLS", 0);
             arm(Method::BLACKBOX, false);
-            gcs().send_text(MAV_SEVERITY_WARNING, "BlackBox: arming at %.1f m/s", speed3d);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "BlackBox: arming at %.1f m/s", speed3d);
         }
         if (_armed && now - last_over_3dspeed_ms > 20000U) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "BlackBox: disarming at %.1f m/s", speed3d);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "BlackBox: disarming at %.1f m/s", speed3d);
             disarm(Method::BLACKBOX, false);
         }
     }

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -513,7 +513,7 @@ void Plane::set_flight_stage(AP_FixedWing::FlightStage fs)
     landing.handle_flight_stage_change(fs == AP_FixedWing::FlightStage::LAND);
 
     if (fs == AP_FixedWing::FlightStage::ABORT_LANDING) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
                         int(auto_state.takeoff_altitude_rel_cm/100));
     }
 
@@ -609,7 +609,7 @@ void Plane::update_flight_stage(void)
                     set_flight_stage(AP_FixedWing::FlightStage::ABORT_LANDING);
                 } else if (landing.get_abort_throttle_enable() && get_throttle_input() >= 90 &&
                            landing.request_go_around()) {
-                    gcs().send_text(MAV_SEVERITY_INFO,"Landing aborted via throttle");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Landing aborted via throttle");
                     set_flight_stage(AP_FixedWing::FlightStage::ABORT_LANDING);
                 } else {
                     set_flight_stage(AP_FixedWing::FlightStage::LAND);
@@ -658,7 +658,7 @@ void Plane::disarm_if_autoland_complete()
         /* we have auto disarm enabled. See if enough time has passed */
         if (millis() - auto_state.last_flying_ms >= landing.get_disarm_delay()*1000UL) {
             if (arming.disarm(AP_Arming::Method::AUTOLANDED)) {
-                gcs().send_text(MAV_SEVERITY_INFO,"Auto disarmed");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Auto disarmed");
             }
         }
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1087,11 +1087,11 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_MAV_CMD_DO_PARACHUTE(const mavlink_command_
         case PARACHUTE_RELEASE:
             // treat as a manual release which performs some additional check of altitude
             if (plane.parachute.released()) {
-                gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute already released");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Parachute already released");
                 return MAV_RESULT_FAILED;
             }
             if (!plane.parachute.enabled()) {
-                gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute not enabled");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Parachute not enabled");
                 return MAV_RESULT_FAILED;
             }
             if (!plane.parachute_manual_release()) {
@@ -1248,7 +1248,7 @@ void GCS_MAVLINK_Plane::handleMessage(const mavlink_message_t &msg)
 
         // just do altitude for now
         plane.next_WP_loc.alt += -packet.z*100.0;
-        gcs().send_text(MAV_SEVERITY_INFO, "Change alt to %.1f",
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Change alt to %.1f",
                         (double)((plane.next_WP_loc.alt - plane.home.alt)*0.01));
         
         break;
@@ -1295,7 +1295,7 @@ void GCS_MAVLINK_Plane::handleMessage(const mavlink_message_t &msg)
                     cmd.content.location.terrain_alt = true;
                     break;
                 default:
-                    gcs().send_text(MAV_SEVERITY_WARNING, "Invalid coord frame in SET_POSTION_TARGET_GLOBAL_INT");
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Invalid coord frame in SET_POSTION_TARGET_GLOBAL_INT");
                     msg_valid = false;
                     break;
             }    

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -60,17 +60,17 @@ void RC_Channel_Plane::do_aux_function_q_assist_state(AuxSwitchPos ch_flag)
 {
     switch(ch_flag) {
         case AuxSwitchPos::HIGH:
-            gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Force enabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QAssist: Force enabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_FORCE);
             break;
 
         case AuxSwitchPos::MIDDLE:
-            gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Enabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QAssist: Enabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_ENABLED);
             break;
 
         case AuxSwitchPos::LOW:
-            gcs().send_text(MAV_SEVERITY_INFO, "QAssist: Disabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QAssist: Disabled");
             plane.quadplane.set_q_assist_state(plane.quadplane.Q_ASSIST_STATE_ENUM::Q_ASSIST_DISABLED);
             break;
     }
@@ -82,15 +82,15 @@ void RC_Channel_Plane::do_aux_function_crow_mode(AuxSwitchPos ch_flag)
         switch(ch_flag) {
         case AuxSwitchPos::HIGH:
             plane.crow_mode = Plane::CrowMode::CROW_DISABLED;
-            gcs().send_text(MAV_SEVERITY_INFO, "Crow Flaps Disabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Crow Flaps Disabled");
             break;
         case AuxSwitchPos::MIDDLE:
-            gcs().send_text(MAV_SEVERITY_INFO, "Progressive Crow Flaps"); 
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Progressive Crow Flaps"); 
             plane.crow_mode = Plane::CrowMode::PROGRESSIVE;   
             break;
         case AuxSwitchPos::LOW:
             plane.crow_mode = Plane::CrowMode::NORMAL;
-            gcs().send_text(MAV_SEVERITY_INFO, "Normal Crow Flaps");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Normal Crow Flaps");
             break;
         }    
 }
@@ -221,7 +221,7 @@ bool RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwit
 
     case AUX_FUNC::REVERSE_THROTTLE:
         plane.reversed_throttle = (ch_flag == AuxSwitchPos::HIGH);
-        gcs().send_text(MAV_SEVERITY_INFO, "RevThrottle: %s", plane.reversed_throttle?"ENABLE":"DISABLE");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RevThrottle: %s", plane.reversed_throttle?"ENABLE":"DISABLE");
         break;
 
     case AUX_FUNC::AUTO:
@@ -277,7 +277,7 @@ bool RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwit
         const bool enable = (ch_flag == AuxSwitchPos::HIGH);
         if (enable != plane.quadplane.vfwd_enable_active) {
             plane.quadplane.vfwd_enable_active = enable;
-            gcs().send_text(MAV_SEVERITY_INFO, "QFwdThr: %s", enable?"ON":"OFF");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QFwdThr: %s", enable?"ON":"OFF");
         }
         break;
     }
@@ -318,7 +318,7 @@ bool RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const AuxSwit
                 }
                 break;
             }
-            gcs().send_text(MAV_SEVERITY_INFO, "NON AUTO TERRN: %s", plane.non_auto_terrain_disable?"OFF":"ON");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "NON AUTO TERRN: %s", plane.non_auto_terrain_disable?"OFF":"ON");
         break;
 
     case AUX_FUNC::CROW_SELECT:

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -701,7 +701,7 @@ void Plane::rangefinder_height_update(void)
                 flightstage_good_for_rangefinder_landing &&
                 g.rangefinder_landing) {
                 rangefinder_state.in_use = true;
-                gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)rangefinder_state.height_estimate);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)rangefinder_state.height_estimate);
             }
         }
         rangefinder_state.last_distance = distance;
@@ -740,7 +740,7 @@ void Plane::rangefinder_height_update(void)
             if (fabsf(rangefinder_state.correction - rangefinder_state.initial_correction) > 30) {
                 // the correction has changed by more than 30m, reset use of Lidar. We may have a bad lidar
                 if (rangefinder_state.in_use) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder disengaged at %.2fm", (double)rangefinder_state.height_estimate);
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Rangefinder disengaged at %.2fm", (double)rangefinder_state.height_estimate);
                 }
                 memset(&rangefinder_state, 0, sizeof(rangefinder_state));
             }

--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -104,7 +104,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Plane::handle_avoidance(const AP_Avoidance::Ob
     }
 
     if (failsafe_state_change) {
-        gcs().send_text(MAV_SEVERITY_ALERT, "Avoid: Performing action: %d", actual_action);
+        GCS_SEND_TEXT(MAV_SEVERITY_ALERT, "Avoid: Performing action: %d", actual_action);
     }
 
     // return with action taken
@@ -116,7 +116,7 @@ void AP_Avoidance_Plane::handle_recovery(RecoveryAction recovery_action)
     // check we are coming out of failsafe
     if (plane.failsafe.adsb) {
         plane.failsafe.adsb = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Avoid: Resuming with action: %u", (unsigned)recovery_action);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Avoid: Resuming with action: %u", (unsigned)recovery_action);
 
         // restore flight mode if requested and user has not changed mode since
         if (plane.control_mode_reason == ModeReason::AVOIDANCE) {

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -126,7 +126,7 @@ void Plane::autotune_start(void)
     const bool tune_pitch = g2.axis_bitmask.get() & int8_t(AutoTuneAxis::PITCH);
     const bool tune_yaw = g2.axis_bitmask.get() & int8_t(AutoTuneAxis::YAW);
     if (tune_roll || tune_pitch || tune_yaw) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Started autotune");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Started autotune");
         if (tune_roll) { 
             rollController.autotune_start();
         }
@@ -137,9 +137,9 @@ void Plane::autotune_start(void)
             yawController.autotune_start();
         }
         autotuning = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "Autotuning %s%s%s", tune_roll?"roll ":"", tune_pitch?"pitch ":"", tune_yaw?"yaw":"");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Autotuning %s%s%s", tune_roll?"roll ":"", tune_pitch?"pitch ":"", tune_yaw?"yaw":"");
     } else {
-        gcs().send_text(MAV_SEVERITY_INFO, "No axis selected for tuning!");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No axis selected for tuning!");
     }        
 }
 
@@ -153,7 +153,7 @@ void Plane::autotune_restore(void)
     yawController.autotune_restore();
     if (autotuning) {
         autotuning = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Stopped autotune");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Stopped autotune");
     }
 }
 

--- a/ArduPlane/ekf_check.cpp
+++ b/ArduPlane/ekf_check.cpp
@@ -77,7 +77,7 @@ void Plane::ekf_check()
                 AP::logger().Write_Error(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -99,9 +99,9 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
         break;
     }
     if (failsafe.saved_mode_number != control_mode->mode_number()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "RC Short Failsafe: switched to %s", control_mode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RC Short Failsafe: switched to %s", control_mode->name());
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "RC Short Failsafe On");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RC Short Failsafe On");
     }
 }
 
@@ -208,18 +208,18 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
     case Mode::Number::INITIALISING:
         break;
     }
-    gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe On: %s", (reason == ModeReason:: GCS_FAILSAFE) ? "GCS" : "RC Long", control_mode->name());
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Failsafe On: %s", (reason == ModeReason:: GCS_FAILSAFE) ? "GCS" : "RC Long", control_mode->name());
 }
 
 void Plane::failsafe_short_off_event(ModeReason reason)
 {
     // We're back in radio contact
-    gcs().send_text(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
     failsafe.state = FAILSAFE_NONE;
     // restore entry mode if desired but check that our current mode is still due to failsafe
     if (control_mode_reason == ModeReason::RADIO_FAILSAFE) { 
        set_mode_by_number(failsafe.saved_mode_number, ModeReason::RADIO_FAILSAFE_RECOVERY);
-       gcs().send_text(MAV_SEVERITY_INFO,"Flight mode %s restored",control_mode->name());
+       GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Flight mode %s restored",control_mode->name());
     }
 }
 
@@ -228,10 +228,10 @@ void Plane::failsafe_long_off_event(ModeReason reason)
     long_failsafe_pending = false;
     // We're back in radio contact with RC or GCS
     if (reason == ModeReason:: GCS_FAILSAFE) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe Off");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "GCS Failsafe Off");
     }
     else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "RC Long Failsafe Cleared");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RC Long Failsafe Cleared");
     }
     failsafe.state = FAILSAFE_NONE;
 }

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -315,9 +315,9 @@ void Plane::crash_detection_update(void)
             arming.disarm(AP_Arming::Method::CRASH);
         }
         if (crashed_near_land_waypoint) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Hard landing detected");
         } else {
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash detected");
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Crash detected");
         }
     }
 }

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -9,7 +9,7 @@ bool ModeAuto::_enter()
     if (plane.previous_mode == &plane.mode_guided &&
         quadplane.guided_wait_takeoff_on_mode_enter) {
         if (!plane.mission.starts_with_takeoff_cmd()) {
-            gcs().send_text(MAV_SEVERITY_ERROR,"Takeoff waypoint required");
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"Takeoff waypoint required");
             quadplane.guided_wait_takeoff = true;
             return false;
         }
@@ -29,7 +29,7 @@ bool ModeAuto::_enter()
 
     if (hal.util->was_watchdog_armed()) {
         if (hal.util->persistent_data.waypoint_num != 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Watchdog: resume WP %u", hal.util->persistent_data.waypoint_num);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Watchdog: resume WP %u", hal.util->persistent_data.waypoint_num);
             plane.mission.set_current_cmd(hal.util->persistent_data.waypoint_num);
             hal.util->persistent_data.waypoint_num = 0;
         }
@@ -66,7 +66,7 @@ void ModeAuto::update()
         // this could happen if AP_Landing::restart_landing_sequence() returns false which would only happen if:
         // restart_landing_sequence() is called when not executing a NAV_LAND or there is no previous nav point
         plane.set_mode(plane.mode_rtl, ModeReason::MISSION_END);
-        gcs().send_text(MAV_SEVERITY_INFO, "Aircraft in auto without a running mission");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Aircraft in auto without a running mission");
         return;
     }
 

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -56,7 +56,7 @@ bool ModeQRTL::_enter()
             }
 
             // we're close to destination and already running VTOL motors, don't transition and don't climb
-            gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 d=%.1f r=%.1f", dist, radius);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position1 d=%.1f r=%.1f", dist, radius);
             poscontrol.set_state(QuadPlane::QPOS_POSITION1);
         }
     }
@@ -140,7 +140,7 @@ void ModeQRTL::run()
                     if (plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, target_alt_abs_cm)) {
                         RTL_alt_abs_cm = MIN(RTL_alt_abs_cm, target_alt_abs_cm);
                     }
-                    gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 d=%.1f r=%.1f", dist, radius);
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position1 d=%.1f r=%.1f", dist, radius);
                     poscontrol.set_state(QuadPlane::QPOS_POSITION1);
                 }
 

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -85,12 +85,12 @@ void ModeTakeoff::update()
         // see if we will skip takeoff as already flying
         if (plane.is_flying() && (millis() - plane.started_flying_ms > 10000U) && ahrs.groundspeed() > 3) {
             if (altitude >= alt) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Above TKOFF alt - loitering");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Above TKOFF alt - loitering");
                 plane.next_WP_loc = plane.current_loc;
                 takeoff_started = true;
                 plane.set_flight_stage(AP_FixedWing::FlightStage::NORMAL);
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Climbing to TKOFF alt then loitering");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Climbing to TKOFF alt then loitering");
                 plane.next_WP_loc = plane.current_loc;
                 plane.next_WP_loc.alt += ((alt - altitude) *100);
                 plane.next_WP_loc.offset_bearing(direction, dist);
@@ -114,7 +114,7 @@ void ModeTakeoff::update()
             plane.set_flight_stage(AP_FixedWing::FlightStage::TAKEOFF);
 
             if (!plane.throttle_suppressed) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Takeoff to %.0fm for %.1fm heading %.1f deg",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Takeoff to %.0fm for %.1fm heading %.1f deg",
                                 alt, dist, direction);
                 takeoff_started = true;
             }

--- a/ArduPlane/mode_thermal.cpp
+++ b/ArduPlane/mode_thermal.cpp
@@ -45,7 +45,7 @@ void ModeThermal::update_soaring()
         sq(position.x)+sq(position.y) > sq(plane.g2.soaring_controller.max_radius) &&
         plane.previous_mode->mode_number()!=Mode::Number::AUTO) {
         // Some other loiter status, and outside of maximum soaring radius, and previous mode wasn't AUTO
-        gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Outside SOAR_MAX_RADIUS, RTL");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: Outside SOAR_MAX_RADIUS, RTL");
         plane.set_mode(plane.mode_rtl, ModeReason::SOARING_DRIFT_EXCEEDED);
         return;
     }
@@ -143,7 +143,7 @@ bool ModeThermal::exit_heading_aligned() const
 
 void ModeThermal::restore_mode(const char *reason, ModeReason modereason)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Soaring: %s, restoring %s", reason, plane.previous_mode->name());
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: %s, restoring %s", reason, plane.previous_mode->name());
     plane.set_mode(*plane.previous_mode, modereason);
 }
 

--- a/ArduPlane/motor_test.cpp
+++ b/ArduPlane/motor_test.cpp
@@ -84,14 +84,14 @@ MAV_RESULT QuadPlane::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t m
     }
 
     if (motors->armed()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Must be disarmed for motor test");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Must be disarmed for motor test");
         return MAV_RESULT_FAILED;
     }
 
     // Check Motor test is allowed
     char failure_msg[50] {};
     if (!motors->motor_test_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Motor Test: %s", failure_msg);
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Motor Test: %s", failure_msg);
         return MAV_RESULT_FAILED;
     }
 

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -23,9 +23,9 @@ void Plane::parachute_release()
         return;
     }
     if (parachute.released()) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released again");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Parachute: Released again");
     } else {
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Parachute: Released");
     }
 
     // release parachute
@@ -52,7 +52,7 @@ bool Plane::parachute_manual_release()
     if (parachute.alt_min() > 0 && relative_ground_altitude(false) < parachute.alt_min() &&
             auto_state.last_flying_ms > 0) {
         // Allow manual ground tests by only checking if flying too low if we've taken off
-        gcs().send_text(MAV_SEVERITY_WARNING, "Parachute: Too low");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Parachute: Too low");
         return false;
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -844,7 +844,7 @@ bool QuadPlane::setup(void)
 
     char frame_and_type_string[30];
     motors->get_frame_and_type_string(frame_and_type_string, ARRAY_SIZE(frame_and_type_string));
-    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised, %s", frame_and_type_string);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QuadPlane initialised, %s", frame_and_type_string);
     initialised = true;
     return true;
 }
@@ -875,7 +875,7 @@ void QuadPlane::run_esc_calibration(void)
         return;
     }
     if (!AP_Notify::flags.esc_calibration) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Starting ESC calibration");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Starting ESC calibration");
     }
     AP_Notify::flags.esc_calibration = true;
     switch (esc_calibration) {
@@ -1496,7 +1496,7 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
                 // we've been below assistant alt for Q_ASSIST_DELAY seconds
                 if (!in_alt_assist) {
                     in_alt_assist = true;
-                    gcs().send_text(MAV_SEVERITY_INFO, "Alt assist %.1fm", height_above_ground);
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Alt assist %.1fm", height_above_ground);
                 }
                 return true;
             }
@@ -1541,7 +1541,7 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
     bool ret = (now - angle_error_start_ms) >= assist_delay*1000;
     if (ret && !in_angle_assist) {
         in_angle_assist = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "Angle assist r=%d p=%d",
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Angle assist r=%d p=%d",
                                          (int)(ahrs.roll_sensor/100),
                                          (int)(ahrs.pitch_sensor/100));
     }
@@ -1573,7 +1573,7 @@ void SLT_Transition::update()
         if (!in_forced_transition) {
             const bool show_message = transition_state != TRANSITION_AIRSPEED_WAIT || transition_start_ms == 0;
             if (show_message) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
             }
             transition_state = TRANSITION_AIRSPEED_WAIT;
             if (transition_start_ms == 0) {
@@ -1590,7 +1590,7 @@ void SLT_Transition::update()
     // the tilt will decrease rapidly)
     if (quadplane.tiltrotor.fully_fwd() && transition_state != TRANSITION_AIRSPEED_WAIT) {
         if (transition_state == TRANSITION_TIMER) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition FW done");
         }
         transition_state = TRANSITION_DONE;
         transition_start_ms = 0;
@@ -1609,7 +1609,7 @@ void SLT_Transition::update()
         quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
         // we hold in hover until the required airspeed is reached
         if (transition_start_ms == 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition airspeed wait");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition airspeed wait");
             transition_start_ms = now;
         }
 
@@ -1618,7 +1618,7 @@ void SLT_Transition::update()
         (quadplane.transition_failure.timeout > 0) &&
         ((now - transition_start_ms) > ((uint32_t)quadplane.transition_failure.timeout * 1000))) {
             if (!quadplane.transition_failure.warned) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Transition failed, exceeded time limit");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Transition failed, exceeded time limit");
                 quadplane.transition_failure.warned = true;
             }
             // if option is set and ground speed> 1/2 arspd_fbw_min for non-tiltrotors, then complete transition, otherwise QLAND.
@@ -1650,7 +1650,7 @@ void SLT_Transition::update()
         if (have_airspeed && aspeed > plane.aparm.airspeed_min && !quadplane.assisted_flight) {
             transition_state = TRANSITION_TIMER;
             airspeed_reached_tilt = quadplane.tiltrotor.current_tilt;
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition airspeed reached %.1f", (double)aspeed);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition airspeed reached %.1f", (double)aspeed);
         }
         quadplane.assisted_flight = true;
 
@@ -1704,7 +1704,7 @@ void SLT_Transition::update()
             in_forced_transition = false;
             transition_start_ms = 0;
             transition_low_airspeed_ms = 0;
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition done");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition done");
         }
         float trans_time_ms = MAX((float)quadplane.transition_time_ms.get(),1);
         float transition_scale = (trans_time_ms - transition_timer_ms) / trans_time_ms;
@@ -2080,17 +2080,17 @@ void QuadPlane::motors_output(bool run_rate_controller)
 bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state) const
 {
     if (!available()) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "VTOL not available");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "VTOL not available");
         return false;
     }
     if (plane.control_mode != &plane.mode_auto) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "VTOL transition only in AUTO");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "VTOL transition only in AUTO");
         return false;
     }
     switch (state) {
     case MAV_VTOL_STATE_MC:
         if (!plane.auto_state.vtol_mode) {
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Entered VTOL mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Entered VTOL mode");
         }
         plane.auto_state.vtol_mode = true;
         // This is a precaution. It should be looked after by the call to QuadPlane::mode_enter(void) on mode entry.
@@ -2100,7 +2100,7 @@ bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state) const
         
     case MAV_VTOL_STATE_FW:
         if (plane.auto_state.vtol_mode) {
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
         }
         plane.auto_state.vtol_mode = false;
 
@@ -2110,7 +2110,7 @@ bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state) const
         break;
     }
 
-    gcs().send_text(MAV_SEVERITY_NOTICE, "Invalid VTOL mode");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Invalid VTOL mode");
     return false;
 }
 
@@ -2267,17 +2267,17 @@ void QuadPlane::poscontrol_init_approach(void)
     if (option_is_set(QuadPlane::OPTION::DISABLE_APPROACH)) {
         // go straight to QPOS_POSITION1
         poscontrol.set_state(QPOS_POSITION1);
-        gcs().send_text(MAV_SEVERITY_INFO,"VTOL Position1 d=%.1f", dist);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL Position1 d=%.1f", dist);
     } else if (poscontrol.get_state() != QPOS_APPROACH) {
         // check if we are close to the destination. We don't want to
         // do a full approach when very close
         if (dist < transition_threshold()) {
             if (tailsitter.enabled() || motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED) {
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL Position1 d=%.1f", dist);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL Position1 d=%.1f", dist);
                 poscontrol.set_state(QPOS_POSITION1);
                 transition->set_last_fw_pitch();
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL airbrake v=%.1f d=%.0f sd=%.0f h=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL airbrake v=%.1f d=%.0f sd=%.0f h=%.1f",
                                 plane.ahrs.groundspeed(),
                                 dist,
                                 stopping_distance(),
@@ -2285,7 +2285,7 @@ void QuadPlane::poscontrol_init_approach(void)
                 poscontrol.set_state(QPOS_AIRBRAKE);
             }
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO,"VTOL approach d=%.1f", dist);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL approach d=%.1f", dist);
             poscontrol.set_state(QPOS_APPROACH);
         }
         poscontrol.thrust_loss_start_ms = 0;
@@ -2403,7 +2403,7 @@ void QuadPlane::vtol_position_controller(void)
             // thus not doing qassist checking, force POSITION1 mode
             // now. We don't expect this to trigger, it is a failsafe
             // for a logic error
-            gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 nvtol");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position1 nvtol");
             poscontrol.set_state(QPOS_POSITION1);
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         }
@@ -2476,7 +2476,7 @@ void QuadPlane::vtol_position_controller(void)
         if (poscontrol.get_state() == QPOS_APPROACH && distance < stop_distance) {
             if (tailsitter.enabled() || motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED) {
                 // tailsitters don't use airbrake stage for landing
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 v=%.1f d=%.0f sd=%.0f h=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position1 v=%.1f d=%.0f sd=%.0f h=%.1f",
                                 groundspeed,
                                 plane.auto_state.wp_distance,
                                 stop_distance,
@@ -2484,7 +2484,7 @@ void QuadPlane::vtol_position_controller(void)
                 poscontrol.set_state(QPOS_POSITION1);
                 transition->set_last_fw_pitch();
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL airbrake v=%.1f d=%.0f sd=%.0f h=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL airbrake v=%.1f d=%.0f sd=%.0f h=%.1f",
                                 groundspeed,
                                 distance,
                                 stop_distance,
@@ -2512,7 +2512,7 @@ void QuadPlane::vtol_position_controller(void)
              closing_speed < desired_closing_speed*0.5 || // too slow ground speed
              labs(plane.ahrs.roll_sensor - plane.nav_roll_cd) > attitude_error_threshold_cd || // bad attitude
              labs(plane.ahrs.pitch_sensor - plane.nav_pitch_cd) > attitude_error_threshold_cd)) {
-            gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 v=%.1f d=%.1f h=%.1f dc=%.1f",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position1 v=%.1f d=%.1f h=%.1f dc=%.1f",
                             (double)groundspeed,
                             (double)plane.auto_state.wp_distance,
                             plane.relative_ground_altitude(plane.g.rangefinder_landing),
@@ -2551,7 +2551,7 @@ void QuadPlane::vtol_position_controller(void)
                     poscontrol.thrust_loss_start_ms = now_ms;
                 }
                 if (now_ms - poscontrol.thrust_loss_start_ms > 5000) {
-                    gcs().send_text(MAV_SEVERITY_INFO,"VTOL pos1 thrust loss as=%.1f at=%.1f",
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL pos1 thrust loss as=%.1f at=%.1f",
                                     aspeed, aspeed_threshold);
                     poscontrol.set_state(QPOS_POSITION1);
                     transition->set_last_fw_pitch();
@@ -2563,7 +2563,7 @@ void QuadPlane::vtol_position_controller(void)
             // handle loss of forward thrust in approach based on low airspeed detection
             if (poscontrol.get_state() == QPOS_APPROACH && aspeed < aspeed_threshold &&
                 motors->get_desired_spool_state() < AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED) {
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL pos1 low speed as=%.1f at=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL pos1 low speed as=%.1f at=%.1f",
                                 aspeed, aspeed_threshold);
                 poscontrol.set_state(QPOS_POSITION1);
                 transition->set_last_fw_pitch();
@@ -2638,7 +2638,7 @@ void QuadPlane::vtol_position_controller(void)
             const float yaw_err_deg = wrap_180(target_yaw_deg - degrees(plane.ahrs.yaw));
             bool overshoot = (closing_groundspeed < 0 || fabsf(yaw_err_deg) > 60);
             if (overshoot && !poscontrol.overshoot) {
-                gcs().send_text(MAV_SEVERITY_INFO,"VTOL Overshoot d=%.1f cs=%.1f yerr=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL Overshoot d=%.1f cs=%.1f yerr=%.1f",
                                 distance, closing_groundspeed, yaw_err_deg);
                 poscontrol.overshoot = true;
                 pos_control->set_accel_desired_xy_cmss(Vector2f());
@@ -2732,7 +2732,7 @@ void QuadPlane::vtol_position_controller(void)
             // if continuous tiltrotor only advance to position 2 once tilts have finished moving
             poscontrol.set_state(QPOS_POSITION2);
             poscontrol.pilot_correction_done = false;
-            gcs().send_text(MAV_SEVERITY_INFO,"VTOL position2 started v=%.1f d=%.1f h=%.1f",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"VTOL position2 started v=%.1f d=%.1f h=%.1f",
                             (double)ahrs.groundspeed(), (double)plane.auto_state.wp_distance,
                             plane.relative_ground_altitude(plane.g.rangefinder_landing));
         }
@@ -3116,7 +3116,7 @@ void QuadPlane::takeoff_controller(void)
         set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         takeoff_start_time_ms = now;
         if (now - plane.takeoff_state.rudder_takeoff_warn_ms > TAKEOFF_RUDDER_WARNING_TIMEOUT) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Takeoff waiting for rudder release");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Takeoff waiting for rudder release");
             plane.takeoff_state.rudder_takeoff_warn_ms = now;
         }
         return;
@@ -3419,14 +3419,14 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
     
     // check for failure conditions
     if (is_positive(takeoff_failure_scalar) && ((now - takeoff_start_time_ms) > takeoff_time_limit_ms)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Failed to complete takeoff within time limit");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Failed to complete takeoff within time limit");
         plane.set_mode(plane.mode_qland, ModeReason::VTOL_FAILED_TAKEOFF);
         return false;
     }
 
 #if AP_AIRSPEED_ENABLED
     if (is_positive(maximum_takeoff_airspeed) && (plane.airspeed.get_airspeed() > maximum_takeoff_airspeed)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Failed to complete takeoff, excessive wind");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Failed to complete takeoff, excessive wind");
         plane.set_mode(plane.mode_qland, ModeReason::VTOL_FAILED_TAKEOFF);
         return false;
     }
@@ -3504,7 +3504,7 @@ bool QuadPlane::check_land_complete(void)
     }
     if (land_detector(4000)) {
         poscontrol.set_state(QPOS_LAND_COMPLETE);
-        gcs().send_text(MAV_SEVERITY_INFO,"Land complete");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Land complete");
 
         if (plane.in_auto_mission_id(MAV_CMD_NAV_PAYLOAD_PLACE)) {
             // for payload place with full landing we shutdown motors
@@ -3589,7 +3589,7 @@ bool QuadPlane::verify_vtol_land(void)
             plane.g2.landing_gear.deploy_for_landing();
 #endif
             last_land_final_agl = plane.relative_ground_altitude(plane.g.rangefinder_landing);
-            gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Land descend started");
             if (plane.control_mode == &plane.mode_auto) {
                 // set height to mission height, so we can use the mission
                 // WP height for triggering land final if no rangefinder
@@ -3612,7 +3612,7 @@ bool QuadPlane::verify_vtol_land(void)
             plane.g2.ice_control.engine_control(0, 0, 0);
         }
 #endif  // AP_ICENGINE_ENABLED
-        gcs().send_text(MAV_SEVERITY_INFO,"Land final started");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Land final started");
     }
 
     // at land_final_alt begin final landing
@@ -3627,13 +3627,13 @@ bool QuadPlane::verify_vtol_land(void)
          poscontrol.get_state() == QPOS_LAND_FINAL)) {
         const auto &cmd = plane.mission.get_current_nav_cmd();
         if (cmd.p1 > 0 && plane.current_loc.alt*0.01 < land_descend_start_alt - cmd.p1*0.01) {
-            gcs().send_text(MAV_SEVERITY_INFO,"Payload place aborted");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Payload place aborted");
             poscontrol.set_state(QPOS_LAND_ABORT);
         }
     }
     
     if (check_land_complete() && plane.mission.continue_after_land()) {
-        gcs().send_text(MAV_SEVERITY_INFO,"Mission continue");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Mission continue");
         return true;
     }
     return false;
@@ -3912,15 +3912,15 @@ void QuadPlane::set_alt_target_current(void)
 bool QuadPlane::do_user_takeoff(float takeoff_altitude)
 {
     if (plane.control_mode != &plane.mode_guided) {
-        gcs().send_text(MAV_SEVERITY_INFO, "User Takeoff only in GUIDED mode");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "User Takeoff only in GUIDED mode");
         return false;
     }
     if (!plane.arming.is_armed_and_safety_off()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Must be armed for takeoff");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Must be armed for takeoff");
         return false;
     }
     if (is_flying()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Already flying - no takeoff");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Already flying - no takeoff");
         return false;
     }
     plane.auto_state.vtol_loiter = true;

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -292,7 +292,7 @@ void Plane::control_failsafe()
         // throttle has dropped below the mark
         failsafe.throttle_counter++;
         if (failsafe.throttle_counter == 10) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "on");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "on");
             failsafe.rc_failsafe = true;
             AP_Notify::flags.failsafe_radio = true;
         }
@@ -307,7 +307,7 @@ void Plane::control_failsafe()
             failsafe.throttle_counter = 3;
         }
         if (failsafe.throttle_counter == 1) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "off");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Throttle failsafe %s", "off");
         } else if(failsafe.throttle_counter == 0) {
             failsafe.rc_failsafe = false;
             AP_Notify::flags.failsafe_radio = false;
@@ -323,7 +323,7 @@ void Plane::trim_radio()
     }
 
     if (plane.control_mode != &mode_manual) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "trim failed, not in manual mode");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "trim failed, not in manual mode");
         return;
     }
 
@@ -333,13 +333,13 @@ void Plane::trim_radio()
         // more than 20 percent range left then assume the
         // sticks are not properly centered. This also prevents
         // problems with starting APM with the TX off
-        gcs().send_text(MAV_SEVERITY_ERROR, "trim failed, large roll and pitch input");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "trim failed, large roll and pitch input");
         return;
     }
 
     if (degrees(ahrs.get_gyro().length()) > 30.0) {
         // rotating more than 30 deg/second
-        gcs().send_text(MAV_SEVERITY_ERROR, "trim failed, large movement");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "trim failed, large movement");
         return;
     }
 
@@ -376,7 +376,7 @@ void Plane::trim_radio()
     channel_pitch->set_and_save_trim();
     channel_rudder->set_and_save_trim();
 
-    gcs().send_text(MAV_SEVERITY_NOTICE, "trim complete");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "trim complete");
 }
 
 /*

--- a/ArduPlane/soaring.cpp
+++ b/ArduPlane/soaring.cpp
@@ -47,7 +47,7 @@ void Plane::update_soaring() {
 
             // Test for switch into THERMAL mode
             if (g2.soaring_controller.check_thermal_criteria()) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Thermal detected, entering %s", mode_thermal.name());
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: Thermal detected, entering %s", mode_thermal.name());
                 set_mode(mode_thermal, ModeReason::SOARING_THERMAL_DETECTED);
             }
         }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -163,10 +163,10 @@ void Plane::startup_ground(void)
     set_mode(mode_initializing, ModeReason::INITIALISED);
 
 #if (GROUND_START_DELAY > 0)
-    gcs().send_text(MAV_SEVERITY_NOTICE,"Ground start with delay");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Ground start with delay");
     delay(GROUND_START_DELAY * 1000);
 #else
-    gcs().send_text(MAV_SEVERITY_INFO,"Ground start");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Ground start");
 #endif
 
     //INS ground start
@@ -267,7 +267,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 #if HAL_QUADPLANE_ENABLED
     if (new_mode.is_vtol_mode() && !plane.quadplane.available()) {
         // dont try and switch to a Q mode if quadplane is not enabled and initalized
-        gcs().send_text(MAV_SEVERITY_INFO,"Q_ENABLE 0");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Q_ENABLE 0");
         // make sad noise
         if (reason != ModeReason::INITIALISED) {
             AP_Notify::events.user_mode_change_failed = 1;
@@ -278,7 +278,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 #else
     if (new_mode.is_vtol_mode()) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-        gcs().send_text(MAV_SEVERITY_INFO,"HAL_QUADPLANE_ENABLED=0");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"HAL_QUADPLANE_ENABLED=0");
         // make sad noise
         if (reason != ModeReason::INITIALISED) {
             AP_Notify::events.user_mode_change_failed = 1;
@@ -295,7 +295,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
         fence.get_breaches() &&
         in_fence_recovery() &&
         !mode_reason_is_landing_sequence(reason)) {
-        gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, in fence recovery", new_mode.name());
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Mode change to %s denied, in fence recovery", new_mode.name());
         AP_Notify::events.user_mode_change_failed = 1;
         return false;
     }
@@ -303,7 +303,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
 
     // Check if GCS mode change is disabled via parameter
     if ((reason == ModeReason::GCS_COMMAND) && !gcs_mode_enabled(new_mode.mode_number())) {
-        gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name());
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name());
         return false;
     }
 
@@ -322,7 +322,7 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
     // attempt to enter new mode
     if (!new_mode.enter()) {
         // Log error that we failed to enter desired flight mode
-        gcs().send_text(MAV_SEVERITY_WARNING, "Flight mode change failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Flight mode change failed");
 
         // we failed entering new mode, roll back to old
         previous_mode = &old_previous_mode;
@@ -440,9 +440,9 @@ void Plane::check_short_failsafe()
 void Plane::startup_INS_ground(void)
 {
     if (ins.gyro_calibration_timing() != AP_InertialSensor::GYRO_CAL_NEVER) {
-        gcs().send_text(MAV_SEVERITY_ALERT, "Beginning INS calibration. Do not move plane");
+        GCS_SEND_TEXT(MAV_SEVERITY_ALERT, "Beginning INS calibration. Do not move plane");
     } else {
-        gcs().send_text(MAV_SEVERITY_ALERT, "Skipping INS calibration");
+        GCS_SEND_TEXT(MAV_SEVERITY_ALERT, "Skipping INS calibration");
     }
 
     ahrs.init();

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -517,15 +517,15 @@ bool Tailsitter::transition_fw_complete(void)
         return true;
     }
     if (labs(quadplane.ahrs_view->pitch_sensor) > transition_angle_fw*100) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition FW done");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition FW done");
         return true;
     }
     if (labs(quadplane.ahrs_view->roll_sensor) > MAX(4500, plane.roll_limit_cd + 500)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, roll error");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Transition FW done, roll error");
         return true;
     }
     if (AP_HAL::millis() - transition->fw_transition_start_ms > ((transition_angle_fw+(transition->fw_transition_initial_pitch*0.01f))/transition_rate_fw)*1500) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Transition FW done, timeout");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Transition FW done, timeout");
         return true;
     }
     // still waiting
@@ -547,13 +547,13 @@ bool Tailsitter::transition_vtol_complete(void) const
         // if we are not moving (hence on the ground?) or don't know
         // transition immediately to tilt motors up and prevent prop strikes
         if (quadplane.ahrs.groundspeed() < 1.0f) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done, zero throttle");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition VTOL done, zero throttle");
             return true;
         }
     }
     const float trans_angle = get_transition_angle_vtol();
     if (labs(plane.ahrs.pitch_sensor) > trans_angle*100) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Transition VTOL done");
         return true;
     }
     int32_t roll_cd = labs(plane.ahrs.roll_sensor);
@@ -561,11 +561,11 @@ bool Tailsitter::transition_vtol_complete(void) const
         roll_cd = 18000 - roll_cd;
     }
     if (roll_cd > MAX(4500, plane.roll_limit_cd + 500)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, roll error");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Transition VTOL done, roll error");
         return true;
     }
     if (AP_HAL::millis() - transition->vtol_transition_start_ms >  ((trans_angle-(transition->vtol_transition_initial_pitch*0.01f))/transition_rate_vtol)*1500) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Transition VTOL done, timeout");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Transition VTOL done, timeout");
         return true;
     }
     return false;

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -37,7 +37,7 @@ bool Plane::auto_takeoff_check(void)
         takeoff_state.waiting_for_rudder_neutral = true;
         // warn if we have been waiting a long time
         if (now - takeoff_state.rudder_takeoff_warn_ms > TAKEOFF_RUDDER_WARNING_TIMEOUT) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Takeoff waiting for rudder release");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Takeoff waiting for rudder release");
             takeoff_state.rudder_takeoff_warn_ms = now;
         }
         // since we are still waiting, dont takeoff
@@ -89,7 +89,7 @@ bool Plane::auto_takeoff_check(void)
         takeoff_state.launchTimerStarted = true;
         takeoff_state.last_tkoff_arm_time = now;
         if (now - takeoff_state.last_report_ms > 2000) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec",
                               (double)TECS_controller.get_VXdot(), (double)(wait_time_ms*0.001f));
             takeoff_state.last_report_ms = now;
         }
@@ -98,7 +98,7 @@ bool Plane::auto_takeoff_check(void)
     // Only perform velocity check if not timed out
     if ((now - takeoff_state.last_tkoff_arm_time) > wait_time_ms+100U) {
         if (now - takeoff_state.last_report_ms > 2000) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Timeout AUTO");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Timeout AUTO");
             takeoff_state.last_report_ms = now;
         }
         goto no_launch;
@@ -108,7 +108,7 @@ bool Plane::auto_takeoff_check(void)
         // Check aircraft attitude for bad launch
         if (ahrs.pitch_sensor <= -3000 || ahrs.pitch_sensor >= 4500 ||
             (!fly_inverted() && labs(ahrs.roll_sensor) > 3000)) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Bad launch AUTO");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Bad launch AUTO");
             takeoff_state.accel_event_counter = 0;
             goto no_launch;
         }
@@ -117,7 +117,7 @@ bool Plane::auto_takeoff_check(void)
     // Check ground speed and time delay
     if (((gps.ground_speed() > g.takeoff_throttle_min_speed || is_zero(g.takeoff_throttle_min_speed))) &&
         ((now - takeoff_state.last_tkoff_arm_time) >= wait_time_ms)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Triggered AUTO. GPS speed = %.1f", (double)gps.ground_speed());
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Triggered AUTO. GPS speed = %.1f", (double)gps.ground_speed());
         takeoff_state.launchTimerStarted = false;
         takeoff_state.last_tkoff_arm_time = 0;
         takeoff_state.start_time_ms = now;
@@ -245,7 +245,7 @@ int16_t Plane::get_takeoff_pitch_min_cd(void)
                 relative_alt_cm >= 1000 &&
                 sec_to_target <= g.takeoff_pitch_limit_reduction_sec) {
                 // make a note of that altitude to use it as a start height for scaling
-                gcs().send_text(MAV_SEVERITY_INFO, "Takeoff level-off starting at %dm", int(remaining_height_to_target_cm/100));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Takeoff level-off starting at %dm", int(remaining_height_to_target_cm/100));
                 auto_state.height_below_takeoff_to_level_off_cm = remaining_height_to_target_cm;
             }
         }
@@ -290,7 +290,7 @@ int8_t Plane::takeoff_tail_hold(void)
 
 return_zero:
     if (auto_state.fbwa_tdrag_takeoff_mode) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "FBWA tdrag off");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FBWA tdrag off");
         auto_state.fbwa_tdrag_takeoff_mode = false;
     }
     return 0;

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -105,7 +105,7 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Arming motors");
 #endif
 
     AP_AHRS &ahrs = AP::ahrs();
@@ -161,7 +161,7 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Disarming motors");
 #endif
 
     auto &ahrs = AP::ahrs();

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -321,10 +321,10 @@ bool Sub::control_check_barometer()
 {
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     if (!ap.depth_sensor_present) { // can't hold depth without a depth sensor
-        gcs().send_text(MAV_SEVERITY_WARNING, "Depth sensor is not connected.");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Depth sensor is not connected.");
         return false;
     } else if (failsafe.sensor_health) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Depth sensor error.");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Depth sensor error.");
         return false;
     }
 #endif

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -423,7 +423,7 @@ bool GCS_MAVLINK_Sub::handle_guided_request(AP_Mission::Mission_Command &cmd)
 MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
     if (sub.motors.armed()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Disarm before calibration.");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Disarm before calibration.");
         return MAV_RESULT_FAILED;
     }
 
@@ -440,7 +440,7 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
     if (packet.y == 1) {
         // compassmot calibration
         //result = sub.mavlink_compassmot(chan);
-        gcs().send_text(MAV_SEVERITY_INFO, "#CompassMot calibration not supported");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "#CompassMot calibration not supported");
         return MAV_RESULT_UNSUPPORTED;
     }
 

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -16,13 +16,13 @@ bool Sub::start_command(const AP_Mission::Mission_Command& cmd)
 
     // target alt must be negative (underwater)
     if (target_loc.alt > 0.0f) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "BAD NAV ALT %0.2f", (double)target_loc.alt);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "BAD NAV ALT %0.2f", (double)target_loc.alt);
         return false;
     }
 
     // only tested/supported alt frame so far is AltFrame::ABOVE_HOME, where Home alt is always water's surface ie zero depth
     if (target_loc.get_alt_frame() != Location::AltFrame::ABOVE_HOME) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "BAD NAV AltFrame %d", (int8_t)target_loc.get_alt_frame());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "BAD NAV AltFrame %d", (int8_t)target_loc.get_alt_frame());
         return false;
     }
 
@@ -194,7 +194,7 @@ bool Sub::verify_command(const AP_Mission::Mission_Command& cmd)
 
     default:
         // error message
-        gcs().send_text(MAV_SEVERITY_WARNING,"Skipping invalid cmd #%i",cmd.id);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Skipping invalid cmd #%i",cmd.id);
         // return true if we do not recognize the command so that we move on to the next command
         return true;
     }
@@ -407,7 +407,7 @@ void Sub::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max_ms = 0;
 #endif
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 #if NAV_GUIDED == ENABLED
@@ -443,7 +443,7 @@ bool Sub::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     // check if timer has run out
     if (((AP_HAL::millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }
 

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -85,7 +85,7 @@ void Sub::failsafe_sensors_check()
     }
 
     failsafe.sensor_health = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Depth sensor error!");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Depth sensor error!");
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_SENSORS, LogErrorCode::BAD_DEPTH);
 
     if (control_mode == Mode::Number::ALT_HOLD || control_mode == Mode::Number::SURFACE || sub.flightmode->requires_GPS()) {
@@ -141,7 +141,7 @@ void Sub::failsafe_ekf_check()
 
     if (AP_HAL::millis() > failsafe.last_ekf_warn_ms + 20000) {
         failsafe.last_ekf_warn_ms = AP_HAL::millis();
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF bad");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF bad");
     }
 
     if (g.fs_ekf_action == FS_EKF_ACTION_DISARM) {
@@ -188,7 +188,7 @@ void Sub::failsafe_pilot_input_check()
     failsafe.pilot_input = true;
 
     AP::logger().Write_Error(LogErrorSubsystem::PILOT_INPUT, LogErrorCode::FAILSAFE_OCCURRED);
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Lost manual control");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Lost manual control");
 
     set_neutral_controls();
 
@@ -226,7 +226,7 @@ void Sub::failsafe_internal_pressure_check()
     // Warn every 30 seconds
     if (failsafe.internal_pressure && tnow > last_pressure_warn_ms + 30000) {
         last_pressure_warn_ms = tnow;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Internal pressure critical!");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Internal pressure critical!");
     }
 }
 
@@ -258,7 +258,7 @@ void Sub::failsafe_internal_temperature_check()
     // Warn every 30 seconds
     if (failsafe.internal_temperature && tnow > last_temperature_warn_ms + 30000) {
         last_temperature_warn_ms = tnow;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Internal temperature critical!");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Internal temperature critical!");
     }
 }
 
@@ -285,7 +285,7 @@ void Sub::failsafe_leak_check()
     // Always send a warning every 20 seconds
     if (tnow > failsafe.last_leak_warn_ms + 20000) {
         failsafe.last_leak_warn_ms = tnow;
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Leak Detected");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Leak Detected");
     }
 
     // Do nothing if we have already triggered the failsafe action, or if the motors are disarmed
@@ -337,7 +337,7 @@ void Sub::failsafe_gcs_check()
     // Send a warning every 30 seconds
     if (tnow - failsafe.last_gcs_warn_ms > 30000) {
         failsafe.last_gcs_warn_ms = tnow;
-        gcs().send_text(MAV_SEVERITY_WARNING, "MYGCS: %u, heartbeat lost", g.sysid_my_gcs.get());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "MYGCS: %u, heartbeat lost", g.sysid_my_gcs.get());
     }
 
     // do nothing if we have already triggered the failsafe action, or if the motors are disarmed
@@ -403,7 +403,7 @@ void Sub::failsafe_crash_check()
     // Send warning to GCS
     if (tnow > failsafe.last_crash_warn_ms + 20000) {
         failsafe.last_crash_warn_ms = tnow;
-        gcs().send_text(MAV_SEVERITY_WARNING,"Crash detected");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Crash detected");
     }
 
     // Only perform failsafe action once
@@ -432,7 +432,7 @@ void Sub::failsafe_terrain_check()
     // check for clearing of event
     if (trigger_event != failsafe.terrain) {
         if (trigger_event) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe terrain triggered");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Failsafe terrain triggered");
             failsafe_terrain_on_event();
         } else {
             AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_TERRAIN, LogErrorCode::ERROR_RESOLVED);

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -203,10 +203,10 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
             video_toggle = !video_toggle;
             if (video_toggle) {
                 video_switch = 1900;
-                gcs().send_text(MAV_SEVERITY_INFO,"Video Toggle: Source 2");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Video Toggle: Source 2");
             } else {
                 video_switch = 1100;
-                gcs().send_text(MAV_SEVERITY_INFO,"Video Toggle: Source 1");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Video Toggle: Source 1");
             }
         }
         break;
@@ -295,7 +295,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
             } else {
                 gain = 1.0f;
             }
-            gcs().send_text(MAV_SEVERITY_INFO,"#Gain: %2.0f%%",(double)gain*100);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"#Gain: %2.0f%%",(double)gain*100);
         }
         break;
     case JSButton::button_function_t::k_gain_inc:
@@ -311,7 +311,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
                 gain = constrain_float(gain + (g.maxGain-g.minGain)/(g.numGainSettings-1), g.minGain, g.maxGain);
             }
 
-            gcs().send_text(MAV_SEVERITY_INFO,"#Gain is %2.0f%%",(double)gain*100);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"#Gain is %2.0f%%",(double)gain*100);
         }
         break;
     case JSButton::button_function_t::k_gain_dec:
@@ -327,7 +327,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
                 gain = constrain_float(gain - (g.maxGain-g.minGain)/(g.numGainSettings-1), g.minGain, g.maxGain);
             }
 
-            gcs().send_text(MAV_SEVERITY_INFO,"#Gain is %2.0f%%",(double)gain*100);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,"#Gain is %2.0f%%",(double)gain*100);
         }
         break;
     case JSButton::button_function_t::k_trim_roll_inc:
@@ -353,9 +353,9 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
             bool input_hold_engaged_last = input_hold_engaged;
             input_hold_engaged = zTrim || xTrim || yTrim;
             if (input_hold_engaged) {
-                gcs().send_text(MAV_SEVERITY_INFO,"#Input Hold Set");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"#Input Hold Set");
             } else if (input_hold_engaged_last) {
-                gcs().send_text(MAV_SEVERITY_INFO,"#Input Hold Disabled");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"#Input Hold Disabled");
             }
             controls_reset_since_input_hold = !input_hold_engaged;
         }
@@ -567,10 +567,10 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
         if (!held) {
             roll_pitch_flag = !roll_pitch_flag;
             if (roll_pitch_flag) {
-                gcs().send_text(MAV_SEVERITY_INFO, "#Attitude Control");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "#Attitude Control");
             }
             else {
-                gcs().send_text(MAV_SEVERITY_INFO, "#Movement Control");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "#Movement Control");
             }
         }
         break;

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -85,7 +85,7 @@ bool Sub::set_mode(Mode::Number mode, ModeReason reason)
 
     if (new_flightmode->requires_GPS() &&
         !sub.position_ok()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s requires position", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change failed: %s requires position", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }
@@ -95,13 +95,13 @@ bool Sub::set_mode(Mode::Number mode, ModeReason reason)
     if (!sub.control_check_barometer() && // maybe use ekf_alt_ok() instead?
         flightmode->has_manual_throttle() &&
         !new_flightmode->has_manual_throttle()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }
 
     if (!new_flightmode->init(false)) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"Flight mode change failed %s", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Flight mode change failed %s", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -461,7 +461,7 @@ bool ModeAuto::auto_terrain_recover_start()
     position_control->set_max_speed_accel_z(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
     position_control->set_correction_speed_accel_z(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
 
-    gcs().send_text(MAV_SEVERITY_WARNING, "Attempting auto failsafe recovery");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Attempting auto failsafe recovery");
     return true;
 }
 
@@ -510,7 +510,7 @@ void ModeAuto::auto_terrain_recover_run()
 
             // 1.5 seconds of healthy rangefinder means we can resume mission with terrain enabled
             if (AP_HAL::millis() > rangefinder_recovery_ms + 1500) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Terrain failsafe recovery successful!");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Terrain failsafe recovery successful!");
                 sub.failsafe_terrain_set_status(true); // Reset failsafe timers
                 sub.failsafe.terrain = false; // Clear flag
                 sub.auto_mode = Auto_Loiter; // Switch back to loiter for next iteration
@@ -525,7 +525,7 @@ void ModeAuto::auto_terrain_recover_run()
     default:
         // Terrain failsafe recovery has failed, terrain data is not available
         // and rangefinder is not connected, or has stopped responding
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery failure: No Rangefinder!");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery failure: No Rangefinder!");
         sub.failsafe_terrain_act();
         rangefinder_recovery_ms = 0;
         return;
@@ -534,7 +534,7 @@ void ModeAuto::auto_terrain_recover_run()
     // exit on failure (timeout)
     if (AP_HAL::millis() > sub.fs_terrain_recover_start_ms + FS_TERRAIN_RECOVER_TIMEOUT_MS) {
         // Recovery has failed, revert to failsafe action
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery timeout!");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery timeout!");
         sub.failsafe_terrain_act();
     }
 

--- a/ArduSub/mode_motordetect.cpp
+++ b/ArduSub/mode_motordetect.cpp
@@ -133,21 +133,21 @@ void ModeMotordetect::run()
         Vector3f directions(roll, pitch, yaw);
         // Good read, not inverted
         if (directions == motors.get_motor_angular_factors(current_motor)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Thruster %d is ok!", current_motor + 1);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Thruster %d is ok!", current_motor + 1);
         }
         // Good read, inverted
         else if (-directions == motors.get_motor_angular_factors(current_motor)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Thruster %d is reversed! Saving it!", current_motor + 1);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Thruster %d is reversed! Saving it!", current_motor + 1);
             motors.set_reversed(current_motor, true);
         }
         // Bad read!
         else {
-            gcs().send_text(MAV_SEVERITY_INFO, "Bad thrust read, trying to push the other way...");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Bad thrust read, trying to push the other way...");
             // If we got here, we couldn't identify anything that made sense.
             // Let's try pushing the thruster the other way, maybe we are in too shallow waters or hit something
             if (current_direction == DOWN) {
                 // The reading for the second direction was also bad, we failed.
-                gcs().send_text(MAV_SEVERITY_WARNING, "Failed! Please check Thruster %d and frame setup!", current_motor + 1);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed! Please check Thruster %d and frame setup!", current_motor + 1);
                 md_state = DONE;
                 break;
             }
@@ -162,7 +162,7 @@ void ModeMotordetect::run()
         current_direction = UP;
         if (!motors.motor_is_enabled(current_motor)) {
             md_state = DONE;
-            gcs().send_text(MAV_SEVERITY_WARNING, "Motor direction detection is complete.");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Motor direction detection is complete.");
         }
         break;
     }

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -32,19 +32,19 @@ bool Sub::init_motor_test()
     // Ten second cooldown period required with no do_set_motor requests required
     // after failure.
     if (tnow < last_do_motor_test_fail_ms + 10000 && last_do_motor_test_fail_ms > 0) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "10 second cooldown required after motor test");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "10 second cooldown required after motor test");
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL,"Disarm hardware safety switch before testing motors.");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Disarm hardware safety switch before testing motors.");
         return false;
     }
 
     // Make sure we are on the ground
     if (!motors.armed()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Arm motors before testing motors.");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Arm motors before testing motors.");
         return false;
     }
 
@@ -64,7 +64,7 @@ bool Sub::verify_motor_test()
 
     // Require at least 2 Hz incoming do_set_motor requests
     if (AP_HAL::millis() > last_do_motor_test_ms + 500) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Motor test timed out!");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Motor test timed out!");
         pass = false;
     }
 
@@ -89,7 +89,7 @@ bool Sub::handle_do_motor_test(mavlink_command_int_t command) {
         // instead of spamming error messages
         if (AP_HAL::millis() > (tLastInitializationFailed + 2000)) {
             if (!init_motor_test()) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "motor test initialization failed!");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "motor test initialization failed!");
                 tLastInitializationFailed = AP_HAL::millis();
                 return false; // init fail
             }
@@ -106,12 +106,12 @@ bool Sub::handle_do_motor_test(mavlink_command_int_t command) {
     const uint32_t test_type = command.y;
 
     if (test_type != MOTOR_TEST_ORDER_BOARD) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "bad test type %0.2f", (double)test_type);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "bad test type %0.2f", (double)test_type);
         return false; // test type not supported here
     }
 
     if (is_equal(throttle_type, (float)MOTOR_TEST_THROTTLE_PILOT)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "bad throttle type %0.2f", (double)throttle_type);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "bad throttle type %0.2f", (double)throttle_type);
 
         return false; // throttle type not supported here
     }

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -312,7 +312,7 @@ bool AP_Arming_Blimp::arm(const AP_Arming::Method method, const bool do_arming_c
         AP::notify().update();
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors"); //MIR kept in - usually only in SITL
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Arming motors"); //MIR kept in - usually only in SITL
 
     auto &ahrs = AP::ahrs();
 
@@ -371,7 +371,7 @@ bool AP_Arming_Blimp::disarm(const AP_Arming::Method method, bool do_disarm_chec
         return false;
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors"); //MIR keeping in - usually only in SITL
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Disarming motors"); //MIR keeping in - usually only in SITL
 
 
     auto &ahrs = AP::ahrs();

--- a/Blimp/RC_Channel.cpp
+++ b/Blimp/RC_Channel.cpp
@@ -133,7 +133,7 @@ void Blimp::save_trim()
     float pitch_trim = ToRad((float)channel_front->get_control_in()/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     AP::logger().Write_Event(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Trim saved");
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions
@@ -142,7 +142,7 @@ void Blimp::auto_trim_cancel()
 {
     auto_trim_counter = 0;
     AP_Notify::flags.save_trim = false;
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim cancelled");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim cancelled");
 }
 
 void Blimp::auto_trim()
@@ -186,7 +186,7 @@ void Blimp::auto_trim()
         // on last iteration restore leds and accel gains to normal
         if (auto_trim_counter == 0) {
             AP_Notify::flags.save_trim = false;
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim: Trims saved");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim: Trims saved");
         }
     }
 }

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -72,7 +72,7 @@ void Blimp::ekf_check()
                 AP::logger().Write_Error(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();
@@ -189,7 +189,7 @@ void Blimp::check_ekf_reset()
     if ((ahrs.get_primary_core_index() != ekf_primary_core) && (ahrs.get_primary_core_index() != -1)) {
         ekf_primary_core = ahrs.get_primary_core_index();
         AP::logger().Write_Error(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }
 }
 
@@ -233,7 +233,7 @@ void Blimp::check_vibration()
                 vibration_check.high_vibes = false;
                 vibration_check.clear_ms = 0;
                 AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_VIBE, LogErrorCode::FAILSAFE_RESOLVED);
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Vibration compensation OFF");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Vibration compensation OFF");
             }
         }
         vibration_check.start_ms = 0;
@@ -253,7 +253,7 @@ void Blimp::check_vibration()
             // switch ekf to use resistant gains
             vibration_check.high_vibes = true;
             AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_VIBE, LogErrorCode::FAILSAFE_OCCURRED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Vibration compensation ON");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Vibration compensation ON");
         }
     }
 }

--- a/Blimp/events.cpp
+++ b/Blimp/events.cpp
@@ -32,22 +32,22 @@ void Blimp::failsafe_radio_on_event()
     // Conditions to deviate from FS_THR_ENABLE selection and send specific GCS warning
     if (should_disarm_on_failsafe()) {
         // should immediately disarm when we're on the ground
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Disarming");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio Failsafe - Disarming");
         arming.disarm(AP_Arming::Method::RADIOFAILSAFE);
         desired_action = Failsafe_Action_None;
 
     } else if (flightmode->is_landing() && ((battery.has_failsafed() && battery.get_highest_failsafe_priority() <= FAILSAFE_LAND_PRIORITY))) {
         // Allow landing to continue when battery failsafe requires it (not a user option)
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio + Battery Failsafe - Continuing Landing");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio + Battery Failsafe - Continuing Landing");
         desired_action = Failsafe_Action_Land;
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING)) {
         // Allow landing to continue when FS_OPTIONS is set to continue landing
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Landing");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Landing");
         desired_action = Failsafe_Action_Land;
 
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio Failsafe");
     }
 
     // Call the failsafe action handler
@@ -60,7 +60,7 @@ void Blimp::failsafe_radio_off_event()
     // no need to do anything except log the error as resolved
     // user can now override roll, pitch, yaw and throttle and even use flight mode switch to restore previous flight mode
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_RADIO, LogErrorCode::FAILSAFE_RESOLVED);
-    gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe Cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Radio Failsafe Cleared");
 }
 
 void Blimp::handle_battery_failsafe(const char *type_str, const int8_t action)
@@ -74,14 +74,14 @@ void Blimp::handle_battery_failsafe(const char *type_str, const int8_t action)
         // should immediately disarm when we're on the ground
         arming.disarm(AP_Arming::Method::BATTERYFAILSAFE);
         desired_action = Failsafe_Action_None;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe - Disarming");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Battery Failsafe - Disarming");
 
     } else if (flightmode->is_landing() && failsafe_option(FailsafeOption::CONTINUE_IF_LANDING) && desired_action != Failsafe_Action_None) {
         // Allow landing to continue when FS_OPTIONS is set to continue when landing
         desired_action = Failsafe_Action_Land;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe - Continuing Landing");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Battery Failsafe - Continuing Landing");
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Battery Failsafe");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Battery Failsafe");
     }
 
     // Battery FS options already use the Failsafe_Options enum. So use them directly.
@@ -169,10 +169,10 @@ void Blimp::gpsglitch_check()
         ap.gps_glitching = gps_glitching;
         if (gps_glitching) {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::GPS_GLITCH);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"GPS Glitch");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"GPS Glitch");
         } else {
             AP::logger().Write_Error(LogErrorSubsystem::GPS, LogErrorCode::ERROR_RESOLVED);
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"GPS Glitch cleared");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"GPS Glitch cleared");
         }
     }
 }

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -77,7 +77,7 @@ bool Blimp::set_mode(Mode::Number mode, ModeReason reason)
     if (!ignore_checks &&
         new_flightmode->requires_GPS() &&
         !blimp.position_ok()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s requires position", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change failed: %s requires position", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }
@@ -88,13 +88,13 @@ bool Blimp::set_mode(Mode::Number mode, ModeReason reason)
         !blimp.ekf_alt_ok() &&
         flightmode->has_manual_throttle() &&
         !new_flightmode->has_manual_throttle()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }
 
     if (!new_flightmode->init(ignore_checks)) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"Flight mode change failed %s", new_flightmode->name());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Flight mode change failed %s", new_flightmode->name());
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
     }

--- a/Blimp/motors.cpp
+++ b/Blimp/motors.cpp
@@ -43,7 +43,7 @@ void Blimp::arm_motors_check()
 
         // arm the motors and configure for flight
         if (arming_counter == AUTO_TRIM_DELAY && motors->armed() && control_mode == Mode::Number::MANUAL) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim start");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTrim start");
             auto_trim_counter = 250;
             auto_trim_started = false;
         }

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -130,7 +130,7 @@ bool AP_Arming_Rover::arm(AP_Arming::Method method, const bool do_arming_checks)
 
     update_soft_armed();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Throttle armed");
 
     return true;
 }
@@ -150,7 +150,7 @@ bool AP_Arming_Rover::disarm(const AP_Arming::Method method, bool do_disarm_chec
 
     update_soft_armed();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Throttle disarmed");
 
     return true;
 }

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -144,7 +144,7 @@ bool RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const AuxSwit
             // if disarmed clear mission and set home to current location
             if (!rover.arming.is_armed()) {
                 rover.mode_auto.mission.clear();
-                gcs().send_text(MAV_SEVERITY_NOTICE, "SaveWP: Mission cleared!");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "SaveWP: Mission cleared!");
                 if (!rover.set_home_to_current_location(false)) {
                     // ignored
                 }
@@ -243,7 +243,7 @@ bool RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const AuxSwit
             (rover.control_mode != &rover.mode_loiter)
             && (rover.control_mode != &rover.mode_hold) && ch_flag == AuxSwitchPos::HIGH) {
             SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::k_steering);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Steering trim saved!");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Steering trim saved!");
         }
         break;
 

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -33,7 +33,7 @@ bool Rover::set_home(const Location& loc, bool lock)
     mode_auto.mission.write_home_to_storage();
 
     // send text of home position to ground stations
-    gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
             static_cast<double>(loc.lat * 1.0e-7f),
             static_cast<double>(loc.lng * 1.0e-7f),
             static_cast<double>(loc.alt * 0.01f));

--- a/Rover/crash_check.cpp
+++ b/Rover/crash_check.cpp
@@ -50,11 +50,11 @@ void Rover::crash_check()
 
         if (is_balancebot()) {
             // send message to gcs
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Disarming");
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Crash: Disarming");
             arming.disarm(AP_Arming::Method::CRASH);
         } else {
             // send message to gcs
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
             // change mode to hold and disarm
             set_mode(mode_hold, ModeReason::CRASH_FAILSAFE);
             if (g.fs_crash_check == FS_CRASH_HOLD_AND_DISARM) {

--- a/Rover/cruise_learn.cpp
+++ b/Rover/cruise_learn.cpp
@@ -7,7 +7,7 @@ void Rover::cruise_learn_start()
     float speed;
     if (!arming.is_armed() || !g2.attitude_control.get_forward_speed(speed)) {
         cruise_learn.learn_start_ms = 0;
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning NOT started");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning NOT started");
         return;
     }
     // start learning
@@ -16,7 +16,7 @@ void Rover::cruise_learn_start()
     cruise_learn.learn_start_ms = AP_HAL::millis();
     cruise_learn.log_count = 0;
     log_write_cruise_learn();
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning started");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning started");
 }
 
 // update cruise learning with latest speed and throttle
@@ -51,9 +51,9 @@ void Rover::cruise_learn_complete()
         if (thr >= 10.0f && thr <= 100.0f && is_positive(speed)) {
             g.throttle_cruise.set_and_save(thr);
             g.speed_cruise.set_and_save(speed);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learned: Thr:%d Speed:%3.1f", (int)g.throttle_cruise, (double)g.speed_cruise);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learned: Thr:%d Speed:%3.1f", (int)g.throttle_cruise, (double)g.speed_cruise);
         } else {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning failed");
         }
         cruise_learn.learn_start_ms = 0;
         log_write_cruise_learn();

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -57,7 +57,7 @@ void Rover::ekf_check()
                                          LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();
@@ -177,7 +177,7 @@ void Rover::failsafe_ekf_event()
             break;
     }
 
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF failsafe");
 }
 
 // failsafe_ekf_off_event - actions to take when EKF failsafe is cleared
@@ -191,5 +191,5 @@ void Rover::failsafe_ekf_off_event(void)
     failsafe.ekf = false;
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_EKFINAV,
                              LogErrorCode::FAILSAFE_RESOLVED);
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF failsafe cleared");
 }

--- a/Rover/failsafe.cpp
+++ b/Rover/failsafe.cpp
@@ -58,7 +58,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
     }
     if (failsafe.triggered != 0 && failsafe.bits == 0) {
         // a failsafe event has ended
-        gcs().send_text(MAV_SEVERITY_INFO, "%s Failsafe Cleared", type_str);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Failsafe Cleared", type_str);
     }
 
     failsafe.triggered &= failsafe.bits;
@@ -69,7 +69,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
         (control_mode != &mode_rtl) &&
         ((control_mode != &mode_hold || (g2.fs_options & (uint32_t)Failsafe_Options::Failsafe_Option_Active_In_Hold)))) {
         failsafe.triggered = failsafe.bits;
-        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe", type_str);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Failsafe", type_str);
 
         // clear rc overrides
         RC_Channels::clear_overrides();
@@ -78,7 +78,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
             ((failsafe_type == FAILSAFE_EVENT_THROTTLE && g.fs_throttle_enabled == FS_THR_ENABLED_CONTINUE_MISSION) ||
              (failsafe_type == FAILSAFE_EVENT_GCS && g.fs_gcs_enabled == FS_GCS_ENABLED_CONTINUE_MISSION))) {
             // continue with mission in auto mode
-            gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe - Continuing Auto Mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failsafe - Continuing Auto Mode");
         } else {
             switch ((FailsafeAction)g.fs_action.get()) {
             case FailsafeAction::None:

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -6,7 +6,7 @@ bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
     if (mission.num_commands() <= 1) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
         return false;
     }
 
@@ -68,10 +68,10 @@ void ModeAuto::update()
             // if mission is running restart the current command if it is a waypoint command
             if ((mission.state() == AP_Mission::MISSION_RUNNING) && (_submode == SubMode::WP)) {
                 if (mission.restart_current_nav_cmd()) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
                 } else {
                     // failed to restart mission for some reason
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
                 }
             }
         }
@@ -417,7 +417,7 @@ bool ModeAuto::check_trigger(void)
 {
     // check for user pressing the auto trigger to off
     if (auto_triggered && g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 1) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "AUTO triggered off");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AUTO triggered off");
         auto_triggered = false;
         return false;
     }
@@ -437,7 +437,7 @@ bool ModeAuto::check_trigger(void)
 
     // check if trigger pin has been pushed
     if (g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
         auto_triggered = true;
         return true;
     }
@@ -446,7 +446,7 @@ bool ModeAuto::check_trigger(void)
     if (!is_zero(g.auto_kickstart)) {
         const float xaccel = rover.ins.get_accel().x;
         if (xaccel >= g.auto_kickstart) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
             auto_triggered = true;
             return true;
         }
@@ -601,10 +601,10 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
 #if AP_FENCE_ENABLED
         if (cmd.p1 == 0) {  //disable
             rover.fence.enable(false);
-            gcs().send_text(MAV_SEVERITY_INFO, "Fence Disabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fence Disabled");
         } else {  //enable fence
             rover.fence.enable(true);
-            gcs().send_text(MAV_SEVERITY_INFO, "Fence Enabled");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fence Enabled");
         }
 #endif
         break;
@@ -628,7 +628,7 @@ void ModeAuto::exit_mission()
     // play a tone
     AP_Notify::events.mission_complete = 1;
     // send message
-    gcs().send_text(MAV_SEVERITY_NOTICE, "Mission Complete");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Mission Complete");
 
     if (g2.mis_done_behave == MIS_DONE_BEHAVE_LOITER && start_loiter()) {
         return;
@@ -718,7 +718,7 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 
     default:
         // error message
-        gcs().send_text(MAV_SEVERITY_WARNING, "Skipping invalid cmd #%i", cmd.id);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Skipping invalid cmd #%i", cmd.id);
         // return true if we do not recognize the command so that we move on to the next command
         return true;
     }
@@ -794,7 +794,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max_ms = 0;
 #endif
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 // start guided within auto to allow external navigation system to control vehicle
@@ -844,14 +844,14 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
         // check if we are loitering at this waypoint - the message sent to the GCS is different
         if (loiter_duration > 0) {
             // send message including loiter time
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u. Loiter for %u seconds",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached waypoint #%u. Loiter for %u seconds",
                             (unsigned int)cmd.index,
                             (unsigned int)loiter_duration);
             // record the current time i.e. start timer
             loiter_start_time = millis();
         } else {
             // send simpler message to GCS
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u", (unsigned int)cmd.index);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached waypoint #%u", (unsigned int)cmd.index);
         }
     }
 
@@ -890,7 +890,7 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
 {
     const bool result = verify_nav_wp(cmd);
     if (result) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Finished active loiter");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Finished active loiter");
     }
     return result;
 }
@@ -999,7 +999,7 @@ void ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     // set speed for active mode
     if (set_desired_speed(cmd.content.speed.target_ms)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
     }
 }
 

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -256,7 +256,7 @@ void ModeCircle::check_config_speed()
 
     if (config.speed > speed_max) {
         config.speed = speed_max;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: max speed is %4.1f", (double)config.speed);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Circle: max speed is %4.1f", (double)config.speed);
     }
 }
 
@@ -268,6 +268,6 @@ void ModeCircle::check_config_radius()
     // ensure radius is at least as large as vehicle's turn radius
     if (config.radius < rover.g2.turn_radius) {
         config.radius = rover.g2.turn_radius;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: radius increased to TURN_RADIUS (%4.1f)", (double)rover.g2.turn_radius);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Circle: radius increased to TURN_RADIUS (%4.1f)", (double)rover.g2.turn_radius);
     }
 }

--- a/Rover/mode_dock.cpp
+++ b/Rover/mode_dock.cpp
@@ -60,13 +60,13 @@ bool ModeDock::_enter()
 {
     // refuse to enter the mode if dock is not in sight
     if (!rover.precland.enabled() || !rover.precland.target_acquired()) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Dock: target not acquired");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Dock: target not acquired");
         return false;
     }
 
     if (hdg_corr_enable && is_negative(desired_dir)) {
         // DOCK_DIR is required for heading correction
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Dock: Set DOCK_DIR or disable heading correction");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Dock: Set DOCK_DIR or disable heading correction");
         return false;
     }
 
@@ -132,7 +132,7 @@ void ModeDock::update()
         _docking_complete = true;
 
         // send a one time notification to GCS
-        gcs().send_text(MAV_SEVERITY_INFO, "Dock: Docking complete");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Dock: Docking complete");
 
         // initialise mode loiter if it is a boat
         if (rover.is_boat()) {

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -53,7 +53,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -77,7 +77,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -112,7 +112,7 @@ void ModeGuided::update()
             // handle timeout
             if (_have_strthr && (AP_HAL::millis() - _strthr_time_ms) > 3000) {
                 _have_strthr = false;
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
             }
             if (_have_strthr) {
                 // pass latest steering and throttle directly to motors library
@@ -136,7 +136,7 @@ void ModeGuided::update()
             break;
 
         default:
-            gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
             break;
     }
 }

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -37,7 +37,7 @@ void ModeRTL::update()
         // send notification
         if (send_notification) {
             send_notification = false;
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached destination");
         }
 
         // we have reached the destination

--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -47,7 +47,7 @@ void ModeSmartRTL::update()
                 Vector3f dest_NED;
                 if (!g2.smart_rtl.pop_point(dest_NED)) {
                     // if not more points, we have reached home
-                    gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached destination");
                     smart_rtl_state = SmartRTLState::StopAtHome;
                     break;
                 } else {
@@ -56,7 +56,7 @@ void ModeSmartRTL::update()
                     if (g2.smart_rtl.peek_point(next_dest_NED)) {
                         if (!g2.wp_nav.set_desired_location_NED(dest_NED, next_dest_NED)) {
                             // this should never happen because the EKF origin should already be set
-                            gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
+                            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;
                             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                         }
@@ -64,7 +64,7 @@ void ModeSmartRTL::update()
                         // no next point so add only immediate point
                         if (!g2.wp_nav.set_desired_location_NED(dest_NED)) {
                             // this should never happen because the EKF origin should already be set
-                            gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
+                            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;
                             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                         }

--- a/Rover/sailboat.cpp
+++ b/Rover/sailboat.cpp
@@ -477,7 +477,7 @@ float Sailboat::calc_heading(float desired_heading_cd)
 
     // if tack triggered, calculate target heading
     if (should_tack && (now - tack_clear_ms) > TACK_RETRY_TIME_MS) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Sailboat: Tacking");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Sailboat: Tacking");
         // calculate target heading for the new tack
         switch (current_tack) {
             case AP_WindVane::Sailboat_Tack::TACK_PORT:
@@ -502,7 +502,7 @@ float Sailboat::calc_heading(float desired_heading_cd)
                 // if we have throttle available use it for another two time periods to get the tack done
                 tack_assist = true;
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Sailboat: Tacking timed out");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Sailboat: Tacking timed out");
                 clear_tack();
             }
         }
@@ -533,7 +533,7 @@ void Sailboat::set_motor_state(UseMotor state, bool report_failure)
         rover.get_frame_type() != rover.g2.motors.frame_type::FRAME_TYPE_UNDEFINED) {
         motor_state = state;
     } else if (report_failure) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Sailboat: failed to enable motor");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Sailboat: failed to enable motor");
     }
 }
 

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -252,7 +252,7 @@ bool Rover::set_mode(Mode &new_mode, ModeReason reason)
 
     // Check if GCS mode change is disabled via parameter
     if ((reason == ModeReason::GCS_COMMAND) && !gcs_mode_enabled((Mode::Number)new_mode.mode_number())) {
-        gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name4());
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name4());
         return false;
     }
 
@@ -261,7 +261,7 @@ bool Rover::set_mode(Mode &new_mode, ModeReason reason)
         // Log error that we failed to enter desired flight mode
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE,
                                  LogErrorCode(new_mode.mode_number()));
-        gcs().send_text(MAV_SEVERITY_WARNING, "Flight mode change failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Flight mode change failed");
         return false;
     }
 
@@ -306,7 +306,7 @@ bool Rover::set_mode(Mode::Number new_mode, ModeReason reason)
 
 void Rover::startup_INS_ground(void)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
     hal.scheduler->delay(100);
 
     ahrs.init();

--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -113,7 +113,7 @@ void AP_Periph_FW::init()
 #if HAL_GCS_ENABLED
     gcs().setup_console();
     gcs().setup_uarts();
-    gcs().send_text(MAV_SEVERITY_INFO, "AP_Periph GCS Initialised!");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AP_Periph GCS Initialised!");
 #endif
 
     stm32_watchdog_pat();

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -219,7 +219,7 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
     }
 
     if (!active_msg_sent) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Weathervane Active: %s", dir_string);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Weathervane Active: %s", dir_string);
         active_msg_sent = true;
     }
 

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -119,21 +119,21 @@ bool AC_AutoTune::init_position_controller(void)
 void AC_AutoTune::send_step_string()
 {
     if (pilot_override) {
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Paused: Pilot Override Active");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Paused: Pilot Override Active");
         return;
     }
     switch (step) {
     case WAITING_FOR_LEVEL:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Leveling");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Leveling");
         return;
     case UPDATE_GAINS:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Updating Gains");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Updating Gains");
         return;
     case TESTING:
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Testing");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Testing");
         return;
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: unknown step");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: unknown step");
 }
 
 const char *AC_AutoTune::type_string() const
@@ -234,7 +234,7 @@ void AC_AutoTune::run()
     }
     if (pilot_override) {
         if (now - last_pilot_override_warning > 1000) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: pilot overrides active");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: pilot overrides active");
             last_pilot_override_warning = now;
         }
     }
@@ -277,7 +277,7 @@ bool AC_AutoTune::currently_level()
     // display warning if vehicle fails to level
     if ((now_ms - level_start_time_ms > AUTOTUNE_LEVEL_WARNING_INTERVAL_MS) &&
         (now_ms - level_fail_warning_time_ms > AUTOTUNE_LEVEL_WARNING_INTERVAL_MS)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "AutoTune: failing to level, please tune manually");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: failing to level, please tune manually");
         level_fail_warning_time_ms = now_ms;
     }
 
@@ -601,22 +601,22 @@ void AC_AutoTune::update_gcs(uint8_t message_id) const
 {
     switch (message_id) {
     case AUTOTUNE_MESSAGE_STARTED:
-        gcs().send_text(MAV_SEVERITY_INFO,"AutoTune: Started");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"AutoTune: Started");
         break;
     case AUTOTUNE_MESSAGE_STOPPED:
-        gcs().send_text(MAV_SEVERITY_INFO,"AutoTune: Stopped");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"AutoTune: Stopped");
         break;
     case AUTOTUNE_MESSAGE_SUCCESS:
-        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Success");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: Success");
         break;
     case AUTOTUNE_MESSAGE_FAILED:
-        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: Failed");
         break;
     case AUTOTUNE_MESSAGE_TESTING:
-        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Pilot Testing");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: Pilot Testing");
         break;
     case AUTOTUNE_MESSAGE_SAVED_GAINS:
-        gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: Saved gains for %s%s%s%s",
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: Saved gains for %s%s%s%s",
                         (axes_completed&AUTOTUNE_AXIS_BITMASK_ROLL)?"Roll ":"",
                         (axes_completed&AUTOTUNE_AXIS_BITMASK_PITCH)?"Pitch ":"",
                         (axes_completed&AUTOTUNE_AXIS_BITMASK_YAW)?"Yaw(E)":"",

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -88,7 +88,7 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
             pull_from_tgt_buffer(tgt_cnt, tgt_ampl, tgt_time);
             push_to_meas_buffer(0, 0.0f, 0);
             push_to_tgt_buffer(0, 0.0f, 0);
-            // gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: tgt_cnt=%f meas_cnt=%f", (double)(tgt_cnt), (double)(meas_cnt));
+            // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: tgt_cnt=%f meas_cnt=%f", (double)(tgt_cnt), (double)(meas_cnt));
 
             if (meas_cnt == tgt_cnt && meas_cnt != 0) {
                 if (tgt_ampl > 0.0f) {
@@ -135,7 +135,7 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
 
         curr_test_freq = tgt_freq;
         cycle_complete = true;
-        // gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: cycles completed");
+        // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: cycles completed");
         return;
     }
 

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -244,12 +244,12 @@ void AC_AutoTune_Heli::test_run(AxisType test_axis, const float dir_sign)
         attitude_control->input_euler_angle_roll_pitch_yaw(roll_cd, pitch_cd, desired_yaw_cd, true);
 
         if ((tune_type == RP_UP || tune_type == RD_UP) && (max_rate_p.max_allowed <= 0.0f || max_rate_d.max_allowed <= 0.0f)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Max Gain Determination Failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Max Gain Determination Failed");
             mode = FAILED;
             AP::logger().Write_Event(LogEvent::AUTOTUNE_FAILED);
             update_gcs(AUTOTUNE_MESSAGE_FAILED);
         } else if ((tune_type == MAX_GAINS || tune_type == RP_UP || tune_type == RD_UP || tune_type == SP_UP) && exceeded_freq_range(start_freq)){
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Exceeded frequency range");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Exceeded frequency range");
             mode = FAILED;
             AP::logger().Write_Event(LogEvent::AUTOTUNE_FAILED);
             update_gcs(AUTOTUNE_MESSAGE_FAILED);
@@ -291,7 +291,7 @@ void AC_AutoTune_Heli::do_gcs_announcements()
         return;
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: %s %s", axis_string(), type_string());
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: %s %s", axis_string(), type_string());
     send_step_string();
     switch (tune_type) {
     case RD_UP:
@@ -300,11 +300,11 @@ void AC_AutoTune_Heli::do_gcs_announcements()
     case SP_UP:
     case TUNE_CHECK:
         if (is_equal(start_freq,stop_freq)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Dwell");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Dwell");
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Sweep");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Sweep");
             if (settle_time == 0) {
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f phase=%f", (double)(curr_test.freq), (double)(curr_test.gain), (double)(curr_test.phase));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f phase=%f", (double)(curr_test.freq), (double)(curr_test.gain), (double)(curr_test.phase));
             }
         }
         break;
@@ -351,8 +351,8 @@ void AC_AutoTune_Heli::do_post_test_gcs_announcements() {
     if (step == UPDATE_GAINS) {
         switch (tune_type) {
         case RFF_UP:
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: target=%f rotation=%f command=%f", (double)(test_tgt_rate_filt*57.3f), (double)(test_rate_filt*57.3f), (double)(test_command_filt));
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ff=%f", (double)tune_rff);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: target=%f rotation=%f command=%f", (double)(test_tgt_rate_filt*57.3f), (double)(test_rate_filt*57.3f), (double)(test_command_filt));
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: ff=%f", (double)tune_rff);
             break;
         case RP_UP:
         case RD_UP:
@@ -360,18 +360,18 @@ void AC_AutoTune_Heli::do_post_test_gcs_announcements() {
         case MAX_GAINS:
             if (is_equal(start_freq,stop_freq)) {
                 // announce results of dwell
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f", (double)(test_phase[freq_cnt]));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: freq=%f gain=%f", (double)(test_freq[freq_cnt]), (double)(test_gain[freq_cnt]));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: ph=%f", (double)(test_phase[freq_cnt]));
                if (tune_type == RP_UP) {
-                   gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: rate_p=%f", (double)(tune_rp));
+                   GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: rate_p=%f", (double)(tune_rp));
                } else if (tune_type == RD_UP) {
-               gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: rate_d=%f", (double)(tune_rd));
+               GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: rate_d=%f", (double)(tune_rd));
                } else if (tune_type == SP_UP) {
-                   gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: angle_p=%f tune_accel=%f max_accel=%f", (double)(tune_sp), (double)(tune_accel), (double)(test_accel_max));
+                   GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: angle_p=%f tune_accel=%f max_accel=%f", (double)(tune_sp), (double)(tune_accel), (double)(test_accel_max));
                }
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: max_freq=%f max_gain=%f", (double)(sweep.maxgain.freq), (double)(sweep.maxgain.gain));
-                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph180_freq=%f ph180_gain=%f", (double)(sweep.ph180.freq), (double)(sweep.ph180.gain));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: max_freq=%f max_gain=%f", (double)(sweep.maxgain.freq), (double)(sweep.maxgain.gain));
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: ph180_freq=%f ph180_gain=%f", (double)(sweep.ph180.freq), (double)(sweep.ph180.gain));
             }
             break;
         default:
@@ -681,9 +681,9 @@ void AC_AutoTune_Heli::report_final_gains(AxisType test_axis) const
 // report gain formatting helper
 void AC_AutoTune_Heli::report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float rate_ff, float angle_P, float max_accel) const
 {
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.4f, I:%0.4f, D:%0.5f, FF:%0.4f",axis_string,rate_P,rate_I,rate_D,rate_ff);
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.2f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.4f, I:%0.4f, D:%0.5f, FF:%0.4f",axis_string,rate_P,rate_I,rate_D,rate_ff);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.2f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
 }
 
 
@@ -1710,10 +1710,10 @@ void AC_AutoTune_Heli::updating_max_gains(float *freq, float *gain, float *phase
         }
     }
     if (found_max_p && found_max_d) {
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Max rate P freq=%f gain=%f", (double)(max_rate_p.freq), (double)(max_rate_p.gain));
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_p=%f", (double)(max_rate_p.phase), (double)(max_rate_p.max_allowed));
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Max Rate D freq=%f gain=%f", (double)(max_rate_d.freq), (double)(max_rate_d.gain));
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_d=%f", (double)(max_rate_d.phase), (double)(max_rate_d.max_allowed));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Max rate P freq=%f gain=%f", (double)(max_rate_p.freq), (double)(max_rate_p.gain));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_p=%f", (double)(max_rate_p.phase), (double)(max_rate_p.max_allowed));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Max Rate D freq=%f gain=%f", (double)(max_rate_d.freq), (double)(max_rate_d.gain));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_d=%f", (double)(max_rate_d.phase), (double)(max_rate_d.max_allowed));
     }
 
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -116,7 +116,7 @@ void AC_AutoTune_Multi::do_gcs_announcements()
     if (now - announce_time < AUTOTUNE_ANNOUNCE_INTERVAL_MS) {
         return;
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: %s %s %u%%", axis_string(), type_string(), (counter * (100/AUTOTUNE_SUCCESS_COUNT)));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: %s %s %u%%", axis_string(), type_string(), (counter * (100/AUTOTUNE_SUCCESS_COUNT)));
     announce_time = now;
 }
 
@@ -487,9 +487,9 @@ void AC_AutoTune_Multi::report_final_gains(AxisType test_axis) const
 // report gain formatting helper
 void AC_AutoTune_Multi::report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float angle_P, float max_accel) const
 {
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.3f, I:%0.3f, D:%0.4f",axis_string,rate_P,rate_I,rate_D);
-    gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.3f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s complete", axis_string);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s Rate: P:%0.3f, I:%0.3f, D:%0.4f",axis_string,rate_P,rate_I,rate_D);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.3f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
 }
 
 // twitching_test_rate - twitching tests

--- a/libraries/AC_CustomControl/AC_CustomControl.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl.cpp
@@ -123,30 +123,30 @@ void AC_CustomControl::set_custom_controller(bool enabled)
 
     // don't allow accidental main controller reset without active custom controller
     if (_controller_type == CustomControlType::CONT_NONE) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Custom controller is not enabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Custom controller is not enabled");
         return;
     }
 
     // controller type is out of range
     if (_controller_type > CUSTOMCONTROL_MAX_TYPES) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Custom controller type is out of range");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Custom controller type is out of range");
         return;
     }
 
     // backend is not created
     if (_backend == nullptr) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Reboot to enable selected custom controller");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reboot to enable selected custom controller");
         return;
     }
 
     if (_custom_controller_mask == 0 && enabled) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Axis mask is not set");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Axis mask is not set");
         return;
     }
 
     // reset main controller
     if (!enabled) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Custom controller is OFF");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Custom controller is OFF");
         // don't reset if the empty backend is selected
         if (_controller_type > CustomControlType::CONT_EMPTY) {
             reset_main_att_controller();
@@ -156,7 +156,7 @@ void AC_CustomControl::set_custom_controller(bool enabled)
     if (enabled && _controller_type > CustomControlType::CONT_NONE) {
         // reset custom controller filter, integrator etc.
         _backend->reset();
-        gcs().send_text(MAV_SEVERITY_INFO, "Custom controller is ON");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Custom controller is ON");
     }
 
     _custom_controller_active = enabled;

--- a/libraries/AC_CustomControl/AC_CustomControl_Empty.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_Empty.cpp
@@ -57,7 +57,7 @@ Vector3f AC_CustomControl_Empty::update(void)
     // arducopter main attitude controller already ran
     // we don't need to do anything else
 
-    gcs().send_text(MAV_SEVERITY_INFO, "empty custom controller working");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "empty custom controller working");
 
     // return what arducopter main controller outputted
     return Vector3f(_motors->get_roll(), _motors->get_pitch(), _motors->get_yaw());

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -203,7 +203,7 @@ void AC_Fence::auto_enable_fence_after_takeoff(void)
         case AC_Fence::AutoEnable::ALWAYS_ENABLED:
         case AC_Fence::AutoEnable::ENABLE_DISABLE_FLOOR_ONLY:
             enable(true);
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence enabled (auto enabled)");
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence enabled (auto enabled)");
             break;
         default:
             // fence does not auto-enable in other takeoff conditions
@@ -219,11 +219,11 @@ void AC_Fence::auto_disable_fence_for_landing(void)
     switch (auto_enabled()) {
         case AC_Fence::AutoEnable::ALWAYS_ENABLED:
             enable(false);
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence disabled (auto disable)");
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence disabled (auto disable)");
             break;
         case AC_Fence::AutoEnable::ENABLE_DISABLE_FLOOR_ONLY:
             disable_floor();
-            gcs().send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
             break;
         default:
             // fence does not auto-disable in other landing conditions

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -20,7 +20,7 @@
 #define POLYFENCE_LOADER_DEBUGGING 0
 
 #if POLYFENCE_LOADER_DEBUGGING
-#define Debug(fmt, args ...)  do { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
+#define Debug(fmt, args ...)  do { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
 #else
 #define Debug(fmt, args ...)
 #endif
@@ -356,7 +356,7 @@ bool AC_PolyFence_loader::scan_eeprom(scan_fn_t scan_fn)
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
             AP_HAL::panic("Fence corrupt (offset=%u)", read_offset);
 #endif
-            gcs().send_text(MAV_SEVERITY_WARNING, "Fence corrupt");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Fence corrupt");
             return false;
         }
 
@@ -700,13 +700,13 @@ bool AC_PolyFence_loader::load_from_eeprom()
             boundary.points_lla = next_storage_point_lla;
             boundary.count = index.count;
             if (index.count < 3) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: invalid polygon vertex count %u", index.count);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: invalid polygon vertex count %u", index.count);
                 storage_valid = false;
                 break;
             }
             storage_offset += 1; // skip vertex count
             if (!read_polygon_from_storage(ekf_origin, storage_offset, index.count, next_storage_point, next_storage_point_lla)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: polygon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: polygon read failed");
                 storage_valid = false;
                 break;
             }
@@ -719,13 +719,13 @@ bool AC_PolyFence_loader::load_from_eeprom()
             boundary.points_lla = next_storage_point_lla;
             boundary.count = index.count;
             if (index.count < 3) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: invalid polygon vertex count %u", index.count);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: invalid polygon vertex count %u", index.count);
                 storage_valid = false;
                 break;
             }
             storage_offset += 1; // skip vertex count
             if (!read_polygon_from_storage(ekf_origin, storage_offset, index.count, next_storage_point, next_storage_point_lla)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: polygon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: polygon read failed");
                 storage_valid = false;
                 break;
             }
@@ -736,12 +736,12 @@ bool AC_PolyFence_loader::load_from_eeprom()
         case AC_PolyFenceType::CIRCLE_EXCLUSION: {
             ExclusionCircle &circle = _loaded_circle_exclusion_boundary[_num_loaded_circle_exclusion_boundaries];
             if (!read_latlon_from_storage(storage_offset, circle.point)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
             if (!scale_latlon_from_origin(ekf_origin, circle.point, circle.pos_cm)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
@@ -752,7 +752,7 @@ bool AC_PolyFence_loader::load_from_eeprom()
                 circle.radius = fence_storage.read_float(storage_offset);
             }
             if (!is_positive(circle.radius)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: non-positive circle radius");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: non-positive circle radius");
                 storage_valid = false;
                 break;
             }
@@ -763,12 +763,12 @@ bool AC_PolyFence_loader::load_from_eeprom()
         case AC_PolyFenceType::CIRCLE_INCLUSION: {
             InclusionCircle &circle = _loaded_circle_inclusion_boundary[_num_loaded_circle_inclusion_boundaries];
             if (!read_latlon_from_storage(storage_offset, circle.point)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
             if (!scale_latlon_from_origin(ekf_origin, circle.point, circle.pos_cm)){
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
@@ -779,7 +779,7 @@ bool AC_PolyFence_loader::load_from_eeprom()
                 circle.radius = fence_storage.read_float(storage_offset);
             }
             if (!is_positive(circle.radius)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "AC_Fence: non-positive circle radius");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: non-positive circle radius");
                 storage_valid = false;
                 break;
             }
@@ -788,13 +788,13 @@ bool AC_PolyFence_loader::load_from_eeprom()
         }
         case AC_PolyFenceType::RETURN_POINT:
             if (_loaded_return_point != nullptr) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
                 storage_valid = false;
                 break;
             }
             _loaded_return_point = next_storage_point;
             if (_loaded_return_point_lla != nullptr) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
                 storage_valid = false;
                 break;
             }
@@ -802,12 +802,12 @@ bool AC_PolyFence_loader::load_from_eeprom()
             // Read the point from storage
             if (!read_latlon_from_storage(storage_offset, *next_storage_point_lla)) {
                 storage_valid = false;
-                gcs().send_text(MAV_SEVERITY_WARNING, "PolyFence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: latlon read failed");
                 break;
             }
             if (!scale_latlon_from_origin(ekf_origin, *next_storage_point_lla, *next_storage_point)) {
                 storage_valid = false;
-                gcs().send_text(MAV_SEVERITY_WARNING, "PolyFence: latlon read failed");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: latlon read failed");
                 break;
             }
             next_storage_point++;
@@ -914,7 +914,7 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
         case AC_PolyFenceType::POLYGON_INCLUSION:
         case AC_PolyFenceType::POLYGON_EXCLUSION:
             if (new_items[i].vertex_count < 3) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Invalid vertex count (%u)", new_items[i].vertex_count);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Invalid vertex count (%u)", new_items[i].vertex_count);
                 return false;
             }
             if (expected_type_count == 0) {
@@ -923,10 +923,10 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
                 expecting_type = new_items[i].type;
             } else {
                 if (new_items[i].type != expecting_type) {
-                    gcs().send_text(MAV_SEVERITY_WARNING, "Received incorrect vertex type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Received incorrect vertex type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
                     return false;
                 } else if (new_items[i].vertex_count != orig_expected_type_count) {
-                    gcs().send_text(MAV_SEVERITY_WARNING, "Unexpected vertex count want=%u got=%u\n", orig_expected_type_count, new_items[i].vertex_count);
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Unexpected vertex count want=%u got=%u\n", orig_expected_type_count, new_items[i].vertex_count);
                     return false;
                 }
             }
@@ -942,11 +942,11 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
         case AC_PolyFenceType::CIRCLE_INCLUSION:
         case AC_PolyFenceType::CIRCLE_EXCLUSION:
             if (expected_type_count) {
-               gcs().send_text(MAV_SEVERITY_WARNING, "Received incorrect type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
+               GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Received incorrect type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
                return false;
             }
             if (!is_positive(new_items[i].radius)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Non-positive circle radius");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Non-positive circle radius");
                 return false;
             }
             validate_latlon = true;
@@ -954,13 +954,13 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
 
         case AC_PolyFenceType::RETURN_POINT:
             if (expected_type_count) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Received incorrect type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Received incorrect type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
                 return false;
             }
 
             // spec says only one return point allowed
             if (seen_return_point) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Multiple return points");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Multiple return points");
                 return false;
             }
             seen_return_point = true;
@@ -972,14 +972,14 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
 
         if (validate_latlon) {
             if (!check_latlng(new_items[i].loc[0], new_items[i].loc[1])) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Bad lat or lon");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Bad lat or lon");
                 return false;
             }
         }
     }
 
     if (expected_type_count) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Incorrect item count");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Incorrect item count");
         return false;
     }
 
@@ -1022,12 +1022,12 @@ uint16_t AC_PolyFence_loader::fence_storage_space_required(const AC_PolyFenceIte
 bool AC_PolyFence_loader::write_fence(const AC_PolyFenceItem *new_items, uint16_t count)
 {
     if (!validate_fence(new_items, count)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Fence validation failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Fence validation failed");
         return false;
     }
 
     if (fence_storage_space_required(new_items, count) > fence_storage.size()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Fence exceeds storage size");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Fence exceeds storage size");
         return false;
     }
 
@@ -1118,7 +1118,7 @@ bool AC_PolyFence_loader::write_fence(const AC_PolyFenceItem *new_items, uint16_
     if (!index_eeprom()) {
         AP_HAL::panic("Failed to index eeprom");
     }
-    gcs().send_text(MAV_SEVERITY_DEBUG, "Fence Indexed OK");
+    GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "Fence Indexed OK");
 #endif
 
     // start logger logging new fence

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -401,7 +401,7 @@ bool AC_PrecLand::target_acquired()
     if ((AP_HAL::millis()-_last_update_ms) > LANDING_TARGET_TIMEOUT_MS) {
         if (_target_acquired) {
             // just lost the landing target, inform the user. This message will only be sent once every time target is lost
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Target Lost");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PrecLand: Target Lost");
         }
         // not had a sensor update since a long time
         // probably lost the target
@@ -513,7 +513,7 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
             // Update if a new Line-Of-Sight measurement is available
             if (construct_pos_meas_using_rangefinder(rangefinder_alt_m, rangefinder_alt_valid)) {
                 if (!_estimator_initialized) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Target Found");
                     _estimator_initialized = true;
                 }
                 _target_pos_rel_est_NE.x = _target_pos_rel_meas_NED.x;
@@ -546,7 +546,7 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
                 float xy_pos_var = sq(_target_pos_rel_meas_NED.z*(0.01f + 0.01f*AP::ahrs().get_gyro().length()) + 0.02f);
                 if (!_estimator_initialized) {
                     // Inform the user landing target has been found
-                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Target Found");
                     // start init of EKF. We will let the filter consume the data for a while before it available for consumption
                     // reset filter state
                     if (inertial_data_delayed->inertialNavVelocityValid) {
@@ -602,11 +602,11 @@ void AC_PrecLand::check_ekf_init_timeout()
         if (AP_HAL::millis()-_last_update_ms > EKF_INIT_SENSOR_MIN_UPDATE_MS) {
             // we have lost the target, not enough readings to initialize the EKF
             _estimator_initialized = false;
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Init Failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PrecLand: Init Failed");
         } else if (AP_HAL::millis()-_estimator_init_ms > EKF_INIT_TIME_MS) {
             // the target has been visible for a while, EKF should now have initialized to a good value
             _target_acquired = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Init Complete");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Init Complete");
         }
     }
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -64,7 +64,7 @@ void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, u
             //we do not support this frame
             if (!_wrong_frame_msg_sent) {
                 _wrong_frame_msg_sent = true;
-                gcs().send_text(MAV_SEVERITY_INFO,"Plnd: Frame not supported ");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Plnd: Frame not supported ");
             }
             return;
         }

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -186,7 +186,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         _retry_state = RetryLanding::IN_PROGRESS;
         // inform the user what we are doing
         if (_retry_count <= _precland->get_max_retry_allowed()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retrying");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retrying");
         }
         retry_pos_m = go_to_pos;
         return Status::RETRYING;
@@ -219,7 +219,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         if (fabsf(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
             // we have descended to the original height where we started the climb from
             _retry_state = RetryLanding::COMPLETE;
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");
         }
         return Status::RETRYING;
     }
@@ -249,7 +249,7 @@ AC_PrecLand_StateMachine::FailSafeAction AC_PrecLand_StateMachine::get_failsafe_
         // start the timer
         failsafe_start_ms = AP_HAL::millis();
         failsafe_initialized = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Failsafe Measures");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Failsafe Measures");
     }
 
     // Depending on the strictness we will either land vertically, wait for some time and then land vertically, not land at all

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -195,7 +195,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
         const AC_Fence *ap_fence = AP::fence();
         if ((ap_fence != nullptr && ap_fence->get_breaches() != 0) || check_altlimit()) {
             if (!_terminate) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to fence breach");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terminating due to fence breach");
                 _terminate.set_and_notify(1);
             }
         }
@@ -213,7 +213,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
         (mode == AFS_MANUAL || mode == AFS_STABILIZED || !_rc_term_manual_only) &&
         _rc_fail_time_seconds > 0 &&
             (AP_HAL::millis() - last_valid_rc_ms) > (_rc_fail_time_seconds * 1000.0f)) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to RC failure");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terminating due to RC failure");
         _terminate.set_and_notify(1);
     }
     
@@ -241,7 +241,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
         // we startup in preflight mode. This mode ends when
         // we first enter auto.
         if (mode == AFS_AUTO) {
-            gcs().send_text(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO");
+            GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO");
             _state = STATE_AUTO;
         }
         break;
@@ -249,7 +249,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
     case STATE_AUTO:
         // this is the normal mode. 
         if (!gcs_link_ok) {
-            gcs().send_text(MAV_SEVERITY_DEBUG, "AFS State: DATA_LINK_LOSS");
+            GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "AFS State: DATA_LINK_LOSS");
             _state = STATE_DATA_LINK_LOSS;
             if (_wp_comms_hold) {
                 _saved_wp = mission.get_current_nav_cmd().index;
@@ -266,7 +266,7 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
             break;
         }
         if (!gps_lock_ok) {
-            gcs().send_text(MAV_SEVERITY_DEBUG, "AFS State: GPS_LOSS");
+            GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "AFS State: GPS_LOSS");
             _state = STATE_GPS_LOSS;
             if (_wp_gps_loss) {
                 _saved_wp = mission.get_current_nav_cmd().index;
@@ -287,13 +287,13 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
             // leads to termination if AFS_DUAL_LOSS is 1
             if(_enable_dual_loss) {
                 if (!_terminate) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to dual loss");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terminating due to dual loss");
                     _terminate.set_and_notify(1);
                 }
             }
         } else if (gcs_link_ok) {
             _state = STATE_AUTO;
-            gcs().send_text(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO, GCS now OK");
+            GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO, GCS now OK");
 
             if (option_is_set(Option::CONTINUE_AFTER_RECOVERED)) {
                 break;
@@ -314,11 +314,11 @@ AP_AdvancedFailsafe::check(uint32_t last_valid_rc_ms)
             // losing GCS link when GPS lock lost
             // leads to termination if AFS_DUAL_LOSS is 1
             if (!_terminate && _enable_dual_loss) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to dual loss");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terminating due to dual loss");
                 _terminate.set_and_notify(1);
             }
         } else if (gps_lock_ok) {
-            gcs().send_text(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO, GPS now OK");
+            GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "AFS State: AFS_AUTO, GPS now OK");
             _state = STATE_AUTO;
             // we only return to the mission if we have not exceeded AFS_MAX_GPS_LOSS
             if (_saved_wp != 0 &&
@@ -428,7 +428,7 @@ bool AP_AdvancedFailsafe::should_crash_vehicle(void)
 // returns true if AFS is in the desired termination state
 bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reason) {
     if (!_enable) {
-        gcs().send_text(MAV_SEVERITY_INFO, "AFS not enabled, can't terminate the vehicle");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AFS not enabled, can't terminate the vehicle");
         return false;
     }
 
@@ -439,13 +439,13 @@ bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reaso
 
     if(should_terminate == is_terminating) {
         if (is_terminating) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Terminating due to %s", reason);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Terminating due to %s", reason);
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "Aborting termination due to %s", reason);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Aborting termination due to %s", reason);
         }
         return true;
     } else if (should_terminate && _terminate_action != TERMINATE_ACTION_TERMINATE) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Unable to terminate, termination is not configured");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unable to terminate, termination is not configured");
     }
     return false;
 }
@@ -482,7 +482,7 @@ void AP_AdvancedFailsafe::max_range_update(void)
     if (distance_km > _max_range_km) {
         uint32_t now = AP_HAL::millis();
         if (now - _term_range_notice_ms > 5000) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Terminating due to range %.1fkm", distance_km);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Terminating due to range %.1fkm", distance_km);
             _term_range_notice_ms = now;
         }
         _terminate.set_and_notify(1);

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1647,7 +1647,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
     running_arming_checks = false;
 
     if (armed && do_arming_checks && checks_to_perform == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Warning: Arming Checks Disabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Warning: Arming Checks Disabled");
     }
     
 #if HAL_GYROFFT_ENABLED
@@ -1676,7 +1676,7 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
             // If a fence is set to auto-enable, turn on the fence
             if (fence->auto_enabled() == AC_Fence::AutoEnable::ONLY_WHEN_ARMED) {
                 fence->enable(true);
-                gcs().send_text(MAV_SEVERITY_INFO, "Fence: auto-enabled");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fence: auto-enabled");
             }
         }
     }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -256,7 +256,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
 AP_Baro *AP_Baro::_singleton;
 
 #if HAL_GCS_ENABLED
-#define BARO_SEND_TEXT(severity, format, args...) gcs().send_text(severity, format, ##args)
+#define BARO_SEND_TEXT(severity, format, args...) GCS_SEND_TEXT(severity, format, ##args)
 #else
 #define BARO_SEND_TEXT(severity, format, args...)
 #endif

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -948,7 +948,7 @@ void AP_BattMonitor::checkPoweringOff(void)
             cmd_msg.command = MAV_CMD_POWER_OFF_INITIATED;
             cmd_msg.param1 = i+1;
             GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
-            gcs().send_text(MAV_SEVERITY_WARNING, "Vehicle %d battery %d is powering off", mavlink_system.sysid, i+1);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Vehicle %d battery %d is powering off", mavlink_system.sysid, i+1);
 #endif
 
             // only send this once

--- a/libraries/AP_Beacon/AP_Beacon_Marvelmind.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Marvelmind.cpp
@@ -37,7 +37,7 @@ extern const AP_HAL::HAL& hal;
 
 #if MM_DEBUG_LEVEL
   #include <GCS_MAVLink/GCS.h>
-  #define Debug(level, fmt, args ...)  do { if (level <= MM_DEBUG_LEVEL) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } } while (0)
+  #define Debug(level, fmt, args ...)  do { if (level <= MM_DEBUG_LEVEL) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ## args); } } while (0)
 #else
   #define Debug(level, fmt, args ...)
 #endif

--- a/libraries/AP_BoardConfig/IMU_heater.cpp
+++ b/libraries/AP_BoardConfig/IMU_heater.cpp
@@ -108,7 +108,7 @@ void AP_BoardConfig::set_imu_temp(float current)
 #endif // HAL_LOGGING_ENABLED
 
 #if 0
-    gcs().send_text(MAV_SEVERITY_INFO, "Heater: Out=%.1f Temp=%.1f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Heater: Out=%.1f Temp=%.1f",
                     double(heater.output),
                     double(avg));
 #endif

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -141,7 +141,7 @@ void AP_Camera_MAVLinkCamV2::handle_message(mavlink_channel_t chan, const mavlin
         const uint8_t fw_ver_build = (_cam_info.firmware_version & 0xFF000000) >> 24;
 
         // display camera info to user
-        gcs().send_text(MAV_SEVERITY_INFO, "Camera: %s.32 %s.32 fw:%u.%u.%u.%u",
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Camera: %s.32 %s.32 fw:%u.%u.%u.%u",
                 _cam_info.vendor_name,
                 _cam_info.model_name,
                 (unsigned)fw_ver_major,

--- a/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
+++ b/libraries/AP_Camera/AP_Camera_SoloGimbal.cpp
@@ -12,7 +12,7 @@
 bool AP_Camera_SoloGimbal::trigger_pic()
 {
     if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "GoPro Not Available");
         return false;
     }
 
@@ -21,21 +21,21 @@ bool AP_Camera_SoloGimbal::trigger_pic()
 
     if (gopro_capture_mode == GOPRO_CAPTURE_MODE_PHOTO) {
         // Trigger shutter start to take a photo
-        gcs().send_text(MAV_SEVERITY_INFO, "GoPro Photo Trigger");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro Photo Trigger");
         mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_start);
 
     } else if (gopro_capture_mode == GOPRO_CAPTURE_MODE_VIDEO) {
         if (gopro_is_recording) {
             // GoPro is recording, so stop recording
-            gcs().send_text(MAV_SEVERITY_INFO, "GoPro Recording Stop");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro Recording Stop");
             mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_stop);
         } else {
             // GoPro is not recording, so start recording
-            gcs().send_text(MAV_SEVERITY_INFO, "GoPro Recording Start");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro Recording Start");
             mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_SHUTTER,gopro_shutter_start);
         }
     } else {
-        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Unsupported Capture Mode");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "GoPro Unsupported Capture Mode");
         return false;
     }
 
@@ -52,7 +52,7 @@ void AP_Camera_SoloGimbal::cam_mode_toggle()
     uint8_t gopro_capture_mode_values[4] = { };
 
     if (gopro_status != GOPRO_HEARTBEAT_STATUS_CONNECTED) {
-        gcs().send_text(MAV_SEVERITY_ERROR, "GoPro Not Available");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "GoPro Not Available");
         return;
     }
 
@@ -60,12 +60,12 @@ void AP_Camera_SoloGimbal::cam_mode_toggle()
         case GOPRO_CAPTURE_MODE_VIDEO:
             if (gopro_is_recording) {
                 // GoPro is recording, cannot change modes
-                gcs().send_text(MAV_SEVERITY_INFO, "GoPro recording, can't change modes");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro recording, can't change modes");
             } else {
                 // Change to camera mode
                 gopro_capture_mode_values[0] = GOPRO_CAPTURE_MODE_PHOTO;
                 mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_CAPTURE_MODE,gopro_capture_mode_values);
-                gcs().send_text(MAV_SEVERITY_INFO, "GoPro changing to mode photo");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro changing to mode photo");
             }
             break;
 
@@ -74,7 +74,7 @@ void AP_Camera_SoloGimbal::cam_mode_toggle()
             // Change to video mode
             gopro_capture_mode_values[0] =  GOPRO_CAPTURE_MODE_VIDEO;
             mavlink_msg_gopro_set_request_send(heartbeat_channel, mavlink_system.sysid, MAV_COMP_ID_GIMBAL,GOPRO_COMMAND_CAPTURE_MODE,gopro_capture_mode_values);
-            gcs().send_text(MAV_SEVERITY_INFO, "GoPro changing to mode video");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GoPro changing to mode video");
             break;
     }
 }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1481,7 +1481,7 @@ void Compass::_detect_backends(void)
                     }
                     // We have found a replacement mag, let's replace the existing one
                     // with this by setting the priority to zero and calling uavcan probe 
-                    gcs().send_text(MAV_SEVERITY_ALERT, "Mag: Compass #%d with DEVID %lu replaced", uint8_t(i), (unsigned long)_priority_did_list[i]);
+                    GCS_SEND_TEXT(MAV_SEVERITY_ALERT, "Mag: Compass #%d with DEVID %lu replaced", uint8_t(i), (unsigned long)_priority_did_list[i]);
                     _priority_did_stored_list[i].set_and_save(0);
                     _priority_did_list[i] = 0;
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -454,13 +454,13 @@ void AP_Follow::init_offsets_if_required(const Vector3f &dist_vec_ned)
     if ((_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) && get_target_heading_deg(target_heading_deg)) {
         // rotate offsets from north facing to vehicle's perspective
         _offset.set(rotate_vector(-dist_vec_ned, -target_heading_deg));
-        gcs().send_text(MAV_SEVERITY_INFO, "Relative follow offset loaded");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Relative follow offset loaded");
     } else {
         // initialise offset in NED frame
         _offset.set(-dist_vec_ned);
         // ensure offset_type used matches frame of offsets saved
         _offset_type.set(AP_FOLLOW_OFFSET_TYPE_NED);
-        gcs().send_text(MAV_SEVERITY_INFO, "N-E-D follow offset loaded");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "N-E-D follow offset loaded");
     }
 }
 

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -121,7 +121,7 @@ bool AP_Generator_RichenPower::get_reading()
     const uint8_t minor = (version % 100) / 10;
     const uint8_t point = version % 10;
     if (!protocol_information_anounced) {
-        gcs().send_text(MAV_SEVERITY_INFO, "RichenPower: protocol %u.%u.%u", major, minor, point);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RichenPower: protocol %u.%u.%u", major, minor, point);
         protocol_information_anounced = true;
     }
 
@@ -208,7 +208,7 @@ void AP_Generator_RichenPower::check_maintenance_required()
 
         if (last_reading.errors & (1U<<uint16_t(Errors::MaintenanceRequired))) {
             if (now - last_maintenance_warning_ms > 60000) {
-                gcs().send_text(MAV_SEVERITY_NOTICE, "Generator: requires maintenance");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Generator: requires maintenance");
                 last_maintenance_warning_ms = now;
             }
         }
@@ -263,7 +263,7 @@ void AP_Generator_RichenPower::update_runstate()
     // because the vehicle is crashed.
     if (AP::vehicle()->is_crashed()) {
         if (!vehicle_was_crashed) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Crash; stopping generator");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Crash; stopping generator");
             pilot_desired_runstate = RunState::STOP;
             vehicle_was_crashed = true;
         }

--- a/libraries/AP_Generator/AP_Generator_RichenPower.h
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.h
@@ -66,7 +66,7 @@ private:
     RunState pilot_desired_runstate = RunState::STOP;
     RunState commanded_runstate = RunState::STOP;  // output is based on this
     void set_pilot_desired_runstate(RunState newstate) {
-        // gcs().send_text(MAV_SEVERITY_INFO, "RichenPower: Moving to state (%u) from (%u)\n", (unsigned)newstate, (unsigned)runstate);
+        // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RichenPower: Moving to state (%u) from (%u)\n", (unsigned)newstate, (unsigned)runstate);
         pilot_desired_runstate = newstate;
     }
     void update_runstate();

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -236,10 +236,10 @@ void AP_GyroFFT::init(uint16_t loop_rate_hz)
     // INS: XYZ_AXIS_COUNT * INS_MAX_INSTANCES * _window_size, DSP: 3 * _window_size, FFT: XYZ_AXIS_COUNT + 3 * _window_size
     const uint32_t allocation_count = (XYZ_AXIS_COUNT * INS_MAX_INSTANCES + 3 + XYZ_AXIS_COUNT + 3 + _num_frames) * sizeof(float);
     if (allocation_count * FFT_DEFAULT_WINDOW_SIZE > hal.util->available_memory() / 2) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "AP_GyroFFT: disabled, required %u bytes", (unsigned int)allocation_count * FFT_DEFAULT_WINDOW_SIZE);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AP_GyroFFT: disabled, required %u bytes", (unsigned int)allocation_count * FFT_DEFAULT_WINDOW_SIZE);
         return;
     } else if (allocation_count * _window_size > hal.util->available_memory() / 2) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "AP_GyroFFT: req alloc %u bytes (free=%u)", (unsigned int)allocation_count * _window_size, (unsigned int)hal.util->available_memory());
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AP_GyroFFT: req alloc %u bytes (free=%u)", (unsigned int)allocation_count * _window_size, (unsigned int)hal.util->available_memory());
         _window_size.set(FFT_DEFAULT_WINDOW_SIZE);
     }
     // save any changes that were made
@@ -252,7 +252,7 @@ void AP_GyroFFT::init(uint16_t loop_rate_hz)
         _fft_sampling_rate_hz = loop_rate_hz / _sample_mode;
         for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             if (!_downsampled_gyro_data[axis].set_size(_window_size + _samples_per_frame)) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate window for AP_GyroFFT");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to allocate window for AP_GyroFFT");
                 return;
             }
         }
@@ -261,7 +261,7 @@ void AP_GyroFFT::init(uint16_t loop_rate_hz)
 
     _ref_energy = new Vector3f[_window_size];
     if (_ref_energy == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to allocate window for AP_GyroFFT");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to allocate window for AP_GyroFFT");
         return;
     }
 
@@ -312,7 +312,7 @@ void AP_GyroFFT::init(uint16_t loop_rate_hz)
     // initialise the HAL DSP subsystem
     _state = hal.dsp->fft_init(_window_size, _fft_sampling_rate_hz, _num_frames);
     if (_state == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to initialize DSP engine");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to initialize DSP engine");
         return;
     }
 
@@ -619,7 +619,7 @@ bool AP_GyroFFT::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len)
 
     // check for sane frequency resolution - for 1k backends with length 32 this will be 32Hz
     if (_state->_bin_resolution > 50.0f) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: resolution is %.1fHz, increase length", _state->_bin_resolution);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: resolution is %.1fHz, increase length", _state->_bin_resolution);
         return true; // a low resolution is not fatal
     }
 #if 0 // these calculations do not result in a long enough expected delay
@@ -643,7 +643,7 @@ bool AP_GyroFFT::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len)
 
     if (_calibrated) {
         // provide the user with some useful information about what they have configured
-        gcs().send_text(MAV_SEVERITY_INFO, "FFT: calibrated %.1fKHz/%.1fHz/%.1fHz", _fft_sampling_rate_hz * 0.001f,
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FFT: calibrated %.1fKHz/%.1fHz/%.1fHz", _fft_sampling_rate_hz * 0.001f,
              _state->_bin_resolution * 0.5, 1000.0f * XYZ_AXIS_COUNT / _frame_time_ms);
     }
 
@@ -699,7 +699,7 @@ void AP_GyroFFT::start_notch_tune()
     }
 
     if (!hal.dsp->fft_start_average(_state)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to start FFT averaging");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: Unable to start FFT averaging");
     }
     // throttle averaging for average fft calculation
     _avg_throttle_out = 0.0f;
@@ -754,25 +754,25 @@ void AP_GyroFFT::stop_notch_tune()
     uint8_t harmonics;
     float harmonic = calculate_notch_frequency(freqs, numpeaks, _harmonic_fit, harmonics);
 
-    gcs().send_text(MAV_SEVERITY_INFO, "FFT: Found peaks at %.1f/%.1f/%.1fHz", freqs[0], freqs[1], freqs[2]);
-    gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Selected %.1fHz\n", harmonic);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FFT: Found peaks at %.1f/%.1f/%.1fHz", freqs[0], freqs[1], freqs[2]);
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: Selected %.1fHz\n", harmonic);
 
     // if we don't have a throttle value then all bets are off
     if (is_zero(_avg_throttle_out) || is_zero(harmonic)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to calculate notch: need stable hover");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: Unable to calculate notch: need stable hover");
         AP_Notify::events.autotune_failed = true;
         return;
     }
 
     if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
             harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_failed = true;
         // save results to FFT slots
         _throttle_ref.set(_avg_throttle_out);
         _freq_hover_hz.set(harmonic);
     } else {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_complete = true;
     }
 }
@@ -1002,9 +1002,9 @@ void AP_GyroFFT::write_log_messages()
     if ((now - _last_output_ms) > 1000) {
         // doing this from the update thread overflows the stack
         WITH_SEMAPHORE(_sem);
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: f:%.1f, fr:%.1f, b:%u, fd:%.1f",
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: f:%.1f, fr:%.1f, b:%u, fd:%.1f",
                         _debug_state._center_freq_hz_filtered[FrequencyPeak::CENTER][_update_axis], _debug_state._center_freq_hz[_update_axis], _debug_max_bin, _debug_max_bin_freq);
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: bw:%.1f, e:%.1f, r:%.1f, snr:%.1f",
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: bw:%.1f, e:%.1f, r:%.1f, snr:%.1f",
                         _debug_state._center_bandwidth_hz_filtered[FrequencyPeak::CENTER][_update_axis], _debug_max_freq_bin, _ref_energy[_debug_max_bin][_update_axis], _debug_snr);
         _last_output_ms = now;
     }
@@ -1374,7 +1374,7 @@ void AP_GyroFFT::update_ref_energy(uint16_t max_bin)
 float AP_GyroFFT::self_test_bin_frequencies()
 {
     if (_state->_window_size * sizeof(float) > hal.util->available_memory() / 2) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: unable to run self-test, required %u bytes", (unsigned int)(_state->_window_size * sizeof(float)));
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: unable to run self-test, required %u bytes", (unsigned int)(_state->_window_size * sizeof(float)));
         return 0.0f;
     }
 
@@ -1420,7 +1420,7 @@ float AP_GyroFFT::self_test(float frequency, FloatBuffer& test_window)
     uint16_t max_bin = hal.dsp->fft_analyse(_state, _config._fft_start_bin, _config._fft_end_bin, _config._attenuation_cutoff);
 
     if (max_bin == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: self-test failed, failed to find frequency %.1f", frequency);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: self-test failed, failed to find frequency %.1f", frequency);
     }
 
     calculate_noise(true, _config);
@@ -1429,11 +1429,11 @@ float AP_GyroFFT::self_test(float frequency, FloatBuffer& test_window)
     // make sure the selected frequencies are in the right bin
     max_divergence = MAX(max_divergence, fabsf(frequency - _thread_state._center_freq_hz[0]));
     if (_thread_state._center_freq_hz[0] < (frequency - MAX(_state->_bin_resolution * 0.5f, 1)) || _thread_state._center_freq_hz[0] > (frequency + MAX(_state->_bin_resolution * 0.5f, 1))) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "FFT: self-test failed: wanted %.1f, had %.1f", frequency, _thread_state._center_freq_hz[0]);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: self-test failed: wanted %.1f, had %.1f", frequency, _thread_state._center_freq_hz[0]);
     }
 #if DEBUG_FFT
     else {
-        gcs().send_text(MAV_SEVERITY_INFO, "FFT: self-test succeeded: wanted %.1f, had %.1f", frequency, _thread_state._center_freq_hz[0]);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "FFT: self-test succeeded: wanted %.1f, had %.1f", frequency, _thread_state._center_freq_hz[0]);
     }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -261,7 +261,7 @@ uint64_t Util::get_hw_rtc() const
 #if AP_BOOTLOADER_FLASHING_ENABLED
 
 #if HAL_GCS_ENABLED
-#define Debug(fmt, args ...)  do { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
+#define Debug(fmt, args ...)  do { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
 #endif // HAL_GCS_ENABLED
 
 #ifndef Debug

--- a/libraries/AP_HAL_ESP32/RCInput.cpp
+++ b/libraries/AP_HAL_ESP32/RCInput.cpp
@@ -121,7 +121,7 @@ void RCInput::_timer_tick(void)
 #ifndef HAL_NO_UARTDRIVER
     if (rc_protocol && rc_protocol != last_protocol) {
         last_protocol = rc_protocol;
-        gcs().send_text(MAV_SEVERITY_DEBUG, "RCInput: decoding %s", last_protocol);
+        GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "RCInput: decoding %s", last_protocol);
     }
 #endif
 

--- a/libraries/AP_HAL_ESP32/Util.cpp
+++ b/libraries/AP_HAL_ESP32/Util.cpp
@@ -199,7 +199,7 @@ uint64_t Util::get_hw_rtc() const
 #define Debug(fmt, args ...)  do { hal.console->printf(fmt, ## args); } while (0)
 #else
 #include <GCS_MAVLink/GCS.h>
-#define Debug(fmt, args ...)  do { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
+#define Debug(fmt, args ...)  do { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ## args); } while (0)
 #endif
 
 Util::FlashBootloader Util::flash_bootloader()

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -253,7 +253,7 @@ bool AP_Landing::verify_land(const Location &prev_WP_loc, Location &next_WP_loc,
     default:
         // returning TRUE while executing verify_land() will increment the
         // mission index which in many cases will trigger an RTL for end-of-mission
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Landing configuration error, invalid LAND_TYPE");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Landing configuration error, invalid LAND_TYPE");
         success = true;
         break;
     }
@@ -486,14 +486,14 @@ bool AP_Landing::restart_landing_sequence()
             mission.set_current_cmd(current_index+1))
     {
         // if the next immediate command is MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT to climb, do it
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Restarted landing sequence. Climbing to %dm", (signed)cmd.content.location.alt/100);
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Restarted landing sequence. Climbing to %dm", (signed)cmd.content.location.alt/100);
         success =  true;
     }
     else if (do_land_start_index != 0 &&
             mission.set_current_cmd(do_land_start_index))
     {
         // look for a DO_LAND_START and use that index
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Restarted landing via DO_LAND_START: %d",do_land_start_index);
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Restarted landing via DO_LAND_START: %d",do_land_start_index);
         success =  true;
     }
     else if (prev_cmd_with_wp_index != AP_MISSION_CMD_INDEX_NONE &&
@@ -501,10 +501,10 @@ bool AP_Landing::restart_landing_sequence()
     {
         // if a suitable navigation waypoint was just executed, one that contains lat/lng/alt, then
         // repeat that cmd to restart the landing from the top of approach to repeat intended glide slope
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Restarted landing sequence at waypoint %d", prev_cmd_with_wp_index);
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Restarted landing sequence at waypoint %d", prev_cmd_with_wp_index);
         success =  true;
     } else {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Unable to restart landing sequence");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Unable to restart landing sequence");
         success =  false;
     }
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -345,7 +345,7 @@ bool AP_Landing_Deepstall::override_servos(void)
 
     if (elevator == nullptr) {
         // deepstalls are impossible without these channels, abort the process
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Deepstall: Unable to find the elevator channels");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Deepstall: Unable to find the elevator channels");
         request_go_around();
         return false;
     }
@@ -533,17 +533,17 @@ void AP_Landing_Deepstall::build_approach_path(bool use_current_heading)
 
 #ifdef DEBUG_PRINTS
     // TODO: Send this information via a MAVLink packet
-    gcs().send_text(MAV_SEVERITY_INFO, "Arc: %3.8f %3.8f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Arc: %3.8f %3.8f",
                                      (double)(arc.lat / 1e7),(double)( arc.lng / 1e7));
-    gcs().send_text(MAV_SEVERITY_INFO, "Loiter en: %3.8f %3.8f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Loiter en: %3.8f %3.8f",
                                      (double)(arc_entry.lat / 1e7), (double)(arc_entry.lng / 1e7));
-    gcs().send_text(MAV_SEVERITY_INFO, "Loiter ex: %3.8f %3.8f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Loiter ex: %3.8f %3.8f",
                                      (double)(arc_exit.lat / 1e7), (double)(arc_exit.lng / 1e7));
-    gcs().send_text(MAV_SEVERITY_INFO, "Extended: %3.8f %3.8f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Extended: %3.8f %3.8f",
                                      (double)(extended_approach.lat / 1e7), (double)(extended_approach.lng / 1e7));
-    gcs().send_text(MAV_SEVERITY_INFO, "Extended by: %f (%f)", (double)approach_extension_m,
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Extended by: %f (%f)", (double)approach_extension_m,
                                      (double)expected_travel_distance);
-    gcs().send_text(MAV_SEVERITY_INFO, "Target Heading: %3.1f", (double)target_heading_deg);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Target Heading: %3.1f", (double)target_heading_deg);
 #endif // DEBUG_PRINTS
 
 }
@@ -590,7 +590,7 @@ float AP_Landing_Deepstall::predict_travel_distance(const Vector3f wind, const f
 
     if(print) {
         // allow printing the travel distances on the final entry as its used for tuning
-        gcs().send_text(MAV_SEVERITY_INFO, "Deepstall: Entry: %0.1f (m) Travel: %0.1f (m)",
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Deepstall: Entry: %0.1f (m) Travel: %0.1f (m)",
                                          (double)stall_distance, (double)predicted_travel_distance);
     }
 
@@ -620,7 +620,7 @@ float AP_Landing_Deepstall::update_steering()
         // panic if no position source is available
         // continue the stall but target just holding the wings held level as deepstall should be a minimal
         // energy configuration on the aircraft, and if a position isn't available aborting would be worse
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Deepstall: Invalid data from AHRS. Holding level");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Deepstall: Invalid data from AHRS. Holding level");
         hold_level = true;
     }
 
@@ -652,7 +652,7 @@ float AP_Landing_Deepstall::update_steering()
     float error = wrap_PI(constrain_float(desired_change, -yaw_rate_limit_rps, yaw_rate_limit_rps) - yaw_rate);
 
 #ifdef DEBUG_PRINTS
-    gcs().send_text(MAV_SEVERITY_INFO, "x: %f e: %f r: %f d: %f",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "x: %f e: %f r: %f d: %f",
                                     (double)crosstrack_error,
                                     (double)error,
                                     (double)degrees(yaw_rate),

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -38,7 +38,7 @@ void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, cons
     type_slope_flags.post_stats = false;
 
     type_slope_stage = SlopeStage::NORMAL;
-    gcs().send_text(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude);
 }
 
 void AP_Landing::type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed)
@@ -106,9 +106,9 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
         if (type_slope_stage != SlopeStage::FINAL) {
             type_slope_flags.post_stats = true;
             if (is_flying && (AP_HAL::millis()-last_flying_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps.ground_speed());
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps.ground_speed());
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
                                   (double)height, (double)sink_rate,
                                   (double)gps.ground_speed(),
                                   (double)current_loc.get_distance(next_WP_loc));
@@ -122,7 +122,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
             AP_LandingGear *LG_inst = AP_LandingGear::get_singleton();
             if (LG_inst != nullptr && !LG_inst->check_before_land()) {
                 type_slope_request_go_around();
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Landing gear was not deployed");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Landing gear was not deployed");
             }
 #endif
         }
@@ -158,7 +158,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     // this is done before disarm_if_autoland_complete() so that it happens on the next loop after the disarm
     if (type_slope_flags.post_stats && !is_armed) {
         type_slope_flags.post_stats = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)current_loc.get_distance(next_WP_loc));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)current_loc.get_distance(next_WP_loc));
     }
 
     // check if we should auto-disarm after a confirmed landing
@@ -226,7 +226,7 @@ void AP_Landing::type_slope_adjust_landing_slope_for_rangefinder_bump(AP_FixedWi
 
         // is projected slope too steep?
         if (new_slope_deg - initial_slope_deg > slope_recalc_steep_threshold_to_abort) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Landing slope too steep, aborting (%.0fm %.1fdeg)",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Landing slope too steep, aborting (%.0fm %.1fdeg)",
                                              (double)rangefinder_state.correction, (double)(new_slope_deg - initial_slope_deg));
             alt_offset = rangefinder_state.correction;
             flags.commanded_go_around = true;
@@ -319,7 +319,7 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     bool is_first_calc = is_zero(slope);
     slope = (sink_height - aim_height) / (total_distance - flare_distance);
     if (is_first_calc) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
     }
 
     // calculate point along that slope 500m ahead

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -169,7 +169,7 @@ void AP_LandingGear::deploy()
     // send message only if output has been configured
     if (!_deployed &&
         SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "LandingGear: DEPLOY");
     }
 
     // set deployed flag
@@ -195,7 +195,7 @@ void AP_LandingGear::retract()
 
     // send message only if output has been configured
     if (SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "LandingGear: RETRACT");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "LandingGear: RETRACT");
     }
 }
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -801,7 +801,7 @@ void AP_Logger_File::start_new_log(void)
 
     // set _open_error here to avoid infinite recursion.  Simply
     // writing a prioritised block may try to open a log - which means
-    // if anything in the start_new_log path does a gcs().send_text()
+    // if anything in the start_new_log path does a GCS_SEND_TEXT()
     // (for example), you will end up recursing if we don't take
     // precautions.  We will reset _open_error if we actually manage
     // to open the log...

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -313,12 +313,12 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
                 _idle_throttle = constrain_float( get_arot_idle_output(), 0.0f, 0.4f);
             }
             if (!_autorotating) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Autorotation");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Autorotation");
                 _autorotating =true;
             }
         } else {
             if (_autorotating) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Autorotation Stopped");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Autorotation Stopped");
                 _autorotating =false;
             }
             // set rotor control speed to idle speed parameter, this happens instantly and ignores ramping
@@ -326,7 +326,7 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
                 _idle_throttle += 0.001f;
                 if (_control_output >= 1.0f) {
                     _idle_throttle = get_idle_output();
-                    gcs().send_text(MAV_SEVERITY_INFO, "Turbine startup");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Turbine startup");
                     _starting = false;
                 }
             } else {
@@ -408,7 +408,7 @@ void AP_MotorsHeli_RSC::update_rotor_ramp(float rotor_ramp_input, float dt)
     if (_rotor_ramp_output < rotor_ramp_input) {
         if (_use_bailout_ramp) {
             if (!_bailing_out) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "bailing_out");
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "bailing_out");
                 _bailing_out = true;
                 if (_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {_gov_bailing_out = true;}
             }
@@ -563,9 +563,9 @@ void AP_MotorsHeli_RSC::autothrottle_run()
                 governor_reset();
                 _governor_fault = true;
                 if (_rotor_rpm >= (_governor_rpm + _governor_range)) {
-                    gcs().send_text(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Overspeed");
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Overspeed");
                 } else {
-                    gcs().send_text(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Underspeed");
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Underspeed");
                 }
             }
         } else {
@@ -577,7 +577,7 @@ void AP_MotorsHeli_RSC::autothrottle_run()
         if (_rotor_rpm > (_governor_rpm + _governor_range) && !_gov_bailing_out) {
             _governor_fault = true;
             governor_reset();
-            gcs().send_text(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Overspeed");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Governor Fault: Rotor Overspeed");
             _governor_output = 0.0f;
 
         // when performing power recovery from autorotation, this waits for user to load rotor in order to 
@@ -594,7 +594,7 @@ void AP_MotorsHeli_RSC::autothrottle_run()
                 _governor_engage = true;
                 _autothrottle = true;
                 _gov_bailing_out = false;
-                gcs().send_text(MAV_SEVERITY_NOTICE, "Governor Engaged");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Governor Engaged");
             }
         } else {
             // temporary use of throttle curve and ramp timer to accelerate rotor to governor min torque rise speed

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -266,7 +266,7 @@ void AP_MotorsMatrix_6DoF_Scripting::add_motor(int8_t motor_num, float roll_fact
 
         uint8_t chan;
         if (!SRV_Channels::find_channel(function, chan)) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
             return;
         }
 

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -199,7 +199,7 @@ void AP_Mount_Gremsy::handle_gimbal_device_information(const mavlink_message_t &
     const uint8_t fw_ver_build = (info.firmware_version & 0xFF000000) >> 24;
 
     // display gimbal info to user
-    gcs().send_text(MAV_SEVERITY_INFO, "Mount: %s %s fw:%u.%u.%u.%u",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mount: %s %s fw:%u.%u.%u.%u",
             info.vendor_name,
             info.model_name,
             (unsigned)fw_ver_major,

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -310,14 +310,14 @@ void AP_Mount_Viewpro::process_packet()
             const uint8_t patch_ver = atoi((const char*)fw_patch_str) & 0xFF;
             _firmware_version = (patch_ver << 16) | (minor_ver << 8) | major_ver;
             _got_firmware_version = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "%s fw:%u.%u.%u", send_text_prefix, (unsigned)major_ver, (unsigned)minor_ver, (unsigned)patch_ver);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s fw:%u.%u.%u", send_text_prefix, (unsigned)major_ver, (unsigned)minor_ver, (unsigned)patch_ver);
             break;
         }
         case CommConfigCmd::QUERY_MODEL:
             // gimbal model, length is 10 bytes
             strncpy((char *)_model_name, (const char *)&_msg_buff[_msg_buff_data_start+1], sizeof(_model_name)-1);
             _got_model_name = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "%s %s", send_text_prefix, (const char*)_model_name);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s %s", send_text_prefix, (const char*)_model_name);
             break;
         default:
             // unsupported control command
@@ -337,16 +337,16 @@ void AP_Mount_Viewpro::process_packet()
             _last_tracking_status = tracking_status;
             switch (tracking_status) {
             case TrackingStatus::STOPPED:
-                gcs().send_text(MAV_SEVERITY_INFO, "%s tracking OFF", send_text_prefix);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s tracking OFF", send_text_prefix);
                 break;
             case TrackingStatus::SEARCHING:
-                gcs().send_text(MAV_SEVERITY_INFO, "%s tracking searching", send_text_prefix);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s tracking searching", send_text_prefix);
                 break;
             case TrackingStatus::TRACKING:
-                gcs().send_text(MAV_SEVERITY_INFO, "%s tracking ON", send_text_prefix);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s tracking ON", send_text_prefix);
                 break;
             case TrackingStatus::LOST:
-                gcs().send_text(MAV_SEVERITY_INFO, "%s tracking Lost", send_text_prefix);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s tracking Lost", send_text_prefix);
                 break;
             }
         }
@@ -365,7 +365,7 @@ void AP_Mount_Viewpro::process_packet()
         const bool recording = (recording_status == RecordingStatus::RECORDING);
         if (recording != _recording) {
             _recording = recording;
-            gcs().send_text(MAV_SEVERITY_INFO,  "%s recording %s", send_text_prefix, _recording ? "ON" : "OFF");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,  "%s recording %s", send_text_prefix, _recording ? "ON" : "OFF");
         }
 
         // get optical zoom times

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.cpp
@@ -39,12 +39,12 @@ bool AP_OSD_MSP_DisplayPort::init(void)
     // check if we have a DisplayPort backend to use
     const AP_MSP *msp = AP::msp();
     if (msp == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"MSP backend not available");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"MSP backend not available");
         return false;
     }
     _displayport = msp->find_protocol(AP_SerialManager::SerialProtocol_MSP_DisplayPort);
     if (_displayport == nullptr) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"MSP DisplayPort uart not available");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"MSP DisplayPort uart not available");
         return false;
     }
     // re-init port here for use in this thread

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -43,7 +43,7 @@
 
 #include <GCS_MAVLink/GCS.h>
 #if RP_DEBUG_LEVEL
-  #define Debug(level, fmt, args ...)  do { if (level <= RP_DEBUG_LEVEL) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ## args); } } while (0)
+  #define Debug(level, fmt, args ...)  do { if (level <= RP_DEBUG_LEVEL) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ## args); } } while (0)
 #else
   #define Debug(level, fmt, args ...)
 #endif
@@ -250,7 +250,7 @@ void AP_Proximity_RPLidarA2::get_readings()
             Debug(1, "Got RPLidar Information");
             char xbuffer[64]{};
             memcpy((void*)xbuffer, (void*)&_payload.information, 63);
-            gcs().send_text(MAV_SEVERITY_INFO, "RPLidar: (%s)", xbuffer);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RPLidar: (%s)", xbuffer);
 #endif
             // 63 is the magic number of bytes in the spewed-out
             // reset data ... so now we'll just drop that stuff on

--- a/libraries/AP_Radio/AP_Radio_bk2425.cpp
+++ b/libraries/AP_Radio/AP_Radio_bk2425.cpp
@@ -33,7 +33,7 @@ extern const AP_HAL::HAL& hal;
 // This is for debugging issues with frequency hopping and synchronisation.
 #define DebugPrintf(level, fmt, args...)   do { if (AP_Radio_beken::radio_singleton && ((level) <= AP_Radio_beken::radio_singleton->get_debug_level())) { printf(fmt, ##args); }} while (0)
 // Output debug information on the mavlink to the UART connected to the WiFi, wrapped in MavLink packets
-#define DebugMavlink(level, fmt, args...)   do { if ((level) <= get_debug_level()) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
+#define DebugMavlink(level, fmt, args...)   do { if ((level) <= get_debug_level()) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
 
 
 #if SUPPORT_BK_DEBUG_PINS

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -29,7 +29,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define Debug(level, fmt, args...)   do { if ((level) <= get_debug_level()) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
+#define Debug(level, fmt, args...)   do { if ((level) <= get_debug_level()) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
 
 // object instance for trampoline
 AP_Radio_cc2500 *AP_Radio_cc2500::radio_singleton;

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -40,7 +40,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define Debug(level, fmt, args...)   do { if ((level) <= get_debug_level()) { gcs().send_text(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
+#define Debug(level, fmt, args...)   do { if ((level) <= get_debug_level()) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, fmt, ##args); }} while (0)
 
 #define LP_FIFO_SIZE  16      // Physical data FIFO lengths in Radio
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.cpp
@@ -104,7 +104,7 @@ void AP_RangeFinder_HC_SR04::update(void)
             state.distance_m = 0.0f;
         }
     } else {
-        // gcs().send_text(MAV_SEVERITY_WARNING, "Pong!");
+        // GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Pong!");
         // a new reading - convert time to distance
         state.distance_m = (value_us * (1.0/58.0f)) * 0.01f;  // 58 is from datasheet, mult for performance
 
@@ -134,7 +134,7 @@ void AP_RangeFinder_HC_SR04::update(void)
     // consider sending new ping
     if (now - last_ping_ms > 67) { // read ~@15Hz - recommended 60ms delay from datasheet
         last_ping_ms = now;
-        // gcs().send_text(MAV_SEVERITY_INFO, "Ping!");
+        // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Ping!");
         // raise stop pin for n-microseconds
         hal.gpio->pinMode(trigger_pin, HAL_GPIO_OUTPUT);
         hal.gpio->write(trigger_pin, 1);

--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -118,7 +118,7 @@ void AP_SmartRTL::init()
     // check if memory allocation failed
     if (_path == nullptr || _prune.loops == nullptr || _simplify.stack == nullptr) {
         log_action(SRTL_DEACTIVATED_INIT_FAILED);
-        gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL deactivated: init failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "SmartRTL deactivated: init failed");
         free(_path);
         free(_prune.loops);
         free(_simplify.stack);
@@ -390,7 +390,7 @@ void AP_SmartRTL::run_background_cleanup()
     // warn if buffer is about to be filled
     uint32_t now_ms = AP_HAL::millis();
     if ((path_points_count >0) && (path_points_count >= _path_points_max - 9) && (now_ms - _last_low_space_notify_ms > 10000)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL Low on space!");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL Low on space!");
        _last_low_space_notify_ms = now_ms;
     }
 
@@ -866,7 +866,7 @@ void AP_SmartRTL::deactivate(SRTL_Actions action, const char *reason)
 {
     _active = false;
     log_action(action);
-    gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL deactivated: %s", reason);
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "SmartRTL deactivated: %s", reason);
 }
 
 // logging

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -428,15 +428,15 @@ void SoaringController::update_active_state(bool override_disable)
         switch (status) {
             case ActiveStatus::SOARING_DISABLED:
                 // It's not enabled, but was enabled on the last loop.
-                gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Disabled.");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: Disabled.");
                 set_throttle_suppressed(false);
                 break;
             case ActiveStatus::MANUAL_MODE_CHANGE:
                 // It's enabled, but wasn't on the last loop.
-                gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Enabled, manual mode changes.");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: Enabled, manual mode changes.");
                 break;
             case ActiveStatus::AUTO_MODE_CHANGE:
-                gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Enabled, automatic mode changes.");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Soaring: Enabled, automatic mode changes.");
                 break;
         }
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -180,7 +180,7 @@ void AP_VisualOdom_IntelT265::align_yaw(const Vector3f &position, const Quaterni
     // trim yaw by difference between ahrs and sensor yaw
     const float yaw_trim_orig = _yaw_trim;
     _yaw_trim = wrap_2PI(yaw_rad - sens_yaw);
-    gcs().send_text(MAV_SEVERITY_INFO, "VisOdom: yaw shifted %d to %d deg",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "VisOdom: yaw shifted %d to %d deg",
                     (int)degrees(_yaw_trim - yaw_trim_orig),
                     (int)wrap_360(degrees(sens_yaw + _yaw_trim)));
 
@@ -337,7 +337,7 @@ void AP_VisualOdom_IntelT265::handle_voxl_camera_reset_jump(const Vector3f &sens
     }
 
     // warng user of reset
-    gcs().send_text(MAV_SEVERITY_WARNING, "VisOdom: reset");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "VisOdom: reset");
 
     // align sensor yaw to match current yaw estimate
     align_yaw_to_ahrs(sensor_pos, sensor_att);

--- a/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_SITL_Quadrature.cpp
@@ -55,7 +55,7 @@ void AP_WheelEncoder_SITL_Quadrature::update(void)
     // distance from center of wheel axis to each wheel
     const double half_wheelbase = ( fabsf(_frontend.get_pos_offset(0).y) + fabsf(_frontend.get_pos_offset(1).y) )/2.0f;
     if (is_zero(half_wheelbase)) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "WheelEncoder: wheel offset not set!");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "WheelEncoder: wheel offset not set!");
     }
 
     if (_state.instance == 0) { 
@@ -69,7 +69,7 @@ void AP_WheelEncoder_SITL_Quadrature::update(void)
 
     const double radius = _frontend.get_wheel_radius(_state.instance);
     if (is_zero(radius)) { // avoid divide by zero
-        gcs().send_text(MAV_SEVERITY_WARNING, "WheelEncoder: wheel radius not set!");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "WheelEncoder: wheel radius not set!");
         return; 
     }
 

--- a/libraries/AP_WindVane/AP_WindVane_Analog.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Analog.cpp
@@ -55,7 +55,7 @@ void AP_WindVane_Analog::calibrate()
         _cal_start_ms = AP_HAL::millis();
         _cal_volt_max = _current_analog_voltage;
         _cal_volt_min = _current_analog_voltage;
-        gcs().send_text(MAV_SEVERITY_INFO, "WindVane: Calibration started, rotate wind vane");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: Calibration started, rotate wind vane");
     }
 
     // record min and max voltage
@@ -70,11 +70,11 @@ void AP_WindVane_Analog::calibrate()
             // save min and max voltage
             _frontend._dir_analog_volt_max.set_and_save(_cal_volt_max);
             _frontend._dir_analog_volt_min.set_and_save(_cal_volt_min);
-            gcs().send_text(MAV_SEVERITY_INFO, "WindVane: Calibration complete (volt min:%.1f max:%1.f)",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: Calibration complete (volt min:%.1f max:%1.f)",
             (double)_cal_volt_min,
             (double)_cal_volt_max);
         } else {
-             gcs().send_text(MAV_SEVERITY_INFO, "WindVane: Calibration failed (volt diff %.1f below %.1f)",
+             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: Calibration failed (volt diff %.1f below %.1f)",
             (double)volt_diff,
             (double)WINDVANE_CALIBRATION_VOLT_DIFF_MIN);
         }

--- a/libraries/AP_WindVane/AP_WindVane_Backend.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Backend.cpp
@@ -27,7 +27,7 @@ AP_WindVane_Backend::AP_WindVane_Backend(AP_WindVane &frontend) :
 // calibrate WindVane
 void AP_WindVane_Backend::calibrate()
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "WindVane: No cal required");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: No cal required");
     _frontend._calibration.set_and_save(0);
     return;
 }

--- a/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_ModernDevice.cpp
@@ -66,7 +66,7 @@ void AP_WindVane_ModernDevice::update_speed()
 
 void AP_WindVane_ModernDevice::calibrate()
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "WindVane: rev P. zero wind voltage offset set to %.1f",double(_current_analog_voltage));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "WindVane: rev P. zero wind voltage offset set to %.1f",double(_current_analog_voltage));
     _frontend._speed_sensor_voltage_offset.set_and_save(_current_analog_voltage);
     _frontend._calibration.set_and_save(0);
 }

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -460,14 +460,14 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
     // check if only one of skid-steering output has been configured
     if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) != SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
         if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: check skid steering config");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PreArm: check skid steering config");
         }
         return false;
     }
     // check if only one of throttle or steering outputs has been configured, if has a sail allow no throttle
     if ((has_sail() || SRV_Channels::function_assigned(SRV_Channel::k_throttle)) != SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
         if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: check steering and throttle config");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PreArm: check steering and throttle config");
         }
         return false;
     }
@@ -476,7 +476,7 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
         if (!SRV_Channels::function_assigned(function)) {
             if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: servo function %u unassigned", function);
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PreArm: servo function %u unassigned", function);
             }
             return false;
         }
@@ -601,7 +601,7 @@ void AP_MotorsUGV::add_omni_motor_num(int8_t motor_num)
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
         if (!SRV_Channels::find_channel(function, chan)) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
         }
     }
 }

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -118,7 +118,7 @@ void GCS::send_named_float(const char *name, float value) const
 void GCS::enable_high_latency_connections(bool enabled)
 {
     high_latency_link_enabled = enabled;
-    gcs().send_text(MAV_SEVERITY_NOTICE, "High Latency %s", enabled ? "enabled" : "disabled");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "High Latency %s", enabled ? "enabled" : "disabled");
 }
 
 bool GCS::get_high_latency_status()

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1074,7 +1074,7 @@ bool GCS_MAVLINK::set_mavlink_message_id_interval(const uint32_t mavlink_id,
 {
     const ap_message id = mavlink_id_to_ap_message_id(mavlink_id);
     if (id == MSG_LAST) {
-        gcs().send_text(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)mavlink_id);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)mavlink_id);
         return false;
     }
     return set_ap_message_interval(id, interval_ms);
@@ -1819,7 +1819,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
 
     if (uint16_t(now16_ms - try_send_message_stats.statustext_last_sent_ms) > 10000U) {
         if (try_send_message_stats.longest_time_us) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): ap_msg=%u took %uus to send",
                             chan,
                             try_send_message_stats.longest_id,
@@ -1828,42 +1828,42 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
         }
         if (try_send_message_stats.no_space_for_message &&
             (is_active() || is_streaming())) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): out-of-space: %u",
                             chan,
                             try_send_message_stats.no_space_for_message);
             try_send_message_stats.no_space_for_message = 0;
         }
         if (try_send_message_stats.out_of_time) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): out-of-time=%u",
                             chan,
                             try_send_message_stats.out_of_time);
             try_send_message_stats.out_of_time = 0;
         }
         if (max_slowdown_ms) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): max slowdown=%u",
                             chan,
                             max_slowdown_ms);
             max_slowdown_ms = 0;
         }
         if (try_send_message_stats.behind) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): behind=%u",
                             chan,
                             try_send_message_stats.behind);
             try_send_message_stats.behind = 0;
         }
         if (try_send_message_stats.fnbts_maxtime) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): fnbts_maxtime=%uus",
                             chan,
                             try_send_message_stats.fnbts_maxtime);
             try_send_message_stats.fnbts_maxtime = 0;
         }
         if (try_send_message_stats.max_retry_deferred_body_us) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "GCS.chan(%u): retry_body_maxtime=%uus (%u)",
                             chan,
                             try_send_message_stats.max_retry_deferred_body_us,
@@ -1873,7 +1873,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
         }
 
         for (uint8_t i=0; i<ARRAY_SIZE(deferred_message_bucket); i++) {
-            gcs().send_text(MAV_SEVERITY_INFO,
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                             "B. intvl. (%u): %u %u %u %u %u",
                             chan,
                             deferred_message_bucket[0].interval_ms,
@@ -2860,7 +2860,7 @@ MAV_RESULT GCS_MAVLINK::set_message_interval(uint32_t msg_id, int32_t interval_u
 {
     const ap_message id = mavlink_id_to_ap_message_id(msg_id);
     if (id == MSG_LAST) {
-        gcs().send_text(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)msg_id);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)msg_id);
         return MAV_RESULT_DENIED;
     }
 
@@ -3332,7 +3332,7 @@ void GCS_MAVLINK::handle_timesync(const mavlink_message_t &msg)
         }
         const uint64_t round_trip_time_us = (timesync_receive_timestamp_ns() - _timesync_request.sent_ts1)*0.001f;
 #if 0
-        gcs().send_text(MAV_SEVERITY_INFO,
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,
                         "timesync response sysid=%u (latency=%fms)",
                         msg.sysid,
                         round_trip_time_us*0.001f);
@@ -4301,7 +4301,7 @@ void GCS_MAVLINK::send_sim_state() const
 MAV_RESULT GCS_MAVLINK::handle_command_flash_bootloader(const mavlink_command_long_t &packet)
 {
     if (uint32_t(packet.param5) != 290876) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Magic not set");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Magic not set");
         return MAV_RESULT_FAILED;
     }
 
@@ -4312,7 +4312,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_flash_bootloader(const mavlink_command_lo
         return MAV_RESULT_ACCEPTED;
 #if AP_SIGNED_FIRMWARE
     case AP_HAL::Util::FlashBootloader::NOT_SIGNED:
-        gcs().send_text(MAV_SEVERITY_ERROR, "Bootloader not signed");
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Bootloader not signed");
         break;
 #endif
     default:
@@ -4344,9 +4344,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_set_sensor_offsets(const mavlin
 MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
     // fast barometer calibration
-    gcs().send_text(MAV_SEVERITY_INFO, "Updating barometer calibration");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Updating barometer calibration");
     AP::baro().update_calibration();
-    gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer calibration complete");
 
 #if AP_AIRSPEED_ENABLED
 
@@ -4433,7 +4433,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_comma
 {
     if (hal.util->get_soft_armed()) {
         // *preflight*, remember?
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Disarm to allow calibration");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Disarm to allow calibration");
         return MAV_RESULT_FAILED;
     }
     // now call subclass methods:
@@ -6043,7 +6043,7 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         // message as part of send_message.
         // This message will be sent out at the same rate as the
         // unknown message, so should be safe.
-        gcs().send_text(MAV_SEVERITY_DEBUG, "Sending unknown message (%u)", id);
+        GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "Sending unknown message (%u)", id);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Sending unknown ap_message %u", id);
 #endif
@@ -6384,7 +6384,7 @@ void GCS::update_passthru(void)
         _passthru.last_port1_data_ms = now;
         _passthru.baud1 = baud1;
         _passthru.baud2 = baud2;
-        gcs().send_text(MAV_SEVERITY_INFO, "Passthru enabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Passthru enabled");
         if (!_passthru.timer_installed) {
             _passthru.timer_installed = true;
             hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&GCS::passthru_timer, void));
@@ -6402,7 +6402,7 @@ void GCS::update_passthru(void)
             _passthru.port2->end();
             _passthru.port2->begin(baud2);
         }
-        gcs().send_text(MAV_SEVERITY_INFO, "Passthru disabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Passthru disabled");
     } else if (enabled &&
                _passthru.timeout_s &&
                now - _passthru.last_port1_data_ms > uint32_t(_passthru.timeout_s)*1000U) {
@@ -6420,7 +6420,7 @@ void GCS::update_passthru(void)
             _passthru.port2->end();
             _passthru.port2->begin(baud2);
         }
-        gcs().send_text(MAV_SEVERITY_INFO, "Passthru timed out");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Passthru timed out");
     }
 }
 
@@ -6500,7 +6500,7 @@ bool GCS_MAVLINK::mavlink_coordinate_frame_to_location_alt_frame(const MAV_FRAME
         return true;
     default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        gcs().send_text(MAV_SEVERITY_INFO, "Unknown mavlink coordinate frame %u", coordinate_frame);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Unknown mavlink coordinate frame %u", coordinate_frame);
 #endif
         return false;
     }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -63,7 +63,7 @@ bool GCS_MAVLINK::ftp_init(void) {
 failed:
     delete ftp.requests;
     ftp.requests = nullptr;
-    gcs().send_text(MAV_SEVERITY_WARNING, "failed to initialize MAVFTP");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "failed to initialize MAVFTP");
 
     return false;
 }
@@ -579,7 +579,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                 case FTP_OP::TruncateFile:
                 default:
                     // this was bad data, just nack it
-                    gcs().send_text(MAV_SEVERITY_DEBUG, "Unsupported FTP: %d", static_cast<int>(request.opcode));
+                    GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "Unsupported FTP: %d", static_cast<int>(request.opcode));
                     ftp_error(reply, FTP_ERROR::Fail);
                     break;
             }

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -290,7 +290,7 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
     }
 
     if ((parameter_flags & AP_PARAM_FLAG_INTERNAL_USE_ONLY) || vp->is_read_only()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
         // send the readonly value
         send_parameter_value(key, var_type, old_value);
         return;

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -47,7 +47,7 @@ bool MissionItemProtocol::mavlink2_requirement_met(const GCS_MAVLINK &_link, con
     if (!_link.sending_mavlink1()) {
         return true;
     }
-    gcs().send_text(MAV_SEVERITY_WARNING, "Need mavlink2 for item transfer");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Need mavlink2 for item transfer");
     send_mission_ack(_link, msg, MAV_MISSION_UNSUPPORTED);
     return false;
 }
@@ -196,7 +196,7 @@ void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
 
     if (!mission_request_warning_sent) {
         mission_request_warning_sent = true;
-        gcs().send_text(MAV_SEVERITY_WARNING, "got MISSION_REQUEST; use MISSION_REQUEST_INT!");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "got MISSION_REQUEST; use MISSION_REQUEST_INT!");
     }
 
     // buffer space is checked by send_message
@@ -209,7 +209,7 @@ void MissionItemProtocol::send_mission_item_warning()
         return;
     }
     mission_item_warning_sent = true;
-    gcs().send_text(MAV_SEVERITY_WARNING, "got MISSION_ITEM; GCS should send MISSION_ITEM_INT");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "got MISSION_ITEM; GCS should send MISSION_ITEM_INT");
 }
 
 void MissionItemProtocol::handle_mission_write_partial_list(GCS_MAVLINK &_link,
@@ -221,7 +221,7 @@ void MissionItemProtocol::handle_mission_write_partial_list(GCS_MAVLINK &_link,
     if ((unsigned)packet.start_index > item_count() ||
         (unsigned)packet.end_index > item_count() ||
         packet.end_index < packet.start_index) {
-        gcs().send_text(MAV_SEVERITY_WARNING,"Flight plan update rejected"); // FIXME: Remove this anytime after 2020-01-22
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Flight plan update rejected"); // FIXME: Remove this anytime after 2020-01-22
         send_mission_ack(_link, msg, MAV_MISSION_ERROR);
         return;
     }

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -222,7 +222,7 @@ MAV_MISSION_RESULT MissionItemProtocol_Fence::allocate_receive_resources(const u
     if (allocation_size != 0) {
         _new_items = (AC_PolyFenceItem*)malloc(allocation_size);
         if (_new_items == nullptr) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Out of memory for upload");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Out of memory for upload");
             return MAV_MISSION_ERROR;
         }
     }

--- a/libraries/SITL/SIM_Buzzer.cpp
+++ b/libraries/SITL/SIM_Buzzer.cpp
@@ -102,19 +102,19 @@ void Buzzer::update(const struct sitl_input &input)
     const uint32_t now = AP_HAL::millis();
     if (on) {
         if (!was_on) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "%u: Buzzer on", now);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%u: Buzzer on", now);
             on_time = now;
             was_on = true;
             xdemoSound.play();
         }
         if (now - on_time > duration_ms/2) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "%u: Buzzer on again", now);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%u: Buzzer on again", now);
             on_time = now;
             xdemoSound.play();
         }
     } else {
         if (was_on) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "%u: Buzzer off", now);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%u: Buzzer off", now);
             xdemoSound.stop();
             was_on = false;
         }

--- a/libraries/SITL/SIM_IntelligentEnergy24.cpp
+++ b/libraries/SITL/SIM_IntelligentEnergy24.cpp
@@ -64,7 +64,7 @@ void IntelligentEnergy24::update(const struct sitl_input &input)
     if (!enabled.get()) {
         return;
     }
-    // gcs().send_text(MAV_SEVERITY_INFO, "fuelcell update");
+    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "fuelcell update");
     update_send();
 }
 

--- a/libraries/SITL/SIM_RF_Wasp.cpp
+++ b/libraries/SITL/SIM_RF_Wasp.cpp
@@ -57,7 +57,7 @@ void RF_Wasp::check_configuration()
                     offs += 1; // for '>'
                     offs += 1; // for space
                     strncpy(string_configs[i].value, &_buffer[offs], MIN(ARRAY_SIZE(config.format), unsigned(cr - _buffer - offs - 1))); // -1 for the lf, -1 for the cr
-//                    gcs().send_text(MAV_SEVERITY_INFO, "Wasp: config (%s) (%s)", string_configs[i].name, string_configs[i].value);
+//                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Wasp: config (%s) (%s)", string_configs[i].name, string_configs[i].value);
                     char response[128];
                     const size_t x = snprintf(response,
                                               ARRAY_SIZE(response),
@@ -80,7 +80,7 @@ void RF_Wasp::check_configuration()
                     char tmp[32]{};
                     strncpy(tmp, &_buffer[offs], MIN(ARRAY_SIZE(config.format), unsigned(cr - _buffer - offs - 1))); // -1 for the lf, -1 for the cr
                     *(integer_configs[i].value) = atoi(tmp);
-//                    gcs().send_text(MAV_SEVERITY_INFO, "Wasp: config (%s) (%d)", integer_configs[i].name, *(integer_configs[i].value));
+//                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Wasp: config (%s) (%d)", integer_configs[i].name, *(integer_configs[i].value));
                     char response[128];
                     const size_t x = snprintf(response,
                                               ARRAY_SIZE(response),

--- a/libraries/SITL/SIM_ToshibaLED.cpp
+++ b/libraries/SITL/SIM_ToshibaLED.cpp
@@ -17,7 +17,7 @@ void SITL::ToshibaLED::update(const class Aircraft &aircraft)
     last_print_pwm1 = get_register(ToshibaLEDDevReg::PWM1);
     last_print_pwm2 = get_register(ToshibaLEDDevReg::PWM2);
     last_print_enable = get_register(ToshibaLEDDevReg::ENABLE);
-    // gcs().send_text(MAV_SEVERITY_INFO, "SIM_ToshibaLED: PWM0=%u PWM1=%u PWM2=%u ENABLE=%u", last_print_pwm0, last_print_pwm1, last_print_pwm2, last_print_enable);
+    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM_ToshibaLED: PWM0=%u PWM1=%u PWM2=%u ENABLE=%u", last_print_pwm0, last_print_pwm1, last_print_pwm2, last_print_enable);
 
     if (get_register(ToshibaLEDDevReg::ENABLE)) {
         // here we convert from 0-15 BGR (the PWM values from the i2c bus)


### PR DESCRIPTION
If a peripheral is selected, change the definition to one that does not notify the GCS of the message.