### PR TITLE
AP_AHRS: ensure we check health of the sensor we are using.

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -49,7 +49,7 @@ float Plane::calc_speed_scaler(void)
         // no speed estimate and not armed, use a unit scaling
         speed_scaler = 1;
     }
-    if (!plane.ahrs.airspeed_sensor_enabled()  && 
+    if (!plane.ahrs.using_airspeed_sensor()  && 
         (plane.flight_option_enabled(FlightOptions::SURPRESS_TKOFF_SCALING)) &&
         (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF)) { //scaling is suppressed during climb phase of automatic takeoffs with no airspeed sensor being used due to problems with inaccurate airspeed estimates
         return MIN(speed_scaler, 1.0f) ;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1475,7 +1475,7 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
     // assistance due to Q_ASSIST_SPEED
     // if option bit is enabled only allow assist with real airspeed sensor
     if ((have_airspeed && aspeed < assist_speed) && 
-       (!option_is_set(QuadPlane::OPTION::DISABLE_SYNTHETIC_AIRSPEED_ASSIST) || ahrs.airspeed_sensor_enabled())) {
+       (!option_is_set(QuadPlane::OPTION::DISABLE_SYNTHETIC_AIRSPEED_ASSIST) || ahrs.using_airspeed_sensor())) {
         in_angle_assist = false;
         angle_error_start_ms = 0;
         return true;

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -196,7 +196,7 @@ void Plane::read_radio()
         && channel_throttle->get_control_in() > 50
         && stickmixing) {
         float nudge = (channel_throttle->get_control_in() - 50) * 0.02f;
-        if (ahrs.airspeed_sensor_enabled()) {
+        if (ahrs.using_airspeed_sensor()) {
             airspeed_nudge_cm = (aparm.airspeed_max * 100 - aparm.airspeed_cruise_cm) * nudge;
         } else {
             throttle_nudge = (aparm.throttle_max - aparm.throttle_cruise) * nudge;

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -134,7 +134,7 @@ bool Plane::suppress_throttle(void)
         // require 5m/s. This prevents throttle up due to spiky GPS
         // groundspeed with bad GPS reception
 #if AP_AIRSPEED_ENABLED
-        if ((!ahrs.airspeed_sensor_enabled()) || airspeed.get_airspeed() >= 5) {
+        if ((!ahrs.using_airspeed_sensor()) || airspeed.get_airspeed() >= 5) {
             // we're moving at more than 5 m/s
             throttle_suppressed = false;
             return false;        
@@ -605,7 +605,7 @@ void Plane::set_servos_flaps(void)
 
     if (control_mode->does_auto_throttle()) {
         int16_t flapSpeedSource = 0;
-        if (ahrs.airspeed_sensor_enabled()) {
+        if (ahrs.using_airspeed_sensor()) {
             flapSpeedSource = target_airspeed_cm * 0.01f;
         } else {
             flapSpeedSource = aparm.throttle_cruise;

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -185,7 +185,7 @@ void Plane::takeoff_calc_pitch(void)
         return;
     }
 
-    if (ahrs.airspeed_sensor_enabled()) {
+    if (ahrs.using_airspeed_sensor()) {
         int16_t takeoff_pitch_min_cd = get_takeoff_pitch_min_cd();
         calc_nav_pitch();
         if (nav_pitch_cd < takeoff_pitch_min_cd) {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -151,6 +151,9 @@ public:
     // if we have an estimate
     bool airspeed_estimate(float &airspeed_ret, AirspeedEstimateType &type) const;
 
+    // return true if the current AHRS airspeed estimate (from airspeed_estimate method) is directly derived from an airspeed sensor
+    bool using_airspeed_sensor() const;
+
     // return a true airspeed estimate (navigation airspeed) if
     // available. return true if we have an estimate
     bool airspeed_estimate_true(float &airspeed_ret) const;
@@ -163,12 +166,13 @@ public:
     // returns false if the data is unavailable
     bool airspeed_health_data(float &innovation, float &innovationVariance, uint32_t &age_ms) const;
 
-    // return true if airspeed comes from an airspeed sensor, as
-    // opposed to an IMU estimate
-    bool airspeed_sensor_enabled(void) const;
+    // return true if a airspeed sensor is enabled
+    bool airspeed_sensor_enabled(void) const {
+        // FIXME: make this a method on the active backend
+        return AP_AHRS_Backend::airspeed_sensor_enabled();
+    }
 
-    // return true if airspeed comes from a specific airspeed sensor, as
-    // opposed to an IMU estimate
+    // return true if a airspeed from a specific airspeed sensor is enabled
     bool airspeed_sensor_enabled(uint8_t airspeed_index) const {
         // FIXME: make this a method on the active backend
         return AP_AHRS_Backend::airspeed_sensor_enabled(airspeed_index);
@@ -909,6 +913,9 @@ private:
 
     // get current location estimate
     bool _get_location(Location &loc) const;
+
+    // return true if a airspeed sensor should be used for the AHRS airspeed estimate
+    bool _should_use_airspeed_sensor(uint8_t airspeed_index) const;
     
     /*
       update state structure

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -390,7 +390,7 @@ void AP_TECS::_update_speed(float DT)
         _vel_dot_lpf = _vel_dot_lpf * (1.0f - alpha) + _vel_dot * alpha;
     }
 
-    bool use_airspeed = _use_synthetic_airspeed_once || _use_synthetic_airspeed.get() || _ahrs.airspeed_sensor_enabled();
+    bool use_airspeed = _use_synthetic_airspeed_once || _use_synthetic_airspeed.get() || _ahrs.using_airspeed_sensor();
 
     // Convert equivalent airspeeds to true airspeeds and harmonise limits
 
@@ -923,7 +923,7 @@ void AP_TECS::_update_pitch(void)
     // A SKE_weighting of 2 provides 100% priority to speed control. This is used when an underspeed condition is detected. In this instance, if airspeed
     // rises above the demanded value, the pitch angle will be increased by the TECS controller.
     _SKE_weighting = constrain_float(_spdWeight, 0.0f, 2.0f);
-    if (!(_ahrs.airspeed_sensor_enabled() || _use_synthetic_airspeed)) {
+    if (!(_ahrs.using_airspeed_sensor() || _use_synthetic_airspeed)) {
         _SKE_weighting = 0.0f;
     } else if (_flight_stage == AP_FixedWing::FlightStage::VTOL) {
         // if we are in VTOL mode then control pitch without regard to
@@ -1326,7 +1326,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     // Note that caller can demand the use of
     // synthetic airspeed for one loop if needed. This is required
     // during QuadPlane transition when pitch is constrained
-    if (_ahrs.airspeed_sensor_enabled() || _use_synthetic_airspeed || _use_synthetic_airspeed_once) {
+    if (_ahrs.using_airspeed_sensor() || _use_synthetic_airspeed || _use_synthetic_airspeed_once) {
         _update_throttle_with_airspeed();
         _use_synthetic_airspeed_once = false;
         _using_airspeed_for_throttle = true;


### PR DESCRIPTION
The `airspeed_sensor_enabled()` function checks the primary sensor, however, we may not be using the primary sensor thanks to affinity. 

The problem is whenever affinity tries to use a sensor other than primary. It checks health, but not use.

https://github.com/ArduPilot/ardupilot/blob/e0a012919c5ab11a964a70890237960d96b01a03/libraries/AP_AHRS/AP_AHRS.cpp#L3080-L3085

I should add that I have not checked if affinity could actually try and use a sensor which is not set to use. So this may or may-not be possible to hit this issue.