### PR TITLE
Plane: send attitude target message implementation (for quadplanes)

### DIFF
--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -32,6 +32,7 @@ protected:
 
     void send_aoa_ssa();
     void send_attitude() const override;
+    void send_attitude_target() override;
     void send_wind() const;
 
     bool persist_streamrates() const override { return true; }


### PR DESCRIPTION
Minor modification -  implementation of the send_attitude_target msg. streaming (for quadplanes). The code is analogous in its structure and functionality to the implementation in Copter. 



This is the same mod as reviewed in #25253. I broke the PR along the way, but now it is all good (and requesting to pull to master, as instructed). 