### PR TITLE
AP_TECS: log SKE weight since both weights are now [0,1]

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1047,10 +1047,30 @@ void AP_TECS::_update_pitch(void)
     _last_pitch_dem = _pitch_dem;
 
     if (AP::logger().should_log(_log_bitmask)){
-        AP::logger().WriteStreaming("TEC2","TimeUS,PEW,EBD,EBE,EBDD,EBDE,EBDDT,Imin,Imax,I,KI,pmin,pmax",
-                                    "Qffffffffffff",
+        // log to AP_Logger
+        // @LoggerMessage: TEC2
+        // @Vehicles: Plane
+        // @Description: Additional information about the Total Energy Control System
+        // @URL: http://ardupilot.org/plane/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.html
+        // @Field: TimeUS: Time since system startup
+        // @Field: PEW: Potential energy weighting
+        // @Field: KEW: Kinetic energy weighting
+        // @Field: EBD: Energy balance demand
+        // @Field: EBE: Energy balance error
+        // @Field: EBDD: Energy balance rate demand
+        // @Field: EBDE: Energy balance rate error
+        // @Field: EBDDT: Energy balance rate demand + Energy balance rate error*pitch_damping
+        // @Field: Imin: Minimum integrator value
+        // @Field: Imax: Maximum integrator value
+        // @Field: I: Energy balance error integral
+        // @Field: KI: Pitch demand kinetic energy integral
+        // @Field: pmin: Pitch min
+        // @Field: pmax: Pitch max
+        AP::logger().WriteStreaming("TEC2","TimeUS,PEW,KEW,EBD,EBE,EBDD,EBDE,EBDDT,Imin,Imax,I,KI,pmin,pmax",
+                                    "Qfffffffffffff",
                                     AP_HAL::micros64(),
                                     (double)SPE_weighting,
+                                    (double)_SKE_weighting,
                                     (double)SEB_dem,
                                     (double)SEB_est,
                                     (double)SEBdot_dem,


### PR DESCRIPTION
## Context
TECs weighting is now between 0 and 1 for both weights as seen here:  https://github.com/ArduPilot/ardupilot/blob/fb87369c7ef174c4ae2eda996a97dbc283bc1df5/libraries/AP_TECS/AP_TECS.cpp#L948C1-L951C1

We can no longer infer the other weight from here: https://github.com/ArduPilot/ardupilot/blob/fb87369c7ef174c4ae2eda996a97dbc283bc1df5/libraries/AP_TECS/AP_TECS.cpp#L946

## Proposal
Add a log message for `_SKE_weight` directly.

## Testing
[00000035.BIN.txt](https://github.com/ArduPilot/ardupilot/files/12934151/00000035.BIN.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/e97ad377-92d0-4dc7-8609-7bbb5ee6ca80)
Figure: Demonstration of how `TEC2.PEW` remains 1 even though `TEC2.KEW` is changing.