### PR TITLE
AP_HAL_ChibiOS: RADIX2HD Probe external I2C compasses

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
@@ -161,6 +161,9 @@ IMU BMI270 SPI:bmi270 ROTATION_ROLL_180
 
 BARO DPS310 I2C:0:0x76
 
+# probe external compasses (same bus as internal)
+define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+
 # filesystem setup on sdcard
 define HAL_OS_FATFS_IO 1
 


### PR DESCRIPTION
Probing of external I2C compasses was missing for RADIX2HD. 

I tested it with a HMC5983. Both the compass and the internal DPS310 baro on the same I2C bus are working as expected.

Please also backport this to 4.4