### PR TITLE
AP_DroneCAN: add support for detecting downed link

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1136,8 +1136,9 @@ void AP_Periph_FW::processTx(void)
                   active if it has had a successful transmit in the
                   last 2 seconds
                  */
-                const auto *stats = _ins.iface->get_statistics();
-                if (stats == nullptr || now_us - stats->last_transmit_us < 2000000UL) {
+                volatile const auto *stats = _ins.iface->get_statistics();
+                uint64_t last_transmit_us = stats->last_transmit_us;
+                if (stats == nullptr || AP_HAL::micros64() - last_transmit_us < 2000000UL) {
                     sent = false;
                 }
             } else {

--- a/libraries/AP_DroneCAN/AP_Canard_iface.cpp
+++ b/libraries/AP_DroneCAN/AP_Canard_iface.cpp
@@ -214,6 +214,20 @@ void CanardInterface::processTx(bool raw_commands_only = false) {
         if (txq == nullptr) {
             return;
         }
+        // volatile as the value can change at any time during can interrupt
+        // we need to ensure that this is not optimized
+        volatile const auto *stats = ifaces[iface]->get_statistics();
+        uint64_t last_transmit_us = stats->last_transmit_us;
+        bool iface_down = true;
+        if (stats == nullptr || (AP_HAL::micros64() - last_transmit_us) < 200000UL) {
+            /*
+            We were not able to queue the frame for
+            sending. Only mark the send as failing if the
+            interface is active. We consider an interface as
+            active if it has had successful transmits for some time.
+            */
+            iface_down = false;
+        } 
         // scan through list of pending transfers
         while (true) {
             auto txf = &txq->frame;
@@ -240,15 +254,22 @@ void CanardInterface::processTx(bool raw_commands_only = false) {
             if (!write) {
                 // if there is no space then we need to start from the
                 // top of the queue, so wait for the next loop
-                break;
-            }
-            if ((txf->iface_mask & (1U<<iface)) && (AP_HAL::micros64() < txf->deadline_usec)) {
+                if (!iface_down) {
+                    break;
+                } else {
+                    txf->iface_mask &= ~(1U<<iface);
+                }
+            } else if ((txf->iface_mask & (1U<<iface)) && (AP_HAL::micros64() < txf->deadline_usec)) {
                 // try sending to interfaces, clearing the mask if we succeed
                 if (ifaces[iface]->send(txmsg, txf->deadline_usec, 0) > 0) {
                     txf->iface_mask &= ~(1U<<iface);
                 } else {
                     // if we fail to send then we try sending on next interface
-                    break;
+                    if (!iface_down) {
+                        break;
+                    } else {
+                        txf->iface_mask &= ~(1U<<iface);
+                    }
                 }
             }
             // look at next transfer


### PR DESCRIPTION
* Follows similar implementation down for AP_Periph https://github.com/ArduPilot/ardupilot/pull/24840/commits/d892df492bebba23ebf42186f3179533891dc7cb but for DroneCAN. This ensures that we are not filling up buffers with stale transactions just because second interface is down/disconnected.
