### PR TITLE
AP_Compass: fix AK09916 hangup issue

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -311,8 +311,15 @@ void AP_Compass_AK09916::_update()
     }
 
     if (!(regs.st1 & 0x01)) {
+        no_data++;
+        if (no_data == 5) {
+            _reset();
+            _setup_mode();
+            no_data = 0;
+        }
         goto check_registers;
     }
+    no_data = 0;
 
     /* Check for overflow. See AK09916's datasheet*/
     if ((regs.st2 & 0x08)) {

--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -97,6 +97,7 @@ private:
     bool _initialized;
     enum Rotation _rotation;
     enum AP_Compass_Backend::DevTypes _devtype;
+    uint8_t no_data;
 };
 
 


### PR DESCRIPTION
* During production testing it was found that AK09916 significant percentage (~15%) of Cubes AK09916 will hangup for around half a second and then come back. To resolve this we call reset to AK09916 and that seems to be solving the issue

[CompassFail.zip](https://github.com/ArduPilot/ardupilot/files/12987889/CompassFail.zip)
    