### PR TITLE
Remove handling of PREFLIGHT_SET_SENSOR_OFFSETS

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -8613,19 +8613,16 @@ Also, ignores heartbeats not from our target system'''
     def zero_mag_offset_parameters(self, compass_count=3):
         self.progress("Zeroing Mag OFS parameters")
         self.get_sim_time()
-        self.run_cmd(
-            mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
-            p1=2, # param1 (compass0)
-        )
-        self.run_cmd(
-            mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
-            p1=5, # param1 (compass1)
-        )
-        self.run_cmd(
-            mavutil.mavlink.MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
-            p1=6, # param1 (compass2)
-        )
+        zero_offset_parameters_hash = {}
+        for num in "", "2", "3":
+            for axis in "X", "Y", "Z":
+                name = "COMPASS_OFS%s_%s" % (num, axis)
+                zero_offset_parameters_hash[name] = 0
+        self.set_parameters(zero_offset_parameters_hash)
+        # force-save the calibration values:
+        self.run_cmd_int(mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION, p2=76)
         self.progress("zeroed mag parameters")
+
         params = [
             [("SIM_MAG1_OFS1_X", "COMPASS_OFS_X", 0),
              ("SIM_MAG1_OFS1_Y", "COMPASS_OFS_Y", 0),

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -626,7 +626,6 @@ protected:
     virtual uint32_t telem_delay() const = 0;
 
     MAV_RESULT handle_command_run_prearm_checks(const mavlink_command_long_t &packet);
-    MAV_RESULT handle_command_preflight_set_sensor_offsets(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_flash_bootloader(const mavlink_command_long_t &packet);
 
     // generally this should not be overridden; Plane overrides it to ensure

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4327,25 +4327,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_flash_bootloader(const mavlink_command_lo
     return MAV_RESULT_FAILED;
 }
 
-MAV_RESULT GCS_MAVLINK::handle_command_preflight_set_sensor_offsets(const mavlink_command_long_t &packet)
-{
-    Compass &compass = AP::compass();
-
-    uint8_t compassNumber = -1;
-    if (is_equal(packet.param1, 2.0f)) {
-        compassNumber = 0;
-    } else if (is_equal(packet.param1, 5.0f)) {
-        compassNumber = 1;
-    } else if (is_equal(packet.param1, 6.0f)) {
-        compassNumber = 2;
-    }
-    if (compassNumber == (uint8_t) -1) {
-        return MAV_RESULT_FAILED;
-    }
-    compass.set_and_save_offsets(compassNumber, Vector3f(packet.param2, packet.param3, packet.param4));
-    return MAV_RESULT_ACCEPTED;
-}
-
 MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro(const mavlink_message_t &msg)
 {
     // fast barometer calibration
@@ -4805,11 +4786,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_FLASH_BOOTLOADER:
         result = handle_command_flash_bootloader(packet);
         break;
-
-    case MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS: {
-        result = handle_command_preflight_set_sensor_offsets(packet);
-        break;
-    }
 
     default:
         result = try_command_long_as_command_int(packet, msg);


### PR DESCRIPTION
```
    This was the old offboard-calibration code.
    
    We've checked MAVProxy, QGC and MissionPlanner and they're not using this code.
    
    The onboard calibration stuff is better.
```