### PR TITLE
AP_NavEKF3: delay use of zero-sideslip for 10 seconds

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -627,10 +627,7 @@ bool NavEKF3_core::using_extnav_for_yaw() const
  */
 bool NavEKF3_core::assume_zero_sideslip(void) const
 {
-    // we don't assume zero sideslip for ground vehicles as EKF could
-    // be quite sensitive to a rapid spin of the ground vehicle if
-    // traction is lost
-    return dal.get_fly_forward() && dal.get_vehicle_class() != AP_DAL::VehicleClass::GROUND;
+    return fly_forward_active;
 }
 
 // sets the local NED origin using a LLH location (latitude, longitude, height)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -449,6 +449,9 @@ void NavEKF3_core::InitialiseVariables()
     EKFGSF_yaw_valid_count = 0;
 
     effectiveMagCal = effective_magCal();
+
+    fly_forward_start_ms = 0;
+    fly_forward_active = false;
 }
 
 // Use a function call rather than a constructor to initialise variables because it enables the filter to be re-started in flight if necessary.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1306,6 +1306,10 @@ private:
     bool bodyVelFusionDelayed;          // true when body frame velocity fusion has been delayed
     bool bodyVelFusionActive;           // true when body frame velocity fusion is active
 
+    // time when fly_forward became true
+    uint32_t fly_forward_start_ms;
+    bool fly_forward_active;
+
 #if EK3_FEATURE_BODY_ODOM
     // wheel sensor fusion
     EKF_obs_buffer_t<wheel_odm_elements> storedWheelOdm;    // body velocity data buffer


### PR DESCRIPTION
this is a test patch to demonstrate in replay that delaying sideslip fusion for 10s helps with real log data.
The idea is to wait until sideslip is reduced after completing transition, and also wait until yaw is somewhat sorted out from a bad compass
this is an example with the log from @Rolf-G 
![image](https://github.com/ArduPilot/ardupilot/assets/831867/4bd76f89-bf53-4f89-8b6b-8a2686622ddb)
