### PR TITLE
Mount: servo backend attitude reporting fix

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5120,7 +5120,7 @@ class AutoTestCopter(AutoTest):
             self.progress("Pitching vehicle")
             self.do_pitch(despitch)
             self.wait_pitch(despitch, despitch_tolerance)
-            self.test_mount_pitch(-despitch, 1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+            self.test_mount_pitch(0, 1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
 
             # point gimbal at specified angle
             self.progress("Point gimbal using GIMBAL_MANAGER_PITCHYAW (ANGLE)")

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -125,7 +125,14 @@ bool AP_Mount_Servo::has_pan_control() const
 // get attitude as a quaternion.  returns true on success
 bool AP_Mount_Servo::get_attitude_quaternion(Quaternion& att_quat)
 {
-    att_quat.from_euler(_angle_bf_output_rad);
+    // no feedback from gimbal so simply report targets
+    // mnt_target.angle_rad always holds latest angle targets
+
+    // ensure yaw target is in body-frame with limits applied
+    const float yaw_bf = constrain_float(mnt_target.angle_rad.get_bf_yaw(), radians(_params.yaw_angle_min), radians(_params.yaw_angle_max));
+
+    // convert to quaternion
+    att_quat.from_euler(Vector3f{mnt_target.angle_rad.roll, mnt_target.angle_rad.pitch, yaw_bf});
     return true;
 }
 


### PR DESCRIPTION
This fixes a bug in the AP_Mount_Servo backend's attitude reporting to the GCS sent via the [GIMBAL_DEVICE_ATTITUDE_STATUS](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L6042).  The current implementation uses the target output angles sent to the gimbal which is OK for BrushlessPWM but incorrect for regular Servo gimbals.  This PR changes the attitude reporting so that the target angle sent to the backend is used.  This is the best we can do for these gimbals because they do not typically have a way to return their actual angles.

By the way, the AP_Mount_Servo backend is actually used for two slightly different mount types

- MNT1_TYPE = 1 ([Servo](https://ardupilot.org/copter/docs/common-camera-gimbal.html)) is for gimbals implemented with actual servos
- MNT1_TYPE = 7 ([BrushlessPWM](https://ardupilot.org/copter/docs/common-brushless-pwm-gimbal.html)) is for brushless gimbals that accept a PWM input for the angle target but implement their own attitude control

This has been tested in SITL and below are some screen shots before-vs-after for the Servo backends (e.g. MNT1_TYPE = 1).  There's no change in behvaiour for MNT1_TYPE = 7 (BrushlessPWM).  In this test MP's Payload screen was used to point the gimbal downwards and the vehicle was flown around a course.  Some debug was added to display the output in Euler angles.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/1fc6ff00-2ed2-44fe-bb40-9d5b720124e3)

Afterwards we see the correct actual angle is reported
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/a14b1ffd-958e-4aa5-8c6c-bc1b736da62d)

@peterbarker, I've also correct a mistake in the Mount autotest that actually relied on the bug.  The test was checking that the reported pitch angle from the mount was the opposite of the vehicle's pitch angle.  .. but of course with a properly stabilized gimbal the reported pitch angle will not change as the vehicle's attitude changes.



