### PR TITLE
Plane: Mode LoiterAltQLand to reuse same loiter point if available

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -113,6 +113,9 @@ bool Mode::enter()
         plane.adsb.set_is_auto_mode(does_auto_navigation());
 #endif
 
+        // set the nav controller stale AFTER _enter() so that we can check if we're currently in a loiter during the mode change
+        plane.nav_controller->set_data_is_stale();
+
         // reset steering integrator on mode change
         plane.steerController.reset_I();
 

--- a/ArduPlane/mode_LoiterAltQLand.cpp
+++ b/ArduPlane/mode_LoiterAltQLand.cpp
@@ -10,17 +10,13 @@ bool ModeLoiterAltQLand::_enter()
         return true;
     }
 
+    // If we were already in a loiter then use that waypoint. Else, use the current point
+    const bool already_in_a_loiter = plane.nav_controller->reached_loiter_target() && !plane.nav_controller->data_is_stale();
+    const Location loiter_wp = already_in_a_loiter ? plane.next_WP_loc : plane.current_loc;
+
     ModeLoiter::_enter();
 
-#if AP_TERRAIN_AVAILABLE
-    if (plane.terrain_enabled_in_mode(Mode::Number::QLAND)) {
-        plane.next_WP_loc.set_alt_cm(quadplane.qrtl_alt*100UL, Location::AltFrame::ABOVE_TERRAIN);
-    } else {
-        plane.next_WP_loc.set_alt_cm(quadplane.qrtl_alt*100UL, Location::AltFrame::ABOVE_HOME);
-    }
-#else
-    plane.next_WP_loc.set_alt_cm(quadplane.qrtl_alt*100UL, Location::AltFrame::ABOVE_HOME);
-#endif
+    handle_guided_request(loiter_wp);
 
     switch_qland();
 


### PR DESCRIPTION
Current behavior:
- When switching to mode LoiterAltQLand we set the current location as the center of the loiter.

Problem:
- If we were already performing a loiter then our circle center changes

New/Proposed behavior in this PR:
- When switching to mode LoiterAltQLand, if we were already in a loiter then continue using that same center location point
