### PR TITLE
Plane: mode LoiterAltQLand to use QRTL

### DIFF
--- a/ArduPlane/mode_LoiterAltQLand.cpp
+++ b/ArduPlane/mode_LoiterAltQLand.cpp
@@ -38,7 +38,9 @@ void ModeLoiterAltQLand::switch_qland()
 {
     ftype dist;
     if ((!plane.current_loc.get_alt_distance(plane.next_WP_loc, dist) || is_negative(dist)) && plane.nav_controller->reached_loiter_target()) {
-        plane.set_mode(plane.mode_qland, ModeReason::LOITER_ALT_REACHED_QLAND);
+        const Location loiter_wp = plane.next_WP_loc;
+        plane.set_mode(plane.mode_qrtl, ModeReason::LOITER_ALT_REACHED_QLAND);
+        plane.set_next_WP(loiter_wp);
     }
 }
 


### PR DESCRIPTION
Current behavior:
- After we loiter-down to altitude we switch to QLAND which stops the aircraft right where we are and immediately land.

Problem:
- Aircraft lands somewhere randomly on the circle's perimeter. Can not reliably choose where we land.

New/Proposed behavior:
- Aircraft lands at the center of the loiter circle which is a selectable place (especially with PR https://github.com/ArduPilot/ardupilot/pull/25318)



Possible future PR suggestions for this flight mode:
- hold-off the loiter "exit" until we are down-wind so that the land approach will be into the wind
- rename the ModeReason
- rename the flight mode