### PR TITLE
waf: remove SKETCHBOOK define

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -508,6 +508,7 @@ class Board:
     def build(self, bld):
         bld.ap_version_append_str('GIT_VERSION', bld.git_head_hash(short=True))
         bld.ap_version_append_int('GIT_VERSION_INT', int("0x" + bld.git_head_hash(short=True), base=16))
+        bld.ap_version_append_str('AP_BUILD_ROOT', bld.srcnode.abspath())
         import time
         ltime = time.localtime()
         if bld.env.build_dates:

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -46,6 +46,9 @@
 #include <time.h>
 #include <sys/time.h>
 
+#define FORCE_VERSION_H_INCLUDE
+#include "ap_version.h"
+
 extern HAL_SITL& hal;
 
 using namespace HALSITL;
@@ -356,7 +359,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     bool storage_fram_enabled = false;
     bool erase_all_storage = false;
 
-    if (asprintf(&autotest_dir, SKETCHBOOK "/Tools/autotest") <= 0) {
+    if (asprintf(&autotest_dir, AP_BUILD_ROOT "/Tools/autotest") <= 0) {
         AP_HAL::panic("out of memory");
     }
     _set_signal_handlers();

--- a/libraries/SITL/SIM_AIS.cpp
+++ b/libraries/SITL/SIM_AIS.cpp
@@ -26,6 +26,9 @@
 
 #include <SITL/SITL.h>
 
+#define FORCE_VERSION_H_INCLUDE
+#include "ap_version.h"
+
 extern const AP_HAL::HAL& hal;
 
 using namespace SITL;
@@ -34,7 +37,7 @@ using namespace SITL;
 AIS::AIS() : SerialDevice::SerialDevice()
 {
     char* file_path;
-    IGNORE_RETURN(asprintf(&file_path, SKETCHBOOK "/libraries/SITL/SIM_AIS_data.txt"));
+    IGNORE_RETURN(asprintf(&file_path, AP_BUILD_ROOT "/libraries/SITL/SIM_AIS_data.txt"));
 
     file = fopen(file_path,"r");
 

--- a/wscript
+++ b/wscript
@@ -584,12 +584,6 @@ def configure(cfg):
     else:
         cfg.env.ENABLE_HEADER_CHECKS = False
 
-    # TODO: Investigate if code could be changed to not depend on the
-    # source absolute path.
-    cfg.env.prepend_value('DEFINES', [
-        'SKETCHBOOK="' + cfg.srcnode.abspath() + '"',
-    ])
-
     # Always use system extensions
     cfg.define('_GNU_SOURCE', 1)
 


### PR DESCRIPTION
this removes the only build root specific define on the g++ command line, which allows for better ccache results between build directories
