### PR TITLE
SITL: reduce the impact of long socket glitches in realflight

### DIFF
--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -36,6 +36,7 @@ public:
     ~SocketAPM();
 
     bool connect(const char *address, uint16_t port);
+    bool connect_timeout(const char *address, uint16_t port, uint32_t timeout_ms);
     bool bind(const char *address, uint16_t port);
     bool reuseaddress() const;
     bool set_blocking(bool blocking) const;

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -595,7 +595,11 @@ void FlightAxis::socket_creator(void)
             usleep(500);
             continue;
         }
-        if (!sck->connect(controller_ip, controller_port)) {
+        /*
+          don't let the connection take more than 100ms (10Hz). Longer
+          than this and we are better off trying for a new socket
+         */
+        if (!sck->connect_timeout(controller_ip, controller_port, 100)) {
             ::printf("connect failed\n");
             delete sck;
             usleep(5000);


### PR DESCRIPTION
this times out socket connects in an attempt to reduce glitches. It seems to help on my network

