### PR TITLE
IMU: Fixed ICM42688 "stuck" gyro issue

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -319,6 +319,8 @@ private:
 
     // logging
     void Write_ACC(const uint8_t instance, const uint64_t sample_us, const Vector3f &accel) const __RAMFUNC__; // Write ACC data packet: raw accel data
-    void Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro) const __RAMFUNC__;  // Write GYR data packet: raw gyro data
+
+protected:
+    void Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro, bool use_sample_timestamp=false) const __RAMFUNC__;  // Write GYR data packet: raw gyro data
 
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -137,6 +137,9 @@ extern const AP_HAL::HAL& hal;
 #define INV3_ID_ICM42670      0x67
 #define INV3_ID_ICM45686      0xE9
 
+// enable logging at FIFO rate for debugging
+#define INV3_ENABLE_FIFO_LOGGING 0
+
 /*
   really nice that this sensor has an option to request little-endian
   data
@@ -336,6 +339,9 @@ void AP_InertialSensor_Invensensev3::accumulate()
 
 bool AP_InertialSensor_Invensensev3::accumulate_samples(const FIFOData *data, uint8_t n_samples)
 {
+#if INV3_ENABLE_FIFO_LOGGING
+    const uint64_t tstart = AP_HAL::micros64();
+#endif
     for (uint8_t i = 0; i < n_samples; i++) {
         const FIFOData &d = data[i];
 
@@ -351,6 +357,10 @@ bool AP_InertialSensor_Invensensev3::accumulate_samples(const FIFOData *data, ui
 
         accel *= accel_scale;
         gyro *= gyro_scale;
+
+#if INV3_ENABLE_FIFO_LOGGING
+        Write_GYR(gyro_instance, tstart+(i*backend_period_us), gyro, true);
+#endif
 
         const float temp = d.temperature * temp_sensitivity + temp_zero;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -125,6 +125,9 @@ extern const AP_HAL::HAL& hal;
 #define INV3BANK_456_IPREG_SYS1_ADDR 0xA400
 #define INV3BANK_456_IPREG_SYS2_ADDR 0xA500
 
+// ICM42688 specific registers
+#define INV3REG_42688_INTF_CONFIG1  0x4d
+
 // WHOAMI values
 #define INV3_ID_ICM40605      0x33
 #define INV3_ID_ICM40609      0x3b
@@ -909,6 +912,10 @@ bool AP_InertialSensor_Invensensev3::hardware_init(void)
         // disable STC
         uint8_t reg = register_read_bank_icm456xy(INV3BANK_456_IPREG_TOP1_ADDR, 0x68);  // I3C_STC_MODE b2
         register_write_bank_icm456xy(INV3BANK_456_IPREG_TOP1_ADDR, 0x68, reg & ~0x04);
+    } else if (inv3_type == Invensensev3_Type::ICM42688) {
+        // fix for the "stuck gyro" issue
+        const uint8_t v = register_read(INV3REG_42688_INTF_CONFIG1);
+        register_write(INV3REG_42688_INTF_CONFIG1, (v & 0x3F) | 0x40);
     }
 
     return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -20,9 +20,9 @@ void AP_InertialSensor_Backend::Write_ACC(const uint8_t instance, const uint64_t
 }
 
 // Write GYR data packet: raw gyro data
-void AP_InertialSensor_Backend::Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro) const
+void AP_InertialSensor_Backend::Write_GYR(const uint8_t instance, const uint64_t sample_us, const Vector3f &gyro, bool use_sample_timestamp) const
 {
-        const uint64_t now = AP_HAL::micros64();
+        const uint64_t now = use_sample_timestamp?sample_us:AP_HAL::micros64();
         const struct log_GYR pkt{
             LOG_PACKET_HEADER_INIT(LOG_GYR_MSG),
             time_us   : now,


### PR DESCRIPTION
This fixes issue #25025 
the ICM42688 has an "AFSR" feature (enabled by default) where it switches between a low-noise mode at angular rates below 100 deg/sec and a higher noise mode above that level. When it switches it causes the gyro to become "stuck" for between 1ms and 2ms, leading to a significant gyro bias that can under some circumstances lead to a crash of the vehicle if it is not able to switch to another IMU.
This PR does 2 things:
 - it disables this AFSR feature on the ICM42688
 - it enables optional FIFO rate logging to make the fix apparent in a log using the GYR log message. This FIFO rate logging is disabled by default

