### PR TITLE
AP_Notify: Stop alarm when EKF goes from abnormal to normal

### DIFF
--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -442,6 +442,8 @@ void AP_ToneAlarm::update()
         flags.failsafe_ekf = AP_Notify::flags.failsafe_ekf;
         if (flags.failsafe_ekf) {
             play_tone(AP_NOTIFY_TONE_EKF_ALERT);
+        } else {
+            stop_cont_tone();
         }
     }
 }


### PR DESCRIPTION
While flying in LOTER mode, a GPS anomaly caused the EKF fail-safe action to transition to ALTHOLD mode.
After that, the alarm continued to sound even after the GPS anomaly became normal.
The alarm did not stop when I changed the flight mode to LOITER.
I deactivate the alarm when the GPS becomes normal.