### PR TITLE
AP_Scripting: added get_cell_voltage and balance arming check

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -874,6 +874,23 @@ const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t in
     }
 }
 
+// get once cell voltage (for scripting)
+bool AP_BattMonitor::get_cell_voltage(uint8_t instance, uint8_t cell, float &voltage) const
+{
+    if (!has_cell_voltages(instance) ||
+        cell >= AP_BATT_MONITOR_CELLS_MAX) {
+        return false;
+    }
+    const auto &cell_voltages = get_cell_voltages(instance);
+    const uint16_t voltage_mv = cell_voltages.cells[cell];
+    if (voltage_mv == 0 || voltage_mv == UINT16_MAX) {
+        // UINT16_MAX is used as invalid indicator
+        return false;
+    }
+    voltage = voltage_mv*0.001;
+    return true;
+}
+
 // returns true if there is a temperature reading
 bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance) const
 {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -232,6 +232,9 @@ public:
     const cells &get_cell_voltages() const { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
     const cells &get_cell_voltages(const uint8_t instance) const;
 
+    // get once cell voltage (for scripting)
+    bool get_cell_voltage(uint8_t instance, uint8_t cell, float &voltage) const;
+
     // temperature
     bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); }
     bool get_temperature(float &temperature, const uint8_t instance) const;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2718,6 +2718,12 @@ function battery:healthy(instance) end
 ---@return integer
 function battery:num_instances() end
 
+-- get individual cell voltage
+---@param instance integer
+---@param cell integer
+---@return number|nil
+function battery:get_cell_voltage(instance, cell) end
+
 
 -- desc
 ---@class arming

--- a/libraries/AP_Scripting/examples/cell_balance_check.lua
+++ b/libraries/AP_Scripting/examples/cell_balance_check.lua
@@ -1,0 +1,48 @@
+--[[
+ script implementing pre-arm check that batteries are well balanced
+--]]
+
+local MAX_CELL_DEVIATION = 0.2
+
+local auth_id = arming:get_aux_auth_id()
+
+local NCELLS_MAX = 16
+
+function check_cell_balance(bnum)
+   local min_volt = -1
+   local max_volt = -1
+   for c=0,NCELLS_MAX do
+      local voltage = battery:get_cell_voltage(bnum, c)
+      if not voltage then
+         break
+      end
+      if min_volt == -1 or min_volt > voltage then
+         min_volt = voltage
+      end
+      if max_volt == -1 or max_volt < voltage then
+         max_volt = voltage
+      end
+   end
+   local vdiff = max_volt - min_volt
+   if vdiff > MAX_CELL_DEVIATION then
+      arming:set_aux_auth_failed(auth_id, string.format("Batt[%u] imbalance %.1fV", bnum+1, vdiff))
+      return false
+   end
+   return true
+end
+
+function update()
+   local num_batts = battery:num_instances()
+   local ok = true
+   for i=0,num_batts do
+      if not check_cell_balance(i) then
+         ok = false
+      end
+   end
+   if ok then
+      arming:set_aux_auth_passed(auth_id)
+   end
+   return update, 500
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -90,6 +90,7 @@ singleton AP_BattMonitor method overpower_detected boolean uint8_t 0 ud->num_ins
 singleton AP_BattMonitor method get_temperature boolean float'Null uint8_t 0 ud->num_instances()
 singleton AP_BattMonitor method get_cycle_count boolean uint8_t 0 ud->num_instances() uint16_t'Null
 singleton AP_BattMonitor method reset_remaining boolean uint8_t 0 ud->num_instances() float 0 100
+singleton AP_BattMonitor method get_cell_voltage boolean uint8_t'skip_check uint8_t'skip_check float'Null
 
 include AP_GPS/AP_GPS.h
 


### PR DESCRIPTION
This adds get_cell_voltage() to get an individual cell voltage in a lua script. This allows for a pre-arm check for cell balance
I implemented this using a simple instance/cell get call instead of returning the whole cells structure as it is much simpler to implement and meets the needs for a pre-arm check where cell voltages will not be rapidly changing. We could add a userdata for the whole cells structure but that adds complexity for a case we don't need

