### PR TITLE
hwdef: Make Crazyflie2 board and JHEMCU-GSF405A board only autobuild for Copter

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/crazyflie2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/crazyflie2/hwdef.dat
@@ -124,3 +124,5 @@ define HAL_USE_ADC FALSE
 
 include ../include/minimize_features.inc
 
+# This is a board that's not really intended for anything other than copter
+AUTOBUILD_TARGETS Copter


### PR DESCRIPTION
These two boards are both made for very small quadcopters and it would be difficult to use them for a different vehicle, so probably best to stop autobuilding them for all vehicles.

Also, they're both currently failing to build for Plane.