### PR TITLE
Make it possible to surrpress the status text on arming/disarming the aircraft.

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -708,7 +708,7 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors");
+    send_arm_disarm_statustext("Arming motors");
 #endif
 
     // Remember Orientation
@@ -800,7 +800,7 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors");
+    send_arm_disarm_statustext("Disarming motors");
 #endif
 
     auto &ahrs = AP::ahrs();

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -319,7 +319,7 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
     // rising edge of delay_arming oneshot
     delay_arming = true;
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+    send_arm_disarm_statustext("Throttle armed");
 
     return true;
 }
@@ -379,8 +379,8 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
     // re-initialize speed variable used in AUTO and GUIDED for
     // DO_CHANGE_SPEED commands
     plane.new_airspeed_cm = -1;
-    
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
+
+    send_arm_disarm_statustext("Throttle disarmed");
 
     return true;
 }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -105,7 +105,7 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors");
+    send_arm_disarm_statustext("Arming motors");
 #endif
 
     AP_AHRS &ahrs = AP::ahrs();
@@ -161,7 +161,7 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors");
+    send_arm_disarm_statustext("Disarming motors");
 #endif
 
     auto &ahrs = AP::ahrs();

--- a/Blimp/AP_Arming.cpp
+++ b/Blimp/AP_Arming.cpp
@@ -312,7 +312,7 @@ bool AP_Arming_Blimp::arm(const AP_Arming::Method method, const bool do_arming_c
         AP::notify().update();
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Arming motors"); //MIR kept in - usually only in SITL
+    send_arm_disarm_statustext("Arming motors"); //MIR kept in - usually only in SITL
 
     auto &ahrs = AP::ahrs();
 
@@ -371,8 +371,7 @@ bool AP_Arming_Blimp::disarm(const AP_Arming::Method method, bool do_disarm_chec
         return false;
     }
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Disarming motors"); //MIR keeping in - usually only in SITL
-
+    send_arm_disarm_statustext("Disarming motors"); //MIR keeping in - usually only in SITL
 
     auto &ahrs = AP::ahrs();
 

--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -130,7 +130,7 @@ bool AP_Arming_Rover::arm(AP_Arming::Method method, const bool do_arming_checks)
 
     update_soft_armed();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");
+    send_arm_disarm_statustext("Throttle armed");
 
     return true;
 }
@@ -150,7 +150,7 @@ bool AP_Arming_Rover::disarm(const AP_Arming::Method method, bool do_disarm_chec
 
     update_soft_armed();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
+    send_arm_disarm_statustext("Throttle disarmed");
 
     return true;
 }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
-    // @Values: 0:None,1:Disable prearm display
+    // @Values: 0:None,1:Disable prearm display,2:Do not send status text on state change
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,   AP_Arming, _arming_options, 0),
 
@@ -1723,6 +1723,14 @@ bool AP_Arming::disarm(const AP_Arming::Method method, bool do_disarm_checks)
 #endif
 
     return true;
+}
+
+void AP_Arming::send_arm_disarm_statustext(const char *str) const
+{
+    if (option_enabled(AP_Arming::Option::DISABLE_STATUSTEXT_ON_STATE_CHANGE)) {
+        return;
+    }
+    gcs().send_text(MAV_SEVERITY_INFO, "%s", str);
 }
 
 AP_Arming::Required AP_Arming::arming_required() const

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -139,11 +139,14 @@ public:
     
     // enum for ARMING_OPTIONS parameter
     enum class Option : int32_t {
-        DISABLE_PREARM_DISPLAY   = (1U << 0),
+        DISABLE_PREARM_DISPLAY             = (1U << 0),
+        DISABLE_STATUSTEXT_ON_STATE_CHANGE = (1U << 1),
     };
     bool option_enabled(Option option) const {
         return (_arming_options & uint32_t(option)) != 0;
     }
+
+    void send_arm_disarm_statustext(const char *string) const;
 
     static bool method_is_GCS(Method method) {
         return (method == Method::MAVLINK || method == Method::DDS);


### PR DESCRIPTION
I don't find the status text of "Throttle armed" useful at all on plane, particularly because I have both generally good tracking of that, and on a ICE plane where you may be starting the throttle while disarmed this is particularly misleading. Interestingly both copter and sub actually only sent text messages in SITL, so presumably this isn't a unique opinion.

This adds an opt in behavior to not send the message. SITL tested on plane.