### PR TITLE
AP_InertialSensor: init all notch center frequencies

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -986,7 +986,9 @@ AP_InertialSensor::init(uint16_t loop_rate)
         if (!notch.params.enabled() && !fft_enabled) {
             continue;
         }
-        notch.calculated_notch_freq_hz[0] = notch.params.center_freq_hz();
+        for (uint8_t i = 0; i < ARRAY_SIZE(notch.calculated_notch_freq_hz); i++) {
+            notch.calculated_notch_freq_hz[i] = notch.params.center_freq_hz();
+        }
         notch.num_calculated_notch_frequencies = 1;
         notch.num_dynamic_notches = 1;
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -217,7 +217,7 @@ void HarmonicNotchFilter<T>::update(float center_freq_hz)
 
     // adjust the fundamental center frequency to be in the allowable range
     const float nyquist_limit = _sample_freq_hz * 0.48f;
-    center_freq_hz = constrain_float(center_freq_hz, 1.0f, nyquist_limit);
+    center_freq_hz = constrain_float(center_freq_hz, 0.0f, nyquist_limit);
 
     _num_enabled_filters = 0;
     // update all of the filters using the new center frequency and existing A & Q
@@ -278,7 +278,7 @@ void HarmonicNotchFilter<T>::update(uint8_t num_centers, const float center_freq
             continue;
         }
 
-        const float notch_center = constrain_float(center_freq_hz[center_n] * (harmonic_n+1), 1.0f, nyquist_limit);
+        const float notch_center = constrain_float(center_freq_hz[center_n] * (harmonic_n+1), 0.0f, nyquist_limit);
         if (_composite_notches != 2) {
             // only enable the filter if its center frequency is below the nyquist frequency
             if (notch_center < nyquist_limit) {

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -32,7 +32,7 @@ public:
     // allocate a bank of notch filters for this harmonic notch filter
     void allocate_filters(uint8_t num_notches, uint32_t harmonics, uint8_t composite_notches);
     // expand filter bank with new filters
-    void expand_filter_count(uint8_t num_notches);
+    void expand_filter_count(uint16_t total_notches);
     // initialize the underlying filters using the provided filter parameters
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
     // update the underlying filters' center frequencies using center_freq_hz as the fundamental
@@ -60,11 +60,11 @@ private:
     // number of notches that make up a composite notch
     uint8_t _composite_notches;
     // number of allocated filters
-    uint8_t _num_filters;
+    uint16_t _num_filters;
     // pre-calculated number of harmonics
     uint8_t _num_harmonics;
     // number of enabled filters
-    uint8_t _num_enabled_filters;
+    uint16_t _num_enabled_filters;
     bool _initialised;
 
     // have we failed to expand filters?

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -71,7 +71,7 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
                                           _center_freq_hz * NOTCH_MAX_SLEW_UPPER);
     }
 
-    if ((new_center_freq > 2.0) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)) {
+    if (is_positive(new_center_freq) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)) {
         float omega = 2.0 * M_PI * new_center_freq / sample_freq_hz;
         float alpha = sinf(omega) / (2 * Q);
         b0 =  1.0 + alpha*sq(A);

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -27,8 +27,12 @@
 
 
 template <class T>
+class HarmonicNotchFilter;
+
+template <class T>
 class NotchFilter {
 public:
+    friend class HarmonicNotchFilter<T>;
     // set parameters
     void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
     void init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q);


### PR DESCRIPTION
We were only setting the first notch center freq. If multi source data is missing it just does a hold on that channel so if never init and never getting data it can be stuck holding at that 0 value. 