### PR TITLE
AP_HAL: Improve speed param download in network links (sitl/linux)

### DIFF
--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -443,3 +443,10 @@ uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes)
     }
     return last_receive_us;
 }
+
+uint32_t UARTDriver::bw_in_bytes_per_second() const
+{
+    // if connected, assume at least a 10/100Mbps connection
+    const uint32_t bitrate = (_connected && _ip != nullptr) ? 10E6 : _baudrate;
+    return bitrate/10; // convert bits to bytes minus overhead
+};

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -54,6 +54,8 @@ public:
      */
     uint64_t receive_time_constraint_us(uint16_t nbytes) override;
 
+    uint32_t bw_in_bytes_per_second() const override;
+
 private:
     AP_HAL::OwnPtr<SerialDevice> _device;
     bool _console;

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -987,5 +987,11 @@ ssize_t UARTDriver::get_system_outqueue_length() const
 #endif
 }
 
+uint32_t UARTDriver::bw_in_bytes_per_second() const
+{
+    // if connected, assume at least a 10/100Mbps connection
+    const uint32_t bitrate = (_connected && _tcp_client_addr != nullptr) ? 10E6 : _uart_baudrate;
+    return bitrate/10; // convert bits to bytes minus overhead
+};
 #endif // CONFIG_HAL_BOARD
 

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -46,6 +46,8 @@ public:
     void set_stop_bits(int n) override;
     bool set_unbuffered_writes(bool on) override;
 
+    uint32_t bw_in_bytes_per_second() const override;
+
     void _timer_tick(void) override;
 
     /*


### PR DESCRIPTION
This improves parameter loading speed with SITL and Linux. After the linked patch, parameter loading speed (not using mavftp) got ~10x slower.

There is no reason for assuming that these are limited to 57600 baud.

In my tests:
param fetch in master with QGC takes ~30 seconds
with this patch (thanks @magicrub), it takes ~2s

Linux shows similar results

~Apparently it was a typo in here:~
https://github.com/ArduPilot/ardupilot/commit/866db281a6de3fce07a5e2214e9893c9aabc8e72#diff-da049e0cf2dd85cd33145ab82688554b96b56444b22e5475a1d961e259aa69d9L136