### PR TITLE
AP_BattMonitor: added option allowing split InfoAux

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -47,6 +47,9 @@ bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const
     if (!has_current() || !_state.healthy) {
         return false;
     }
+    if (isnan(_state.consumed_mah) || _params._pack_capacity <= 0) {
+        return false;
+    }
 
     const float mah_remaining = _params._pack_capacity - _state.consumed_mah;
     percentage = constrain_float(100 * mah_remaining / _params._pack_capacity, 0, UINT8_MAX);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.h
@@ -63,10 +63,7 @@ private:
     void handle_battery_info_aux(const ardupilot_equipment_power_BatteryInfoAux &msg);
     void update_interim_state(const float voltage, const float current, const float temperature_K, const uint8_t soc);
 
-    static bool match_battery_id(uint8_t instance, uint8_t battery_id) {
-        // when serial number is negative, all batteries are accepted. Else, it must match
-        return (AP::battery().get_serial_number(instance) < 0) || (AP::battery().get_serial_number(instance) == (int32_t)battery_id);
-    }
+    static bool match_battery_id(uint8_t instance, uint8_t battery_id);
 
     // MPPT related enums and methods
     enum class MPPT_FaultFlags : uint8_t {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -150,7 +150,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options
     // @Description: This sets options to change the behaviour of the battery monitor
-    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS
+    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Allow DroneCAN InfoAux to be from a different CAN node
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 #endif // HAL_BUILD_AP_PERIPH

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -25,6 +25,7 @@ public:
         MPPT_Power_Off_At_Boot              = (1U<<4),  // MPPT Disabled at startup (aka boot), if HW supports it
         MPPT_Power_On_At_Boot               = (1U<<5),  // MPPT Enabled at startup (aka boot), if HW supports it. If Power_Off_at_Boot is also set, the behavior is Power_Off_at_Boot
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
+        AllowSplitAuxInfo                   = (1U<<7),  // allow different node to provide aux info for DroneCAN
     };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }


### PR DESCRIPTION
This allows for a different CAN node to provide InfoAux messages for cell voltages to the node providing base current/voltage. This is useful to allow for a separate balance plug AP_Periph CAN node

The PR also includes a small cleanup to reduce flash usage in the driver
tested by ARACE on MatekH743-bdshot
