### PR TITLE
AP_Logger: correct the filling order of the struct

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -573,14 +573,13 @@ bool AP_Logger_Backend::Write_VER()
         patch: fwver.patch,
         fw_type: fwver.fw_type,
         git_hash: fwver.fw_hash,
-        build_type: fwver.vehicle_type,
     };
     strncpy(pkt.fw_string, fwver.fw_string, ARRAY_SIZE(pkt.fw_string)-1);
 
 #ifdef APJ_BOARD_ID
     pkt._APJ_BOARD_ID = APJ_BOARD_ID;
 #endif
-
+    pkt.build_type = fwver.vehicle_type;
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 


### PR DESCRIPTION
correct compilation errors like this:
../../libraries/AP_Logger/AP_Logger_Backend.cpp: In member function ‘bool AP_Logger_Backend::Write_VER()’:
../../libraries/AP_Logger/AP_Logger_Backend.cpp:577:5: sorry, unimplemented: non-trivial designated initializers not supported
     };
     ^
