### PR TITLE
Tools/AP_Bootloader: add two board IDs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -266,6 +266,9 @@ AP_HW_VIMDRONES_MOSAIC_X5            1405
 AP_HW_VIMDRONES_MOSAIC_H             1406
 AP_HW_VIMDRONES_PERIPH               1407
 
+AP_HW_PIXHAWK1_PERIPH                1408
+AP_HW_PIXHAWK1-1M_PERIPH             1409
+
 # IDs 5000-5099 reserved for Carbonix
 # IDs 5200-5209 reserved for Airvolute
 AP_HW_AIRVOLUTE_DCS2             5200

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -52,7 +52,7 @@ define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_CHIBIOS_FMUV3
 # Now we need to specify the APJ_BOARD_ID. This is the ID that the
 # bootloader presents to GCS software so it knows if this firmware is
 # suitable for the board. Please see
-# https://github.com/ArduPilot/Bootloader/blob/master/hw_config.h for
+# https://github.com/ArduPilot/ardupilot/blob/master/Tools/AP_Bootloader/board_types.txt for
 # a list of current board IDs. If you add a new board type then please
 # get it added to that repository so we don't get conflicts.
 


### PR DESCRIPTION
add two board IDs for periph hardware