### PR TITLE
Plane: rework set_servos_controlled function

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1096,6 +1096,7 @@ private:
     void set_servos_idle(void);
     void set_servos();
     void set_servos_controlled(void);
+    void set_takeoff_expected(void);
     void set_servos_old_elevons(void);
     void set_servos_flaps(void);
     void set_landing_gear(void);


### PR DESCRIPTION
A relatively small rework to pave the way for future clean ups. 

- reworks the `flight_stage_determines_max_throttle` calculation. Result is the same but method is less confusing.
- always outputs 0 scaled throttle is `!is_armed_and_safety_off()`, this prevents a miss match between the scaled value and the output PWM value that can cause slew limits and other functions that use the scaled value to get confused. 
-  moves the unrelated `set_takeoff_expected` functionality to its own function. 