### PR TITLE
Fix comment in AP_Mission.cpp

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -265,7 +265,7 @@ void AP_Mission::reset()
 }
 
 /// clear - clears out mission
-///     returns true if mission was running so it could not be cleared
+///     returns false if mission was running so it could not be cleared
 bool AP_Mission::clear()
 {
     // do not allow clearing the mission while it is running unless disarmed


### PR DESCRIPTION
The comment for the AP_Mission::clear method had an incorrect claim as to the return value