### PR TITLE
AP_Rally: support altitude frames

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -408,9 +408,10 @@ void ModeRTL::build_path()
 //   return target's altitude is updated to a higher altitude that the vehicle can safely return at (frame may also be set)
 void ModeRTL::compute_return_target()
 {
-    // set return target to nearest rally point or home position (Note: alt is absolute)
+    // set return target to nearest rally point or home position
 #if HAL_RALLY_ENABLED
     rtl_path.return_target = copter.rally.calc_best_rally_or_home_location(copter.current_loc, ahrs.get_home().alt);
+    rtl_path.return_target.change_alt_frame(Location::AltFrame::ABSOLUTE);
 #else
     rtl_path.return_target = ahrs.get_home();
 #endif

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -519,7 +519,8 @@ bool AP_Logger_Backend::Write_RallyPoint(uint8_t total,
         sequence        : sequence,
         latitude        : rally_point.lat,
         longitude       : rally_point.lng,
-        altitude        : rally_point.alt
+        altitude        : rally_point.alt,
+        flags           : rally_point.flags
     };
     return WriteBlock(&pkt_rally, sizeof(pkt_rally));
 }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -548,6 +548,7 @@ struct PACKED log_Rally {
     int32_t latitude;
     int32_t longitude;
     int16_t altitude;
+    uint8_t flags;
 };
 
 struct PACKED log_Performance {
@@ -968,6 +969,7 @@ struct PACKED log_VER {
 // @Field: Lat: latitude of rally point
 // @Field: Lng: longitude of rally point
 // @Field: Alt: altitude of rally point
+// @Field: Flags: altitude frame flags
 
 // @LoggerMessage: RCI2
 // @Description: (More) RC input channels to vehicle
@@ -1286,7 +1288,7 @@ LOG_STRUCTURE_FROM_FENCE \
     { LOG_DF_FILE_STATS, sizeof(log_DSF), \
       "DSF", "QIHIIII", "TimeUS,Dp,Blk,Bytes,FMn,FMx,FAv", "s--b---", "F--0---" }, \
     { LOG_RALLY_MSG, sizeof(log_Rally), \
-      "RALY", "QBBLLh", "TimeUS,Tot,Seq,Lat,Lng,Alt", "s--DUm", "F--GGB" },  \
+      "RALY", "QBBLLhB", "TimeUS,Tot,Seq,Lat,Lng,Alt,Flags", "s--DUm-", "F--GGB-" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
       "MAV", "QBHHHBHH",   "TimeUS,chan,txp,rxp,rxdp,flags,ss,tf", "s#----s-", "F-000-C-" },   \
 LOG_STRUCTURE_FROM_VISUALODOM \

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -129,12 +129,8 @@ Location AP_Rally::rally_location_to_location(const RallyLocation &rally_loc) co
         rally_loc.lat,
         rally_loc.lng,
         rally_loc.alt * 100,
-        Location::AltFrame::ABOVE_HOME
+        (rally_loc.alt_frame_valid == 1) ? Location::AltFrame(rally_loc.alt_frame) : Location::AltFrame::ABOVE_HOME
     };
-
-    // notionally the following call can fail, but we have no facility
-    // to return that fact here:
-    ret.change_alt_frame(Location::AltFrame::ABSOLUTE);
 
     return ret;
 }

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -30,9 +30,16 @@ struct PACKED RallyLocation {
     int16_t alt;        //transit altitude (and loiter altitude) in meters (absolute);
     int16_t break_alt;  //when autolanding, break out of loiter at this alt (meters)
     uint16_t land_dir;   //when the time comes to auto-land, try to land in this direction (centidegrees)
-    uint8_t flags;      //bit 0 = seek favorable winds when choosing a landing poi
-                        //bit 1 = do auto land after arriving
-                        //all other bits are for future use.
+    union {
+        uint8_t flags; 
+        struct {
+            uint8_t favorable_winds : 1; // bit 0 = seek favorable winds when choosing a landing poi
+            uint8_t do_auto_land    : 1; // bit 1 = do auto land after arriving
+            uint8_t alt_frame_valid : 1; // bit 2 = true if following alt frame value should be used, else Location::AltFrame::ABOVE_HOME
+            uint8_t alt_frame       : 2; // Altitude frame following Location::AltFrame enum
+            uint8_t unused          : 3;
+        };
+    };
 };
 
 /// @class    AP_Rally


### PR DESCRIPTION
This work is sponsored by Spektreworks.

This adds support for alt frames in rally points. There were some free bits in "flags" that we can use. This assumes that those unused bits are zero. It is possible that they are none zero in storage if uploaded with the old `RALLY_POINT` MAVLink message.  

Tested conversion from old format, all alt frames manually on plane and added new method to the existing `TerrainRally` plane test. 