### PR TITLE
APM_Control: Allow autotune level 0 to actually reach the lowest entries of the autotune level table

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -556,7 +556,7 @@ void AP_AutoTune::update_rmax(void)
 
     if (level == 0) {
         // this level means to keep current values of RMAX and TCONST
-        target_rmax = constrain_float(current.rmax_pos, 75, 720);
+        target_rmax = constrain_float(current.rmax_pos, 20, 720);
         target_tau = constrain_float(current.tau, 0.1, 2);
     } else {
         target_rmax = tuning_table[level-1].rmax;


### PR DESCRIPTION
It would be nice to be able to use `AUTOTUNE_LEVEL` 0 anywhere down to the bottom entries that it can reach. (IE if you want to do a RMAX of 30 (which is level 2), with a custom tau you can't actually do that at the moment.