### PR TITLE
Fix C++ One Definition Rule violations and misc. UB

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -149,7 +149,7 @@ void AP_CANManager::init()
         if (hal.can[i] == nullptr) {
             // So if this interface is not allocated allocate it here,
             // also pass the index of the CANBus
-            const_cast <AP_HAL::HAL&> (hal).can[i] = new HAL_CANIface(i);
+            hal.can[i] = new HAL_CANIface(i);
         }
 
         // Initialise the interface we just allocated
@@ -305,7 +305,7 @@ bool AP_CANManager::register_driver(AP_CAN::Protocol dtype, AP_CANDriver *driver
         if (hal.can[i] == nullptr) {
             // if this interface is not allocated allocate it here,
             // also pass the index of the CANBus
-            const_cast <AP_HAL::HAL&> (hal).can[i] = new HAL_CANIface(i);
+            hal.can[i] = new HAL_CANIface(i);
         }
 
         // Initialise the interface we just allocated

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -58,13 +58,6 @@ extern const AP_HAL::HAL &hal;
 
 extern const AP_HAL::HAL &hal;
 
-struct PACKED sample_regs {
-    uint8_t st1;
-    int16_t val[3];
-    uint8_t tmps;
-    uint8_t st2;
-};
-
 AP_Compass_AK09916::AP_Compass_AK09916(AP_AK09916_BusDriver *bus,
                                         bool force_external,
                                         enum Rotation rotation)
@@ -477,7 +470,7 @@ bool AP_AK09916_BusDriver_Auxiliary::configure()
 
 bool AP_AK09916_BusDriver_Auxiliary::start_measurements()
 {
-    if (_bus->register_periodic_read(_slave, REG_ST1, sizeof(sample_regs)) < 0) {
+    if (_bus->register_periodic_read(_slave, REG_ST1, sizeof(AP_Compass_AK09916::sample_regs)) < 0) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -75,6 +75,14 @@ public:
 
     void read() override;
 
+    /* Must be public so the BusDriver can access its definition */
+    struct PACKED sample_regs {
+        uint8_t st1;
+        int16_t val[3];
+        uint8_t tmps;
+        uint8_t st2;
+    };
+
 private:
     AP_Compass_AK09916(AP_AK09916_BusDriver *bus, bool force_external,
                        enum Rotation rotation);

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -49,11 +49,6 @@
 
 #define AK8963_MILLIGAUSS_SCALE 10.0f
 
-struct PACKED sample_regs {
-    int16_t val[3];
-    uint8_t st2;
-};
-
 extern const AP_HAL::HAL &hal;
 
 AP_Compass_AK8963::AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
@@ -379,7 +374,7 @@ bool AP_AK8963_BusDriver_Auxiliary::configure()
 
 bool AP_AK8963_BusDriver_Auxiliary::start_measurements()
 {
-    if (_bus->register_periodic_read(_slave, AK8963_HXL, sizeof(sample_regs)) < 0) {
+    if (_bus->register_periodic_read(_slave, AK8963_HXL, sizeof(AP_Compass_AK8963::sample_regs)) < 0) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -39,6 +39,12 @@ public:
 
     void read() override;
 
+    /* Must be public so the BusDriver can access its definition */
+    struct PACKED sample_regs {
+        int16_t val[3];
+        uint8_t st2;
+    };
+
 private:
     AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
                       enum Rotation rotation);

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -47,11 +47,6 @@
 #define LSM9DS1M_INT_THS_L_M        0x32
 #define LSM9DS1M_INT_THS_H_M        0x33
 
-struct PACKED sample_regs {
-    uint8_t status;
-    int16_t val[3];
-};
-
 extern const AP_HAL::HAL &hal;
 
 AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(AP_HAL::OwnPtr<AP_HAL::Device> dev,

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -42,6 +42,11 @@ private:
     uint8_t _compass_instance;
     float _scaling;
     enum Rotation _rotation;
+
+    struct PACKED sample_regs {
+        uint8_t status;
+        int16_t val[3];
+    };
 };
 
 #endif

--- a/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/DroneCAN_sniffer.cpp
+++ b/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/DroneCAN_sniffer.cpp
@@ -117,7 +117,7 @@ static void cb_GetNodeInfoRequest(const CanardRxTransfer &transfer, const uavcan
 
 void DroneCAN_sniffer::init(void)
 {
-    const_cast <AP_HAL::HAL&> (hal).can[driver_index] = new HAL_CANIface(driver_index);
+    hal.can[driver_index] = new HAL_CANIface(driver_index);
     
     if (hal.can[driver_index] == nullptr) {
         AP_HAL::panic("Couldn't allocate CANManager, something is very wrong");

--- a/libraries/AP_HAL/HAL.cpp
+++ b/libraries/AP_HAL/HAL.cpp
@@ -15,7 +15,6 @@ HAL::FunCallbacks::FunCallbacks(void (*setup_fun)(void), void (*loop_fun)(void))
 // access serial ports using SERIALn numbering
 AP_HAL::UARTDriver* AP_HAL::HAL::serial(uint8_t sernum) const
 {
-    UARTDriver **uart_array = const_cast<UARTDriver**>(&uartA);
     // this mapping captures the historical use of uartB as SERIAL3
     const uint8_t mapping[] = { 0, 2, 3, 1, 4, 5, 6, 7, 8, 9 };
     static_assert(sizeof(mapping) == num_serial, "num_serial must match mapping");

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -53,16 +53,17 @@ public:
         AP_HAL::CANIface** _can_ifaces)
 #endif
         :
-        uartA(_uartA),
-        uartB(_uartB),
-        uartC(_uartC),
-        uartD(_uartD),
-        uartE(_uartE),
-        uartF(_uartF),
-        uartG(_uartG),
-        uartH(_uartH),
-        uartI(_uartI),
-        uartJ(_uartJ),
+        uart_array{
+            _uartA,
+            _uartB,
+            _uartC,
+            _uartD,
+            _uartE,
+            _uartF,
+            _uartG,
+            _uartH,
+            _uartI,
+            _uartJ},
         i2c_mgr(_i2c_mgr),
         spi(_spi),
         wspi(_wspi),
@@ -112,19 +113,6 @@ public:
 
     virtual void run(int argc, char * const argv[], Callbacks* callbacks) const = 0;
 
-private:
-    // the uartX ports must be contiguous in ram for the serial() method to work
-    AP_HAL::UARTDriver* uartA;
-    AP_HAL::UARTDriver* uartB UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartC UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartD UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartE UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartF UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartG UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartH UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartI UNUSED_PRIVATE_MEMBER;
-    AP_HAL::UARTDriver* uartJ UNUSED_PRIVATE_MEMBER;
-
 public:
     AP_HAL::I2CDeviceManager* i2c_mgr;
     AP_HAL::SPIDeviceManager* spi;
@@ -151,6 +139,10 @@ public:
 
     static constexpr uint8_t num_serial = 10;
 
+private:
+    AP_HAL::UARTDriver* uart_array[num_serial];
+
+public:
 #if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
     AP_HAL::SIMState *simstate;
 #endif

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -141,9 +141,9 @@ public:
     AP_HAL::Flash       *flash;
     AP_HAL::DSP         *dsp;
 #if HAL_NUM_CAN_IFACES > 0
-    AP_HAL::CANIface* can[HAL_NUM_CAN_IFACES];
+    mutable AP_HAL::CANIface* can[HAL_NUM_CAN_IFACES];
 #else
-    AP_HAL::CANIface** can;
+    mutable AP_HAL::CANIface** can;
 #endif
 
     // access to serial ports using SERIALn_ numbering

--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -85,7 +85,7 @@
 #error "Unsupported MCU for FDCAN"
 #endif
 
-extern AP_HAL::HAL& hal;
+extern const AP_HAL::HAL& hal;
 
 #define STR(x) #x
 #define XSTR(x) STR(x)

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -84,7 +84,7 @@
 #endif
 
 
-extern AP_HAL::HAL& hal;
+extern const AP_HAL::HAL& hal;
 
 using namespace ChibiOS;
 


### PR DESCRIPTION
Fix various violations of the C++ [One Definition Rule](https://en.cppreference.com/w/cpp/language/definition) discovered during testing with LTO.

Fix a couple of easy UB cases noticed when doing the above.

Not necessarily an exhaustive list, but this does fix the complete list of violations diagnosed by GCC.

No code size or functional change.