### PR TITLE
hwdef: minimize_features on mini-pix, not minimize_fpv_osd

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/mini-pix/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mini-pix/hwdef.dat
@@ -148,5 +148,5 @@ define HAL_GPIO_C_LED_PIN 2
 define HAL_GPIO_LED_ON  0
 define HAL_GPIO_LED_OFF 1
 
-include ../include/minimize_fpv_osd.inc
+include ../include/minimize_features.inc
 


### PR DESCRIPTION
Andy pointed out this was the wrong include in a recent PR, post-merge.
