### PR TITLE
AP_Bootloader: Fix AIRVOLUTE format issue

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -267,10 +267,10 @@ AP_HW_VIMDRONES_MOSAIC_H             1406
 AP_HW_VIMDRONES_PERIPH               1407
 
 # IDs 5000-5099 reserved for Carbonix
-# IDs 5200-5209 reserved for Airvolute
-AP_HW_AIRVOLUTE_DCS2             5200
-
 # IDs 5100-5199 reserved for SYPAQ Systems
+# IDs 5200-5209 reserved for Airvolute
+AP_HW_AIRVOLUTE_DCS2                 5200
+
 # IDs 6000-6099 reserved for SpektreWorks
 
 # OpenDroneID enabled boards. Use 10000 + the base board ID


### PR DESCRIPTION
AP_Bootloader: Fix AIRVOLUTE format issue

Which was discussed in https://github.com/ArduPilot/ardupilot/pull/25398