### PR TITLE
AP_SerialManager: Add serial baud rate specification

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -161,7 +161,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 0_BAUD
     // @DisplayName: Serial0 baud rate
     // @Description: The baud rate used on the USB console. Most stm32-based boards can support rates of up to 1500. If you setup a rate you cannot support and then can't connect to your board you should load a firmware from a different vehicle type. That will reset all your parameters to defaults.
-    // @Values: 1:1200,2:2400,4:4800,9:9600,19:19200,38:38400,57:57600,111:111100,115:115200,230:230400,256:256000,460:460800,500:500000,921:921600,1500:1500000,2000:2000000
+    // @Values: 1:1200,2:2400,4:4800,9:9600,19:19200,38:38400,57:57600,111:111100,115:115200,230:230400,256:256000,460:460800,500:500000,921:921600,1500:1500000,2000:2000000,3000:3000000
     // @User: Standard
     AP_GROUPINFO("0_BAUD",  0, AP_SerialManager, state[0].baud, DEFAULT_SERIAL0_BAUD/1000),
 
@@ -186,7 +186,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_BAUD
     // @DisplayName: Telem1 Baud Rate
     // @Description: The baud rate used on the Telem1 port. Most stm32-based boards can support rates of up to 1500. If you setup a rate you cannot support and then can't connect to your board you should load a firmware from a different vehicle type. That will reset all your parameters to defaults.
-    // @Values: 1:1200,2:2400,4:4800,9:9600,19:19200,38:38400,57:57600,111:111100,115:115200,230:230400,256:256000,460:460800,500:500000,921:921600,1500:1500000,2000:2000000
+    // @Values: 1:1200,2:2400,4:4800,9:9600,19:19200,38:38400,57:57600,111:111100,115:115200,230:230400,256:256000,460:460800,500:500000,921:921600,1500:1500000,2000:2000000,3000:3000000
     // @User: Standard
     AP_GROUPINFO("1_BAUD", 2, AP_SerialManager, state[1].baud, DEFAULT_SERIAL1_BAUD),
 #endif
@@ -677,9 +677,10 @@ uint32_t AP_SerialManager::map_baudrate(int32_t rate)
     case 921:  return 921600;
     case 1500:  return 1500000;
     case 2000:  return 2000000;
+    case 3000:  return 3000000;
     }
 
-    if (rate > 2000) {
+    if (rate > 3000) {
         // assume it is a direct baudrate. This allows for users to
         // set an exact baudrate as long as it is over 2000 baud
         return (uint32_t)rate;


### PR DESCRIPTION
I was able to communicate with the APM PLANNER2 on my PC using the CUBE ORANGE PLUS USB at 3000000 bps.
I need faster telemetry communication with CC.

AFTER
![Screenshot from 2023-10-31 02-37-17](https://github.com/ArduPilot/ardupilot/assets/646194/13fc1c85-3622-4b0e-9376-e574e776d45b)

![Screenshot from 2023-10-31 02-30-28](https://github.com/ArduPilot/ardupilot/assets/646194/bf1031a1-6f28-4e7c-8f1e-4df4623ec84a)