### PR TITLE
AP_TECS: scale velRateMin correctly with airspeed

### DIFF
--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -349,9 +349,10 @@ private:
     // pitch demand before limiting
     float _pitch_dem_unc;
 
-    // Maximum and minimum specific total energy rate limits
-    float _STEdot_max;
-    float _STEdot_min;
+    // Specific total energy rate limits
+    float _STEdot_max;     // Specific total energy rate gain at cruise airspeed & THR_MAX (m/s/s)
+    float _STEdot_min;     // Specific total energy rate loss at cruise airspeed & THR_MIN (m/s/s)
+    float _STEdot_neg_max; // Specific total energy rate loss at max airspeed & THR_MIN (m/s/s)
 
     // Maximum and minimum floating point throttle limits
     float _THRmaxf;


### PR DESCRIPTION
This PR improves TECS deceleration rates by allowing to decrease speed more rapidly, the faster a plane is going.

### Description
The current calculation for `velRateMin` scales incorrectly with airspeed, where currently, the max allowable velocity rate _decreases_ as velocity increases. i.e. the faster an aircraft is going, the less-quickly it's able to slow down. This is particularly problematic on aircraft which operate over a wide range of speeds or which have a large difference between `TECS_SINK_MIN` and `TECS_SINK_MAX`, since they are empirically determined.

This change introduces discrete calculations for:
* `_STEdot_neg_max` — Specific total energy rate at max speed (using `TECS_SINK_MAX`)
* `velRateNegCruise` — Velocity rate at cruise speed (existing velocity rate calc at `TRIM_ARSPD_CM`)
* `velRateNegMax` — Velocity rate at max speed (existing velocity rate calc at `ARSPD_FBW_MAX`)

The change then replaces the `velRateMin` calculation with a linear interpolation between the velocity rates at cruise and max speed, which is capped at those values outside the bounds of cruise and max speed. The deceleration margin is also decreased from 50% to 10% to improve deceleration rate performance.

### Testing
This change was tested in ArduPilot SITL ([Plane-4.3.3](https://github.com/ArduPilot/ardupilot/tree/Plane-4.3.3)) with the following sequence:
1. Takeoff the plane
2. Send guided mode command to a distant point or for a large loiter
3. Issue `MAV_CMD_DO_CHANGE_SPEED` commands to increase and decrease speed setpoint
4. Issue `MAV_CMD_DO_CHANGE_ALTITUDE` commands to increase and decrease altitude setpoint

#### Before
Notice the blue at line at the top of graph (behind the green) representing `TECS.sp`, this is the plane's airspeed. Before this change, it required just over 6 minutes for the plane to decelerate from 75 m/s to 40 m/s. Extremely slow, and not by limitation of the aircraft  — throttle is being modulated to maintain a gradual deceleration.

![Current TECS example](https://github.com/ArduPilot/ardupilot/assets/24783918/2cf7a257-488d-46e4-ad25-b0c4cac09228)

#### After
Notice again the blue line representing `TECS.sp`. After this change, the plane requires only 40 seconds to decelerate from 75 m/s to 40 m/s.

![Updated TECS example](https://github.com/ArduPilot/ardupilot/assets/24783918/d0c247c6-ad80-4b52-a1da-d9a9e1bab127)

_Note:_ all TECS parameters are identical between runs.

#### Summary
Here we can see the rates produced from our capped linear interpolation between velocity rate at cruise and max speeds compared against what currently exists.


![velocity vs airspeed](https://github.com/ArduPilot/ardupilot/assets/24783918/048534ee-0e0d-4cdd-9470-62585aca37a0)

**X 40** m/s = `TRIM_ARSPD_CM` (cruise airspeed)
**X 80** m/s = `ARSPD_FBW_MAX` (max airspeed)