### PR TITLE
Sub: scale get_pilot_desired_climb_rate() deadzone and output with pilot gain

### DIFF
--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -96,8 +96,8 @@ float Sub::get_pilot_desired_climb_rate(float throttle_control)
 
     float desired_rate = 0.0f;
     float mid_stick = channel_throttle->get_control_mid();
-    float deadband_top = mid_stick + g.throttle_deadzone;
-    float deadband_bottom = mid_stick - g.throttle_deadzone;
+    float deadband_top = mid_stick + g.throttle_deadzone * gain;
+    float deadband_bottom = mid_stick - g.throttle_deadzone * gain;
 
     // ensure a reasonable throttle value
     throttle_control = constrain_float(throttle_control,0.0f,1000.0f);

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -271,7 +271,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Param: JS_THR_GAIN
     // @DisplayName: Throttle gain scalar
-    // @Description: Scalar for gain on the throttle channel
+    // @Description: Scalar for gain on the throttle channel. Gets scaled with the current JS gain
     // @User: Standard
     // @Range: 0.5 4.0
     GSCALAR(throttle_gain, "JS_THR_GAIN", 1.0f),


### PR DESCRIPTION
This fixes an issue where trying to control altitude with very low pilot gain (say 10%) has no result at all.
This happens is because the input is scaled so much it falls into the deadzone area. This PR scales the deadzone with the pilot gain.
