### PR TITLE
Autotest: improve flapping Sub test

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -457,6 +457,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def MAV_CMD_DO_CHANGE_SPEED(self):
         '''ensure vehicle changes speeds when DO_CHANGE_SPEED received'''
         items = [
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, -3),  # Dive so we have constrat drag
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 2000, 0, -1),
             (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
         ]
@@ -465,6 +466,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.run_cmd(mavutil.mavlink.MAV_CMD_MISSION_START)
         self.progress("SENT MISSION START")
+        self.wait_mode('AUTO')
+        self.wait_current_waypoint(2)  # wait after we finish diving to 3m
         for run_cmd in self.run_cmd, self.run_cmd_int:
             for speed in [1, 1.5, 0.5]:
                 run_cmd(mavutil.mavlink.MAV_CMD_DO_CHANGE_SPEED, p2=speed)


### PR DESCRIPTION
I noticed that the recently updated MAV_CMD_DO_CHANGE_SPEED test is flapping.
I ran this change 20 times with no failures.