### PR TITLE
GCS_MAVLink: correct mavlink result when airspeed not available

### DIFF
--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -237,6 +237,15 @@ class AutoTestBlimp(TestSuite):
 
         self.disarm_vehicle()
 
+    def PREFLIGHT_Pressure(self):
+        '''test triggering pressure calibration with mavlink command'''
+        # as airspeed is not instantiated on Blimp we expect to
+        # instantly get back an accepted.
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+            p3=1, # p3, baro
+        )
+
     def tests(self):
         '''return list of all tests'''
         # ret = super(AutoTestBlimp, self).tests()
@@ -244,6 +253,7 @@ class AutoTestBlimp(TestSuite):
         ret.extend([
             self.FlyManual,
             self.FlyLoiter,
+            self.PREFLIGHT_Pressure,
         ])
         return ret
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4352,10 +4352,11 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro(const mavlink
             return MAV_RESULT_TEMPORARILY_REJECTED;
         }
         airspeed->calibrate(false);
+        return MAV_RESULT_IN_PROGRESS;
     }
 #endif
 
-    return MAV_RESULT_IN_PROGRESS;
+    return MAV_RESULT_ACCEPTED;
 }
 
 MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg)


### PR DESCRIPTION
only in progress if we have started a task running