### PR TITLE
Plane: Cruise: only lock in heading once moving forwards

### DIFF
--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -58,11 +58,17 @@ void ModeCruise::navigate()
         return;
     }
 #endif
+
+    // check if we are moving in the direction of the front of the vehicle
+    const int32_t ground_course_cd = plane.gps.ground_course_cd();
+    const bool moving_forwards = fabsf(wrap_PI(radians(ground_course_cd * 0.01) - plane.ahrs.yaw)) < M_PI_2;
+
     if (!locked_heading &&
         plane.channel_roll->get_control_in() == 0 &&
         plane.rudder_input() == 0 &&
         plane.gps.status() >= AP_GPS::GPS_OK_FIX_2D &&
         plane.gps.ground_speed() >= 3 &&
+        moving_forwards &&
         lock_timer_ms == 0) {
         // user wants to lock the heading - start the timer
         lock_timer_ms = millis();
@@ -73,7 +79,7 @@ void ModeCruise::navigate()
         // from user
         locked_heading = true;
         lock_timer_ms = 0;
-        locked_heading_cd = plane.gps.ground_course_cd();
+        locked_heading_cd = ground_course_cd;
         plane.prev_WP_loc = plane.current_loc;
     }
     if (locked_heading) {


### PR DESCRIPTION
If transitioning from VTOL is possible to have a ground course that does not agree with the vehicles heading. We do check for a speed of more than 3m/s, but with strong wind (or flying backwards) it is possible to exceed this.

Currently in this case we will transition and do a 180 at the same time:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/626a5345-67d4-4fe3-8ced-2e307bdb8db4)

With this patch we move off forwards:

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/e9027c9c-b01a-47fd-b6b1-5b8a4001b330)

Reported in https://github.com/ArduPilot/ardupilot/issues/25434

Moving forward logic stolen from https://github.com/ArduPilot/ardupilot/pull/24834

[tests.zip](https://github.com/ArduPilot/ardupilot/files/13228459/tests.zip)
