### PR TITLE
AP_GPS: Remove GPS_TC_BLEND

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -343,7 +343,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Units: s
     // @Range: 5.0 30.0
     // @User: Advanced
-    AP_GROUPINFO("_BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),
+    // Had key 21, no longer used
 #endif
 
     // @Param: _DRV_OPTIONS
@@ -484,11 +484,6 @@ void AP_GPS::init(const AP_SerialManager& serial_manager)
         }
     }
     _last_instance_swap_ms = 0;
-
-#if defined(GPS_BLENDED_INSTANCE)
-    // Initialise class variables used to do GPS blending
-    _omega_lpf = 1.0f / constrain_float(_blend_tc, 5.0f, 30.0f);
-#endif
 
     // prep the state instance fields
     for (uint8_t i = 0; i < GPS_MAX_INSTANCES; i++) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -605,7 +605,6 @@ protected:
     AP_Int16 _delay_ms[GPS_MAX_RECEIVERS];
     AP_Int8  _com_port[GPS_MAX_RECEIVERS];
     AP_Int8 _blend_mask;
-    AP_Float _blend_tc;
     AP_Int16 _driver_options;
     AP_Int8 _primary;
 #if HAL_ENABLE_DRONECAN_DRIVERS
@@ -739,7 +738,6 @@ private:
     Vector3f _blended_antenna_offset; // blended antenna offset
     float _blended_lag_sec; // blended receiver lag in seconds
     float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
-    float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output
     uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy
 


### PR DESCRIPTION
Tidy up of what looks like an old hangover from an improvement to me.  I cannot find where this time constant or the lpf omega is used anymore.

Not sure what best practice is with old param meta data