### PR TITLE
Copter: Send a message that matches the number of devices

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -494,12 +494,23 @@ AP_GROUPEND
 
 static const ap_message STREAM_RAW_SENSORS_msgs[] = {
     MSG_RAW_IMU,
+#if INS_MAX_INSTANCES > 1
     MSG_SCALED_IMU2,
+#if INS_MAX_INSTANCES > 2
     MSG_SCALED_IMU3,
+#endif
+#endif
+#if AP_BARO_ENABLED
     MSG_SCALED_PRESSURE,
+#if BARO_MAX_INSTANCES > 1
     MSG_SCALED_PRESSURE2,
+#if BARO_MAX_INSTANCES > 2
     MSG_SCALED_PRESSURE3,
+#endif
+#endif
+#endif
 };
+
 static const ap_message STREAM_EXTENDED_STATUS_msgs[] = {
     MSG_SYS_STATUS,
     MSG_POWER_STATUS,


### PR DESCRIPTION
There are FCs with one, two, or three IMUs.
There are vehicles with 0, 1, 2, or 3 barometric pressure sensors.
Therefore, messages are sent according to the HWDEF settings.