### PR TITLE
Filtering: re-work harmonic notch filter freq clamping and disable

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1012,7 +1012,7 @@ AP_InertialSensor::init(uint16_t loop_rate)
         sensors_used += _use(i);
     }
 
-    uint8_t num_filters = 0;
+    uint16_t num_filters = 0;
     for (auto &notch : harmonic_notches) {
         // calculate number of notches we might want to use for harmonic notch
         if (notch.params.enabled() || fft_enabled) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2285,7 +2285,12 @@ void AP_InertialSensor::acal_update()
 }
 #endif
 
-// Update the harmonic notch frequency
+/*
+  Update the harmonic notch frequency
+
+  Note that zero is a valid value and will disable the notch unless
+  the TreatLowAsMin option is set
+*/
 void AP_InertialSensor::HarmonicNotch::update_freq_hz(float scaled_freq)
 {
     calculated_notch_freq_hz[0] = scaled_freq;
@@ -2294,7 +2299,7 @@ void AP_InertialSensor::HarmonicNotch::update_freq_hz(float scaled_freq)
 
 // Update the harmonic notch frequency
 void AP_InertialSensor::HarmonicNotch::update_frequencies_hz(uint8_t num_freqs, const float scaled_freq[]) {
-    // protect against zero as the scaled frequency
+    // note that we allow zero through, which will disable the notch
     for (uint8_t i = 0; i < num_freqs; i++) {
         calculated_notch_freq_hz[i] = scaled_freq[i];
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1016,11 +1016,9 @@ AP_InertialSensor::init(uint16_t loop_rate)
     for (auto &notch : harmonic_notches) {
         // calculate number of notches we might want to use for harmonic notch
         if (notch.params.enabled() || fft_enabled) {
-            const bool double_notch = notch.params.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch);
-            const bool triple_notch = notch.params.hasOption(HarmonicNotchFilterParams::Options::TripleNotch);
             const bool all_sensors = notch.params.hasOption(HarmonicNotchFilterParams::Options::EnableOnAllIMUs);
             num_filters += __builtin_popcount(notch.params.harmonics())
-                * notch.num_dynamic_notches * (double_notch ? 2 : triple_notch ? 3 : 1)
+                * notch.num_dynamic_notches * notch.params.num_composite_notches()
                 * (all_sensors?sensors_used:1);
         }
     }
@@ -1035,10 +1033,8 @@ AP_InertialSensor::init(uint16_t loop_rate)
         if (_use(i)) {
             for (auto &notch : harmonic_notches) {
                 if (notch.params.enabled() || fft_enabled) {
-                    const bool double_notch = notch.params.hasOption(HarmonicNotchFilterParams::Options::DoubleNotch);
-                    const bool triple_notch = notch.params.hasOption(HarmonicNotchFilterParams::Options::TripleNotch);
                     notch.filter[i].allocate_filters(notch.num_dynamic_notches,
-                                                     notch.params.harmonics(), double_notch ? 2 : triple_notch ? 3 : 1);
+                                                     notch.params.harmonics(), notch.params.num_composite_notches());
                     // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
                     notch.filter[i].init(_gyro_raw_sample_rates[i], notch.params);
                 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -986,9 +986,6 @@ AP_InertialSensor::init(uint16_t loop_rate)
         if (!notch.params.enabled() && !fft_enabled) {
             continue;
         }
-        for (uint8_t i = 0; i < ARRAY_SIZE(notch.calculated_notch_freq_hz); i++) {
-            notch.calculated_notch_freq_hz[i] = notch.params.center_freq_hz();
-        }
         notch.num_calculated_notch_frequencies = 1;
         notch.num_dynamic_notches = 1;
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -1043,8 +1040,7 @@ AP_InertialSensor::init(uint16_t loop_rate)
                     notch.filter[i].allocate_filters(notch.num_dynamic_notches,
                                                      notch.params.harmonics(), double_notch ? 2 : triple_notch ? 3 : 1);
                     // initialise default settings, these will be subsequently changed in AP_InertialSensor_Backend::update_gyro()
-                    notch.filter[i].init(_gyro_raw_sample_rates[i], notch.calculated_notch_freq_hz[0],
-                                         notch.params.bandwidth_hz(), notch.params.attenuation_dB());
+                    notch.filter[i].init(_gyro_raw_sample_rates[i], notch.params);
                 }
             }
         }
@@ -1835,25 +1831,21 @@ void AP_InertialSensor::_save_gyro_calibration()
  */
 void AP_InertialSensor::HarmonicNotch::update_params(uint8_t instance, bool converging, float gyro_rate)
 {
-    const float center_freq = calculated_notch_freq_hz[0];
     if (!is_equal(last_bandwidth_hz[instance], params.bandwidth_hz()) ||
         !is_equal(last_attenuation_dB[instance], params.attenuation_dB()) ||
-        (params.tracking_mode() == HarmonicNotchDynamicMode::Fixed && !is_equal(last_center_freq_hz[instance], center_freq)) ||
+        (params.tracking_mode() == HarmonicNotchDynamicMode::Fixed &&
+         !is_equal(last_center_freq_hz[instance], params.center_freq_hz())) ||
         converging) {
-        filter[instance].init(gyro_rate,
-                              center_freq,
-                              params.bandwidth_hz(),
-                              params.attenuation_dB());
-        last_center_freq_hz[instance] = center_freq;
+        filter[instance].init(gyro_rate, params);
+        last_center_freq_hz[instance] = params.center_freq_hz();
         last_bandwidth_hz[instance] = params.bandwidth_hz();
         last_attenuation_dB[instance] = params.attenuation_dB();
     } else if (params.tracking_mode() != HarmonicNotchDynamicMode::Fixed) {
         if (num_calculated_notch_frequencies > 1) {
             filter[instance].update(num_calculated_notch_frequencies, calculated_notch_freq_hz);
         } else {
-            filter[instance].update(center_freq);
+            filter[instance].update(calculated_notch_freq_hz[0]);
         }
-        last_center_freq_hz[instance] = center_freq;
     }
 }
 
@@ -2300,10 +2292,7 @@ void AP_InertialSensor::acal_update()
 // Update the harmonic notch frequency
 void AP_InertialSensor::HarmonicNotch::update_freq_hz(float scaled_freq)
 {
-    // protect against zero as the scaled frequency
-    if (is_positive(scaled_freq)) {
-        calculated_notch_freq_hz[0] = scaled_freq;
-    }
+    calculated_notch_freq_hz[0] = scaled_freq;
     num_calculated_notch_frequencies = 1;
 }
 
@@ -2311,9 +2300,7 @@ void AP_InertialSensor::HarmonicNotch::update_freq_hz(float scaled_freq)
 void AP_InertialSensor::HarmonicNotch::update_frequencies_hz(uint8_t num_freqs, const float scaled_freq[]) {
     // protect against zero as the scaled frequency
     for (uint8_t i = 0; i < num_freqs; i++) {
-        if (is_positive(scaled_freq[i])) {
-            calculated_notch_freq_hz[i] = scaled_freq[i];
-        }
+        calculated_notch_freq_hz[i] = scaled_freq[i];
     }
     // any uncalculated frequencies will float at the previous value or the initialized freq if none
     num_calculated_notch_frequencies = num_freqs;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -145,24 +145,24 @@ bool AP_InertialSensor::BatchSampler::Write_ISBD() const
 // @Field: TimeUS: microseconds since system startup
 // @Field: I: instance
 // @Field: NDn: number of active harmonic notches
-// @Field: NF1: desired notch centre frequency for motor 1
-// @Field: NF2: desired notch centre frequency for motor 2
-// @Field: NF3: desired notch centre frequency for motor 3
-// @Field: NF4: desired notch centre frequency for motor 4
-// @Field: NF5: desired notch centre frequency for motor 5
-// @Field: NF6: desired notch centre frequency for motor 6
-// @Field: NF7: desired notch centre frequency for motor 7
-// @Field: NF8: desired notch centre frequency for motor 8
-// @Field: NF9: desired notch centre frequency for motor 9
-// @Field: NF10: desired notch centre frequency for motor 10
-// @Field: NF11: desired notch centre frequency for motor 11
-// @Field: NF12: desired notch centre frequency for motor 12
+// @Field: NF1: desired harmonic notch centre frequency for motor 1
+// @Field: NF2: desired harmonic notch centre frequency for motor 2
+// @Field: NF3: desired harmonic notch centre frequency for motor 3
+// @Field: NF4: desired harmonic notch centre frequency for motor 4
+// @Field: NF5: desired harmonic notch centre frequency for motor 5
+// @Field: NF6: desired harmonic notch centre frequency for motor 6
+// @Field: NF7: desired harmonic notch centre frequency for motor 7
+// @Field: NF8: desired harmonic notch centre frequency for motor 8
+// @Field: NF9: desired harmonic notch centre frequency for motor 9
+// @Field: NF10: desired harmonic notch centre frequency for motor 10
+// @Field: NF11: desired harmonic notch centre frequency for motor 11
+// @Field: NF12: desired harmonic notch centre frequency for motor 12
 
 // @LoggerMessage: FTNS
 // @Description: Filter Tuning Message
 // @Field: TimeUS: microseconds since system startup
 // @Field: I: instance
-// @Field: NF: desired notch centre frequency
+// @Field: NF: desired harmonic notch centre frequency
 
 void AP_InertialSensor::write_notch_log_messages() const
 {

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -11,6 +11,7 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <Filter/Filter.h>
 #include "AP_Logger.h"
 
 #if HAL_LOGGER_FENCE_ENABLED
@@ -574,6 +575,7 @@ bool AP_Logger_Backend::Write_VER()
         patch: fwver.patch,
         fw_type: fwver.fw_type,
         git_hash: fwver.fw_hash,
+        filter_version: AP_FILTER_VERSION,
     };
     strncpy(pkt.fw_string, fwver.fw_string, ARRAY_SIZE(pkt.fw_string)-1);
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -660,6 +660,7 @@ struct PACKED log_VER {
     char fw_string[64];
     uint16_t _APJ_BOARD_ID;
     uint8_t build_type;
+    uint8_t filter_version;
 };
 
 
@@ -1170,6 +1171,7 @@ struct PACKED log_VER {
 // @Field: FWS: Firmware version string
 // @Field: APJ: Board ID
 // @Field: BU: Build vehicle type
+// @Field: FV: Filter version
 
 // @LoggerMessage: MOTB
 // @Description: Motor mixer information
@@ -1300,7 +1302,7 @@ LOG_STRUCTURE_FROM_AIS \
     { LOG_SCRIPTING_MSG, sizeof(log_Scripting), \
       "SCR",   "QNIii", "TimeUS,Name,Runtime,Total_mem,Run_mem", "s#sbb", "F-F--", true }, \
     { LOG_VER_MSG, sizeof(log_VER), \
-      "VER",   "QBHBBBBIZHB", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ,BU", "s----------", "F----------", false }, \
+      "VER",   "QBHBBBBIZHBB", "TimeUS,BT,BST,Maj,Min,Pat,FWT,GH,FWS,APJ,BU,FV", "s-----------", "F-----------", false }, \
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt), \
       "MOTB", "QfffffB",  "TimeUS,LiftMax,BatVolt,ThLimit,ThrAvMx,ThrOut,FailFlags", "s------", "F------" , true }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -750,7 +750,6 @@ void AP_Vehicle::update_throttle_notch(AP_InertialSensor::HarmonicNotch &notch)
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI||APM_BUILD_TYPE(APM_BUILD_Rover)
     const float ref_freq = notch.params.center_freq_hz();
     const float ref = notch.params.reference();
-    const float min_ratio = notch.params.freq_min_ratio();
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
     const AP_Motors* motors = AP::motors();
@@ -760,7 +759,7 @@ void AP_Vehicle::update_throttle_notch(AP_InertialSensor::HarmonicNotch &notch)
     const float motors_throttle = motors != nullptr ? abs(motors->get_throttle() / 100.0f) : 0;
 #endif
 
-    float throttle_freq = ref_freq * MAX(min_ratio, sqrtf(motors_throttle / ref));
+    float throttle_freq = ref_freq * sqrtf(MAX(0,motors_throttle) / ref);
 
     notch.update_freq_hz(throttle_freq);
 #endif
@@ -780,17 +779,6 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
         return;
     }
 
-#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
-    const AP_Motors* motors = AP::motors();
-    if (motors != nullptr && motors->get_spool_state() == AP_Motors::SpoolState::SHUT_DOWN) {
-        notch.set_inactive(true);
-    } else {
-        notch.set_inactive(false);
-    }
-#else  // APM_BUILD_Rover: keep notch active
-    notch.set_inactive(false);
-#endif
-
     switch (notch.params.tracking_mode()) {
         case HarmonicNotchDynamicMode::UpdateThrottle: // throttle based tracking
             // set the harmonic notch filter frequency approximately scaled on motor rpm implied by throttle
@@ -805,9 +793,9 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
             float rpm;
             if (rpm_sensor != nullptr && rpm_sensor->get_rpm(sensor, rpm)) {
                 // set the harmonic notch filter frequency from the main rotor rpm
-                notch.update_freq_hz(MAX(ref_freq * notch.params.freq_min_ratio(), rpm * ref * (1.0/60)));
+                notch.update_freq_hz(rpm * ref * (1.0/60));
             } else {
-                notch.update_freq_hz(ref_freq);
+                notch.update_freq_hz(0);
             }
             break;
         }
@@ -819,18 +807,13 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
                 float notches[INS_MAX_NOTCHES];
                 // ESC telemetry will return 0 for missing data, but only after 1s
                 const uint8_t num_notches = AP::esc_telem().get_motor_frequencies_hz(INS_MAX_NOTCHES, notches);
-                for (uint8_t i = 0; i < num_notches; i++) {
-                    if (!is_zero(notches[i])) {
-                        notches[i] =  MAX(ref_freq, notches[i]);
-                    }
-                }
                 if (num_notches > 0) {
                     notch.update_frequencies_hz(num_notches, notches);
                 } else {    // throttle fallback
                     update_throttle_notch(notch);
                 }
             } else {
-                notch.update_freq_hz(MAX(ref_freq, AP::esc_telem().get_average_motor_frequency_hz() * ref));
+                notch.update_freq_hz(AP::esc_telem().get_average_motor_frequency_hz() * ref);
             }
             break;
 #endif
@@ -842,20 +825,14 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
                 const uint8_t peaks = gyro_fft.get_weighted_noise_center_frequencies_hz(notch.num_dynamic_notches, notches);
 
                 if (peaks > 0) {
-                    for (uint8_t i = 0; i < peaks; i++) {
-                        notches[i] =  MAX(ref_freq, notches[i]);
-                    }
+                    notch.set_inactive(false);
                     notch.update_frequencies_hz(peaks, notches);
                 } else {    // since FFT can be used post-filter it is better to disable the notch when there is no data
                     notch.set_inactive(true);
                 }
             } else {
                 float center_freq = gyro_fft.get_weighted_noise_center_freq_hz();
-                if (!is_zero(center_freq)) {
-                    notch.update_freq_hz(MAX(ref_freq, center_freq));
-                } else {    // since FFT can be used post-filter it is better to disable the notch when there is no data
-                    notch.set_inactive(true);
-                }
+                notch.update_freq_hz(center_freq);
             }
             break;
 #endif

--- a/libraries/Filter/Filter.h
+++ b/libraries/Filter/Filter.h
@@ -9,3 +9,12 @@
 #include "LowPassFilter.h"
 #include "ModeFilter.h"
 #include "Butter.h"
+
+/*
+  the filter version is logged in the VER message to assist the online
+  analysis tools, so they can display the right filter formulas for
+  this version of the code
+  This should be incremented on significant filtering changes
+ */
+#define AP_FILTER_VERSION 2
+

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -204,6 +204,10 @@ void HarmonicNotchFilter<T>::allocate_filters(uint8_t num_notches, uint32_t harm
 template <class T>
 void HarmonicNotchFilter<T>::expand_filter_count(uint16_t total_notches)
 {
+    if (total_notches <= _num_filters) {
+        // enough already
+        return;
+    }
     if (_alloc_has_failed) {
         // we've failed to allocate before, don't try again
         return;
@@ -228,7 +232,7 @@ void HarmonicNotchFilter<T>::expand_filter_count(uint16_t total_notches)
   set the center frequency of a single notch
  */
 template <class T>
-void HarmonicNotchFilter<T>::set_center_frequency(uint8_t idx, float notch_center, float spread_mul, uint8_t harmonic_mul)
+void HarmonicNotchFilter<T>::set_center_frequency(uint16_t idx, float notch_center, float spread_mul, uint8_t harmonic_mul)
 {
     const float nyquist_limit = _sample_freq_hz * 0.48f;
     auto &notch = _filters[idx];
@@ -307,7 +311,7 @@ void HarmonicNotchFilter<T>::update(float center_freq_hz)
 
     _num_enabled_filters = 0;
     // update all of the filters using the new center frequency and existing A & Q
-    for (uint8_t i = 0; i < HNF_MAX_HARMONICS && _num_enabled_filters < _num_filters; i++) {
+    for (uint16_t i = 0; i < HNF_MAX_HARMONICS && _num_enabled_filters < _num_filters; i++) {
         if ((1U<<i) & _harmonics) {
             const float notch_center = center_freq_hz;
             const uint8_t harmonic_mul = i+1;
@@ -336,7 +340,7 @@ void HarmonicNotchFilter<T>::update(uint8_t num_centers, const float center_freq
     // adjust the frequencies to be in the allowable range
     const float nyquist_limit = _sample_freq_hz * 0.48f;
 
-    uint16_t total_notches = num_centers * _num_harmonics * _composite_notches;
+    const uint16_t total_notches = num_centers * _num_harmonics * _composite_notches;
     if (total_notches > _num_filters) {
         // alloc realloc of filters
         expand_filter_count(total_notches);

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -427,17 +427,19 @@ void HarmonicNotchFilter<T>::reset()
 // @Description: Filter Center Message - per motor
 // @Field: TimeUS: microseconds since system startup
 // @Field: I: instance
-// @Field: NDn: number of active dynamic harmonic notches
-// @Field: CF1: centre frequency for motor 1
-// @Field: CF2: centre frequency for motor 2
-// @Field: CF3: centre frequency for motor 3
-// @Field: CF4: centre frequency for motor 4
-// @Field: CF5: centre frequency for motor 5
-// @Field: HF1: 2nd harmonic frequency for motor 1
-// @Field: HF2: 2nd harmonic frequency for motor 2
-// @Field: HF3: 2nd harmonic frequency for motor 3
-// @Field: HF4: 2nd harmonic frequency for motor 4
-// @Field: HF5: 2nd harmonic frequency for motor 5
+// @Field: NF: total number of active harmonic notches
+// @Field: CF1: First harmonic centre frequency for motor 1
+// @Field: CF2: First harmonic centre frequency for motor 2
+// @Field: CF3: First harmonic centre frequency for motor 3
+// @Field: CF4: First harmonic centre frequency for motor 4
+// @Field: CF5: First harmonic centre frequency for motor 5
+// @Field: CF6: First harmonic centre frequency for motor 6
+// @Field: HF1: Second harmonic centre frequency for motor 1
+// @Field: HF2: Second harmonic centre frequency for motor 2
+// @Field: HF3: Second harmonic centre frequency for motor 3
+// @Field: HF4: Second harmonic centre frequency for motor 4
+// @Field: HF5: Second harmonic centre frequency for motor 5
+// @Field: HF6: Second harmonic centre frequency for motor 6
 
 // @LoggerMessage: FCNS
 // @Description: Filter Center Message
@@ -448,7 +450,7 @@ void HarmonicNotchFilter<T>::reset()
 
 /*
   log center frequencies of 1st and 2nd harmonic of a harmonic notch
-  instance for up to 5 frequency sources
+  instance for up to 6 frequency sources
 
   the instance number passed in corresponds to the harmonic notch
   instance in AP_InertialSensor
@@ -465,9 +467,9 @@ void HarmonicNotchFilter<T>::log_notch_centers(uint8_t instance, uint64_t now_us
     if (_num_filters == 0 || filters_per_source == 0) {
         return;
     }
-    const uint8_t num_sources = MIN(5, _num_filters / filters_per_source);
-    float centers[5] {};
-    float first_harmonic[5] {};
+    const uint8_t num_sources = MIN(6, _num_filters / filters_per_source);
+    float centers[6] {};
+    float first_harmonic[6] {};
 
     for (uint8_t i=0; i<num_sources; i++) {
         /*
@@ -480,12 +482,12 @@ void HarmonicNotchFilter<T>::log_notch_centers(uint8_t instance, uint64_t now_us
 
     if (num_sources > 1) {
         AP::logger().WriteStreaming(
-            "FCN", "TimeUS,I,NDn,CF1,CF2,CF3,CF4,CF5,HF1,HF2,HF3,HF4,HF5", "s#-zzzzzzzzzz", "F------------", "QBBffffffffff",
+            "FCN", "TimeUS,I,NF,CF1,CF2,CF3,CF4,CF5,CF6,HF1,HF2,HF3,HF4,HF5,HF6", "s#-zzzzzzzzzzzz", "F--------------", "QBHffffffffffff",
             now_us,
             instance,
-            num_sources,
-            centers[0], centers[1], centers[2], centers[3], centers[4],
-            first_harmonic[0], first_harmonic[1], first_harmonic[2], first_harmonic[3], first_harmonic[4]);
+            _num_filters,
+            centers[0], centers[1], centers[2], centers[3], centers[4], centers[5],
+            first_harmonic[0], first_harmonic[1], first_harmonic[2], first_harmonic[3], first_harmonic[4], first_harmonic[5]);
     } else {
         // log single center frequency
         AP::logger().WriteStreaming(

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -39,6 +39,11 @@
 #endif
 
 /*
+  cutoff proportion of sample rate above which we do not use the notch
+ */
+#define HARMONIC_NYQUIST_CUTOFF 0.48f
+
+/*
   point at which the harmonic notch goes to zero attenuation
  */
 #define NOTCHFILTER_ATTENUATION_CUTOFF 0.25
@@ -166,7 +171,7 @@ void HarmonicNotchFilter<T>::init(float sample_freq_hz, HarmonicNotchFilterParam
     const float attenuation_dB = params->attenuation_dB();
     float center_freq_hz = params->center_freq_hz();
 
-    const float nyquist_limit = sample_freq_hz * 0.48f;
+    const float nyquist_limit = sample_freq_hz * HARMONIC_NYQUIST_CUTOFF;
     const float bandwidth_limit = bandwidth_hz * 0.52f;
 
     // remember the lowest frequency we will have a notch enabled at
@@ -248,7 +253,7 @@ void HarmonicNotchFilter<T>::expand_filter_count(uint16_t total_notches)
 template <class T>
 void HarmonicNotchFilter<T>::set_center_frequency(uint16_t idx, float notch_center, float spread_mul, uint8_t harmonic_mul)
 {
-    const float nyquist_limit = _sample_freq_hz * 0.48f;
+    const float nyquist_limit = _sample_freq_hz * HARMONIC_NYQUIST_CUTOFF;
     auto &notch = _filters[idx];
 
     // scale the notch with the harmonic multiplier
@@ -339,7 +344,7 @@ void HarmonicNotchFilter<T>::update(uint8_t num_centers, const float center_freq
     }
 
     // adjust the frequencies to be in the allowable range
-    const float nyquist_limit = _sample_freq_hz * 0.48f;
+    const float nyquist_limit = _sample_freq_hz * HARMONIC_NYQUIST_CUTOFF;
 
     const uint16_t total_notches = num_centers * _num_harmonics * _composite_notches;
     if (total_notches > _num_filters) {

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -119,17 +119,26 @@ public:
 
     // set the fundamental center frequency of the harmonic notch
     void set_center_freq_hz(float center_freq) { _center_freq_hz.set(center_freq); }
+
     // set the bandwidth of the harmonic notch
     void set_bandwidth_hz(float bandwidth_hz) { _bandwidth_hz.set(bandwidth_hz); }
+
+    // set the attenuation of the harmonic notch
+    void set_attenuation(float attenuation_dB) { _attenuation_dB.set(attenuation_dB); }
+    
     // harmonics enabled on the harmonic notch
     uint32_t harmonics(void) const { return _harmonics; }
+
     // set the harmonics value
     void set_harmonics(uint32_t hmncs) { _harmonics.set(hmncs); }
+
     // has the user set the harmonics value
     void set_default_harmonics(uint32_t hmncs) { _harmonics.set_default(hmncs); }
+
     // reference value of the harmonic notch
     float reference(void) const { return _reference; }
     void set_reference(float ref) { _reference.set(ref); }
+
     // notch options
     bool hasOption(Options option) const { return _options & uint16_t(option); }
     // notch dynamic tracking mode
@@ -141,6 +150,9 @@ public:
         return _freq_min_ratio;
     }
     void set_freq_min_ratio(float ratio) { _freq_min_ratio.set(ratio); }
+
+    // set options flags
+    void set_options(uint16_t options) { _options.set(options); }
 
     // save parameters
     void save_params();

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -54,6 +54,11 @@ public:
     // reset each of the underlying filters
     void reset();
 
+    /*
+      log notch center frequencies and first harmonic
+     */
+    void log_notch_centers(uint8_t instance, uint64_t now_us) const;
+
 private:
     // underlying bank of notch filters
     NotchFilter<T>*  _filters;

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -47,7 +47,7 @@ public:
       spread_mul is a scale factor for spreading of double or triple notch
       harmonic_mul is the multiplier for harmonics, 1 is for the fundamental
     */
-    void set_center_frequency(uint8_t idx, float center_freq_hz, float spread_mul, uint8_t harmonic_mul);
+    void set_center_frequency(uint16_t idx, float center_freq_hz, float spread_mul, uint8_t harmonic_mul);
 
     // apply a sample to each of the underlying filters in turn
     T apply(const T &sample);

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -36,7 +36,7 @@ public:
     // expand filter bank with new filters
     void expand_filter_count(uint16_t total_notches);
     // initialize the underlying filters using the provided filter parameters
-    void init(float sample_freq_hz, const HarmonicNotchFilterParams &params);
+    void init(float sample_freq_hz, HarmonicNotchFilterParams &params);
     // update the underlying filters' center frequencies using center_freq_hz as the fundamental
     void update(float center_freq_hz);
     // update all of the underlying center frequencies individually
@@ -83,10 +83,8 @@ private:
     // minimum frequency (from INS_HNTCH_FREQ * INS_HNTCH_FM_RAT)
     float _minimum_freq;
 
-    /*
-      flag for treating a very low frequency as the min frequency
-    */
-    bool _treat_low_freq_as_min;
+    // pointer to params object for this filter
+    HarmonicNotchFilterParams *params;
 };
 
 // Harmonic notch update mode
@@ -156,6 +154,11 @@ public:
 
     // save parameters
     void save_params();
+
+    // return the number of composite notches given the options
+    uint8_t num_composite_notches(void) const {
+        return hasOption(Options::DoubleNotch) ? 2 : hasOption(Options::TripleNotch) ? 3: 1;
+    }
 
 private:
     // configured notch harmonics

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -59,7 +59,10 @@ template <class T>
 void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q)
 {
     // don't update if no updates required
-    if (initialised && is_equal(center_freq_hz, _center_freq_hz) && is_equal(sample_freq_hz, _sample_freq_hz)) {
+    if (initialised &&
+        is_equal(center_freq_hz, _center_freq_hz) &&
+        is_equal(sample_freq_hz, _sample_freq_hz) &&
+        is_equal(A, _A)) {
         return;
     }
 
@@ -91,6 +94,7 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
 
         _center_freq_hz = new_center_freq;
         _sample_freq_hz = sample_freq_hz;
+        _A = A;
         initialised = true;
     } else {
         // leave center_freq_hz at last value

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -48,6 +48,11 @@ public:
         initialised = false;
     }
 
+    // return the frequency to log for the notch
+    float logging_frequency(void) const {
+        return initialised?_center_freq_hz:0;
+    }
+
 protected:
 
     bool initialised, need_reset;

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -44,6 +44,10 @@ public:
     // calculate attenuation and quality from provided center frequency and bandwidth
     static void calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q); 
 
+    void disable(void) {
+        initialised = false;
+    }
+
 protected:
 
     bool initialised, need_reset;

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -52,7 +52,7 @@ protected:
 
     bool initialised, need_reset;
     float b0, b1, b2, a1, a2;
-    float _center_freq_hz, _sample_freq_hz;
+    float _center_freq_hz, _sample_freq_hz, _A;
     T ntchsig1, ntchsig2, signal2, signal1;
 };
 

--- a/libraries/Filter/tests/plot_harmonictest2.gnu
+++ b/libraries/Filter/tests/plot_harmonictest2.gnu
@@ -1,0 +1,11 @@
+#!/usr/bin/gnuplot -persist
+set y2tics 0,10
+set ytics nomirror
+set style data linespoints
+set key autotitle
+set datafile separator ","
+set key autotitle columnhead
+set xlabel "Freq(Hz)"
+set ylabel "Attenuation(dB)"
+#set ylabel2 "PhaseLag(deg)"
+plot "harmonicnotch_test2.csv" using 1:2 axis x1y1, "harmonicnotch_test2.csv" using 1:3 axis x1y2

--- a/libraries/Filter/tests/plot_harmonictest3.gnu
+++ b/libraries/Filter/tests/plot_harmonictest3.gnu
@@ -1,0 +1,12 @@
+#!/usr/bin/gnuplot -persist
+set y2tics 0,10
+set ytics nomirror
+set style data linespoints
+set key autotitle
+set datafile separator ","
+set key autotitle columnhead
+set xlabel "Freq(Hz)"
+set ylabel "Attenuation(dB)"
+#set ylabel2 "PhaseLag(deg)"
+plot "harmonicnotch_test3.csv" using 1:2 axis x1y1, "harmonicnotch_test3.csv" using 1:3 axis x1y2, "harmonicnotch_test3.csv" using 1:4 axis x1y1, "harmonicnotch_test3.csv" using 1:5 axis x1y2
+

--- a/libraries/Filter/tests/plot_harmonictest4.gnu
+++ b/libraries/Filter/tests/plot_harmonictest4.gnu
@@ -1,0 +1,12 @@
+#!/usr/bin/gnuplot -persist
+set y2tics 0,10
+set ytics nomirror
+set style data linespoints
+set key autotitle
+set datafile separator ","
+set key autotitle columnhead
+set xlabel "Freq(Hz)"
+set ylabel "Attenuation(dB)"
+set key left bottom
+plot "harmonicnotch_test4.csv" using 1:2, "harmonicnotch_test4.csv" using 1:3, "harmonicnotch_test4.csv" using 1:4, "harmonicnotch_test4.csv" using 1:5, "harmonicnotch_test4.csv" using 1:6, "harmonicnotch_test4.csv" using 1:7, "harmonicnotch_test4.csv" using 1:8
+

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -6,6 +6,11 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
+static double ratio_to_dB(double ratio)
+{
+    return 10*log(ratio);
+}
+
 /*
   test if a reset of a notch filter results in no glitch in the following samples
   with constant input
@@ -74,7 +79,6 @@ TEST(NotchFilterTest, HarmonicNotchTest)
 {
     const uint8_t num_test_freq = 150;
     const uint8_t harmonics = 15;
-    const uint8_t num_harmonics = __builtin_popcount(harmonics);
     const float base_freq = 46;
     const float bandwidth = base_freq/2;
     const float attenuation_dB = 60;
@@ -86,7 +90,6 @@ TEST(NotchFilterTest, HarmonicNotchTest)
     const float test_amplitude = 0.7;
     const double dt = 1.0 / rate_hz;
 
-    bool double_notch = true;
     HarmonicNotchFilter<float> filters[num_test_freq][chained_filters] {};
     struct {
         double in;
@@ -105,13 +108,14 @@ TEST(NotchFilterTest, HarmonicNotchTest)
     for (uint8_t i=0; i<num_test_freq; i++) {
         for (uint8_t c=0; c<chained_filters; c++) {
             auto &f = filters[i][c];
-            f.allocate_filters(num_harmonics, harmonics, double_notch?2:1);
             HarmonicNotchFilterParams notch_params {};
+            notch_params.set_options(uint16_t(HarmonicNotchFilterParams::Options::TreatLowAsMin) |
+                                     uint16_t(HarmonicNotchFilterParams::Options::DoubleNotch));
             notch_params.set_attenuation(attenuation_dB);
             notch_params.set_bandwidth_hz(bandwidth);
             notch_params.set_center_freq_hz(base_freq);
             notch_params.set_freq_min_ratio(1.0);
-            notch_params.set_options(uint16_t(HarmonicNotchFilterParams::Options::TreatLowAsMin));
+            f.allocate_filters(1, harmonics, notch_params.num_composite_notches());
             f.init(rate_hz, notch_params);
             f.update(base_freq);
         }
@@ -149,7 +153,7 @@ TEST(NotchFilterTest, HarmonicNotchTest)
     for (uint8_t i=0; i<num_test_freq; i++) {
         const float freq = i+1;
         const float lag_degrees = integrals[i].get_lag_degrees(freq);
-        fprintf(f, "%.1f,%f,%f\n", freq, integrals[i].out/integrals[i].in, lag_degrees);
+        fprintf(f, "%.3f,%f,%f\n", freq, integrals[i].out/integrals[i].in, lag_degrees);
     }
     fclose(f);
     printf("Wrote %s\n", csv_file);
@@ -161,6 +165,164 @@ TEST(NotchFilterTest, HarmonicNotchTest)
     EXPECT_NEAR(integrals[1].get_lag_degrees(2), 22.03, 0.5);
     EXPECT_NEAR(integrals[4].get_lag_degrees(5), 55.23, 0.5);
     EXPECT_NEAR(integrals[9].get_lag_degrees(10), 112.23, 0.5);
+}
+
+
+/*
+  calculate attenuation and phase lag for a single harmonic notch filter
+ */
+static void test_one_filter(float base_freq, float attenuation_dB,
+                            float bandwidth, float test_freq, float source_freq,
+                            uint16_t harmonics, uint16_t options,
+                            float &phase_lag, float &out_attenuation_dB)
+{
+    const uint16_t rate_hz = 2000;
+    const uint32_t samples = 50000;
+    const float test_amplitude = 1.0;
+    const double dt = 1.0 / rate_hz;
+
+    HarmonicNotchFilter<float> filter {};
+    struct {
+        double last_in;
+        double last_out;
+        double v_max;
+        uint32_t last_crossing;
+        uint32_t total_lag_samples;
+        uint32_t lag_count;
+        float get_lag_degrees(const float freq) const {
+            const float lag_avg = total_lag_samples/float(lag_count);
+            return (360.0 * lag_avg * freq) / rate_hz;
+        }
+    } integral {};
+
+    auto &f = filter;
+
+
+    HarmonicNotchFilterParams notch_params {};
+    notch_params.set_options(options);
+    notch_params.set_attenuation(attenuation_dB);
+    notch_params.set_bandwidth_hz(bandwidth);
+    notch_params.set_center_freq_hz(base_freq);
+    notch_params.set_freq_min_ratio(1.0);
+    f.allocate_filters(1, harmonics, notch_params.num_composite_notches());
+    f.init(rate_hz, notch_params);
+    f.update(source_freq);
+
+    for (uint32_t s=0; s<samples; s++) {
+        const double t = s * dt;
+
+        const double sample = sin(test_freq * t * 2 * M_PI) * test_amplitude;
+        float v = sample;
+        v = f.apply(v);
+        if (s >= samples/10) {
+            integral.v_max = MAX(integral.v_max, v);
+        }
+        if (sample >= 0 && integral.last_in < 0) {
+            integral.last_crossing = s;
+        }
+        if (v >= 0 && integral.last_out < 0 && integral.last_crossing != 0) {
+            integral.total_lag_samples += s - integral.last_crossing;
+            integral.lag_count++;
+        }
+        integral.last_in = sample;
+        integral.last_out = v;
+        f.update(source_freq);
+    }
+    phase_lag = integral.get_lag_degrees(test_freq);
+    out_attenuation_dB = ratio_to_dB(integral.v_max/test_amplitude);
+}
+
+/*
+  test the test_one_filter function
+ */
+TEST(NotchFilterTest, HarmonicNotchTest2)
+{
+    const float min_freq = 1.0;
+    const float max_freq = 200;
+    const uint16_t steps = 2000;
+
+    const char *csv_file = "harmonicnotch_test2.csv";
+    FILE *f = fopen(csv_file, "w");
+    fprintf(f, "Freq(Hz),Attenuation(dB),Lag(deg)\n");
+
+    for (uint16_t i=0; i<steps; i++) {
+        float attenuation_dB, phase_lag;
+        const float test_freq = min_freq + i*(max_freq-min_freq)/steps;
+        test_one_filter(50, 30, 25, test_freq, 50, 3, uint16_t(HarmonicNotchFilterParams::Options::TripleNotch), phase_lag, attenuation_dB);
+        fprintf(f, "%.3f,%f,%f\n", test_freq, attenuation_dB, phase_lag);
+    }
+    fclose(f);
+}
+
+/*
+  test behaviour with TreatLowAsMin, we expect attenuation to decrease
+  as we get close to zero source frequency and phase lag to approach
+  zero
+ */
+TEST(NotchFilterTest, HarmonicNotchTest3)
+{
+    const float min_freq = 1.0;
+    const float max_freq = 200;
+    const uint16_t steps = 1000;
+
+    const char *csv_file = "harmonicnotch_test3.csv";
+    FILE *f = fopen(csv_file, "w");
+    fprintf(f, "Freq(Hz),Attenuation1(dB),Lag1(deg),Attenuation2(dB),Lag2(deg)\n");
+
+    const float source_freq = 35;
+    for (uint16_t i=0; i<steps; i++) {
+        float attenuation_dB1, phase_lag1;
+        float attenuation_dB2, phase_lag2;
+        const float test_freq = min_freq + i*(max_freq-min_freq)/steps;
+        // first with TreatLowAsMin
+        test_one_filter(50, 30, 25, test_freq, source_freq, 1, uint16_t(HarmonicNotchFilterParams::Options::TreatLowAsMin),
+                        phase_lag1,
+                        attenuation_dB1);
+        // and without
+        test_one_filter(50, 30, 25, test_freq, source_freq, 1, 0,
+                        phase_lag2,
+                        attenuation_dB2);
+        fprintf(f, "%.3f,%f,%f,%f,%f\n", test_freq, attenuation_dB1, phase_lag1, attenuation_dB2, phase_lag2);
+
+        // the phase lag with the attenuation adjustment should not be
+        // more than without for frequencies below min freq
+        if (test_freq < 50) {
+            EXPECT_LE(phase_lag2, phase_lag1);
+        }
+    }
+    fclose(f);
+}
+
+/*
+  show the progress of a multi-harmonic notch as the source frequency drops below the min frequency
+ */
+TEST(NotchFilterTest, HarmonicNotchTest4)
+{
+    const float min_freq = 1.0;
+    const float max_freq = 250;
+    const uint16_t steps = 1000;
+
+    const char *csv_file = "harmonicnotch_test4.csv";
+    FILE *f = fopen(csv_file, "w");
+    fprintf(f, "Freq(Hz),60Hz(dB),50Hz(dB),40Hz(dB),30Hz(dB),20Hz(dB),10Hz(dB),0Hz(dB)\n");
+
+    for (uint16_t i=0; i<steps; i++) {
+        float phase_lag;
+        const float source_freq[7] { 60, 50, 40, 30, 20, 10, 0 };
+        float attenuations[7];
+        const float test_freq = min_freq + i*(max_freq-min_freq)/steps;
+        for (uint8_t F = 0; F < ARRAY_SIZE(source_freq); F++) {
+            test_one_filter(50, 30, 25, test_freq, source_freq[F], 15, 0,
+                            phase_lag,
+                            attenuations[F]);
+        }
+        fprintf(f, "%.3f,%f,%f,%f,%f,%f,%f,%f\n",
+                test_freq,
+                attenuations[0], attenuations[1], attenuations[2],
+                attenuations[3], attenuations[4], attenuations[5],
+                attenuations[6]);
+    }
+    fclose(f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -106,7 +106,14 @@ TEST(NotchFilterTest, HarmonicNotchTest)
         for (uint8_t c=0; c<chained_filters; c++) {
             auto &f = filters[i][c];
             f.allocate_filters(num_harmonics, harmonics, double_notch?2:1);
-            f.init(rate_hz, base_freq, bandwidth, attenuation_dB);
+            HarmonicNotchFilterParams notch_params {};
+            notch_params.set_attenuation(attenuation_dB);
+            notch_params.set_bandwidth_hz(bandwidth);
+            notch_params.set_center_freq_hz(base_freq);
+            notch_params.set_freq_min_ratio(1.0);
+            notch_params.set_options(uint16_t(HarmonicNotchFilterParams::Options::TreatLowAsMin));
+            f.init(rate_hz, notch_params);
+            f.update(base_freq);
         }
     }
 


### PR DESCRIPTION
This reworks the harmonic notch setup. Major changes include:
 - move all clamping decisions down to one place in HarmonicNotchFilter<T>::set_center_frequency
 - by default disable notch completely when freq is under 50% of min freq
 - added INS_HNTCH_OPTS bit to use min freq when RPM source stops (for heli governors)
 - make the double and triple notch clearer, note this changes the spread for harmonics, need to think if that is correct
 - removed code that initialised frequencies to the min freq, instead rely on update calls
 - allow harmonic notches to run in quadplanes in fwd flight
