### PR TITLE
AP_Scripting: add binding for GCS last seen time

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2312,6 +2312,10 @@ function gcs:get_high_latency_status() end
 ---@param text string
 function gcs:send_text(severity, text) end
 
+-- Return the system time when a gcs with id of SYSID_MYGCS was last seen
+---@return uint32_t_ud -- system time in milliseconds
+function gcs:last_seen() end
+
 -- desc
 ---@class relay
 relay = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -248,6 +248,8 @@ singleton GCS method set_message_interval MAV_RESULT'enum uint8_t 0 MAVLINK_COMM
 singleton GCS method send_named_float void string float'skip_check
 singleton GCS method frame_type MAV_TYPE'enum
 singleton GCS method get_hud_throttle int16_t
+singleton GCS method sysid_myggcs_last_seen_time_ms uint32_t
+singleton GCS method sysid_myggcs_last_seen_time_ms rename last_seen
 
 singleton GCS method get_high_latency_status boolean
 singleton GCS method get_high_latency_status depends HAL_HIGH_LATENCY2_ENABLED == 1


### PR DESCRIPTION
This adds a binding for `sysid_myggcs_last_seen_time_ms` renaming it to `last_seen` such then it can be called as `gcs:last_seen()`.

This allows GCS failsafe actions to be implemented in scripting. Very basic example:

```
function update()

  local gcs_dt = millis() - gcs:last_seen()

  gcs:send_text(0, string.format("Last GCS was: %0.2f seconds ago", gcs_dt:tofloat() * 0.001))

  return update, 1000
end

return update()
```
