### PR TITLE
Fix GSOF autobaud detection message.

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13187,7 +13187,7 @@ switch value'''
             (6, "SBP", None, "SBP", 5, 'detected'),
             # (7, "SBP2", 9, "SBP2", 5),  # broken, "waiting for config data"
             (8, "NOVA", 15, "NOVA", 5, 'detected'),  # no attempt to auto-detect this in AP_GPS
-            (11, "GSOF", 11, "GSOF", 5, 'detected'),
+            (11, "GSOF", 11, "GSOF", 5, 'specified'), # no attempt to auto-detect this in AP_GPS
             (19, "MSP", 19, "MSP", 32, 'specified'),  # no attempt to auto-detect this in AP_GPS
             # (9, "FILE"),
         ]

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -753,6 +753,11 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
         dstate->auto_detected_baud = false; // specified, not detected
         return new AP_GPS_ExternalAHRS(*this, state[instance], nullptr);
 #endif
+#if AP_GPS_GSOF_ENABLED
+    case GPS_TYPE_GSOF:
+        dstate->auto_detected_baud = false; // specified, not detected
+        return new AP_GPS_GSOF(*this, state[instance], _port[instance]);
+#endif //AP_GPS_GSOF_ENABLED
     default:
         break;
     }
@@ -802,10 +807,6 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
     case GPS_TYPE_SBF:
         return new AP_GPS_SBF(*this, state[instance], _port[instance]);
 #endif //AP_GPS_SBF_ENABLED
-#if AP_GPS_GSOF_ENABLED
-    case GPS_TYPE_GSOF:
-        return new AP_GPS_GSOF(*this, state[instance], _port[instance]);
-#endif //AP_GPS_GSOF_ENABLED
 #if AP_GPS_NOVA_ENABLED
     case GPS_TYPE_NOVA:
         return new AP_GPS_NOVA(*this, state[instance], _port[instance]);


### PR DESCRIPTION
On the GSOF driver, previously, it said "detected", which made it seem like it already happened. After chasing this down, the message is right, but the GSOF driver is missing certain flags. 

It needs to set `dstate->auto_detected_baud = false`

After this change, the logs now state:
```
AP: GPS 1: specified as GSOF
AP: GPS 1: specified as GSOF
AP: GPS 1: specified as GSOF
```

Before this change, the logs stated:
```
AP: GPS 1: detected as GSOF at 4800 baud
AP: GPS 1: detected as GSOF at 19200 baud
AP: GPS 1: detected as GSOF at 38400 baud
```

