### PR TITLE
AP_Scripting: add bindings for fence

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2999,3 +2999,19 @@ function mavlink:send_chan(chan, msgid, message) end
 -- Block a given MAV_CMD from being procceced by ArduPilot
 ---@param comand_id integer
 function mavlink:block_command(comand_id) end
+
+-- Geofence library
+---@class fence
+fence = {}
+
+-- Returns the time at which the current breach started
+---@return uint32_t_ud system_time milliseconds
+function fence:get_breach_time() end
+
+-- Returns the type bitmask of any breached fences
+---@return integer fence_type bitmask
+---| 1 # Maximim altitude
+---| 2 # Circle
+---| 4 # Polygon
+---| 8 # Minimum altitude
+function fence:get_breaches() end

--- a/libraries/AP_Scripting/examples/FenceBreach.lua
+++ b/libraries/AP_Scripting/examples/FenceBreach.lua
@@ -1,0 +1,39 @@
+-- Example of checking and reporting on geo-fence breach
+
+local breach_lookup = {
+  [1] = "Maximim altitude",
+  [2] = "Circle",
+  [4] = "Polygon",
+  [8] = "Minimum altitude"
+}
+
+-- Lookup brach type bitmask and return the names of any breached fences
+local function get_breach_names(breaches)
+  local msg = ""
+  for bitmaks, name in pairs(breach_lookup) do
+    if (breaches & bitmaks) ~= 0 then
+      -- And + delimiter between types if more than one
+      if (string.len(msg) > 0) then
+        msg = msg .. " + "
+      end
+      msg = msg .. name
+    end
+  end
+
+  return msg
+end
+
+function update()
+
+  local breaches = fence:get_breaches()
+  if breaches ~= 0 then
+    -- Time passed since fence breach
+    local breach_time = millis() - fence:get_breach_time()
+
+    gcs:send_text(0, string.format("Breached: %s fence, outside for %0.2f seconds", get_breach_names(breaches), breach_time:tofloat() * 0.001))
+  end
+
+  return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -795,3 +795,10 @@ singleton mavlink manual register_rx_msgid lua_mavlink_register_rx_msgid 1
 singleton mavlink manual send_chan lua_mavlink_send_chan 3
 singleton mavlink manual receive_chan lua_mavlink_receive_chan 0
 singleton mavlink manual block_command lua_mavlink_block_command 1
+
+include AC_Fence/AC_Fence.h depends AP_FENCE_ENABLED
+include AC_Fence/AC_Fence_config.h
+singleton AC_Fence depends AP_FENCE_ENABLED
+singleton AC_Fence rename fence
+singleton AC_Fence method get_breaches uint8_t
+singleton AC_Fence method get_breach_time uint32_t


### PR DESCRIPTION
This adds bindings allowing fence failsafe actions to be taken by scripting. A simple example:
```
function update()

  local breaches = fence:get_breaches()
  if breaches ~= 0 then
    local msg = ""
    local breach = false
    if (breaches & 1) ~= 0 then
      msg = msg .. "Maximim altitude"
      breach = true
    end
    if (breaches & 2) ~= 0 then
      if breach then
        msg = msg .. " + "
      end
      msg = msg .. "Circle"
      breach = true
    end
    if (breaches & 4) ~= 0 then
      if breach then
        msg = msg .. " + "
      end
      msg = msg .. "Polygon"
      breach = true
    end
    if (breaches & 8) ~= 0 then
      if breach then
        msg = msg .. " + "
      end
      msg = msg .. "Minimum altitude"
    end

    local breach_time = millis() - fence:get_breach_time()

    gcs:send_text(0, string.format("Breached: %s fence, outside for %0.2f seconds", msg, breach_time:tofloat() * 0.001))

  end


  return update, 1000
end

return update()

```