### PR TITLE
AP_GPS: Add configurable baud rate/port for AP_GPS_GSOF

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -430,6 +430,24 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 #endif // GPS_MAX_RECEIVERS > 1
 #endif // HAL_ENABLE_DRONECAN_DRIVERS
 
+#if AP_GPS_GSOF_ENABLED
+    // @Param: _GSOF_BAUD1
+    // @DisplayName: Baud rate for the first GSOF GPS 
+    // @Description: What baud rate to configure the first GSOF GPS to
+    // @Values: 7:115k, 11:230k
+    // @User: Advanced
+    AP_GROUPINFO("_GSOF_BAUD1", 32, AP_GPS, _gsof_baud[0], 7),
+
+#if GPS_MAX_RECEIVERS > 1
+    // @Param: _GSOF_BAUD2
+    // @DisplayName: Baud rate for the second GSOF GPS
+    // @Description: What baud rate to configure the second GSOF GPS to
+    // @Values: 7:115k, 11:230k
+    // @User: Advanced
+    AP_GROUPINFO("_GSOF_BAUD2", 33, AP_GPS, _gsof_baud[1], 7),
+#endif // GPS_MAX_RECEIVERS > 1
+#endif //AP_GPS_GSOF_ENABLED
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -607,6 +607,7 @@ protected:
     AP_Int8 _blend_mask;
     AP_Int16 _driver_options;
     AP_Int8 _primary;
+    AP_Int8 _gsof_baud[GPS_MAX_RECEIVERS];
 #if HAL_ENABLE_DRONECAN_DRIVERS
     AP_Int32 _node_id[GPS_MAX_RECEIVERS];
     AP_Int32 _override_node_id[GPS_MAX_RECEIVERS];

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -55,16 +55,29 @@ private:
         FREQ_50_HZ = 15,
         FREQ_100_HZ = 16,
     };
+    
+    // A subset of the supported baud rates in the GSOF protocol that are useful.
+    // These values are not documented in the API.
+    // The matches the GPS_GSOF_BAUD parameter.
+    enum class HW_Baud {
+        BAUD115K = 0x07,
+        BAUD230K = 0x0B,
+    };
 
     bool parse(const uint8_t temp) WARN_IF_UNUSED;
     bool process_message() WARN_IF_UNUSED;
-    void requestBaud(const uint8_t portindex);
 
     // Send a request to the GPS to enable a message type on the port at the specified rate.
     // Note - these request functions currently ignore the ACK from the device.
     // If the device is already sending serial traffic, there is no mechanism to prevent conflict.
     // According to the manufacturer, the best approach is to switch to ethernet.
     void requestGSOF(const uint8_t messageType, const HW_Port portIndex, const Output_Rate rateHz);
+
+    // Send a request to the GPS to configure its baud rate on a certain (serial) port.
+    // Note - these request functions currently ignore the ACK from the device.
+    // If the device is already sending serial traffic, there is no mechanism to prevent conflict.
+    // According to the manufacturer, the best approach is to switch to ethernet.
+    void requestBaud(const HW_Port portIndex, const HW_Baud baudRate);
 
     double SwapDouble(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
     float SwapFloat(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;


### PR DESCRIPTION
## Overview
* Add in ability to support 115k and 230k baud rates through AP params
* Default behavior for baud rate is preserved at 115k
* Removed support (bug?) for trying to output GSOF on the NMEA port
* Modified function signature to take in port as a param
* Added a baud rate validation helper to validate the AP param is a supported baud rate



## Demo
You can see in the screenshot, the config UI shows the device is now configured on COM2 for 230k, which is the desired behavior when the user sets the parameter correctly. COM2 is the TTL level serial port that users typically connect to a flight controller. 
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/b47a185a-e891-4055-abe3-eddeb245519e)

## Preserving behavior
Old behavior was to configure the NTRIP Caster 3 and COM1 (RS232) for GSOF output, which wasn't useful on most drones. This breaks that behavior. I think it's obvious no one was using this. 

## Testing
I've tested this on my bench with a PX1 connected to SITL. The configuration at both baud rates works, and this improves the default port assignment to work with the right COM port at TTL level logic. The validity checks for GSOF pass in SITL. 

## To decide before merge
One thing to discuss is how this parameter should interact with `GPS_DRV_OPTIONS`. Perhaps this approach:
```
@Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200. Ignored on GSOF; use GPS_GSOF_BAUDn instead,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL
```

## Future work
In a future PR, I will implement the support for checking acknowledgment of commands. This is blocked due to some usage issues in the Linux serial HAL.  
