### PR TITLE
gcs method for checking connection to gcs

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -250,6 +250,7 @@ singleton GCS method frame_type MAV_TYPE'enum
 singleton GCS method get_hud_throttle int16_t
 singleton GCS method sysid_myggcs_last_seen_time_ms uint32_t
 singleton GCS method sysid_myggcs_last_seen_time_ms rename last_seen
+singleton GCS method is_connected boolean
 
 singleton GCS method get_high_latency_status boolean
 singleton GCS method get_high_latency_status depends HAL_HIGH_LATENCY2_ENABLED == 1

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1150,7 +1150,18 @@ public:
     }
     // called when valid traffic has been seen from our GCS
     void sysid_myggcs_seen(uint32_t seen_time_ms) {
+        if (seen_time_ms > _sysid_mygcs_last_seen_time_ms) {
+            _sysid_mygcs_seen_freq_hz = 1000.f / (seen_time_ms - _sysid_mygcs_last_seen_time_ms);
+        } else {
+            _sysid_mygcs_seen_freq_hz = 1.f;
+        }
         _sysid_mygcs_last_seen_time_ms = seen_time_ms;
+    }
+
+    bool is_connected() {
+        const int connection_timeout = 5000;
+        return (AP_HAL::millis() - _sysid_mygcs_last_seen_time_ms < connection_timeout
+                && _sysid_mygcs_seen_freq_hz >= 0.95);
     }
 
     void send_to_active_channels(uint32_t msgid, const char *pkt);
@@ -1280,6 +1291,7 @@ private:
 
     // time we last saw traffic from our GCS
     uint32_t _sysid_mygcs_last_seen_time_ms;
+    float _sysid_mygcs_seen_freq_hz;
 
     void service_statustext(void);
 #if HAL_MEM_CLASS <= HAL_MEM_CLASS_192 || CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
the is_connected method returns false if packets from the gcs did not arrive for 5 seconds and is return true when packets arrive more than once a second

used in custom version of dead reckoning script, tested on real hardware