### PR TITLE
autotest: add tests for NAV_CONTROLLER_OUTPUT 

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10489,6 +10489,33 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.reboot_sitl()  # unlock home position
 
+    def NAV_CONTROLLER_OUTPUT(self):
+        '''tests for NAV_CONTROLLER_OUTPUT message'''
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, 100, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, -100, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.set_current_waypoint(1)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "target_bearing": 45,
+            },
+            poll=True,
+            epsilon=1,
+            drain_mav=True,
+        )
+        self.set_current_waypoint(2)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "target_bearing": 315,
+            },
+            poll=True,
+            epsilon=1,
+            drain_mav=True,
+        )
+
     def tests2b(self):  # this block currently around 9.5mins here
         '''return list of all tests'''
         ret = ([
@@ -10558,6 +10585,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.MAV_CMD_SET_EKF_SOURCE_SET,
             self.MAV_CMD_NAV_TAKEOFF,
             self.MAV_CMD_NAV_TAKEOFF_command_int,
+            self.NAV_CONTROLLER_OUTPUT,
         ])
         return ret
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5240,6 +5240,32 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         home = self.home_position_as_mav_location()
         self.assert_distance(home, adsb_vehicle_loc, 0, 10000)
 
+    def NAV_CONTROLLER_OUTPUT(self):
+        '''tests for NAV_CONTROLLER_OUTPUT message'''
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, 100, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, -100, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.set_current_waypoint(1)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "nav_bearing": 45,
+                "target_bearing": 45,
+            },
+            epsilon=1,
+            poll=True,
+        )
+        self.set_current_waypoint(2)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "nav_bearing": -45,
+            },
+            epsilon=1,
+            poll=True,
+        )
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -5345,6 +5371,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TerrainRally,
             self.MAV_CMD_NAV_LOITER_UNLIM,
             self.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+            self.NAV_CONTROLLER_OUTPUT,
         ])
         return ret
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6614,6 +6614,31 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_FENCE_ENABLE, p1=0)
         self.assert_fence_disabled()
 
+    def NAV_CONTROLLER_OUTPUT(self):
+        '''tests for NAV_CONTROLLER_OUTPUT message'''
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, 100, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, -100, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.set_current_waypoint(1)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "target_bearing": 45,
+            },
+            epsilon=1,
+            poll=True,
+        )
+        self.set_current_waypoint(2)
+        self.assert_received_message_field_values(
+            "NAV_CONTROLLER_OUTPUT", {
+                "target_bearing": 315,
+            },
+            epsilon=1,
+            poll=True,
+        )
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -6697,6 +6722,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.MAV_CMD_DO_SET_REVERSE,
             self.MAV_CMD_GET_HOME_POSITION,
             self.MAV_CMD_DO_FENCE_ENABLE,
+            self.NAV_CONTROLLER_OUTPUT,
         ])
         return ret
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3901,7 +3901,11 @@ class TestSuite(ABC):
                                              poll=False,
                                              timeout=None,
                                              check_context=False,
+                                             drain_mav=False,
                                              ):
+        if drain_mav:
+            self.drain_mav()
+
         if poll:
             self.poll_message(message)
         m = self.assert_receive_message(


### PR DESCRIPTION
We should really canonicalise here, probably on the -180 to 180 range

The fields are int16_t degrees

 - Plane uses -180 to 180
 - Copter uses 0-360
 - Sub uses... well, that's going to take some digging
 - tracker uses 0-360
 - Rover uses 0-360
 - PX4 AutoPilot uses -180 to 180
 - QGC doesn't use NAV_CONTROLLER_OUTPUT
 - MissionPlanner uses 0-360 internally
 - MAVProxy just throws the values at the trig functions when drawing lines
   - console is inconsistent between Copter / Plane, one saying -45 the other 315
