### PR TITLE
AP_HAL_ChibiOS: RADIX2HD Probe external I2C compasses (4.4 backport)

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
@@ -166,6 +166,9 @@ IMU BMI270 SPI:bmi270 ROTATION_ROLL_180
 
 BARO DPS310 I2C:0:0x76
 
+# probe external compasses (same bus as internal)
+define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+
 # filesystem setup on sdcard
 define HAL_OS_FATFS_IO 1
 define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"


### PR DESCRIPTION
Backport of  #24724 to 4.4