### PR TITLE
AP_RCTelemetry: throttle CRSF request RX device info messages

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -468,7 +468,11 @@ void AP_CRSF_Telem::process_packet(uint8_t idx)
                 GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,"%s: RX device ping failed", get_protocol_string());
             } else {
                 calc_device_ping(AP_RCProtocol_CRSF::CRSF_ADDRESS_CRSF_RECEIVER);
-                GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,"%s: requesting RX device info", get_protocol_string());
+                uint32_t tnow_ms = AP_HAL::millis();
+                if ((tnow_ms - _crsf_version.last_request_info_ms) > 5000) {
+                    _crsf_version.last_request_info_ms = tnow_ms;
+                    GCS_SEND_TEXT(MAV_SEVERITY_DEBUG,"%s: requesting RX device info", get_protocol_string());
+                }
             }
             break;
         case DEVICE_PING:

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -335,6 +335,7 @@ private:
         bool use_rf_mode;
         AP_RCProtocol_CRSF::ProtocolType protocol;
         bool pending = true;
+        uint32_t last_request_info_ms;
     } _crsf_version;
 
     struct {


### PR DESCRIPTION
I'm not sure you'll like it, but I like it a lot and hence dare to suggest:

There are situations in which one wants to use CRSF, but only with one wire (receiver Tx -> ardupilot Rx), without the additional telemetry wire (receiver Rx <- ardupilot Tx). Examples would be companions or third-party receivers. In such cases the RCTelemetry library sends 50 statustest messages at 2 Hz rate, i.e., for a total of 25 seconds, before it concludes it can stop requesting a CRSF message. The PR here throttles the sending of these statustext messages to one every 5 seconds, which should be really sufficient to have the full attention of the user.

Alternatives: One could add an option which either supresses sending these messages (similar to RC_Channels::Option::SUPPRESS_CRSF_MESSAGE) or which disables the requesting. I think the simple throttling is preferable since it doesn't need user interactions nor any documentation.

The code change has been massively tested for a long while on a copter.

Behavior before this PR:

![crsfping-before](https://github.com/ArduPilot/ardupilot/assets/6089567/a363f245-7f9c-4f81-bbff-ec9f5afc2ad2)

Behavior after this PR:

![crsfping-after](https://github.com/ArduPilot/ardupilot/assets/6089567/b9d26602-8ded-490e-9d8f-e1e621b0c0d7)

