### PR TITLE
AP_Arming: Reduce response time when checks go from true to false

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -304,6 +304,9 @@ private:
     uint32_t last_prearm_display_ms;  // last time we send statustexts for prearm failures
     bool running_arming_checks;  // true if the arming checks currently being performed are being done because the vehicle is trying to arm the vehicle
     
+    bool last_prearm_checks_result; // result of last prearm check
+    bool report_immediately; // set to true when check goes from true to false, to trigger immediate report
+
     void update_arm_gpio();
 };
 


### PR DESCRIPTION
That's another one where I'm not sure you'll like it, but I like it a lot and hence dare to suggest:

The prearmchecks code in AP_Arming serve two functions, first to handle the prearmchecks at startup and report on this and second for continously checkingy health of some components. An example of the latter is the Gremsy gimbal driver, which checks for the gimbal failure flags as well as for the presence of a response from the gimbal: https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mount/AP_Mount_Gremsy.cpp#L108-L122. These tests can go from passed to fail anytime later during continious operation, and this is then reported by the AP_Arming library.

However, the AP_Arming library reports in 30 second time slices, which means that the report can be sent out up to 30 seconds after the issue actually happened. This isn't most desirable, but one rather would want a health failure to be reported ASAP. 

This PR modifies the time slicing code, such that when the prearm state goes from passed to fail it reports nearly immedately. There is a short delay of 0.75 seconds in order to prevent report storms in case multiple health checks go from passed to fail in a short period of time (which also menas that only the last is reported).

The code change has been flown for a long while on a copter.
