### PR TITLE
Copter: fix 440-beta1 release notes

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -232,7 +232,6 @@ Changes from 4.3.6
         - Touchdown detection threshold is configurable (see PLDP_THRESH)
     - Position controller angle max adjusted inflight with CH6 Tuning knob (set TUNE=59)
     - Surface tracking time constant allows tuning response (see SURFTRAK_TC)
-    - Takeoff throttle max is configurable (see TKOFF_TH_MAX)
     - Throttle-Gain boost increases attitude control gains when throttle high (see ATC_THR_G_BOOST)
     - Waypoint navigation cornering acceleration is configurable (see WPNAV_ACCEL_C)
     - WeatherVane into the wind in Auto and Guided modes (see WVANE_ENABLE)


### PR DESCRIPTION
As reported in [this thread](https://discuss.ardupilot.org/t/copter-4-4-1-released/107005/3), the TKOFF_TH_MAX feature was not actually included in Copter-4.4.0 so we need to fix the release notes.