### PR TITLE
AP_Scripting: add checksum of running and loaded scripts with arming check

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -18,6 +18,7 @@
 #include "AP_Filesystem_config.h"
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/Util.h>
+#include <AP_Math/AP_Math.h>
 
 static AP_Filesystem fs;
 
@@ -285,6 +286,37 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
     buf[i] = '\0';
     return true;
 }
+
+// run crc32 over file with given name, returns true if successful
+bool AP_Filesystem::crc32(const char *fname, uint32_t& checksum)
+{
+    // Open file in readonly mode
+    int fd = open(fname, O_RDONLY);
+    if (fd == -1) {
+        return false;
+    }
+
+    // Buffer to store data temporarily
+    const ssize_t buff_len = 64;
+    uint8_t buf[buff_len];
+
+    // Read into buffer and run crc
+    ssize_t read_size;
+    do {
+        read_size = read(fd, buf, buff_len);
+        if (read_size == -1) {
+            // Read error, note that we have changed the checksum value in this case
+            close(fd);
+            return false;
+        }
+        checksum = crc_crc32(checksum, buf, MIN(read_size, buff_len));
+    } while (read_size > 0);
+
+    close(fd);
+
+    return true;
+}
+
 
 #if AP_FILESYSTEM_FORMAT_ENABLED
 // format filesystem

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -108,6 +108,9 @@ public:
     // returns null-terminated string; cr or lf terminates line
     bool fgets(char *buf, uint8_t buflen, int fd);
 
+    // run crc32 over file with given name, returns true if successful
+    bool crc32(const char *fname, uint32_t& checksum) WARN_IF_UNUSED;
+
     // format filesystem.  This is async, monitor get_format_status for progress
     bool format(void);
 

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -41,6 +41,8 @@ public:
 
     void init(void);
 
+    void update();
+
     bool enabled(void) const { return _enable != 0; };
     bool should_run(void) const { return enabled() && !_stop; }
 
@@ -134,15 +136,23 @@ private:
     bool repl_start(void);
     void repl_stop(void);
 
-    void load_script(const char *filename); // load a script from a file
-
     void thread(void); // main script execution thread
+
+    // Check if DEBUG_OPTS bit has been set to save current checksum values to params
+    void save_checksum();
+
+    // Mask down to 23 bits for comparison with parameters, this the length of the a float mantissa, to deal with the float transport of parameters over MAVLink
+    // The full range of uint32 integers cannot be represented by a float.
+    const uint32_t checksum_param_mask = 0x007FFFFF;
 
     AP_Int8 _enable;
     AP_Int32 _script_vm_exec_count;
     AP_Int32 _script_heap_size;
     AP_Int8 _debug_options;
     AP_Int16 _dir_disable;
+    AP_Int32 _required_loaded_checksum;
+    AP_Int32 _required_running_checksum;
+
 
     bool _thread_failed; // thread allocation failed
     bool _init_failed;  // true if memory allocation failed

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -36,6 +36,10 @@ HAL_Semaphore lua_scripts::error_msg_buf_sem;
 uint8_t lua_scripts::print_error_count;
 uint32_t lua_scripts::last_print_ms;
 
+uint32_t lua_scripts::loaded_checksum;
+uint32_t lua_scripts::running_checksum;
+HAL_Semaphore lua_scripts::crc_sem;
+
 lua_scripts::lua_scripts(const AP_Int32 &vm_steps, const AP_Int32 &heap_size, const AP_Int8 &debug_options, struct AP_Scripting::terminal_s &_terminal)
     : _vm_steps(vm_steps),
       _debug_options(debug_options),
@@ -198,6 +202,19 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
     new_script->name = filename;
     new_script->lua_ref = luaL_ref(L, LUA_REGISTRYINDEX);   // cache the reference
     new_script->next_run_ms = AP_HAL::millis64() - 1; // force the script to be stale
+
+    // Get checksum of file
+    uint32_t crc = 0;
+    if (AP::FS().crc32(filename, crc)) {
+        // Record crc of this script
+        new_script->crc = crc;
+        {
+            // Apply crc to checksum of all scripts
+            WITH_SEMAPHORE(crc_sem);
+            loaded_checksum ^= crc;
+            running_checksum ^= crc;
+        }
+    }
 
     return new_script;
 }
@@ -391,6 +408,13 @@ void lua_scripts::remove_script(lua_State *L, script_info *script) {
     }
     _heap.deallocate(script->name);
     _heap.deallocate(script);
+
+    {
+        // Remove from running checksum
+        WITH_SEMAPHORE(crc_sem);
+        running_checksum ^= script->crc;
+    }
+
 }
 
 void lua_scripts::reschedule_script(script_info *script) {
@@ -604,6 +628,19 @@ void lua_scripts::run(void) {
         error_msg_buf = nullptr;
     }
     error_msg_buf_sem.give();
+}
+
+// Return the file checksums of running and loaded scripts
+uint32_t lua_scripts::get_loaded_checksum()
+{
+    WITH_SEMAPHORE(crc_sem);
+    return loaded_checksum;
+}
+
+uint32_t lua_scripts::get_running_checksum()
+{
+    WITH_SEMAPHORE(crc_sem);
+    return running_checksum;
 }
 
 #endif  // AP_SCRIPTING_ENABLED

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -54,6 +54,7 @@ public:
         SUPPRESS_SCRIPT_LOG = 1U << 2,
         LOG_RUNTIME = 1U << 3,
         DISABLE_PRE_ARM = 1U << 4,
+        SAVE_CHECKSUM = 1U << 5,
     };
 
 private:
@@ -64,6 +65,7 @@ private:
     typedef struct script_info {
        int lua_ref;          // reference to the loaded script object
        uint64_t next_run_ms; // time (in milliseconds) the script should next be run at
+       uint32_t crc;         // crc32 checksum
        char *name;           // filename for the script // FIXME: This information should be available from Lua
        script_info *next;
     } script_info;
@@ -125,6 +127,11 @@ private:
     static uint32_t last_print_ms;
     int current_ref;
 
+    // XOR of crc32 of running scripts
+    static uint32_t loaded_checksum;
+    static uint32_t running_checksum;
+    static HAL_Semaphore crc_sem;
+
 public:
     // must be static for use in atpanic, public to allow bindings to issue none fatal warnings
     static void set_and_print_new_error_message(MAV_SEVERITY severity, const char *fmt, ...) FMT_PRINTF(2,3);
@@ -134,6 +141,10 @@ public:
 
     // get semaphore for above error buffer
     static AP_HAL::Semaphore* get_last_error_semaphore() { return &error_msg_buf_sem; }
+
+    // Return the file checksums of running and loaded scripts
+    static uint32_t get_loaded_checksum();
+    static uint32_t get_running_checksum();
 
 };
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -22,6 +22,7 @@
 #include <AP_IOMCU/AP_IOMCU.h>
 extern AP_IOMCU iomcu;
 #endif
+#include <AP_Scripting/AP_Scripting.h>
 
 #define SCHED_TASK(func, rate_hz, max_time_micros, prio) SCHED_TASK_CLASS(AP_Vehicle, &vehicle, func, rate_hz, max_time_micros, prio)
 
@@ -562,9 +563,7 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if HAL_EFI_ENABLED
     SCHED_TASK_CLASS(AP_EFI,       &vehicle.efi,            update,                   50, 200, 250),
 #endif
-#if HAL_INS_ACCELCAL_ENABLED
     SCHED_TASK(one_Hz_update,                                                         1, 100, 252),
-#endif
 #if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
     SCHED_TASK(check_motor_noise,      5,     50, 252),
 #endif
@@ -944,6 +943,14 @@ void AP_Vehicle::one_Hz_update(void)
         }
 #endif
     }
+
+#if AP_SCRIPTING_ENABLED
+    AP_Scripting *scripting = AP_Scripting::get_singleton();
+    if (scripting != nullptr) {
+        scripting->update();
+    }
+#endif
+
 }
 
 void AP_Vehicle::check_motor_noise()


### PR DESCRIPTION
This allows a arming check that the correct scripts are running and loaded preventing a missing SD card from meaning critical scripts are missing. 

This does a crc32 on the each file and XOR's the result for multiple files. The crc caculation gives the same result per file as the `crc32` command on linux and pages such as this one:  https://emn178.github.io/online-tools/crc32_checksum.html

However, because of float parameter transport we can't actually set the CRC we want into parameters, so this is still a draft. 

We could move to a 16 bit checksum, or add a "lock in scripts" command to set the current value to the parameters.

This is also very much a pass/fail arming check, we can only tell that the check sum failed, we cannot tell which script is missing. 

I the future this would allow a fail safe action to be taken if the running scripts do not match the expected checksum.