### PR TITLE
AP_GPS: Increase robustness of GSOF configuration with ACK/NACK handling and retry logic

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -108,7 +108,7 @@ private:
             ENDTX
         };
 
-        State state;
+        State state = State::STARTTX;
 
         uint8_t status;
         uint8_t packettype;
@@ -142,6 +142,6 @@ private:
     uint8_t gsofmsgreq_index;
     const uint8_t gsofmsgreq[5] = {1,2,8,9,12};
     bool is_baud_configured {false};
-    bool is_configured {false};
+    bool gsof_configured {false};
 };
 #endif

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -16,6 +16,7 @@
 //
 //  Trimble GPS driver for ArduPilot.
 //	Code by Michael Oborne
+//  Maintained by Ryan Friedman
 //  https://receiverhelp.trimble.com/oem-gnss/index.html#Welcome.html?TocPath=_____1
 
 #pragma once
@@ -56,17 +57,35 @@ private:
         FREQ_100_HZ = 16,
     };
 
+    // A subset of the supported baud rates in the GSOF protocol that are useful.
+    // These values are not documented in the API.
+    // The matches the GPS_GSOF_BAUD parameter.
+    enum class HW_Baud {
+        BAUD115K = 0x07,
+        BAUD230K = 0x0B,
+    };
+
     bool parse(const uint8_t temp) WARN_IF_UNUSED;
     bool process_message() WARN_IF_UNUSED;
+    // Send a request to the GPS to configure its baud rate on a certain (serial) port.
+    // Note - these request functions expect an ACK from the device.
+    // If the device is already sending serial traffic, there is no mechanism to prevent this.
+    // According to the manufacturer, the best approach is to switch to ethernet. 
+    // Use one port for configuration data and another for stream data to prevent conflict.
+    // Because there is only one TTL serial interface exposed, the approach here is using retry logic.
+    bool requestBaud(const HW_Port portIndex, const HW_Baud baudRate) WARN_IF_UNUSED;
+    // Send a request to the GPS to enable a message type on the port.
+    bool requestGSOF(const uint8_t messageType, const HW_Port portIndex, const Output_Rate rateHz) WARN_IF_UNUSED;
+    
+    bool disableOutput(const HW_Port portIndex) WARN_IF_UNUSED;
 
-    // Send a request to the GPS to set the baud rate on the specified port.
-    // Note - these request functions currently ignore the ACK from the device.
-    // If the device is already sending serial traffic, there is no mechanism to prevent conflict.
-    // According to the manufacturer, the best approach is to switch to ethernet.
-    void requestBaud(const HW_Port portIndex);
-    // Send a request to the GPS to enable a message type on the port at the specified rate.
-    void requestGSOF(const uint8_t messageType, const HW_Port portIndex, const Output_Rate rateHz);
+    // Generic handler for sending command and checking return code.
+    // Make sure to disableOutput() before doing configuration.
+    bool requestResponse(const uint8_t* buf, const uint8_t len) WARN_IF_UNUSED;
 
+    static void populateChecksum(uint8_t* buf, const uint8_t len);
+    void populateOutgoingTransNumber(uint8_t* buf);
+    
     double SwapDouble(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
     float SwapFloat(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
     uint32_t SwapUint32(const uint8_t* src, const uint32_t pos) const WARN_IF_UNUSED;
@@ -102,12 +121,27 @@ private:
         uint8_t checksumcalc;
     } msg;
 
+
     static const uint8_t STX = 0x02;
     static const uint8_t ETX = 0x03;
+    static const uint8_t ACK = 0x06;
+    static const uint8_t NACK = 0x15;
 
-    uint8_t packetcount;
+    // How long to wait from sending configuration data for a response.
+    // This assumes delay is the same regardless of baud rate.
+    static const uint8_t configuration_wait_time_ms {5};
+    // How many attempts to attempt configuration. 
+    // Raising this makes the initialization more immune to data conflicts with streamed data.
+    // Raising it too high will trigger the watchdog.
+    // Lowering this makes the driver quicker to return from initialization calls.
+    static const uint8_t configuration_attempts {3};
+
+    // The counter for number of outgoing packets
+    uint8_t packetOutboundTransNumber;
     uint32_t gsofmsg_time;
     uint8_t gsofmsgreq_index;
     const uint8_t gsofmsgreq[5] = {1,2,8,9,12};
+    bool is_baud_configured {false};
+    bool is_configured {false};
 };
 #endif


### PR DESCRIPTION
# Purpose

This PR implements robust configuration in the GSOF driver. The core design change here is to read responses to configuration commands, and check they were successful.

The DCOL commands have an ACK/NACK return code (single byte). During configuration, the first step now is to disable all data channels (streaming) so they don't conflict with configuration data. 

Next, the same original commands are run as before, except this time a response is attempted to be read before continuing. 

Even though all data channels are disabled before configuration,  as the requestGSOF command starts going through each request, the unit starts sending data again. The only way I could get around this is by adding retry logic. 

While doing this, I broke apart the checksum and transaction number into separate utilities to reduce code duplication.

Previous behaivor was to not check for a response. The GPS device was assumed to be working. 

Finally, the time to configure the GSOF driver was cut down by an order of magnitude: from 601 milliseconds to 41 milliseconds. In the event that the driver fails in flight, and ArduPilot wants to cycle through all the bauds, this could allow significantly quicker recovery time. 

Solves #25484.

# Changes

* Refactor checksum to unique function
* Clear uart before reading data
* Add ack/nack check
* Implement output disable before requesting GSOF data
* Improve debug message to have line number
* Use debug in more code
 
# Demo

See attached screenshot. All configuration responses result in ACK, which means they are valid.
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/5fbd2251-6396-408f-af28-c5ed91d6ea19)

# Conflict Resolution

You can see here, a configuration item was attempted while existing data was coming in the UART. The ACK shows up at the end. 
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/454bf8ac-9533-4582-a0e2-398340764612)

In this case, the new behavior will do a retry of the config slightly later, since the current serial read will fail the request/response routine because more than one byte will be read.

# Testing Performed

* Run configuration 10 times on device with data already enabled, and ensure it configures successfully each time.
* Verify retry logic caused by conflict works

## Autotest logic

Without changes to the simulator, ` test.CopterTests2b.GPSTypes` will fail because it doesn't support reading data. Currently, SITL swallows all the bytes:
https://github.com/ArduPilot/ardupilot/blob/0f0bc78de9d33bb599dc4d73211b4493d15f5ae6/libraries/SITL/SIM_GPS.cpp#L1605-L1610

There's a reason this is probably the case - active configuration may break data replay. 
