### PR TITLE
Copter: 4.4.3 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.4.3 14-Nov-2023
+Changes from 4.4.3-beta1
+1) AP_GPS: correct uBlox M10 configuration on low flash boards
+------------------------------------------------------------------
 Copter 4.4.3-beta1 07-Nov-2023
 Changes from 4.4.2
 1) Autopilot related enhancements and fixes

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.4.3-beta1"
+#define THISFIRMWARE "ArduCopter V4.4.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,3,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,4,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,5 @@
-Release 4.4.3-beta1 4th November 2023
--------------------------------------
+Release 4.4.3 14th November 2023
+--------------------------------
 
 Changes from 4.4.2:
 
@@ -14,6 +14,7 @@ Changes from 4.4.2:
  - protect against notch filtering with uninitialised RPM source in ESC telemetry
  - allow lua scripts to populate full ESC telemetry data
  - added YJUAV_A6SE_H743 support
+ - fixed uBlox M10 GPS support on boards with 1M flash
 
 Release 4.4.2 23th October 2023
 -------------------------------

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.4.3-beta1"
+#define THISFIRMWARE "ArduPlane V4.4.3"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,3,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,4,3,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,7 +1,11 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.4.0-beta10 14-Nov-2023
+Changes from 4.4.0-beta9
+1) AP_GPS: correct uBlox M10 configuration on low flash boards
+------------------------------------------------------------------
 Rover 4.4.0-beta9 07-Nov-2023
-Changes from 4.4.2
+Changes from 4.4.0-beta8
 1) Autopilot related enhancements and fixes
     - BETAFTP-F405 board configuration fixes
     - CubeOrangePlus-BG edition ICM45486 IMU setup fixed

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.4.0-beta9"
+#define THISFIRMWARE "ArduRover V4.4.0-beta10"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+8
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+9
 
 #define FW_MAJOR 4
 #define FW_MINOR 4

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -931,7 +931,6 @@ uint8_t AP_GPS_UBLOX::config_key_size(ConfigKey key) const
  */
 int8_t AP_GPS_UBLOX::find_active_config_index(ConfigKey key) const
 {
-#if GPS_MOVING_BASELINE
     if (active_config.list == nullptr) {
         return -1;
     }
@@ -940,7 +939,7 @@ int8_t AP_GPS_UBLOX::find_active_config_index(ConfigKey key) const
             return (int8_t)i;
         }
     }
-#endif
+
     return -1;
 }
 


### PR DESCRIPTION
This is the Copter-4.4.3 release which is the same as the 4.4.3-beta1 with one addition PR added:

- https://github.com/ArduPilot/ardupilot/pull/25477

The full list of commits can be seen int he 4.4.3-beta1 and 4.4.3 columns of [this project](https://github.com/ArduPilot/ardupilot/projects/27).