### PR TITLE
SRV_Channel: fix RCInxScaled when input is range (instead of angle)

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -60,7 +60,15 @@ void SRV_Channel::output_ch(void)
                 int16_t radio_in = c->get_radio_in();
                 if (passthrough_mapped) {
                     if (rc().has_valid_input()) {
-                        radio_in = pwm_from_angle(c->norm_input_dz() * 4500);
+                        switch (c->get_type()) {
+                        case RC_Channel::ControlType::ANGLE:
+                            radio_in = pwm_from_angle(c->norm_input_dz() * 4500);
+                            break;
+                        case RC_Channel::ControlType::RANGE:
+                            // convert RC normalised input from -1 to +1 range to 0 to +1 and output as range
+                            radio_in = pwm_from_range((c->norm_input_ignore_trim() + 1.0) * 0.5 * 4500);
+                            break;
+                        }
                     } else {
                         // no valid input.  If we are in radio
                         // failsafe then go to trim values (if


### PR DESCRIPTION
This resolves a bug in the servo output when the SERVOx_FUNCTION = RCIn**X**Scaled and the RCInput is a range instead of an angle.  For example on Copter the problem occurs when RCx_FUNCTION = RCIn3Scaled..  Details of the issue are explained in issue https://github.com/ArduPilot/ardupilot/issues/25524 and is also [discussed here](https://discuss.ardupilot.org/t/release-rover-4-4-as-stable-ok/106080/6).

In current master the PWM output will always be between SERVOx_TRIM (e.g. 1500) and SERVOx_MAX (e.g. 2000).  After this change the PWM output is correctly in the SERVOx_MIN (e.g. 1000) to SERVOx_MAX (e.g. 2000) range.

I've tested this fairly carefully including before and after tests.

Test1 | Fn=RCIN3Scaled | RC3_TRIM=1106
-- | -- | --
RC3 input | RC9 output (before) | RC9 output (after)
1106 | 1500 | **1100**
1500 | 1683 | **1482**
1930 | 1900 | 1900
FS | 1500 | 1500
  |   |  
**Test2** | **Fn=RCIN3Scaled** | **RC3_TRIM=1500**
RC3 input | RC9 output (before) | RC9 output (after)
1106 | 1100 | 1100
1500 | 1500 | **1482**
1930 | 1900 | 1900
FS | 1500 | 1500
  |   |  
**Test3** | **Fn=RCIN2Scaled** | **RC2_TRIM=1520**
RC2 input | RC9 output | RC9 output (after)
1093 | 1100 | 1100
1520 | 1500 | 1500
1936 | 1900 | 1900
FS | 1500 | 1500
  |   |  
**Test4** | **MP Servo/Relay Page** |  
Input | RC9 output (before) | RC9 output (after)
1000 | 1100 | 1100
1500 | 1500 | 1500
2000 | 1900 | 1900

I've also tested that the failsafe behaviour is unchanged.  Namely in case of an RC failsafe, the PWM output stays unchanged OR moves to SERVOx_TRIM depending upon the SERVO_RC_FS_MSK parameter bits.

The above tests were done with these parameters

**Param** | **Value**
-- | --
RC3_MIN | 1106
RC3_MAX | 1930
RC3_TRIM | 1106
RC3_DZ | 30
RC2_MIN | 1095
RC2_MAX | 1934
RC2_TRIM | 1520
RC2_DZ | 20
SERVO9_MIN | 1100
SERVO9_MAX | 1900
SERVO9_TRIM | 1500


