### PR TITLE
Add HAL config to provide GPIO that reflects arm/disarm to control RF power modules

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1681,7 +1681,9 @@ bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
         }
     }
 #endif
-
+#if defined(HAL_ARM_GPIO_PIN)
+    update_arm_gpio();
+#endif
     return armed;
 }
 
@@ -1721,9 +1723,20 @@ bool AP_Arming::disarm(const AP_Arming::Method method, bool do_disarm_checks)
         }
     }
 #endif
-
+#if defined(HAL_ARM_GPIO_PIN)
+    update_arm_gpio();
+#endif
     return true;
 }
+
+#if defined(HAL_ARM_GPIO_PIN)
+void AP_Arming::update_arm_gpio()
+{
+    if (!AP_BoardConfig::arming_gpio_disabled()) {
+        hal.gpio->write(HAL_ARM_GPIO_PIN, HAL_ARM_GPIO_POL_INVERT ? !armed : armed);
+    }
+}
+#endif
 
 void AP_Arming::send_arm_disarm_statustext(const char *str) const
 {

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -303,6 +303,8 @@ private:
 
     uint32_t last_prearm_display_ms;  // last time we send statustexts for prearm failures
     bool running_arming_checks;  // true if the arming checks currently being performed are being done because the vehicle is trying to arm the vehicle
+    
+    void update_arm_gpio();
 };
 
 namespace AP {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -289,7 +289,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Board options
     // @Description: Board specific option flags
-    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters, 3:Enable Debug Pins, 4:Unlock flash on reboot, 5:Write protect firmware flash on reboot, 6:Write protect bootloader flash on reboot, 7:Skip board validation
+    // @Bitmask: 0:Enable hardware watchdog, 1:Disable MAVftp, 2:Enable set of internal parameters, 3:Enable Debug Pins, 4:Unlock flash on reboot, 5:Write protect firmware flash on reboot, 6:Write protect bootloader flash on reboot, 7:Skip board validation, 8:Disable board arming gpio output change on arm/disarm
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 19, AP_BoardConfig, _options, HAL_BRD_OPTIONS_DEFAULT),
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -155,8 +155,18 @@ public:
         UNLOCK_FLASH = (1<<4),
         WRITE_PROTECT_FLASH = (1<<5),
         WRITE_PROTECT_BOOTLOADER = (1<<6),
-        SKIP_BOARD_VALIDATION = (1<<7)
+        SKIP_BOARD_VALIDATION = (1<<7),
+        DISABLE_ARMING_GPIO = (1<<8)
     };
+
+    //return true if arming gpio output is disabled
+    static bool arming_gpio_disabled(void) {
+        return _singleton?(_singleton->_options & DISABLE_ARMING_GPIO)!=0:1;
+    }
+    
+#ifndef HAL_ARM_GPIO_POL_INVERT
+#define HAL_ARM_GPIO_POL_INVERT 0
+#endif
 
     // return true if ftp is disabled
     static bool ftp_disabled(void) {


### PR DESCRIPTION
Hwdef would include define of HAL_ARM_GPIO_PIN <gpio pin number> to change pin level  on arm/disarm...IF... BRD_OPTIONS bit 8 (Disable arm gpio) is not set

Polarity can be changed using HAL_ARM_GIPO_POL_INVERT (1 to change pin output polarity)   default if not defined is dont change

it is the bootloader's responsibility to set the initial gpio state.

this should be also controllable by the user, if desired, with a relay assignment

tested using a board's blue led