### PR TITLE
AP_RangeFinder: Move to a process that uses maximum value acquisition

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_JRE_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_JRE_Serial.cpp
@@ -53,8 +53,6 @@ bool AP_RangeFinder_JRE_Serial::get_reading(float &reading_m)
     uint16_t valid_count = 0;   // number of valid readings
     uint16_t invalid_count = 0; // number of invalid readings
     float sum = 0;
-    // max distance the sensor can reliably measure - read from parameters
-    const int16_t distance_cm_max = max_distance_cm();
 
     // read a maximum of 8192 bytes per call to this function:
     uint16_t bytes_available = MIN(uart->available(), 8192U);
@@ -136,7 +134,7 @@ bool AP_RangeFinder_JRE_Serial::get_reading(float &reading_m)
     // all readings were invalid so return out-of-range-high value
     if (invalid_count > 0) {
         no_signal = true;
-        reading_m = MIN(MAX(DIST_MAX_CM, distance_cm_max + OUT_OF_RANGE_ADD_CM), UINT16_MAX) * 0.01f;
+        reading_m = MIN(MAX(DIST_MAX_CM, max_distance_cm() + OUT_OF_RANGE_ADD_CM), UINT16_MAX) * 0.01f;
         return true;
     }
 


### PR DESCRIPTION
The value of distance_cm_max is used for invalid values.
For normal values, it is not used.
Therefore, it is better to get the maximum value in the illegal value process.
This process is executed each time, thus increasing processing time.
const int16_t distance_cm_max = max_distance_cm();