### PR TITLE
Tools: ros2: Fix missing networking

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -410,12 +410,16 @@ def do_build(opts, frame_options):
 
     if opts.enable_dds:
         cmd_configure.append("--enable-dds")
+        if configure_target == 'sitl' and "--enable-networking" not in cmd_configure:
+            cmd_configure.append("--enable-networking")
 
-    if opts.enable_networking:
+    if opts.enable_networking and configure_target == 'sitl':
         cmd_configure.append("--enable-networking")
 
     if opts.enable_networking_tests:
         cmd_configure.append("--enable-networking-tests")
+        if "--enable-networking" not in cmd_configure:
+            cmd_configure.append("--enable-networking")
 
     pieces = [shlex.split(x) for x in opts.waf_configure_args]
     for piece in pieces:

--- a/wscript
+++ b/wscript
@@ -267,13 +267,13 @@ submodules at specific revisions.
                  help="Enables GPS logging")
     
     g.add_option('--enable-dds', action='store_true',
-                 help="Enable the dds client to connect with ROS2/DDS")
+                 help="Enable the dds client to connect with ROS2/DDS.")
 
     g.add_option('--enable-networking', action='store_true',
                  help="Enable the networking code")
 
     g.add_option('--enable-networking-tests', action='store_true',
-                 help="Enable the networking test code")
+                 help="Enable the networking test code. Automatically enables networking.")
     
     g.add_option('--enable-dronecan-tests', action='store_true',
                  default=False,


### PR DESCRIPTION
* DDS was built without networking so UDP stopped working

This wasn't caught because `colcon test` doesn't run in CI (yet). Note, `--enable-networking` should only do something on SITL. On hardware, it's automatically enabled if an ethernet port is detected. If you set `--enable-networking` on master when compiling for Pixhawk6X, it breaks.
