### PR TITLE
quadplane: mode_rtl: don't RTL during ground-idle

### DIFF
--- a/ArduPlane/mode_rtl.cpp
+++ b/ArduPlane/mode_rtl.cpp
@@ -18,6 +18,15 @@ bool ModeRTL::_enter()
             return true;
         }
 
+        // treat RTL as QLAND if we are armed and idling in a q-mode on the ground
+        // (when disarmed, allow RTL mode, so pilots can test switches)
+        if (plane.arming.is_armed() &&
+                plane.control_mode->is_vtol_mode() &&
+                plane.quadplane.motors->get_desired_spool_state() == AP_Motors::DesiredSpoolState::GROUND_IDLE) {
+            plane.set_mode(plane.mode_qland, ModeReason::QLAND_INSTEAD_OF_RTL);
+            return true;
+        }
+
         // if Q_RTL_MODE is QRTL always, immediately switch to QRTL mode
         if (plane.quadplane.rtl_mode == QuadPlane::RTL_MODE::QRTL_ALWAYS) {
             plane.set_mode(plane.mode_qrtl, ModeReason::QRTL_INSTEAD_OF_RTL);


### PR DESCRIPTION
Similar to how we handle guided waiting for takeoff, we should treat RTL as QLand when the autopilot is confident that it is not flying. This is common when on the ground in QHover or QLoiter waiting to visually confirm all props are spinning. We don't want an errant switch flip to trigger a transition to forward flight.

Original description of this PR below:
> Similar to how we handle guided waiting for takeoff, we should treat RTL as QLand when the desired spool state is `GROUND_IDLE`. This should only occur on the ground. This is common when on the ground in QHover or QLoiter waiting to visually confirm all props are spinning. We don't want an errant switch flip to trigger a transition to forward flight.
> 
> This can also happen in QStabilize when airmode is disabled and the stick is all the way down, but that shouldn't really happen in flight, and if it does, it is brief enough that it would be unlikely to be happening during an RTL trigger. Even if it does, QLand is not the worst thing in the world for that edge-case.