### PR TITLE
AP_Networking: added NET_Pn_ network ports for AP_SerialManager

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -148,8 +148,8 @@ class Board:
             )
             cfg.msg("Enabled custom controller", 'no', color='YELLOW')
 
-        if cfg.options.enable_networking:
-            env.CXXFLAGS += ['-DAP_NETWORKING_ENABLED=1']
+        if cfg.options.disable_networking:
+            env.CXXFLAGS += ['-DAP_NETWORKING_ENABLED=0']
 
         if cfg.options.enable_networking_tests:
             env.CXXFLAGS += ['-DAP_NETWORKING_TESTS_ENABLED=1']
@@ -674,6 +674,9 @@ class sitl(Board):
             '-Werror=missing-declarations',
         ]
 
+        if not cfg.options.disable_networking:
+            env.CXXFLAGS += ['-DAP_NETWORKING_ENABLED=1']
+        
         if cfg.options.ubsan or cfg.options.ubsan_abort:
             env.CXXFLAGS += [
                 "-fsanitize=undefined",

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -530,6 +530,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.MotorThrustHoverParameterIgnore,
             self.SET_POSITION_TARGET_GLOBAL_INT,
             self.TestLogDownloadMAVProxy,
+            self.TestLogDownloadMAVProxyNetwork,
             self.MAV_CMD_NAV_LOITER_UNLIM,
             self.MAV_CMD_NAV_LAND,
             self.MAV_CMD_MISSION_START,

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -413,8 +413,8 @@ def do_build(opts, frame_options):
         if configure_target == 'sitl' and "--enable-networking" not in cmd_configure:
             cmd_configure.append("--enable-networking")
 
-    if opts.enable_networking and configure_target == 'sitl':
-        cmd_configure.append("--enable-networking")
+    if opts.disable_networking or configure_target != "sitl":
+        cmd_configure.append("--disable-networking")
 
     if opts.enable_networking_tests:
         cmd_configure.append("--enable-networking-tests")
@@ -1336,8 +1336,8 @@ group_sim.add_option("", "--sim-address",
                      help="IP address of the simulator. Defaults to localhost")
 group_sim.add_option("--enable-dds", action='store_true',
                      help="Enable the dds client to connect with ROS2/DDS")
-group_sim.add_option("--enable-networking", action='store_true',
-                     help="Enable networking")
+group_sim.add_option("--disable-networking", action='store_true',
+                     help="Disable networking APIs")
 group_sim.add_option("--enable-networking-tests", action='store_true',
                      help="Enable networking tests")
 

--- a/Tools/scripts/build_tests/test_ccache.py
+++ b/Tools/scripts/build_tests/test_ccache.py
@@ -44,7 +44,7 @@ def ccache_stats():
 
 
 def build_board(boardname):
-    subprocess.run(["./waf", "configure", "--board", boardname])
+    subprocess.run(["./waf", "configure", "--board", boardname, '--disable-networking'])
     subprocess.run(["./waf", "clean", "copter"])
 
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -965,18 +965,19 @@ class ChibiOSHWDef(object):
             f.write('#define STM32_USB_USE_OTG2                  TRUE\n')
 
         if 'ETH1' in self.bytype:
-            f.write('// Configure for Ethernet support\n')
-            f.write('#define CH_CFG_USE_MAILBOXES                TRUE\n')
-            f.write('#define HAL_USE_MAC                         TRUE\n')
-            f.write('#define MAC_USE_EVENTS                      TRUE\n')
-            f.write('#define STM32_ETH_BUFFERS_EXTERN\n')
-            f.write('#define AP_NETWORKING_ENABLED               TRUE\n')
             self.build_flags.append('USE_LWIP=yes')
-            self.env_vars['WITH_NETWORKING'] = True
-        else:
-            f.write('#define AP_NETWORKING_ENABLED               FALSE\n')
-            self.build_flags.append('USE_LWIP=no')
-            self.env_vars['WITH_NETWORKING'] = False
+            f.write('''
+
+#ifndef AP_NETWORKING_ENABLED
+// Configure for Ethernet support
+#define AP_NETWORKING_ENABLED               1
+#define CH_CFG_USE_MAILBOXES                TRUE
+#define HAL_USE_MAC                         TRUE
+#define MAC_USE_EVENTS                      TRUE
+#define STM32_ETH_BUFFERS_EXTERN
+#endif
+
+''')
 
         defines = self.get_mcu_config('DEFINES', False)
         if defines is not None:

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -140,6 +140,9 @@ void AP_Networking::init()
 #if AP_NETWORKING_TESTS_ENABLED
     start_tests();
 #endif
+
+    // init network mapped serialmanager ports
+    ports_init();
 }
 
 /*

--- a/libraries/AP_Networking/AP_Networking_Config.h
+++ b/libraries/AP_Networking/AP_Networking_Config.h
@@ -74,3 +74,7 @@
 #define AP_NETWORKING_TEST_IP "192.168.13.2"
 #endif
 #endif
+
+#ifndef AP_NETWORKING_NUM_PORTS
+#define AP_NETWORKING_NUM_PORTS 4
+#endif

--- a/libraries/AP_Networking/AP_Networking_port.cpp
+++ b/libraries/AP_Networking/AP_Networking_port.cpp
@@ -1,0 +1,181 @@
+/*
+  class for networking mapped ports
+ */
+
+#include "AP_Networking_Config.h"
+
+#if AP_NETWORKING_ENABLED
+
+#include "AP_Networking.h"
+#include <AP_HAL/utility/Socket.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_Math/AP_Math.h>
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_Networking::Port::var_info[] = {
+    // @Param: TYPE
+    // @DisplayName: Port type
+    // @Description: Port type
+    // @Values: 0:Disabled, 1:UDP client
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("TYPE", 1,  AP_Networking::Port, type, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: PROTOCOL
+    // @DisplayName: protocol
+    // @Description: protocol
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("PROTOCOL", 2,  AP_Networking::Port, state.protocol, 0),
+
+    // @Group: IP
+    // @Path: AP_Networking_address.cpp
+    AP_SUBGROUPINFO(ip, "IP", 3,  AP_Networking::Port, AP_Networking_IPV4),
+
+    // @Param: PORT
+    // @DisplayName: Port number
+    // @Description: Port number
+    // @Range: 0 65535
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("PORT", 4,  AP_Networking::Port, port, 0),
+    
+    AP_GROUPEND
+};
+
+/*
+  initialise mapped network ports
+ */
+void AP_Networking::ports_init(void)
+{
+    // init in reverse order to keep the linked list in
+    // AP_SerialManager in the right order
+    for (int8_t i=ARRAY_SIZE(ports)-1; i>= 0; i--) {
+        auto &p = ports[i];
+        NetworkPortType ptype = (NetworkPortType)p.type;
+        p.state.idx = AP_SERIALMANAGER_NET_PORT_1 + i;
+        switch (ptype) {
+        case NetworkPortType::NONE:
+            break;
+        case NetworkPortType::UDP_CLIENT:
+            p.udp_client_init();
+            break;
+        }
+        if (p.sock != nullptr) {
+            AP::serialmanager().register_port(&p);
+        }
+    }
+}
+
+/*
+  initialise a UDP client
+ */
+void AP_Networking::Port::udp_client_init(void)
+{
+    if (!init_buffers(4096)) {
+        return;
+    }
+    sock = new SocketAPM(true);
+    if (sock == nullptr) {
+        return;
+    }
+    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_Networking::Port::udp_client_loop, void), "NET", 2048, AP_HAL::Scheduler::PRIORITY_UART, 0)) {
+        AP_BoardConfig::allocation_error("Failed to allocate UDP client thread");
+    }
+}
+
+/*
+  update a UDP client
+ */
+void AP_Networking::Port::udp_client_loop(void)
+{
+    while (!hal.scheduler->is_system_initialized()) {
+        hal.scheduler->delay(100);
+    }
+    hal.scheduler->delay(1000);
+
+    const char *dest = ip.get_str();
+    if (!sock->connect(dest, port.get())) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "UDP[%u]: Failed to connect to %s", (unsigned)state.idx, dest);
+        delete sock;
+        sock = nullptr;
+        return;
+    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UDP[%u]: connected to %s:%u", (unsigned)state.idx, dest, unsigned(port.get()));
+
+    while (true) {
+        hal.scheduler->delay_microseconds(500);
+
+        // handle outgoing packets
+        uint32_t available;
+        const auto *ptr = writebuffer->readptr(available);
+        if (ptr != nullptr) {
+            const auto ret = sock->send(ptr, available);
+            if (ret > 0) {
+                writebuffer->advance(ret);
+            }
+        }
+
+        // handle incoming packets
+        const auto space = readbuffer->space();
+        if (space > 0) {
+            const uint32_t n = MIN(350U, space);
+            uint8_t buf[n];
+            const auto ret = sock->recv(buf, n, 0);
+            if (ret > 0) {
+                readbuffer->write(buf, ret);
+            }
+        }
+    }
+}
+
+/*
+  available space in outgoing buffer
+ */
+uint32_t AP_Networking::Port::txspace(void)
+{
+    return writebuffer->space();
+}
+
+void AP_Networking::Port::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
+{
+    // TODO: use buffer sizes
+}
+
+size_t AP_Networking::Port::_write(const uint8_t *buffer, size_t size)
+{
+    return writebuffer->write(buffer, size);
+}
+
+ssize_t AP_Networking::Port::_read(uint8_t *buffer, uint16_t count)
+{
+    return readbuffer->read(buffer, count);
+}
+
+uint32_t AP_Networking::Port::_available()
+{
+    return readbuffer->available();
+}
+
+
+bool AP_Networking::Port::_discard_input()
+{
+    readbuffer->clear();
+    return true;
+}
+
+/*
+  initialise read/write buffers
+ */
+bool AP_Networking::Port::init_buffers(uint32_t size)
+{
+    readbuffer = new ByteBuffer(size);
+    writebuffer = new ByteBuffer(size);
+    return readbuffer != nullptr && writebuffer != nullptr;
+}
+
+#endif // AP_NETWORKING_ENABLED

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -246,7 +246,7 @@ public:
 
     // get the passthru ports if enabled
     bool get_passthru(AP_HAL::UARTDriver *&port1, AP_HAL::UARTDriver *&port2, uint8_t &timeout_s,
-                      uint32_t &baud1, uint32_t &baud2) const;
+                      uint32_t &baud1, uint32_t &baud2);
 
     // disable passthru by settings SERIAL_PASS2 to -1
     void disable_passthru(void);
@@ -283,6 +283,9 @@ public:
         // serial index number
         uint8_t idx;
     };
+
+    // get a state from serial index
+    const UARTState *get_state_by_id(uint8_t id) const;
 
     // search through managed serial connections looking for the
     // instance-nth UART which is running protocol protocol.

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -210,7 +210,36 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     // @Group: NET_
     // @Path: ../AP_Networking/AP_Networking.cpp
     AP_SUBGROUPINFO(networking, "NET_", 21, AP_Vehicle, AP_Networking),
+
+    /*
+      the NET_Pn_ parameters need to be in AP_Vehicle as otherwise we
+      are too deep in the parameter tree
+     */
+
+#if AP_NETWORKING_NUM_PORTS > 0
+    // @Group: NET_P1_
+    // @Path: ../AP_Networking/AP_Networking_port.cpp
+    AP_SUBGROUPINFO(networking.ports[0], "NET_P1_", 22, AP_Vehicle, AP_Networking::Port),
 #endif
+
+#if AP_NETWORKING_NUM_PORTS > 1
+    // @Group: NET_P2_
+    // @Path: ../AP_Networking/AP_Networking_port.cpp
+    AP_SUBGROUPINFO(networking.ports[1], "NET_P2_", 23, AP_Vehicle, AP_Networking::Port),
+#endif
+
+#if AP_NETWORKING_NUM_PORTS > 2
+    // @Group: NET_P3_
+    // @Path: ../AP_Networking/AP_Networking_port.cpp
+    AP_SUBGROUPINFO(networking.ports[2], "NET_P3_", 24, AP_Vehicle, AP_Networking::Port),
+#endif
+
+#if AP_NETWORKING_NUM_PORTS > 3
+    // @Group: NET_P4_
+    // @Path: ../AP_Networking/AP_Networking_port.cpp
+    AP_SUBGROUPINFO(networking.ports[3], "NET_P4_", 25, AP_Vehicle, AP_Networking::Port),
+#endif
+#endif // AP_NETWORKING_ENABLED
 
     AP_GROUPEND
 };

--- a/wscript
+++ b/wscript
@@ -269,8 +269,8 @@ submodules at specific revisions.
     g.add_option('--enable-dds', action='store_true',
                  help="Enable the dds client to connect with ROS2/DDS.")
 
-    g.add_option('--enable-networking', action='store_true',
-                 help="Enable the networking code")
+    g.add_option('--disable-networking', action='store_true',
+                 help="Disable the networking API code")
 
     g.add_option('--enable-networking-tests', action='store_true',
                  help="Enable the networking test code. Automatically enables networking.")


### PR DESCRIPTION
This is an alternative approach to allowing UART drivers as AP_Networking ports

Tested on CubeRed and Pixhawk6X, works with MAVLink and gimbal SIYI ZT30
