### PR TITLE
Periph: Allow showing serialmanager params without HAL_GCS_ENABLED

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -443,7 +443,9 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Range: 1 255
     // @User: Advanced
     GSCALAR(sysid_this_mav,         "SYSID_THISMAV",  MAV_SYSTEM_ID),
+#endif
 
+#if HAL_GCS_ENABLED || defined(HAL_PERIPH_SHOW_SERIAL_MANAGER_PARAMS)
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp
     GOBJECT(serial_manager, "SERIAL",   AP_SerialManager),

--- a/libraries/AP_HAL_ChibiOS/hwdef/kha_eth/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/kha_eth/hwdef.dat
@@ -135,11 +135,12 @@ define DISABLE_SERIAL_ESC_COMM TRUE
 define HAL_NO_RCIN_THREAD
 #define HAL_NO_GPIO_IRQ
 define HAL_DISABLE_LOOP_DELAY
+define HAL_PERIPH_SHOW_SERIAL_MANAGER_PARAMS
 
 
 define PERIPH_FW TRUE
 #define NO_DATAFLASH TRUE
-define HAL_LOGGING_ENABLED TRUE
+define HAL_LOGGING_ENABLED FALSE
 
 #################################
 # AP_Periph - configurations specific to this App


### PR DESCRIPTION
Allow showing serialmanager params without HAL_GCS_ENABLED

I also enabled this in board target kha_eth and also snuck in a logging change while I was changing that hwdef