### PR TITLE
AP_Parachute: Added throttle suppression parameter according to the parachute release rule

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -74,8 +74,9 @@ void Plane::throttle_slew_limit(SRV_Channel::Aux_servo_function_t func)
 bool Plane::suppress_throttle(void)
 {
 #if PARACHUTE == ENABLED
-    if (control_mode->does_auto_throttle() && parachute.release_initiated()) {
-        // throttle always suppressed in auto-throttle modes after parachute release initiated
+    if (parachute.release_initiated() && (parachute.throttle_suppress() == AP_PARACHUTE_THROTTLE_ALWAYS_SUPPRESS ||
+        (parachute.throttle_suppress() == AP_PARACHUTE_THROTTLE_SUPPRESS_ONLY_AUTO && control_mode->does_auto_throttle()))) {
+        // the throttle is suppressed if the parachute parameter value allows it
         throttle_suppressed = true;
         return true;
     }

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -81,6 +81,13 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 7, AP_Parachute, _options, 0),
 
+    // @Param: THR_SUPR
+    // @DisplayName: Throttle suppress after parachute release
+    // @Description: Throttle suppress after parachute release. Default: 1
+    // @Values: 0:Not suppress,1:Only auto throttle modes,2:Always suppress
+    // @User: Standard
+    AP_GROUPINFO("THR_SUPPR", 8, AP_Parachute, _throttle_suppress, AP_PARACHUTE_THROTTLE_SUPPRESS_ONLY_AUTO),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -21,6 +21,10 @@
 
 #define AP_PARACHUTE_CRITICAL_SINK_DEFAULT      0    // default critical sink speed in m/s to trigger emergency parachute
 
+#define AP_PARACHUTE_THROTTLE_NOT_SUPPRESS       0 // do not suppress throttle due to an parachute
+#define AP_PARACHUTE_THROTTLE_SUPPRESS_ONLY_AUTO 1 // suppress throttle only if autothrottle modes
+#define AP_PARACHUTE_THROTTLE_ALWAYS_SUPPRESS    2 // always suppress throttle, regardless of mode
+
 #ifndef HAL_PARACHUTE_ENABLED
 // default to parachute enabled to match previous configs
 #define HAL_PARACHUTE_ENABLED 1
@@ -85,6 +89,9 @@ public:
 
     // check settings are valid
     bool arming_checks(size_t buflen, char *buffer) const;
+
+    // throttle_suppress - returns the current rule for throttle suppression when the parachute is released
+    int8_t throttle_suppress() const { return _throttle_suppress; };
     
     static const struct AP_Param::GroupInfo        var_info[];
 
@@ -101,6 +108,7 @@ private:
     AP_Int16    _alt_min;       // min altitude the vehicle should have before parachute is released
     AP_Int16    _delay_ms;      // delay before chute release for motors to stop
     AP_Float    _critical_sink;      // critical sink rate to trigger emergency parachute
+    AP_Int8     _throttle_suppress; // 0 - do not suppress throttle due to an parachute; 1 - suppress throttle only if autothrottle modes; 2 - always suppress throttle, regardless of mode
 
     // internal variables
     uint32_t    _release_time;  // system time that parachute is ordered to be released (actual release will happen 0.5 seconds later)


### PR DESCRIPTION
When I land the fixed wing plane by parachute in FBWA mode and forget put away throttle then the parachute lines wrap around the blades and the plane crashes.

CHUTE_THR_SUPPR:
0: do not suppress throttle due to an parachute
1 (default): suppress throttle only if autothrottle modes
2: always suppress throttle, regardless of mode