### PR TITLE
AP_HAL_ChibiOS: base HAL_USE_SPI on devices not buses

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1523,7 +1523,9 @@ INCLUDE common.ld
             if t.startswith('SPI'):
                 self.spi_list.append(t)
         self.spi_list = sorted(self.spi_list)
-        if len(self.spi_list) == 0:
+        if len(self.spidev) != 0 and len(self.spi_list) == 0:
+            self.error("Have SPI devices but no SPI bus?!")
+        if len(self.spidev) == 0:
             f.write('#define HAL_USE_SPI FALSE\n')
             return
         devlist = []


### PR DESCRIPTION
fixes compilation problem with gcc 10.3

```
../../libraries/AP_HAL_ChibiOS/SPIDevice.cpp: In static member function 'static void ChibiOS::SPIDeviceManager::__static_initialization_and_destruction_0(int, int)': ../../libraries/AP_HAL_ChibiOS/SPIDevice.cpp:76:18: error: statement has no effect [-Werror=unused-value]
   76 | ChibiOS::SPIDesc SPIDeviceManager::device_table[] = { HAL_SPI_DEVICE_LIST };
      |                  ^~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors
```
