### PR TITLE
Remove EKF2 from all builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -462,8 +462,8 @@ class Board:
         # We always want to use PRI format macros
         cfg.define('__STDC_FORMAT_MACROS', 1)
 
-        if cfg.options.disable_ekf2:
-            env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=0']
+        if cfg.options.enable_ekf2:
+            env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=1']
 
         if cfg.options.disable_ekf3:
             env.CXXFLAGS += ['-DHAL_NAVEKF3_AVAILABLE=0']

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -654,6 +654,12 @@ class sitl(Board):
         cfg.define('AP_NOTIFY_LP5562_BUS', 2)
         cfg.define('AP_NOTIFY_LP5562_ADDR', 0x30)
 
+        try:
+            env.CXXFLAGS.remove('-DHAL_NAVEKF2_AVAILABLE=0')
+        except ValueError:
+            pass
+        env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=1']
+
         if self.with_can:
             cfg.define('HAL_NUM_CAN_IFACES', 2)
             env.DEFINES.update(CANARD_MULTI_IFACE=1,

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -378,8 +378,8 @@ def do_build(opts, frame_options):
     if opts.math_check_indexes:
         cmd_configure.append("--enable-math-check-indexes")
 
-    if opts.disable_ekf2:
-        cmd_configure.append("--disable-ekf2")
+    if opts.enable_ekf2:
+        cmd_configure.append("--enable-ekf2")
 
     if opts.disable_ekf3:
         cmd_configure.append("--disable-ekf3")
@@ -1299,7 +1299,7 @@ group_sim.add_option("--flash-storage",
 group_sim.add_option("--fram-storage",
                      action='store_true',
                      help="use fram storage emulation")
-group_sim.add_option("--disable-ekf2",
+group_sim.add_option("--enable-ekf2",
                      action='store_true',
                      help="disable EKF2 in build")
 group_sim.add_option("--disable-ekf3",

--- a/libraries/AP_AHRS/AP_AHRS_config.h
+++ b/libraries/AP_AHRS/AP_AHRS_config.h
@@ -16,8 +16,8 @@
 #endif
 
 #ifndef HAL_NAVEKF2_AVAILABLE
-// only default to EK2 enabled on boards with over 1M flash
-#define HAL_NAVEKF2_AVAILABLE (BOARD_FLASH_SIZE>1024)
+// EKF2 slated compiled out by default in 4.5, slated to be removed.
+#define HAL_NAVEKF2_AVAILABLE 0
 #endif
 
 #ifndef HAL_NAVEKF3_AVAILABLE

--- a/wscript
+++ b/wscript
@@ -360,10 +360,10 @@ configuration in order to save typing.
         default=False,
         help='Use flash storage emulation.')
 
-    g.add_option('--disable-ekf2',
+    g.add_option('--enable-ekf2',
         action='store_true',
         default=False,
-        help='Configure without EKF2.')
+        help='Configure with EKF2.')
 
     g.add_option('--disable-ekf3',
         action='store_true',


### PR DESCRIPTION
We're looking to remove EKF2 from the codebase.

This is a first step; we'll retain the ability to compile it in on the custom build server and OEM setups and the like for at least one stable version.
