### PR TITLE
Fix SerialLED scripting interface

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -352,12 +352,12 @@ public:
       setup serial led output data for a given output channel
       and led number. A led number of -1 means all LEDs. LED 0 is the first LED
      */
-    virtual void set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) {}
+    virtual bool set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) { return false; }
 
     /*
       trigger send of serial led
      */
-    virtual void serial_led_send(const uint16_t chan) {}
+    virtual bool serial_led_send(const uint16_t chan) { return false; }
 
     virtual void timer_info(ExpandingString &str) {}
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2506,29 +2506,29 @@ void RCOutput::_set_profiled_clock(pwm_group *grp, uint8_t idx, uint8_t led)
   setup serial LED output data for a given output channel
   and a LED number. LED -1 is all LEDs
 */
-void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
+bool RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
 {
     if (!_initialised) {
-        return;
+        return false;
     }
 
     uint8_t i = 0;
     pwm_group *grp = find_chan(chan, i);
 
     if (!grp) {
-        return;
+        return false;
     }
 
     if (grp->serial_led_pending) {
         // dont allow setting new data if a send is pending
         // would result in a fight over the mutex
-        return;
-    };
+        return false;
+    }
 
     WITH_SEMAPHORE(grp->serial_led_mutex);
 
     if (grp->serial_nleds == 0 || led >= grp->serial_nleds) {
-        return;
+        return false;
     }
 
     if ((grp->current_mode != grp->led_mode) && is_led_protocol(grp->led_mode)) {
@@ -2545,7 +2545,7 @@ void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t 
                 }
                 grp->led_mode = MODE_PWM_NONE;
                 grp->serial_nleds = 0;
-                return;
+                return false;
             }
         }
 
@@ -2556,11 +2556,11 @@ void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t 
             // Failed to set output mode
             grp->led_mode = MODE_PWM_NONE;
             grp->serial_nleds = 0;
-            return;
+            return false;
         }
 
     } else if (!is_led_protocol(grp->current_mode)) {
-        return;
+        return false;
     }
 
     if (led == -1) {
@@ -2568,7 +2568,7 @@ void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t 
         for (uint8_t n=0; n<grp->serial_nleds; n++) {
             serial_led_set_single_rgb_data(*grp, i, n, red, green, blue);
         }
-        return;
+        return true;
     }
 
     // if not ouput clock and trailing frames, run through all LED's to do it now
@@ -2579,6 +2579,8 @@ void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t 
         }
     }
     serial_led_set_single_rgb_data(*grp, i, uint8_t(led), red, green, blue);
+
+    return true;
 }
 
 /*
@@ -2603,26 +2605,26 @@ void RCOutput::serial_led_set_single_rgb_data(pwm_group& group, uint8_t idx, uin
 /*
   trigger send of serial led data for one group
 */
-void RCOutput::serial_led_send(const uint16_t chan)
+bool RCOutput::serial_led_send(const uint16_t chan)
 {
     if (!_initialised) {
-        return;
+        return false;
     }
 
     if (led_thread_ctx == nullptr) {
-        return;
+        return false;
     }
 
     uint8_t i;
     pwm_group *grp = find_chan(chan, i);
     if (!grp) {
-        return;
+        return false;
     }
 
     WITH_SEMAPHORE(grp->serial_led_mutex);
 
     if (grp->serial_nleds == 0 || !is_led_protocol(grp->current_mode)) {
-        return;
+        return false;
     }
 
     if (grp->prepared_send) {
@@ -2630,6 +2632,8 @@ void RCOutput::serial_led_send(const uint16_t chan)
         serial_led_pending = true;
         chEvtSignal(led_thread_ctx, EVT_LED_SEND);
     }
+
+    return true;
 }
 #endif // HAL_SERIALLED_ENABLED
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2626,9 +2626,9 @@ void RCOutput::serial_led_send(const uint16_t chan)
     }
 
     if (grp->prepared_send) {
-        chEvtSignal(led_thread_ctx, EVT_LED_SEND);
         grp->serial_led_pending = true;
         serial_led_pending = true;
+        chEvtSignal(led_thread_ctx, EVT_LED_SEND);
     }
 }
 #endif // HAL_SERIALLED_ENABLED

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -254,12 +254,12 @@ public:
       setup serial LED output data for a given output channel
       and LEDs number. LED -1 is all LEDs
      */
-    void set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) override;
+    bool set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) override;
 
     /*
       trigger send of serial LED data
      */
-    void serial_led_send(const uint16_t chan) override;
+    bool serial_led_send(const uint16_t chan) override;
 #endif
     /*
       rcout thread

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -125,34 +125,36 @@ bool RCOutput::set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, ou
     return false;
 }
 
-void RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
+bool RCOutput::set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
 {
     if (chan > 15) {
-        return;
+        return false;
     }
     SITL::SIM *sitl = AP::sitl();
     if (led == -1) {
         for (uint8_t i=0; i < sitl->led.num_leds[chan]; i++) {
             set_serial_led_rgb_data(chan, i, red, green, blue);
         }
-        return;
+        return true;
     }
     if (led < -1 || led >= sitl->led.num_leds[chan]) {
-        return;
+        return false;
     }
     if (sitl) {
         sitl->led.rgb[chan][led].rgb[0] = red;
         sitl->led.rgb[chan][led].rgb[1] = green;
         sitl->led.rgb[chan][led].rgb[2] = blue;
     }
+    return true;
 }
 
-void RCOutput::serial_led_send(const uint16_t chan)
+bool RCOutput::serial_led_send(const uint16_t chan)
 {
     SITL::SIM *sitl = AP::sitl();
     if (sitl) {
         sitl->led.send_counter++;
     }
+    return true;
 }
 
 #endif //CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -42,8 +42,8 @@ public:
       Serial LED emulation
      */
     bool set_serial_led_num_LEDs(const uint16_t chan, uint8_t num_leds, output_mode mode = MODE_PWM_NONE, uint32_t clock_mask = 0) override;
-    void set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) override;
-    void serial_led_send(const uint16_t chan) override;
+    bool set_serial_led_rgb_data(const uint16_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue) override;
+    bool serial_led_send(const uint16_t chan) override;
     
 private:
     SITL_State *_sitlState;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1984,6 +1984,7 @@ serialLED = {}
 
 -- desc
 ---@param chan integer
+---@return boolean
 function serialLED:send(chan) end
 
 -- desc
@@ -1992,6 +1993,7 @@ function serialLED:send(chan) end
 ---@param red integer
 ---@param green integer
 ---@param blue integer
+---@return boolean
 function serialLED:set_RGB(chan, led_index, red, green, blue) end
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -313,8 +313,8 @@ singleton AP_SerialLED depends AP_SERIALLED_ENABLED
 singleton AP_SerialLED method set_num_neopixel boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
 singleton AP_SerialLED method set_num_neopixel_rgb boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
 singleton AP_SerialLED method set_num_profiled boolean uint8_t 1 16 uint8_t 0 AP_SERIALLED_MAX_LEDS
-singleton AP_SerialLED method set_RGB void uint8_t 1 16 int8_t -1 INT8_MAX uint8_t'skip_check uint8_t'skip_check uint8_t'skip_check
-singleton AP_SerialLED method send void uint8_t 1 16
+singleton AP_SerialLED method set_RGB boolean uint8_t 1 16 int8_t -1 INT8_MAX uint8_t'skip_check uint8_t'skip_check uint8_t'skip_check
+singleton AP_SerialLED method send boolean uint8_t 1 16
 
 include SRV_Channel/SRV_Channel.h
 singleton SRV_Channels depends (!defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_RC_OUT))

--- a/libraries/AP_SerialLED/AP_SerialLED.cpp
+++ b/libraries/AP_SerialLED/AP_SerialLED.cpp
@@ -62,20 +62,21 @@ bool AP_SerialLED::set_num_profiled(uint8_t chan, uint8_t num_leds)
 }
 
 // set RGB value on LED number. LED number -1 is all LEDs. First LED is 0. chan is PWM output, 1..16
-void AP_SerialLED::set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
+bool AP_SerialLED::set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
 {
     if (chan >= 1 && chan <= 16) {
-        hal.rcout->set_serial_led_rgb_data(chan-1, led, red, green, blue);
+        return hal.rcout->set_serial_led_rgb_data(chan-1, led, red, green, blue);
     }
+    return false;
 }
 
 // trigger sending of LED changes to LEDs
-void AP_SerialLED::send(uint8_t chan)
+bool AP_SerialLED::send(uint8_t chan)
 {
     if (chan >= 1 && chan <= 16) {
-        hal.rcout->serial_led_send(chan-1);
+        return hal.rcout->serial_led_send(chan-1);
     }
-
+    return false;
 }
 
 #endif  // AP_SERIALLED_ENABLED

--- a/libraries/AP_SerialLED/AP_SerialLED.h
+++ b/libraries/AP_SerialLED/AP_SerialLED.h
@@ -42,10 +42,10 @@ public:
     void set_RGB_mask(uint8_t chan, uint32_t ledmask, uint8_t red, uint8_t green, uint8_t blue);
 
     // set RGB value on LED. LED -1 is all LEDs. LED 0 is first LED. chan is PWM output, 1..16
-    void set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue);
+    bool set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue);
 
     // trigger sending of LED changes to LEDs
-    void send(uint8_t chan);
+    bool send(uint8_t chan);
 
     // singleton support
     static AP_SerialLED *get_singleton(void) {


### PR DESCRIPTION
This fixes two issues:
- A race condition in serial_led_send() which could mean that sending out data could be delayed
- Allow scripts to know the return status of serial_led_send() and set_serial_led_rgb_data() so that they can retry if necessary

The first commit should be back-ported to 4.4