### PR TITLE
AP_SerialManager: Add missing option for XRCE DDS

### DIFF
--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -149,8 +149,6 @@ Follow the steps to use the microROS Agent
     - Do "Creating the micro-ROS agent"
     - Source your ROS workspace
 
-Until this [PR](https://github.com/micro-ROS/micro-ROS.github.io/pull/401) is merged, ignore the notes about `foxy`. It works on `humble`.
-
 ## Using the ROS 2 CLI to Read Ardupilot Data
 
 After your setups are complete, do the following:
@@ -252,7 +250,7 @@ In order to consume the transforms, it's highly recommended to [create and run a
 
 ## Using ROS 2 services
 
-The `AP_DDS` libraary exposes services which are automatically mapped to ROS 2 
+The `AP_DDS` library exposes services which are automatically mapped to ROS 2 
 services using appropriate naming conventions for topics and message and service
 types. An earlier version of `AP_DDS` required the use of the eProsima
 [Integration Service](https://github.com/eProsima/Integration-Service) to map
@@ -338,7 +336,7 @@ Note that a service interface always requires a Request / Response pair.
 #### ROS 2 topic and service names
 
 The ROS 2 design article: [Topic and Service name mapping to DDS](https://design.ros2.org/articles/topic_and_service_names.html) describes the mapping of ROS 2 topic and service
-names to DDS. Each ROS 2 subsytem is provided a prefix when mapped to DDS.
+names to DDS. Each ROS 2 subsystem is provided a prefix when mapped to DDS.
 The request / response pair for services require an additional suffix.
 
 | ROS 2 subsystem | DDS Prefix | DDS Suffix |

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -178,7 +178,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp, 45:DDS XRCE
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, DEFAULT_SERIAL1_PROTOCOL),


### PR DESCRIPTION
This was missing from the wiki:
https://ardupilot.org/copter/docs/parameters.html#serial1-protocol-telem1-protocol-selection