### PR TITLE
AP_RCProtocol: crsf, don't mix private and function variables

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -458,7 +458,7 @@ void AP_RCProtocol_CRSF::decode_variable_bit_channels(const uint8_t* payload, ui
     }
 
     // calculate the number of channels packed
-    uint8_t numOfChannels = MIN(uint8_t(((frame_length - 2) * 8 - CRSF_SUBSET_RC_STARTING_CHANNEL_BITS) / channelBits), CRSF_MAX_CHANNELS);
+    uint8_t numOfChannels = MIN(uint8_t(((frame_length - 2) * 8 - CRSF_SUBSET_RC_STARTING_CHANNEL_BITS) / channelBits), nchannels);
 
     // unpack the channel data
     uint8_t bitsMerged = 0;
@@ -476,10 +476,10 @@ void AP_RCProtocol_CRSF::decode_variable_bit_channels(const uint8_t* payload, ui
             bitsMerged += 8;
         }
         // check for corrupt frame
-        if (uint8_t(channel_data->starting_channel + n) >= CRSF_MAX_CHANNELS) {
+        if (uint8_t(channel_data->starting_channel + n) >= nchannels) {
             return;
         }
-        _channels[channel_data->starting_channel + n] =
+        values[channel_data->starting_channel + n] =
             uint16_t(channelScale * float(uint16_t(readValue & channelMask)) + 988);
         readValue >>= channelBits;
         bitsMerged -= channelBits;


### PR DESCRIPTION
In method `decode_variable_bit_channels()` the last two arguments `nchannels` and `*values` are not used, but instead the constant `CRSF_MAX_CHANNELS` and the private field `_channels` are used. This doesn't make sense.

Since the method `decode_variable_bit_channels()` is private, and only private fields or constants need to be used one in principle could make it to have no arguments. However, it looks as if the intention was to make it look similar to the function `decode_11bit_channels()`. Hence, in this PR the argument list of `decode_variable_bit_channels()` is not modified, but the function code is changed to call `nchannels` and `*values`, removing the dependency on outside variables.