### PR TITLE
Plane: QAssist speed warning added

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1496,7 +1496,7 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
                 // we've been below assistant alt for Q_ASSIST_DELAY seconds
                 if (!in_alt_assist) {
                     in_alt_assist = true;
-                    gcs().send_text(MAV_SEVERITY_INFO, "Alt assist %.1fm", height_above_ground);
+                    gcs().send_text(MAV_SEVERITY_WARNING, "Alt assist %.1fm", height_above_ground);
                 }
                 return true;
             }
@@ -1541,7 +1541,7 @@ bool QuadPlane::should_assist(float aspeed, bool have_airspeed)
     bool ret = (now - angle_error_start_ms) >= assist_delay*1000;
     if (ret && !in_angle_assist) {
         in_angle_assist = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "Angle assist r=%d p=%d",
+        gcs().send_text(MAV_SEVERITY_WARNING, "Angle assist r=%d p=%d",
                                          (int)(ahrs.roll_sensor/100),
                                          (int)(ahrs.pitch_sensor/100));
     }
@@ -1573,7 +1573,7 @@ void SLT_Transition::update()
         if (!in_forced_transition) {
             const bool show_message = transition_state != TRANSITION_AIRSPEED_WAIT || transition_start_ms == 0;
             if (show_message) {
-                gcs().send_text(MAV_SEVERITY_INFO, "Transition started airspeed %.1f", (double)aspeed);
+                gcs().send_text(MAV_SEVERITY_WARNING, "QAssist: Transition started airspeed %.1f", (double)aspeed);
             }
             transition_state = TRANSITION_AIRSPEED_WAIT;
             if (transition_start_ms == 0) {


### PR DESCRIPTION
Added a message to be sent when aircraft enters QAssist but added the check that it is between Q_ASSIST_SPEED and half of ARSPD_FBW_MIN so that the message doesn't show up during fwd transition from low arspd. This means it should only show up in fwd flight when airspeed drops below Q_ASSIST_SPEED
The main point of this is to increase pilot awareness of QAssist. By increasing the severity of these messages they will show up on MissionPlanner's HUD.