### PR TITLE
AP_Mount: Add nan check to avoid Internal error

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -846,7 +846,8 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_int_t 
     case MAV_CMD_DO_MOUNT_CONTROL:
         // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
         if ((copter.camera_mount.get_mount_type() != AP_Mount::Type::None) &&
-            !copter.camera_mount.has_pan_control()) {
+            !copter.camera_mount.has_pan_control() &&
+            !isnan(packet.param3)) {
             copter.flightmode->auto_yaw.set_yaw_angle_rate((float)packet.param3, 0.0f);
         }
         break;

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -292,7 +292,7 @@ void AP_Mount_Backend::handle_mount_control(const mavlink_mount_control_t &packe
 // handle do_mount_control command.  Returns MAV_RESULT_ACCEPTED on success
 MAV_RESULT AP_Mount_Backend::handle_command_do_mount_control(const mavlink_command_int_t &packet)
 {
-    const MAV_MOUNT_MODE new_mode = (MAV_MOUNT_MODE)packet.z;
+    const MAV_MOUNT_MODE new_mode = (MAV_MOUNT_MODE)(isnan(packet.z) ? 0.0 : packet.z);
 
     // interpret message fields based on mode
     switch (new_mode) {
@@ -306,9 +306,9 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_mount_control(const mavlink_comma
 
     case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
         // set body-frame target angles (in degrees) from mavlink message
-        const float pitch_deg = packet.param1;  // param1: pitch (in degrees)
-        const float roll_deg = packet.param2;   // param2: roll in degrees
-        const float yaw_deg = packet.param3;    // param3: yaw in degrees
+        const float pitch_deg = isnan(packet.param1) ? 0.0 : packet.param1;  // param1: pitch (in degrees)
+        const float roll_deg = isnan(packet.param2) ? 0.0 : packet.param2;   // param2: roll in degrees
+        const float yaw_deg = isnan(packet.param3) ? 0.0 : packet.param3;    // param3: yaw in degrees
 
         // warn if angles are invalid to catch angles sent in centi-degrees
         if ((fabsf(pitch_deg) > 90) || (fabsf(roll_deg) > 180) || (fabsf(yaw_deg) > 360)) {
@@ -316,7 +316,7 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_mount_control(const mavlink_comma
             return MAV_RESULT_FAILED;
         }
 
-        set_angle_target(packet.param2, packet.param1, packet.param3, false);
+        set_angle_target(roll_deg, pitch_deg, yaw_deg, false);
         return MAV_RESULT_ACCEPTED;
     }
 


### PR DESCRIPTION
An Internal Error occurs when receiving and processing NaN in the MAV_CMD_DO_MOUNT_CONTROL (205) command. I think parameter sanitization is necessary. The NaN was a failure on the client application side, but as a result, it led to the aircraft crashing.

STABILIZE> long 205 0 0 NaN 0 0 0 2
This command can cause crash.

<img width="1541" alt="Screenshot 0005-11-20 at 20 30 42" src="https://github.com/ArduPilot/ardupilot/assets/22985371/1cada826-34c1-403e-8436-831008b4b4ed">

I tested this fix with SITL to confirm.
<img width="766" alt="Screenshot 0005-11-20 at 20 47 34" src="https://github.com/ArduPilot/ardupilot/assets/22985371/e19b321d-19d1-44ce-aec6-1ba867015356">
