### PR TITLE
AP_Compass: fix C++ One Definition Rule violations

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -58,13 +58,6 @@ extern const AP_HAL::HAL &hal;
 
 extern const AP_HAL::HAL &hal;
 
-struct PACKED sample_regs {
-    uint8_t st1;
-    int16_t val[3];
-    uint8_t tmps;
-    uint8_t st2;
-};
-
 AP_Compass_AK09916::AP_Compass_AK09916(AP_AK09916_BusDriver *bus,
                                         bool force_external,
                                         enum Rotation rotation)
@@ -477,7 +470,7 @@ bool AP_AK09916_BusDriver_Auxiliary::configure()
 
 bool AP_AK09916_BusDriver_Auxiliary::start_measurements()
 {
-    if (_bus->register_periodic_read(_slave, REG_ST1, sizeof(sample_regs)) < 0) {
+    if (_bus->register_periodic_read(_slave, REG_ST1, sizeof(AP_Compass_AK09916::sample_regs)) < 0) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -75,6 +75,14 @@ public:
 
     void read() override;
 
+    /* Must be public so the BusDriver can access its definition */
+    struct PACKED sample_regs {
+        uint8_t st1;
+        int16_t val[3];
+        uint8_t tmps;
+        uint8_t st2;
+    };
+
 private:
     AP_Compass_AK09916(AP_AK09916_BusDriver *bus, bool force_external,
                        enum Rotation rotation);

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -49,11 +49,6 @@
 
 #define AK8963_MILLIGAUSS_SCALE 10.0f
 
-struct PACKED sample_regs {
-    int16_t val[3];
-    uint8_t st2;
-};
-
 extern const AP_HAL::HAL &hal;
 
 AP_Compass_AK8963::AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
@@ -379,7 +374,7 @@ bool AP_AK8963_BusDriver_Auxiliary::configure()
 
 bool AP_AK8963_BusDriver_Auxiliary::start_measurements()
 {
-    if (_bus->register_periodic_read(_slave, AK8963_HXL, sizeof(sample_regs)) < 0) {
+    if (_bus->register_periodic_read(_slave, AK8963_HXL, sizeof(AP_Compass_AK8963::sample_regs)) < 0) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -39,6 +39,12 @@ public:
 
     void read() override;
 
+    /* Must be public so the BusDriver can access its definition */
+    struct PACKED sample_regs {
+        int16_t val[3];
+        uint8_t st2;
+    };
+
 private:
     AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
                       enum Rotation rotation);

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -47,11 +47,6 @@
 #define LSM9DS1M_INT_THS_L_M        0x32
 #define LSM9DS1M_INT_THS_H_M        0x33
 
-struct PACKED sample_regs {
-    uint8_t status;
-    int16_t val[3];
-};
-
 extern const AP_HAL::HAL &hal;
 
 AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(AP_HAL::OwnPtr<AP_HAL::Device> dev,

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -42,6 +42,11 @@ private:
     uint8_t _compass_instance;
     float _scaling;
     enum Rotation _rotation;
+
+    struct PACKED sample_regs {
+        uint8_t status;
+        int16_t val[3];
+    };
 };
 
 #endif


### PR DESCRIPTION
Two structs with the same name must have exactly the same definition, no matter where they occur in the program, otherwise the program is undefined. This problem is diagnosed by the compiler when LTO is enabled (which it currently not for Ardupilot).

Move each sample register struct definition into the associated class definition so they are in a different namespace and no longer identically named, thus fixing this issue.

There is no code size or functional change. Supersedes #25394