### PR TITLE
Correct AP_Filter defines 

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
@@ -388,3 +388,7 @@
 #ifndef AP_ICENGINE_ENABLED
 #define AP_ICENGINE_ENABLED 0
 #endif
+
+#ifndef AP_FILTER_ENABLED
+#define AP_FILTER_ENABLED 0
+#endif

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -568,7 +568,7 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED
     SCHED_TASK(check_motor_noise,      5,     50, 252),
 #endif
-#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+#if AP_FILTER_ENABLED
     SCHED_TASK_CLASS(AP_Filters,   &vehicle.filters,        update,                   1, 100, 252),
 #endif
     SCHED_TASK(update_arming,          1,     50, 253),

--- a/libraries/Filter/AP_Filter.cpp
+++ b/libraries/Filter/AP_Filter.cpp
@@ -1,9 +1,11 @@
+#include "AP_Filter_config.h"
+
+#if AP_FILTER_ENABLED
+
 #include "AP_Filter.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
 
 extern const AP_HAL::HAL& hal;
 
@@ -152,4 +154,4 @@ AP_Filters &filters()
 
 }
 
-#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+#endif // AP_FILTER_ENABLED

--- a/libraries/Filter/AP_Filter_params.cpp
+++ b/libraries/Filter/AP_Filter_params.cpp
@@ -1,8 +1,10 @@
+#include "AP_Filter_config.h"
+
+#if AP_FILTER_ENABLED
+
 #include "AP_Filter.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
-
-#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
 
 const AP_Param::GroupInfo AP_Filter_params::var_info[] = {
 
@@ -22,4 +24,4 @@ AP_Filter_params::AP_Filter_params()
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+#endif // AP_FILTER_ENABLED

--- a/libraries/Filter/AP_NotchFilter_params.cpp
+++ b/libraries/Filter/AP_NotchFilter_params.cpp
@@ -1,8 +1,10 @@
+#include "AP_Filter_config.h"
+
+#if AP_FILTER_ENABLED
+
 #include "AP_Filter.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
-
-#if AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
 
 const AP_Param::GroupInfo AP_NotchFilter_params::var_info[] = {
   
@@ -50,4 +52,4 @@ bool AP_NotchFilter_params::setup_notch_filter(NotchFilterFloat& filter, float s
     return true;
 }
 
-#endif // AP_FILTER_ENABLED && !APM_BUILD_TYPE(APM_BUILD_AP_Periph)
+#endif // AP_FILTER_ENABLED


### PR DESCRIPTION
 - checking the build type is very rarely used and definitely not required here
 - fix boilerplate to conform to normal pattern of including the config header and #if'ing based on the _ENABLED directly after that
