### PR TITLE
AP_Networking: Allow Broadcast

### DIFF
--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -119,6 +119,8 @@ bool SocketAPM::connect(const char *address, uint16_t port)
         if (ret == -1) {
             goto fail_mc;
         }
+    } else if (datagram && sockaddr.sin_addr.s_addr == INADDR_BROADCAST) {
+        set_broadcast();
     }
 
     ret = CALL_PREFIX(connect)(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));


### PR DESCRIPTION
Add define AP_NETWORKING_SOCKETS_BROADCAST_ALLOWED to enable Broadcast IP (255.255.255.255) on sockets.