### PR TITLE
AP_Motors: Heli: dual and quad: remove un-needed override methods

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -50,12 +50,6 @@ public:
     // calculate_armed_scalars - recalculates scalars that can change while armed
     void calculate_armed_scalars() override;
 
-    // has_flybar - returns true if we have a mechical flybar
-    bool has_flybar() const  override { return AP_MOTORS_HELI_NOFLYBAR; }
-
-    // supports_yaw_passthrought - returns true if we support yaw passthrough
-    bool supports_yaw_passthrough() const  override { return false; }
-
     // servo_test - move servos through full range of movement
     void servo_test() override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -37,12 +37,6 @@ public:
     // calculate_armed_scalars - recalculates scalars that can change while armed
     void calculate_armed_scalars() override;
 
-    // has_flybar - returns true if we have a mechanical flybar
-    bool has_flybar() const  override { return AP_MOTORS_HELI_NOFLYBAR; }
-
-    // supports_yaw_passthrought - returns true if we support yaw passthrough
-    bool supports_yaw_passthrough() const  override { return false; }
-
     // servo_test - move servos through full range of movement
     void servo_test() override;
 


### PR DESCRIPTION
`AP_MotorsHeli_Quad` and `AP_MotorsHeli_Dual` both inherit from `AP_MotorsHeli` which implements the same methods. There is no need to override. 

https://github.com/ArduPilot/ardupilot/blob/b5e2f9aa0a7337d9bb1d5cc4e57bb472b112a5c1/libraries/AP_Motors/AP_MotorsHeli.h#L72-L73

https://github.com/ArduPilot/ardupilot/blob/b5e2f9aa0a7337d9bb1d5cc4e57bb472b112a5c1/libraries/AP_Motors/AP_MotorsHeli.h#L120-L121

Alternately we could make the base class a pure virtual so the child class must implement. 