### PR TITLE
.git-blame-ignore-revs: Ignore black format change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# This file allows ignoring commits in git blame view on Github.
+# For more info, see here:
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# Tools: ros2: Run ament_black on all files
+85172b56467668bee9fa0e68081027b13bc18c4a


### PR DESCRIPTION
This reduces commit noise in Tools/ros2 by ignoring our mass-format commit when we switched to black. I'd like to propose this as a way to start ignoring commits in ArduPilot that are format-only. 

For more info on how this feature works, see here:
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

This approach is used on other major repos with >1M Lines of Code like GDAL:
https://gdal.org/development/rfc/rfc69_cplusplus_formatting.html

This strategy can be used in the future to ignore things like
* flake8 format
* astyle format changes
* Fixing incorrect indent errors: 

Using automated formatting reduces developer time, so that people like Randy do not need to spend [cognitive load nitpicking style](https://github.com/ArduPilot/ardupilot/pull/25541#discussion_r1399882470) and instead focus on logic errors and other things that affect behavior or maintainability.

Yes, refactor and automated tools need to be applied carefully because it makes backporting difficult. This PR in no way changes that existing process, but it does reduce the developer effect of mass-changes on the git blame.
