### PR TITLE
AP_Stats: initialise parameter defaults

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -47,6 +47,7 @@ AP_Stats *AP_Stats::_singleton;
 // constructor
 AP_Stats::AP_Stats(void)
 {
+    AP_Param::setup_object_defaults(this, var_info);
     _singleton = this;
 }
 


### PR DESCRIPTION
* We noticed that STAT_BOOTCNT wasn't incrementing. The reason was that param.reset was being set to 0 and resetting everything at boot.