### PR TITLE
Tools: autotest: Fix exception in junit printing for double  to str conversion during failed test

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -1477,15 +1477,15 @@ class Result(object):
     def __str__(self):
         ret = "  %s (%s)" % (self.test.name, self.test.description)
         if self.passed:
-            return ret + " OK"
+            return f"{ret} OK"
         if self.reason is not None:
-            ret += " (" + self.reason + ")"
+            ret += f" ({self.reason} )"
         if self.exception is not None:
-            ret += " (" + str(self.exception) + ")"
+            ret += f" ({str(self.exception)})"
         if self.debug_filename is not None:
-            ret += " (see " + self.debug_filename + ")"
+            ret += f" (see {self.debug_filename})"
         if self.time_elapsed is not None:
-            ret += " (duration " + self.time_elapsed + "s)"
+            ret += f" (duration {self.time_elapsed} s)"
         return ret
 
 


### PR DESCRIPTION
## Background

You can't concetenate a double to a string without fstring or a type change. This wasn't on master branch, but the test does have a failure that caused this crash. 

## Logs

```
$ python3 ./Tools/autotest/autotest.py build.Plane test.Plane.MicroStrainEAHRS7

>>>> FAILED STEP: test.Plane.MicroStrainEAHRS7 at Thu Nov 23 00:14:29 2023 (can only concatenate str (not "float") to str)
Traceback (most recent call last):
  File "/home/ryan/Dev/ros2_ws/src/ardupilot/./Tools/autotest/autotest.py", line 718, in run_tests
    success = run_step(step)
  File "/home/ryan/Dev/ros2_ws/src/ardupilot/./Tools/autotest/autotest.py", line 525, in run_step
    return run_specific_test(specific_test_to_run, binary, **fly_opts)
  File "/home/ryan/Dev/ros2_ws/src/ardupilot/./Tools/autotest/autotest.py", line 385, in run_specific_test
    return tester.autotest(tests=[a], allow_skips=False, step_name=step), tester
  File "/home/ryan/Dev/ros2_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 13797, in autotest
    print(str(failure))
  File "/home/ryan/Dev/ros2_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 1490, in __str__
    ret += " (duration " + self.time_elapsed + "s)"
TypeError: can only concatenate str (not "float") to str
FAILED 1 tests: ['test.Plane.MicroStrainEAHRS7']