### PR TITLE
Networking: added multicast support

### DIFF
--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -23,12 +23,18 @@
 #include "Socket.h"
 #include <errno.h>
 
+#if AP_NETWORKING_BACKEND_CHIBIOS
+#define CALL_PREFIX(x) ::lwip_##x
+#else
+#define CALL_PREFIX(x) ::x
+#endif
+
 /*
   constructor
  */
 SocketAPM::SocketAPM(bool _datagram) :
     SocketAPM(_datagram, 
-              socket(AF_INET, _datagram?SOCK_DGRAM:SOCK_STREAM, 0))
+              CALL_PREFIX(socket)(AF_INET, _datagram?SOCK_DGRAM:SOCK_STREAM, 0))
 {}
 
 SocketAPM::SocketAPM(bool _datagram, int _fd) :
@@ -36,23 +42,23 @@ SocketAPM::SocketAPM(bool _datagram, int _fd) :
     fd(_fd)
 {
 #ifdef FD_CLOEXEC
-    fcntl(fd, F_SETFD, FD_CLOEXEC);
+    CALL_PREFIX(fcntl)(fd, F_SETFD, FD_CLOEXEC);
 #endif
     if (!datagram) {
         int one = 1;
-        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+        CALL_PREFIX(setsockopt)(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     }
 }
 
 SocketAPM::~SocketAPM()
 {
     if (fd != -1) {
-#if AP_NETWORKING_BACKEND_CHIBIOS
-        ::lwip_close(fd);
-#else
-        ::close(fd);
-#endif
+        CALL_PREFIX(close)(fd);
         fd = -1;
+    }
+    if (fd_in != -1) {
+        CALL_PREFIX(close)(fd_in);
+        fd_in = -1;
     }
 }
 
@@ -74,16 +80,58 @@ void SocketAPM::make_sockaddr(const char *address, uint16_t port, struct sockadd
 bool SocketAPM::connect(const char *address, uint16_t port)
 {
     struct sockaddr_in sockaddr;
+    int ret;
     make_sockaddr(address, port, sockaddr);
 
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    if (::lwip_connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
-#else
-    if (::connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+    if (datagram && is_multicast_address(sockaddr)) {
+        /*
+          connect fd_in as a multicast UDP socket
+         */
+        fd_in = CALL_PREFIX(socket)(AF_INET, SOCK_DGRAM, 0);
+        if (fd_in == -1) {
+            return false;
+        }
+        struct sockaddr_in sockaddr_mc = sockaddr;
+        int one = 1;
+        struct ip_mreq mreq {};
+#ifdef FD_CLOEXEC
+        CALL_PREFIX(fcntl)(fd_in, F_SETFD, FD_CLOEXEC);
 #endif
+        IGNORE_RETURN(CALL_PREFIX(setsockopt)(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)));
+
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
+        /*
+          on cygwin you need to bind to INADDR_ANY then use the multicast
+          IP_ADD_MEMBERSHIP to get on the right address
+        */
+        sockaddr_mc.sin_addr.s_addr = htonl(INADDR_ANY);
+#endif
+    
+        ret = CALL_PREFIX(bind)(fd_in, (struct sockaddr *)&sockaddr_mc, sizeof(sockaddr));
+        if (ret == -1) {
+            goto fail_mc;
+        }
+
+        mreq.imr_multiaddr.s_addr = sockaddr.sin_addr.s_addr;
+        mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+
+        ret = CALL_PREFIX(setsockopt)(fd_in, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+        if (ret == -1) {
+            goto fail_mc;
+        }
+    }
+
+    ret = CALL_PREFIX(connect)(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    if (ret != 0) {
         return false;
     }
+    connected = true;
     return true;
+
+fail_mc:
+    CALL_PREFIX(close)(fd_in);
+    fd_in = -1;
+    return false;
 }
 
 /*
@@ -96,11 +144,7 @@ bool SocketAPM::connect_timeout(const char *address, uint16_t port, uint32_t tim
 
     set_blocking(false);
 
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    int ret = ::lwip_connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-#else
-    int ret = ::connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-#endif
+    int ret = CALL_PREFIX(connect)(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (ret == 0) {
         // instant connect?
         return true;
@@ -117,7 +161,8 @@ bool SocketAPM::connect_timeout(const char *address, uint16_t port, uint32_t tim
     if (getsockopt(fd, SOL_SOCKET, SO_ERROR, (void*)&sock_error, &len) != 0) {
         return false;
     }
-    return sock_error == 0;
+    connected = sock_error == 0;
+    return connected;
 }
 
 /*
@@ -128,11 +173,7 @@ bool SocketAPM::bind(const char *address, uint16_t port)
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);
 
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    if (::lwip_bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
-#else
-    if (::bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
-#endif
+    if (CALL_PREFIX(bind)(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
         return false;
     }
     return true;
@@ -145,7 +186,7 @@ bool SocketAPM::bind(const char *address, uint16_t port)
 bool SocketAPM::reuseaddress(void) const
 {
     int one = 1;
-    return (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != -1);
+    return (CALL_PREFIX(setsockopt)(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != -1);
 }
 
 /*
@@ -155,9 +196,15 @@ bool SocketAPM::set_blocking(bool blocking) const
 {
     int fcntl_ret;
     if (blocking) {
-        fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK);
+        fcntl_ret = CALL_PREFIX(fcntl)(fd, F_SETFL, CALL_PREFIX(fcntl)(fd, F_GETFL, 0) & ~O_NONBLOCK);
+        if (fd_in != -1) {
+            fcntl_ret |= CALL_PREFIX(fcntl)(fd_in, F_SETFL, CALL_PREFIX(fcntl)(fd_in, F_GETFL, 0) & ~O_NONBLOCK);
+        }
     } else {
-        fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+        fcntl_ret = CALL_PREFIX(fcntl)(fd, F_SETFL, CALL_PREFIX(fcntl)(fd, F_GETFL, 0) | O_NONBLOCK);
+        if (fd_in != -1) {
+            fcntl_ret |= CALL_PREFIX(fcntl)(fd_in, F_SETFL, CALL_PREFIX(fcntl)(fd_in, F_GETFL, 0) | O_NONBLOCK);
+        }
     }
     return fcntl_ret != -1;
 }
@@ -168,7 +215,7 @@ bool SocketAPM::set_blocking(bool blocking) const
 bool SocketAPM::set_cloexec() const
 {
 #ifdef FD_CLOEXEC
-    return (fcntl(fd, F_SETFD, FD_CLOEXEC) != -1);
+    return (CALL_PREFIX(fcntl)(fd, F_SETFD, FD_CLOEXEC) != -1);
 #else
     return false;
 #endif
@@ -179,11 +226,7 @@ bool SocketAPM::set_cloexec() const
  */
 ssize_t SocketAPM::send(const void *buf, size_t size) const
 {
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    return ::lwip_send(fd, buf, size, 0);
-#else
-    return ::send(fd, buf, size, 0);
-#endif
+    return CALL_PREFIX(send)(fd, buf, size, 0);
 }
 
 /*
@@ -193,11 +236,7 @@ ssize_t SocketAPM::sendto(const void *buf, size_t size, const char *address, uin
 {
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    return ::lwip_sendto(fd, buf, size, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-#else
-    return ::sendto(fd, buf, size, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-#endif
+    return CALL_PREFIX(sendto)(fd, buf, size, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 }
 
 /*
@@ -209,11 +248,29 @@ ssize_t SocketAPM::recv(void *buf, size_t size, uint32_t timeout_ms)
         return -1;
     }
     socklen_t len = sizeof(in_addr);
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    return ::lwip_recvfrom(fd, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr, &len);
-#else
-    return ::recvfrom(fd, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr, &len);
-#endif
+    int fin = get_read_fd();
+    ssize_t ret;
+    ret = CALL_PREFIX(recvfrom)(fin, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr, &len);
+    if (ret <= 0) {
+        return ret;
+    }
+    if (fd_in != -1) {
+        /*
+          for multicast check we are not receiving from ourselves
+         */
+        struct sockaddr_in send_addr;
+        socklen_t send_len = sizeof(send_addr);
+        if (CALL_PREFIX(getsockname)(fd, (struct sockaddr *)&send_addr, &send_len) != 0) {
+            return -1;
+        }
+        if (in_addr.sin_port == send_addr.sin_port &&
+            in_addr.sin_family == send_addr.sin_family &&
+            in_addr.sin_addr.s_addr == send_addr.sin_addr.s_addr) {
+            // discard packets from ourselves
+            return -1;
+        }
+    }
+    return ret;
 }
 
 /*
@@ -228,7 +285,7 @@ void SocketAPM::last_recv_address(const char *&ip_addr, uint16_t &port) const
 void SocketAPM::set_broadcast(void) const
 {
     int one = 1;
-    setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
+    CALL_PREFIX(setsockopt)(fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
 }
 
 /*
@@ -240,12 +297,13 @@ bool SocketAPM::pollin(uint32_t timeout_ms)
     struct timeval tv;
 
     FD_ZERO(&fds);
-    FD_SET(fd, &fds);
+    int fin = get_read_fd();
+    FD_SET(fin, &fds);
 
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000UL;
 
-    if (select(fd+1, &fds, nullptr, nullptr, &tv) != 1) {
+    if (CALL_PREFIX(select)(fin+1, &fds, nullptr, nullptr, &tv) != 1) {
         return false;
     }
     return true;
@@ -266,7 +324,7 @@ bool SocketAPM::pollout(uint32_t timeout_ms)
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000UL;
 
-    if (select(fd+1, nullptr, &fds, nullptr, &tv) != 1) {
+    if (CALL_PREFIX(select)(fd+1, nullptr, &fds, nullptr, &tv) != 1) {
         return false;
     }
     return true;
@@ -277,11 +335,7 @@ bool SocketAPM::pollout(uint32_t timeout_ms)
  */
 bool SocketAPM::listen(uint16_t backlog) const
 {
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    return ::lwip_listen(fd, (int)backlog) == 0;
-#else
-    return ::listen(fd, (int)backlog) == 0;
-#endif
+    return CALL_PREFIX(listen)(fd, (int)backlog) == 0;
 }
 
 /*
@@ -294,18 +348,25 @@ SocketAPM *SocketAPM::accept(uint32_t timeout_ms)
         return nullptr;
     }
 
-#if AP_NETWORKING_BACKEND_CHIBIOS
-    int newfd = ::lwip_accept(fd, nullptr, nullptr);
-#else
-    int newfd = ::accept(fd, nullptr, nullptr);
-#endif
+    int newfd = CALL_PREFIX(accept)(fd, nullptr, nullptr);
     if (newfd == -1) {
         return nullptr;
     }
     // turn off nagle for lower latency
     int one = 1;
-    setsockopt(newfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    CALL_PREFIX(setsockopt)(newfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     return new SocketAPM(false, newfd);
+}
+
+/*
+  return true if an address is in the multicast range
+ */
+bool SocketAPM::is_multicast_address(struct sockaddr_in &addr) const
+{
+    const uint32_t mc_lower = 0xE0000000; // 224.0.0.0
+    const uint32_t mc_upper = 0xEFFFFFFF; // 239.255.255.255
+    const uint32_t haddr = ntohl(addr.sin_addr.s_addr);
+    return haddr >= mc_lower && haddr <= mc_upper;
 }
 
 #endif // AP_NETWORKING_BACKEND_ANY

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -70,11 +70,26 @@ public:
     // listen has been used. A new socket is returned
     SocketAPM *accept(uint32_t timeout_ms);
 
+    // get a FD suitable for read selection
+    int get_read_fd(void) const {
+        return fd_in != -1? fd_in : fd;
+    }
+
+    bool is_connected(void) const {
+        return connected;
+    }
+
 private:
     bool datagram;
     struct sockaddr_in in_addr {};
+    bool is_multicast_address(struct sockaddr_in &addr) const;
 
     int fd = -1;
+
+    // fd_in is used for multicast UDP
+    int fd_in = -1;
+
+    bool connected;
 
     void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
 };

--- a/libraries/AP_HAL_SITL/CAN_Multicast.cpp
+++ b/libraries/AP_HAL_SITL/CAN_Multicast.cpp
@@ -38,83 +38,9 @@ bool CAN_Multicast::init(uint8_t instance)
 {
     // setup incoming multicast socket
     char address[] = MCAST_ADDRESS_BASE;
-    struct sockaddr_in sockaddr {};
-    struct ip_mreq mreq {};
-    int one = 1;
-    int ret;
 
-#ifdef HAVE_SOCK_SIN_LEN
-    sockaddr.sin_len = sizeof(sockaddr);
-#endif
     address[strlen(address)-1] = '0' + instance;
-
-    sockaddr.sin_port = htons(MCAST_PORT);
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(address);
-
-    fd_in = socket(AF_INET, SOCK_DGRAM, 0);
-    if (fd_in == -1) {
-        goto fail;
-    }
-    ret = fcntl(fd_in, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        goto fail;
-    }
-    if (setsockopt(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) == -1) {
-        goto fail;
-    }
-
-    // close on exec, to allow reboot
-    fcntl(fd_in, F_SETFD, FD_CLOEXEC);
-
-#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
-    /*
-      on cygwin you need to bind to INADDR_ANY then use the multicast
-      IP_ADD_MEMBERSHIP to get on the right address
-     */
-    sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-#endif
-    
-    ret = bind(fd_in, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    if (ret == -1) {
-        goto fail;
-    }
-
-    mreq.imr_multiaddr.s_addr = inet_addr(address);
-    mreq.imr_interface.s_addr = htonl(INADDR_ANY);
-
-    ret = setsockopt(fd_in, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
-    if (ret == -1) {
-        goto fail;
-    }
-
-    // setup outgoing socket
-    fd_out = socket(AF_INET, SOCK_DGRAM, 0);
-    if (fd_out == -1) {
-        goto fail;
-    }
-    ret = fcntl(fd_out, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        goto fail;
-    }
-
-    ret = connect(fd_out, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    if (ret == -1) {
-        goto fail;
-    }
-    
-    return true;
-
-fail:
-    if (fd_in != -1) {
-        (void)close(fd_in);
-        fd_in = -1;
-    }
-    if (fd_out != -1) {
-        (void)close(fd_out);
-        fd_out = -1;
-    }
-    return false;
+    return sock.connect(address, MCAST_PORT);
 }
 
 /*
@@ -135,7 +61,7 @@ bool CAN_Multicast::send(const AP_HAL::CANFrame &frame)
     memcpy(pkt.data, frame.data, data_length);
     pkt.crc = crc16_ccitt((uint8_t*)&pkt.flags, data_length+6, 0xFFFFU);
 
-    return ::send(fd_out, (void*)&pkt, data_length+10, 0) == data_length+10;
+    return sock.send((void*)&pkt, data_length+10) == data_length+10;
 }
 
 /*
@@ -144,9 +70,7 @@ bool CAN_Multicast::send(const AP_HAL::CANFrame &frame)
 bool CAN_Multicast::receive(AP_HAL::CANFrame &frame)
 {
     struct mcast_pkt pkt;
-    struct sockaddr_in src_addr;
-    socklen_t src_len = sizeof(src_addr);
-    ssize_t ret = ::recvfrom(fd_in, (void*)&pkt, sizeof(pkt), MSG_DONTWAIT, (struct sockaddr *)&src_addr, &src_len);
+    ssize_t ret = sock.recv((void*)&pkt, sizeof(pkt), 0);
     if (ret < 10) {
         return false;
     }
@@ -154,18 +78,6 @@ bool CAN_Multicast::receive(AP_HAL::CANFrame &frame)
         return false;
     }
     if (pkt.crc != crc16_ccitt((uint8_t*)&pkt.flags, ret-4, 0xFFFFU)) {
-        return false;
-    }
-
-    // ensure it isn't a packet we sent
-    struct sockaddr_in send_addr;
-    socklen_t send_len = sizeof(send_addr);
-    if (getsockname(fd_out, (struct sockaddr *)&send_addr, &send_len) != 0) {
-        return false;
-    }
-    if (src_addr.sin_port == send_addr.sin_port &&
-        src_addr.sin_family == send_addr.sin_family &&
-        src_addr.sin_addr.s_addr == send_addr.sin_addr.s_addr) {
         return false;
     }
 

--- a/libraries/AP_HAL_SITL/CAN_Multicast.h
+++ b/libraries/AP_HAL_SITL/CAN_Multicast.h
@@ -13,12 +13,11 @@ public:
     bool send(const AP_HAL::CANFrame &frame) override;
     bool receive(AP_HAL::CANFrame &frame) override;
     int get_read_fd(void) const override {
-        return fd_in;
+        return sock.get_read_fd();
     }
 
 private:
-    int fd_in = -1;
-    int fd_out = -1;
+    SocketAPM sock{true};
 };
 
 #endif // HAL_NUM_CAN_IFACES

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -138,59 +138,11 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
  */
 void SimMCast::multicast_open(void)
 {
-    struct sockaddr_in sockaddr {};
-    int ret;
-
-#ifdef HAVE_SOCK_SIN_LEN
-    sockaddr.sin_len = sizeof(sockaddr);
-#endif
-    sockaddr.sin_port = htons(SITL_MCAST_PORT);
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
-
-    mc_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (mc_fd == -1) {
-        fprintf(stderr, "socket failed - %s\n", strerror(errno));
+    if (!sock.connect(SITL_MCAST_IP, SITL_MCAST_PORT)) {
+        fprintf(stderr, "multicast socket failed - %s\n", strerror(errno));
         exit(1);
     }
-    ret = fcntl(mc_fd, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
-        exit(1);
-    }
-    int one = 1;
-    if (setsockopt(mc_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) == -1) {
-        fprintf(stderr, "setsockopt failed: %s\n", strerror(errno));
-        exit(1);
-    }
-
-#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
-    /*
-      on cygwin you need to bind to INADDR_ANY then use the multicast
-      IP_ADD_MEMBERSHIP to get on the right address
-     */
-    sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-#endif
-    
-    ret = bind(mc_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    if (ret == -1) {
-        fprintf(stderr, "multicast bind failed on port %u - %s\n",
-                (unsigned)ntohs(sockaddr.sin_port),
-                strerror(errno));
-        exit(1);
-    }
-
-    struct ip_mreq mreq {};
-    mreq.imr_multiaddr.s_addr = inet_addr(SITL_MCAST_IP);
-    mreq.imr_interface.s_addr = htonl(INADDR_ANY);
-
-    ret = setsockopt(mc_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
-    if (ret == -1) {
-        fprintf(stderr, "multicast membership add failed on port %u - %s\n",
-                (unsigned)ntohs(sockaddr.sin_port),
-                strerror(errno));
-        exit(1);
-    }
+    servo_sock.set_blocking(false);
     ::printf("multicast receiver initialised\n");
 }
 
@@ -199,29 +151,17 @@ void SimMCast::multicast_open(void)
  */
 void SimMCast::servo_fd_open(void)
 {
-    servo_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (servo_fd == -1) {
-        fprintf(stderr, "socket failed - %s\n", strerror(errno));
+    const char *in_addr = nullptr;
+    uint16_t port;
+    sock.last_recv_address(in_addr, port);
+    if (in_addr == nullptr) {
+        return;
+    }
+    if (!servo_sock.connect(in_addr, SITL_SERVO_PORT)) {
+        fprintf(stderr, "servo socket failed - %s\n", strerror(errno));
         exit(1);
     }
-    int ret = fcntl(servo_fd, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
-        exit(1);
-    }
-    int one = 1;
-    if (setsockopt(servo_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) == -1) {
-        fprintf(stderr, "setsockopt failed: %s\n", strerror(errno));
-        exit(1);
-    }
-
-    in_addr.sin_port = htons(SITL_SERVO_PORT);
-
-    ret = connect(servo_fd, (struct sockaddr *)&in_addr, sizeof(in_addr));
-    if (ret == -1) {
-        fprintf(stderr, "multicast servo connect failed\n");
-        exit(1);
-    }
+    servo_sock.set_blocking(false);
 }
 
 /*
@@ -241,7 +181,7 @@ void SimMCast::servo_send(void)
     for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
         out_float[i] = (mask & (1U<<i)) ? out[i] : nanf("");
     }
-    send(servo_fd, (void*)out_float, sizeof(out_float), 0);
+    servo_sock.send((void*)out_float, sizeof(out_float));
 }
 
 /*
@@ -257,8 +197,7 @@ void SimMCast::multicast_read(void)
         printf("Waiting for multicast state\n");
     }
     struct SITL::sitl_fdm state;
-    socklen_t len = sizeof(in_addr);
-    while (recvfrom(mc_fd, (void*)&state, sizeof(state), MSG_WAITALL, (sockaddr *)&in_addr, &len) != sizeof(state)) {
+    while (sock.recv((void*)&state, sizeof(state), 0) != sizeof(state)) {
         // nop
     }
     if (_sitl->state.timestamp_us == 0) {
@@ -278,7 +217,7 @@ void SimMCast::multicast_read(void)
     }
     hal.scheduler->stop_clock(_sitl->state.timestamp_us + base_time_us);
     HALSITL::Scheduler::timer_event();
-    if (servo_fd == -1) {
+    if (!servo_sock.is_connected()) {
         servo_fd_open();
     } else {
         servo_send();

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.h
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.h
@@ -30,9 +30,8 @@ public:
     void update(const struct sitl_input &input) override;
 
 private:
-    int mc_fd = -1;
-    int servo_fd = -1;
-    struct sockaddr_in in_addr;
+    SocketAPM sock{true};
+    SocketAPM servo_sock{true};
 
     // offset between multicast timestamp and local timestamp
     uint64_t base_time_us;

--- a/libraries/AP_Networking/AP_Networking_ChibiOS.cpp
+++ b/libraries/AP_Networking/AP_Networking_ChibiOS.cpp
@@ -121,6 +121,13 @@ bool AP_Networking_ChibiOS::init()
 
     lwipInit(lwip_options);
 
+#if LWIP_IGMP
+    if (ETH != nullptr) {
+        // enbale "permit multicast" so we can receive multicast packets
+        ETH->MACPFR |= ETH_MACPFR_PM;
+    }
+#endif
+
     return true;
 }
 


### PR DESCRIPTION
This adds multicast support to SocketAPM, which also allows it to be used by AP_Networking for a UDP_CLIENT port. It will automatically use multicast when the destination IP is in the multicast range
This also sets up SITL to use SocketAPM, which removes two other implementations of multicast UDP sockets, simplifying the SITL code
For SITL this allows for the NET_Pn_ ports to send multicast by just choosing the right IP address range. For ChibiOS there is a bit more work needed as we don't yet enable the multicast support in lwip. I'm looking at the changes needed for lwip multicast support 

Note: this requires the following ChibiOS PR: https://github.com/ArduPilot/ChibiOS/pull/84

