### PR TITLE
Rover: auto keeps navigating while paused at waypoints

### DIFF
--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -82,21 +82,15 @@ void ModeAuto::update()
     switch (_submode) {
         case SubMode::WP:
         {
-            // check if we've reached the destination
-            if (!g2.wp_nav.reached_destination() || g2.wp_nav.is_fast_waypoint()) {
-                // update navigation controller
-                navigate_to_waypoint();
-            } else {
-                // we have reached the destination so stay here
-                if (rover.is_boat()) {
-                    if (!start_loiter()) {
-                        start_stop();
-                    }
-                } else {
-                    start_stop();
-                }
+            // boats loiter once the waypoint is reached
+            if (rover.is_boat() && g2.wp_nav.reached_destination() && !g2.wp_nav.is_fast_waypoint()) {
+                start_loiter();
+
                 // update distance to destination
                 _distance_to_destination = rover.current_loc.get_distance(g2.wp_nav.get_destination());
+            } else {
+                // update navigation controller
+                navigate_to_waypoint();
             }
             break;
         }

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -83,13 +83,13 @@ void ModeAuto::update()
         case SubMode::WP:
         {
             // boats loiter once the waypoint is reached
+            bool keep_navigating = true;
             if (rover.is_boat() && g2.wp_nav.reached_destination() && !g2.wp_nav.is_fast_waypoint()) {
-                start_loiter();
+                keep_navigating = !start_loiter();
+            }
 
-                // update distance to destination
-                _distance_to_destination = rover.current_loc.get_distance(g2.wp_nav.get_destination());
-            } else {
-                // update navigation controller
+            // update navigation controller
+            if (keep_navigating) {
                 navigate_to_waypoint();
             }
             break;

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -505,6 +505,10 @@ void AR_WPNav::update_steering_and_speed(const Location &current_loc, float dt)
 {
     _cross_track_error = calc_crosstrack_error(current_loc);
 
+    // update position controller
+    _pos_control.set_reversed(_reversed);
+    _pos_control.update(dt);
+
     // handle pivot turns
     if (_pivot.active()) {
         // decelerate to zero
@@ -512,14 +516,11 @@ void AR_WPNav::update_steering_and_speed(const Location &current_loc, float dt)
         _desired_heading_cd = _reversed ? wrap_360_cd(oa_wp_bearing_cd() + 18000) : oa_wp_bearing_cd();
         _desired_turn_rate_rads = is_zero(_desired_speed_limited) ? _pivot.get_turn_rate_rads(_desired_heading_cd * 0.01, dt) : 0;
         _desired_lat_accel = 0.0f;
-        return;
+    } else {
+        _desired_speed_limited = _pos_control.get_desired_speed();
+        _desired_turn_rate_rads = _pos_control.get_desired_turn_rate_rads();
+        _desired_lat_accel = _pos_control.get_desired_lat_accel();
     }
-
-    _pos_control.set_reversed(_reversed);
-    _pos_control.update(dt);
-    _desired_speed_limited = _pos_control.get_desired_speed();
-    _desired_turn_rate_rads = _pos_control.get_desired_turn_rate_rads();
-    _desired_lat_accel = _pos_control.get_desired_lat_accel();
 }
 
 // settor to allow vehicle code to provide turn related param values to this library (should be updated regularly)


### PR DESCRIPTION
This PR improves improves auto modes handling of corners especially for skid-steering vehicles by keeping the position controller active during delays and pivot turns.

The detailed changes are:

1. Auto's WP submode continues to "navigate_to_waypoint" even after reaching the destination instead of switching to the Stop submode.  This means the vehicle will continue to try to correct any position errors during the delay which (for better or worse) may mean the vehicle even backs up.
2. AR_WPNav continues to update the position controller even during pivot turns.  The position controller's desired turn rate output is ignored but its desired speed is used meaning the vehicle may move forward or backwards to stay close to the segments origin.  Another positive effect is that when pivoting at a corner, the previous waypoint's destination is used as the new segments origin.
3. AC_PosControl does not enforce a minimum speed when the vehicle is stopping.  This minimum speed was added to ensure that Ackermann steering vehicles do not become stuck if the target position is directly to the left or right of the vehicle.  Once the top item was implemented though this minimum speed led to the vehicle driving slowly away from the waypoint during the delay.

This has been successfully tested in SITL and on a real vehicle.  Below are some before vs after screen shots of the overshoot:
![overshoot-before](https://github.com/ArduPilot/ardupilot/assets/1498098/1e4933d6-db27-456c-9c6c-be6b41a3cec7)
![overshoot-after](https://github.com/ArduPilot/ardupilot/assets/1498098/3985fa4f-ece7-40c2-aef1-62edb0146853)

Here are before vs after screen shots of some debug output of the active leg's origin and destination.  As we pass the waypoint we can see that in the "after" pic the previous leg's destination has become the following leg's origin.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/3744fabe-2be2-4fae-8402-33c09c7c1030)
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/c399eaf3-5696-430e-a679-9ae6eb5c94fd)

There are potentially other solutions to some of these issues:

- Auto's WP submode might continue to control the vehicle (after reaching the waypoint) for just some specified minimum time to allow the vehicle to settle.  3 seconds might be enough.
- We could ensure the previous leg's destination is used for the next leg by caching it away and the forcibly setting the next leg's origin.
- AC_PosControl's minimum speed might only be applied when the target is more then 45degrees off from the vehicle's heading
