### PR TITLE
AP_BattMonitor: fixed battery percentage with aux info

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -137,7 +137,8 @@ void AP_BattMonitor_DroneCAN::update_interim_state(const float voltage, const fl
 
     const uint32_t tnow = AP_HAL::micros();
 
-    if (!_has_battery_info_aux || _mppt.is_detected) {
+    if (!_has_battery_info_aux ||
+        !use_CAN_SoC()) {
         const uint32_t dt_us = tnow - _interim_state.last_time_micros;
 
         // update total current drawn since startup


### PR DESCRIPTION
when we have aux battery information we had assumed the CAN device would provide the battery remaining percentage. We should obey the "do not use CAN SoC" with or without an AUX message

This fixes CAN battery monitors with a cell monitor