### PR TITLE
AP_Scripting: simplify Rover quick tune

### DIFF
--- a/libraries/AP_Scripting/applets/rover-quicktune.md
+++ b/libraries/AP_Scripting/applets/rover-quicktune.md
@@ -1,6 +1,6 @@
 # Rover QuickTune
 
-Rover QuickTune tunes the steering (aka turn rate), speed and position controller velocity gains for rovers and boats
+Rover QuickTune tunes the steering (aka turn rate) and speed controller gains for rovers and boats
 
 The script is designed to be used in Circle mode and updates the following parameters
 
@@ -15,14 +15,11 @@ ATC_SPEED_I
 ATC_SPEED_D
 CRUISE_SPEED
 CRUISE_THROTTLE
-PSC_VEL_P
-PSC_VEL_I
-PSC_VEL_D
 
 # How To Use
 Install this script in the autopilot's SD card's APM/scripts directory
 Set SCR_ENABLE to 1 and reboot the autopilot
-Set RTUN_ENABLE to 1.
+Set RTUN_ENABLE to 1 (default)
 
 Set RCx_OPTION = 300 where "x" refers to the transmitter's 2 or 3 position switch
 use to start/stop/save tuning.  E.g. if channel 6 is used set RC6_OPTION = 300
@@ -30,7 +27,7 @@ use to start/stop/save tuning.  E.g. if channel 6 is used set RC6_OPTION = 300
 If necessary, the RTUN_RC_FUNC parameter can be set to another number (e.g. 302 for scripting3)
 to avoid RCx_OPTION conflicts with other scripts.
 
-If only a 2-position switch is available set RTUN_AUTO_SAVE to 1
+By default the tune is saved a few seconds after completion.  To control saving of the tune manually set RTUN_AUTO_SAVE to 0
 
 Arm the vehicle and switch to Circle mode
 Optionally set CIRC_SPEED (or WP_SPEED) to about half the vehicle's max speed
@@ -40,23 +37,15 @@ Note the above parmaters only take effect when the vehicle is switched into Circ
 Move the RC switch to the middle position to begin the tuning process.
 Text messages should appear on the ground station's messages area showing progress
 
-For P and D gain tuning, the relevant gain is slowly raised until the vehicle begins to oscillate after which the gain is reduced and the script moves onto the next gain.
-
-For FF tuning, the steering or throttle output are compared to the response for at least 10 seconds.
+During tuning the steering or throttle output are compared to the response for at least 10 seconds.
 A message may appear stating the steering, turn rate, throttle or speed are too low in which case
 the vehicle speed should be increased (Mission Planner's Action tab "Change Speed" button may be used)
-or the radius should be reduced.  The velocity FF is not tuned (nor does it need to be).
+or the radius should be reduced.
 
 By default the gains will be tuned in this order:
 
- - ATC_STR_RAT_D
- - ATC_STR_RAT_P and I
- - ATC_STR_RAT_FF
- - ATC_SPEED_D
- - ATC_SPEED_P
- - CRUISE_SPEED and CRUISE_THROTTLE
- - PSC_VEL_D
- - PSC_VEL_P and I
+- ATC_STR_RAT_FF, then ATC_STR_RAT_P and I are set to ratios of the FF
+- CRUISE_SPEED and CRUISE_THROTTLE, then ATC_SPEED_P and I are set to ratios of the FF
 
 The script will also adjust filter settings:
 
@@ -67,7 +56,7 @@ Save the tune by raising the RC switch to the high position
 
 If the RC switch is moved high (ie. Save Tune) before the tune is completed the tune will pause, and any parameters completed will be saved and the current value of the one being actively tuned will remain active. You can resume tuning by returning the switch again to the middle position.  If the RC switch is moved to the low position, the parameter currently being tuned will be reverted but any previously saved parameters will remain.
 
-If you move the switch to the low position at any time in the tune before using the Tune Save switch position, then all parameters will be reverted to their original values. Parameters will also be reverted if you disarm before saving.
+If you move the switch to the low position at any time in the tune before gains are saved, then all parameters will be reverted to their original values. Parameters will also be reverted if you disarm before saving.
 
 If the pilot gives steering or throttle input during tuning then tuning is paused for 4 seconds.  Tuning restarts once the pilot returns to the input to the neutral position.
 
@@ -86,50 +75,38 @@ By default RCx_OPTIONS of 300 (scripting1) is used
 
 ## RTUN_AXES
 
-The axes that will be tuned. The default is 7 meaning steering, speed and velocity
-This parameter is a bitmask, so set 1 to tune just steering.  2 for speed. 4 for velocity
+The axes that will be tuned. The default is 3 meaning steering and speed
+This parameter is a bitmask, so set 1 to tune just steering.  2 for just speed
 
-## RTUN_DOUBLE_TIME
+## RTUN_STR_FFRATIO
 
-How quickly a gain is raised while tuning. This is the number of seconds
-for the gain to double. Most users will want to leave this at the default of 10 seconds.
+Ratio between measured response and FF gain. Raise this to get a higher FF gain
+The default of 0.9 is good for most users.
 
-## RTUN_PD_GAINMARG
+## RTUN_STR_P_RATIO
 
-The percentage P and D gain margin to use. Once the oscillation point is found
-the gain is reduced by this percentage. The default of 80% is good for most users.
+Ratio between steering FF and P gains. Raise this to get a higher P gain, 0 to leave P unchanged
+The default of 0.2 is good for most users.
 
-## RTUN_FF_GAINMARG
+## RTUN_STR_I_RATIO
 
-The percentage FF gain margin to use. Once the output and response are used to calculate
-the ideal feed-forward, the value is reduced by this percentage. The default of 20% is good for most users.
+Ratio between steering FF and I gains. Raise this to get a higher I gain, 0 to leave I unchanged
+The default of 0.2 is good for most users.
 
-## RTUN_OSC_SMAX
+## RTUN_SPD_FFRATIO
 
-The Oscillation threshold in Hertz for detecting oscillation
-The default of 5Hz is good for most vehicles  but on very large vehicles
-you may wish to lower this. For a vehicle of 50kg a value of 3 is likely to be good.
-For a vehicle of 100kg a value of 1.5 is likely to be good.
+Ratio between measured response and CRUISE_THROTTLE value. Raise this to get a higher CRUISE_THROTTLE value
+The default of 1.0 is good for most users.
 
-You can tell you have this set too high if you still have visible
-oscillations after a parameter has completed tuning. In that case
-halve this parameter and try again.
+## RTUN_SPD_P_RATIO
 
-## RTUN_SPD_P_MAX
+Ratio between speed FF and P gain. Raise this to get a higher P gain, 0 to leave P unchanged
+The default of 1.0 is good for most users.
 
-The speed controller P gain max (aka ATC_SPEED_P)
+## RTUN_SPD_I_RATIO
 
-## RTUN_SPD_D_MAX
-
-The speed controller D gain max (aka ATC_SPEED_D)
-
-## RTUN_PI_RATIO
-
-The ratio for P to I. This should normally be 1, but on some large vehicles a value of up to 3 can be
-used if the I term in the PID is causing too much phase lag.
-
-If RTUN_RP_PI_RATIO is less than 1 then the I value will not be
-changed at all when P is changed.
+Ratio between speed FF and I gain. Raise this to get a higher I gain, 0 to leave I unchanged
+The default of 1.0 is good for most users.
 
 ## RTUN_AUTO_FILTER
 


### PR DESCRIPTION
This greatly simplifies the Rover quiktune so that it only tunes the Steering (aka Turn rate) and Speed controller feed-forward values.  It then simply sets the corresponding P and I values to configurable ratios of the feed-forward.

While the rover tune received initial positive feedback, over time it became clear that the gains it produced were always too high and to get them into a reasonable range we had to set the backoff margin to ridiculously high values like 90% at which point it became very questionable as to whether the raise-gains-until-it-oscillates method is appropriate for rovers and boats.

This has been successfully tested in SITL and on a real vehicle.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/24729

The [testing discussion is here](https://discuss.ardupilot.org/t/rover-quiktune-simplified-testers-wanted/109733).