### PR TITLE
AP_Stats: Make cumulative flight time updates optional

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -37,7 +37,22 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Units: s
     // @ReadOnly: True
     // @User: Standard
-    AP_GROUPINFO("_RESET",    3, AP_Stats, params.reset, 1),
+    AP_GROUPINFO("_RESET",      3, AP_Stats, params.reset, 1),
+
+    // @Param: _INTTIM
+    // @DisplayName: Statistics Flush Interval Time
+    // @Description: Interval between flushing statistics to EEPROM
+    // @Range: 1000 30000
+    // @Units: ms
+    // @User: Standard
+    AP_GROUPINFO("_INTTIM",     4, AP_Stats, params.intervaltime, 30000),
+
+    // @Param: _NFT
+    // @DisplayName: National Flight Time
+    // @Description: Total FlightTime
+    // @Values: 0:Default,1:Japan
+    // @User: Standard
+    AP_GROUPINFO("_NFT",        5, AP_Stats, params.nationalflighttime, 0),
 
     AP_GROUPEND
 };
@@ -97,7 +112,7 @@ void AP_Stats::update()
 {
     WITH_SEMAPHORE(sem);
     const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms -  last_flush_ms > flush_interval_ms) {
+    if (now_ms -  last_flush_ms > uint32_t(params.intervaltime)) {
         update_flighttime();
         update_runtime();
         flush();
@@ -131,8 +146,16 @@ void AP_Stats::set_flying(const bool is_flying)
             _flying_ms = AP_HAL::millis();
         }
     } else {
-        update_flighttime();
-        _flying_ms = 0;
+        switch (params.nationalflighttime) {
+        case 0:  // Default
+            update_flighttime();
+            _flying_ms = 0;
+            break;
+        case 1:  // Japan
+            break;
+        default:
+            break;
+        }
     }
 }
 

--- a/libraries/AP_Stats/AP_Stats.h
+++ b/libraries/AP_Stats/AP_Stats.h
@@ -55,12 +55,13 @@ private:
         AP_Int32 flttime;
         AP_Int32 runtime;
         AP_Int32 reset;
+        AP_Int16 intervaltime;
+        AP_Int8  nationalflighttime;
     } params;
 
     void copy_variables_from_parameters();
 
-    uint64_t last_flush_ms; // in terms of system uptime
-    const uint16_t flush_interval_ms = 30000;
+    uint32_t last_flush_ms; // in terms of system uptime
 
     uint64_t _flying_ms;
     uint64_t _last_runtime_ms;


### PR DESCRIPTION
Flight time for unmanned aircraft in Japan is defined as the time from the first takeoff until the power is turned off.
ArduPilot defines flight time as the time from takeoff to landing.
I would like to add the option to use the flight time in the country of Japan as the cumulative flight time.


This is part of the flight record established by the Japanese Civil Aviation Bureau.
(1) Flight record
(a) Flight records shall be recorded for each flight.
(b) One flight in the flight log shall be defined as the time when the unmanned aircraft takes off from the place of departure after activating the power supply, lands at the destination, and then deactivates the power supply. For example, if, after landing at the destination, the power is turned off to load or unload luggage, change batteries, etc., the flight is considered to be one, but if the aircraft departs for another point with the power activated, or if it continuously takes off and lands, the flight is considered to be one until it lands at the final destination and the power is turned off. If, after landing at the final destination, the aircraft makes a landing including a continuous takeoff and landing at another point before turning off the power supply, this point shall be entered in the flight record as a transit point. However, under operational conditions In such cases, however, the flight record shall include the actual flight time. In such cases, efforts should be made to grasp and manage the actual flight time.


![Screenshot from 2023-11-25 17-46-38](https://github.com/ArduPilot/ardupilot/assets/646194/0119e309-78b9-4e20-8f9f-4d4a264a5ccd)
