### PR TITLE
Plane: Quadplane: check for valid RC before passing throttle to outputs

### DIFF
--- a/ArduPlane/motor_test.cpp
+++ b/ArduPlane/motor_test.cpp
@@ -56,9 +56,11 @@ void QuadPlane::motor_test_output()
         pwm = motor_test.throttle_value;
         break;
 
-    case MOTOR_TEST_THROTTLE_PILOT:
-        pwm = thr_min_pwm + (thr_max_pwm - thr_min_pwm) * plane.get_throttle_input()*0.01f;
+    case MOTOR_TEST_THROTTLE_PILOT: {
+        const float throttle_input = rc().has_valid_input() ? plane.get_throttle_input() : 0.0;
+        pwm = thr_min_pwm + (thr_max_pwm - thr_min_pwm) * throttle_input*0.01f;
         break;
+    }
 
     default:
         motor_test_stop();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -879,10 +879,12 @@ void QuadPlane::run_esc_calibration(void)
     }
     AP_Notify::flags.esc_calibration = true;
     switch (esc_calibration) {
-    case 1:
+    case 1: {
         // throttle based calibration
-        motors->set_throttle_passthrough_for_esc_calibration(plane.get_throttle_input() * 0.01f);
+        const float throttle_input = rc().has_valid_input() ? plane.get_throttle_input() : 0.0;
+        motors->set_throttle_passthrough_for_esc_calibration(throttle_input * 0.01f);
         break;
+    }
     case 2:
         // full range calibration
         motors->set_throttle_passthrough_for_esc_calibration(1);


### PR DESCRIPTION
Extract from https://github.com/ArduPilot/ardupilot/pull/25416

This ensures that pilot throttle is valid before outputting to motors. These two special cases are a outside of our typical code paths so its a good idea to double check. 

In both cases currently it is possible that the throttle will be hard coded to 50% here:

https://github.com/ArduPilot/ardupilot/blob/ee592476ce43414ba9f8dad164360c22bbf31299/ArduPlane/radio.cpp#L261-L274

I suspect its fine and we keep the spool state at shut down but this ensures we never output the wrong thing.