### PR TITLE
Expose DDS as option in Custom Build Server

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -79,10 +79,9 @@ class Board:
             ]
             env.DEFINES.update(AP_DDS_ENABLED = 1)
             # check for microxrceddsgen
-            cfg.find_program('microxrceddsgen',mandatory=True)
+            cfg.find_program('microxrceddsgen', mandatory=True)
         else:
             env.ENABLE_DDS = False
-            env.DEFINES.update(AP_DDS_ENABLED = 0)
 
         # setup for supporting onvif cam control
         if cfg.options.enable_onvif:

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -371,6 +371,9 @@ BUILD_OPTIONS = [
     #    Feature('Filesystem', 'FILESYSTEM_POSIX', 'AP_FILESYSTEM_POSIX_ENABLED', 'Enable POSIX filesystem', 0, None),
     Feature('Filesystem', 'FILESYSTEM_ROMFS', 'AP_FILESYSTEM_ROMFS_ENABLED', 'Enable @ROMFS/ filesystem', 0, None),
     Feature('Filesystem', 'FILESYSTEM_SYS', 'AP_FILESYSTEM_SYS_ENABLED', 'Enable @SYS/ filesystem', 0, None),
+
+    Feature('DDS', 'DDS_ENABLED', 'AP_DDS_ENABLED', 'Enable DDS Support', 1, None),
+
 ]
 
 BUILD_OPTIONS.sort(key=lambda x: (x.category + x.label))

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -236,6 +236,7 @@ class ExtractFeatures(object):
             ('COMPASS_CAL_ENABLED', 'CompassCalibrator::stop'),
             ('AP_TUNING_ENABLED', 'AP_Tuning::check_input'),
             ('AP_DRONECAN_SERIAL_ENABLED', 'AP_DroneCAN_Serial::update'),
+            ('AP_DDS_ENABLED', 'AP_DDS_Client::main_loop'),
         ]
 
     def progress(self, msg):

--- a/libraries/AP_DDS/AP_DDS_config.h
+++ b/libraries/AP_DDS/AP_DDS_config.h
@@ -4,7 +4,7 @@
 #include <AP_Networking/AP_Networking_Config.h>
 
 #ifndef AP_DDS_ENABLED
-#define AP_DDS_ENABLED 1
+#define AP_DDS_ENABLED 0
 #endif
 
 // UDP only on SITL for now

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -29,6 +29,7 @@
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Button/AP_Button.h>
 #include <AP_Compass/AP_Compass.h>
+#include <AP_DDS/AP_DDS_config.h>
 #include <AP_EFI/AP_EFI.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Generator/AP_Generator.h>


### PR DESCRIPTION
I want DDS available through the custom build server. 

 Later, UDP support and visual odom can be exposed as optional features.
 
 Solves #23280