### PR TITLE
Plane: ignore invalid pilot throttle

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -190,6 +190,9 @@ public:
      */
     bool should_disable_TECS() const;
 
+    // Get pilot throttle input with deadzone, this will return 50% throttle in failsafe!
+    float get_throttle_input() const;
+
 private:
     AP_AHRS &ahrs;
 

--- a/ArduPlane/reverse_thrust.cpp
+++ b/ArduPlane/reverse_thrust.cpp
@@ -125,6 +125,10 @@ bool Plane::have_reverse_thrust(void) const
  */
 float Plane::get_throttle_input(bool no_deadzone) const
 {
+    if (!rc().has_valid_input()) {
+        // Return 0 if there is no valid input
+        return 0.0;
+    }
     float ret;
     if (no_deadzone) {
         ret = channel_throttle->get_control_in_zero_dz();
@@ -143,6 +147,10 @@ float Plane::get_throttle_input(bool no_deadzone) const
  */
 float Plane::get_adjusted_throttle_input(bool no_deadzone) const
 {
+    if (!rc().has_valid_input()) {
+        // Return 0 if there is no valid input
+        return 0.0;
+    }
     if ((plane.channel_throttle->get_type() != RC_Channel::ControlType::RANGE) ||
         (flight_option_enabled(FlightOptions::CENTER_THROTTLE_TRIM)) == 0) {
        return  get_throttle_input(no_deadzone);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -551,9 +551,7 @@ void Plane::set_servos_controlled(void)
                control_mode == &mode_fbwa ||
                control_mode == &mode_autotune) {
         // a manual throttle mode
-        if (!rc().has_valid_input()) {
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, g.throttle_passthru_stabilize ? 0.0 : MAX(min_throttle,0));
-        } else if (g.throttle_passthru_stabilize) {
+        if (g.throttle_passthru_stabilize) {
             // manual pass through of throttle while in FBWA or
             // STABILIZE mode with THR_PASS_STAB set
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));


### PR DESCRIPTION
Extract from https://github.com/ArduPilot/ardupilot/pull/25416 superseding https://github.com/ArduPilot/ardupilot/pull/25631

This now always ignores pilot throttle if there is invalid RC. Currently on master you can get stuck at your last throttle in some cases with guided or suppressed passthrough and manual mode. This should be covered by the `set_control_in` call here:

https://github.com/ArduPilot/ardupilot/blob/bf6bd3a023da746cf21319138cab7cb6be3b2cef/ArduPlane/radio.cpp#L278

However that does not fix all cases. 

If we call `get_throttle_input(true)` to get the no deadzone value we call `get_control_in_zero_dz`:

https://github.com/ArduPilot/ardupilot/blob/bf6bd3a023da746cf21319138cab7cb6be3b2cef/ArduPlane/reverse_thrust.cpp#L123-L139

However, `get_control_in_zero_dz` does not use `control_in` it uses `radio_in` so our `set_control_in` call is bypassed. 

https://github.com/ArduPilot/ardupilot/blob/bf6bd3a023da746cf21319138cab7cb6be3b2cef/libraries/RC_Channel/RC_Channel.cpp#L391-L397

https://github.com/ArduPilot/ardupilot/blob/bf6bd3a023da746cf21319138cab7cb6be3b2cef/libraries/RC_Channel/RC_Channel.cpp#L361-L379

The problem with `get_adjusted_throttle_input` is that is uses `norm_input` with again bypasses `control_in` 

Recreation:

Turn off short fail-safe (`FS_SHORT_ACTN` 3)
Arm and go to full throttle in manual.
Have a RC fail-safe, (`SIM_RC_FAIL` 1)

Master:
Throttle remains at 100% until long action.

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/b42c2f7a-7672-457d-b99e-58e9b47d493b)

PR:

Throttle goes to 0 as soon as RC is lost, throttle is output again once in RTL.
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/62149853-4bc9-4e01-a5f9-0d717cb44a35)

The same issue also affects roll/pitch/yaw inputs in some modes....



