### PR TITLE
Rover: Circle mode aux function support and SYSID_MYGCS param desc fix

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -23,6 +23,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @DisplayName: Ground station MAVLink system ID
     // @Description: The identifier of the ground station in the MAVLink protocol. Don't change this unless you also modify the ground station to match.
     // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",    255),
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -46,6 +46,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: My ground station number
     // @Description: Allows restricting radio overrides to only come from my ground station
     // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,   "SYSID_MYGCS",     255),
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -23,6 +23,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Ground station MAVLink system ID
     // @Description: The identifier of the ground station in the MAVLink protocol. Don't change this unless you also modify the ground station to match.
     // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",    255),
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -47,6 +47,8 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: SYSID_MYGCS
     // @DisplayName: My ground station number
     // @Description: Allows restricting radio overrides to only come from my ground station
+    // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,   "SYSID_MYGCS",     255),
 

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -41,6 +41,7 @@ const AP_Param::Info Blimp::var_info[] = {
     // @DisplayName: My ground station number
     // @Description: Allows restricting radio overrides to only come from my ground station
     // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,   "SYSID_MYGCS",     255),
 

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -42,6 +42,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: MAVLink ground station ID
     // @Description: The identifier of the ground station in the MAVLink protocol. Don't change this unless you also modify the ground station to match.
     // @Range: 1 255
+    // @Increment: 1
     // @User: Advanced
     GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",      255),
 

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -33,6 +33,7 @@ void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const AuxSw
     // the following functions do not need initialising:
     case AUX_FUNC::ACRO:
     case AUX_FUNC::AUTO:
+    case AUX_FUNC::CIRCLE:
     case AUX_FUNC::FOLLOW:
     case AUX_FUNC::GUIDED:
     case AUX_FUNC::HOLD:
@@ -224,6 +225,10 @@ bool RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const AuxSwit
     // set mode to Simple
     case AUX_FUNC::SIMPLE:
         do_aux_function_change_mode(rover.mode_simple, ch_flag);
+        break;
+
+    case AUX_FUNC::CIRCLE:
+        do_aux_function_change_mode(rover.g2.mode_circle, ch_flag);
         break;
 
     // trigger sailboat tack

--- a/libraries/APM_Control/AR_PosControl.cpp
+++ b/libraries/APM_Control/AR_PosControl.cpp
@@ -56,7 +56,7 @@ const AP_Param::GroupInfo AR_PosControl::var_info[] = {
     // @Param: _VEL_I
     // @DisplayName: Velocity (horizontal) I gain
     // @Description: Velocity (horizontal) I gain.  Corrects long-term difference between desired and actual velocity to a target acceleration
-    // @Range: 0.02 1.00
+    // @Range: 0.00 1.00
     // @Increment: 0.01
     // @User: Advanced
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -171,7 +171,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter}: 69:POSHOLD Mode
     // @Values{Copter}: 70:ALTHOLD Mode
     // @Values{Copter}: 71:FLOWHOLD Mode
-    // @Values{Copter,Plane}: 72:CIRCLE  Mode
+    // @Values{Copter,Rover,Plane}: 72:CIRCLE Mode
     // @Values{Copter}: 73:DRIFT Mode
     // @Values{Rover}: 74:Sailboat motoring 3pos
     // @Values{Copter}: 75:SurfaceTrackingUpDown


### PR DESCRIPTION
This PR adds Rover support for the existing Circle mode auxiliary function switch.  Circle mode was added to Rover in PR https://github.com/ArduPilot/ardupilot/pull/23890 back in may.

There are also these unrelated parameter description fixes that I noticed while making the above change:

- Rover's PSC_VEL_I parameter range is updated to allow "0" which is actually the params default value.
- SYSID_MYGCS parameter increment is set to "1" for all vehicles.  This should fix MP's odd behaviour of making it easy to set the parameter to values like 254.9 (see below how this can happen)

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/e9a29a5b-97cc-4ceb-aa4a-624aab2ca45f)


These changes have been lightly tested in SITL.