### PR TITLE
Rover: Extra pre-arm checks on outputs

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -457,6 +457,18 @@ bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
 //  returns true if checks pass, false if they fail.  report should be true to send text messages to GCS
 bool AP_MotorsUGV::pre_arm_check(bool report) const
 {
+    // check that there's defined outputs, inc scripting and sail
+    if(!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) &&
+       !SRV_Channels::function_assigned(SRV_Channel::k_throttleRight) &&
+       !SRV_Channels::function_assigned(SRV_Channel::k_throttle) &&
+       !SRV_Channels::function_assigned(SRV_Channel::k_steering) &&
+       !SRV_Channels::function_assigned(SRV_Channel::k_scripting1) &&
+       !has_sail()) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: no motor, sail or scripting outputs defined");
+        }
+        return false;
+    }
     // check if only one of skid-steering output has been configured
     if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) != SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
         if (report) {


### PR DESCRIPTION
This PR extends the current pre-arm check for motor/steering config to include a check for _no_ controllable outputs.

So, the check will fail if there's no steering, throttle, sail or scripting1 servo outputs configured.

The reason for this is that I've worked through several user-support cases where the user has configured all the ``SERVOn_FUNCTION`` parameters as ``RCINn`` (RC pass-through).

This has the effect (for the user) that manual mode _seemingly_ works fine, but any other modes have no output - leading to a very confused user.

Tested in SITL.