### PR TITLE
Tools: ros2: Add geopose test

### DIFF
--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -92,6 +92,11 @@ colcon test --packages-select ardupilot_dds_tests
 colcon test-result --all --verbose
 ```
 
+To debug a specific test, you can do the following:
+```
+colcon --log-level DEBUG test --packages-select ardupilot_dds_tests --event-handlers=console_direct+ --pytest-args -k test_dds_udp_geopose_msg_recv -s
+```
+
 ## Install macOS
 
 The install procedure on macOS is similar, except that all dependencies

--- a/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
+++ b/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
@@ -144,7 +144,7 @@ def achieved_goal(goal_global_pos, cur_geopose):
     p2 = (cur_pos.latitude, cur_pos.longitude, cur_pos.altitude)
 
     flat_distance = distance.distance(p1[:2], p2[:2]).m
-    euclidian_distance = math.sqrt(flat_distance ** 2 + (p2[2] - p1[2]) ** 2)
+    euclidian_distance = math.sqrt(flat_distance**2 + (p2[2] - p1[2]) ** 2)
     print(f"Goal is {euclidian_distance} meters away")
     return euclidian_distance < 150
 

--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -27,7 +27,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ardupilot_msgs</test_depend>
   <test_depend>ardupilot_sitl</test_depend>
-  <test_depend>builtin_interfaces</test_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>geographic_msgs</exec_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_pytest</test_depend>
   <test_depend>launch_ros</test_depend>
@@ -35,6 +36,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>sensor_msgs</test_depend>
+  <test_depend>python-scipy</test_depend>
 
 
   <export>

--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>geographic_msgs</exec_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_pytest</test_depend>
+  <test_depend>micro_ros_agent</test_depend>
   <test_depend>launch_ros</test_depend>
   <exec_depend>micro_ros_msgs</exec_depend>
   <test_depend>python3-pytest</test_depend>

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -26,9 +26,11 @@ from launch_pytest.tools import process as process_tools
 
 from builtin_interfaces.msg import Time
 
+TOPIC = "ap/time"
+
 
 class TimeListener(rclpy.node.Node):
-    """Subscribe to Time messages on /ap/time."""
+    """Subscribe to Time messages."""
 
     def __init__(self):
         """Initialise the node."""
@@ -36,7 +38,7 @@ class TimeListener(rclpy.node.Node):
         self.msg_event_object = threading.Event()
 
         # Declare and acquire `topic` parameter.
-        self.declare_parameter("topic", "ap/time")
+        self.declare_parameter("topic", TOPIC)
         self.topic = self.get_parameter("topic").get_parameter_value().string_value
 
     def start_subscriber(self):
@@ -89,7 +91,7 @@ def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)
 def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial):
-    """Test /ap/time is published by AP_DDS."""
+    """Test Time is published by AP_DDS."""
     _, actions = launch_sitl_copter_dds_serial
     virtual_ports = actions["virtual_ports"].action
     micro_ros_agent = actions["micro_ros_agent"].action
@@ -107,7 +109,7 @@ def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial)
         node = TimeListener()
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
-        assert msgs_received_flag, "Did not receive 'ROS_Time' msgs."
+        assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
     finally:
         rclpy.shutdown()
     yield
@@ -115,7 +117,7 @@ def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial)
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_udp)
 def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp):
-    """Test /ap/time is published by AP_DDS."""
+    """Test Time is published by AP_DDS."""
     _, actions = launch_sitl_copter_dds_udp
     micro_ros_agent = actions["micro_ros_agent"].action
     mavproxy = actions["mavproxy"].action
@@ -131,7 +133,7 @@ def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp):
         node = TimeListener()
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
-        assert msgs_received_flag, "Did not receive 'ROS_Time' msgs."
+        assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
     finally:
         rclpy.shutdown()
     yield


### PR DESCRIPTION
# Purpose

* Add geopose test
* Add missing deps
* Reduce some duplication

# How to test

```bash
source /opt/ros/humble/setup.bash
colcon build --packages-up-to ardupilot_dds_tests
colcon --log-level DEBUG test --packages-select ardupilot_dds_tests --event-handlers=console_direct+
```

# Known issue

The heading reported by ROS2 never matches CMAC's configured heading. It's not clear whether the heading configured in `locations.txt` is magnetic or true north, but it's more off than that.

