### PR TITLE
Tools: sort serial ports for uploader

### DIFF
--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -1007,7 +1007,7 @@ def ports_to_try(args):
     if "linux" in _platform or "darwin" in _platform or "cygwin" in _platform:
         import glob
         for pattern in patterns:
-            portlist += glob.glob(pattern)
+            portlist += sorted(glob.glob(pattern))
     else:
         portlist = patterns
 


### PR DESCRIPTION
this ensures that the first port on linux is used, the 2nd port may not have mavlink enabled
this is why --upload sometimes fails to reboot the board