### PR TITLE
Copter: Auto mode CONDITION_YAW treats neg relative angle with CCW direction as CCW

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -110,6 +110,10 @@ void Mode::AutoYaw::set_fixed_yaw(float angle_deg, float turn_rate_ds, int8_t di
 
     // calculate final angle as relative to vehicle heading or absolute
     if (relative_angle) {
+        // if both negative relative angle and CCW direction rotate in CCW direction
+        if (is_negative(angle_deg) && (direction < 0)) {
+            direction = 0;
+        }
         _fixed_yaw_offset_cd = angle_deg * 100.0 * (direction >= 0 ? 1.0 : -1.0);
     } else {
         // absolute angle

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -118,9 +118,9 @@ void Mode::AutoYaw::set_fixed_yaw(float angle_deg, float turn_rate_ds, int8_t di
     } else {
         // absolute angle
         _fixed_yaw_offset_cd = wrap_180_cd(angle_deg * 100.0 - _yaw_angle_cd);
-        if ( direction < 0 && is_positive(_fixed_yaw_offset_cd) ) {
+        if (direction < 0 && is_positive(_fixed_yaw_offset_cd)) {
             _fixed_yaw_offset_cd -= 36000.0;
-        } else if ( direction > 0 && is_negative(_fixed_yaw_offset_cd) ) {
+        } else if (direction > 0 && is_negative(_fixed_yaw_offset_cd)) {
             _fixed_yaw_offset_cd += 36000.0;
         }
     }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1850,8 +1850,6 @@ void ModeAuto::do_yaw(const AP_Mission::Mission_Command& cmd)
 // Do (Now) commands
 /********************************************************************************/
 
-
-
 void ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.content.speed.target_ms > 0) {


### PR DESCRIPTION
This makes Auto mode's handling of the CONDITION_YAW command slightly more intuitive in the case where the user has specified both a negative relative angle and a CCW direction (e.g. Deg = -90, Dir = -1, Relative=1).

Currently master interprets this double negative as a positive and will rotate the vehicle in the clockwise direction.  With this change the double negative is interpreted as a negative and so the vehicle rotates in the CCW direction.

This PR also includes some drive-by formatting fixes.

This has been lightly tested in SITL and works as expected.
![condyaw-fix-before-vs-after](https://github.com/ArduPilot/ardupilot/assets/1498098/0149d5b4-46e4-4d38-b1af-3371d80a2956)

Note that CONDITION_YAW can also be sent as an immediate command (e.g. while the vehicle is GUIDED mode) but [that handler rejects negative angles](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_Mavlink.cpp#L913) so the double-negative case is never met.  We could them consistent by removing [these few lines](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_Mavlink.cpp#L913) and the modify the MAVLink spec ([see related PR](https://github.com/mavlink/mavlink/pull/2058))

This resolves issue https://github.com/ArduPilot/ardupilot/issues/23874