### PR TITLE
AP_Periph: disable UART reboot check for non-debug builds

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -77,6 +77,15 @@
 #define HAL_PERIPH_CAN_MIRROR 0
 #endif
 
+#if defined(HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT) && !defined(HAL_DEBUG_BUILD) && !defined(HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_NON_DEBUG)
+/* this checking for reboot can lose bytes on GPS modules and other
+ * serial devices. It is really only relevent on a debug build if you
+ * really want it for non-debug build then define
+ * HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_NON_DEBUG in hwdef.dat
+ */
+#undef HAL_PERIPH_LISTEN_FOR_SERIAL_UART_REBOOT_CMD_PORT
+#endif
+
 #include "Parameters.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
this was causing loss of bytes on GPS peripherals as the reboot check swallowed data. The option is really only meant for debug builds to make ./waf AP_Periph --upload work, so disable by default on non-debug builds

we could just remove this option where it is in hwdef.dat files, but I know quite a few peripherals are out-of-tree, so this catches the error for those too

the symptoms were high GPS delta values