### PR TITLE
Tools: fix AP_Periph param docs generator

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -109,11 +109,12 @@ def lua_applets():
 
 libraries = []
 
-# AP_Vehicle also has parameters rooted at "", but isn't referenced
-# from the vehicle in any way:
-ap_vehicle_lib = Library("", reference="VEHICLE") # the "" is tacked onto the front of param name
-setattr(ap_vehicle_lib, "Path", os.path.join('..', 'libraries', 'AP_Vehicle', 'AP_Vehicle.cpp'))
-libraries.append(ap_vehicle_lib)
+if args.vehicle != "AP_Periph":
+    # AP_Vehicle also has parameters rooted at "", but isn't referenced
+    # from the vehicle in any way:
+    ap_vehicle_lib = Library("", reference="VEHICLE") # the "" is tacked onto the front of param name
+    setattr(ap_vehicle_lib, "Path", os.path.join('..', 'libraries', 'AP_Vehicle', 'AP_Vehicle.cpp'))
+    libraries.append(ap_vehicle_lib)
 
 libraries.append(lua_applets())
 


### PR DESCRIPTION
fix AP_Periph param docs generator by not generating *ALL* params from AP_Vehicle when you really just want Periph's param docs. 