### PR TITLE
Rename sum8 to sum8_with_carry

### DIFF
--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -481,7 +481,7 @@ uint32_t crc_crc24(const uint8_t *bytes, uint16_t len)
 }
 
 // simple 8 bit checksum used by FPort
-uint8_t crc_sum8(const uint8_t *p, uint8_t len)
+uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len)
 {
     uint16_t sum = 0;
     for (uint8_t i=0; i<len; i++) {

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -35,8 +35,10 @@ uint32_t crc32_small(uint32_t crc, const uint8_t *buf, uint32_t size);
 uint32_t crc_crc24(const uint8_t *bytes, uint16_t len);
 uint16_t crc_crc16_ibm(uint16_t crc_accum, uint8_t *data_blk_ptr, uint16_t data_blk_size);
 
-// checksum used by SPORT/FPort
-uint8_t crc_sum8(const uint8_t *p, uint8_t len);
+// checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
+// sum, then adds those two bytes together.  Returns the complement of
+// the final sum.
+uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len);
 
 // Copyright (C) 2010 Swift Navigation Inc.
 // Contact: Fergus Noble <fergus@swift-nav.com>

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -179,7 +179,7 @@ void AP_RCProtocol_FPort::decode_downlink(const FPort_Frame &frame)
     buf[3] = telem_data.packet.appid & 0xFF;
     buf[4] = telem_data.packet.appid >> 8;
     memcpy(&buf[5], &telem_data.packet.data, 4);
-    buf[9] = crc_sum8(&buf[0], 9);
+    buf[9] = crc_sum8_with_carry(&buf[0], 9);
 
     // perform byte stuffing per FPort spec
     uint8_t len = 0;
@@ -307,7 +307,7 @@ reset:
 bool AP_RCProtocol_FPort::check_checksum(void)
 {
     const uint8_t len = byte_input.buf[1]+2;
-    return crc_sum8(&byte_input.buf[1], len) == 0x00;
+    return crc_sum8_with_carry(&byte_input.buf[1], len) == 0x00;
 }
 
 // support byte input

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -179,7 +179,7 @@ void AP_RCProtocol_FPort2::decode_downlink(const FPort2_Frame &frame)
         // get fresh telem_data in the next call
         telem_data.available = false;
     }
-    buf[9] = crc_sum8(&buf[1], 8);
+    buf[9] = crc_sum8_with_carry(&buf[1], 8);
     
     uart->write(buf, sizeof(buf));
 #endif
@@ -286,7 +286,7 @@ reset:
 // check checksum byte
 bool AP_RCProtocol_FPort2::check_checksum(void)
 {
-    return crc_sum8(&byte_input.buf[1], byte_input.control_len-1) == 0;
+    return crc_sum8_with_carry(&byte_input.buf[1], byte_input.control_len-1) == 0;
 }
 
 // support byte input


### PR DESCRIPTION
@Ryanf55 pointed out that "sum8" should be reserved for sum-bytes-modulus-256 only as that's the common name for that algorithm.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
HerePro             *                                                                     
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```