### PR TITLE
EKF3: allow earth-frame fields to be estimated with an origin but no GPS

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -690,15 +690,7 @@ void NavEKF3_core::readGpsData()
     }
 
     if (gpsGoodToAlign && !have_table_earth_field) {
-        const auto &compass = dal.compass();
-        if (compass.have_scale_factor(magSelectIndex) &&
-            compass.auto_declination_enabled()) {
-            getEarthFieldTable(gpsloc);
-            if (frontend->_mag_ef_limit > 0) {
-                // initialise earth field from tables
-                stateStruct.earth_magfield = table_earth_field_ga;
-            }
-        }
+        setEarthFieldFromLocation(gpsloc);
     }
 
     // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -233,6 +233,9 @@ public:
     // Returns true if the set was successful
     bool setLatLng(const Location &loc, float posAccuracy, uint32_t timestamp_ms);
 
+    // Popoluates the WMM data structure with the field at the given location
+    void setEarthFieldFromLocation(const Location &loc);
+
     // return estimated height above ground level
     // return false if ground height is not being estimated.
     bool getHAGL(float &HAGL) const;


### PR DESCRIPTION
This is my attempt at fixing https://github.com/ArduPilot/ardupilot/issues/18229

Here's a log using it:
[00000228.zip](https://github.com/ArduPilot/ardupilot/files/13502545/00000228.zip)
I am using a script to set the origin so we can use the earth field database.


I can see that XKF2 fields are all populated for magnetic field in body frame and earth frame.

![image](https://github.com/ArduPilot/ardupilot/assets/4013804/4d97de56-8818-462b-98bf-2e6a66020247)

I am not sure of what else to look at, though. magnetic field innovations seem bad, but at least they exist?
![image](https://github.com/ArduPilot/ardupilot/assets/4013804/74c70e6d-94d1-4c12-a2ec-19aac1081910)

