### PR TITLE
AP_HAL_ChibiOS: Set RADIX2HD HAL_I2C_INTERNAL_MASK

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/hwdef.dat
@@ -165,6 +165,7 @@ BARO DPS310 I2C:0:0x76
 
 # probe external compasses (same bus as internal)
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+define HAL_I2C_INTERNAL_MASK 0
 
 # filesystem setup on sdcard
 define HAL_OS_FATFS_IO 1


### PR DESCRIPTION
The detection of external compasses wasn't working and I though I had it fixed in #25291. It still wasn't working because `HAL_I2C_INTERNAL_MASK` wasn't set and so no external buses were scanned (as `HAL_I2C_INTERNAL_MASK` defaults to 1). 

Note that for some reason it was working with the HMC5983 I used for testing, but other compasses, e.g., the QMC5883L were not working. 
