### PR TITLE
Networking: fixed cache disable area size calculation

### DIFF
--- a/libraries/AP_Networking/AP_Networking_ChibiOS.cpp
+++ b/libraries/AP_Networking/AP_Networking_ChibiOS.cpp
@@ -37,7 +37,7 @@ bool AP_Networking_ChibiOS::allocate_buffers()
                                 sizeof(uint32_t)*STM32_MAC_TRANSMIT_BUFFERS*AP_NETWORKING_EXTERN_MAC_BUFFER_SIZE; // typically == 9240
 
     // ensure that we allocate 32-bit aligned memory, and mark it non-cacheable
-    uint32_t size = 2;
+    uint32_t size = 1;
     uint8_t rasr = 0;
     // find size closest to power of 2
     while (size < total_size) {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -313,14 +313,14 @@ void AP_Vehicle::setup()
     gcs().init();
 #endif
 
-#if AP_NETWORKING_ENABLED
-    networking.init();
-#endif
-
     // initialise serial ports
     serial_manager.init();
 #if HAL_GCS_ENABLED
     gcs().setup_console();
+#endif
+
+#if AP_NETWORKING_ENABLED
+    networking.init();
 #endif
 
     // Register scheduler_delay_cb, which will run anytime you have


### PR DESCRIPTION
an off by one bug led to some of the memory being cacheable, which led to TCP checksum errors
