### PR TITLE
Restore use of the VTX_MAX_POWER parameter

### DIFF
--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -515,7 +515,7 @@ void AP_VideoTX::change_power(int8_t position)
     // first find out how many possible levels there are
     uint8_t num_active_levels = 0;
     for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
-        if (_power_levels[i].active != PowerActive::Inactive) {
+        if (_power_levels[i].active != PowerActive::Inactive && _power_levels[i].mw <= _max_power_mw) {
             num_active_levels++;
         }
     }


### PR DESCRIPTION
This functionality was lost when a significant rewrite of this code was done in commit 0658f060301c9230c5b170bbad005dee68fbcd8a

This restores the documented use of MAX_POWER for the 6 position switch power control.

Without this change I was unable to select 25mw via a radio channel on two builds with two different VTX boards controlled via IRC TRAMP.

I've tested this change with the following hardware and VTX protocols:
 GOKU F405 1-2S 12A 5-in-1 400mw + ELRS AIO board (TRAMP)
GOKU VTX 625 (TRAMP)
TBS Unify Pro Nano (SA)
