### PR TITLE
AP_Scripting: Add filtering of incoming frames

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.cpp
@@ -29,7 +29,19 @@ bool ScriptingCANSensor::write_frame(AP_HAL::CANFrame &out_frame, const uint32_t
 void ScriptingCANSensor::handle_frame(AP_HAL::CANFrame &frame)
 {
     WITH_SEMAPHORE(sem);
-    if (buffer_list != nullptr) {
+    // Check if frame matches any filters
+    bool find = false;
+    for (int i=0;i<MAX_FILTERS;i++) {
+        if (filter_mask[i] == UINT32_MAX) {
+            break;
+        }
+        if ((frame.id & filter_mask[i]) == filter_value[i]) {
+            find = true;
+            break;
+        }
+    }
+
+    if (buffer_list != nullptr && find) {
         buffer_list->handle_frame(frame);
     }
 }

--- a/libraries/AP_Scripting/AP_Scripting_CANSensor.h
+++ b/libraries/AP_Scripting/AP_Scripting_CANSensor.h
@@ -29,6 +29,8 @@
 
 #if AP_SCRIPTING_CAN_SENSOR_ENABLED
 
+#define MAX_FILTERS 8
+
 #include <AP_CANManager/AP_CANSensor.h>
 
 class ScriptingCANBuffer;
@@ -38,6 +40,10 @@ public:
     ScriptingCANSensor(AP_CAN::Protocol dtype)
         : CANSensor("Script") {
         register_driver(dtype);
+        for (int i=0;i<MAX_FILTERS;i++) {
+            filter_mask[i] = UINT32_MAX;
+            filter_value[i] = UINT32_MAX;
+        }
     }
 
     // handler for outgoing frames, using uint32
@@ -48,6 +54,19 @@ public:
 
     // add a new buffer to this sensor
     ScriptingCANBuffer* add_buffer(uint32_t buffer_len);
+
+    uint32_t filter_mask[MAX_FILTERS]; 
+    uint32_t filter_value[MAX_FILTERS];
+
+    void add_filter(uint32_t mask, uint32_t value) {
+        for (int i=0;i<MAX_FILTERS;i++) {
+            if (filter_mask[i] == UINT32_MAX) {
+                filter_mask[i] = mask;
+                filter_value[i] = value;
+                return;
+            }
+        }
+    }
 
 private:
 
@@ -73,6 +92,10 @@ public:
 
     // recursively add new buffer
     void add_buffer(ScriptingCANBuffer* new_buff);
+
+    void add_filter(uint32_t mask, uint32_t value) {
+        sensor.add_filter(mask, value);
+    }
 
 private:
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -981,6 +981,13 @@ local ScriptingCANBuffer_ud = {}
 ---@return CANFrame_ud|nil
 function ScriptingCANBuffer_ud:read_frame() end
 
+-- Add a filter to the CAN buffer, mask is bitwise ANDed with the frame id and compared to value if not match frame is not buffered
+-- By default no filters are added and all frames are buffered, write is not affected by filters
+-- Maxmum number of filters is 8
+---@param mask uint32_t_ud
+---@param value uint32_t_ud
+function ScriptingCANBuffer_ud:add_filter(mask, value) end
+
 -- desc
 ---@param frame CANFrame_ud
 ---@param timeout_us uint32_t_ud

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -602,7 +602,7 @@ userdata AP_HAL::CANFrame method isErrorFrame boolean
 ap_object ScriptingCANBuffer depends AP_SCRIPTING_CAN_SENSOR_ENABLED
 ap_object ScriptingCANBuffer method write_frame boolean AP_HAL::CANFrame uint32_t'skip_check
 ap_object ScriptingCANBuffer method read_frame boolean AP_HAL::CANFrame'Null
-
+ap_object ScriptingCANBuffer method add_filter void uint32_t'skip_check uint32_t'skip_check
 
 include ../Tools/AP_Periph/AP_Periph.h depends defined(HAL_BUILD_AP_PERIPH)
 singleton AP_Periph_FW depends defined(HAL_BUILD_AP_PERIPH)


### PR DESCRIPTION
Add filters to the CAN buffer; mask is bitwise ANDed with the frame ID and compared to value if not match frame is not buffered
-- By default, no filters are added, and all frames are buffered, writing is not affected by filters
-- Maximum number of filters is 8

Usage : driver:add_filter(mask, value)

Why?
 - On a shared bus non, handled frames can be filtered out, making processing relevant frames easier and requiring less buffer and slower script update.
 - Can add script driver for composite DroneCan devices with custom or experimental messages without the need for processing the frames that a non-script driver already handles. (Processing a single 1Hz custom message from a GPS/MAG device with maximum buffer size requires 5ms update time without filtering. A slower update or smaller buffer causes drop of messages)

