### PR TITLE
AP_HAL_ChibiOS: disable core m4 use to silence the chibios asserts

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeRedPrimary/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeRedPrimary/hwdef.dat
@@ -45,6 +45,11 @@ define HAL_IMU_TEMP_MARGIN_LOW_DEFAULT 5
 CANFD_SUPPORTED 8
 
 STM32_ST_USE_TIMER 12
+
+# disable core m4 use to silence the asserts
+# checking allocation of peripherals
+define STM32_HAS_M4 0
+
 define CH_CFG_ST_RESOLUTION 16
 
 # use last 2 pages for flash storage


### PR DESCRIPTION
checking allocation of peripherals