### PR TITLE
Tools: add Debian 12 support to prereqs script

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -39,6 +39,8 @@ jobs:
           - os: archlinux
             name: latest
           - os: debian
+            name: bookworm
+          - os: debian
             name: bullseye
           - os: debian
             name: buster

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -84,6 +84,11 @@ if [ ${RELEASE_CODENAME} == 'bionic' ] ; then
     SITLCFML_VERSION="2.4"
     PYTHON_V="python3"
     PIP=pip3
+elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
+    SITLFML_VERSION="2.5"
+    SITLCFML_VERSION="2.5"
+    PYTHON_V="python3"
+    PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'buster' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
@@ -162,7 +167,8 @@ fi
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
 
-if [ ${RELEASE_CODENAME} == 'lunar' ] ||
+if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+   [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ]; then
     # on Lunar (and presumably later releases), we install in venv, below
     PYTHON_PKGS+=" numpy pyparsing psutil"
@@ -173,7 +179,8 @@ fi
 
 # add some packages required for commonly-used MAVProxy modules:
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-    if [ ${RELEASE_CODENAME} == 'lunar' ] ||
+    if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+       [ ${RELEASE_CODENAME} == 'lunar' ] ||
        [ ${RELEASE_CODENAME} == 'mantic' ]; then
         PYTHON_PKGS+=" matplotlib scipy opencv-python pyyaml"
         SITL_PKGS+=" xterm libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION}"
@@ -261,6 +268,8 @@ elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
          [ ${RELEASE_CODENAME} == 'jammy' ]; then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
+elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
+    SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'buster' ]; then
@@ -277,6 +286,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
            [ ${RELEASE_CODENAME} == 'focal' ]; then
     SITL_PKGS+=" libjpeg8-dev"
+  elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
+    SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
   elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
   elif [ ${RELEASE_CODENAME} == 'mantic' ]; then
@@ -293,8 +304,12 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng12-0 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   fi
 
-  if [ ${RELEASE_CODENAME} == 'lunar' ]; then
+  if [ ${RELEASE_CODENAME} == 'bookworm' ]; then
       PYTHON_PKGS+=" opencv-python"
+      SITL_PKGS+=" python3-wxgtk4.0"
+      SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
+      PYTHON_PKGS+=" wxpython opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   elif [ ${RELEASE_CODENAME} == 'mantic' ]; then
@@ -343,7 +358,8 @@ fi
 PIP_USER_ARGUMENT="--user"
 
 # create a Python venv on more recent releases:
-if [ ${RELEASE_CODENAME} == 'lunar' ] ||
+if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+   [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ]; then
     $APT_GET install python3.11-venv
     python3 -m venv $HOME/venv-ardupilot
@@ -369,7 +385,8 @@ if [ "$GITHUB_ACTIONS" == "true" ]; then
     PIP_USER_ARGUMENT+=" --progress-bar off"
 fi
 
-if [ ${RELEASE_CODENAME} == 'lunar' ] ||
+if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+   [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ]; then
     # must do this ahead of wxPython pip3 run :-/
     $PIP install $PIP_USER_ARGUMENT -U attrdict3


### PR DESCRIPTION
Added `bookworm` alongside `lunar` and `mantic`.

Tested via Proxmox LXC container(s) running fully updated Debian 12 instances.