### PR TITLE
ArduPlane: initialize the accz integrator at takeoff

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -421,6 +421,19 @@ private:
     // return which vfwd method to use
     ActiveFwdThr get_vfwd_method(void) const;
 
+    // initial accz integrator value to use at takeoff
+    AP_Float fast_ground_break_integrator;
+
+    // flag to only set the integrator once per takeoff
+    bool not_done_takeoff_set_integrator;
+
+    // specifies if fast ground break is enabled to pre-initialize the accz integrator
+    enum class FstGrndBrk : uint8_t {
+        OFF = 0,
+        ON  = 1,
+    };
+    AP_Enum<FstGrndBrk> is_fast_ground_break_enabled;
+
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;
 


### PR DESCRIPTION
Currently the integrator gets set to the lowest value at takeoff since throttle demand is near zero and hover throttle could be saved in the Q_M_THST_HOVER parameter. This allows the user to specify a desired initialization percentage/100.

For small vehicles this is unlikely to be needed. For larger (heavier) quadplanes this should prevent prolonged time on the ground at a low power setting where the vehicle could be light on the landing gear and skip across the ground.

## Testing
### Baseline
[baseline.BIN.txt](https://github.com/ArduPilot/ardupilot/files/13591072/baseline.BIN.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/364ed52c-003f-481a-a1a0-50b96d3fb423)
Figure:
1) Integrator initializes at large negative value.
2) Vehicle lifts off ~1.5 seconds later

### Feature Disabled
[disabled.BIN.txt](https://github.com/ArduPilot/ardupilot/files/13591061/disabled.BIN.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/d06bb126-b879-41cb-b19f-3dfc67c5991a)
Figure: Similar results to baseline.
1) Integrator initializes at large negative value.
2) Vehicle lifts off ~1.5 seconds later

### Feature Enabled at zero
[enabled.BIN.txt](https://github.com/ArduPilot/ardupilot/files/13591062/enabled.BIN.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/f1334812-f25a-49b8-a62e-1d85a1d2e02d)
Figure: 
1) Integrator initializes at zero.
2) Vehicle lifts off ~1 second later