### PR TITLE
ROS2 sitl package added ardupilot_msgs dependency

### DIFF
--- a/Tools/ros2/ardupilot_sitl/package.xml
+++ b/Tools/ros2/ardupilot_sitl/package.xml
@@ -22,6 +22,7 @@
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
 
+  <build_depend>ardupilot_msgs</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR adds a build dependency to the `ardupilot_sitl` package that allows colcon to build `ardupilot_msgs` when asked to `colcon build --packages-up-to ardupilot_sitl`.

How to test: 

- If you have a ros2_ws already, delete `ros_msgs` from the _install_ folder
- Before this PR, run `colcon build --packages-up-to ardupilot_sitl` and verify that no ardupilot messages are built (either inspect the install folder or source the environment and then `ros2 interface list`)
- With this PR, `ardupilot_msgs` will be visible in the install folder. Verify that messages are available with `ros2 interface list`, which will show those services:

```
Services:
    action_msgs/srv/CancelGoal
    ardupilot_msgs/srv/ArmMotors
    ardupilot_msgs/srv/ModeSwitch
```
