### PR TITLE
HAL_ChibiOS: removed restriction on begin() in same thread as read()

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -662,7 +662,7 @@ uint32_t UARTDriver::get_usb_baud() const
 
 uint32_t UARTDriver::_available()
 {
-    if (!_rx_initialised || _uart_owner_thd != chThdGetSelfX()) {
+    if (!_rx_initialised) {
         return 0;
     }
     if (sdef.is_usb) {
@@ -686,9 +686,6 @@ uint32_t UARTDriver::txspace()
 
 bool UARTDriver::_discard_input()
 {
-    if (_uart_owner_thd != chThdGetSelfX()){
-        return false;
-    }
     if (!_rx_initialised) {
         return false;
     }
@@ -704,9 +701,6 @@ bool UARTDriver::_discard_input()
 
 ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
 {
-    if (_uart_owner_thd != chThdGetSelfX()){
-        return -1;
-    }
     if (!_rx_initialised) {
         return -1;
     }


### PR DESCRIPTION
this removes the restriction that a read() on a UART in HAL_ChibiOS be on the same thread that did the begin(). The reason for the restriction is that the ringbuffer is not safe for multi-thread read, but the pattern we have moved to is that the caller needs to use a HAL_Semaphore mutex to ensure it is safe.

A good example of this is AP_ExternalAHRS. While testing the InertialLabs driver the testers found it would not work if SCHED_LOOP_RATE was less than the devices frame rate (which is 200Hz). So it didn't work for plane.

The reason it didn't work is that the AP_ExternalAHRS_InertialLabs driver does a check_uart() call both in update() and in the dedicated thread. The reason this is done is it minimises latency in getting new IMU data at the time we need it. The driver follows the same pattern as other AP_ExternalAHRS drivers.

This all works fine in SITL as SITL allows multiple threads to do available() and read() on a uart, so SITL testing was fine, but on a ChibiOS board with SCHED_LOOP_RATE=50 (a plane) the UART quickly became clogged and corrupted if the check_uart() from the main thread happened to run first and thus link the main thread to the uart. This meant the main loop was the only one allowed to read, so it read at 50Hz for 200Hz data.

We could require all these drivers to use a new begin() before each available() or read() call, but I thin it is better to remove this restriction and make ChibiOS match SITL behaviour.

Also note that HAL_Linux and HAL_ESP32 don't have the restriction, so HAL_ChibiOS was the odd one out