### PR TITLE
DDS - REP-147 Goal Interface Support for Plane (position only)

### DIFF
--- a/ArduPlane/AP_ExternalControl_Plane.cpp
+++ b/ArduPlane/AP_ExternalControl_Plane.cpp
@@ -1,0 +1,22 @@
+/*
+  external control library for plane
+ */
+
+
+#include "AP_ExternalControl_Plane.h"
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+#include "Plane.h"
+
+/*
+  Sets the target global position for a loiter point.
+*/
+bool AP_ExternalControl_Plane::set_global_position(const Location& loc)
+{
+
+    // set_target_location already checks if plane is ready for external control.
+    // It doesn't check if flying or armed, just that it's in guided mode.
+    return plane.set_target_location(loc);
+}
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/AP_ExternalControl_Plane.h
+++ b/ArduPlane/AP_ExternalControl_Plane.h
@@ -1,0 +1,21 @@
+
+/*
+  external control library for plane
+ */
+#pragma once
+
+#include <AP_ExternalControl/AP_ExternalControl.h>
+
+#if AP_EXTERNAL_CONTROL_ENABLED
+
+#include <AP_Common/Location.h>
+
+class AP_ExternalControl_Plane : public AP_ExternalControl {
+public:
+    /*
+        Sets the target global position for a loiter point.
+    */
+    bool set_global_position(const Location& loc) override WARN_IF_UNUSED;
+};
+
+#endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -798,8 +798,8 @@ bool Plane::get_wp_crosstrack_error_m(float &xtrack_error) const
     return true;
 }
 
-#if AP_SCRIPTING_ENABLED
-// set target location (for use by scripting)
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+// set target location (for use by external control and scripting)
 bool Plane::set_target_location(const Location &target_loc)
 {
     Location loc{target_loc};
@@ -816,7 +816,9 @@ bool Plane::set_target_location(const Location &target_loc)
     plane.set_guided_WP(loc);
     return true;
 }
+#endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 
+#if AP_SCRIPTING_ENABLED
 // set target location (for use by scripting)
 bool Plane::get_target_location(Location& target_loc)
 {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1245,8 +1245,10 @@ public:
     void failsafe_check(void);
     bool is_landing() const override;
     bool is_taking_off() const override;
-#if AP_SCRIPTING_ENABLED
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
     bool set_target_location(const Location& target_loc) override;
+#endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+#if AP_SCRIPTING_ENABLED
     bool get_target_location(Location& target_loc) override;
     bool update_target_location(const Location &old_loc, const Location &new_loc) override;
     bool set_velocity_match(const Vector2f &velocity) override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -85,7 +85,7 @@
 #include <AP_Follow/AP_Follow.h>
 #include <AP_ExternalControl/AP_ExternalControl_config.h>
 #if AP_EXTERNAL_CONTROL_ENABLED
-#include <AP_ExternalControl/AP_ExternalControl.h>
+#include "AP_ExternalControl_Plane.h"
 #endif
 
 #include "GCS_Mavlink.h"
@@ -166,6 +166,10 @@ public:
     friend class ModeTakeoff;
     friend class ModeThermal;
     friend class ModeLoiterAltQLand;
+
+#if AP_EXTERNAL_CONTROL_ENABLED
+    friend class AP_ExternalControl_Plane;
+#endif
 
     Plane(void);
 
@@ -776,9 +780,9 @@ private:
 
     AP_Param param_loader {var_info};
 
-    // dummy implementation of external control
+    // external control library
 #if AP_EXTERNAL_CONTROL_ENABLED
-    AP_ExternalControl external_control;
+    AP_ExternalControl_Plane external_control;
 #endif
 
     static const AP_Scheduler::Task scheduler_tasks[];

--- a/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
+++ b/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright 2023 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Run a single-waypoint mission on Plane.
+
+Warning - This is NOT production code; it's a simple demo of capability.
+"""
+
+import math
+import rclpy
+import time
+import errno
+
+from rclpy.node import Node
+from builtin_interfaces.msg import Time
+from ardupilot_msgs.msg import GlobalPosition
+from geographic_msgs.msg import GeoPoseStamped
+from geopy import distance
+from geopy import point
+from ardupilot_msgs.srv import ArmMotors
+from ardupilot_msgs.srv import ModeSwitch
+
+
+PLANE_MODE_TAKEOFF = 13
+PLANE_MODE_GUIDED = 15
+
+FRAME_GLOBAL_INT = 5
+
+# Hard code some known locations
+# Note - Altitude in geopy is in km!
+GRAYHOUND_TRACK = point.Point(latitude=-35.345996, longitude=149.159017, altitude=0.575)
+CMAC = point.Point(latitude=-35.3627010, longitude=149.1651513, altitude=0.585)
+
+
+class PlaneWaypointFollower(Node):
+    """Plane follow waypoints using guided control."""
+
+    def __init__(self):
+        """Initialise the node."""
+        super().__init__("plane_waypoint_follower")
+
+        self.declare_parameter("arm_topic", "/ap/arm_motors")
+        self._arm_topic = self.get_parameter("arm_topic").get_parameter_value().string_value
+        self._client_arm = self.create_client(ArmMotors, self._arm_topic)
+        while not self._client_arm.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('arm service not available, waiting again...')
+
+        self.declare_parameter("mode_topic", "/ap/mode_switch")
+        self._mode_topic = self.get_parameter("mode_topic").get_parameter_value().string_value
+        self._client_mode_switch = self.create_client(ModeSwitch, self._mode_topic)
+        while not self._client_mode_switch.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('mode switch service not available, waiting again...')
+
+        self.declare_parameter("global_position_topic", "/ap/cmd_gps_pose")
+        self._global_pos_topic = self.get_parameter("global_position_topic").get_parameter_value().string_value
+        self._global_pos_pub = self.create_publisher(GlobalPosition, self._global_pos_topic, 1)
+
+        # Create subscriptions after services are up
+        self.declare_parameter("geopose_topic", "/ap/geopose/filtered")
+        self._geopose_topic = self.get_parameter("geopose_topic").get_parameter_value().string_value
+        qos = rclpy.qos.QoSProfile(
+            reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT, durability=rclpy.qos.DurabilityPolicy.VOLATILE, depth=1
+        )
+
+        self._subscription_geopose = self.create_subscription(GeoPoseStamped, self._geopose_topic, self.geopose_cb, qos)
+        self._cur_geopose = GeoPoseStamped()
+
+    def geopose_cb(self, msg: GeoPoseStamped):
+        """Process a GeoPose message."""
+        stamp = msg.header.stamp
+        if stamp.sec:
+            self.get_logger().info("From AP : Geopose [sec:{}, nsec: {}]".format(stamp.sec, stamp.nanosec))
+
+            # Store current state
+            self._cur_geopose = msg
+
+    def arm(self):
+        req = ArmMotors.Request()
+        req.arm = True
+        future = self._client_arm.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        return future.result()
+
+    def arm_with_timeout(self, timeout: rclpy.duration.Duration):
+        """Try to arm. Returns true on success, or false if arming fails or times out."""
+        armed = False
+        start = self.get_clock().now()
+        while not armed and self.get_clock().now() - start < timeout:
+            armed = self.arm().result
+            time.sleep(1)
+        return armed
+
+    def switch_mode(self, mode):
+        req = ModeSwitch.Request()
+        assert mode in [PLANE_MODE_TAKEOFF, PLANE_MODE_GUIDED]
+        req.mode = mode
+        future = self._client_mode_switch.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        return future.result()
+
+    def switch_mode_with_timeout(self, desired_mode: int, timeout: rclpy.duration.Duration):
+        """Try to switch mode. Returns true on success, or false if mode switch fails or times out."""
+        is_in_desired_mode = False
+        start = self.get_clock().now()
+        while not is_in_desired_mode:
+            result = self.switch_mode(desired_mode)
+            # Handle successful switch or the case that the vehicle is already in expected mode
+            is_in_desired_mode = result.status or result.curr_mode == desired_mode
+            time.sleep(1)
+
+        return is_in_desired_mode
+
+    def get_cur_geopose(self):
+        """Return latest geopose."""
+        return self._cur_geopose
+
+    def send_goal_position(self, goal_global_pos):
+        """Send goal position. Must be in guided for this to work."""
+        self._global_pos_pub.publish(goal_global_pos)
+
+
+def achieved_goal(goal_global_pos, cur_geopose):
+    """Return true if the current position (LLH) is close enough to the goal (within the orbit radius)."""
+    # Use 3D geopy distance calculation
+    # https://geopy.readthedocs.io/en/stable/#module-geopy.distance
+    goal_lat = goal_global_pos
+
+    p1 = (goal_global_pos.latitude, goal_global_pos.longitude, goal_global_pos.altitude)
+    cur_pos = cur_geopose.pose.position
+    p2 = (cur_pos.latitude, cur_pos.longitude, cur_pos.altitude)
+
+    flat_distance = distance.distance(p1[:2], p2[:2]).m
+    euclidian_distance = math.sqrt(flat_distance**2 + (p2[2] - p1[2]) ** 2)
+    print(f"Goal is {euclidian_distance} meters away")
+    return euclidian_distance < 150
+
+
+def main(args=None):
+    """Node entry point."""
+    rclpy.init(args=args)
+    node = PlaneWaypointFollower()
+    try:
+        # Block till armed, which will wait for EKF3 to initialize
+        if not node.arm_with_timeout(rclpy.duration.Duration(seconds=30)):
+            raise RuntimeError("Unable to arm")
+
+        # Block till in takeoff
+        if not node.switch_mode_with_timeout(PLANE_MODE_TAKEOFF, rclpy.duration.Duration(seconds=20)):
+            raise RuntimeError("Unable to switch to takeoff mode")
+
+        is_ascending_to_takeoff_alt = True
+        while is_ascending_to_takeoff_alt:
+            rclpy.spin_once(node)
+            time.sleep(1.0)
+
+            # Hard code waiting in takeoff to reach operating altitude of 630m
+            # This is just a hack because geopose is reported with absolute rather than relative altitude,
+            # and this node doesn't have access to the terrain data
+            is_ascending_to_takeoff_alt = node.get_cur_geopose().pose.position.altitude < CMAC.altitude * 1000 + 45
+
+        if is_ascending_to_takeoff_alt:
+            raise RuntimeError("Failed to reach takeoff altitude")
+
+        if not node.switch_mode_with_timeout(PLANE_MODE_GUIDED, rclpy.duration.Duration(seconds=20)):
+            raise RuntimeError("Unable to switch to guided mode")
+
+        # Send a guided WP with location, frame ID, alt frame
+        goal_pos = GlobalPosition()
+        goal_pos.latitude = GRAYHOUND_TRACK.latitude
+        goal_pos.longitude = GRAYHOUND_TRACK.longitude
+        DESIRED_AGL = 60
+        goal_pos.altitude = GRAYHOUND_TRACK.altitude * 1000 + DESIRED_AGL
+        goal_pos.coordinate_frame = FRAME_GLOBAL_INT
+        goal_pos.header.frame_id = "map"
+
+        node.send_goal_position(goal_pos)
+
+        start = node.get_clock().now()
+        has_achieved_goal = False
+        while not has_achieved_goal and node.get_clock().now() - start < rclpy.duration.Duration(seconds=120):
+            rclpy.spin_once(node)
+            has_achieved_goal = achieved_goal(goal_pos, node.get_cur_geopose())
+            time.sleep(1.0)
+
+        if not has_achieved_goal:
+            raise RuntimeError("Unable to achieve goal location")
+
+        print("Goal achieved")
+
+    except KeyboardInterrupt:
+        pass
+
+    # Destroy the node explicitly.
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -8,11 +8,13 @@
   <license>GLP-3.0</license>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>ardupilot_msgs</exec_depend>
   <exec_depend>ardupilot_sitl</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_pytest</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>micro_ros_msgs</exec_depend>
+  <exec_depend>python3-geopy</exec_depend>
   <exec_depend>python3-pytest</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>socat</exec_depend>
@@ -23,6 +25,7 @@
   <test_depend>ament_uncrustify</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ardupilot_msgs</test_depend>
   <test_depend>ardupilot_sitl</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_pytest</test_depend>

--- a/Tools/ros2/ardupilot_dds_tests/setup.py
+++ b/Tools/ros2/ardupilot_dds_tests/setup.py
@@ -25,6 +25,7 @@ setup(
     entry_points={
         'console_scripts': [
             "time_listener = ardupilot_dds_tests.time_listener:main",
+            "plane_waypoint_follower = ardupilot_dds_tests.plane_waypoint_follower:main",
         ],
     },
 )

--- a/Tools/ros2/ardupilot_msgs/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_msgs/CMakeLists.txt
@@ -5,14 +5,18 @@ project(ardupilot_msgs)
 # Find dependencies.
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 # --------------------------------------------------------------------------- #
 # Generate and export message interfaces.
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/GlobalPosition.msg"
   "srv/ArmMotors.srv"
   "srv/ModeSwitch.srv"
+  DEPENDENCIES geometry_msgs std_msgs
   ADD_LINTER_TESTS
 )
 

--- a/Tools/ros2/ardupilot_msgs/msg/GlobalPosition.msg
+++ b/Tools/ros2/ardupilot_msgs/msg/GlobalPosition.msg
@@ -1,0 +1,30 @@
+# Experimental REP-147 Goal Interface
+# https://ros.org/reps/rep-0147.html#goal-interface
+
+std_msgs/Header header
+
+uint8 coordinate_frame
+uint8 FRAME_GLOBAL_INT = 5
+uint8 FRAME_GLOBAL_REL_ALT = 6
+uint8 FRAME_GLOBAL_TERRAIN_ALT = 11
+
+uint16 type_mask
+uint16 IGNORE_LATITUDE = 1 # Position ignore flags
+uint16 IGNORE_LONGITUDE = 2
+uint16 IGNORE_ALTITUDE = 4
+uint16 IGNORE_VX = 8  # Velocity vector ignore flags
+uint16 IGNORE_VY = 16
+uint16 IGNORE_VZ = 32
+uint16 IGNORE_AFX = 64 # Acceleration/Force vector ignore flags
+uint16 IGNORE_AFY = 128
+uint16 IGNORE_AFZ = 256
+uint16 FORCE = 512 # Force in af vector flag
+uint16 IGNORE_YAW = 1024
+uint16 IGNORE_YAW_RATE = 2048
+
+float64 latitude
+float64 longitude
+float32 altitude # in meters, AMSL or above terrain
+geometry_msgs/Twist velocity
+geometry_msgs/Twist acceleration_or_force
+float32 yaw

--- a/Tools/ros2/ardupilot_msgs/package.xml
+++ b/Tools/ros2/ardupilot_msgs/package.xml
@@ -11,6 +11,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_copyright</test_depend>

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -15,9 +15,9 @@ public:
     uint8_t loiter_xtrack : 1;          // 0 to crosstrack from center of waypoint, 1 to crosstrack from tangent exit location
 
     // note that mission storage only stores 24 bits of altitude (~ +/- 83km)
-    int32_t alt;
-    int32_t lat;
-    int32_t lng;
+    int32_t alt; // in cm
+    int32_t lat; // in 1E7 degrees
+    int32_t lng; // in 1E7 degrees
 
     /// enumeration of possible altitude types
     enum class AltFrame {

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -4,6 +4,8 @@
 
 #include "uxr/client/client.h"
 #include "ucdr/microcdr.h"
+
+#include "ardupilot_msgs/msg/GlobalPosition.h"
 #include "builtin_interfaces/msg/Time.h"
 
 #include "sensor_msgs/msg/NavSatFix.h"
@@ -65,6 +67,8 @@ private:
     static sensor_msgs_msg_Joy rx_joy_topic;
     // incoming REP147 velocity control
     static geometry_msgs_msg_TwistStamped rx_velocity_control_topic;
+    // incoming REP147 goal interface global position
+    static ardupilot_msgs_msg_GlobalPosition rx_global_position_control_topic;
     // outgoing transforms
     tf2_msgs_msg_TFMessage tx_static_transforms_topic;
     tf2_msgs_msg_TFMessage tx_dynamic_transforms_topic;

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.h
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.h
@@ -1,11 +1,19 @@
 #pragma once
 
 #if AP_DDS_ENABLED
+#include "ardupilot_msgs/msg/GlobalPosition.h"
 #include "geometry_msgs/msg/TwistStamped.h"
+
+#include <AP_Common/Location.h>
 
 class AP_DDS_External_Control
 {
 public:
+    // REP-147 Goal Interface Global Position Control
+    // https://ros.org/reps/rep-0147.html#goal-interface
+    static bool handle_global_position_control(ardupilot_msgs_msg_GlobalPosition& cmd_pos);
     static bool handle_velocity_control(geometry_msgs_msg_TwistStamped& cmd_vel);
+private:
+    static bool convert_alt_frame(const uint8_t frame_in,  Location::AltFrame& frame_out);
 };
 #endif // AP_DDS_ENABLED

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -22,6 +22,7 @@ enum class TopicIndex: uint8_t {
     JOY_SUB,
     DYNAMIC_TRANSFORMS_SUB,
     VELOCITY_CONTROL_SUB,
+    GLOBAL_POSITION_SUB,
 };
 
 static inline constexpr uint8_t to_underlying(const TopicIndex index)
@@ -141,5 +142,15 @@ constexpr struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .topic_profile_label = "velocitycontrol__t",
         .dw_profile_label = "",
         .dr_profile_label = "velocitycontrol__dr",
+    },
+    {
+        .topic_id = to_underlying(TopicIndex::GLOBAL_POSITION_SUB),
+        .pub_id = to_underlying(TopicIndex::GLOBAL_POSITION_SUB),
+        .sub_id = to_underlying(TopicIndex::GLOBAL_POSITION_SUB),
+        .dw_id = uxrObjectId{.id=to_underlying(TopicIndex::GLOBAL_POSITION_SUB), .type=UXR_DATAWRITER_ID},
+        .dr_id = uxrObjectId{.id=to_underlying(TopicIndex::GLOBAL_POSITION_SUB), .type=UXR_DATAREADER_ID},
+        .topic_profile_label = "globalposcontrol__t",
+        .dw_profile_label = "",
+        .dr_profile_label = "globalposcontrol__dr",
     },
 };

--- a/libraries/AP_DDS/Idl/ardupilot_msgs/msg/GlobalPosition.idl
+++ b/libraries/AP_DDS/Idl/ardupilot_msgs/msg/GlobalPosition.idl
@@ -1,0 +1,60 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from ardupilot_msgs/msg/GlobalPosition.msg
+// generated code does not contain a copyright notice
+
+#include "geometry_msgs/msg/Twist.idl"
+#include "std_msgs/msg/Header.idl"
+
+module ardupilot_msgs {
+  module msg {
+    module GlobalPosition_Constants {
+      const uint8 FRAME_GLOBAL_INT = 5;
+      const uint8 FRAME_GLOBAL_REL_ALT = 6;
+      const uint8 FRAME_GLOBAL_TERRAIN_ALT = 11;
+      @verbatim (language="comment", text=
+        "Position ignore flags")
+      const uint16 IGNORE_LATITUDE = 1;
+      const uint16 IGNORE_LONGITUDE = 2;
+      const uint16 IGNORE_ALTITUDE = 4;
+      @verbatim (language="comment", text=
+        "Velocity vector ignore flags")
+      const uint16 IGNORE_VX = 8;
+      const uint16 IGNORE_VY = 16;
+      const uint16 IGNORE_VZ = 32;
+      @verbatim (language="comment", text=
+        "Acceleration/Force vector ignore flags")
+      const uint16 IGNORE_AFX = 64;
+      const uint16 IGNORE_AFY = 128;
+      const uint16 IGNORE_AFZ = 256;
+      @verbatim (language="comment", text=
+        "Force in af vector flag")
+      const uint16 FORCE = 512;
+      const uint16 IGNORE_YAW = 1024;
+      const uint16 IGNORE_YAW_RATE = 2048;
+    };
+    @verbatim (language="comment", text=
+      "Experimental REP-147 Goal Interface" "\n"
+      "https://ros.org/reps/rep-0147.html#goal-interface")
+    struct GlobalPosition {
+      std_msgs::msg::Header header;
+
+      uint8 coordinate_frame;
+
+      uint16 type_mask;
+
+      double latitude;
+
+      double longitude;
+
+      @verbatim (language="comment", text=
+        "in meters, AMSL or above terrain")
+      float altitude;
+
+      geometry_msgs::msg::Twist velocity;
+
+      geometry_msgs::msg::Twist acceleration_or_force;
+
+      float yaw;
+    };
+  };
+};

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -216,6 +216,7 @@ Published topics:
  * /rosout [rcl_interfaces/msg/Log] 1 publisher
 
 Subscribed topics:
+ * /ap/cmd_gps_pose [ardupilot_msgs/msg/GlobalPosition] 1 subscriber
  * /ap/cmd_vel [geometry_msgs/msg/TwistStamped] 1 subscriber
  * /ap/joy [sensor_msgs/msg/Joy] 1 subscriber
  * /ap/tf [tf2_msgs/msg/TFMessage] 1 subscriber
@@ -310,6 +311,10 @@ cp /opt/ros/humble/share/builtin_interfaces/msg/Time.idl libraries/AP_DDS/Idl/bu
 
 # Build the code again with the `--enable-dds` flag as described above
 ```
+
+If the message is custom for ardupilot, first create the ROS message in `Tools/ros2/ardupilot_msgs/msg/GlobalPosition.msg`.
+Then, build ardupilot_msgs with colcon.
+Finally, copy the IDL folder from the install directory into the source tree.
 
 ### Rules for adding topics and services to `dds_xrce_profile.xml`
 

--- a/libraries/AP_DDS/dds_xrce_profile.xml
+++ b/libraries/AP_DDS/dds_xrce_profile.xml
@@ -276,4 +276,19 @@
     <request_topic_name>rq/ap/mode_switchRequest</request_topic_name>
     <reply_topic_name>rr/ap/mode_switchReply</reply_topic_name>
   </replier>
+  <topic profile_name="globalposcontrol__t">
+    <name>rt/ap/cmd_gps_pose</name>
+    <dataType>ardupilot_msgs::msg::dds_::GlobalPosition_</dataType>
+    <historyQos>
+      <kind>KEEP_LAST</kind>
+      <depth>5</depth>
+    </historyQos>
+  </topic>
+  <data_reader profile_name="globalposcontrol__dr">
+    <topic>
+      <kind>NO_KEY</kind>
+      <name>rt/ap/cmd_gps_pose</name>
+      <dataType>ardupilot_msgs::msg::dds_::GlobalPosition_</dataType>
+    </topic>
+  </data_reader>
 </profiles>

--- a/libraries/AP_ExternalControl/AP_ExternalControl.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.h
@@ -8,6 +8,7 @@
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 
+#include <AP_Common/Location.h>
 #include <AP_Math/AP_Math.h>
 
 class AP_ExternalControl
@@ -24,9 +25,18 @@ public:
         return false;
     }
 
+    /*
+        Sets the target global position with standard guided mode behavior.
+    */
+    virtual bool set_global_position(const Location& loc) WARN_IF_UNUSED {
+        return false;
+    }
+
     static AP_ExternalControl *get_singleton(void) WARN_IF_UNUSED {
         return singleton;
     }
+protected:
+    ~AP_ExternalControl() {}
 
 private:
     static AP_ExternalControl *singleton;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -30,6 +30,7 @@
 #include <AP_Button/AP_Button.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_EFI/AP_EFI.h>
+#include <AP_ExternalControl/AP_ExternalControl_config.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Generator/AP_Generator.h>
 #include <AP_Notify/AP_Notify.h>                    // Notify library
@@ -151,12 +152,15 @@ public:
     // returns true if the vehicle has crashed
     virtual bool is_crashed() const;
 
+#if AP_EXTERNAL_CONTROL_ENABLED
+    // Method to control vehicle position for use by external control
+    virtual bool set_target_location(const Location& target_loc) { return false; }
+#endif // AP_EXTERNAL_CONTROL_ENABLED
 #if AP_SCRIPTING_ENABLED
     /*
       methods to control vehicle for use by scripting
     */
     virtual bool start_takeoff(float alt) { return false; }
-    virtual bool set_target_location(const Location& target_loc) { return false; }
     virtual bool set_target_pos_NED(const Vector3f& target_pos, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative, bool terrain_alt) { return false; }
     virtual bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) { return false; }
     virtual bool set_target_posvelaccel_NED(const Vector3f& target_pos, const Vector3f& target_vel, const Vector3f& target_accel, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) { return false; }


### PR DESCRIPTION
# Purpose

This adds DDS support for controlling global position control in LLH of Plane in alignment with REP-147's proposed [High Level Goal Interface](https://ros.org/reps/rep-0147.html#goal-interface).  It relies on [GUIDED](https://ardupilot.org/plane/docs/guided-mode.html) mode in plane. When supplying position, it's intended to be used for in features like "Click to go here" from the GCS. This is NOT a good interface for low-level carrot-on-stick kind of control due to the loitering behavior around the target point.

# Assumptions

* `map` frame in ROS would be used for this type of control

# Limitations

* Only plane implements the interface,  other vehicles will ignore the command.
* Only position control is supported. The ROS interface supports velocity and accel, but it's ignored for now.

# Demo

In ArduPilot repo:
```bash
./Tools/autotest/sim_vehicle.py -w -v ArduPlane --console  --enable-dds --map -DG
```

Run MicroROS Agent
```bash
cd ~/ros2_ws
. /opt/ros/humble/setup.bash
colcon build --packages-up-to ardupilot_sitl
. install/setup.bash
cd src/ardupilot/libraries/AP_DDS
ros2 run micro_ros_agent micro_ros_agent udp4 -p 2019 -r dds_xrce_profile.xml
```

Now, get the plane flying. Once EKF3 is initialized
```
arm throttle
mode takeoff
```

Wait a bit for it to start loitering, then switch to guided. 
```
mode guided
```


Now, command the drone to head north from CMAC to the [grayhound track](https://www.google.com/maps/place/35%C2%B020'45.6%22S+149%C2%B009'32.5%22E/@-35.3559008,149.1620387,2910m/data=!3m1!1e3!4m4!3m3!8m2!3d-35.345996!4d149.159017?entry=ttu) at -35.345996, 149.159017 with an altitude of 40m above home. You only need to send it once with `--once` because this goal is latching on plane. 

```
cd ~/ros2_ws
. /opt/ros/humble/setup.bash
colcon build --packages-up-to ardupilot_msgs
. install/setup.bash
ros2 topic pub /ap/cmd_gps_pose  ardupilot_msgs/msg/GlobalPosition "{header: {frame_id: map}, latitude: -35.345996, longitude: 149.159017, altitude: 40, coordinate_frame: 6}" --once
```

You'll see a pink and green line appear pointing to the middle of the greyhound track as soon as the first message is published. 
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/bfac394b-d2d9-4858-8302-592781c44bcb)

After a while, it will do a clockwise loiter at the target location.
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/5d1d9a3d-39b1-42ab-a446-36bf873b111d)

If you kill the terminal for publishing, the plane will continue to loiter about the same spot and stay in guided mode.

# What about through a ROS node?

Good thing you asked, you can run an example waypoint follower here, which arms the plane, does the takeoff, switches to guided, commands a location, and closes when the goal is reached.

```bash
ros2 run ardupilot_dds_tests plane_waypoint_follower 
```

# Future work

* Add a click-to-go feature to Foxglove's map panel. 
* CI through ROS
* Handle stale data through timestamps

# Considerations

This message is honestly poorly designed; I think this needs to have `experimental` topic prefix untill we can work with the ROS TSC and Aerial Working Group on a new one. 
* `coordinate_frame` has a default value of 0 not represented in the frames of 5,6,11
* `type_make` is pointless, when you could just set fields to NaN. 
* Even worse, you can't disable `velocity.angular` or `acceleration_or_force.angular` with `type_mask`
* If you are sending both target position, velocity and acceleration, but it's a plane with limited control DOF that may conflict, this is ambiguous. 
* There is no documented frames for velocity and acceleration - is it body, NED, ENU, etc? 
* And yea, the usual, no altitude datum concept. Absolute can't encode a datum. 


