### PR TITLE
Plane: slew vtol takeoff throttle similar to copter

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -634,6 +634,10 @@ private:
     uint32_t takeoff_last_run_ms;
     float takeoff_start_alt;
 
+    // ramp time of throttle during take-off
+    AP_Float q_takeoff_throttle_slew_time;
+    AP_Float q_takeoff_throttle_max;
+
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;


### PR DESCRIPTION
Slew the takeoff throttle in order to cleanly break ground.

This is done similar to copter.

https://github.com/ArduPilot/ardupilot/blob/00a65632eb593ab0e38358adf0f6b8200c72fd01/ArduCopter/takeoff.cpp#L159-L181

Note: no navigation is done first in plane and the states to decide landing are slightly different.

## Testing
[00000100.BIN.txt](https://github.com/ArduPilot/ardupilot/files/13605323/00000100.BIN.txt)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/b4566537-4e19-4411-88b8-933a69723cd6)
Figure: RATE.AOut slewed over 2 seconds.
