### PR TITLE
ROS2 - ardupilot_sitl launch file to include a "out" parameter for Mavproxy

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -284,21 +284,21 @@ class MAVProxyLaunch:
 
         # Retrieve launch arguments.
         master = LaunchConfiguration("master").perform(context)
-        # out = LaunchConfiguration("out").perform(context)
+        out = LaunchConfiguration("out").perform(context)
         sitl = LaunchConfiguration("sitl").perform(context)
 
         # Display launch arguments.
         print(f"command:          {command}")
         print(f"master:           {master}")
         print(f"sitl:             {sitl}")
+        print(f"out:              {out}")
 
         # Create action.
         mavproxy_process = ExecuteProcess(
             cmd=[
                 [
                     f"{command} ",
-                    "--out ",
-                    "127.0.0.1:14550 ",
+                    f"--out {out} ",
                     "--out ",
                     "127.0.0.1:14551 ",
                     f"--master {master} ",


### PR DESCRIPTION
The ROS2 ardupilot_sitl launch file is currently setting the --out argument to mavproxy as default to localhost:14550. This PR allows to change the default output, in case for example we launch the node on a docker container and we want to connect to a Ground Station running on the host.

How to test:
We can follow the example provided in https://ardupilot.org/dev/docs/ros2-sitl.html and launch the _sitl_ with:

`ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501`

This should output something like:
![image](https://github.com/ArduPilot/ardupilot/assets/2077106/e2c25e98-b7bf-45ca-9873-9ce3f9fa5f61)
which shows that, by default, the output is still localhost:14550

We can then add the option `out:=udp:<any_ip_address>:<any_port>`, and verify that the output to the launch file becomes:
![image](https://github.com/ArduPilot/ardupilot/assets/2077106/6b76f01c-bfe7-4b2d-aa53-0bf480b493a7)

We can then use either mavproxy or any GUI to connect to the UDP stream. In my case, I went from my Ubuntu Virtual Machine to my Windows host where I run QGCS:
![image](https://github.com/ArduPilot/ardupilot/assets/2077106/0c173547-fb93-4ac2-acd5-3ae58bb368d8)


