### PR TITLE
Detect board class by inheritance instead of naming

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -570,6 +570,9 @@ def get_boards_names():
 
     return sorted(list(_board_classes.keys()), key=str.lower)
 
+def is_board_based(board, cls):
+    return issubclass(_board_classes[board], cls)
+
 def get_ap_periph_boards():
     '''Add AP_Periph boards based on existance of periph keywork in hwdef.dat or board name'''
     list_ap = [s for s in list(_board_classes.keys()) if "periph" in s]

--- a/wscript
+++ b/wscript
@@ -644,9 +644,9 @@ def generate_tasklist(ctx, do_print=True):
             elif 'iofirmware' in board:
                 task['targets'] = ['iofirmware', 'bootloader']
             else:
-                if 'sitl' in board or 'SITL' in board:
+                if boards.is_board_based(board, boards.sitl):
                     task['targets'] = ['antennatracker', 'copter', 'heli', 'plane', 'rover', 'sub', 'replay']
-                elif 'linux' in board:
+                elif boards.is_board_based(board, boards.linux):
                     task['targets'] = ['antennatracker', 'copter', 'heli', 'plane', 'rover', 'sub']
                 else:
                     task['targets'] = ['antennatracker', 'copter', 'heli', 'plane', 'rover', 'sub', 'bootloader']


### PR DESCRIPTION
Not all (actually none?) Linux boards have `linux` in their names, but the task detection logic only checks that, resulting in Linux boards being misclassified. In practical terms this means they also pull the unnecessary bootloader in, but overall this makes the clause misleading.

This PR adds functionality to detect the base class of the board by probing inheritance and thus fixes this.