### PR TITLE
AP_GPS: increase the RTCM buffer length to 1024

### DIFF
--- a/libraries/AP_GPS/RTCM3_Parser.h
+++ b/libraries/AP_GPS/RTCM3_Parser.h
@@ -19,7 +19,8 @@
 #pragma once
 #include <stdint.h>
 
-#define RTCM3_MAX_PACKET_LEN 300
+#define RTCM3_MAX_PACKET_LEN 1024
+
 class RTCM3_Parser {
 public:
     // process one byte, return true if packet found


### PR DESCRIPTION
* GPS with L5 support can have RTCM message lengths greater than 300 bytes. 