### PR TITLE
Tools: ignore the error from brew update

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -103,7 +103,8 @@ function maybe_prompt_user() {
 # see https://github.com/orgs/Homebrew/discussions/3895
 find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
 
-brew update
+# brew update randomly failing on CI, so ignore errors:
+brew update || true
 brew install gawk curl coreutils wget
 
 PIP=pip


### PR DESCRIPTION
* brew update was crashing due node update, which we don't use. In general we don't want to fail just because brew update can't do its job cleanly.