### PR TITLE
Plane: allow takeoff setting expected in manual and move landing override up

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1091,7 +1091,7 @@ private:
     // servos.cpp
     void set_servos_idle(void);
     void set_servos();
-    void set_servos_controlled(void);
+    void set_throttle(void);
     void set_takeoff_expected(void);
     void set_servos_old_elevons(void);
     void set_servos_flaps(void);

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -135,6 +135,9 @@ bool Mode::enter()
            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "In landing sequence: mission reset");
            plane.mission.reset();
         }
+
+        // Make sure the flight stage is correct for the new mode
+        plane.update_flight_stage();
     }
 
     return enter_result;

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -829,8 +829,13 @@ void Plane::set_servos(void)
     quadplane.update();
 #endif
 
+    if (flight_stage == AP_FixedWing::FlightStage::LAND) {
+        // allow landing to override servos if it would like to
+        landing.override_servos();
+    }
+
     if (control_mode != &mode_manual) {
-        set_servos_controlled();
+        set_throttle();
         set_takeoff_expected();
     }
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -472,13 +472,8 @@ void Plane::throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle)
 /*
   setup output channels all non-manual modes
  */
-void Plane::set_servos_controlled(void)
+void Plane::set_throttle(void)
 {
-    if (flight_stage == AP_FixedWing::FlightStage::LAND) {
-        // allow landing to override servos if it would like to
-        landing.override_servos();
-    }
-
     // convert 0 to 100% (or -100 to +100) into PWM
     int8_t min_throttle = aparm.throttle_min.get();
     int8_t max_throttle = aparm.throttle_max.get();
@@ -836,8 +831,10 @@ void Plane::set_servos(void)
 
     if (control_mode != &mode_manual) {
         set_throttle();
-        set_takeoff_expected();
     }
+
+    // Warn AHRS if we might take off soon
+    set_takeoff_expected();
 
     // setup flap outputs
     set_servos_flaps();


### PR DESCRIPTION
One functional change to allow take off expected to be set in manual. This will only happen if not flying armed and either high throttle or a throw is detected.

Mode enter now updates flight stage. This would usually happen at 10Hz in the `update_alt` call or in `setup_glide_slope` which RTL already calls as part of its enter.

With the flight stage race removed we can be sure that we will never be in `FlightStage::LAND` in manual mode. This means the landing servo override can be moved up with no change in behavior. 

I have also renamed `set_servos_controlled` to `set_throttle`.
