### PR TITLE
Allow proper shutdown in Linux

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -463,7 +463,11 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         }
     }
 
-    setup_signal_handlers();
+    // NOTE: signal handlers are only set before the main loop, so
+    // that if anything before the loops hangs, the default signals
+    // can still stop the process proprely, although without proper
+    // teardown.
+    // This isn't perfect, but still prevents an unkillable process.
 
     scheduler->init();
     gpio->init();
@@ -492,6 +496,8 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
 #if AP_MODULE_SUPPORTED
     AP_Module::call_hook_setup_complete();
 #endif
+
+    setup_signal_handlers();
 
     while (!_should_exit) {
         callbacks->loop();

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.h
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.h
@@ -2,6 +2,8 @@
 
 #include <AP_HAL/AP_HAL.h>
 
+#include <signal.h>
+
 class HAL_Linux : public AP_HAL::HAL {
 public:
     HAL_Linux();
@@ -12,7 +14,7 @@ public:
     static void exit_signal_handler(int);
 
 protected:
-    bool _should_exit = false;
+    volatile sig_atomic_t _should_exit = false;
 };
 
 #if HAL_NUM_CAN_IFACES


### PR DESCRIPTION
This addresses 2 problems for Linux builds:
1. If the code hangs during initializations in `HAL_Linux::run` (e.g. missing a critical sensor) the whole process would lock up and not respond to `SIGINT` / `SIGTERM`, which makes it inconvenient to work with. The solution is suboptimal because in such a shutdown scenario the teardown would be skipped, however otherwise `callbacks->setup()` in particular needs to be made interruptible instead.
2.  Signal handler runs in a separate context, so the compiler may choose to optimize the loop condition out. Marking it as volatile explicitly prevents this.