### PR TITLE
AP_DAL: remove tmp_location from global namespace

### DIFF
--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -3,24 +3,12 @@
 #include <AP_Logger/AP_Logger.h>
 #include "AP_DAL.h"
 
-// we use a static here as the "location" accessor wants to be const
-static Location tmp_location[GPS_MAX_INSTANCES];
-
 AP_DAL_GPS::AP_DAL_GPS()
 {
     for (uint8_t i=0; i<ARRAY_SIZE(_RGPI); i++) {
         _RGPI[i].instance = i;
         _RGPJ[i].instance = i;
     }
-}
-
-const Location &AP_DAL_GPS::location(uint8_t instance) const
-{
-    Location &loc = tmp_location[instance];
-    loc.lat = _RGPJ[instance].lat;
-    loc.lng = _RGPJ[instance].lng;
-    loc.alt = _RGPJ[instance].alt;
-    return loc;
 }
 
 void AP_DAL_GPS::start_frame()
@@ -61,5 +49,9 @@ void AP_DAL_GPS::start_frame()
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);
+
+        tmp_location[i].lat = RGPJ.lat;
+        tmp_location[i].lng = RGPJ.lng;
+        tmp_location[i].alt = RGPJ.alt;
     }
 }

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -26,7 +26,9 @@ public:
     GPS_Status status() const {
         return status(primary_sensor());
     }
-    const Location &location(uint8_t instance) const;
+    const Location &location(uint8_t instance) const {
+        return tmp_location[instance];
+    }
     bool have_vertical_velocity(uint8_t instance) const {
         return _RGPI[instance].have_vertical_velocity;
     }
@@ -125,6 +127,10 @@ public:
     }
     void handle_message(const log_RGPJ &msg) {
         _RGPJ[msg.instance] = msg;
+
+        tmp_location[msg.instance].lat = msg.lat;
+        tmp_location[msg.instance].lng = msg.lng;
+        tmp_location[msg.instance].alt = msg.alt;
     }
 
 private:
@@ -132,4 +138,6 @@ private:
     struct log_RGPH _RGPH;
     struct log_RGPI _RGPI[GPS_MAX_INSTANCES];
     struct log_RGPJ _RGPJ[GPS_MAX_INSTANCES];
+
+    Location tmp_location[GPS_MAX_INSTANCES];
 };


### PR DESCRIPTION
removes this from the global namespace and means it isn't included when DAL isn't

update the location where we update the fields.