### PR TITLE
AC_PID: tidy interface and add logging of resets and I term sets

### DIFF
--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -323,7 +323,7 @@ void AC_PID::update_i(float dt, bool limit)
 
 float AC_PID::get_p() const
 {
-    return _error * _kp;
+    return _pid_info.P;
 }
 
 float AC_PID::get_i() const
@@ -333,7 +333,7 @@ float AC_PID::get_i() const
 
 float AC_PID::get_d() const
 {
-    return _kd * _derivative;
+    return _pid_info.D;
 }
 
 float AC_PID::get_ff() const

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -198,6 +198,7 @@ float AC_PID::update_all(float target, float measurement, float dt, bool limit, 
     }
 
     // reset input filter to value received
+    _pid_info.reset = _flags._reset_filter;
     if (_flags._reset_filter) {
         _flags._reset_filter = false;
         _target = target;
@@ -319,6 +320,10 @@ void AC_PID::update_i(float dt, bool limit)
     }
     _pid_info.I = _integrator;
     _pid_info.limit = limit;
+
+    // Set I set flag for logging and clear
+    _pid_info.I_term_set = _flags._I_set;
+    _flags._I_set = false;
 }
 
 float AC_PID::get_p() const
@@ -343,6 +348,7 @@ float AC_PID::get_ff() const
 
 void AC_PID::reset_I()
 {
+    _flags._I_set = true;
     _integrator = 0.0;
 }
 
@@ -404,6 +410,7 @@ float AC_PID::get_filt_D_alpha(float dt) const
 
 void AC_PID::set_integrator(float integrator)
 {
+    _flags._I_set = true;
     _integrator = constrain_float(integrator, -_kimax, _kimax);
 }
 
@@ -411,6 +418,7 @@ void AC_PID::relax_integrator(float integrator, float dt, float time_constant)
 {
     integrator = constrain_float(integrator, -_kimax, _kimax);
     if (is_positive(dt)) {
+        _flags._I_set = true;
         _integrator = _integrator + (integrator - _integrator) * (dt / (dt + time_constant));
     }
 }

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -336,7 +336,7 @@ float AC_PID::get_d() const
     return _kd * _derivative;
 }
 
-float AC_PID::get_ff()
+float AC_PID::get_ff() const
 {
     return  _pid_info.FF + _pid_info.DFF;
 }

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -402,16 +402,6 @@ float AC_PID::get_filt_D_alpha(float dt) const
     return calc_lowpass_alpha_dt(dt, _filt_D_hz);
 }
 
-void AC_PID::set_integrator(float target, float measurement, float integrator)
-{
-    set_integrator(target - measurement, integrator);
-}
-
-void AC_PID::set_integrator(float error, float integrator)
-{
-    _integrator = constrain_float(integrator - error * _kp, -_kimax, _kimax);
-}
-
 void AC_PID::set_integrator(float integrator)
 {
     _integrator = constrain_float(integrator, -_kimax, _kimax);

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -184,6 +184,7 @@ protected:
     // flags
     struct ac_pid_flags {
         bool _reset_filter :1; // true when input filter should be reset during next call to set_input
+        bool _I_set :1; // true if if the I terms has been set externally including zeroing
     } _flags;
 
     // internal variables

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -72,17 +72,11 @@ public:
     // todo: remove function when it is no longer used.
     float update_error(float error, float dt, bool limit = false);
 
-    //  update_i - update the integral
-    //  if the limit flag is set the integral is only allowed to shrink
-    void update_i(float dt, bool limit);
-
     // get_pid - get results from pid controller
-    float get_pid() const;
-    float get_pi() const;
     float get_p() const;
     float get_i() const;
     float get_d() const;
-    float get_ff();
+    float get_ff() const;
 
     // reset_I - reset the integrator
     void reset_I();
@@ -113,9 +107,11 @@ public:
     AP_Float &filt_E_hz() { return _filt_E_hz; }
     AP_Float &filt_D_hz() { return _filt_D_hz; }
     AP_Float &slew_limit() { return _slew_rate_max; }
+    AP_Float &kDff() { return _kdff; }
 
     float imax() const { return _kimax.get(); }
     float pdmax() const { return _kpdmax.get(); }
+
     float get_filt_T_alpha(float dt) const;
     float get_filt_E_alpha(float dt) const;
     float get_filt_D_alpha(float dt) const;
@@ -131,6 +127,7 @@ public:
     void filt_E_hz(const float v);
     void filt_D_hz(const float v);
     void slew_limit(const float v);
+    void kDff(const float v) { _kdff.set(v); }
 
     // set the desired and actual rates (for logging purposes)
     void set_target_rate(float target) { _pid_info.target = target; }
@@ -150,19 +147,16 @@ public:
 
     const AP_PIDInfo& get_pid_info(void) const { return _pid_info; }
 
-    AP_Float &kDff() { return _kdff; }
-    void kDff(const float v) { _kdff.set(v); }
     void set_notch_sample_rate(float);
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
-    // the time constant tau is not currently configurable, but is set
-    // as an AP_Float to make it easy to make it configurable for a
-    // single user of AC_PID by adding the parameter in the param
-    // table of the parent class. It is made public for this reason
-    AP_Float _slew_rate_tau;
-    
 protected:
+
+    //  update_i - update the integral
+    //  if the limit flag is set the integral is only allowed to shrink
+    void update_i(float dt, bool limit);
 
     // parameters
     AP_Float _kp;
@@ -180,6 +174,13 @@ protected:
     AP_Int8 _notch_T_filter;
     AP_Int8 _notch_E_filter;
 #endif
+
+    // the time constant tau is not currently configurable, but is set
+    // as an AP_Float to make it easy to make it configurable for a
+    // single user of AC_PID by adding the parameter in the param
+    // table of the parent class. It is made public for this reason
+    AP_Float _slew_rate_tau;
+
     SlewLimiter _slew_limiter{_slew_rate_max, _slew_rate_tau};
 
     // flags

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -134,8 +134,6 @@ public:
     void set_actual_rate(float actual) { _pid_info.actual = actual; }
 
     // integrator setting functions
-    void set_integrator(float target, float measurement, float i);
-    void set_integrator(float error, float i);
     void set_integrator(float i);
     void relax_integrator(float integrator, float dt, float time_constant);
 

--- a/libraries/AC_PID/AP_PIDInfo.h
+++ b/libraries/AC_PID/AP_PIDInfo.h
@@ -19,4 +19,6 @@ struct AP_PIDInfo {
     float slew_rate;
     bool limit;
     bool PD_limit;
+    bool reset;
+    bool I_term_set;
 };

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -478,6 +478,8 @@ void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
     enum class log_PID_Flags : uint8_t {
         LIMIT = 1U<<0, // true if the output is saturated, I term anti windup is active
         PD_SUM_LIMIT =  1U<<1, // true if the PD sum limit is active
+        RESET = 1U<<2, // true if the controller was reset
+        I_TERM_SET = 1U<<3, // true if the I term has been set externally including reseting to 0
     };
 
     uint8_t flags = 0;
@@ -486,6 +488,12 @@ void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
     }
     if (info.PD_limit) {
         flags |= (uint8_t)log_PID_Flags::PD_SUM_LIMIT;
+    }
+    if (info.reset) {
+        flags |= (uint8_t)log_PID_Flags::RESET;
+    }
+    if (info.I_term_set) {
+        flags |= (uint8_t)log_PID_Flags::I_TERM_SET;
     }
 
     const struct log_PID pkt{


### PR DESCRIPTION
This does some tidying of the interface and adds some logging.

- moves `update_i` and `_slew_rate_tau` to protected, this means external code cannot see them, nothing it using them so there is no external change.
- removes `get_pid()` and `get_pi()` from the header as the functions are not implemented
- updates `get_p`, `get_d` ~~and `get_i`~~ to return the value from `_pid_info` this means there exactly the same values as would be summed and returned from the `update_all` call. Currently P and D are re-calculated and thus skip the application of slew limit and P+D max. I term can be set externally so currently you would not get the same value as was used if there had been a I term set. 
- `get_ff` is now const this is in line with the other `get_..` methods
-  `set_integrator` with target, measurement and integrator and `set_integrator` with error and integrator have been removed, there are no users.
- Logging flags have been added to show when the controller has been reset and when the I term has been set externally. These are added to the existing flags field so there is no increase in log size.