### PR TITLE
Plane: extend support of SET_POSITION_TARGET_GLOBAL_INT

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1478,8 +1478,6 @@ void GCS_MAVLINK_Plane::handle_set_position_target_global_int(const mavlink_mess
                 plane.adjust_altitude_target();
             }
         }
-
-        break;
     }
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlink_command_int_t &packet)


### PR DESCRIPTION
This PR extends support for the mavlink handler of SET_POSITION_TARGET_GLOBAL_INT to handle position (lat, lon) setpoints as well as altitude changes. If velocity and acceleration data is provided it is used to calculate the path curvature expressed as a loiter radius and direction.

### See Also

- https://github.com/ArduPilot/ardupilot/pull/25722

### Motivation

- Support offboard terrain navigation, in particular the port to ROS 2 of https://github.com/ethz-asl/terrain-navigation.

### Detail

The following control methods from `Plane` are used:
- `plane.control_mode->handle_guided_request()` is passed the position setpoint.
- `plane.mode_guided.set_radius_and_direction()` is passed the radius and direction calculated from setpoint velocity and acceleration.
- `plane.adjust_altitude_target` is called to force update the altitude, otherwise the current altitude set in `set_guided_WP` is used if the setpoint update rate is greater than the scheduled update rate of `adjust_altitude_target`, and the plane will not achieve the desired altitude.

### Testing

- Initial testing in SITL using the default quadplane model with the terrain navigation package commanding setpoints.

### Tasks
 
- [ ] Correct handling of the `type_mask` and `coordinate_frame` fields of `SET_POSITION_TARGET_GLOBAL_INT`.
- [ ] Check fields are valid (position, velocity, acceleration).
- [ ] Verify use of plane control functions is valid.