### PR TITLE
Tools: mac: force install to avoid npm installation error

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -104,8 +104,8 @@ function maybe_prompt_user() {
 find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
 
 # brew update randomly failing on CI, so ignore errors:
-brew update || true
-brew install gawk curl coreutils wget
+brew update
+brew install --force --overwrite gawk curl coreutils wget
 
 PIP=pip
 if maybe_prompt_user "Install python using pyenv [N/y]?" ; then


### PR DESCRIPTION
2023-12-11T23:04:39.8671350Z already exists. You may want to remove it:
2023-12-11T23:04:39.8679620Z   rm '/usr/local/lib/node_modules/npm/node_modules/@npmcli/agent/lib/agents.js'
2023-12-11T23:04:39.8682240Z
2023-12-11T23:04:39.8691710Z To force the link and overwrite all conflicting files:
2023-12-11T23:04:39.8700070Z   brew link --overwrite node@18
2023-12-11T23:04:39.8726220Z
2023-12-11T23:04:39.8736300Z To list all files that would be deleted:
2023-12-11T23:04:39.8744090Z   brew link --overwrite --dry-run node@18

... also remove hack to force update to succeed