### PR TITLE
AP_SerialManager: Reserving serial protocol ID for future Vertiq IFCI implementation

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -80,6 +80,7 @@ public:
         SerialProtocol_Tramp = 44,
         SerialProtocol_DDS_XRCE = 45,
         SerialProtocol_IMUOUT = 46,
+        // Reserving Serial Protocol 47 for SerialProtocol_IQ
         SerialProtocol_NumProtocols                    // must be the last value
     };
 


### PR DESCRIPTION
This pull request would reserve the ID 47 for our serial protocol so we don't need to keep updating our future pull request's ID as discussed in the devcall on 12/11/2023.