### PR TITLE
AP_Motors: Heli: RotorControlState to enum class and helper to remove duplication

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -590,3 +590,26 @@ void AP_MotorsHeli::set_desired_rotor_speed(float desired_speed)
 {
     _main_rotor.set_desired_speed(desired_speed);
 }
+
+// Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
+AP_MotorsHeli_RSC::RotorControlState AP_MotorsHeli::get_rotor_control_state() const
+{
+    switch (_spool_state) {
+        case SpoolState::SHUT_DOWN:
+            // sends minimum values out to the motors
+            return AP_MotorsHeli_RSC::RotorControlState::STOP;
+        case SpoolState::GROUND_IDLE:
+            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
+            return AP_MotorsHeli_RSC::RotorControlState::IDLE;
+        case SpoolState::SPOOLING_UP:
+        case SpoolState::THROTTLE_UNLIMITED:
+            // set motor output based on thrust requests
+            return AP_MotorsHeli_RSC::RotorControlState::ACTIVE;
+        case SpoolState::SPOOLING_DOWN:
+            // sends idle output to motors and wait for rotor to stop
+            return AP_MotorsHeli_RSC::RotorControlState::IDLE;
+    }
+
+    // Should be unreachable, but needed to keep the compiler happy
+    return AP_MotorsHeli_RSC::RotorControlState::STOP;
+}

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -190,7 +190,7 @@ void AP_MotorsHeli::output_min()
     // move swash to mid
     move_actuators(0.0f,0.0f,0.5f,0.0f);
 
-    update_motor_control(ROTOR_CONTROL_STOP);
+    update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
 
     // override limits flags
     set_limit_flag_pitch_roll_yaw(true);

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -191,6 +191,9 @@ protected:
     // update_motor_controls - sends commands to motor controllers
     virtual void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) = 0;
 
+    // Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
+    AP_MotorsHeli_RSC::RotorControlState get_rotor_control_state() const;
+
     // run spool logic
     void                output_logic();
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -189,7 +189,7 @@ protected:
     AP_MotorsHeli_RSC   _main_rotor;            // main rotor
 
     // update_motor_controls - sends commands to motor controllers
-    virtual void update_motor_control(RotorControlState state) = 0;
+    virtual void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) = 0;
 
     // run spool logic
     void                output_logic();

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -525,25 +525,8 @@ void AP_MotorsHeli_Dual::output_to_motors()
     _swashplate1.output();
     _swashplate2.output();
 
-    switch (_spool_state) {
-        case SpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
-            break;
-        case SpoolState::GROUND_IDLE:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-        case SpoolState::SPOOLING_UP:
-        case SpoolState::THROTTLE_UNLIMITED:
-            // set motor output based on thrust requests
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
-            break;
-        case SpoolState::SPOOLING_DOWN:
-            // sends idle output to motors and wait for rotor to stop
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-    }
+    update_motor_control(get_rotor_control_state());
+
 }
 
 // servo_test - move servos through full range of movement

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -360,12 +360,12 @@ void AP_MotorsHeli_Dual::mix_intermeshing(float pitch_input, float roll_input, f
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Dual::update_motor_control(RotorControlState state)
+void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
 {
     // Send state update to motors
     _main_rotor.output(state);
 
-    if (state == ROTOR_CONTROL_STOP) {
+    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP) {
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -528,20 +528,20 @@ void AP_MotorsHeli_Dual::output_to_motors()
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
             // sends minimum values out to the motors
-            update_motor_control(ROTOR_CONTROL_STOP);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
             break;
         case SpoolState::GROUND_IDLE:
             // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
             // set motor output based on thrust requests
-            update_motor_control(ROTOR_CONTROL_ACTIVE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
             break;
         case SpoolState::SPOOLING_DOWN:
             // sends idle output to motors and wait for rotor to stop
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
     }
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -65,7 +65,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
 
     // get_swashplate - calculate movement of each swashplate based on configuration
     float get_swashplate(int8_t swash_num, int8_t swash_axis, float pitch_input, float roll_input, float yaw_input, float coll_input);

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -273,25 +273,8 @@ void AP_MotorsHeli_Quad::output_to_motors()
         rc_write_angle(AP_MOTORS_MOT_1+i, _out[i] * QUAD_SERVO_MAX_ANGLE);
     }
 
-    switch (_spool_state) {
-        case SpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
-            break;
-        case SpoolState::GROUND_IDLE:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-        case SpoolState::SPOOLING_UP:
-        case SpoolState::THROTTLE_UNLIMITED:
-            // set motor output based on thrust requests
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
-            break;
-        case SpoolState::SPOOLING_DOWN:
-            // sends idle output to motors and wait for rotor to stop
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-    }
+    update_motor_control(get_rotor_control_state());
+
 }
 
 // servo_test - move servos through full range of movement

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -145,12 +145,12 @@ void AP_MotorsHeli_Quad::calculate_roll_pitch_collective_factors()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Quad::update_motor_control(RotorControlState state)
+void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
 {
     // Send state update to motors
     _main_rotor.output(state);
 
-    if (state == ROTOR_CONTROL_STOP) {
+    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP) {
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -276,20 +276,20 @@ void AP_MotorsHeli_Quad::output_to_motors()
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
             // sends minimum values out to the motors
-            update_motor_control(ROTOR_CONTROL_STOP);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
             break;
         case SpoolState::GROUND_IDLE:
             // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
             // set motor output based on thrust requests
-            update_motor_control(ROTOR_CONTROL_ACTIVE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
             break;
         case SpoolState::SPOOLING_DOWN:
             // sends idle output to motors and wait for rotor to stop
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
     }
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -49,7 +49,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
 
     // calculate_roll_pitch_collective_factors - setup rate factors
     void calculate_roll_pitch_collective_factors ();

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -275,7 +275,7 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
     }
 
     switch (state) {
-    case ROTOR_CONTROL_STOP:
+    case RotorControlState::STOP:
         // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
         update_rotor_ramp(0.0f, dt);
 
@@ -296,7 +296,7 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         _idle_throttle = get_idle_output();
         break;
 
-    case ROTOR_CONTROL_IDLE:
+    case RotorControlState::IDLE:
         // set rotor ramp to decrease speed to zero
         update_rotor_ramp(0.0f, dt);
 
@@ -348,7 +348,7 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         _control_output = _idle_throttle;
         break;
 
-    case ROTOR_CONTROL_ACTIVE:
+    case RotorControlState::ACTIVE:
         // set main rotor ramp to increase to full speed
         update_rotor_ramp(1.0f, dt);
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -30,13 +30,6 @@
 // RSC governor defaults
 #define AP_MOTORS_HELI_RSC_GOVERNOR_RANGE_DEFAULT     100
 
-// rotor controller states
-enum RotorControlState {
-    ROTOR_CONTROL_STOP = 0,
-    ROTOR_CONTROL_IDLE,
-    ROTOR_CONTROL_ACTIVE
-};
-
 // rotor control modes
 enum RotorControlMode {
     ROTOR_CONTROL_MODE_DISABLED = 0,
@@ -58,6 +51,13 @@ public:
         _default_channel(default_channel)
     {
         AP_Param::setup_object_defaults(this, var_info);
+    };
+
+    // rotor controller states
+    enum class RotorControlState {
+        STOP = 0,
+        IDLE,
+        ACTIVE
     };
 
     // init_servo - servo initialization on start-up

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -347,13 +347,13 @@ uint32_t AP_MotorsHeli_Single::get_motor_mask()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Single::update_motor_control(RotorControlState state)
+void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
 {
     // Send state update to motors
     _tail_rotor.output(state);
     _main_rotor.output(state);
 
-    if (state == ROTOR_CONTROL_STOP){
+    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP){
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -504,20 +504,20 @@ void AP_MotorsHeli_Single::output_to_motors()
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
             // sends minimum values out to the motors
-            update_motor_control(ROTOR_CONTROL_STOP);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
             break;
         case SpoolState::GROUND_IDLE:
             // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
         case SpoolState::SPOOLING_UP:
         case SpoolState::THROTTLE_UNLIMITED:
             // set motor output based on thrust requests
-            update_motor_control(ROTOR_CONTROL_ACTIVE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
             break;
         case SpoolState::SPOOLING_DOWN:
             // sends idle output to motors and wait for rotor to stop
-            update_motor_control(ROTOR_CONTROL_IDLE);
+            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
             break;
     }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -501,25 +501,7 @@ void AP_MotorsHeli_Single::output_to_motors()
     _swashplate.output();
 
     // Output main rotor
-    switch (_spool_state) {
-        case SpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
-            break;
-        case SpoolState::GROUND_IDLE:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-        case SpoolState::SPOOLING_UP:
-        case SpoolState::THROTTLE_UNLIMITED:
-            // set motor output based on thrust requests
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::ACTIVE);
-            break;
-        case SpoolState::SPOOLING_DOWN:
-            // sends idle output to motors and wait for rotor to stop
-            update_motor_control(AP_MotorsHeli_RSC::RotorControlState::IDLE);
-            break;
-    }
+    update_motor_control(get_rotor_control_state());
 
     // Output tail rotor
     switch (get_tail_type()) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -86,7 +86,7 @@ protected:
     void init_outputs() override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
 
     // heli_move_actuators - moves swash plate and tail rotor
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) override;


### PR DESCRIPTION
The recent tail clean up means we can remove the spool state to rotor control state conversion that is done for each heli type. This adds a new helper function so we only have to do it in one place. It also moves `RotorControlState` inside `AP_MotorsHeli_RSC` and converts to a enum class.

Should be no functional change.