### PR TITLE
Plane: Quadplane: log tailsitter speed scaling in TSIT msg

### DIFF
--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -102,6 +102,7 @@ enum log_messages {
     LOG_PIDG_MSG,
     LOG_AETR_MSG,
     LOG_OFG_MSG,
+    LOG_TSIT_MSG,
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3663,7 +3663,6 @@ void QuadPlane::Log_Write_QControl_Tuning()
         target_climb_rate   : target_climb_rate_cms,
         climb_rate          : int16_t(inertial_nav.get_velocity_z_up_cms()),
         throttle_mix        : attitude_control->get_throttle_mix(),
-        speed_scaler        : tailsitter.log_spd_scaler,
         transition_state    : transition->get_log_transition_state(),
         assist              : assisted_flight,
     };

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -156,7 +156,6 @@ public:
         int16_t  target_climb_rate;
         int16_t  climb_rate;
         float    throttle_mix;
-        float    speed_scaler;
         uint8_t  transition_state;
         uint8_t  assist;
     };

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -17,6 +17,7 @@
 #include <AP_Param/AP_Param.h>
 #include "transition.h"
 #include <AP_Motors/AP_MotorsTailsitter.h>
+#include <AP_Logger/LogStructure.h>
 
 class QuadPlane;
 class AP_MotorsMulticopter;
@@ -66,9 +67,11 @@ public:
     // return true if pitch control should be relaxed
     bool relax_pitch();
 
+    // Write tailsitter specific log
+    void write_log();
+
     // tailsitter speed scaler
     float last_spd_scaler = 1.0f; // used to slew rate limiting with TAILSITTER_GSCL_ATT_THR option
-    float log_spd_scaler; // for QTUN log
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -111,6 +114,23 @@ public:
     AP_MotorsTailsitter* tailsitter_motors;
 
 private:
+
+    // Tailsitter specific log message
+    struct PACKED log_tailsitter {
+        LOG_PACKET_HEADER;
+        uint64_t time_us;
+        float throttle_scaler;
+        float speed_scaler;
+        float min_throttle;
+    };
+
+    // Data to be logged
+    struct {
+        float throttle_scaler;
+        float speed_scaler;
+        float min_throttle;
+    } log_data;
+
 
     bool setup_complete;
 


### PR DESCRIPTION
This adds a new tailsitter log message `TSIT`. This allows moving the speed scale `Sscl` out of `QTUN`. In addition to that value this also logs the throttle only scale and the disk loading min throttle. For those last two values to be different you need to be not using throttle scaling for speed scale and be using min outflow speed with disk theory. 

This is currently at full loop rate. 

As a drive by I also put the "PIQ" message definitions behind `HAL_QUADPLANE_ENABLED` which should save a little flash on boards without quadplane.

We might want to add more stuff in the future, but this is a start. 