### PR TITLE
AP_ExternalAHRS: Reserve Aeron ID

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -60,6 +60,7 @@ public:
 #endif
         // 8 reserved for SBG
         // 9 reserved for EulerNav
+        // 10 reserved for Aeron
     };
 
     static AP_ExternalAHRS *get_singleton(void) {


### PR DESCRIPTION
We are planning to add our IMU support as an ExternalAHRS in the Ardupilot.