### PR TITLE
AP_Stats: update flight time on disarm

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -72,6 +72,7 @@ void AP_Stats::flush()
 {
     params.flttime.set_and_save_ifchanged(flttime);
     params.runtime.set_and_save_ifchanged(runtime);
+    last_flush_ms = AP_HAL::millis();
 }
 
 void AP_Stats::update_flighttime()
@@ -101,7 +102,6 @@ void AP_Stats::update()
         update_flighttime();
         update_runtime();
         flush();
-        last_flush_ms = now_ms;
     }
     const uint32_t params_reset = params.reset;
     if (params_reset != reset || params_reset == 0) {
@@ -131,7 +131,11 @@ void AP_Stats::set_flying(const bool is_flying)
             _flying_ms = AP_HAL::millis();
         }
     } else {
-        update_flighttime();
+        if (_flying_ms) {
+            update_flighttime();
+            update_runtime();
+            flush();
+        }
         _flying_ms = 0;
     }
 }


### PR DESCRIPTION
This PR fixes an issue where flight time was not being updated if the power was shut down immediately after flight.
Since the update occurs in 30-second cycles, turning off the power before the update process means the last flight time is not added.

I have modified update function so that the flight time updates upon disarming, in addition to the regular updates every 30 seconds.

I have confirmed that the flight time is updated immediately after disarming in SITL.