### PR TITLE
AP_Periph: added CAN deadline handling

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -416,8 +416,16 @@ public:
                           uint16_t data_type_id,
                           uint8_t priority,
                           const void* payload,
-                          uint16_t payload_len);
+                          uint16_t payload_len,
+                          uint8_t iface_mask=0);
 
+    bool canard_respond(CanardInstance* canard_instance,
+                        CanardRxTransfer* transfer,
+                        uint64_t data_type_signature,
+                        uint16_t data_type_id,
+                        const uint8_t *payload,
+                        uint16_t payload_len);
+    
     void onTransferReceived(CanardInstance* canard_instance,
                             CanardRxTransfer* transfer);
     bool shouldAcceptTransfer(const CanardInstance* canard_instance,
@@ -465,7 +473,7 @@ public:
 #if HAL_PERIPH_CAN_MIRROR
     void processMirror(void);
 #endif // HAL_PERIPH_CAN_MIRROR
-    void cleanup_stale_transactions(uint64_t &timestamp_usec);
+    void cleanup_stale_transactions(uint64_t timestamp_usec);
     void update_rx_protocol_stats(int16_t res);
     void node_status_send(void);
     bool can_do_dna();

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -438,22 +438,24 @@ class Board:
                 '-Wl,--gc-sections',
             ]
 
-        if self.with_can and not cfg.env.AP_PERIPH:
-            env.AP_LIBRARIES += [
-                'AP_DroneCAN',
-                'modules/DroneCAN/libcanard/*.c',
-                ]
-            if cfg.options.enable_dronecan_tests:
+        if self.with_can:
+            # for both AP_Perip and main fw enable deadlines
+            env.DEFINES.update(CANARD_ENABLE_DEADLINE = 1)
+
+            if not cfg.env.AP_PERIPH:
+                env.AP_LIBRARIES += [
+                    'AP_DroneCAN',
+                    'modules/DroneCAN/libcanard/*.c',
+                    ]
+                if cfg.options.enable_dronecan_tests:
+                    env.DEFINES.update(AP_TEST_DRONECAN_DRIVERS = 1)
+
                 env.DEFINES.update(
-                    AP_TEST_DRONECAN_DRIVERS = 1
+                    DRONECAN_CXX_WRAPPERS = 1,
+                    USE_USER_HELPERS = 1,
+                    CANARD_ALLOCATE_SEM=1
                 )
 
-            env.DEFINES.update(
-                DRONECAN_CXX_WRAPPERS = 1,
-                USE_USER_HELPERS = 1,
-                CANARD_ENABLE_DEADLINE = 1,
-                CANARD_ALLOCATE_SEM=1
-            )
 
 
         if cfg.options.build_dates:

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -468,6 +468,20 @@ def setup_canmgr_build(cfg):
 
     cfg.get_board().with_can = True
 
+def setup_canperiph_build(cfg):
+    '''enable CAN build for peripherals'''
+    env = cfg.env
+    env.DEFINES += [
+        'CANARD_ENABLE_DEADLINE=1',
+        ]
+
+    if cfg.env.HAL_CANFD_SUPPORTED:
+        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=1']
+    else:
+        env.DEFINES += ['UAVCAN_SUPPORT_CANFD=0']
+
+    cfg.get_board().with_can = True
+    
 def load_env_vars(env):
     '''optionally load extra environment variables from env.py in the build directory'''
     print("Checking for env.py")
@@ -578,6 +592,8 @@ def configure(cfg):
     load_env_vars(cfg.env)
     if env.HAL_NUM_CAN_IFACES and not env.AP_PERIPH:
         setup_canmgr_build(cfg)
+    if env.HAL_NUM_CAN_IFACES and env.AP_PERIPH and not env.BOOTLOADER:
+        setup_canperiph_build(cfg)
     if env.HAL_NUM_CAN_IFACES and env.AP_PERIPH and int(env.HAL_NUM_CAN_IFACES)>1 and not env.BOOTLOADER:
         env.DEFINES += [ 'CANARD_MULTI_IFACE=1' ]
     setup_optimization(cfg.env)


### PR DESCRIPTION
This enables deadlines in libcandard for AP_Periph. It fixes an issue with the C-RTK2-HP where we would get long GPS deltas when the safety switch was on.
The cause was the Fix2 CAN frames being discarded early due to a combination of the low transmit slots on the F4 and the slight increase in traffic with the safety on
I suspect this may fix issues with high delta on other boards too

![image](https://github.com/ArduPilot/ardupilot/assets/831867/77af20c3-3493-40f2-a9c1-2323426859ed)
