### PR TITLE
Plane: rework forward throttle voltage compensation into sub class and split min/max from throttle

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1175,7 +1175,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("FWD_BAT_VOLT_MAX", 23, ParametersG2, fwd_thr_batt_voltage_max, 0.0f),
+    AP_GROUPINFO("FWD_BAT_VOLT_MAX", 23, ParametersG2, fwd_batt_cmp.batt_voltage_max, 0.0f),
 
     // @Param: FWD_BAT_VOLT_MIN
     // @DisplayName: Forward throttle battery voltage compensation minimum voltage
@@ -1184,14 +1184,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("FWD_BAT_VOLT_MIN", 24, ParametersG2, fwd_thr_batt_voltage_min, 0.0f),
+    AP_GROUPINFO("FWD_BAT_VOLT_MIN", 24, ParametersG2, fwd_batt_cmp.batt_voltage_min, 0.0f),
 
     // @Param: FWD_BAT_IDX
     // @DisplayName: Forward throttle battery compensation index
     // @Description: Which battery monitor should be used for doing compensation for the forward throttle
     // @Values: 0:First battery, 1:Second battery
     // @User: Advanced
-    AP_GROUPINFO("FWD_BAT_IDX", 25, ParametersG2, fwd_thr_batt_idx, 0),
+    AP_GROUPINFO("FWD_BAT_IDX", 25, ParametersG2, fwd_batt_cmp.batt_idx, 0),
 
     // @Param: FS_EKF_THRESH
     // @DisplayName: EKF failsafe variance threshold

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -542,9 +542,26 @@ public:
     AP_Int8 crow_flap_aileron_matching;
 
     // Forward throttle battery voltage compensation
-    AP_Float fwd_thr_batt_voltage_max;
-    AP_Float fwd_thr_batt_voltage_min;
-    AP_Int8  fwd_thr_batt_idx;
+    class FWD_BATT_CMP {
+    public:
+        // Calculate the throttle scale to compensate for battery voltage drop
+        void update();
+
+        // Apply throttle scale to min and max limits
+        void apply_min_max(int8_t &min_throttle, int8_t &max_throttle) const;
+
+        // Apply throttle scale to throttle demand
+        float apply_throttle(float throttle) const;
+
+        AP_Float batt_voltage_max;
+        AP_Float batt_voltage_min;
+        AP_Int8  batt_idx;
+
+    private:
+        bool enabled;
+        float ratio;
+    } fwd_batt_cmp;
+
 
 #if OFFBOARD_GUIDED == ENABLED
     // guided yaw heading PID

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1103,7 +1103,6 @@ private:
     void servos_auto_trim(void);
     void servos_twin_engine_mix();
     void force_flare();
-    void throttle_voltage_comp(int8_t &min_throttle, int8_t &max_throttle) const;
     void throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle);
     void throttle_slew_limit(SRV_Channel::Aux_servo_function_t func);
     bool suppress_throttle(void);


### PR DESCRIPTION
Added a sub class to tidy the functionality slightly. This will cost a little flash, the key thing is to split the application to min/max and to the actual throttle output. There are not both applied in all cases. Spiting them now paves the way for further re-work later. 