### PR TITLE
Plane:fix auto fence enable in Mode Takeoff

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -784,6 +784,7 @@ protected:
     AP_Int8 level_pitch;
 
     bool takeoff_started;
+    bool have_auto_enabled_fence;
     Location start_loc;
 
     bool _enter() override;


### PR DESCRIPTION
fixes bug in Mode takeoff where autoenable occurs immediately after initial phase of climb and triggers min alt fence breach....AUTO takeoffs (both fw and VTOL) do not autoenable until takeoff alt is obtained....this does the same


addresses #25783

