### PR TITLE
Plane:fix auto fence enable in Mode Takeoff

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -787,6 +787,9 @@ protected:
     Location start_loc;
 
     bool _enter() override;
+#if AP_FENCE_ENABLED
+    void _exit() override;
+#endif
 };
 
 #if HAL_SOARING_ENABLED

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -137,10 +137,6 @@ void ModeTakeoff::update()
         plane.next_WP_loc.alt += alt*100.0;
 
         plane.set_flight_stage(AP_FixedWing::FlightStage::NORMAL);
-
-#if AP_FENCE_ENABLED
-        plane.fence.auto_enable_fence_after_takeoff();
-#endif
     }
 
     if (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF) {
@@ -164,4 +160,11 @@ void ModeTakeoff::navigate()
     // Zero indicates to use WP_LOITER_RAD
     plane.update_loiter(0);
 }
-
+#if AP_FENCE_ENABLED
+void ModeTakeoff::_exit()
+{
+    if (plane.is_flying() && plane.is_flying()) {
+        plane.fence.auto_enable_fence_after_takeoff();
+    }
+}
+#endif


### PR DESCRIPTION
fixes bug in Mode takeoff where autoenable occurs immediately after initial phase of climb and triggers min alt fence breach....AUTO takeoffs (both fw and VTOL) do not auto-enable until takeoff alt is obtained and mission moves to next item....this does roughly the equivalent


addresses https://github.com/ArduPilot/ardupilot/issues/25783