### PR TITLE
AP_ExternalAHRS: Fix typos in configuration for microstrain7

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -16,7 +16,7 @@
     $ sim_vehicle.py -v Plane -A "--serial3=uart:/dev/3dm-gq7" --console --map -DG
     $ ./Tools/autotest/sim_vehicle.py -v Plane -A "--serial3=uart:/dev/3dm-gq7" -DG
     param set AHRS_EKF_TYPE 11
-    param set EAHRS_TYPE 4
+    param set EAHRS_TYPE 7
     param set GPS_TYPE 21
     param set SERIAL3_BAUD 115
     param set SERIAL3_PROTOCOL 36

--- a/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
+++ b/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
@@ -11,7 +11,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  support for MicroStrain CX5/GX5-45 serially connected AHRS Systems
+  support for MicroStrain MIP parsing
  */
 
 #define ALLOW_DOUBLE_MATH_FUNCTIONS


### PR DESCRIPTION
Fix typos in configuration docs and file descriptions