### PR TITLE
ChibiOS: faster millis micros64 implementation

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -13,10 +13,13 @@
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include "EKF_Maths.h"
 
-#if HAL_WITH_DSP && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if HAL_WITH_DSP
 #include <arm_math.h>
-#include <hrt.h>
 #endif
+#include <hrt.h>
+#include <ch.h>
+#endif // HAL_BOARD_CHIBIOS
 
 void setup();
 void loop();
@@ -202,11 +205,47 @@ static void show_timings(void)
     TIMEIT("SEM", { WITH_SEMAPHORE(sem); v_out_32 += v_32;}, 100);
 }
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+static void test_div1000(void)
+{
+    hal.console->printf("Testing div1000\n");
+    for (uint32_t i=0; i<2000000; i++) {
+        uint64_t v;
+        hal.util->get_random_vals((uint8_t*)&v, sizeof(v));
+        uint64_t v1 = v / 1000ULL;
+        uint64_t v2 = _hrt_div1000(v);
+        if (v1 != v2) {
+            AP_HAL::panic("ERROR: 0x%llx v1=0x%llx v2=0x%llx\n",
+                          (unsigned long long)v, (unsigned long long)v1, (unsigned long long)v2);
+            return;
+        }
+    }
+    // test from locked context
+    for (uint32_t i=0; i<2000000; i++) {
+        uint64_t v;
+        hal.util->get_random_vals((uint8_t*)&v, sizeof(v));
+        chSysLock();
+        uint64_t v1 = v / 1000ULL;
+        uint64_t v2 = _hrt_div1000(v);
+        chSysUnlock();
+        if (v1 != v2) {
+            AP_HAL::panic("ERROR: 0x%llx v1=0x%llx v2=0x%llx\n",
+                          (unsigned long long)v, (unsigned long long)v1, (unsigned long long)v2);
+            return;
+        }
+    }
+    hal.console->printf("div1000 OK\n");
+}
+#endif
+
 void loop()
 {
     show_sizes();
     hal.console->printf("\n");
     show_timings();
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    test_div1000();
+#endif
     hal.console->printf("\n");
     hal.scheduler->delay(3000);
 }

--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -15,6 +15,7 @@
 
 #if HAL_WITH_DSP && CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 #include <arm_math.h>
+#include <hrt.h>
 #endif
 
 void setup();
@@ -129,6 +130,13 @@ static void show_timings(void)
     TIMEIT("millis16()", AP_HAL::millis16(), 200);
     TIMEIT("micros64()", AP_HAL::micros64(), 200);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    TIMEIT("hrt_micros32()", hrt_micros32(), 200);
+    TIMEIT("hrt_micros64()", hrt_micros64(), 200);
+    TIMEIT("hrt_millis32()", hrt_millis32(), 200);
+    TIMEIT("hrt_millis64()", hrt_millis64(), 200);
+#endif
+    
     TIMEIT("fadd", v_out += v_f, 100);
     TIMEIT("fsub", v_out -= v_f, 100);
     TIMEIT("fmul", v_out *= v_f, 100);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
@@ -37,7 +37,7 @@
   boot in microseconds, and which wraps at 0xFFFFFFFF.
 
   On top of this base function we build get_systime_us32() which has
-  the same property, but which also maintains timer_base_us64 to allow
+  the same property, but which allows for a startup offset
   for micros64()
 */
 
@@ -68,48 +68,84 @@ static uint32_t system_time_u32_us(void)
 #error "unsupported timer resolution"
 #endif
 
-// offset for micros64()
-static uint64_t timer_base_us64;
-
 static uint32_t get_systime_us32(void)
 {
-    static uint32_t last_us32;
     uint32_t now = system_time_u32_us();
 #ifdef AP_BOARD_START_TIME
     now += AP_BOARD_START_TIME;
 #endif
-    if (now < last_us32) {
-        const uint64_t dt_us = 0x100000000ULL;
-        timer_base_us64 += dt_us;
-    }
-    last_us32 = now;
     return now;
 }
 
 /*
-  for the exposed functions we use chSysGetStatusAndLockX() to prevent
-  an interrupt changing the globals while allowing this call from any
-  context
+  for the exposed functions we use chVTGetTimeStampI which handles
+  wrap and directly gives a uint64_t (aka systimestamp_t)
 */
+
+uint64_t hrt_micros64I()
+{
+#ifdef AP_BOARD_START_TIME
+    return chVTGetTimeStampI() + AP_BOARD_START_TIME;
+#endif
+    return chVTGetTimeStampI();
+}
+
+static inline bool is_locked(void) {
+    return !port_irq_enabled(port_get_irq_status());
+}
 
 uint64_t hrt_micros64()
 {
-    syssts_t sts = chSysGetStatusAndLockX();
-    uint32_t now = get_systime_us32();
-    uint64_t ret = timer_base_us64 + now;
-    chSysRestoreStatusX(sts);
-    return ret;
+    if (is_locked()) {
+        return chVTGetTimeStampI();
+    } else if (port_is_isr_context()) {
+        uint64_t ret;
+        chSysLockFromISR();
+        ret = chVTGetTimeStampI();
+        chSysUnlockFromISR();
+        return ret;
+    } else {
+        uint64_t ret;
+        chSysLock();
+        ret = chVTGetTimeStampI();
+        chSysUnlock();
+        return ret;
+    }
 }
 
 uint32_t hrt_micros32()
 {
-    syssts_t sts = chSysGetStatusAndLockX();
-    uint32_t ret = get_systime_us32();
-    chSysRestoreStatusX(sts);
-    return ret;
+#if CH_CFG_ST_RESOLUTION == 16
+    // boards with 16 bit timers need to call get_systime_us32() in a
+    // lock state because on those boards we have local static
+    // variables that need protection
+    if (is_locked()) {
+        return get_systime_us32();
+    } else if (port_is_isr_context()) {
+        uint32_t ret;
+        chSysLockFromISR();
+        ret = get_systime_us32();
+        chSysUnlockFromISR();
+        return ret;
+    } else {
+        uint32_t ret;
+        chSysLock();
+        ret = get_systime_us32();
+        chSysUnlock();
+        return ret;
+    }
+#else
+    return get_systime_us32();
+#endif
 }
 
+uint32_t hrt_millis64()
+{
+    return _hrt_div1000(hrt_micros64());
+}
+        
 uint32_t hrt_millis32()
 {
-    return (uint32_t)(hrt_micros64() / 1000U);
+    return (uint32_t)(hrt_millis64());
 }
+

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.h
@@ -4,10 +4,48 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 void hrt_init(void);
 uint64_t hrt_micros64(void);
+uint64_t hrt_micros64I(void); // from locked context
+uint64_t hrt_micros64_from_ISR(void); // from an ISR
 uint32_t hrt_micros32(void);
 uint32_t hrt_millis32(void);
+uint32_t hrt_millis32I(void); // from locked context
+uint32_t hrt_millis32_from_ISR(void); // from an ISR
+uint32_t hrt_millis64(void);
+
+/*
+  thanks to:
+  https://0x414b.com/2021/04/16/arm-division.html
+ */
+static inline uint64_t _hrt_umul64x64hi(uint32_t b, uint32_t a, uint32_t d, uint32_t c)
+{
+    __asm__ ("\n\
+umull   r4, r5, %[b], %[d]   \n\
+umull   %[d], r4, %[a], %[d]    \n\
+adds    r5, %[d]         \n\
+umull   %[d], %[a], %[a], %[c]  \n\
+adcs    r4, %[d]        \n\
+adc     %[a], #0        \n\
+umull   %[c], %[b], %[b], %[c]  \n\
+adds    r5, %[c]        \n\
+adcs    %[b], r4        \n\
+adc     %[a], #0        \n\
+"   : [a] "+r" (a), [b] "+r" (b), [c] "+r" (c), [d] "+r" (d) : : "r4", "r5");
+    return (uint64_t) a << 32 | b;
+}
+
+/*
+  return x / 1000
+  faster than the gcc implementation using _hrt_umul64x64hi() by about 3x
+*/
+static inline uint64_t _hrt_div1000(uint64_t x)
+{
+    x >>= 3U;
+    return _hrt_umul64x64hi((uint32_t)x, x >> 32U, 0xe353f7cfU, 0x20c49ba5U) >> 4U;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -30,6 +30,9 @@
 #include "hal.h"
 #include <hrt.h>
 
+// we rely on systimestamp_t for 64 bit timestamps
+static_assert(sizeof(uint64_t) == sizeof(systimestamp_t), "unexpected systimestamp_t size");
+
 #if CH_CFG_ST_RESOLUTION == 16
 static_assert(sizeof(systime_t) == 2, "expected 16 bit systime_t");
 #elif CH_CFG_ST_RESOLUTION == 32
@@ -385,7 +388,7 @@ __FASTRAMFUNC__ uint64_t micros64()
 
 __FASTRAMFUNC__ uint64_t millis64()
 {
-    return hrt_micros64() / 1000U;
+    return hrt_millis64();
 }
 
 


### PR DESCRIPTION
This greatly speeds up our time functions

@andyp1per this needs testing with DShot and BDShot, on F4 and H7

H743, 32 bit timer, old code:
```
micros()    0.0622 usec/call
micros16()  0.0616 usec/call
millis()    0.5189 usec/call
millis16()  0.5702 usec/call
micros64()  0.2969 usec/call
hrt_micros32()  0.2658 usec/call
hrt_micros64()  0.2769 usec/call
hrt_millis32()  0.4887 usec/call
```
H743, 32 bit timer, new code:
```
micros()    0.0627 usec/call
micros16()  0.0616 usec/call
millis()    0.2662 usec/call
millis16()  0.2787 usec/call
micros64()  0.2002 usec/call
hrt_micros32()  0.0722 usec/call
hrt_micros64()  0.1906 usec/call
hrt_millis32()  0.2456 usec/call
hrt_millis64()  0.2460 usec/call
```

matekh743 (16 bit timer) old code:
```
micros()    0.3432 usec/call
micros16()  0.0618 usec/call
millis()    0.5554 usec/call
millis16()  0.6051 usec/call
micros64()  0.3370 usec/call
hrt_micros32()  0.3107 usec/call
hrt_micros64()  0.3137 usec/call
hrt_millis32()  0.5205 usec/call
```
matekh743 (16 bit timer) new code:
```
micros()    0.1915 usec/call
micros16()  0.0622 usec/call
millis()    0.2572 usec/call
millis16()  0.3009 usec/call
micros64()  0.2059 usec/call
hrt_micros32()  0.1862 usec/call
hrt_micros64()  0.1963 usec/call
hrt_millis32()  0.2489 usec/call
hrt_millis64()  0.2468 usec/call
```

f405, old:
```
micros()    0.1004 usec/call
micros16()  0.1264 usec/call
millis()    1.2906 usec/call
millis16()  1.3632 usec/call
micros64()  0.6696 usec/call
hrt_micros32()  0.5704 usec/call
hrt_micros64()  0.6454 usec/call
hrt_millis32()  1.2894 usec/call
```
f405, new:
```
micros()    0.1008 usec/call
micros16()  0.1254 usec/call
millis()    0.6922 usec/call
millis16()  0.7419 usec/call
micros64()  0.4704 usec/call
hrt_micros32()  0.1247 usec/call
hrt_micros64()  0.4474 usec/call
hrt_millis32()  0.6696 usec/call
hrt_millis64()  0.6666 usec/call
```