### PR TITLE
AP_ExternalARHS: Don't offer IMU by default

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -65,6 +65,11 @@ AP_ExternalAHRS_MicroStrain7::AP_ExternalAHRS_MicroStrain7(AP_ExternalAHRS *_fro
         AP_BoardConfig::allocation_error("MicroStrain7 failed to allocate ExternalAHRS update thread");
     }
 
+    // don't offer IMU by default, at 100Hz it is too slow for many aircraft
+    set_default_sensors(uint16_t(AP_ExternalAHRS::AvailableSensor::GPS) |
+                        uint16_t(AP_ExternalAHRS::AvailableSensor::BARO) |
+                        uint16_t(AP_ExternalAHRS::AvailableSensor::COMPASS));
+
     hal.scheduler->delay(5000);
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "MicroStrain7 ExternalAHRS initialised");
 }


### PR DESCRIPTION
MicroStrain won't support >400Hz yet, so don't offer IMU data by default.
This matches AdNav driver behavior, and is recommended by Tridge.