### PR TITLE
Copter/AC_Avoidance: option to support "fast waypoints" when using Dijkstras

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -78,8 +78,8 @@ AP_OABendyRuler::AP_OABendyRuler()
     _bearing_prev = FLT_MAX;
 }
 
-// run background task to find best path and update avoidance_results
-// returns true and updates origin_new and destination_new if a best path has been found
+// run background task to find best path
+// returns true and updates origin_new and destination_new if a best path has been found.  returns false if OA is not required
 // bendy_type is set to the type of BendyRuler used
 bool AP_OABendyRuler::update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, OABendyType &bendy_type, bool proximity_only)
 {

--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -22,8 +22,9 @@ public:
         OA_BENDY_VERTICAL   = 2,
     };
 
-    // run background task to find best path and update avoidance_results
-    // returns true and populates origin_new and destination_new if OA is required.  returns false if OA is not required
+    // run background task to find best path
+    // returns true and updates origin_new and destination_new if a best path has been found.  returns false if OA is not required
+    // bendy_type is set to the type of BendyRuler used
     bool update(const Location& current_loc, const Location& destination, const Vector2f &ground_speed_vec, Location &origin_new, Location &destination_new, OABendyType &bendy_type, bool proximity_only);
 
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -40,19 +40,30 @@ AP_OADijkstra::AP_OADijkstra(AP_Int16 &options) :
 }
 
 // calculate a destination to avoid fences
-// returns DIJKSTRA_STATE_SUCCESS and populates origin_new and destination_new if avoidance is required
-AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new)
+// returns DIJKSTRA_STATE_SUCCESS and populates origin_new, destination_new and next_destination_new if avoidance is required
+// next_destination_new will be non-zero if there is a next destination
+// dest_to_next_dest_clear will be set to true if the path from (the input) destination to (input) next_destination is clear
+AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current_loc,
+                                                         const Location &destination,
+                                                         const Location &next_destination,
+                                                         Location& origin_new,
+                                                         Location& destination_new,
+                                                         Location& next_destination_new,
+                                                         bool& dest_to_next_dest_clear)
 {
     WITH_SEMAPHORE(AP::fence()->polyfence().get_loaded_fence_semaphore());
 
     // avoidance is not required if no fences
     if (!some_fences_enabled()) {
+        dest_to_next_dest_clear = _dest_to_next_dest_clear = true;
         Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
         return DIJKSTRA_STATE_NOT_REQUIRED;
     }
 
     // no avoidance required if destination is same as current location
     if (current_loc.same_latlon_as(destination)) {
+        // we do not check path to next destination so conservatively set to false
+        dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
         Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
         return DIJKSTRA_STATE_NOT_REQUIRED;
     }
@@ -83,6 +94,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     if (!_inclusion_polygon_with_margin_ok) {
         _inclusion_polygon_with_margin_ok = create_inclusion_polygon_with_margin(_polyfence_margin * 100.0f, error_id);
         if (!_inclusion_polygon_with_margin_ok) {
+            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
             report_error(error_id);
             Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
@@ -93,6 +105,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     if (!_exclusion_polygon_with_margin_ok) {
         _exclusion_polygon_with_margin_ok = create_exclusion_polygon_with_margin(_polyfence_margin * 100.0f, error_id);
         if (!_exclusion_polygon_with_margin_ok) {
+            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
             report_error(error_id);
             Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
@@ -103,6 +116,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     if (!_exclusion_circle_with_margin_ok) {
         _exclusion_circle_with_margin_ok = create_exclusion_circle_with_margin(_polyfence_margin * 100.0f, error_id);
         if (!_exclusion_circle_with_margin_ok) {
+            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
             report_error(error_id);
             Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
@@ -114,6 +128,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         _polyfence_visgraph_ok = create_fence_visgraph(error_id);
         if (!_polyfence_visgraph_ok) {
             _shortest_path_ok = false;
+            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
             report_error(error_id);
             Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
@@ -133,9 +148,10 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         }
     }
 
-    // rebuild path if destination has changed
-    if (!destination.same_latlon_as(_destination_prev)) {
+    // rebuild path if destination or next_destination has changed
+    if (!destination.same_latlon_as(_destination_prev) || !next_destination.same_latlon_as(_next_destination_prev)) {
         _destination_prev = destination;
+        _next_destination_prev = next_destination;
         _shortest_path_ok = false;
     }
 
@@ -143,17 +159,28 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     if (!_shortest_path_ok) {
         _shortest_path_ok = calc_shortest_path(current_loc, destination, error_id);
         if (!_shortest_path_ok) {
+            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
             report_error(error_id);
             Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
         }
         // start from 2nd point on path (first is the original origin)
         _path_idx_returned = 1;
+
+        // check if path from destination to next_destination intersects with a fence
+        _dest_to_next_dest_clear = false;
+        if (!next_destination.is_zero()) {
+            Vector2f seg_start, seg_end;
+            if (destination.get_vector_xy_from_origin_NE(seg_start) && next_destination.get_vector_xy_from_origin_NE(seg_end)) {
+                _dest_to_next_dest_clear = !intersects_fence(seg_start, seg_end);
+            }
+        }
     }
 
     // path has been created, return latest point
     Vector2f dest_pos;
-    if (get_shortest_path_point(_path_idx_returned, dest_pos)) {
+    uint8_t path_length = get_shortest_path_numpoints() > 0 ? (get_shortest_path_numpoints() - 1) : 0;
+    if ((_path_idx_returned < path_length) && get_shortest_path_point(_path_idx_returned, dest_pos)) {
 
         // for the first point return origin as current_loc
         Vector2f origin_pos;
@@ -172,6 +199,23 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         destination_new.lat = temp_loc.lat;
         destination_new.lng = temp_loc.lng;
 
+        // if present also provide next destination if present to allow smooth cornering
+        next_destination_new.zero();
+        Vector2f next_dest_pos;
+        if ((_path_idx_returned + 1 < path_length) && get_shortest_path_point(_path_idx_returned + 1, next_dest_pos)) {
+            // convert offset from ekf origin to Location
+            Location next_loc(Vector3f{next_dest_pos.x, next_dest_pos.y, 0.0}, Location::AltFrame::ABOVE_ORIGIN);
+            next_destination_new = destination;
+            next_destination_new.lat = next_loc.lat;
+            next_destination_new.lng = next_loc.lng;
+        } else {
+            // return destination as next_destination
+            next_destination_new = destination;
+        }
+
+        // path to next destination clear state is still valid from previous calcs (was calced along with shortest path)
+        dest_to_next_dest_clear = _dest_to_next_dest_clear;
+
         // check if we should advance to next point for next iteration
         const bool near_oa_wp = current_loc.get_distance(destination_new) <= 2.0f;
         const bool past_oa_wp = current_loc.past_interval_finish_line(origin_new, destination_new);
@@ -179,11 +223,13 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
             _path_idx_returned++;
         }
         // log success
-        Write_OADijkstra(DIJKSTRA_STATE_SUCCESS, 0, _path_idx_returned, _path_numpoints, destination, destination_new);
+        Write_OADijkstra(DIJKSTRA_STATE_SUCCESS, 0, _path_idx_returned, get_shortest_path_numpoints(), destination, destination_new);
         return DIJKSTRA_STATE_SUCCESS;
     }
 
     // we have reached the destination so avoidance is no longer required
+    // path to next destination clear state is still valid from previous calcs
+    dest_to_next_dest_clear = _dest_to_next_dest_clear;
     Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
     return DIJKSTRA_STATE_NOT_REQUIRED;
 }

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -179,7 +179,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
 
     // path has been created, return latest point
     Vector2f dest_pos;
-    uint8_t path_length = get_shortest_path_numpoints() > 0 ? (get_shortest_path_numpoints() - 1) : 0;
+    const uint8_t path_length = get_shortest_path_numpoints() > 0 ? (get_shortest_path_numpoints() - 1) : 0;
     if ((_path_idx_returned < path_length) && get_shortest_path_point(_path_idx_returned, dest_pos)) {
 
         // for the first point return origin as current_loc
@@ -199,7 +199,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         destination_new.lat = temp_loc.lat;
         destination_new.lng = temp_loc.lng;
 
-        // if present also provide next destination if present to allow smooth cornering
+        // provide next destination to allow smooth cornering
         next_destination_new.zero();
         Vector2f next_dest_pos;
         if ((_path_idx_returned + 1 < path_length) && get_shortest_path_point(_path_idx_returned + 1, next_dest_pos)) {

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -934,7 +934,7 @@ bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &d
 }
 
 // return point from final path as an offset (in cm) from the ekf origin
-bool AP_OADijkstra::get_shortest_path_point(uint8_t point_num, Vector2f& pos)
+bool AP_OADijkstra::get_shortest_path_point(uint8_t point_num, Vector2f& pos) const
 {
     if ((_path_numpoints == 0) || (point_num >= _path_numpoints)) {
         return false;

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -182,7 +182,7 @@ private:
     Vector2f _path_destination;                         // destination position used in shortest path calculations (offset in cm from EKF origin)
 
     // return point from final path as an offset (in cm) from the ekf origin
-    bool get_shortest_path_point(uint8_t point_num, Vector2f& pos);
+    bool get_shortest_path_point(uint8_t point_num, Vector2f& pos) const;
 
     // find the position of a node as an offset (in cm) from the ekf origin
     // returns true if successful and pos is updated

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -30,8 +30,16 @@ public:
     };
 
     // calculate a destination to avoid the polygon fence
-    // returns DIJKSTRA_STATE_SUCCESS and populates origin_new and destination_new if avoidance is required
-    AP_OADijkstra_State update(const Location &current_loc, const Location &destination, Location& origin_new, Location& destination_new);
+    // returns DIJKSTRA_STATE_SUCCESS and populates origin_new, destination_new and next_destination_new if avoidance is required
+    // next_destination_new will be non-zero if there is a next destination
+    // dest_to_next_dest_clear will be set to true if the path from (the input) destination to (input) next_destination is clear
+    AP_OADijkstra_State update(const Location &current_loc,
+                               const Location &destination,
+                               const Location &next_destination,
+                               Location& origin_new,
+                               Location& destination_new,
+                               Location& next_destination_new,
+                               bool& dest_to_next_dest_clear);
 
 private:
 
@@ -124,7 +132,9 @@ private:
     bool _shortest_path_ok;
 
     Location _destination_prev;     // destination of previous iterations (used to determine if path should be re-calculated)
+    Location _next_destination_prev;// next_destination of previous iterations (used to determine if path should be re-calculated)
     uint8_t _path_idx_returned;     // index into _path array which gives location vehicle should be currently moving towards
+    bool _dest_to_next_dest_clear;  // true if path from dest to next_dest is clear (i.e. does not intersects a fence)
 
     // inclusion polygon (with margin) related variables
     float _polyfence_margin = 10;           // margin around polygon defaults to 10m but is overriden with set_fence_margin
@@ -180,6 +190,9 @@ private:
     uint8_t _path_numpoints;                            // number of points on return path
     Vector2f _path_source;                              // source point used in shortest path calculations (offset in cm from EKF origin)
     Vector2f _path_destination;                         // destination position used in shortest path calculations (offset in cm from EKF origin)
+
+    // return number of points on path
+    uint8_t get_shortest_path_numpoints() const { return _path_numpoints; }
 
     // return point from final path as an offset (in cm) from the ekf origin
     bool get_shortest_path_point(uint8_t point_num, Vector2f& pos) const;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @DisplayName: Options while recovering from Object Avoidance
     // @Description: Bitmask which will govern vehicles behaviour while recovering from Obstacle Avoidance (i.e Avoidance is turned off after the path ahead is clear).   
     // @Bitmask{Rover}: 0: Reset the origin of the waypoint to the present location, 1: log Dijkstra points
-    // @Bitmask{Copter}: 1: log Dijkstra points
+    // @Bitmask{Copter}: 1:log Dijkstra points, 2:Allow fast waypoints (Dijkastras only)
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 5, AP_OAPathPlanner, _options, OA_OPTIONS_DEFAULT),
 

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -186,12 +186,17 @@ AP_OAPathPlanner::OAPathPlannerUsed AP_OAPathPlanner::map_bendytype_to_pathplann
 }
 
 // provides an alternative target location if path planning around obstacles is required
-// returns true and updates result_loc with an intermediate location
+// returns true and updates result_origin, result_destination, result_next_destination with an intermediate path
+// result_dest_to_next_dest_clear is set to true if the path from result_destination to result_next_destination is clear (only supported by Dijkstras)
+// path_planner_used updated with which path planner produced the result
 AP_OAPathPlanner::OA_RetState AP_OAPathPlanner::mission_avoidance(const Location &current_loc,
                                          const Location &origin,
                                          const Location &destination,
+                                         const Location &next_destination,
                                          Location &result_origin,
                                          Location &result_destination,
+                                         Location &result_next_destination,
+                                         bool &result_dest_to_next_dest_clear,
                                          OAPathPlannerUsed &path_planner_used)
 {
     // exit immediately if disabled or thread is not running from a failed init
@@ -212,20 +217,25 @@ AP_OAPathPlanner::OA_RetState AP_OAPathPlanner::mission_avoidance(const Location
     avoidance_request.current_loc = current_loc;
     avoidance_request.origin = origin;
     avoidance_request.destination = destination;
+    avoidance_request.next_destination = next_destination;
     avoidance_request.ground_speed_vec = AP::ahrs().groundspeed_vector();
     avoidance_request.request_time_ms = now;
 
-    // check result's destination matches our request
-    const bool destination_matches = (destination.lat == avoidance_result.destination.lat) && (destination.lng == avoidance_result.destination.lng);
+    // check result's destination and next_destination matches our request
+    // e.g. check this result was using our current inputs and not from an old request
+    const bool destination_matches = destination.same_latlon_as(avoidance_result.destination);
+    const bool next_destination_matches = next_destination.same_latlon_as(avoidance_result.next_destination);
 
     // check results have not timed out
     const bool timed_out = (now - avoidance_result.result_time_ms > OA_TIMEOUT_MS) && (now - _activated_ms > OA_TIMEOUT_MS);
 
     // return results from background thread's latest checks
-    if (destination_matches && !timed_out) {
+    if (destination_matches && next_destination_matches && !timed_out) {
         // we have a result from the thread
         result_origin = avoidance_result.origin_new;
         result_destination = avoidance_result.destination_new;
+        result_next_destination = avoidance_result.next_destination_new;
+        result_dest_to_next_dest_clear = avoidance_result.dest_to_next_dest_clear;
         path_planner_used = avoidance_result.path_planner_used;
         return avoidance_result.ret_state;
     }
@@ -270,8 +280,11 @@ void AP_OAPathPlanner::avoidance_thread()
 
         _oadatabase.update();
 
+        // values returned by path planners
         Location origin_new;
         Location destination_new;
+        Location next_destination_new;
+        bool dest_to_next_dest_clear = false;
         {
             WITH_SEMAPHORE(_rsem);
             if (now - avoidance_request.request_time_ms > OA_TIMEOUT_MS) {
@@ -282,9 +295,10 @@ void AP_OAPathPlanner::avoidance_thread()
             // copy request to avoid conflict with main thread
             avoidance_request2 = avoidance_request;
 
-            // store passed in origin and destination so we can return it if object avoidance is not required
+            // store passed in origin, destination and next_destination so we can return it if object avoidance is not required
             origin_new = avoidance_request.origin;
             destination_new = avoidance_request.destination;
+            next_destination_new = avoidance_request.next_destination;
         }
 
         // run background task looking for best alternative destination
@@ -313,7 +327,13 @@ void AP_OAPathPlanner::avoidance_thread()
                 continue;
             }
             _oadijkstra->set_fence_margin(_margin_max);
-            const AP_OADijkstra::AP_OADijkstra_State dijkstra_state = _oadijkstra->update(avoidance_request2.current_loc, avoidance_request2.destination, origin_new, destination_new);
+            const AP_OADijkstra::AP_OADijkstra_State dijkstra_state = _oadijkstra->update(avoidance_request2.current_loc,
+                                                                                          avoidance_request2.destination,
+                                                                                          avoidance_request2.next_destination,
+                                                                                          origin_new,
+                                                                                          destination_new,
+                                                                                          next_destination_new,
+                                                                                          dest_to_next_dest_clear);
             switch (dijkstra_state) {
             case AP_OADijkstra::DIJKSTRA_STATE_NOT_REQUIRED:
                 res = OA_NOT_REQUIRED;
@@ -354,7 +374,13 @@ void AP_OAPathPlanner::avoidance_thread()
             }
 #if AP_FENCE_ENABLED
             _oadijkstra->set_fence_margin(_margin_max);
-            const AP_OADijkstra::AP_OADijkstra_State dijkstra_state = _oadijkstra->update(avoidance_request2.current_loc, avoidance_request2.destination, origin_new, destination_new);
+            const AP_OADijkstra::AP_OADijkstra_State dijkstra_state = _oadijkstra->update(avoidance_request2.current_loc,
+                                                                                          avoidance_request2.destination,
+                                                                                          avoidance_request2.next_destination,
+                                                                                          origin_new,
+                                                                                          destination_new,
+                                                                                          next_destination_new,
+                                                                                          dest_to_next_dest_clear);
             switch (dijkstra_state) {
             case AP_OADijkstra::DIJKSTRA_STATE_NOT_REQUIRED:
                 res = OA_NOT_REQUIRED;
@@ -376,9 +402,18 @@ void AP_OAPathPlanner::avoidance_thread()
         {
             // give the main thread the avoidance result
             WITH_SEMAPHORE(_rsem);
+
+            // place the destination and next destination used into the result (used by the caller to verify the result matches their request)
             avoidance_result.destination = avoidance_request2.destination;
+            avoidance_result.next_destination = avoidance_request2.next_destination;
+            avoidance_result.dest_to_next_dest_clear = dest_to_next_dest_clear;
+
+            // fill the result structure with the intermediate path
             avoidance_result.origin_new = (res == OA_SUCCESS) ? origin_new : avoidance_result.origin_new;
             avoidance_result.destination_new = (res == OA_SUCCESS) ? destination_new : avoidance_result.destination;
+            avoidance_result.next_destination_new = (res == OA_SUCCESS) ? next_destination_new : avoidance_result.next_destination;
+
+            // create new avoidance result.dest_to_next_dest_clear field.  fill in with results from dijkstras or leave as unknown
             avoidance_result.result_time_ms = AP_HAL::millis();
             avoidance_result.path_planner_used = path_planner_used;
             avoidance_result.ret_state = res;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -48,13 +48,17 @@ public:
     };
 
     // provides an alternative target location if path planning around obstacles is required
-    // returns true and updates result_origin and result_destination with an intermediate path
+    // returns true and updates result_origin, result_destination and result_next_destination with an intermediate path
+    // result_dest_to_next_dest_clear is set to true if the path from result_destination to result_next_destination is clear  (only supported by Dijkstras)
     // path_planner_used updated with which path planner produced the result
     OA_RetState mission_avoidance(const Location &current_loc,
                            const Location &origin,
                            const Location &destination,
+                           const Location &next_destination,
                            Location &result_origin,
                            Location &result_destination,
+                           Location &result_next_destination,
+                           bool &result_dest_to_next_dest_clear,
                            OAPathPlannerUsed &path_planner_used) WARN_IF_UNUSED;
 
     // enumerations for _TYPE parameter
@@ -90,6 +94,7 @@ private:
         Location current_loc;
         Location origin;
         Location destination;
+        Location next_destination;
         Vector2f ground_speed_vec;
         uint32_t request_time_ms;
     } avoidance_request, avoidance_request2;
@@ -97,8 +102,11 @@ private:
     // an avoidance result from the avoidance thread
     struct {
         Location destination;       // destination vehicle is trying to get to (also used to verify the result matches a recent request)
+        Location next_destination;  // next destination vehicle is trying to get to (also used to verify the result matches a recent request)
         Location origin_new;        // intermediate origin.  The start of line segment that vehicle should follow
         Location destination_new;   // intermediate destination vehicle should move towards
+        Location next_destination_new; // intermediate next destination vehicle should move towards
+        bool dest_to_next_dest_clear; // true if the path from destination_new to next_destination_new is clear and does not require path planning  (only supported by Dijkstras)
         uint32_t result_time_ms;    // system time the result was calculated (used to verify the result is recent)
         OAPathPlannerUsed path_planner_used;    // path planner that produced the result
         OA_RetState ret_state;      // OA_SUCCESS if the vehicle should move along the path from origin_new to destination_new

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -115,7 +115,9 @@ private:
     AP_OABendyRuler *_oabendyruler; // Bendy Ruler algorithm
     AP_OADijkstra *_oadijkstra;     // Dijkstra's algorithm
     AP_OADatabase _oadatabase;      // Database of dynamic objects to avoid
-    uint32_t avoidance_latest_ms;   // last time Dijkstra's or BendyRuler algorithms ran
+    uint32_t avoidance_latest_ms;   // last time Dijkstra's or BendyRuler algorithms ran (in the avoidance thread)
+    uint32_t _last_update_ms;       // system time that mission_avoidance was called in main thread
+    uint32_t _activated_ms;         // system time that object avoidance was most recently activated (used to avoid timeout error on first run)
 
     bool proximity_only = true;
     static AP_OAPathPlanner *_singleton;

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -74,6 +74,7 @@ public:
         OA_OPTION_DISABLED = 0,
         OA_OPTION_WP_RESET = (1 << 0),
         OA_OPTION_LOG_DIJKSTRA_POINTS = (1 << 1),
+        OA_OPTION_FAST_WAYPOINTS = (1 << 2),
     };
 
     uint16_t get_options() const { return _options;}

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -627,6 +627,29 @@ bool AC_WPNav::is_active() const
     return (AP_HAL::millis() - _wp_last_update) < 200;
 }
 
+// force stopping at next waypoint.  Used by Dijkstra's object avoidance when path from destination to next destination is not clear
+// only affects regular (e.g. non-spline) waypoints
+// returns true if this had any affect on the path
+bool AC_WPNav::force_stop_at_next_wp()
+{
+    // exit immediately if vehicle was going to stop anyway
+    if (!_flags.fast_waypoint) {
+        return false;
+    }
+
+    _flags.fast_waypoint = false;
+
+    // update this_leg's final velocity and next leg's initial velocity to zero
+    if (!_this_leg_is_spline) {
+        _scurve_this_leg.set_destination_speed_max(0);
+    }
+    if (!_next_leg_is_spline) {
+        _scurve_next_leg.init();
+    }
+
+    return true;
+}
+
 // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
 bool AC_WPNav::get_terrain_offset(float& offset_cm)
 {

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -350,6 +350,7 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
 
     _this_leg_is_spline = false;
     _scurve_next_leg.init();
+    _next_destination.zero();       // clear next destination
     _flags.fast_waypoint = false;   // default waypoint back to slow
     _flags.reached_destination = false;
 
@@ -379,6 +380,9 @@ bool AC_WPNav::set_wp_destination_next(const Vector3f& destination, bool terrain
 
     // next destination provided so fast waypoint
     _flags.fast_waypoint = true;
+
+    // record next destination
+    _next_destination = destination;
 
     return true;
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -163,6 +163,11 @@ public:
     // returns true if update_wpnav has been run very recently
     bool is_active() const;
 
+    // force stopping at next waypoint.  Used by Dijkstra's object avoidance when path from destination to next destination is not clear
+    // only affects regular (e.g. non-spline) waypoints
+    // returns true if this had any affect on the path
+    bool force_stop_at_next_wp();
+
     ///
     /// spline methods
     ///

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -273,6 +273,7 @@ protected:
     float       _wp_desired_speed_xy_cms;   // desired wp speed in cm/sec
     Vector3f    _origin;                // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination;           // target destination in cm from ekf origin
+    Vector3f    _next_destination;      // next target destination in cm from ekf origin
     float       _track_scalar_dt;       // time compression multiplier to slow the progress along the track
     float       _offset_vel;            // horizontal velocity reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
     float       _offset_accel;          // horizontal acceleration reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -77,14 +77,25 @@ bool AC_WPNav_OA::update_wpnav()
             _origin_oabak = _origin;
             _destination_oabak = _destination;
             _terrain_alt_oabak = _terrain_alt;
+            _next_destination_oabak = _next_destination;
         }
 
-        // convert origin and destination to Locations and pass into oa
+        // convert origin, destination and next_destination to Locations and pass into oa
         const Location origin_loc(_origin_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         const Location destination_loc(_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-        Location oa_origin_new, oa_destination_new;
+        const Location next_destination_loc(_next_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        Location oa_origin_new, oa_destination_new, oa_next_destination_new;
+        bool dest_to_next_dest_clear = true;
         AP_OAPathPlanner::OAPathPlannerUsed path_planner_used = AP_OAPathPlanner::OAPathPlannerUsed::None;
-        const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc, origin_loc, destination_loc, oa_origin_new, oa_destination_new, path_planner_used);
+        const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc,
+                                                                                    origin_loc,
+                                                                                    destination_loc,
+                                                                                    next_destination_loc,
+                                                                                    oa_origin_new,
+                                                                                    oa_destination_new,
+                                                                                    oa_next_destination_new,
+                                                                                    dest_to_next_dest_clear,
+                                                                                    path_planner_used);
 
         switch (oa_retstate) {
 
@@ -95,11 +106,31 @@ bool AC_WPNav_OA::update_wpnav()
                     // trigger terrain failsafe
                     return false;
                 }
+
+                // if path from destination to next_destination is clear
+                if (dest_to_next_dest_clear && (oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS)) {
+                    // set next destination if non-zero
+                    if (!_next_destination_oabak.is_zero()) {
+                        set_wp_destination_next(_next_destination_oabak);
+                    }
+                }
                 _oa_state = oa_retstate;
+            }
+
+            // ensure we stop at next waypoint
+            // Note that this check is run on every iteration even if the path planner is not active
+            if (!dest_to_next_dest_clear) {
+                force_stop_at_next_wp();
             }
             break;
 
         case AP_OAPathPlanner::OA_PROCESSING:
+            if (oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS) {
+                // if fast waypoint option is set, proceed during processing
+                break;
+            }
+            FALLTHROUGH;
+
         case AP_OAPathPlanner::OA_ERROR:
             // during processing or in case of error stop the vehicle
             // by setting the oa_destination to a stopping point
@@ -108,6 +139,7 @@ bool AC_WPNav_OA::update_wpnav()
                 Vector3f stopping_point;
                 get_wp_stopping_point(stopping_point);
                 _oa_destination = Location(stopping_point, Location::AltFrame::ABOVE_ORIGIN);
+                _oa_next_destination.zero();
                 if (set_wp_destination(stopping_point, false)) {
                     _oa_state = oa_retstate;
                 }
@@ -130,6 +162,8 @@ bool AC_WPNav_OA::update_wpnav()
                     Location origin_oabak_loc(_origin_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
                     Location destination_oabak_loc(_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
                     oa_destination_new.linearly_interpolate_alt(origin_oabak_loc, destination_oabak_loc);
+
+                    // set new OA adjusted destination
                     if (!set_wp_destination_loc(oa_destination_new)) {
                         // trigger terrain failsafe
                         return false;
@@ -137,6 +171,17 @@ bool AC_WPNav_OA::update_wpnav()
                     // if new target set successfully, update oa state and destination
                     _oa_state = oa_retstate;
                     _oa_destination = oa_destination_new;
+
+                    // if a next destination was provided then use it
+                    if ((oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS) && !oa_next_destination_new.is_zero()) {
+                        // calculate oa_next_destination_new's altitude using linear interpolation between original origin and destination
+                        // this "next destination" is still an intermediate point between the origin and destination
+                        Location next_destination_oabak_loc(_next_destination_oabak, _terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                        oa_next_destination_new.linearly_interpolate_alt(origin_oabak_loc, destination_oabak_loc);
+                        if (set_wp_destination_next_loc(oa_next_destination_new)) {
+                            _oa_next_destination = oa_next_destination_new;
+                        }
+                    }
                 }
                 break;
 

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -91,7 +91,10 @@ bool AC_WPNav_OA::update_wpnav()
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_state != oa_retstate) {
                 // object avoidance has become inactive so reset target to original destination
-                set_wp_destination(_destination_oabak, _terrain_alt_oabak);
+                if (!set_wp_destination(_destination_oabak, _terrain_alt_oabak)) {
+                    // trigger terrain failsafe
+                    return false;
+                }
                 _oa_state = oa_retstate;
             }
             break;

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -40,6 +40,8 @@ protected:
     AP_OAPathPlanner::OA_RetState _oa_state;    // state of object avoidance, if OA_SUCCESS we use _oa_destination to avoid obstacles
     Vector3f    _origin_oabak;          // backup of _origin so it can be restored when oa completes
     Vector3f    _destination_oabak;     // backup of _destination so it can be restored when oa completes
+    Vector3f    _next_destination_oabak;// backup of _next_destination so it can be restored when oa completes
     bool        _terrain_alt_oabak;     // true if backup origin and destination z-axis are terrain altitudes
     Location    _oa_destination;        // intermediate destination during avoidance
+    Location    _oa_next_destination;   // intermediate next destination during avoidance
 };

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -168,6 +168,7 @@ protected:
     uint32_t _last_update_ms;       // system time of last call to update
     Location _origin;               // origin Location (vehicle will travel from the origin to the destination)
     Location _destination;          // destination Location when in Guided_WP
+    Location _next_destination;     // next destination Location when in Guided_WP
     bool _orig_and_dest_valid;      // true if the origin and destination have been set
     bool _reversed;                 // execute the mission by backing up
     enum class NavControllerType {

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -39,17 +39,28 @@ void AR_WPNav_OA::update(float dt)
     // run path planning around obstacles
     bool stop_vehicle = false;
 
-    // backup _origin and _destination when not doing oa
+    // backup _origin, _destination and _next_destination when not doing oa
     if (!_oa_active) {
         _origin_oabak = _origin;
         _destination_oabak = _destination;
+        _next_destination_oabak = _next_destination;
     }
 
     AP_OAPathPlanner *oa = AP_OAPathPlanner::get_singleton();
     if (oa != nullptr) {
-        Location oa_origin_new, oa_destination_new;
+        Location oa_origin_new, oa_destination_new, oa_next_destination_new;
         AP_OAPathPlanner::OAPathPlannerUsed path_planner_used;
-        const AP_OAPathPlanner::OA_RetState oa_retstate = oa->mission_avoidance(current_loc, _origin_oabak, _destination_oabak, oa_origin_new, oa_destination_new, path_planner_used);
+        bool dest_to_next_dest_clear;
+        const AP_OAPathPlanner::OA_RetState oa_retstate = oa->mission_avoidance(current_loc,
+                                                                                _origin_oabak,
+                                                                                _destination_oabak,
+                                                                                _next_destination_oabak,
+                                                                                oa_origin_new,
+                                                                                oa_destination_new,
+                                                                                oa_next_destination_new,
+                                                                                dest_to_next_dest_clear,
+                                                                                path_planner_used);
+
         switch (oa_retstate) {
 
         case AP_OAPathPlanner::OA_NOT_REQUIRED:

--- a/libraries/AR_WPNav/AR_WPNav_OA.h
+++ b/libraries/AR_WPNav/AR_WPNav_OA.h
@@ -36,8 +36,10 @@ private:
     bool _oa_active;                // true if we should use alternative destination to avoid obstacles
     Location _origin_oabak;         // backup of _origin so it can be restored when oa completes
     Location _destination_oabak;    // backup of _desitnation so it can be restored when oa completes
+    Location _next_destination_oabak; // backup of _next_destination so it can be restored when oa completes
     Location _oa_origin;            // intermediate origin during avoidance
     Location _oa_destination;       // intermediate destination during avoidance
+    Location _oa_next_destination;  // intermediate next destination during avoidance
     float _oa_distance_to_destination; // OA (object avoidance) distance from vehicle to _oa_destination in meters
     float _oa_wp_bearing_cd;        // OA adjusted heading to _oa_destination in centi-degrees
 };


### PR DESCRIPTION
This allows Copters using Dijkstras avoidance to fly through waypoints at the regular speed (using SCurves) instead of always stopping.  This behaviour is enabled by setting AVOID_OPTIONS's bit 2 (e.g set to "4).  The parameters' default value has not been changed so the existing behaviour is maintained for unsuspecting users.

This change does add some danger of fence breaches:

1. During OA "processing" (when the vehicle has just arrived at a WP and Dijkstras is calculating a safe path to the next WP) the vehicle will start moving towards the next waypoint.  If a fence is placed very close to the waypoint the vehicle may breach it but this is unlikely because the vehicle will have stopped at the waypoint because Dijkstar's has been enhanced to check again one more waypoint.  So the distance covered just depends upon how quickly the new path is calculated and the vehicle's acceleration.  This scenario has been tested (see screen shots below).
2. SCurves can lead to the vehicle cutting the corner significantly and again if a fence is placed too close a breach may occur.
3. Splines may actually be flown as splines (previously they ended up as straight segments) meaning the vehicle may be far off the segment that Dijkstra's calculated.

I think we can reduce the dangers by updating the wiki to explain the risks and tell users to place fences further from the mission path (e.g. 20m or so should be more than enough).

BendyRuler's behaviour is  unchanged.

This PR also includes these drive-by changes:

1. AC_Avoidance's get_shortest_path_point is constified (NFC)
5. AC_PathPlanner (an interface class to hide differences betweeen BendyRuler & Dijkstras) no longer timesout when it is first called.  Users don't actually see the timeout so this is also essentially an NFC.
6. BendyRuler gets a minor comment fix

This partially resolves https://github.com/ArduPilot/ardupilot/issues/20140.

This has been fairly well tested in SITL and below are before vs after screen shots showing the vehicle flies quickly and smoothly through the corners

![testing-screen-shot-before](https://github.com/ArduPilot/ardupilot/assets/1498098/42e79694-b674-41e8-8322-ebb07150702d)
![testing-screen-shot-after](https://github.com/ArduPilot/ardupilot/assets/1498098/90f95ed1-7aca-4229-bad2-fb26801a43ab)

