### PR TITLE
Copter-4.4.4 / Rover-4.4.0 release

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Copter 4.4.4 05-Dec-2023
+Copter 4.4.4 19-Dec-2023 / 4.4.4-beta1 05-Dec-2023
 Changes from 4.4.3
 1) Autopilot related enhancement and fixes
     - CubeOrange Sim-on-hardware compilation fix

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.4.4-beta1"
+#define THISFIRMWARE "ArduCopter V4.4.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,4,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,4,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 4
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,6 +1,6 @@
 Rover Release Notes:
 ------------------------------------------------------------------
-Rover 4.4.0-beta11 05-Dec-2023
+Rover 4.4.0 19-Dec-2023 / Rover 4.4.0-beta11 05-Dec-2023
 Changes from 4.4.0-beta10
 1) Autopilot related enhancement and fixes
     - CubeOrange Sim-on-hardware compilation fix

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.4.0-beta11"
+#define THISFIRMWARE "ArduRover V4.4.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_BETA+10
+#define FIRMWARE_VERSION 4,4,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 4
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This is the Copter-4.4.4 and Rover-4.4.0 release. No changes vs the beta except for the version label and releases notes.