### PR TITLE
AP_HAL_SITL: ensure stdint include

### DIFF
--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -35,6 +35,7 @@
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <cstring>
+#include <cstdint>
 #include "Scheduler.h"
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Common/ExpandingString.h>


### PR DESCRIPTION
Compilation started breaking after a system update with:
```
CXX Compiler                             : g++ 13.2.1 
```

I suspect that `stdint` types have been pulled implicitly by some other header and they aren't for some reason anymore, so including the header explicitly ensures it doesn't break and shouldn't affect anything negatively if it's already included.