### PR TITLE
AP_ICEngine: add support for starter relay

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -622,6 +622,13 @@ void AP_ICEngine::set_starter(bool on)
 #if AP_ICENGINE_TCA9554_STARTER_ENABLED
     tca9554_starter.set_starter(on);
 #endif
+
+#if AP_RELAY_ENABLED
+    AP_Relay *relay = AP::relay();
+    if (relay != nullptr) {
+        relay->set(AP_Relay_Params::FUNCTION::ICE_STARTER, on);
+    }
+#endif // AP_RELAY_ENABLED
 }
 
 

--- a/libraries/AP_Relay/AP_Relay_Params.cpp
+++ b/libraries/AP_Relay/AP_Relay_Params.cpp
@@ -14,6 +14,7 @@ const AP_Param::GroupInfo AP_Relay_Params::var_info[] = {
     // @Values{Rover}: 6:Bushed motor reverse 2 throttle-right or omni motor 2
     // @Values{Rover}: 7:Bushed motor reverse 3 omni motor 3
     // @Values{Rover}: 8:Bushed motor reverse 4 omni motor 4
+    // @Values{Plane}: 9:ICE Starter
 
     // @User: Standard
     AP_GROUPINFO_FLAGS("FUNCTION", 1, AP_Relay_Params, function, (float)FUNCTION::NONE, AP_PARAM_FLAG_ENABLE),

--- a/libraries/AP_Relay/AP_Relay_Params.h
+++ b/libraries/AP_Relay/AP_Relay_Params.h
@@ -28,6 +28,7 @@ public:
         BRUSHED_REVERSE_2 = 6,
         BRUSHED_REVERSE_3 = 7,
         BRUSHED_REVERSE_4 = 8,
+        ICE_STARTER = 9,
         NUM_FUNCTIONS // must be the last entry
     };
 


### PR DESCRIPTION
With the new relay re-work (https://github.com/ArduPilot/ardupilot/pull/25108) its very easy to add new functions. This adds a relay output for ICE starter, very simple change as a `set_starter` method already exists. 