### PR TITLE
Add support for BMI088 on Pixhawk6c

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C/hwdef.dat
@@ -239,6 +239,9 @@ SPIDEV ramtron  SPI2 DEVID1  FRAM_CS      MODE3  8*MHZ  8*MHZ
 # 2 IMUs
 IMU Invensensev3 SPI:icm42688 ROTATION_PITCH_180_YAW_90
 IMU BMI055 SPI:bmi055_a SPI:bmi055_g ROTATION_PITCH_180
+# BMI055 is replaced by BMI088 on the lastest hardware revision
+# They use the same CPU signal pins
+IMU BMI088 SPI:bmi055_a SPI:bmi055_g ROTATION_PITCH_180
 
 define HAL_DEFAULT_INS_FAST_SAMPLE 3
 


### PR DESCRIPTION
BMI 055 is about to be discontinued. BMI 088 and BMI 055 have the same functions and PCB footprint.  We use BMI088 to replace BMI055 on the lastest hardware revision.  These changes have been tested on Pixhawk6c and pixhawk6c-MINI. They can all work properly.
