### PR TITLE
Plane: correct TKOFF_LVL_ALT metadata

### DIFF
--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -17,7 +17,7 @@ const AP_Param::GroupInfo ModeTakeoff::var_info[] = {
 
     // @Param: LVL_ALT
     // @DisplayName: Takeoff mode altitude level altitude
-    // @Description: This is the altitude below which the wings are held level for TAKEOFF and AUTO modes. Below this altitude, roll demand is restricted to LEVEL_ROLL_LIMIT. Normal-flight roll restriction resumes above TKOFF_LVL_ALT*2 or TKOFF_ALT, whichever is lower. Roll limits are scaled while between those altitudes for a smooth transition.
+    // @Description: This is the altitude below which the wings are held level for TAKEOFF and AUTO modes. Below this altitude, roll demand is restricted to LEVEL_ROLL_LIMIT. Normal-flight roll restriction resumes above TKOFF_LVL_ALT*3 or TKOFF_ALT, whichever is lower. Roll limits are scaled while between TKOFF_LVL_ALT and those altitudes for a smooth transition.
     // @Range: 0 50
     // @Increment: 1
     // @Units: m


### PR DESCRIPTION
NFC...changed to match actual takeoff_calc_roll code