### PR TITLE
HAL_ChibiOS: fixed SPI build on F1xx

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -26,7 +26,7 @@
 #include "Device.h"
 
 #ifndef HAL_SPI_SCK_SAVE_RESTORE
-#define HAL_SPI_SCK_SAVE_RESTORE TRUE
+#define HAL_SPI_SCK_SAVE_RESTORE !defined(STM32F1)
 #endif
 
 namespace ChibiOS {


### PR DESCRIPTION
F1 does not have palReadLineMode()

fixes ZubaxGNSS build
