### PR TITLE
Mode takeoff fixes for fence autoenable

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -205,6 +205,9 @@ void AC_Fence::disable_floor()
 */
 void AC_Fence::auto_enable_fence_after_takeoff(void)
 {
+    if (_enabled) {
+        return;
+    } 
     switch(auto_enabled()) {
         case AC_Fence::AutoEnable::ALWAYS_ENABLED:
         case AC_Fence::AutoEnable::ENABLE_DISABLE_FLOOR_ONLY:


### PR DESCRIPTION
fixes bug in Mode takeoff where autoenable occurs immediately after initial phase of climb and triggers min alt fence breach....AUTO takeoffs (both fw and VTOL) do not auto-enable until takeoff alt is obtained and mission moves to next item....this does roughly the equivalent

addresses https://github.com/ArduPilot/ardupilot/issues/25783

also fixes the climb portion from TKOFF_LVL_ALT to TKOFF_ALT which used to drop throttle immediately to TECS and release roll/pitch limits instead of smoothly backing off like autotakeoffs in AUTO