### PR TITLE
AHRS: move wind helper maths functions from AP_Landing to AP_AHRS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -812,6 +812,32 @@ bool AP_AHRS::_wind_estimate(Vector3f &wind) const
     return false;
 }
 
+
+/*
+ * Determine how aligned heading_deg is with the wind. Return result
+ * is 1.0 when perfectly aligned heading into wind, -1 when perfectly
+ * aligned with-wind, and zero when perfect cross-wind. There is no
+ * distinction between a left or right cross-wind. Wind speed is ignored
+ */
+float AP_AHRS::wind_alignment(const float heading_deg) const
+{
+    Vector3f wind;
+    if (!wind_estimate(wind)) {
+        return 0;
+    }
+    const float wind_heading_rad = atan2f(-wind.y, -wind.x);
+    return cosf(wind_heading_rad - radians(heading_deg));
+}
+
+/*
+ * returns forward head-wind component in m/s. Negative means tail-wind.
+ */
+float AP_AHRS::head_wind(void) const
+{
+    const float alignment = wind_alignment(yaw_sensor*0.01f);
+    return alignment * wind_estimate().xy().length();
+}
+
 /*
   return true if the current AHRS airspeed estimate is directly derived from an airspeed sensor
  */

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -114,6 +114,15 @@ public:
     // return a wind estimation vector, in m/s; returns 0,0,0 on failure
     bool wind_estimate(Vector3f &wind) const;
 
+    // Determine how aligned heading_deg is with the wind. Return result
+    // is 1.0 when perfectly aligned heading into wind, -1 when perfectly
+    // aligned with-wind, and zero when perfect cross-wind. There is no
+    // distinction between a left or right cross-wind. Wind speed is ignored
+    float wind_alignment(const float heading_deg) const;
+
+    // returns forward head-wind component in m/s. Negative means tail-wind
+    float head_wind(void) const;
+
     // instruct DCM to update its wind estimate:
     void estimate_wind() {
 #if AP_AHRS_DCM_ENABLED

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -549,33 +549,6 @@ bool AP_Landing::get_target_altitude_location(Location &location)
 }
 
 /*
- * Determine how aligned heading_deg is with the wind. Return result
- * is 1.0 when perfectly aligned heading into wind, -1 when perfectly
- * aligned with-wind, and zero when perfect cross-wind. There is no
- * distinction between a left or right cross-wind. Wind speed is ignored
- */
-float AP_Landing::wind_alignment(const float heading_deg)
-{
-    const Vector3f wind = ahrs.wind_estimate();
-    const float wind_heading_rad = atan2f(-wind.y, -wind.x);
-    return cosf(wind_heading_rad - radians(heading_deg));
-}
-
-/*
- * returns head-wind in m/s, 0 for tail-wind.
- */
-float AP_Landing::head_wind(void)
-{
-    const float alignment = wind_alignment(ahrs.yaw_sensor*0.01f);
-
-    if (alignment <= 0) {
-        return 0;
-    }
-
-    return alignment * ahrs.wind_estimate().length();
-}
-
-/*
  * returns target airspeed in cm/s depending on flight stage
  */
 int32_t AP_Landing::get_target_airspeed_cm(void)

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -91,8 +91,6 @@ public:
 
     // helper functions
     bool restart_landing_sequence(void);
-    float wind_alignment(const float heading_deg);
-    float head_wind(void);
     int32_t get_target_airspeed_cm(void);
 
     // accessor functions for the params and states

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -368,7 +368,7 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
 
     // when landing, add half of head-wind.
     const float head_wind_comp = constrain_float(wind_comp, 0.0f, 100.0f)*0.01;
-    const int32_t head_wind_compensation_cm = head_wind() * head_wind_comp * 100;
+    const int32_t head_wind_compensation_cm = ahrs.head_wind() * head_wind_comp * 100;
 
     const uint32_t max_airspeed_cm = AP_Landing::allow_max_airspeed_on_land() ? aparm.airspeed_max*100 : aparm.airspeed_cruise_cm;
     

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3008,6 +3008,18 @@ function ahrs:groundspeed_vector() end
 ---@return Vector3f_ud
 function ahrs:wind_estimate() end
 
+-- Determine how aligned heading_deg is with the wind. Return result
+-- is 1.0 when perfectly aligned heading into wind, -1 when perfectly
+-- aligned with-wind, and zero when perfect cross-wind. There is no
+-- distinction between a left or right cross-wind. Wind speed is ignored
+---@param heading_deg number
+---@return number
+function ahrs:wind_alignment(heading_deg) end
+
+-- Forward head-wind component in m/s. Negative means tail-wind
+---@return number
+function ahrs:head_wind() end
+
 -- desc
 ---@return number|nil
 function ahrs:get_hagl() end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -38,6 +38,8 @@ singleton AP_AHRS method get_gyro Vector3f
 singleton AP_AHRS method get_accel Vector3f
 singleton AP_AHRS method get_hagl boolean float'Null
 singleton AP_AHRS method wind_estimate Vector3f
+singleton AP_AHRS method wind_alignment float'skip_check float'skip_check
+singleton AP_AHRS method head_wind float'skip_check
 singleton AP_AHRS method groundspeed_vector Vector2f
 singleton AP_AHRS method get_velocity_NED boolean Vector3f'Null
 singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null


### PR DESCRIPTION
I've written this code a few times in scripts and I just realized I wrote it 7 years ago in AP_Landing.. so lets move it to AP_AHRS. It would turn [messy LUA code like this](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/examples/jump_tags_into_wind_landing.lua#L91-L104) into 1 line.

wind_alignment():
You pass a heading to wind_alignment and it will return from -1 to +1 how aligned it is with the wind. +1 is perfectly inline headwind (your heading matches wind heading), 0 is perfect cross-wind, and -1 is perfect tailwind. This is useful to check arbitrary headings to the wind such as different legs of an auto mission

head_wind():
calls wind_alignment with our current yaw and converts to the meters/sec component