### PR TITLE
ChibiOS: reimplement div1000 in C

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.c
@@ -25,6 +25,8 @@
 
 #pragma GCC optimize("O2")
 
+#include "../../../AP_Math/div1000.h"
+
 /*
   we have 4 possible configurations of boards, made up of boards that
   have the following properties:
@@ -139,9 +141,9 @@ uint32_t hrt_micros32()
 #endif
 }
 
-uint32_t hrt_millis64()
+uint64_t hrt_millis64()
 {
-    return _hrt_div1000(hrt_micros64());
+    return uint64_div1000(hrt_micros64());
 }
         
 uint32_t hrt_millis32()

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/hrt.h
@@ -13,38 +13,7 @@ uint32_t hrt_micros32(void);
 uint32_t hrt_millis32(void);
 uint32_t hrt_millis32I(void); // from locked context
 uint32_t hrt_millis32_from_ISR(void); // from an ISR
-uint32_t hrt_millis64(void);
-
-/*
-  thanks to:
-  https://0x414b.com/2021/04/16/arm-division.html
- */
-static inline uint64_t _hrt_umul64x64hi(uint32_t b, uint32_t a, uint32_t d, uint32_t c)
-{
-    __asm__ ("\n\
-umull   r4, r5, %[b], %[d]   \n\
-umull   %[d], r4, %[a], %[d]    \n\
-adds    r5, %[d]         \n\
-umull   %[d], %[a], %[a], %[c]  \n\
-adcs    r4, %[d]        \n\
-adc     %[a], #0        \n\
-umull   %[c], %[b], %[b], %[c]  \n\
-adds    r5, %[c]        \n\
-adcs    %[b], r4        \n\
-adc     %[a], #0        \n\
-"   : [a] "+r" (a), [b] "+r" (b), [c] "+r" (c), [d] "+r" (d) : : "r4", "r5");
-    return (uint64_t) a << 32 | b;
-}
-
-/*
-  return x / 1000
-  faster than the gcc implementation using _hrt_umul64x64hi() by about 3x
-*/
-static inline uint64_t _hrt_div1000(uint64_t x)
-{
-    x >>= 3U;
-    return _hrt_umul64x64hi((uint32_t)x, x >> 32U, 0xe353f7cfU, 0x20c49ba5U) >> 4U;
-}
+uint64_t hrt_millis64(void);
 
 #ifdef __cplusplus
 }

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -9,6 +9,7 @@
 #include <AP_HAL/system.h>
 
 #include "Scheduler.h"
+#include <AP_Math/div1000.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -179,18 +180,7 @@ uint64_t micros64()
 
 uint64_t millis64()
 {
-    const HALSITL::Scheduler* scheduler = HALSITL::Scheduler::from(hal.scheduler);
-    uint64_t stopped_usec = scheduler->stopped_clock_usec();
-    if (stopped_usec) {
-        return stopped_usec / 1000;
-    }
-
-    struct timeval tp;
-    gettimeofday(&tp, nullptr);
-    uint64_t ret = 1.0e3*((tp.tv_sec + (tp.tv_usec*1.0e-6)) -
-                          (state.start_time.tv_sec +
-                           (state.start_time.tv_usec*1.0e-6)));
-    return ret;
+    return uint64_div1000(micros64());
 }
 
 } // namespace AP_HAL

--- a/libraries/AP_Math/div1000.h
+++ b/libraries/AP_Math/div1000.h
@@ -1,0 +1,26 @@
+/*
+  return 64 bit x / 1000
+  faster than the normal gcc implementation using by about 3x
+  With thanks to https://0x414b.com/2021/04/16/arm-division.html
+  and https://stackoverflow.com/questions/74765410/multiply-two-uint64-ts-and-store-result-to-uint64-t-doesnt-seem-to-work
+*/
+static inline uint64_t uint64_div1000(uint64_t x)
+{
+    x >>= 3U;
+    uint64_t a_lo = (uint32_t)x;
+    uint64_t a_hi = x >> 32;
+    const uint64_t b_lo = 0xe353f7cfU;
+    const uint64_t b_hi = 0x20c49ba5U;
+
+    uint64_t a_x_b_hi = a_hi * b_hi;
+    uint64_t a_x_b_mid = a_hi * b_lo;
+    uint64_t b_x_a_mid = b_hi * a_lo;
+    uint32_t a_x_b_lo = (a_lo * b_lo)>>32;
+
+    // 64-bit product + two 32-bit values
+    uint64_t middle = a_x_b_mid + a_x_b_lo + (uint32_t)b_x_a_mid;
+
+    // 64-bit product + two 32-bit values
+    uint64_t r = a_x_b_hi + (middle >> 32) + (b_x_a_mid >> 32);
+    return r >> 4U;
+}

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -7,6 +7,7 @@
 #include <AP_gtest.h>
 
 #include <AP_Math/AP_Math.h>
+#include <AP_Math/div1000.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -690,6 +691,17 @@ TEST(CRCTest, parity)
     EXPECT_EQ(parity(0b110), 0);
     EXPECT_EQ(parity(0b111), 1);
     EXPECT_EQ(parity(0b11111111), 0);
+}
+
+TEST(MathTest, div1000)
+{
+    for (uint32_t i=0; i<1000000; i++) {
+        uint64_t v;
+        EXPECT_EQ(hal.util->get_random_vals((uint8_t*)&v, sizeof(v)), true);
+        uint64_t v1 = v / 1000ULL;
+        uint64_t v2 = uint64_div1000(v);
+        EXPECT_EQ(v1, v2);
+    }
 }
 
 AP_GTEST_PANIC()


### PR DESCRIPTION
This removes the assembler implementation for an equivalent (and just as fast) C implementation,
used by millis() so speed is critical
this means we can test it in CI and use it in SITL
