### PR TITLE
AP_Baro: slow down slew rate of param BARO_ALT_OFFSET

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -899,7 +899,7 @@ void AP_Baro::update(void)
     if (fabsf(_alt_offset - _alt_offset_active) > 0.01f) {
         // If there's more than 1cm difference then slowly slew to it via LPF.
         // The EKF does not like step inputs so this keeps it happy.
-        _alt_offset_active = (0.95f*_alt_offset_active) + (0.05f*_alt_offset);
+        _alt_offset_active = (0.98f*_alt_offset_active) + (0.02f*_alt_offset);
     } else {
         _alt_offset_active = _alt_offset;
     }


### PR DESCRIPTION
This changes the time constant from 15-20s to around a minute.

This slows down the slew rate when changing BARO_ALT_OFFSET. The reason it's so slow is to hide the change from the EKF. If it happens too fast then the EKF gets angry at the baro. When I added this param 8 years ago the slew-rate would take about 15-20 seconds and the EKF was happy with that. However, recently I've seen the EKF start to complain about it so I guess it's gotten better. Good problem to have!