### PR TITLE
Improve function of MIN_ALT fence

### DIFF
--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -212,7 +212,8 @@ private:
     // other internal variables
     bool            _floor_enabled;         // fence floor is enabled
     float           _home_distance;         // distance from home in meters (provided by main code)
-    float           _curr_alt;
+    float           _curr_alt;              // above home in meters
+    bool            _been_above_min_alt;    // used to enable floor after takeoffs
 
 
     // breach information


### PR DESCRIPTION
FENCE_ENABLE enables or disables fences , but on boot, floor is disabled, blocking the MIN_ALT fence operation unless an overt enable occurs, ie switch or GCS command...FENCE_ENABLE itself does not impact floor state.

This PR: Enables the floor (if not enabled) once MIN_ALT is achieved. Use a flag to record the achievement to prevent further enables. This flag is reset to allow re-enables after landings disable the floor: on disarm or when below 3m(or whatever) to home alt which will allows most vehicle landings to takeoff again without disarm and the floor re-instated. 

The reset algorithm for the flag which allows floor to be autoenabled again, was chosen since "landed" is not state in fixed wing and was minimal code. If the landing does not reset the flag, its no worse than present behavior and requires an overt fence enable or disarm to allow another takeoff. I will work on a separate PR to create a "landed" state call for both plane and copter that this library can use to replace the height above home reset term.

A lot of Plane SITL testing has been done, but more is will be done for Copter...

I will fix commit message a bit later