### PR TITLE
Min alt breach fix

### DIFF
--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -60,6 +60,7 @@ void Plane::fence_check()
         case AC_FENCE_ACTION_GUIDED:
         case AC_FENCE_ACTION_GUIDED_THROTTLE_PASS:
         case AC_FENCE_ACTION_RTL_AND_LAND:
+            fence.disable_floor();
             if (fence_act == AC_FENCE_ACTION_RTL_AND_LAND) {
                 if (control_mode == &mode_auto &&
                     mission.get_in_landing_sequence_flag() &&

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -443,8 +443,8 @@ bool AC_Fence::check_fence_alt_min()
         _alt_min_breach_distance = _alt_min - _curr_alt;
 
         // check for a new breach or a breach of the backup fence
-        if (!(_breached_fences & AC_FENCE_TYPE_ALT_MIN) ||
-            (!is_zero(_alt_min_backup) && _curr_alt <= _alt_min_backup)) {
+        if (_floor_enabled && (!(_breached_fences & AC_FENCE_TYPE_ALT_MIN) ||
+            (!is_zero(_alt_min_backup) && _curr_alt <= _alt_min_backup))) {
 
             // new breach
             record_breach(AC_FENCE_TYPE_ALT_MIN);


### PR DESCRIPTION
Dont declare a MIN_ALT breach unless floor is enabled....in Plane disable floor during fence recovery actions involving a mode change(RTL or GUIDED) so that mode switches can occur after landing