### PR TITLE
Copter: support set-position-target-global-int with only yaw or yaw rate specified

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1372,6 +1372,8 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
             copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
             copter.mode_guided.set_destination(pos_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative, false);
+        } if (pos_ignore && vel_ignore && acc_ignore && (!yaw_ignore || !yaw_rate_ignore)) {
+            copter.mode_guided.set_yaw_state(!yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, false);
         } else {
             // input is not valid so stop
             copter.mode_guided.init(true);
@@ -1476,6 +1478,8 @@ void GCS_MAVLINK_Copter::handleMessage(const mavlink_message_t &msg)
             copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
             copter.mode_guided.set_destination(loc, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
+        } if (pos_ignore && vel_ignore && acc_ignore && (!yaw_ignore || !yaw_rate_ignore)) {
+            copter.mode_guided.set_yaw_state(!yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, false);
         } else {
             // input is not valid so stop
             copter.mode_guided.init(true);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1038,6 +1038,7 @@ public:
     void set_velaccel(const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false, bool log_request = true);
     bool set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
     bool set_destination_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
+    void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 
     // get position, velocity and acceleration targets
     const Vector3p& get_target_pos() const;
@@ -1132,7 +1133,6 @@ private:
     void velaccel_control_run();
     void pause_control_run();
     void posvelaccel_control_run();
-    void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
 
     // controls which controller is run (pos or vel):
     SubMode guided_mode = SubMode::TakeOff;


### PR DESCRIPTION
This adds support for callers to provide only yaw or yaw rate when sending the [SET_POSITION_TARGET_GLOBAL_INT](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L4809) or [SET_POSITION_TARGET_LOCAL_NED](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L4792) messages.

The change is relatively simple.  We just need to make the existing set_yaw_state() method public and then use it in GCS_MAVLink.cpp where we handle these two messages.

This only affects copters in Guided mode.

We also need to slightly update one of the Developer wiki's [MAVLink interfaces pages](https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html).

This has been lightly tested in SITL.

Not that it matters but I noticed this while testing out the [MAVProxy Chat module](https://ardupilot.org/mavproxy/docs/modules/chat.html) and found that the bot was unable to command the yaw of the vehicle.