### PR TITLE
AP_Scripting: examples: update examples for fixed io.open behaviour

### DIFF
--- a/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
+++ b/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
@@ -14,6 +14,9 @@ local file_name
 while true do
   file_name = string.format('Particle %i.csv',index)
   local file = io.open(file_name)
+  if file == nil then
+    break
+  end
   local first_line = file:read(1) -- try and read the first character
   io.close(file)
   if first_line == nil then

--- a/libraries/AP_Scripting/examples/mission-save.lua
+++ b/libraries/AP_Scripting/examples/mission-save.lua
@@ -14,6 +14,9 @@ local function save_to_SD()
   while true do
     file_name = string.format('%i.waypoints',index)
     local file = io.open(file_name)
+    if file == nil then
+      break
+    end
     local first_line = file:read(1) -- try and read the first character
     io.close(file)
     if first_line == nil then


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/22171 means that `io.open` can return `nil` so we need to check. Previous behavior was to always return a object. 