### PR TITLE
Plane: ask flight mode if min/max throttle limits should be applied

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1095,6 +1095,7 @@ private:
     // servos.cpp
     void set_servos_idle(void);
     void set_servos();
+    float apply_throttle_limits(float throttle_in);
     void set_throttle(void);
     void set_takeoff_expected(void);
     void set_servos_old_elevons(void);

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -135,6 +135,8 @@ public:
     // true if is taking 
     virtual bool is_taking_off() const;
 
+    // true if throttle min/max limits should be applied
+    bool use_throttle_limits() const;
 
 protected:
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4742,4 +4742,10 @@ float QuadPlane::get_throttle_input() const
     return ret;
 }
 
+// return true if forward throttle from forward_throttle_pct() should be used
+bool QuadPlane::allow_forward_throttle_in_vtol_mode() const
+{
+    return in_vtol_mode() && motors->armed() && (motors->get_desired_spool_state() != AP_Motors::DesiredSpoolState::SHUT_DOWN);
+}
+
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -729,6 +729,11 @@ private:
      */
     void setup_rp_fw_angle_gains(void);
 
+    /*
+      return true if forward throttle from forward_throttle_pct() should be used
+     */
+    bool allow_forward_throttle_in_vtol_mode() const;
+
 public:
     void motor_test_output();
     MAV_RESULT mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type,

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -495,11 +495,11 @@ void Plane::throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle)
     }
 }
 #endif // #if AP_BATTERY_WATT_MAX_ENABLED
-    
+
 /*
-  setup output channels all non-manual modes
+  Apply min/max limits to throttle
  */
-void Plane::set_throttle(void)
+float Plane::apply_throttle_limits(float throttle_in)
 {
     // convert 0 to 100% (or -100 to +100) into PWM
     int8_t min_throttle = aparm.throttle_min.get();
@@ -531,13 +531,21 @@ void Plane::set_throttle(void)
     }
 
     // compensate for battery voltage drop
-    g2.fwd_batt_cmp.update();
     g2.fwd_batt_cmp.apply_min_max(min_throttle, max_throttle);
 
 #if AP_BATTERY_WATT_MAX_ENABLED
     // apply watt limiter
     throttle_watt_limiter(min_throttle, max_throttle);
 #endif
+
+    return constrain_float(throttle_in, min_throttle, max_throttle);
+}
+
+/*
+  setup output channels all non-manual modes
+ */
+void Plane::set_throttle(void)
+{
 
     if (!arming.is_armed_and_safety_off()) {
         // Always set 0 scaled even if overriding to zero pwm.
@@ -571,6 +579,9 @@ void Plane::set_throttle(void)
         return;
     }
 
+    // Update voltage scaling
+    g2.fwd_batt_cmp.update();
+
 #if AP_SCRIPTING_ENABLED
     if (nav_scripting_active()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.nav_scripting.throttle_pct);
@@ -588,8 +599,7 @@ void Plane::set_throttle(void)
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
         } else {
             // get throttle, but adjust center to output TRIM_THROTTLE if flight option set
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle,
-                                            constrain_int16(get_adjusted_throttle_input(true), min_throttle, max_throttle));
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_adjusted_throttle_input(true));
         }
     } else if (control_mode->is_guided_mode() &&
                guided_throttle_passthru) {
@@ -600,17 +610,22 @@ void Plane::set_throttle(void)
         float fwd_thr = 0;
         // if enabled ask quadplane code for forward throttle
         if (quadplane.allow_forward_throttle_in_vtol_mode()) {
-            fwd_thr = constrain_float(quadplane.forward_throttle_pct(), min_throttle, max_throttle);
+            fwd_thr = quadplane.forward_throttle_pct();
         }
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, fwd_thr);
 #endif  // HAL_QUADPLANE_ENABLED
 
     } else {
-        // Apply min/max limits and voltage compensation to throttle output from flight mode
+        // Apply voltage compensation to throttle output from flight mode
         const float throttle = g2.fwd_batt_cmp.apply_throttle(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle));
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, constrain_float(throttle, min_throttle, max_throttle));
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
     }
 
+    if (control_mode->use_throttle_limits()) {
+        // Apply min/max throttle limits
+        const float limited_throttle = apply_throttle_limits(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle));
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, limited_throttle);
+    }
 }
 
 /*

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -591,10 +591,8 @@ void Plane::set_throttle(void)
 #if HAL_QUADPLANE_ENABLED
     } else if (quadplane.in_vtol_mode()) {
         float fwd_thr = 0;
-        // if armed and not spooled down ask quadplane code for forward throttle
-        if (quadplane.motors->armed() &&
-            quadplane.motors->get_desired_spool_state() != AP_Motors::DesiredSpoolState::SHUT_DOWN) {
-
+        // if enabled ask quadplane code for forward throttle
+        if (quadplane.allow_forward_throttle_in_vtol_mode()) {
             fwd_thr = constrain_float(quadplane.forward_throttle_pct(), min_throttle, max_throttle);
         }
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, fwd_thr);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -551,7 +551,10 @@ void Plane::set_throttle(void)
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::Limit::ZERO_PWM);
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::Limit::ZERO_PWM);
         }
-    } else if (suppress_throttle()) {
+        return;
+    }
+
+    if (suppress_throttle()) {
         if (g.throttle_suppress_manual) {
             // manual pass through of throttle while throttle is suppressed
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
@@ -565,11 +568,15 @@ void Plane::set_throttle(void)
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0.0);
 
         }
+        return;
+    }
+
 #if AP_SCRIPTING_ENABLED
-    } else if (nav_scripting_active()) {
+    if (nav_scripting_active()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.nav_scripting.throttle_pct);
+    } else
 #endif
-    } else if (control_mode == &mode_stabilize ||
+           if (control_mode == &mode_stabilize ||
                control_mode == &mode_training ||
                control_mode == &mode_acro ||
                control_mode == &mode_fbwa ||


### PR DESCRIPTION
More throttle output re-work, this is another step towards keeping it contained within the flight modes. 

There is a little more going on in this PR than the others, I have split each change into its own commit, which hopefully when reviewed in sequence will make it more clear. 

Firstly this adds a helper for quadplane `allow_forward_throttle_in_vtol_mode` this is so we can used it in two places in the last commit.

Secondly this adds in early returns in the `set_throttle` function for disarmed and throttle suppressed. This makes the final commit simpler by ensuring min/max limits are never applied in that case.

Finally this moves the decision if min/max limits should be applied down in to the flight mode. The existing logic is duplicated (for now) in `mode.cpp`, the same function is used by all modes. In the future we could use overrides. 

To minimize the diff the top of the current `set_throttle` function is moved to a new function `apply_throttle_limits` which applys the limits and returns the throttle. The voltage scaling function is kept in the `set_throttle` function so it is calculated on every loop.

There is some change in behavior. The watt limit and ICE idle functions are now only called if their output will be used. The current behavior is to always call those methods to update throttle min/max but not always use the limits. In both cases this should result in better results as throwing away the limits breaks the feedback loop. However testing will be needed to ensure they deal with the gap in between calls correctly (they should because there already not called in manual mode). 