### PR TITLE
AP_HAL: added Events API test

### DIFF
--- a/libraries/AP_DroneCAN/AP_Canard_iface.cpp
+++ b/libraries/AP_DroneCAN/AP_Canard_iface.cpp
@@ -413,6 +413,8 @@ void CanardInterface::process(uint32_t duration_ms) {
         } else {
             break;
         }
+        // ensure that this thread can't take all the CPU
+        hal.scheduler->delay_microseconds(50);
     }
 #endif
 }

--- a/libraries/AP_HAL/EventHandle.cpp
+++ b/libraries/AP_HAL/EventHandle.cpp
@@ -1,3 +1,4 @@
+#include <AP_HAL/EventHandle.h>
 #include "EventHandle.h"
 #include <AP_HAL/AP_HAL.h>
 

--- a/libraries/AP_HAL/EventHandle.h
+++ b/libraries/AP_HAL/EventHandle.h
@@ -2,7 +2,6 @@
 
 #include "AP_HAL_Namespace.h"
 #include <stdint.h>
-#include "AP_HAL_Boards.h"
 
 class AP_HAL::EventSource {
 public:
@@ -15,7 +14,11 @@ public:
 
     // Wait on an Event handle, method for internal use by EventHandle
     virtual bool wait(uint16_t duration_us, AP_HAL::EventHandle* evt_handle) = 0;
+
+    virtual ~EventSource() {}
 };
+
+#include "AP_HAL_Boards.h"
 
 class AP_HAL::EventHandle {
 public:

--- a/libraries/AP_HAL/board/chibios.h
+++ b/libraries/AP_HAL/board/chibios.h
@@ -64,8 +64,9 @@
 #include <AP_HAL_ChibiOS/Semaphores.h>
 #define HAL_Semaphore ChibiOS::Semaphore
 
-#include <AP_HAL/EventHandle.h>
+#include <AP_HAL_ChibiOS/EventSource.h>
 #define HAL_EventHandle AP_HAL::EventHandle
+#define HAL_EventSource ChibiOS::EventSource
 #endif
 
 /* string names for well known SPI devices */

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -55,8 +55,9 @@
 #include <AP_HAL_SITL/Semaphores.h>
 #define HAL_Semaphore HALSITL::Semaphore
 
-#include <AP_HAL/EventHandle.h>
+#include <AP_HAL_SITL/EventSource.h>
 #define HAL_EventHandle AP_HAL::EventHandle
+#define HAL_EventSource HALSITL::EventSource
 #endif
 
 #ifndef HAL_NUM_CAN_IFACES

--- a/libraries/AP_HAL/examples/Events/Events.cpp
+++ b/libraries/AP_HAL/examples/Events/Events.cpp
@@ -1,0 +1,91 @@
+/*
+  simple test of UART interfaces
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/EventHandle.h>
+
+#include <stdio.h>
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class EventTest {
+public:
+    HAL_EventSource src;
+    HAL_EventHandle handle;
+
+    void setup(void);
+    void loop(void);
+    void thread1(void);
+    void thread2(void);
+
+    HAL_Semaphore sem;
+    uint32_t ops, timeouts;
+    uint32_t last_print_us;
+};
+
+void EventTest::setup(void)
+{
+    handle.register_event(1);
+    handle.set_source(&src);
+
+    hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&EventTest::thread1, void), "thd1", 2048, AP_HAL::Scheduler::PRIORITY_SPI, 0);
+    hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&EventTest::thread2, void), "thd2", 2048, AP_HAL::Scheduler::PRIORITY_SPI, 0);
+    ::printf("Setup event threads\n");
+}
+
+void EventTest::thread2(void)
+{
+    while (true) {
+        auto ret = handle.wait(0xFFFFU);
+        WITH_SEMAPHORE(sem);
+        if (ret) {
+            ops++;
+        } else {
+            timeouts++;
+        }
+    }
+}
+
+void EventTest::thread1(void)
+{
+    while (true) {
+        hal.scheduler->delay_microseconds(100);
+        // change the signal to send in this line to test timeout
+        // handling and correct differentiation of events
+        src.signal(1);
+    }
+}
+
+void EventTest::loop(void)
+{
+    uint32_t now_us = AP_HAL::micros();
+    float dt = (now_us - last_print_us)*1.0e-6;
+    last_print_us = now_us;
+    WITH_SEMAPHORE(sem);
+    ::printf("tick %u %.3f ops/s %.3f timeouts/s\n",
+             unsigned(AP_HAL::millis()),
+             ops/dt,
+             timeouts/dt);
+    ops = 0;
+    timeouts = 0;
+}
+
+static EventTest *et;
+
+void setup(void)
+{
+    et = new EventTest;
+    et->setup();
+}
+
+void loop(void)
+{
+    et->loop();
+    hal.scheduler->delay(1000);
+}
+
+AP_HAL_MAIN();

--- a/libraries/AP_HAL/examples/Events/wscript
+++ b/libraries/AP_HAL/examples/Events/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )

--- a/libraries/AP_HAL_ChibiOS/EventSource.h
+++ b/libraries/AP_HAL_ChibiOS/EventSource.h
@@ -1,15 +1,10 @@
 #pragma once
-#include <AP_HAL/AP_HAL.h>
-
-#include <stdint.h>
-#include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_HAL/AP_HAL_Macros.h>
 #include <AP_HAL/EventHandle.h>
-#include "AP_HAL_ChibiOS_Namespace.h"
 #include <ch.hpp>
 
 #if CH_CFG_USE_EVENTS == TRUE
 class ChibiOS::EventSource : public AP_HAL::EventSource {
+private:
     // Single event source to be shared across multiple users
     chibios_rt::EventSource ch_evt_src_;
 

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#pragma once
+
+#ifdef   __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef LWIP_OPTTEST_FILE
+#include "lwipopts_test.h"
+#else /* LWIP_OPTTEST_FILE */
+
+#define LWIP_IPV4                  1
+#define LWIP_IPV6                  0
+
+#define MEM_LIBC_MALLOC 1
+#define MEMP_MEM_MALLOC 1
+#define LWIP_NETCONN_SEM_PER_THREAD 0
+
+
+#define NO_SYS                     0
+#define LWIP_SOCKET                (NO_SYS==0)
+#define LWIP_NETCONN               (NO_SYS==0)
+#define LWIP_NETIF_API             (NO_SYS==0)
+
+#define LWIP_IGMP                  LWIP_IPV4
+#define LWIP_ICMP                  LWIP_IPV4
+
+#define LWIP_SNMP                  LWIP_UDP
+#define MIB2_STATS                 LWIP_SNMP
+#ifdef LWIP_HAVE_MBEDTLS
+#define LWIP_SNMP_V3               (LWIP_SNMP)
+#endif
+
+#define LWIP_DNS                   LWIP_UDP
+#define LWIP_MDNS_RESPONDER        LWIP_UDP
+
+#define LWIP_NUM_NETIF_CLIENT_DATA (LWIP_MDNS_RESPONDER)
+
+#define LWIP_HAVE_LOOPIF           1
+#define LWIP_NETIF_LOOPBACK        1
+#define LWIP_LOOPBACK_MAX_PBUFS    10
+
+#define TCP_LISTEN_BACKLOG         1
+
+#define LWIP_COMPAT_SOCKETS        0
+#define LWIP_SO_RCVTIMEO           1
+#define LWIP_SO_RCVBUF             1
+
+#define LWIP_TCPIP_CORE_LOCKING    1
+
+#define LWIP_NETIF_LINK_CALLBACK        1
+#define LWIP_NETIF_STATUS_CALLBACK      1
+#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+
+#define USE_PPP 1
+
+#define LWIP_TIMEVAL_PRIVATE 0
+#define LWIP_FD_SET_PRIVATE 0
+
+// #define LWIP_DEBUG
+#ifdef LWIP_DEBUG
+#define LWIP_DBG_MIN_LEVEL         0
+#define PPP_DEBUG                  LWIP_DBG_ON
+#define MEM_DEBUG                  LWIP_DBG_ON
+#define MEMP_DEBUG                 LWIP_DBG_ON
+#define PBUF_DEBUG                 LWIP_DBG_OFF
+#define API_LIB_DEBUG              LWIP_DBG_OFF
+#define API_MSG_DEBUG              LWIP_DBG_OFF
+#define TCPIP_DEBUG                LWIP_DBG_ON
+#define NETIF_DEBUG                LWIP_DBG_ON
+#define SOCKETS_DEBUG              LWIP_DBG_OFF
+#define DNS_DEBUG                  LWIP_DBG_OFF
+#define AUTOIP_DEBUG               LWIP_DBG_OFF
+#define DHCP_DEBUG                 LWIP_DBG_OFF
+#define IP_DEBUG                   LWIP_DBG_OFF
+#define IP_REASS_DEBUG             LWIP_DBG_OFF
+#define ICMP_DEBUG                 LWIP_DBG_OFF
+#define IGMP_DEBUG                 LWIP_DBG_OFF
+#define UDP_DEBUG                  LWIP_DBG_OFF
+#define TCP_DEBUG                  LWIP_DBG_ON
+#define TCP_INPUT_DEBUG            LWIP_DBG_ON
+#define TCP_OUTPUT_DEBUG           LWIP_DBG_ON
+#define TCP_RTO_DEBUG              LWIP_DBG_OFF
+#define TCP_CWND_DEBUG             LWIP_DBG_OFF
+#define TCP_WND_DEBUG              LWIP_DBG_OFF
+#define TCP_FR_DEBUG               LWIP_DBG_OFF
+#define TCP_QLEN_DEBUG             LWIP_DBG_OFF
+#define TCP_RST_DEBUG              LWIP_DBG_OFF
+#endif
+
+#define LWIP_DBG_TYPES_ON         (LWIP_DBG_ON|LWIP_DBG_TRACE|LWIP_DBG_STATE|LWIP_DBG_FRESH|LWIP_DBG_HALT)
+
+
+/* ---------- Memory options ---------- */
+/* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
+   lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
+   byte alignment -> define MEM_ALIGNMENT to 2. */
+/* MSVC port: intel processors don't need 4-byte alignment,
+   but are faster that way! */
+#define MEM_ALIGNMENT           4U
+
+/* MEM_SIZE: the size of the heap memory. If the application will send
+a lot of data that needs to be copied, this should be set high. */
+#define MEM_SIZE               10240
+
+/* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
+   sends a lot of data out of ROM (or other static memory), this
+   should be set high. */
+#define MEMP_NUM_PBUF           100
+/* MEMP_NUM_RAW_PCB: the number of UDP protocol control blocks. One
+   per active RAW "connection". */
+#define MEMP_NUM_RAW_PCB        3
+/* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
+   per active UDP "connection". */
+#define MEMP_NUM_UDP_PCB        8
+/* MEMP_NUM_TCP_PCB: the number of simultaneously active TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB        5
+/* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB_LISTEN 8
+/* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
+   segments. */
+#define MEMP_NUM_TCP_SEG        16
+/* MEMP_NUM_SYS_TIMEOUT: the number of simultaneously active
+   timeouts. */
+#define MEMP_NUM_SYS_TIMEOUT    17
+
+/* The following four are used only with the sequential API and can be
+   set to 0 if the application only will use the raw API. */
+/* MEMP_NUM_NETBUF: the number of struct netbufs. */
+#define MEMP_NUM_NETBUF         100
+/* MEMP_NUM_NETCONN: the number of struct netconns. */
+#define MEMP_NUM_NETCONN        200
+/* MEMP_NUM_TCPIP_MSG_*: the number of struct tcpip_msg, which is used
+   for sequential API communication and incoming packets. Used in
+   src/api/tcpip.c. */
+#define MEMP_NUM_TCPIP_MSG_API   16
+#define MEMP_NUM_TCPIP_MSG_INPKT 16
+
+
+/* ---------- Pbuf options ---------- */
+/* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
+#define PBUF_POOL_SIZE          120
+
+/* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
+#define PBUF_POOL_BUFSIZE       256
+
+/** SYS_LIGHTWEIGHT_PROT
+ * define SYS_LIGHTWEIGHT_PROT in lwipopts.h if you want inter-task protection
+ * for certain critical regions during buffer allocation, deallocation and memory
+ * allocation and deallocation.
+ */
+#define SYS_LIGHTWEIGHT_PROT    (NO_SYS==0)
+
+
+/* ---------- TCP options ---------- */
+#define LWIP_TCP                1
+#define TCP_TTL                 255
+
+#define LWIP_ALTCP              (LWIP_TCP)
+#ifdef LWIP_HAVE_MBEDTLS
+#define LWIP_ALTCP_TLS          (LWIP_TCP)
+#define LWIP_ALTCP_TLS_MBEDTLS  (LWIP_TCP)
+#endif
+
+
+/* Controls if TCP should queue segments that arrive out of
+   order. Define to 0 if your device is low on memory. */
+#define TCP_QUEUE_OOSEQ         1
+
+/* TCP Maximum segment size. */
+#define TCP_MSS                 1024
+
+/* TCP sender buffer space (bytes). */
+#define TCP_SND_BUF             2048
+
+/* TCP sender buffer space (pbufs). This must be at least = 2 *
+   TCP_SND_BUF/TCP_MSS for things to work. */
+#define TCP_SND_QUEUELEN       (4 * TCP_SND_BUF/TCP_MSS)
+
+/* TCP writable space (bytes). This must be less than or equal
+   to TCP_SND_BUF. It is the amount of space which must be
+   available in the tcp snd_buf for select to return writable */
+#define TCP_SNDLOWAT           (TCP_SND_BUF/2)
+
+/* TCP receive window. */
+#define TCP_WND                 (20 * 1024)
+
+/* Maximum number of retransmissions of data segments. */
+#define TCP_MAXRTX              12
+
+/* Maximum number of retransmissions of SYN segments. */
+#define TCP_SYNMAXRTX           4
+
+
+/* ---------- ARP options ---------- */
+#define LWIP_ARP                1
+#define ARP_TABLE_SIZE          10
+#define ARP_QUEUEING            1
+
+
+/* ---------- IP options ---------- */
+/* Define IP_FORWARD to 1 if you wish to have the ability to forward
+   IP packets across network interfaces. If you are going to run lwIP
+   on a device with only one network interface, define this to 0. */
+#define IP_FORWARD              1
+
+/* IP reassembly and segmentation.These are orthogonal even
+ * if they both deal with IP fragments */
+#define IP_REASSEMBLY           1
+#define IP_REASS_MAX_PBUFS      (10 * ((1500 + PBUF_POOL_BUFSIZE - 1) / PBUF_POOL_BUFSIZE))
+#define MEMP_NUM_REASSDATA      IP_REASS_MAX_PBUFS
+#define IP_FRAG                 1
+#define IPV6_FRAG_COPYHEADER    1
+
+/* ---------- ICMP options ---------- */
+#define ICMP_TTL                255
+
+
+/* ---------- DHCP options ---------- */
+/* Define LWIP_DHCP to 1 if you want DHCP configuration of
+   interfaces. */
+#define LWIP_DHCP               0
+
+/* 1 if you want to do an ARP check on the offered address
+   (recommended). */
+#define DHCP_DOES_ARP_CHECK    (LWIP_DHCP)
+
+
+/* ---------- AUTOIP options ------- */
+#define LWIP_AUTOIP            (LWIP_DHCP)
+#define LWIP_DHCP_AUTOIP_COOP  (LWIP_DHCP && LWIP_AUTOIP)
+
+
+/* ---------- UDP options ---------- */
+#define LWIP_UDP                1
+#define LWIP_UDPLITE            LWIP_UDP
+#define UDP_TTL                 255
+
+
+/* ---------- RAW options ---------- */
+#define LWIP_RAW                1
+
+
+/* ---------- Statistics options ---------- */
+
+#define LWIP_STATS              1
+#define LWIP_STATS_DISPLAY      1
+
+#if LWIP_STATS
+#define LINK_STATS              1
+#define IP_STATS                1
+#define ICMP_STATS              1
+#define IGMP_STATS              1
+#define IPFRAG_STATS            1
+#define UDP_STATS               1
+#define TCP_STATS               1
+#define MEM_STATS               1
+#define MEMP_STATS              1
+#define PBUF_STATS              1
+#define SYS_STATS               1
+#endif /* LWIP_STATS */
+
+/* ---------- NETBIOS options ---------- */
+#define LWIP_NETBIOS_RESPOND_NAME_QUERY 1
+
+/* ---------- PPP options ---------- */
+
+#define PPP_SUPPORT             1      /* Set > 0 for PPP */
+
+#if PPP_SUPPORT
+
+#define NUM_PPP                 1      /* Max PPP sessions. */
+
+
+/* Select modules to enable.  Ideally these would be set in the makefile but
+ * we're limited by the command line length so you need to modify the settings
+ * in this file.
+ */
+#define PPPOE_SUPPORT           0
+#define PPPOS_SUPPORT           1
+
+#define PAP_SUPPORT             0      /* Set > 0 for PAP. */
+#define CHAP_SUPPORT            0      /* Set > 0 for CHAP. */
+#define MSCHAP_SUPPORT          0      /* Set > 0 for MSCHAP */
+#define CBCP_SUPPORT            0      /* Set > 0 for CBCP (NOT FUNCTIONAL!) */
+#define CCP_SUPPORT             0      /* Set > 0 for CCP */
+#define VJ_SUPPORT              1      /* Set > 0 for VJ header compression. */
+#define MD5_SUPPORT             0      /* Set > 0 for MD5 (see also CHAP) */
+
+#endif /* PPP_SUPPORT */
+
+#endif /* LWIP_OPTTEST_FILE */
+
+/* The following defines must be done even in OPTTEST mode: */
+
+#if !defined(NO_SYS) || !NO_SYS /* default is 0 */
+void sys_check_core_locking(void);
+#define LWIP_ASSERT_CORE_LOCKED()  sys_check_core_locking()
+#endif
+
+#ifndef LWIP_PLATFORM_ASSERT
+/* Define LWIP_PLATFORM_ASSERT to something to catch missing stdio.h includes */
+void ap_networking_platform_assert(const char *msg, int line, const char *file);
+#define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(x, __LINE__, __FILE__)
+#endif
+
+/*
+  map LWIP debugging onto ap_networking_printf to allow for easier
+  redirection to a file or dedicated serial port
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+int ap_networking_printf(const char *fmt, ...);
+#ifdef __cplusplus
+}
+#endif
+#define LWIP_PLATFORM_DIAG(x)    do {ap_networking_printf x; } while(0)
+
+#define AP_NETWORKING_LWIP_DEBUG_FILE "lwip.log"
+
+#ifdef   __cplusplus
+}
+#endif
+    


### PR DESCRIPTION
This adds a test for our AP_HAL::EventHandle API. It seems to show the API is broken in several ways:

 - wait() returns true on timeout
 - timeouts happen even when a valid signal is sent (test achieves 15 ops/s when it should be 10k ops/s)
 - there is a race on wait() where if the signal was sent before the wait it isn't seen
 - the API implies the event mask is local to the EventHandle, but it isn't, it is a thread property, so you could get events from other sources waking you

Note that to test on ChibiOS boards with IOMCU you need to comment out the IOMCU in the hwdef.dat (ping @andyp1per, its due to the ESC telemetry panic)

note: to build use: ./waf --target examples/Events

I am considering the following:
 - rename HAL_Semaphore to HAL_Mutex (that was always an error)
 - add a true HAL_Semaphore with signal() support
 - build a new EventHandle API on top of signalling semaphores

Note that this PR doesn't build in CI as it is missing SITL events support. I do have a SITL implementation, but as the API is so broken right now it can't really be completed till the ChibiOS one is fixed
