### PR TITLE
Copter: do not use RC input if it is not valid

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -71,7 +71,7 @@ void Copter::update_throttle_hover()
 float Copter::get_pilot_desired_climb_rate()
 {
     // throttle failsafe check
-    if (failsafe.radio || !rc().has_ever_seen_rc_input()) {
+    if (!rc().has_valid_input()) {
         return 0.0f;
     }
 

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -330,7 +330,7 @@ AC_AttitudeControl::HeadingCommand Mode::AutoYaw::get_heading()
 {
     // process pilot's yaw input
     _pilot_yaw_rate_cds = 0.0;
-    if (!copter.failsafe.radio && copter.flightmode->use_pilot_yaw()) {
+    if (rc().has_valid_input() && copter.flightmode->use_pilot_yaw()) {
         // get pilot's desired yaw rate
         _pilot_yaw_rate_cds = copter.flightmode->get_pilot_desired_yaw_rate();
         if (!is_zero(_pilot_yaw_rate_cds)) {

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -464,8 +464,7 @@ void Copter::notify_flight_mode() {
 // returns desired angle in centi-degrees
 void Mode::get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const
 {
-    // throttle failsafe check
-    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
+    if (!rc().has_valid_input()) {
         roll_out_cd = 0.0;
         pitch_out_cd = 0.0;
         return;
@@ -486,8 +485,7 @@ Vector2f Mode::get_pilot_desired_velocity(float vel_max) const
 {
     Vector2f vel;
 
-    // throttle failsafe check
-    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
+    if (!rc().has_valid_input()) {
         return vel;
     }
     // fetch roll and pitch inputs
@@ -693,7 +691,7 @@ void Mode::land_run_horizontal_control()
     }
 
     // process pilot inputs
-    if (!copter.failsafe.radio) {
+    if (rc().has_valid_input()) {
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
@@ -808,7 +806,7 @@ void Mode::land_run_normal_or_precland(bool pause_descent)
 // The passed in location is expected to be NED and in m
 void Mode::precland_retry_position(const Vector3f &retry_pos)
 {
-    if (!copter.failsafe.radio) {
+    if (rc().has_valid_input()) {
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
@@ -1004,8 +1002,7 @@ Mode::AltHoldModeState Mode::get_alt_hold_state(float target_climb_rate_cms)
 // returns desired yaw rate in centi-degrees per second
 float Mode::get_pilot_desired_yaw_rate() const
 {
-    // throttle failsafe check
-    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
+    if (!rc().has_valid_input()) {
         return 0.0f;
     }
 

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -55,7 +55,7 @@ void ModeCircle::run()
 
     // pilot changes to circle rate and radius
     // skip if in radio failsafe
-    if (!copter.failsafe.radio && copter.circle_nav->pilot_control_enabled()) {
+    if (rc().has_valid_input() && copter.circle_nav->pilot_control_enabled()) {
         // update the circle controller's radius target based on pilot pitch stick inputs
         const float radius_current = copter.circle_nav->get_radius_cm();           // circle controller's radius target, which begins as the circle_radius parameter
         const float pitch_stick = channel_pitch->norm_input_dz();               // pitch stick normalized -1 to 1

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -95,7 +95,7 @@ void ModeLand::nogps_run()
     float target_roll = 0.0f, target_pitch = 0.0f;
 
     // process pilot inputs
-    if (!copter.failsafe.radio) {
+    if (rc().has_valid_input()) {
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -267,7 +267,7 @@ void ModeRTL::descent_run()
     }
 
     // process pilot's input
-    if (!copter.failsafe.radio) {
+    if (rc().has_valid_input()) {
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -113,7 +113,7 @@ void ModeTurtle::change_motor_direction(bool reverse)
 void ModeTurtle::run()
 {
     const float flip_power_factor = 1.0f - CRASH_FLIP_EXPO * 0.01f;
-    const bool norc = copter.failsafe.radio || !rc().has_ever_seen_rc_input();
+    const bool norc = !rc().has_valid_input();
     const float stick_deflection_pitch = norc ? 0.0f : channel_pitch->norm_input_dz();
     const float stick_deflection_roll = norc ? 0.0f : channel_roll->norm_input_dz();
     const float stick_deflection_yaw = norc ? 0.0f : channel_yaw->norm_input_dz();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -330,7 +330,7 @@ void Copter::update_auto_armed()
             return;
         }
         // if in stabilize or acro flight mode and throttle is zero, auto-armed should become false
-        if(flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio) {
+        if (flightmode->has_manual_throttle() && ap.throttle_zero && rc().has_valid_input()) {
             set_auto_armed(false);
         }
 

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -230,7 +230,7 @@ void ToyMode::update()
     uint16_t ch6_in = RC_Channels::get_radio_in(CH_6);
     uint16_t ch7_in = RC_Channels::get_radio_in(CH_7);
 
-    if (copter.failsafe.radio || ch5_in < 900) {
+    if (!rc().has_valid_input() || ch5_in < 900) {
         // failsafe handling is outside the scope of toy mode, it does
         // normal failsafe actions, just setup a blink pattern
         green_blink_pattern = BLINK_NO_RX;
@@ -693,7 +693,7 @@ bool ToyMode::set_and_remember_mode(Mode::Number mode, ModeReason reason)
  */
 void ToyMode::trim_update(void)
 {
-    if (hal.util->get_soft_armed() || copter.failsafe.radio) {
+    if (hal.util->get_soft_armed() || !rc().has_valid_input()) {
         // only when disarmed and with RC link
         trim.start_ms = 0;
         return;

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -22,7 +22,7 @@ void Copter::tuning()
     }
 
     // exit immediately when radio failsafe is invoked or transmitter has not been turned on
-    if (failsafe.radio || failsafe.radio_counter != 0 || rc_tuning->get_radio_in() == 0) {
+    if (!rc().has_valid_input() || rc_tuning->get_radio_in() == 0) {
         return;
     }
 


### PR DESCRIPTION
in the case the user is supplying RC input via RC overrides (from the GCS), the Radio failsafe will never be true.

If the GCS stops sending messages then we do not want to use stale data!

Problem description from Discord:
```
Hi all,
Can anyone clarify what the expected behaviour is if a GCS controlled drone (no RC receiver) goes into GCS failsafe (triggering RTL)?
I am testing in SITL and it continues to replay the last manual_control message received.
e.g. if manual_control message was to pitch forwards immediately before GCS failsafe, the drone pitches forward in the descent phase of RTL.
Is there a way to make it go to a neutral, or stop value?
```
