### PR TITLE
AP_OSD_MSP_DisplayPort: update some symbols

### DIFF
--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -81,8 +81,8 @@ private:
     static const uint8_t SYM_WSPD = 0x57;
     static const uint8_t SYM_VSPD = 0x5E;
     static const uint8_t SYM_WPNO = 0x23;
-    static const uint8_t SYM_WPDIR = 0xE6;
-    static const uint8_t SYM_WPDST = 0xE7;
+    static const uint8_t SYM_WPDIR = 0x44;
+    static const uint8_t SYM_WPDST = 0x77;
     static const uint8_t SYM_FTMIN = 0xE8;
     static const uint8_t SYM_FTSEC = 0x99;
 
@@ -137,14 +137,14 @@ private:
     static const uint8_t SYM_FLY = 0x9C;
     static const uint8_t SYM_EFF = 0xF2;
     static const uint8_t SYM_AH = 0xF3;
-    static const uint8_t SYM_MW = 0xF4;
+    static const uint8_t SYM_MW = 0x5E;
     static const uint8_t SYM_CLK = 0x08;
     static const uint8_t SYM_KILO = 0x4B;
     static const uint8_t SYM_TERALT = 0x7F;
     static const uint8_t SYM_FENCE_ENABLED = 0xF5;
     static const uint8_t SYM_FENCE_DISABLED = 0xF6;
     static const uint8_t SYM_RNGFD = 0x7F;
-    static const uint8_t SYM_LQ = 0xF8;
+    static const uint8_t SYM_LQ = 0x51;
 
     static constexpr uint8_t symbols[AP_OSD_NUM_SYMBOLS] {
         SYM_M,


### PR DESCRIPTION
Change some symbols to be within BTFL fonts range, trying to make them meaningful.

SYM_WPDIR - changed to just the letter "D"
SYM_WPDST - changed to the symbol ">"
SYM_MW - changed to the symbol "^"  (an approximation by using the power symbol in some programming languages)
SYM_LQ - changed to the letter "Q" 

This should affect only MSP DisplayPort based OSD's using the BTFL fonts. Since the implemented font set is not complete, some approximations are necessary. If anyone has better suggestions for the approximations, please feel free to comment with them. 

Below is the implemented fonts reference:

![BTFL_DJI_fonts](https://github.com/ArduPilot/ardupilot/assets/9812730/04ac7bcb-261d-4ff7-9b57-4a43bb978fe9)
