### PR TITLE
Tools: Scripts: decode_ICSR: use `decoder_m4_pendsvset` function

### DIFF
--- a/Tools/scripts/decode_ICSR.py
+++ b/Tools/scripts/decode_ICSR.py
@@ -28,7 +28,7 @@ class DecodeICSR(object):
             ("25", "PENDSTCLR", self.decoder_m4_pendstclr),
             ("26", "PENDSTSET", self.decoder_m4_pendstset),
             ("27", "PENDSVCLR", self.decoder_m4_pendsvclr),
-            ("28", "PENDSVSET", self.decoder_m4_pendstset),
+            ("28", "PENDSVSET", self.decoder_m4_pendsvset),
             ("29-30", "RESERVED4", None),
             ("31", "NMIPENDSET", self.decoder_m4_nmipendset),
         ]


### PR DESCRIPTION
The `decoder_m4_pendsvset` is not used instead `decoder_m4_pendstset` is used twice. Spotted while porting to js for https://github.com/ArduPilot/WebTools/pull/98



