### PR TITLE
AC_Avoidance: clarify Options bit mask metadata

### DIFF
--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
     // @DisplayName: Options while recovering from Object Avoidance
     // @Description: Bitmask which will govern vehicles behaviour while recovering from Obstacle Avoidance (i.e Avoidance is turned off after the path ahead is clear).   
     // @Bitmask{Rover}: 0: Reset the origin of the waypoint to the present location, 1: log Dijkstra points
-    // @Bitmask{Copter}: 1:log Dijkstra points, 2:Allow fast waypoints (Dijkastras only)
+    // @Bitmask{Copter}: 0: Unused by Copter, 1:log Dijkstra points, 2:Allow fast waypoints (Dijkastras only)
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 5, AP_OAPathPlanner, _options, OA_OPTIONS_DEFAULT),
 


### PR DESCRIPTION
NFC...I think omitting bit 0 is confusing even though its not used...people get values and bits confused all the time, I think this will help on this particular param