### PR TITLE
AR_Motors: fix support for omni vehicles

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -142,7 +142,7 @@ void AP_MotorsUGV::init(uint8_t frtype)
     setup_safety_output();
 
     // setup for omni vehicles
-    if (is_omni()) {
+    if (_frame_type != FRAME_TYPE_UNDEFINED) {
         setup_omni();
     }
 }


### PR DESCRIPTION
This PR fix the support for omni vehicles in rover that seems broken for some time. We can not use ```is_omni()``` here because it check for ```_motors_num > 0``` which will be set in ```setup_omni()```.