### PR TITLE
autotest: fixed flapping sub log download test

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -4273,6 +4273,7 @@ class TestSuite(ABC):
         self.context_push()
         self.set_parameters({
             "NET_ENABLED": 1,
+            "LOG_DISARMED": 1,
             "LOG_DARM_RATEMAX": 2, # make small logs
             # UDP client
             "NET_P1_TYPE": 1,


### PR DESCRIPTION
the log being downloaded can be very large, and times out. Setting LOG_DISARMED=1 gives us a small log to download