### PR TITLE
GPS: fixed 2 NMEA bugs

### DIFF
--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -152,3 +152,14 @@ bool AP_HAL::UARTDriver::discard_input()
     }
     return _discard_input();
 }
+
+/*
+  default implementation of receive_time_constraint_us() will be used
+  for subclasses that don't implement the call (eg. network
+  sockets). Best we can do is to use the current timestamp as we don't
+  know the transport delay
+ */
+uint64_t AP_HAL::UARTDriver::receive_time_constraint_us(uint16_t nbytes)
+{
+    return AP_HAL::micros64();
+}

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -137,10 +137,8 @@ public:
       This takes account of the baudrate of the link. For transports
       that have no baudrate (such as USB) the time estimate may be
       less accurate.
-
-      A return value of zero means the HAL does not support this API
      */
-    virtual uint64_t receive_time_constraint_us(uint16_t nbytes) { return 0; }
+    virtual uint64_t receive_time_constraint_us(uint16_t nbytes);
 
     virtual uint32_t bw_in_bytes_per_second() const {
         return 5760;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -112,7 +112,7 @@ void AP_NMEA_Output::update()
 
     // format time string
     char tstring[10];
-    snprintf(tstring, sizeof(tstring), "%02u%02u%05.2f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+    hal.util->snprintf(tstring, sizeof(tstring), "%02u%02u%05.2f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
 
     Location loc;
     const auto &gps = AP::gps();
@@ -131,7 +131,7 @@ void AP_NMEA_Output::update()
     char lat_string[13];
     double deg = fabs(loc.lat * 1.0e-7f);
     double min_dec = ((fabs(loc.lat) - (unsigned)deg * 1.0e7)) * 60 * 1.e-7f;
-    snprintf(lat_string,
+    hal.util->snprintf(lat_string,
             sizeof(lat_string),
             "%02u%08.5f,%c",
             (unsigned) deg,
@@ -142,7 +142,7 @@ void AP_NMEA_Output::update()
     char lng_string[14];
     deg = fabs(loc.lng * 1.0e-7f);
     min_dec = ((fabs(loc.lng) - (unsigned)deg * 1.0e7)) * 60 * 1.e-7f; 
-    snprintf(lng_string,
+    hal.util->snprintf(lng_string,
             sizeof(lng_string),
             "%03u%08.5f,%c",
             (unsigned) deg,
@@ -208,7 +208,7 @@ void AP_NMEA_Output::update()
                                     lng_string,
                                     fix_quality,
                                     gps.num_sats(),
-                                    gps.get_hdop(),
+                                    gps.get_hdop()*0.01,
                                     loc.alt * 0.01f);
 
         space_required += gga_length;
@@ -219,7 +219,7 @@ void AP_NMEA_Output::update()
     if ((_message_enable_bitmask.get() & static_cast<int16_t>(Enabled_Messages::GPRMC)) != 0) {
         // format date string
         char dstring[7];
-        snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
+        hal.util->snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
 
         // get speed
 #if AP_AHRS_ENABLED


### PR DESCRIPTION
altitude from NMEA_Output was zero due to passing a uint16_t for hdop, and it didn't work over network ports due to lack of receive time constrain function