### PR TITLE
Copter: Throw mode check altitude params

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -696,6 +696,20 @@ const AP_Param::Info Copter::var_info[] = {
     // @Values: 0:Stopped,1:Running
     // @User: Standard
     GSCALAR(throw_motor_start, "THROW_MOT_START", (float)ModeThrow::PreThrowMotorState::STOPPED),
+
+    // @Param: THROW_ALT_MIN
+    // @DisplayName: Throw mode minimum altitude
+    // @Description: Minimum altitude above which Throw mode will detect a throw or a drop - 0 to disable the check
+    // @Units: m
+    // @User: Advanced
+    GSCALAR(throw_altitude_min, "THROW_ALT_MIN", 0),
+
+    // @Param: THROW_ALT_MAX
+    // @DisplayName: Throw mode maximum altitude
+    // @Description: Maximum altitude under which Throw mode will detect a throw or a drop - 0 to disable the check
+    // @Units: m
+    // @User: Advanced
+    GSCALAR(throw_altitude_max, "THROW_ALT_MAX", 0),
 #endif
 
 #if OSD_ENABLED || OSD_PARAM_ENABLED

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -383,6 +383,8 @@ public:
         // 254,255: reserved
 
         k_param_vehicle = 257, // vehicle common block of parameters
+        k_param_throw_altitude_min,
+        k_param_throw_altitude_max,
 
         // the k_param_* space is 9-bits in size
         // 511: reserved
@@ -463,6 +465,8 @@ public:
 
 #if MODE_THROW_ENABLED == ENABLED
     AP_Enum<ModeThrow::PreThrowMotorState>         throw_motor_start;
+    AP_Int16         throw_altitude_min; // minimum altitude in m above which a throw can be detected
+    AP_Int16         throw_altitude_max; // maximum altitude in m below which a throw can be detected
 #endif
 
     AP_Int16                rc_speed; // speed of fast RC Channels in Hz


### PR DESCRIPTION
Allow the user to set altitude restrictions in which a throw can be detected via parameters.
This feature has been really useful preventing accidental throw detection, which I am sure many users struggled with during fully autonomous missions.
The scenario in which we use it is with a VTOL plane which has many copters attached to it.
The copters would tend to detect a throw and attempt to stabilize when still attached to the plane, during transition to fixed wing or turbulence.
The problem is solved by simply setting the throw altitude max parameter below the transition altitude.
Only when the plane descends to perform the drop copters are able to stabilize.
Code modifications are very simple, testing was performed in SITL to ensure the feature works as intended with different parameter values.
This is the second version after all reviews, below is a picture of a scenario where we used these changes, copters are attached under a VTOL and ready for drop in designated areas:
![Zrzut ekranu 2024-01-02 235325](https://github.com/ArduPilot/ardupilot/assets/38810823/200a363b-e220-462e-8d0b-edf58387ed22)

