### PR TITLE
AP_OpticalFlow: Move variables to be used in the preprocessor

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -265,9 +265,9 @@ void AP_OpticalFlow::stop_calibration()
 void AP_OpticalFlow::update_state(const OpticalFlow_state &state)
 {
     _state = state;
-    _last_update_ms = AP_HAL::millis();
 
 #if AP_AHRS_ENABLED
+    _last_update_ms = AP_HAL::millis();
     // write to log and send to EKF if new data has arrived
     AP::ahrs().writeOptFlowMeas(quality(),
                                 _state.flowRate,


### PR DESCRIPTION
A preprocessor was added.
This addition causes wasteful processing to be performed.
I move to the preprocessor-in-process to be used.