### PR TITLE
AP_Networking: don't build lwip code if not needed

### DIFF
--- a/libraries/AP_Networking/AP_Networking_Config.h
+++ b/libraries/AP_Networking/AP_Networking_Config.h
@@ -50,6 +50,8 @@
 #define AP_NETWORKING_SOCKETS_ENABLED AP_NETWORKING_ENABLED
 #endif
 
+#define AP_NETWORKING_NEED_LWIP (AP_NETWORKING_BACKEND_CHIBIOS || AP_NETWORKING_BACKEND_PPP)
+
 // ---------------------------
 // IP Features
 // ---------------------------

--- a/libraries/AP_Networking/lwip_hal/arch/sys_arch.cpp
+++ b/libraries/AP_Networking/lwip_hal/arch/sys_arch.cpp
@@ -4,6 +4,9 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Networking/AP_Networking_Config.h>
+
+#if AP_NETWORKING_NEED_LWIP
 #include <AP_HAL/Semaphores.h>
 #include <AP_Math/AP_Math.h>
 
@@ -384,4 +387,6 @@ sys_arch_unprotect(sys_prot_t pval)
         lwprot_mutex.give();
     }
 }
+
+#endif // AP_NETWORKING_NEED_LWIP
 


### PR DESCRIPTION
this saves a bit of compile time, but also means devs not doing networking don't need to update the submodules