### PR TITLE
AP_Scripting: fixed memory leak in sendfile()

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -328,7 +328,6 @@ void AP_Scripting::thread(void) {
                 _net_sockets[i] = nullptr;
             }
         }
-        num_net_sockets = 0;
 #endif // AP_NETWORKING_ENABLED
         
         // Clear blocked commands

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -121,7 +121,6 @@ public:
 
 #if AP_NETWORKING_ENABLED
     // SocketAPM storage
-    uint8_t num_net_sockets;
     SocketAPM *_net_sockets[SCRIPTING_MAX_NUM_NET_SOCKET];
 #endif
 


### PR DESCRIPTION
this leaked the SocketAPM on each sendfile() call, we now rely on the script calling close(). The net_webserver.lua is already using close() correctly, this change just makes close able to find the socket
tested on CubeOrange and in SITL, confirmed this fixes the leak. Found with valgrind