### PR TITLE
DroneCAN: fixed subscribe before params loaded bug

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -208,7 +208,6 @@ void AP_CANManager::init()
                 continue;
             }
 
-            AP_Param::load_object_from_eeprom((AP_DroneCAN*)_drivers[drv_num], AP_DroneCAN::var_info);
         } else
 #endif
 #if HAL_PICCOLO_CAN_ENABLE
@@ -220,7 +219,6 @@ void AP_CANManager::init()
                 continue;
             }
 
-            AP_Param::load_object_from_eeprom((AP_PiccoloCAN*)_drivers[drv_num], AP_PiccoloCAN::var_info);
         } else
 #endif
         {
@@ -273,7 +271,6 @@ void AP_CANManager::init()
                 continue;
             }
 
-            AP_Param::load_object_from_eeprom((AP_DroneCAN*)_drivers[i], AP_DroneCAN::var_info);
             _drivers[i]->init(i, true);
             _driver_type_cache[i] = (AP_CAN::Protocol) _drv_param[i]._driver_type.get();
         }

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -287,6 +287,7 @@ _dna_server(*this, canard_iface, driver_index)
         _SRV_conf[i].servo_pending = false;
     }
 
+    AP_Param::load_object_from_eeprom(this, var_info);
     debug_dronecan(AP_CANManager::LOG_INFO, "AP_DroneCAN constructed\n\r");
 }
 

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -108,6 +108,7 @@ const AP_Param::GroupInfo AP_PiccoloCAN::var_info[] = {
 AP_PiccoloCAN::AP_PiccoloCAN()
 {
     AP_Param::setup_object_defaults(this, var_info);
+    AP_Param::load_object_from_eeprom(this, var_info);
 
     debug_can(AP_CANManager::LOG_INFO, "PiccoloCAN: constructed\n\r");
 }


### PR DESCRIPTION
we need to load parameters in the constructor to ensure we don't subscribe before we have parameters. Fixes a bug found by WickedShell where the wrong CAN ESC offset is used on startup

this can cause incorrect notch filters if an ESC status message arrives during startup and the user has an ESC offset set in CAN_D1_UC_ESC_OFS
