### PR TITLE
SITL: SIM_Frame: fixed per_motor_vars config loading

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -413,7 +413,7 @@ void Frame::load_frame_params(const char *model_json)
                 // use default value
                 continue;
             }
-            if (vars[i].t == VarType::FLOAT) {
+            if (per_motor_vars[i].t == VarType::FLOAT) {
                 parse_float(v, label_name, *(((float *)per_motor_vars[i].ptr) + j));
 
             } else if (per_motor_vars[i].t == VarType::VECTOR3F) {


### PR DESCRIPTION
This line was referencing the config type from the wrong variable array (vars rather than per_motor_vars), making it so that per motor variables (motor position, thrust vector, and yaw factor) could not be loaded into SITL