### PR TITLE
autotest: fixed missing Blimp for enum parsing

### DIFF
--- a/Tools/autotest/logger_metadata/enum_parse.py
+++ b/Tools/autotest/logger_metadata/enum_parse.py
@@ -18,6 +18,7 @@ class EnumDocco(object):
         "Copter": "ArduCopter",
         "Plane": "ArduPlane",
         "Tracker": "AntennaTracker",
+        "Blimp": "Blimp",
     }
 
     def __init__(self, vehicle):


### PR DESCRIPTION
![image](https://github.com/ArduPilot/ardupilot/assets/831867/895e54bf-4315-4679-b7bb-205c9ab3dd5c)
