### PR TITLE
Set height AGL in simulated periph state

### DIFF
--- a/libraries/AP_HAL/SIMState.cpp
+++ b/libraries/AP_HAL/SIMState.cpp
@@ -384,7 +384,7 @@ void SIMState::set_height_agl(void)
         AP_Terrain *_terrain = AP_Terrain::get_singleton();
         if (_terrain != nullptr &&
             _terrain->height_amsl(location, terrain_height_amsl)) {
-            _sitl->height_agl = _sitl->state.altitude - terrain_height_amsl;
+            _sitl->state.height_agl = _sitl->state.altitude - terrain_height_amsl;
             return;
         }
     }
@@ -392,7 +392,7 @@ void SIMState::set_height_agl(void)
 
     if (_sitl != nullptr) {
         // fall back to flat earth model
-        _sitl->height_agl = _sitl->state.altitude - home_alt;
+        _sitl->state.height_agl = _sitl->state.altitude - home_alt;
     }
 }
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -598,7 +598,7 @@ void SITL_State::set_height_agl(void)
         AP_Terrain *_terrain = AP_Terrain::get_singleton();
         if (_terrain != nullptr &&
             _terrain->height_amsl(location, terrain_height_amsl, false)) {
-            _sitl->height_agl = _sitl->state.altitude - terrain_height_amsl;
+            _sitl->state.height_agl = _sitl->state.altitude - terrain_height_amsl;
             return;
         }
     }
@@ -606,7 +606,7 @@ void SITL_State::set_height_agl(void)
 
     if (_sitl != nullptr) {
         // fall back to flat earth model
-        _sitl->height_agl = _sitl->state.altitude - home_alt;
+        _sitl->state.height_agl = _sitl->state.altitude - home_alt;
     }
 }
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_SITL.cpp
@@ -64,9 +64,9 @@ void AP_OpticalFlow_SITL::update(void)
 
     // estimate range to centre of image
     float range;
-    if (rotmat.c.z > 0.05f && _sitl->height_agl > 0) {
+    if (rotmat.c.z > 0.05f && _sitl->state.height_agl > 0) {
         Vector3f relPosSensorEF = rotmat * posRelSensorBF;
-        range = (_sitl->height_agl - relPosSensorEF.z) / rotmat.c.z;
+        range = (_sitl->state.height_agl - relPosSensorEF.z) / rotmat.c.z;
     } else {
         range = 1e38f;
     }

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -131,7 +131,7 @@ float AP_Proximity_SITL::distance_min() const
 bool AP_Proximity_SITL::get_upward_distance(float &distance) const
 {
     // return distance to fence altitude
-    distance = MAX(0.0f, fence_alt_max->get() - sitl->height_agl);
+    distance = MAX(0.0f, fence_alt_max->get() - sitl->state.height_agl);
     return true;
 }
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -490,7 +490,7 @@ float Aircraft::perpendicular_distance_to_rangefinder_surface() const
 {
     switch ((Rotation)sitl->sonar_rot.get()) {
     case Rotation::ROTATION_PITCH_270:
-        return sitl->height_agl;
+        return sitl->state.height_agl;
     case ROTATION_NONE ... ROTATION_YAW_315:
         return sitl->measure_distance_at_angle_bf(location, sitl->sonar_rot.get()*45);
     default:

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -92,6 +92,10 @@ struct sitl_fdm {
 
     // earthframe wind, from backends that know it
     Vector3f wind_ef;
+
+    // AGL altitude, usually derived from the terrain database in simulation:
+    float height_agl;
+
 };
 
 // number of rc output channels
@@ -152,9 +156,6 @@ public:
     // throttle when motors are active
     float throttle;
 
-    // height above ground
-    float height_agl;
-    
     static const struct AP_Param::GroupInfo var_info[];
     static const struct AP_Param::GroupInfo var_info2[];
     static const struct AP_Param::GroupInfo var_info3[];


### PR DESCRIPTION
..... required to have OpticalFlow-on-simulated-periph work correctly (`AP_OpticalFlow_SITL` uses it)
