### PR TITLE
AP_Networking: fixed build of evtimer.c on firmware server

### DIFF
--- a/libraries/AP_Networking/lwip_hal/arch/evtimer.c
+++ b/libraries/AP_Networking/lwip_hal/arch/evtimer.c
@@ -5,6 +5,7 @@
 #include <hal.h>
 
 #if CH_CFG_USE_EVENTS
-#include "../../modules/ChibiOS/os/various/evtimer.c"
+// this include relies on -I for modules/ChibiOS/os/various/cpp_wrappers
+#include <../evtimer.c>
 #endif
 


### PR DESCRIPTION
the firmware server uses --out option to waf configure which changes the include paths
this is causing the build server to not produce binaries
