### PR TITLE
HAL_ChibiOS: fixed DMA on SPI on H743

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -631,6 +631,10 @@ bool mem_is_dma_safe(const void *addr, uint32_t size, bool filesystem_op)
 #else
     uint32_t flags = MEM_REGION_FLAG_DMA_OK;
 #if defined(STM32H7)
+    if (!filesystem_op) {
+        // use bouncebuffer for all non FS ops on H7
+        return false;
+    }
     if (((uint32_t)addr) & 0x1F) {
         return false;
     }


### PR DESCRIPTION
this fixes DMA failures affecting IMUs on H743. The reason for the failure is not yet clear, but this reverts back to our old stragegy of always using the bouncebuffer on H7 as a quick workaround
update: found the reason for the failure. The problem is the SPIv3 driver for H7 doesn't do cache invalidation/flush. We rely on the bouncebuffer code to do that. 