### PR TITLE
AP_Mount: switch to RC_TARGETING on RC input

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -240,6 +240,10 @@ protected:
     void calculate_poi();
 #endif
 
+    // change to RC_TARGETTING mode if rc inputs have changed by more than the dead zone
+    // should be called on every update
+    void set_rctargeting_on_rcinput_change();
+
     // get pilot input (in the range -1 to +1) received through RC
     void get_rc_input(float& roll_in, float& pitch_in, float& yaw_in) const;
 
@@ -307,6 +311,13 @@ protected:
     bool _target_sysid_location_set;// true if _target_sysid has been set
 
     uint32_t _last_warning_ms;      // system time of last warning sent to GCS
+
+    // structure holding the last RC inputs
+    struct {
+        int16_t roll_in;
+        int16_t pitch_in;
+        int16_t yaw_in;
+    } last_rc_input;
 
     // structure holding mavlink sysid and compid of controller of this gimbal
     // see MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE and GIMBAL_MANAGER_STATUS

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -20,6 +20,9 @@ void AP_Mount_Gremsy::update()
         return;
     }
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // update based on mount mode
     switch (get_mode()) {
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -18,6 +18,9 @@ void AP_Mount_SToRM32::update()
         return;
     }
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // flag to trigger sending target angles to gimbal
     bool resend_now = false;
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -29,6 +29,9 @@ void AP_Mount_SToRM32_serial::update()
 
     read_incoming(); // read the incoming messages from the gimbal
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // flag to trigger sending target angles to gimbal
     bool resend_now = false;
 

--- a/libraries/AP_Mount/AP_Mount_Scripting.cpp
+++ b/libraries/AP_Mount/AP_Mount_Scripting.cpp
@@ -15,6 +15,9 @@ extern const AP_HAL::HAL& hal;
 // update mount position - should be called periodically
 void AP_Mount_Scripting::update()
 {
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // update based on mount mode
     switch (get_mode()) {
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -27,6 +27,9 @@ void AP_Mount_Servo::init()
 // update mount position - should be called periodically
 void AP_Mount_Servo::update()
 {
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     auto mount_mode = get_mode();
     switch (mount_mode) {
         // move mount to a "retracted position" or to a position where a fourth servo can retract the entire mount into the fuselage

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -103,6 +103,9 @@ void AP_Mount_Siyi::update()
     // run zoom control
     update_zoom_control();
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // Get the target angles or rates first depending on the current mount mode
     switch (get_mode()) {
         case MAV_MOUNT_MODE_RETRACT: {

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -31,6 +31,9 @@ void AP_Mount_SoloGimbal::update()
         return;
     }
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // update based on mount mode
     switch(get_mode()) {
         // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -76,6 +76,9 @@ void AP_Mount_Viewpro::update()
     // send vehicle attitude and position
     send_m_ahrs();
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // if tracking is active we do not send new targets to the gimbal
     if (_last_tracking_status == TrackingStatus::SEARCHING || _last_tracking_status == TrackingStatus::TRACKING) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -110,6 +110,9 @@ void AP_Mount_Xacti::update()
         return;
     }
 
+    // change to RC_TARGETING mode if RC input has changed
+    set_rctargeting_on_rcinput_change();
+
     // update based on mount mode
     switch (get_mode()) {
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?


### PR DESCRIPTION
This is a slightly simplified version of PR https://github.com/ArduPilot/ardupilot/pull/25850

This PR makes it more convenient for users to retake manual control of the gimbal using RC input.  Currently users can only retake control after pushing a button on the ground station (see below).
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/78781556-249c-4b40-89f2-b96d63887912)

With this new change, the Mount's mode is automatically changed to RC_TARGETING if the user moves one of the configured mount RC inputs by at least the channel's deadzone or 10pwm (whichever is larger).  The only exception is when the mode is in RETRACT mode.

This has been tested on real hardware (a CubeOrange paired with a Xacti camera gimbal) and I could easily move between controlling the gimbal with the RC inputs and Mission Planner's Payload screen.