### PR TITLE
AC_WPNav: ACCEL_C defaults to 2x ACCEL

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
 
     // @Param: ACCEL_C
     // @DisplayName: Waypoint Cornering Acceleration
-    // @Description: Defines the maximum cornering acceleration in cm/s/s used during missions, zero uses max lean angle.
+    // @Description: Defines the maximum cornering acceleration in cm/s/s used during missions.  If zero uses 2x accel value.
     // @Units: cm/s/s
     // @Range: 0 500
     // @Increment: 10

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -87,8 +87,8 @@ public:
     /// get_wp_acceleration - returns acceleration in cm/s/s during missions
     float get_wp_acceleration() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss : WPNAV_ACCELERATION; }
 
-    /// get_wp_acceleration - returns acceleration in cm/s/s during missions
-    float get_corner_acceleration() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss : get_wp_acceleration(); }
+    /// get_corner_acceleration - returns maximum acceleration in cm/s/s used during cornering in missions
+    float get_corner_acceleration() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss : 2.0 * get_wp_acceleration(); }
 
     /// get_wp_destination waypoint using position vector
     /// x,y are distance from ekf origin in cm


### PR DESCRIPTION
We've had numerous support issues involving users complaining that Copter-4.4 doesn't cut the corners as much as is it in previous versions.  The advice to users has been to set WPNAV_ACCEL_C to 2x the WPNAV_ACCEL value to get back to the behaviour they had in previous versions.  This PR makes the default WPNAV_ACCEL_C produce this behaviour.

This changes the maximum cornering acceleration to be 2x the regular waypoint acceleration (previously was 1x).

Increasing this acceleration results in the WPNAV_RADIUS parameter being the most likely limitation to how widely SCurves corners are cut.

Below are before-vs-after screen shots of the path taken during a rectangular mission with WPNAV_RADIUS = 5000 (e.g. 50m).
![before-vs-after-radius50](https://github.com/ArduPilot/ardupilot/assets/1498098/10d730b8-1f17-443e-a206-5d20e0d0c6eb)

Here are before-vs-after screen shots when WPNAV_RADIUS = 200 (e.g. 2m which is the default) and we see there's no obvious change in behaviour.
![before-vs-after-radius2](https://github.com/ArduPilot/ardupilot/assets/1498098/c6773986-c2c1-4b8a-b2c4-a213d5d59515)

