### PR TITLE
Tools: ros2: pass verbose flag to micro-ROS agent.

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -142,6 +142,8 @@ class MicroRosAgentLaunch:
             transport,
             "--middleware",
             middleware,
+            "--verbose",
+            verbose,
         ]
 
         if transport in ["udp4", "udp6", "tcp4", "tcp6"]:


### PR DESCRIPTION
Update the micro-ROS agent launch script to pass the verbose flag.

### Testing

This is the new expected behaviour. Previously the default verbosity level of 4 would always be set.

```bash
$ ros2 launch ardupilot_sitl micro_ros_agent.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml verbose:=6
[INFO] [launch]: All log files can be found below /Users/rhys/.ros/log/2024-01-08-14-30-56-023186-MacBookPro2-2.local-4579
[INFO] [launch]: Default logging verbosity is set to INFO
namespace:        
transport:        udp4
middleware:       dds
verbose:          6
discovery:        7400
port:             2019
refs:             /Users/rhys/Code/ros2/humble/ros2-ardupilot/install/ardupilot_sitl/share/ardupilot_sitl/config/dds_xrce_profile.xml
[INFO] [micro_ros_agent-1]: process started with pid [4580]
[micro_ros_agent-1] [1704724256.232910] info     | UDPv4AgentLinux.cpp | init                     | running...             | port: 2019
[micro_ros_agent-1] [1704724256.233653] info     | Root.cpp           | set_verbose_level        | logger setup           | verbose_level: 6
```