### PR TITLE
AP_HAL_ChibiOS: Only test SPI clock if  SPI is enabled

### DIFF
--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -227,7 +227,7 @@ static void main_loop()
 
     hal.serial(0)->begin(SERIAL0_BAUD);
 
-#ifdef HAL_SPI_CHECK_CLOCK_FREQ
+#if (HAL_USE_SPI == TRUE) && defined(HAL_SPI_CHECK_CLOCK_FREQ)
     // optional test of SPI clock frequencies
     ChibiOS::SPIDevice::test_clock_freq();
 #endif


### PR DESCRIPTION
Fixes building of the `NucleoH743` which has `HAL_SPI_CHECK_CLOCK_FREQ` defined but no SPI bus (there are pins but no devices by default). Reported on discord: https://discord.com/channels/674039678562861068/780728024756781056/1194021251602202767