### PR TITLE
AP_Arming: remove entire airspeed_checks if AP_AIRSPEED_ENABLED is off

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -66,8 +66,10 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
     // call parent class checks
     bool ret = AP_Arming::pre_arm_checks(display_failure);
 
+#if AP_AIRSPEED_ENABLED
     // Check airspeed sensor
     ret &= AP_Arming::airspeed_checks(display_failure);
+#endif
 
     if (plane.g.fs_timeout_long < plane.g.fs_timeout_short && plane.g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
         check_failed(display_failure, "FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -303,9 +303,9 @@ bool AP_Arming::barometer_checks(bool report)
     return true;
 }
 
+#if AP_AIRSPEED_ENABLED
 bool AP_Arming::airspeed_checks(bool report)
 {
-#if AP_AIRSPEED_ENABLED
     if (check_enabled(ARMING_CHECK_AIRSPEED)) {
         const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
         if (airspeed == nullptr) {
@@ -319,10 +319,10 @@ bool AP_Arming::airspeed_checks(bool report)
             }
         }
     }
-#endif
 
     return true;
 }
+#endif  // AP_AIRSPEED_ENABLED
 
 #if HAL_LOGGING_ENABLED
 bool AP_Arming::logging_checks(bool report)
@@ -1198,8 +1198,6 @@ bool AP_Arming::proximity_checks(bool report) const
         check_failed(report, "%s", buffer);
         return false;
     }
-    return true;
-
     return true;
 }
 #endif  // HAL_PROXIMITY_ENABLED

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -236,8 +236,6 @@ protected:
 
     bool fettec_checks(bool display_failure) const;
 
-    bool kdecan_checks(bool display_failure) const;
-
 #if HAL_PROXIMITY_ENABLED
     virtual bool proximity_checks(bool report) const;
 #endif


### PR DESCRIPTION
saves bytes and removes some redundant code which is obscured when the ifdefs are inside the body

... also adds a missing include and a redundant return