### PR TITLE
Tools: uploader.py: set write_timeout

### DIFF
--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -275,7 +275,7 @@ class uploader(object):
         self.force_erase = force_erase
 
         # open the port, keep the default timeout short so we can poll quickly
-        self.port = serial.Serial(portname, baudrate_bootloader, timeout=2.0)
+        self.port = serial.Serial(portname, baudrate_bootloader, timeout=2.0, write_timeout=2.0)
         self.baudrate_bootloader = baudrate_bootloader
         if baudrate_bootloader_flash is not None:
             self.baudrate_bootloader_flash = baudrate_bootloader_flash


### PR DESCRIPTION
This is needed to prevent Windows from hanging when trying to write to
"Standard Serial over Bluetooth" ports.