### PR TITLE
AP_Mount.cpp: send gimbal_manager_status msg when control changes

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -358,6 +358,9 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_gimbal_manager_configure(const ma
         return MAV_RESULT_FAILED;
     }
 
+    // backup the current values so we can detect a change
+    mavlink_control_id_t prev_control_id = mavlink_control_id;
+
     // convert negative packet1 and packet2 values
     int16_t new_sysid = packet.param1;
     switch (new_sysid) {
@@ -380,6 +383,11 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_gimbal_manager_configure(const ma
             mavlink_control_id.sysid = packet.param1;
             mavlink_control_id.compid = packet.param2;
             break;
+    }
+
+    // send gimbal_manager_status if control has changed
+    if (prev_control_id != mavlink_control_id) {
+        gcs().send_message(MSG_GIMBAL_MANAGER_STATUS);
     }
 
     return MAV_RESULT_ACCEPTED;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -310,9 +310,13 @@ protected:
 
     // structure holding mavlink sysid and compid of controller of this gimbal
     // see MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE and GIMBAL_MANAGER_STATUS
-    struct {
+    struct mavlink_control_id_t {
         uint8_t sysid;
         uint8_t compid;
+
+        // equality operators
+        bool operator==(const mavlink_control_id_t &rhs) const { return (sysid == rhs.sysid && compid == rhs.compid); }
+        bool operator!=(const mavlink_control_id_t &rhs) const { return !(*this == rhs); }
     } mavlink_control_id;
 };
 


### PR DESCRIPTION
This sends a [GIMBAL_MANAGER_STATUS ](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5997C9-L5997C9)message in cases where a [DO_GIMBAL_MANAGER_CONFIGURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1662) command has led to a change in who/what is in control of the gimbal.

This change has been split out and simplified from this original PR https://github.com/ArduPilot/ardupilot/pull/25850 and is part of the ongoing work to create [QGC's custom gimbal control screen](https://github.com/mavlink/qgroundcontrol/pull/10667).

The original justification for the change is below:

_By default we are sending this message at 0.2 Hz. This is totally fine as no more rate is needed, but whenever control changes it is interesting to notify as soon as possible, so the rest of the mavlink network understands the change in control as soon as possible_

These have been tested now in SITL and here is a related wiki PR https://github.com/ArduPilot/ardupilot_wiki/pull/5703