### PR TITLE
Plane: Patch heading check for turn flexibility

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -333,7 +333,7 @@ public:
     void navigate() override;
 
     bool isHeadingLinedUp(const Location loiterCenterLoc, const Location targetLoc);
-    bool isHeadingLinedUp_cd(const int32_t bearing_cd);
+    bool isHeadingLinedUp_cd(const int32_t bearing_cd, const int32_t initial_bearing_margin_cd = 1000);
 
     bool allows_throttle_nudging() const override { return true; }
 


### PR DESCRIPTION
Removing breakout logic for "next" waypoints within 1->1.05 of loiter turn radius, adding extra heading buffer to compensate for potential overshooting on initial turn.

The current “breakout” logic is unintuitive, and possibly unnecessary for "next" waypoints within between 1->1.05 of the loiter turn radius since it is in fact possible to point at that waypoint, though admittedly more difficult. Though overshooting does have more impact on “next” waypoints within 1->1.05 of loiter turn radius, a perhaps more correct approach is to increase threshold in this case, not to enforce breakout logic.

Without change, clean turn into turn requested, but breakout logic enforced
![Screenshot 2024-01-11 at 2 44 31 PM](https://github.com/ArduPilot/ardupilot/assets/56382146/8f082865-e021-4571-a34e-c1120d8a0479)

With change - no overshooting
<img width="528" alt="Screenshot 2024-01-02 at 1 50 23 AM" src="https://github.com/ArduPilot/ardupilot/assets/56382146/49f4b8c3-bfc2-4b4d-bce6-377d5111bef2">
With change (radius decreased dramatically to cause overshooting). Note that now that breakout logic is not hit, it falls back to the default loopback logic. In the case of overshooting, the existing logic to increase tolerance on a loopback is sufficient to handle this without a shotgun approach of enforcing breakout logic for all “next” waypoints within 1->1.05.
![Screenshot 2024-01-11 at 2 45 45 PM](https://github.com/ArduPilot/ardupilot/assets/56382146/7af90426-d57e-4697-8838-c996247c544d)

Notes:
1.  I chose 20 degrees so as to keep things aligned with the 10 deg increments, but I have noticed as low as 15 degrees performs just fine as well. It is a balance between having a stringent heading check which gives higher accuracy of when the plane actually leaves the loiter, but with bad overshooting performance vs looser heading check which gives lower accuracy of when the acceptance criteria is hit, but better overshooting performance. perhaps this should be eventually configurable/allowable to be turned on/off with heading_required, see below.
3. My primary interest is to be able to fly the path above, this seemed like the lowest lift change to expand ArduPlane's capability. Alternatively - merging https://github.com/ArduPilot/ardupilot/pull/25873 and adding respecting of the [heading required](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TURNS) field (if # of bits allows)  might also be an approach, if that is preferred to be explored by the maintainers.