### PR TITLE
AR_Motors: fix prearm for omni outputs

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -494,7 +494,8 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
        !have_throttle &&
        !SRV_Channels::function_assigned(SRV_Channel::k_steering) &&
        !SRV_Channels::function_assigned(SRV_Channel::k_scripting1) &&
-       !has_sail()) {
+       !has_sail() &&
+       !is_omni()) {
         if (report) {
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PreArm: no motor, sail or scripting outputs defined");
         }


### PR DESCRIPTION
This fix the prearm check for omni vehicle when only omni motors are defined.