### PR TITLE
AP_Networking: enable networking on macOS

### DIFF
--- a/libraries/AP_Networking/AP_Networking_Config.h
+++ b/libraries/AP_Networking/AP_Networking_Config.h
@@ -7,8 +7,8 @@
 
 
 #ifndef AP_NETWORKING_ENABLED
-#if defined(__APPLE__) || defined(__clang__)
-// MacOS can't build lwip, and clang fails on linux
+#if !defined(__APPLE__) && defined(__clang__)
+// clang fails on linux
 #define AP_NETWORKING_ENABLED 0
 #else
 #define AP_NETWORKING_ENABLED ((CONFIG_HAL_BOARD == HAL_BOARD_LINUX) || (CONFIG_HAL_BOARD == HAL_BOARD_SITL))

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -36,6 +36,23 @@ extern "C"
 {
 #endif
 
+/* macOS specific */
+#if defined(__APPLE__)
+/* lwip/contrib/ports/unix/port/netif/sio.c */
+#include <util.h>
+
+/* lwip/src/apps/http/makefsdata/makefsdata.c  */
+#define GETCWD(path, len)             getcwd(path, len)
+#define GETCWD_SUCCEEDED(ret)         (ret != NULL)
+#define CHDIR(path)                   chdir(path)
+#define CHDIR_SUCCEEDED(ret)          (ret == 0)
+
+/* lwip/src/netif/ppp/fsm.c */
+/* lwip/src/netif/ppp/pppos.c */
+/* lwip/src/netif/ppp/vj.c */
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 #ifdef LWIP_OPTTEST_FILE
 #include "lwipopts_test.h"
 #else /* LWIP_OPTTEST_FILE */

--- a/libraries/AP_Networking/wscript
+++ b/libraries/AP_Networking/wscript
@@ -8,9 +8,9 @@ def configure(cfg):
     if not cfg.env.BOARD_CLASS in ['SITL', 'LINUX', 'ChibiOS']:
         return
 
-    # networking doesn't build on MacOSX or clang
-    if platform.system() == 'Darwin' or 'clang++' in cfg.env.COMPILER_CXX:
-        return
+    # networking doesn't build with clang unless using macOS
+    if platform.system() != 'Darwin' and 'clang++' in cfg.env.COMPILER_CXX:
+       return
 
     extra_src = [
         'modules/lwip/src/core/*c',


### PR DESCRIPTION
Add config for macOS / clang to `lwipopts.h`.

- Replaces: https://github.com/ArduPilot/lwip/pull/1

### Testing

System
- macOS Sonoma 14.2.1
- Xcode 15.1 

1. Run the AP_DDS / UDP SITL tests on macOS (networking required for this to work because of Socket_native). 

2. PPP webserver test (following the rover auto test example) 

<img width="912" alt="ap-sitl-ppp-macos" src="https://github.com/ArduPilot/ardupilot/assets/24916364/9afeb5dd-1fb3-4660-a1a3-58c47d94ed54">

<img width="913" alt="ap-sitl-webserver-macos" src="https://github.com/ArduPilot/ardupilot/assets/24916364/e214faea-f9c4-48fa-8c69-6942901ae4a0">

3. DDS and webserver via PPP

- Update DDS_IPn params to the host / companion computer IP address
- Run the micro-ROS agent: 

```
ros2 launch ardupilot_sitl micro_ros_agent.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml verbose:=6
```

<img width="865" alt="ap-sitl-dds+webserver-macos" src="https://github.com/ArduPilot/ardupilot/assets/24916364/e17545bf-735f-46f6-904d-625ef264dcd2">
