### PR TITLE
Correct defines use in Bootloader code

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -109,6 +109,7 @@ int main(void)
         try_boot = false;
         timeout = 0;
     }
+#if AP_CHECK_FIRMWARE_ENABLED
     const auto ok = check_good_firmware();
     if (ok != check_fw_result_t::CHECK_FW_OK) {
         // bad firmware CRC, don't try and boot
@@ -116,6 +117,7 @@ int main(void)
         try_boot = false;
         led_set(LED_BAD_FW);
     }
+#endif  // AP_CHECK_FIRMWARE_ENABLED
 #ifndef BOOTLOADER_DEV_LIST
     else if (timeout != 0) {
         // fast boot for good firmware

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -22,6 +22,10 @@
 // optional uprintf() code for debug
 // #define BOOTLOADER_DEBUG SD1
 
+#ifndef AP_BOOTLOADER_ALWAYS_ERASE
+#define AP_BOOTLOADER_ALWAYS_ERASE 0
+#endif
+
 #if defined(BOOTLOADER_DEV_LIST)
 static BaseChannel *uarts[] = { BOOTLOADER_DEV_LIST };
 #if HAL_USE_SERIAL == TRUE
@@ -32,10 +36,6 @@ static uint8_t last_uart;
 
 #ifndef BOOTLOADER_BAUDRATE
 #define BOOTLOADER_BAUDRATE 115200
-#endif
-
-#ifndef AP_BOOTLOADER_ALWAYS_ERASE
-#define AP_BOOTLOADER_ALWAYS_ERASE 0
 #endif
 
 // #pragma GCC optimize("O0")


### PR DESCRIPTION
 - sometimes a method doesn't exist
 - a define was nested within another #if which it shouldn't have been
