### PR TITLE
RC_Channel: options in alphabetical order

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -104,146 +104,147 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DZ",   5, RC_Channel, dead_zone, 0),
 
+
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
     // @Values{Copter, Rover, Plane, Blimp}: 0:Do Nothing
+    // @Values{Copter, Rover, Plane}: 52:ACRO Mode
+    // @Values{Copter}: 70:ALTHOLD Mode
+    // @Values{Copter, Rover, Plane}: 16:AUTO Mode
+    // @Values{Copter}: 99:AUTO RTL
+    // @Values{Copter}: 17:AUTOTUNE Mode
+    // @Values{Copter}: 33:BRAKE Mode
+    // @Values{Copter,Rover,Plane}: 72:CIRCLE Mode
+    // @Values{Plane}: 150:CRUISE Mode
+    // @Values{Copter}: 73:DRIFT Mode
+    // @Values{Plane}: 92:FBWA Mode
     // @Values{Copter}: 2:FLIP Mode
-    // @Values{Copter}: 3:Simple Mode
+    // @Values{Copter}: 71:FLOWHOLD Mode
+    // @Values{Copter, Rover}: 57:FOLLOW Mode
+    // @Values{Copter, Rover, Plane}: 55:GUIDED Mode
+    // @Values{Rover}: 54:HOLD Mode
+    // @Values{Copter, Blimp}: 18:LAND Mode
+    // @Values{Copter, Rover, Plane}: 56:LOITER Mode
+    // @Values{Rover, Plane}: 51:MANUAL Mode
+    // @Values{Copter}: 69:POSHOLD Mode
+    // @Values{Plane}: 108:QRTL Mode
+    // @Values{Plane}: 170:QSTABILIZE Mode
     // @Values{Copter, Rover, Plane}: 4:RTL
+    // @Values{Rover}: 59:Simple Mode
+    // @Values{Copter, Rover}: 42:SMARTRTL Mode
+    // @Values{Copter}: 68:STABILIZE Mode
+    // @Values{Copter}: 76:STANDBY Mode
+    // @Values{Rover}: 53:STEERING Mode
+    // @Values{Plane}: 77:TAKEOFF Mode
+    // @Values{Copter}: 37:THROW Mode
+    // @Values{Plane}: 98:TRAINING Mode
+    // @Values{Copter}: 151:TURTLE Mode
+    // @Values{Copter}: 60:ZigZag Mode
+    // @Values{Copter}: 14:Acro Trainer
+    // @Values{Copter, Plane}: 38:ADSB Avoidance Enable
+    // @Values{Plane}: 210:Airbrakes
+    // @Values{Copter, Plane}: 84:AirMode
+    // @Values{Plane}: 91:Airspeed Ratio Calibration
+    // @Values{Copter, Rover, Plane}: 165:Arm/Emergency Motor Stop
+    // @Values{Blimp}: 153:ArmDisarm
+    // @Values{Copter, Rover, Plane}: 153:ArmDisarm (4.2 and higher)
+    // @Values{Copter}: 154:ArmDisarm with AirMode  (4.2 and higher)
+    // @Values{Plane}: 154:ArmDisarm with Quadplane AirMode (4.2 and higher)
+    // @Values{Copter, Rover, Plane}: 41:ArmDisarm (4.1 and lower)
+    // @Values{Copter}: 26:AttCon Accel Limits
+    // @Values{Copter}: 25:AttCon Feed Forward
+    // @Values{Copter, Rover, Plane}: 24:Auto Mission Reset
+    // @Values{Copter, Rover, Plane, Blimp}: 172:Battery MPPT Enable
+    // @Values{Copter, Rover, Plane, Blimp}: 171:Calibrate Compasses
+    // @Values{Copter, Rover, Plane, Blimp}: 174:Camera Image Tracking
+    // @Values{Copter, Rover, Plane, Blimp}: 175:Camera Lens
+    // @Values{Copter, Rover, Plane}: 102:Camera Mode Toggle
+    // @Values{Copter, Rover, Plane, Blimp}: 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus
+    // @Values{Copter, Rover, Plane}: 9:Camera Trigger
+    // @Values{Copter, Rover, Plane}: 58:Clear Waypoints
+    // @Values{Copter, Rover, Plane}: 62:Compass Learn
+    // @Values{Plane}: 87:Crow Select
+    // @Values{Rover, Plane}: 106:Disable Airspeed Use
+    // @Values{Copter, Rover, Plane, Blimp}: 81:Disarm
+    // @Values{Copter, Rover, Plane, Blimp}: 90:EKF Pos Source
+    // @Values{Plane}: 107:Enable FW Autotune
+    // @Values{Plane}: 95:FBWA taildragger takeoff mode
+    // @Values{Copter, Rover, Plane}: 11:Fence Enable
+    // @Values{Copter, Rover, Plane}: 162:FFT Tune
+    // @Values{Rover, Plane}:  208:Flap
+    // @Values{Plane}: 157:Force FS Action to FBWA
+    // @Values{Copter}: 159:Force IS_Flying
+    // @Values{Copter, Plane}: 85:Generator
+    // @Values{Copter, Rover}: 19:Gripper Release
+    // @Values{Copter, Plane}: 43:InvertedFlight Enable
+    // @Values{Plane}: 89:Landing Flare
+    // @Values{Copter, Plane}: 29:Landing Gear
+    // @Values{Rover}: 50:LearnCruise Speed
+    // @Values{Copter}: 30:Lost Copter Sound
+    // @Values{Plane}: 30:Lost Plane Sound
+    // @Values{Rover}: 30:Lost Rover Sound
+    // @Values{Rover}: 207:MainSail
+    // @Values{Copter, Rover, Plane}: 31:Motor Emergency Stop
+    // @Values{Copter}: 32:Motor Interlock
+    // @Values{Copter, Rover, Plane}: 163:Mount Lock
+    // @Values{Copter, Rover, Plane}: 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw
+    // @Values{Plane}: 86:Non Auto Terrain Follow Disable
+    // @Values{Copter, Plane}: 158:Optflow Calibration
+    // @Values{Copter}: 23:Parachute 3pos
+    // @Values{Copter}: 21:Parachute Enable
+    // @Values{Copter, Plane}: 22:Parachute Release
+    // @Values{Copter, Rover, Plane, Blimp}: 164:Pause Stream Logging
+    // @Values{Rover}: 202:Pitch
+    // @Values{Plane}: 173:Plane AUTO Mode Landing Abort
+    // @Values{Copter}: 39:PrecLoiter Enable
+    // @Values{Copter, Rover}: 40:Proximity Avoidance Enable
+    // @Values{Plane}: 82:QAssist 3pos
+    // @Values{Plane}: 176:Quadplane Fwd Throttle Override enable
+    // @Values{Copter}: 10:RangeFinder Enable
+    // @Values{Copter, Rover, Plane, Blimp}: 46:RC Override Enable
+    // @Values{Copter, Rover, Plane}: 28:Relay On/Off
+    // @Values{Copter, Rover, Plane}: 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off
+    // @Values{Copter, Rover, Plane}: 66:Relay5 On/Off, 67:Relay6 On/Off
+    // @Values{Copter, Rover, Plane}: 27:Retract Mount1
+    // @Values{Plane}: 64:Reverse Throttle
+    // @Values{Rover}: 201:Roll
+    // @Values{Copter, Rover, Plane}: 78:RunCam Control
+    // @Values{Copter, Rover, Plane}: 79:RunCam OSD Control
+    // @Values{Rover}: 74:Sailboat motoring 3pos
+    // @Values{Rover}: 63:Sailboat Tack
     // @Values{Copter}: 5:Save Trim
     // @Values{Rover}: 5:Save Trim (4.1 and lower)
     // @Values{Copter, Rover}: 7:Save WP
-    // @Values{Copter, Rover, Plane}: 9:Camera Trigger
-    // @Values{Copter}: 10:RangeFinder Enable
-    // @Values{Copter, Rover, Plane}: 11:Fence Enable
-    // @Values{Copter}: 13:Super Simple Mode
-    // @Values{Copter}: 14:Acro Trainer
+    // @Values{Copter, Rover, Plane}: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Plane}: 155:Set roll pitch and yaw trim to current servo and RC
+    // @Values{Rover}: 155:Set steering trim to current servo and RC
+    // @Values{Copter}: 152:SIMPLE heading reset
+    // @Values{Copter}: 3:Simple Mode
+    // @Values{Plane}: 88:Soaring Enable
     // @Values{Copter}: 15:Sprayer Enable
-    // @Values{Copter, Rover, Plane}: 16:AUTO Mode
-    // @Values{Copter}: 17:AUTOTUNE Mode
-    // @Values{Copter, Blimp}: 18:LAND Mode
-    // @Values{Copter, Rover}: 19:Gripper Release
-    // @Values{Copter}: 21:Parachute Enable
-    // @Values{Copter, Plane}: 22:Parachute Release
-    // @Values{Copter}: 23:Parachute 3pos
-    // @Values{Copter, Rover, Plane}: 24:Auto Mission Reset
-    // @Values{Copter}: 25:AttCon Feed Forward
-    // @Values{Copter}: 26:AttCon Accel Limits
-    // @Values{Copter, Rover, Plane}: 27:Retract Mount1
-    // @Values{Copter, Rover, Plane}: 28:Relay On/Off
-    // @Values{Copter, Plane}: 29:Landing Gear
-    // @Values{Copter}: 30:Lost Copter Sound
-    // @Values{Rover}: 30:Lost Rover Sound
-    // @Values{Plane}: 30:Lost Plane Sound
-    // @Values{Copter, Rover, Plane}: 31:Motor Emergency Stop
-    // @Values{Copter}: 32:Motor Interlock
-    // @Values{Copter}: 33:BRAKE Mode
-    // @Values{Copter, Rover, Plane}: 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off
-    // @Values{Copter}: 37:THROW Mode
-    // @Values{Copter, Plane}: 38:ADSB Avoidance Enable
-    // @Values{Copter}: 39:PrecLoiter Enable
-    // @Values{Copter, Rover}: 40:Proximity Avoidance Enable
-    // @Values{Copter, Rover, Plane}: 41:ArmDisarm (4.1 and lower)
-    // @Values{Copter, Rover}: 42:SMARTRTL Mode
-    // @Values{Copter, Plane}: 43:InvertedFlight Enable
-    // @Values{Copter}: 44:Winch Enable, 45:Winch Control
-    // @Values{Copter, Rover, Plane, Blimp}: 46:RC Override Enable
-    // @Values{Copter}: 47:User Function 1, 48:User Function 2, 49:User Function 3
-    // @Values{Rover}: 50:LearnCruise Speed
-    // @Values{Rover, Plane}: 51:MANUAL Mode
-    // @Values{Copter, Rover, Plane}: 52:ACRO Mode
-    // @Values{Rover}: 53:STEERING Mode
-    // @Values{Rover}: 54:HOLD Mode
-    // @Values{Copter, Rover, Plane}: 55:GUIDED Mode
-    // @Values{Copter, Rover, Plane}: 56:LOITER Mode
-    // @Values{Copter, Rover}: 57:FOLLOW Mode
-    // @Values{Copter, Rover, Plane}: 58:Clear Waypoints
-    // @Values{Rover}: 59:Simple Mode
-    // @Values{Copter}: 60:ZigZag Mode
-    // @Values{Copter}: 61:ZigZag SaveWP
-    // @Values{Copter, Rover, Plane}: 62:Compass Learn
-    // @Values{Rover}: 63:Sailboat Tack
-    // @Values{Plane}: 64:Reverse Throttle
-    // @Values{Copter, Rover, Plane, Blimp}: 65:GPS Disable
-    // @Values{Copter, Rover, Plane}: 66:Relay5 On/Off, 67:Relay6 On/Off
-    // @Values{Copter}: 68:STABILIZE Mode
-    // @Values{Copter}: 69:POSHOLD Mode
-    // @Values{Copter}: 70:ALTHOLD Mode
-    // @Values{Copter}: 71:FLOWHOLD Mode
-    // @Values{Copter,Rover,Plane}: 72:CIRCLE Mode
-    // @Values{Copter}: 73:DRIFT Mode
-    // @Values{Rover}: 74:Sailboat motoring 3pos
+    // @Values{Copter}: 13:Super Simple Mode
     // @Values{Copter}: 75:SurfaceTrackingUpDown
-    // @Values{Copter}: 76:STANDBY Mode
-    // @Values{Plane}: 77:TAKEOFF Mode
-    // @Values{Copter, Rover, Plane}: 78:RunCam Control
-    // @Values{Copter, Rover, Plane}: 79:RunCam OSD Control
+    // @Values{Copter,Plane,Rover,Blimp,Sub,Tracker}: 112:SwitchExternalAHRS
+    // @Values{Rover}: 156:Torqeedo Clear Err
+    // @Values{Plane}: 96:Trigger re-reading of mode switch
+    // @Values{Copter}: 161:Turbine Start(heli)
+    // @Values{Copter}: 109:use Custom Controller
+    // @Values{Copter}: 47:User Function 1, 48:User Function 2, 49:User Function 3
     // @Values{Copter}: 80:VisOdom Align
     // @Values{Rover}: 80:VisoOdom Align
-    // @Values{Copter, Rover, Plane, Blimp}: 81:Disarm
-    // @Values{Plane}: 82:QAssist 3pos
-    // @Values{Copter}: 83:ZigZag Auto
-    // @Values{Copter, Plane}: 84:AirMode
-    // @Values{Copter, Plane}: 85:Generator
-    // @Values{Plane}: 86:Non Auto Terrain Follow Disable
-    // @Values{Plane}: 87:Crow Select
-    // @Values{Plane}: 88:Soaring Enable
-    // @Values{Plane}: 89:Landing Flare
-    // @Values{Copter, Rover, Plane, Blimp}: 90:EKF Pos Source
-    // @Values{Plane}: 91:Airspeed Ratio Calibration
-    // @Values{Plane}: 92:FBWA Mode
-    // @Values{Copter, Rover, Plane}: 94:VTX Power
-    // @Values{Plane}: 95:FBWA taildragger takeoff mode
-    // @Values{Plane}: 96:Trigger re-reading of mode switch
-    // @Values{Rover}: 97:Windvane home heading direction offset
-    // @Values{Plane}: 98:TRAINING Mode
-    // @Values{Copter}: 99:AUTO RTL
-    // @Values{Copter, Rover, Plane, Blimp}: 100:KillIMU1, 101:KillIMU2
-    // @Values{Copter, Rover, Plane}: 102:Camera Mode Toggle
-    // @Values{Copter, Rover, Plane}: 105:GPS Disable Yaw
-    // @Values{Rover, Plane}: 106:Disable Airspeed Use
-    // @Values{Plane}: 107:Enable FW Autotune
-    // @Values{Plane}: 108:QRTL Mode
-    // @Values{Copter}: 109:use Custom Controller
-    // @Values{Copter, Rover, Plane, Blimp}:  110:KillIMU3
-    // @Values{Copter,Plane,Rover,Blimp,Sub,Tracker}: 112:SwitchExternalAHRS
-    // @Values{Plane}: 150:CRUISE Mode
-    // @Values{Copter}: 151:TURTLE Mode
-    // @Values{Copter}: 152:SIMPLE heading reset
-    // @Values{Copter, Rover, Plane}: 153:ArmDisarm (4.2 and higher)
-    // @Values{Blimp}: 153:ArmDisarm
-    // @Values{Copter}: 154:ArmDisarm with AirMode  (4.2 and higher)
-    // @Values{Plane}: 154:ArmDisarm with Quadplane AirMode (4.2 and higher)
-    // @Values{Rover}: 155:Set steering trim to current servo and RC
-    // @Values{Plane}: 155:Set roll pitch and yaw trim to current servo and RC
-    // @Values{Rover}: 156:Torqeedo Clear Err
-    // @Values{Plane}: 157:Force FS Action to FBWA
-    // @Values{Copter, Plane}: 158:Optflow Calibration
-    // @Values{Copter}: 159:Force IS_Flying
-    // @Values{Plane}: 160:Weathervane Enable
-    // @Values{Copter}: 161:Turbine Start(heli)
-    // @Values{Copter, Rover, Plane}: 162:FFT Tune
-    // @Values{Copter, Rover, Plane}: 163:Mount Lock
-    // @Values{Copter, Rover, Plane, Blimp}: 164:Pause Stream Logging
-    // @Values{Copter, Rover, Plane}: 165:Arm/Emergency Motor Stop
-    // @Values{Copter, Rover, Plane, Blimp}: 166:Camera Record Video, 167:Camera Zoom, 168:Camera Manual Focus, 169:Camera Auto Focus
-    // @Values{Plane}: 170:QSTABILIZE Mode
-    // @Values{Copter, Rover, Plane, Blimp}: 171:Calibrate Compasses
-    // @Values{Copter, Rover, Plane, Blimp}: 172:Battery MPPT Enable
-    // @Values{Plane}: 173:Plane AUTO Mode Landing Abort
-    // @Values{Copter, Rover, Plane, Blimp}: 174:Camera Image Tracking
-    // @Values{Copter, Rover, Plane, Blimp}: 175:Camera Lens
-    // @Values{Plane}: 176:Quadplane Fwd Throttle Override enable
-    // @Values{Rover}: 201:Roll
-    // @Values{Rover}: 202:Pitch
-    // @Values{Rover}: 207:MainSail
-    // @Values{Rover, Plane}:  208:Flap
     // @Values{Plane}: 209:VTOL Forward Throttle
-    // @Values{Plane}: 210:Airbrakes
+    // @Values{Copter, Rover, Plane}: 94:VTX Power
     // @Values{Rover}: 211:Walking Height
-    // @Values{Copter, Rover, Plane}: 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw
-    // @Values{Copter, Rover, Plane}: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8
+    // @Values{Plane}: 160:Weathervane Enable
+    // @Values{Copter}: 44:Winch Enable, 45:Winch Control
+    // @Values{Rover}: 97:Windvane home heading direction offset
+    // @Values{Copter}: 83:ZigZag Auto
+    // @Values{Copter}: 61:ZigZag SaveWP
+    // @Values{Copter, Rover, Plane, Blimp}: 65:GPS Disable
+    // @Values{Copter, Rover, Plane}: 105:GPS Disable Yaw
+    // @Values{Copter, Rover, Plane, Blimp}: 100:KillIMU1, 101:KillIMU2
+    // @Values{Copter, Rover, Plane, Blimp}:  110:KillIMU3
     // @User: Standard
     AP_GROUPINFO_FRAME("OPTION",  6, RC_Channel, option, 0, AP_PARAM_FRAME_COPTER|AP_PARAM_FRAME_ROVER|AP_PARAM_FRAME_PLANE|AP_PARAM_FRAME_BLIMP),
 


### PR DESCRIPTION
Our list of RCx_OPTION parameter values is very long and users struggle to find what they are looking for.

This PR reorders them mostly in alphabetical order with some exceptions:

1. "Do Nothing" remains at the top
2. Flight modes are at the top
3. Developer only items (or perhaps dangerous options) are right at the bottom including (e.g. "GPS Disable", "KillIMU")

There are some small issues that I could have fixed but put off for a follow-up PR to keep it easier to verify and merge:

a. some lines still have multiple items on them (e.g. "300:Scripting1, 301:Scripting2.." and "166:Camera Record Video, 167:Camera Zoom)
b. some items are badly named, (e.g. "use Custom Controller")
c. some are used to define the channel is used for control (e.g. Roll, Walking Height).  We could group these, perhaps below the modes

I have carefully verified that no items have been lost in this change.  I asked ChatGPT to do it first but it failed so I resorted to a spreadsheet with multiple cross checks.
