### PR TITLE
CRSF device info checks

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -95,6 +95,10 @@ public:
         return true;
     }
 
+    bool is_detected() const {
+        return frontend._detected_protocol != AP_RCProtocol::NONE && frontend.backend[frontend._detected_protocol] == this;
+    }
+
 #if AP_VIDEOTX_ENABLED
     // called by static methods to confiig video transmitters:
     static void configure_vtx(uint8_t band, uint8_t channel, uint8_t power, uint8_t pitmode);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -302,7 +302,7 @@ void AP_RCProtocol_CRSF::update(void)
 
     // never received RC frames, but have received CRSF frames so make sure we give the telemetry opportunity to run
     uint32_t now = AP_HAL::micros();
-    if (_last_frame_time_us > 0 && (!get_rc_frame_count() || !is_tx_active())
+    if (_last_frame_time_us > 0 && (!get_rc_input_count() || !is_tx_active())
         && now - _last_frame_time_us > CRSF_INTER_FRAME_TIME_US_250HZ) {
         process_telemetry(false);
         _last_frame_time_us = now;

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -185,8 +185,13 @@ bool AP_CRSF_Telem::process_rf_mode_changes()
     if (crsf != nullptr) {
         uart = crsf->get_UART();
     }
+
     if (uart == nullptr) {
         return true;
+    }
+
+    if (!crsf->is_detected()) {
+        return false;
     }
     // not ready yet
     if (!uart->is_initialized()) {
@@ -402,11 +407,11 @@ bool AP_CRSF_Telem::is_packet_ready(uint8_t idx, bool queue_empty)
     case GENERAL_COMMAND:
         return _baud_rate_request.pending;
     case VERSION_PING:
-        return _crsf_version.pending;
+        return _crsf_version.pending && AP::crsf()->is_detected(); // only send pings if protocol has been detected
     case HEARTBEAT:
         return true; // always send heartbeat if enabled
     case DEVICE_PING:
-        return !_crsf_version.pending; // only send pings if version has been negotiated
+        return !_crsf_version.pending;  // only send pings if version has been negotiated
     default:
         return _enable_telemetry;
     }

--- a/libraries/AP_RCTelemetry/AP_GHST_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_GHST_Telem.cpp
@@ -111,8 +111,13 @@ bool AP_GHST_Telem::process_rf_mode_changes()
     if (ghost != nullptr) {
         uart = ghost->get_UART();
     }
+
     if (uart == nullptr) {
         return true;
+    }
+
+    if (!ghost->is_detected()) {
+        return false;
     }
     // not ready yet
     if (!uart->is_initialized()) {


### PR DESCRIPTION
This removes the CRSF version spam that you can get while protocol detection is going on. With this change CRSF will only ping for versions and make rf changes if the front end protocol has been detected.