### PR TITLE
hwdef: correct compilation of revo-mini-sd

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-sd/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-sd/hwdef.dat
@@ -17,12 +17,8 @@ undef HAL_LOGGING_DATAFLASH_ENABLED
 # filesystem setup on sdcard
 define HAL_OS_FATFS_IO 1
 
-# disable SMBUS monitors to save flash
-define AP_BATTERY_SMBUS_ENABLED 0
-
 # disable parachute and sprayer to save flash
 define HAL_PARACHUTE_ENABLED 0
-define HAL_SPRAYER_ENABLED 0
 
 # reduce max size of embedded params for apj_tool.py
 define AP_PARAM_MAX_EMBEDDED_PARAM 1024
@@ -30,5 +26,3 @@ define HAL_GYROFFT_ENABLED 0
 
 # save some flash
 include ../include/save_some_flash.inc
-
-define AP_GRIPPER_ENABLED 0


### PR DESCRIPTION
this isn't built on the firmware server, so we won't notice when it dies

In this case the SMBUS batter define was being set differently

Also remove some redundant defines which come from includes anyway