### PR TITLE
hwdef: remove un-needed AP_PARAM_MAX_EMBEDDED_PARAM default

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/hwdef.dat
@@ -157,8 +157,6 @@ define HAL_BATT_CURR_SCALE 26.7
 #define BOARD_RSSI_ANA_PIN 8
 #define HAL_DEFAULT_AIRSPEED_PIN 10
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_WITH_DSP FALSE
 define HAL_GYROFFT_ENABLED 0
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A/hwdef.dat
@@ -149,8 +149,6 @@ define HAL_OSD_TYPE_DEFAULT 1
 # Font for OSD
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
-# -------reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_GYROFFT_ENABLED 0
 
 # --------------------- save flash ----------------------

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
@@ -164,6 +164,3 @@ define HAL_MSP_ENABLED 1
 # need to probe external baros even 'though we're minimised:
 undef AP_BARO_PROBE_EXTERNAL_I2C_BUSES
 define AP_BARO_PROBE_EXTERNAL_I2C_BUSES 1
-
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/hwdef.dat
@@ -156,9 +156,6 @@ define STM32_PWM_USE_ADVANCED TRUE
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
 define HAL_MOUNT_ENABLED 0
 
 # save some flash

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-CAN/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-CAN/hwdef.dat
@@ -170,9 +170,4 @@ undef AP_BATTERY_SMBUS_ENABLED
 define AP_BATTERY_SMBUS_ENABLED 0
 define HAL_PARACHUTE_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
-
-
 define DEFAULT_NTF_LED_TYPES 487

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-TE/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-TE/hwdef.dat
@@ -170,8 +170,6 @@ define HAL_BATT_CURR_SCALE 66.7
 define BOARD_RSSI_ANA_PIN 8
 define HAL_DEFAULT_AIRSPEED_PIN 10
 
-# -------reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_GYROFFT_ENABLED 0
 
 # --------------------- save flash ----------------------

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -182,8 +182,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 
 define STM32_PWM_USE_ADVANCED TRUE
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_GYROFFT_ENABLED 0
 
 # save some flash

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
@@ -160,9 +160,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
 # save some flash
 include ../include/save_some_flash.inc
 include ../include/minimize_fpv_osd.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/hwdef.dat
@@ -169,8 +169,6 @@ PC13 PINIO1 OUTPUT GPIO(81) LOW
 
 define STM32_PWM_USE_ADVANCED TRUE
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_WITH_DSP FALSE
 
 # save some flash

--- a/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
@@ -128,9 +128,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
 # minimal drivers to reduce flash usage
 include ../include/minimize_fpv_osd.inc
 include ../include/no_bootloader_DFU.inc

--- a/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VRUBrain-v51/hwdef.dat
@@ -136,8 +136,6 @@ FLASH_RESERVE_START_KB 64
 # enable RAMTROM parameter storage
 #define HAL_WITH_RAMTRON 1
 
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
 # enable FAT filesystem
 define HAL_OS_FATFS_IO 1
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
@@ -154,9 +154,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
-
 # save some flash
 include ../include/save_some_flash.inc
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-sd/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/revo-mini-sd/hwdef.dat
@@ -24,8 +24,6 @@ define AP_BATTERY_SMBUS_ENABLED 0
 define HAL_PARACHUTE_ENABLED 0
 define HAL_SPRAYER_ENABLED 0
 
-# reduce max size of embedded params for apj_tool.py
-define AP_PARAM_MAX_EMBEDDED_PARAM 1024
 define HAL_GYROFFT_ENABLED 0
 
 # save some flash


### PR DESCRIPTION
these boards have <= 1024, and we have code in place which defaults this value tto 1024