### PR TITLE
AP_ADSB: send absolute height in GPS packet to MXS device

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
@@ -692,7 +692,7 @@ void AP_ADSB_Sagetech_MXS::send_gps_msg()
     }
 
     int32_t height;
-    if (_frontend._my_loc.initialised() && _frontend._my_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, height)) {
+    if (_frontend._my_loc.initialised() && _frontend._my_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, height)) {
         gps.height = height * 0.01;
     } else {
         gps.height = 0.0;


### PR DESCRIPTION
Documentation specifies WGS-84 ellipsoid.

This work sponsored by Spektreworks
