### PR TITLE
Match thread stack pointer types to ChibiOS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
@@ -186,10 +186,10 @@ void stm32_flash_protect_flash(bool bootloader, bool protect);
 void stm32_flash_unprotect_flash(void);
 
 // allow stack view code to show free ISR stack
-extern uint32_t __main_stack_base__;
-extern uint32_t __main_stack_end__;
-extern uint32_t __main_thread_stack_base__;
-extern uint32_t __main_thread_stack_end__;
+extern stkalign_t __main_stack_base__;
+extern stkalign_t __main_stack_end__;
+extern stkalign_t __main_thread_stack_base__;
+extern stkalign_t __main_thread_stack_end__;
 
 #ifdef __cplusplus
 }

--- a/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
+++ b/libraries/AP_IOMCU/iofirmware/iofirmware.cpp
@@ -341,8 +341,8 @@ void AP_IOMCU_FW::init()
 
 #if CH_DBG_ENABLE_STACK_CHECK == TRUE
 static void stackCheck(uint16_t& mstack, uint16_t& pstack) {
-    extern uint32_t __main_stack_base__[];
-    extern uint32_t __main_stack_end__[];
+    extern stkalign_t __main_stack_base__[];
+    extern stkalign_t __main_stack_end__[];
     uint32_t stklimit = (uint32_t)__main_stack_end__;
     uint32_t stkbase  = (uint32_t)__main_stack_base__;
     uint32_t *crawl   = (uint32_t *)stkbase;
@@ -354,8 +354,8 @@ static void stackCheck(uint16_t& mstack, uint16_t& pstack) {
     chDbgAssert(free > 0, "mstack exhausted");
     mstack = (uint16_t)free;
 
-    extern uint32_t __main_thread_stack_base__[];
-    extern uint32_t __main_thread_stack_end__[];
+    extern stkalign_t __main_thread_stack_base__[];
+    extern stkalign_t __main_thread_stack_end__[];
     stklimit = (uint32_t)__main_thread_stack_end__;
     stkbase  = (uint32_t)__main_thread_stack_base__;
     crawl   = (uint32_t *)stkbase;


### PR DESCRIPTION
`__main_thread_stack_base__` and `__main_thread_stack_end__` are variables whose address is defined to be the corresponding part of the stack. These are declared as `extern stkalign_t` in ChibiOS code, and being declared as `extern uint32_t` in ArduPilot code creates a warning at link time when using LTO. Correct the declaration to eliminate this warning.

Also update `__main_stack_base__` and `__main_stack_end__` which don't currently trigger this warning but serve similar purposes and so might in the future.

The hardware expects an alignment of `stkalign_t` (which is 8 bytes) and the linker script defines the variable values with this alignment as well, so this is safe.

No code size or functional change.