### PR TITLE
Sort Values in RCn_OPTIONS in apm.pdef.xml

### DIFF
--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -65,7 +65,7 @@ DO NOT EDIT
             t += "<ul>\n"
 
             for field in param.__dict__.keys():
-                if field not in ['name', 'DisplayName', 'Description', 'User'] and field in known_param_fields:
+                if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         values = (param.__dict__[field]).split(',')
                         t += "<table><th>Value</th><th>Meaning</th>\n"

--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -56,7 +56,7 @@ class JSONEmit(Emit):
                 name = name.split(':')[1]
 
             # Remove various unwanted keys
-            for key in 'real_path', 'SortValues':
+            for key in 'real_path', 'SortValues', '__field_text':
                 try:
                     param.__dict__.pop(key)
                 except KeyError:

--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -55,9 +55,12 @@ class JSONEmit(Emit):
             if ':' in name:
                 name = name.split(':')[1]
 
-            # Remove real_path key
-            if 'real_path' in param.__dict__:
-                param.__dict__.pop('real_path')
+            # Remove various unwanted keys
+            for key in 'real_path', 'SortValues':
+                try:
+                    param.__dict__.pop(key)
+                except KeyError:
+                    pass
 
             # Get range section if available
             range_json = {}

--- a/Tools/autotest/param_metadata/mdemit.py
+++ b/Tools/autotest/param_metadata/mdemit.py
@@ -90,7 +90,7 @@ class MDEmit(Emit):
             t += "\n\n%s" % param.Description
             
             for field in param.__dict__.keys():
-                if field not in ['name', 'DisplayName', 'Description', 'User'] and field in known_param_fields:
+                if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         values = (param.__dict__[field]).split(',')
                         t += "\n\n|Value|Meaning|"

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -51,6 +51,7 @@ known_param_fields = [
              'ReadOnly',
              'Calibration',
              'Vector3Parameter',
+             'SortValues'
                       ]
 
 # Follow SI units conventions from:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -263,7 +263,7 @@ This list is automatically generated from the latest ardupilot source code, and 
             headings = []
             row = []
             for field in sorted(param.__dict__.keys()):
-                if (field not in ['name', 'DisplayName', 'Description', 'User', 'RebootRequired'] and
+                if (field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues', 'RebootRequired'] and
                         field in known_param_fields):
                     headings.append(field)
                     if field in field_table_info and Emit.prog_values_field.match(param.__dict__[field]):

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -2,6 +2,7 @@ from lxml import etree
 
 from emit import Emit
 from param import known_param_fields, known_units
+import re
 
 # Emit ArduPilot documentation in an machine readable XML format
 class XmlEmit(Emit):
@@ -30,6 +31,18 @@ class XmlEmit(Emit):
     def start_libraries(self):
         self.current_element = self.libraries
 
+    def sorted_Values_keys(self, nv_pairs, zero_at_top=False):
+        '''sorts name/value pairs derived from items in @Values.  Sorts by
+        value, with special attention paid to common "Do nothing" values'''
+        keys = nv_pairs.keys()
+        def sort_key(value):
+            description = nv_pairs[value]
+            if zero_at_top and value == "0":
+                # make sure this item goes at the top of the list:
+                return "AAAAAAA"
+            return description
+        return sorted(keys, key=sort_key)
+
     def emit(self, g):
         xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.reference)  # i.e. ArduPlane
 
@@ -50,17 +63,36 @@ class XmlEmit(Emit):
 
             # Add values as chidren of this node
             for field in param.__dict__.keys():
-                if field not in ['name', 'DisplayName', 'Description', 'User'] and field in known_param_fields:
+                if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         xml_values = etree.SubElement(xml_param, 'values')
                         values = (param.__dict__[field]).split(',')
+                        nv_unsorted = {}
                         for value in values:
                             v = value.split(':')
                             if len(v) != 2:
                                 raise ValueError("Bad value (%s)" % v)
                             # i.e. numeric value, string label
-                            xml_value = etree.SubElement(xml_values, 'value', code=v[0])
-                            xml_value.text = v[1]
+                            if v[0] in nv_unsorted:
+                                raise ValueError("%s already exists" % v[0])
+                            nv_unsorted[v[0]] = v[1]
+
+                        all_keys = nv_unsorted.keys()
+                        if hasattr(param, 'SortValues'):
+                            sort = getattr(param, 'SortValues').lower()
+                            zero_at_top = False
+                            if sort == 'alphabeticalzeroattop':
+                                zero_at_top = True
+                            else:
+                                raise ValueError("Unknown sort (%s)" % sort)
+
+                            all_keys = self.sorted_Values_keys(nv_unsorted, zero_at_top=zero_at_top)
+
+                        for key in all_keys:
+                            value = nv_unsorted[key]
+
+                            xml_value = etree.SubElement(xml_values, 'value', code=key)
+                            xml_value.text = value
 
                     elif field == 'Units':
                         abreviated_units = param.__dict__[field]

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -107,6 +107,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: OPTION
     // @DisplayName: RC input option
     // @Description: Function assigned to this RC channel
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values{Copter, Rover, Plane, Blimp}: 0:Do Nothing
     // @Values{Copter}: 2:FLIP Mode
     // @Values{Copter}: 3:Simple Mode


### PR DESCRIPTION
This is an alternative to PR https://github.com/ArduPilot/ardupilot/pull/25963 and adds support for a new "@SortValues : AlphabeticalZeroAtTop" parameter description and this new definition has been added for the RCn_OPTION parameters.

Once merged this will affect the apm.pdef.xml files that are found [here for Copter](https://autotest.ardupilot.org/Parameters/ArduCopter/).

This PR does not change the "emitter" that produces the html files for the wiki.  E.g. the RCn_OPTION sorting on our wiki [here](https://ardupilot.org/copter/docs/parameters.html#rc1-option-rc-input-option) is unaffected.

As a drive-by we also fixed an existing bug in the JSON emitter that was producing unnecessary "__field_text" entries.  Open [this file](https://autotest.ardupilot.org/Parameters/ArduCopter/apm.pdef.json) and drill down a few levels on any item to see the problem.

This has been tested to confirm other emitters were not affected.

Below is an example of what the RCn_OPTION param descriptions look like:

```
      <param humanName="RC input option" name="RC3_OPTION" documentation="Function assigned to this RC channel" user="Standard">
        <field name="SortValues">AlphabeticalZeroAtTop</field>
        <values>
          <value code="0">Do Nothing</value>
          <value code="52">ACRO Mode</value>
          <value code="38">ADSB Avoidance Enable</value>
          <value code="70">ALTHOLD Mode</value>
          <value code="16">AUTO Mode</value>
          <value code="99">AUTO RTL</value>
          <value code="17">AUTOTUNE Mode</value>
          <value code="14">Acro Trainer</value>
          <value code="84">AirMode</value>
          <value code="165">Arm/Emergency Motor Stop</value>
          <value code="41">ArmDisarm (4.1 and lower)</value>
          <value code="153">ArmDisarm (4.2 and higher)</value>
          <value code="154">ArmDisarm with AirMode  (4.2 and higher)</value>
          <value code="26">AttCon Accel Limits</value>
          <value code="25">AttCon Feed Forward</value>
          <value code="24">Auto Mission Reset</value>
          <value code="33">BRAKE Mode</value>
          <value code="172">Battery MPPT Enable</value>
          <value code="72">CIRCLE Mode</value>
          <value code="171">Calibrate Compasses</value>
          <value code="169">Camera Auto Focus</value>
```
