### PR TITLE
AP_HAL_SITL: allow sim_vehicle.py -I to work again

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -663,7 +663,7 @@ void SITL_State::multicast_state_open(void)
     }
 
     sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-    sockaddr.sin_port = htons(SITL_SERVO_PORT);
+    sockaddr.sin_port = htons(SITL_SERVO_PORT + _instance);
 
     ret = bind(servo_in_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (ret == -1) {


### PR DESCRIPTION
... or at least not die instantly because instance-0 has bound this port


I don't know what a complete fix for this looks like, as peripherals also do instance numbers.

Perhaps the "fix" is to only bind this port on instance 0; no owrry about which vehicle a peripheral needs to listen to to get its servo data then...
