### PR TITLE
AP_Relay: pre-arm check for pin conflicts between relays.

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -472,6 +472,18 @@ bool AP_Relay::arming_checks(size_t buflen, char *buffer) const
             }
             return false;
         }
+
+        // Each pin can only be used by a single relay
+        for (uint8_t j=i+1; j<ARRAY_SIZE(_params); j++) {
+            if (!function_valid((AP_Relay_Params::FUNCTION)_params[j].function.get())) {
+                // Relay disabled
+                continue;
+            }
+            if (pin == _params[j].pin.get()) {
+                hal.util->snprintf(buffer, buflen, "pin conflict RELAY%u_PIN = RELAY%u_PIN", int(i+1), int(j+1));
+                return false;
+            }
+        }
     }
     return true;
 }


### PR DESCRIPTION
This adds a pre-arm check for conflicting pins between two relays. If the user has two functions using the same pin neither will work as expected. This could be especially bad if the pin for something critical is also used by some thing trivial, for example parachute and camera trigger.

