### PR TITLE
AP_Relay: use correct define for DroneCAN relay

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -12,6 +12,7 @@
 #include "AP_Relay.h"
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -646,7 +646,7 @@ bool AP_Relay::send_relay_status(const GCS_MAVLINK &link) const
     uint16_t present_mask = 0;
     uint16_t on_mask = 0;
     for (uint8_t i=0; i<ARRAY_SIZE(_params); i++) {
-        if (!enabled(i)) {
+        if (!function_valid(_params[i].function)) {
             continue;
         }
         const uint16_t relay_bit_mask = 1U << i;

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -15,7 +15,6 @@
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Relay/AP_Relay_Params.h>
-#include <AP_Common/Bitmask.h>
 
 #ifndef AP_RELAY_NUM_RELAYS
   #define AP_RELAY_NUM_RELAYS 6

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -95,7 +95,7 @@ private:
     // Get relay state from pin number
     bool get_pin(const int16_t pin) const;
 
-#if HAL_ENABLE_DRONECAN_DRIVERS
+#if AP_RELAY_DRONECAN_ENABLED
     // Virtual DroneCAN pins
     class DroneCAN {
     public:
@@ -130,7 +130,7 @@ private:
         } state[num_pins];
 
     } dronecan;
-#endif // HAL_ENABLE_DRONECAN_DRIVERS
+#endif // AP_RELAY_DRONECAN_ENABLED
 
 };
 

--- a/libraries/AP_Relay/AP_Relay_Params.h
+++ b/libraries/AP_Relay/AP_Relay_Params.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AP_Param/AP_Param.h>
-#include "AP_Relay_config.h"
 
 class AP_Relay_Params {
 public:


### PR DESCRIPTION
I missed this one when adding `AP_RELAY_DRONECAN_ENABLED` in https://github.com/ArduPilot/ardupilot/pull/25862. 