### PR TITLE
Plane: ask mode if battery voltage compensation should be done

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -290,3 +290,35 @@ bool Mode::use_throttle_limits() const
 
     return true;
 }
+
+// true if voltage correction should be applied to throttle
+bool Mode::use_battery_compensation() const
+{
+#if AP_SCRIPTING_ENABLED
+    if (plane.nav_scripting_active()) {
+        return false;
+    }
+#endif
+
+    if (this == &plane.mode_stabilize ||
+        this == &plane.mode_training ||
+        this == &plane.mode_acro ||
+        this == &plane.mode_fbwa ||
+        this == &plane.mode_autotune) {
+        // a manual throttle mode
+        return false;
+    }
+
+    if (is_guided_mode() && plane.guided_throttle_passthru) {
+        // manual pass through of throttle while in GUIDED
+        return false;
+    }
+
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.in_vtol_mode()) {
+        return false;
+    }
+#endif
+
+    return true;
+}

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -138,6 +138,9 @@ public:
     // true if throttle min/max limits should be applied
     bool use_throttle_limits() const;
 
+    // true if voltage correction should be applied to throttle
+    bool use_battery_compensation() const;
+
 protected:
 
     // subclasses override this to perform checks before entering the mode

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -614,8 +614,9 @@ void Plane::set_throttle(void)
         }
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, fwd_thr);
 #endif  // HAL_QUADPLANE_ENABLED
+    }
 
-    } else {
+    if (control_mode->use_battery_compensation()) {
         // Apply voltage compensation to throttle output from flight mode
         const float throttle = g2.fwd_batt_cmp.apply_throttle(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle));
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);


### PR DESCRIPTION
A continuation of the plane throttle output tidy ups. This asks the flight mode if voltage compensation should be applied. This can't be moved up to the flight mode when the throttle is set because throttle is used and modified in a number of other places. Voltage compensation must be the last thing done before outputting. 