### PR TITLE
hwdef: enable ROMFS if we have a defaults filepath to embed

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2591,6 +2591,7 @@ Please run: Tools/scripts/build_bootloaders.py %s
 
         if os.path.exists(self.processed_defaults_filepath()):
             self.write_define(f, 'AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED', 1)
+            self.write_define(f, 'AP_FILESYSTEM_ROMFS_ENABLED', 1)
         else:
             self.write_define(f, 'AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED', 0)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2591,7 +2591,6 @@ Please run: Tools/scripts/build_bootloaders.py %s
 
         if os.path.exists(self.processed_defaults_filepath()):
             self.write_define(f, 'AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED', 1)
-            self.write_define(f, 'AP_FILESYSTEM_ROMFS_ENABLED', 1)
         else:
             self.write_define(f, 'AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED', 0)
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2144,7 +2144,7 @@ bool AP_Param::parse_param_line(char *line, char **vname, float &value, bool &re
 }
 
 
-#if AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED
+#if AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED || AP_PARAM_DYNAMIC_ENABLED
 
 // increments num_defaults for each default found in filename
 bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaults)

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -732,7 +732,16 @@ private:
       load a parameter defaults file. This happens as part of load_all()
      */
     static bool count_defaults_in_file(const char *filename, uint16_t &num_defaults);
+    static bool count_param_defaults(const volatile char *ptr, int32_t length, uint16_t &count);
     static bool read_param_defaults_file(const char *filename, bool last_pass, uint16_t &idx);
+
+    // load a defaults.parm using AP_FileSystem:
+    static void load_defaults_file_from_filesystem(const char *filename, bool lastpass);
+    // load an @ROMFS defaults.parm using ROMFS API:
+    static void load_defaults_file_from_romfs(const char *filename, bool lastpass);
+
+    // load defaults from supplied string:
+    static void load_param_defaults(const volatile char *ptr, int32_t length, bool last_pass);
 
     /*
       load defaults from embedded parameters


### PR DESCRIPTION
Corrects defaults on MatekL431-RC