### PR TITLE
ICP201XX Baro Driver Fix

### DIFF
--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -106,6 +106,7 @@ bool AP_Baro_ICP201XX::init()
     uint8_t id = 0xFF;
     uint8_t ver = 0xFF;
     read_reg(REG_DEVICE_ID, &id);
+    read_reg(REG_DEVICE_ID, &id);
     read_reg(REG_VERSION, &ver);
 
     if (id != ICP201XX_ID) {


### PR DESCRIPTION
**Changes**

- Updated the baro identification code according to the datasheet (see below)
![image](https://github.com/ArduPilot/ardupilot/assets/1869324/9927d503-1021-4f0e-813f-4610b91c841b)

**Why**
In certain situations, the driver failed to ID the barometer correctly. In my case, the register for the ID was returning 0x40 instead of 0x63. It would work however when clicking the reboot button found in the compass section. I suspect in this case, the baro was already prepped and ready for reading. Digging further, I found the blurb in the datasheet that mentions the situation I was running into and how to address, hence the double read of the ID (reading seems to work fine vs writing as indicated in the blub). 

