### PR TITLE
Plane: move forward throttle output in VTOL modes to QuadPlane update

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1866,6 +1866,15 @@ void QuadPlane::update(void)
 
     tiltrotor.update();
 
+    if (in_vtol_mode()) {
+        // if enabled output forward throttle else 0
+        float fwd_thr = 0;
+        if (allow_forward_throttle_in_vtol_mode()) {
+            fwd_thr = forward_throttle_pct();
+        }
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, fwd_thr);
+    }
+
 #if HAL_LOGGING_ENABLED
     // motors logging
     if (motors->armed()) {

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -605,15 +605,6 @@ void Plane::set_throttle(void)
                guided_throttle_passthru) {
         // manual pass through of throttle while in GUIDED
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
-#if HAL_QUADPLANE_ENABLED
-    } else if (quadplane.in_vtol_mode()) {
-        float fwd_thr = 0;
-        // if enabled ask quadplane code for forward throttle
-        if (quadplane.allow_forward_throttle_in_vtol_mode()) {
-            fwd_thr = quadplane.forward_throttle_pct();
-        }
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, fwd_thr);
-#endif  // HAL_QUADPLANE_ENABLED
     }
 
     if (control_mode->use_battery_compensation()) {


### PR DESCRIPTION
Finally getting to some of the tidy ups. This moves the outputting of forward throttle in VTOL modes up to QuadPlane output. There is no huge change in ordering, `quadplane.update()` is called a couple of lines above the `set_throttle` where were currently running this code.

https://github.com/ArduPilot/ardupilot/blob/6ce4dfea5747e959746f652fe823c7e7458693bb/ArduPlane/servos.cpp#L871-L883