### PR TITLE
AP_RTC/AP_AccelCal: remove pointless assignment of total_delay_ms

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -44,9 +44,8 @@ void AP_AccelCal::update()
     if (_started) {
         update_status();
 
-        AccelCalibrator *cal;
         uint8_t num_active_calibrators = 0;
-        for(uint8_t i=0; (cal = get_calibrator(i)); i++) {
+        for(uint8_t i=0; get_calibrator(i) != nullptr; i++) {
             num_active_calibrators++;
         }
         if (num_active_calibrators != _num_active_calibrators) {
@@ -56,6 +55,7 @@ void AP_AccelCal::update()
         if(_start_collect_sample) {
             collect_sample();
         }
+        AccelCalibrator *cal;
         switch(_status) {
             case ACCEL_CAL_NOT_STARTED:
                 fail();

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -243,7 +243,7 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
         total_delay_ms += ms - curr_ms;
     }
     if (largest_element == 1 && total_delay_ms < 0) {
-        return static_cast<uint32_t>(total_delay_ms += 1000);
+        return static_cast<uint32_t>(total_delay_ms + 1000);
     }
 
     // calculate sec to target
@@ -251,7 +251,7 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
         total_delay_ms += (sec - curr_sec)*1000;
     }
     if (largest_element == 2 && total_delay_ms < 0) {
-        return static_cast<uint32_t>(total_delay_ms += (60*1000));
+        return static_cast<uint32_t>(total_delay_ms + (60*1000));
     }
 
     // calculate min to target
@@ -259,7 +259,7 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
         total_delay_ms += (min - curr_min)*60*1000;
     }
     if (largest_element == 3 && total_delay_ms < 0) {
-        return static_cast<uint32_t>(total_delay_ms += (60*60*1000));
+        return static_cast<uint32_t>(total_delay_ms + (60*60*1000));
     }
 
     // calculate hours to target
@@ -267,7 +267,7 @@ uint32_t AP_RTC::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms
         total_delay_ms += (hour - curr_hour)*60*60*1000;
     }
     if (largest_element == 4 && total_delay_ms < 0) {
-        return static_cast<uint32_t>(total_delay_ms += (24*60*60*1000));
+        return static_cast<uint32_t>(total_delay_ms + (24*60*60*1000));
     }
 
     // total delay in milliseconds


### PR DESCRIPTION
this is a stack variable, so assigning a new value to it in a return statement is pointless.

Pointed out by clang-scan-build