### PR TITLE
Add option to override L5 signal health and also support to enable it

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -347,7 +347,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _DRV_OPTIONS
     // @DisplayName: driver options
     // @Description: Additional backend specific options
-    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL, 5: Override GPS satellite health of L5 band from L1 health 
+    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL, 5:Override GPS satellite health of L5 band from L1 health
     // @User: Advanced
     AP_GROUPINFO("_DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -347,7 +347,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: _DRV_OPTIONS
     // @DisplayName: driver options
     // @Description: Additional backend specific options
-    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL
+    // @Bitmask: 0:Use UART2 for moving baseline on ublox,1:Use base station for GPS yaw on SBF,2:Use baudrate 115200,3:Use dedicated CAN port b/w GPSes for moving baseline,4:Use ellipsoid height instead of AMSL, 5: Override GPS satellite health of L5 band from L1 health 
     // @User: Advanced
     AP_GROUPINFO("_DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -624,6 +624,7 @@ protected:
         UBX_Use115200     = (1U << 2U),
         UAVCAN_MBUseDedicatedBus  = (1 << 3U),
         HeightEllipsoid   = (1U << 4),
+        GPSL5HealthOverride = (1U << 5)
     };
 
     // check if an option is set

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -245,8 +245,8 @@ const AP_GPS_UBLOX::config_list AP_GPS_UBLOX::config_M10[] {
   config changes for L5 modules
 */
 const AP_GPS_UBLOX::config_list AP_GPS_UBLOX::config_L5_ovrd_ena[] {
-    {ConfigKey::CFG_SIGNAL_GPS_L5_ENA, 1},
     {ConfigKey::CFG_SIGNAL_L5_HEALTH_OVRD, 1},
+    {ConfigKey::CFG_SIGNAL_GPS_L5_ENA, 1},
 };
 
 const AP_GPS_UBLOX::config_list AP_GPS_UBLOX::config_L5_ovrd_dis[] {
@@ -453,13 +453,13 @@ AP_GPS_UBLOX::_request_next_config(void)
         if (supports_l5 && option_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
             const config_list *list = config_L5_ovrd_ena;
             const uint8_t list_length = ARRAY_SIZE(config_L5_ovrd_ena);
-            if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_ALL)) {
+            if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_RAM | UBX_VALSET_LAYER_BBR)) {
                 _next_message--;
             }
         } else if (supports_l5 && !option_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
             const config_list *list = config_L5_ovrd_dis;
             const uint8_t list_length = ARRAY_SIZE(config_L5_ovrd_dis);
-            if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_ALL)) {
+            if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_RAM | UBX_VALSET_LAYER_BBR)) {
                 _next_message--;
             }
         }

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -100,7 +100,8 @@
 #define CONFIG_RTK_MOVBASE   (1<<17)
 #define CONFIG_TIM_TM2       (1<<18)
 #define CONFIG_M10           (1<<19)
-#define CONFIG_LAST          (1<<20) // this must always be the last bit
+#define CONFIG_L5            (1<<20)
+#define CONFIG_LAST          (1<<21) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
 
@@ -317,6 +318,8 @@ private:
         CFG_SIGNAL_NAVIC_ENA            = 0x10310026,
         CFG_SIGNAL_NAVIC_L5_ENA         = 0x1031001d,
 
+        CFG_SIGNAL_L5_HEALTH_OVRD       = 0x10320001,
+
         // other keys
         CFG_NAVSPG_DYNMODEL             = 0x20110021,
 
@@ -513,7 +516,7 @@ private:
     struct PACKED ubx_mon_ver {
         char swVersion[30];
         char hwVersion[10];
-        char extension; // extensions are not enabled
+        char extension[50]; // extensions are not enabled
     };
     struct PACKED ubx_nav_svinfo_header {
         uint32_t itow;
@@ -738,6 +741,7 @@ private:
         STEP_RTK_MOVBASE, // setup moving baseline
         STEP_TIM_TM2,
         STEP_M10,
+        STEP_L5,
         STEP_LAST
     };
 
@@ -872,7 +876,10 @@ private:
     RTCM3_Parser *rtcm3_parser;
 #endif // GPS_MOVING_BASELINE
 
+    bool supports_l5;
     static const config_list config_M10[];
+    static const config_list config_L5_ovrd_ena[];
+    static const config_list config_L5_ovrd_dis[];
 };
 
 #endif


### PR DESCRIPTION
* Since GPS L5 signal is currently marked unhealthy ublox by default doesn't use it. To allow using L5, we need to allow override the health using the L1 equivalent. This PR refers this document for this https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf 
* Also adds support to enable L5 signal in general.