### PR TITLE
AP_Baro: Suppress dangling pointer warnings.

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -135,20 +135,20 @@ void AP_Baro_BMP388::timer(void)
 {
     uint8_t buf[7];
 
-    if (!read_registers(BMP388_REG_STATUS, buf, sizeof(buf))) {
-        return;
-    }
-    const uint8_t status = buf[0];
-    if ((status & 0x20) != 0) {
-        // we have pressure data
-        update_pressure((buf[3] << 16) | (buf[2] << 8) | buf[1]);
-    }
-    if ((status & 0x40) != 0) {
-        // we have temperature data
-        update_temperature((buf[6] << 16) | (buf[5] << 8) | buf[4]);
-    }
+    if (read_registers(BMP388_REG_STATUS, buf, sizeof(buf))) {
+        const uint8_t status = buf[0];
 
-    dev->check_next_register();
+        if ((status & 0x20) != 0) {
+            // we have pressure data
+            update_pressure((buf[3] << 16) | (buf[2] << 8) | buf[1]);
+        }
+        if ((status & 0x40) != 0) {
+            // we have temperature data
+            update_temperature((buf[6] << 16) | (buf[5] << 8) | buf[4]);
+        }
+
+        dev->check_next_register();
+    }
 }
 
 // transfer data to the frontend


### PR DESCRIPTION
The compilation stalls because of the dangling pointer warning errors in `AP_Baro_BMP388's::timer(void)`.

- G++ version: 12.1.0

Executing `Tools/scripts/build_all.sh`, the output is: 

```
[  56/2906] Compiling libraries/AP_Baro/AP_Baro_BMP085.cpp
../../libraries/AP_Baro/AP_Baro_BMP388.cpp: In member function ‘void AP_Baro_BMP388::timer()’:
../../libraries/AP_Baro/AP_Baro_BMP388.cpp:151:34: error: dangling pointer to ‘buf’ may be used [-Werror=dangling-pointer=]
  151 |         update_temperature((buf[6] << 16) | (buf[5] << 8) | buf[4]);
      |                             ~~~~~^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors

Waf: Leaving directory `/home/berkay/ardupilot/build/sitl'
Build failed
 -> task in 'objs/AP_Baro' failed (exit status 1):
        {task 281473078730256: cxx AP_Baro_BMP388.cpp -> AP_Baro_BMP388.cpp.0.o}
 (run with -v to display more information)
```

Somehow, transforming the if guard and the early return into a normal if branch suppresses the warnings.

This is probably related to #24142.
