### PR TITLE
AP_Compass: fix memory leak around allocation of ExternalAHRS compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1026,11 +1026,25 @@ Compass::StateIndex Compass::_get_state_id(Compass::Priority priority) const
 #endif
 }
 
-bool Compass::_add_backend(AP_Compass_Backend *backend)
+#if COMPASS_MAX_UNREG_DEV > 0
+#define CHECK_UNREG_LIMIT_RETURN  if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) return false
+#define CHECK_UNREG_LIMIT_RETURN_VOID  if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) return
+#else
+#define CHECK_UNREG_LIMIT_RETURN
+#define CHECK_UNREG_LIMIT_RETURN_VOID
+#endif
+
+bool Compass::_add_backend(DriverType driver_type, AP_Compass_Backend *backend)
 {
     if (!backend) {
         return false;
     }
+
+    if (!_driver_enabled(driver_type)) {
+        return false;
+    }
+
+    CHECK_UNREG_LIMIT_RETURN;
 
     if (_backend_count == COMPASS_MAX_BACKEND) {
         return false;
@@ -1068,20 +1082,10 @@ bool Compass::_have_i2c_driver(uint8_t bus, uint8_t address) const
     return false;
 }
 
-#if COMPASS_MAX_UNREG_DEV > 0
-#define CHECK_UNREG_LIMIT_RETURN  if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV) return
-#else
-#define CHECK_UNREG_LIMIT_RETURN
-#endif
-
 /*
-  macro to add a backend with check for too many backends or compass
-  instances. We don't try to start more than the maximum allowed
+  macro to add a backend; should be removed / content folded into "callers"
  */
-#define ADD_BACKEND(driver_type, backend)   \
-    do { if (_driver_enabled(driver_type)) { _add_backend(backend); } \
-        CHECK_UNREG_LIMIT_RETURN; \
-    } while (0)
+#define ADD_BACKEND(driver_type, backend) _add_backend(driver_type, backend)
 
 #define GET_I2C_DEVICE(bus, address) _have_i2c_driver(bus, address)?nullptr:hal.i2c_mgr->get_device(bus, address)
 
@@ -1319,7 +1323,11 @@ void Compass::_detect_backends(void)
 #if AP_COMPASS_EXTERNALAHRS_ENABLED
     const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::COMPASS);
     if (serial_port >= 0) {
-        ADD_BACKEND(DRIVER_EXTERNALAHRS, new AP_Compass_ExternalAHRS(serial_port));
+        auto *backend = new AP_Compass_ExternalAHRS(serial_port);
+        if (!ADD_BACKEND(DRIVER_EXTERNALAHRS, backend)) {
+            delete backend;
+            backend = nullptr;
+        }
     }
 #endif
     
@@ -1340,13 +1348,13 @@ void Compass::_detect_backends(void)
     // probe DroneCAN before I2C and SPI so that DroneCAN compasses
     // default to first in the list for a new board
     probe_dronecan_compasses();
-    CHECK_UNREG_LIMIT_RETURN;
+    CHECK_UNREG_LIMIT_RETURN_VOID;
 #endif
 
 #ifdef HAL_PROBE_EXTERNAL_I2C_COMPASSES
     // allow boards to ask for external probing of all i2c compass types in hwdef.dat
     _probe_external_i2c_compasses();
-    CHECK_UNREG_LIMIT_RETURN;
+    CHECK_UNREG_LIMIT_RETURN_VOID;
 #endif
 
 #if AP_COMPASS_MSP_ENABLED
@@ -1358,7 +1366,7 @@ void Compass::_detect_backends(void)
 #endif
 
     // finally look for i2c and spi compasses not found yet
-    CHECK_UNREG_LIMIT_RETURN;
+    CHECK_UNREG_LIMIT_RETURN_VOID;
     probe_i2c_spi_compasses();
 
     if (_backend_count == 0 ||
@@ -1389,7 +1397,7 @@ void Compass::probe_i2c_spi_compasses(void)
     case AP_BoardConfig::PX4_BOARD_PIXHAWK_PRO:
     case AP_BoardConfig::PX4_BOARD_AEROFC:
         _probe_external_i2c_compasses();
-        CHECK_UNREG_LIMIT_RETURN;
+        CHECK_UNREG_LIMIT_RETURN_VOID;
         break;
 
     case AP_BoardConfig::PX4_BOARD_PCNC1:
@@ -1528,9 +1536,7 @@ void Compass::probe_dronecan_compasses(void)
     }
     for (uint8_t i=0; i<COMPASS_MAX_BACKEND; i++) {
         AP_Compass_Backend* _uavcan_backend = AP_Compass_DroneCAN::probe(i);
-        if (_uavcan_backend) {
-            _add_backend(_uavcan_backend);
-        }
+        _add_backend(DriverType::DRIVER_UAVCAN, _uavcan_backend);
 #if COMPASS_MAX_UNREG_DEV > 0
         if (_unreg_compass_count == COMPASS_MAX_UNREG_DEV)  {
             break;
@@ -1563,9 +1569,10 @@ void Compass::probe_dronecan_compasses(void)
 
                 AP_Compass_Backend* _uavcan_backend = AP_Compass_DroneCAN::probe(j);
                 if (_uavcan_backend) {
-                    _add_backend(_uavcan_backend);
-                    // we also need to remove the id from unreg list
-                    remove_unreg_dev_id(detected_devid);
+                    if (_add_backend(DriverType::DRIVER_UAVCAN, _uavcan_backend)) {
+                        // we also need to remove the id from unreg list
+                        remove_unreg_dev_id(detected_devid);
+                    }
                 } else {
                     // the mag has already been allocated,
                     // let's begin the replacement
@@ -1698,10 +1705,8 @@ Compass::_detect_runtime(void)
     if (_driver_enabled(DRIVER_UAVCAN)) {
         for (uint8_t i=0; i<COMPASS_MAX_BACKEND; i++) {
             AP_Compass_Backend* _uavcan_backend = AP_Compass_DroneCAN::probe(i);
-            if (_uavcan_backend) {
-                _add_backend(_uavcan_backend);
-            }
-            CHECK_UNREG_LIMIT_RETURN;
+            _add_backend(DriverType::DRIVER_UAVCAN, _uavcan_backend);
+            CHECK_UNREG_LIMIT_RETURN_VOID;
         }
     }
 #endif  // AP_COMPASS_DRONECAN_ENABLED

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -381,7 +381,6 @@ private:
     bool register_compass(int32_t dev_id, uint8_t& instance);
 
     // load backend drivers
-    bool _add_backend(AP_Compass_Backend *backend);
     void _probe_external_i2c_compasses(void);
     void _detect_backends(void);
     void probe_i2c_spi_compasses(void);
@@ -485,6 +484,8 @@ private:
         DRIVER_QMC5883P =20,
 #endif
 };
+
+    bool _add_backend(DriverType driver_type, AP_Compass_Backend *backend);
 
     bool _driver_enabled(enum DriverType driver_type);
     


### PR DESCRIPTION
```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -744   *           -744    -744              -744   -744   -744
HerePro             16                                                                    
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                -248   *           -248    -248              -248   -240   -248
MatekF405                      -232   *           -232    -240              -240   -240   -232
Pixhawk1-1M-bdshot             -304               -312    -304              -312   -304   -304
f103-QiotekPeriph   -24                                                                   
f303-Universal      -8                                                                    
iomcu                                                           *                         
revo-mini                      16     *           16      16                8      8      16
skyviper-v2450                                    24                                      
```