### PR TITLE
AP_HAL_ChibiOS: fix set_pin and _pin_scalar methods for ADC2 and ADC3

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -148,6 +148,22 @@ float AnalogSource::_pin_scaler(void)
             break;
         }
     }
+#ifdef HAL_ANALOG2_PINS
+    for (uint8_t i=0; i<ADC2_GRP1_NUM_CHANNELS; i++) {
+        if (AnalogIn::pin_config[i].analog_pin == _pin && (_pin != ANALOG_INPUT_NONE)) {
+            scaling = AnalogIn::pin_config[i].scaling;
+            break;
+        }
+    }
+#endif
+#ifdef HAL_ANALOG3_PINS
+    for (uint8_t i=0; i<ADC3_GRP1_NUM_CHANNELS; i++) {
+        if (AnalogIn::pin_config[i].analog_pin == _pin && (_pin != ANALOG_INPUT_NONE)) {
+            scaling = AnalogIn::pin_config[i].scaling;
+            break;
+        }
+    }
+#endif
     return scaling;
 }
 
@@ -195,6 +211,22 @@ bool AnalogSource::set_pin(uint8_t pin)
                 break;
             }
         }
+#ifdef HAL_ANALOG2_PINS
+        for (uint8_t i=0; i<ADC2_GRP1_NUM_CHANNELS; i++) {
+            if (AnalogIn::pin_config_2[i].analog_pin == pin) {
+                found_pin = true;
+                break;
+            }
+        }
+#endif
+#ifdef HAL_ANALOG3_PINS
+        for (uint8_t i=0; i<ADC3_GRP1_NUM_CHANNELS; i++) {
+            if (AnalogIn::pin_config_3[i].analog_pin == pin) {
+                found_pin = true;
+                break;
+            }
+        }
+#endif
     }
     if (!found_pin) {
         return false;

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
@@ -1305,10 +1305,13 @@ ADC2_map = {
 	# format is PIN : ADC2_CHAN
 	"PF13"  :   2,
 	"PB1"	:	5,
+	"PF14"  :   6,
 }
 
 ADC3_map = {
 	# format is PIN : ADC3_CHAN
 	"PC3"   :   1,
 	"PF3"	:   5,
+	"PF5"   :   4,
+	"PF4"   :   9,
 }


### PR DESCRIPTION
* We weren't looking into pin lists for ADC2 and ADC3. 