### PR TITLE
AP_Logger: Correct for loop condition

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -289,7 +289,7 @@ static uint8_t count_commas(const char *string)
 /// return a unit name given its ID
 const char* AP_Logger::unit_name(const uint8_t unit_id)
 {
-    for (uint8_t i=0; i<unit_id; i++) {
+    for (uint8_t i=0; i<_num_units; i++) {
         if (_units[i].ID == unit_id) {
             return _units[i].unit;
         }
@@ -300,7 +300,7 @@ const char* AP_Logger::unit_name(const uint8_t unit_id)
 /// return a multiplier value given its ID
 double AP_Logger::multiplier_name(const uint8_t multiplier_id)
 {
-    for (uint8_t i=0; i<multiplier_id; i++) {
+    for (uint8_t i=0; i<_num_multipliers; i++) {
         if (_multipliers[i].ID == multiplier_id) {
             return _multipliers[i].multiplier;
         }


### PR DESCRIPTION
fix #26002
This PR corrects the for-loop condition expression in functions unit_name and multiplier_name of AP_Logger.cpp.
As described in the issue these were using the ID to search for (which could be something like: 'e' = 101), and not the actual size of the arrays, so could theoretically overrun the array when searching.
(Although as the loop with break when a match is found, it is pretty unlikely unless bad units/multipliers get used somehow).

SITL compiled and ran OK with the change.