### PR TITLE
Allow FTP upload of fence and rally points

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -27,6 +27,7 @@
 #include <AP_Rally/AP_Rally.h>
 #include <GCS_MAVLink/MissionItemProtocol_Rally.h>
 #include <GCS_MAVLink/MissionItemProtocol_Fence.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 extern int errno;
@@ -211,10 +212,12 @@ int AP_Filesystem_Mission::stat(const char *name, struct stat *stbuf)
  */
 bool AP_Filesystem_Mission::check_file_name(const char *name, enum MAV_MISSION_TYPE &mtype)
 {
+#if AP_MISSION_ENABLED
     if (strcmp(name, "mission.dat") == 0) {
         mtype = MAV_MISSION_TYPE_MISSION;
         return true;
     }
+#endif
 #if AP_FENCE_ENABLED
     if (strcmp(name, "fence.dat") == 0) {
         mtype = MAV_MISSION_TYPE_FENCE;
@@ -261,6 +264,7 @@ bool AP_Filesystem_Mission::get_item(uint32_t idx, enum MAV_MISSION_TYPE mtype, 
 uint32_t AP_Filesystem_Mission::get_num_items(enum MAV_MISSION_TYPE mtype) const
 {
     switch (mtype) {
+#if AP_MISSION_ENABLED
     case MAV_MISSION_TYPE_MISSION: {
         auto *mission = AP::mission();
         if (!mission) {
@@ -268,18 +272,17 @@ uint32_t AP_Filesystem_Mission::get_num_items(enum MAV_MISSION_TYPE mtype) const
         }
         return mission->num_commands();
     }
-        
-    case MAV_MISSION_TYPE_FENCE: {
+#endif
+
 #if AP_FENCE_ENABLED
+    case MAV_MISSION_TYPE_FENCE: {
         auto *fence = AP::fence();
         if (fence == nullptr) {
             return 0;
         }
         return fence->polyfence().num_stored_items();
-#else
-        return 0;
-#endif
     }
+#endif
 
 #if HAL_RALLY_ENABLED
     case MAV_MISSION_TYPE_RALLY: {
@@ -381,6 +384,30 @@ bool AP_Filesystem_Mission::finish_upload(const rfile &r)
         }
     }
 
+    switch (r.mtype) {
+#if AP_MISSION_ENABLED
+    case MAV_MISSION_TYPE_MISSION:
+        return finish_upload_mission(hdr, r, b);
+#endif
+#if HAL_RALLY_ENABLED
+    case MAV_MISSION_TYPE_RALLY:
+        return finish_upload_rally(hdr, r, b);
+#endif
+#if AP_FENCE_ENABLED
+    case MAV_MISSION_TYPE_FENCE:
+        return finish_upload_fence(hdr, r, b);
+#endif
+    default:
+        // really should not get here....
+        break;
+    }
+
+    return false;
+}
+
+#if AP_MISSION_ENABLED
+bool AP_Filesystem_Mission::finish_upload_mission(const struct header &hdr, const rfile &r, const uint8_t *b)
+{
     auto *mission = AP::mission();
     if (mission == nullptr) {
         return false;
@@ -389,16 +416,17 @@ bool AP_Filesystem_Mission::finish_upload(const rfile &r)
     if ((hdr.options & unsigned(Options::NO_CLEAR)) == 0) {
         mission->clear();
     }
-    for (uint32_t i=0; i<nitems; i++) {
+    for (uint32_t i=0; i<hdr.num_items; i++) {
         mavlink_mission_item_int_t m {};
         AP_Mission::Mission_Command cmd;
+        const uint8_t item_size = MAVLINK_MSG_ID_MISSION_ITEM_INT_LEN;
         memcpy(&m, &b[sizeof(hdr)+i*item_size], item_size);
         const MAV_MISSION_RESULT res = AP_Mission::mavlink_int_to_mission_cmd(m, cmd);
         if (res != MAV_MISSION_ACCEPTED) {
             return false;
         }
         if (cmd.id == MAV_CMD_DO_JUMP &&
-            (cmd.content.jump.target >= nitems || cmd.content.jump.target == 0)) {
+            (cmd.content.jump.target >= hdr.num_items || cmd.content.jump.target == 0)) {
             return false;
         }
         uint16_t idx = i + hdr.start;
@@ -414,5 +442,92 @@ bool AP_Filesystem_Mission::finish_upload(const rfile &r)
     }
     return true;
 }
+#endif  // AP_MISSION_ENABLED
+
+#if AP_FENCE_ENABLED
+bool AP_Filesystem_Mission::finish_upload_fence(const struct header &hdr, const rfile &r, const uint8_t *b)
+{
+    bool success = false;
+
+    AC_PolyFenceItem *new_items = nullptr;
+
+    auto *fence = AP::fence();
+    if (fence == nullptr) {
+        goto OUT;
+    }
+
+    if ((hdr.options & unsigned(Options::NO_CLEAR)) != 0) {
+        // Only complete fences can be uploaded for now.
+        goto OUT;
+    }
+
+    // passing nullptr and 0 items through to Polyfence loader is
+    // absolutely OK:
+    if (hdr.num_items != 0) {
+        new_items = new AC_PolyFenceItem[hdr.num_items];
+        if (new_items == nullptr) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Out of memory for upload");
+            goto OUT;
+        }
+    }
+
+    // convert from MISSION_ITEM_INT to AC_PolyFenceItem:
+    for (uint32_t i=0; i<hdr.num_items; i++) {
+        mavlink_mission_item_int_t m {};
+        const uint8_t item_size = MAVLINK_MSG_ID_MISSION_ITEM_INT_LEN;
+        memcpy(&m, &b[sizeof(hdr)+i*item_size], item_size);
+        const MAV_MISSION_RESULT res = MissionItemProtocol_Fence::convert_MISSION_ITEM_INT_to_AC_PolyFenceItem(m, new_items[i]);
+        if (res != MAV_MISSION_ACCEPTED) {
+            goto OUT;
+        }
+    }
+
+    success = fence->polyfence().write_fence(new_items, hdr.num_items);
+
+OUT:
+
+    delete[] new_items;
+
+    return success;
+}
+#endif  // AP_FENCE_ENABLED
+
+#if HAL_RALLY_ENABLED
+bool AP_Filesystem_Mission::finish_upload_rally(const struct header &hdr, const rfile &r, const uint8_t *b)
+{
+    bool success = false;
+
+    auto *rally = AP::rally();
+    if (rally == nullptr) {
+        goto OUT;
+    }
+
+    if ((hdr.options & unsigned(Options::NO_CLEAR)) != 0) {
+        //only complete sets of rally points can be added ATM
+        goto OUT;
+    }
+
+    rally->truncate(0);
+
+    for (uint32_t i=0; i<hdr.num_items; i++) {
+        mavlink_mission_item_int_t m {};
+        RallyLocation cmd;
+        const uint8_t item_size = MAVLINK_MSG_ID_MISSION_ITEM_INT_LEN;
+        memcpy(&m, &b[sizeof(hdr)+i*item_size], item_size);
+        const MAV_MISSION_RESULT res = MissionItemProtocol_Rally::convert_MISSION_ITEM_INT_to_RallyLocation(m, cmd);
+        if (res != MAV_MISSION_ACCEPTED) {
+            goto OUT;
+        }
+
+        if (!rally->append(cmd)) {
+            goto OUT;
+        }
+    }
+    success = true;
+
+OUT:
+    return success;
+}
+#endif  // HAL_RALLY_ENABLED
 
 #endif  // AP_FILESYSTEM_MISSION_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.h
@@ -72,6 +72,9 @@ private:
 
     // finish loading items
     bool finish_upload(const rfile &r);
+    bool finish_upload_mission(const struct header &hdr, const rfile &r, const uint8_t *b);
+    bool finish_upload_fence(const struct header &hdr, const rfile &r, const uint8_t *b);
+    bool finish_upload_rally(const struct header &hdr, const rfile &r, const uint8_t *b);
 
     // see if a block of memory is all zero
     bool all_zero(const uint8_t *b, uint8_t size) const;

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -95,7 +95,7 @@ uint16_t MissionItemProtocol_Fence::item_count() const
     return _fence.polyfence().num_stored_items();
 }
 
-static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_AC_PolyFenceItem(const mavlink_mission_item_int_t &mission_item_int, AC_PolyFenceItem &ret)
+MAV_MISSION_RESULT MissionItemProtocol_Fence::convert_MISSION_ITEM_INT_to_AC_PolyFenceItem(const mavlink_mission_item_int_t &mission_item_int, AC_PolyFenceItem &ret)
 {
     if (mission_item_int.frame != MAV_FRAME_GLOBAL &&
         mission_item_int.frame != MAV_FRAME_GLOBAL_INT &&

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
@@ -2,6 +2,8 @@
 
 #include "MissionItemProtocol.h"
 
+#include <AC_Fence/AC_Fence.h>
+
 class AC_PolyFence_loader;
 
 class MissionItemProtocol_Fence : public MissionItemProtocol {
@@ -21,7 +23,9 @@ public:
       static function to format mission item as mavlink_mission_item_int_t
     */
     static bool get_item_as_mission_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet);
-    
+
+    static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_AC_PolyFenceItem(const mavlink_mission_item_int_t &mission_item_int, class AC_PolyFenceItem &ret);
+
 protected:
 
     ap_message next_item_ap_message_id() const override {

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
@@ -20,7 +20,9 @@ public:
       static function to get rally item as mavlink_mission_item_int_t
     */
     static bool get_item_as_mission_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet);
-    
+
+    static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_RallyLocation(const mavlink_mission_item_int_t &cmd, class RallyLocation &ret) WARN_IF_UNUSED;
+
 protected:
 
     ap_message next_item_ap_message_id() const override {
@@ -41,8 +43,6 @@ private:
                                 const mavlink_message_t &msg,
                                 const mavlink_mission_request_int_t &packet,
                                 mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
-
-    static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_RallyLocation(const mavlink_mission_item_int_t &cmd, class RallyLocation &ret) WARN_IF_UNUSED;
 
 };
 


### PR DESCRIPTION
Tested in SITL, using MAVProxy, both rally and ftp ftp up/down.  waypoints still work.


Tested with Valgrind, no problems on fence / rally.  Pre-existing valgrind uninitialised stack allocation bug preserved (see https://github.com/ArduPilot/ardupilot/pull/26063)
