### PR TITLE
Add support for unsetting parameters (track default values again)

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5318,6 +5318,34 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         home = self.home_position_as_mav_location()
         self.assert_distance(home, adsb_vehicle_loc, 0, 10000)
 
+    def unset_parameter(self, name):
+        self.mav.mav.param_unset_send(
+            self.sysid_thismav(),
+            1,
+            name.encode('ascii')
+        )
+        self.wait_message_field_values('PARAM_VALUE', {
+            'param_id': name,
+        })
+
+    def ParamUnset(self):
+        '''check unsetting of parameters'''
+        old_values = self.get_parameters(['AHRS_EKF_TYPE', 'LOG_BITMASK'])
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 37,
+            'LOG_BITMASK': 2,
+        })
+        self.unset_parameter('AHRS_EKF_TYPE')
+        self.assert_parameter_values({
+            'AHRS_EKF_TYPE': old_values['AHRS_EKF_TYPE'],
+            'LOG_BITMASK': 2,
+        })
+        self.unset_parameter('LOG_BITMASK')
+        self.assert_parameter_values({
+            'AHRS_EKF_TYPE': old_values['AHRS_EKF_TYPE'],
+            'LOG_BITMASK': old_values['LOG_BITMASK'],
+        })
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -5425,6 +5453,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TerrainRally,
             self.MAV_CMD_NAV_LOITER_UNLIM,
             self.MAV_CMD_NAV_RETURN_TO_LAUNCH,
+            self.ParamUnset,
         ])
         return ret
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1112,7 +1112,7 @@ void AP_Param::notify() const {
 /*
   Save the variable to HAL storage, synchronous version
 */
-void AP_Param::save_sync(bool force_save, bool send_to_gcs)
+void AP_Param::save_sync(bool force_save, bool send_to_gcs, bool unset)
 {
     uint32_t group_element = 0;
     const struct GroupInfo *ginfo;
@@ -1164,13 +1164,33 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
     uint16_t ofs;
     if (scan(&phdr, &ofs)) {
         // found an existing copy of the variable
-        eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
+        if (unset) {
+            // adjust the header
+            struct Param_header tmp = phdr;
+            set_key(tmp, _unset_key);
+            eeprom_write_check((uint8_t*)&tmp, ofs, sizeof(tmp));
+
+            // reset the in-memory value:
+            if (ginfo != nullptr) {
+                set_value((enum ap_var_type)phdr.type, this, get_default_value(this, *ginfo));
+            } else {
+                set_value((enum ap_var_type)phdr.type, this, get_default_value(this, *info));
+            }
+
+        } else {
+            // adjust the value
+            eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
+        }
         if (send_to_gcs) {
             send_parameter(name, (enum ap_var_type)phdr.type, idx);
         }
         return;
     }
     if (ofs == (uint16_t) ~0) {
+        return;
+    }
+    if (unset) {
+        // can't unset a variable we didn't find
         return;
     }
 
@@ -1222,9 +1242,18 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
 */
 void AP_Param::save(bool force_save)
 {
-    struct param_save p, p2;
-    p.param = this;
-    p.force_save = force_save;
+    const struct param_save p {
+        this,
+        true,  // force save
+        false  // don't unset
+    };
+
+    enqueue_param_save(p, force_save);
+}
+
+void AP_Param::enqueue_param_save(const struct param_save &p, bool force_save)
+{
+    struct param_save p2;
     if (save_queue.peek(p2) &&
         p2.param == this &&
         p2.force_save == force_save) {
@@ -1250,6 +1279,17 @@ void AP_Param::save(bool force_save)
     }
 }
 
+void AP_Param::unset()
+{
+    const struct param_save p {
+        this,
+        true,  // force-set
+        true  // unset
+    };
+
+    enqueue_param_save(p, true);
+}
+
 /*
   background function for saving parameters. This runs on the IO thread
  */
@@ -1257,7 +1297,7 @@ void AP_Param::save_io_handler(void)
 {
     struct param_save p;
     while (save_queue.pop(p)) {
-        p.param->save_sync(p.force_save, true);
+        p.param->save_sync(p.force_save, true, p.unset);
     }
     if (hal.scheduler->is_system_initialized()) {
         // pay the cost of parameter counting in the IO thread
@@ -1343,7 +1383,8 @@ bool AP_Param::load(void)
     return true;
 }
 
-bool AP_Param::configured_in_storage(void) const
+// returns the offset of the phdr for this variable in eeprom:
+bool AP_Param::find_offset_in_storage(uint16_t &ofs) const
 {
     uint32_t group_element = 0;
     const struct GroupInfo *ginfo;
@@ -1367,10 +1408,15 @@ bool AP_Param::configured_in_storage(void) const
     phdr.group_element = group_element;
 
     // scan EEPROM to find the right location
-    uint16_t ofs;
-
     // only vector3f can have non-zero idx for now
     return scan(&phdr, &ofs) && (phdr.type == AP_PARAM_VECTOR3F || idx == 0);
+}
+
+bool AP_Param::configured_in_storage(void) const
+{
+    uint16_t ofs;
+
+    return find_offset_in_storage(ofs);
 }
 
 bool AP_Param::configured_in_defaults_file(bool &read_only) const

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -400,7 +400,7 @@ public:
     ///
     /// @return                True if the variable was saved successfully.
     ///
-    void save_sync(bool force_save, bool send_to_gcs);
+    void save_sync(bool force_save, bool send_to_gcs, bool unset=false);
 
     /// flush all pending parameter saves
     /// used on reboot
@@ -447,6 +447,8 @@ public:
       set a parameter to a float
     */
     void set_float(float value, enum ap_var_type var_type);
+
+    void unset();
 
     // load default values for scalars in a group
     static void         setup_object_defaults(const void *object_pointer, const struct GroupInfo *group_info);
@@ -634,6 +636,8 @@ private:
     static const uint8_t        _sentinal_type  = 0x1F;
     static const uint8_t        _sentinal_group = 0xFF;
 
+    static const uint16_t       _unset_key   = 0x1FE;
+
     static uint16_t             _frame_type_flags;
 
     /*
@@ -759,6 +763,9 @@ private:
 
     // return true if the parameter is configured in EEPROM/FRAM
     bool configured_in_storage(void) const;
+    // return true if parameter is configured in storage, and store
+    // location in supplied offset reference
+    bool find_offset_in_storage(uint16_t &offset) const;
 
     // send a parameter to all GCS instances
     void send_parameter(const char *name, enum ap_var_type param_header_type, uint8_t idx) const;
@@ -812,9 +819,11 @@ private:
     struct PACKED param_save {
         AP_Param *param;
         bool force_save;
+        bool unset;
     };
     static ObjectBuffer_TS<struct param_save> save_queue;
     static bool registered_save_handler;
+    void enqueue_param_save(const struct param_save &p, bool force_save);
 
     // background function for saving parameters
     void save_io_handler(void);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -560,6 +560,7 @@ protected:
 
     void handle_common_param_message(const mavlink_message_t &msg);
     void handle_param_set(const mavlink_message_t &msg);
+    void handle_param_unset(const mavlink_message_t &msg);
     void handle_param_request_list(const mavlink_message_t &msg);
     void handle_param_request_read(const mavlink_message_t &msg);
     virtual bool params_ready() const { return true; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3956,6 +3956,7 @@ void GCS_MAVLINK::handle_message(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
     case MAVLINK_MSG_ID_PARAM_SET:
+    case MAVLINK_MSG_ID_PARAM_UNSET:
     case MAVLINK_MSG_ID_PARAM_REQUEST_READ:
         handle_common_param_message(msg);
         break;


### PR DESCRIPTION
The general concept is to go through all of the same things we do when saving values, but instead of updating the value reset the key to a flag value.  Once done searching for that parameter in storage will fail.  The type is NOT changed so when scanning we know the size of the variable.

I'm quite aware this leaks storage.  Future improvements would have us remember suitable empty slots for each type we might store and use them when storing.  This is a major complication, IMO.

 - need to add a sanity check so we never store under the key (we don't have one for the sentinel value!)
 - valgrind
 - check Vector3 still works appropriately
 - 