### PR TITLE
HAL_ChibiOS: raise SDMMC clock limit on H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_mcuconf.h
@@ -633,10 +633,9 @@
 // limit ISR count per byte
 #define STM32_I2C_ISR_LIMIT                 6
 
-// limit SDMMC clock to 12.5MHz by default. This increases
-// reliability
+// limit SDMMC clock to 50MHz by default
 #ifndef STM32_SDC_MAX_CLOCK
-#define STM32_SDC_MAX_CLOCK                 12500000
+#define STM32_SDC_MAX_CLOCK                 50000000
 #endif
 
 #ifndef STM32_WSPI_USE_QUADSPI1


### PR DESCRIPTION
this allows for faster log download on ethernet.
On CubeRedPrimary log download using the web server on ethernet goes up from 2.4MByte/s to 4.0MByte/s

I don't think this should go straight into 4.5.x, I'd like to see if anyone notices any reliability issues with the faster clock first
