### PR TITLE
Plane: move guided throttle passthrough to mode_guided

### DIFF
--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -82,13 +82,21 @@ void ModeGuided::update()
         plane.calc_nav_pitch();
     }
 
-    // Received an external msg that guides throttle in the last 3 seconds?
-    if (plane.aparm.throttle_cruise > 1 &&
+    // Throttle output
+    if (plane.guided_throttle_passthru) {
+        // manual passthrough of throttle in fence breach
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.get_throttle_input(true));
+
+    }  else if (plane.aparm.throttle_cruise > 1 &&
             plane.guided_state.last_forced_throttle_ms > 0 &&
             millis() - plane.guided_state.last_forced_throttle_ms < 3000) {
+        // Received an external msg that guides throttle in the last 3 seconds?
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.guided_state.forced_throttle);
+
     } else {
+        // TECS control
         plane.calc_throttle();
+
     }
 
 }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -601,10 +601,6 @@ void Plane::set_throttle(void)
             // get throttle, but adjust center to output TRIM_THROTTLE if flight option set
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_adjusted_throttle_input(true));
         }
-    } else if (control_mode->is_guided_mode() &&
-               guided_throttle_passthru) {
-        // manual pass through of throttle while in GUIDED
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, get_throttle_input(true));
     }
 
     if (control_mode->use_battery_compensation()) {


### PR DESCRIPTION
More throttle output tidyup. This moves guided throttle pass throughout up to guided mode.

I there is no change in behavior,  except that throttle passthrough will no longer work in VTOL modes because its now overridden by VTOL forward throttle output that was moved in https://github.com/ArduPilot/ardupilot/pull/26028.

Tested in SITL with `FENCE_ACTION` 7.0.

Not really related to this PR, but I don't really understand why this would ever be wanted....