### PR TITLE
Move can_mgr.init call up to AP_Vehicle

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -5,10 +5,6 @@ static const StorageAccess wp_storage(StorageManager::StorageMission);
 
 void Tracker::init_ardupilot()
 {
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    can_mgr.init();
-#endif
-
     // initialise notify
     notify.init();
     AP_Notify::flags.pre_arm_check = true;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -15,10 +15,6 @@ static void failsafe_check_static()
 
 void Copter::init_ardupilot()
 {
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    can_mgr.init();
-#endif
-
     // init cargo gripper
 #if AP_GRIPPER_ENABLED
     g2.gripper.init();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -19,10 +19,6 @@ void Plane::init_ardupilot()
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    can_mgr.init();
-#endif
-
     rollController.convert_pid();
     pitchController.convert_pid();
 

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -14,10 +14,6 @@ static void failsafe_check_static()
 
 void Sub::init_ardupilot()
 {
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    can_mgr.init();
-#endif
-
     // init cargo gripper
 #if AP_GRIPPER_ENABLED
     g2.gripper.init();

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -14,10 +14,6 @@ static void failsafe_check_static()
 
 void Rover::init_ardupilot()
 {
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    can_mgr.init();
-#endif
-
     // init gripper
 #if AP_GRIPPER_ENABLED
     g2.gripper.init();

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -238,6 +238,7 @@ def ap_get_all_libraries(bld):
             continue
         libraries.append(name)
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
+    libraries.append('AP_PiccoloCAN/piccolo_protocol')
     return libraries
 
 @conf

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -360,6 +360,10 @@ void AP_Vehicle::setup()
 
     BoardConfig.init();
 
+#if HAL_CANMANAGER_ENABLED
+    can_mgr.init();
+#endif
+
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
 


### PR DESCRIPTION
note that these calls are right at the top of init_ardupilot, so moving them into the caller of that function is equivalent.
