### PR TITLE
Prevent conflicts between CRSF and GHST leading to radio failsafes

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -67,6 +67,10 @@ public:
         return frontend.rc_protocols_mask;
     }
 
+    bool protocol_enabled(enum AP_RCProtocol::rcprotocol_t protocol) const {
+        return frontend.protocol_enabled(protocol);
+    }
+
     // get RSSI
     int16_t get_RSSI(void) const {
         return rssi;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -238,6 +238,10 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
         return;
     }
 
+    if (_frame.device_address != DeviceAddress::CRSF_ADDRESS_FLIGHT_CONTROLLER) {
+        return;
+    }
+
     // parse the length
     if (_frame_ofs == CSRF_HEADER_TYPE_LEN) {
         _frame_crc = crc8_dvb_s2(0, _frame.type);
@@ -617,7 +621,7 @@ void AP_RCProtocol_CRSF::process_handshake(uint32_t baudrate)
         || baudrate != CRSF_BAUDRATE
         || baudrate == get_bootstrap_baud_rate()
         || uart->get_baud_rate() == get_bootstrap_baud_rate()
-        || (get_rc_protocols_mask() & ((1U<<(uint8_t(AP_RCProtocol::CRSF)+1))+1)) == 0) {
+        || !protocol_enabled(AP_RCProtocol::CRSF)) {
         return;
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
@@ -152,6 +152,10 @@ void AP_RCProtocol_GHST::_process_byte(uint32_t timestamp_us, uint8_t byte)
         return;
     }
 
+    if (_frame.device_address != DeviceAddress::GHST_ADDRESS_FLIGHT_CONTROLLER) {
+        return;
+    }
+
     // parse the length
     if (_frame_ofs == GHST_HEADER_TYPE_LEN) {
         _frame_crc = crc8_dvb_s2(0, _frame.type);
@@ -421,17 +425,18 @@ void AP_RCProtocol_GHST::process_byte(uint8_t byte, uint32_t baudrate)
     _process_byte(AP_HAL::micros(), byte);
 }
 
-// change the bootstrap baud rate to ELRS standard if configured
+// change the bootstrap baud rate to Ghost standard if configured
 void AP_RCProtocol_GHST::process_handshake(uint32_t baudrate)
 {
     AP_HAL::UARTDriver *uart = get_current_UART();
 
-    // only change the baudrate if we are bootstrapping CRSF
+    // only change the baudrate if we are specifically bootstrapping Ghost
     if (uart == nullptr
         || baudrate != CRSF_BAUDRATE
         || baudrate == GHST_BAUDRATE
         || uart->get_baud_rate() == GHST_BAUDRATE
-        || (get_rc_protocols_mask() & ((1U<<(uint8_t(AP_RCProtocol::GHST)+1))+1)) == 0) {
+        || !protocol_enabled(AP_RCProtocol::GHST)
+        || protocol_enabled(AP_RCProtocol::CRSF)) {
         return;
     }
 


### PR DESCRIPTION
Discriminate GHST and CRSF based on first byte
do not change to GHST baudrate unless it has been specifically configured

@rmackay9 @tridge this will need to go into 4.5 asap