### PR TITLE
AP_HAL: add power status bits to logger metadata

### DIFF
--- a/Tools/autotest/logger_metadata/enum_parse.py
+++ b/Tools/autotest/logger_metadata/enum_parse.py
@@ -92,6 +92,10 @@ class EnumDocco(object):
             raise ValueError("Failed to match (%s)" % line)
 
     def enumerations_from_file(self, source_file):
+        def debug(x):
+            pass
+        # if source_file == "/home/pbarker/rc/ardupilot/libraries/AP_HAL/AnalogIn.h":
+        #     debug = print
         state_outside = "outside"
         state_inside = "inside"
 
@@ -103,6 +107,7 @@ class EnumDocco(object):
             in_class = None
             while True:
                 line = f.readline()
+                #  debug(f"{state} line: {line}")
                 if line == "":
                     break
                 line = line.rstrip()
@@ -113,7 +118,7 @@ class EnumDocco(object):
                     if re.match("class .*;", line) is not None:
                         # forward-declaration of a class
                         continue
-                    m = re.match("class *(\w+)", line)
+                    m = re.match("class *([:\w]+)", line)
                     if m is not None:
                         in_class = m.group(1)
                         continue
@@ -125,6 +130,7 @@ class EnumDocco(object):
                     if m is not None:
                         # all one one line!  Thanks!
                         enum_name = m.group(2)
+                        debug("ol: %s: %s" % (source_file, enum_name))
                         entries_string = m.group(3)
                         entry_names = [x.strip() for x in entries_string.split(",")]
                         count = 0
@@ -139,7 +145,7 @@ class EnumDocco(object):
                     m = re.match(".*enum\s*(class)? *([\w]+)\s*(?::.*_t)? *{", line)
                     if m is not None:
                         enum_name = m.group(2)
-                        # print("%s: %s" % (source_file, enum_name))
+                        debug("%s: %s" % (source_file, enum_name))
                         entries = []
                         last_value = None
                         state = state_inside
@@ -172,7 +178,7 @@ class EnumDocco(object):
                     if name is None:
                         skip_enumeration = True
                         continue
-                    # print(" name=(%s) value=(%s) comment=(%s)\n" % (name, value, comment))
+                    debug(" name=(%s) value=(%s) comment=(%s)\n" % (name, value, comment))
                     if value is None:
                         if last_value is None:
                             value = 0
@@ -190,6 +196,7 @@ class EnumDocco(object):
     class Enumeration(object):
 
         def __init__(self, name, entries):
+            # print("creating enum %s" % name)
             self.name = name
             self.entries = entries
 
@@ -246,4 +253,4 @@ if __name__ == '__main__':
         sys.exit(1)
 
     s.run()
-    print("Enumerations: %s" % s.enumerations)
+#    print("Enumerations: %s" % s.enumerations)

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -325,15 +325,20 @@ class LoggerDocco(object):
 
     def parse_file(self, filepath):
         with open(filepath) as f:
-            #            print("Opened (%s)" % filepath)
+#            print("Opened (%s)" % filepath)
             lines = f.readlines()
             f.close()
+        def debug(x):
+            pass
+#        if filepath == "/home/pbarker/rc/ardupilot/libraries/AP_HAL/AnalogIn.h":
+#            debug = print
         state_outside = "outside"
         state_inside = "inside"
         messagedef = ""
         state = state_outside
         docco = None
         for line in lines:
+            debug(f"{state}: {line}")
             if messagedef:
                 messagedef = messagedef + line
                 if "}" in line or ";" in line:

--- a/libraries/AP_HAL/AnalogIn.h
+++ b/libraries/AP_HAL/AnalogIn.h
@@ -42,6 +42,16 @@ public:
     // failures can still be diagnosed
     virtual uint16_t accumulated_power_status_flags(void) const { return 0; }
 
+    // this enum class is 1:1 with MAVLink's MAV_POWER_STATUS enumeration!
+    enum class PowerStatusFlag : uint16_t {
+        BRICK_VALID = 1,                  // main brick power supply valid
+        SERVO_VALID = 2,                  // main servo power supply valid for FMU
+        USB_CONNECTED = 4,                // USB power is connected
+        PERIPH_OVERCURRENT = 8,           // peripheral supply is in over-current state
+        PERIPH_HIPOWER_OVERCURRENT = 16,  // hi-power peripheral supply is in over-current state
+        CHANGED = 32,                     // Power status has changed since boot
+    };
+
 #if HAL_WITH_MCU_MONITORING
     virtual float mcu_temperature(void) { return 0; }
     virtual float mcu_voltage(void) { return 0; }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -954,7 +954,9 @@ struct PACKED log_VER {
 // @Field: Vcc: Flight board voltage
 // @Field: VServo: Servo rail voltage
 // @Field: Flags: System power flags
+// @FieldBitmaskEnum: Flags: AP_HAL::AnalogIn::PowerStatusFlag
 // @Field: AccFlags: Accumulated System power flags; all flags which have ever been set
+// @FieldBitmaskEnum: AccFlags: AP_HAL::AnalogIn::PowerStatusFlag
 // @Field: Safety: Hardware Safety Switch status
 
 // @LoggerMessage: MCU


### PR DESCRIPTION
```
pbarker@fx:~/rc/ardupilot(pr/power-flags-metadata)$ diff -u LogMessages.rst{-master,}
--- LogMessages.rst-master	2024-02-02 14:04:14.393640400 +1100
+++ LogMessages.rst	2024-02-02 14:40:57.747704313 +1100
@@ -4528,19 +4528,51 @@
 
 System power information
 
-+----------+----+--------------------------------------------------------------------+
-| TimeUS   | μs | Time since system startup                                          |
-+----------+----+--------------------------------------------------------------------+
-| Vcc      | V  | Flight board voltage                                               |
-+----------+----+--------------------------------------------------------------------+
-| VServo   | V  | Servo rail voltage                                                 |
-+----------+----+--------------------------------------------------------------------+
-| Flags    |    | System power flags                                                 |
-+----------+----+--------------------------------------------------------------------+
-| AccFlags |    | Accumulated System power flags; all flags which have ever been set |
-+----------+----+--------------------------------------------------------------------+
-| Safety   |    | Hardware Safety Switch status                                      |
-+----------+----+--------------------------------------------------------------------+
++----------+---------+-------------------------------------------------------------------------------------------+
+| TimeUS   | μs      | Time since system startup                                                                 |
++----------+---------+-------------------------------------------------------------------------------------------+
+| Vcc      | V       | Flight board voltage                                                                      |
++----------+---------+-------------------------------------------------------------------------------------------+
+| VServo   | V       | Servo rail voltage                                                                        |
++----------+---------+-------------------------------------------------------------------------------------------+
+| Flags    | bitmask | System power flags                                                                        |
+|          |         | Bitmask values:                                                                           |
+|          |         |                                                                                           |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | BRICK_VALID                | 1  | main brick power supply valid                       | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | SERVO_VALID                | 2  | main servo power supply valid for FMU               | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | USB_CONNECTED              | 4  | USB power is connected                              | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | PERIPH_OVERCURRENT         | 8  | peripheral supply is in over-current state          | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | PERIPH_HIPOWER_OVERCURRENT | 16 | hi-power peripheral supply is in over-current state | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | CHANGED                    | 32 | Power status has changed since boot                 | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         |                                                                                           |
++----------+---------+-------------------------------------------------------------------------------------------+
+| AccFlags | bitmask | Accumulated System power flags; all flags which have ever been set                        |
+|          |         | Bitmask values:                                                                           |
+|          |         |                                                                                           |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | BRICK_VALID                | 1  | main brick power supply valid                       | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | SERVO_VALID                | 2  | main servo power supply valid for FMU               | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | USB_CONNECTED              | 4  | USB power is connected                              | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | PERIPH_OVERCURRENT         | 8  | peripheral supply is in over-current state          | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | PERIPH_HIPOWER_OVERCURRENT | 16 | hi-power peripheral supply is in over-current state | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         | | CHANGED                    | 32 | Power status has changed since boot                 | |
+|          |         | +----------------------------+----+-----------------------------------------------------+ |
+|          |         |                                                                                           |
++----------+---------+-------------------------------------------------------------------------------------------+
+| Safety   |         | Hardware Safety Switch status                                                             |
++----------+---------+-------------------------------------------------------------------------------------------+
 
 
 .. _PRTN:
```

While I've added this enumeration, I haven't changed the code to use it as part of this PR.  I'd like to do that as it means we don't need the mavlink headers for compiling a peripheral with battery support in it.
