### PR TITLE
AP_Parachute:  Optional (CHUTE_OPTIONS:1) disarm before parachute release

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -269,7 +269,6 @@ void Copter::parachute_check()
     }
 
     if (parachute.release_initiated()) {
-        copter.arming.disarm(AP_Arming::Method::PARACHUTE_RELEASE);
         return;
     }
 
@@ -331,9 +330,6 @@ void Copter::parachute_check()
 // parachute_release - trigger the release of the parachute, disarm the motors and notify the user
 void Copter::parachute_release()
 {
-    // disarm motors
-    arming.disarm(AP_Arming::Method::PARACHUTE_RELEASE);
-
     // release parachute
     parachute.release();
 

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -140,8 +140,6 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
         if(g.fs_action_long == FS_ACTION_LONG_PARACHUTE) {
 #if PARACHUTE == ENABLED
             parachute_release();
-            //stop motors to avoid parachute tangling
-            plane.arming.disarm(AP_Arming::Method::PARACHUTE_RELEASE, false);
 #endif
         } else if (g.fs_action_long == FS_ACTION_LONG_GLIDE) {
             set_mode(mode_fbwa, reason);
@@ -191,8 +189,6 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
         if(g.fs_action_long == FS_ACTION_LONG_PARACHUTE) {
 #if PARACHUTE == ENABLED
             parachute_release();
-            //stop motors to avoid parachute tangling
-            plane.arming.disarm(AP_Arming::Method::PARACHUTE_RELEASE, false);
 #endif
         } else if (g.fs_action_long == FS_ACTION_LONG_GLIDE) {
             set_mode(mode_fbwa, reason);

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -19,7 +19,8 @@
 
 #define AP_PARACHUTE_ALT_MIN_DEFAULT            10     // default min altitude the vehicle should have before parachute is released
 
-#define AP_PARACHUTE_CRITICAL_SINK_DEFAULT      0    // default critical sink speed in m/s to trigger emergency parachute
+#define AP_PARACHUTE_CRITICAL_SINK_DEFAULT      0      // default critical sink speed in m/s to trigger emergency parachute
+#define AP_PARACHUTE_OPTIONS_DEFAULT            0      // default parachute options: enabled disarm after parachute release
 
 #ifndef HAL_PARACHUTE_ENABLED
 // default to parachute enabled to match previous configs
@@ -115,6 +116,7 @@ private:
 
     enum class Options : uint8_t {
         HoldOpen = (1U<<0),
+        SkipDisarmBeforeParachuteRelease = (1U<<1),
     };
 
     AP_Int32    _options;


### PR DESCRIPTION
Based on discussion of PR #25570 and #25562.

Disarm before parachute release to avoid parachute tangling if parameter CHUTE_OPTIONS:1 = 0.