### PR TITLE
HAL_ChibiOS: fixed support for STM32H7A3

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_A3_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_A3_mcuconf.h
@@ -18,6 +18,9 @@
  */
 #pragma once
 
+// this is a newer H7 varient
+#define STM32_ENFORCE_H7_REV_XY
+
 // MPU region for ethernet
 #define STM32_NOCACHE_MPU_REGION_ETH            MPU_REGION_2
 


### PR DESCRIPTION
need to tell ChibiOS this is a newer H7

this line was in my test fw but was removed during a review cleanup. Turns out it is needed