### PR TITLE
AP_ExternalAHRS: Populate Microstrain7 orientation from filter

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -90,7 +90,7 @@ public:
 
         Vector3f accel;
         Vector3f gyro;
-        Quaternion quat;
+        Quaternion quat; // NED
         Location location;
         Vector3f velocity;
         Location origin;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -134,9 +134,6 @@ void AP_ExternalAHRS_MicroStrain7::post_imu() const
         WITH_SEMAPHORE(state.sem);
         state.accel = imu_data.accel;
         state.gyro = imu_data.gyro;
-
-        state.quat = imu_data.quat;
-        state.have_quaternion = true;
     }
 
     {
@@ -188,6 +185,9 @@ void AP_ExternalAHRS_MicroStrain7::post_filter() const
         // Use GNSS 0 even though it may be bad.
         state.location = Location{filter_data.lat, filter_data.lon, gnss_data[0].msl_altitude, Location::AltFrame::ABSOLUTE};
         state.have_location = true;
+
+        state.quat = filter_data.attitude_quat;
+        state.have_quaternion = true;
     }
 
     for (int instance = 0; instance < NUM_GNSS_INSTANCES; instance++) {

--- a/libraries/AP_ExternalAHRS/MicroStrain_common.h
+++ b/libraries/AP_ExternalAHRS/MicroStrain_common.h
@@ -86,6 +86,9 @@ protected:
         float ned_velocity_east;
         float ned_velocity_down;
         float speed_accuracy;
+        // 4x1 vector representation of the quaternion describing the orientation of the device with respect to the NED local-level frame.
+        // NED [Qw, Qx, Qy, Qz]
+        Quaternion attitude_quat;
     } filter_data;
 
     enum class DescriptorSet {

--- a/libraries/SITL/SIM_MicroStrain.cpp
+++ b/libraries/SITL/SIM_MicroStrain.cpp
@@ -13,7 +13,15 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-    simulate MicroStrain GNSS-INS devices
+    Simulate MicroStrain CX5 GNSS-INS devices
+    
+    Usage:
+    PARAMS:
+        param set AHRS_EKF_TYPE 11
+        param set EAHRS_TYPE 2
+        param set SERIAL3_PROTOCOL 36
+        param set SERIAL3_BAUD 115
+    sim_vehicle.py -v Plane -A "--serial3=sim:MicroStrain5" --console --map -DG
 */
 #include "SIM_MicroStrain.h"
 #include <stdio.h>

--- a/libraries/SITL/SIM_MicroStrain.h
+++ b/libraries/SITL/SIM_MicroStrain.h
@@ -1,12 +1,5 @@
 // Created by Asa Davis and Davis Schenkenberger on 23rd September 21.
 
-//usage:
-//PARAMS:
-// param set AHRS_EKF_TYPE 11
-// param set EAHRS_TYPE 2
-// param set SERIAL3_PROTOCOL 36
-// param set SERIAL3_BAUD 115
-// sim_vehicle.py -v Plane -A "--serial3=sim:MicroStrain7" --console --map -DG
 #pragma once
 
 #include "SIM_Aircraft.h"

--- a/libraries/SITL/SIM_MicroStrain7.cpp
+++ b/libraries/SITL/SIM_MicroStrain7.cpp
@@ -13,7 +13,15 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-    simulate MicroStrain 7-series GNSS-INS devices
+    Simulate MicroStrain 7-series GNSS-INS devices
+
+    Usage:
+    PARAMS:
+        param set AHRS_EKF_TYPE 11
+        param set EAHRS_TYPE 7
+        param set SERIAL3_PROTOCOL 36
+        param set SERIAL3_BAUD 115
+    sim_vehicle.py -v Plane -A "--serial3=sim:MicroStrain7" --console --map -DG
 */
 
 #include "SIM_MicroStrain.h"
@@ -140,8 +148,17 @@ void MicroStrain7::send_filter_packet(void)
     put_int(packet, 0x03); // Dynamics mode (Airborne)
     put_int(packet, 0); // Filter flags (None, no warnings)
 
-    packet.header[3] = packet.payload_size;
+    // Add Attitude Quaternion
+    // https://s3.amazonaws.com/files.microstrain.com/GQ7+User+Manual/external_content/dcp/Data/filter_data/data/mip_field_filter_attitude_quaternion.htm
+    packet.payload[packet.payload_size++] = 0x14; // Attitude Quaternion Field Size
+    packet.payload[packet.payload_size++] = 0x03; // Descriptor
+    put_float(packet, fdm.quaternion.q1);
+    put_float(packet, fdm.quaternion.q2);
+    put_float(packet, fdm.quaternion.q3);
+    put_float(packet, fdm.quaternion.q4);
+    put_int(packet, 0x0001); // Valid flags
 
+    packet.header[3] = packet.payload_size;
 
     send_packet(packet);
 }


### PR DESCRIPTION
# Purpose
* Populating AHRS orientation from IMU was not correct, this should be populated by the full navigation filter orientation packet. 
* This requires users to turn on the orientation output on the filter (WIKI needed for which channels to enable in SensorConnect anyways)
* I would like this backported to 4.5 as it is a bug to use IMU orientation for EARHS instead of the navigation solution

# Testing

This needs testing before merge and a comment in the method on what quaternion order the Microstrain packet is in. I assume it's the same as the other packet, but would like to verify on hardware before merge.

`./Tools/autotest/autotest.py build.Plane test.Plane.MicroStrainEAHRS7`

FYI @CraigElder 