### PR TITLE
Plane: fixed handling of arming with safety on

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -287,7 +287,7 @@ void AP_Arming_Plane::change_arm_state(void)
 {
     update_soft_armed();
 #if HAL_QUADPLANE_ENABLED
-    plane.quadplane.set_armed(is_armed_and_safety_off());
+    plane.quadplane.set_armed(hal.util->get_soft_armed());
 #endif
 }
 


### PR DESCRIPTION
if safety is on and you force arm them turn safety off then Q modes cannot run the motors as the AP_Motors armed state will still be off.

This ensures that the motors are armed immediately we arm. This matches what copter does when arming with safety on