### PR TITLE
HAL_ChibiOS: fixed I2C4 on STM32G4

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -67,9 +67,9 @@ def can_share(periph, noshare_list):
     return False
 
 
-# list of peripherals on H7 that are on DMAMUX2 and BDMA
+# list of peripherals that are on DMAMUX2 and BDMA
 have_DMAMUX = False
-DMAMUX2_peripherals = [ 'I2C4', 'SPI6', 'ADC3' ]
+DMAMUX2_peripherals = []
 
 def dmamux_channel(key):
     '''return DMAMUX channel for H7'''
@@ -297,6 +297,10 @@ def write_dma_header(f, peripheral_list, mcu_type, dma_exclude=[],
     '''write out a DMA resolver header file'''
     global dma_map, have_DMAMUX, has_bdshot
     timer_ch_periph = []
+
+    if mcu_type.startswith('STM32H7'):
+        global DMAMUX2_peripherals
+        DMAMUX2_peripherals = [ 'I2C4', 'SPI6', 'ADC3' ]
 
     has_bdshot = False
 


### PR DESCRIPTION
I2C4 is not on BDMA on G4
