### PR TITLE
Dds yaw control plane

### DIFF
--- a/ArduCopter/AP_ExternalControl_Copter.cpp
+++ b/ArduCopter/AP_ExternalControl_Copter.cpp
@@ -12,7 +12,7 @@
   set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw
   velocity is in earth frame, NED, m/s
 */
-bool AP_ExternalControl_Copter::set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)
+bool AP_ExternalControl_Copter::set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, const float yaw_rate_rads)
 {
     if (!ready_for_external_control()) {
         return false;

--- a/ArduCopter/AP_ExternalControl_Copter.h
+++ b/ArduCopter/AP_ExternalControl_Copter.h
@@ -14,7 +14,7 @@ public:
       Velocity is in earth frame, NED [m/s].
       Yaw is in earth frame, NED [rad/s].
      */
-    bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads) override WARN_IF_UNUSED;
+    bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, const float yaw_rate_rads) override WARN_IF_UNUSED;
 private:
     /*
       Return true if Copter is ready to handle external control data.

--- a/ArduPlane/AP_ExternalControl_Plane.cpp
+++ b/ArduPlane/AP_ExternalControl_Plane.cpp
@@ -19,4 +19,14 @@ bool AP_ExternalControl_Plane::set_global_position(const Location& loc)
     return plane.set_target_location(loc);
 }
 
+/*
+    Sets only the target yaw rate
+    Yaw is in earth frame, NED [rad/s]
+*/
+bool AP_ExternalControl_Plane::set_yaw_rate(const float yaw_rate_rads)
+{
+    // TODO validate yaw rate is feasible for current dynamics
+    return plane.set_target_yaw_rate(yaw_rate_rads);
+}
+
 #endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/AP_ExternalControl_Plane.h
+++ b/ArduPlane/AP_ExternalControl_Plane.h
@@ -16,6 +16,12 @@ public:
         Sets the target global position for a loiter point.
     */
     bool set_global_position(const Location& loc) override WARN_IF_UNUSED;
+
+    /*
+        Sets only the target yaw rate
+        Yaw is in earth frame, NED [rad/s]
+    */
+    bool set_yaw_rate(const float yaw_rate_rads) override WARN_IF_UNUSED;
 };
 
 #endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -824,6 +824,19 @@ bool Plane::set_target_location(const Location &target_loc)
     plane.set_guided_WP(loc);
     return true;
 }
+
+bool Plane::set_target_yaw_rate(const float yaw_rate)
+{
+    if (plane.control_mode != &plane.mode_guided) {
+        // only accept yaw rate updates when in GUIDED mode
+        return false;
+    }
+
+    const auto direction_is_ccw = yaw_rate < 0;
+    plane.mode_guided.set_radius_and_direction(abs(yaw_rate), direction_is_ccw);
+
+    return true;
+}
 #endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 
 #if AP_SCRIPTING_ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1249,6 +1249,7 @@ public:
     bool is_taking_off() const override;
 #if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
     bool set_target_location(const Location& target_loc) override;
+    bool set_target_yaw_rate(const float yaw_rate_rads) override;
 #endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 #if AP_SCRIPTING_ENABLED
     bool get_target_location(Location& target_loc) override;

--- a/Rover/AP_ExternalControl_Rover.cpp
+++ b/Rover/AP_ExternalControl_Rover.cpp
@@ -12,7 +12,7 @@
   set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw
   velocity is in earth frame, NED, m/s
 */
-bool AP_ExternalControl_Rover::set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)
+bool AP_ExternalControl_Rover::set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, const float yaw_rate_rads)
 {
     if (!ready_for_external_control()) {
         return false;

--- a/Rover/AP_ExternalControl_Rover.h
+++ b/Rover/AP_ExternalControl_Rover.h
@@ -14,7 +14,7 @@ public:
       Velocity is in earth frame, NED [m/s].
       Yaw is in earth frame, NED [rad/s].
      */
-    bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)override WARN_IF_UNUSED;
+    bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, const float yaw_rate_rads)override WARN_IF_UNUSED;
 private:
     /*
       Return true if Rover is ready to handle external control data.

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -55,6 +55,8 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
     if (external_control == nullptr) {
         return false;
     }
+    
+    // TODO handle stale data from timestamp gracefully.
 
     if (strcmp(cmd_vel.header.frame_id, BASE_LINK_FRAME_ID) == 0) {
         // Convert commands from body frame (x-forward, y-left, z-up) to NED.
@@ -64,7 +66,8 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
             float(cmd_vel.twist.linear.y),
             float(-cmd_vel.twist.linear.z) };
         const float yaw_rate = -cmd_vel.twist.angular.z;
-        if (linear_velocity_base_link == Vector3f(NAN, NAN, NAN)) {
+
+        if (linear_velocity_base_link.is_all_nan()) {
             return external_control->set_yaw_rate(yaw_rate);
         }
 

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -64,10 +64,14 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
             float(cmd_vel.twist.linear.y),
             float(-cmd_vel.twist.linear.z) };
         const float yaw_rate = -cmd_vel.twist.angular.z;
+        if (linear_velocity_base_link == Vector3f(NAN, NAN, NAN)) {
+            return external_control->set_yaw_rate(yaw_rate);
+        }
 
         auto &ahrs = AP::ahrs();
         linear_velocity = ahrs.body_to_earth(linear_velocity_base_link);
-        return external_control->set_linear_velocity_and_yaw_rate(linear_velocity, yaw_rate);
+
+        return external_control->set_linear_velocity_and_yaw_rate(linear_velocity, yaw_rate);       
     }
 
     else if (strcmp(cmd_vel.header.frame_id, MAP_FRAME) == 0) {

--- a/libraries/AP_ExternalControl/AP_ExternalControl.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.h
@@ -21,7 +21,7 @@ public:
       Velocity is in earth frame, NED [m/s].
       Yaw is in earth frame, NED [rad/s].
      */
-    virtual bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads) WARN_IF_UNUSED {
+    virtual bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, const float yaw_rate_rads) WARN_IF_UNUSED {
         return false;
     }
 
@@ -29,6 +29,14 @@ public:
         Sets the target global position with standard guided mode behavior.
     */
     virtual bool set_global_position(const Location& loc) WARN_IF_UNUSED {
+        return false;
+    }
+
+    /*
+        Sets only the target yaw rate
+        Yaw is in earth frame, NED [rad/s]
+    */
+    virtual bool set_yaw_rate(const float yaw_rate_rads) WARN_IF_UNUSED {
         return false;
     }
 

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -367,6 +367,12 @@ bool Vector3<T>::is_nan(void) const
 }
 
 template <typename T>
+bool Vector3<T>::is_all_nan(void) const
+{
+    return isnan(x) && isnan(y) && isnan(z);
+}
+
+template <typename T>
 bool Vector3<T>::is_inf(void) const
 {
     return isinf(x) || isinf(y) || isinf(z);

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -182,6 +182,9 @@ public:
     // check if any elements are NAN
     bool is_nan(void) const WARN_IF_UNUSED;
 
+    // check if all elements are NAN
+    bool is_all_nan(void) const WARN_IF_UNUSED;
+
     // check if any elements are infinity
     bool is_inf(void) const WARN_IF_UNUSED;
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -160,6 +160,9 @@ public:
 #if AP_EXTERNAL_CONTROL_ENABLED
     // Method to control vehicle position for use by external control
     virtual bool set_target_location(const Location& target_loc) { return false; }
+    // Method to control vehicle yaw rate for use by external control
+    // Yaw is in earth frame, NED [rad/s]
+    virtual bool set_target_yaw_rate(const float yaw_rate_rads) { return false; }
 #endif // AP_EXTERNAL_CONTROL_ENABLED
 #if AP_SCRIPTING_ENABLED
     /*


### PR DESCRIPTION
# Purpose

Add lower level controls ability for turn rate on Plane when using DDS that isn't tied to a waypoint

# Usage

```bash
ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped "{header: {frame_id: base_link}, twist: {linear: {x: .nan, y: .nan, z: .nan}, angular: {z: -0.01}}}" --once
```

# Problem

Seems like the navigation mode is overriding the lower level commands. I need to find a way to bypass it. Tips are appreciated.
