### PR TITLE
AP_RCProtocol: use constructor from parent class in ibus

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.cpp
@@ -20,11 +20,6 @@
 
 #include "AP_RCProtocol_IBUS.h"
 
-// constructor
-AP_RCProtocol_IBUS::AP_RCProtocol_IBUS(AP_RCProtocol &_frontend) :
-    AP_RCProtocol_Backend(_frontend)
-{}
-
 // decode a full IBUS frame
 bool AP_RCProtocol_IBUS::ibus_decode(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe)
 {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
@@ -30,7 +30,8 @@
 class AP_RCProtocol_IBUS : public AP_RCProtocol_Backend
 {
 public:
-    AP_RCProtocol_IBUS(AP_RCProtocol &_frontend);
+    using AP_RCProtocol_Backend::AP_RCProtocol_Backend;
+
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:


### PR DESCRIPTION
```
Board               AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       -16             -16    *           -16     -16               -16    -16    -16
HerePro             *                                                                                     
Hitec-Airspeed      *                                                                                     
KakuteH7-bdshot                -16             -16    *           -16     -16               -16    -16    -16
MatekF405                      -8              -8     *           -16     -16               -16    -8     -16
Pixhawk1-1M-bdshot             -16             -16                -16     -16               -16    -16    -16
f103-QiotekPeriph   *                                                                                     
f303-Universal      *                                                                                     
iomcu                                                                           -16                       
revo-mini                      -8              -8     *           -16     -16               -16    -8     -16
skyviper-v2450                                                    *                                       
```
