### PR TITLE
vscode: set lua version to 5.3

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,4 +1,5 @@
 {
     "cSpell.language": "en-GB",
-    "astyle.astylerc": "${workspaceFolder}/Tools/CodeStyle/astylerc"
+    "astyle.astylerc": "${workspaceFolder}/Tools/CodeStyle/astylerc",
+    "Lua.runtime.version": "Lua 5.3"
 }


### PR DESCRIPTION
This adds the scripting lua version to the vscode default settings. 