### PR TITLE
AP_HAL_SITL: remove deprecated --uartX options

### DIFF
--- a/Tools/completion/zsh/_ap_bin
+++ b/Tools/completion/zsh/_ap_bin
@@ -21,16 +21,6 @@ _ap_bin() {
     '--gimbal[enable simulated MAVLink gimbal]' \
     '--autotest-dir[set directory for additional files]:DIR:' \
     '--defaults[set path to defaults file]:PATH:' \
-    '--uartA[(deprecated) set device string for SERIAL0]:DEVICE:' \
-    '--uartC[(deprecated) set device string for SERIAL1]:DEVICE:' \
-    '--uartD[(deprecated) set device string for SERIAL2]:DEVICE:' \
-    '--uartB[(deprecated) set device string for SERIAL3]:DEVICE:' \
-    '--uartE[(deprecated) set device string for SERIAL4]:DEVICE:' \
-    '--uartF[(deprecated) set device string for SERIAL5]:DEVICE:' \
-    '--uartG[(deprecated) set device string for SERIAL6]:DEVICE:' \
-    '--uartH[(deprecated) set device string for SERIAL7]:DEVICE:' \
-    '--uartI[(deprecated) set device string for SERIAL8]:DEVICE:' \
-    '--uartJ[(deprecated) set device string for SERIAL9]:DEVICE:' \
     '--serial0[set device string for SERIAL0]:DEVICE:' \
     '--serial1[set device string for SERIAL1]:DEVICE:' \
     '--serial2[set device string for SERIAL2]:DEVICE:' \

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -381,8 +381,6 @@ class MAVProxyLaunch:
 class SITLLaunch:
     """Launch functions for ArduPilot SITL."""
 
-    # Labels for the optional uart launch arguments.
-    UART_LABELS = ["A", "B", "C", "D", "E", "F", "H", "I", "J"]
     MAX_SERIAL_PORTS = 10
 
     @staticmethod
@@ -432,13 +430,6 @@ class SITLLaunch:
         if home:
             cmd_args.append(f"--home {home} ")
             print(f"home:             {home}")
-
-        # Optional uart arguments.
-        for label in SITLLaunch.UART_LABELS:
-            arg = LaunchConfiguration(f"uart{label}").perform(context)
-            if arg:
-                cmd_args.append(f"--uart{label} {arg} ")
-                print(f"uart{label}:            {arg}")
 
         # Optional serial arguments.
         for label in range(10):
@@ -646,16 +637,6 @@ class SITLLaunch:
             ),
         ]
 
-        # UART launch arguments.
-        uart_args = []
-        for label in SITLLaunch.UART_LABELS:
-            arg = DeclareLaunchArgument(
-                f"uart{label}",
-                default_value="",
-                description=f"set device string for UART{label}.",
-            )
-            uart_args.append(arg)
-
         # Serial launch arguments.
         serial_args = []
         for label in range(SITLLaunch.MAX_SERIAL_PORTS):
@@ -666,4 +647,4 @@ class SITLLaunch:
             )
             serial_args.append(arg)
 
-        return launch_args + uart_args + serial_args
+        return launch_args + serial_args

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -96,16 +96,6 @@ void SITL_State::_usage(void)
            "\t--gimbal                 enable simulated MAVLink gimbal\n"
            "\t--autotest-dir DIR       set directory for additional files\n"
            "\t--defaults path          set path to defaults file\n"
-           "\t--uartA device           (deprecated) set device string for SERIAL0\n"
-           "\t--uartC device           (deprecated) set device string for SERIAL1\n" // ordering captures the historical use of uartB as SERIAL3
-           "\t--uartD device           (deprecated) set device string for SERIAL2\n"
-           "\t--uartB device           (deprecated) set device string for SERIAL3\n"
-           "\t--uartE device           (deprecated) set device string for SERIAL4\n"
-           "\t--uartF device           (deprecated) set device string for SERIAL5\n"
-           "\t--uartG device           (deprecated) set device string for SERIAL6\n"
-           "\t--uartH device           (deprecated) set device string for SERIAL7\n"
-           "\t--uartI device           (deprecated) set device string for SERIAL8\n"
-           "\t--uartJ device           (deprecated) set device string for SERIAL9\n"
            "\t--serial0 device         set device string for SERIAL0\n"
            "\t--serial1 device         set device string for SERIAL1\n"
            "\t--serial2 device         set device string for SERIAL2\n"
@@ -474,11 +464,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             static const uint8_t mapping[] = { 0, 3, 1, 2, 4, 5, 6, 7, 8, 9 };
             int serial_idx = mapping[uart_idx];
             char uart_letter = (char)(uart_idx)+'A';
-            printf("WARNING: deprecated option --uart%c will be removed in a "
-                "future release. Use --serial%d instead.\n",
-                uart_letter, serial_idx);
-            _serial_path[serial_idx] = gopt.optarg;
-            break;
+            printf("ERROR: Removed option --uart%c supplied. "
+                "Use --serial%d instead.\n", uart_letter, serial_idx);
+            exit(1);
         }
         case CMDLINE_SERIAL0:
         case CMDLINE_SERIAL1:

--- a/libraries/SITL/SIM_InertialLabs.h
+++ b/libraries/SITL/SIM_InertialLabs.h
@@ -4,7 +4,7 @@
 // param set EAHRS_TYPE 5
 // param set SERIAL4_PROTOCOL 36
 // param set SERIAL4_BAUD 460800
-// sim_vehicle.py -v ArduPlane -D --console --map -A --uartE=sim:ILabs
+// sim_vehicle.py -v ArduPlane -D --console --map -A --serial4=sim:ILabs
 #pragma once
 
 #include "SIM_Aircraft.h"

--- a/libraries/SITL/SIM_Loweheiser.h
+++ b/libraries/SITL/SIM_Loweheiser.h
@@ -15,7 +15,7 @@
 /*
   Simulator for the Loweheiser EFI/generator
 
-./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=sim:loweheiser --speedup=1 --console
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --serial5=sim:loweheiser --speedup=1 --console
 
 param set SIM_EFI_TYPE 2
 param set SERIAL5_PROTOCOL 2
@@ -57,7 +57,7 @@ long SET_MESSAGE_INTERVAL 225 100000
 
 # run SITL against real generator:
 DEV=/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller-if00-port0
-./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --uartF=uart:$DEV:115200 --speedup=1 --console
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --serial5=uart:$DEV:115200 --speedup=1 --console
 
 # run generator test script against simulator:
 python ./libraries/AP_Generator/scripts/test-loweheiser.py tcp:localhost:5762


### PR DESCRIPTION
Code remains to check for use of these options and give an error which contains the correct option to use, due to the non-intuitive mapping between --uartX and --serialN.

A future version will remove that code too, plus the similar deprecation warning in AP_HAL_Linux.

Tested that the arguments are correctly rejected.
