### PR TITLE
AP_Scripting: add ROMFS to lua path

### DIFF
--- a/libraries/AP_Scripting/lua/src/loadlib.c
+++ b/libraries/AP_Scripting/lua/src/loadlib.c
@@ -798,7 +798,11 @@ LUAMOD_API int luaopen_package (lua_State *L) {
   luaL_newlib(L, pk_funcs);  /* create 'package' table */
   // createsearcherstable(L);
   /* set paths */
+#if defined(ARDUPILOT_BUILD)
+  setpath(L, "path", LUA_PATH_VAR, lua_get_modules_path());
+#else
   setpath(L, "path", LUA_PATH_VAR, LUA_PATH_DEFAULT);
+#endif
   // setpath(L, "cpath", LUA_CPATH_VAR, LUA_CPATH_DEFAULT);
   /* store config information */
   lua_pushliteral(L, LUA_DIRSEP "\n" LUA_PATH_SEP "\n" LUA_PATH_MARK "\n"

--- a/libraries/AP_Scripting/lua/src/luaconf.h
+++ b/libraries/AP_Scripting/lua/src/luaconf.h
@@ -195,11 +195,13 @@
 #define LUA_LDIR	"!\\lua\\"
 #define LUA_CDIR	"!\\"
 #define LUA_SHRDIR	"!\\..\\share\\lua\\" LUA_VDIR "\\"
+#if !defined(ARDUPILOT_BUILD)
 #define LUA_PATH_DEFAULT  \
 		LUA_LDIR"?.lua;"  LUA_LDIR"?\\init.lua;" \
 		LUA_CDIR"?.lua;"  LUA_CDIR"?\\init.lua;" \
 		LUA_SHRDIR"?.lua;" LUA_SHRDIR"?\\init.lua;" \
 		".\\?.lua;" ".\\?\\init.lua"
+#endif
 #define LUA_CPATH_DEFAULT \
 		LUA_CDIR"?.dll;" \
 		LUA_CDIR"..\\lib\\lua\\" LUA_VDIR "\\?.dll;" \
@@ -210,9 +212,11 @@
 #define LUA_ROOT	"/usr/local/"
 #define LUA_LDIR	SCRIPTING_DIRECTORY "/modules/"
 #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+#if !defined(ARDUPILOT_BUILD)
 #define LUA_PATH_DEFAULT  \
 		LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua;" \
 		"./?.lua;" "./?/init.lua"
+#endif
 #define LUA_CPATH_DEFAULT \
 		LUA_CDIR"?.so;" LUA_CDIR"loadall.so;" "./?.so"
 #endif			/* } */

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -920,6 +920,33 @@ int lua_get_current_ref()
     return scripting->get_current_ref();
 }
 
+// This is used when loading modules with require, lua must only look in enabled directory's
+const char* lua_get_modules_path()
+{
+#define LUA_PATH_ROMFS "@ROMFS/scripts/modules/?.lua;" "@ROMFS/scripts/modules/?/init.lua"
+#define LUA_PATH_SCRIPTS LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua"
+
+    uint16_t dir_disable = AP_Scripting::get_singleton()->get_disabled_dir();
+    dir_disable &= uint16_t(AP_Scripting::SCR_DIR::SCRIPTS) | uint16_t(AP_Scripting::SCR_DIR::ROMFS);
+    if (dir_disable == 0) {
+        // Both directory's are enabled, return both, ROMFS takes priority
+        return LUA_PATH_ROMFS ";" LUA_PATH_SCRIPTS;
+    }
+
+    if ((dir_disable & uint16_t(AP_Scripting::SCR_DIR::SCRIPTS)) == 0) {
+        // Only scripts enabled
+        return LUA_PATH_SCRIPTS;
+    }
+
+    if ((dir_disable & uint16_t(AP_Scripting::SCR_DIR::ROMFS)) == 0) {
+        // Only ROMFS enabled
+        return LUA_PATH_ROMFS;
+    }
+
+    // Nothing enabled?
+    return "";
+}
+
 // Simple print to GCS or over CAN
 int lua_print(lua_State *L) {
     // Only support a single argument

--- a/libraries/AP_Scripting/lua_common_defs.h
+++ b/libraries/AP_Scripting/lua_common_defs.h
@@ -27,5 +27,6 @@
 #endif // REPL_OUT
 
 int lua_get_current_ref();
+const char* lua_get_modules_path();
 void lua_abort(void) __attribute__((noreturn));
 


### PR DESCRIPTION
This allows `require` to find modules in ROMFS. Possibly helps with other file system methods too. Note that this adds the new search path even if we don't have ROMFS compiled in. I think it will be fine, but I have not tested. 

Adding `"./modules/?.lua;" "./modules/?/init.lua"` to get to the same place relative to a script loaded in ROMFS does not seem to work, I'm not sure why. 

This should allow a SD card script to require something from ROMFS, which using relative paths would not. Because of the ordering it should also mean a SD card version of the same file gets priority over a ROMFS copy. Its convenient for development but might give users a very exciting way to break stuff. We could swap the ordering so ROMFS takes priority. Again, I have not tested this.