### PR TITLE
AP_Scripting: Add calibrating method

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1506,6 +1506,10 @@ function ins:get_gyro_health(instance) end
 ---@return boolean
 function ins:get_accel_health(instance) end
 
+-- Get if the INS is currently calibrating
+---@return boolean
+function ins:calibrating() end
+
 -- desc
 ---@class Motors_dynamic
 Motors_dynamic = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -633,6 +633,7 @@ singleton AP_InertialSensor rename ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
 singleton AP_InertialSensor method get_gyro_health boolean uint8_t'skip_check
 singleton AP_InertialSensor method get_accel_health boolean uint8_t'skip_check
+singleton AP_InertialSensor method calibrating boolean
 
 singleton CAN manual get_device lua_get_CAN_device 1
 singleton CAN manual get_device2 lua_get_CAN_device2 1


### PR DESCRIPTION
Added the ins:calibrating() binding to scripting to be able to tell if the autopilot is calibrating or not so that we don't run other processes

This was tested on a Cube Orange Plus.