### PR TITLE
AP_Scripting: Add getting of gyro/accel values

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1495,8 +1495,8 @@ ins = {}
 ---@return number
 function ins:get_temperature(instance) end
 
--- Check if a specific gyrometer sensor is healthy
----@param instance integer -- the 0-based index of the gyrometer instance to return.
+-- Check if a specific gyroscope sensor is healthy
+---@param instance integer -- the 0-based index of the gyroscope instance to return.
 ---@return boolean
 function ins:get_gyro_health(instance) end
 
@@ -1508,6 +1508,16 @@ function ins:get_accel_health(instance) end
 -- Get if the INS is currently calibrating
 ---@return boolean
 function ins:calibrating() end
+
+-- Get the value of a specific gyroscope
+---@param instance integer -- the 0-based index of the gyroscope instance to return.
+---@return Vector3f_ud
+function ins:get_gyro(instance) end
+
+-- Get the value of a specific accelerometer
+---@param instance integer -- the 0-based index of the accelerometer instance to return.
+---@return Vector3f_ud
+function ins:get_accel(instance) end
 
 -- desc
 ---@class Motors_dynamic

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -634,6 +634,8 @@ singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTA
 singleton AP_InertialSensor method get_gyro_health boolean uint8_t'skip_check
 singleton AP_InertialSensor method get_accel_health boolean uint8_t'skip_check
 singleton AP_InertialSensor method calibrating boolean
+singleton AP_InertialSensor method get_gyro Vector3f uint8_t'skip_check
+singleton AP_InertialSensor method get_accel Vector3f uint8_t'skip_check
 
 singleton CAN manual get_device lua_get_CAN_device 1
 singleton CAN manual get_device2 lua_get_CAN_device2 1


### PR DESCRIPTION
Added bindings for ins:get_gyro(instance) and ins:get_accel(instance) so that scripting can get the readings from individual sensors. We need this to be able to validate that the IMUs are reading correctly for testing purposes.

This has been tested using the Cube Orange Plus