### PR TITLE
Added inertial sensor consistency checking for LUA access

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -352,44 +352,15 @@ bool AP_Arming::logging_checks(bool report)
 #if AP_INERTIALSENSOR_ENABLED
 bool AP_Arming::ins_accels_consistent(const AP_InertialSensor &ins)
 {
-    const uint8_t accel_count = ins.get_accel_count();
-    if (accel_count <= 1) {
-        return true;
-    }
-
-    const Vector3f &prime_accel_vec = ins.get_accel();
     const uint32_t now = AP_HAL::millis();
-    for(uint8_t i=0; i<accel_count; i++) {
-        if (!ins.use_accel(i)) {
-            continue;
-        }
-        // get next accel vector
-        const Vector3f &accel_vec = ins.get_accel(i);
-        Vector3f vec_diff = accel_vec - prime_accel_vec;
-        // allow for user-defined difference, typically 0.75 m/s/s. Has to pass in last 10 seconds
-        float threshold = accel_error_threshold;
-        if (i >= 2) {
-            /*
-              we allow for a higher threshold for IMU3 as it
-              runs at a different temperature to IMU1/IMU2,
-              and is not used for accel data in the EKF
-            */
-            threshold *= 3;
-        }
-
-        // EKF is less sensitive to Z-axis error
-        vec_diff.z *= 0.5f;
-
-        if (vec_diff.length() > threshold) {
-            // this sensor disagrees with the primary sensor, so
-            // accels are inconsistent:
-            last_accel_pass_ms = 0;
-            return false;
-        }
+    if (!ins.accels_consistent(accel_error_threshold)) {
+        // accels are inconsistent:
+        last_accel_pass_ms = 0;
+        return false;
     }
 
     if (last_accel_pass_ms == 0) {
-        // we didn't return false in the loop above, so sensors are
+        // we didn't return false above, so sensors are
         // consistent right now:
         last_accel_pass_ms = now;
     }
@@ -404,30 +375,15 @@ bool AP_Arming::ins_accels_consistent(const AP_InertialSensor &ins)
 
 bool AP_Arming::ins_gyros_consistent(const AP_InertialSensor &ins)
 {
-    const uint8_t gyro_count = ins.get_gyro_count();
-    if (gyro_count <= 1) {
-        return true;
-    }
-
-    const Vector3f &prime_gyro_vec = ins.get_gyro();
     const uint32_t now = AP_HAL::millis();
-    for(uint8_t i=0; i<gyro_count; i++) {
-        if (!ins.use_gyro(i)) {
-            continue;
-        }
-        // get next gyro vector
-        const Vector3f &gyro_vec = ins.get_gyro(i);
-        const Vector3f vec_diff = gyro_vec - prime_gyro_vec;
-        // allow for up to 5 degrees/s difference
-        if (vec_diff.length() > radians(5)) {
-            // this sensor disagrees with the primary sensor, so
-            // gyros are inconsistent:
-            last_gyro_pass_ms = 0;
-            return false;
-        }
+    // allow for up to 5 degrees/s difference
+    if (!ins.gyros_consistent(5)) {
+        // gyros are inconsistent:
+        last_gyro_pass_ms = 0;
+        return false;
     }
 
-    // we didn't return false in the loop above, so sensors are
+    // we didn't return false above, so sensors are
     // consistent right now:
     if (last_gyro_pass_ms == 0) {
         last_gyro_pass_ms = now;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -137,6 +137,7 @@ public:
     bool get_gyro_health(uint8_t instance) const { return (instance<_gyro_count) ? _gyro_healthy[instance] : false; }
     bool get_gyro_health(void) const { return get_gyro_health(_primary_gyro); }
     bool get_gyro_health_all(void) const;
+    bool gyros_consistent(uint8_t threshold) const;
     uint8_t get_gyro_count(void) const { return MIN(INS_MAX_INSTANCES, _gyro_count); }
     bool gyro_calibrated_ok(uint8_t instance) const { return _gyro_cal_ok[instance]; }
     bool gyro_calibrated_ok_all() const;
@@ -146,6 +147,7 @@ public:
     bool get_accel_health(uint8_t instance) const { return (instance<_accel_count) ? _accel_healthy[instance] : false; }
     bool get_accel_health(void) const { return get_accel_health(_primary_accel); }
     bool get_accel_health_all(void) const;
+    bool accels_consistent(float accel_error_threshold) const;
     uint8_t get_accel_count(void) const { return MIN(INS_MAX_INSTANCES, _accel_count); }
     bool accel_calibrated_ok_all() const;
     bool use_accel(uint8_t instance) const;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1495,10 +1495,20 @@ ins = {}
 ---@return number
 function ins:get_temperature(instance) end
 
+-- Check if the gyrometers are consistent
+---@param threshold integer -- the allowed threshold in degrees per second
+---@return boolean
+function ins:gyros_consistent(threshold) end
+
 -- Check if a specific gyroscope sensor is healthy
 ---@param instance integer -- the 0-based index of the gyroscope instance to return.
 ---@return boolean
 function ins:get_gyro_health(instance) end
+
+-- Check if the accelerometers are consistent
+---@param threshold float -- the threshold allowed before returning false
+---@return boolean
+function ins:accels_consistent(threshold) end
 
 -- Check if a specific accelerometer sensor is healthy
 ---@param instance integer -- the 0-based index of the accelerometer instance to return.

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -636,10 +636,12 @@ singleton AP_InertialSensor depends AP_INERTIALSENSOR_ENABLED
 singleton AP_InertialSensor rename ins
 singleton AP_InertialSensor method get_temperature float uint8_t 0 INS_MAX_INSTANCES
 singleton AP_InertialSensor method get_gyro_health boolean uint8_t'skip_check
+singleton AP_InertialSensor method accels_consistent boolean float'skip_check
 singleton AP_InertialSensor method get_accel_health boolean uint8_t'skip_check
 singleton AP_InertialSensor method calibrating boolean
 singleton AP_InertialSensor method get_gyro Vector3f uint8_t'skip_check
 singleton AP_InertialSensor method get_accel Vector3f uint8_t'skip_check
+singleton AP_InertialSensor method gyros_consistent boolean uint8_t'skip_check
 
 singleton CAN manual get_device lua_get_CAN_device 1
 singleton CAN manual get_device2 lua_get_CAN_device2 1


### PR DESCRIPTION
Added ins:gyros_consistent(threshold, consistency_seconds) and ins:accels_consistent(threshold, consistency_seconds) for access to LUA for our testing requirements.

With this i also moved ins_accels_consistent and ins_gyros_consistent from AP_Arming to AP_IntertialSensor as i feel that this makes more sense. If this was still in AP_Arming you would need to pass the ins to the function via scripting which i'm not entirely sure how to do.

I also added the threshold and consistency_seconds to be parameters as they were hard coded previously and we need to be sensitive via scripting.