### PR TITLE
Allow multiple UDP clients to connect/disconnect/reconnect

### DIFF
--- a/Tools/AP_Periph/Web/scripts/pppgw_webui.lua
+++ b/Tools/AP_Periph/Web/scripts/pppgw_webui.lua
@@ -938,6 +938,9 @@ local function Client(_sock, _idx)
 
    function self.remove()
       DEBUG(string.format("%u: removing client OFFSET=%u", idx, offset))
+      if self.closed then
+         return
+      end
       sock:close()
       self.closed = true
    end

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -327,8 +327,12 @@ ssize_t SOCKET_CLASS_NAME::recv(void *buf, size_t size, uint32_t timeout_ms)
     socklen_t len = sizeof(struct sockaddr_in);
     int fin = get_read_fd();
     ssize_t ret;
-    ret = CALL_PREFIX(recvfrom)(fin, buf, size, MSG_DONTWAIT, (sockaddr *)&last_in_addr[0], &len);
-    if (ret <= 0) {
+    uint32_t in_addr[4] = {};
+    ret = CALL_PREFIX(recvfrom)(fin, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr[0], &len);
+    if (ret > 0) {
+        // only update last_in_addr if we received data
+        memcpy(last_in_addr, in_addr, sizeof(last_in_addr));
+    } else {
         if (!datagram && connected && ret == 0) {
             // remote host has closed connection
             connected = false;

--- a/libraries/AP_HAL/utility/Socket.hpp
+++ b/libraries/AP_HAL/utility/Socket.hpp
@@ -43,6 +43,7 @@ public:
 
     ssize_t send(const void *pkt, size_t size) const;
     ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
+    ssize_t sendto(const void *buf, size_t size, uint32_t address, uint16_t port);
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
     // return the IP address and port of the last received packet
@@ -50,6 +51,9 @@ public:
 
     // return the IP address and port of the last received packet, using caller supplied buffer
     const char *last_recv_address(char *ip_addr_buf, uint8_t buflen, uint16_t &port) const;
+
+    // return the IP address and port of the last received packet
+    bool last_recv_address(uint32_t &ip_addr, uint16_t &port) const;
 
     // return true if there is pending data for input
     bool pollin(uint32_t timeout_ms);

--- a/libraries/AP_HAL/utility/packetise.cpp
+++ b/libraries/AP_HAL/utility/packetise.cpp
@@ -2,11 +2,10 @@
   support for sending UDP packets on MAVLink packet boundaries.
  */
 
-#include <GCS_MAVLink/GCS.h>
-
-#if HAL_GCS_ENABLED
-
 #include "packetise.h"
+
+#if AP_MAVLINK_PACKETISE_ENABLED
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 /*
   return the number of bytes to send for a packetised connection
@@ -68,4 +67,4 @@ uint16_t mavlink_packetise(ByteBuffer &writebuf, uint16_t n)
     return n;
 }
 
-#endif // HAL_GCS_ENABLED
+#endif // AP_MAVLINK_PACKETISE_ENABLED

--- a/libraries/AP_HAL/utility/packetise.h
+++ b/libraries/AP_HAL/utility/packetise.h
@@ -1,4 +1,10 @@
 #pragma once
+#include "RingBuffer.h"
+#include <GCS_MAVLink/GCS_config.h>
+
+#ifndef AP_MAVLINK_PACKETISE_ENABLED
+#define AP_MAVLINK_PACKETISE_ENABLED HAL_GCS_ENABLED
+#endif
 
 /*
   return the number of bytes to send for a packetised connection

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -266,6 +266,8 @@ private:
         uint32_t last_size_rx;
         bool packetise;
         bool connected;
+        uint32_t last_udp_connect_address;
+        uint16_t last_udp_connect_port;
         bool have_received;
         bool close_on_recv_error;
 

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -270,7 +270,7 @@ private:
         uint16_t last_udp_connect_port;
         bool have_received;
         bool close_on_recv_error;
-
+        uint32_t last_udp_srv_recv_time_ms;
         HAL_Semaphore sem;
     };
 #endif // AP_NETWORKING_REGISTER_PORT_ENABLED

--- a/libraries/AP_Networking/AP_Networking_port.cpp
+++ b/libraries/AP_Networking/AP_Networking_port.cpp
@@ -255,7 +255,7 @@ void AP_Networking::Port::tcp_server_loop(void)
             sock = listen_sock->accept(100);
             if (sock != nullptr) {
                 sock->set_blocking(false);
-                char buf[16];
+                char buf[IP4_STR_LEN];
                 uint16_t last_port;
                 const char *last_addr = listen_sock->last_recv_address(buf, sizeof(buf), last_port);
                 if (last_addr != nullptr) {
@@ -351,8 +351,8 @@ bool AP_Networking::Port::send_receive(void)
         uint16_t last_port = 0;
         if (sock->last_recv_address(last_addr, last_port)) {
             if (!connected || (last_addr != last_udp_connect_address) || (last_port != last_udp_connect_port)) {
-                char last_addr_str[16];
-                sock->inet_addr_to_str(last_addr, last_addr_str, 16);
+                char last_addr_str[IP4_STR_LEN];
+                sock->inet_addr_to_str(last_addr, last_addr_str, sizeof(last_addr_str));
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UDP[%u]: connected to %s:%u", unsigned(state.idx), last_addr_str, unsigned(last_port));
                 connected = true;
                 last_udp_connect_address = last_addr;

--- a/libraries/AP_Networking/AP_Networking_port.cpp
+++ b/libraries/AP_Networking/AP_Networking_port.cpp
@@ -345,6 +345,22 @@ bool AP_Networking::Port::send_receive(void)
         }
     }
 
+    if (type == NetworkPortType::UDP_SERVER && have_received) {
+        // connect the socket to the last receive address if we have one
+        uint32_t last_addr = 0;
+        uint16_t last_port = 0;
+        if (sock->last_recv_address(last_addr, last_port)) {
+            if (!connected || (last_addr != last_udp_connect_address) || (last_port != last_udp_connect_port)) {
+                char last_addr_str[16];
+                sock->inet_addr_to_str(last_addr, last_addr_str, 16);
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UDP[%u]: connected to %s:%u", unsigned(state.idx), last_addr_str, unsigned(last_port));
+                connected = true;
+                last_udp_connect_address = last_addr;
+                last_udp_connect_port = last_port;
+            }
+        }
+    }
+
     if (connected) {
         // handle outgoing packets
         uint32_t available;
@@ -353,7 +369,7 @@ bool AP_Networking::Port::send_receive(void)
             WITH_SEMAPHORE(sem);
             available = writebuffer->available();
             available = MIN(300U, available);
-#if HAL_GCS_ENABLED
+#if AP_MAVLINK_PACKETISE_ENABLED
             if (packetise) {
                 available = mavlink_packetise(*writebuffer, available);
             }
@@ -368,23 +384,27 @@ bool AP_Networking::Port::send_receive(void)
             WITH_SEMAPHORE(sem);
             n = writebuffer->peekbytes(buf, available);
         }
-        if (n > 0) {
-            const auto ret = sock->send(buf, n);
-            if (ret > 0) {
-                WITH_SEMAPHORE(sem);
-                writebuffer->advance(ret);
-                active = true;
-            }
+
+        // nothing to send return
+        if (n <= 0) {
+            return active;
         }
-    } else {
-        if (type == NetworkPortType::UDP_SERVER && have_received) {
-            // connect the socket to the last receive address if we have one
-            char buf[16];
-            uint16_t last_port;
-            const char *last_addr = sock->last_recv_address(buf, sizeof(buf), last_port);
-            if (last_addr != nullptr && port != 0) {
-                connected = sock->connect(last_addr, last_port);
+
+        ssize_t ret = -1;
+        if (type == NetworkPortType::UDP_SERVER) {
+            // UDP Server uses sendto, allowing us to change the destination address port on the fly
+            if(last_udp_connect_address != 0 && last_udp_connect_port != 0) {
+                ret = sock->sendto(buf, n, last_udp_connect_address, last_udp_connect_port);
             }
+        } else {
+            // TCP Server and Client and UDP Client use send
+            ret = sock->send(buf, n);
+        }
+
+        if (ret > 0) {
+            WITH_SEMAPHORE(sem);
+            writebuffer->advance(ret);
+            active = true;
         }
     }
 


### PR DESCRIPTION
Tested on a variant of CubePilot CANMod. The issue was that we were using connected UDP Server socket. Meaning once we connect to an application, then we shutdown that application and then restart the application the listen port on the application can change. But the UDP Server will be stuck with old IP:Port and will not even listen to the new application.

This PR moves to using sendto command with IP:Port from last received packet.
This is the case for example with Mavproxy, or any other client where the data is sent without binding to specific port.