### PR TITLE
Extract reporting of RC status bits into GCS base class

### DIFF
--- a/AntennaTracker/RC_Channel.h
+++ b/AntennaTracker/RC_Channel.h
@@ -25,6 +25,9 @@ public:
         return &obj_channels[chan];
     }
 
+    // we always trust our RC inputs ATM:
+    bool in_rc_failsafe() const override { return false; }
+
 protected:
 
     // note that these callbacks are not presently used on Tracker:

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -60,7 +60,7 @@ void Copter::update_throttle_hover()
 float Copter::get_pilot_desired_climb_rate(float throttle_control)
 {
     // throttle failsafe check
-    if (failsafe.radio || !ap.rc_receiver_present) {
+    if (failsafe.radio || !rc().has_ever_seen_rc_input()) {
         return 0.0f;
     }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -366,7 +366,7 @@ private:
             uint8_t land_complete           : 1; // 7       // true if we have detected a landing
             uint8_t new_radio_frame         : 1; // 8       // Set true if we have new PWM data to act on from the Radio
             uint8_t usb_connected_unused    : 1; // 9       // UNUSED
-            uint8_t rc_receiver_present     : 1; // 10      // true if we have an rc receiver present (i.e. if we've ever received an update
+            uint8_t rc_receiver_present_unused : 1; // 10      // UNUSED
             uint8_t compass_mot             : 1; // 11      // true if we are currently performing compassmot calibration
             uint8_t motor_test              : 1; // 12      // true if we are currently performing the motors test
             uint8_t initialised             : 1; // 13      // true once the init_ardupilot function has completed.  Extended status to GCS is not sent until this completes

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -42,16 +42,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
-    const Copter::ap_t &ap = copter.ap;
-
-    if (ap.rc_receiver_present) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    }
-    if (ap.rc_receiver_present && !copter.failsafe.radio) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    }
-
     // update flightmode-specific flags:
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -472,7 +472,7 @@ void Copter::notify_flight_mode() {
 void Mode::get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const
 {
     // throttle failsafe check
-    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
         roll_out_cd = 0.0;
         pitch_out_cd = 0.0;
         return;
@@ -494,7 +494,7 @@ Vector2f Mode::get_pilot_desired_velocity(float vel_max) const
     Vector2f vel;
 
     // throttle failsafe check
-    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
         return vel;
     }
     // fetch roll and pitch inputs
@@ -1013,7 +1013,7 @@ Mode::AltHoldModeState Mode::get_alt_hold_state(float target_climb_rate_cms)
 float Mode::get_pilot_desired_yaw_rate(float yaw_in)
 {
     // throttle failsafe check
-    if (copter.failsafe.radio || !copter.ap.rc_receiver_present) {
+    if (copter.failsafe.radio || !rc().has_ever_seen_rc_input()) {
         return 0.0f;
     }
 

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -113,7 +113,7 @@ void ModeTurtle::change_motor_direction(bool reverse)
 void ModeTurtle::run()
 {
     const float flip_power_factor = 1.0f - CRASH_FLIP_EXPO * 0.01f;
-    const bool norc = copter.failsafe.radio || !copter.ap.rc_receiver_present;
+    const bool norc = copter.failsafe.radio || !rc().has_ever_seen_rc_input();
     const float stick_deflection_pitch = norc ? 0.0f : channel_pitch->norm_input_dz();
     const float stick_deflection_roll = norc ? 0.0f : channel_roll->norm_input_dz();
     const float stick_deflection_yaw = norc ? 0.0f : channel_yaw->norm_input_dz();

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -87,9 +87,6 @@ void Copter::read_radio()
         set_throttle_and_failsafe(channel_throttle->get_radio_in());
         set_throttle_zero_flag(channel_throttle->get_control_in());
 
-        // RC receiver must be attached if we've just got input
-        ap.rc_receiver_present = true;
-
         // pass pilot input through to motors (used to allow wiggling servos while disarmed on heli, single, coax copters)
         radio_passthrough_to_motors();
 
@@ -115,7 +112,7 @@ void Copter::read_radio()
         // throttle failsafe not enabled
         return;
     }
-    if (!ap.rc_receiver_present && !motors->armed()) {
+    if (!rc().has_ever_seen_rc_input() && !motors->armed()) {
         // we only failsafe if we are armed OR we have ever seen an RC receiver
         return;
     }
@@ -137,7 +134,7 @@ void Copter::set_throttle_and_failsafe(uint16_t throttle_pwm)
     if (throttle_pwm < (uint16_t)g.failsafe_throttle_value) {
 
         // if we are already in failsafe or motors not armed pass through throttle and exit
-        if (failsafe.radio || !(ap.rc_receiver_present || motors->armed())) {
+        if (failsafe.radio || !(rc().has_ever_seen_rc_input() || motors->armed())) {
             return;
         }
 

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -98,13 +98,6 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;
     }
 
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    uint32_t last_valid = plane.failsafe.last_valid_rc_ms;
-    if (millis() - last_valid < 200) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    }
-
 #if AP_TERRAIN_AVAILABLE
     switch (plane.terrain.status()) {
     case AP_Terrain::TerrainStatusDisabled:

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -151,7 +151,7 @@ private:
             uint8_t logging_started         : 1; // 4       // true if logging has started
             uint8_t land_complete           : 1; // 5       // true if we have detected a landing
             uint8_t new_radio_frame         : 1; // 6       // Set true if we have new PWM data to act on from the Radio
-            uint8_t rc_receiver_present     : 1; // 7       // true if we have an rc receiver present (i.e. if we've ever received an update
+            uint8_t rc_receiver_present_unused     : 1; // 7       // UNUSED
             uint8_t compass_mot             : 1; // 8       // true if we are currently performing compassmot calibration
             uint8_t motor_test              : 1; // 9       // true if we are currently performing the motors test
             uint8_t initialised             : 1; // 10      // true once the init_ardupilot function has completed.  Extended status to GCS is not sent until this completes

--- a/Blimp/GCS_Blimp.cpp
+++ b/Blimp/GCS_Blimp.cpp
@@ -32,14 +32,4 @@ void GCS_Blimp::update_vehicle_sensor_status_flags(void)
 
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
-
-    const Blimp::ap_t &ap = blimp.ap;
-
-    if (ap.rc_receiver_present) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    }
-    if (ap.rc_receiver_present && !blimp.failsafe.radio) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
-    }
 }

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -162,7 +162,7 @@ void Mode::update_navigation()
 void Mode::get_pilot_input(Vector3f &pilot, float &yaw)
 {
     // throttle failsafe check
-    if (blimp.failsafe.radio || !blimp.ap.rc_receiver_present) {
+    if (blimp.failsafe.radio || !rc().has_ever_seen_rc_input()) {
         pilot.y = 0;
         pilot.x = 0;
         pilot.z = 0;

--- a/Blimp/radio.cpp
+++ b/Blimp/radio.cpp
@@ -61,9 +61,6 @@ void Blimp::read_radio()
         set_throttle_and_failsafe(channel_up->get_radio_in());
         set_throttle_zero_flag(channel_up->get_control_in());
 
-        // RC receiver must be attached if we've just got input
-        ap.rc_receiver_present = true;
-
         const float dt = (tnow_ms - last_radio_update_ms)*1.0e-3f;
         rc_throttle_control_in_filter.apply(channel_up->get_control_in(), dt);
         last_radio_update_ms = tnow_ms;
@@ -87,7 +84,7 @@ void Blimp::read_radio()
         // throttle failsafe not enabled
         return;
     }
-    if (!ap.rc_receiver_present && !motors->armed()) {
+    if (!rc().has_ever_seen_rc_input() && !motors->armed()) {
         // we only failsafe if we are armed OR we have ever seen an RC receiver
         return;
     }
@@ -109,7 +106,7 @@ void Blimp::set_throttle_and_failsafe(uint16_t throttle_pwm)
     if (throttle_pwm < (uint16_t)g.failsafe_throttle_value) {
 
         // if we are already in failsafe or motors not armed pass through throttle and exit
-        if (failsafe.radio || !(ap.rc_receiver_present || motors->armed())) {
+        if (failsafe.radio || !(rc().has_ever_seen_rc_input() || motors->armed())) {
             return;
         }
 

--- a/Tools/scripts/du32_change.py
+++ b/Tools/scripts/du32_change.py
@@ -41,7 +41,7 @@ class DU32Change(object):
             "land_complete",
             "new_radio_frame",
             "usb_connected_unused",
-            "rc_receiver_present",
+            "rc_receiver_present_unused",
             "compass_mot",
             "motor_test",
             "initialised",

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -18,6 +18,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_GPS/AP_GPS.h>
+#include <RC_Channel/RC_Channel.h>
 
 #include "MissionItemProtocol_Waypoints.h"
 #include "MissionItemProtocol_Rally.h"
@@ -336,6 +337,16 @@ void GCS::update_sensor_status_flags()
         control_sensors_enabled |= MAV_SYS_STATUS_PREARM_CHECK;
         if (hal.util->get_soft_armed() || AP_Notify::flags.pre_arm_check) {
             control_sensors_health |= MAV_SYS_STATUS_PREARM_CHECK;
+        }
+    }
+#endif
+
+#if AP_RC_CHANNEL_ENABLED
+    if (rc().has_ever_seen_rc_input()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
+        if (!rc().in_rc_failsafe()) {  // should this be has_valid_input?
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
         }
     }
 #endif

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -589,6 +589,12 @@ public:
     bool get_aux_cached(RC_Channel::aux_func_t aux_fn, uint8_t &pos);
 #endif
 
+    // returns true if we've ever seen RC input, via overrides or via
+    // AP_RCProtocol
+    bool has_ever_seen_rc_input() const {
+        return _has_ever_seen_rc_input;
+    }
+
     // get failsafe timeout in milliseconds
     uint32_t get_fs_timeout_ms() const { return MAX(_fs_timeout * 1000, 100); }
 
@@ -613,6 +619,9 @@ private:
     AP_Int32  _options;
     AP_Int32  _protocols;
     AP_Float _fs_timeout;
+
+    // set to true if we see overrides or other RC input
+    bool _has_ever_seen_rc_input;
 
     RC_Channel *flight_mode_channel() const;
 

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -78,6 +78,8 @@ bool RC_Channels::read_input(void)
         return false;
     }
 
+    _has_ever_seen_rc_input = true;
+
     has_new_overrides = false;
 
     last_update_ms = AP_HAL::millis();


### PR DESCRIPTION
This makes all vehicles set these status bits based off the same information.

Tested on CubeOrange using a DroneCAN-connected R-XSR for all vehicles (but not periph...)

Note that ArduCopter is using the "RC receiver bits" as "pilot control" bits (i.e. if we receive overrides they are counted as "rc receiver").  This is long-standing behaviour.

Plane changes semantics to work like Copter.  Previously if you did not have an RC receiver connected it would appear red ("unhealthy") in the MAVProxy interface.  Now it stays black until Plane sees a receiver.  If that receiver disappears then it will go red ('unhealthy").

Copter is unchanged.

Blimp is unchanged.

Sub does weird things; it uses overrides as a matter of course (see `set_neutral_controls`), basically always providing overrides.  We now report the bits in the GCS.

Tracker changes to report these bits (and never enters failsafe; it never checks values are valid before using them....).

Rover gets reporting just like Copter.

This PR change is purely a reporting change to the GCS; no RC failsafe detection or behaviour is changed.
