### PR TITLE
Revert "board_list.py: correct autobuild target name"

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -16,7 +16,7 @@ class Board(object):
         self.name = name
         self.is_ap_periph = False
         self.autobuild_targets = [
-            'AntennaTracker',
+            'Tracker',
             'Blimp',
             'Copter',
             'Heli',


### PR DESCRIPTION
This reverts commit 039701b6167d22ef8a4eb039152a70722a365484.

This broken builds on the build server.  We should be correcting the other way anyway, from antennatracker -> tracker