### PR TITLE
Mount: Siyi waits for non-zero cam firmware version

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -353,11 +353,16 @@ void AP_Mount_Siyi::process_packet()
         _fw_version.camera.major = _msg_buff[_msg_buff_data_start+2];  // firmware major version
         _fw_version.camera.minor = _msg_buff[_msg_buff_data_start+1];  // firmware minor version
         _fw_version.camera.patch = _msg_buff[_msg_buff_data_start+0];  // firmware revision (aka patch)
-        
+
         _fw_version.gimbal.major = _msg_buff[_msg_buff_data_start+6];  // firmware major version
         _fw_version.gimbal.minor = _msg_buff[_msg_buff_data_start+5];  // firmware minor version
         _fw_version.gimbal.patch = _msg_buff[_msg_buff_data_start+4];  // firmware revision (aka patch)
-        
+
+        // camera firmware version may be all zero soon after startup.  giveup and try again later
+        if (_fw_version.camera.major == 0 && _fw_version.camera.minor == 0 && _fw_version.camera.patch == 0) {
+            break;
+        }
+
         _fw_version.received = true;
 
         // display camera info to user


### PR DESCRIPTION
The Siyi A8 (at least) will report an all-zero camera firmware version for the first 20seconds after startup.  Assuming the gimbal and autopilot are powered up together this may or may not result in a warning sent to the user (see below):

This PR changes the Siyi mount driver so that it does not complete initialisation until a non-zero camera version is provided.

The only downside is Siyi gimbals that always report camera fw version of 0,0,0 will become unusable.  I'm not aware of any Siyi gimbals that do this however.

This has been tested on real hardware.

**Before:**
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/afe21f94-46ff-42e5-a1e8-ea48ac69fc27)

**After:**
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/387984ae-0be1-4bf7-a067-4b75e0fd52ec)

[Related discussion is here.](https://discuss.ardupilot.org/t/siyi-a8-camera-fw-version-reporting-issue/112870)