### PR TITLE
.github: Autotest build need debug flag, rover also need enable-math-…

### DIFF
--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -200,7 +200,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/blimp
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -198,7 +198,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/arducopter
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -192,7 +192,7 @@ jobs:
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl_periph_universal
+          ./waf configure --board sitl_periph_universal --debug
           ./waf build --target bin/AP_Periph
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -199,7 +199,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/arduplane
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -200,7 +200,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug --enable-math-check-indexes
           ./waf build --target bin/ardurover
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -201,7 +201,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/ardusub
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -201,7 +201,7 @@ jobs:
             export CXX=clang++
           fi
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/antennatracker
           ccache -s
           ccache -z


### PR DESCRIPTION
…check-indexes. Fix caching

This allow all autotest to reuse the cached build from 1rst step as intended. We gain about 4min CI time per autotest 
Previously : 
![image](https://github.com/ArduPilot/ardupilot/assets/705341/fd73af06-98a1-4e87-a223-0a02062fca83)


now : 
![image](https://github.com/ArduPilot/ardupilot/assets/705341/98452dbe-bd8b-4147-bc80-2c6bcee16d40)

(Size difference is because that is 2 differents branch)
