### PR TITLE
Feature/assert fix

### DIFF
--- a/libraries/AP_Math/AP_GeodesicGrid.cpp
+++ b/libraries/AP_Math/AP_GeodesicGrid.cpp
@@ -101,7 +101,6 @@
  *  by the non-zero coefficient.
  */
 
-#include <assert.h>
 
 #include "AP_GeodesicGrid.h"
 

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -32,6 +32,9 @@
 #ifndef MATH_CHECK_INDEXES
 #define MATH_CHECK_INDEXES 0
 #endif
+#if MATH_CHECK_INDEXES
+#include <assert.h>
+#endif
 
 #include <cmath>
 #include <float.h>


### PR DESCRIPTION
```
In file included from ../../libraries/AP_Math/control.h:4,
                 from ../../libraries/AC_WPNav/AC_WPNav_OA.cpp:1:
../../libraries/AP_Math/vector2.h: In member function ‘T& Vector2<T>::operator[](uint8_t)’:
../../libraries/AP_Math/vector2.h:123:9: error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available [-fpermissive]
  123 |         assert(i >= 0 && i < 2);
      |         ^~~~~~
compilation terminated due to -Wfatal-errors.
```

when building copter with waf configure --enable-math-check-indexes 