### PR TITLE
AP_Scripting: prevent use of closed network socket

### DIFF
--- a/libraries/AP_Scripting/applets/net_webserver.lua
+++ b/libraries/AP_Scripting/applets/net_webserver.lua
@@ -913,7 +913,10 @@ local function Client(_sock, _idx)
 
    function self.remove()
       DEBUG(string.format("%u: removing client OFFSET=%u", idx, offset))
-      sock:close()
+      if sock then
+         sock:close()
+         sock = nil
+      end
       self.closed = true
    end
 

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -826,6 +826,7 @@ int SocketAPM_close(lua_State *L) {
             ud->close();
             delete ud;
             scripting->_net_sockets[i] = nullptr;
+            *check_SocketAPM(L, 1) = nullptr;
             break;
         }
     }


### PR DESCRIPTION
this gives a lua exception if you try to do this:
```
 sock:recv(1024)
 sock:close()
 sock:recv(1024)
```
without this we dereference null, causing a crash
initially noticed by @magicrub 