### PR TITLE
Copter: Add DDS details to release notes for 4.5

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -116,6 +116,18 @@ Changes from 4.4.4
 8) Parameters renamed
     - COMPASS_TYPEMASK renamed to COMPASS_DISBLMSK
 9) ROS2 / DDS support
+    - Added support for EProsima MicroXRCEDDS as a transport in SITL and hardware
+    - Added sensor data topic support such as NavSatStatus and BatteryState
+    - Added velocity control support in Copter
+    - Added a new AP_ExternalControl library for generic control support in SI units
+    - Added support for building ArduPilot with the colcon build system
+    - DDS topics comply with ROS REP-147
+    - Added Gazebo Garden and Gazebo Harmonic simulation with examples
+    - Added support for ROS 2 services such as Arm and Mode control
+    - Added high level goal interface for waypoints
+    - Wiki updated to support ROS 2
+    - Added ROS 2 launch scripts for SITL, MAVProxy and micro-ROS agent
+    - Add pytests for DDS client and ROS 2 launch scripts and integrate into CI
 10) Camera and gimbal enhancements
     - Calculates location where camera gimbal is pointing (see CAMERA_FOV_STATUS)
     - CAMx_MNT_INST allows specifying which mount camera is in

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -134,6 +134,18 @@ Changes from 4.4.4
     - ROLL_LIMIT_DEG replaces LIM_ROLL_CD
     - RTL_ALTITUDE replaces ALT_HOLD_RTL
 8) ROS2 / DDS support
+    - Added support for EProsima MicroXRCEDDS as a transport in SITL and hardware
+    - Added sensor data topic support such as NavSatStatus and BatteryState
+    - Added a new AP_ExternalControl library for generic control support in SI units
+    - Added support for building ArduPilot with the colcon build system
+    - Added high level goal interface (waypoints) similar to MAVLink global position
+    - DDS topics comply with ROS REP-147
+    - Added Gazebo Garden and Gazebo Harmonic simulation with examples
+    - Added support for ROS 2 services such as Arm and Mode control
+    - Added high level goal interface for waypoints
+    - Wiki updated to support ROS 2
+    - Added ROS 2 launch scripts for SITL, MAVProxy and micro-ROS agent
+    - Add pytests for DDS client and ROS 2 launch scripts and integrate into CI
 9) Camera and gimbal enhancements
     - Calculates location where camera gimbal is pointing (see CAMERA_FOV_STATUS)
     - CAMx_MNT_INST allows specifying which mount camera is in

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -103,6 +103,17 @@ Changes from 4.4.4
 6) Parameters renamed
     - COMPASS_TYPEMASK renamed to COMPASS_DISBLMSK
 7) ROS2 / DDS support
+    - Added support for EProsima MicroXRCEDDS as a transport in SITL and hardware
+    - Added sensor data topic support such as NavSatStatus and BatteryState
+    - Added a new AP_ExternalControl library for generic control support in SI units
+    - Added support for building ArduPilot with the colcon build system
+    - DDS topics comply with ROS REP-147
+    - Added Gazebo Garden and Gazebo Harmonic simulation with examples
+    - Added support for ROS 2 services such as Arm and Mode control
+    - Added high level goal interface for waypoints
+    - Wiki updated to support ROS 2
+    - Added ROS 2 launch scripts for SITL, MAVProxy and micro-ROS agent
+    - Add pytests for DDS client and ROS 2 launch scripts and integrate into CI
 8) Camera and gimbal enhancements
     - Calculates location where camera gimbal is pointing (see CAMERA_FOV_STATUS)
     - CAMx_MNT_INST allows specifying which mount camera is in


### PR DESCRIPTION
Start the release notes for DDS for 4.5. Let me know which branch they should target, and if I should copy them to other vehicles. 

THere is vehicle-specific support in DDS, so I might want to handle that. For example, the waypoint support only works in plane right now.