### PR TITLE
chibios_hwdef.py: allow re-use of bootloader from other boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1106,7 +1106,7 @@ class ChibiOSHWDef(object):
             f.write('#define APP_START_OFFSET_KB %u\n' % self.get_config('APP_START_OFFSET_KB', default=0, type=int))
         f.write('\n')
 
-        ram_reserve_start,ram0_start_address = self.get_ram_reserve_start()
+        ram_reserve_start, ram0_start_address = self.get_ram_reserve_start()
         f.write('#define HAL_RAM0_START 0x%08x\n' % ram0_start_address)
         if ram_reserve_start > 0:
             f.write('#define HAL_RAM_RESERVE_START 0x%08x\n' % ram_reserve_start)
@@ -1385,7 +1385,7 @@ class ChibiOSHWDef(object):
         if ext_flash_size > 32:
             self.error("We only support 24bit addressing over external flash")
 
-        ram_reserve_start,ram0_start_address = self.get_ram_reserve_start()
+        ram_reserve_start, ram0_start_address = self.get_ram_reserve_start()
         if ram_reserve_start > 0 and ram0_start_address == ram0_start:
             ram0_start += ram_reserve_start
             ram0_len -= ram_reserve_start
@@ -2413,6 +2413,10 @@ INCLUDE common.ld
         this_dir = os.path.realpath(__file__)
         rootdir = os.path.relpath(os.path.join(this_dir, "../../../../.."))
         hwdef_dirname = os.path.basename(os.path.dirname(args.hwdef[0]))
+        # allow re-using of bootloader from different build:
+        use_bootloader_from_board = self.get_config('USE_BOOTLOADER_FROM_BOARD', default=None, required=False)
+        if use_bootloader_from_board is not None:
+            hwdef_dirname = use_bootloader_from_board
         bootloader_filename = "%s_bl.bin" % (hwdef_dirname,)
         bootloader_path = os.path.join(rootdir,
                                        "Tools",


### PR DESCRIPTION
This should be useful for people wanting to make OEM setups but don't want to re-build (or copy...) the bootloader.

```
env added HAS_EXTERNAL_FLASH_SECTIONS=0
env added CHIBIOS_BUILD_FLAGS=USE_FATFS=yes CHIBIOS_STARTUP_MK=os/common/startup/ARMCMx/compilers/GCC/mk/startup_stm32h7xx.mk CHIBIOS_PLATFORM_MK=os/hal/ports/STM32/STM32H7xx/platform.mk MCU=cortex-m7 ENV_UDEFS=-DCHPRINTF_USE_FLOAT=1
Padded 16 bytes for bootloader.bin to 38816
Embedding file bootloader.bin:/home/pbarker/rc/ardupilot/Tools/bootloaders/CubeOrange_bl.bin
Embedding file defaults.parm:/home/pbarker/rc/ardupilot/build/e0-CubeOrange/processed_defaults.parm
Embedding file hwdef.dat:/home/pbarker/rc/ardupilot/build/e0-CubeOrange/hw.dat
```

Note it getting the bootloader from `CubeOrange`, not `e0-CubeOrange`  That's because of this hwdef:
```
diff --git a/libraries/AP_HAL_ChibiOS/hwdef/e0-CubeOrange/hwdef.dat b/libraries/
AP_HAL_ChibiOS/hwdef/e0-CubeOrange/hwdef.dat
new file mode 100644
index 00000000000..34acb794376
--- /dev/null
+++ b/libraries/AP_HAL_ChibiOS/hwdef/e0-CubeOrange/hwdef.dat
@@ -0,0 +1,3 @@
+include ../CubeOrange/hwdef.dat
+
+USE_BOOTLOADER_FROM_BOARD CubeOrange
```


![image](https://github.com/ArduPilot/ardupilot/assets/7077857/1082f7e4-45a7-47ec-aa49-ca888b6e6851)

