### PR TITLE
Move parameter storage formatting up to AP_Vehicle 

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -584,23 +584,7 @@ const AP_Param::Info Tracker::var_info[] = {
 
 void Tracker::load_parameters(void)
 {
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
-
-        // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
-
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->printf("done.\n");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    uint32_t before = AP_HAL::micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
@@ -616,8 +600,6 @@ void Tracker::load_parameters(void)
 #if HAL_LOGGING_ENABLED
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
 #endif
-
-    hal.console->printf("load_all took %luus\n", (unsigned long)(AP_HAL::micros() - before));
 
 #if HAL_HAVE_SAFETY_SWITCH
     // configure safety switch to allow stopping the motors while armed

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1338,25 +1338,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Copter::load_parameters(void)
 {
-    hal.util->set_soft_armed(false);
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
-
-        // erase all parameters
-        DEV_PRINTF("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
-
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        DEV_PRINTF("done.\n");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    uint32_t before = micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
     AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
 #if AP_LANDINGGEAR_ENABLED
@@ -1409,11 +1392,8 @@ void Copter::load_parameters(void)
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
 #endif
 
-    hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
-
     // setup AP_Param frame type flags
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_COPTER);
-
 }
 
 // handle conversion of PID gains

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1344,23 +1344,8 @@ static const RCConversionInfo rc_option_conversion[] = {
 
 void Plane::load_parameters(void)
 {
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-        // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
-
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->printf("done.\n");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    uint32_t before = micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
     AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
     // setup defaults in SRV_Channels
@@ -1577,6 +1562,4 @@ void Plane::load_parameters(void)
 #if HAL_LOGGING_ENABLED
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
 #endif
-
-    hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
 }

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -732,26 +732,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Sub::load_parameters()
 {
-    hal.util->set_soft_armed(false);
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-    if (!g.format_version.load() ||
-            g.format_version != Parameters::k_format_version) {
-
-        // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
-
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->println("done.");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    uint32_t before = AP_HAL::micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
-    hal.console->printf("load_all took %uus\n", (unsigned)(AP_HAL::micros() - before));
     AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_SUB);

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -840,25 +840,7 @@ ParametersG2::ParametersG2(void)
 
 void Blimp::load_parameters(void)
 {
-    hal.util->set_soft_armed(false);
-
-    if (!g.format_version.load() ||
-        g.format_version != Parameters::k_format_version) {
-
-        // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
-
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->printf("done.\n");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    uint32_t before = micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
 #if AP_STATS_ENABLED
@@ -893,8 +875,6 @@ void Blimp::load_parameters(void)
 #if HAL_LOGGING_ENABLED
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
 #endif
-
-    hal.console->printf("load_all took %uus\n", (unsigned)(micros() - before));
 
     // setup AP_Param frame type flags
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_BLIMP);

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -811,22 +811,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
 
 void Rover::load_parameters(void)
 {
-    if (!g.format_version.load() ||
-         g.format_version != Parameters::k_format_version) {
-        // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
-        StorageManager::erase();
-        AP_Param::erase_all();
+    AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-        // save the current format version
-        g.format_version.set_and_save(Parameters::k_format_version);
-        hal.console->printf("done.\n");
-    }
-    g.format_version.set_default(Parameters::k_format_version);
-
-    const uint32_t before = micros();
-    // Load all auto-loaded EEPROM variables
-    AP_Param::load_all();
     AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_ROVER);
@@ -839,7 +825,6 @@ void Rover::load_parameters(void)
     }
 
     SRV_Channels::upgrade_parameters();
-    hal.console->printf("load_all took %uus\n", unsigned(micros() - before));
 
     // convert CH7_OPTION to RC7_OPTION for Rover-3.4 to 3.5 upgrade
     const AP_Param::ConversionInfo ch7_option_info = { Parameters::k_param_ch7_option, 0, AP_PARAM_INT8, "RC7_OPTION" };

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -287,6 +287,8 @@ protected:
 
     virtual void init_ardupilot() = 0;
     virtual void load_parameters() = 0;
+    void load_parameters(AP_Int16 &format_version, const uint16_t expected_format_version);
+
     virtual void set_control_channels() {}
 
     // board specific config

--- a/libraries/AP_Vehicle/Parameters.cpp
+++ b/libraries/AP_Vehicle/Parameters.cpp
@@ -1,0 +1,24 @@
+#include "AP_Vehicle.h"
+
+#include <AP_Param/AP_Param.h>
+#include <StorageManager/StorageManager.h>
+
+void AP_Vehicle::load_parameters(AP_Int16 &format_version, const uint16_t expected_format_version)
+{
+    if (!format_version.load() ||
+        format_version != expected_format_version) {
+
+        // erase all parameters
+        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
+        AP_Param::erase_all();
+
+        // save the current format version
+        format_version.set_and_save(expected_format_version);
+        hal.console->printf("done.\n");
+    }
+    format_version.set_default(expected_format_version);
+
+    // Load all auto-loaded EEPROM variables
+    AP_Param::load_all();
+}


### PR DESCRIPTION
Tested in SITL; parameters are preserved going from master to this, and setting FORMAT_VERSION still erases parameters.

I've chosen this shape (vehicles call a method on the base class) as not all vehicles which inherit from AP_Vehicle actually have a k_format_version (e.g. Replay).  These vehicles do their own thing, so we have to consider the format-version-checking an optional feature which AP_Vehicle can provide.


