### PR TITLE
autotest: change default board for test_build_options

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -49,7 +49,7 @@ class TestBuildOptions(object):
                  do_step_disable_in_turn=True,
                  do_step_enable_in_turn=True,
                  build_targets=None,
-                 board="DevEBoxH7v2",
+                 board="CubeOrange",  # DevEBoxH7v2 also works
                  extra_hwdef=None):
         self.extra_hwdef = extra_hwdef
         self.sizes_nothing_disabled = None


### PR DESCRIPTION
rather more rpresentative of what people are likely to compile for