### PR TITLE
TECS: Use true demanded pitch for throttle calculations without airspeed

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -600,7 +600,8 @@ void Plane::update_alt()
                                                  get_takeoff_pitch_min_cd(),
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
-                                                 aerodynamic_load_factor);
+                                                 aerodynamic_load_factor,
+                                                 radians(nav_pitch_cd * 0.01));
     }
 }
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -52,7 +52,8 @@ public:
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
                                float hgt_afe,
-                               float load_factor);
+                               float load_factor,
+                               float pitch_dem);
 
     // demanded throttle in percentage
     // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
@@ -452,7 +453,7 @@ private:
     void _update_throttle_with_airspeed(void);
 
     // Update Demanded Throttle Non-Airspeed
-    void _update_throttle_without_airspeed(int16_t throttle_nudge);
+    void _update_throttle_without_airspeed(int16_t throttle_nudge, float pitch_dem);
 
     // get integral gain which is flight_stage dependent
     float _get_i_gain(void);


### PR DESCRIPTION
When not using an airspeed sensor, TECS interpolates the throttle output based on max, min  and trim throttle and current and demanded max, min and trim pitch. In guided mode however if pitch overrides are given, TECS will still use its own pitch demands for interpolation  purposes in the high pass filter, resulting in an initial throttle output in the opposite direction as that which would suit the true demanded pitch as the drone deviates from the intended altitude. This results in avoidable over and underspeeds.

To illustrate this I used the SkywalkerX8 drone in  Gazebo. Here the drone achieved its required altitude, resulting in a zero pitch requirement. At this point a script is activated to force the drone to pitch at -10 degrees for 17 seconds. With the current code an increase in the throttle and speed is observed immediately after forcing the pitch. This can be seen below in the purple and red graphs respectively:

![TECSPitch](https://github.com/ArduPilot/ardupilot/assets/38490253/be06e2ec-b9e1-429a-8d5b-8b668b1b166f)

With the change however this not observed:

![TruePitch](https://github.com/ArduPilot/ardupilot/assets/38490253/5e32c873-8837-4b83-8d52-260cd43c8683)

An argument could be made that this is intended behaviour as TECS is using the throttle to maintain the required altitude, but I would argue that without an airspeed sensor the code was written in such a way that pitch is the primary actor for altitude control with throttle outputs designed to keep the drone within the set airspeed limits through pitch interpolation.
