### PR TITLE
HAL_Linux: reduce delay(ms) jitter

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -173,15 +173,20 @@ void Scheduler::delay(uint16_t ms)
         return;
     }
 
-    uint64_t start = AP_HAL::millis64();
+    if (ms == 0) {
+        return;
+    }
 
-    while ((AP_HAL::millis64() - start) < ms) {
+    uint64_t now = AP_HAL::micros64();
+    uint64_t end = now + 1000UL * ms + 1U;
+    do {
         // this yields the CPU to other apps
-        microsleep(1000);
+        microsleep(MIN(1000UL, end-now));
         if (in_main_thread() && _min_delay_cb_ms <= ms) {
             call_delay_cb();
         }
-    }
+        now = AP_HAL::micros64();
+    } while (now < end);
 }
 
 void Scheduler::delay_microseconds(uint16_t us)


### PR DESCRIPTION
Fix delay(1) rarely returning immediately due to a TOCTOU when the millisecond increment occurred during a call to delay(), just after millis() was first sampled. On my RPi4, delay(1) returned immediately once per 5-20k calls to delay(1) that delay.
This also prevents delay(ms) from returning early due to starting in the middle of a millisecond, and each loop taking slightly longer than a millisecond.

Reduce the last call to microsleep according to the remaining time needed in the last loop iteration.

This is a histogram of delay(100) time taken for both approaches, on an isolated core with only the timer interrupt:
![histogram](https://github.com/ArduPilot/ardupilot/assets/348896/65c2853a-a8e1-4625-9692-7567bd1dea47)

I'd like to do a little more testing with this first, but also wanted to ask for feedback.