### PR TITLE
RC_Channel: correct compilation when AP_MISSION_ENABLED is false

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1066,6 +1066,7 @@ void RC_Channel::do_aux_function_fence(const AuxSwitchPos ch_flag)
 }
 #endif
 
+#if AP_MISSION_ENABLED
 void RC_Channel::do_aux_function_clear_wp(const AuxSwitchPos ch_flag)
 {
     if (ch_flag == AuxSwitchPos::HIGH) {
@@ -1076,6 +1077,7 @@ void RC_Channel::do_aux_function_clear_wp(const AuxSwitchPos ch_flag)
         mission->clear();
     }
 }
+#endif  // AP_MISSION_ENABLED
 
 #if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
 void RC_Channel::do_aux_function_relay(const uint8_t relay, bool val)
@@ -1178,6 +1180,7 @@ void RC_Channel::do_aux_function_rc_override_enable(const AuxSwitchPos ch_flag)
     }
 }
 
+#if AP_MISSION_ENABLED
 void RC_Channel::do_aux_function_mission_reset(const AuxSwitchPos ch_flag)
 {
     if (ch_flag != AuxSwitchPos::HIGH) {
@@ -1189,6 +1192,7 @@ void RC_Channel::do_aux_function_mission_reset(const AuxSwitchPos ch_flag)
     }
     mission->reset();
 }
+#endif
 
 void RC_Channel::do_aux_function_fft_notch_tune(const AuxSwitchPos ch_flag)
 {


### PR DESCRIPTION
We're calling methods on the mission object in here - not going to work if its not compiled in