### PR TITLE
AP_Scripting: include extern-hal line to fix compilation

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2924,6 +2924,8 @@ int main(int argc, char **argv) {
   // for set_and_print_new_error_message deprecate warning
   fprintf(source, "#include <AP_Scripting/lua_scripts.h>\n");
 
+  fprintf(source, "extern const AP_HAL::HAL& hal;\n");
+
   trace(TRACE_GENERAL, "Starting emission");
 
   emit_headers(source);


### PR DESCRIPTION
this external line was coming in from a header file somewhere...

there are lines like this in `lua_generated_bindings.cpp`:

```
    AP_HAL::AnalogSource *data = hal.analogin->channel(            ANALOG_INPUT_NONE);
```

... so we really should generally know what `hal` looks like.
