### PR TITLE
AP_Scripting: Add filesystem crc32 binding

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -290,6 +290,9 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
 // run crc32 over file with given name, returns true if successful
 bool AP_Filesystem::crc32(const char *fname, uint32_t& checksum)
 {
+    // Ensure value is initialized
+    checksum = 0;
+
     // Open file in readonly mode
     int fd = open(fname, O_RDONLY);
     if (fd == -1) {

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3411,6 +3411,10 @@ function fs:format() end
 ---@return number
 function fs:get_format_status() end
 
+-- Get crc32 checksum of a file with given name
+---@return uint32_t_ud|nil
+function fs:crc32(file_name) end
+
 -- desc
 ---@class networking
 networking = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -894,6 +894,7 @@ singleton AP_Filesystem method format boolean
 singleton AP_Filesystem method format depends AP_FILESYSTEM_FORMAT_ENABLED
 singleton AP_Filesystem method get_format_status uint8_t'skip_check
 singleton AP_Filesystem method get_format_status depends AP_FILESYSTEM_FORMAT_ENABLED
+singleton AP_Filesystem method crc32 boolean string uint32_t'Null
 
 include AP_RTC/AP_RTC.h depends AP_RTC_ENABLED
 include AP_RTC/AP_RTC_config.h


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/26157 made me realize that we only apply our checksum to the loaded scripts, those scripts could then be using modules that could be incorrectly versioned. This adds a binding for the same crc32 function we use for the scripting check sum, this allows scripts to checksum there modules if they want to. 

However, I was unable to get the correct checksum because we were not initializing the pass by reference values, so the checksum did not start with 0 and the crc32 function does not zero it. This is possibly a issue else where but we have not noticed....