### PR TITLE
Tools: added -e to cygwin build

### DIFF
--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -7,6 +7,7 @@
 # the script assumes you start in the root of the ardupilot git tree
 
 set -x
+set -e
 
 # TOOLCHAIN=i686-pc-cygwin
 TOOLCHAIN=x86_64-pc-cygwin
@@ -22,13 +23,16 @@ git config --global --add safe.directory /cygdrive/d/a/ardupilot/ardupilot
 rm -rf artifacts
 mkdir artifacts
 
+# cygwin doesn't work out the parallelism properly
+WAF_OPTIONS="-j8"
+
 (
     python ./waf --color yes --toolchain $TOOLCHAIN --board sitl configure 2>&1
-    python ./waf plane 2>&1
-    python ./waf copter 2>&1
-    python ./waf heli 2>&1
-    python ./waf rover 2>&1
-    python ./waf sub 2>&1
+    python ./waf plane $WAF_OPTIONS 2>&1
+    python ./waf copter $WAF_OPTIONS 2>&1
+    python ./waf heli $WAF_OPTIONS 2>&1
+    python ./waf rover $WAF_OPTIONS 2>&1
+    python ./waf sub $WAF_OPTIONS 2>&1
 ) | tee artifacts/build.txt
 
 # copy both with exe and without to cope with differences


### PR DESCRIPTION
error if any part of build fails

also ensure cygwin build in CI is parallelised

note: this PR will fail until rebased on #26215