### PR TITLE
AP_Camera: fix video recording while armed

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -17,11 +17,13 @@ AP_Camera_Backend::AP_Camera_Backend(AP_Camera &frontend, AP_Camera_Params &para
 // update - should be called at 50hz
 void AP_Camera_Backend::update()
 {
-    // Check CAMx_OPTIONS and start/stop recording based on arm/disarm
-    if (_params.options.get() & CAMOPTIONS::REC_ARM_DISARM) {
+    // Check camera options and start/stop recording based on arm/disarm
+    if ((_params.options.get() & (uint8_t)Options::RecordWhileArmed) != 0) {
         if (hal.util->get_soft_armed() != last_is_armed) {
             last_is_armed = hal.util->get_soft_armed();
-            record_video(last_is_armed);
+            if (!record_video(last_is_armed)) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Camera: failed to %s recording", last_is_armed ? "start" : "stop");
+            }
         }
     }
 

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -36,8 +36,9 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_Camera_Backend);
 
-    enum CAMOPTIONS {
-        REC_ARM_DISARM = 0, // Recording start/stop on Arm/Disarm
+    // camera options parameter values
+    enum class Options : int8_t {
+        RecordWhileArmed = (1 << 0U)
     };
 
     // init - performs any required initialisation


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/ArduPilot/ardupilot/pull/25883 that meant the CAM1_OPTIONS's RecordWhileArmed option was not working.

This has been tested on real hardware (CubeOrangePlus + Xacti CX-CB100)

![image](https://github.com/ArduPilot/ardupilot/assets/1498098/920912ab-500a-4da2-8c85-54cc7478de1d)

FYI @Hwurzburg (not saying it's all your fault of course, I reviewed and merged it and also didn't catch the issue).