### PR TITLE
Plane: allow set_throttle in manual and move disarmed override up

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -398,6 +398,13 @@ public:
     void update() override;
 
     void run() override;
+
+    // true if throttle min/max limits should be applied
+    bool use_throttle_limits() const { return false; }
+
+    // true if voltage correction should be applied to throttle
+    bool use_battery_compensation() const { return false; }
+
 };
 
 


### PR DESCRIPTION
More throttle tidy ups, by ensuring `use_throttle_limits`, `use_battery_compensation` and `suppress_throttle` return false in manual mode we can remove the not in manual check on the `set_throttle` function. Moving the `is_armed_and_safety_off` case up means it keeps the manual check and its in the same function as the other `is_armed` case that does a very similar thing. The next step is to combine those two checks.