### PR TITLE
AP_DroneCAN: DNA Server: log duplicate nodes in CAND

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -40,6 +40,7 @@ class AP_DroneCAN_DNA_Server
     Bitmask<128> verified_mask;
     Bitmask<128> node_seen_mask;
     Bitmask<128> logged;
+    Bitmask<128> logged_duplicate;
     Bitmask<128> node_healthy_mask;
 
     uint8_t last_logging_count;


### PR DESCRIPTION
This means we get a CAND log of any duplicate nodes that turn up, this should make it much easier to track down what is going on. It still get the log even if ignore duplicates is set, its still valid to log because it better represents the peripherals connected. Logging is still only done if a log has been started, if the issue is a boot you would have to enable disarmed logging to get the original unique ID that caused the conflict.

Note that we only get 1 extra log, so if there are multiple duplicates we only get the first. 

Tested by deliberately setting two static IDs to conflict. In this case the two devices were both here2's so only the UID is different, but the other fields would also be different for other devices. 

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/3222f228-b14c-4c0b-bef5-6b770d573a70)