### PR TITLE
ROMFS: allow list over FTP

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -510,6 +510,8 @@ class Board:
                         # exclude emacs tmp files
                         continue
                     fname = root[len(custom_dir)+1:]+"/"+f
+                    if fname.startswith("/"):
+                        fname = fname[1:]
                     env.ROMFS_FILES += [(fname,root+"/"+f)]
 
     def pre_build(self, bld):

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -64,6 +64,7 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
     { nullptr, fs_local },
 #if AP_FILESYSTEM_ROMFS_ENABLED
     { "@ROMFS/", fs_romfs },
+    { "@ROMFS", fs_romfs },
 #endif
 #if AP_FILESYSTEM_PARAM_ENABLED
     { "@PARAM/", fs_param },

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -66,6 +66,12 @@ const uint8_t *AP_ROMFS::find_decompress(const char *name, uint32_t &size)
         return nullptr;
     }
 
+    if (f->decompressed_size == 0) {
+        // empty file
+        size = 0;
+        return decompressed_data;
+    }
+
     // explicitly null-terminate the data
     decompressed_data[f->decompressed_size] = 0;
 
@@ -117,7 +123,23 @@ const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
 {
     const size_t dlen = strlen(dirname);
     for ( ; ofs < ARRAY_SIZE(files); ofs++) {
-        if ((dlen == 0) || (strncmp(dirname, files[ofs].filename, dlen) == 0)) {
+        if (strncmp(dirname, files[ofs].filename, dlen) == 0) {
+            const char last_char = files[ofs].filename[dlen];
+            if (dlen != 0 && last_char != '/' && last_char != 0) {
+                // only a partial match, skip
+                continue;
+            }
+            /*
+              prevent duplicate directories
+             */
+            const char *start_name = files[ofs].filename + dlen + 1;
+            const char *slash = strchr(start_name, '/');
+            if (ofs > 0 && slash != nullptr) {
+                auto len = slash - start_name;
+                if (memcmp(files[ofs].filename, files[ofs-1].filename, len+dlen+1) == 0) {
+                    continue;
+                }
+            }
             // found one
             return files[ofs++].filename;
         }

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -117,8 +117,7 @@ const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
 {
     const size_t dlen = strlen(dirname);
     for ( ; ofs < ARRAY_SIZE(files); ofs++) {
-        if (strncmp(dirname, files[ofs].filename, dlen) == 0 &&
-            files[ofs].filename[dlen] == '/') {
+        if ((dlen == 0) || (strncmp(dirname, files[ofs].filename, dlen) == 0)) {
             // found one
             return files[ofs++].filename;
         }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -624,6 +624,12 @@ void GCS_MAVLINK::ftp_list_dir(struct pending_ftp &request, struct pending_ftp &
 
     request.data[sizeof(request.data) - 1] = 0; // ensure the path is null terminated
 
+    // Strip trailing /
+    const size_t dir_len = strlen((char *)request.data);
+    if ((dir_len > 1) && (request.data[dir_len - 1] == '/')) {
+        request.data[dir_len - 1] = 0;
+    }
+
     // open the dir
     auto *dir = AP::FS().opendir((char *)request.data);
     if (dir == nullptr) {


### PR DESCRIPTION
Currently scripting will try and load any scripts in the `@ROMFS/scripts` directory or subdirectorys. This means it will also attempt to load any modules which will fail and cause a pre-arm. This is needed for https://github.com/ArduPilot/ardupilot/pull/26157 to be useful.

Tested in SITL with `ROMFS_custom`.