### PR TITLE
waf: remove richenpower special-case

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -654,7 +654,6 @@ class sitl(Board):
         cfg.define('AP_SIM_ENABLED', 1)
         cfg.define('HAL_WITH_SPI', 1)
         cfg.define('HAL_WITH_RAMTRON', 1)
-        cfg.define('AP_GENERATOR_RICHENPOWER_ENABLED', 1)
         cfg.define('AP_OPENDRONEID_ENABLED', 1)
         cfg.define('AP_SIGNED_FIRMWARE', 0)
 


### PR DESCRIPTION
we started to include this everywhere anyway


... initially we set this to be only on by request.  We had to change that to be on by default, so this line is now redundant in SITL.
