### PR TITLE
AP_TemperatureSensor: correct compilation when GCS not available

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
@@ -36,6 +36,7 @@ static const uint8_t TSYS03_CMD_READ_ADC    = 0x00;
 void AP_TemperatureSensor_TSYS03::init()
 {
     constexpr char name[] = "TSYS03";
+    (void)name;  // sometimes this is unused (e.g. HAL_GCS_ENABLED false)
 
 #if AP_TEMPERATURE_SENSOR_TSYS03_ENFORCE_KNOWN_VALID_I2C_ADDRESS
     // I2C Address: Default to using TSYS03_ADDR_CSB0 & Check I2C Address is Correct


### PR DESCRIPTION
This variable becomes unused