### PR TITLE
Precland cleanups

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -403,7 +403,7 @@ bool AC_PrecLand::target_acquired()
     if ((AP_HAL::millis()-_last_update_ms) > LANDING_TARGET_TIMEOUT_MS) {
         if (_target_acquired) {
             // just lost the landing target, inform the user. This message will only be sent once every time target is lost
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Target Lost");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PrecLand: Target Lost");
         }
         // not had a sensor update since a long time
         // probably lost the target
@@ -515,7 +515,7 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
             // Update if a new Line-Of-Sight measurement is available
             if (construct_pos_meas_using_rangefinder(rangefinder_alt_m, rangefinder_alt_valid)) {
                 if (!_estimator_initialized) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Target Found");
                     _estimator_initialized = true;
                 }
                 _target_pos_rel_est_NE.x = _target_pos_rel_meas_NED.x;
@@ -548,7 +548,7 @@ void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_va
                 float xy_pos_var = sq(_target_pos_rel_meas_NED.z*(0.01f + 0.01f*AP::ahrs().get_gyro().length()) + 0.02f);
                 if (!_estimator_initialized) {
                     // Inform the user landing target has been found
-                    gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Target Found");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Target Found");
                     // start init of EKF. We will let the filter consume the data for a while before it available for consumption
                     // reset filter state
                     if (_inertial_data_delayed->inertialNavVelocityValid) {
@@ -604,11 +604,11 @@ void AC_PrecLand::check_ekf_init_timeout()
         if (AP_HAL::millis()-_last_update_ms > EKF_INIT_SENSOR_MIN_UPDATE_MS) {
             // we have lost the target, not enough readings to initialize the EKF
             _estimator_initialized = false;
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PrecLand: Init Failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PrecLand: Init Failed");
         } else if (AP_HAL::millis()-_estimator_init_ms > EKF_INIT_TIME_MS) {
             // the target has been visible for a while, EKF should now have initialized to a good value
             _target_acquired = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Init Complete");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Init Complete");
         }
     }
 }

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -203,17 +203,17 @@ private:
     AP_Int8                     _retry_max;         // PrecLand Maximum number of retires to a failed landing
     AP_Float                    _retry_timeout_sec; // Time for which vehicle continues descend even if target is lost. After this time period, vehicle will attempt a landing retry depending on PLND_STRICT param.
     AP_Int8                     _retry_behave;      // Action to do when trying a landing retry
-    AP_Float                    _sensor_min_alt;     // PrecLand minimum height required for detecting target
-    AP_Float                    _sensor_max_alt;     // PrecLand maximum height the sensor can detect target
-    AP_Int16                    _options;            // Bitmask for extra options
-    AP_Enum<Rotation>           _orient;             // Orientation of camera/sensor
+    AP_Float                    _sensor_min_alt;    // PrecLand minimum height required for detecting target
+    AP_Float                    _sensor_max_alt;    // PrecLand maximum height the sensor can detect target
+    AP_Int16                    _options;           // Bitmask for extra options
+    AP_Enum<Rotation>           _orient;            // Orientation of camera/sensor
 
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently after estimator is initialized
     bool                        _estimator_initialized; // true if estimator has been initialized after few seconds of the target being detected by sensor
     uint32_t                    _estimator_init_ms; // system time in millisecond when EKF was init
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen
-    uint32_t                    _last_valid_target_ms;       // last time PrecLand library had a output of the landing target position
+    uint32_t                    _last_valid_target_ms;      // last time PrecLand library had a output of the landing target position
 
     PosVelEKF                   _ekf_x, _ekf_y;     // Kalman Filter for x and y axis
     uint32_t                    _outlier_reject_count;  // mini-EKF's outlier counter (3 consecutive outliers lead to EKF accepting updates)
@@ -242,6 +242,7 @@ private:
         uint64_t time_usec;
     };
     ObjectArray<inertial_data_frame_s> *_inertial_history;
+    struct inertial_data_frame_s *_inertial_data_delayed;
 
     // backend state
     struct precland_state {
@@ -251,7 +252,7 @@ private:
 
     // write out PREC message to log:
     void Write_Precland();
-    uint32_t last_log_ms;  // last time we logged
+    uint32_t _last_log_ms;  // last time we logged
 
     static AC_PrecLand *_singleton; //singleton
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -47,7 +47,7 @@ void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, u
             //we do not support this frame
             if (!_wrong_frame_msg_sent) {
                 _wrong_frame_msg_sent = true;
-                gcs().send_text(MAV_SEVERITY_INFO,"Plnd: Frame not supported ");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Plnd: Frame not supported ");
             }
             return;
         }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -30,23 +30,6 @@ bool AC_PrecLand_Companion::get_los_body(Vector3f& ret) {
     return false;
 }
 
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_Companion::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_Companion::have_los_meas()
-{
-    return _have_los_meas;
-}
-
-// return distance to target
-float AC_PrecLand_Companion::distance_to_target()
-{
-    return _distance_to_target;
-}
-
 void AC_PrecLand_Companion::handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms)
 {
     _distance_to_target = packet.distance;

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -31,13 +31,13 @@ public:
     bool get_los_body(Vector3f& ret) override;
 
     // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
+    uint32_t los_meas_time_ms() override { return _los_meas_time_ms; }
 
     // return true if there is a valid los measurement available
-    bool have_los_meas() override;
+    bool have_los_meas() override { return _have_los_meas; }
 
     // returns distance to target in meters (0 means distance is not known)
-    float distance_to_target() override;
+    float distance_to_target() override { return _distance_to_target; }
 
     // parses a mavlink message from the companion computer
     void handle_msg(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
@@ -45,14 +45,4 @@ bool AC_PrecLand_IRLock::get_los_body(Vector3f& ret) {
     return false;
 }
 
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_IRLock::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_IRLock::have_los_meas() {
-    return _have_los_meas;
-}
-
 #endif // AC_PRECLAND_IRLOCK_ENABLED

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -36,10 +36,10 @@ public:
     bool get_los_body(Vector3f& ret) override;
 
     // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
+    uint32_t los_meas_time_ms() override { return _los_meas_time_ms; }
 
     // return true if there is a valid los measurement available
-    bool have_los_meas() override;
+    bool have_los_meas() override { return _have_los_meas; }
 
 private:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -39,19 +39,14 @@ void AC_PrecLand_SITL::update()
     _have_los_meas = _have_los_meas && AP_HAL::millis() - _los_meas_time_ms <= 1000;
 }
 
-bool AC_PrecLand_SITL::have_los_meas() {
-    return AP_HAL::millis() - _los_meas_time_ms < 1000;
-}
-
 // provides a unit vector towards the target in body frame
 //  returns same as have_los_meas()
 bool AC_PrecLand_SITL::get_los_body(Vector3f& ret) {
-    if (AP_HAL::millis() - _los_meas_time_ms > 1000) {
-        // no measurement for a full second; no vector available
-        return false;
+    if (have_los_meas()) {
+        ret = _los_meas_body;
+        return true;
     }
-    ret = _los_meas_body;
-    return true;
+    return false;
 }
 
 #endif  // AC_PRECLAND_SITL_ENABLED

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -33,7 +33,7 @@ public:
     uint32_t los_meas_time_ms() override { return _los_meas_time_ms; }
 
     // return true if there is a valid los measurement available
-    bool have_los_meas() override;
+    bool have_los_meas() override { return _have_los_meas; }
 
     // returns distance to target in meters (0 means distance is not known)
     float distance_to_target() override { return _distance_to_target; }

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
@@ -45,14 +45,4 @@ bool AC_PrecLand_SITL_Gazebo::get_los_body(Vector3f& ret) {
     return false;
 }
 
-// returns system time in milliseconds of last los measurement
-uint32_t AC_PrecLand_SITL_Gazebo::los_meas_time_ms() {
-    return _los_meas_time_ms;
-}
-
-// return true if there is a valid los measurement available
-bool AC_PrecLand_SITL_Gazebo::have_los_meas() {
-    return _have_los_meas;
-}
-
 #endif  // AC_PRECLAND_SITL_GAZEBO_ENABLED

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
@@ -31,10 +31,10 @@ public:
     bool get_los_body(Vector3f& ret) override;
 
     // returns system time in milliseconds of last los measurement
-    uint32_t los_meas_time_ms() override;
+    uint32_t los_meas_time_ms() override { return _los_meas_time_ms; }
 
     // return true if there is a valid los measurement available
-    bool have_los_meas() override;
+    bool have_los_meas() override { return _have_los_meas; }
 
 private:
     AP_IRLock_SITL_Gazebo irlock;

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -186,7 +186,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         _retry_state = RetryLanding::IN_PROGRESS;
         // inform the user what we are doing
         if (_retry_count <= _precland->get_max_retry_allowed()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retrying");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retrying");
         }
         retry_pos_m = go_to_pos;
         return Status::RETRYING;
@@ -219,7 +219,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         if (fabsf(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
             // we have descended to the original height where we started the climb from
             _retry_state = RetryLanding::COMPLETE;
-            gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");
         }
         return Status::RETRYING;
     }
@@ -249,7 +249,7 @@ AC_PrecLand_StateMachine::FailSafeAction AC_PrecLand_StateMachine::get_failsafe_
         // start the timer
         failsafe_start_ms = AP_HAL::millis();
         failsafe_initialized = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "PrecLand: Failsafe Measures");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Failsafe Measures");
     }
 
     // Depending on the strictness we will either land vertically, wait for some time and then land vertically, not land at all


### PR DESCRIPTION
Removes code duplication in SITL
Make SITL behave like other backends
Small (mostly NFC) cleanups on the Precland that make the future sensor lag estimation PR smaller.
