### PR TITLE
Autotest: Generate LogMessages.xml for Sub

### DIFF
--- a/Tools/scripts/build_log_message_documentation.sh
+++ b/Tools/scripts/build_log_message_documentation.sh
@@ -27,6 +27,6 @@ generate_log_message_documentation() {
     xz -e <"$VEHICLE_DIR"/LogMessages.xml >"$VEHICLE_DIR"/LogMessages.xml.xz.new && mv "$VEHICLE_DIR"/LogMessages.xml.xz.new "$VEHICLE_DIR"/LogMessages.xml.xz
 }
 
-for vehicle in Rover Plane Copter Tracker Blimp; do
+for vehicle in Rover Plane Copter Tracker Blimp Sub; do
     generate_log_message_documentation "$vehicle"
 done


### PR DESCRIPTION
After brief discussion on a previous PR (https://github.com/ArduPilot/MAVProxy/pull/1320#issuecomment-1936996052), I got thinking about the idea using the log message meta data for various things within MAVExplorer, and I noticed that the meta-data for "Sub" does not get created and stored in here: https://autotest.ardupilot.org/LogMessages/ alongside the others.

The aim of this PR is to create LogMessages.* files for 'Sub', and include them with the others on the autotest web site.

Tested locally by running 'Tools/scripts/build_log_message_documentation.sh', and got the full set of meta-data in the local 'buildlogs\LogMessages' folder.