### PR TITLE
AP_OAPathPlanner: using static constexpr instead const

### DIFF
--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -24,11 +24,11 @@
 extern const AP_HAL::HAL &hal;
 
 // parameter defaults
-const float OA_MARGIN_MAX_DEFAULT = 5;
-const int16_t OA_OPTIONS_DEFAULT = 1;
+static constexpr float OA_MARGIN_MAX_DEFAULT = 5;
+static constexpr int16_t OA_OPTIONS_DEFAULT = 1;
 
-const int16_t OA_UPDATE_MS = 1000;      // path planning updates run at 1hz
-const int16_t OA_TIMEOUT_MS = 3000;     // results over 3 seconds old are ignored
+static constexpr int16_t OA_UPDATE_MS = 1000;      // path planning updates run at 1hz
+static constexpr int16_t OA_TIMEOUT_MS = 3000;     // results over 3 seconds old are ignored
 
 const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
 


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/23716/commits/d6a0fbe718ab7a2e6ec3dc9178a35815904e5ed4 so we can discuss the meat of (and rename) that other PR properly.

@xianglunkai 

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```
