### PR TITLE
Copter: Autotune performance and safety enhancements

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -10,18 +10,18 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
-#define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500     // restart tuning if pilot has left sticks in middle for 2 seconds
+#define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500         // restart tuning if pilot has left sticks in middle for 2 seconds
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
- # define AUTOTUNE_LEVEL_ANGLE_CD           500     // angle which qualifies as level (Plane uses more relaxed 5deg)
- # define AUTOTUNE_LEVEL_RATE_RP_CD        1000     // rate which qualifies as level for roll and pitch (Plane uses more relaxed 10deg/sec)
+ # define AUTOTUNE_LEVEL_ANGLE_CD           500         // angle which qualifies as level (Plane uses more relaxed 5deg)
+ # define AUTOTUNE_LEVEL_RATE_RP_CD         1000        // rate which qualifies as level for roll and pitch (Plane uses more relaxed 10deg/sec)
 #else
- # define AUTOTUNE_LEVEL_ANGLE_CD           250     // angle which qualifies as level
- # define AUTOTUNE_LEVEL_RATE_RP_CD         500     // rate which qualifies as level for roll and pitch
+ # define AUTOTUNE_LEVEL_ANGLE_CD           250         // angle which qualifies as level
+ # define AUTOTUNE_LEVEL_RATE_RP_CD         500         // rate which qualifies as level for roll and pitch
 #endif
-#define AUTOTUNE_LEVEL_RATE_Y_CD            750     // rate which qualifies as level for yaw
-#define AUTOTUNE_REQUIRED_LEVEL_TIME_MS     250     // time we require the aircraft to be level before starting next test
-#define AUTOTUNE_LEVEL_TIMEOUT_MS          2000     // time out for level
-#define AUTOTUNE_LEVEL_WARNING_INTERVAL_MS 5000     // level failure warning messages sent at this interval to users
+#define AUTOTUNE_LEVEL_RATE_Y_CD            750         // rate which qualifies as level for yaw
+#define AUTOTUNE_REQUIRED_LEVEL_TIME_MS     250         // time we require the aircraft to be level before starting next test
+#define AUTOTUNE_LEVEL_TIMEOUT_MS           2000        // time out for level
+#define AUTOTUNE_LEVEL_WARNING_INTERVAL_MS  5000        // level failure warning messages sent at this interval to users
 #define AUTOTUNE_ANGLE_MAX_RLLPIT_SCALE     2.0 / 3.0   // maximum allowable angle during testing, as a fraction of angle_max
 
 AC_AutoTune::AC_AutoTune()

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -272,7 +272,7 @@ bool AC_AutoTune::currently_level()
 {
     // abort AutoTune if we pass 2 * AUTOTUNE_LEVEL_TIMEOUT_MS
     const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - level_start_time_ms > 2 * AUTOTUNE_LEVEL_TIMEOUT_MS) {
+    if (now_ms - level_start_time_ms > 3 * AUTOTUNE_LEVEL_TIMEOUT_MS) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "AutoTune: Failed to level, please tune manually");
         mode = FAILED;
         LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -44,11 +44,6 @@
 
 #define AUTOTUNE_ANNOUNCE_INTERVAL_MS 2000
 
-#define AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_SCALE  1.0 / 4.0   // minimum target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_ANGLE_RLLPIT_SCALE      1.0 / 2.0   // target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_MIN_ANGLE_YAW_SCALE     1.0 / 8.0   // minimum target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_ANGLE_YAW_SCALE         2.0 / 3.0   // target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
-
 class AC_AutoTune
 {
 public:
@@ -282,7 +277,7 @@ protected:
     float    rate_max;                              // maximum rate variable - parent and multi
     float    test_accel_max;                        // maximum acceleration variable
     float    step_scaler;                           // scaler to reduce maximum target step - parent and multi
-    float    abort_angle;                           // Angle that test is aborted- parent and multi
+    float    angle_finish;                           // Angle that test is aborted- parent and multi
     float    desired_yaw_cd;                        // yaw heading during tune - parent and Tradheli
 
     LowPassFilterFloat  rotation_rate_filt;         // filtered rotation rate in radians/second
@@ -313,6 +308,24 @@ protected:
 private:
     // return true if we have a good position estimate
     virtual bool position_ok();
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float target_angle_max_rp_cd() const = 0;
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float target_angle_max_y_cd() const = 0;
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float target_angle_min_rp_cd() const = 0;
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float target_angle_min_y_cd() const = 0;
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float angle_lim_max_rp_cd() const = 0;
+
+    // methods subclasses must implement to specify max/min test angles:
+    virtual float angle_lim_neg_rpy_cd() const = 0;
 
     // initialise position controller
     bool init_position_controller();

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -211,8 +211,8 @@ protected:
         RD_DOWN = 1,              // rate D is being tuned down
         RP_UP = 2,                // rate P is being tuned up
         RFF_UP = 3,               // rate FF is being tuned up
-        SP_UP = 4,                // angle P is being tuned up
-        SP_DOWN = 5,              // angle P is being tuned down
+        SP_DOWN = 4,              // angle P is being tuned down
+        SP_UP = 5,                // angle P is being tuned up
         MAX_GAINS = 6,            // max allowable stable gains are determined
         TUNE_CHECK = 7,           // frequency sweep with tuned gains
         TUNE_COMPLETE = 8         // Reached end of tuning

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -273,6 +273,7 @@ protected:
     float    test_angle_max;                        // the maximum angle achieved during TESTING_ANGLE step-multi only
     uint32_t step_start_time_ms;                    // start time of current tuning step (used for timeout checks)
     uint32_t step_time_limit_ms;                    // time limit of current autotune process
+    uint32_t level_start_time_ms;                   // start time of waiting for level
     int8_t   counter;                               // counter for tuning gains
     float    target_rate;                           // target rate-multi only
     float    target_angle;                          // target angle-multi only
@@ -330,8 +331,6 @@ private:
 
     // variables
     uint32_t override_time;                         // the last time the pilot overrode the controls
-    uint32_t level_start_time_ms;                   // start time of waiting for level
-    uint32_t level_fail_warning_time_ms;            // last time level failure warning message was sent to GCS
 
     // time in ms of last pilot override warning
     uint32_t last_pilot_override_warning;

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -44,9 +44,10 @@
 
 #define AUTOTUNE_ANNOUNCE_INTERVAL_MS 2000
 
-#define AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_CD 1000    // minimum target angle during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_ANGLE_RLLPIT_CD     2000    // target angle during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_ANGLE_YAW_CD        3000    // target angle during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_SCALE  1.0 / 4.0   // minimum target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_TARGET_ANGLE_RLLPIT_SCALE      1.0 / 2.0   // target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_TARGET_MIN_ANGLE_YAW_SCALE     1.0 / 8.0   // minimum target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_TARGET_ANGLE_YAW_SCALE         2.0 / 3.0   // target angle, as a fraction of angle_max, during TESTING_RATE step that will cause us to move to next step
 
 class AC_AutoTune
 {

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -60,6 +60,14 @@
 #define AUTOTUNE_SEQ_BITMASK_MAX_GAIN        8
 #define AUTOTUNE_SEQ_BITMASK_TUNE_CHECK      16
 
+// angle limits preserved from previous behaviour as Multi changed:
+#define AUTOTUNE_ANGLE_TARGET_MAX_RP_CD     2000    // target angle during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_ANGLE_TARGET_MIN_RP_CD     1000    // minimum target angle during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_ANGLE_TARGET_MAX_Y_CD      3000    // target angle during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_ANGLE_TARGET_MIN_Y_CD      500     // target angle during TESTING_RATE step that will cause us to move to next step
+#define AUTOTUNE_ANGLE_MAX_RP_CD            3000    // maximum allowable angle in degrees during testing
+#define AUTOTUNE_ANGLE_NEG_RPY_CD           1000    // maximum allowable angle in degrees during testing
+
 const AP_Param::GroupInfo AC_AutoTune_Heli::var_info[] = {
 
     // @Param: AXES
@@ -1722,6 +1730,36 @@ void AC_AutoTune_Heli::updating_max_gains(float *freq, float *gain, float *phase
         gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: ph=%f rate_d=%f", (double)(max_rate_d.phase), (double)(max_rate_d.max_allowed));
     }
 
+}
+
+float AC_AutoTune_Heli::target_angle_max_rp_cd() const
+{
+    return AUTOTUNE_ANGLE_TARGET_MAX_RP_CD;
+}
+
+float AC_AutoTune_Heli::target_angle_max_y_cd() const
+{
+    return AUTOTUNE_ANGLE_TARGET_MAX_Y_CD;
+}
+
+float AC_AutoTune_Heli::target_angle_min_rp_cd() const
+{
+    return AUTOTUNE_ANGLE_TARGET_MIN_RP_CD;
+}
+
+float AC_AutoTune_Heli::target_angle_min_y_cd() const
+{
+    return AUTOTUNE_ANGLE_TARGET_MIN_Y_CD;
+}
+
+float AC_AutoTune_Heli::angle_lim_max_rp_cd() const
+{
+    return AUTOTUNE_ANGLE_MAX_RP_CD;
+}
+
+float AC_AutoTune_Heli::angle_lim_neg_rpy_cd() const
+{
+    return AUTOTUNE_ANGLE_NEG_RPY_CD;
 }
 
 #if HAL_LOGGING_ENABLED

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -156,6 +156,18 @@ private:
         DRB     = 2,
     };
 
+    float target_angle_max_rp_cd() const override;
+
+    float target_angle_max_y_cd() const override;
+
+    float target_angle_min_rp_cd() const override;
+
+    float target_angle_min_y_cd() const override;
+
+    float angle_lim_max_rp_cd() const override;
+
+    float angle_lim_neg_rpy_cd() const override;
+
     // Feedforward test used to determine Rate FF gain
     void rate_ff_test_init();
     void rate_ff_test_run(float max_angle_cds, float target_rate_cds, float dir_sign);

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -44,7 +44,7 @@
  *
  */
 
-#define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   1000U     // timeout for tuning mode's testing step
+#define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   2000U     // timeout for tuning mode's testing step
 
 #define AUTOTUNE_RD_STEP                  0.05f     // minimum increment when increasing/decreasing Rate D term
 #define AUTOTUNE_RP_STEP                  0.05f     // minimum increment when increasing/decreasing Rate P term

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo AC_AutoTune_Multi::var_info[] = {
     // @Description: Autotune aggressiveness. Defines the bounce back used to detect size of the D term.
     // @Range: 0.05 0.10
     // @User: Standard
-    AP_GROUPINFO("AGGR", 2, AC_AutoTune_Multi, aggressiveness, 0.1f),
+    AP_GROUPINFO("AGGR", 2, AC_AutoTune_Multi, aggressiveness, 0.075f),
 
     // @Param: MIN_D
     // @DisplayName: AutoTune minimum D

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -99,9 +99,9 @@ const AP_Param::GroupInfo AC_AutoTune_Multi::var_info[] = {
     // @Param: MIN_D
     // @DisplayName: AutoTune minimum D
     // @Description: Defines the minimum D gain
-    // @Range: 0.001 0.006
+    // @Range: 0.0001 0.005
     // @User: Standard
-    AP_GROUPINFO("MIN_D", 3, AC_AutoTune_Multi, min_d,  0.001f),
+    AP_GROUPINFO("MIN_D", 3, AC_AutoTune_Multi, min_d,  0.0005f),
 
     AP_GROUPEND
 };

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -367,6 +367,7 @@ void AC_AutoTune_Multi::load_test_gains()
         if (axis == YAW_D) {
             attitude_control->get_rate_yaw_pid().kD(tune_yaw_rd);
         } else {
+            attitude_control->get_rate_yaw_pid().kD(0.0);
             attitude_control->get_rate_yaw_pid().filt_E_hz(tune_yaw_rLPF);
         }
         attitude_control->get_rate_yaw_pid().filt_T_hz(0.0f);

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -932,13 +932,18 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
         if (tune_d <= tune_d_min) {
             tune_d = tune_d_min;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "AutoTune: Rate D Gain Determination Failed");
+            mode = FAILED;
+            LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
         }
         // decrease P gain to match D gain reduction
         tune_p -= tune_p*tune_p_step_ratio;
         // do not decrease the P term past the minimum
         if (tune_p <= tune_p_min) {
             tune_p = tune_p_min;
-            LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "AutoTune: Rate P Gain Determination Failed");
+            mode = FAILED;
+            LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
         }
         // cancel change in direction
         positive_direction = !positive_direction;
@@ -987,6 +992,9 @@ void AC_AutoTune_Multi::updating_angle_p_down(float &tune_p, float tune_p_min, f
             tune_p = tune_p_min;
             counter = AUTOTUNE_SUCCESS_COUNT;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "AutoTune: Angle P Gain Determination Failed");
+            mode = FAILED;
+            LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
        }
     }
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -72,7 +72,7 @@
 
 // roll and pitch axes
 #define AUTOTUNE_TARGET_RATE_RLLPIT_CDS     18000   // target roll/pitch rate during AUTOTUNE_STEP_TWITCHING step
-#define AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS 4500    // target roll/pitch rate during AUTOTUNE_STEP_TWITCHING step
+#define AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS 4500    // target min roll/pitch rate during AUTOTUNE_STEP_TWITCHING step
 
 // yaw axis
 #define AUTOTUNE_TARGET_RATE_YAW_CDS        9000        // target yaw rate during AUTOTUNE_STEP_TWITCHING step
@@ -536,9 +536,9 @@ void AC_AutoTune_Multi::twitching_test_rate(float rate, float rate_target_max, f
         meas_rate_min = rate;
     }
 
-    // calculate early stopping time based on the time it takes to get to 75%
-    if (meas_rate_max < rate_target_max * 0.75f) {
-        // the measurement not reached the 75% threshold yet
+    // calculate early stopping time based on the time it takes to get to 63.21%
+    if (meas_rate_max < rate_target_max * 0.6321) {
+        // the measurement not reached the 63.21% threshold yet
         step_time_limit_ms = (now - step_start_time_ms) * 3;
         step_time_limit_ms = MIN(step_time_limit_ms, AUTOTUNE_TESTING_STEP_TIMEOUT_MS);
     }
@@ -612,9 +612,9 @@ void AC_AutoTune_Multi::twitching_test_angle(float angle, float rate, float angl
         meas_rate_min = rate;
     }
 
-    // calculate early stopping time based on the time it takes to get to 75%
-    if (meas_angle_max < angle_target_max * 0.75f) {
-        // the measurement not reached the 75% threshold yet
+    // calculate early stopping time based on the time it takes to get to 63.21%
+    if (meas_angle_max < angle_target_max * 0.6321) {
+        // the measurement not reached the 63.21% threshold yet
         step_time_limit_ms = (now - step_start_time_ms) * 3;
         step_time_limit_ms = MIN(step_time_limit_ms, AUTOTUNE_TESTING_STEP_TIMEOUT_MS);
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -563,6 +563,7 @@ void AC_AutoTune_Multi::twitching_test_rate(float rate, float rate_target_max, f
 // update min and max and test for end conditions
 void AC_AutoTune_Multi::twitching_abort_rate(float angle, float rate, float angle_max, float meas_rate_min)
 {
+    const uint32_t now = AP_HAL::millis();
     if (angle >= angle_max) {
         if (is_equal(rate, meas_rate_min) && step_scaler > 0.5f) {
             // we have reached the angle limit before completing the measurement of maximum and minimum
@@ -571,6 +572,8 @@ void AC_AutoTune_Multi::twitching_abort_rate(float angle, float rate, float angl
             // ignore result and start test again
             step = WAITING_FOR_LEVEL;
             positive_direction = twitch_reverse_direction();
+            step_start_time_ms = now;
+            level_start_time_ms = now;
         } else {
             step = UPDATE_GAINS;
         }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -75,9 +75,8 @@
 #define AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS 4500    // target roll/pitch rate during AUTOTUNE_STEP_TWITCHING step
 
 // yaw axis
-#define AUTOTUNE_TARGET_RATE_YAW_CDS        9000    // target yaw rate during AUTOTUNE_STEP_TWITCHING step
-#define AUTOTUNE_TARGET_MIN_ANGLE_YAW_CD     500    // minimum target angle during TESTING_RATE step that will cause us to move to next step
-#define AUTOTUNE_TARGET_MIN_RATE_YAW_CDS    1500    // minimum target yaw rate during AUTOTUNE_STEP_TWITCHING step
+#define AUTOTUNE_TARGET_RATE_YAW_CDS        9000        // target yaw rate during AUTOTUNE_STEP_TWITCHING step
+#define AUTOTUNE_TARGET_MIN_RATE_YAW_CDS    1500        // minimum target yaw rate during AUTOTUNE_STEP_TWITCHING step
 
 // second table of user settable parameters for quadplanes, this
 // allows us to go beyond the 64 parameter limit
@@ -1133,14 +1132,14 @@ void AC_AutoTune_Multi::twitch_test_init()
     case ROLL: {
         target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, step_scaler*AUTOTUNE_TARGET_RATE_RLLPIT_CDS);
         target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_roll())*100.0f, AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, target_max_rate);
-        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_roll())*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_CD, AUTOTUNE_TARGET_ANGLE_RLLPIT_CD);
+        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_roll())*100.0f, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_SCALE, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_RLLPIT_SCALE);
         rotation_rate_filt.set_cutoff_frequency(attitude_control->get_rate_roll_pid().filt_D_hz()*2.0f);
         break;
     }
     case PITCH: {
         target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, step_scaler*AUTOTUNE_TARGET_RATE_RLLPIT_CDS);
         target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_pitch())*100.0f, AUTOTUNE_TARGET_MIN_RATE_RLLPIT_CDS, target_max_rate);
-        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_pitch())*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_CD, AUTOTUNE_TARGET_ANGLE_RLLPIT_CD);
+        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_pitch())*100.0f, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_MIN_ANGLE_RLLPIT_SCALE, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_RLLPIT_SCALE);
         rotation_rate_filt.set_cutoff_frequency(attitude_control->get_rate_pitch_pid().filt_D_hz()*2.0f);
         break;
     }
@@ -1148,7 +1147,7 @@ void AC_AutoTune_Multi::twitch_test_init()
     case YAW_D: {
         target_max_rate = MAX(AUTOTUNE_TARGET_MIN_RATE_YAW_CDS, step_scaler*AUTOTUNE_TARGET_RATE_YAW_CDS);
         target_rate = constrain_float(ToDeg(attitude_control->max_rate_step_bf_yaw()*0.75f)*100.0f, AUTOTUNE_TARGET_MIN_RATE_YAW_CDS, target_max_rate);
-        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_yaw()*0.75f)*100.0f, AUTOTUNE_TARGET_MIN_ANGLE_YAW_CD, AUTOTUNE_TARGET_ANGLE_YAW_CD);
+        target_angle = constrain_float(ToDeg(attitude_control->max_angle_step_bf_yaw()*0.75f)*100.0f, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_MIN_ANGLE_YAW_SCALE, attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_YAW_SCALE);
         if (axis == YAW_D) {
             rotation_rate_filt.set_cutoff_frequency(attitude_control->get_rate_yaw_pid().filt_D_hz()*2.0f);
         } else {

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -1232,7 +1232,6 @@ void AC_AutoTune_Multi::twitch_test_run(AxisType test_axis, const float dir_sign
     // hold current attitude
 
     if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
-        attitude_control->input_rate_bf_roll_pitch_yaw(0.0f, 0.0f, 0.0f);
         // step angle targets on first iteration
         if (twitch_first_iter) {
             twitch_first_iter = false;
@@ -1251,7 +1250,9 @@ void AC_AutoTune_Multi::twitch_test_run(AxisType test_axis, const float dir_sign
                 // request yaw to 20deg
                 attitude_control->input_angle_step_bf_roll_pitch_yaw(0.0f, 0.0f, dir_sign * target_angle);
                 break;
-            }
+            } 
+        } else {
+            attitude_control->input_rate_bf_roll_pitch_yaw(0.0f, 0.0f, 0.0f);
         }
     } else {
         attitude_control->input_rate_bf_roll_pitch_yaw_2(0.0f, 0.0f, 0.0f);

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -1163,9 +1163,9 @@ void AC_AutoTune_Multi::twitch_test_run(AxisType test_axis, const float dir_sign
     // disable rate limits
     attitude_control->use_sqrt_controller(false);
     // hold current attitude
-    attitude_control->input_rate_bf_roll_pitch_yaw(0.0f, 0.0f, 0.0f);
 
     if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
+        attitude_control->input_rate_bf_roll_pitch_yaw(0.0f, 0.0f, 0.0f);
         // step angle targets on first iteration
         if (twitch_first_iter) {
             twitch_first_iter = false;
@@ -1187,6 +1187,7 @@ void AC_AutoTune_Multi::twitch_test_run(AxisType test_axis, const float dir_sign
             }
         }
     } else {
+        attitude_control->input_rate_bf_roll_pitch_yaw_2(0.0f, 0.0f, 0.0f);
         // Testing rate P and D gains so will set body-frame rate targets.
         // Rate controller will use existing body-frame rates and convert to motor outputs
         // for all axes except the one we override here.

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -532,7 +532,7 @@ void AC_AutoTune_Multi::twitching_test_rate(float rate, float rate_target_max, f
     }
 
     // capture minimum measurement after the measurement has peaked (aka "bounce back")
-    if ((rate < meas_rate_min) && (meas_rate_max > rate_target_max * 0.5f)) {
+    if ((rate < meas_rate_min) && (meas_rate_max > rate_target_max * 0.25)) {
         // the measurement is bouncing back
         meas_rate_min = rate;
     }
@@ -591,7 +591,7 @@ void AC_AutoTune_Multi::twitching_test_angle(float angle, float rate, float angl
     }
 
     // capture minimum angle after we have reached a reasonable maximum angle
-    if ((angle < meas_angle_min) && (meas_angle_max > angle_target_max * 0.5f)) {
+    if ((angle < meas_angle_min) && (meas_angle_max > angle_target_max * 0.25)) {
         // the measurement is bouncing back
         meas_angle_min = angle;
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -570,6 +570,7 @@ void AC_AutoTune_Multi::twitching_abort_rate(float angle, float rate, float angl
             step_scaler *= 0.9f;
             // ignore result and start test again
             step = WAITING_FOR_LEVEL;
+            positive_direction = twitch_reverse_direction();
         } else {
             step = UPDATE_GAINS;
         }
@@ -944,8 +945,6 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
         }
-        // cancel change in direction
-        positive_direction = !positive_direction;
     } else {
         if (ignore_next == false) {
             // if maximum measurement was lower than target so decrement the success counter

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -819,6 +819,8 @@ void AC_AutoTune_Multi::updating_rate_d_up(float &tune_d, float tune_d_min, floa
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+                // This may be mean AGGR should be increased or MIN_D decreased
+                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Min Rate D limit reached");
             }
         }
     } else if ((meas_rate_max < rate_target*(1.0f-AUTOTUNE_D_UP_DOWN_MARGIN)) && (tune_p <= tune_p_max)) {
@@ -874,6 +876,8 @@ void AC_AutoTune_Multi::updating_rate_d_down(float &tune_d, float tune_d_min, fl
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+                // This may be mean AGGR should be increased or MIN_D decreased
+                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Min Rate D limit reached");
             }
         }
     } else if ((meas_rate_max < rate_target*(1.0f-AUTOTUNE_D_UP_DOWN_MARGIN)) && (tune_p <= tune_p_max)) {
@@ -907,6 +911,8 @@ void AC_AutoTune_Multi::updating_rate_d_down(float &tune_d, float tune_d_min, fl
                 tune_d = tune_d_min;
                 counter = AUTOTUNE_SUCCESS_COUNT;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
+                // This may be mean AGGR should be increased or MIN_D decreased
+                gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: Min Rate D limit reached");
             }
         }
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -1097,38 +1097,6 @@ void AC_AutoTune_Multi::Log_AutoTuneDetails()
     Log_Write_AutoTuneDetails(lean_angle, rotation_rate);
 }
 
-float AC_AutoTune_Multi::target_angle_max_rp_cd() const
-{
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MAX_RP_SCALE;
-}
-
-float AC_AutoTune_Multi::target_angle_max_y_cd() const
-{
-    // Aircraft with small lean angle will generally benefit from proportional smaller yaw twitch size
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MAX_Y_SCALE;
-}
-
-float AC_AutoTune_Multi::target_angle_min_rp_cd() const
-{
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MIN_RP_SCALE;
-}
-
-float AC_AutoTune_Multi::target_angle_min_y_cd() const
-{
-    // Aircraft with small lean angle will generally benefit from proportional smaller yaw twitch size
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MIN_Y_SCALE;
-}
-
-float AC_AutoTune_Multi::angle_lim_max_rp_cd() const
-{
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_ANGLE_ABORT_RP_SCALE;
-}
-
-float AC_AutoTune_Multi::angle_lim_neg_rpy_cd() const
-{
-    return attitude_control->lean_angle_max_cd() * AUTOTUNE_ANGLE_NEG_RP_SCALE;
-}
-
 // @LoggerMessage: ATUN
 // @Description: Copter/QuadPlane AutoTune
 // @Vehicles: Copter, Plane
@@ -1183,6 +1151,38 @@ void AC_AutoTune_Multi::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds
         rate_cds*0.01f);
 }
 #endif  // HAL_LOGGING_ENABLED
+
+float AC_AutoTune_Multi::target_angle_max_rp_cd() const
+{
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MAX_RP_SCALE;
+}
+
+float AC_AutoTune_Multi::target_angle_max_y_cd() const
+{
+    // Aircraft with small lean angle will generally benefit from proportional smaller yaw twitch size
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MAX_Y_SCALE;
+}
+
+float AC_AutoTune_Multi::target_angle_min_rp_cd() const
+{
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MIN_RP_SCALE;
+}
+
+float AC_AutoTune_Multi::target_angle_min_y_cd() const
+{
+    // Aircraft with small lean angle will generally benefit from proportional smaller yaw twitch size
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_TARGET_ANGLE_MIN_Y_SCALE;
+}
+
+float AC_AutoTune_Multi::angle_lim_max_rp_cd() const
+{
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_ANGLE_ABORT_RP_SCALE;
+}
+
+float AC_AutoTune_Multi::angle_lim_neg_rpy_cd() const
+{
+    return attitude_control->lean_angle_max_cd() * AUTOTUNE_ANGLE_NEG_RP_SCALE;
+}
 
 void AC_AutoTune_Multi::twitch_test_init()
 {

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.h
@@ -156,7 +156,7 @@ private:
 
     // updating_rate_p_up_d_down - increase P to ensure the target is reached while checking bounce back isn't increasing
     // P is increased until we achieve our target within a reasonable time while reducing D if bounce back increases above the threshold
-    void updating_rate_p_up_d_down(float &tune_d, float tune_d_min, float tune_d_step_ratio, float &tune_p, float tune_p_min, float tune_p_max, float tune_p_step_ratio, float rate_target, float meas_rate_min, float meas_rate_max);
+    void updating_rate_p_up_d_down(float &tune_d, float tune_d_min, float tune_d_step_ratio, float &tune_p, float tune_p_min, float tune_p_max, float tune_p_step_ratio, float rate_target, float meas_rate_min, float meas_rate_max, bool fail_min_d = true);
 
     // updating_angle_p_down - decrease P until we don't reach the target before time out
     // P is decreased to ensure we are not overshooting the target

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.h
@@ -139,8 +139,8 @@ private:
     void twitch_test_init();
     void twitch_test_run(AxisType test_axis, const float dir_sign);
 
-    void twitching_test_rate(float rate, float rate_target, float &meas_rate_min, float &meas_rate_max);
-    void twitching_abort_rate(float angle, float rate, float angle_max, float meas_rate_min);
+    void twitching_test_rate(float angle, float rate, float rate_target, float &meas_rate_min, float &meas_rate_max, float &meas_angle_min);
+    void twitching_abort_rate(float angle, float rate, float angle_max, float meas_rate_min, float angle_min);
     void twitching_test_angle(float angle, float rate, float angle_target, float &meas_angle_min, float &meas_angle_max, float &meas_rate_min, float &meas_rate_max);
 
     // measure acceleration during twitch test

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.h
@@ -63,6 +63,18 @@ protected:
     // reset the update gain variables for multi
     void reset_update_gain_variables() override {};
 
+    float target_angle_max_rp_cd() const override;
+
+    float target_angle_max_y_cd() const override;
+
+    float target_angle_min_rp_cd() const override;
+
+    float target_angle_min_y_cd() const override;
+
+    float angle_lim_max_rp_cd() const override;
+
+    float angle_lim_neg_rpy_cd() const override;
+
     void test_init() override;
     void test_run(AxisType test_axis, const float dir_sign) override;
 


### PR DESCRIPTION
This PR attempts to address some of the long term concerns with AutoTune.

1. Autotune now fails when it becomes clear the aircraft will probably fail to tune well.
2. The recovery from the rate twitch makes use of the control model to reduce the severity of the ESC command. This should dramatically reduce the chance of desync.
3. The waiting for level criteria has been adjusted to reduce the chance initial conditions cause problems with the tests.
4. The practice of sipping a side in an attempt to save time has been removed as it causes aircraft velocity to build. I believe removing this is a net gain in both time and reliability.
5. Base test angles on ratio's of ANGLE_MAX.

These changes are expected to dramatically reduce crashes due to desync and successful autotune with bad/dangerous tunes. 

We will see an increase number of complaints and questions along the lines of "Why did autotune fail to complete" and "Autotune failed with a failed to level error".

Improvements for a future PR
1) Make the test twitch more consistent on each test by continuing the twitch after the measurement is complete. This will keep twitches symmetrical and reduce the build up of velocity
2) Update the twitch rate and angle target based on the results of the last four twitches to reduce the number of aborted tests and therefore the total time taken.
3) Another protection I should add is to stop angle P term increase when negative rates are observed but angle overshoot is small. This will help prevent excessively large Ange P results.