### PR TITLE
RC_Channel: Set the number of radio channels

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -11,7 +11,9 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/Bitmask.h>
 
+#ifndef NUM_RC_CHANNELS
 #define NUM_RC_CHANNELS 16
+#endif
 
 /// @class	RC_Channel
 /// @brief	Object managing one RC channel


### PR DESCRIPTION
The maximum number of radio channels is 16.
The number of channels varies depending on the radio system.
FUTABA has 18 channels in their propo.
Save flash memory by setting the number of channels for the radio used.
The number of radio channels can be recognized by notifying the GCS.

setting
![Screenshot from 2024-02-17 16-10-04](https://github.com/ArduPilot/ardupilot/assets/646194/c52cbfb3-a7db-49f9-add8-e30828d6d60f)

Not set
![Screenshot from 2024-02-17 16-17-03](https://github.com/ArduPilot/ardupilot/assets/646194/b366df7d-5be9-4802-8190-c7e717b0be47)