### PR TITLE
Plane: fixed ramp of motors on back transition in tilt quadplanes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1761,10 +1761,8 @@ void SLT_Transition::update()
     }
 
     case TRANSITION_DONE:
-        if (!quadplane.tiltrotor.motors_active()) {
-            quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
-            motors->output();
-        }
+        quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
+        motors->output();
         set_last_fw_pitch();
         in_forced_transition = false;
         return;
@@ -1851,7 +1849,7 @@ void QuadPlane::update(void)
             plane.control_mode == &plane.mode_acro ||
             plane.control_mode == &plane.mode_training) {
             // in manual modes quad motors are always off
-            if (!tiltrotor.motors_active() && !tailsitter.enabled()) {
+            if (!tailsitter.enabled()) {
                 set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
                 motors->output();
             }

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -148,7 +148,7 @@ void AP_MotorsMatrix::output_to_motors()
         case SpoolState::SHUT_DOWN: {
             // no output
             for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-                if (motor_enabled[i]) {
+                if (motor_enabled_mask(i)) {
                     _actuator[i] = 0.0f;
                 }
             }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -272,6 +272,8 @@ void AP_MotorsMulticopter::output()
     // check for any external limit flags
     update_external_limits();
 
+    // clear mask of overridden motors
+    _motor_mask_override = 0;
 };
 
 void AP_MotorsMulticopter::update_external_limits()
@@ -727,6 +729,8 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float 
 {
     const int16_t pwm_min = get_pwm_output_min();
     const int16_t pwm_range = get_pwm_output_max() - pwm_min;
+
+    _motor_mask_override = mask;
 
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -733,8 +733,8 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float 
     _motor_mask_override = mask;
 
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-        if (motor_enabled[i]) {
-            if ((mask & (1U << i)) && armed() && get_interlock()) {
+        if (motor_enabled[i] && (mask & (1U << i)) != 0) {
+            if (armed() && get_interlock()) {
                 /*
                  apply rudder mixing differential thrust
                  copter frame roll is plane frame yaw as this only
@@ -742,11 +742,12 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float 
                  */
                 float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
                 set_actuator_with_slew(_actuator[i], thrust + diff_thrust);
-                int16_t pwm_output = pwm_min + pwm_range * _actuator[i];
-                rc_write(i, pwm_output);
             } else {
-                rc_write(i, pwm_min);
+                // zero throttle
+                _actuator[i] = 0.0;
             }
+            int16_t pwm_output = pwm_min + pwm_range * _actuator[i];
+            rc_write(i, pwm_output);
         }
     }
 }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -192,4 +192,14 @@ protected:
 
     // array of motor output values
     float _actuator[AP_MOTORS_MAX_NUM_MOTORS];
+
+    /* motor enabled, checking the override mask
+       _motor_mask_override is only set for tilt quadplanes
+     */
+    bool motor_enabled_mask(uint8_t i) const {
+        return motor_enabled[i] && (_motor_mask_override & (1U << i)) == 0;
+    }
+
+    // mask of overridden motors (used by quadplane tiltrotors)
+    uint16_t _motor_mask_override;
 };

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -92,7 +92,7 @@ void AP_MotorsTri::output_to_motors()
             // sends minimum values out to the motors
             for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled_mask(i)) {
-                    rc_write(AP_MOTORS_MOT_1+i, output_to_pwm(0));
+                    _actuator[AP_MOTORS_MOT_1+i] = 0;
                 }
             }
             rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -90,9 +90,11 @@ void AP_MotorsTri::output_to_motors()
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
             // sends minimum values out to the motors
-            _actuator[AP_MOTORS_MOT_1] = 0.0;
-            _actuator[AP_MOTORS_MOT_2] = 0.0;
-            _actuator[AP_MOTORS_MOT_4] = 0.0;
+            for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled_mask(i)) {
+                    rc_write(AP_MOTORS_MOT_1+i, output_to_pwm(0));
+                }
+            }
             rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);
             break;
         case SpoolState::GROUND_IDLE:


### PR DESCRIPTION
this removes the special case for SHUT_DOWN state of the motors in tilt quadplanes. The old code seemed to assume that the output_motor_mask() doesn't work in SHUT_DOWN state, but in fact it does, so we can get proper spoolup behavious on back transition just by removing the special case

this PR builds on https://github.com/ArduPilot/ardupilot/pull/26248 to give us a quadplane-tilt frame for testing
