### PR TITLE
AC_AttitudeControl: fix reset_target_and_rate method

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -934,11 +934,11 @@ void AC_AttitudeControl::reset_target_and_rate(bool reset_rate)
 {
     // move attitude target to current attitude
     _ahrs.get_quat_body_to_ned(_attitude_target);
+    _attitude_target.to_euler(_euler_angle_target);
 
     if (reset_rate) {
-        // Convert euler angle derivative of desired attitude into a body-frame angular velocity vector for feedforward
         _ang_vel_target.zero();
-        _euler_angle_target.zero();
+        _euler_rate_target.zero();
     }
 }
 


### PR DESCRIPTION
This method is resetting the euler angle target not the euler rate target. It also only updates the `_attitude_target` quaternion so the euler is not up to date. 

The only users that have `reset_rate` true are in copter acro while in shut down or ground idle:

https://github.com/ArduPilot/ardupilot/blob/1d08662c726a794190e49211f56550ea25c16e9e/ArduCopter/mode_acro.cpp#L34-L46