### PR TITLE
Correct CRSF spelling (CSRF->CRSF)

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -150,7 +150,7 @@ static const char* get_frame_type(uint8_t byte, uint8_t subtype = 0)
 #define CRSF_INTER_FRAME_TIME_US_250HZ    4000U // At fastest, frames are sent by the transmitter every 4 ms, 250 Hz
 #define CRSF_INTER_FRAME_TIME_US_150HZ    6667U // At medium, frames are sent by the transmitter every 6.667 ms, 150 Hz
 #define CRSF_INTER_FRAME_TIME_US_50HZ    20000U // At slowest, frames are sent by the transmitter every 20ms, 50 Hz
-#define CSRF_HEADER_TYPE_LEN     (CSRF_HEADER_LEN + 1)           // header length including type
+#define CRSF_HEADER_TYPE_LEN     (CRSF_HEADER_LEN + 1)           // header length including type
 
 #define CRSF_DIGITAL_CHANNEL_MIN 172
 #define CRSF_DIGITAL_CHANNEL_MAX 1811
@@ -234,7 +234,7 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
     add_to_buffer(_frame_ofs++, byte);
 
     // need a header to get the length
-    if (_frame_ofs < CSRF_HEADER_TYPE_LEN) {
+    if (_frame_ofs < CRSF_HEADER_TYPE_LEN) {
         return;
     }
 
@@ -243,7 +243,7 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
     }
 
     // parse the length
-    if (_frame_ofs == CSRF_HEADER_TYPE_LEN) {
+    if (_frame_ofs == CRSF_HEADER_TYPE_LEN) {
         _frame_crc = crc8_dvb_s2(0, _frame.type);
         // check for garbage frame
         if (_frame.length > CRSF_FRAME_PAYLOAD_MAX) {
@@ -253,19 +253,19 @@ void AP_RCProtocol_CRSF::_process_byte(uint32_t timestamp_us, uint8_t byte)
     }
 
     // update crc
-    if (_frame_ofs < _frame.length + CSRF_HEADER_LEN) {
+    if (_frame_ofs < _frame.length + CRSF_HEADER_LEN) {
         _frame_crc = crc8_dvb_s2(_frame_crc, byte);
     }
 
     // overflow check
-    if (_frame_ofs > _frame.length + CSRF_HEADER_LEN) {
+    if (_frame_ofs > _frame.length + CRSF_HEADER_LEN) {
         _frame_ofs = 0;
         return;
     }
 
     // decode whatever we got and expect
-    if (_frame_ofs == _frame.length + CSRF_HEADER_LEN) {
-        log_data(AP_RCProtocol::CRSF, timestamp_us, (const uint8_t*)&_frame, _frame_ofs - CSRF_HEADER_LEN);
+    if (_frame_ofs == _frame.length + CRSF_HEADER_LEN) {
+        log_data(AP_RCProtocol::CRSF, timestamp_us, (const uint8_t*)&_frame, _frame_ofs - CRSF_HEADER_LEN);
 
         // we consumed the partial frame, reset
         _frame_ofs = 0;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -29,8 +29,8 @@
 
 #define CRSF_MAX_CHANNELS   24U      // Maximum number of channels from crsf datastream
 #define CRSF_FRAMELEN_MAX   64U      // maximum possible framelength
-#define CSRF_HEADER_LEN     2U       // header length
-#define CRSF_FRAME_PAYLOAD_MAX (CRSF_FRAMELEN_MAX - CSRF_HEADER_LEN)     // maximum size of the frame length field in a packet
+#define CRSF_HEADER_LEN     2U       // header length
+#define CRSF_FRAME_PAYLOAD_MAX (CRSF_FRAMELEN_MAX - CRSF_HEADER_LEN)     // maximum size of the frame length field in a packet
 #define CRSF_BAUDRATE      416666U
 #define ELRS_BAUDRATE      420000U
 #define CRSF_TX_TIMEOUT    500000U   // the period after which the transmitter is considered disconnected (matches copters failsafe)

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -78,7 +78,7 @@ void AP_CRSF_Telem::setup_wfq_scheduler(void)
     // priority[i] = 1/_scheduler.packet_weight[i]
     // rate[i] = LinkRate * ( priority[i] / (sum(priority[1-n])) )
 
-    // CSRF telemetry rate is 150Hz (4ms) max, so these rates must fit
+    // CRSF telemetry rate is 150Hz (4ms) max, so these rates must fit
     add_scheduler_entry(50, 100);   // heartbeat        10Hz
     add_scheduler_entry(5, 20);     // parameters       50Hz (generally not active unless requested by the TX)
     add_scheduler_entry(50, 120);   // Attitude and compass 8Hz

--- a/libraries/AP_RCTelemetry/AP_GHST_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_GHST_Telem.cpp
@@ -74,7 +74,7 @@ void AP_GHST_Telem::setup_wfq_scheduler(void)
     // priority[i] = 1/_scheduler.packet_weight[i]
     // rate[i] = LinkRate * ( priority[i] / (sum(priority[1-n])) )
 
-    // CSRF telemetry rate is 150Hz (4ms) max, so these rates must fit
+    // CRSF telemetry rate is 150Hz (4ms) max, so these rates must fit
     add_scheduler_entry(50, 120);   // Attitude and compass 8Hz
     add_scheduler_entry(200, 1000); // VTX parameters    1Hz
     add_scheduler_entry(1300, 500); // battery           2Hz


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/26183/files#diff-b461323452ea70e83fbc1217b71154b88fad81484395ac5dde19ba7ad5c57327R244-R246
