### PR TITLE
Plane: QLAND if long failsafe on VTOL takeoff

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -175,6 +175,14 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
             // don't failsafe in a landing sequence
             break;
         }
+
+#if HAL_QUADPLANE_ENABLED
+        if (quadplane.in_vtol_takeoff()) {
+            set_mode(mode_qland, reason);
+            // QLAND if in VTOL takeoff
+            break;
+        }
+#endif
         FALLTHROUGH;
 
     case Mode::Number::AVOID_ADSB:


### PR DESCRIPTION
For QuadPlanes utilizing the RTL_AUTOLAND functionality with DO_LAND_START points and the Q_RTL_MODE parameter set to 0, in order to use a mission-based landing approach:

Presently, if a LONG_FAILSAFE event is triggered during an automated VTOL takeoff, the aircraft will transition back to forward flight regardless of its current altitude, and continue to the waypoint subsequent to the DO_LAND_START command. This behavior presents a significant safety risk, especially for larger aircraft.

This change results in the aircraft entering QLAND mode if a LONG_FAILSAFE is triggered during a VTOL takeoff.

Tested in SITL. 