### PR TITLE
Add TECS option to allow low drag planes to descend faster

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -542,8 +542,10 @@ void AP_TECS::_update_height_demand(void)
             _hgt_dem_rate_ltd = _hgt_dem_rate_ltd - _sink_rate_limit * _DT;
             _sink_fraction = 1.0f;
         } else {
-            if (is_negative(hgt_dem - _hgt_dem_rate_ltd)) {
-                _sink_fraction = (hgt_dem - _hgt_dem_rate_ltd) / (-_sink_rate_limit * _DT);
+            const float numerator = hgt_dem - _hgt_dem_rate_ltd;
+            const float denominator = - _sink_rate_limit * _DT;
+            if (is_negative(numerator) && is_negative(denominator)) {
+                _sink_fraction = numerator / denominator;
             } else {
                 _sink_fraction = 0.0f;
             }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -246,7 +246,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Extra TECS options
     // @Description: This allows the enabling of special features in the speed/height controller.
-    // @Bitmask: 0:GliderOnly
+    // @Bitmask: 0:GliderOnly,1:AllowDescentSpeedup
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 28, AP_TECS, _options, 0),
 
@@ -458,6 +458,11 @@ void AP_TECS::_update_speed(float DT)
 
 void AP_TECS::_update_speed_demand(void)
 {
+    if (_options & OPTION_DESCENT_SPEEDUP) {
+        // Allow demanded speed to  go to maximum when descending at maximum descent rate
+        _TAS_dem = _TAS_dem + (_TASmax - _TAS_dem) * _sink_fraction;
+    }
+
     // Set the airspeed demand to the minimum value if an underspeed condition exists
     // or a bad descent condition exists
     // This will minimise the rate of descent resulting from an engine failure,
@@ -532,9 +537,16 @@ void AP_TECS::_update_height_demand(void)
         // Limit height rate of change
         if ((hgt_dem - _hgt_dem_rate_ltd) > (_climb_rate_limit * _DT)) {
             _hgt_dem_rate_ltd = _hgt_dem_rate_ltd + _climb_rate_limit * _DT;
+            _sink_fraction = 0.0f;
         } else if ((hgt_dem - _hgt_dem_rate_ltd) < (-_sink_rate_limit * _DT)) {
             _hgt_dem_rate_ltd = _hgt_dem_rate_ltd - _sink_rate_limit * _DT;
+            _sink_fraction = 1.0f;
         } else {
+            if (is_negative(hgt_dem - _hgt_dem_rate_ltd)) {
+                _sink_fraction = (hgt_dem - _hgt_dem_rate_ltd) / (-_sink_rate_limit * _DT);
+            } else {
+                _sink_fraction = 0.0f;
+            }
             _hgt_dem_rate_ltd = hgt_dem;
         }
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -336,8 +336,6 @@ private:
         // true when a reset of airspeed and height states to current is performed on this frame
         bool reset:1;
 
-        // true when we are allowing the plane to speed up on descent to maintain the target descent rate
-        bool speedup:1;
     };
     union {
         struct flags _flags;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -197,7 +197,8 @@ private:
     AP_Float _hgt_dem_tconst;
 
     enum {
-        OPTION_GLIDER_ONLY=(1<<0)
+        OPTION_GLIDER_ONLY=(1<<0),
+        OPTION_DESCENT_SPEEDUP=(1<<1)
     };
 
     AP_Float _pitch_ff_v0;
@@ -334,6 +335,9 @@ private:
 
         // true when a reset of airspeed and height states to current is performed on this frame
         bool reset:1;
+
+        // true when we are allowing the plane to speed up on descent to maintain the target descent rate
+        bool speedup:1;
     };
     union {
         struct flags _flags;
@@ -389,6 +393,7 @@ private:
     // used to scale max climb and sink limits to match vehicle ability
     float _max_climb_scaler;
     float _max_sink_scaler;
+    float _sink_fraction;
 
     // Specific energy error quantities
     float _STE_error;


### PR DESCRIPTION
During descent with low drag planes, TECs will limit the rate of descent so that the specified  mission speed can be maintained. This result in shallow descents.

One of the main reason for wanting this is to be able to better predict (forward planning) how far we should set waypoints when coming in for landing. With low drag airframes,  no matter what max decent in TECS is set to, the aircraft achieves some fraction of that. This means the approach has to be done from unnecessarily far away which becomes a safety risk due to obstacles. If a Loiter to alt method of descent is used it still wastes mission time.

This PR addresses the issue by adding an enum to TECS_OPTIONS that progressively increases set speed to the maximum allowed as the descent rate approaches the TECS internal limit. This works effectively in SITL.

<img width="1020" alt="Screenshot 2024-02-20 at 9 41 28 am" src="https://github.com/ArduPilot/ardupilot/assets/3596952/279aaed9-bdd8-423f-a166-0c7e831b0f32">
<img width="1034" alt="Screenshot 2024-02-20 at 9 41 20 am" src="https://github.com/ArduPilot/ardupilot/assets/3596952/78f7e8d7-01a7-474b-ae14-516dfa844b73">

Because this is off by default, it could be included in the plane Beta release without risk.