### PR TITLE
Fence: allow for storage expansion of fence items on microSD

### DIFF
--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -159,6 +159,12 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+#if AP_SDCARD_STORAGE_ENABLED
+    bool failed_sdcard_storage(void) const {
+        return _poly_loader.failed_sdcard_storage();
+    }
+#endif
+
 private:
     static AC_Fence *_singleton;
 

--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -186,6 +186,11 @@ public:
     }
 
 
+#if AP_SDCARD_STORAGE_ENABLED
+    bool failed_sdcard_storage(void) const {
+        return _failed_sdcard_storage;
+    }
+#endif
 
 private:
     // multi-thread access support
@@ -423,6 +428,11 @@ private:
     bool index_eeprom() WARN_IF_UNUSED;
 
     uint16_t fence_storage_space_required(const AC_PolyFenceItem *new_items, uint16_t count);
+
+#if AP_SDCARD_STORAGE_ENABLED
+    // true if we failed to load SDCard storage on init
+    bool _failed_sdcard_storage;
+#endif
 };
 
 #endif // AP_FENCE_ENABLED

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1244,6 +1244,13 @@ bool AP_Arming::fence_checks(bool display_failure)
         check_failed(display_failure, "%s", fail_msg);
     }
 
+#if AP_SDCARD_STORAGE_ENABLED
+    if (fence->failed_sdcard_storage() || StorageManager::storage_failed()) {
+        check_failed(display_failure, "Failed to open fence storage");
+        return false;
+    }
+#endif
+    
     return false;
 }
 #endif  // AP_FENCE_ENABLED

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -354,6 +354,14 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("SD_MISSION", 24, AP_BoardConfig, sdcard_storage.mission_kb, 0),
+
+    // @Param: SD_FENCE
+    // @DisplayName:  SDCard Fence size
+    // @Description: This sets the amount of storage in kilobytes reserved on the microsd card in fence.stg for fence storage.
+    // @Range: 0 64
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("SD_FENCE", 29, AP_BoardConfig, sdcard_storage.fence_kb, 0),
 #endif
 
     // index 25 used by SER5_RTSCTS

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -221,6 +221,11 @@ public:
     static uint16_t get_sdcard_mission_kb(void) {
         return _singleton? _singleton->sdcard_storage.mission_kb.get() : 0;
     }
+
+    // return number of kb of fence storage to use on microSD
+    static uint16_t get_sdcard_fence_kb(void) {
+        return _singleton? _singleton->sdcard_storage.fence_kb.get() : 0;
+    }
 #endif
 
 private:
@@ -244,6 +249,7 @@ private:
 #if AP_SDCARD_STORAGE_ENABLED
     struct {
         AP_Int16 mission_kb;
+        AP_Int16 fence_kb;
     } sdcard_storage;
 #endif
 


### PR DESCRIPTION
this uses the same mechanism as BRD_SD_MISSION with a new BRD_SD_FENCE parameter
I have tested briefly in SITL
